### PR TITLE
fix extract_2d highlevel call [#2462]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,7 @@ extract_1d
 extract_2d
 ----------
 - NRC_TSGRISM implemented with set source location and extraction options [#1710, #1235]
+- Fixed step calling error for unreferenced attribute [#2463]
 
 firstframe
 ----------

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -12,7 +12,8 @@ log.setLevel(logging.DEBUG)
 
 
 def extract2d(input_model, slit_name=None, apply_wavecorr=False,
-              reference_files={}, grism_objects=None, extract_height=None):
+              reference_files={}, grism_objects=None, extract_height=None,
+              extract_orders=None):
     """
     The main extract_2d function
 
@@ -59,7 +60,7 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False,
             output_model = extract_tso_object(input_model,
                                               reference_files=reference_files,
                                               extract_height=extract_height,
-                                              extract_orders=None)
+                                              extract_orders=extract_orders)
         else:
             output_model = extract_grism_objects(input_model,
                                                  grism_objects=grism_objects,

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -16,8 +16,9 @@ class Extract2dStep(Step):
     spec = """
         slit_name = string(default=None)
         apply_wavecorr = boolean(default=True)
-        grism_objects = list(default=None)
+        extract_orders = list(default=None)
         extract_height =  int(default=None)
+        grism_objects = list(default=None)
     """
 
     reference_file_types = ['wavecorr', 'wavelengthrange']
@@ -31,7 +32,8 @@ class Extract2dStep(Step):
         with datamodels.open(input_model) as dm:
             output_model = extract_2d.extract2d(dm, self.slit_name, self.apply_wavecorr,
                                                 reference_files=reference_file_names,
-                                                grism_objects=grism_objects,
-                                                extract_height=extract_height)
+                                                extract_orders=self.extract_orders,
+                                                grism_objects=self.grism_objects,
+                                                extract_height=self.extract_height)
 
         return output_model


### PR DESCRIPTION
closes #2462 

local testing shows this is a decent fix, using the jwst-edit context with the updated rmap that the step wants for `nrc_tsgrism`. 
```
strun ../data/nircam/extract_2d.cfg ../data/tso_wcs_assigned_test.fits

2018-09-05 14:26:16,265 - stpipe.extract_2d - INFO - Extract2dStep instance created.
2018-09-05 14:26:16,293 - stpipe.extract_2d - INFO - Step extract_2d running with args ('../data/tso_wcs_assigned_test.fits',).
2018-09-05 14:26:23,133 - stpipe.extract_2d - INFO - EXP_TYPE is NRC_TSGRISM
2018-09-05 14:26:23,155 - stpipe.extract_2d - INFO - Using default order extraction from reference file
2018-09-05 14:26:23,230 - stpipe.extract_2d - INFO - xmin, xmax: 647.9255139717636 1845.7302759243282  ymin, ymax: 0 63.0
2018-09-05 14:26:25,774 - stpipe.extract_2d - INFO - WCS made explicit for order: 1
2018-09-05 14:26:25,774 - stpipe.extract_2d - INFO - Trace extents are: (xmin:647, ymin:0), (xmax:1845, ymax:63)
2018-09-05 14:26:25,901 - stpipe.extract_2d - INFO - Finished extractions
2018-09-05 14:26:27,360 - stpipe.extract_2d - INFO - Saved model in tso_wcs_assigned_test_extract_2d.fits
2018-09-05 14:26:27,360 - stpipe.extract_2d - INFO - Step extract_2d done
```