### PR TITLE
PEP8 cleanup of jump step

### DIFF
--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -76,8 +76,8 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     log.info('Executing two-point difference method')
     start = time.time()
 
-    median_slopes = twopt.find_CRs( data, gdq, readnoise_2d,
-                                    rejection_threshold, nframes)
+    median_slopes = twopt.find_crs(data, gdq, readnoise_2d,
+                                           rejection_threshold, nframes)
 
     elapsed = time.time() - start
     log.debug('Elapsed time = %g sec' %elapsed)
@@ -93,8 +93,8 @@ def detect_jumps (input_model, gain_model, readnoise_model,
         # Now apply the y-intercept method
         log.info('Executing yintercept method')
         start = time.time()
-        yint.find_CRs( data, err, gdq, times, readnoise_2d,
-                       rejection_threshold, signal_threshold, median_slopes)
+        yint.find_crs(data, err, gdq, times, readnoise_2d,
+                        rejection_threshold, signal_threshold, median_slopes)
         elapsed = time.time() - start
         log.debug('Elapsed time = %g sec' %elapsed)
 

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -1,39 +1,40 @@
-from jwst.jump.twopoint_difference import find_CRs
-import numpy as np
 import pytest
+import numpy as np
+
+from jwst.jump.twopoint_difference import find_crs
 from jwst.datamodels import dqflags
 
-#@pytest.mark.skip(reason="testing skipping")
-def test_noCRs_NoFlux():
-    ngroups=5
-    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
-    assert(0 == np.max(find_CRs(data,gdq,read_noise,rej_threshold,nframes))) # no CR found
 
-#@pytest.mark.skip
-def test_5grps_cr3_NoFlux():
-    ngroups=5
+def test_nocrs_noflux(setup_cube):
+    ngroups = 5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    assert(0 == np.max(find_crs(data, gdq, read_noise, rej_threshold, nframes))) # no CR found
+
+
+def test_5grps_cr3_noflux(setup_cube):
+    ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
 
     data[0, 0:2, 100, 100] = 10.0
     data[0, 2:5, 100, 100] = 1000
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq)) #a CR was found
     assert(2 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
 
-#@pytest.mark.skip("testing skipping")
-def test_5grps_cr2_NoFlux():
-    ngroups=5
+
+def test_5grps_cr2_noflux(setup_cube):
+    ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
 
     data[0, 0, 100, 100] = 10.0
     data[0, 1:6, 100, 100] = 1000
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq)) #a CR was found
     assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
 
-##@pytest.mark.skip("testing skipping")
-def test_6grps_negative_differences_zeromedian():
-    ngroups=6
+
+def test_6grps_negative_differences_zeromedian(setup_cube):
+    ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
 
     data[0, 0, 100, 100] = 100
@@ -42,52 +43,50 @@ def test_6grps_negative_differences_zeromedian():
     data[0, 3, 100, 100] = 105
     data[0, 4, 100, 100] = 100
     data[0, 5, 100, 100] = 100
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print('shape '+str(medianDiff.shape))
-    print('median differences of 100,100 '+str(medianDiff[0,100,100]))
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print('shape '+str(median_diff.shape))
+    print('median differences of 100,100 '+str(median_diff[0,100,100]))
     assert(0 == np.max(gdq)) #no CR was found
-    assert(0 == medianDiff[0,100,100]) #Median difference is zero
+    assert(0 == median_diff[0,100,100]) #Median difference is zero
 
 
-#@pytest.mark.skip("testing skipping")
-def test_5grps_cr2_NegJumpFlux():
-    ngroups=5
+def test_5grps_cr2_negjumpflux(setup_cube):
+    ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
 
     data[0, 0, 100, 100] = 1000.0
     data[0, 1:6, 100, 100] = 10
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq)) #a CR was found
     assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
 
-#@pytest.mark.skip("testing skipping")
-def test_3grps_cr2_NoFlux():
-    ngroups=3
+
+def test_3grps_cr2_noflux(setup_cube):
+    ngroups = 3
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     data[0, 0, 100, 100] = 10.0
     data[0, 1:4, 100, 100] = 1000
     print("test data "+repr(data[0,:,100,100]))
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     print(repr(gdq[0, :, 100, 100]))
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(4 == np.max(gdq)) #a CR was found
     #    assert(1,np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
     assert(np.array_equal([0, 4, 0], gdq[0, :, 100, 100]))
 
 
-##@pytest.mark.xfail("testing skipping")
-def test_4grps_cr2_NoFlux():
-    ngroups=4
+def test_4grps_cr2_noflux(setup_cube):
+    ngroups = 4
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     data[0, 0, 100, 100] = 10.0
     data[0, 1:4, 100, 100] = 1000
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq)) #a CR was found
     assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
 
