### PR TITLE
pep8 setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ matrix:
           env: SETUP_CMD='build_sphinx'
                CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_DOC_DEPENDENCIES"
                PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi'
+        - os: linux
+          env: MAIN_CMD='flake8 --count'
+               SETUP_CMD='jwst' TEST_CMD='flake8 --version --select=F401, F402, F841, E722'
 
     allow_failures:
         # PEP8 will fail for numerous reasons. Ignore it.

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ matrix:
                CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_DOC_DEPENDENCIES"
                PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi'
         - os: linux
-          env: MAIN_CMD='flake8 --count'
-               SETUP_CMD='jwst' TEST_CMD='flake8 --version --select=F401, F402, F841, E722 --max-line-length=110 '
+          env: MAIN_CMD='flake8 --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722 --max-line-length=110'
+               SETUP_CMD='jwst'
 
     allow_failures:
         # PEP8 will fail for numerous reasons. Ignore it.

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
                PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi'
         - os: linux
           env: MAIN_CMD='flake8 --count'
-               SETUP_CMD='jwst' TEST_CMD='flake8 --version --select=F401, F402, F841, E722'
+               SETUP_CMD='jwst' TEST_CMD='flake8 --version --select=F401, F402, F841, E722 --max-line-length=110 '
 
     allow_failures:
         # PEP8 will fail for numerous reasons. Ignore it.


### PR DESCRIPTION
Addresses #2329.
This is a (conservative) attempt to define some initial PEP8 rules and is up for discussion. The PEP8 codes enabled here (these will make a build fail) are:
```
E101: indentation contains mixed spaces and tabs
E111: indentation is not a multiple of four
E112: expected an indented block
E113: unexpected indentation
E401: multiple imports on one line
E402: module level import not at top of file
E711: comparison to None should be ‘if cond is None:’

--max-line-length=110

F*: all flake8 codes
Some of the failures reported here are
F401: something is imported but never used
F841: variable is assigned but never used
F821: undefined variable
F811: redefinition of unused variable
```
Definition of all flake8 codes is [here](http://flake8.pycqa.org/en/latest/user/error-codes.html).

If something should be removed from this list please comment below.
Once these are resolved (~1200 messages) we can add more codes.

These involve the following steps:
* [x] ami @jdavies-st
* [x] assign_wcs  - ~@nden~ @sosey to look at two remaining issues
* [ ] associations
* [x] background @jdavies-st
* [x] barshadow  @stscirij 
* [x] combine_1d @philhodge
* [x] coron @jdavies-st
* [x] cube_build @jemorrison
* [x] cube_skymatch @nden
* [x] datamodels @jdavies-st
* [x] darkcurrent @jdavies-st
* [x] dq_init  @stscirij 
* [x] emission @jdavies-st
* [x] engdblog @nden
* [ ] exp_to_source @jdavies-st
* [x] extract_1d @philhodge
* [x] extract_2d @nden
* [x] first_frame @jemorrison
* [ ] fits_generator @stscirij 
* [x] flatfield @philhodge
* [x] fringe (@stscicrawford)
* [x] gain_scale @hbushouse
* [x] group_scale @hbushouse
* [x] guider_cds @hbushouse
* [x] imprint @hbushouse
* [x] ipc @philhodge
* [x] jump @jdavies-st
* [ ] jwpsf @jdavies-st
* [x] last_frame @jemorrison
* [ ] lib @jdavies-st
* [x] linearity @hbushouse
* [x] model_blender  @stsci-hack
* [x] mrs_imatch @nden
* [x] msa_flagopen  @stscirij 
* [x] outlier_detection @jdavies-st
* [x] pathloss     @stscirij 
* [x] persistence @philhodge
* [x] photom @hbushouse
* [x] pipeline @hbushouse
* [ ] ramp_fitting @dmggh
* [x] refpix   @stscirij 
* [x] resample  @jdavies-st
* [x] reset @jemorrison
* [x] rscd @jemorrison
* [x] saturation @hbushouse
* [x] skymatch @nden
* [x] source_catalog    @larrybradley
* [x] src_type @hbushouse
* [x] stpipe @jdavies-st
* [x] straylight @jemorrison
* [x] superbias @hbushouse
* [x] tests_nightly @jdavies-st
* [x] timeconversion  @nden
* [x] transforms         @nden
* [x] tso_photometry    @larrybradley
* [x] tweakreg @nden
* [x] wfs_combine @dmggh 
* [x] white_light @hbushouse
* [x] wiimatch @nden

Please put your github name next to a step you intend to work on. When done (PR with changes merged) , check it off. I'll keep this open until all steps are checked off and rebase. When all is fixed this should pass. 
Note that we don't need to fix the failures in the job that says `allowed failures`. 