### PR TITLE
enable extract_2d for NRC_TSGRISM in pipeline [#2549]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -163,6 +163,8 @@ pipeline
 
 - Implement specific exit status for "no science on detector" [#2336]
 
+- Enabled `extract_2d` for NRC_TSGRISM [#2460]
+
 ramp_fitting
 ------------
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -220,16 +220,12 @@ class Spec2Pipeline(Pipeline):
         if exp_type in ['NRS_MSASPEC', 'NRS_IFU']:
             input = self.msa_flagging(input)
 
-        # It isn't really necessary to include 'NRC_TSGRISM' in this list,
-        # but it doesn't hurt, and it makes it clear that flat_field
+        # This makes it clear that flat_field
         # should be done before extract_2d for all WFSS/GRISM data.
         if exp_type in ['NRC_WFSS', 'NIS_WFSS', 'NRC_TSGRISM']:
             # Apply flat-field correction
             input = self.flat_field(input)
-
-            if exp_type != 'NRC_TSGRISM':
-                input = self.extract_2d(input)
-
+            input = self.extract_2d(input)
         else:
             # Extract 2D sub-windows for NIRSpec slit and MSA
             if exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_MSASPEC']:


### PR DESCRIPTION
closes #2459

I'm going to open a separate issue for the `grism_objects` discussed there as I see another bug with call flow for `extract_orders`