### PR TITLE
Fix bug in resample_spec wavelength reverse lookup table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -160,6 +160,13 @@ refpix
 resample
 --------
 
+- Fixed spectral resampling so the 2D output for MIRI LRS and NIRSpec MSA
+  has the correct orientation and a dispersion that matches the input, i.e.
+  non-linear if a prism is in the optical path. [#2348]
+
+- Fixed bug in spectral resampling of MIRI LRS where the interpolation of the
+  dispersion was failing. [#2422]
+
 reset
 -----
 


### PR DESCRIPTION
When `resample_spec` creates an output frame, the wavelengths are done via tabular interpolation.  Both the forward transform (pixels to wavelength) and reverse transform (wavelength to pixels) need to be defined.  This fixes a bug in the reverse where for MIRI LRS fixed slit data, the wavelength is descending as a function of pixel index.  For `scipy.interpolate`, which is the underlying interpolation method used in the tabular models, the interpolation points need to be strictly ascending.

Resolves issue #2395.