### PR TITLE
Update calwebb_tso1 for skipped steps

### DIFF
--- a/jwst/pipeline/calwebb_tso1.cfg
+++ b/jwst/pipeline/calwebb_tso1.cfg
@@ -1,6 +1,6 @@
 name = "Detector1Pipeline"
 class = "jwst.pipeline.Detector1Pipeline"
-save_calibrated_ramp = False
+save_calibrated_ramp = True
 
     [steps]
       [[group_scale]]
@@ -11,6 +11,8 @@ save_calibrated_ramp = False
       [[superbias]]
       [[refpix]]
       [[rscd]]
+      [[firstframe]]
+        skip = True
       [[lastframe]]
         skip = True
       [[linearity]]


### PR DESCRIPTION
Update the `calwebb_tso1` cfg file to skip the `firstframe` step and save the corrected ramp product. Fixes #1455.