### PR TITLE
spectral footprint

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -1,7 +1,14 @@
 import logging
 import importlib
 from gwcs.wcs import WCS
-from.util import update_s_region
+from .util import update_s_region_keyword, update_s_region_imaging
+from ..associations.lib.dms_base import (TSO_EXP_TYPES, ACQ_EXP_TYPES,
+                                         IMAGE2_SCIENCE_EXP_TYPES,
+                                         IMAGE2_NONSCIENCE_EXP_TYPES)
+
+IMAGING_TYPES = set(tuple(ACQ_EXP_TYPES) + tuple(IMAGE2_SCIENCE_EXP_TYPES)
+                    + tuple(IMAGE2_NONSCIENCE_EXP_TYPES))
+
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -50,9 +57,11 @@ def load_wcs(input_model, reference_files={}):
         wcs = WCS(pipeline)
         output_model.meta.wcs = wcs
         output_model.meta.cal_step.assign_wcs = 'COMPLETE'
-        exclude_types = ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_IFU',
-                         'NRS_MSASPEC', 'NRS_LAMP', 'MIR_MRS', 'NIS_SOSS',
-                         'NRC_WFSS', 'NRC_TSGRISM', 'NIS_WFSS', 'NRS_AUTOFLAT']
+        exclude_types = ['nrc_wfss', 'nrc_tsgrism', 'nis_wfss',
+                         'nrs_fixedslit', 'nrs_ifu', 'nrs_msaspec',
+                         'nrs_autowave', 'nrs_autoflat', 'nrs_lamp',
+                         'nrs_brightobj', 'mir_lrs-fixedslit', 'mir_lrs-slitless',
+                         'mir_mrs', 'nis_soss']
 
         if output_model.meta.exposure.type not in exclude_types:
             orig_s_region = output_model.meta.wcsinfo.s_region.strip()
@@ -62,6 +71,24 @@ def load_wcs(input_model, reference_files={}):
         else:
             log.info("assign_wcs did not update S_REGION for type {0}".format(output_model.meta.exposure.type))
         log.info("COMPLETED assign_wcs")
+
+        if output_model.meta.exposure.type.lower() not in exclude_types:
+            if output_model.meta.exposure.type.lower() in IMAGING_TYPES:
+                try:
+                    update_s_region_imaging(output_model)
+                except:
+                    log.error("Unable to update S_REGION for type {}".format(
+                        output_model.meta.exposure.type))
+                else:
+                    log.info("assign_wcs updated S_REGION to {0}".format(
+                        output_model.meta.wcsinfo.s_region))
+            else:
+                try:
+                    update_s_region_spectral(output_model)
+                except:
+                    log.info("Unable to update S_REGION for type {}".format(
+                        output_model.meta.exposure.type))
+    log.info("COMPLETED assign_wcs")
     return output_model
 
 

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -63,15 +63,6 @@ def load_wcs(input_model, reference_files={}):
                          'nrs_brightobj', 'mir_lrs-fixedslit', 'mir_lrs-slitless',
                          'mir_mrs', 'nis_soss']
 
-        if output_model.meta.exposure.type not in exclude_types:
-            orig_s_region = output_model.meta.wcsinfo.s_region.strip()
-            update_s_region(output_model)
-            if orig_s_region != output_model.meta.wcsinfo.s_region.strip():
-                log.info("assign_wcs updated S_REGION to {0}".format(output_model.meta.wcsinfo.s_region))
-        else:
-            log.info("assign_wcs did not update S_REGION for type {0}".format(output_model.meta.exposure.type))
-        log.info("COMPLETED assign_wcs")
-
         if output_model.meta.exposure.type.lower() not in exclude_types:
             if output_model.meta.exposure.type.lower() in IMAGING_TYPES:
                 try:

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -14,7 +14,7 @@ from astropy.table import QTable
 
 
 from gwcs import WCS
-from gwcs.wcstools import wcs_from_fiducial
+from gwcs.wcstools import wcs_from_fiducial, grid_from_bounding_box
 from gwcs import utils as gwutils
 
 from . import pointing
