### PR TITLE
add error messages to check_wcs_structure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -212,6 +212,8 @@ tso_photometry
 tweakreg
 --------
 
+- Updated tweakreg to use `wcs.available_frames` to get the names of the frames in 
+  a WCS pipeline. [#2590]
 wfs_combine
 -----------
 

--- a/jwst/tweakreg/wcsimage.py
+++ b/jwst/tweakreg/wcsimage.py
@@ -75,7 +75,7 @@ class ImageWCS():
         # perform additional check that if tangent plane correction is already
         # present in the WCS pipeline, it is of TPCorr class and that
         # its parameters are consistent with reference angles:
-        frms = [f[0] for f in wcs.pipeline]
+        frms = wcs.available_frames
         if 'v2v3corr' in frms:
             self._v23name = 'v2v3corr'
             self._tpcorr = deepcopy(wcs.pipeline[frms.index('v2v3corr')-1][1])
@@ -116,8 +116,8 @@ class ImageWCS():
     def _update_transformations(self):
         # define transformations from detector/world coordinates to
         # the tangent plane:
-        detname = self._wcs.pipeline[0][0]
-        worldname = self._wcs.pipeline[-1][0]
+        detname = self._wcs.pipeline[0][0].name
+        worldname = self._wcs.pipeline[-1][0].name
 
         self._world_to_v23 = self._wcs.get_transform(worldname, self._v23name)
         self._v23_to_world = self._wcs.get_transform(self._v23name, worldname)
@@ -169,7 +169,7 @@ class ImageWCS():
             *before* ``matrix`` transformations are applied.
 
         """
-        frms = [f[0] for f in self._wcs.pipeline]
+        frms = wcs.available_frames
 
         # if original WCS did not have tangent-plane corrections, create
         # new correction and add it to the WCs pipeline:

--- a/jwst/tweakreg/wcsimage.py
+++ b/jwst/tweakreg/wcsimage.py
@@ -169,7 +169,7 @@ class ImageWCS():
             *before* ``matrix`` transformations are applied.
 
         """
-        frms = wcs.available_frames
+        frms = self._wcs.available_frames
 
         # if original WCS did not have tangent-plane corrections, create
         # new correction and add it to the WCs pipeline:

--- a/jwst/tweakreg/wcsimage.py
+++ b/jwst/tweakreg/wcsimage.py
@@ -64,7 +64,7 @@ class ImageWCS():
         """
         valid, message =  self._check_wcs_structure(wcs)
         if not valid:
-            raise ValueError(message)
+            raise ValueError("Unsupported WCS structure." + message)
 
         self._ra_ref = ra_ref
         self._dec_ref = dec_ref
@@ -214,37 +214,45 @@ class ImageWCS():
         if wcs is None or wcs.pipeline is None:
             message = "WCS is None."
             valid = False
+            return valid, message
 
         frms = wcs.available_frames
         nframes = len(frms)
         if nframes < 3:
-            message = "There are more than 3 frames in this WCS pipeline."
+            message = "There are fewer than 3 frames in the WCS pipeline."
             valid = False
+            return valid, message
 
         if frms.count(frms[0]) > 1 or frms.count(frms[-1]) > 1:
             valid = False
             message = "One or more frames in the WCS pipeline are not unique."
-            
+            return valid, message
+
         if frms.count('v2v3') != 1:
             valid = False
             message = "More than 1 'v2v3' frames in the WCS pipeline."
+            return valid, message
             
         idx_v2v3 = frms.index('v2v3')
         if idx_v2v3 == 0 or idx_v2v3 == (nframes - 1):
             valid = False
             message = "'v2v3' frame is either first or last in the WCS pipeline."
+            return valid, message
             
         nv2v3corr = frms.count('v2v3corr')
         if nv2v3corr == 0:
             valid = True
+            return valid, message
         elif nv2v3corr > 1:
             valid = False
-            message = "There are more than 1 'nv2v3corr' frames in the WCS pipeline."
+            message = "There are more than one 'v2v3corr' correction frames in the WCS pipeline."
+            return valid, message
             
         idx_v2v3corr = frms.index('v2v3corr')
         if idx_v2v3corr != (idx_v2v3 + 1) or idx_v2v3corr == (nframes - 1):
             valid = False
             message = "'v2v3corr' frame is not in the correct position in the WCS pipeline."
+            return valid, message
         return valid, message
 
     def det_to_world(self, x, y):


### PR DESCRIPTION
Attempt to fix #2548. This PR only adds error messages to the `_check_wcs_structure` method in order to facilitate debugging. I also fixed one "bug" - the way to get the names of all frames in the WCS pipeline is `wcs.available_frames`. The way it was done a list of frame objects was returned.

When I run the regression test now I get a different error. It is looking for a frame called `v2v3corr`. I thought at this point in the code `v2v3corr` should not be in the pipeline but I am not very familiar with the code. @mcara
```
Traceback (most recent call last):
  File "scripts/strun", line 26, in <module>
    step = Step.from_cmdline(sys.argv[1:])
  File "/internal/1/astropy/jwst/jwst/stpipe/step.py", line 162, in from_cmdline
    return cmdline.step_from_cmdline(args)
  File "/internal/1/astropy/jwst/jwst/stpipe/cmdline.py", line 297, in step_from_cmdline
    step.run(*positional)
  File "/internal/1/astropy/jwst/jwst/stpipe/step.py", line 400, in run
    step_result = self.process(*args)
  File "/internal/1/astropy/jwst/jwst/tweakreg/tweakreg_step.py", line 114, in process
    wcsimlist = list(map(self._imodel2wcsim, g))
  File "/internal/1/astropy/jwst/jwst/tweakreg/tweakreg_step.py", line 170, in _imodel2wcsim
    meta={'image_model': image_model}
  File "/internal/1/astropy/jwst/jwst/tweakreg/wcsimage.py", line 360, in __init__
    self.set_wcs(wcs, ref_angles)
  File "/internal/1/astropy/jwst/jwst/tweakreg/wcsimage.py", line 411, in set_wcs
    dec_ref=ref_angles['dec_ref']
  File "/internal/1/astropy/jwst/jwst/tweakreg/wcsimage.py", line 65, in __init__
    valid, message =  self._check_wcs_structure(wcs)
  File "/internal/1/astropy/jwst/jwst/tweakreg/wcsimage.py", line 244, in _check_wcs_structure
    idx_v2v3corr = frms.index('v2v3corr')
ValueError: 'v2v3corr' is not in list
```