### PR TITLE
Rewrote the hasattr method in Datamodels

### DIFF
--- a/jwst/datamodels/ifuimage.py
+++ b/jwst/datamodels/ifuimage.py
@@ -38,13 +38,13 @@ class IFUImageModel(model_base.DataModel):
             self.data = init.data
             self.dq = init.dq
             self.err = init.err
-            if hasattr(init, 'area'):
+            if init.hasattr('area'):
                 self.area = init.area
-            if hasattr(init, 'relsens2d'):
+            if init.hasattr('relsens2d'):
                 self.relsens2d = init.relsens2d
-            if hasattr(init, 'var_poisson'):
+            if init.hasattr('var_poisson'):
                 self.var_poisson = init.var_poisson
-            if hasattr(init, 'var_rnoise'):
+            if init.hasattr('var_rnoise'):
                 self.var_rnoise = init.var_rnoise
             return
         super(IFUImageModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -212,19 +212,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                     self.meta.filename = os.path.basename(filename)
 
         # if the input model doesn't have a date set, use the current date/time
-        if hasattr(self, "meta") and hasattr(self.meta, 'date'):
-            if self.meta.date is None:
-                current_date = Time(datetime.datetime.now())
-                current_date.format = 'isot'
-                self.meta.date = current_date.value
+        if not self.meta.hasattr('date'):
+            current_date = Time(datetime.datetime.now())
+            current_date.format = 'isot'
+            self.meta.date = current_date.value
 
         # store the data model type, if not already set
         klass = self.__class__.__name__
         if klass != 'DataModel':
-            if hasattr(self.meta, 'model_type'):
-                if self.meta.model_type is None:
-                    self.meta.model_type = klass
-            else:
+            if not self.meta.hasattr('model_type'):
                 self.meta.model_type = klass
 
     def __repr__(self):

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -62,7 +62,7 @@ class MultiSlitModel(model_base.DataModel):
             s = SlitModel(**kwargs)
             s.update(self)
 
-            if hasattr(slit.meta, 'wcs'):
+            if slit.meta.hasattr('wcs'):
                 s.meta.wcs = slit.meta.wcs
             return s
         else:

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -252,12 +252,11 @@ class ObjectNode(Node):
                 raise AttributeError(
                     "Attribute '{0}' missing".format(attr))
 
-    def __hasattr__(self, attr):
-        return (attr in self._instance or
-                _find_property(self._schema, attr))
-
     def __iter__(self):
         return NodeIterator(self)
+
+    def hasattr(self, attr):
+        return attr in self._instance
 
     def items(self):
         # Return a (key, value) tuple for the node

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -44,16 +44,16 @@ class SlitDataModel(model_base.DataModel):
             self.err = init.err
             self.relsens = init.relsens
             self.area = init.area
-            if hasattr(init, 'wavelength'):
+            if init.hasattr('wavelength'):
                 self.wavelength = init.wavelength
-            if hasattr(init, 'var_poisson'):
+            if init.hasattr('var_poisson'):
                 self.var_poisson = init.var_poisson
-            if hasattr(init, 'var_rnoise'):
+            if init.hasattr('var_rnoise'):
                 self.var_rnoise = init.var_rnoise
             for key in kwargs:
                 setattr(key, kwargs[key])
 
-            if hasattr(init.meta, 'wcs'):
+            if init.meta.hasattr('wcs'):
                 self.meta.wcs = init.meta.wcs
             else:
                 self.meta.wcs = None
@@ -145,15 +145,15 @@ class SlitModel(model_base.DataModel):
             self.err = init.err
             self.relsens = init.relsens
             self.area = init.area
-            if hasattr(init, 'wavelength'):
+            if init.hasattr('wavelength'):
                 self.wavelength = init.wavelength
-            if hasattr(init, 'var_poisson'):
+            if init.hasattr('var_poisson'):
                 self.var_poisson = init.var_poisson
-            if hasattr(init, 'var_rnoise'):
+            if init.hasattr('var_rnoise'):
                 self.var_rnoise = init.var_rnoise
-            if hasattr(init, 'int_times'):
+            if init.hasattr('int_times'):
                 self.int_times = init.int_times
-            if hasattr(init.meta, 'wcs'):
+            if init.meta.hasattr('wcs'):
                 self.meta.wcs = init.meta.wcs
             else:
                 self.meta.wcs = None

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -448,6 +448,14 @@ def test_object_node_iterator():
     assert 'date' in items
     assert 'model_type' in items
 
+def test_hasattr():
+    model = DataModel()
+
+    has_date = model.meta.hasattr('date')
+    assert has_date, "Check that date exists"
+
+    has_filename = model.meta.hasattr('filename')
+    assert not has_filename, "Check that filename does not exist"
 
 def test_multislit_model():
     data = np.arange(24, dtype=np.float32).reshape((6, 4))


### PR DESCRIPTION
The `__hasattr__` method has been replaced by `hasattr`. It tests to see
if a node has a specified attribute, much like the hasattr function in
Python. However, the hasattr method does not create the attribute
while the hasatter function does. This is a peculiarity of the
implementation of Datamodels nodes and not a general issue for Python.

I added a new test for hasattr and went through the datamodels code to
replace the use of the hasattr function with the new method where that
was appropriate.