@@ -140,7 +140,7 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
     wnew = wcs_from_fiducial(fiducial, coordinate_frame=out_frame,
                              projection=prj, transform=transform)
 
-    footprints = [w.footprint() for w in wcslist]
+    footprints = [w.footprint().T for w in wcslist]
     domain_bounds = np.hstack([wnew.backward_transform(*f) for f in footprints])
     for axs in domain_bounds:
         axs -= axs.min()
@@ -172,7 +172,7 @@ def compute_fiducial(wcslist, bounding_box=None, domain=None):
     axes_types = wcslist[0].output_frame.axes_type
     spatial_axes = np.array(axes_types) == 'SPATIAL'
     spectral_axes = np.array(axes_types) == 'SPECTRAL'
-    footprints = np.hstack([w.footprint(bounding_box=bounding_box) for w in wcslist])
+    footprints = np.hstack([w.footprint(bounding_box=bounding_box).T for w in wcslist])
     spatial_footprint = footprints[spatial_axes]
     spectral_footprint = footprints[spectral_axes]
 
@@ -542,26 +542,35 @@ def get_num_msa_open_shutters(shutter_state):
     return num
 
 
-def update_s_region(model):
-    """
-    Update the ``S_REGION`` keyword usiong ``WCS.footprint``.
+def bounding_box_from_shape(model):
+    """Create a bounding box from the shape of the data.
 
