### PR TITLE
Nonlinear wavelength for cube_build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,7 @@ csv_tools
 
 cube_build
 ----------
-This version supports creating IFU Cubes with non-linear wavelength dimension.
+This version supports creating IFU Cubes with non-linear wavelength dimension. [#2598]
 
 
 cube_skymatch

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,24 +44,6 @@ cube_build
 ----------
 This version supports creating IFU Cubes with non-linear wavelength dimension.
 
-IFU cubes made from multiple band may have a non-linear wavelength dimension. 
-The wavelength ranges, spectral size, spectral roi size to use to build the
-IFU Cube  are read in from the CUBEPAR reference files for each band. If the 
-spectral size is not the same for all the bands then the IFU cubes will have
-a nonlinear wavelength dimension. The wavelength to use for the output IFU 
-are found in additional table extensions in the CUBEPAR reference file. 
-In addition, the spectral region of influence can also vary as a function
-of wavelength for these type IFU cubes. The spectral region of influence
-is also found in the additional tables in the CUBEPAR reference file.
-The output of these non-linear IFU cubes contain the wavelength planes of
-the IFU cube in the extension table 'WCS-TABLE' 
-
-This version also uses the minimum and maximum wavelengths defined in the 
-first extension of the CUBEPAR reference file to set the wavelength range
-of the IFU Cube for a linear wavelength dimension. Before the wavelength range
-was calculated from the data. The values found in the CUBEPAR reference file
-clips the wavelength ranges so that the boundaries of the IFU cube do not
-contain sparse data.  
 
 cube_skymatch
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,8 +42,26 @@ csv_tools
 
 cube_build
 ----------
+This version supports creating IFU Cubes with non-linear wavelength dimension.
 
+IFU cubes made from multiple band may have a non-linear wavelength dimension. 
+The wavelength ranges, spectral size, spectral roi size to use to build the
+IFU Cube  are read in from the CUBEPAR reference files for each band. If the 
+spectral size is not the same for all the bands then the IFU cubes will have
+a nonlinear wavelength dimension. The wavelength to use for the output IFU 
+are found in additional table extensions in the CUBEPAR reference file. 
+In addition, the spectral region of influence can also vary as a function
+of wavelength for these type IFU cubes. The spectral region of influence
+is also found in the additional tables in the CUBEPAR reference file.
+The output of these non-linear IFU cubes contain the wavelength planes of
+the IFU cube in the extension table 'WCS-TABLE' 
 
+This version also uses the minimum and maximum wavelengths defined in the 
+first extension of the CUBEPAR reference file to set the wavelength range
+of the IFU Cube for a linear wavelength dimension. Before the wavelength range
+was calculated from the data. The values found in the CUBEPAR reference file
+clips the wavelength ranges so that the boundaries of the IFU cube do not
+contain sparse data.  
 
 cube_skymatch
 -------------

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -149,10 +149,8 @@ def fitswcs_transform_from_model(wcsinfo, wavetable=None):
                 astmodels.Shift(wcsinfo['CRVAL'][sp_axis])
         else :
             # Wave dimension is an array that needs to be converted to a table
-            waves = wavetable['wavelength'][0,0]
-            print('in pointing',waves[0:15])
-            print(waves.shape)
-            print(type(waves))
+            waves = wavetable['wavelength']
+            waves = waves.flatten()
             spectral_transform = astmodels.Tabular1D(lookup_table=waves) 
 
         transform = transform & spectral_transform

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -120,7 +120,7 @@ def wcsinfo_from_model(input_model):
     return wcsinfo
 
 
-def fitswcs_transform_from_model(wcsinfo, wavetab=None):
+def fitswcs_transform_from_model(wcsinfo, wavetable=None):
     """
     Create a WCS object using from datamodel.meta.wcsinfo.
     Transforms assume 0-based coordinates.
@@ -142,14 +142,18 @@ def fitswcs_transform_from_model(wcsinfo, wavetab=None):
     transform = gwutils.make_fitswcs_transform(wcsinfo)
     if spectral_axes:
         sp_axis = spectral_axes[0]
-        if wavetab is None :
+        if wavetable is None :
             # Subtract one from CRPIX which is 1-based.
             spectral_transform = astmodels.Shift(-(wcsinfo['CRPIX'][sp_axis] - 1)) | \
                 astmodels.Scale(wcsinfo['CDELT'][sp_axis]) | \
                 astmodels.Shift(wcsinfo['CRVAL'][sp_axis])
         else :
             # Wave dimension is an array that needs to be converted to a table
-            spectral_transform = astmodels.Tabular1D(lookup_table=wavetab) 
+            waves = wavetable['wavelength'][0,0]
+            print('in pointing',waves[0:15])
+            print(waves.shape)
+            print(type(waves))
+            spectral_transform = astmodels.Tabular1D(lookup_table=waves) 
 
         transform = transform & spectral_transform
 

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -149,8 +149,7 @@ def fitswcs_transform_from_model(wcsinfo, wavetable=None):
                 astmodels.Shift(wcsinfo['CRVAL'][sp_axis])
         else :
             # Wave dimension is an array that needs to be converted to a table
-            waves = wavetable['wavelength']
-            waves = waves.flatten()
+            waves = wavetable['wavelength'].flatten()
             spectral_transform = astmodels.Tabular1D(lookup_table=waves) 
 
         transform = transform & spectral_transform

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -214,7 +214,8 @@ class CubeBlot():
 
             if self.instrument == 'MIRI':
                 valid3 = np.isfinite(lam_det)
-                good_data = valid3 & pixel_mask
+                good_data1 = valid3 & pixel_mask
+                good_data = np.where(good_data1)
             elif self.instrument == 'NIRSPEC':
                 good_data = np.where(flag_det == 1)
 
@@ -222,7 +223,6 @@ class CubeBlot():
             ra_blot = ra_det[good_data]
             dec_blot = dec_det[good_data]
             wave_blot = lam_det[good_data]
-            
             crval1 = model.meta.wcsinfo.crval1
             crval2 = model.meta.wcsinfo.crval2
 

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -88,7 +88,7 @@ class CubeData():
 #________________________________________________________________________________
         self.determine_band_coverage(master_table)
 #________________________________________________________________________________
-# InstrumentDefaults is an  dictionary that holds default parameters for
+# instrument_defaults is an  dictionary class that holds default parameters for
 # difference instruments and for each band
 #________________________________________________________________________________
         instrument_info = instrument_defaults.InstrumentInfo()

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -42,6 +42,8 @@ def read_cubepars(par_filename,
     The correct elements of instrument_info are filled in
 
     """
+
+
     if instrument == 'MIRI':
         ptab = datamodels.MiriIFUCubeParsModel(par_filename)
         number_bands = len(all_channel)

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -218,8 +218,7 @@ def read_resolution_file(resol_filename,
         this_sub = all_subchannel[i]
         compare_band = this_channel + this_sub
         for tabdata in ptab.resolving_power_table:
-            table_sub_band = tabdata['SUB_BAND']
-            table_sub_band = table_sub_band.lower()
+            table_sub_band = tabdata['SUB_BAND'].lower()
             table_wave_center = tabdata['R_CENTRE']
             table_res_a_low = tabdata['R_A_LOW']
             table_res_b_low = tabdata['R_B_LOW']

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -217,6 +217,7 @@ def read_resolution_file(resol_filename,
         compare_band = this_channel + this_sub
         for tabdata in ptab.resolving_power_table:
             table_sub_band = tabdata['SUB_BAND']
+            table_sub_band = table_sub_band.lower()
             table_wave_center = tabdata['R_CENTRE']
             table_res_a_low = tabdata['R_A_LOW']
             table_res_b_low = tabdata['R_B_LOW']

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -95,7 +95,6 @@ class CubeBuildStep (Step):
         # 2. world
         self.interpolation = 'pointcloud' # true for self.weighting  = 'msm' or 'miripsf'
 
-
         # if the weighting is area then interpolation is area
         # if the weighting is area then interpolation is area. Weighting of area or interpolation
         # of area is only for single band data.
@@ -294,13 +293,13 @@ class CubeBuildStep (Step):
             else:
                 result = thiscube.build_ifucube()
                 cube_container.append(result)
-
             if self.debug_pixel == 1:
                 self.spaxel_debug.close()
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)
 
+        
         return cube_container
 
 #********************************************************************************
@@ -329,10 +328,6 @@ class CubeBuildStep (Step):
         """
         valid_channel = ['1', '2', '3', '4', 'all']
         valid_subchannel = ['short', 'medium', 'long', 'all']
-#        valid_fwa = ['f070lp', 'f100lp', 'f100lp', 'g170lp',
-#                    'g170lp', 'f290lp', 'f290lp', 'clear', 'all']
-#        valid_gwa = ['g140m', 'g140h', 'G140M', 'g140h', 'g235m', 'g235h',
-#                    'g395m', 'g395h', 'prism', 'all']
 
         valid_fwa = ['f070lp', 'f100lp', 'g170lp',
                     'g170lp', 'f290lp', 'clear', 'all']

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -273,7 +273,7 @@ class CubeBuildStep (Step):
 # if linear wavelength (single band) single values for rois, roiw, weight_power, softrad
 # if not linear wavelength (multi bands) an array based on wavelength for:
 #  rois, roiw, weight_power, softrad
-
+ 
             thiscube.determine_cube_parameters()
 
             thiscube.setup_ifucube_wcs()
@@ -298,6 +298,7 @@ class CubeBuildStep (Step):
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)
+
 
         
         return cube_container

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -95,7 +95,11 @@ class CubeBuildStep (Step):
         # 2. world
         self.interpolation = 'pointcloud' # true for self.weighting  = 'msm' or 'miripsf'
 
+
         # if the weighting is area then interpolation is area
+        # if the weighting is area then interpolation is area. Weighting of area or interpolation
+        # of area is only for single band data.
+
         if self.weighting == 'area':
             self.interpolation = 'area'
             self.coord_system = 'alpha-beta'
@@ -262,11 +266,16 @@ class CubeBuildStep (Step):
                 **pars_cube)
 
 #________________________________________________________________________________
+            thiscube.check_ifucube() # basic checks
 
-            thiscube.check_ifucube() # basic checks and get roi size
+# Based on channel/subchannel or grating/prism find
+# spatial spaxel size, min wave, max wave
+# set linear_wavelength to true or false depending on which type of IFU cube creating
+# if linear wavelength (single band) single values for rois, roiw, weight_power, softrad
+# if not linear wavelength (multi bands) an array based on wavelength for:
+#  rois, roiw, weight_power, softrad
 
-# find the min & max final coordinates of cube: map each slice to cube
-# find the min & max value in each dimension
+            thiscube.determine_cube_parameters()
 
             thiscube.setup_ifucube_wcs()
 #________________________________________________________________________________

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -242,7 +242,8 @@ class CubeBuildStep (Step):
 # or (grating,filter)
 
         num_cubes, cube_pars = cubeinfo.number_cubes()
-        if not self.single: self.log.info('Number of ifucubes produced by a this run %i', num_cubes)
+        if not self.single: self.log.info('Number of ifucubes produced by a this run %i',
+                                          num_cubes)
 
         cube_container = datamodels.ModelContainer() # ModelContainer of ifucubes
 
@@ -298,7 +299,6 @@ class CubeBuildStep (Step):
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)
-
 
         
         return cube_container

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -330,7 +330,7 @@ class CubeBuildStep (Step):
         valid_channel = ['1', '2', '3', '4', 'all']
         valid_subchannel = ['short', 'medium', 'long', 'all']
 
-        valid_fwa = ['f070lp', 'f100lp', 'g170lp',
+        valid_fwa = ['f070lp', 'f100lp',
                     'g170lp', 'f290lp', 'clear', 'all']
         valid_gwa = ['g140m', 'g140h', 'g235m', 'g235h',
                      'g395m', 'g395h', 'prism', 'all']

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -242,7 +242,8 @@ class CubeBuildStep (Step):
 # or (grating,filter)
 
         num_cubes, cube_pars = cubeinfo.number_cubes()
-        if not self.single: self.log.info('Number of ifucubes produced by a this run %i',
+        if not self.single: 
+            self.log.info('Number of ifucubes produced by a this run %i',
                                           num_cubes)
 
         cube_container = datamodels.ModelContainer() # ModelContainer of ifucubes

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -21,7 +21,7 @@ class CubeBuildStep (Step):
          channel = option('1','2','3','4','all',default='all') # Options: 1,2,3,4, or all
          band = option('short','medium','long','all',default='all') # Options: short, medium, long, all
          grating   = option('prism','g140m','g140h','g235m','g235h',g395m','g395h','all',default='all') # Options: prism,g140m,g140h,g235m,g235h,g395m,g395h, or all
-         filter   = option('clear','f100lp','f070lp','g170lp','f290lp','all',default='all') # Options: clear,f100lp,f070lp,g170lp,f290lp, or all
+         filter   = option('clear','f100lp','f070lp','f170lp','f290lp','all',default='all') # Options: clear,f100lp,f070lp,f170lp,f290lp, or all
          scale1 = float(default=0.0) # cube sample size to use for axis 1, arc seconds
          scale2 = float(default=0.0) # cube sample size to use for axis 2, arc seconds
          scalew = float(default=0.0) # cube sample size to use for axis 3, microns

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -136,7 +136,7 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
     The weighting function is based on the distance the point cloud member and spaxel
     center in the alph-beta coordinate system.
     The alpha and beta value of each point cloud member is passed to this routine
-    The alpha and beta value of the spaxel center is also past in.
+    The alpha and beta value of the spaxel center is also passed in.
 
     Parameters
     ----------

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -1,14 +1,12 @@
  # Routines used in Spectral Cube Building
 import numpy as np
-import math
 import logging
-from . import coord
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 #________________________________________________________________________________
 def match_det2cube_msm(naxis1, naxis2, naxis3,
-                       cdelt1, cdelt2, 
+                       cdelt1, cdelt2,
                        zcdelt3,
                        xcenters, ycenters, zcoord,
                        spaxel_flux,
@@ -29,7 +27,7 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
     Parameters
     ----------
     naxis1,naxis2,naxis3: size of the ifucube
-    cdelt1,cdelt2 : ifucube spaxel size 
+    cdelt1,cdelt2 : ifucube spaxel size
     cdelt3_normal: ifu spectral size at wavelength
     rois_pixel, roiw_pixel: region of influence size in spatial and spectral dimension
     weight_power: msm weighting parameter
@@ -48,14 +46,14 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
     """
 
     nplane = naxis1 * naxis2
-    
+
 # now loop over the pixel values for this region and find the spaxels that fall
 # withing the region of interest.
     nn = coord1.size
 
-#    ilow = 0 
-#    ihigh = 0 
-#    imatch  = 0 
+#    ilow = 0
+#    ihigh = 0
+#    imatch  = 0
 #    print('looping over n points mapping to cloud',nn)
 #________________________________________________________________________________
     for ipt in range(0, nn - 1):
@@ -72,19 +70,18 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
         indexz = np.where(abs(zcoord - wave[ipt]) <= roiw_pixel[ipt])
 
         # on the wavelength boundaries the point cloud may not be in the IFUCube
-        # the edge cases are skipped and not included in final IFUcube. 
+        # the edge cases are skipped and not included in final IFUcube.
+        # Left commented code for checking later for NIRSPEC the spectral size
+        # in the reference file may be too small
 #        if len(indexz[0]) == 0:
-#            if wave[ipt] < zcoord[0]: 
+#            if wave[ipt] < zcoord[0]:
 #               ilow = ilow + 1
-
 #            elif wave[ipt] > zcoord[-1]: 
 #               ihigh = ihigh + 1
 #            else:
 #                imatch = imatch + 1
 #                print(' no z match found ',wave[ipt],roiw_pixel[ipt])
-#                print(zcoord[0:10])
 #                print(zcoord[naxis3-11:naxis3])
-#                print(zcoord[-1])
 #                diff = abs(zcoord[naxis3-11:naxis3] - wave[ipt])
 #                print(diff)
 #                exit()
@@ -92,7 +89,7 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
             d1 = np.array(coord1[ipt] - xcenters[indexr]) / cdelt1
             d2 = np.array(coord2[ipt] - ycenters[indexr]) / cdelt2
             d3 = np.array(wave[ipt] - zcoord[indexz]) / zcdelt3[indexz]
-        
+
             dxy = (d1 * d1) + (d2 * d2)
 
         # shape of dxy is #indexr or number of overlaps in spatial plane
@@ -125,7 +122,7 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
                            spaxel_flux,
                            spaxel_weight,
                            spaxel_iflux,
-                           spaxel_alpha,spaxel_beta,spaxel_wave,
+                           spaxel_alpha, spaxel_beta, spaxel_wave,
                            flux,
                            coord1, coord2, wave, alpha_det, beta_det,
                            rois_pixel, roiw_pixel, weight_pixel, softrad_pixel):
@@ -157,7 +154,7 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
 
     rois_pixel, roiw_pixel: region of influence size in spatial and spectral dimension
     weight_pixel: msm weighting parameter
-    softrad_pxiel: weighting paramter 
+    softrad_pxiel: weighting paramter
 
     Returns
     -------
@@ -174,7 +171,6 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
 #________________________________________________________________________________
     for ipt in range(0, nn - 1):
         lower_limit = softrad_pixel[ipt]
-
 #________________________________________________________________________________
         # xcenters, ycenters is a flattened 1-D array of the 2 X 2 xy plane
         # cube coordinates.
@@ -188,9 +184,6 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
         indexr = np.where(radius <= rois_pixel[ipt])
         indexz = np.where(abs(zcoord - wave[ipt]) <= roiw_pixel[ipt])
 
-        zlam = zcoord[indexz]        # z Cube values falling in wavelength roi
-        xi_cube = xcenters[indexr]   # x Cube values within radius
-        eta_cube = ycenters[indexr]  # y cube values with the radius
 #________________________________________________________________________________
 # loop over the points in the ROI
         for iz, zz in enumerate(indexz[0]):

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -53,9 +53,9 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
 # withing the region of interest.
     nn = coord1.size
 
-    ilow = 0 
-    ihigh = 0 
-    imatch  = 0 
+#    ilow = 0 
+#    ihigh = 0 
+#    imatch  = 0 
 #    print('looping over n points mapping to cloud',nn)
 #________________________________________________________________________________
     for ipt in range(0, nn - 1):
@@ -73,14 +73,14 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
 
         # on the wavelength boundaries the point cloud may not be in the IFUCube
         # the edge cases are skipped and not included in final IFUcube. 
-        if len(indexz[0]) == 0:
-            if wave[ipt] < zcoord[0]: 
-               ilow = ilow + 1
+#        if len(indexz[0]) == 0:
+#            if wave[ipt] < zcoord[0]: 
+#               ilow = ilow + 1
 
-            elif wave[ipt] > zcoord[-1]: 
-               ihigh = ihigh + 1
-            else:
-                imatch = imatch + 1
+#            elif wave[ipt] > zcoord[-1]: 
+#               ihigh = ihigh + 1
+#            else:
+#                imatch = imatch + 1
 #                print(' no z match found ',wave[ipt],roiw_pixel[ipt])
 #                print(zcoord[0:10])
 #                print(zcoord[naxis3-11:naxis3])
@@ -88,7 +88,7 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
 #                diff = abs(zcoord[naxis3-11:naxis3] - wave[ipt])
 #                print(diff)
 #                exit()
-        else:
+        if len(indexz[0]) > 0:
             d1 = np.array(coord1[ipt] - xcenters[indexr]) / cdelt1
             d2 = np.array(coord2[ipt] - ycenters[indexr]) / cdelt2
             d3 = np.array(wave[ipt] - zcoord[indexz]) / zcdelt3[indexz]
@@ -115,9 +115,9 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
             spaxel_weight[icube_index] = spaxel_weight[icube_index] + weight_distance
             spaxel_iflux[icube_index] = spaxel_iflux[icube_index] + 1
 
-    print('Number of pixels not in ifu cube too low wavelength', ilow)
-    print('Number of pixels not in ifu cube too high wavelength', ihigh)
-    print('Number of pixels not in ifu cube not match', imatch)
+#    print('Number of pixels not in ifu cube too low wavelength', ilow)
+#    print('Number of pixels not in ifu cube too high wavelength', ihigh)
+#    print('Number of pixels not in ifu cube not match', imatch)
 #_______________________________________________________________________
 def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
                            naxis1, naxis2, naxis3,

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1260,7 +1260,7 @@ class IFUCubeData():
             wave = np.asarray(self.wavelength_table, dtype=np.float32)
             # for now we need to pad wavelength to fix datamodel size
             num = len(wave)
-            nn = 2000 # This number needs to match the shape of the
+            nn = 10420 # This number needs to match the shape of the
             # wavetable['wavelength'] value in the ifucube.schema.
             # In the future it would be good to remove that we have to
             # set the size of this value in the schema.
@@ -1332,8 +1332,13 @@ class IFUCubeData():
             ifucube_model.meta.wcsinfo.crpix3 = self.crpix3
         else:
             ifucube_model.meta.wcsinfo.ctype3 = 'WAVE-TAB'
-            ifucube_model.meta.wcsinfo.ps3_0 = 'WSC-TABLE'
+            ifucube_model.meta.wcsinfo.ps3_0 = 'WCS-TABLE'
             ifucube_model.meta.wcsinfo.ps3_1 = 'wavelength'
+            ifucube_model.meta.wcsinfo.crval3 = 1.0
+            ifucube_model.meta.wcsinfo.crpix3 = 1.0
+            ifucube_model.meta.wcsinfo.cdelt3 = None
+            ifucube_model.meta.wcsinfo.wavedim = '(1,10420)'
+            #print('wrote',ifucube_model.meta.wcsinfo.wavedim)
 
         ifucube_model.meta.wcsinfo.ctype1 = 'RA---TAN'
         ifucube_model.meta.wcsinfo.ctype2 = 'DEC--TAN'

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -41,19 +41,20 @@ class IFUCubeData():
                  **pars_cube):
 
         self.new_code = 0
