### PR TITLE
PEP8 cleanup of datamodels

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -65,7 +65,11 @@ from .trapdensity import TrapDensityModel
 from .trappars import TrapParsModel
 from .trapsfilled import TrapsFilledModel
 from .tsophot import TsoPhotModel
-from .wcs_ref_models import *
+from .wcs_ref_models import (DistortionModel, DistortionMRSModel, SpecwcsModel,
+    RegionsModel, WavelengthrangeModel, CameraModel, CollimatorModel, OTEModel,
+    FOREModel, FPAModel, IFUPostModel, IFUFOREModel, IFUSlicerModel, MSAModel,
+    FilteroffsetModel, DisperserModel, NIRCAMGrismModel, NIRISSGrismModel,
+    WaveCorrModel)
 from .wfssbkg import WfssBkgModel
 from .util import open
 

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -1,36 +1,3 @@
-# Copyright (C) 2010 Association of Universities for Research in Astronomy(AURA)
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#     1. Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#
-#     2. Redistributions in binary form must reproduce the above
-#       copyright notice, this list of conditions and the following
-#       disclaimer in the documentation and/or other materials provided
-#       with the distribution.
-#
-#     3. The name of AURA and its representatives may not be used to
-#       endorse or promote products derived from this software without
-#       specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
-# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL AURA BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-# DAMAGE.
-
-
-__version__ = '0.9.3'
-
-from os.path import basename
 from astropy.io import registry
 
 from . import ndmodel
