### PR TITLE
Remove version and PEP8 fixes

### DIFF
--- a/jwst/source_catalog/__init__.py
+++ b/jwst/source_catalog/__init__.py
@@ -1,1 +1,3 @@
 from .source_catalog_step import SourceCatalogStep
+
+__all__ = ['SourceCatalogStep']

--- a/jwst/source_catalog/__init__.py
+++ b/jwst/source_catalog/__init__.py
@@ -1,3 +1,1 @@
 from .source_catalog_step import SourceCatalogStep
-
-__version__ = '0.9.3'

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -121,8 +121,8 @@ def make_source_catalog(model, kernel_fwhm, kernel_xsize, kernel_ysize,
     # units of electron/s.  Poisson noise is not included for pixels
     # where data < 0.
     exptime = model.meta.resample.product_exposure_time    # total exptime
-    #total_error = np.sqrt(bkg_error**2 +
-    #                      np.maximum(model.data / exptime, 0))
+    # total_error = np.sqrt(bkg_error**2 +
+    #                       np.maximum(model.data / exptime, 0))
     total_error = np.sqrt(data_std**2 + np.maximum(model.data / exptime, 0))
 
     wcs = model.get_fits_wcs()

--- a/jwst/tso_photometry/__init__.py
+++ b/jwst/tso_photometry/__init__.py
@@ -1,1 +1,3 @@
 from .tso_photometry_step import TSOPhotometryStep
+
+__all__ = ['TSOPhotometryStep']

--- a/jwst/tso_photometry/__init__.py
+++ b/jwst/tso_photometry/__init__.py
@@ -1,3 +1,1 @@
 from .tso_photometry_step import TSOPhotometryStep
-
-__version__ = '0.9.3'

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -127,7 +127,7 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
             nrows = 0                   # flag as bad
         else:
             log.debug("Times are from the INT_TIMES table.")
-            time_arr = mid_utc[offset : offset + num_integ]
+            time_arr = mid_utc[offset: offset + num_integ]
             int_times = Time(time_arr, format='mjd', scale='utc')
     else:
         log.debug("Times were computed from EXPSTART and TGROUP.")

--- a/jwst/tso_photometry/tso_photometry_step.py
+++ b/jwst/tso_photometry/tso_photometry_step.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-import asdf
-from ..stpipe import Step, cmdline
+from ..stpipe import Step
 from ..datamodels import CubeModel
 from ..datamodels import TsoPhotModel
 from ..lib.catalog_utils import replace_suffix_ext
@@ -85,11 +84,11 @@ def get_ref_data(reffile, pupil='ANY'):
                              item.radius_inner, item.radius_outer)
 
     if value is not None:
-         (radius, radius_inner, radius_outer) = value
+        (radius, radius_inner, radius_outer) = value
     elif val_any_pupil is not None:
-         (radius, radius_inner, radius_outer) = val_any_pupil
+        (radius, radius_inner, radius_outer) = val_any_pupil
     else:
-         (radius, radius_inner, radius_outer) = (0., 0., 0.)
+        (radius, radius_inner, radius_outer) = (0., 0., 0.)
 
     ref_model.close()
 


### PR DESCRIPTION
This PR:

* Removes version from `tso_photometry` and `source_catalog` steps (#2352)
* PEP8 fixes in both steps (part of #2340)