-
+        
         self.input_filenames = input_filenames
         self.pipeline = pipeline
 
         self.input_models = input_models # needed when building single mode IFU cubes
         self.output_name_base = output_name_base
+        self.num_files = None
 
         self.instrument = instrument
         self.detector = detector
         self.list_par1 = list_par1
         self.list_par2 = list_par2
 
-        self.instrument_info = instrument_info
+        self.instrument_info = instrument_info #dictionary class imported in cube_build.py
         self.master_table = master_table
         self.output_type = output_type
         self.scale1 = pars_cube.get('scale1')
@@ -61,10 +62,11 @@ class IFUCubeData():
         self.scalew = pars_cube.get('scalew')
         self.rois = pars_cube.get('rois')
         self.roiw = pars_cube.get('roiw')
-
+        self.spatial_size = None
+        self.spectral_size = None
+        
         self.interpolation = pars_cube.get('interpolation')
         self.coord_system = pars_cube.get('coord_system')
-
         self.wavemin = pars_cube.get('wavemin')
         self.wavemax = pars_cube.get('wavemax')
         self.weighting = pars_cube.get('weighting')
@@ -79,18 +81,27 @@ class IFUCubeData():
         self.output_name = ''
         self.this_cube_filenames = []
 
-        self.Cdelt1 = None
-        self.Cdelt2 = None
-        self.Cdelt3 = None
-        self.Crpix1 = None
-        self.Crpix2 = None
-        self.Crpix3 = None
-        self.Crval1 = None
-        self.Crval2 = None
-        self.Crval3 = None
+        self.soft_rad = None
+        self.linear_wavelength = True
+        self.roiw_table = None
+        self.rois_table = None
+        self.softrad_table = None
+        self.weight_power_table = None
+        self.wavelength_table = None
+
+        self.cdelt1 = None
+        self.cdelt2 = None
+        self.cdelt3 = None
+        self.crpix1 = None
+        self.crpix2 = None
+        self.crpix3 = None
+        self.crval1 = None
+        self.crval2 = None
+        self.crval3 = None
         self.naxis1 = None
         self.naxis2 = None
         self.naxis3 = None
+        self.cdelt3_normal = None 
 
         self.a_min = 0
         self.a_max = 0
@@ -117,7 +128,7 @@ class IFUCubeData():
 
         Returns
         -------