+    Note: The bounding box of a ``CubeModel`` is the bounding_box of one
+    of the stacked images.
     """
-    bbox = None
-    def _bbox_from_shape(model):
+    if isinstance(input_model, (CubeModel, IFUCubeModel)):
+        shape = model.data[0].shape
+    else:
         shape = model.data.shape
-        bbox = ((0, shape[1]), (0, shape[0]))
-        return bbox
-    try:
-        bbox = model.meta.wcs.bounding_box
-    except NotImplementedError:
-        bbox = _bbox_from_shape(model)
+
+    bbox = ((-0.5, shape[1] - 0.5),
+            (-0.5, shape[0] - 0.5))
+    return bbox
+
+
+def update_s_region_imaging(model):
+    """
+    Update the ``S_REGION`` keyword using ``WCS.footprint``.
+    """
+
+    bbox = model.meta.wcs.bounding_box
 
     if bbox is None:
-        bbox = _bbox_from_shape(model)
+        bbox = bounding_box_from_shape(model)
 
-    # footprint is an array of shape (2, 2) or (3, 3)
-    footprint = model.meta.wcs.footprint(bbox, center=True)
+    # footprint is an array of shape (2, 4) as we
+    # are interested only in the footprint on the sky
+    footprint = model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T
     # take only imaging footprint
     footprint = footprint[:2, :]
 
@@ -571,7 +580,28 @@ def update_s_region(model):
         footprint[0][negative_ind] = 360 + footprint[0][negative_ind]
 
     footprint = footprint.T
+    update_s_region_keyword(model, footprint)
 
+
+def update_s_region_spectral(model):
+    swcs = model.meta.wcs
+
+    bbox = swcs.bounding_box
+    if bbox is None:
+        bbox = bounding_box_from_shape(model)
+
+    x, y = grid_from_bounding_box(bbox)
+    ra, dec, lam = swcs(x, y)
+    footprint = np.array([[np.nanmin(ra), np.nanmin(dec)],
+                 [np.nanmax(ra), np.nanmin(dec)],
+                 [np.nanmax(ra), np.nanmax(dec)],
+                 [np.nanmin(ra), np.nanmax(dec)]])
+    update_s_region_keyword(model, footprint)
+
+
+def update_s_region_keyword(model, footprint):
+    """ Update the S_REGION keyword.
+    """
     s_region = (
         "POLYGON ICRS "
         " {0:.9f} {1:.9f}"
@@ -580,6 +610,7 @@ def update_s_region(model):
         " {6:.9f} {7:.9f}".format(*footprint.flatten()))
     if "nan" in s_region:
         # do not update s_region if there are NaNs.
-        log.info("There are NaNs in s_region")
+        log.info("There are NaNs in s_region, S_REGION not updated.")
     else:
         model.meta.wcsinfo.s_region = s_region
+        log.info("Update S_REGION to {}".format(model.meta.wcsinfo.s_region))

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -292,6 +292,10 @@ SHORT,MEDIUM,LONG, or ALL
             if(self.debug_pixel ==1):
                 self.spaxel_debug.close()
 
+        sregion = Final_IFUCube.meta.wcs.footprint(kind="spatial")
+        Final_IFUCube.meta.wcsinfo.s_region = sregion
+        log.info("Updated S_REGION to {}".format(s_region))
+
         return Final_IFUCube
 
 #********************************************************************************

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -72,7 +72,7 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
                                                         exp_type, apply_wavecorr, reffile)
         set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi)
         orig_s_region = output_model.meta.wcsinfo.s_region.strip()
-        util.update_s_region(output_model)
+        util.update_s_region_spectral(output_model)
         if orig_s_region != output_model.meta.wcsinfo.s_region.strip():
             log.info('extract_2d updated S_REGION to '
                      '{0}'.format(output_model.meta.wcsinfo.s_region))
@@ -86,7 +86,7 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
 
             slits.append(new_model)
             orig_s_region = new_model.meta.wcsinfo.s_region.strip()
-            util.update_s_region(new_model)
+            util.update_s_region_spectral(new_model)
             if orig_s_region != new_model.meta.wcsinfo.s_region.strip():
                 log.info('extract_2d updated S_REGION to {0}'.format(new_model.meta.wcsinfo.s_region))
             # set x/ystart values relative to the image (screen) frame.

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -74,7 +74,6 @@ class ResampleSpecStep(ResampleStep):
 
             for model in resamp.output_models:
                 model.meta.cal_step.resample = "COMPLETE"
-                update_s_region(model)
                 model.meta.asn.pool_name = input_models.meta.pool_name
                 model.meta.asn.table_name = input_models.meta.table_name
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -2,7 +2,7 @@ from ..stpipe import Step
 from .. import datamodels
 from . import resample_spec, ResampleStep
 from ..exp_to_source import multislit_to_container
-from ..assign_wcs.util import update_s_region
+from ..assign_wcs.util import update_s_region_spectral
 
 
 __all__ = ["ResampleSpecStep"]
@@ -53,9 +53,6 @@ class ResampleSpecStep(ResampleStep):
                 # Do the resampling
                 resamp.do_drizzle()
 
-                for model in resamp.output_models:
-                    update_s_region(model)
-
                 if len(resamp.output_models) == 1:
                     out_slit = resamp.output_models[0]
                     output.products.append(out_slit)
@@ -87,5 +84,8 @@ class ResampleSpecStep(ResampleStep):
                 result = resamp.output_models[0]
             else:
                 result = resamp.output_models
+
+        for model in result.products:
+            update_s_region_spectral(model)
 
         return result

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -7,7 +7,7 @@ from ..extern.configobj.validate import Validator
 from ..extern.configobj.configobj import ConfigObj
 from .. import datamodels
 from . import resample
-from ..assign_wcs.util import update_s_region
+from ..assign_wcs import util
 
 
 __all__ = ["ResampleStep"]
@@ -63,7 +63,7 @@ class ResampleStep(Step):
 
         for model in resamp.output_models:
             model.meta.cal_step.resample = "COMPLETE"
-            update_s_region(model)
+            util.update_s_region_imaging(model)
             model.meta.asn.pool_name = input_models.meta.pool_name
             model.meta.asn.table_name = input_models.meta.table_name
 


### PR DESCRIPTION
This is part one of #1744.

There are two functions now - `update_s_region_imaging` and `update_s_region_spectral`.

The flow is:
- `set_telescope_pointing` populates `S_REGION` using the vertices of the APERZTURE in the SIAF file.
   For this to work we need the correct APERTURE in the level 1B headers (populated by SDP).
- `assign_wcs` updates `S_REGION` for imaging types.
- `extract_2d updates the keyword for each slit
- `resample` updates fo rimaging and spectral (@jdavies-st)
- `cube_build` updates it for cubes (@jemorrison please look at the changes)
