### PR TITLE
Move no model type warning in datamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ datamodels
 
 - Improved error messaging when loading fits files into data models. [#2298]
 
+- New warning message when opening a file without DATAMODL keyword. [#2248]
+
 - New info method, similar to the method in astropy fits [#2268]
 
 dq_init

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -150,6 +150,8 @@ def open(init=None, extensions=None, **kwargs):
         log.debug('Opening as {0}'.format(new_class))
 
     # Actually open the model
+    model = new_class(init, extensions=extensions, **kwargs)
+
     if not has_model_type:
         class_name = new_class.__name__.split('.')[-1]
         if file_name:
@@ -160,9 +162,6 @@ def open(init=None, extensions=None, **kwargs):
                 "model_type not found. Opening model as a {}".format(class_name)
         warnings.warn(errmsg, NoTypeWarning)
 
-    model = new_class(init, extensions=extensions, **kwargs)
-
-    if not has_model_type:
         try:
             delattr(model.meta, 'model_type')
         except AttributeError:


### PR DESCRIPTION
The recently introduced warning that is printed when the DATAMODL keyword is not present in a FITS file is a subtle change to the existing interface. This is because it precedes any warning produced when a FITS file is opened and confuses any code that might be trapping warning messages when a datamodel is opened. This update preserves the existing interface by moving the test to after the datamodel is opened, so any error or warning during the open takes precedence over it. This update changes nothing Other than changing the location of the warning in the output.

This change also adds a line about the warning to the CHANGES file.