-        return the ROI suze to use
+        major problems - cube_build is  being run incorrectly. 
 
         """
         num1 = len(self.list_par1)
@@ -127,7 +138,7 @@ class IFUCubeData():
             this_b = self.list_par2[i]
             n = len(self.master_table.FileMap[self.instrument][this_a][this_b])
             num_files = num_files + n
-
+        self.num_files = num_files
 # do some basic checks on the cubes
         if(self.interpolation == "area"):
             if(num_files > 1):
@@ -148,20 +159,10 @@ class IFUCubeData():
                 raise IncorrectInput("Cubes built in alpha-beta coordinate system" +
                                      " are built from a single file")
 #________________________________________________________________________________
-# get the ROI sizes
-        roi = self.determine_roi_size()
-        # if the user has not set the size of the ROI then use defaults in reference
-        # parameter file
+#********************************************************************************
 
-        if self.roiw == 0.0: self.roiw = roi[0]
-        if self.rois == 0.0:  # user did not set so use defaults
-            self.rois = roi[1]
-            if self.output_type == 'single' or num_files < 4:
-                self.rois = self.rois * 1.5
-                log.info('Increasing spatial region of interest' +
-                        'default value set for 4 dithers %f', self.rois)
-        if self.interpolation == 'pointcloud':
-            log.info('Region of interest spatial, wavelength  %f %f', self.rois, self.roiw)
+
+
 #________________________________________________________________________________
 #********************************************************************************
 # update the output name
@@ -211,221 +212,7 @@ class IFUCubeData():
         return newname
 
 #********************************************************************************
-    def setup_ifucube_wcs(self):
 
-        """
-        Short Summary
-        -------------
-        Function to determine the min and max coordinates of the spectral
-        cube, given channel & subchannel
-
-        Parameter
-        ----------
-        self.master_table:  A table that contains the channel/subchannel or
-        filter/grating for each input file
-        self.instrument_info: Default information on the MIRI and NIRSPEC instruments.
-
-        Returns
-        -------
-        Cube Dimension Information:
-        Footprint of cube: min and max of coordinates of cube.
-
-        If the coordinate system is alpha-beta (MIRI) then min and max
-        coordinates of alpha (arc sec), beta (arc sec) and lambda (microns)
-        If the coordinate system is world then the min and max of
-        ra(degress), dec (degrees) and lambda (microns) is returned.
-        """
-#________________________________________________________________________________
-# Scale is 3 dimensions and is determined from values held in  instrument_info.GetScale
-        scale = self.determine_scale()
-        self.Cdelt1 = scale[0]
-        self.Cdelt2 = scale[1]
-        self.Cdelt3 = scale[2]
-
-        parameter1 = self.list_par1
-        parameter2 = self.list_par2
-        a_min = []
-        a_max = []
-        b_min = []
-        b_max = []
-        lambda_min = []
-        lambda_max = []
-
-        self.num_bands = len(self.list_par1)
-        log.info('Number of bands in cube  %i', self.num_bands)
-
-        for i in range(self.num_bands):
-            this_a = parameter1[i]
-            this_b = parameter2[i]
-            log.debug('Working on data  from %s,%s', this_a, this_b)
-            n = len(self.master_table.FileMap[self.instrument][this_a][this_b])
-            log.debug('number of files %d ', n)
-            for k in range(n):
-                amin = 0.0
-                amax = 0.0
-                bmin = 0.0
-                bmax = 0.0
-                lmin = 0.0
-                lmax = 0.0
-
-                ifile = self.master_table.FileMap[self.instrument][this_a][this_b][k]
-#________________________________________________________________________________
-# Open the input data model
-# Find the footprint of the image
-                with datamodels.IFUImageModel(ifile) as input_model:
-                    if self.instrument == 'NIRSPEC':
-                        flag_data = 0
-#                        t0 = time.time()
-                        ch_footprint = cube_build_wcs_util.find_footprint_NIRSPEC(
-                            input_model,
-                            flag_data,
-                            self.coord_system)
-#                        t1 = time.time()
-#                        print('time to find footprint',t1-t0) 
-                        amin, amax, bmin, bmax, lmin, lmax = ch_footprint
-#________________________________________________________________________________
-                    if self.instrument == 'MIRI':
-                        ch_footprint = cube_build_wcs_util.find_footprint_MIRI(
-                            input_model,
-                            this_a,
-                            self.instrument_info,
-                            self.coord_system)
-                        amin, amax, bmin, bmax, lmin, lmax = ch_footprint
-
-                    a_min.append(amin)
-                    a_max.append(amax)
-                    b_min.append(bmin)
-                    b_max.append(bmax)
-                    lambda_min.append(lmin)
-                    lambda_max.append(lmax)
-#________________________________________________________________________________
-    # done looping over files determine final size of cube
-
-        final_a_min = min(a_min)
-        final_a_max = max(a_max)
-        final_b_min = min(b_min)
-        final_b_max = max(b_max)
-        final_lambda_min = min(lambda_min)
-        final_lambda_max = max(lambda_max)
-
-        if self.wavemin is not None and self.wavemin > final_lambda_min:
-            final_lambda_min = self.wavemin
-            log.info('Changed min wavelength of cube to %f ', final_lambda_min)
-
-        if self.wavemax is not None and self.wavemax < final_lambda_max:
-            final_lambda_max = self.wavemax
-            log.info('Changed max wavelength of cube to %f ', final_lambda_max)
-#________________________________________________________________________________
-        if self.instrument == 'MIRI' and self.coord_system == 'alpha-beta':
-        #  we have a 1 to 1 mapping in beta dimension.
-            nslice = self.instrument_info.GetNSlice(parameter1[0])
-            log.info('Beta Scale %f ', self.Cdelt2)
-            self.Cdelt2 = (final_b_max - final_b_min) / nslice
-            final_b_max = final_b_min + (nslice) * self.Cdelt2
-            log.info('Changed the Beta Scale dimension so we have 1 -1 mapping between beta and slice #')
-            log.info('New Beta Scale %f ', self.Cdelt2)
-#________________________________________________________________________________
-# Test that we have data (NIRSPEC NRS2 only has IFU data for 3 configurations)
-        test_a = final_a_max - final_a_min
-        test_b = final_b_max - final_b_min
-        test_w = final_lambda_max - final_lambda_min
-        tolerance1 = 0.00001
-        tolerance2 = 0.1
-        if(test_a < tolerance1 or test_b < tolerance1 or test_w < tolerance2):
-            log.info('No Valid IFU slice data found %f %f %f ', test_a, test_b, test_w)
-#________________________________________________________________________________
-        cube_footprint = (final_a_min, final_a_max, final_b_min, final_b_max,
-                      final_lambda_min, final_lambda_max)
-#________________________________________________________________________________
-    # Based on Scaling and Min and Max values determine naxis1, naxis2, naxis3
-    # set cube CRVALs, CRPIXs and xyz coords (center  x,y,z vector spaxel centers)
-
-        if self.coord_system == 'world':
-            self.set_geometry(cube_footprint)
-        else:
-            self.set_geometryAB(cube_footprint) # local coordinate system
-        self.print_cube_geometry()
-
-#********************************************************************************
-    def determine_scale(self):
-#********************************************************************************
-        """
-        Short Summary
-        -------------
-        Determine the scale (sampling) in the 3 dimensions for the cube.
-        If the IFU cube covers more than 1 band - then use the rules to
-        define the spatial and spectral sample size to use for the cube
-        Current Rule: using the minimum
-
-        Parameters
-        ----------
-        self.instrument_info holds the defaults scales for each channel/subchannel (MIRI)
-        or Grating (NIRSPEC)
-
-        Returns
-        -------
-        scale, holding the scale for the 3 dimensions of the cube/
-
-        """
-        scale = [0, 0, 0]
-        if self.instrument == 'MIRI':
-            number_bands = len(self.list_par1)
-            min_a = 1000.00
-            min_b = 1000.00
-            min_w = 1000.00
-            for i in range(number_bands):
-                this_channel = self.list_par1[i]
-                this_sub = self.list_par2[i]
-                a_scale, b_scale, w_scale = self.instrument_info.GetScale(this_channel,
-                                                                              this_sub)
-                if a_scale < min_a:
-                    min_a = a_scale
-                if b_scale < min_b:
-                    min_b = b_scale
-                if w_scale < min_w:
-                    min_w = w_scale
-            scale = [min_a, min_b, min_w]
-
-        elif self.instrument == 'NIRSPEC':
-            number_gratings = len(self.list_par1)
-            min_a = 1000.00
-            min_b = 1000.00
-            min_w = 1000.00
-
-            for i in range(number_gratings):
-                this_gwa = self.list_par1[i]
-                this_filter = self.list_par2[i]
-                a_scale, b_scale, w_scale = self.instrument_info.GetScale(this_gwa,
-                                                                          this_filter)
-                if a_scale < min_a:
-                    min_a = a_scale
-                if b_scale < min_b:
-                    min_b = b_scale
-                if w_scale < min_w:
-                    min_w = w_scale
-            scale = [min_a, min_b, min_w]
-#________________________________________________________________________________
-# check and see if the user has set the scale or set by cfg.
-
-        a_scale = scale[0]
-        if self.scale1 != 0.0:
-            a_scale = self.scale1
-
-        b_scale = scale[1]
-        if self.scale2 != 0.0:
-            b_scale = self.scale2
-        w_scale = scale[2]
-        # temp fix for large cubes - need to change to variable wavelength scale
-        if self.scalew == 0 and self.num_bands > 6:
-            w_scale = w_scale * 2
-        if self.scalew == 0 and self.num_bands > 9:
-            w_scale = w_scale * 2
-        if self.scalew != 0.0:
-            w_scale = self.scalew
-
-        scale = [a_scale, b_scale, w_scale]
-        return scale
-#_______________________________________________________________________
 #_______________________________________________________________________
     def set_geometry(self, footprint):
 
@@ -449,29 +236,29 @@ class IFUCubeData():
         ra_ave = circmean(ravalues * u.deg).value
 #        log.info('Ra average %f12.8', ra_ave)
 
-        self.Crval1 = ra_ave
-        self.Crval2 = dec_ave
-        xi_center, eta_center = coord.radec2std(self.Crval1, self.Crval2,
+        self.crval1 = ra_ave
+        self.crval2 = dec_ave
+        xi_center, eta_center = coord.radec2std(self.crval1, self.crval2,
                                                 ra_ave, dec_ave)
-        xi_min, eta_min = coord.radec2std(self.Crval1, self.Crval2, ra_min, dec_min)
-        xi_max, eta_max = coord.radec2std(self.Crval1, self.Crval2, ra_max, dec_max)
+        xi_min, eta_min = coord.radec2std(self.crval1, self.crval2, ra_min, dec_min)
+        xi_max, eta_max = coord.radec2std(self.crval1, self.crval2, ra_max, dec_max)
 #________________________________________________________________________________
 # find the CRPIX1 CRPIX2 - xi and eta centered at 0,0
 # to find location of center abs of min values is how many pixels
-        n1a = int(math.ceil(math.fabs(xi_min) / self.Cdelt1))
-        n2a = int(math.ceil(math.fabs(eta_min) / self.Cdelt2))
+        n1a = int(math.ceil(math.fabs(xi_min) / self.cdelt1))
+        n2a = int(math.ceil(math.fabs(eta_min) / self.cdelt2))
 
-        n1b = int(math.ceil(math.fabs(xi_max) / self.Cdelt1))
-        n2b = int(math.ceil(math.fabs(eta_max) / self.Cdelt2))
+        n1b = int(math.ceil(math.fabs(xi_max) / self.cdelt1))
+        n2b = int(math.ceil(math.fabs(eta_max) / self.cdelt2))
 
-        xi_min = 0.0 - (n1a * self.Cdelt1) - (self.Cdelt1 / 2.0)
-        xi_max = (n1b * self.Cdelt1) + (self.Cdelt1 / 2.0)
+        xi_min = 0.0 - (n1a * self.cdelt1) - (self.cdelt1 / 2.0)
+        xi_max = (n1b * self.cdelt1) + (self.cdelt1 / 2.0)
 
-        eta_min = 0.0 - (n2a * self.Cdelt2) - (self.Cdelt2 / 2.0)
-        eta_max = (n2b * self.Cdelt2) + (self.Cdelt2 / 2.0)
+        eta_min = 0.0 - (n2a * self.cdelt2) - (self.cdelt2 / 2.0)
+        eta_max = (n2b * self.cdelt2) + (self.cdelt2 / 2.0)
 
-        self.Crpix1 = float(n1a) + 1.0
-        self.Crpix2 = float(n2a) + 1.0
+        self.crpix1 = float(n1a) + 1.0
+        self.crpix2 = float(n2a) + 1.0
 
         self.naxis1 = n1a + n1b
         self.naxis2 = n2a + n2b
@@ -483,66 +270,75 @@ class IFUCubeData():
 
 # center of spaxels
         self.xcoord = np.zeros(self.naxis1)
-        xstart = xi_min + self.Cdelt1 / 2.0
+        xstart = xi_min + self.cdelt1 / 2.0
         for i in range(self.naxis1):
             self.xcoord[i] = xstart
-            xstart = xstart + self.Cdelt1
+            xstart = xstart + self.cdelt1
 
         self.ycoord = np.zeros(self.naxis2)
-        ystart = eta_min + self.Cdelt2 / 2.0
+        ystart = eta_min + self.cdelt2 / 2.0
         for i in range(self.naxis2):
             self.ycoord[i] = ystart
-            ystart = ystart + self.Cdelt2
+            ystart = ystart + self.cdelt2
 
         ygrid = np.zeros(self.naxis2 * self.naxis1)
         xgrid = np.zeros(self.naxis2 * self.naxis1)
-#        ycube,xcube = np.mgrid[0:self.naxis2,0:self.naxis1]
 
+
+        
         k = 0
-#        xstart = self.xcoord[0]
-#        for i in range(self.naxis1):
-#            ystart = self.ycoord[0]
-#            for j in range(self.naxis2):
-#                xgrid[k] = xstart
-#                ygrid[k] = ystart
-#                ystart = ystart + self.Cdelt2
-#                k = k + 1
-#            xstart = xstart + self.Cdelt1
-
         ystart = self.ycoord[0]
         for i in range(self.naxis2):
             xstart = self.xcoord[0]
             for j in range(self.naxis1):
                 xgrid[k] = xstart
                 ygrid[k] = ystart
-                xstart = xstart + self.Cdelt1
+                xstart = xstart + self.cdelt1
                 k = k + 1
-            ystart = ystart + self.Cdelt2
+            ystart = ystart + self.cdelt2
 
+
+#        ycube,xcube = np.mgrid[0:self.naxis2,
+#                               0:self.naxis1]    
+#        xcube = xcube.flatten()
+#        ycube = ycube.flatten()
 
         self.xcenters = xgrid
         self.ycenters = ygrid
-
 #_______________________________________________________________________
         #set up the lambda (z) coordinate of the cube
-        self.lambda_min = lambda_min
-        self.lambda_max = lambda_max
-        range_lambda = self.lambda_max - self.lambda_min
-        self.naxis3 = int(math.ceil(range_lambda / self.Cdelt3))
+        self.cdelt3_normal = None 
+        if self.linear_wavelength:
+            self.lambda_min = lambda_min
+            self.lambda_max = lambda_max
+            range_lambda = self.lambda_max - self.lambda_min
+            self.naxis3 = int(math.ceil(range_lambda / self.cdelt3))
 
          # adjust max based on integer value of naxis3
-        lambda_center = (self.lambda_max + self.lambda_min) / 2.0
-        self.lambda_min = lambda_center - (self.naxis3 / 2.0) * self.Cdelt3
-        self.lambda_max = self.lambda_min + (self.naxis3) * self.Cdelt3
+            lambda_center = (self.lambda_max + self.lambda_min) / 2.0
+            self.lambda_min = lambda_center - (self.naxis3 / 2.0) * self.cdelt3
+            self.lambda_max = self.lambda_min + (self.naxis3) * self.cdelt3
 
-        self.zcoord = np.zeros(self.naxis3)
-        self.Crval3 = self.lambda_min
-        self.Crpix3 = 1.0
-        zstart = self.lambda_min + self.Cdelt3 / 2.0
-        for i in range(self.naxis3):
-            self.zcoord[i] = zstart
-            zstart = zstart + self.Cdelt3
+            self.zcoord = np.zeros(self.naxis3)
+            self.crval3 = self.lambda_min
+            self.crpix3 = 1.0
+            zstart = self.lambda_min + self.cdelt3 / 2.0
+            for i in range(self.naxis3):
+                self.zcoord[i] = zstart
+                zstart = zstart + self.cdelt3
 
+        else:
+            self.naxis3 = len(self.wavelength_table)
+            self.zcoord = np.asarray(self.wavelength_table)
+            self.crval3 = self.wavelength_table[0]
+            self.crpix3 = 1.0
+# set up the cdelt3_normal normalizing array used in cube_cloud.py
+        cdelt3_normal = np.zeros(self.naxis3)
+        for j in range (self.naxis3-1):
+            cdelt3_normal[j] = self.zcoord[j+1] - self.zcoord[j]
+
+        cdelt3_normal[self.naxis3-1] = cdelt3_normal[self.naxis3-2]
+        self.cdelt3_normal = cdelt3_normal
 #_______________________________________________________________________
     def set_geometryAB(self, footprint):
         """
