### PR TITLE
Make tweakreg source detection threshold higher

### DIFF
--- a/jwst/pipeline/calwebb_image3.cfg
+++ b/jwst/pipeline/calwebb_image3.cfg
@@ -4,7 +4,6 @@ class = "jwst.pipeline.Image3Pipeline"
     [steps]
       [[tweakreg]]
         config_file = tweakreg.cfg
-        skip = True
       [[skymatch]]
         config_file = skymatch.cfg
       [[outlier_detection]]

--- a/jwst/pipeline/tweakreg.cfg
+++ b/jwst/pipeline/tweakreg.cfg
@@ -3,9 +3,9 @@ class = "jwst.tweakreg.TweakRegStep"
 
 save_catalogs = False
 catalog_format = 'ecsv'
-kernel_fwhm = 2.
-snr_threshold = 3.
-enforce_user_order = True
+kernel_fwhm = 2.5
+snr_threshold = 10.
+enforce_user_order = False
 expand_refcat = False
 minobj = 15
 searchrad = 1.0

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -1,9 +1,7 @@
-#! /usr/bin/env python
 """
 JWST pipeline step for image alignment.
 
 :Authors: Mihai Cara
-
 
 """
 from astropy.table import Table
@@ -31,7 +29,7 @@ class TweakRegStep(Step):
         save_catalogs = boolean(default=False) # Write out catalogs?
         catalog_format = string(default='ecsv')   # Catalog output file format
         kernel_fwhm = float(default=2.5)    # Gaussian kernel FWHM in pixels
-        snr_threshold = float(default=5.0)  # SNR threshold above the bkg
+        snr_threshold = float(default=10.0)  # SNR threshold above the bkg
 
         # Optimize alignment order:
         enforce_user_order = boolean(default=False) # Align images in user specified order?
@@ -41,7 +39,7 @@ class TweakRegStep(Step):
 
         # Object matching parameters:
         minobj = integer(default=15) # Minimum number of objects acceptable for matching
-        searchrad = float(default=10.0) # The search radius in arcsec for a match
+        searchrad = float(default=1.0) # The search radius in arcsec for a match
         use2dhist = boolean(default=True) # Use 2d histogram to find initial offset?
         separation = float(default=0.5) # Minimum object separation in arcsec
         tolerance = float(default=1.0) # Matching tolerance for xyxymatch in arcsec


### PR DESCRIPTION
The low source detection threshold SNR of 3.0 was causing spurious detections in `tweakreg`.  Many spurious sources would be detected and an incorrect alignment was computed.  Better to err on the side of caution and have a high detection threshold of 10.  If there are too few sources found at this higher detection threshold, then the step is skipped, which I believe is a desirable default for pipeline use.

Also made consistent between the .cfg and default spec the parameters
```
enforce_user_order = True
kernel_fwhm = 2.5
searchrad = 1.0
```
Could reviewer(s) confirm that these are reasonable defaults?  The point is to have them be consistent between the default config and the default spec.

Finally, `tweakreg` has been off in our default configuration for a long time.  Time turn turn it back on.

Resolves #2489.