### PR TITLE
Add back in fixture mk_tmp_dirs

### DIFF
--- a/jwst/pipeline/tests/helpers.py
+++ b/jwst/pipeline/tests/helpers.py
@@ -10,6 +10,7 @@ import tempfile
 # simply to make available from this module.
 from ...tests.helpers import (
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
 )
@@ -21,20 +22,6 @@ SCRIPT_DATA_PATH = path.join(SCRIPT_PATH, 'data')
 
 
 @pytest.fixture
-def mk_tmp_dirs():
-    """Setup testing directories"""
-    tmp_current_path = tempfile.mkdtemp()
-    tmp_data_path = tempfile.mkdtemp()
-    tmp_config_path = tempfile.mkdtemp()
-
-    old_path = os.getcwd()
-    try:
-        os.chdir(tmp_current_path)
-        yield (tmp_current_path, tmp_data_path, tmp_config_path)
-    finally:
-        os.chdir(old_path)
-
-
 def update_asn_basedir(asn_file, root=None):
     """Create an association with filenames update
     for a different directory

--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -6,6 +6,7 @@ import pytest
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
 )
 

--- a/jwst/pipeline/tests/test_calwebb_spec2.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2.py
@@ -8,6 +8,7 @@ from shutil import copyfile
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
 )
 
 from ...associations.asn_from_list import asn_from_list

--- a/jwst/pipeline/tests/test_calwebb_spec2_nrs_msa.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2_nrs_msa.py
@@ -7,6 +7,7 @@ from shutil import copy as file_copy
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
 )

--- a/jwst/pipeline/tests/test_calwebb_spec3_mir_lrs_fixedslit.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3_mir_lrs_fixedslit.py
@@ -14,6 +14,7 @@ import pytest
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
     update_asn_basedir,

--- a/jwst/pipeline/tests/test_calwebb_spec3_mir_mrs.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3_mir_mrs.py
@@ -14,6 +14,7 @@ from os import path
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
     update_asn_basedir,

--- a/jwst/pipeline/tests/test_calwebb_spec3_mir_mrs_dither.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3_mir_mrs_dither.py
@@ -12,6 +12,7 @@ from os import path
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
 )

--- a/jwst/pipeline/tests/test_calwebb_spec3_nrs_msa.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3_nrs_msa.py
@@ -8,6 +8,7 @@ from shutil import copy as file_copy
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
 )

--- a/jwst/pipeline/tests/test_nis_ami3.py
+++ b/jwst/pipeline/tests/test_nis_ami3.py
@@ -6,6 +6,7 @@ from os import path
 
 from .helpers import (
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
     update_asn_basedir,

--- a/jwst/pipeline/tests/test_nis_soss_tso3.py
+++ b/jwst/pipeline/tests/test_nis_soss_tso3.py
@@ -7,6 +7,7 @@ from os import path
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
     update_asn_basedir,

--- a/jwst/pipeline/tests/test_nrc_coron3.py
+++ b/jwst/pipeline/tests/test_nrc_coron3.py
@@ -7,6 +7,7 @@ from os import path
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
     update_asn_basedir,

--- a/jwst/pipeline/tests/test_nrc_detector1.py
+++ b/jwst/pipeline/tests/test_nrc_detector1.py
@@ -6,6 +6,7 @@ from os import path
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
 )

--- a/jwst/pipeline/tests/test_nrc_image3.py
+++ b/jwst/pipeline/tests/test_nrc_image3.py
@@ -4,6 +4,7 @@ from os import path
 
 from .helpers import (
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
 )

--- a/jwst/pipeline/tests/test_nrc_tso3.py
+++ b/jwst/pipeline/tests/test_nrc_tso3.py
@@ -8,6 +8,7 @@ from os import path
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
     update_asn_basedir,

--- a/jwst/pipeline/tests/test_nrs_spec2_bright_obj.py
+++ b/jwst/pipeline/tests/test_nrs_spec2_bright_obj.py
@@ -6,6 +6,7 @@ from os import path
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
 )

--- a/jwst/pipeline/tests/test_nrs_tso3.py
+++ b/jwst/pipeline/tests/test_nrs_tso3.py
@@ -6,6 +6,7 @@ from os import path
 
 from .helpers import (
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
     update_asn_basedir,

--- a/jwst/pipeline/tests/test_wfs_combine.py
+++ b/jwst/pipeline/tests/test_wfs_combine.py
@@ -6,6 +6,7 @@ from os import path
 from .helpers import (
     SCRIPT_DATA_PATH,
     abspath,
+    mk_tmp_dirs,
     require_bigdata,
     runslow,
     update_asn_basedir,

--- a/jwst/stpipe/tests/util.py
+++ b/jwst/stpipe/tests/util.py
@@ -38,6 +38,8 @@ import pytest
 import re
 import tempfile
 
+from ...tests.helpers import mk_tmp_dirs
+
 
 class ListHandler(logging.Handler):
     def __init__(self):
@@ -122,20 +124,6 @@ def t_path(partial_path):
     """Construction the full path for test files"""
     test_dir = os.path.dirname(__file__)
     return os.path.join(test_dir, partial_path)
-
-
-@pytest.fixture
-def mk_tmp_dirs():
-    tmp_current_path = tempfile.mkdtemp()
-    tmp_data_path = tempfile.mkdtemp()
-    tmp_config_path = tempfile.mkdtemp()
-
-    old_path = os.getcwd()
-    try:
-        os.chdir(tmp_current_path)
-        yield (tmp_current_path, tmp_data_path, tmp_config_path)
-    finally:
-        os.chdir(old_path)
 
 
 @contextlib.contextmanager

--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -4,6 +4,7 @@ import os
 from os import path
 import pytest
 import re
+import tempfile
 
 import crds
 
@@ -107,3 +108,18 @@ def test_word_precision_check():
     assert word_precision_check(s1, s2, length=1)
     assert not word_precision_check(s2, s3)
     assert word_precision_check(s2, s4, length=2)
+
+
+@pytest.fixture
+def mk_tmp_dirs():
+    """Create a set of temporary directorys and change to one of them."""
+    tmp_current_path = tempfile.mkdtemp()
+    tmp_data_path = tempfile.mkdtemp()
+    tmp_config_path = tempfile.mkdtemp()
+
+    old_path = os.getcwd()
+    try:
+        os.chdir(tmp_current_path)
+        yield (tmp_current_path, tmp_data_path, tmp_config_path)
+    finally:
+        os.chdir(old_path)


### PR DESCRIPTION
At some point in PEP8 fixing, a fixture was removed from a number of tests. They are added back in, so that once #2445 is dealt with, there is consistency during the process.