@@ -557,58 +353,58 @@ class IFUCubeData():
 
         #set up the a (x) coordinates of the cube
         range_a = self.a_max - self.a_min
-        self.naxis1 = int(math.ceil(range_a / self.Cdelt1))
+        self.naxis1 = int(math.ceil(range_a / self.cdelt1))
 
         # adjust min and max based on integer value of naxis1
         a_center = (self.a_max + self.a_min) / 2.0
-        self.a_min = a_center - (self.naxis1 / 2.0) * self.Cdelt1
-        self.a_max = a_center + (self.naxis1 / 2.0) * self.Cdelt1
+        self.a_min = a_center - (self.naxis1 / 2.0) * self.cdelt1
+        self.a_max = a_center + (self.naxis1 / 2.0) * self.cdelt1
 
         self.xcoord = np.zeros(self.naxis1)
-        self.Crval1 = self.a_min
-        self.Crpix1 = 0.5
-        xstart = self.a_min + self.Cdelt1 / 2.0
+        self.crval1 = self.a_min
+        self.crpix1 = 0.5
+        xstart = self.a_min + self.cdelt1 / 2.0
         for i in range(self.naxis1):
             self.xcoord[i] = xstart
-            xstart = xstart + self.Cdelt1
+            xstart = xstart + self.cdelt1
 #_______________________________________________________________________
         #set up the lambda (z) coordinate of the cube
         range_lambda = self.lambda_max - self.lambda_min
-        self.naxis3 = int(math.ceil(range_lambda / self.Cdelt3))
+        self.naxis3 = int(math.ceil(range_lambda / self.cdelt3))
 
          # adjust max based on integer value of naxis3
         lambda_center = (self.lambda_max + self.lambda_min) / 2.0
 
-        self.lambda_min = lambda_center - (self.naxis3 / 2.0) * self.Cdelt3
-        self.lambda_max = lambda_center + (self.naxis3 / 2.0) * self.Cdelt3
+        self.lambda_min = lambda_center - (self.naxis3 / 2.0) * self.cdelt3
+        self.lambda_max = lambda_center + (self.naxis3 / 2.0) * self.cdelt3
 
-        self.lambda_max = self.lambda_min + (self.naxis3) * self.Cdelt3
+        self.lambda_max = self.lambda_min + (self.naxis3) * self.cdelt3
 
         self.zcoord = np.zeros(self.naxis3)
-        self.Crval3 = self.lambda_min
-        self.Crpix3 = 1.0
-        zstart = self.lambda_min + self.Cdelt3 / 2.0
+        self.crval3 = self.lambda_min
+        self.crpix3 = 1.0
+        zstart = self.lambda_min + self.cdelt3 / 2.0
 
         for i in range(self.naxis3):
             self.zcoord[i] = zstart
-            zstart = zstart + self.Cdelt3
+            zstart = zstart + self.cdelt3
 #_______________________________________________________________________
         # set up the naxis2 parameters
         range_b = self.b_max - self.b_min
 
-        self.naxis2 = int(math.ceil(range_b / self.Cdelt2))
+        self.naxis2 = int(math.ceil(range_b / self.cdelt2))
         b_center = (self.b_max + self.b_min) / 2.0
     # adjust min and max based on integer value of naxis2
-        self.b_max = b_center + (self.naxis2 / 2.0) * self.Cdelt2
-        self.b_min = b_center - (self.naxis2 / 2.0) * self.Cdelt2
+        self.b_max = b_center + (self.naxis2 / 2.0) * self.cdelt2
+        self.b_min = b_center - (self.naxis2 / 2.0) * self.cdelt2
 
         self.ycoord = np.zeros(self.naxis2)
-        self.Crval2 = self.b_min
-        self.Crpix2 = 0.5
-        ystart = self.b_min + self.Cdelt2 / 2.0
+        self.crval2 = self.b_min
+        self.crpix2 = 0.5
+        ystart = self.b_min + self.cdelt2 / 2.0
         for i in range(self.naxis2):
             self.ycoord[i] = ystart
-            ystart = ystart + self.Cdelt2
+            ystart = ystart + self.cdelt2
 
 #_______________________________________________________________________
     def print_cube_geometry(self):
@@ -619,18 +415,29 @@ class IFUCubeData():
 
         log.info('Cube Geometry:')
         if self.coord_system == 'alpha-beta':
-            log.info('axis# Naxis  CRPIX    CRVAL      CDELT(arc sec)  MIN & Max (alpha,beta arc sec)')
+            log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(arc sec)  MIN & Max (alpha,beta arc sec)')
         else:
-            log.info('axis# Naxis  CRPIX    CRVAL      CDELT(arc sec)  MIN & Max (xi,eta arc sec)')
+            log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(arc sec)  MIN & Max (xi,eta arc sec)')
             log.info('Axis 1 %5d  %5.2f %12.8f %12.8f %12.8f %12.8f',
-                     self.naxis1, self.Crpix1, self.Crval1, self.Cdelt1,
+                     self.naxis1, self.crpix1, self.crval1, self.cdelt1,
                      self.a_min, self.a_max)
             log.info('Axis 2 %5d  %5.2f %12.8f %12.8f %12.8f %12.8f',
-                     self.naxis2, self.Crpix2, self.Crval2, self.Cdelt2,
+                     self.naxis2, self.crpix2, self.crval2, self.cdelt2,
                      self.b_min, self.b_max)
-            log.info('Axis 3 %5d  %5.2f %12.8f %12.8f %12.8f %12.8f',
-                     self.naxis3, self.Crpix3, self.Crval3, self.Cdelt3,
-                     self.lambda_min, self.lambda_max)
+            if self.linear_wavelength:
+                log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(microns)  MIN & Max (microns)')
+                log.info('Axis 3 %5d  %5.2f %12.8f %12.8f %12.8f %12.8f',
+                         self.naxis3, self.crpix3, self.crval3, self.cdelt3,
+                         self.lambda_min, self.lambda_max)
+
+            if not self.linear_wavelength:
+                log.info('Non-linear wavelength dimension, CDELT3 variable')
+                log.info('axis#  Naxis  CRPIX    CRVAL     MIN & Max (microns)')
+                log.info('Axis 3 %5d  %5.2f %12.8f %12.8f %12.8f',
+                         self.naxis3, self.crpix3, self.crval3,
+                         self.wavelength_table[0], self.wavelength_table[self.naxis3-1])
+
+
 
         if self.instrument == 'MIRI':
         # length of channel and subchannel are the same
@@ -711,13 +518,14 @@ class IFUCubeData():
                                                                    subtract_background,
                                                                    ifile)
 
-                    coord1, coord2, wave, flux, alpha_det, beta_det = pixelresult
+                    coord1, coord2, wave, flux, rois_pixel, roiw_pixel, weight_pixel,\
+                        softrad_pixel, alpha_det, beta_det = pixelresult
                     if self.weighting == 'msm':
                         t0 = time.time()
 #                        if self.new_code:
 #                            print('calling new cube_cloud')
 #                            cube_cloud_quick.match_det2cube_msm(self.naxis1,self.naxis2,self.naxis3,
-#                                                              self.Cdelt1,self.Cdelt2,self.Cdelt3,
+#                                                              self.cdelt1,self.cdelt2,self.cdelt3,
 #                                                              self.rois,self.roiw,self.weight_power,
 #                                                              self.xcoord,self.ycoord,self.zcoord,
 #                                                              self.spaxel_flux,
@@ -728,14 +536,16 @@ class IFUCubeData():
 #                        else:
 #                            print('calling old cube_cloud')
                         cube_cloud.match_det2cube_msm(self.naxis1, self.naxis2, self.naxis3,
-                                                      self.Cdelt1, self.Cdelt2, self.Cdelt3,
-                                                      self.rois, self.roiw, self.weight_power,
+                                                      self.cdelt1, self.cdelt2, self.cdelt3,
+                                                      self.cdelt3_normal,self.roiw,
                                                       self.xcenters, self.ycenters, self.zcoord,
                                                       self.spaxel_flux,
                                                       self.spaxel_weight,
                                                       self.spaxel_iflux,
                                                       flux,
-                                                      coord1, coord2, wave)
+                                                      coord1, coord2, wave, 
+                                                      rois_pixel, roiw_pixel, weight_pixel,
+                                                      softrad_pixel)
 
 
                         t1 = time.time()
@@ -757,8 +567,8 @@ class IFUCubeData():
                                                               worldtov23,
                                                               v2ab_transform,
                                                               self.naxis1, self.naxis2, self.naxis3,
-                                                              self.Cdelt1, self.Cdelt2, self.Cdelt3,
-                                                              self.Crval1, self.Crval2,
+                                                              self.cdelt1, self.cdelt2, self.cdelt3,
+                                                              self.crval1, self.crval2,
                                                               self.rois, self.roiw,
                                                               self.weight_power,
                                                               self.xcenters, self.ycenters, self.zcoord,
@@ -795,8 +605,8 @@ class IFUCubeData():
                                                         self.spaxel_weight,
                                                         self.spaxel_iflux,
                                                         self.xcoord, self.zcoord,
-                                                        self.Crval1, self.Crval3,
-                                                        self.Cdelt1, self.Cdelt3,
+                                                        self.crval1, self.crval3,
+                                                        self.cdelt1, self.cdelt3,
                                                         self.naxis1, self.naxis2)
                         t1 = time.time()
 
