### PR TITLE
Fix failing NIRISS SOSS spec2 reg test

### DIFF
--- a/jwst/tests_nightly/general/niriss/test_nirisssoss2_pipeline.py
+++ b/jwst/tests_nightly/general/niriss/test_nirisssoss2_pipeline.py
@@ -15,7 +15,7 @@ pytestmark = [
 def test_nirisssoss2pipeline1(_bigdata):
     """
 
-    Regression test of calwebb_spec2 pipeline performed on NIRISS SOSS data.
+    Regression test of calwebb_tso_spec2 pipeline performed on NIRISS SOSS data.
 
     """
     collect_pipeline_cfgs()
@@ -23,39 +23,32 @@ def test_nirisssoss2pipeline1(_bigdata):
         'calwebb_tso_spec2.cfg',
         op.join(
             _bigdata,
-            'pipelines/jw00034001001_01101_00001_NIRISS_rate_ref.fits'
+            'pipelines/jw10003001002_03101_00001-seg003_nis_rateints.fits'
         )
     ]
     Step.from_cmdline(args)
 
-    n_cr = 'jw00034001001_01101_00001_NIRISS_calints.fits'
+    # Compare the _calints products
+    n_cr = 'jw10003001002_03101_00001-seg003_nis_calints.fits'
+    n_ref = _bigdata+'pipelines/jw10003001002_03101_00001-seg003_nis_calints_ref.fits'
     h = pf.open(n_cr)
-    n_ref = op.join(
-        _bigdata,
-        'pipelines/jw00034001001_01101_00001_NIRISS_calints_ref.fits'
-    )
     href = pf.open(n_ref)
-    newh = pf.HDUList([
-        h['primary'], h['sci'], h['err'], h['dq'], h['relsens']
-    ])
-    newhref = pf.HDUList([
-        href['primary'], href['sci'], href['err'], href['dq'], href['relsens']
-    ])
     result = pf.diff.FITSDiff(
-        newh, newhref,
+        h, href,
+        ignore_hdus=['INT_TIMES', 'VAR_POISSON', 'VAR_RNOISE', 'ASDF'],
         ignore_keywords=['DATE', 'CAL_VER', 'CAL_VCS', 'CRDS_VER', 'CRDS_CTX'],
         rtol=0.00001
     )
     assert result.identical, result.report()
 
-    n_cr = 'jw00034001001_01101_00001_NIRISS_x1dints.fits'
+    # Compare the _x1dints products
+    n_cr = 'jw10003001002_03101_00001-seg003_nis_x1dints.fits'
+    n_ref = _bigdata+'/pipelines/jw10003001002_03101_00001-seg003_nis_x1dints_ref.fits'
     h = pf.open(n_cr)
-    n_ref = _bigdata+'/pipelines/jw00034001001_01101_00001_NIRISS_x1dints_ref.fits'
     href = pf.open(n_ref)
-    newh = pf.HDUList([h['primary'], h['extract1d']])
-    newhref = pf.HDUList([href['primary'], href['extract1d']])
     result = pf.diff.FITSDiff(
-        newh, newhref,
+        h, href,
+        ignore_hdus=['INT_TIMES', 'ASDF'],
         ignore_keywords=['DATE', 'CAL_VER', 'CAL_VCS', 'CRDS_VER', 'CRDS_CTX'],
         rtol=0.00001
     )


### PR DESCRIPTION
Fixes the problems with the current NIRISS SOSS calspec2 pipeline regression test. It's currently throwing an error because it can't find the expected type of output product (_calints), because the current data set used in the test has only NINTS=1 and no TSOVISIT keyword (to tell stpipe that it's TSO data). Even with the TSOVISIT keyword, this data set is completely inappropriate for SOSS mode, because of NINTS=1. So the test has been modified to use a new data set with NINTS=50 and TSOVISIT=T. It now produces _calints and _x1dints products, as it should, and is also a true test of the ``calwebb_tso_spec2`` pipeline config. The necessary input/output data files have been uploaded to the jwcalibdev `/data4/jwst_test_data/pipelines/` directory.