### PR TITLE
Implements NRC_TSGRISM with set source location and extraction options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ assign_wcs
 - Added a wavelength correction for the effective velocity of JWST
   relative to the barycenter.                                  [#2359, #2406]
 
+- NRC_TSGRISM assigns source location to set pixel [#1235]
 associations
 ------------
 
@@ -83,6 +84,7 @@ extract_1d
 
 extract_2d
 ----------
+- NRC_TSGRISM implemented with set source location and extraction options [#1710, #1235]
 
 firstframe
 ----------

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -160,13 +160,17 @@ def tsgrism(input_model, reference_files):
     # begin at 0,0, so no need to translate the crpix to full frame
     # because they already are in full frame coordinates.
     xc, yc = (input_model.meta.wcsinfo.crpix1, input_model.meta.wcsinfo.crpix2)
+    xcenter = Const1D(xc)
+    xcenter.inverse = Const1D(xc)
+    ycenter = Const1D(yc)
+    ycenter.inverse = Const1D(yc)
 
     # x, y, order in goes to transform to full array location and order
     # get the shift to full frame coordinates
-    subarray2full = subarray_transform(input_model) & Identity(1)
-    sub2direct = (subarray2full | Mapping((0, 1, 0, 1, 2)) |\
-                  (Identity(2) & Const1D(xc) & Const1D(yc) & Identity(1)) |\
-                  det2det).rename('subarray_to_detector')
+    sub2full = subarray_transform(input_model) & Identity(1)
+    sub2direct = (sub2full | Mapping((0, 1, 0, 1, 2)) |
+                  (Identity(2) & xcenter & ycenter & Identity(1)) |
+                  det2det)
 
     # take us from full frame detector to v2v3
     distortion = imaging_distortion(input_model, reference_files) & Identity(2)
@@ -233,7 +237,7 @@ def wfss(input_model, reference_files):
     the direct image to get the min and max wavelengths
     which correspond to t=0 and t=1, this currently has been done by the team
     and the min and max wavelengths to use to calculate t are stored in the
-    grism reference file as wrange, which can be selected by wrange_selector
+    grism reference file as wavelengthrange, which can be selected by waverange_selector
     which contains the filter names.
 
     All the following was moved to the extract_2d stage.

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -298,7 +298,7 @@ def not_implemented_mode(input_model, ref):
     return None
 
 
-def get_object_info(catalog_name=''):
+def get_object_info(catalog_name=None):
     """Return a list of SkyObjects from the direct image
 
     the source_catalog step are read into a list of  SkyObjects
@@ -318,6 +318,8 @@ def get_object_info(catalog_name=''):
     -----
 
     """
+    if catalog_name is None:
+        raise TypeError("Expected name of the catalog file")
     objects = []
     catalog = QTable.read(catalog_name, format='ascii.ecsv')
 
@@ -359,7 +361,8 @@ def get_object_info(catalog_name=''):
     return objects
 
 
-def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
+def create_grism_bbox(input_model, reference_files,
+                      mmag_extract=99.0):
     """Create bounding boxes for each object in the catalog
 
     The sky coordinates in the catalog image are first related
@@ -379,7 +382,6 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
     mmag_extract : float
         The faintest magnitude to extract from the catalog
 
-
     Returns
     -------
     A list of GrismObject(s) for every source in the catalog
@@ -388,17 +390,17 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
 
     Notes
     -----
-    The wavelengthrange reference file is used to govern the extent of the bounding box
-    for each object. The name of the catalog has been stored in the input models meta
-    information under the source_catalog key.
+    The wavelengthrange reference file is used to govern the extent of the
+    bounding box for each object. The name of the catalog has been stored
+    in the input models meta information under the source_catalog key.
 
-    It's left to the calling routine to cut the bounding boxes at the extent of the
-    detector (for example, extract 2d would only extract the on-detector portion of
-    the bounding box)
+    It's left to the calling routine to cut the bounding boxes at the extent
+    of the detector (for example, extract 2d would only extract the on-detector
+    portion of the bounding box)
 
-    Bounding box dispersion direction is dependent on the filter and module for NIRCAM
-    and changes for GRISMR, but is consistent for GRISMC,
-    see https://jwst-docs.stsci.edu/display/JTI/NIRCam+Wide+Field+Slitless+Spectroscopy
+    Bounding box dispersion direction is dependent on the filter and module for
+    NIRCAM and changes for GRISMR, but is consistent for GRISMC, see
+    https://jwst-docs.stsci.edu/display/JTI/NIRCam+Wide+Field+Slitless+Spectroscopy
 
     NIRISS only has one detector, but GRISMC disperses along rows and GRISMR disperses
     along columns.
@@ -433,9 +435,6 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
     xsize = input_model.meta.subarray.xsize
     ysize = input_model.meta.subarray.ysize
 
-    # extract the catalog objects
-    if input_model.meta.source_catalog.filename is None:
-        raise ValueError("No source catalog listed in datamodel")
     skyobject_list = get_object_info(input_model.meta.source_catalog.filename)
 
     # get the imaging transform to record the center of the object in the image
@@ -482,6 +481,7 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
                 if (disperse_row_right or disperse_column):
                     wave_min = lmin
                     wave_max = lmax
+
 
                 xmin, ymin, _, _, _ = sky_to_grism(obj.sky_bbox_ll.ra.value, obj.sky_bbox_ll.dec.value, lmin, order)
                 xmax, ymax, _, _, _ = sky_to_grism(obj.sky_bbox_ur.ra.value, obj.sky_bbox_ur.dec.value, lmax, order)

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -246,7 +246,7 @@ def is_fits(input):
         isfits = True in [input.endswith(l) for l in names]
 
     # if input is a fits file determine what kind of fits it is
-    #waiver fits len(shape) == 3
+    # waiver fits len(shape) == 3
     if isfits:
         if not f:
             try:
@@ -445,13 +445,12 @@ def create_grism_bbox(input_model, reference_files,
 
     # Get the disperser parameters which have the wave limits
     with WavelengthrangeModel(reference_files['wavelengthrange']) as f:
-        wrange = f.wrange
-        wrange_selector = f.wrange_selector
+        waverange_selector = f.waverange_selector
         orders = f.order
 
     # All objects in the catalog will use the same filter for translation
     # that filter is the one that was used in front of the grism
-    fselect = wrange_selector.index(filter_name)
+    fselect = waverange_selector.index(filter_name)
 
     grism_objects = []  # the return list of GrismObjects
     for obj in skyobject_list:
@@ -472,7 +471,7 @@ def create_grism_bbox(input_model, reference_files,
                 # drive the extraction extent. The location of the min and
                 # max wavelengths for each order are used to get the location
                 # of the +/- sides of the bounding box in the grism image
-                lmin, lmax = wrange[oidx][fselect]
+                lmin, lmax = waverange[oidx][fselect]
 
                 # we need to be specific with dispersion direction here?
                 # I think this should be taken care of in the trace polys

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -445,6 +445,8 @@ def create_grism_bbox(input_model, reference_files,
 
     # Get the disperser parameters which have the wave limits
     with WavelengthrangeModel(reference_files['wavelengthrange']) as f:
+        if (f.meta.exposure.type == "NRC_TSGRISM"):
+            raise ValueError("Wavelengthrange reference file not meant for WFSS mode")
         waverange_selector = f.waverange_selector
         orders = f.order
 

--- a/jwst/datamodels/schemas/wavelengthrange.schema.yaml
+++ b/jwst/datamodels/schemas/wavelengthrange.schema.yaml
@@ -5,17 +5,13 @@ definitions:
       A tuple consisting of order and filter dependent wavelength ranges
     type: object
     properties:
-      wfss-wavelengthrange:
+      type: array
+      items:
         type: array
-        items:
-          type: array
           items:
-            type:
-              - number
-              - string
-              - number
-              - number
-      title: Order, Filter, Minwave, Maxwave
+            type: number
+            type: string
+    title: Order, Filter, Minwave, Maxwave
     additionalProperties: false
   slit-wavelengthrange:
     description: |
@@ -28,10 +24,9 @@ definitions:
         items:
           type: array
           items:
-            type:
-              - number
-              - number
-      title: Minwave, Maxwave
+            type: number
+            type: number
+    title: Minwave, Maxwave
     additionalProperties: false
 allOf:
 - $ref: referencefile.schema.yaml

--- a/jwst/datamodels/schemas/wavelengthrange.schema.yaml
+++ b/jwst/datamodels/schemas/wavelengthrange.schema.yaml
@@ -1,4 +1,24 @@
 title: WAVELENGTHRANGE reference file model
+definitions:
+  wfss-wavelengthrange:
+    description: |
+      A tuple consisting of order and filter dependent wavelength ranges
+    properties:
+      type: array
+      items:
+        type: [number, string, number, number]
+    title: Order, Filter, Minwave, Maxwave
+    additionalProperties: False
+  slit-wavelengthrange:
+    description: |
+      An array containing an array of min and max wavelength ranges
+      that can be indexed by waverange_selector
+    properties:
+      type: array
+      items:
+        type: [number, number]
+    title: Minwave, Maxwave
+    additionalProperties: False
 allOf:
 - $ref: referencefile.schema.yaml
 - $ref: keyword_exptype.schema.yaml
@@ -11,20 +31,21 @@ allOf:
         A keyword which is a selector for the different ranges.
         For MIRI MRS this is a <channel><band>, for exmaple, "1SHORT".
         For NirSpec the identifier is <filter>_<grating>, for example F070LP_G140H.
-        For NIRCAM grisms the identifier is [order][filter].
-        For NIRISS grisms the identifier is [order][filter].
+        For WFSS and TSGRISM modes, this is the list of available filters.
       type: array
       items:
         type: string
     wavelengthrange:
+      description: |
+        Wavelength range values 
       type: array
       items:
-        type: array
-        items:
-          type: number
-          minItems: 2
-          maxItems: 2
+        anyOf:    
+          - $ref: "#/definitions/wfss-wavelengthrange"
+          - $ref: "#/definitions/slit-wavelengthrange"
     order:
+      description: |
+        For WFSS, this is the list of orders that are available for this file
       type: array
       items:
         type: integer

--- a/jwst/datamodels/schemas/wavelengthrange.schema.yaml
+++ b/jwst/datamodels/schemas/wavelengthrange.schema.yaml
@@ -1,33 +1,17 @@
 title: WAVELENGTHRANGE reference file model
 definitions:
   wfss-wavelengthrange:
-    description: |
-      A tuple consisting of order and filter dependent wavelength ranges
-    type: object
-    properties:
-      type: array
-      items:
-        type: array
-          items:
-            type: number
-            type: string
-    title: Order, Filter, Minwave, Maxwave
-    additionalProperties: false
+    type: array
+    items:
+      - type: number
+      - type: string
+      - type: number
+      - type: number
   slit-wavelengthrange:
-    description: |
-      An array containing an array of min and max wavelength ranges
-      that can be indexed by waverange_selector
-    type: object
-    properties:
-      slit-wavelengthrange:
-        type: array
-        items:
-          type: array
-          items:
-            type: number
-            type: number
-    title: Minwave, Maxwave
-    additionalProperties: false
+    type: array
+    items:
+      - type: number
+      - type: number
 allOf:
 - $ref: referencefile.schema.yaml
 - $ref: keyword_exptype.schema.yaml
@@ -46,14 +30,16 @@ allOf:
         type: string
     wavelengthrange:
       description: |
-        Wavelength range values 
-      type: array
-      items:
-        anyOf:    
+        Wavelength range values
+      anyOf:
+        - type: array
+          items:
           - $ref: "#/definitions/wfss-wavelengthrange"
+        - type: array
+          items:
           - $ref: "#/definitions/slit-wavelengthrange"
     order:
-      description: |
+      desrription: |
         For WFSS, this is the list of orders that are available for this file
       type: array
       items:

--- a/jwst/datamodels/schemas/wavelengthrange.schema.yaml
+++ b/jwst/datamodels/schemas/wavelengthrange.schema.yaml
@@ -3,22 +3,36 @@ definitions:
   wfss-wavelengthrange:
     description: |
       A tuple consisting of order and filter dependent wavelength ranges
+    type: object
     properties:
-      type: array
-      items:
-        type: [number, string, number, number]
-    title: Order, Filter, Minwave, Maxwave
-    additionalProperties: False
+      wfss-wavelengthrange:
+        type: array
+        items:
+          type: array
+          items:
+            type:
+              - number
+              - string
+              - number
+              - number
+      title: Order, Filter, Minwave, Maxwave
+    additionalProperties: false
   slit-wavelengthrange:
     description: |
       An array containing an array of min and max wavelength ranges
       that can be indexed by waverange_selector
+    type: object
     properties:
-      type: array
-      items:
-        type: [number, number]
-    title: Minwave, Maxwave
-    additionalProperties: False
+      slit-wavelengthrange:
+        type: array
+        items:
+          type: array
+          items:
+            type:
+              - number
+              - number
+      title: Minwave, Maxwave
+    additionalProperties: false
 allOf:
 - $ref: referencefile.schema.yaml
 - $ref: keyword_exptype.schema.yaml

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -5,15 +5,16 @@
 import logging
 
 from .nirspec import nrs_extract2d
-from .grisms import extract_grism_objects
+from .grisms import extract_grism_objects, extract_tso_object
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_files={}, grism_objects=[]):
+def extract2d(input_model, slit_name=None, apply_wavecorr=False,
+              reference_files={}, grism_objects=None, extract_height=None):
     """
-    The main extract_2d function.
+    The main extract_2d function
 
     Parameters
     ----------
@@ -27,28 +28,45 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_files
         Reference files.
     grism_objects : list
         A list of grism objects.
+    extract_height: int
+        Cross-dispersion extraction height to use for grisms. This will override
+        the defaults which for WFSS specify the size of the object in the 
+        catalog, for NRC_TSGRISM a set size of 64 pixels is used.
     """
 
     nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ',
                  'NRS_LAMP', 'NRS_AUTOFLAT']
-    grism_modes = ['NIS_WFSS', 'NRC_WFSS']
+    nrc_modes = ['NIS_WFSS', 'NRC_WFSS', 'NRC_TSGRISM']
+
+    if grism_objects is None:
+        grism_objects = []
+    if not isinstance(grism_objects, list):
+        raise TypeError("Expected grism_objects to be of type list")
 
     exp_type = input_model.meta.exposure.type.upper()
     log.info('EXP_TYPE is {0}'.format(exp_type))
 
     if exp_type in nrs_modes:
-        output_model = nrs_extract2d(input_model, slit_name=slit_name,
+        output_model = nrs_extract2d(input_model,
+                                     slit_name=slit_name,
                                      apply_wavecorr=apply_wavecorr,
                                      reference_files=reference_files)
 
-    elif exp_type in grism_modes:
-        output_model = extract_grism_objects(input_model, grism_objects=grism_objects, reference_files=reference_files)
+    elif exp_type in nrc_modes:
+        if exp_type == 'NRC_TSGRISM':
+            output_model = extract_tso_object(input_model,
+                                              reference_files=reference_files,
+                                              extract_height=extract_height)
+        else:
+            output_model = extract_grism_objects(input_model,
+                                                 grism_objects=grism_objects,
+                                                 reference_files=reference_files,
+                                                 extract_height=extract_height)
 
     else:
         log.info("'EXP_TYPE {} not supported for extract 2D".format(exp_type))
         input_model.meta.cal_step.extract_2d = 'SKIPPED'
         return input_model
-
 
     # Set the step status to COMPLETE
     output_model.meta.cal_step.extract_2d = 'COMPLETE'

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -29,7 +29,7 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False,
     grism_objects : list
         A list of grism objects.
     extract_height: int
-        Cross-dispersion extraction height to use for time seriesgrisms.
+        Cross-dispersion extraction height to use for time series grisms.
         This will override the default which for NRC_TSGRISM is a set 
         size of 64 pixels.
     """

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -54,6 +54,8 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False,
 
     elif exp_type in slitless_modes:
         if exp_type == 'NRC_TSGRISM':
+            if extract_height is None:
+                extract_height = 64
             output_model = extract_tso_object(input_model,
                                               reference_files=reference_files,
                                               extract_height=extract_height,

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -29,14 +29,14 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False,
     grism_objects : list
         A list of grism objects.
     extract_height: int
-        Cross-dispersion extraction height to use for grisms. This will override
-        the defaults which for WFSS specify the size of the object in the 
-        catalog, for NRC_TSGRISM a set size of 64 pixels is used.
+        Cross-dispersion extraction height to use for time seriesgrisms.
+        This will override the default which for NRC_TSGRISM is a set 
+        size of 64 pixels.
     """
 
     nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ',
                  'NRS_LAMP', 'NRS_AUTOFLAT']
-    nrc_modes = ['NIS_WFSS', 'NRC_WFSS', 'NRC_TSGRISM']
+    slitless_modes = ['NIS_WFSS', 'NRC_WFSS', 'NRC_TSGRISM']
 
     if grism_objects is None:
         grism_objects = []
@@ -52,7 +52,7 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False,
                                      apply_wavecorr=apply_wavecorr,
                                      reference_files=reference_files)
 
-    elif exp_type in nrc_modes:
+    elif exp_type in slitless_modes:
         if exp_type == 'NRC_TSGRISM':
             output_model = extract_tso_object(input_model,
                                               reference_files=reference_files,
@@ -60,8 +60,7 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False,
         else:
             output_model = extract_grism_objects(input_model,
                                                  grism_objects=grism_objects,
-                                                 reference_files=reference_files,
-                                                 extract_height=extract_height)
+                                                 reference_files=reference_files)
 
     else:
         log.info("'EXP_TYPE {} not supported for extract 2D".format(exp_type))

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -56,7 +56,11 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False,
         if exp_type == 'NRC_TSGRISM':
             output_model = extract_tso_object(input_model,
                                               reference_files=reference_files,
-                                              extract_height=extract_height)
+                                              extract_height=extract_height,
+                                              extract_orders=[("F277W", [1]),
+                                                              ("F322W2", [1]),
+                                                              ("F356W", [1]),
+                                                              ("F444W", [1])])
         else:
             output_model = extract_grism_objects(input_model,
                                                  grism_objects=grism_objects,

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -59,10 +59,7 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False,
             output_model = extract_tso_object(input_model,
                                               reference_files=reference_files,
                                               extract_height=extract_height,
-                                              extract_orders=[("F277W", [1]),
-                                                              ("F322W2", [1]),
-                                                              ("F356W", [1]),
-                                                              ("F444W", [1])])
+                                              extract_orders=None)
         else:
             output_model = extract_grism_objects(input_model,
                                                  grism_objects=grism_objects,

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -14,9 +14,10 @@ class Extract2dStep(Step):
     """
 
     spec = """
-        slit_name = string(default = None)
+        slit_name = string(default=None)
         apply_wavecorr = boolean(default=True)
-        grism_objects = list(default=list())
+        grism_objects = list(default=None)
+        extract_height =  int(default=None)
     """
 
     reference_file_types = ['wavecorr', 'wavelengthrange']
@@ -29,6 +30,7 @@ class Extract2dStep(Step):
 
         with datamodels.open(input_model) as dm:
             output_model = extract_2d.extract2d(dm, self.slit_name, self.apply_wavecorr,
-                                                reference_files=reference_file_names)
+                                                reference_files=reference_file_names,
+                                                extract_height=extract_height)
 
         return output_model

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -31,6 +31,7 @@ class Extract2dStep(Step):
         with datamodels.open(input_model) as dm:
             output_model = extract_2d.extract2d(dm, self.slit_name, self.apply_wavecorr,
                                                 reference_files=reference_file_names,
+                                                grism_objects=grism_objects,
                                                 extract_height=extract_height)
 
         return output_model

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -14,9 +14,109 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def extract_grism_objects(input_model, grism_objects=[], reference_files={}):
+def extract_tso_object(input_model,
+                       reference_files=None,
+                       extract_height=None):
     """
-    Extract 2d boxes around each objects spectra per order.
+    Extract the spectrum for a NIRCAM TSO observation.
+
+    Parameters
+    ----------
+    input_model : jwst.datamodels.CubeModel
+
+    reference_files : dict
+        Needs to include the name of the wavelengthrange reference file
+
+    extract_height: int
+        The extraction height, in total, for the spectra in the
+        cross-dispersion direction. If this is other than None,
+        it will override the team default of 64 pixels.
+
+    Returns
+    -------
+    output_model : jwst.datamodels.MultiSlitModel()
+
+
+    Notes
+    -----
+    This method supports NRC_TSGRISM only
+
+    GrismObject is a named tuple which contains distilled
+    information about each catalog object and the bounding
+    boxes that will be used to define the 2d extraction area.
+
+    https://jwst-docs.stsci.edu/display/JTI/NIRCam+Grism+Time+Series
+    """
+
+    if not isinstance(reference_files, dict):
+        raise TypeError("Expected a dictionary for reference_files")
+
+    if not isinstance(input_model, CubeModel):
+        raise TypeError('The input data model must be a CubeModel.')
+
+    log.info("Extracting grism objects into MultiSlitModel")
+    output_model = datamodels.MultiSlitModel()
+    output_model.update(input_model)
+
+    inwcs = input_model.meta.wcs
+    subwcs = copy.deepcopy(inwcs)
+
+    for order in obj.order_bounding.keys():
+        # Add the shift to the lower corner to each subarray WCS object
+        # The shift should just be the lower bounding box corner
+        # also replace the object center location inputs to the GrismDispersion
+        # model with the known object center and order information (in pixels of direct image)
+        # This is changes the user input to the model from (x,y,x0,y0,order) -> (x,y)
+        #
+        # The bounding boxes here are also limited to the size of the detector
+        # The check for boxes entirely off the detector is done in create_grism_bbox right now
+        bb = obj.order_bounding[order]
+        # limit the boxes to the detector
+        ymin, ymax = (max(bb[0][0], 0), min(bb[0][1], input_model.meta.subarray.ysize))
+        xmin, xmax = (max(bb[1][0], 0), min(bb[1][1], input_model.meta.subarray.xsize))
+        # only the first two numbers in the Mapping are used
+        # the order and source position are put directly into
+        # the new wcs for the subarray for the forward transform
+        tr = inwcs.get_transform('grism_detector', 'detector')
+        tr = Identity(2) | Mapping((0, 1, 0, 1, 0)) | (Shift(xmin) & Shift(ymin) &
+                                                       Const1D(obj.xcentroid) &
+                                                       Const1D(obj.ycentroid) &
+                                                       Const1D(order)) | tr
+        subwcs.set_transform('grism_detector', 'detector', tr)
+        log.info("Subarray extracted for obj: {} order: {}:".format(obj.sid, order))
+        log.info("Subarray extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
+        ext_data = input_model.data[ymin : ymax + 1, xmin : xmax + 1].copy()
+        ext_err = input_model.err[ymin : ymax + 1, xmin : xmax + 1].copy()
+        ext_dq = input_model.dq[ymin : ymax + 1, xmin : xmax + 1].copy()
+        new_model = datamodels.SlitModel(data=ext_data, err=ext_err, dq=ext_dq)
+        new_model.meta.wcs = subwcs
+
+        new_model.meta.wcsinfo.spectral_order = order
+        # set x/ystart values relative to the image (screen) frame.
+        # The overall subarray offset is recorded in model.meta.subarray.
+        # nslit = obj.sid - 1  # catalog id starts at zero
+        new_model.name = str(obj.sid)
+        new_model.xstart = xmin + 1
+        new_model.xsize = (xmax - xmin) + 1
+        new_model.ystart = ymin + 1
+        new_model.ysize = (ymax - ymin) + 1
+        new_model.source_xpos = obj.xcentroid
+        new_model.source_ypos = obj.ycentroid
+        new_model.source_id = obj.sid
+        new_model.bunit_data = input_model.meta.bunit_data
+        new_model.bunit_err = input_model.meta.bunit_err
+        slits.append(new_model)
+
+    output_model.slits.extend(slits)
+    del subwcs
+    return output_model
+
+
+def extract_grism_objects(input_model,
+                          grism_objects=None,
+                          reference_files=None):
+    """
+    Extract 2d boxes around each objects spectra for each order.
 
     Parameters
     ----------
@@ -25,7 +125,7 @@ def extract_grism_objects(input_model, grism_objects=[], reference_files={}):
     grism_objects : list(GrismObject)
         A list of GrismObjects
 
-    reffile : dict
+    reference_files : dict
         Needs to include the name of the wavelengthrange reference file
 
 
@@ -45,19 +145,22 @@ def extract_grism_objects(input_model, grism_objects=[], reference_files={}):
     boxes that will be used to define the 2d extraction area.
 
     """
-    if not grism_objects:
+    if reference_files is None:
+        raise TypeError("Expected a dictionary for reference_files")
+
+    if grism_objects is None:
         # get the wavelengthrange reference file from the input_model
         if (not reference_files['wavelengthrange'] or reference_files['wavelengthrange'] == 'N/A'):
             raise ValueError("Expected name of wavelengthrange reference file")
         else:
-            grism_objects = util.create_grism_bbox(input_model, reference_files)
+            grism_objects = util.create_grism_bbox(input_model, reference_files, extract_height)
             log.info("Grism object list created from source catalog: {0:s}"
                      .format(input_model.meta.source_catalog.filename))
 
     if not isinstance(grism_objects, list):
             raise ValueError("Expected input grism objects to be a list")
 
-    log.info("Creating output model")
+    log.info("Extracting grism objects into MultiSlitModel")
     output_model = datamodels.MultiSlitModel()
     output_model.update(input_model)
 
@@ -123,7 +226,7 @@ def extract_grism_objects(input_model, grism_objects=[], reference_files={}):
             # subwcs.set_transform('detector', 'grism_detector', tr)
 
             log.info("Subarray extracted for obj: {} order: {}:".format(obj.sid, order))
-            log.info("Subarray extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin,ymin,xmax,ymax))
+            log.info("Subarray extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
 
             ext_data = input_model.data[ymin : ymax + 1, xmin : xmax + 1].copy()
             ext_err = input_model.err[ymin : ymax + 1, xmin : xmax + 1].copy()

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -8,7 +8,7 @@ from astropy.modeling.models import Shift, Const1D, Mapping, Identity
 
 from .. import datamodels
 from ..assign_wcs import util
-
+from ..datamodels import CubeModel, WavelengthrangeModel
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -16,7 +16,8 @@ log.setLevel(logging.DEBUG)
 
 def extract_tso_object(input_model,
                        reference_files=None,
-                       extract_height=None):
+                       extract_height=None,
+                       extract_orders=None):
     """
     Extract the spectrum for a NIRCAM TSO observation.
 
@@ -30,7 +31,14 @@ def extract_tso_object(input_model,
     extract_height: int
         The extraction height, in total, for the spectra in the
         cross-dispersion direction. If this is other than None,
-        it will override the team default of 64 pixels.
+        it will override the team default of 64 pixels. The team
+        wants the source centered near row 34, so the extraction
+        height is not the same on either size of the central pixel.
+
+    extract_orders: list[ints]
+        This is an optional parameter that will override the
+        orders specified for extraction in the wavelengthrange
+        reference file.
 
     Returns
     -------
@@ -39,76 +47,139 @@ def extract_tso_object(input_model,
 
     Notes
     -----
-    This method supports NRC_TSGRISM only
+    This method supports NRC_TSGRISM only, where only one
+    bright object is considered in the field, so there's
+    no catalog of sources and the object is assumed to
+    have been observed at the aperture location crpix1/2.
 
     GrismObject is a named tuple which contains distilled
     information about each catalog object and the bounding
     boxes that will be used to define the 2d extraction area.
+
+    Since this mode has a single known source location the utilities
+    used in the WFSS modes are overkill, instead, similar structures
+    are created during the extrac 2d process and then directly used.
 
     https://jwst-docs.stsci.edu/display/JTI/NIRCam+Grism+Time+Series
     """
 
     if not isinstance(reference_files, dict):
         raise TypeError("Expected a dictionary for reference_files")
+    if 'wavelengthrange' not in reference_files.keys():
+        raise KeyError("No wavelengthrange reference file specified")
 
     if not isinstance(input_model, CubeModel):
-        raise TypeError('The input data model must be a CubeModel.')
+        raise TypeError('The input data model is not a CubeModel.')
 
-    log.info("Extracting grism objects into MultiSlitModel")
+    if extract_height is None:
+        extract_height = 64  # set by the teams
+
+    log.info("Extracting into a MultiSlitModel")
     output_model = datamodels.MultiSlitModel()
     output_model.update(input_model)
 
-    inwcs = input_model.meta.wcs
-    subwcs = copy.deepcopy(inwcs)
+    subwcs = copy.deepcopy(input_model.meta.wcs)
 
-    for order in obj.order_bounding.keys():
-        # Add the shift to the lower corner to each subarray WCS object
-        # The shift should just be the lower bounding box corner
-        # also replace the object center location inputs to the GrismDispersion
-        # model with the known object center and order information (in pixels of direct image)
-        # This is changes the user input to the model from (x,y,x0,y0,order) -> (x,y)
-        #
-        # The bounding boxes here are also limited to the size of the detector
-        # The check for boxes entirely off the detector is done in create_grism_bbox right now
-        bb = obj.order_bounding[order]
-        # limit the boxes to the detector
-        ymin, ymax = (max(bb[0][0], 0), min(bb[0][1], input_model.meta.subarray.ysize))
-        xmin, xmax = (max(bb[1][0], 0), min(bb[1][1], input_model.meta.subarray.xsize))
-        # only the first two numbers in the Mapping are used
-        # the order and source position are put directly into
-        # the new wcs for the subarray for the forward transform
-        tr = inwcs.get_transform('grism_detector', 'detector')
-        tr = Identity(2) | Mapping((0, 1, 0, 1, 0)) | (Shift(xmin) & Shift(ymin) &
-                                                       Const1D(obj.xcentroid) &
-                                                       Const1D(obj.ycentroid) &
-                                                       Const1D(order)) | tr
-        subwcs.set_transform('grism_detector', 'detector', tr)
-        log.info("Subarray extracted for obj: {} order: {}:".format(obj.sid, order))
-        log.info("Subarray extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
-        ext_data = input_model.data[ymin : ymax + 1, xmin : xmax + 1].copy()
-        ext_err = input_model.err[ymin : ymax + 1, xmin : xmax + 1].copy()
-        ext_dq = input_model.dq[ymin : ymax + 1, xmin : xmax + 1].copy()
-        new_model = datamodels.SlitModel(data=ext_data, err=ext_err, dq=ext_dq)
-        new_model.meta.wcs = subwcs
+    # Get the disperser parameters which have the wave limits
+    with WavelengthrangeModel(reference_files['wavelengthrange']) as f:
+        if (f.meta.instrument.name != 'NIRCAM'):
+            raise ValueError("Wavelengthrange reference file not for NIRCAM!")
+        wavelengthrange = f.wavelengthrange
+        ref_extract_orders = f.extract_orders
 
-        new_model.meta.wcsinfo.spectral_order = order
-        # set x/ystart values relative to the image (screen) frame.
-        # The overall subarray offset is recorded in model.meta.subarray.
-        # nslit = obj.sid - 1  # catalog id starts at zero
-        new_model.name = str(obj.sid)
-        new_model.xstart = xmin + 1
-        new_model.xsize = (xmax - xmin) + 1
-        new_model.ystart = ymin + 1
-        new_model.ysize = (ymax - ymin) + 1
-        new_model.source_xpos = obj.xcentroid
-        new_model.source_ypos = obj.ycentroid
-        new_model.source_id = obj.sid
-        new_model.bunit_data = input_model.meta.bunit_data
-        new_model.bunit_err = input_model.meta.bunit_err
-        slits.append(new_model)
+    # this supports the user override
+    if extract_orders is None:
+        extract_orders = ref_extract_orders
+
+    available_orders = [x[1] for x in extract_orders if x[0] == input_model.meta.instrument.filter].pop()
+    length, _, _ = input_model.data.shape
+
+    slits = []
+    for trace_image in range(length):
+        for order in available_orders:
+            range_select = [(x[2], x[3]) for x in wavelengthrange if (x[0] == order and x[1] == input_model.meta.instrument.filter)]
+            # All objects in the catalog will use the same filter for translation
+            # that filter is the one that was used in front of the grism
+            lmin, lmax = range_select.pop()
+
+            # create the order bounding box
+            transform = input_model.meta.wcs.get_transform('full_detector', 'grism_detector')
+            xmin, ymin, _ = transform(input_model.meta.wcsinfo.crpix1,
+                                      input_model.meta.wcsinfo.crpix2,
+                                      lmin,
+                                      order)
+            xmax, ymax, _ = transform(input_model.meta.wcsinfo.crpix1,
+                                      input_model.meta.wcsinfo.crpix2,
+                                      lmax,
+                                      order)
+
+            # Add the shift to the lower corner to each subarray WCS object
+            # The shift should just be the lower bounding box corner
+            # also replace the object center location inputs to the GrismDispersion
+            # model with the known object center and order information (in pixels of direct image)
+            # This is changes the user input to the model from (x,y,x0,y0,order) -> (x,y)
+            #
+            # The bounding boxes here are also limited to the size of the detector in the
+            # dispersion direction and 64 pixels in the cross-dispersion 
+            # The check for boxes entirely off the detector is done in create_grism_bbox right now
+
+            # The team wants the object to fall near  row 34 for all cutouts,
+            # but the default cutout height is 64pixel (32 on either side)
+            # so use crpix2 when it equals 34, but  bump the ycenter by 2 pixel
+            # in other cases  so that the height is 30 above and 34 below (in full frame)
+            extract_y_center = input_model.meta.wcsinfo.crpix2
+            if input_model.meta.wcsinfo.crpix2 != 34:
+                extract_y_center = extract_y_center - 2
+            extract_y_min = extract_y_center - 34
+            extract_y_max = extract_y_center + 30
+
+            # limit the boxes to the detector
+            ymin, ymax = (max(extract_y_min, 0), min(extract_y_max, input_model.meta.subarray.ysize))
+            xmin, xmax = (max(xmin, 0), min(xmax, input_model.meta.subarray.xsize))
+            log.info("xmin, xmax: {} {}  ymin, ymax: {} {}".format(xmin, xmax, ymin, ymax))
+            # only the first two numbers in the Mapping are used
+            # the order and source position are put directly into
+            # the new wcs for the subarray for the forward transform
+            order_model = Const1D(order)
+            order_model.inverse = Const1D(order)
+            tr = input_model.meta.wcs.get_transform('grism_detector', 'full_detector')
+            tr = Mapping((0, 1, 0)) | (Shift(xmin) & Shift(ymin) & order_model) | tr
+            subwcs.set_transform('grism_detector', 'full_detector', tr)
+            log.info("Extracting from image: {}".format(trace_image))
+            log.info("Subarray extracted for order: {}:".format(order))
+            log.info("Subarray extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
+
+            xmin = int(xmin)
+            xmax = int(xmax)
+            ymin = int(ymin)
+            ymax = int(ymax)
+
+            # cut it out
+            ext_data = input_model.data[trace_image][ymin: ymax + 1, xmin: xmax + 1].copy()
+            ext_err = input_model.err[trace_image][ymin: ymax + 1, xmin: xmax + 1].copy()
+            ext_dq = input_model.dq[trace_image][ymin: ymax + 1, xmin: xmax + 1].copy()
+            new_model = datamodels.SlitModel(data=ext_data, err=ext_err, dq=ext_dq)
+            new_model.meta.wcs = subwcs
+
+            new_model.meta.wcsinfo.spectral_order = order
+            # set x/ystart values relative to the image (screen) frame.
+            # The overall subarray offset is recorded in model.meta.subarray.
+            # nslit = obj.sid - 1  # catalog id starts at zero
+            new_model.name = str(1)
+            new_model.xstart = xmin + 1
+            new_model.xsize = (xmax - xmin) + 1
+            new_model.ystart = ymin + 1
+            new_model.ysize = (ymax - ymin) + 1
+            new_model.source_xpos = input_model.meta.wcsinfo.crpix1
+            new_model.source_ypos = input_model.meta.wcsinfo.crpix2
+            new_model.source_id = 1
+            new_model.bunit_data = input_model.meta.bunit_data
+            new_model.bunit_err = input_model.meta.bunit_err
+            slits.append(new_model)
 
     output_model.slits.extend(slits)
     del subwcs
+    log.info("Finished extractions")
     return output_model
 
 
@@ -153,7 +224,7 @@ def extract_grism_objects(input_model,
         if (not reference_files['wavelengthrange'] or reference_files['wavelengthrange'] == 'N/A'):
             raise ValueError("Expected name of wavelengthrange reference file")
         else:
-            grism_objects = util.create_grism_bbox(input_model, reference_files, extract_height)
+            grism_objects = util.create_grism_bbox(input_model, reference_files)
             log.info("Grism object list created from source catalog: {0:s}"
                      .format(input_model.meta.source_catalog.filename))
 
@@ -228,28 +299,23 @@ def extract_grism_objects(input_model,
             log.info("Subarray extracted for obj: {} order: {}:".format(obj.sid, order))
             log.info("Subarray extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
 
-            ext_data = input_model.data[ymin : ymax + 1, xmin : xmax + 1].copy()
-            ext_err = input_model.err[ymin : ymax + 1, xmin : xmax + 1].copy()
-            ext_dq = input_model.dq[ymin : ymax + 1, xmin : xmax + 1].copy()
+            ext_data = input_model.data[ymin: ymax + 1, xmin: xmax + 1].copy()
+            ext_err = input_model.err[ymin: ymax + 1, xmin: xmax + 1].copy()
+            ext_dq = input_model.dq[ymin: ymax + 1, xmin: xmax + 1].copy()
 
-
-            #new_model = datamodels.ImageModel(data=ext_data, err=ext_err, dq=ext_dq)
+            # new_model = datamodels.ImageModel(data=ext_data, err=ext_err, dq=ext_dq)
             new_model = datamodels.SlitModel(data=ext_data, err=ext_err, dq=ext_dq)
             new_model.meta.wcs = subwcs
-            # Not sure this makes sense for grism exposures since the trace
-            # doesn't really have a footprint itself, it relates back to the
-            # size of the object in the direct image. So what is really wanted
-            # here?
-            # util.update_s_region(new_model)
             new_model.meta.wcsinfo.spectral_order = order
+
             # set x/ystart values relative to the image (screen) frame.
             # The overall subarray offset is recorded in model.meta.subarray.
             # nslit = obj.sid - 1  # catalog id starts at zero
             new_model.name = str(obj.sid)
             new_model.xstart = xmin + 1
-            new_model.xsize = (xmax - xmin) + 1
+            new_model.xsize = (xmax - xmin)
             new_model.ystart = ymin + 1
-            new_model.ysize = (ymax - ymin) + 1
+            new_model.ysize = (ymax - ymin)
             new_model.source_xpos = obj.xcentroid
             new_model.source_ypos = obj.ycentroid
             new_model.source_id = obj.sid

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -96,6 +96,7 @@ def extract_tso_object(input_model,
         output_model.update(input_model)
 
     subwcs = copy.deepcopy(input_model.meta.wcs)
+
     for order in available_orders:
         range_select = [(x[2], x[3]) for x in wavelengthrange if (x[0] == order and x[1] == input_model.meta.instrument.filter)]
         # All objects in the catalog will use the same filter for translation
@@ -139,6 +140,7 @@ def extract_tso_object(input_model,
         ymin, ymax = (max(extract_y_min, 0), min(extract_y_max, input_model.meta.subarray.ysize))
         xmin, xmax = (max(xmin, 0), min(xmax, input_model.meta.subarray.xsize))
         log.info("xmin, xmax: {} {}  ymin, ymax: {} {}".format(xmin, xmax, ymin, ymax))
+
         # only the first two numbers in the Mapping are used
         # the order and source position are put directly into
         # the new wcs for the subarray for the forward transform
@@ -147,8 +149,6 @@ def extract_tso_object(input_model,
         tr = input_model.meta.wcs.get_transform('grism_detector', 'full_detector')
         tr = Mapping((0, 1, 0)) | (Shift(xmin) & Shift(ymin) & order_model) | tr
         subwcs.set_transform('grism_detector', 'full_detector', tr)
-        log.info("Subarrays extracted for order: {}:".format(order))
-        log.info("Subarray extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
 
         xmin = int(xmin)
         xmax = int(xmax)
@@ -159,6 +159,9 @@ def extract_tso_object(input_model,
         ext_data = input_model.data[:, ymin: ymax + 1, xmin: xmax + 1].copy()
         ext_err = input_model.err[:, ymin: ymax + 1, xmin: xmax + 1].copy()
         ext_dq = input_model.dq[:, ymin: ymax + 1, xmin: xmax + 1].copy()
+
+        log.info("Subarrays extracted for order: {}:".format(order))
+        log.info("Subarray extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
 
         if output_model.meta.model_type == "SlitModel":
             output_model.data = ext_data

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -79,6 +79,8 @@ def extract_tso_object(input_model,
     with WavelengthrangeModel(reference_files['wavelengthrange']) as f:
         if (f.meta.instrument.name != 'NIRCAM'):
             raise ValueError("Wavelengthrange reference file not for NIRCAM!")
+        if (f.meta.exposure.type != 'NRC_TSGRISM'):
+            raise ValueError("Wavelengthrange reference file not for TSGRISM")
         wavelengthrange = f.wavelengthrange
         ref_extract_orders = f.extract_orders
 
@@ -87,6 +89,8 @@ def extract_tso_object(input_model,
     if extract_orders is None:
         log.info("Using default order extraction from reference file")
         extract_orders = ref_extract_orders
+    else:
+        raise NotImplementedError("Multiple order extraction for TSO not currently implemented")
 
     available_orders = [x[1] for x in extract_orders if x[0] == input_model.meta.instrument.filter].pop()
 
@@ -101,7 +105,6 @@ def extract_tso_object(input_model,
     output_model.update(input_model)
     subwcs = copy.deepcopy(input_model.meta.wcs)
 
-    slits = []
     for order in available_orders:
         range_select = [(x[2], x[3]) for x in wavelengthrange if (x[0] == order and x[1] == input_model.meta.instrument.filter)]
         # All objects in the catalog will use the same filter for translation


### PR DESCRIPTION
***DO NOT MERGE THIS PR UNTIL AFTER SNAPSHOT FOR 0.10 IS TAKEN***
closes #1710,  closes #1235
related to #1756

This PR accomplishes several things:

* it reworks` assign_wcs` for the `NRC_TSGRISM` mode to always use the values for `CRPIX1` and `CRPIX2` as the source location. The new way to call the WCS object is:  `wcs(x, y, order)` which prints ra, dec, wavelength, order, where ra,dec is `CRVAL1, CRVAL2`.  The inverse transform is `wcs(wavelength, order)` which prints out x, y, order  using the same ra, dec values. 

* it implements `extract_2d` for the first time for this mode. Since there is a single source location for all exposures, no catalog of sources are needed. Hence, this does not use the same methods that the WFSS modes use to do extraction and is much simpler, and much faster. The input model is a `jwst.datamodels.CubeModel`, and depending on the number of orders to be extracted for the filter in process, the output will either be a `jwst.datamodel.SlitModel` or a `jwst.datamodel.MultiSlitModel` with 3D data members.  Where, each slit is valid for 1 order, but may contain n integrations. The output wcs is also altered here to take into account that we now know the order of the data it's attached to, so the calling structure is again simplified to: `wcs(x, y)` which prints wavelength, order... but I just realized I could remove the order and go straight from (x,y) <-> (wavelength) at this point....another commit might be added tomorrow

* extract_orders.... this is also a new feature, first meant for use with the WFSS modes, but since I have the updated `wavelengthrange` reference file all made and I was writing most of this step from scratch for TSO I added those updates in this PR as well. For `NRC_TSGRISM` if nothing is passed for the parameter `extract_orders` in `extract_tso_object()` then it will use the ones specified in the reference file parameter of the same name. Currently, for this mode explicitly, `extract_2d` has the default set to only extract the first order for filters used with this mode.

*reviewers* should note that the reference file update changes the calls for the WFSS mode as well, those files will be updated in a corollary PR that I will merge locally with this branch before submitting. We should coordinate the acceptance of both these PRs with each other before delivery of the reference file to CRDS so that CRDS can validate the new datamodels with the appropriate code base. 