### PR TITLE
Added annotation to embedded ASDF exception message

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -537,7 +537,10 @@ def _load_history(hdulist, tree):
 
 
 def from_fits(hdulist, schema, extensions, context):
-    ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions)
+    try:
+        ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions)
+    except Exception as exc:
+        raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc
 
     known_keywords, known_datas = _load_from_schema(hdulist, schema,
                                                     ff.tree, context)


### PR DESCRIPTION
This enables CRDS certify to issue an error message like this:

     Validation error : JWST Data Models: ERROR loading embedded ASDF: newline not found

instead of a less helpful message like this:

     Validation error : JWST Data Models: newline not found

Certify options for trapping this robustly are pretty limited, this particular
pull was inspired by a corrupt .fits with bad/missing ASDF extension which
bubbles up to CRDS as "ValueError('newline not found')".

IMHO the datamodels are probably the right place to add explanation since
they're doing the funky embedded ASDF thing.   I guess an alternative would
be to improve the ASDF embed functions.