### PR TITLE
Wavetab

### DIFF
--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -120,7 +120,7 @@ def wcsinfo_from_model(input_model):
     return wcsinfo
 
 
-def fitswcs_transform_from_model(wcsinfo,wavetab=None):
+def fitswcs_transform_from_model(wcsinfo, wavetab=None):
     """
     Create a WCS object using from datamodel.meta.wcsinfo.
     Transforms assume 0-based coordinates.
@@ -216,7 +216,7 @@ def create_fitswcs(inp, input_frame=None):
         sp_axis = spectral_axes[0]
         if wcsinfo['CTYPE'][sp_axis] == 'WAVE-TAB':
             wavetable = inp.wavetable
-        transform = fitswcs_transform_from_model(wcsinfo,wavetable)
+        transform = fitswcs_transform_from_model(wcsinfo, wavetable)
         output_frame = frame_from_model(wcsinfo)
     #elif isinstance(inp, six.string_types):
         #transform = create_fitswcs_transform(inp)

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -120,7 +120,7 @@ def wcsinfo_from_model(input_model):
     return wcsinfo
 
 
-def fitswcs_transform_from_model(wcsinfo):
+def fitswcs_transform_from_model(wcsinfo,inp):
     """
     Create a WCS object using from datamodel.meta.wcsinfo.
     Transforms assume 0-based coordinates.
@@ -140,13 +140,16 @@ def fitswcs_transform_from_model(wcsinfo):
     #sp_axis = spectral_axes[0]
 
     transform = gwutils.make_fitswcs_transform(wcsinfo)
-    #if wcsinfo['WCSAXES'] == 3:
     if spectral_axes:
         sp_axis = spectral_axes[0]
+        if wcsinfo['CTYPE'][sp_axis] == 'WAVE-TAB' :
+            wavetable = inp.wavetable
+            spectral_transform = astmodels.Tabular1D(lookup_table=wavetable) 
+        else :
         # Subtract one from CRPIX which is 1-based.
-        spectral_transform = astmodels.Shift(-(wcsinfo['CRPIX'][sp_axis] - 1)) | \
-                           astmodels.Scale(wcsinfo['CDELT'][sp_axis]) | \
-                           astmodels.Shift(wcsinfo['CRVAL'][sp_axis])
+            spectral_transform = astmodels.Shift(-(wcsinfo['CRPIX'][sp_axis] - 1)) | \
+                astmodels.Scale(wcsinfo['CDELT'][sp_axis]) | \
+                astmodels.Shift(wcsinfo['CRVAL'][sp_axis])
         transform = transform & spectral_transform
 
     return transform
@@ -207,7 +210,7 @@ def frame_from_model(wcsinfo):
 def create_fitswcs(inp, input_frame=None):
     if isinstance(inp, DataModel):
         wcsinfo = wcsinfo_from_model(inp)
-        transform = fitswcs_transform_from_model(wcsinfo)
+        transform = fitswcs_transform_from_model(wcsinfo,inp)
         output_frame = frame_from_model(wcsinfo)
     #elif isinstance(inp, six.string_types):
         #transform = create_fitswcs_transform(inp)

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -120,7 +120,7 @@ def wcsinfo_from_model(input_model):
     return wcsinfo
 
 
-def fitswcs_transform_from_model(wcsinfo,inp):
+def fitswcs_transform_from_model(wcsinfo,wavetab=None):
     """
     Create a WCS object using from datamodel.meta.wcsinfo.
     Transforms assume 0-based coordinates.
@@ -142,14 +142,15 @@ def fitswcs_transform_from_model(wcsinfo,inp):
     transform = gwutils.make_fitswcs_transform(wcsinfo)
     if spectral_axes:
         sp_axis = spectral_axes[0]
-        if wcsinfo['CTYPE'][sp_axis] == 'WAVE-TAB' :
-            wavetable = inp.wavetable
-            spectral_transform = astmodels.Tabular1D(lookup_table=wavetable) 
-        else :
-        # Subtract one from CRPIX which is 1-based.
+        if wavetab is None :
+            # Subtract one from CRPIX which is 1-based.
             spectral_transform = astmodels.Shift(-(wcsinfo['CRPIX'][sp_axis] - 1)) | \
                 astmodels.Scale(wcsinfo['CDELT'][sp_axis]) | \
                 astmodels.Shift(wcsinfo['CRVAL'][sp_axis])
+        else :
+            # Wave dimension is an array that needs to be converted to a table
+            spectral_transform = astmodels.Tabular1D(lookup_table=wavetab) 
+
         transform = transform & spectral_transform
 
     return transform
@@ -210,7 +211,12 @@ def frame_from_model(wcsinfo):
 def create_fitswcs(inp, input_frame=None):
     if isinstance(inp, DataModel):
         wcsinfo = wcsinfo_from_model(inp)
-        transform = fitswcs_transform_from_model(wcsinfo,inp)
+        wavetable = None
+        spatial_axes, spectral_axes, unknown = gwutils.get_axes(wcsinfo)
+        sp_axis = spectral_axes[0]
+        if wcsinfo['CTYPE'][sp_axis] == 'WAVE-TAB':
+            wavetable = inp.wavetable
+        transform = fitswcs_transform_from_model(wcsinfo,wavetable)
         output_frame = frame_from_model(wcsinfo)
     #elif isinstance(inp, six.string_types):
         #transform = create_fitswcs_transform(inp)

--- a/jwst/datamodels/ifucube.py
+++ b/jwst/datamodels/ifucube.py
@@ -13,22 +13,26 @@ class IFUCubeModel(model_base.DataModel):
     init : any
         Any of the initializers supported by `~jwst.datamodels.DataModel`.
 
-    data : numpy array
+    data: numpy array
         The science data.  3-D.
 
-    dq : numpy array
+    dq: numpy array
         The data quality array.  3-D.
 
-    err : numpy array
+    err: numpy array
         The error array.  3-D
 
-    weightmap : numpy array
+    weightmap: numpy array
         The weight map array.  3-D
+
+    wavetable:  1-D table 
+        Optional table of  wavelengths of IFUCube slices
+     
     """
     schema_url = "ifucube.schema.yaml"
 
     def __init__(self, init=None, data=None, dq=None, err=None, 
-                 weightmap=None, hdrtab=None,  **kwargs):
+                 weightmap=None, wavetable=None, hdrtab=None,  **kwargs):
         super(IFUCubeModel, self).__init__(init=init, **kwargs)
 
         if data is not None:
