### PR TITLE
Re-enable and fix errors with ASDF schema tester

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,9 +14,9 @@ try:
 except (NameError, KeyError):
     pass
 
-#pytest_plugins = [
-    #'asdf.tests.schema_tester'
-#]
+pytest_plugins = [
+    'asdf.tests.schema_tester'
+]
 
 # Add option to run slow tests
 def pytest_addoption(parser):

--- a/jwst/__init__.py
+++ b/jwst/__init__.py
@@ -8,3 +8,6 @@ import sys
 if sys.version_info < (3, 5):
     raise ImportError("JWST does not support Python 2.x, 3.0, 3.1, 3.2, 3.3 or 3.4."
                       "Beginning with JWST 0.9, Python 3.5 and above is required.")
+
+from .transforms.jwextension import JWSTExtension
+from .datamodels.extension import BaseExtension


### PR DESCRIPTION
This should resolve #2205 and allow the ASDF schema tester to run successfully under both `pytest` and `python setup.py test`.