### PR TITLE
fix ifupost schema

### DIFF
--- a/jwst/datamodels/schemas/ifupost.schema.yaml
+++ b/jwst/datamodels/schemas/ifupost.schema.yaml
@@ -93,6 +93,8 @@ allOf:
       $ref: "#definitions/slice_transforms"
     slice_28:
       $ref: "#definitions/slice_transforms"
+    slice_29:
+      $ref: "#definitions/slice_transforms"
     meta:
       type: object
       properties:
@@ -108,4 +110,3 @@ allOf:
           anyOf:
             - type: string
             - $ref: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
-additionalProperties: false


### PR DESCRIPTION
Testing of the scripts that generate the ifupost file and perhaps stricter checking in the pipeline revealed a problem with the ifupost schema. The schema included `additionalProperties=false` and this prevented a history entry to be added.
There's not problem with the current reference file.