-#@pytest.mark.skip("testing skipping")
-def test_5grps_cr2_nframe2():
-    ngroups=5
+
+def test_5grps_cr2_nframe2(setup_cube):
+    ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes=2
     data[0, 0, 100, 100] = 10.0
@@ -95,30 +94,31 @@ def test_5grps_cr2_nframe2():
     data[0, 2, 100, 100] = 1002
     data[0, 3, 100, 100] = 1001
     data[0, 4, 100, 100] = 1005
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     print(repr(gdq[0, :, 100, 100]))
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,4,0,0], gdq[0, :, 100, 100]) )
 
+
 @pytest.mark.xfail
-def test_4grps_twocrs_2nd_4th():
-    ngroups=4
+def test_4grps_twocrs_2nd_4th(setup_cube):
+    ngroups = 4
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes=1
     data[0, 0, 100, 100] = 10.0
     data[0, 1, 100, 100] = 60
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     print(repr(gdq[0, :, 100, 100]))
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,0,4] , gdq[0, :, 100, 100]) )
 
-#@pytest.mark.skip("testing skipping")
-def test_5grps_twocrs_2nd_5th():
-    ngroups=5
+
+def test_5grps_twocrs_2nd_5th(setup_cube):
+    ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes=1
     data[0, 0, 100, 100] = 10.0
@@ -126,14 +126,14 @@ def test_5grps_twocrs_2nd_5th():
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4] ,gdq[0, :, 100, 100]) )
 
-#@pytest.mark.skip("testing skipping")
-def test_5grps_twocrs_2nd_5thbig():
-    ngroups=5
+
+def test_5grps_twocrs_2nd_5thbig(setup_cube):
+    ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes=1
     data[0, 0, 100, 100] = 10.0
@@ -141,14 +141,14 @@ def test_5grps_twocrs_2nd_5thbig():
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 2115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4] , gdq[0, :, 100, 100]) )
 
-#@pytest.mark.skip("testing skipping")
-def test_10grps_twocrs_2nd_8th_big():
-    ngroups=10
+
+def test_10grps_twocrs_2nd_8th_big(setup_cube):
+    ngroups = 10
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes=1
     data[0, 0, 100, 100] = 10.0
@@ -161,14 +161,14 @@ def test_10grps_twocrs_2nd_8th_big():
     data[0, 7, 100, 100] = 2115
     data[0, 8, 100, 100] = 2115
     data[0, 9, 100, 100] = 2115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , gdq[0, :, 100, 100]) )
 
-#@pytest.mark.skip("testing skipping")
-def test_10grps_twocrs_10percenthit():
-    ngroups=10
+
+def test_10grps_twocrs_10percenthit(setup_cube):
+    ngroups = 10
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes=2
     data[0:200, 0, 100, 100] = 10.0
@@ -181,14 +181,14 @@ def test_10grps_twocrs_10percenthit():
     data[0:200, 7, 100, 100] = 2115
     data[0:200, 8, 100, 100] = 2115
     data[0:200, 9, 100, 100] = 2115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , gdq[0, :, 100, 100]) )
 
-#@pytest.mark.skip("testing skipping")
-def test_5grps_twocrs_2nd_5thbig_nframes2():
-    ngroups=5
+
+def test_5grps_twocrs_2nd_5thbig_nframes2(setup_cube):
+    ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10*np.sqrt(2))
     nframes=2
     data[0, 0, 100, 100] = 10.0
@@ -196,15 +196,14 @@ def test_5grps_twocrs_2nd_5thbig_nframes2():
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 2115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4] , gdq[0, :, 100, 100]) )
 
 
-#@pytest.mark.skip("testing skipping")
-def test_6grps_twocrs_2nd_5th():
-    ngroups=6
+def test_6grps_twocrs_2nd_5th(setup_cube):
+    ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes=1
     data[0, 0, 100, 100] = 10.0
@@ -213,14 +212,14 @@ def test_6grps_twocrs_2nd_5th():
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
     data[0, 5, 100, 100] = 115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ",medianDiff[0,100,100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ",median_diff[0,100,100])
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
 
-#@pytest.mark.skip("testing skipping")
-def test_6grps_twocrs_2nd_5th_nframes2():
-    ngroups=6
+
+def test_6grps_twocrs_2nd_5th_nframes2(setup_cube):
+    ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10*np.sqrt(2))
     nframes=2
     data[0, 0, 100, 100] = 10.0
@@ -229,13 +228,13 @@ def test_6grps_twocrs_2nd_5th_nframes2():
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
     data[0, 5, 100, 100] = 115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
 
-#@pytest.mark.skip("testing skipping")
-def test_6grps_twocrs_twopixels_nframes2():
-    ngroups=6
+
+def test_6grps_twocrs_twopixels_nframes2(setup_cube):
+    ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10*np.sqrt(2))
     nframes=2
     data[0, 0, 100, 100] = 10.0
