### PR TITLE
Revert "Ramp fit fixes for ramps that are all NaNs"

### DIFF
--- a/docs/jwst/ramp_fitting/main.rst
+++ b/docs/jwst/ramp_fitting/main.rst
@@ -33,32 +33,21 @@ for all unsaturated pixels in that integration will be calculated to be the
 value of the science data in that group divided by the group time.  If the
 input dataset has only two groups per integration, the count rate for all
 unsaturated pixels in each integration will be calculated using the differences 
-of the 2 valid values of the science data. If a ramp is saturated in the first
-group in an integration of any input dataset, its slope and variance will not be
-calculated, and the ramp will not contribute to the overall slope or variances.  
-If any input dataset contains ramps saturated in their second group, the count
-rates for those pixels in that integration will be calculated to be the value
-of the science data in the first group divided by the group time.  If a ramp
-has a good first group followed by a cosmic ray ray in the second group, the
-first segment for this ramp will be the single first good group. If that
-segment is the only segment in the ramp, the ramp's slope will be calculated to 
-be the value of the science data in that group divided by the group time. If
-there are other segments in the ramp, the single-group first segment will be
-discarded and only the other segment(s) in the ramp will be used in further
-calculations.
-
-
-After computing the slopes for all segments for a given pixel, the final slope is
-calculated as a weighted average from all segments in all integrations, and is
-written to a file as the primary output product.  In this output product, the 4-D
-GROUPDQ from all integrations is compressed into 2-D, which is then merged (using 
-a bitwise OR) with the input 2-D PIXELDQ to create the output DQ array. The 3-D
-VAR_POISSON and VAR_RNOISE arrays from all integrations are averaged into
-corresponding 2-D output arrays.  If the ramp fitting step is run by itself, the
-output file name will have the suffix '_RampFit' or the suffix '_RampFitStep'; if
-the ramp fitting step is run as part of the calwebb_detector1 pipeline, the final
-output file name will have the suffix '_rate'.  In either case, the user can
-override this name by specifying an output file name.
+of the 2 valid values of the science data.  If any input dataset contains ramps
+saturated in their second group, the count rates for those pixels in that
+integration will be calculated to be the value of the science data in the first 
+group divided by the group time. After computing the slopes for all segments for a
+given pixel, the final slope is determined as a weighted average from all
+segments in all integrations, and is written to a file as the primary output
+product.  In this output product, the 4-D GROUPDQ from all integrations is
+compressed into 2-D, which is then merged (using a bitwise OR) with the input 2-D
+PIXELDQ to create the output DQ array. The 3-D VAR_POISSON and VAR_RNOISE arrays
+from all integrations are averaged into corresponding 2-D output arrays.  If the
+ramp fitting step is run by itself, the output file name will have the suffix
+'_RampFit' or the suffix '_RampFitStep'; if the ramp fitting step is run as part
+of the calwebb_detector1 pipeline, the final output file name will have the suffix
+'_rate'.  In either case, the user can override this name by specifying an output
+file name.
 
 
 If the input exposure contains more than one integration, the resulting slope
@@ -68,12 +57,10 @@ in this product is the result for a given integration.  In this output product,
 the GROUPDQ data for a given integration is compressed into 2-D, which is then
 merged with the input 2-D PIXELDQ to create the output DQ array for each
 integration. The 3-D VAR_POISSON and VAR_RNOISE from an integration are calculated
-by averaging over the fit segments in the corresponding 4-D arrays. If the input
-dataset has a GROUP table (which contains time stamps corresponding to readout
-times at the group level), the table will also be included in the output product
-as the INT_TIMES extension.  By default, the name of this output product is based
-on the name of the input file and will have the suffix '_rateints'; the user can
-override this name by specifying a name using the parameter int_name.
+by averaging over the fit segments in the corresponding 4-D arrays.  By default,
+the name of this output product is based on the name of the input file and will
+have the suffix '_rateints'; the user can override this name by specifying a
+name using the parameter int_name.
 
 
 A third, optional output product is also available and is produced only when

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -29,9 +29,12 @@ log.setLevel(logging.DEBUG)
 
 BUFSIZE = 1024 * 30000  # 30Mb cache size for data section
 
+# Replace zero or negative variances with this.
+LARGE_VARIANCE = 1.e8
+
 
 def ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
