### PR TITLE
Provide CI utils 'skip_disable' argument in correct form

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -1,6 +1,6 @@
 //@Library('utils@master') _  // For development only.
 
-if (utils.scm_checkout(skip_disable=true)) return
+if (utils.scm_checkout(['skip_disable':true])) return
 
 def test_env = [
     "HOME=./",


### PR DESCRIPTION
The machinery internal to the CI support library changed to conform to the prescribed method of handling default argument values in Groovy. Previous attempt was based on faulty documentation, apparently.

Testing indicates this should really do the trick.

| Function argument  | Commit message  | Result |
| ------------- |:-------------:| -----:|
| `['skip_disable':true]` |  `[skip ci]` appears | build proceeds |
| `['skip_disable':true]` | regular commit message | build proceeds |
| none | `[skip ci]` appears | build skipped |
| none | regular commit message | build proceeds |