@@ -250,15 +249,15 @@ def test_6grps_twocrs_twopixels_nframes2():
     data[0, 3, 200, 100] = 60
     data[0, 4, 200, 100] = 115
     data[0, 5, 200, 100] = 115
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq)) #a CR was found
     print("100 100 dq",repr(gdq[0,:,100,100]))
     print("200 100 dq",repr(gdq[0,:,200,100]))
     assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
     assert(np.array_equal([0, 0, 4, 0, 4, 0] , gdq[0, :, 200, 100]))
 
-#@pytest.mark.skip("testing skipping")
-def test_5grps_cr2_negslope():
+
+def test_5grps_cr2_negslope(setup_cube):
     ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes = 1
@@ -267,12 +266,13 @@ def test_5grps_cr2_negslope():
     data[0, 2, 100, 100] = -200
     data[0, 3, 100, 100] = -260
     data[0, 4, 100, 100] = -360
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(4 == np.max(gdq))  # a CR was found
     assert(np.array_equal([0, 0, 4, 0, 0] , gdq[0, :, 100, 100]))
-#@pytest.mark.skip
-def test_6grps_1CR():
+
+
+def test_6grps_1cr(setup_cube):
     ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
     nframes = 1
@@ -282,11 +282,12 @@ def test_6grps_1CR():
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 1146
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
-    assert(11 == medianDiff[0, 100, 100])
-#@pytest.mark.skip
-def test_7grps_1CR():
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(11 == median_diff[0, 100, 100])
+
+
+def test_7grps_1cr(setup_cube):
     ngroups = 7
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
     nframes = 1
@@ -297,11 +298,12 @@ def test_7grps_1CR():
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 60
     data[0, 6, 100, 100] = 1160
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
-    assert(11.5 == medianDiff[0, 100, 100])
-#@pytest.mark.skip
-def test_5grps_noCR():
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(11.5 == median_diff[0, 100, 100])
+
+
+def test_5grps_nocr(setup_cube):
     ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
     nframes = 1
@@ -310,11 +312,12 @@ def test_5grps_noCR():
     data[0, 2, 100, 100] = 21
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
-    assert(11 == medianDiff[0, 100, 100])
-#@pytest.mark.skip
-def test_6grps_noCR():
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(11 == median_diff[0, 100, 100])
+
+
+def test_6grps_nocr(setup_cube):
     ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
     nframes = 1
@@ -324,61 +327,60 @@ def test_6grps_noCR():
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 60
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
-    assert(11.5 == medianDiff[0, 100, 100])
+    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(11.5 == median_diff[0, 100, 100])
 
 
-#@pytest.mark.skip("testing skipping")
-def test_10grps_cr2_gt3sigma():
+def test_10grps_cr2_gt3sigma(setup_cube):
     ngroups = 10
     crmag=16
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5)
     nframes = 1
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq))  # a CR was found
     assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
 
-#@pytest.mark.skip(reason="testing skipping")
-def test_10grps_cr2_3sigma_noCR():
+
+def test_10grps_cr2_3sigma_nocr(setup_cube):
     ngroups = 10
     crmag=15
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5)
     nframes = 1
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(gdq))  # a CR was found
     assert(np.array_equal([0, 0, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
 
-#@pytest.mark.skip(reason="testing skipping")
-def test_10grps_cr2_gt3sigma_2frames():
+
+def test_10grps_cr2_gt3sigma_2frames(setup_cube):
     ngroups = 10
     crmag=16
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5*np.sqrt(2))
     nframes = 2
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq))  # a CR was found
     assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
 
-#@pytest.mark.skip("testing skipping")
-def test_10grps_cr2_3sigma_2frames_noCR():
+
+def test_10grps_cr2_3sigma_2frames_nocr(setup_cube):
     ngroups = 10
     crmag=15
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5*np.sqrt(2))
     nframes = 2
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(gdq))  # a CR was found
     assert(np.array_equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0] , gdq[0, :, 100, 100]))
 
-#@pytest.mark.skip(reason="testing skipping")
-def test_10grps_noCR_2pixels_sigma0():
+
+def test_10grps_nocr_2pixels_sigma0(setup_cube):
     ngroups = 10
     crmag = 15
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
@@ -387,10 +389,11 @@ def test_10grps_noCR_2pixels_sigma0():
     data[0, 1:11, 100, 100] = crmag
     read_noise[500, 500] = 0.0
     read_noise[600, 600] = 0.0
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(gdq))  # no CR was found
-#@pytest.mark.skip
-def test_5grps_Satat4_CRat3():
+
+
+def test_5grps_satat4_crat3(setup_cube):
     ngroups = 5
     #crmag = 1000
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
@@ -402,12 +405,12 @@ def test_5grps_Satat4_CRat3():
     data[0, 4, 100, 100] = 61000
     gdq[0, 3, 100, 100] = dqflags.group['SATURATED']
     gdq[0, 4, 100, 100] = dqflags.group['SATURATED']
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-   # assert(4 == np.max(gdq))  # no CR was found
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    # assert(4 == np.max(gdq))  # no CR was found
     assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'],dqflags.group['SATURATED'], dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
 