-             algorithm, weighting):
+              algorithm, weighting):
     """
     Extended Summary
     ----------------
@@ -40,7 +43,7 @@ def ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
     cosmic rays) of the pixel's ramp divided by the effective integration time.
     The weighting parameter must currently be set to 'optim', to use the optimal
     weighting (paper by Fixsen, ref. TBA) will be used in the fitting; this is
-    currently the only supported weighting scheme.
+    currently the only supported weighting scheme.   
 
     Parameters
     ----------
@@ -133,7 +136,7 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
         gain for all pixels
 
     weighting: string
-        'optimal' specifies that optimal weighting should be used; currently
+        'optimal' specifies that optimal weighting should be used; currently 
         the only weighting supported.
 
     Returns
@@ -196,18 +199,17 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
 
     # Get GROUP DQ and ERR arrays from input file
     gdq_cube = model.groupdq
-    gdq_cube_shape = gdq_cube.shape
 
     # get max number of segments fit in all integrations
     max_seg = calc_num_seg(gdq_cube, n_int)
-    del gdq_cube
-
     f_max_seg = 0  # final number to use, usually overwritten by actual value
 
-    (dq_int, median_diffs_2d, num_seg_per_int, sat_0th_group_int) =\
-        utils.alloc_arrays_1(n_int, imshape)
+    (slope_int, dq_int, var_p3, var_r3, median_diffs_2d, var_p4, var_r4,
+        var_both4, var_both3, inv_var_p4, inv_var_r4, inv_var_both4,
+        s_inv_var_p3, s_inv_var_r3, s_inv_var_both3, segs_4, num_seg_per_int) =\
+        utils.alloc_arrays(n_int, imshape, max_seg)
 
-    opt_res = utils.OptRes(n_int, imshape, max_seg, nreads, save_opt)
+    opt_res = utils.OptRes(n_int, imshape, max_seg, nreads)
 
     # Get Pixel DQ array from input file. The incoming RampModel has uint8
     #   PIXELDQ, but ramp fitting will update this array here by flagging
@@ -232,10 +234,11 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
     #   sections to calculate the estimated median slopes, which will be used
     #   to calculate the variances. This is the same method to estimate slopes
     #   as is done in the jump detection step, except here CR-affected and
-    #   saturated groups have already been flagged. The actual, fit, slopes for
+    #   saturated groups have already been flagged. The actual, fit, slopes for 
     #   each segment are also calculated here.
     # Loop over data integrations:
     for num_int in range(0, n_int):
+
         # Loop over data sections
         for rlo in range(0, cubeshape[1], nrows):
             rhi = rlo + nrows
@@ -255,8 +258,7 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
                 astype(np.float32)
 
             # Get appropriate sections
-            gdq_sect = model.get_section('groupdq')[num_int, :, rlo:rhi, :]
-
+            gdq_sect = gdq_cube[num_int, :, rlo:rhi, :]
             rn_sect = readnoise_2d[rlo:rhi, :]
             gain_sect = gain_2d[rlo:rhi, :]
 
@@ -265,7 +267,6 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
                                   dqflags.group['SATURATED']) != 0)
 
             data_sect[ where_sat ] = np.NaN
-            del where_sat
 
             # Compute the first differences of all groups
             first_diffs_sect = np.diff(data_sect, axis=0)
@@ -289,7 +290,7 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
                 #   starting at group 1.  The purpose of starting at index 1 is
                 #   to shift all the indices down by 1, so they line up with the
                 #   indices in first_diffs.
-                first_diffs_sect[ i_group-1, i_yy, i_xx ] = np.NaN
+                first_diffs_sect[ i_group-1, i_yy, i_xx ] = np.NaN 
 
                 # Check for pixels in which there is good data in 0th group, but
                 #   all first_diffs for this ramp are NaN because there are too
@@ -301,30 +302,22 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
                 if len (wh_min[0] > 0 ):
                     first_diffs_sect[0,:,:][ wh_min ] = data_sect[0,:,:][ wh_min ]
 
-                del wh_min
-
             # All first differences affected by saturation and CRs have been set
             #  to NaN, so compute the median of all non-NaN first differences.
-            nan_med = np.nanmedian(first_diffs_sect, axis=0)
-            nan_med[np.isnan(nan_med)] = 0. # in case all first_diffs_sect are nans
-            median_diffs_2d[ rlo:rhi, : ] += nan_med 
+            median_diffs_2d[ rlo:rhi, : ] += np.nanmedian(first_diffs_sect, axis=0 )
 
             # Calculate the slope of each segment
             t_dq_cube, inv_var, opt_res, f_max_seg, num_seg = \
-                 calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, 
-                            rn_sect, gain_sect, max_seg, ngroups, weighting,
-                            f_max_seg, group_time)
+                 calc_slope(data_sect, gdq_sect, frame_time, opt_res, rn_sect,
+                            gain_sect, max_seg, ngroups, weighting, f_max_seg,
+                            group_time)
 
             # Populate 3D num_seg { integ, y, x } with 2D num_seg for this data
             #  section (y,x) and integration (num_int)
             sect_shape = data_sect.shape[-2:]
             num_seg_per_int[num_int, rlo:rhi, :] = num_seg.reshape(sect_shape)
 
-            # Populate integ-spec slice which is set if 0th group has SAT
-            wh_sat0 = np.where( np.bitwise_and(gdq_sect[0,:,:], 
-                                dqflags.group['SATURATED']))
-            if ( len(wh_sat0[0] ) > 0):
-                sat_0th_group_int[num_int, rlo:rhi, :][ wh_sat0 ] = 1
+            gdq_cube[num_int, :, rlo:rhi, :] = t_dq_cube
 
             pixeldq_sect = pixeldq[rlo:rhi, :].copy()
             dq_int[num_int, rlo:rhi, :] = \
@@ -332,16 +325,15 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
 
             # Loop over the segments and copy the reshaped 2D segment-specific
             #  results for the current data section to the 4D output arrays.
-            opt_res.reshape_res(num_int, rlo, rhi, sect_shape, ff_sect, save_opt)
+            opt_res.reshape_res(num_int, rlo, rhi, sect_shape, ff_sect)
 
-            if save_opt:
-                # Calculate difference between each slice and the previous slice
-                #   as approximation to cosmic ray amplitude for those pixels
-                #   having their DQ set for cosmic rays
-                data_diff = data_sect - utils.shift_z(data_sect, -1)
-                dq_cr = np.bitwise_and(dqflags.group['JUMP_DET'], gdq_sect)
+            # Calculate difference between each slice and the previous slice
+            #   as approximation to cosmic ray amplitude for those pixels
+            #   having their DQ set for cosmic rays
+            data_diff = data_sect - utils.shift_z(data_sect, -1)
+            dq_cr = np.bitwise_and(dqflags.group['JUMP_DET'], gdq_sect)
 
-                opt_res.cr_mag_seg[num_int, :, rlo:rhi, :] = \
+            opt_res.cr_mag_seg[num_int, :, rlo:rhi, :] = \
                        data_diff * (dq_cr != 0)
 
     # Compute the final 2D array of differences; create rate array
@@ -349,12 +341,6 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
     med_rates = median_diffs_2d/group_time
 
     del median_diffs_2d
-    del first_diffs_sect
-
-    (var_p3, var_r3, var_p4, var_r4,
-        var_both4, var_both3, inv_var_p4, inv_var_r4, inv_var_both4,
-        s_inv_var_p3, s_inv_var_r3, s_inv_var_both3, segs_4) =\
-        utils.alloc_arrays_2(n_int, imshape, max_seg)
 
     # In this 'Second Pass' over the data, loop over integrations and data
     #   sections to calculate the variances of the slope using the estimated
@@ -383,7 +369,7 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
 
             # data_sect and gdq_sect are: [ groups, y, x ]
             data_sect = model.get_section('data')[num_int, :, rlo:rhi, :]
-            gdq_sect = model.get_section('groupdq')[num_int, :, rlo:rhi, :]
+            gdq_sect = gdq_cube[num_int, :, rlo:rhi, :]
 
             rn_sect = readnoise_2d[rlo:rhi, :]
             gain_sect = gain_2d[rlo:rhi, :]
@@ -397,35 +383,36 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
             var_p4[num_int, :, rlo:rhi, :] = den_p3 * med_rates[ rlo:rhi, :]
             var_r4[num_int, :, rlo:rhi, :] = num_r3 * den_r3
 
-            del den_r3, den_p3, num_r3, segs_beg_3
+        var_p4[var_p4 < 0.] = 0. # ignore contributions from negative slopes
+        var_p4 = utils.rem_nan_inf(var_p4)
 
-
-        # The next 4 statements zero out entries for non-existing segments, and
-        #   set the variances for segments having negative slopes (the segment
-        #   variance is proportional to the median estimated slope) to
-        #   outrageously large values so that they will have negligible
-        #   contributions.
-        var_p4[num_int,:,:,:] *= ( segs_4[num_int,:,:,:] > 0)
-        var_p4[var_p4 <= 0.] = utils.LARGE_VARIANCE
-        var_r4[num_int,:,:,:] *= ( segs_4[num_int,:,:,:] > 0)
-        var_r4[var_r4 <= 0.] = utils.LARGE_VARIANCE
+        var_r4[var_r4 < 0.] = 0.
+        var_r4 = utils.rem_nan_inf(var_r4)
 
         inv_var_p4[num_int, :, :, :] = 1./var_p4[num_int, :, :, :]
+        inv_var_p4 = utils.rem_nan_inf(inv_var_p4)
         s_inv_var_p3[num_int, :, :] = (inv_var_p4[num_int, :, :, :]).sum(axis=0)
+
         var_p3[num_int, :, :] = 1./ s_inv_var_p3[num_int, :, :]
+        var_p3 = utils.rem_nan_inf(var_p3)
+
         inv_var_r4[num_int, :, :, :] = 1./var_r4[num_int, :, :, :]
+        inv_var_r4 = utils.rem_nan_inf(inv_var_r4)
+
         s_inv_var_r3[num_int, :, :] = (inv_var_r4[num_int, :, :, :]).sum(axis=0)
         var_r3[num_int, :, :] = 1./ s_inv_var_r3[num_int, :, :]
+        var_r3 = utils.rem_nan_inf(var_r3)
 
         var_both4[ num_int,:,:,:] = var_r4[num_int,:,:,:] + var_p4[num_int,:,:,:]
         inv_var_both4[num_int, :, :, :] = 1./var_both4[num_int, :, :, :]
+        inv_var_both4 = utils.rem_nan_inf(inv_var_both4)
 
         # Want to retain values in the 4D arrays only for the segments that each
         #   pixel has, so will zero out values for the higher indices. Creating
         #   and manipulating intermediate arrays (views, such as var_p4_int
         #   will zero out the appropriate indices in var_p4 and var_r4.)
         # Extract the slice of 4D arrays for the current integration
-        #
+        # 
         var_p4_int = var_p4[ num_int,:,:,:]   # [ segment, y, x ]
         var_r4_int = var_r4[ num_int,:,:,:]
         inv_var_both4_int = inv_var_both4[ num_int,:,:,:]
@@ -447,6 +434,21 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
         arr_ind_all = np.array([np.arange( var_p4_int2.shape[0] ),] *
                                 num_pix).transpose()
 
+        var_p4_int2[ arr_ind_all >= num_seg_int1 ] = 0
+        var_r4_int2[ arr_ind_all >= num_seg_int1 ] = 0
+        inv_var_both4_int2[ arr_ind_all >= num_seg_int1 ] = 0
+
+        var_p4_int = var_p4_int2.reshape((var_p4_int.shape[0],
+                                          var_p4_int.shape[1],
+                                          var_p4_int.shape[2]))
+
+        var_r4_int = var_r4_int2.reshape((var_r4_int.shape[0],
+                                          var_r4_int.shape[1],
+                                          var_r4_int.shape[2]))
+
+        inv_var_both4_int = inv_var_both4_int2.reshape((inv_var_both4_int.shape[0],
+                        inv_var_both4_int.shape[1], inv_var_both4_int.shape[2]))
+
         # Zero out non-existing segments
         var_p4_int *= ( segs_4[num_int,:,:,:] > 0)
         var_r4_int *= ( segs_4[num_int,:,:,:] > 0)
@@ -455,8 +457,13 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
         s_inv_var_both3[num_int,:,:] = (inv_var_both4[num_int,:,:,:]).sum(axis=0)
         var_both3[num_int, :, :] = 1./s_inv_var_both3[num_int, :, :]
 
-    var_p4 *= ( segs_4[:,:,:,:] > 0) # Zero out non-existing segments for these
-    var_r4 *= ( segs_4[:,:,:,:] > 0)
+    var_p3 = utils.rem_nan_inf(var_p3)
+    var_p3[var_p3 < 0.] = 0.   # ignore contributions from negative slopes
+
+    var_r3 = utils.rem_nan_inf(var_r3)
+
+    var_both3 = utils.rem_nan_inf(var_both3)
+    var_both3[ var_both3 < 0.] = 0.
 
     # Now that the segment-specific and integration-specific variances have
     #   been calculated, the segment-specific, integration-specific, and
@@ -470,59 +477,55 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
 
     slope_seg = opt_res.slope_seg.copy()
     slope_by_var4 = slope_seg / var_both4
+    slope_by_var4 = utils.rem_nan_inf(slope_by_var4)
 
-    s_slope_by_var3 = slope_by_var4.sum(axis=1) # sum over segments (not integs)
+    s_slope_by_var3 = slope_by_var4.sum(axis=1) # sum over SEGMENTS (not integs)
     s_slope_by_var2 = s_slope_by_var3.sum(axis=0) # sum over integrations
 
     s_inv_var_both2 = s_inv_var_both3.sum(axis=0)
 
     # Compute the 'dataset-averaged' slope
     slope_dataset2 = s_slope_by_var2/s_inv_var_both2
-
-    #  Replace nans in slope_dataset2 with 0 (for non-existing segments)
-    slope_dataset2[np.isnan(slope_dataset2)] = 0. # 
+    slope_dataset2 = utils.rem_nan_inf(slope_dataset2)
 
     # Compute the integration-specific slope
     the_num = (slope_seg * inv_var_both4).sum(axis = 1) # sum over all segments
     the_den = (inv_var_both4).sum(axis=1)
-    slope_int = the_num/the_den
 
-    # Clean up ramps that are SAT on their initial groups; set ramp parameters  
-    #   for variances and slope so they will not contribute
-    var_p3, var_both3, slope_int = utils.fix_sat_ramps( sat_0th_group_int,    
-                                           var_p3, var_both3, slope_int) 
+    slope_int = the_num/the_den
+    slope_int = utils.rem_nan_inf(slope_int)
 
     # Loop over data integrations to calculate integration-specific pedestal
-    if save_opt:
-        dq_slice = np.zeros((gdq_cube_shape[2],gdq_cube_shape[3]),
-                            dtype=np.uint32)
-
-        for num_int in range(0, n_int):
-            dq_slice =  model.get_section('groupdq')[num_int, 0, :, :]
-            opt_res.ped_int[ num_int, :, : ] = \
-                utils.calc_pedestal(num_int, slope_int, opt_res.firstf_int, 
-                    dq_slice, nframes, groupgap, dropframes1)
+    for num_int in range(0, n_int):
+        opt_res.ped_int[ num_int, :, : ] = \
+            utils.calc_pedestal(num_int, slope_int, opt_res.firstf_int,\
+            gdq_cube, nframes, groupgap, dropframes1)
 
     # Compute 2D 'error' for primary output; this is the standard deviation due
     # to both the Poisson and read noise
     var_p2 = 1/(s_inv_var_p3.sum(axis=0))
+    var_p2 = utils.rem_nan_inf(var_p2)
+    var_p2[ var_p2 < 0.] = 0.
+
     var_r2 = 1/(s_inv_var_r3.sum(axis=0))
+    var_r2 = utils.rem_nan_inf(var_r2)
+    var_r2[ var_r2 < 0.] = 0.
+
     err_2d = np.sqrt( var_p2 + var_r2 )
 
     # Collect optional results for output
-    if save_opt:
-        gdq_cube = model.groupdq  
-        opt_res.shrink_crmag(n_int, gdq_cube, imshape, nreads)
-        del gdq_cube 
+    opt_res.shrink_crmag(n_int, gdq_cube, imshape, nreads)
 
-        # Truncate results at the maximum number of segments found
-        opt_res.slope_seg = opt_res.slope_seg[:,:f_max_seg,:,:]
-        opt_res.sigslope_seg = opt_res.sigslope_seg[:,:f_max_seg,:,:]
-        opt_res.yint_seg = opt_res.yint_seg[:,:f_max_seg,:,:]
-        opt_res.sigyint_seg = opt_res.sigyint_seg[:,:f_max_seg,:,:]
-        opt_res.weights = (inv_var_both4[:,:f_max_seg,:,:])**2.
-        opt_res.var_p_seg = var_p4[:,:f_max_seg,:,:]
-        opt_res.var_r_seg = var_r4[:,:f_max_seg,:,:]
+    # Truncate results at the maximum number of segments found
+    opt_res.slope_seg = opt_res.slope_seg[:,:f_max_seg,:,:]
+    opt_res.sigslope_seg = opt_res.sigslope_seg[:,:f_max_seg,:,:]
+    opt_res.yint_seg = opt_res.yint_seg[:,:f_max_seg,:,:]
+    opt_res.sigyint_seg = opt_res.sigyint_seg[:,:f_max_seg,:,:]
+    opt_res.weights = (inv_var_both4[:,:f_max_seg,:,:])**2.
+    opt_res.var_p_seg = var_p4[:,:f_max_seg,:,:]
+    opt_res.var_r_seg = var_r4[:,:f_max_seg,:,:]
+
+    if save_opt:
         opt_model = opt_res.output_optional(model, effintim)
     else:
         opt_model = None
@@ -802,7 +805,7 @@ def gls_ramp_fit(model,
     # Compress all integration's dq arrays to create 2D PIXELDDQ array for
     #   primary output
     final_pixeldq = dq_compress_final(dq_int, n_int)
-    
+
     if n_int > 1:
         effintim = 1.                   # slopes are already in DN/s
         int_model = utils.output_integ(model, slope_int, slope_err_int, dq_int,
@@ -990,7 +993,7 @@ def calc_nrows(model, buffsize, cubeshape, nreads):
     return nrows
 
 
-def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect, gain_sect,
+def calc_slope(data_sect, gdq_sect, frame_time, opt_res, rn_sect, gain_sect,
                i_max_seg, ngroups, weighting, f_max_seg, group_time):
     """
     Short Summary
