### PR TITLE
Add validate_required_fields to DataModel

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -335,6 +335,27 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                               self._pass_invalid_values,
                               self._strict_validation)
 
+    def validate_required_fields(self):
+        """
+        Walk the schema and make sure all required fields are
+        in the model
+        """
+        def callback(schema, path, combiner, ctx, recurse):
+            if 'fits_required' not in schema:
+                return
+
+            node = ctx
+            for attr in path:
+                node = getattr(node, attr)
+                if node is None:
+                    break
+
+            validate.value_change(path, node, schema,
+                                  ctx._pass_invalid_values,
+                                  ctx._strict_validation)
+
+        mschema.walk_schema(self._schema, callback, ctx=self)
+
     def info(self):
         """
         Return datatype and dimension for each array or table
@@ -467,6 +488,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if dir_path:
             path_head = dir_path
         output_path = os.path.join(path_head, path_tail)
+
+        self.validate_required_fields()
 
         # TODO: Support gzip-compressed fits
         if ext == '.fits':

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -344,6 +344,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             if 'fits_required' not in schema:
                 return
 
+            # Get the value pointed at by the path to the node,
+            # or None in case there is no entry for the node
             node = ctx
             for attr in path:
                 node = getattr(node, attr)

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import warnings
+import jsonschema
 
 import pytest
 from astropy.time import Time

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -476,6 +476,46 @@ def test_info():
                 assert words[2] == "float32", "Correct type for err"
     assert matches== 3, "Check all extensions are described"
 
+def test_validate_on_read():
+    im1 = ImageModel((10,10))
+    schema = im1.meta._schema
+    schema['properties']['calibration_software_version']['fits_required'] = True
+
+    try:
+        im2 = ImageModel(FITS_FILE,
+                          schema=im1._schema,
+                          strict_validation=True)
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+        im2.close()
+
+    im1.close()
+    assert caught, "Test of validation while reading image"
+
+def test_validate_required_field():
+    im = ImageModel((10,10), strict_validation=True)
+    schema = im.meta._schema
+    schema['properties']['telescope']['fits_required'] = True
+
+    try:
+        im.validate_required_fields()
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+    assert caught, "Test of validate_required_fields"
+
+    im.meta.telescope = 'JWST'
+    try:
+        im.validate_required_fields()
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+    assert not caught, "Test of validate_required_fields"
+
 def test_multislit_model():
     data = np.arange(24, dtype=np.float32).reshape((6, 4))
     err = np.arange(24, dtype=np.float32).reshape((6, 4)) + 2


### PR DESCRIPTION
An issue was raised during a meeting that datamodels was not correctly
validating schema items with the fits_required attribute. I did some
checking and found that fits_required is used in validation when
reading a fits file or deleting a model value. But it was not used in
validation when writing a model. The reason is that when writing the
code traverses the model, not the schema, so fields that are missing
in the model are not detected. I've added a new method,
validate_required_fields, to model_base.py that traverses the schema
and checks all fields where fits_required is true. This method is
called in save() before writing the file. It honors the usual flags,
pass_invalid_values and strict_validation.
   
I also added two tests to test_models.py to check the handling of
fits_required. Fits_required is not currently used in any of the
schemas, so for the present the new method has no effect.
