### PR TITLE
Remove warning message when opening a model from a shape or array

### DIFF
--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -66,6 +66,7 @@ def test_broadcast2():
 
 def test_from_hdulist():
     from astropy.io import fits
+    warnings.simplefilter("ignore")
     with fits.open(FITS_FILE) as hdulist:
         with open_model(hdulist) as dm:
             dm.data
@@ -127,6 +128,7 @@ def test_open():
     with open_model((50, 50)) as dm:
         pass
 
+    warnings.simplefilter("ignore")
     with open_model(FITS_FILE) as dm:
         assert isinstance(dm, QuadModel)
 
@@ -375,6 +377,7 @@ def test_image_with_extra_keyword_to_multislit():
 
 @pytest.fixture(scope="module")
 def container():
+    warnings.simplefilter("ignore")
     with ModelContainer(ASN_FILE, persist=True) as c:
         for m in c:
             m.meta.observation.program_number = '0001'
@@ -444,6 +447,7 @@ def test_hasattr():
     assert not has_filename, "Check that filename does not exist"
 
 def test_info():
+    warnings.simplefilter("ignore")
     with open_model(FITS_FILE) as model:
         info = model.info()
     matches = 0

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -4,6 +4,7 @@ Test datamodel.open
 
 import os
 import os.path
+import warnings
 
 import pytest
 import numpy as np
@@ -18,6 +19,7 @@ from .. import (DataModel, ModelContainer, ImageModel, ReferenceFileModel,
 def test_open_fits():
     """Test opening a model from a FITS file"""
 
+    warnings.simplefilter("ignore")
     fits_file = t_path('test.fits')
     m = open(fits_file)
     assert isinstance(m, DataModel)
@@ -53,6 +55,7 @@ def test_open_hdulist():
     model.close()
 
 def test_open_image():
+    warnings.simplefilter("ignore")
     image_name = t_path('jwst_image.fits')
     model = open(image_name)
     assert type(model) == ImageModel
@@ -65,7 +68,8 @@ def test_open_reference_files():
              'nircam_photom.fits' : NircamPhotomModel,
              'nircam_gain.fits' : GainModel,
              'nircam_readnoise.fits' : ReadnoiseModel}
-    
+
+    warnings.simplefilter("ignore")
     for base_name, klass in files.items():
         file = t_path(base_name)
         model = open(file)
@@ -73,7 +77,7 @@ def test_open_reference_files():
             ndim = len(model.shape)
         else:
             ndim = 0
-            
+
         if ndim == 0:
             my_klass = ReferenceFileModel
         elif ndim == 2:
@@ -84,10 +88,10 @@ def test_open_reference_files():
             my_klass = ReferenceQuadModel
         else:
             my_klass = None
-            
+
         assert isinstance(model, my_klass)
         model.close()
-        
+
         model = klass(file)
         assert isinstance(model, klass)
         model.close()

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -112,6 +112,9 @@ def open(init=None, extensions=None, **kwargs):
     if hdulist:
         # So we don't need to open the image twice
         init = hdulist
+        info = init.fileinfo(0)
+        if info is not None:
+            file_name = info.get('filename')
 
         try:
             hdu = hdulist[('SCI', 1)]
@@ -157,10 +160,7 @@ def open(init=None, extensions=None, **kwargs):
         if file_name:
             errmsg = \
                 "model_type not found. Opening {} as a {}".format(file_name, class_name)
-        else:
-            errmsg = \
-                "model_type not found. Opening model as a {}".format(class_name)
-        warnings.warn(errmsg, NoTypeWarning)
+            warnings.warn(errmsg, NoTypeWarning)
 
         try:
             delattr(model.meta, 'model_type')


### PR DESCRIPTION
Datamodels currently issues a warning message when a new model is opened if that model does not have a DATAMODL header keyword. The code will issue this message even when a model is created from scratch using a shape or numpy array. This update only issues a warning message if the
datamodel is opened from a file or hdu with an associated file.

It also suppresses several warning messages in tests about the missing DATAMODL header keyword.