### PR TITLE
A new script to add or remove filenames from an association file

### DIFF
--- a/jwst/associations/asn_edit.py
+++ b/jwst/associations/asn_edit.py
@@ -196,8 +196,9 @@ def _lookup(asn, filename, ignore_suffix=False):
     found = []
     path = _path(filename)
     basename = op.basename(path)
+    (root, ext) = op.splitext(basename)
     if ignore_suffix:
-        search_key, separator = suffix.remove_suffix(basename)
+        search_key, separator = suffix.remove_suffix(root)
     else:
         search_key = basename
 
@@ -206,8 +207,11 @@ def _lookup(asn, filename, ignore_suffix=False):
             expname = member.get('expname')
             if expname:
                 if ignore_suffix:
-                    expname, separator = suffix.remove_suffix(expname)
-                if search_key == expname:
+                    (root, ext) = op.splitext(expname)
+                    match_key, separator = suffix.remove_suffix(root)
+                else:
+                    match_key = expname
+                if search_key == match_key:
                     found.append((i, j))
 
     return found

--- a/jwst/associations/asn_edit.py
+++ b/jwst/associations/asn_edit.py
@@ -1,0 +1,237 @@
+import os
+import sys
+import json
+import os.path as op
+
+from ..lib import suffix
+from . import Association, AssociationNotValidError
+
+#-----------------------------------------------------------------------
+# Externally callable functions
+
+def add(asn, filenames, exptype):
+    """
+    Add new filenames to association
+
+    Parameters
+    ----------
+    asn: object
+        An association object
+
+    filenames: list of str
+        The filenames to be added to the association
+
+    exptype: str
+        The exposure type of the filenames to be added
+
+
+    Returns
+    -------
+    The modified association object
+
+
+    Raises
+    ------
+    ValueError
+        If a filename to be added was not found in the filesystem
+
+
+     """
+    not_found = []
+    for filename in filenames:
+        path = _path(filename)
+        if not op.exists(path):
+            not_found.append(filename)
+
+    if len(not_found) > 0:
+        filename = ','.join(not_found)
+        raise ValueError("Filenames not found: " + filename)
+
+    for filename in filenames:
+        path = _path(filename)
+        expname = op.basename(path)
+        member = {'expname': expname, 'exptype': exptype}
+
+        for product in asn['products']:
+            product['members'].append(member)
+
+    return asn
+
+
+def reader(association_file):
+    """
+    Read the association file or die trying
+
+    Parameters
+    ----------
+    association_file: str
+        An association filename
+
+
+    Returns
+    -------
+    The association object
+
+
+    Raises
+    ------
+    IOError
+        An error occurred when reading the association file
+
+
+    """
+    association_path = _path(association_file)
+    asn_format = association_path.split('.')[-1]
+    if asn_format != 'json':
+        raise IOError("This is not an association file: " +
+                       association_file)
+    try:
+        with open(association_path) as fd:
+            serialized = fd.read()
+            asn = Association.load(serialized, format=asn_format)
+    except AssociationNotValidError:
+        raise IOError("Cannot read association file: " +
+                       association_file)
+    return asn
+
+
+def remove(asn, filenames, ignore):
+    """
+    Remove the named files from the association
+
+    Parameters
+    ----------
+    asn: object
+        An association object
+
+    filenames: list of str
+        The filenames to be removed the association
+
+    ignore: bool
+        Ignore the filename suffix when matching filenames?
+
+
+    Returns
+    -------
+    The modified association object
+
+
+    Raises
+    ------
+    ValueError
+        If a filename to be removed was not found in the association
+
+
+    """
+    not_found = []
+    for filename in filenames:
+        found = _lookup(asn, filename, ignore_suffix=ignore)
+
+        if len(found) == 0:
+            not_found.append(filename)
+        else:
+            for i, j in found[::-1]:
+                del asn['products'][i]['members'][j]
+                if len(asn['products'][i]['members']) == 0:
+                    del asn['products'][i]
+
+
+    if len(not_found) > 0:
+        filename = ','.join(not_found)
+        raise ValueError("Filenames not found: " + filename)
+
+    return asn
+
+
+def writer(asn, output_file):
+    """
+    Write the association out to disk
+
+    Parameters
+    ----------
+    asn: object
+        An association object
+
+    output_file: str
+        The filename of the association
+
+    Raises
+    ------
+    ValueError
+        The output filename was not a json file
+
+
+    """
+
+    asn_format = output_file.split('.')[-1]
+    if asn_format != 'json':
+        raise ValueError('Only json format supported for output: ' +
+                         output_file)
+
+    serialized = json.dumps(asn, indent=4, separators=(',', ': '))
+
+    in_place = op.exists(output_file)
+    if in_place:
+        temp_file = _rename(output_file)
+
+    try:
+        fd = open(output_file, 'w')
+        fd.write(serialized)
+        fd.close()
+    except:
+        if in_place:
+            os.rename(temp_file, output_file)
+        raise
+    if in_place:
+        os.remove(temp_file)
+
+#-----------------------------------------------------------------------
+# Internal functions
+
+def _lookup(asn, filename, ignore_suffix=False):
+    """
+    Look up the locations a file is found in an association
+    """
+
+    found = []
+    path = _path(filename)
+    basename = op.basename(path)
+    if ignore_suffix:
+        search_key, separator = suffix.remove_suffix(basename)
+    else:
+        search_key = basename
+
+    for i, product in enumerate(asn['products']):
+        for j, member in  enumerate(product['members']):
+            expname = member.get('expname')
+            if expname:
+                if ignore_suffix:
+                    expname, separator = suffix.remove_suffix(expname)
+                if search_key == expname:
+                    found.append((i, j))
+
+    return found
+
+
+def _path(filename):
+    """
+    Command line filename processing
+    """
+
+    return op.abspath(op.expanduser(op.expandvars(filename)))
+
+
+def _rename(output_file):
+    """
+    Rename output file to prevent overwriting
+    """
+
+    trial = 0
+    while 1:
+        trial += 1
+        temp_file = "%s.sv%02d" % (output_file, trial)
+        if not op.exists(temp_file):
+            os.rename(output_file, temp_file)
+            return temp_file
+
+

