### PR TITLE
Fix handling of default data array name

### DIFF
--- a/jwst/datamodels/amilg.py
+++ b/jwst/datamodels/amilg.py
@@ -43,3 +43,12 @@ class AmiLgModel(model_base.DataModel):
 
         if solns_table is not None:
             self.solns_table = solns_table
+
+    def get_primary_array_name(self):
+        """
+        Returns the name "primary" array for this model, which
+        controls the size of other arrays that are implicitly created.
+        This is intended to be overridden in the subclasses if the
+        primary array's name is not "data".
+        """
+        return 'fit_image'

--- a/jwst/datamodels/linearity.py
+++ b/jwst/datamodels/linearity.py
@@ -42,3 +42,12 @@ class LinearityModel(ReferenceFileModel):
 
         # Implicitly create arrays
         self.dq = self.dq
+
+    def get_primary_array_name(self):
+        """
+        Returns the name "primary" array for this model, which
+        controls the size of other arrays that are implicitly created.
+        This is intended to be overridden in the subclasses if the
+        primary array's name is not "data".
+        """
+        return 'coeffs'

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -186,17 +186,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         # Instantiate the primary array of the image
         if is_array:
-            primary_array = self.get_primary_array_name()
-            if primary_array is None:
+            primary_array_name = self.get_primary_array_name()
+            if not primary_array_name:
                 raise TypeError(
                     "Array passed to DataModel.__init__, but model has "
                     "no primary array in its schema")
-            setattr(self, primary_array, init)
+            setattr(self, primary_array_name, init)
 
         if is_shape:
-            try:
-                getattr(self, self.get_primary_array_name())
-            except AttributeError:
+            if not self.get_primary_array_name():
                 raise TypeError(
                     "Shape passed to DataModel.__init__, but model has "
                     "no primary array in its schema")
@@ -320,7 +318,11 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         This is intended to be overridden in the subclasses if the
         primary array's name is not "data".
         """
-        return 'data'
+        if properties._find_property(self._schema, 'data'):
+            primary_array_name = 'data'
+        else:
+            primary_array_name = ''
+        return primary_array_name
 
     def on_save(self, path=None):
         """
@@ -475,10 +477,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     @property
     def shape(self):
         if self._shape is None:
-            if self.get_primary_array_name() in self._instance:
-                return getattr(self, self.get_primary_array_name()).shape
-            else:
-                return None
+            primary_array_name = self.get_primary_array_name()
+            if primary_array_name and self.hasattr(primary_array_name):
+                primary_array = getattr(self, primary_array_name)
+                self._shape = primary_array.shape
         return self._shape
 
     def my_attribute(self, attr):

--- a/jwst/datamodels/ndmodel.py
+++ b/jwst/datamodels/ndmodel.py
@@ -114,14 +114,22 @@ class NDModel(nddata_base.NDDataBase):
         """
         Read the stored dataset.
         """
-        return self.__getattr__('data')
+        primary_array_name = self.get_primary_array_name()
+        if primary_array_name:
+            primary_array = self.__getattr__(primary_array_name)
+        else:
+            raise AttributeError("No attribute 'data'")
+        return primary_array
 
     @data.setter
     def data(self, value):
         """
         Write the stored dataset.
         """
-        properties.ObjectNode.__setattr__(self, 'data', value)
+        primary_array_name = self.get_primary_array_name()
+        if not primary_array_name:
+            primary_array_name = 'data'
+        properties.ObjectNode.__setattr__(self, primary_array_name, value)
 
     @property
     def mask(self):


### PR DESCRIPTION
Datamodels normally store their most significant data in an array
named 'data'. Datamodels allows this to be changed in a subclass by
overriding the method get_primary_array_name. The base class returns
the name 'data'. I've modified it so that it now checks the schema and
returns the empty string if it is not found. I used the empty string
rather than None in case a user feeds the result directly into
getattr. A value of None will throw an error and both are falsey. The
new code prevents datamodels that contain tables from reporting that
they have a data array.

I've modified the shape method/property to test the result of
get_primary_array_name, which restores the behavior I accidentally
changed when adding the hasattr method.

I've modified the data getter/setter in NDModel to call
get_primary_array_name. This fixes a bug where the code assumed the
name was 'data'. NDModel is a mixin class that provides compatibility
with astropy's NDData.

I've added methods overriding get_primary_array_name to AMilgModel and
LinearityModel, since, according to the schema, these two classes,
along with MaskModel, have data arrays with names other than 'data'.