### PR TITLE
Change 'build_mode' to 'name' to reflect CI utils update.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def PY_SETUP = "python setup.py"
 // Generate distributions
 dist = new BuildConfig()
 dist.nodetype = 'linux'
-dist.build_mode = 'dist'
+dist.name = 'dist'
 dist.build_cmds = [
     "${CONDA_INST} numpy",
     "${PY_SETUP} sdist",
@@ -84,12 +84,12 @@ matrix += dist
 // Compile documentation
 docs = new BuildConfig()
 docs.nodetype = 'linux'
-docs.build_mode = 'docs'
+docs.name = 'docs'
 docs.build_cmds = [
     "conda config --add channels ${CONDA_CHANNEL}",
-    "${CONDA_CREATE} -n ${docs.build_mode} ${CONDA_DOC_DEPS} ${CONDA_DEPS}",
-    "with_env -n ${docs.build_mode} ${PIP_INST} ${PIP_DOC_DEPS}",
-    "with_env -n ${docs.build_mode} ${PY_SETUP} build_sphinx"
+    "${CONDA_CREATE} -n ${docs.name} ${CONDA_DOC_DEPS} ${CONDA_DEPS}",
+    "with_env -n ${docs.name} ${PIP_INST} ${PIP_DOC_DEPS}",
+    "with_env -n ${docs.name} ${PY_SETUP} build_sphinx"
 ]
 matrix += docs
 
@@ -104,7 +104,7 @@ for (py in PY_VERSIONS) {
             bc = new BuildConfig()
             bc.nodetype = 'linux'
             bc.env_vars = ENV_SETUP
-            bc.build_mode = NAME
+            bc.name = NAME
             bc.build_cmds = [
                 "conda config --add channels ${CONDA_CHANNEL}",
                 "${CONDA_CREATE} -n ${NAME} \

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -59,7 +59,7 @@ node("jwst") {
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
 bc.env_vars = test_env
-bc.build_mode = PY_VER
+bc.name = PY_VER
 
 bc.test_cmds = [
     "conda config --add channels ${CONDA_CHANNEL}",


### PR DESCRIPTION
The CI utilities library that Jenkins uses to provide the convenience syntax used in the Jenkinsfile has been updated to temporarily honor both `.build_mode` and `.name` as a step towards transitioning to the new property `.name` for clarity. Once all projects using the CI utilities are updated, support for the old `.build_mode` name will be removed.