### PR TITLE
compute the NRS IFU footprint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ assign_wcs
 - The bounding box for Nirspec WCS objects was modified to include the
   edges of the pixels. [#2491]
   
+- Updated assign_wcs to compute the sky footprint of MIRI MRS and Nirspec
+  IFU observations. [#2472]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -1,7 +1,8 @@
 import logging
 import importlib
 from gwcs.wcs import WCS
-from .util import update_s_region_spectral, update_s_region_imaging
+from .util import (update_s_region_spectral, update_s_region_imaging,
+                   update_s_region_nrs_ifu)
 from ..associations.lib.dms_base import (ACQ_EXP_TYPES, IMAGE2_SCIENCE_EXP_TYPES,
                                          IMAGE2_NONSCIENCE_EXP_TYPES,
                                          SPEC2_SCIENCE_EXP_TYPES)
@@ -63,7 +64,7 @@ def load_wcs(input_model, reference_files={}):
         output_model.meta.wcs = wcs
         output_model.meta.cal_step.assign_wcs = 'COMPLETE'
         exclude_types = ['nrc_wfss', 'nrc_tsgrism', 'nis_wfss',
-                         'nrs_fixedslit', 'nrs_ifu', 'nrs_msaspec',
+                         'nrs_fixedslit', 'nrs_msaspec',
                          'nrs_autowave', 'nrs_autoflat', 'nrs_lamp',
                          'nrs_brightobj', 'mir_lrs-fixedslit', 'mir_lrs-slitless',
                          'mir_mrs', 'nis_soss']
@@ -78,6 +79,8 @@ def load_wcs(input_model, reference_files={}):
                 else:
                     log.info("assign_wcs updated S_REGION to {0}".format(
                         output_model.meta.wcsinfo.s_region))
+            elif  output_model.meta.exposure.type.lower() == "nrs_ifu":
+                update_s_region_nrs_ifu(output_model, mod)
             else:
                 try:
                     update_s_region_spectral(output_model)

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -2,7 +2,7 @@ import logging
 import importlib
 from gwcs.wcs import WCS
 from .util import (update_s_region_spectral, update_s_region_imaging,
-                   update_s_region_nrs_ifu)
+                   update_s_region_nrs_ifu, update_s_region_mrs)
 from ..associations.lib.dms_base import (ACQ_EXP_TYPES, IMAGE2_SCIENCE_EXP_TYPES,
                                          IMAGE2_NONSCIENCE_EXP_TYPES,
                                          SPEC2_SCIENCE_EXP_TYPES)
@@ -67,7 +67,7 @@ def load_wcs(input_model, reference_files={}):
                          'nrs_fixedslit', 'nrs_msaspec',
                          'nrs_autowave', 'nrs_autoflat', 'nrs_lamp',
                          'nrs_brightobj', 'mir_lrs-fixedslit', 'mir_lrs-slitless',
-                         'mir_mrs', 'nis_soss']
+                         'nis_soss']
 
         if output_model.meta.exposure.type.lower() not in exclude_types:
             if output_model.meta.exposure.type.lower() in IMAGING_TYPES:
@@ -81,6 +81,8 @@ def load_wcs(input_model, reference_files={}):
                         output_model.meta.wcsinfo.s_region))
             elif  output_model.meta.exposure.type.lower() == "nrs_ifu":
                 update_s_region_nrs_ifu(output_model, mod)
+            elif output_model.meta.exposure.type.lower() == 'mir_mrs':
+                update_s_region_mrs(output_model)
             else:
                 try:
                     update_s_region_spectral(output_model)

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -636,6 +636,33 @@ def update_s_region_keyword(model, footprint):
         log.info("Update S_REGION to {}".format(model.meta.wcsinfo.s_region))
 
 
+def update_s_region_nrs_ifu(output_model, mod):
+    """
+    Update S_REGION for NRS_IFU observations using the instrument model.
+
+    Parameters
+    ----------
+    output_model : `~jwst.datamodels.IFUImageModel`
+        The output of assign_wcs.
+    mod : module
+        The imported ``nirspec`` module.
+    """
+    wcs_list = mod.nrs_ifu_wcs(output_model)
+    ra_total = []
+    dec_total = []
+    for wcs in wcs_list:
+        x, y = grid_from_bounding_box(wcs.bounding_box)
+        ra, dec, lam = wcs(x, y)
+        ra_total.append((np.nanmax(ra), np.nanmin(ra)))
+        dec_total.append((np.nanmax(dec), np.nanmin(dec)))
+    ra_max = np.asarray(ra_total)[:,0].max()
+    ra_min = np.asarray(ra_total)[:,1].min()
+    dec_max = np.asarray(dec_total)[:,0].max()
+    dec_min = np.asarray(dec_total)[:,0].min()
+    footprint = np.array([ra_min, dec_min, ra_max, dec_min, ra_max, dec_max, ra_min, dec_max])
+    update_s_region_keyword(output_model, footprint)
+
+    
 def velocity_correction(velosys):
     """
     Compute wavelength correction to Barycentric reference frame.


### PR DESCRIPTION
This PR adds the computation of the footprint of the entire Nirspec IFU on the sky. Previously the footprint was not computed in assign_wcs. Instead the one computed based on the SIAF model was kept.  The motivation of recomputing it here is to decrease the computational time in `cube_build`. Of course this would not have much effect on the calspec2 pipeline. It takes ~30 sec to compute it so it adds considerable time to cube_build when many observations are processed.
The wavelength range can be used as a spectral footprint. It can be obtained from
`model.meta.wcsinfo.wave_start` and `model.meta.wcsinfo.wave_end`.
@jemorrison

This doesn't need to go in 0.11.