@@ -1014,9 +1017,6 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect, gain
 
     opt_res: OptRes object
         contains quantities related to fitting for optional output
-
-    save_opt: boolean
-       save optional fitting results
 
     rn_sect: float, 2D array
         read noise values for all pixels in data section
@@ -1133,7 +1133,7 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect, gain
     end_heads = (end_st > 0).sum(axis=0)
 
     # Create object to hold optional results
-    opt_res.init_2d(npix, i_max_seg, save_opt)
+    opt_res.init_2d(npix, i_max_seg)
 
     # LS fit until 'nreads' iterations or all pixels in
     #    section have been processed
@@ -1151,8 +1151,8 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect, gain
         # for all pixels, update arrays, summing slope and variance
         f_max_seg, num_seg = \
               fit_next_segment(start, end_st, end_heads, pixel_done, data_sect,
-                 mask_2d, mask_2d_init, inv_var, num_seg, opt_res, save_opt,
-                 rn_sect, gain_sect, ngroups, weighting, f_max_seg, group_time)
+                      mask_2d, mask_2d_init, inv_var, num_seg, opt_res, rn_sect,
+                      gain_sect, ngroups, weighting, f_max_seg, group_time)
 
         if f_max_seg is None:
             f_max_seg = 1
@@ -1165,8 +1165,8 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect, gain
 
 
 def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