@@ -862,17 +672,21 @@ class IFUCubeData():
                                                            subtract_background,
                                                            self.input_models[j])
 
-            coord1, coord2, wave, flux, alpha_det, beta_det = pixelresult
+            coord1, coord2, wave, flux, rois_pixel, roiw_pixel, weight_pixel, \
+                softrad_pixel, alpha_det, beta_det = pixelresult
 
             cube_cloud.match_det2cube_msm(self.naxis1, self.naxis2, self.naxis3,
-                                              self.Cdelt1, self.Cdelt2, self.Cdelt3,
-                                              self.rois, self.roiw, self.weight_power,
-                                              self.xcenters, self.ycenters, self.zcoord,
-                                              self.spaxel_flux,
-                                              self.spaxel_weight,
-                                              self.spaxel_iflux,
-                                              flux,
-                                              coord1, coord2, wave)
+                                          self.cdelt1, self.cdelt2, self.cdelt3,
+                                          self.cdelt3_normal,
+                                          self.roiw,
+                                          self.xcenters, self.ycenters, self.zcoord,
+                                          self.spaxel_flux,
+                                          self.spaxel_weight,
+                                          self.spaxel_iflux,
+                                          flux,
+                                          coord1, coord2, wave,
+                                          rois_pixel, roiw_pixel, weight_pixel,
+                                          softrad_pixel)
 #_______________________________________________________________________
 # shove Flux and iflux in the  final ifucube
             self.find_spaxel_flux()
@@ -888,7 +702,7 @@ class IFUCubeData():
         return single_ifucube_container
 #********************************************************************************
 
-    def determine_roi_size(self):
+    def determine_cube_parameters(self):
         """
         Short Summary
         -------------
@@ -908,41 +722,287 @@ class IFUCubeData():
         roi size for spatial and wavelength
 
         """
+        # initialize 
+        spaxel_roi = None
+        wave_roi = None
+        weight_power = None
 
-        roi = [0, 0]
-        if self.instrument == 'MIRI':
-            number_bands = len(self.list_par1)
-            min_s = 1000.00
-            min_w = 1000.00
+        number_bands = len(self.list_par1)
+        spaxelsize = np.zeros(number_bands)
+        spectralsize = np.zeros(number_bands)
+        rois =  np.zeros(number_bands)
+        roiw =  np.zeros(number_bands)
+        power=  np.zeros(number_bands)
+        softrad =  np.zeros(number_bands)
+        minwave =  np.zeros(number_bands)
+        maxwave =  np.zeros(number_bands)
+        print('number of bands for ifu',number_bands)
+        for i in range(number_bands):
+            if self.instrument == 'MIRI':
+                par1 = self.list_par1[i]
+                par2 = self.list_par2[i]
+            elif self.instrument == 'NIRSPEC':
+                par1 = self.list_par1[i]
+                par2 = self.list_par2[i]
 
-            for i in range(number_bands):
-                this_channel = self.list_par1[i]
-                this_sub = self.list_par2[i]
-                wroi = self.instrument_info.GetWaveRoi(this_channel, this_sub)
-                if wroi < min_w:
-                    min_w = wroi
-                sroi = self.instrument_info.GetSpatialRoi(this_channel, this_sub)
-                if sroi < min_s:
-                    min_s = sroi
-            roi = [min_w, min_s]
+            roiw[i] = self.instrument_info.GetWaveRoi(par1, par2)
+            rois[i] = self.instrument_info.GetSpatialRoi(par1, par2)
 
-        elif self.instrument == 'NIRSPEC':
-            number_gratings = len(self.list_par1)
-            min_s = 1000.00
-            min_w = 1000.00
+            a_scale, b_scale, w_scale = self.instrument_info.GetScale(par1,
+                                                                      par2)
+            spaxelsize[i] = a_scale
+            spectralsize[i] = w_scale
+            print('scales',a_scale,b_scale,w_scale,par1,par2)
 
-            for i in range(number_gratings):
-                this_gwa = self.list_par1[i]
-                this_filter = self.list_par2[i]
+            power[i] = self.instrument_info.GetMSMPower(par1, par2)
+            softrad[i] = self.instrument_info.GetSoftRad(par1, par2)
+            minwave[i] = self.instrument_info.GetWaveMin(par1, par2)
+            maxwave[i] = self.instrument_info.GetWaveMax(par1, par2)
+# Check the spatial size. If it is the same for the array set up the parameters
+        all_same = np.all(spaxelsize == spaxelsize[0])
+        if all_same:
+            self.spatial_size = spaxelsize[0]
+            spatial_roi = rois[0]
+        else:
+            index_min = np.argmin(spaxelsize)
+            self.spatial_size = spaxelsize[index_min]
+            spatial_roi = rois[index_min]
+# find min and max wavelength
+        min_wave = np.amin(minwave)
+        max_wave = np.amax(maxwave)                
 
-                wroi = self.instrument_info.GetWaveRoi(this_gwa, this_filter)
-                if wroi < min_w:
-                    min_w = wroi
-                sroi = self.instrument_info.GetSpatialRoi(this_gwa, this_filter)
-                if sroi < min_s:
-                    min_s = sroi
-            roi = [min_w, min_s]
-        return roi
+        if self.wavemin is None: 
+            self.wavemin = min_wave
+        else:
+            self.wavemin = np.float64(self.wavemin)
+
+        if self.wavemax is None: 
+            self.wavemax = max_wave
+        else:
+            self.wavemax = np.float64(self.wavemax)
+
+# now check spectral step
+        all_same_spectral = np.all(spectralsize == spectralsize[0])
+        if all_same_spectral:
+            self.spectral_size = spectralsize[0]
+            wave_roi = roiw[0]
+            self.soft_rad = softrad[0]
+            weight_power = power[0]
+        else:
+            self.linear_wavelength = False
+            if self.instrument == 'MIRI':
+                table = self.instrument_info.Get_multichannel_table()
+                table_wavelength,table_sroi,table_wroi,table_power,table_softrad = table
+
+# getting MIRI Table Values
+            elif self.instrument == 'NIRSPEC':
+# determine if have Prism, Medium or High resolution
+                med = ['g140m','g235m','g395m']
+                high = ['g140h','g235h','g395h']
+                prism = ['prism']
+                
+                for i in range(number_bands):
+                    par1 = self.list_par1[i]
+                    if par1 in prism: 
+                        table = self.instrument_info.Get_prism_table()
+                    if par1 in med: 
+                        table = self.instrument_info.Get_med_table()
+                    if par1 in high: 
+                        table = self.instrument_info.Get_high_table()
+                    table_wavelength,table_sroi,table_wroi,table_power,table_softrad = table
+# based on Min and Max wavelength - pull out the tables values that fall in this range
+            print('wave range',self.wavemin,self.wavemax)
+            # find the closest
+            imin = (np.abs(table_wavelength - self.wavemin)).argmin()
+            imax = (np.abs(table_wavelength - self.wavemax)).argmin()
+            if imin > 1 and  table_wavelength[imin] > self.wavemin: imin = imin - 1
+            if (imax < len(table_wavelength) and  
+                self.wavemax > table_wavelength[imax]): imax = imax  + 1
+            print('index of wavelength values',imin,imax)
+
+            self.roiw_table = table_wroi[imin:imax]
+            self.rois_table = table_sroi[imin:imax]
+            self.softrad_table = table_softrad[imin:imax]
+            self.weight_power_table = table_power[imin:imax]
+            self.wavelength_table = table_wavelength[imin:imax]
+
+# check if the user has set the cube parameters to use
+        if self.rois == 0: self.rois = spatial_roi
+        if self.output_type == 'single' or self.num_files < 4:
+            self.rois = self.rois * 1.5
+            log.info('Increasing spatial region of interest' +
+                     'default value set for 4 dithers %f', self.rois)        
+        if self.scale1 != 0: 
+            self.spatial_size = scale1
+        if self.scalew != 0: 
+            self.spectral_size = scalew
+            self.linear_wavelength = True 
+            #set wave_roi, weight_power, soft_rad to same values if they are in  list
+        if self.roiw == 0: self.roiw = wave_roi
+        if self.weight_power == 0: self.weight_power = weight_power
+
+        print('spatial size', self.spatial_size)
+        print('spectral size', self.spectral_size)
+        print('spatial roi', self.rois)
+        print('wave min and max',self.wavemin, self.wavemax)
+        print('linear wavelength',self.linear_wavelength)
+        print('roiw',self.roiw)
+        print('weight',self.weight_power)
+
+
+#        if self.interpolation == 'pointcloud':
+#            log.info('Region of interest spatial, wavelength  %f %f', self.rois, self.roiw)
+
+#********************************************************************************
+    def setup_ifucube_wcs(self):
+
+        """
+        Short Summary
+        -------------
+        Function to determine the min and max coordinates of the spectral
+        cube, given channel & subchannel
+
+        Parameter
+        ----------
+        self.master_table:  A table that contains the channel/subchannel or
+        filter/grating for each input file
+        self.instrument_info: Default information on the MIRI and NIRSPEC instruments.
+
+        Returns
+        -------
+        Cube Dimension Information:
+        Footprint of cube: min and max of coordinates of cube.
+
+        If the coordinate system is alpha-beta (MIRI) then min and max
+        coordinates of alpha (arc sec), beta (arc sec) and lambda (microns)
+        If the coordinate system is world then the min and max of
+        ra(degress), dec (degrees) and lambda (microns) is returned.
+
+        """
+#________________________________________________________________________________
+# Scale is 3 dimensions and is determined from values held in  instrument_info.GetScale
+#        scale = self.determine_scale()
+
+        self.cdelt1 = self.spatial_size
+        self.cdelt2 = self.spatial_size
+        if self.linear_wavelength:
+            self.cdelt3 = self.spectral_size
+
+        parameter1 = self.list_par1
+        parameter2 = self.list_par2
+        a_min = []
+        a_max = []
+        b_min = []
+        b_max = []
+        lambda_min = []
+        lambda_max = []
+
+        self.num_bands = len(self.list_par1)
+        log.info('Number of bands in cube  %i', self.num_bands)
+
+        for i in range(self.num_bands):
+            this_a = parameter1[i]
+            this_b = parameter2[i]
+            log.debug('Working on data  from %s,%s', this_a, this_b)
+            n = len(self.master_table.FileMap[self.instrument][this_a][this_b])
+            log.debug('number of files %d ', n)
+            for k in range(n):
+                amin = 0.0
+                amax = 0.0
+                bmin = 0.0
+                bmax = 0.0
+                lmin = 0.0
+                lmax = 0.0
+
+                ifile = self.master_table.FileMap[self.instrument][this_a][this_b][k]
+#________________________________________________________________________________
+# Open the input data model
+# Find the footprint of the image
+                with datamodels.IFUImageModel(ifile) as input_model:
+                    if self.instrument == 'NIRSPEC':
+                        flag_data = 0
+#                        t0 = time.time()
+                        ch_footprint = cube_build_wcs_util.find_footprint_NIRSPEC(
+                            input_model,
+                            flag_data,
+                            self.coord_system)
+#                        t1 = time.time()
+#                        print('time to find footprint',t1-t0)
+ 
+                        amin, amax, bmin, bmax, lmin, lmax = ch_footprint
+                        print(amin, amax, bmin ,bmax)
+                        amin, bmin, amax, bmin2, amax2, bmax, amin2, bmax2 = \
+                            input_model.meta.wcsinfo.s_region
+                        print(amin, amax, bmin, bmax, amin2, amax2, bmin2, bmax2)
+#________________________________________________________________________________
+                    if self.instrument == 'MIRI':
+                        ch_footprint = cube_build_wcs_util.find_footprint_MIRI(
+                            input_model,
+                            this_a,
+                            self.instrument_info,
+                            self.coord_system)
+                        amin, amax, bmin, bmax, lmin, lmax = ch_footprint
+
+                        print(amin, amax, bmin ,bmax)
+
+                        footprint = input_model.meta.wcs.footprint
+                        
+                        print(footprint)
+                        print(type(footprint))
+
+                        amin, bmin, amax, bmin2, amax2, bmax, amin2, bmax2 = fp
+                        print(amin, amax, bmin, bmax, amin2, amax2, bmin2, bmax2)
+                    a_min.append(amin)
+                    a_max.append(amax)
+                    b_min.append(bmin)
+                    b_max.append(bmax)
+                    lambda_min.append(lmin)
+                    lambda_max.append(lmax)
+#________________________________________________________________________________
+    # done looping over files determine final size of cube
+
+        final_a_min = min(a_min)
+        final_a_max = max(a_max)
+        final_b_min = min(b_min)
+        final_b_max = max(b_max)
+        final_lambda_min = min(lambda_min)
+        final_lambda_max = max(lambda_max)
+
+        print('wavelengths',final_lambda_min,final_lambda_max,self.wavemin,self.wavemax)
+
+        final_lambda_min = self.wavemin
+        final_lambda_max = self.wavemax
+
+#________________________________________________________________________________
+        if self.instrument == 'MIRI' and self.coord_system == 'alpha-beta':
+        #  we have a 1 to 1 mapping in beta dimension.
+            nslice = self.instrument_info.GetNSlice(parameter1[0])
+            log.info('Beta Scale %f ', self.cdelt2)
+            self.cdelt2 = (final_b_max - final_b_min) / nslice
+            final_b_max = final_b_min + (nslice) * self.cdelt2
+            log.info('Changed the Beta Scale dimension so we have 1 -1 mapping between beta and slice #')
+            log.info('New Beta Scale %f ', self.cdelt2)
+#________________________________________________________________________________
+# Test that we have data (NIRSPEC NRS2 only has IFU data for 3 configurations)
+        test_a = final_a_max - final_a_min
+        test_b = final_b_max - final_b_min
+        tolerance1 = 0.00001
+        if(test_a < tolerance1 or test_b < tolerance1):
+            log.info('No Valid IFU slice data found %f %f ', test_a, test_b)
+#________________________________________________________________________________
+        cube_footprint = (final_a_min, final_a_max, final_b_min, final_b_max,
+                      final_lambda_min, final_lambda_max)
+#________________________________________________________________________________
+    # Based on Scaling and Min and Max values determine naxis1, naxis2, naxis3
+    # set cube CRVALs, CRPIXs and xyz coords (center  x,y,z vector spaxel centers)
+
+        if self.coord_system == 'world':
+            self.set_geometry(cube_footprint)
+        else:
+            self.set_geometryAB(cube_footprint) # local coordinate system
+        self.print_cube_geometry()
+
+
 
 #********************************************************************************
     def map_detector_to_outputframe(self, this_par1, this_par2,
@@ -1085,11 +1145,31 @@ class IFUCubeData():
                     # good data holds the location of pixels we want to map to cube
             flux = flux_all[good_data]
             wave = wave[good_data]
+# based on the wavelength define the sroi, wroi, weight_power and softrad to use
+# in matching detector to spaxel values
+
+            rois_det = np.zeros(wave.shape)
+            roiw_det = np.zeros(wave.shape)
+            weight_det = np.zeros(wave.shape)
+            softrad_det = np.zeros(wave.shape)
+            if self.linear_wavelength:
+                rois_det[:] = self.rois
+                roiw_det[:] = self.roiw
+                weight_det[:] = self.weight_power
+                softrad_det[:] = self.soft_rad
+            else:
+                #for each wavelength find the closest point in the self.wavelength_table
+                for iw, w in enumerate(wave):
+                    ifound = (np.abs(self.wavelength_table - w)).argmin()
+                    rois_det[iw] = self.rois_table[ifound]
+                    roiw_det[iw] = self.roiw_table[ifound]
+                    softrad_det[iw] = self.softrad_table[ifound]
+                    weight_det[iw] = self.weight_power_table[ifound]
 
             if self.coord_system == 'world':
                 ra_use = ra[good_data]
                 dec_use = dec[good_data]
-                coord1, coord2 = coord.radec2std(self.Crval1, self.Crval2, ra_use, dec_use)
+                coord1, coord2 = coord.radec2std(self.crval1, self.crval2, ra_use, dec_use)
                 if self.weighting == 'miripsf':
                     alpha_det = alpha[good_data]
                     beta_det = beta[good_data]
@@ -1097,7 +1177,8 @@ class IFUCubeData():
                 coord1 = alpha[good_data]
                 coord2 = beta[good_data]
 
-        return coord1, coord2, wave, flux, alpha_det, beta_det
+        return coord1, coord2, wave, flux, rois_det, roiw_det, weight_det, \
+            softrad_det, alpha_det, beta_det
 
 #********************************************************************************
     def find_spaxel_flux(self):
@@ -1155,7 +1236,23 @@ class IFUCubeData():
         dq_cube = np.zeros((naxis3, naxis2, naxis1))
         err_cube = np.zeros((naxis3, naxis2, naxis1))
 
-        ifucube_model = datamodels.IFUCubeModel(data=data, dq=dq_cube, err=err_cube, weightmap=idata)
+        
+        if self.linear_wavelength:
+            ifucube_model = datamodels.IFUCubeModel(data=data, dq=dq_cube, 
+                                                    err=err_cube, 
+                                                    weightmap=idata)
+        else:
+
+            wave = np.zeros(2000)
+            nelements = len(self.wavelength_table)
+            for i in range(nelements):
+                wave[i] = self.wavelength_table[i]
+            ifucube_model = datamodels.IFUCubeModel(data=data, dq=dq_cube, 
+                                                    err=err_cube, 
+                                                    weightmap=idata,
+                                                    wavetable=wave)
+#                                                    wavetable=self.wavelength_table)
+
         ifucube_model.update(self.input_models[j])
         ifucube_model.meta.filename = self.output_name
 
@@ -1188,22 +1285,29 @@ class IFUCubeData():
                 ifucube_model.meta.instrument.channel + str(self.list_par1[m]))
 
 #______________________________________________________________________
