### PR TITLE
Fix ModelContainer copy() method to copy everything, including metadata

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -164,17 +164,26 @@ class ModelContainer(model_base.DataModel):
         self._open_model(index)
         return self._models.pop(index)
 
-    def copy(self):
+    def copy(self, memo=None):
         """
         Returns a deep copy of the models in this model container.
         """
-        models_copy = []
-        for model in self._models:
-            if isinstance(model, model_base.DataModel):
-                models_copy.append(model.copy())
+        result = self.__class__(init=None,
+                                extensions=self._extensions,
+                                pass_invalid_values=self._pass_invalid_values,
+                                strict_validation=self._strict_validation)
+        instance = copy.deepcopy(self._instance, memo=memo)
+        result._asdf = AsdfFile(instance, extensions=self._extensions)
+        result._instance = instance
+        result._iscopy = self._iscopy
+        result._schema = result._schema
+        result._ctx = result
+        for m in self._models:
+            if isinstance(m, model_base.DataModel):
+                result.append(m.copy())
             else:
-                models_copy.append(model)
-        return self.__class__(init=models_copy)
+                result.append(m)
+        return result
 
     def from_asn(self, filepath, **kwargs):
         """


### PR DESCRIPTION
Resolves #1844.