### PR TITLE
Eliminate Warnings from outlier docs

### DIFF
--- a/docs/jwst/outlier_detection/outlier_detection_ifu.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_ifu.rst
@@ -8,28 +8,33 @@ This module serves as the interface for applying outlier_detection to IFU
  basic outlier detection algorithm used with HST data, as adapted to JWST IFU
  observations.
 
- Specifically, this routine performs the following operations (modified from the
- :ref:`outlier-detection-image`):
+ Specifically, this routine performs the following operations (modified from 
+ :ref:`Default Outlier Detection Algorithm <outlier-detection-imaging>` ):
 
  * Extract parameter settings from input model and merge them with any user-provided values
 
-   - the same set of parameters available to :ref:`outlier-detection-imaging`
+   - the same set of parameters available to 
+     :ref:`Default Outlier Detection Algorithm <outlier-detection-imaging>` 
      also applies to this code
 
- * Resample all input :py:class:`~jwst.datamodels.IFUImageModel` images into
+ * Resample all input :py:class:`~jwst.datamodels.IFUImageModel` images into 
    :py:class:`~jwst.datamodels.IFUCubeModel` observations.
 
-   - Resampling uses :py:class:`~jwst.cube_build.CubeBuildStep` to create
+   - Resampling uses :py:class:`~jwst.cube_build.CubeBuildStep` to create 
      :py:class:`~jwst.datamodels.IFUCubeModel` formatted data for processing.
-   - Resampled cubes will be written out to disk if ``save_intermediate_results`` parameter has been set to `True`
+   - Resampled cubes will be written out to disk if ``save_intermediate_results`` 
+     parameter has been set to `True`
 
- * Creates a median image from the set of resampled :py:class:`~jwst.datamodels.IFUCubeModel` observations
+ * Creates a median image from the set of resampled 
+   :py:class:`~jwst.datamodels.IFUCubeModel` observations
 
-   - Median image will be written out to disk if ``save_intermediate_results`` parameter has been set to `True`
+   - Median image will be written out to disk if ``save_intermediate_results`` 
+     parameter has been set to `True`
 
  * Blot median image to match each original input exposure.
 
-   - Resampled/blotted cubes will be written out to disk if ``save_intermediate_results`` parameter has been set to `True`
+   - Resampled/blotted cubes will be written out to disk if 
+     ``save_intermediate_results`` parameter has been set to `True`
 
  * Perform statistical comparison between blotted image and original image to identify outliers.
  * Updates input data model DQ arrays with mask of detected outliers.

--- a/docs/jwst/outlier_detection/outlier_detection_spec.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_spec.rst
@@ -9,19 +9,21 @@ basic outlier detection algorithm used with HST data, as adapted to JWST
 spectroscopic observations.
 
 Specifically, this routine performs the following operations (modified from the
-:ref:`outlier-detection-image`):
+:ref:`Default Outlier Detection Algorithm <outlier-detection-imaging>` ):
 
 * Extract parameter settings from input model and merge them with any user-provided values
 
-  - the same set of parameters available to :ref:`outlier-detection-imaging`
+  - the same set of parameters available to :ref:`Default Outlier Detection Algorithm <outlier-detection-imaging>`
     also applies to this code
 
 * Convert input data, as needed, to make sure it is in a format that can be processed
 
-  - A ModelContainer serves as the basic format for all processing performed by
+  - A :py:class:`~jwst.datamodels.ModelContainer` serves as the basic format 
+    for all processing performed by
     this step, as each entry will be treated as an element of a stack of images
     to be processed to identify bad-pixels/cosmic-rays and other artifacts.
-  - If the input data is a CubeModel, convert it into a ModelContainer.
+  - If the input data is a :py:class:`~jwst.datamodels.CubeModel`, convert it into a 
+    :py:class:`~jwst.datamodels.ModelContainer`.
     This allows each plane of the cube to be treated as a separate 2D image
     for resampling (if done at all) and for combining into a median image.
 


### PR DESCRIPTION
This eliminates the warnings produced by the outlier_detection docs.  It also adds missing cross-references to a couple of places where ModelContainer and CubeModel were mentioned.

Addresses #2287 (at least partially).