### PR TITLE
Sanitize GWA_TTIL keyword for NIRSpec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,8 @@ firstframe
 fits_generator
 --------------
 
+- NIRSpec data now automatically sanitizes the GWA_TILT keyword. [#2494]
+
 
 flatfield
 ---------

--- a/jwst/fits_generator/create_dms_data.py
+++ b/jwst/fits_generator/create_dms_data.py
@@ -369,8 +369,10 @@ def flip_rotate(input_hdulist):
         slowaxis = 1
         gwaxtilt = sanitize(header, 'GWA_XTIL', type=float)
         gwaytilt = sanitize(header, 'GWA_YTIL', type=float)
+        gwa_tilt = sanitize(header, 'GWA_TTIL', type=float)
         header['GWA_XTIL'] = gwaxtilt
         header['GWA_YTIL'] = gwaytilt
+        header['GWA_TTIL'] = gwa_tilt
     elif sca == 492:
         #
         # NIRSpec NRS2
@@ -426,8 +428,10 @@ def flip_rotate(input_hdulist):
         slowaxis = -1
         gwaxtilt = sanitize(header, 'GWA_XTIL', type=float)
         gwaytilt = sanitize(header, 'GWA_YTIL', type=float)
+        gwa_tilt = sanitize(header, 'GWA_TTIL', type=float)
         header['GWA_XTIL'] = gwaxtilt
         header['GWA_YTIL'] = gwaytilt
+        header['GWA_TTIL'] = gwa_tilt
     elif sca == 496:
         #
         # TFI/NIRISS is like NRS2: flipped across the line X=Y and then


### PR DESCRIPTION
The GWA_TTIL keyword should be sanitized along with the GWA_XTIL and GWA_YTIL keywords, so that the datamodel doesn't throw a validation error.

Resolves #2493.