### PR TITLE
Enable resample_spec on MIR_LRS-FIXEDSLIT data in spec2 pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,8 @@ pipeline
 - Fixed a typo in calspec2 which prevented the srctype
   step from running. [#2318]
 
+- Enable resample_spec to run on MIRI fixed slit data in calspec2 [#2424]
+
 ramp_fitting
 ------------
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -263,7 +263,7 @@ class Spec2Pipeline(Pipeline):
 
             # Call the resample_spec step for slit data
             self.resample_spec.suffix = 's2d'
-            rectified_result = self.resample_spec(result)
+            result_extra = self.resample_spec(result)
 
         elif exp_type in ['MIR_MRS', 'NRS_IFU']:
 
@@ -273,17 +273,19 @@ class Spec2Pipeline(Pipeline):
             self.cube_build.output_type = 'multi'
             self.cube_build.suffix = 's3d'
             self.cube_build.save_results = False
-            rectified_result = self.cube_build(result)
-            self.save_model(rectified_result[0], 's3d')
+            result_extra = self.cube_build(result)
+            self.save_model(result_extra[0], 's3d')
+        else:
+            result_extra = result
 
         # Extract a 1D spectrum from the 2D/3D data
         if tso_mode:
             self.extract_1d.suffix = 'x1dints'
         else:
             self.extract_1d.suffix = 'x1d'
-        x1d_result = self.extract_1d(rectified_result)
+        x1d_result = self.extract_1d(result_extra)
 
-        rectified_result.close()
+        result_extra.close()
         x1d_result.close()
 
         # That's all folks


### PR DESCRIPTION
The spec2 pipeline has not had `resample_spec` run on MIRI fixed slit data for almost 2 years.  Now that `resample_spec` can be reliably run on MIRI data, we can now re-enable it, giving us test coverage for this mode as well.

Cleaned up the spec2 pipeline a bit to remove two unnecessary datamodel `copy()` operations and changed some variable names for clarity.

A potential bug was found in the following operations:
```
input.close()

return input
```
Nothing was done with the returned datamodel, but if `process()` did try to do something with it, it would (I believe) fail.  So I have removed the `close()` line.