### PR TITLE
Fix update_fits_wcs() to work on DrizProductModels

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -213,18 +213,19 @@ class ResampleData:
             self.output_models.append(output_model)
 
     def update_fits_wcs(self, model):
-        """Update FITS WCS keywords of the resampled image."""
-        if isinstance(model, datamodels.ImageModel):
-            transform = model.meta.wcs.forward_transform
-            model.meta.wcsinfo.crpix1 = -transform[0].offset.value + 1
-            model.meta.wcsinfo.crpix2 = -transform[1].offset.value + 1
-            model.meta.wcsinfo.cdelt1 = transform[3].factor.value
-            model.meta.wcsinfo.cdelt2 = transform[4].factor.value
-            model.meta.wcsinfo.ra_ref = transform[6].lon.value
-            model.meta.wcsinfo.dec_ref = transform[6].lat.value
-            model.meta.wcsinfo.crval1 = model.meta.wcsinfo.ra_ref
-            model.meta.wcsinfo.crval2 = model.meta.wcsinfo.dec_ref
-            model.meta.wcsinfo.pc1_1 = transform[2].matrix.value[0][0]
-            model.meta.wcsinfo.pc1_2 = transform[2].matrix.value[0][1]
-            model.meta.wcsinfo.pc2_1 = transform[2].matrix.value[1][0]
-            model.meta.wcsinfo.pc2_2 = transform[2].matrix.value[1][1]
+        """
+        Update FITS WCS keywords of the resampled image.
+        """
+        transform = model.meta.wcs.forward_transform
+        model.meta.wcsinfo.crpix1 = -transform[0].offset.value + 1
+        model.meta.wcsinfo.crpix2 = -transform[1].offset.value + 1
+        model.meta.wcsinfo.cdelt1 = transform[3].factor.value
+        model.meta.wcsinfo.cdelt2 = transform[4].factor.value
+        model.meta.wcsinfo.ra_ref = transform[6].lon.value
+        model.meta.wcsinfo.dec_ref = transform[6].lat.value
+        model.meta.wcsinfo.crval1 = model.meta.wcsinfo.ra_ref
+        model.meta.wcsinfo.crval2 = model.meta.wcsinfo.dec_ref
+        model.meta.wcsinfo.pc1_1 = transform[2].matrix.value[0][0]
+        model.meta.wcsinfo.pc1_2 = transform[2].matrix.value[0][1]
+        model.meta.wcsinfo.pc2_1 = transform[2].matrix.value[1][0]
+        model.meta.wcsinfo.pc2_2 = transform[2].matrix.value[1][1]


### PR DESCRIPTION
Bug found by @gbrammer where the `update_fits_wcs()` method was only doing the updates on `ImageModel`, but of course the output of `ResampleStep` is a `DrizProductModel`. So this code was never applied and the FITS WCS values were never being updated.  Instead the old values from the first image in the input stack were being retained.

The result was the `SourceCatalogStep` which uses the FITS WCS to write out RA/DEC values was writing them out using the wrong WCS.  Correct `xcentroid, ycentroid` values, but wrong sky coordinates for the sources.

@sosey This should help the grism pipeline.