### PR TITLE
Change iters to maxiters in source_catalog

### DIFF
--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -95,7 +95,7 @@ def make_source_catalog(model, kernel_fwhm, kernel_xsize, kernel_ysize,
     # does not yet contain an IVM map
     mask = (model.wht == 0)
     data_mean, data_median, data_std = sigma_clipped_stats(
-        model.data, mask=mask, sigma=3.0, iters=10)
+        model.data, mask=mask, sigma=3.0, maxiters=10)
     threshold = data_median + (data_std * snr_threshold)
 
     sigma = kernel_fwhm * gaussian_fwhm_to_sigma


### PR DESCRIPTION
The function `astropy.stats.sigma_clipped_stats` call signature has changed.  `iters` has become `maxiters`.  This resolves a deprecation warning in `SourceCatalogStep`.