### PR TITLE
Explicitly define suffixes for the gain_scale output

### DIFF
--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -132,11 +132,13 @@ class Detector1Pipeline(Pipeline):
             input, ints_model = self.ramp_fit(input)
 
         # apply the gain_scale step to the exposure-level product
+        self.gain_scale.suffix = 'gain_scale'
         input = self.gain_scale(input)
 
         # apply the gain scale step to the multi-integration product,
         # if it exists, and then save it
         if ints_model is not None:
+            self.gain_scale.suffix = 'gain_scaleints'
             ints_model = self.gain_scale(ints_model)
             self.save_model(ints_model, 'rateints')
 

--- a/jwst/tests_nightly/general/miri/test_gain_naming.py
+++ b/jwst/tests_nightly/general/miri/test_gain_naming.py
@@ -1,0 +1,54 @@
+from glob import glob
+import os
+import pytest
+
+from astropy.io import fits as pf
+
+from jwst.pipeline.calwebb_detector1 import Detector1Pipeline
+
+pytestmark = [
+    pytest.mark.usefixtures('_jail'),
+    pytest.mark.skipif(not pytest.config.getoption('bigdata'),
+                       reason='requires --bigdata')
+]
+
+def test_detector1pipeline1(_bigdata):
+    """
+    Regression test for gain_scale naming when results are requested to
+    be saved for the gain_scale step.
+    """
+
+    step = Detector1Pipeline()
+    step.group_scale.skip = True
+    step.dq_init.skip = True
+    step.saturation.skip = True
+    step.ipc.skip = True
+    step.superbias.skip = True
+    step.refpix.skip = True
+    step.rscd.skip = True
+    step.firstframe.skip = True
+    step.lastframe.skip = True
+    step.linearity.skip = True
+    step.dark_current.skip = True
+    step.persistence.skip = True
+    step.jump.skip = True
+    step.ramp_fit.skip = False
+
+    step.gain_scale.skip = False
+    step.gain_scale.save_results = True
+
+    expfile = 'jw00001001001_01101_00001_MIRIMAGE'
+    step.run(_bigdata+'/miri/test_sloperpipeline/' + expfile + '_uncal.fits')
+
+
+    files = glob('*.fits')
+
+    output_file = expfile + '_gain_scale.fits'
+    assert output_file in files
+    files.remove(output_file)
+
+    output_file = expfile + '_gain_scaleints.fits'
+    assert output_file in files
+    files.remove(output_file)
+
+    assert not len(files)

--- a/jwst/tests_nightly/notebooks/gain_naming.ipynb
+++ b/jwst/tests_nightly/notebooks/gain_naming.ipynb
@@ -1,0 +1,175 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Abstract"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Testing how to test gain_step naming"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jwst.pipeline import Detector1Pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Library"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Main"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TEST_BIGDATA = '/Users/eisenham/Documents/ssbdev/testdata/pandokia/jwcalibdev/data4/jwst_test_data'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_path = os.path.join(TEST_BIGDATA, 'miri/test_sloperpipeline')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exposure = os.path.join(data_path, 'jw00001001001_01101_00001_MIRIMAGE_uncal.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%rm -f *gain_scale*.fits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline = Detector1Pipeline()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.group_scale.skip = True\n",
+    "pipeline.dq_init.skip = True\n",
+    "pipeline.saturation.skip = True\n",
+    "pipeline.ipc.skip = True\n",
+    "pipeline.superbias.skip = True\n",
+    "pipeline.refpix.skip = True\n",
+    "pipeline.rscd.skip = True\n",
+    "pipeline.firstframe.skip = True\n",
+    "pipeline.lastframe.skip = True\n",
+    "pipeline.linearity.skip = True\n",
+    "pipeline.dark_current.skip = True\n",
+    "pipeline.persistence.skip = True\n",
+    "pipeline.jump.skip = True\n",
+    "pipeline.ramp_fit.skip = False\n",
+    "\n",
+    "pipeline.gain_scale.skip = False\n",
+    "pipeline.gain_scale.save_results = True\n",
+    "\n",
+    "pipeline.save_results = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = pipeline.run(exposure)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%ls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Ready-to-test #2341

The actual issue in #2341 arose from confusion over what output was being produced when the `gain_scale_step` was requested to save its data. Since the step is called twice, once on the integrated ramp, and once on the non-integrated ramp ("ints"), but without any other file specification, caused the second call to use the same suffix as the first, overwriting the first results.

`calwebb_detector1` is modified to explicitly defines two separate suffixes for the two calls, ensuring that the second does not overwrite the first.