### PR TITLE
Datamodels containing submodels have a standard iteration procedure [#2266]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ assign_wcs
 
 - The bounding box for Nirspec WCS objects was modified to include the
   edges of the pixels. [#2491]
-  
+
 - Updated assign_wcs to compute the sky footprint of MIRI MRS and Nirspec
   IFU observations. [#2472]
 
@@ -50,6 +50,8 @@ dark_current
 
 datamodels
 ----------
+
+- Datamodels containing submodels have a standard iteration procedure [#2266]
 
 
 dq_init
@@ -212,8 +214,8 @@ The 0.11.0 release is highlighted by the inclusion of steps for resampling
 spectral images and time series grism observations.   In addition, this
 release had 39 issues closed and a number of pull requests to improve PEP8
 compliance, improve performance, and enhance the testing.  The release also
-included updated documentation for acessing CRDS when running the JWST 
-pipeline and updates to the reference file documentation. 
+included updated documentation for acessing CRDS when running the JWST
+pipeline and updates to the reference file documentation.
 
 ami
 ---
@@ -234,7 +236,7 @@ assign_wcs
 
 - Fixed bug in assign_wcs for ordering of slits for NIRSPEC MSA data [#2366]
 
-- Implemented support for reading and writing WCS information in the 
+- Implemented support for reading and writing WCS information in the
   WAVE-TAB format [#2350]
 
 - Fixed bug in the ording of cube footprint [#2371]
@@ -278,13 +280,13 @@ csv_tools
 
 cube_build
 ---------
-- Removed spaxel.py and replace class with set of arrays [#2472] 
+- Removed spaxel.py and replace class with set of arrays [#2472]
 - reworked in mapping of the detector pixel to the sky spaxel so that consistent
-  code can be used for both MIRI and NIRSPEC data [#2472] 
-- Removed some loops in cube_cloud.py for finding which pixels fall in roi 
-  of spaxels [#2472] 
+  code can be used for both MIRI and NIRSPEC data [#2472]
+- Removed some loops in cube_cloud.py for finding which pixels fall in roi
+  of spaxels [#2472]
 - In a test with MIRI data there was a 13% improvement in the speed of making IFUcubes. In the
-  NIRSPEC case there was a 40% improvment in the speed of creating IFUCubes.  
+  NIRSPEC case there was a 40% improvment in the speed of creating IFUCubes.
 
 - Fixed bug in cube_build.blot_images that was failing for  NIRSPEC IFU images
   with the slide position defined in the WCS [#2345]

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -280,6 +280,12 @@ class ModelContainer(model_base.DataModel):
         """
         return self
 
+    def to_model(self, **kwargs):
+        """
+        Convert all contained models into possibly different models
+        """
+        return [x.to_model(**kwargs) for x in self]
+
     @property
     def models_grouped(self):
         """

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -272,6 +272,15 @@ class ModelContainer(model_base.DataModel):
         return output_paths
 
     @property
+    def collection(self):
+        """
+        ModelContainers are both models and lists of models. This method
+        allows containers to be treated as collections, the same as
+        ordinary models are treated.
+        """
+        return self
+
+    @property
     def models_grouped(self):
         """
         Returns a list of a list of datamodels grouped by exposure.

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -565,7 +565,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return self._shape
 
     def my_attribute(self, attr):
-        properties = frozenset(("shape", "history", "_extra_fits", "schema"))
+        properties = frozenset(("shape", "history", "_extra_fits",
+                                "schema", "collection"))
         return attr in properties
 
     def __setattr__(self, attr, value):
@@ -791,12 +792,16 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         return collection_list
 
-    def to_model(self):
+    def to_model(self, **kwargs):
         """
         Models are also nodes. This function is to prevent to_model
         from trying to convert what is already a model to a model.
         """
-        return self
+        if kwargs:
+            new_class = self.__class__
+            return new_class(init=self, **kwargs)
+        else:
+            return self
 
     def update(self, d, only=''):
         """

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -321,6 +321,19 @@ def test_multislit_copy():
         output = input.copy()
         assert len(output.slits) == 4
 
+def  test_multislit_collection():
+    with ImageModel((64, 64)) as im:
+        with MultiSlitModel(im) as ms:
+            node_list = ms.collection
+            assert type(node_list).__name__ == 'ListNode'
+            for node in node_list:
+                submodel = node.to_model()
+                assert type(submodel).__name__ == 'SlitDataModel'
+
+            submodels = ms.collection.to_model()
+            for submodel in submodels:
+                assert type(submodel).__name__ == 'SlitDataModel'
+
 
 def test_model_with_nonstandard_primary_array():
     ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -426,6 +439,19 @@ def test_modelcontainer_group_names(container):
     container[0].meta.observation.exposure_number = '2'
     assert len(container.group_names) == 2
     container[0].meta.observation.exposure_number = '1'
+
+
+def test_modelcontainer_collection():
+    warnings.simplefilter("ignore")
+    with ModelContainer(ASN_FILE, persist=True) as asn:
+        model_list = asn.collection
+        for model in model_list:
+            submodel = model.to_model()
+            assert type(submodel).__name__ == 'QuadModel'
+
+        submodels = asn.collection.to_model()
+        for submodel in submodels:
+            assert type(submodel).__name__ == 'QuadModel'
 
 
 def test_object_node_iterator():

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -415,39 +415,3 @@ def create_history_entry(description, software=None):
     if software is not None:
         entry['software'] = software
     return entry
-
-
-def from_asn(filename, **kwargs):
-    """
-    Load fits files from a JWST association file into a single model.
-
-    Parameters
-    ----------
-    filename : str
-        The name of an association file.
-    """
-    filepath = op.abspath(op.expanduser(op.expandvars(filename)))
-    try:
-        with open(filepath) as asn_file:
-            asn_data = load_asn(asn_file)
-    except AssociationNotValidError:
-        raise IOError("Cannot read ASN file.")
-
-    model = DataModel(init=None)
-    model.meta.resample.output = asn_data['products'][0]['name']
-    model.meta.table_name = op.basename(op.dirname(filepath))
-    model.meta.pool_name = asn_data['asn_pool']
-
-    ##subschema = []
-    collection_list = []
-    basedir = op.diranme(filepath)
-
-    for member in asn_data['products'][0]['members']:
-        infile = op.join(basedir, member['expname'])
-        collection_list.append(submodel.instance)
-
-        ##submodel = open(infile, **kwargs)
-        ##subschema.append(submodel._schema)
-
-    model.exposures = collection_list
-


### PR DESCRIPTION
Some datamodels are collections of submodels. The most obvious example is ModelContainer, but there are also several Multi-Models (MultiExposureModel, MultiSlitModel, and others.) This update provides a consistent way to access the submodels. A new property, collection, has been added to DataModel. It returns a list of nodes if the schema has a single top level array. Otherwise, it raises an AttributeError. Each node represents a submodel. Because it is a list, it can be looped over or accessed by index. The supporting method to_model() has been added to ObjectNode. It converts a node to a datamodel, but only if the node contains a meta.model_type attribute. If it does not, it raises a ValueError. The method of the same name in ListNode converts the entire array to a list of models.

The corresponding methods collection and to_model() in ModelContainer allow the same code to loop over the models in a model container. The following code examples will work for both:

```
model = dmopen(filename)
node_list = model.collection
for node in node_list:
    submodel = node.to_model()
    print(submodel.info())
submodels = model.collection.to_model()
for submodel in submodels:
    print(submodel.info())
```

