### PR TITLE
Enable tests for datamodel schemas and fix errors

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -764,35 +764,47 @@ properties:
           name:
             title: Subarray used
             type: string
-            enum: # Values grouped by instrument:
+            # Values grouped by instrument:
+            anyOf:
               # FGS
-             [8X8, 32X32, 128X128, 2048X64,
-              SUB128CENTER, SUB128DIAGONAL, SUB128LLCORNER, SUB32CENTER,
-              SUB32DIAGONAL, SUB32LLCORNER, SUB8CENTER, SUB8DIAGONAL, SUB8LLCORNER,
+              - enum:
+                 [8X8, 32X32, 128X128, 2048X64, SUB128CENTER, SUB128DIAGONAL,
+                  SUB128LLCORNER, SUB32CENTER, SUB32DIAGONAL, SUB32LLCORNER,
+                  SUB8CENTER, SUB8DIAGONAL, SUB8LLCORNER]
               # MIRI
-              BRIGHTSKY, MASK1065, MASK1140, MASK1550, MASKLYOT, SLITLESSPRISM,
-              SUB128, SUB256, SUB64, SUBPRISM,
+              - enum:
+                 [BRIGHTSKY, MASK1065, MASK1140, MASK1550, MASKLYOT,
+                  SLITLESSPRISM, SUB128, SUB256, SUB64, SUBPRISM]
               # NIRCam
-              SUB160, SUB160P, SUB320, SUB320A335R, SUB320A430R, SUB320ALWB,
-              SUB32TATS, SUB32TATSGRISM, SUB400P, SUB640, SUB640A210R, SUB640ASWB,
-              SUB64FP1A, SUB64FP1B, SUB64P, SUB8FP1A, SUB8FP1B, SUB96DHSPILA,
-              SUB96DHSPILB, SUBFSA210R, SUBFSA335R, SUBFSA430R, SUBFSALWB, SUBFSASWB,
-              SUBGRISM128, SUBGRISM256, SUBGRISM64, SUBNDA210R, SUBNDA335R,
-              SUBNDA430R, SUBNDALWBL, SUBNDALWBS, SUBNDASWBL, SUBNDASWBS,
+              - enum:
+                  [SUB160, SUB160P, SUB320, SUB320A335R, SUB320A430R,
+                   SUB320ALWB, SUB32TATS, SUB32TATSGRISM, SUB400P, SUB640,
+                   SUB640A210R, SUB640ASWB, SUB64FP1A, SUB64FP1B, SUB64P,
+                   SUB8FP1A, SUB8FP1B, SUB96DHSPILA, SUB96DHSPILB, SUBFSA210R,
+                   SUBFSA335R, SUBFSA430R, SUBFSALWB, SUBFSASWB, SUBGRISM128,
+                   SUBGRISM256, SUBGRISM64, SUBNDA210R, SUBNDA335R, SUBNDA430R,
+                   SUBNDALWBL, SUBNDALWBS, SUBNDASWBL, SUBNDASWBS]
               # Obsolete NIRCam
-              MASKA210R, MASKA430R, MASKBLWB, MASKBSWB,
+              - enum:
+                  [MASKA210R, MASKA430R, MASKBLWB, MASKBSWB]
               # NIRISS
-              SUB64, SUB80, SUB128, SUB256, SUBAMPCAL, SUBSTRIP96, SUBSTRIP256,
-              SUBTAAMI, SUBTASOSS, WFSS64C, WFSS64R, WFSS128C, WFSS128R,
+              - enum:
+                  [SUB64, SUB80, SUB128, SUB256, SUBAMPCAL, SUBSTRIP96,
+                   SUBSTRIP256, SUBTAAMI, SUBTASOSS, WFSS64C, WFSS64R,
+                   WFSS128C, WFSS128R]
               # Obsolete NIRISS
-              SUBSTRIP80,
+              - enum:
+                  [SUBSTRIP80]
               # NIRSpec
-              ALLSLITS, SUBS200A1, SUBS200A2, SUBS200B1, SUBS400A1, SUB1024A, SUB1024B,
-              SUB512, SUB32, SUB512S, SUB2048, STRIPE,
+              - enum:
+                  [ALLSLITS, SUBS200A1, SUBS200A2, SUBS200B1, SUBS400A1,
+                   SUB1024A, SUB1024B, SUB512, SUB32, SUB512S, SUB2048, STRIPE]
               # Obsolete NIRSpec
-              FULL_IRS2, S200A1, S200A2, S200B1, S400A1,
+              - enum:
+                  [FULL_IRS2, S200A1, S200A2, S200B1, S400A1]
               # All
-              FULL, GENERIC, N/A]
+              - enum:
+                  [FULL, GENERIC, N/A]
             fits_keyword: SUBARRAY
             blend_table: True
           xstart:

--- a/jwst/datamodels/schemas/ifucubepars.schema.yaml
+++ b/jwst/datamodels/schemas/ifucubepars.schema.yaml
@@ -1,6 +1,6 @@
 title: Default IFU CUBE parameters data model
 allOf:
-- $ref:	referencefile.schema.yaml
+- $ref: referencefile.schema.yaml
 - type: object
   properties:
     ifucubepars_table:

--- a/jwst/datamodels/schemas/miri_resolution.schema.yaml
+++ b/jwst/datamodels/schemas/miri_resolution.schema.yaml
@@ -1,6 +1,6 @@
-title: Miri Resolution Reference file 
+title: Miri Resolution Reference file
 allOf:
-- $ref:	referencefile.schema.yaml
+- $ref: referencefile.schema.yaml
 - type: object
   properties:
     resolving_power_table:
@@ -9,7 +9,7 @@ allOf:
        datatype:
        - name: band
          datatype: [ascii,16]
-       - name: center 
+       - name: center
          datatype: float32
        - name: a_low
          datatype: float32
@@ -34,27 +34,27 @@ allOf:
        fits_hdu: PSF_FWHM_ALPHA
        datatype:
        - name: a_cutoff
-         datatype: float32 
+         datatype: float32
        - name: a_a_short
-         datatype: float32 
+         datatype: float32
        - name: a_b_short
-         datatype: float32 
+         datatype: float32
        - name: a_a_long
-         datatype: float32 
+         datatype: float32
        - name: a_b_long
-         datatype: float32 
+         datatype: float32
     psf_fwhm_beta_table:
        title: PSF FWHM Beta
        fits_hdu: PSF_FWHM_BETA
        datatype:
        - name: b_cutoff
-         datatype: float32 
+         datatype: float32
        - name: b_a_short
-         datatype: float32 
+         datatype: float32
        - name: b_b_short
-         datatype: float32 
+         datatype: float32
        - name: b_a_long
-         datatype: float32 
+         datatype: float32
        - name: b_b_long
-         datatype: float32 
+         datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/resolution.schema.yaml
+++ b/jwst/datamodels/schemas/resolution.schema.yaml
@@ -1,6 +1,6 @@
-title: Default Resolution Reference file 
+title: Default Resolution Reference file
 allOf:
-- $ref:	referencefile.schema.yaml
+- $ref: referencefile.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/resolution.schema.yaml
+++ b/jwst/datamodels/schemas/resolution.schema.yaml
@@ -4,8 +4,8 @@ allOf:
 - type: object
   properties:
     data:
-    title: Resolving Power table
-    fits_hdu: SCI
-    default: 1.0
-    datatype: float32
+      title: Resolving Power table
+      fits_hdu: SCI
+      default: 1.0
+      datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/subarray.schema.yaml
+++ b/jwst/datamodels/schemas/subarray.schema.yaml
@@ -9,35 +9,47 @@ properties:
           name:
             title: Subarray used
             type: string
-            enum: # Values grouped by instrument:
+            # Values grouped by instrument:
+            anyOf:
               # FGS
