### PR TITLE
fix for command line extract_2d optional grism inputs [#2466]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,7 @@ extract_2d
 ----------
 - NRC_TSGRISM implemented with set source location and extraction options [#1710, #1235]
 - Fixed step calling error for unreferenced attribute [#2463]
+- Fixed type specification for optional grism mode inputs [#2467]
 
 firstframe
 ----------

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -16,9 +16,9 @@ class Extract2dStep(Step):
     spec = """
         slit_name = string(default=None)
         apply_wavecorr = boolean(default=True)
-        extract_orders = list(default=None)
-        extract_height =  int(default=None)
-        grism_objects = list(default=None)
+        extract_orders = int_list(default=None)  # list of orders to extract
+        extract_height =  integer(default=None)  # extraction height in pixels
+        grism_objects = list(default=None)  # list of grism objects to use
     """
 
     reference_file_types = ['wavecorr', 'wavelengthrange']

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -89,10 +89,15 @@ def extract_tso_object(input_model,
     if extract_orders is None:
         log.info("Using default order extraction from reference file")
         extract_orders = ref_extract_orders
+        available_orders = [x[1] for x in extract_orders if x[0] == input_model.meta.instrument.filter].pop()
     else:
-        raise NotImplementedError("Multiple order extraction for TSO not currently implemented")
+        if not isinstance(extract_orders, list):
+            raise TypeError('Expected extract_orders to be a list of integers')
+        print(extract_orders)
+        available_orders = extract_orders
 
-    available_orders = [x[1] for x in extract_orders if x[0] == input_model.meta.instrument.filter].pop()
+    if len(available_orders) > 1:
+        raise NotImplementedError("Multiple order extraction for TSO not currently implemented")
 
     # team currently wants only a slit model
     # if len(available_orders) > 1:


### PR DESCRIPTION
closes #2466 
* updates the int to integer type spec for extract_height
* fixes type specification for user-override extract_orders

For the `--extract_orders`, this allows the user to specify a list of orders to extract that will be used instead of the default in the reference file. The reference file specifies the orders to be extracted by filter. The override will extract the specified orders for any filter. 

This is currently an option in `NRC_TSGRISM`, the team only wants one order extracted, the reference file specifies the first order, if the user would instead like to extract the second order, the `extract_2d.cfg` file can be updated as such:
```
name = "extract_2d" 
class = "jwst.extract_2d.Extract2dStep"
extract_orders = 2,
```
and order 2 will be extracted for the input model that's specified.  The extraction code will return an error if more than one order is specified (such as `extract_orders = 1,2,`) because it only outputs a `SlitModel` not a `MultiSlitModel`.
```
strun extract_2d_orders.cfg ../tso_wcs_assigned_test.fits

2018-09-05 18:19:35,154 - stpipe.extract_2d - INFO - Extract2dStep instance created.
2018-09-05 18:19:35,179 - stpipe.extract_2d - INFO - Step extract_2d running with args ('../tso_wcs_assigned_test.fits',).
2018-09-05 18:19:39,096 - stpipe.extract_2d - INFO - EXP_TYPE is NRC_TSGRISM
[2]
2018-09-05 18:19:39,184 - stpipe.extract_2d - INFO - xmin, xmax: 1948.0147270747234 2048  ymin, ymax: 0 63.0
2018-09-05 18:19:39,575 - stpipe.extract_2d - INFO - WCS made explicit for order: 2
2018-09-05 18:19:39,575 - stpipe.extract_2d - INFO - Trace extents are: (xmin:1948, ymin:0), (xmax:2048, ymax:63)
2018-09-05 18:19:39,692 - stpipe.extract_2d - INFO - Finished extractions
2018-09-05 18:19:40,975 - stpipe.extract_2d - INFO - Saved model in tso_wcs_assigned_test_extract_2d.fits
2018-09-05 18:19:40,975 - stpipe.extract_2d - INFO - Step extract_2d done
```
These are the default results:
```
(jwstdev) bash-3.2$ strun extract_2d.cfg ../tso_wcs_assigned_test.fits 
2018-09-05 18:30:54,643 - stpipe.extract_2d - INFO - Extract2dStep instance created.
2018-09-05 18:30:54,673 - stpipe.extract_2d - INFO - Step extract_2d running with args ('../tso_wcs_assigned_test.fits',).
2018-09-05 18:30:58,698 - stpipe.extract_2d - INFO - EXP_TYPE is NRC_TSGRISM
2018-09-05 18:30:58,719 - stpipe.extract_2d - INFO - Using default order extraction from reference file
2018-09-05 18:30:58,791 - stpipe.extract_2d - INFO - xmin, xmax: 647.9255139717636 1845.7302759243282  ymin, ymax: 0 63.0
2018-09-05 18:30:59,211 - stpipe.extract_2d - INFO - WCS made explicit for order: 1
2018-09-05 18:30:59,211 - stpipe.extract_2d - INFO - Trace extents are: (xmin:647, ymin:0), (xmax:1845, ymax:63)
2018-09-05 18:30:59,326 - stpipe.extract_2d - INFO - Finished extractions
2018-09-05 18:31:00,760 - stpipe.extract_2d - INFO - Saved model in tso_wcs_assigned_test_extract_2d.fits
2018-09-05 18:31:00,760 - stpipe.extract_2d - INFO - Step extract_2d done
```
However, I'm not sure how this would work purely on the command line because these return type errors:
```
571  strun extract_2d.cfg ../tso_wcs_assigned_test.fits --extract_orders=2,
572  strun extract_2d.cfg ../tso_wcs_assigned_test.fits --extract_orders=2
573  strun extract_2d.cfg ../tso_wcs_assigned_test.fits --extract_orders="2,"
574  strun extract_2d.cfg ../tso_wcs_assigned_test.fits --extract_orders=[2,]
575  strun extract_2d.cfg ../tso_wcs_assigned_test.fits --extract_orders=[2]
576  strun extract_2d.cfg ../tso_wcs_assigned_test.fits --extract_orders=2
```
@nden @stscieisenhamer  is there a way you know to specify list optionals, what have I missed?

~~This also only affects this specific entry, anyone can pass `extract_2d.extract2()` the filter specified list and everything works.~~ on second thought, yah, this makes all input for the optional `extract_orders` be a list of ints, which is different than the reference file container, but I think that's okay here since the function only takes one input_model, and the reference file is meant to cover all available options.