@@ -42,6 +46,9 @@ class IFUCubeModel(model_base.DataModel):
 
         if weightmap is not None:
             self.weightmap = weightmap
+
+        if wavetable is not None:
+            self.wavetable = wavetable
 
         if hdrtab is not None:
             self.hdrtab = hdrtab

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -30,6 +30,10 @@ allOf:
               title: EXTNAME of the extension containing data quality mask
               type: string
               fits_keyword: MASKEXT
+            wave_extension:
+              title: EXTNAME of the extension containing wavelength slice data
+              type: string
+              fits_keyword: WAVEEXT
             roi_spatial:
               title: "[arcsec] Size of ROI in spatial dimension"
               type: number
@@ -71,5 +75,11 @@ allOf:
       fits_hdu: WMAP
       default: 0.0
       ndim: 3
+      datatype: float32
+    wavetable:
+      title: Wavelength value for slices
+      fits_hdu: WCS-TAB
+      default: 0.0
+      ndim: 1
       datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -30,10 +30,6 @@ allOf:
               title: EXTNAME of the extension containing data quality mask
               type: string
               fits_keyword: MASKEXT
-            wave_extension:
-              title: EXTNAME of the extension containing wavelength slice data
-              type: string
-              fits_keyword: WAVEEXT
             roi_spatial:
               title: "[arcsec] Size of ROI in spatial dimension"
               type: number
@@ -78,8 +74,8 @@ allOf:
       datatype: float32
     wavetable:
       title: Wavelength value for slices
-      fits_hdu: WCS-TAB
-      default: 0.0
-      ndim: 1
-      datatype: float64
+      fits_hdu: WCS-TABLE
+      datatype:
+      - name: wavelength
+        datatype: float64
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -81,5 +81,5 @@ allOf:
       fits_hdu: WCS-TAB
       default: 0.0
       ndim: 1
-      datatype: float32
+      datatype: float64
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -211,6 +211,16 @@ properties:
             fits_keyword: PC3_3
             fits_hdu: SCI
             blend_table: True
+          ps3_0:
+            title: table extnesion name
+            type: string
+            fits_keyword: PS3_0
+            fits_hdu: SCI
+          ps3_1:
+            title: column name for the coordinate array
+            type: string
+            fits_keyword: PS3_1
+            fits_hdu: SCI
           s_region:
             title: spatial extent of the observation
             type: string

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -212,12 +212,12 @@ properties:
             fits_hdu: SCI
             blend_table: True
           ps3_0:
-            title: table extnesion name
+            title: Coordinate table extension name
             type: string
             fits_keyword: PS3_0
             fits_hdu: SCI
           ps3_1:
-            title: column name for the coordinate array
+            title: Coordinate table column name
             type: string
             fits_keyword: PS3_1
             fits_hdu: SCI


### PR DESCRIPTION
This pr adds the functionality to the datamodels to have WCS-TAB extension tables. 
In the IFUCubeModel a WAVE-TAB (which is a WCS-TAB) was added and will store the
wavelengths of IFU when a non-linear wavelength sampling is used. 
The pipeline can now write and read these types of datamodels. 

One thing  that seemed a little odd is the WAVE-TAB written to the fits file seemed to be in reverse
order (it started with the largest indices - longest wavelengths first). I was not sure it that is "standard" .  It is read in correctly by the pipeline so maybe it is not an issue. 