--- a/jwst/associations/asn_edit.py
+++ b/jwst/associations/asn_edit.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import warnings
 import os.path as op
 
 from ..lib import suffix
@@ -8,6 +9,9 @@ from . import Association, AssociationNotValidError
 
 #-----------------------------------------------------------------------
 # Externally callable functions
+
+class AsnFileWarning(Warning):
+    pass
 
 def add(asn, filenames, exptype):
     """
@@ -37,16 +41,6 @@ def add(asn, filenames, exptype):
 
 
      """
-    not_found = []
-    for filename in filenames:
-        path = _path(filename)
-        if not op.exists(path):
-            not_found.append(filename)
-
-    if len(not_found) > 0:
-        filename = ','.join(not_found)
-        raise ValueError("Filenames not found: " + filename)
-
     for filename in filenames:
         path = _path(filename)
         expname = op.basename(path)
@@ -137,8 +131,8 @@ def remove(asn, filenames, ignore):
 
 
     if len(not_found) > 0:
-        filename = ','.join(not_found)
-        raise ValueError("Filenames not found: " + filename)
+        errmsg = "Filenames not found: " + ','.join(not_found)
+        warnings.warn(errmsg, AsnFileWarning)
 
     return asn
 

--- a/jwst/associations/tests/test_asn_edit.py
+++ b/jwst/associations/tests/test_asn_edit.py
@@ -1,0 +1,66 @@
+import os
+import tempfile
+import os.path as op
+from glob import glob
+from shutil import copyfile, rmtree
+
+from .. import asn_edit
+
+
+ROOT_DIR = None
+DATA_DIR = None
+TMP_DIR = None
+JSON_FILE = None
+TMP_FITS = None
+TMP_FITS2 = None
+TMP_JSON = None
+
+def setup():
+    global ROOT_DIR, DATA_DIR, TMP_DIR, JSON_FILE
+    global TMP_FITS, TMP_FITS2, TMP_JSON, TMP_JSON2
+    ROOT_DIR = op.abspath(op.dirname(__file__))
+    DATA_DIR = op.join(ROOT_DIR, 'data')
+    TMP_DIR = tempfile.mkdtemp()
+
+    JSON_FILE = os.path.join(DATA_DIR, 'asn_level2.json')
+    TMP_FITS = os.path.join(TMP_DIR, 'test_lrs1_rate.fits')
+    TMP_FITS2 = os.path.join(TMP_DIR, 'test_lrs5_rate.fits')
+    TMP_JSON = os.path.join(TMP_DIR, 'asn_level2.json')
+
+    copyfile(JSON_FILE, TMP_JSON)
+    for fname in (TMP_FITS, TMP_FITS2):
+        with open(fname, 'a'):
+            os.utime(fname)
+    os.chdir(TMP_DIR)
+
+
+def teardown():
+    os.chdir(ROOT_DIR)
+    rmtree(TMP_DIR)
+
+
+def test_add_asn():
+    cmd = ["-a", TMP_JSON, TMP_FITS2]
+    asn = asn_edit.reader(TMP_JSON)
+    asn = asn_edit.add(asn, [TMP_FITS2], "science")
+
+    nproducts = len(asn['products'])
+    assert nproducts == 6, "Add a file"
+    found = asn_edit._lookup(asn, "test_lrs5_rate.fits")
+    assert len(found) == nproducts, "Add a file"
+
+
+def test_remove_asn():
+    for ignore in (False, True):
+        asn = asn_edit.reader(TMP_JSON)
+        asn = asn_edit.remove(asn, [TMP_FITS], ignore)
+
+        assert len(asn['products']) == 5, "Remove a file"
+        found = asn_edit._lookup(asn, "test_lrs1_rate.fits")
+        assert len(found) == 0, "Remove a file"
+
+
+for test_function in (test_add_asn, test_remove_asn):
+    setup()
+    test_function()
+    teardown()