-        ifucube_model.meta.wcsinfo.crval1 = self.Crval1
-        ifucube_model.meta.wcsinfo.crval2 = self.Crval2
-        ifucube_model.meta.wcsinfo.crval3 = self.Crval3
-        ifucube_model.meta.wcsinfo.crpix1 = self.Crpix1
-        ifucube_model.meta.wcsinfo.crpix2 = self.Crpix2
-        ifucube_model.meta.wcsinfo.crpix3 = self.Crpix3
-        ifucube_model.meta.wcsinfo.cdelt1 = self.Cdelt1 / 3600.0
-        ifucube_model.meta.wcsinfo.cdelt2 = self.Cdelt2 / 3600.0
-        ifucube_model.meta.wcsinfo.cdelt3 = self.Cdelt3
+        ifucube_model.meta.wcsinfo.crval1 = self.crval1
+        ifucube_model.meta.wcsinfo.crval2 = self.crval2
+        ifucube_model.meta.wcsinfo.crval3 = self.crval3
+        ifucube_model.meta.wcsinfo.crpix1 = self.crpix1
+        ifucube_model.meta.wcsinfo.crpix2 = self.crpix2
+        ifucube_model.meta.wcsinfo.crpix3 = self.crpix3
+        ifucube_model.meta.wcsinfo.cdelt1 = self.cdelt1 / 3600.0
+        ifucube_model.meta.wcsinfo.cdelt2 = self.cdelt2 / 3600.0
+        if self.linear_wavelength:
+            ifucube_model.meta.wcsinfo.cdelt3 = self.cdelt3
+            ifucube_model.meta.wcsinfo.ctype3 = 'WAVE'
+        else:
+
+            ifucube_model.meta.wcsinfo.ctype3 = 'WAVE-TAB'
+            ifucube_model.meta.wcsinfo.ps3_0 = 'WSC-TABLE'
+            ifucube_model.meta.wcsinfo.ps3_1 = 'Wavelength'
 
         ifucube_model.meta.wcsinfo.ctype1 = 'RA---TAN'
         ifucube_model.meta.wcsinfo.ctype2 = 'DEC--TAN'
         ifucube_model.meta.wcsinfo.cunit1 = 'deg'
         ifucube_model.meta.wcsinfo.cunit2 = 'deg'
 
-        ifucube_model.meta.wcsinfo.ctype3 = 'WAVE'
+
         ifucube_model.meta.wcsinfo.cunit3 = 'um'
         ifucube_model.meta.wcsinfo.wcsaxes = 3
         ifucube_model.meta.wcsinfo.pc1_1 = -1

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -41,7 +41,6 @@ class IFUCubeData():
                  **pars_cube):
 
         self.new_code = 0
-        
         self.input_filenames = input_filenames
         self.pipeline = pipeline
 
@@ -64,7 +63,6 @@ class IFUCubeData():
         self.roiw = pars_cube.get('roiw')
         self.spatial_size = None
         self.spectral_size = None
-        
         self.interpolation = pars_cube.get('interpolation')
         self.coord_system = pars_cube.get('coord_system')
         self.wavemin = pars_cube.get('wavemin')
@@ -101,7 +99,7 @@ class IFUCubeData():
         self.naxis1 = None
         self.naxis2 = None
         self.naxis3 = None
-        self.cdelt3_normal = None 
+        self.cdelt3_normal = None
 
         self.a_min = 0
         self.a_max = 0
@@ -128,7 +126,7 @@ class IFUCubeData():
 
         Returns
         -------
-        major problems - cube_build is  being run incorrectly. 
+        major problems - cube_build is  being run incorrectly.
 
         """
         num1 = len(self.list_par1)
@@ -284,8 +282,6 @@ class IFUCubeData():
         ygrid = np.zeros(self.naxis2 * self.naxis1)
         xgrid = np.zeros(self.naxis2 * self.naxis1)
 
-
-        
         k = 0
         ystart = self.ycoord[0]
         for i in range(self.naxis2):
@@ -297,9 +293,8 @@ class IFUCubeData():
                 k = k + 1
             ystart = ystart + self.cdelt2
 
-
 #        ycube,xcube = np.mgrid[0:self.naxis2,
-#                               0:self.naxis1]    
+#                               0:self.naxis1]
 #        xcube = xcube.flatten()
 #        ycube = ycube.flatten()
 
@@ -307,7 +302,7 @@ class IFUCubeData():
         self.ycenters = ygrid
 #_______________________________________________________________________
         #set up the lambda (z) coordinate of the cube
-        self.cdelt3_normal = None 
+        self.cdelt3_normal = None
         if self.linear_wavelength:
             self.lambda_min = lambda_min
             self.lambda_max = lambda_max
@@ -334,10 +329,10 @@ class IFUCubeData():
             self.crpix3 = 1.0
 # set up the cdelt3_normal normalizing array used in cube_cloud.py
         cdelt3_normal = np.zeros(self.naxis3)
-        for j in range (self.naxis3-1):
-            cdelt3_normal[j] = self.zcoord[j+1] - self.zcoord[j]
+        for j in range(self.naxis3 - 1):
+            cdelt3_normal[j] = self.zcoord[j + 1] - self.zcoord[j]
 
-        cdelt3_normal[self.naxis3-1] = cdelt3_normal[self.naxis3-2]
+        cdelt3_normal[self.naxis3 - 1] = cdelt3_normal[self.naxis3 - 2]
         self.cdelt3_normal = cdelt3_normal
 #_______________________________________________________________________
     def set_geometryAB(self, footprint):
@@ -435,9 +430,7 @@ class IFUCubeData():
                 log.info('axis#  Naxis  CRPIX    CRVAL     MIN & Max (microns)')
                 log.info('Axis 3 %5d  %5.2f %12.8f %12.8f %12.8f',
                          self.naxis3, self.crpix3, self.crval3,
-                         self.wavelength_table[0], self.wavelength_table[self.naxis3-1])
-
-
+                         self.wavelength_table[0], self.wavelength_table[self.naxis3 - 1])
 
         if self.instrument == 'MIRI':
         # length of channel and subchannel are the same
@@ -573,7 +566,7 @@ class IFUCubeData():
                                                       self.spaxel_weight,
                                                       self.spaxel_iflux,
                                                       flux,
-                                                      coord1, coord2, wave, 
+                                                      coord1, coord2, wave,
                                                       rois_pixel, roiw_pixel, weight_pixel,
                                                       softrad_pixel)
 
@@ -592,16 +585,14 @@ class IFUCubeData():
                             worldtov23 = input_model.meta.wcs.get_transform("world", "v2v3")
                             v2ab_transform = input_model.meta.wcs.get_transform('v2v3',
                                                                 'alpha_beta')
-                            
+
                             spaxel_v2, spaxel_v3, zl = worldtov23(spaxel_ra,
                                                                   spaxel_dec,
                                                                   spaxel_wave)
 
                             spaxel_alpha, spaxel_beta, spaxel_wave = v2ab_transform(spaxel_v2,
                                                                                     spaxel_v3,
-                                                                                    zl)                            
-
-
+                                                                                    zl)
                             cube_cloud.match_det2cube_miripsf(alpha_resol,
                                                               beta_resol,
                                                               wave_resol,
@@ -610,7 +601,7 @@ class IFUCubeData():
                                                               self.spaxel_flux,
                                                               self.spaxel_weight,
                                                               self.spaxel_iflux,
-                                                              spaxel_alpha,spaxel_beta,spaxel_wave,
+                                                              spaxel_alpha, spaxel_beta, spaxel_wave,
                                                               flux,
                                                               coord1, coord2, wave,
                                                               alpha_det, beta_det,
@@ -714,9 +705,8 @@ class IFUCubeData():
                 softrad_pixel, alpha_det, beta_det = pixelresult
 
             cube_cloud.match_det2cube_msm(self.naxis1, self.naxis2, self.naxis3,
-                                          self.cdelt1, self.cdelt2, self.cdelt3,
+                                          self.cdelt1, self.cdelt2,
                                           self.cdelt3_normal,
-                                          self.roiw,
                                           self.xcenters, self.ycenters, self.zcoord,
                                           self.spaxel_flux,
                                           self.spaxel_weight,
@@ -760,20 +750,19 @@ class IFUCubeData():
         roi size for spatial and wavelength
 
         """
