### PR TITLE
Updates to entire package for py2-to-3 conversion

### DIFF
--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
 from numpy.testing import utils
 from astropy import units as u
 from astropy import wcs

--- a/jwst/assign_wcs/tools/nirspec/compute_world_coordinates.py
+++ b/jwst/assign_wcs/tools/nirspec/compute_world_coordinates.py
@@ -9,7 +9,6 @@ Requested by the NIRSPEC team.
 
 Build 7.1 testing.
 """
-from __future__ import absolute_import, division, unicode_literals, print_function
 import os.path
 import numpy as np
 from astropy.io import fits

--- a/jwst/assign_wcs/tools/nirspec/nirspec_fs_ref_tools.py
+++ b/jwst/assign_wcs/tools/nirspec/nirspec_fs_ref_tools.py
@@ -11,8 +11,6 @@ All ASDF reference files take this into account.
 CDP4 delivery
 """
 
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
 import glob
 import os.path
 import numpy as np

--- a/jwst/background/__init__.py
+++ b/jwst/background/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .subtract_images_step import SubtractImagesStep
 from .background_step import BackgroundStep
 

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import math
 import numpy as np
 

--- a/jwst/background/subtract_images.py
+++ b/jwst/background/subtract_images.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 
 import logging

--- a/jwst/barshadow/__init__.py
+++ b/jwst/barshadow/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .barshadow_step import BarShadowStep
 
 __version__ = '0.9.3'

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 #
 #  Module for calculating bar shadow correction for science data sets
 #

--- a/jwst/coron/__init__.py
+++ b/jwst/coron/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .stack_refs_step import StackRefsStep
 from .align_refs_step import AlignRefsStep
 from .klip_step import KlipStep

--- a/jwst/coron/hlsp.py
+++ b/jwst/coron/hlsp.py
@@ -6,8 +6,6 @@
 
 """
 
-from __future__ import division
-
 import numpy as np
 import math
 

--- a/jwst/coron/klip.py
+++ b/jwst/coron/klip.py
@@ -6,8 +6,6 @@
 
 """
 
-from __future__ import division
-
 import numpy as np
 
 import logging

--- a/jwst/csv_tools/csvconvert.py
+++ b/jwst/csv_tools/csvconvert.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 import argparse
 import inspect
@@ -9,7 +7,7 @@ from .table_to_hdulist import table_to_hdulist
 from .table_to_json import table_to_json
 
 
-class CSVConvertScript(object):
+class CSVConvertScript():
     """Convert a CSV file to other formats
     version of the CSV file.
     """

--- a/jwst/cube_build/CubeD2C.py
+++ b/jwst/cube_build/CubeD2C.py
@@ -1,5 +1,4 @@
 # Routines to read the D2C files
-from __future__ import absolute_import, print_function
 
 import sys
 import numpy as np

--- a/jwst/cube_build/__init__.py
+++ b/jwst/cube_build/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .cube_build_step import CubeBuildStep
 
 __version__ = '0.9.3'

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -1,6 +1,5 @@
 
 # Routines used for building cubes
-from __future__ import absolute_import, print_function
 import sys
 import time
 import numpy as np
