### PR TITLE
Consolidate bounding_box <-> shape utils in assign_wcs

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -542,21 +542,13 @@ def get_num_msa_open_shutters(shutter_state):
 
 def update_s_region(model):
     """
-    Update the ``S_REGION`` keyword usiong ``WCS.footprint``.
-
+    Update the ``S_REGION`` keyword usiong ``WCS.footprint()``.
     """
     bbox = None
-    def _bbox_from_shape(model):
-        shape = model.data.shape
-        bbox = ((0, shape[1]), (0, shape[0]))
-        return bbox
     try:
         bbox = model.meta.wcs.bounding_box
     except NotImplementedError:
-        bbox = _bbox_from_shape(model)
-
-    if bbox is None:
-        bbox = _bbox_from_shape(model)
+        bbox = bounding_box_from_shape(model.data.shape)
 
     # footprint is an array of shape (2, 2) or (3, 3)
     footprint = model.meta.wcs.footprint(bbox, center=True)
@@ -581,3 +573,22 @@ def update_s_region(model):
         log.info("There are NaNs in s_region")
     else:
         model.meta.wcsinfo.s_region = s_region
+
+
+def bounding_box_from_shape(shape):
+    """ Return a bounding_box for WCS based on a 2D numpy shape
+    """
+    bb = []
+    for s in reversed(shape):
+        bb.append((-0.5, s - 0.5))
+    return tuple(bb)
+
+
+def shape_from_bounding_box(bounding_box):
+    """ Return a 2D numpy shape based on the provided bounding_box
+    """
+    size = []
+    for axs in bounding_box:
+        delta = axs[1] - axs[0]
+        size.append(int(delta + 0.5))
+    return tuple(reversed(size))

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -15,6 +15,7 @@ from gwcs import coordinate_frames as cf
 from .. import datamodels
 from . import gwcs_drizzle
 from . import resample_utils
+from ..assign_wcs.util import bounding_box_from_shape
 
 CRBIT = np.uint32(datamodels.dqflags.pixel['JUMP_DET'])
 
@@ -202,7 +203,7 @@ class ResampleSpecData:
         output_wcs = WCS(pipeline)
 
         self.data_size = (slit_height_pix, len(lookup_table))
-        bounding_box = resample_utils.bounding_box_from_shape(self.data_size)
+        bounding_box = bounding_box_from_shape(self.data_size)
         output_wcs.bounding_box = bounding_box
         return output_wcs
 
@@ -351,7 +352,7 @@ class ResampleSpecData:
             output_model = self.blank_output.copy()
             output_model.meta.wcs = self.output_wcs
 
-            bb = resample_utils.bounding_box_from_shape(output_model.data.shape)
+            bb = bounding_box_from_shape(output_model.data.shape)
             output_model.meta.wcs.bounding_box = bb
             output_model.meta.filename = obs_product
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -6,7 +6,9 @@ from astropy.modeling.models import Scale, AffineTransformation2D
 from astropy.modeling import Model
 from gwcs import WCS, wcstools
 
-from ..assign_wcs.util import wcs_from_footprints
+from ..assign_wcs.util import (
+    wcs_from_footprints, bounding_box_from_shape, shape_from_bounding_box
+    )
 
 from . import bitmask
 
@@ -83,25 +85,6 @@ def compute_output_transform(refwcs, filename, fiducial):
     cdelt = Scale(scale) & Scale(scale)
 
     return pc_matrix | cdelt
-
-
-def bounding_box_from_shape(shape):
-    """ Return a bounding_box for WCS based on a numpy shape
-    """
-    bb = []
-    for s in reversed(shape):
-        bb.append((-0.5, s - 0.5))
-    return tuple(bb)
-
-
-def shape_from_bounding_box(bounding_box):
-    """ Return a numpy shape based on the provided bounding_box
-    """
-    size = []
-    for axs in bounding_box:
-        delta = axs[1] - axs[0]
-        size.append(int(delta + 0.5))
-    return tuple(reversed(size))
 
 
 def calc_gwcs_pixmap(in_wcs, out_wcs, shape=None):


### PR DESCRIPTION
Moves two functions for converting from a numpy shape to a `gwcs` bounding box (and the reverse) from `resample` to `assign_wcs`, which is the natural home for these.  Also deletes some redundant code that was in `assign_wcs`.