### PR TITLE
fix ordering of cube footprint

### DIFF
--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -294,8 +294,7 @@ SHORT,MEDIUM,LONG, or ALL
                 self.spaxel_debug.close()
         for cube in Final_IFUCube:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
-            update_s_region_keyword(cube, footprint.T)
-            self.log.info("Updated S_REGION to {}".format(cube.meta.wcsinfo.s_region))
+            update_s_region_keyword(cube, footprint)
 
         return Final_IFUCube
 


### PR DESCRIPTION
Another fix to the cube footprint. The ordering of the corners was not correct. I ran the regression tests locally now and this is hopefully the last fix. :crossed_fingers: 

Just to clarify we need to write out the footrpint as [RA, DEC, RA, DEC ...] of the corners. They were written as [RA, RA..., DEC, DEC,...]. This PR provides the correct order.