-#@pytest.mark.skip
-def test_6grps_Satat6_CRat1():
+
+def test_6grps_satat6_crat1(setup_cube):
     ngroups = 6
     #crmag = 1000
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
@@ -425,13 +428,13 @@ def test_6grps_Satat6_CRat1():
     data[0, 4, 100, 101] = 30010
     data[0, 5, 100, 101] = 35015
     gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
-   # assert(4 == np.max(gdq))  # no CR was found
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    # assert(4 == np.max(gdq))  # no CR was found
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
 
 
 @pytest.mark.xfail
-def test_6grps_Satat6_CRat1_flagadjpixels():
+def test_6grps_satat6_crat1_flagadjpixels(setup_cube):
     ngroups = 6
     #crmag = 1000
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
@@ -449,7 +452,7 @@ def test_6grps_Satat6_CRat1_flagadjpixels():
     data[0, 4, 100, 101] = 30010
     data[0, 5, 100, 101] = 35015
     gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
    # assert(4 == np.max(gdq))  # no CR was found
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 99, 100]))
@@ -457,8 +460,8 @@ def test_6grps_Satat6_CRat1_flagadjpixels():
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 100, 99]))
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 100, 101]))
     
-#@pytest.mark.skip
-def test_10grps_Satat8_CRsat3and6():
+    
+def test_10grps_satat8_crsat3and6(setup_cube):
     ngroups = 10
     #crmag = 1000
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
@@ -472,22 +475,25 @@ def test_10grps_Satat8_CRsat3and6():
     data[0, 6, 100, 100] = 45000
     data[0, 7:11, 100, 100] = 61000
     gdq[0, 7:11, 100, 100] = dqflags.group['SATURATED']
-    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
    # assert(4 == np.max(gdq))  # no CR was found
     assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'], 0, 0, dqflags.group['JUMP_DET'],
                             0,dqflags.group['SATURATED'],dqflags.group['SATURATED'],dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
 
 
-def setup_cube(ngroups,readnoise=10):
-    nints = 1
-    nrows = 2048
-    ncols = 2048
-    rej_threshold = 3
-    nframes = 1
-    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    read_noise = np.zeros(shape=(nrows, ncols), dtype=np.float32)
-    read_noise[:, :] = readnoise
-    #primary_gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
-    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
-    return data, gdq, nframes, read_noise, rej_threshold
+@pytest.fixture(scope='function')
+def setup_cube():
 
+    def _cube(ngroups, readnoise=10):
+        nints = 1
+        nrows = 2048
+        ncols = 2048
+        rej_threshold = 3
+        nframes = 1
+        data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
+        read_noise = np.full((nrows, ncols), readnoise, dtype=np.float32)
+        gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
+
+        return data, gdq, nframes, read_noise, rej_threshold
+
+    return _cube

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -19,7 +19,7 @@ log.setLevel(logging.DEBUG)
 
 HUGE_NUM = np.finfo(np.float32).max
 
-def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
+def find_crs(data, gdq, read_noise, rej_threshold, nframes):
 
     """
     Find CRs/Jumps in each integration within the input data array.

--- a/jwst/jump/yintercept.py
+++ b/jwst/jump/yintercept.py
@@ -54,7 +54,8 @@ class PixelRamp():
                 self.num_semiramps += 1
 
 
-def find_CRs(data, err, gdq, times, read_noise, rejection_threshold, signal_threshold, median_slopes):
+def find_crs(data, err, gdq, times, read_noise, rejection_threshold,
+    signal_threshold, median_slopes):
 
     # Get the attributes of the input data array
     (nints, ngroups, nrows, ncols) = data.shape
@@ -85,7 +86,7 @@ def find_CRs(data, err, gdq, times, read_noise, rejection_threshold, signal_thre
 
                     # Add any new CR flags to input DQ array
                     gdq[integration, :, row, col] = np.bitwise_or(
-                                                        gdq[integration, :, row, col], ramp.dqs)
+                        gdq[integration, :, row, col], ramp.dqs)
 
         # next pixel
     # next integration


### PR DESCRIPTION
Also, converted `setup_cube()` function used in the two-point diff tests to a pytest fixture.

In support of #2340.