### PR TITLE
Remove dangling pointers to data from datamodels

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -551,12 +551,18 @@ def from_fits_hdu(hdu, schema):
     Read the data from a fits hdu into a numpy ndarray
     """
     data = hdu.data
-    data2 = properties._cast(data, schema)
 
-    # Casting a table loses the listeners, so restore them
+    # Save the column listeners for possible restoration
     if hasattr(data, '_coldefs'):
-        coldefs = data._coldefs
-        coldefs2 = data2._coldefs
-        coldefs2._listeners = coldefs._listeners
+        listeners = data._coldefs._listeners
+    else:
+        listeners = None
 
-    return data2
+    # Cast array to type mentioned in schema
+    data = properties._cast(data, schema)
+
+    # Casting a table loses the column listeners, so restore them
+    if listeners is not None:
+        data._coldefs._listeners = listeners
+
+    return data

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -17,6 +17,7 @@ from astropy.wcs import WCS
 
 from asdf import AsdfFile
 from asdf import yamlutil
+from asdf import treeutil
 from asdf import schema as asdf_schema
 from asdf import extension as asdf_extension
 
@@ -32,7 +33,6 @@ from .history import HistoryList
 from .extension import BaseExtension
 from jwst.transforms.jwextension import JWSTExtension
 from gwcs.extension import GWCSExtension
-
 
 class DataModel(properties.ObjectNode, ndmodel.NDModel):
     """
@@ -253,12 +253,29 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    def _drop_arrays(self):
+        def _drop_array(d, p):
+            # Walk tree and delete numpy arrays
+            if isinstance(d, dict):
+                for val in d.values():
+                    _drop_array(val, d)
+            elif isinstance(d, list):
+                for val in d:
+                    _drop_array(val, d)
+            elif isinstance(d, np.ndarray):
+                del d
+            else:
+                pass
+        _drop_array(self._instance, None)
+
     def close(self):
+        if not self._iscopy and self._asdf is not None:
+            self._asdf.close()
+            self._drop_arrays()
+
         for fd in self._files_to_close:
             if fd is not None:
                 fd.close()
-        if not self._iscopy and self._asdf is not None:
-            self._asdf.close()
 
     def get_envar(self, name, value):
         if name in os.environ:


### PR DESCRIPTION
An issue was filed (#2282) that datamodels was not closing file
handles after opening them. After some investigation, it looks like
there are two problems. The first problem is that a fits file is
opened, normally the data in the file is accessed as a memory mapped
array. When the fits file is closed, the handle to the memory map is
omly closed if there is a single reference to the memory map. Normally
this condition is not met. Instead, the memory containing the fits
descriptor is repleased, and some time after this the memory is
garbage collected. When this happens, the file handle tothe memory
mapped array is closed. This causes a problem when a reference to the
fits file descriptor is not released. In that case, the file handle is
not closed and if one is looping over a set of fits files, one file
handle will be leaked for each file.

This fix contains a partial fix for the problem in that it closes some
extra references to the memory mapped data. However, since I have not
located them all, the leak is not yet fixed. The first change was to
add a new method to model_base.py, _drop_arrays, which walks the data
structure and deletes all numpy arrays. The second change is in
from_fits_hdu in fits_support.py, where instead of creating a new copy
of a numpy array before casting it to a new type, it over writes the
original array.