-                     mask_2d_init, inv_var, num_seg, opt_res, save_opt, rn_sect, 
-                     gain_sect, ngroups, weighting, f_max_seg, group_time):
+                     mask_2d_init, inv_var, num_seg, opt_res, rn_sect, gain_sect,
+                     ngroups, weighting, f_max_seg, group_time):
     """
     Extended Summary
     ----------------
@@ -1212,9 +1212,6 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
     opt_res: OptRes object
         optional fitting results to output
 
-    save_opt: boolean
-       save optional fitting results
-
     rn_sect: float, 2D array
         read noise values for all pixels in data section
 
@@ -1253,7 +1250,7 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
 
     # Each returned array below is 1D, for all npix pixels for current segment
     slope, intercept, variance, sig_intercept, sig_slope = fit_lines(data_sect,
-              mask_2d, rn_sect, gain_sect, ngroups, weighting)
+              mask_2d, rn_sect, gain_sect, ngroups, weighting, group_time)
 
     end_locs = end_st[end_heads[all_pix] - 1, all_pix]
     l_interval = end_locs - start # fitting interval length
@@ -1285,8 +1282,8 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
             inv_var[g_pix] += 1.0 / variance[g_pix]
 
             # Append results to arrays
-            opt_res.append_arr(num_seg, g_pix, intercept, slope,
-                sig_intercept, sig_slope, inv_var, save_opt)
+            opt_res.append_arr(num_seg, g_pix, intercept, slope,\
+                sig_intercept, sig_slope, inv_var)
 
             num_seg[g_pix] += 1
             f_max_seg = max(f_max_seg, num_seg.max())
@@ -1297,6 +1294,7 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
     #    - remove current end from end stack
     #    - decrement number of ends
     #    - add slopes and variances to running sums
+
     wh_check = np.where((l_interval > 2) & (end_locs != nreads - 1) & ~pixel_done)
     if(len(wh_check[0]) > 0):
         these_pix = wh_check[0]
@@ -1313,8 +1311,8 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
             inv_var[g_pix] += 1.0 / variance[g_pix]
 
             # Append results to arrays
-            opt_res.append_arr(num_seg, g_pix, intercept, slope,
-                sig_intercept, sig_slope, inv_var, save_opt)
+            opt_res.append_arr(num_seg, g_pix, intercept, slope, \
+                sig_intercept, sig_slope, inv_var)
 
             num_seg[g_pix] += 1
             f_max_seg = max(f_max_seg, num_seg.max())
@@ -1364,8 +1362,8 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
             inv_var[g_pix] += 1.0 / variance[g_pix]
 
             # Append results to arrays
-            opt_res.append_arr(num_seg, g_pix, intercept, slope,
-                sig_intercept, sig_slope, inv_var, save_opt)
+            opt_res.append_arr(num_seg, g_pix, intercept, slope,\
+                sig_intercept, sig_slope, inv_var)
 
             num_seg[g_pix] = 1
 
@@ -1390,7 +1388,7 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
             inv_var[g_pix] += 1.0 / variance[g_pix]
 
             opt_res.append_arr(num_seg, g_pix, intercept, slope,
-                sig_intercept, sig_slope, inv_var, save_opt)
+                sig_intercept, sig_slope, inv_var)
 
             num_seg[g_pix] = 1
 
@@ -1423,15 +1421,17 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
             inv_var[g_pix] += 1.0 / variance[g_pix]
 
             # Append results to arrays
-            opt_res.append_arr(num_seg, g_pix, intercept, slope,
-                               sig_intercept, sig_slope, inv_var, save_opt)
+            opt_res.append_arr(num_seg, g_pix, intercept, slope,\
+               sig_intercept, sig_slope, inv_var)
 
             num_seg[g_pix] += 1
             f_max_seg = max(f_max_seg, num_seg.max())
 
 
     # CASE F) - full-length ramp has 2 good groups not at array end, is now 2 cases:
-    #    - use the 2 good reads to get the slope
+    #  F_MORE - has additional later good groups
+    #  F_ONLY - has NO later good groups
+    #    - for both of the above, use the 2 good groups to get the slope
     #    - set start to -1 to designate all fitting done
     #    - remove current end from end stack
     #    - set number of end to 0
@@ -1479,8 +1479,8 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
         end_heads[(end_heads < 0.)] = 0.
 
         # Append results to arrays
-        opt_res.append_arr(num_seg, these_pix, intercept, slope,
-                           sig_intercept, sig_slope, inv_var, save_opt)
+        opt_res.append_arr(num_seg, these_pix, intercept, slope,\
+            sig_intercept, sig_slope, inv_var)
 
         num_seg[these_pix] += 1
         f_max_seg = max(f_max_seg, num_seg.max())
@@ -1508,7 +1508,7 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
 
         # Append results to arrays
         opt_res.append_arr(num_seg, these_pix, intercept, slope,
-                           sig_intercept, sig_slope, inv_var, save_opt)
+             sig_intercept, sig_slope, inv_var)
 
         num_seg[these_pix] += 1
         f_max_seg = max(f_max_seg, num_seg.max())
@@ -1562,7 +1562,7 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
     # end of fit_next_segment()
 
 
-def fit_lines(data, mask_2d, rn_sect, gain_sect, ngroups, weighting):
+def fit_lines(data, mask_2d, rn_sect, gain_sect, ngroups, weighting, group_time):
     """
     Extended Summary
     ----------------
