### PR TITLE
Fix bug in flatten_combiners

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -102,7 +102,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                                              resolver=file_resolver,
                                              resolve_references=True)
 
-        self._schema = mschema.flatten_combiners(schema)
+        self._schema = mschema.merge_property_trees(schema)
 
         # Provide the object as context to other classes and functions
         self._ctx = self
@@ -585,7 +585,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         new_schema : schema tree
         """
         schema = {'allOf': [self._schema, new_schema]}
-        self._schema = mschema.flatten_combiners(schema)
+        self._schema = mschema.merge_property_trees(schema)
         self.validate()
         return self
 

--- a/jwst/datamodels/schema.py
+++ b/jwst/datamodels/schema.py
@@ -195,7 +195,7 @@ def walk_schema(schema, callback, ctx={}):
 
         for c in ['anyOf', 'oneOf']:
             for i, sub in enumerate(schema.get(c, [])):
-                recurse(sub, path + [i], c, ctx)
+                recurse(sub, path + [c], c, ctx)
 
         if schema.get('type') == 'object':
             for key, val in schema.get('properties', {}).items():
@@ -225,7 +225,10 @@ def flatten_combiners(schema):
         cursor = newschema
         for i in range(len(path)):
             part = path[i]
-            if isinstance(part, int):
+            if part == combiner:
+                cursor = cursor.setdefault(combiner, [])
+                return
+            elif isinstance(part, int):
                 cursor = cursor.setdefault('items', [])
                 while len(cursor) <= part:
                     cursor.append({})
@@ -250,8 +253,6 @@ def flatten_combiners(schema):
             del schema['items']
         if 'allOf' in schema:
             del schema['allOf']
-        if 'anyOf' in schema:
-            del schema['anyOf']
 
         add_entry(path, schema, combiner)
 

--- a/jwst/datamodels/schema.py
+++ b/jwst/datamodels/schema.py
@@ -212,11 +212,17 @@ def walk_schema(schema, callback, ctx={}):
     recurse(schema, [], None, ctx)
 
 
-def flatten_combiners(schema):
+def merge_property_trees(schema):
     """
-    Flattens the allOf and anyOf operations in a JSON schema.
+    Recursively merges property trees that are governed by the "allOf" combiner.
 
-    TODO: Write caveats -- there's a lot
+    The main purpose of this function is to allow multiple subschemas to be
+    combined into a single schema. All of the properties at each level of each
+    subschema are merged together to form a single coherent tree.
+
+    This allows datamodel schemas to be more modular, since various components
+    can be represented in individual files and then referenced elsewhere. They
+    are then combined by this function into a single schema data structure.
     """
     newschema = OrderedDict()
 
@@ -289,5 +295,5 @@ def read_schema(schema_file, extensions=None):
                                      resolver=file_resolver,
                                      resolve_references=True)
 
-    schema = flatten_combiners(schema)
+    schema = merge_property_trees(schema)
     return schema

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -585,13 +585,14 @@ def test_multislit_append_string():
         m.slits.append('junk')
 
 
-def test_flatten_combiners():
+@pytest.mark.parametrize('combiner', ['anyOf', 'oneOf'])
+def test_flatten_combiners(combiner):
 
     s = {
          'type': 'object',
          'properties': {
              'foobar': {
-                 'anyOf': [
+                 combiner: [
                      {
                          'type': 'array',
                          'items': [ {'type': 'string'}, {'type': 'number'} ],

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -18,7 +18,7 @@ from astropy import time
 from .. import util, validate
 from .. import (DataModel, ImageModel, RampModel, MaskModel,
                 MultiSlitModel, AsnModel, CollimatorModel)
-from ..schema import flatten_combiners
+from ..schema import merge_property_trees
 
 from asdf import schema as mschema
 
@@ -586,7 +586,7 @@ def test_multislit_append_string():
 
 
 @pytest.mark.parametrize('combiner', ['anyOf', 'oneOf'])
-def test_flatten_combiners(combiner):
+def test_merge_property_trees(combiner):
 
     s = {
          'type': 'object',
@@ -614,6 +614,6 @@ def test_flatten_combiners(combiner):
          }
     }
 
-    # Make sure that flatten_combiners does not destructively modify schemas
-    f = flatten_combiners(s)
+    # Make sure that merge_property_trees does not destructively modify schemas
+    f = merge_property_trees(s)
     assert f == s

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -18,6 +18,7 @@ from astropy import time
 from .. import util, validate
 from .. import (DataModel, ImageModel, RampModel, MaskModel,
                 MultiSlitModel, AsnModel, CollimatorModel)
+from ..schema import flatten_combiners
 
 from asdf import schema as mschema
 
@@ -582,3 +583,36 @@ def test_multislit_append_string():
     with pytest.raises(jsonschema.ValidationError):
         m = MultiSlitModel(strict_validation=True)
         m.slits.append('junk')
+
+
+def test_flatten_combiners():
+
+    s = {
+         'type': 'object',
+         'properties': {
+             'foobar': {
+                 'anyOf': [
+                     {
+                         'type': 'array',
+                         'items': [ {'type': 'string'}, {'type': 'number'} ],
+                         'minItems': 2,
+                         'maxItems': 2,
+                     },
+                     {
+                         'type': 'array',
+                         'items': [
+                             {'type': 'number'},
+                             {'type': 'string'},
+                             {'type': 'number'}
+                         ],
+                         'minItems': 3,
+                         'maxItems': 3,
+                     }
+                 ]
+             }
+         }
+    }
+
+    # Make sure that flatten_combiners does not destructively modify schemas
+    f = flatten_combiners(s)
+    assert f == s

--- a/jwst/model_blender/blendrules.py
+++ b/jwst/model_blender/blendrules.py
@@ -338,6 +338,8 @@ def _build_schema_rules_dict(schema):
     def build_rules_dict(subschema, path, combiner, ctx, recurse):
         # Only interpret elements of the meta component of the model
         if len(path) > 1 and path[0] == 'meta' and 'items' not in path:
+            if 'anyOf' in path:
+                path = path[:path.index('anyOf')]
             attr = '.'.join(path)
             if subschema.get('properties'):
                 return # Ignore ObjectNodes

--- a/jwst/model_blender/blendrules.py
+++ b/jwst/model_blender/blendrules.py
@@ -338,8 +338,10 @@ def _build_schema_rules_dict(schema):
     def build_rules_dict(subschema, path, combiner, ctx, recurse):
         # Only interpret elements of the meta component of the model
         if len(path) > 1 and path[0] == 'meta' and 'items' not in path:
-            if 'anyOf' in path:
-                path = path[:path.index('anyOf')]
+            for combiner in ['anyOf', 'oneOf']:
+                if combiner in path:
+                    path = path[:path.index(combiner)]
+                    break
             attr = '.'.join(path)
             if subschema.get('properties'):
                 return # Ignore ObjectNodes


### PR DESCRIPTION
This is a proposed fix for the issue described in #2375. It is a bit rough at the moment, and will need to be updated to properly account for `oneOf` as well. It also could use some more thorough tests.

Also, with this fix, it seems like the name `flatten_combiners` is no longer appropriate. The real purpose of this function seems to be to merge external schema file references into a single schema. So maybe `merge_schemas` would be more appropriate.

cc @sosey 