@@ -22,7 +21,7 @@ from . import coord
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-class CubeBlot(object):
+class CubeBlot():
 # CubeBlot - holds all the important information for Blotting an IFU Cube back to detecto:
 
     def __init__(self, median_model,

--- a/jwst/cube_build/coord.py
+++ b/jwst/cube_build/coord.py
@@ -1,6 +1,4 @@
 
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
 import sys
 import numpy as np
 import math

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -1,6 +1,5 @@
 
 # Routines used for building cubes
-from __future__ import absolute_import, print_function
 import sys
 import time
 import numpy as np
@@ -20,7 +19,7 @@ from . import instrument_defaults
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-class CubeData(object):
+class CubeData():
 # CubeData - holds all the importatn informtion for IFU Cube Building:
 # wcs, data, reference data
 

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -1,5 +1,4 @@
 # Routines used for building cubes
-from __future__ import absolute_import, print_function
 
 import sys
 import time

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -1,5 +1,4 @@
 # Routines used for building cubes
-from __future__ import absolute_import, print_function
 
 import sys
 import time

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -1,6 +1,5 @@
 
  # Routines used in Spectral Cube Building
-from __future__ import absolute_import, print_function
 
 import sys
 import numpy as np

--- a/jwst/cube_build/cube_overlap.py
+++ b/jwst/cube_build/cube_overlap.py
@@ -1,5 +1,4 @@
 # Routines used in Spectral Cube Building
-from __future__ import print_function
 
 import sys
 import numpy as np

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -1,5 +1,4 @@
 # Routines used for building cubes
-from __future__ import absolute_import, print_function
 
 import sys
 import time
@@ -18,7 +17,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 #********************************************************************************
-class DataTypes(object):
+class DataTypes():
 #********************************************************************************
 
     """

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -1,5 +1,4 @@
 # Routines used for building cubes
-from __future__ import absolute_import, print_function
 
 import sys
 import time
@@ -16,7 +15,7 @@ log.setLevel(logging.DEBUG)
 
 
 ##################################################################################
-class FileTable(object):
+class FileTable():
     """
     Dictionary that maps the input files to correct:
     MIRI - channel/subchannel

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1,6 +1,5 @@
 
 # Routines used for building cubes
-from __future__ import absolute_import, print_function
 import sys
 import time
 import numpy as np
@@ -28,7 +27,7 @@ from gwcs import wcstools
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-class IFUCubeData(object):
+class IFUCubeData():
 # CubeData - holds all the importatn informtion for IFU Cube Building:
 # wcs, data, reference data
 

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-class InstrumentInfo(object):
+class InstrumentInfo():
 
     def __init__(self):
 # Wavelength varying parameters

--- a/jwst/cube_build/spaxel.py
+++ b/jwst/cube_build/spaxel.py
@@ -14,7 +14,7 @@ log.setLevel(logging.DEBUG)
 
 
 ##################################################################################
-class Spaxel(object):
+class Spaxel():
 
 
     __slots__ = ['flux', 'error','flux_weight','iflux']
@@ -25,7 +25,7 @@ class Spaxel(object):
         self.iflux = 0
         self.error = 0
 
-class SpaxelAB(object):
+class SpaxelAB():
 
     __slots__ = ['flux', 'error', 'flux_weight','iflux']
 

--- a/jwst/cube_skymatch/__init__.py
+++ b/jwst/cube_skymatch/__init__.py
@@ -4,8 +4,6 @@ This package provides support for sky background subtraction and equalization
 (matching).
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 import os
 import logging
 

--- a/jwst/cube_skymatch/cube_skymatch_step.py
+++ b/jwst/cube_skymatch/cube_skymatch_step.py
@@ -7,8 +7,6 @@ JWST pipeline step for sky matching.
 :License: :doc:`../LICENSE`
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 import numpy as np
 

--- a/jwst/cube_skymatch/skycube.py
+++ b/jwst/cube_skymatch/skycube.py
@@ -8,8 +8,6 @@ generalized step: ``cube_skymatch``.
 :License: :doc:`../LICENSE`
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 import numpy as np
 
@@ -17,7 +15,7 @@ import numpy as np
 __all__ = ['SkyCube']
 
 
-class SkyCube(object):
+class SkyCube():
     """
     Container that holds information about properties of a *single*
     image such as:

--- a/jwst/cube_skymatch/skymatch.py
+++ b/jwst/cube_skymatch/skymatch.py
@@ -6,8 +6,6 @@ A module that provides functions for matching sky in overlapping cubes.
 :License: :doc:`../LICENSE`
 
 """
-from __future__ import absolute_import, division, unicode_literals,\
-     print_function
 
 import logging
 import copy

--- a/jwst/dark_current/__init__.py
+++ b/jwst/dark_current/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .dark_current_step import DarkCurrentStep
 
 __version__ = '0.9.3'

--- a/jwst/dark_current/dark_sub.py
+++ b/jwst/dark_current/dark_sub.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 #
 #  Module for dark subtracting science data sets
 #

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -7,7 +7,6 @@ import copy
 from functools import partial
 from inspect import signature
 import os.path as op
-import six
 
 from asdf import AsdfFile
 

--- a/jwst/dq_init/__init__.py
+++ b/jwst/dq_init/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .dq_init_step import DQInitStep
 
 __version__ = '0.9.3'

--- a/jwst/emission/__init__.py
+++ b/jwst/emission/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .emission_step import EmissionStep
 
 __version__ = '0.9.3'

--- a/jwst/emission/emission.py
+++ b/jwst/emission/emission.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-class DataSet(object):
+class DataSet():
     """
     Input dataset for emission subtraction
 

--- a/jwst/firstframe/__init__.py
+++ b/jwst/firstframe/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .firstframe_step import FirstFrameStep
 
 __version__ = '0.9.3'

--- a/jwst/firstframe/tests/test_firstframe.py
+++ b/jwst/firstframe/tests/test_firstframe.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, unicode_literals,
-                        division, print_function)
-
 import numpy as np
 import pytest
 

--- a/jwst/fits_generator/__init__.py
+++ b/jwst/fits_generator/__init__.py
@@ -1,4 +1,2 @@
-from __future__ import absolute_import
-
 __version__ = '0.9.3'
 __vdate__ = '2017-11-01'

--- a/jwst/fits_generator/create_data.py
+++ b/jwst/fits_generator/create_data.py
@@ -10,7 +10,6 @@
 #
 #    get the exposures
 #    create the level1b data
-from __future__ import absolute_import, print_function
 
 import os
 

--- a/jwst/fits_generator/create_dms_data.py
+++ b/jwst/fits_generator/create_dms_data.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import os
 import numpy as np
 from astropy.io import fits

--- a/jwst/fits_generator/generators.py
+++ b/jwst/fits_generator/generators.py
@@ -32,8 +32,6 @@ Contains a number of helper functions for generating header card
 values.
 """
 
-from __future__ import absolute_import
-
 # STDLIB
 import datetime
 

--- a/jwst/fits_generator/main.py
+++ b/jwst/fits_generator/main.py
@@ -27,19 +27,13 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-from __future__ import absolute_import, print_function, with_statement
-
 # THIRD-PARTY
 from astropy.io import fits as pyfits
-import six
 
 # STDLIB
 import glob
 import os
-if six.PY2:
-    from StringIO import StringIO
-else:
-    from io import StringIO
+from io import StringIO
 
 # LOCAL
 from . import input_file_types

--- a/jwst/fits_generator/pyparsing.py
+++ b/jwst/fits_generator/pyparsing.py
@@ -21,7 +21,6 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-from __future__ import print_function
 
 __doc__ = \
 """

--- a/jwst/fits_generator/template.py
+++ b/jwst/fits_generator/template.py
@@ -28,8 +28,6 @@
 # DAMAGE.
 
 # STDLIB
-from __future__ import absolute_import, print_function
-
 from operator import itemgetter
 import os
 import re

--- a/jwst/fringe/__init__.py
+++ b/jwst/fringe/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .fringe_step import FringeStep
 
 __version__ = '0.9.3'

--- a/jwst/fringe/fringe.py
+++ b/jwst/fringe/fringe.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 #
 #  Module for applying fringe correction
 #

--- a/jwst/gain_scale/__init__.py
+++ b/jwst/gain_scale/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .gain_scale_step import GainScaleStep
 
 __version__ = '0.9.3'

--- a/jwst/gain_scale/gain_scale.py
+++ b/jwst/gain_scale/gain_scale.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 #
 #  Module for rescaling data for non-standard gain value
 #

--- a/jwst/group_scale/__init__.py
+++ b/jwst/group_scale/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .group_scale_step import GroupScaleStep
 
 __version__ = '0.9.3'

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 #
 #  Module for rescaling grouped data for NFRAME
 #  not equal to a power of 2

--- a/jwst/guider_cds/__init__.py
+++ b/jwst/guider_cds/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .guider_cds_step import GuiderCdsStep
 
 __version__ = '0.9.3'

--- a/jwst/imprint/__init__.py
+++ b/jwst/imprint/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .imprint_step import ImprintStep
 
 __version__ = '0.9.3'

--- a/jwst/jump/__init__.py
+++ b/jwst/jump/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .jump_step import JumpStep
 
 __version__ = '0.9.3'

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import time
 import logging
 

--- a/jwst/jump/yintercept.py
+++ b/jwst/jump/yintercept.py
@@ -10,7 +10,7 @@ import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-class PixelRamp(object):
+class PixelRamp():
     """
     Base class for a PixelRamp object
     """

--- a/jwst/jwpsf/jwpsf.py
+++ b/jwst/jwpsf/jwpsf.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-from __future__ import absolute_import, print_function
 
 import sys
 import os
@@ -9,18 +8,11 @@ import types
 import numpy as np
 import math
 from astropy.io import fits as pyfits
-import six
 
-if six.PY2:
-    from Tkinter import *
-    import tkSimpleDialog
-    import tkFileDialog
-    import tkMessageBox
-else:
-    from tkinter import *
-    import tkinter.simpledialog as tkSimpleDialog
-    import tkinter.filedialog as tkFileDialog
-    import tkinter.messagebox as tkMessageBox
+from tkinter import *
+import tkinter.simpledialog as tkSimpleDialog
+import tkinter.filedialog as tkFileDialog
+import tkinter.messagebox as tkMessageBox
 
 from . import makepsf
 

--- a/jwst/jwpsf/makepsf.py
+++ b/jwst/jwpsf/makepsf.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-from __future__ import print_function
 
 import sys
 import os.path

--- a/jwst/lastframe/__init__.py
+++ b/jwst/lastframe/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .lastframe_step import LastFrameStep
 
 __version__ = '0.9.3'

--- a/jwst/linearity/__init__.py
+++ b/jwst/linearity/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .linearity_step import LinearityStep
 
 __version__ = '0.9.3'

--- a/jwst/linearity/linearity.py
+++ b/jwst/linearity/linearity.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from ..datamodels import dqflags
 from ..lib import reffile_utils
 from .linearity_func import apply_linearity_func

--- a/jwst/linearity/linearity_func.py
+++ b/jwst/linearity/linearity_func.py
@@ -1,5 +1,3 @@
-from __future__ import division # confidence high
-
 import logging
 
 log = logging.getLogger(__name__)

--- a/jwst/model_blender/blendrules.py
+++ b/jwst/model_blender/blendrules.py
@@ -104,7 +104,7 @@ blender_funcs = {'first': first,
 
 
 # Classes for managing keyword rules
-class KeywordRules(object):
+class KeywordRules():
 
     def __init__(self, model):
         """ Read in the rules used to interpret the keywords from the specified
@@ -266,7 +266,7 @@ class KeywordRules(object):
         return indx
 
 
-class KwRule(object):
+class KwRule():
     """
     This class encapsulates the logic needed for interpreting a single keyword
     rule from a text file.

--- a/jwst/msaflagopen/__init__.py
+++ b/jwst/msaflagopen/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .msaflagopen_step import MSAFlagOpenStep
 
 __version__ = '0.9.3'

--- a/jwst/msaflagopen/msaflag_open.py
+++ b/jwst/msaflagopen/msaflag_open.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 #
 #  Module for flagging the DQ array of pixels affected by failed
 #  open MSA shutters in nirspec science data sets

--- a/jwst/pathloss/__init__.py
+++ b/jwst/pathloss/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .pathloss_step import PathLossStep
 
 __version__ = '0.9.3'

--- a/jwst/pathloss/path_loss.py
+++ b/jwst/pathloss/path_loss.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 #
 #  Module for calculating pathloss correction for science data sets
 #

--- a/jwst/photom/__init__.py
+++ b/jwst/photom/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .photom_step import PhotomStep
 
 __version__ = '0.9.3'

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -13,7 +13,7 @@ log.setLevel(logging.DEBUG)
 PHOT_TOL = 0.001  # relative tolerance between PIXAR_* keys
 
 
-class DataSet(object):
+class DataSet():
     """
     Input dataset to which the photom information will be attached
 

--- a/jwst/pipeline/__init__.py
+++ b/jwst/pipeline/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .calwebb_ami3 import Ami3Pipeline
 from .calwebb_coron3 import Coron3Pipeline
 from .calwebb_dark import DarkPipeline

--- a/jwst/ramp_fitting/compare_cr_files.py
+++ b/jwst/ramp_fitting/compare_cr_files.py
@@ -39,7 +39,6 @@
 # --> status = a1.compare()
 #
 
-from __future__ import division, print_function
 import sys, os, time
 from astropy.io import fits
 import numpy as N

--- a/jwst/ramp_fitting/compare_cr_navg_files.py
+++ b/jwst/ramp_fitting/compare_cr_navg_files.py
@@ -35,7 +35,6 @@
 # --> status = a1.compare()
 #
 
-from __future__ import division, print_function
 import sys, os, time
 from astropy.io import fits
 import numpy as N

--- a/jwst/ramp_fitting/compare_crs.py
+++ b/jwst/ramp_fitting/compare_crs.py
@@ -2,7 +2,6 @@
 #
 # compare_crs.py - compare true and found cosmic rays
 
-from __future__ import division, print_function
 import sys
 import time
 import numpy as np

--- a/jwst/ramp_fitting/create_cube.py
+++ b/jwst/ramp_fitting/create_cube.py
@@ -30,7 +30,6 @@
 #  ... which specifies the values:
 #  readmode = 'deep8', nread = 4, array size = 100, image to sample = 'sim_100.fits', noisy = True, verbosity = 1
 #
-from __future__ import division, print_function
 
 import time, random
 import numpy as N

--- a/jwst/ramp_fitting/gls_fit.py
+++ b/jwst/ramp_fitting/gls_fit.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import logging
 import math
 import time

--- a/jwst/ramp_fitting/mc_2d.py
+++ b/jwst/ramp_fitting/mc_2d.py
@@ -40,7 +40,6 @@
 # --> status = aa.add_crs_all_slices()
 #
 
-from __future__ import division, print_function
 import time, random
 import numpy as N
 import sys, os, math

--- a/jwst/ramp_fitting/mc_3d.py
+++ b/jwst/ramp_fitting/mc_3d.py
@@ -54,7 +54,6 @@
 # --> status = aa.add_crs_all_slices()
 #
 
-from __future__ import division, print_function
 import fits, time, random
 import numpy as N
 import sys, os, math

--- a/jwst/ramp_fitting/rotate_dataset.py
+++ b/jwst/ramp_fitting/rotate_dataset.py
@@ -6,7 +6,6 @@
 # to file for input into ramp_fit_arr.py
 #
 
-from __future__ import absolute_import, division, print_function
 import sys
 import os
 from . import rotate_utils

--- a/jwst/ramp_fitting/rotate_utils.py
+++ b/jwst/ramp_fitting/rotate_utils.py
@@ -2,7 +2,6 @@
 # rotate_utils.py
 # utility functions for creating a rotated dataset
 
-from __future__ import division, print_function
 import os
 import shutil
 import numpy as np

--- a/jwst/refpix/__init__.py
+++ b/jwst/refpix/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .refpix_step import RefPixStep
 
 __version__ = '0.9.3'

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import logging
 
 import numpy as np

--- a/jwst/refpix/reference_pixels.py
+++ b/jwst/refpix/reference_pixels.py
@@ -26,7 +26,6 @@
 #       these smoothed and scaled values should be subtracted from every pixel
 #       in the corresponding row.
 
-from __future__ import division
 import numpy as np
 from scipy import stats
 import logging
@@ -80,7 +79,7 @@ MIR_reference_sections = {'A': {'left': (0, 1024, 0),
                                'data': (0, 1024, 7, 1028, 4)}
                           }
 
-class Dataset(object):
+class Dataset():
     """Base Class to handle passing stuff from routine to routine
 
     Parameters:

--- a/jwst/reset/__init__.py
+++ b/jwst/reset/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .reset_step import ResetStep
 
 __version__ = '0.9.3'

--- a/jwst/rscd/__init__.py
+++ b/jwst/rscd/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .rscd_step import RSCD_Step
 
 __version__ = '0.9.3'

--- a/jwst/saturation/__init__.py
+++ b/jwst/saturation/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .saturation_step import SaturationStep
 
 __version__ = '0.9.3'

--- a/jwst/skymatch/__init__.py
+++ b/jwst/skymatch/__init__.py
@@ -3,8 +3,6 @@ This package provides support for sky background subtraction and equalization
 (matching).
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 from .skymatch_step import SkyMatchStep
 
 import os

--- a/jwst/skymatch/region.py
+++ b/jwst/skymatch/region.py
@@ -20,7 +20,6 @@ Polygon filling algorithm.
 #    http://www.cs.rit.edu/~icss571/filling/how_to.html
 #    http://www.cs.uic.edu/~jbell/CourseNotes/ComputerGraphics/PolygonFilling.html
 #
-from __future__ import division
 from collections import OrderedDict
 import numpy as np
 
@@ -38,7 +37,7 @@ class ValidationError(Exception):
     def __str__(self):
         return self._message
 
-class Region(object):
+class Region():
     """
     Base class for regions.
 
@@ -275,7 +274,7 @@ class Polygon(Region):
         return px[0] >= self._bbox[0] and px[0] <= self._bbox[0] + self._bbox[2] and \
                px[1] >= self._bbox[1] and px[1] <= self._bbox[1] + self._bbox[3]
 
-class Edge(object):
+class Edge():
     """
     Edge representation
 

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -8,8 +8,6 @@ computing intersections and statistics in the overlap regions.
 
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 # STDLIB
 import numpy as np
@@ -27,7 +25,7 @@ __version__ = '0.9.3'
 __vdate__ = '01-March-2016'
 
 
-class SkyImage(object):
+class SkyImage():
     """
     Container that holds information about properties of a *single*
     image such as:
@@ -583,7 +581,7 @@ None, optional
         return si
 
 
-class SkyGroup(object):
+class SkyGroup():
     """
     Holds multiple :py:class:`SkyImage` objects whose sky background values
     must be adjusted together.

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -6,7 +6,6 @@ A module that provides functions for matching sky in overlapping images.
 :License: :doc:`../LICENSE`
 
 """
-from __future__ import division, print_function
 
 # STDLIB
 import os

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -6,8 +6,6 @@ JWST pipeline step for sky matching.
 
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 import collections
 import numpy as np

--- a/jwst/skymatch/skystatistics.py
+++ b/jwst/skymatch/skystatistics.py
@@ -17,7 +17,7 @@ __version__ = '0.9.3'
 __vdate__ = '12-May-2016'
 __author__ = 'Mihai Cara'
 
-class SkyStats(object):
+class SkyStats():
     """
     This is a superclass build on top of
     :py:class:`stsci.imagestats.ImageStats`. Compared to

--- a/jwst/srctype/__init__.py
+++ b/jwst/srctype/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .srctype_step import SourceTypeStep
 
 __version__ = '0.9.3'

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import numpy as np
 from astropy.io import fits
 import logging

--- a/jwst/straylight/__init__.py
+++ b/jwst/straylight/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .straylight_step import StraylightStep
 
 __version__ = '0.9.3'

--- a/jwst/superbias/__init__.py
+++ b/jwst/superbias/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .superbias_step import SuperBiasStep
 
 __version__ = '0.9.3'

--- a/jwst/superbias/bias_sub.py
+++ b/jwst/superbias/bias_sub.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 #
 #  Module for subtracting a super-bias image from science data sets
 #

--- a/jwst/tweakreg/__init__.py
+++ b/jwst/tweakreg/__init__.py
@@ -2,7 +2,6 @@
 This package provides support for image alignment.
 
 """
-from __future__ import absolute_import
 
 __docformat__ = 'restructuredtext'
 

--- a/jwst/tweakreg/imalign.py
+++ b/jwst/tweakreg/imalign.py
@@ -7,8 +7,6 @@ images catalogs "align" to the reference catalog *on the sky*.
 
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 # STDLIB
 import logging

--- a/jwst/tweakreg/linearfit.py
+++ b/jwst/tweakreg/linearfit.py
@@ -6,8 +6,6 @@ sets of 2D points.
 
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 import logging
 import numpy as np
 # LOCAL

--- a/jwst/tweakreg/matchutils.py
+++ b/jwst/tweakreg/matchutils.py
@@ -3,8 +3,6 @@ A module that provides algorithms for initial estimation of shifts
 based on 2D histograms.
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 import logging
 import numpy as np

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -6,8 +6,6 @@ JWST pipeline step for image alignment.
 
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 import os
 import logging

--- a/jwst/tweakreg/wcsimage.py
+++ b/jwst/tweakreg/wcsimage.py
@@ -7,8 +7,6 @@ of image WCS.
 
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 # STDLIB
 import logging
@@ -38,7 +36,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-class ImageWCS(object):
+class ImageWCS():
     """ A class for holding JWST GWCS information and for managing
     tangent-plane corrections.
 
@@ -302,7 +300,7 @@ class ImageWCS(object):
         return ra, dec
 
 
-class WCSImageCatalog(object):
+class WCSImageCatalog():
     """
     A class that holds information pertinent to an image WCS and a source
     catalog of the sources found in that image.
@@ -714,7 +712,7 @@ class WCSImageCatalog(object):
         """
         return self._bb_radec
 
-class WCSGroupCatalog(object):
+class WCSGroupCatalog():
     """
     A class that holds together `WCSImageCatalog` image catalog objects
     whose relative positions are fixed and whose source catalogs should be
@@ -1275,7 +1273,7 @@ def _tp2tp(imwcs1, imwcs2):
     return matrix, shift
 
 
-class RefCatalog(object):
+class RefCatalog():
     """
     An object that holds a reference catalog and provides
     tools for coordinate convertions using reference WCS as well as

--- a/jwst/wfs_combine/__init__.py
+++ b/jwst/wfs_combine/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .wfs_combine_step import WfsCombineStep
 
 __version__ = '0.9.3'

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -2,7 +2,6 @@
 #
 #  wfs_combine.py - combine 2 dithered PSF images
 #
-from __future__ import division
 import numpy as np
 import logging
 from .. import datamodels
@@ -20,7 +19,7 @@ PSF_SIZE = 200 # half width of psf for 12 waves
 BLUR_SIZE = 10  # size of gaussian kernel for convolution
 N_SIZE = 2 # size of neighborhood in create_griddata_array
 
-class DataSet(object):
+class DataSet():
     """
     Two dithered input wavefront sensing images to be combined
 

--- a/jwst/white_light/__init__.py
+++ b/jwst/white_light/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .white_light_step import WhiteLightStep
 
 __version__ = '0.9.3'

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import time
 import logging
 

--- a/jwst/wiimatch/__init__.py
+++ b/jwst/wiimatch/__init__.py
@@ -5,8 +5,6 @@
 
 """
 
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 import os
 
 

--- a/jwst/wiimatch/lsq_optimizer.py
+++ b/jwst/wiimatch/lsq_optimizer.py
@@ -6,8 +6,6 @@ N-dimensional images using (multi-variate) polynomials.
 
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 import copy
 

--- a/jwst/wiimatch/match.py
+++ b/jwst/wiimatch/match.py
@@ -6,8 +6,6 @@ N-dimensional image intensity data using (multivariate) polynomials.
 
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 # STDLIB
 import copy

--- a/jwst/wiimatch/utils.py
+++ b/jwst/wiimatch/utils.py
@@ -4,8 +4,6 @@ This module provides utility functions for use by :py:mod:`wiimatch` module.
 :Author: Mihai Cara (contact: help@stsci.edu)
 
 """
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 
 import numpy as np
 


### PR DESCRIPTION
Lots and lots of updates for #1392. Removed all "future" imports, removed "object" from all class definitions, and removed some instances of "six." There's still a lot of use of "six" in ``fits_generator``, which I'm going to let @stscirij deal with.