### PR TITLE
Mark xfail 3 NIRSpec regression tests [ci skip]

### DIFF
--- a/jwst/tests_nightly/general/nirspec/test_spec2.py
+++ b/jwst/tests_nightly/general/nirspec/test_spec2.py
@@ -15,6 +15,10 @@ pytestmark = [
 ]
 
 
+@pytest.mark.xfail(
+    reason='Input data not available',
+    run=False
+)
 def test_nrs2_nodata_api(_bigdata):
     """
 
@@ -33,6 +37,10 @@ def test_nrs2_nodata_api(_bigdata):
         ))
 
 
+@pytest.mark.xfail(
+    reason='Input data not available',
+    run=False
+)
 def test_nrs2_nodata_strun(_bigdata):
     """Ensure that the appropriate exit status is returned from strun"""
 

--- a/jwst/tests_nightly/general/pipelines/test_nirspec_fs_spec3.py
+++ b/jwst/tests_nightly/general/pipelines/test_nirspec_fs_spec3.py
@@ -17,6 +17,10 @@ pytestmark = [
 ]
 
 
+@pytest.mark.xfail(
+    reason='Input data not available',
+    run=False
+)
 def test_save_source_only(_bigdata):
     """Test saving the source-based files only"""
     datapath = path.join(


### PR DESCRIPTION
These tests are marked as xfail since the input data is not yet available for them.

Once data is available, they should be enabled.