-        # initialize 
-        spaxel_roi = None
+        # initialize
         wave_roi = None
         weight_power = None
 
         number_bands = len(self.list_par1)
         spaxelsize = np.zeros(number_bands)
         spectralsize = np.zeros(number_bands)
-        rois =  np.zeros(number_bands)
-        roiw =  np.zeros(number_bands)
-        power=  np.zeros(number_bands)
-        softrad =  np.zeros(number_bands)
-        minwave =  np.zeros(number_bands)
-        maxwave =  np.zeros(number_bands)
+        rois = np.zeros(number_bands)
+        roiw = np.zeros(number_bands)
+        power = np.zeros(number_bands)
+        softrad = np.zeros(number_bands)
+        minwave = np.zeros(number_bands)
+        maxwave = np.zeros(number_bands)
 
         for i in range(number_bands):
             if self.instrument == 'MIRI':
@@ -790,7 +779,6 @@ class IFUCubeData():
                                                                       par2)
             spaxelsize[i] = a_scale
             spectralsize[i] = w_scale
-#            print('scales',a_scale,b_scale,w_scale,par1,par2)
 
             power[i] = self.instrument_info.GetMSMPower(par1, par2)
             softrad[i] = self.instrument_info.GetSoftRad(par1, par2)
@@ -807,14 +795,14 @@ class IFUCubeData():
             spatial_roi = rois[index_min]
 # find min and max wavelength
         min_wave = np.amin(minwave)
-        max_wave = np.amax(maxwave)                
+        max_wave = np.amax(maxwave)
 
-        if self.wavemin is None: 
+        if self.wavemin is None:
             self.wavemin = min_wave
         else:
             self.wavemin = np.float64(self.wavemin)
 
-        if self.wavemax is None: 
+        if self.wavemax is None:
             self.wavemax = max_wave
         else:
             self.wavemax = np.float64(self.wavemax)
@@ -830,32 +818,31 @@ class IFUCubeData():
             self.linear_wavelength = False
             if self.instrument == 'MIRI':
                 table = self.instrument_info.Get_multichannel_table()
-                table_wavelength,table_sroi,table_wroi,table_power,table_softrad = table
+                table_wavelength, table_sroi, table_wroi, table_power, table_softrad = table
 
 # getting MIRI Table Values
             elif self.instrument == 'NIRSPEC':
 # determine if have Prism, Medium or High resolution
-                med = ['g140m','g235m','g395m']
-                high = ['g140h','g235h','g395h']
+                med = ['g140m', 'g235m', 'g395m']
+                high = ['g140h', 'g235h', 'g395h']
                 prism = ['prism']
-                
+
                 for i in range(number_bands):
                     par1 = self.list_par1[i]
-                    if par1 in prism: 
+                    if par1 in prism:
                         table = self.instrument_info.Get_prism_table()
-                    if par1 in med: 
+                    if par1 in med:
                         table = self.instrument_info.Get_med_table()
-                    if par1 in high: 
+                    if par1 in high:
                         table = self.instrument_info.Get_high_table()
-                    table_wavelength,table_sroi,table_wroi,table_power,table_softrad = table
+                    table_wavelength, table_sroi, table_wroi, table_power, table_softrad = table
 # based on Min and Max wavelength - pull out the tables values that fall in this range
-#            print('wave range',self.wavemin,self.wavemax)
-            # find the closest
+            # find the closest table entries to the self.wavemin and self.wavemax limits
             imin = (np.abs(table_wavelength - self.wavemin)).argmin()
             imax = (np.abs(table_wavelength - self.wavemax)).argmin()
-            if imin > 1 and  table_wavelength[imin] > self.wavemin: imin = imin - 1
-            if (imax < len(table_wavelength) and  
-                self.wavemax > table_wavelength[imax]): imax = imax  + 1
+            if imin > 1 and table_wavelength[imin] > self.wavemin: imin = imin - 1
+            if (imax < len(table_wavelength) and
+                self.wavemax > table_wavelength[imax]): imax = imax + 1
 #            print('index of wavelength values',imin,imax)
 
             self.roiw_table = table_wroi[imin:imax]
@@ -869,23 +856,23 @@ class IFUCubeData():
         if self.output_type == 'single' or self.num_files < 4:
             self.rois = self.rois * 1.5
             log.info('Increasing spatial region of interest' +
-                     'default value set for 4 dithers %f', self.rois)        
-        if self.scale1 != 0: 
-            self.spatial_size = scale1
-        if self.scalew != 0: 
-            self.spectral_size = scalew
-            self.linear_wavelength = True 
+                     'default value set for 4 dithers %f', self.rois)
+        if self.scale1 != 0:
+            self.spatial_size = self.scale1
+        if self.scalew != 0:
+            self.spectral_size = self.scalew
+            self.linear_wavelength = True
             #set wave_roi, weight_power, soft_rad to same values if they are in  list
         if self.roiw == 0: self.roiw = wave_roi
         if self.weight_power == 0: self.weight_power = weight_power
 
-        print('spatial size', self.spatial_size)
-        print('spectral size', self.spectral_size)
-        print('spatial roi', self.rois)
-        print('wave min and max',self.wavemin, self.wavemax)
-        print('linear wavelength',self.linear_wavelength)
-        print('roiw',self.roiw)
-        print('weight',self.weight_power)
+#        print('spatial size', self.spatial_size)
+#        print('spectral size', self.spectral_size)
+#        print('spatial roi', self.rois)
+#        print('wave min and max', self.wavemin, self.wavemax)
+#        print('linear wavelength', self.linear_wavelength)
+#        print('roiw', self.roiw)
+
 
 
 #        if self.interpolation == 'pointcloud':
@@ -918,9 +905,6 @@ class IFUCubeData():
 
         """
 #________________________________________________________________________________
-# Scale is 3 dimensions and is determined from values held in  instrument_info.GetScale
-#        scale = self.determine_scale()
-
         self.cdelt1 = self.spatial_size
         self.cdelt2 = self.spatial_size
         if self.linear_wavelength:
@@ -966,7 +950,7 @@ class IFUCubeData():
                             self.coord_system)
 #                        t1 = time.time()
 #                        print('time to find footprint',t1-t0)
- 
+
                         amin, amax, bmin, bmax, lmin, lmax = ch_footprint
 #                        amin, bmin, amax, bmin2, amax2, bmax, amin2, bmax2 = \
 #                            input_model.meta.wcsinfo.s_region
@@ -980,9 +964,6 @@ class IFUCubeData():
                             self.coord_system)
                         amin, amax, bmin, bmax, lmin, lmax = ch_footprint
 #                        print(amin,amax,bmin,bmax)
-#                        test = input_model.meta.wcs.footprint()
-#                        print('test',test)
-#                        exit()
 #                        region_footprint = input_model.meta.wcsinfo.s_region
 #                        print('region footprint', region_footprint)
 #                        print(type(region_footprint))
@@ -1004,11 +985,10 @@ class IFUCubeData():
         final_lambda_min = min(lambda_min)
         final_lambda_max = max(lambda_max)
 
-#        print('wavelengths',final_lambda_min,final_lambda_max,self.wavemin,self.wavemax)
+        print('wavelengths', final_lambda_min, final_lambda_max, self.wavemin, self.wavemax)
 
         final_lambda_min = self.wavemin
         final_lambda_max = self.wavemax
-
 #________________________________________________________________________________
         if self.instrument == 'MIRI' and self.coord_system == 'alpha-beta':
         #  we have a 1 to 1 mapping in beta dimension.
@@ -1107,7 +1087,6 @@ class IFUCubeData():
                         det2ab_transform = input_model.meta.wcs.get_transform('detector',
                                                                           'alpha_beta')
                         alpha, beta, lam = det2ab_transform(x, y)
-                        
                 elif self.coord_system == 'alpha-beta':
                     det2ab_transform = input_model.meta.wcs.get_transform('detector',
                                                                           'alpha_beta')
@@ -1271,36 +1250,35 @@ class IFUCubeData():
         idata = np.zeros((naxis3, naxis2, naxis1))
         dq_cube = np.zeros((naxis3, naxis2, naxis1))
         err_cube = np.zeros((naxis3, naxis2, naxis1))
-        
+
         if self.linear_wavelength:
-            ifucube_model = datamodels.IFUCubeModel(data=data, dq=dq_cube, 
-                                                    err=err_cube, 
+            ifucube_model = datamodels.IFUCubeModel(data=data, dq=dq_cube,
+                                                    err=err_cube,
                                                     weightmap=idata)
         else:
-            
             nelem = np.array([])
-            wave = np.asarray(self.wavelength_table,dtype=np.float32)
+            wave = np.asarray(self.wavelength_table, dtype=np.float32)
             # for now we need to pad wavelength to fix datamodel size
             num = len(wave)
-            nn = 2000 # This number needs to match the shape of the 
+            nn = 2000 # This number needs to match the shape of the
             # wavetable['wavelength'] value in the ifucube.schema.
             # In the future it would be good to remove that we have to
             # set the size of this value in the schema.
 
-            wave = np.pad(wave,(0,nn-num),'constant')
+            wave = np.pad(wave, (0, nn - num), 'constant')
             newnum = len(wave)
-            print('new num',newnum)
-            allwave = np.zeros((1,1,newnum))
-            allwave[0,0,:] = wave
-            print('allwave shape',allwave.shape)
+            allwave = np.zeros((1, 1, newnum))
+            allwave[0, 0, :] = wave
 
-            nelem = np.append(nelem,num)
-            alldata = np.array(list(zip(np.array(nelem),np.array(allwave))),
+            nelem = np.append(nelem, num)
+# to get the data in the correct format (an array in a single cell in the fit table)
+# I had to zip data. 
+            alldata = np.array(list(zip(np.array(nelem), np.array(allwave))),
                                dtype=datamodels.IFUCubeModel().wavetable.dtype)
 
-            
-            ifucube_model = datamodels.IFUCubeModel(data=data, dq=dq_cube, 
-                                                    err=err_cube, 
+
+            ifucube_model = datamodels.IFUCubeModel(data=data, dq=dq_cube,
+                                                    err=err_cube,
                                                     weightmap=idata,
                                                     wavetable=alldata)
 
@@ -1383,10 +1361,9 @@ class IFUCubeData():
         ifucube_model.meta.ifu.roi_spatial = self.rois
         ifucube_model.meta.ifu.roi_wave = self.roiw
         ifucube_model.meta.ifu.weighting = self.weighting
-
-#        print('ifucube_model.meta.ifu.weighting',self.weighting)
-#        ifucube_model.meta.ifu.weighting = 'msm'
-#        ifucube_model.meta.ifu.weight_power = self.weight_power
+        # weight_power is needed for single cubes. Linear Wavelengths
+        # if non-linear wavelengths then this will be None
+        ifucube_model.meta.ifu.weight_power = self.weight_power
 
         with datamodels.open(self.input_models[j]) as input:
             ifucube_model.meta.bunit_data = input.meta.bunit_data

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1,4 +1,3 @@
-
 # Routines used for building cubes
 import time
 import numpy as np
@@ -15,16 +14,17 @@ from ..assign_wcs import nirspec
 from ..datamodels import dqflags
 from . import cube_build_wcs_util
 from . import cube_overlap
-#from . import cube_cloud_quick
+# from . import cube_cloud_quick
 from . import cube_cloud
 from . import coord
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+
 class IFUCubeData():
-# IFUCubeData - holds all the important information for IFU Cube Building:
-# wcs, data, reference data
+    # IFUCubeData - holds all the important information for IFU Cube Building:
+    # wcs, data, reference data
 
     def __init__(self,
                  pipeline,
@@ -126,7 +126,8 @@ class IFUCubeData():
 
         Returns
         -------
-        major problems - cube_build is  being run incorrectly.
+        none
+        but if cube_build is  being run incorrectly and exception is raised
 
         """
         num1 = len(self.list_par1)
@@ -179,7 +180,8 @@ class IFUCubeData():
                     ch_name = '_ch'
                     for i in range(number_channels):
                         ch_name = ch_name + channels[i]