--- a/scripts/asn_edit
+++ b/scripts/asn_edit
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import argparse
+from ..associations import asn_edit
+
+def main():
+    """
+    Parse command line, read, edit, write association file
+    """
+
+    # Parse command line arguments
+    description_text = \
+    """
+Edit Association File
+
+This script adds or removes filenames from an association file. The
+first argument is the name of the association file. Subsequent
+arguments are the filenames. Options determine which operation is
+perdormed: --add or --remove. If adding files the --type option sets
+the exposure type for the new files. If removing file, the --ignore
+option will not use the filename suffix when matching the filenames for
+removal. Normally the output association file is the same as the input.
+The --output option allows you to set a different filename. All options
+can be abbreviated to their first letter.
+
+When adding files to an association, the file must exist on the disk.
+When removing files, the filename must be found in the association. If
+not, no change will be made to the file.
+    """
+    parser = argparse.ArgumentParser(description=description_text,
+                formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    arg_group = parser.add_mutually_exclusive_group()
+    arg_group.add_argument('-a', '--add', action='store_true',
+                           help= 'Add files to association')
+    arg_group.add_argument('-r', '--remove', action='store_true',
+                           help= 'Remove files to association')
+
+    parser.add_argument('-t', '--type', default='science',
+                        help='Exptype, if adding filenames')
+    parser.add_argument('-i', '--ignore', action='store_true',
+                        help='Ignore suffix on filename when matching')
+
+    parser.add_argument('-o', '--output',
+                        help='Output association name if different than input')
+
+    parser.add_argument('association', help="The association file name")
+
+    parser.add_argument('filenames', nargs="+", help="The filenames to process")
+
+    args = parser.parse_args()
+
+    # Read the association into memory
+    asn = asn_edit.reader(args.association)
+
+    # Either add or remove filenames
+    if args.add:
+        asn_edit.add(asn, args.filenames, args.type)
+    elif args.remove:
+        asn_edit.remove(asn, args.filenames, args.ignore)
+
+    # Write the edited file out again
+    if args.output:
+        output_file = args.output
+    else:
+        output_file = args.association
+    asn_edit.writer(asn, output_file)
+
+main()

--- a/scripts/asn_edit
+++ b/scripts/asn_edit
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-from ..associations import asn_edit
+from jwst.associations import asn_edit
 
 def main():
     """


### PR DESCRIPTION
This update adds a new command line script, supporting code in the associations directory, and tests to add or remove filenames from an association file. Only json format association files are supported.