### PR TITLE
Rewrite datamodels history getter and setter

### DIFF
--- a/jwst/datamodels/history.py
+++ b/jwst/datamodels/history.py
@@ -1,7 +1,9 @@
-from collections import UserList
-
-from asdf import AsdfFile
 from asdf.tags.core import HistoryEntry
+
+def _iterable(values):
+    if isinstance(values, str) or not hasattr(values, '__iter__'):
+        values = (values,)
+    return values
 
 class HistoryList:
     """
@@ -43,8 +45,8 @@ class HistoryList:
     def __eq__(self, other):
         if isinstance(other, HistoryList):
             other = other._entries
-        elif not isinstance(other, list):
-            other = list(other)
+        else:
+            other = _iterable(other)
 
         if len(self) != len(other):
             return False
@@ -69,5 +71,6 @@ class HistoryList:
         self._entries.clear()
 
     def extend(self, values):
+        values = _iterable(values)
         for value in values:
             self.append(value)

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -859,8 +859,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             with `~jwst.datamodels.util.create_history_entry`.
 
         """
-        if not hasattr(values, '__iter__'):
-            values = [values]
         entries = self.history
         entries.clear()
         entries.extend(values)

--- a/jwst/datamodels/tests/test_history.py
+++ b/jwst/datamodels/tests/test_history.py
@@ -27,6 +27,39 @@ def setup():
 def teardown():
     shutil.rmtree(TMP_DIR)
 
+def test_historylist_methods():
+    m = DataModel()
+    h1 = m.history
+
+    info = "First entry"
+    h1.append(info)
+    assert h1 == info, "Append new history entry"
+
+    h2 = m.history
+    assert h2 == info, "Two history lists point to the same object"
+
+    assert len(h1) == 1, "Length of a history list"
+
+    entry = h1[0]
+    assert entry["description"] == info, "Get history list item"
+
+    info += " for real"
+    h1[0] = info
+    assert h1 == info, "Set history list item"
+
+    del h1[0]
+    assert len(h1) == 0, "Delete history list item"
+
+    info = ("First entry", "Second_entry", "Third entry")
+    h1.extend(info)
+    assert len(h1) == 3, "Length of extended history list"
+    assert h1 == info, "Contents of extended history list"
+
+    for entry, item in zip(h1, info):
+        assert entry["description"]  == item, "Iterate over history list"
+
+    h1.clear()
+    assert len(h1) == 0, "Clear history list"
 
 def test_history_from_model_to_fits():
     m = DataModel()


### PR DESCRIPTION
The history records in datamodels are best represented as a list that one appends to. This update rewrites the history getter and setter to implement this by:

Having the getter return a list of history entries. It first creates the list of entries if it does not exist.
    
Rewriting the setter so that it appends to the list of history entries. If the value is not a History Entry, it is converted to a HistoryEntry.
    
Due to the different ways values can be added to the history, it is possible to wind up with a mixed list of HistoryEntry's and other values. This is fixed when the history is written to the fits header.
 