-                        if i < number_channels - 1: ch_name = ch_name + '-'
+                        if i < number_channels - 1:
+                            ch_name = ch_name + '-'
 
                 subchannels = list(set(self.list_par2))
                 number_subchannels = len(subchannels)
@@ -820,7 +822,7 @@ class IFUCubeData():
                 table = self.instrument_info.Get_multichannel_table()
                 table_wavelength, table_sroi, table_wroi, table_power, table_softrad = table
 
-# getting MIRI Table Values
+# getting NIRSPEC Table Values
             elif self.instrument == 'NIRSPEC':
 # determine if have Prism, Medium or High resolution
                 med = ['g140m', 'g235m', 'g395m']
@@ -985,7 +987,7 @@ class IFUCubeData():
         final_lambda_min = min(lambda_min)
         final_lambda_max = max(lambda_max)
 
-        print('wavelengths', final_lambda_min, final_lambda_max, self.wavemin, self.wavemax)
+#        print('wavelengths', final_lambda_min, final_lambda_max, self.wavemin, self.wavemax)
 
         final_lambda_min = self.wavemin
         final_lambda_max = self.wavemax

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -592,11 +592,11 @@ class InstrumentInfo():
         return wavemax
 
     def GetMSMPower(self, parameter1, parameter2):
-        weight_power = self.Info[parameter1][parameter2]['msm_power'] 
+        weight_power = self.Info[parameter1][parameter2]['msm_power']
         return weight_power
 
     def GetSoftRad(self, parameter1, parameter2):
-        softrad = self.Info[parameter1][parameter2]['softrad'] 
+        softrad = self.Info[parameter1][parameter2]['softrad']
         return softrad
 
     def GetScale(self, parameter1, parameter2):
@@ -605,10 +605,9 @@ class InstrumentInfo():
                  self.Info[parameter1][parameter2]['wscale'])
         return scale
 
-
     def Get_multichannel_table(self):
-        table = (self.multich_wavelength, 
-                 self.multich_sroi, 
+        table = (self.multich_wavelength,
+                 self.multich_sroi,
                  self.multich_wroi,
                  self.multich_power,
                  self.multich_softrad)
@@ -620,15 +619,15 @@ class InstrumentInfo():
                  self.prism_wroi,
                  self.prism_power,
                  self.prism_softrad)
-        return table 
-    
+        return table
+
     def Get_med_table(self):
         table = (self.med_wavelength,
                  self.med_sroi,
                  self.med_wroi,
                  self.med_power,
                  self.med_softrad)
-        return table 
+        return table
 
     def Get_high_table(self):
         table = (self.high_wavelength,
@@ -636,9 +635,9 @@ class InstrumentInfo():
                  self.high_wroi,
                  self.high_power,
                  self.high_softrad)
-        return table 
+        return table
 
- 
+
     def GetMIRISliceEndPts(self, parameter1):
         slice_xstart = self.Info[parameter1]['xstart']
         slice_xend = self.Info[parameter1]['xend']

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -494,47 +494,26 @@ class InstrumentInfo():
             self.Info[parameter1][parameter2]['bscale'] = value
 
 
-    def SetSpectralStep(self, value, parameter1, parameter2=None):
-        if parameter2 is None: # data is NIRSPEC paramters do not vary with filter
-            self.Info[parameter1]['wscale'] = value
-        else:
-            self.Info[parameter1][parameter2]['wscale'] = value
+    def SetSpectralStep(self, value, parameter1, parameter2):
+        self.Info[parameter1][parameter2]['wscale'] = value
 
-    def SetWaveMin(self, value, parameter1, parameter2=None):
-        if parameter2 is None: # data is NIRSPEC paramters do not vary with filter
-            self.Info[parameter1]['wavemin'] = value
-        else:
-            self.Info[parameter1][parameter2]['wavemin'] = value
+    def SetWaveMin(self, value, parameter1, parameter2):
+        self.Info[parameter1][parameter2]['wavemin'] = value
 
-    def SetWaveMax(self, value, parameter1, parameter2=None):
-        if parameter2 is None: # data is NIRSPEC paramters do not vary with filter
-            self.Info[parameter1]['wavemax'] = value
-        else:
-            self.Info[parameter1][parameter2]['wavemax'] = value
+    def SetWaveMax(self, value, parameter1, parameter2):
+        self.Info[parameter1][parameter2]['wavemax'] = value
 
-    def SetSpatialROI(self, value, parameter1, parameter2=None):
-        if parameter2 is None: # data is NIRSPEC paramters do not vary with filter
-            self.Info[parameter1]['sroi'] = value
-        else:
-            self.Info[parameter1][parameter2]['sroi'] = value
+    def SetSpatialROI(self, value, parameter1, parameter2):
+        self.Info[parameter1][parameter2]['sroi'] = value
 
-    def SetWaveROI(self, value, parameter1, parameter2=None):
-        if parameter2 is None: # data is NIRSPEC paramters do not vary with filter
-            self.Info[parameter1]['wroi'] = value
-        else:
-            self.Info[parameter1][parameter2]['wroi'] = value
+    def SetWaveROI(self, value, parameter1, parameter2):
+        self.Info[parameter1][parameter2]['wroi'] = value
 
-    def SetMSMPower(self, value, parameter1, parameter2=None):
-        if parameter2 is None: # data is NIRSPEC paramters do not vary with filter
-            self.Info[parameter1]['msm_power'] = value
-        else:
-            self.Info[parameter1][parameter2]['msm_power'] = value
+    def SetMSMPower(self, value, parameter1, parameter2):
+        self.Info[parameter1][parameter2]['msm_power'] = value
 
-    def SetSoftRad(self, value, parameter1, parameter2=None):
-        if parameter2 is None: # data is NIRSPEC paramters do not vary with filter
-            self.Info[parameter1]['softrad'] = value
-        else:
-            self.Info[parameter1][parameter2]['softrad'] = value
+    def SetSoftRad(self, value, parameter1, parameter2):
+        self.Info[parameter1][parameter2]['softrad'] = value
 
     def Set_RP_Wave_Cutoff(self, table_wave_center, this_channel, this_band):
         self.Info[this_channel][this_band]['rp_wave_cuttoff'] = table_wave_center
@@ -554,7 +533,6 @@ class InstrumentInfo():
         self.Info[this_channel][this_band]['rp_b_ave'] = b
         self.Info[this_channel][this_band]['rp_c_ave'] = c
 
-
     def Set_psf_alpha_parameters(self, cutoff,
                                  a_short, b_short, a_long, b_long):
         self.Info['psf_alpha_cuttoff'] = cutoff
@@ -570,8 +548,6 @@ class InstrumentInfo():
         self.Info['psf_beta_b_short'] = b_short
         self.Info['psf_beta_a_long'] = a_long
         self.Info['psf_beta_b_long'] = b_long
-
-
 #______________________________________________________________________
     def Get_RP_ave_Wave(self, this_channel, this_band):
         w = self.Info[this_channel][this_band]['rp_wave_cuttoff']
@@ -599,34 +575,70 @@ class InstrumentInfo():
         b_weight = (b1, b2, b3, b4, b5)
         return b_weight
 
-    def GetWaveRoi(self, parameter1, parameter2=None):
-        if parameter2 is None:
-            roiw = self.Info[parameter1]['wroi']
-        else:
-            roiw = self.Info[parameter1][parameter2]['wroi']
+    def GetWaveRoi(self, parameter1, parameter2):
+        roiw = self.Info[parameter1][parameter2]['wroi']
         return roiw
 
-
-    def GetSpatialRoi(self, parameter1, parameter2=None):
-        if parameter2 is None:
-            rois = self.Info[parameter1]['sroi']
-        else:
-            rois = self.Info[parameter1][parameter2]['sroi']
+    def GetSpatialRoi(self, parameter1, parameter2):
+        rois = self.Info[parameter1][parameter2]['sroi']
         return rois
 
+    def GetWaveMin(self, parameter1, parameter2):
+        wavemin = self.Info[parameter1][parameter2]['wavemin']
+        return wavemin
 
-    def GetScale(self, parameter1, parameter2=None):
-        if parameter2 is None:
-            scale = (self.Info[parameter1]['ascale'],
-                     self.Info[parameter1]['bscale'],
-                     self.Info[parameter1]['wscale'])
-        else:
-            scale = (self.Info[parameter1][parameter2]['ascale'],
-                     self.Info[parameter1][parameter2]['bscale'],
-                     self.Info[parameter1][parameter2]['wscale'])
+    def GetWaveMax(self, parameter1, parameter2):
+        wavemax = self.Info[parameter1][parameter2]['wavemax']
+        return wavemax
+
+    def GetMSMPower(self, parameter1, parameter2):
+        weight_power = self.Info[parameter1][parameter2]['msm_power'] 
+        return weight_power
+
+    def GetSoftRad(self, parameter1, parameter2):
+        softrad = self.Info[parameter1][parameter2]['softrad'] 
+        return softrad
+
+    def GetScale(self, parameter1, parameter2):
+        scale = (self.Info[parameter1][parameter2]['ascale'],
+                 self.Info[parameter1][parameter2]['bscale'],
+                 self.Info[parameter1][parameter2]['wscale'])
         return scale
 
 
+    def Get_multichannel_table(self):
+        table = (self.multich_wavelength, 
+                 self.multich_sroi, 
+                 self.multich_wroi,
+                 self.multich_power,
+                 self.multich_softrad)
+        return table
+
+    def Get_prism_table(self):
+        table = (self.prism_wavelength,
+                 self.prism_sroi,
+                 self.prism_wroi,
+                 self.prism_power,
+                 self.prism_softrad)
+        return table 
+    
+    def Get_med_table(self):
+        table = (self.med_wavelength,
+                 self.med_sroi,
+                 self.med_wroi,
+                 self.med_power,
+                 self.med_softrad)
+        return table 
+
+    def Get_high_table(self):
+        table = (self.high_wavelength,
+                 self.high_sroi,
+                 self.high_wroi,
+                 self.high_power,
+                 self.high_softrad)
+        return table 
+
+ 
     def GetMIRISliceEndPts(self, parameter1):
         slice_xstart = self.Info[parameter1]['xstart']
         slice_xend = self.Info[parameter1]['xend']

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -76,6 +76,9 @@ allOf:
       title: Wavelength value for slices
       fits_hdu: WCS-TABLE
       datatype:
+      - name: nelem
+        datatype: int16
       - name: wavelength
         datatype: float32
+        shape: [2000]
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -80,5 +80,5 @@ allOf:
         datatype: int16
       - name: wavelength
         datatype: float32
-        shape: [2000]
+        shape: [10420]
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -76,7 +76,6 @@ allOf:
       title: Wavelength value for slices
       fits_hdu: WCS-TABLE
       datatype:
-      - name: Wavelength
-        shape: [2000]
-        datatype: float64
+      - name: wavelength
+        datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -76,6 +76,7 @@ allOf:
       title: Wavelength value for slices
       fits_hdu: WCS-TABLE
       datatype:
-      - name: wavelength
+      - name: Wavelength
+        shape: [2000]
         datatype: float64
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -298,3 +298,8 @@ properties:
             type: string
             fits_keyword: SPECSYS
             fits_hdu: SCI
+          wavedim:
+            title: Wavetable dimension
+            type: string
+            fits_keyword: TDIM2
+            fits_hdu: WCS-TABLE


### PR DESCRIPTION
This PR build can create cubes with a nonlinear wavelength dimension. The wavelength bins to use in
the IFU cube are read in from the CUBEPAR reference file.  These types of IFU cubes are created when the input data is from different bands (ie. Ch 1 Short and Ch 1 Medium or for NIRSPEC different filters for the same grating). 
This PR also uses the wavelength ranges given in the CUBEPAR reference file to build cube from
a single band rather than determining the maximum and minimum values from the data. This PR will result in the regression tests failing because the min and max wavelength of the ifucube are slightly different. 
When an ifucube is made from more than 1 band then additional table extensions in the CUBEPARS are used to define the wavelength sampling and the roi to use for each wavelength region. These additional binary table extensions are now being read in with this PR.  One of the requirements if detector pixel is matched to a cube spaxel  is if  falls within a roi in the wavelength dimension set by spectral roi in the wavelength table. If building non-linear wavelength cubes then this
roi spectral varies with wavelength. Each detector pixel has its own associated spectral roi. Adding this feature has slowed down the matching of the detector pixels to the ifucube. 
If an ifucube has a non-linear wavelength dimension then the wavelength planes of the IFU are written to a wavelength array that is contained in the additional FITS extension WCS-TABLE. To make this output file adhere to the FITS standard the TDIM2 keyword in the WCS-TABLE needs to be populated with a string containing the size of the wavelength array. This has not been done in this PR (the keyword is missing when the output FITS file is written).
11 files where changed in this PR with ~1000 lines of code changes. 