### PR TITLE
Add model name and list of required keywords

### DIFF
--- a/docs/jwst/tso_photometry/reference_files.rst
+++ b/docs/jwst/tso_photometry/reference_files.rst
@@ -20,7 +20,7 @@ when creating and populating a new reference file.
 
 ========  ====================
 Keyword   Model Name
---------  --------------------
+========  ====================
 AUTHOR    meta.author
 DATAMODL  meta.model_type
 DATE      meta.data

--- a/docs/jwst/tso_photometry/reference_files.rst
+++ b/docs/jwst/tso_photometry/reference_files.rst
@@ -1,8 +1,8 @@
 Reference File
 ==============
-The tso_photometry step uses a TSOPHOT reference file that supplies values
-of radius (in pixels) for the target aperture and the inner and outer radii
-for the background annulus.
+The tso_photometry step uses a TsoPhotModel reference file, reference type
+TSOPHOT, that supplies values of radius (in pixels) for the target aperture
+and the inner and outer radii for the background annulus.
 
 CRDS Selection Criteria
 -----------------------
@@ -10,6 +10,30 @@ TSOPHOT reference files are selected on the basis of INSTRUME, EXP_TYPE,
 and TSOVISIT.  For MIRI exposures, EXP_TYPE should be MIR_IMAGE.  For
 NIRCam exposures, EXP_TYPE should be NRC_TSIMAGE.  For both MIRI and NIRCam,
 TSOVISIT should be True.
+
+Required keywords
+-----------------
+These keywords are required to be present in a TsoPhotModel reference file.
+The first column gives the FITS keyword names (although these reference
+files are ASDF).  The second column gives the model name, which is needed
+when creating and populating a new reference file.
+
+========  ====================
+Keyword   Model Name
+--------  --------------------
+AUTHOR    meta.author
+DATAMODL  meta.model_type
+DATE      meta.data
+DESCRIP   meta.description
+EXP_TYPE  meta.exposure.type
+FILENAME  meta.filename
+INSTRUME  meta.instrument.name
+PEDIGREE  meta.pedigree
+REFTYPE   meta.reftype
+TELESCOP  meta.telescope
+TSOVISIT  meta.visit.tsovisit
+USEAFTER  meta.useafter
+========  ====================
 
 TSOPHOT Reference File Format
 -----------------------------


### PR DESCRIPTION
The name of the reference file model (i.e. TsoPhotModel) and a list of required FITS keywords and datamodel meta names were added.  See issue #2257.