### PR TITLE
Adjust TPCorr to work with V2, V3 angles in arcsec instead of degrees

### DIFF
--- a/jwst/transforms/tpcorr.py
+++ b/jwst/transforms/tpcorr.py
@@ -127,7 +127,7 @@ class TPCorr(Model):
     @staticmethod
     def cartesian2spherical(x, y, z):
         """
-        Convert cartesian coordinates to spherical coordinates (in deg).
+        Convert cartesian coordinates to spherical coordinates (in acrsec).
 
         """
         h = np.hypot(x, y)
@@ -138,7 +138,7 @@ class TPCorr(Model):
     @staticmethod
     def spherical2cartesian(alpha, delta):
         """
-        Convert spherical coordinates (in deg) to cartesian.
+        Convert spherical coordinates (in arcsec) to cartesian.
 
         """
         alpha = np.deg2rad(alpha / 3600.0)

--- a/jwst/transforms/tpcorr.py
+++ b/jwst/transforms/tpcorr.py
@@ -131,8 +131,8 @@ class TPCorr(Model):
 
         """
         h = np.hypot(x, y)
-        alpha = np.rad2deg(np.arctan2(y, x))
-        delta = np.rad2deg(np.arctan2(z, h))
+        alpha = 3600.0 * np.rad2deg(np.arctan2(y, x))
+        delta = 3600.0 * np.rad2deg(np.arctan2(z, h))
         return alpha, delta
 
     @staticmethod
@@ -141,8 +141,8 @@ class TPCorr(Model):
         Convert spherical coordinates (in deg) to cartesian.
 
         """
-        alpha = np.deg2rad(alpha)
-        delta = np.deg2rad(delta)
+        alpha = np.deg2rad(alpha / 3600.0)
+        delta = np.deg2rad(delta / 3600.0)
         x = np.cos(alpha) * np.cos(delta)
         y = np.cos(delta) * np.sin(alpha)
         z = np.sin(delta)


### PR DESCRIPTION
This PR adresses issue https://github.com/spacetelescope/jwst/issues/2273 by making `TPCorr` work with `V2` and `V3` angles provided in arcseconds instead of the original degrees.