### PR TITLE
create wcs frames in tweakreg

### DIFF
--- a/jwst/tweakreg/wcsimage.py
+++ b/jwst/tweakreg/wcsimage.py
@@ -186,6 +186,15 @@ class ImageWCS():
             pf, pt = pipeline[idx_v2v3]
             pipeline[idx_v2v3] = (pf, deepcopy(self._tpcorr))
             pipeline.insert(idx_v2v3 + 1, ('v2v3corr', pt))
+
+            # The following is a hack around the fact that gwcs does not
+            # currently provide support for inserting a step.
+            for i in range(len(pipeline)):
+                try:
+                    frame = getattr(self._wcs, pipeline[i][0])
+                except AttributeError:
+                    continue
+                pipeline[i] = (frame, pipeline[i][1])
             self._wcs = gwcs.WCS(pipeline, name=self._owcs.name)
             self._v23name = 'v2v3corr'
 
@@ -1174,6 +1183,7 @@ class WCSGroupCatalog():
 
             imcat.imwcs.set_correction(m, s)
             imcat.meta['image_model'].meta.wcs = imcat.wcs
+
 
     def align_to_ref(self, refcat, minobj=15, searchrad=1.0, separation=0.5,
                      use2dhist=True, xoffset=0.0, yoffset=0.0, tolerance=1.0,


### PR DESCRIPTION
tweakreg inserts a new step in the WCS pipeline. It first copies WCS.pipeline and then modifies it. When WCS.pipeline is copied it uses the names of the frames and not the frame objects. This breaks resample because the frame attributes resample uses are missing.

Using strings as frames in GWCS is allowed as convenience. Frame objects are needed for full functionality. In the future this may be fixed in GWCS by implementing `insert_step` method. For now this implements a workaround.
Further resolves #2271