-             [8X8, 32X32, 128X128, 2048X64,
-              SUB128CENTER, SUB128DIAGONAL, SUB128LLCORNER, SUB32CENTER,
-              SUB32DIAGONAL, SUB32LLCORNER, SUB8CENTER, SUB8DIAGONAL, SUB8LLCORNER,
+              - enum:
+                 [8X8, 32X32, 128X128, 2048X64, SUB128CENTER, SUB128DIAGONAL,
+                  SUB128LLCORNER, SUB32CENTER, SUB32DIAGONAL, SUB32LLCORNER,
+                  SUB8CENTER, SUB8DIAGONAL, SUB8LLCORNER]
               # MIRI
-              BRIGHTSKY, MASK1065, MASK1140, MASK1550, MASKLYOT, SLITLESSPRISM,
-              SUB128, SUB256, SUB64, SUBPRISM,
+              - enum:
+                 [BRIGHTSKY, MASK1065, MASK1140, MASK1550, MASKLYOT,
+                  SLITLESSPRISM, SUB128, SUB256, SUB64, SUBPRISM]
               # NIRCam
-              SUB160, SUB160P, SUB320, SUB320A335R, SUB320A430R, SUB320ALWB,
-              SUB32TATS, SUB32TATSGRISM, SUB400P, SUB640, SUB640A210R, SUB640ASWB,
-              SUB64FP1A, SUB64FP1B, SUB64P, SUB8FP1A, SUB8FP1B, SUB96DHSPILA,
-              SUB96DHSPILB, SUBFSA210R, SUBFSA335R, SUBFSA430R, SUBFSALWB, SUBFSASWB,
-              SUBGRISM128, SUBGRISM256, SUBGRISM64, SUBNDA210R, SUBNDA335R,
-              SUBNDA430R, SUBNDALWBL, SUBNDALWBS, SUBNDASWBL, SUBNDASWBS,
+              - enum:
+                  [SUB160, SUB160P, SUB320, SUB320A335R, SUB320A430R,
+                   SUB320ALWB, SUB32TATS, SUB32TATSGRISM, SUB400P, SUB640,
+                   SUB640A210R, SUB640ASWB, SUB64FP1A, SUB64FP1B, SUB64P,
+                   SUB8FP1A, SUB8FP1B, SUB96DHSPILA, SUB96DHSPILB, SUBFSA210R,
+                   SUBFSA335R, SUBFSA430R, SUBFSALWB, SUBFSASWB, SUBGRISM128,
+                   SUBGRISM256, SUBGRISM64, SUBNDA210R, SUBNDA335R, SUBNDA430R,
+                   SUBNDALWBL, SUBNDALWBS, SUBNDASWBL, SUBNDASWBS]
               # Obsolete NIRCam
-              MASKA210R, MASKA430R, MASKBLWB, MASKBSWB,
+              - enum:
+                  [MASKA210R, MASKA430R, MASKBLWB, MASKBSWB]
               # NIRISS
-              SUB64, SUB80, SUB128, SUB256, SUBAMPCAL, SUBSTRIP96, SUBSTRIP256,
-              SUBTAAMI, SUBTASOSS, WFSS64C, WFSS64R, WFSS128C, WFSS128R,
+              - enum:
+                  [SUB64, SUB80, SUB128, SUB256, SUBAMPCAL, SUBSTRIP96,
+                   SUBSTRIP256, SUBTAAMI, SUBTASOSS, WFSS64C, WFSS64R,
+                   WFSS128C, WFSS128R]
               # Obsolete NIRISS
-              SUBSTRIP80,
+              - enum:
+                  [SUBSTRIP80]
               # NIRSpec
-              ALLSLITS, SUBS200A1, SUBS200A2, SUBS200B1, SUBS400A1, SUB1024A, SUB1024B,
-              SUB512, SUB32, SUB512S, SUB2048, STRIPE,
+              - enum:
+                  [ALLSLITS, SUBS200A1, SUBS200A2, SUBS200B1, SUBS400A1,
+                   SUB1024A, SUB1024B, SUB512, SUB32, SUB512S, SUB2048, STRIPE]
               # Obsolete NIRSpec
-              FULL_IRS2, S200A1, S200A2, S200B1, S400A1,
+              - enum:
+                  [FULL_IRS2, S200A1, S200A2, S200B1, S400A1]
               # All
-              FULL, GENERIC, N/A]
+              - enum:
+                  [FULL, GENERIC, N/A]
             fits_keyword: SUBARRAY
           xstart:
             title: Starting pixel in axis 1 direction

--- a/jwst/datamodels/schemas/wavecorr.schema.yaml
+++ b/jwst/datamodels/schemas/wavecorr.schema.yaml
@@ -1,30 +1,30 @@
 title: NirSpec WAVECORR (wavelength zero-point correction) reference file model
 definitions:
   zero_point_correction:
-    - type: object
-      properties:
-        aperture_name:
-          type: string
-          enum: [S200A1, S200A2, S400A1, S1600A1, S200B1, MOS]
-        zero_point_offset:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
-          title: Zero-point offset
-          description: |
-            Zero-point offset (in units of detector pixel) as a function of wavelength (in m)
-            and source offset within the aperture (in units of fraction of the aperture width
-            [SLIT] or pitch [MOS])
-          datatype: float32
-        variance:
-          $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
-          title: Variance of the zero-point offset
-          description: |
-            Estimated variance on the zero-point offset (in units of detector pixel)
-            as a function of wavelength (in m) and source position within the aperture
-            (in units of fraction of [MOS]
-          datatype: float32
-        width:
-          type: number
-          title: Aperture or pitch width [in m]
+    type: object
+    properties:
+      aperture_name:
+        type: string
+        enum: [S200A1, S200A2, S400A1, S1600A1, S200B1, MOS]
+      zero_point_offset:
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        title: Zero-point offset
+        description: |
+          Zero-point offset (in units of detector pixel) as a function of wavelength (in m)
+          and source offset within the aperture (in units of fraction of the aperture width
+          [SLIT] or pitch [MOS])
+        datatype: float32
+      variance:
+        $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+        title: Variance of the zero-point offset
+        description: |
+          Estimated variance on the zero-point offset (in units of detector pixel)
+          as a function of wavelength (in m) and source position within the aperture
+          (in units of fraction of [MOS]
+        datatype: float32
+      width:
+        type: number
+        title: Aperture or pitch width [in m]
 allOf:
 - $ref: referencefile.schema.yaml
 - $ref: keyword_exptype.schema.yaml
@@ -33,4 +33,4 @@ allOf:
     apertures:
       type: array
       items:
-        $ref: "#definitions/zero_point_correction"
+        - $ref: "#definitions/zero_point_correction"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ exclude = extern,sphinx,*parsetab.py
 minversion = 3
 addopts = --ignore=build
 norecursedirs = .eggs build docs/_build relic jwst/tests_nightly
-asdf_schema_root = jwst/transforms/schemas
+asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
This enables the ASDF schema tester for schemas found under `jwst/datamodels/schemas`. It also fixes a number of apparent errors that were exposed by these tests.

Since I'm lacking some context about how the datamodels work, someone should check to make sure the changes I made are in fact valid fixes.

This PR is based on #2240, which should be merged first.