### PR TITLE
Add ci_watson as a test build dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ def PIP_ARGS = "-q"
 def PIP_INST = "pip install ${PIP_ARGS}"
 def PIP_DEPS = ""
 def PIP_DOC_DEPS = "sphinx-automodapi"
-def PIP_TEST_DEPS = "requests_mock"
+def PIP_TEST_DEPS = "requests_mock ci_watson"
 
 // Pytest wrapper
 def PYTEST = "pytest \

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -7,14 +7,27 @@ def test_env = [
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_CONTEXT=jwst-edit",
 ]
-def PYTEST = "pytest -r s --bigdata --basetemp=test_outputs --junit-xml=results.xml"
+
+// Pip related setup
+def PIP_ARGS = "-q"
+def PIP_INST = "pip install ${PIP_ARGS}"
+def PIP_DEPS = ""
+def PIP_TEST_DEPS = "requests_mock ci_watson"
+
+// Pytest wrapper
+def PYTEST = "pytest \
+              -r s \
+              --bigdata \
+              --basetemp=test_outputs \
+              --junit-xml=results.xml"
+
 def TEST_ROOT = "jwst/tests_nightly/general"
 
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
 bc.env_vars = test_env
 bc.name = '3.6'
-bc.conda_channels = ['http://ssb.stsci.edu/conda-dev']
+bc.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
 bc.conda_packages = ['asdf',
                      'astropy',
                      'crds',
@@ -39,6 +52,7 @@ bc.conda_packages = ['asdf',
 ]
 bc.test_cmds = ["printenv | sort",
                 "python setup.py develop",
+                "${PIP_INST} ${PIP_TEST_DEPS}",
                 "${PYTEST} ${TEST_ROOT}"
 ]
 

--- a/conftest.py
+++ b/conftest.py
@@ -36,20 +36,6 @@ def check_url(url):
     return True
 
 
-# Add option to run slow tests access test data
-def pytest_addoption(parser):
-    parser.addoption(
-        "--slow",
-        action="store_true",
-        help="run slow tests"
-    )
-    parser.addoption(
-        "--bigdata",
-        action="store_true",
-        help="Big local datasets"
-    )
-
-
 @pytest.fixture
 def _bigdata():
     """ Return path to large data sets
@@ -66,13 +52,6 @@ def _bigdata():
             return path
 
     raise BigdataError('Data files are not available.')
-
-
-@pytest.fixture(scope='function')
-def _jail(tmpdir):
-    path = str(tmpdir)
-    os.chdir(path)
-    yield
 
 
 @pytest.fixture

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,8 @@ setup(
     ],
     tests_require=[
         'pytest',
-        'requests_mock'
+        'requests_mock',
+        'ci_watson'
     ],
     cmdclass={
         'test': PyTest,


### PR DESCRIPTION
The purpose here is to allow the integration of `ci_watson` ([repo](https://github.com/spacetelescope/ci_watson)) into our testing environment so that its Artifactory functionality can be used in the near future.

This should have no effect on any of our tests, currently.

The removed `pytest` CLI args `--slow` and `--bigdata` plus the `_jail` fixture are implemented in the `ci_watson` plugin and have identical functionality.