@@ -1781,12 +1781,13 @@ def fit_single_read(slope_s, intercept_s, variance_s, sig_intercept_s,
     sig_intercept_s: float, 1D array
         sigma of y-intercepts from fit for data section
     """
+
     data0_slice = data[0, :, :].reshape(npix)
     slope_s[wh_pix_1r] = data0_slice[wh_pix_1r]
 
     # The following arrays will have values correctly calculated later; for
     #    now they are just place-holders
-    variance_s[wh_pix_1r] = utils.LARGE_VARIANCE
+    variance_s[wh_pix_1r] = 0.
     sig_slope_s[wh_pix_1r] = 0.
     intercept_s[wh_pix_1r] = 0.
     sig_intercept_s[wh_pix_1r] = 0.
@@ -1972,6 +1973,13 @@ def calc_opt_fit(nreads_wtd, sumxx, sumx, sumxy, sumy):
     sig_intercept = (sumxx / denominator)**0.5
     sig_slope = (nreads_wtd / denominator)**0.5 # STD of the slope's fit
 
+    # Set to 0 those values that are NaN or Inf just in case these were not
+    # properly handled earlier
+    slope = utils.rem_nan_inf(slope)
+    sig_slope = utils.rem_nan_inf(sig_slope)
+    intercept = utils.rem_nan_inf(intercept)
+    sig_intercept = utils.rem_nan_inf(sig_intercept)
+
     return slope, intercept, sig_slope, sig_intercept
 
 
@@ -2034,7 +2042,7 @@ def fit_1_group(slope_s, intercept_s, variance_s, sig_intercept_s,
 
     # The following arrays will have values correctly calculated later; for
     #    now they are just place-holders
-    variance_s = np.zeros(npix, dtype=np.float32) + utils.LARGE_VARIANCE
+    variance_s = np.zeros(npix, dtype=np.float32)
     sig_slope_s = slope_s * 0.
     intercept_s = slope_s * 0.
     sig_intercept_s = slope_s * 0.
@@ -2124,8 +2132,7 @@ def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s,
     # length) in this function, but are being included here to explicitly
     # cover all possibilities for pixels in datasets with ngroups=2. Will
     # later consider refactoring.
-    wh_sat1 = np.where((mask_2d[:, :].sum(axis=0) == 1) & mask_2d[0, :])
-
+    wh_sat1 = np.where((mask_2d[:, :].sum(axis=0) == 1) & mask_2d[0, :] == True)
     if (len(wh_sat1[0]) > 0):
         data0_slice = data[0, :, :].reshape(npix)
         slope_s[wh_sat1] = data0_slice[wh_sat1]
@@ -2139,7 +2146,6 @@ def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s,
     # which will later be divided by the group exposure time to give the count
     # rate, and recalculate other fit quantities to be benign.
     wh_sat_no = np.where(mask_2d[:, :].sum(axis=0) == 2)
-
     if (len(wh_sat_no[0]) > 0):
         data0_slice = data[0, :, :].reshape(npix)
         data1_slice = data[1, :, :].reshape(npix)
@@ -2365,14 +2371,15 @@ def calc_opt_sums(rn_sect, gain_sect, data_masked, mask_2d, xvalues, good_pix):
     nrd_prime = 0
     power_wt_r = 0
 
+    wh_m2d_f = (np.logical_not(c_mask_2d[0, :])) # ramps where initial group is False
+
     # For all pixels, 'roll' up the leading zeros such that the 0th group of
     #  each pixel is the lowest nonzero group for that pixel
-    wh_m2d_f = np.logical_not(c_mask_2d[0, :]) # ramps where initial group is False
     while (wh_m2d_f.sum() > 0):
         data_masked[:, wh_m2d_f] = np.roll(data_masked[:, wh_m2d_f], -1, axis=0)
         c_mask_2d[:, wh_m2d_f] = np.roll(c_mask_2d[:, wh_m2d_f], -1, axis=0)
         xvalues[:, wh_m2d_f] = np.roll(xvalues[:, wh_m2d_f], -1, axis=0)
-        wh_m2d_f = np.logical_not(c_mask_2d[0, :])
+        wh_m2d_f = (c_mask_2d[0, :] == False)
 
     # Create weighted sums for Poisson noise and read noise
     nreads_wtd = (wt_h * c_mask_2d).sum(axis=0)  # using optimal weights

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -13,7 +13,7 @@ log.setLevel(logging.DEBUG)
 __all__ = ["RampFitStep"]
 
 
-class RampFitStep(Step):
+class RampFitStep (Step):
 
     """
     This step fits a straight line to the value of counts vs. time to
@@ -42,7 +42,7 @@ class RampFitStep(Step):
         with datamodels.RampModel(input) as input_model:
 
             readnoise_filename = self.get_reference_file(input_model,
-                                                         'readnoise')
+                                                          'readnoise')
             gain_filename = self.get_reference_file(input_model, 'gain')
 
             log.info('Using READNOISE reference file: %s', readnoise_filename)


### PR DESCRIPTION
Reverts spacetelescope/jwst#2289

All regression tests involving ramp_fit seem to be taking hours to complete ever since this was merged. So reverting, at least temporarily, to allow the rest of the reg test suite to get a clean run.