### PR TITLE
Fix guidestar table bad_centroid_dq_flag column data type

### DIFF
--- a/jwst/datamodels/schemas/guider_cal.schema.yaml
+++ b/jwst/datamodels/schemas/guider_cal.schema.yaml
@@ -114,7 +114,7 @@ allOf:
       - name: bad_pixel_flag
         datatype: [ascii, 4]
       - name: bad_centroid_dq_flag
-        datatype: int32
+        datatype: [ascii, 12]
       - name: cosmic_ray_hit_flag
         datatype: [ascii, 5]
       - name: sw_subwindow_loc_change_flag

--- a/jwst/datamodels/schemas/guider_raw.schema.yaml
+++ b/jwst/datamodels/schemas/guider_raw.schema.yaml
@@ -114,7 +114,7 @@ allOf:
       - name: bad_pixel_flag
         datatype: [ascii, 4]
       - name: bad_centroid_dq_flag
-        datatype: int32
+        datatype: [ascii, 12]
       - name: cosmic_ray_hit_flag
         datatype: [ascii, 5]
       - name: sw_subwindow_loc_change_flag


### PR DESCRIPTION
The `bad_centroid_dq_flag` column in the guidestar table extension "FGS Centroid Packet" is actually being populated with Engineering values that are data type string, as opposed to the integer data type currently defined for that table column; updated the 2 guider schema.yaml files to instead accept strings. Addresses github issue: Schema update for guidestar centroid table column (#2416)