### PR TITLE
Update IRS2 data model and add reg tests

### DIFF
--- a/jwst/datamodels/irs2.py
+++ b/jwst/datamodels/irs2.py
@@ -6,7 +6,7 @@ __all__ = ['IRS2Model']
 
 class IRS2Model(model_base.DataModel):
     """
-    A data model for the IRS2 reference file.
+    A data model for the IRS2 refpix reference file.
 
     Parameters
     ----------

--- a/jwst/datamodels/schemas/irs2.schema.yaml
+++ b/jwst/datamodels/schemas/irs2.schema.yaml
@@ -1,10 +1,12 @@
-title: IRS2 reference file model
+title: IRS2 refpix reference file data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: referencefile.schema.yaml
+- $ref: keyword_readpatt.schema.yaml
+- $ref: keyword_preadpatt.schema.yaml
 - type: object
   properties:
     irs2_table:
-      title: Reference file for IRS2 correction
+      title: Reference file for IRS2 refpix correction
       fits_hdu: IRS2
       datatype:
       - name: alpha_0

--- a/jwst/tests_nightly/general/nirspec/test_detector1.py
+++ b/jwst/tests_nightly/general/nirspec/test_detector1.py
@@ -1,0 +1,60 @@
+import os
+import pytest
+from astropy.io import fits as pf
+from jwst.pipeline.calwebb_detector1 import Detector1Pipeline
+
+pytestmark = [
+    pytest.mark.usefixtures('_jail'),
+    pytest.mark.skipif(not pytest.config.getoption('bigdata'),
+                       reason='requires --bigdata')
+]
+
+
+def test_detector1pipeline4(_bigdata):
+    """
+
+    Regression test of calwebb_detector1 pipeline performed on NIRSpec data.
+
+    """
+    step = Detector1Pipeline()
+    step.save_calibrated_ramp = True
+    step.ipc.skip = True
+    step.refpix.odd_even_columns = True
+    step.refpix.use_side_ref_pixels = True
+    step.refpix.side_smoothing_length = 11
+    step.refpix.side_gain = 1.0
+    step.refpix.odd_even_rows = True
+    step.persistence.skip = True
+    step.jump.rejection_threshold = 4.0
+    step.ramp_fit.save_opt = False
+    step.output_file = 'jw84600007001_02101_00001_nrs1_rate.fits'
+    step.run(_bigdata+'/pipelines/jw84600007001_02101_00001_nrs1_uncal.fits')
+
+    # Compare ramp product
+    n_ramp = 'jw84600007001_02101_00001_nrs1_ramp.fits'
+    h = pf.open( n_ramp )
+    n_ref = _bigdata+'/pipelines/jw84600007001_02101_00001_nrs1_ramp_ref.fits'
+    href = pf.open( n_ref )
+    newh = pf.HDUList([h['primary'],h['sci'],h['err'],h['groupdq'],h['pixeldq']])
+    newhref = pf.HDUList([href['primary'],href['sci'],href['err'],href['groupdq'],h['pixeldq']])
+    result = pf.diff.FITSDiff(newh,
+                              newhref,
+                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+                              rtol = 0.00001
+    )
+    assert result.identical, result.report()
+
+    # Compare countrate image product
+    n_cr = 'jw84600007001_02101_00001_nrs1_rate.fits'
+    h = pf.open( n_cr )
+    n_ref = _bigdata+'/pipelines/jw84600007001_02101_00001_nrs1_rate_ref.fits'
+    href = pf.open( n_ref )
+    newh = pf.HDUList([h['primary'],h['sci'],h['err'],h['dq']])
+    newhref = pf.HDUList([href['primary'],href['sci'],href['err'],href['dq']])
+    result = pf.diff.FITSDiff(newh,
+                              newhref,
+                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+                              rtol = 0.00001
+    )
+    assert result.identical, result.report()
+

--- a/jwst/tests_nightly/general/nirspec/test_detector1.py
+++ b/jwst/tests_nightly/general/nirspec/test_detector1.py
@@ -19,11 +19,6 @@ def test_detector1pipeline4(_bigdata):
     step = Detector1Pipeline()
     step.save_calibrated_ramp = True
     step.ipc.skip = True
-    step.refpix.odd_even_columns = True
-    step.refpix.use_side_ref_pixels = True
-    step.refpix.side_smoothing_length = 11
-    step.refpix.side_gain = 1.0
-    step.refpix.odd_even_rows = True
     step.persistence.skip = True
     step.jump.rejection_threshold = 4.0
     step.ramp_fit.save_opt = False

--- a/jwst/tests_nightly/general/nirspec/test_refpix_irs2.py
+++ b/jwst/tests_nightly/general/nirspec/test_refpix_irs2.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+from astropy.io import fits as pf
+from jwst.refpix.refpix_step import RefPixStep
+
+from ..helpers import add_suffix
+
+pytestmark = [
+    pytest.mark.usefixtures('_jail'),
+    pytest.mark.skipif(not pytest.config.getoption('bigdata'),
+                       reason='requires --bigdata')
+]
+
+
+def test_refpix_nirspec_irs2(_bigdata):
+    """
+    Regression test of refpix step performed on NIRSpec data using IRS2 readout mode.
+
+    """
+    output_file_base, output_file = add_suffix('refpix2_output.fits', 'refpix')
+
+    try:
+        os.remove(output_file)
+    except:
+        pass
+
+
+
+    RefPixStep.call(_bigdata+'/nirspec/test_bias_drift/jw84600007001_02101_00001_nrs1_superbias.fits',
+                    odd_even_columns=True, use_side_ref_pixels=False, side_smoothing_length=10,
+                    side_gain=1.0, output_file=output_file_base, name='refpix'
+                    )
+    h = pf.open(output_file)
+    href = pf.open(_bigdata+'/nirspec/test_bias_drift/jw84600007001_02101_00001_nrs1_refpix.fits')
+    newh = pf.HDUList([h['primary'],h['sci'],h['err'],h['pixeldq'],h['groupdq']])
+    newhref = pf.HDUList([href['primary'],href['sci'],href['err'],href['pixeldq'],href['groupdq']])
+    result = pf.diff.FITSDiff(newh,
+                              newhref,
+                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+                              rtol = 0.00001
+    )
+    assert result.identical, result.report()

--- a/jwst/tests_nightly/general/nirspec/test_refpix_irs2.py
+++ b/jwst/tests_nightly/general/nirspec/test_refpix_irs2.py
@@ -27,8 +27,7 @@ def test_refpix_nirspec_irs2(_bigdata):
 
 
     RefPixStep.call(_bigdata+'/nirspec/test_bias_drift/jw84600007001_02101_00001_nrs1_superbias.fits',
-                    odd_even_columns=True, use_side_ref_pixels=True, side_smoothing_length=11,
-                    side_gain=1.0, odd_even_rows=True, output_file=output_file_base, name='refpix'
+                    output_file=output_file_base, name='refpix'
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nirspec/test_bias_drift/jw84600007001_02101_00001_nrs1_refpix.fits')

--- a/jwst/tests_nightly/general/nirspec/test_refpix_irs2.py
+++ b/jwst/tests_nightly/general/nirspec/test_refpix_irs2.py
@@ -27,8 +27,8 @@ def test_refpix_nirspec_irs2(_bigdata):
 
 
     RefPixStep.call(_bigdata+'/nirspec/test_bias_drift/jw84600007001_02101_00001_nrs1_superbias.fits',
-                    odd_even_columns=True, use_side_ref_pixels=False, side_smoothing_length=10,
-                    side_gain=1.0, output_file=output_file_base, name='refpix'
+                    odd_even_columns=True, use_side_ref_pixels=True, side_smoothing_length=11,
+                    side_gain=1.0, odd_even_rows=True, output_file=output_file_base, name='refpix'
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nirspec/test_bias_drift/jw84600007001_02101_00001_nrs1_refpix.fits')


### PR DESCRIPTION
Updates the IRS2 refpix data model to define only the keywords needed for this reffile, as was done for all other reffile data models in #861. Also adds 2 regression tests that involve the NIRSpec IRS2 mode correction in the `refpix` step (we didn't have any IRS2 tests before).

Related to #2183.