### PR TITLE
Make wcs attribute a pointer to GWCS object for nddata interface

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -394,14 +394,14 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                 return None
         return self._shape
 
-    def my_attribute(self, attr):
+    def _my_attribute(self, attr):
         properties = frozenset(("shape", "history", "_extra_fits", "schema"))
         return attr in properties
 
     def __setattr__(self, attr, value):
-        if self.my_attribute(attr):
+        if self._my_attribute(attr):
             object.__setattr__(self, attr, value)
-        elif ndmodel.NDModel.my_attribute(self, attr):
+        elif ndmodel.NDModel._my_attribute(self, attr):
             ndmodel.NDModel.__setattr__(self, attr, value)
         else:
             properties.ObjectNode.__setattr__(self, attr, value)
@@ -836,7 +836,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             hdu = fits.ImageHDU(name=hdu_name, header=header)
         hdulist = fits.HDUList([hdu])
 
-        ff = fits_support.from_fits(hdulist, self._schema, validate=False)
+        ff = fits_support.from_fits(hdulist, self._schema)
 
         self._instance = properties.merge_tree(self._instance, ff.tree)
 

--- a/jwst/datamodels/ndmodel.py
+++ b/jwst/datamodels/ndmodel.py
@@ -11,6 +11,8 @@ import collections
 from astropy.extern import six
 from astropy.units import Quantity
 from astropy.nddata import nddata_base
+from astropy import wcs
+import gwcs
 
 from . import util
 from . import filetype
@@ -105,7 +107,7 @@ def write(data, path, *args, **kwargs):
 #---------------------------------------
 
 class NDModel(nddata_base.NDDataBase):
-    def my_attribute(self, attr):
+    def _my_attribute(self, attr):
         """
         Test if attribute is part of the NDData interface
         """
@@ -162,15 +164,30 @@ class NDModel(nddata_base.NDDataBase):
     def wcs(self):
         """
         Read the world coordinate system (WCS) for the dataset.
+
+        Get the GWCS object or if it hasn't been set, generate an astropy WCS
+        object from the header info.
         """
-        return self.get_fits_wcs()
+        try:
+            val = self.meta.wcs
+        except AttributeError:
+            val = None
+        if val:
+            return val
+        else:
+            return self.get_fits_wcs()
 
     @wcs.setter
     def wcs(self, value):
         """
         Write the world coordinate system (WCS) to the dataset.
+
+        Write an astropy WCS or GWCS object as required.
         """
-        return self.set_fits_wcs(value)
+        if isinstance(value, wcs.WCS):
+            self.set_fits_wcs(value)
+        elif isinstance(value, gwcs.WCS):
+            self.meta.wcs = value
 
     @property
     def meta(self):

--- a/jwst/datamodels/ndmodel.py
+++ b/jwst/datamodels/ndmodel.py
@@ -169,12 +169,8 @@ class NDModel(nddata_base.NDDataBase):
         object from the header info.
         """
         try:
-            val = self.meta.wcs
+            return self.meta.wcs
         except AttributeError:
-            val = None
-        if val:
-            return val
-        else:
             return self.get_fits_wcs()
 
     @wcs.setter


### PR DESCRIPTION
- This resolves my concerns in PR #803 that there's two WCS objects that are different in our datamodels since the subclassing of `NDData`.  Now the `NDData` interface points to the GWCS object if it exists.  Also, this PR leaves open the possibility that we may want to use astropy.wcs objects in rectified datamodels in the future.
- Minor change to make the `my_attribute` non-public.