### PR TITLE
add missing fgs image types to footprint calculation

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -6,7 +6,8 @@ from ..associations.lib.dms_base import (ACQ_EXP_TYPES, IMAGE2_SCIENCE_EXP_TYPES
                                          IMAGE2_NONSCIENCE_EXP_TYPES)
 
 IMAGING_TYPES = set(tuple(ACQ_EXP_TYPES) + tuple(IMAGE2_SCIENCE_EXP_TYPES)
-                    + tuple(IMAGE2_NONSCIENCE_EXP_TYPES) + ('nrc_tsimage',))
+                    + tuple(IMAGE2_NONSCIENCE_EXP_TYPES) +
+                    ('fgs_image', 'fgs_focus'))
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
These were inadvertently dropped in #2327. Addnig them back.