### PR TITLE
Fix bug in bounding_box_from_shape

### DIFF
--- a/jwst/assign_wcs/tests/test_util.py
+++ b/jwst/assign_wcs/tests/test_util.py
@@ -1,0 +1,18 @@
+from jwst import datamodels
+from jwst.assign_wcs.util import bounding_box_from_shape
+
+
+def test_bounding_box_from_shape_2d():
+    model = datamodels.ImageModel((512, 2048))
+    bb = bounding_box_from_shape(model.data.shape)
+    assert bb == ((-0.5, 2047.5), (-0.5, 511.5))
+
+
+def test_bounding_box_from_shape_3d():
+    model = datamodels.CubeModel((3, 32, 2048))
+    bb = bounding_box_from_shape(model.data.shape)
+    assert bb == ((-0.5, 2047.5), (-0.5, 31.5))
+
+    model = datamodels.IFUCubeModel((750, 45, 50))
+    bb = bounding_box_from_shape(model.data.shape)
+    assert bb == ((-0.5, 49.5), (-0.5, 44.5))

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -21,7 +21,7 @@ from gwcs import utils as gwutils
 from . import pointing
 from ..lib.catalog_utils import SkyObject
 from ..transforms.models import GrismObject
-from ..datamodels import WavelengthrangeModel, DataModel, CubeModel, IFUCubeModel
+from ..datamodels import WavelengthrangeModel, DataModel
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -637,19 +637,19 @@ def get_num_msa_open_shutters(shutter_state):
     return num
 
 
-def bounding_box_from_shape(model):
+def bounding_box_from_shape(shape):
     """Create a bounding box from the shape of the data.
+
+    Parameters
+    ----------
+    shape : tuple
+        The shape attribute from a `numpy.ndarray` array
 
     Note: The bounding box of a ``CubeModel`` is the bounding_box of one
     of the stacked images.
     """
-    if isinstance(model, (CubeModel, IFUCubeModel)):
-        shape = model.data[0].shape
-    else:
-        shape = model.data.shape
-
-    bbox = ((-0.5, shape[1] - 0.5),
-            (-0.5, shape[0] - 0.5))
+    bbox = ((-0.5, shape[-1] - 0.5),
+            (-0.5, shape[-2] - 0.5))
     return bbox
 
 
@@ -661,7 +661,7 @@ def update_s_region_imaging(model):
     bbox = model.meta.wcs.bounding_box
 
     if bbox is None:
-        bbox = bounding_box_from_shape(model)
+        bbox = bounding_box_from_shape(model.data.shape)
 
     # footprint is an array of shape (2, 4) as we
     # are interested only in the footprint on the sky
@@ -683,7 +683,7 @@ def update_s_region_spectral(model):
 
     bbox = swcs.bounding_box
     if bbox is None:
-        bbox = bounding_box_from_shape(model)
+        bbox = bounding_box_from_shape(model.data.shape)
 
     x, y = grid_from_bounding_box(bbox)
     ra, dec, lam = swcs(x, y)

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -246,9 +246,7 @@ def extract_slit(input_model, slit, exp_type):
         raise ValueError("extract_2d does not work with "
                          "{0} dimensional data".format(ndim))
 
-    slit_wcs.bounding_box = util.bounding_box_from_shape(
-        datamodels.SlitModel(data=ext_data)
-        )
+    slit_wcs.bounding_box = util.bounding_box_from_shape(ext_data.shape)
 
     # compute wavelengths
     x, y = wcstools.grid_from_bounding_box(slit_wcs.bounding_box, step=(1, 1))

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -6,7 +6,7 @@ from astropy.modeling.models import Scale, AffineTransformation2D
 from astropy.modeling import Model
 from gwcs import WCS, wcstools
 
-from ..assign_wcs.util import wcs_from_footprints
+from ..assign_wcs.util import wcs_from_footprints, bounding_box_from_shape
 
 from . import bitmask
 
@@ -83,15 +83,6 @@ def compute_output_transform(refwcs, filename, fiducial):
     cdelt = Scale(scale) & Scale(scale)
 
     return pc_matrix | cdelt
-
-
-def bounding_box_from_shape(shape):
-    """ Return a bounding_box for WCS based on a numpy shape
-    """
-    bb = []
-    for s in reversed(shape):
-        bb.append((-0.5, s - 0.5))
-    return tuple(bb)
 
 
 def shape_from_bounding_box(bounding_box):


### PR DESCRIPTION
Resolves #2549.

This also puts the calling sequence of `bounding_box_from_shape` back to just needing a shape passed to it instead of the full datamodel, as it was a while back.

I've also taken the liberty of pointing some code in `resample` to this version, and removed a duplicate function in `resample`.