@@ -106,7 +73,8 @@ from .util import open
 
 __all__ = [
     'open',
-    'DataModel', 'AmiLgModel', 'AsnModel',
+    'DataModel',
+    'AmiLgModel', 'AsnModel',
     'BarshadowModel', 'CameraModel', 'CollimatorModel',
     'CombinedSpecModel', 'ContrastModel', 'CubeModel',
     'DarkModel', 'DarkMIRIModel',
@@ -159,5 +127,5 @@ except NameError:
         registry.register_identifier('datamodel', DataModel, ndmodel.identify)
 
 _all_models = __all__[1:]
-_local_dict = dict(locals())
-_defined_models = { k: _local_dict[k] for k in _all_models }
+_local_dict = locals()
+_defined_models = {k:_local_dict[k] for k in _all_models}

--- a/jwst/datamodels/arrays.py
+++ b/jwst/datamodels/arrays.py
@@ -64,11 +64,9 @@ def _parse_column(i, entry):
 
         if 'title' in entry:
             col_title = entry['title']
-            if not isinstance(col_title, basestring):
-                raise ValueError(
+            if not isinstance(col_title, str):
+                raise TypeError(
                     "Invalid title {0} in dtype".format(col_title))
-            if isinstance(col_title, unicode):
-                col_title = col_title.encode('ascii')
             col_name = (col_name, col_title)
 
         if 'shape' in entry:

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -1,11 +1,5 @@
-import os.path as op
-import os
 import copy
-import warnings
 from collections import OrderedDict
-import copy
-from functools import partial
-from inspect import signature
 import os.path as op
 
 from asdf import AsdfFile
@@ -110,8 +104,6 @@ class ModelContainer(model_base.DataModel):
                 pass_invalid_values=self._pass_invalid_values
             )
             self._models[index] = model
-
-        return model
 
         return model
 

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -1,11 +1,8 @@
 import datetime
 import os
 import re
-import warnings
 
 import numpy as np
-
-import jsonschema
 
 from astropy.io import fits
 from astropy import time
@@ -444,8 +441,6 @@ def _schema_has_fits_hdu(schema):
 def _load_from_schema(hdulist, schema, tree, context):
     known_keywords = {}
     known_datas = set()
-    invalid_values = set()
-    missing_values = set()
 
     def callback(schema, path, combiner, ctx, recurse):
         result = None

--- a/jwst/datamodels/guidercal.py
+++ b/jwst/datamodels/guidercal.py
@@ -1,5 +1,4 @@
 from . import model_base
-from .dynamicdq import dynamic_mask
 
 __all__ = ['GuiderCalModel']
 

--- a/jwst/datamodels/guiderraw.py
+++ b/jwst/datamodels/guiderraw.py
@@ -1,5 +1,4 @@
 from . import model_base
-from .dynamicdq import dynamic_mask
 
 __all__ = ['GuiderRawModel']
 

--- a/jwst/datamodels/level1b.py
+++ b/jwst/datamodels/level1b.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from . import model_base
 
 __all__ = ['Level1bModel']

--- a/jwst/datamodels/make_header.py
+++ b/jwst/datamodels/make_header.py
@@ -1,5 +1,4 @@
 import re
-import os.path
 import inspect
 import jsonschema
 import numpy as np

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -18,20 +18,15 @@ from astropy.wcs import WCS
 from asdf import AsdfFile
 from asdf import yamlutil
 from asdf import schema as asdf_schema
-from asdf import extension as asdf_extension
 
 from . import ndmodel
 from . import filetype
 from . import fits_support
 from . import properties
 from . import schema as mschema
-from . import util
 from . import validate
 
 from .history import HistoryList
-from .extension import BaseExtension
-from jwst.transforms.jwextension import JWSTExtension
-from gwcs.extension import GWCSExtension
 
 
 class DataModel(properties.ObjectNode, ndmodel.NDModel):
@@ -919,7 +914,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             HDU, pass ``'PRIMARY'``.
         """
         header = wcs.to_header()
-        extensions = self._asdf._extensions
         if hdu_name == 'PRIMARY':
             hdu = fits.PrimaryHDU(header=header)
         else:

--- a/jwst/datamodels/pathloss.py
+++ b/jwst/datamodels/pathloss.py
@@ -1,5 +1,4 @@
 from .reference import ReferenceFileModel
-from .dynamicdq import dynamic_mask
 
 
 __all__ = ['PathlossModel']

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -2,15 +2,12 @@
 
 import copy
 import numpy as np
-import jsonschema
 from astropy.io import fits
 
 from astropy.utils.compat.misc import override__dir__
 
-from asdf import schema
 from asdf import yamlutil
 from asdf.tags.core import ndarray
-from asdf import tagged
 
 from . import util
 from . import validate

--- a/jwst/datamodels/resolution.py
+++ b/jwst/datamodels/resolution.py
@@ -13,7 +13,7 @@ class ResolutionModel(ReferenceFileModel):
         super(ResolutionModel, self).__init__(init=init, **kwargs)
 
         if resolution_table is not None:
-            self.resolution_table = ifucubepars_table
+            self.resolution_table = resolution_table
 
 
 class MiriResolutionModel(ResolutionModel):

--- a/jwst/datamodels/schema_editor.py
+++ b/jwst/datamodels/schema_editor.py
@@ -59,7 +59,6 @@ from asdf import reference
 from asdf import treeutil
 
 from . import model_base
-from . import schema as mschema
 
 
 def enquote(value):
@@ -200,7 +199,7 @@ def save_simple_list(prefix, values, max_length=80):
         line = save_short_line(prefix, value)
     return line
 
-class Keyword_db(object):
+class Keyword_db:
     def __init__(self, directory=""):
         """
         Combine all the top dbs in a directory into a single db
@@ -429,7 +428,7 @@ class Keyword_db(object):
         self.schema = treeutil.walk_and_modify(self.schema, resolve_refs)
 
 
-class Model_db(object):
+class Model_db:
     def __init__(self):
         """
         Load the list of datamodels schema files from the schema directory
@@ -469,7 +468,7 @@ class Model_db(object):
             save_dictionary(fd, schema)
 
 
-class Options(object):
+class Options:
     """
     Get options for running the schema editor from file, command line arguments,
     and interactive user input.
@@ -805,7 +804,7 @@ class Options(object):
                     fd.write("{0} = {1}\n".format(name, value))
 
 
-class Schema_editor(object):
+class Schema_editor:
     def __init__(self, **keywds):
         """
         Initialize the editor options
@@ -1096,24 +1095,24 @@ class Schema_editor(object):
 
                         if keyword_path is None:
                             if not p_name:
-                                done = self.schema_del_value(model_schema,
-                                                             model_name,
-                                                             new_model_path)
+                                self.schema_del_value(model_schema,
+                                                            model_name,
+                                                            new_model_path)
 
                         else:
                             keyword_subschema = self.find_subschema(keyword_schema,
                                                                     keyword_path)
                             if keyword_subschema is not None:
                                 keyword_path = keyword_path.split('.')
-                                done = self.update_schema_fields(keyword_subschema,
-                                                                 model_subschema,
-                                                                 new_model_path)
+                                self.update_schema_fields(keyword_subschema,
+                                                            model_subschema,
+                                                            new_model_path)
 
                                 if not p_name and model_name != keyword_path[-1]:
-                                    done = self.schema_rename_value(model_schema,
-                                                                    keyword_path[-1],
-                                                                    model_name,
-                                                                    new_model_path)
+                                    self.schema_rename_value(model_schema,
+                                                            keyword_path[-1],
+                                                            model_name,
+                                                            new_model_path)
 
                                 if model_fits_name != keyword_fits_name:
                                     fits_dict[keyword_fits_name] = \

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -153,7 +153,6 @@ properties:
             fits_keyword: TIME-END
             blend_rule: last
             blend_table: True
-          
           obs_id:
             title: Programmatic observation identifier
             type: string

--- a/jwst/datamodels/source_container.py
+++ b/jwst/datamodels/source_container.py
@@ -1,8 +1,4 @@
-from . import (
-    ImageModel,
-    ModelContainer,
-    MultiExposureModel
-)
+from . import ModelContainer, MultiExposureModel
 
 __all__ = ['SourceModelContainer']
 

--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -1,5 +1,3 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 import shutil
 import tempfile
@@ -11,7 +9,8 @@ from numpy.testing import assert_array_equal
 
 from asdf import schema as mschema
 
-from .. import DataModel, ImageModel, RampModel, open
+from .. import DataModel, ImageModel, RampModel
+from ..util import open
 
 ROOT_DIR = None
 FITS_FILE = None
@@ -53,7 +52,7 @@ def test_from_new_hdulist():
         from astropy.io import fits
         hdulist = fits.HDUList()
         with open(hdulist) as dm:
-            sci = dm.data
+            dm.data
 
 
 def test_from_new_hdulist2():
@@ -65,7 +64,6 @@ def test_from_new_hdulist2():
     science = fits.ImageHDU(data=data, name='SCI')
     hdulist.append(science)
     with open(hdulist) as dm:
-        sci = dm.data
         dq = dm.dq
         assert dq is not None
 
@@ -94,7 +92,6 @@ def delete_array():
         with open(hdulist) as dm:
             del dm.data
             assert len(hdulist) == 1
-            x = dm.data
 
 
 def test_from_fits():
@@ -182,7 +179,7 @@ def test_extra_fits():
         dm2 = dm.copy()
         dm2.to_fits(TMP_FITS, overwrite=True)
 
-    with DataModel(TMP_FITS) as dm3:
+    with DataModel(TMP_FITS) as dm:
         assert 'BITPIX' not in _header_to_dict(dm.extra_fits.PRIMARY.header)
         assert _header_to_dict(dm.extra_fits.PRIMARY.header)['SCIYSTRT'] == 705
 
@@ -392,9 +389,7 @@ def test_replace_table():
         assert hdulist[1].data.dtype[1].str == '>f4'
         assert hdulist[1].header['TFORM2'] == 'E'
 
-    with DataModel(TMP_FITS,
-                   schema=schema_wide) as m:
-        foo = m.data
+    with DataModel(TMP_FITS, schema=schema_wide) as m:
         m.to_fits(TMP_FITS2, overwrite=True)
 
     with fits.open(TMP_FITS2) as hdulist:

--- a/jwst/datamodels/tests/test_make_header.py
+++ b/jwst/datamodels/tests/test_make_header.py
@@ -1,5 +1,4 @@
-import pytest
-from jwst.datamodels import make_header
+from .. import make_header
 
 def test_make_header():
     # This is mostly a "smoke test" to determine the code works

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -1,26 +1,16 @@
-import datetime
 import os
 import shutil
 import tempfile
 
 import pytest
-try:
-    import yaml
-    has_yaml = True
-except ImportError:
-    has_yaml = False
-
 from astropy.time import Time
-
 import numpy as np
-from numpy.testing.decorators import knownfailureif
 from numpy.testing import assert_allclose
 
 from .. import (DataModel, ImageModel, MaskModel, QuadModel,
                 MultiSlitModel, ModelContainer, SlitModel,
                 SlitDataModel, IFUImageModel)
 from ..util import open as open_model
-from .. import schema
 
 
 ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -77,7 +67,7 @@ def test_from_hdulist():
     from astropy.io import fits
     with fits.open(FITS_FILE) as hdulist:
         with open_model(hdulist) as dm:
-            pass
+            dm.data
         assert hdulist.fileinfo(0)['file'].closed == False
 
 
@@ -88,7 +78,7 @@ def delete_array():
 
 def test_subarray():
     with DataModel(FITS_FILE) as dm:
-        x = dm.meta.subarray.xstart
+        dm.meta.subarray.xstart
 
 
 def roundtrip(func):
@@ -119,19 +109,6 @@ def roundtrip(func):
 def test_from_fits_write(dm):
     dm.to_fits(TMP_FITS, overwrite=True)
     return DataModel.from_fits(TMP_FITS)
-
-
-# @knownfailureif(not has_yaml)
-# @roundtrip
-# def test_from_fits_to_yaml(dm):
-#     dm.to_yaml(TMP_YAML)
-#     return DataModel.from_yaml(TMP_YAML)
-
-
-# @roundtrip
-# def test_from_fits_to_json(dm):
-#     dm.to_json(TMP_JSON)
-#     return DataModel.from_json(TMP_JSON)
 
 
 def test_delete():
@@ -206,7 +183,7 @@ def test_init_with_array3():
     with pytest.raises(ValueError):
         array = np.empty((50,))
         with ImageModel(array) as dm:
-            pass
+            dm.data
 
 
 def test_set_array():
@@ -288,11 +265,11 @@ def test_multislit_metadata():
             ms.slits.append(ms.slits.item())
             ms.slits[-1].data = im.data
         im = ms.slits[0]
-        im.subarray.name = "FULL"
-        assert ms.slits[0].subarray.name == "FULL"
+        im.name = "FOO"
+        assert ms.slits[0].name == "FOO"
 
 
-def test_multislit_metadata():
+def test_multislit_metadata2():
     with MultiSlitModel() as ms:
         ms.slits.append(ms.slits.item())
         for key, val in ms.iteritems():

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -4,6 +4,8 @@ Test datamodel.open
 
 import os
 import os.path
+
+import pytest
 import numpy as np
 from astropy.io import fits
 
@@ -34,14 +36,9 @@ def test_open_shape():
     model.close()
 
 def test_open_illegal():
-    init = 5
-    try:
-        model = open(init)
-    except ValueError:
-        fail = 1
-    else:
-        fail = 0
-    assert fail == 1
+    with pytest.raises(ValueError):
+        init = 5
+        open(init)
 
 def test_open_hdulist():
     hdulist = fits.HDUList()

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import datetime
+from datetime import datetime
 import os
 import shutil
 import tempfile
@@ -13,6 +13,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 import jsonschema
 from astropy.io import fits
 from astropy.modeling import models
+from astropy import time
 
 from .. import util, validate
 from .. import (DataModel, ImageModel, RampModel, MaskModel,
@@ -58,21 +59,16 @@ def test_set_na_ra():
             # Setting an invalid value should raise a ValueError
             dm.meta.target.ra = "FOO"
 
-'''
-def test_date():
-    with pytest.raises(jsonschema.ValidationError):
-        with ImageModel((50, 50), strict_validation=True) as dm:
-            dm.meta.date = 'Not an acceptable date'
-
 
 def test_date2():
-    from astropy import time
-
     with ImageModel((50, 50), strict_validation=True) as dm:
-        assert isinstance(dm.meta.date, (time.Time, datetime.datetime))
-'''
+        time_obj = time.Time(dm.meta.date)
+        assert isinstance(time_obj, time.Time)
+        date_obj = datetime.strptime(dm.meta.date, '%Y-%m-%dT%H:%M:%S.%f')
+        assert isinstance(date_obj, datetime)
 
-transformation_schema = {
+
+TRANSFORMATION_SCHEMA = {
     "allOf": [
         mschema.load_schema(
             os.path.join(os.path.dirname(__file__),
@@ -113,25 +109,21 @@ transformation_schema = {
 
 def test_list():
     with pytest.raises(jsonschema.ValidationError):
-        with ImageModel((50, 50), schema=transformation_schema,
+        with ImageModel((50, 50), schema=TRANSFORMATION_SCHEMA,
                         strict_validation=True) as dm:
             dm.meta.transformations = []
-            object = dm.meta.transformations.item(
-                transformation="SIN",
-                coeff=2.0)
+            dm.meta.transformations.item(transformation="SIN", coeff=2.0)
 
-'''
+
 def test_list2():
     with pytest.raises(jsonschema.ValidationError):
         with ImageModel(
             (50, 50),
-            schema=transformation_schema,
+            schema=TRANSFORMATION_SCHEMA,
             strict_validation=True) as dm:
             dm.meta.transformations = []
-            object = dm.meta.transformations.append(
-                {'transformation': 'FOO',
-                 'coeff': 2.0})
-'''
+            dm.meta.transformations.append({'transformation': 'FOO', 'coeff': 2.0})
+
 
 def test_invalid_fits():
     hdulist = fits.open(FITS_FILE)
@@ -243,74 +235,16 @@ def test_search_schema():
     assert 'meta.target.ra' in results
 
 
-schema_extra = {
-    "type": "object",
-    "properties": {
-        "meta": {
-            "type": "object",
-            "properties": {
-                "foo": {
-                    'title': 'Custom type',
-                    'type': 'string',
-                    'default': 'bar',
-                    'fits_keyword': 'FOO'
-                },
-                "restricted": {
-                    'title': 'Custom type',
-                    'type': 'object',
-                    'additionalProperties': False,
-                    'properties': {
-                        'allowed': {
-                            'type': 'number'
-                        }
-                    }
-                },
-                "bar": {
-                    "type": "object",
-                    "properties": {
-                        "baz": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "subarray": {
-                    "type": "object",
-                    "properties": {
-                        "size": {
-                            'title': 'Subarray size',
-                            'type': 'number'
-                        },
-                        'xstart': {
-                            'type': 'string',
-                            'default': 'fubar'
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-
-
 def test_dictionary_like():
     with DataModel(strict_validation=True) as x:
         x.meta.origin = 'FOO'
         assert x['meta.origin'] == 'FOO'
 
-        try:
-            x['meta.subarray.xsize'] = 'string'
-        except:
-            pass
-        else:
-            raise AssertionError()
+        with pytest.raises(jsonschema.ValidationError):
+            x['meta.subarray.xsize'] = 'FOO'
 
-        try:
-            y = x['meta.FOO.BAR.BAZ']
-        except KeyError:
-            pass
-        else:
-            raise AssertionError()
+        with pytest.raises(KeyError):
+            x['meta.FOO.BAR.BAZ']
 
 
 def test_to_flat_dict():
@@ -644,9 +578,7 @@ def test_validate_transform_from_file():
     m.validate()
 
 
-'''
-def test_multislit_garbage():
+def test_multislit_append_string():
     with pytest.raises(jsonschema.ValidationError):
         m = MultiSlitModel(strict_validation=True)
         m.slits.append('junk')
-'''

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -8,9 +8,6 @@ from os.path import basename
 import numpy as np
 from astropy.io import fits
 
-from asdf import AsdfFile
-from asdf import schema as asdf_schema
-
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -111,7 +108,7 @@ def open(init=None, extensions=None, **kwargs):
         init = hdulist
 
         try:
-            hdu = hdulist[(fits_header_name('SCI'), 1)]
+            hdu = hdulist[('SCI', 1)]
         except (KeyError, NameError):
             shape = ()
         else:
@@ -169,7 +166,7 @@ def _class_from_model_type(hdulist):
 
     if hdulist:
         primary = hdulist[0]
-        model_type = primary.header.get(fits_header_name('DATAMODL'))
+        model_type = primary.header.get('DATAMODL')
 
         if model_type is None:
             new_class = None
@@ -190,11 +187,11 @@ def _class_from_ramp_type(hdulist, shape):
     else:
         if len(shape) == 4:
             try:
-                dqhdu = hdulist[fits_header_name('DQ')]
+                hdulist['DQ']
             except KeyError:
                 # It's a RampModel or MIRIRampModel
                 try:
-                    refouthdu = hdulist[fits_header_name('REFOUT')]
+                    hdulist['REFOUT']
                 except KeyError:
                     # It's a RampModel
                     from . import ramp
@@ -220,7 +217,7 @@ def _class_from_reftype(hdulist, shape):
 
     else:
         primary = hdulist[0]
-        reftype = primary.header.get(fits_header_name('REFTYPE'))
+        reftype = primary.header.get('REFTYPE')
         if reftype is None:
             new_class = None
 
@@ -255,7 +252,7 @@ def _class_from_shape(hdulist, shape):
         new_class = cube.CubeModel
     elif len(shape) == 2:
         try:
-            hdu = hdulist[(fits_header_name('SCI'), 2)]
+            hdulist[('SCI', 2)]
         except (KeyError, NameError):
             # It's an ImageModel
             from . import image
@@ -286,16 +283,6 @@ def can_broadcast(a, b):
 
 def to_camelcase(token):
     return ''.join(x.capitalize() for x in token.split('_-'))
-
-
-def fits_header_name(name):
-    """
-    Returns a FITS header name in the correct form for the current
-    version of Python.
-    """
-    if isinstance(name, bytes):
-        return name.decode('ascii')
-    return name
 
 
 def gentle_asarray(a, dtype):

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -2,13 +2,9 @@ import numpy as np
 import warnings
 from astropy.modeling.core import Model
 from astropy import units as u
-from . import model_base
 
-from .extension import BaseExtension
 from .validate import ValidationWarning
 from .reference import ReferenceFileModel
-from jwst.transforms.jwextension import JWSTExtension
-from gwcs.extension import GWCSExtension
 
 __all__ = ['DistortionModel', 'DistortionMRSModel', 'SpecwcsModel', 'RegionsModel',
            'WavelengthrangeModel', 'CameraModel', 'CollimatorModel', 'OTEModel',
@@ -476,7 +472,7 @@ class IFUSlicerModel(ReferenceFileModel):
         if model is not None:
             self.model = model
         if data is not None:
-            seld.data = data
+            self.data = data
         if init is None:
             self.populate_meta()
 


### PR DESCRIPTION
Clean up `flake8` problems pointed out in PR #2340 for datamodels.

- remove lots of unused imports
- remove python 2 code
- remove unused variables; don't use assignments if not needed
- fix bug in `model_base.py::set_fits_wcs()`
- fix bug in `ResolutionModel`
- fix bug in `tests/test_fits.py::test_from_fits()`
- remove two commented-out tests `test_from_fits_to_yaml()` and `test_from_fits_to_json()` that test no-longer-supported functionality
- fix bug in `tests/test_models.py::test_multislit_metadata()` and rename a test that was using the same name
- enable commented-out test `tests/test_schema.py::test_date2()`
- clarify the asserts in `tests/test_schema.py::test_dictionary_like()`
- re-enable and rename `tests/test_schema.py::test_multislit_append_string()`
- remove `util.py::fits_header_name()` which was for python 2 compatibility
- fix bug in `IFUSlicerModel`

Still there are 4 unresolved `flake8` problems:
```
$ flake8 --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722 --max-line-length=110 .
./__init__.py:68:1: F403 'from .wcs_ref_models import *' used; unable to detect undefined names
./__init__.py:122:5: F405 '_defined_models' may be undefined, or defined from star imports: .wcs_ref_models
./schema_editor.py:754:17: F841 local variable 'current_value' is assigned to but never used
./schema_editor.py:1396:29: F841 local variable 'model_field' is assigned to but never used
4
```
The `__init__.py` issues I don't think are problems.  It is because we use `__all__` in `wcs_ref_models`.  @nden, is this OK, or should we be explicit in the import?

The `schema_editor.py` issues are I think two small bugs.  @bernie-simon, could you take a look at those?