### PR TITLE
Fix timeconverson for change to ephemeris fields

### DIFF
--- a/jwst/timeconversion/__init__.py
+++ b/jwst/timeconversion/__init__.py
@@ -238,7 +238,7 @@ def get_jwst_ephemeris():
     )
     conn = pymssql.connect(server=eserver, database=edb)
     cur = conn.cursor()
-    cur.execute('select * from predictephemeris')
+    cur.execute('select ephem_time,jwst_x,jwst_y,jwst_z,jwst_dx,jwst_dy,jwst_dz from predictephemeris')
     etab = np.array(cur.fetchall())
     return etab
 


### PR DESCRIPTION
Fix the problem in `timeconversion` that was caused by a recent addition of a new field to the ephemeris by retrieving only the fields needed. Not sure if the jwst velocity fields are actually needed in the script, but they were retrieved before, so keeping them for now.

Fixes #2238.