### PR TITLE
Update for current usage of make_output_path

### DIFF
--- a/jwst/outlier_detection/outlier_detection_spec.py
+++ b/jwst/outlier_detection/outlier_detection_spec.py
@@ -76,7 +76,8 @@ class OutlierDetectionSpec(OutlierDetection):
             drizzled_models = sdriz.output_models
             for model in drizzled_models:
                 model.meta.filename = self.make_output_path(
-                    model, suffix=self.resample_suffix
+                    basepath=model.meta.filename,
+                    suffix=self.resample_suffix
                 )
                 if save_intermediate_results:
                     log.info("Writing out resampled spectra...")
@@ -94,7 +95,8 @@ class OutlierDetectionSpec(OutlierDetection):
                                         init=drizzled_models[0].data.shape)
         median_model.meta = drizzled_models[0].meta
         median_model.meta.filename = self.make_output_path(
-            self.input_models[0], suffix='median'
+            basepath=self.input_models[0].meta.filename,
+            suffix='median'
         )
 
         # Perform median combination on set of drizzled mosaics


### PR DESCRIPTION
This call to `make_output_path` was never updated after an API change to the method, which replace the direct use of `DataModel` with just a `basepath`.

Resolves #2338