### PR TITLE
Support asdf flags when creating a new datamodel [#1215]

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -531,9 +531,10 @@ def _load_history(hdulist, tree):
         history['entries'].append(HistoryEntry({'description': entry}))
 
 
-def from_fits(hdulist, schema, extensions, context):
+def from_fits(hdulist, schema, extensions, context, **kwargs):
     try:
-        ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions)
+        ##ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions, **kwargs)
+        ff = from_fits_asdf(hdulist, extensions=extensions, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc
 
@@ -543,6 +544,17 @@ def from_fits(hdulist, schema, extensions, context):
     _load_history(hdulist, ff.tree)
 
     return ff
+
+def from_fits_asdf(hdulist, extensions=None,
+                  ignore_version_mismatch=True,
+                  ignore_unrecognized_tag=False,
+                  **kwargs):
+    kwargs = None
+    return fits_embed.AsdfInFits.open(hdulist,
+                                      extensions=extensions,
+                                      ignore_version_mismatch=ignore_version_mismatch,
+                                      ignore_unrecognized_tag=ignore_unrecognized_tag)
+
 
 def from_fits_hdu(hdu, schema):
     """

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -533,7 +533,6 @@ def _load_history(hdulist, tree):
 
 def from_fits(hdulist, schema, extensions, context, **kwargs):
     try:
-        ##ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions, **kwargs)
         ff = from_fits_asdf(hdulist, extensions=extensions, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -74,6 +74,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         strict_validation: if true, an schema validation errors will generate
             an excption. If false, they will generate a warning.
+
+        kwargs: Aadditional arguments passed to lower level functions
         """
         # Set the extensions
         self._extensions = extensions
@@ -511,7 +513,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return asdf
 
     @classmethod
-    def from_asdf(cls, init, schema=None):
+    def from_asdf(cls, init, schema=None, **kwargs):
         """
         Load a data model from a ASDF file.
 
@@ -526,11 +528,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         schema :
             Same as for `__init__`
 
+
+        kwargs:
+            Aadditional arguments passed to lower level functions
+
         Returns
         -------
         model : DataModel instance
         """
-        return cls(init, schema=schema)
+        return cls(init, schema=schema, **kwargs)
 
     def to_asdf(self, init, *args, **kwargs):
         """
@@ -549,7 +555,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         AsdfFile(self._instance, extensions=self._extensions).write_to(init, *args, **kwargs)
 
     @classmethod
-    def from_fits(cls, init, schema=None):
+    def from_fits(cls, init, schema=None, **kwargs):
         """
         Load a model from a FITS file.
 
@@ -564,11 +570,14 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         schema :
             Same as for `__init__`
 
+        kwargs:
+            Aadditional arguments passed to lower level functions
+
         Returns
         -------
         model : DataModel instance
         """
-        return cls(init, schema=schema)
+        return cls(init, schema=schema, **kwargs)
 
     def to_fits(self, init, *args, **kwargs):
         """

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -117,13 +117,17 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         shape = None
 
         if init is None:
-            asdf = AsdfFile(extensions=extensions)
+            asdf = self.open_asdf(init=None, extensions=self._extensions,
+                                  **kwargs)
 
         elif isinstance(init, dict):
-            asdf = AsdfFile(init, extensions=self._extensions)
+            asdf = self.open_asdf(init=init, extensions=self._extensions,
+                                 **kwargs)
 
         elif isinstance(init, np.ndarray):
-            asdf = AsdfFile(extensions=self._extensions)
+            asdf = self.open_asdf(init=None, extensions=self._extensions,
+                                 **kwargs)
+
             shape = init.shape
             is_array = True
 
@@ -133,7 +137,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                     raise ValueError("shape must be a tuple of ints")
 
             shape = init
-            asdf = AsdfFile()
+            asdf = self.open_asdf(init=None)
             is_shape = True
 
         elif isinstance(init, DataModel):
@@ -156,13 +160,16 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             if file_type == "fits":
                 hdulist = fits.open(init)
-                asdf = fits_support.from_fits(hdulist, self._schema,
-                                              self._extensions, self._ctx)
-
+                asdf = fits_support.from_fits(hdulist,
+                                              self._schema,
+                                              self._extensions,
+                                              self._ctx,
+                                              **kwargs)
                 self._files_to_close.append(hdulist)
 
             elif file_type == "asdf":
-                asdf = AsdfFile.open(init, extensions=self._extensions)
+                asdf = self.open_asdf(init=init, extensions=self._extensions,
+                                      **kwargs)
 
             else:
                 # TODO handle json files as well
@@ -480,6 +487,28 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             raise ValueError("unknown filetype {0}".format(ext))
 
         return output_path
+
+    @staticmethod
+    def open_asdf(init=None, extensions=None,
+                  ignore_version_mismatch=True,
+                  ignore_unrecognized_tag=False,
+                  **kwargs):
+        """
+        Open an asdf object from a filename or create a new asdf object
+        """
+        # Drop arguments not explicitly mentioned in the arg list
+        kwargs = None
+
+        if isinstance(init, str):
+            asdf = AsdfFile.open(init, extensions=extensions,
+                                 ignore_version_mismatch=ignore_version_mismatch,
+                                 ignore_unrecognized_tag=ignore_unrecognized_tag)
+
+        else:
+            asdf = AsdfFile(init, extensions=extensions,
+                            ignore_version_mismatch=ignore_version_mismatch,
+                            ignore_unrecognized_tag=ignore_unrecognized_tag)
+        return asdf
 
     @classmethod
     def from_asdf(cls, init, schema=None):

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -498,8 +498,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         Open an asdf object from a filename or create a new asdf object
         """
-        # Drop arguments not explicitly mentioned in the arg list
-        kwargs = None
 
         if isinstance(init, str):
             asdf = AsdfFile.open(init, extensions=extensions,

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -335,27 +335,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                               self._pass_invalid_values,
                               self._strict_validation)
 
-    def validate_required_fields(self):
-        """
-        Walk the schema and make sure all required fields are
-        in the model
-        """
-        def callback(schema, path, combiner, ctx, recurse):
-            if 'fits_required' not in schema:
-                return
-
-            node = ctx
-            for attr in path:
-                node = getattr(node, attr)
-                if node is None:
-                    break
-
-            validate.value_change(path, node, schema,
-                                  ctx._pass_invalid_values,
-                                  ctx._strict_validation)
-
-        mschema.walk_schema(self._schema, callback, ctx=self)
-
     def info(self):
         """
         Return datatype and dimension for each array or table
@@ -488,8 +467,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if dir_path:
             path_head = dir_path
         output_path = os.path.join(path_head, path_tail)
-
-        self.validate_required_fields()
 
         # TODO: Support gzip-compressed fits
         if ext == '.fits':

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -335,6 +335,27 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                               self._pass_invalid_values,
                               self._strict_validation)
 
+    def validate_required_fields(self):
+        """
+        Walk the schema and make sure all required fields are
+        in the model
+        """
+        def callback(schema, path, combiner, ctx, recurse):
+            if 'fits_required' not in schema:
+                return
+
+            node = ctx
+            for attr in path:
+                node = getattr(node, attr)
+                if node is None:
+                    break
+
+            validate.value_change(path, node, schema,
+                                  ctx._pass_invalid_values,
+                                  ctx._strict_validation)
+
+        mschema.walk_schema(self._schema, callback, ctx=self)
+
     def info(self):
         """
         Return datatype and dimension for each array or table
@@ -467,6 +488,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if dir_path:
             path_head = dir_path
         output_path = os.path.join(path_head, path_tail)
+
+        self.validate_required_fields()
 
         # TODO: Support gzip-compressed fits
         if ext == '.fits':

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -476,46 +476,6 @@ def test_info():
                 assert words[2] == "float32", "Correct type for err"
     assert matches== 3, "Check all extensions are described"
 
-def test_validate_on_read():
-    im1 = ImageModel((10,10))
-    schema = im1.meta._schema
-    schema['properties']['calibration_software_version']['fits_required'] = True
-
-    try:
-        im2 = ImageModel(FITS_FILE,
-                          schema=im1._schema,
-                          strict_validation=True)
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-        im2.close()
-
-    im1.close()
-    assert caught, "Test of validation while reading image"
-
-def test_validate_required_field():
-    im = ImageModel((10,10), strict_validation=True)
-    schema = im.meta._schema
-    schema['properties']['telescope']['fits_required'] = True
-
-    try:
-        im.validate_required_fields()
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-    assert caught, "Test of validate_required_fields"
-
-    im.meta.telescope = 'JWST'
-    try:
-        im.validate_required_fields()
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-    assert not caught, "Test of validate_required_fields"
-
 def test_multislit_model():
     data = np.arange(24, dtype=np.float32).reshape((6, 4))
     err = np.arange(24, dtype=np.float32).reshape((6, 4)) + 2

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -476,6 +476,46 @@ def test_info():
                 assert words[2] == "float32", "Correct type for err"
     assert matches== 3, "Check all extensions are described"
 
+def test_validate_on_read():
+    im1 = ImageModel((10,10))
+    schema = im1.meta._schema
+    schema['properties']['calibration_software_version']['fits_required'] = True
+
+    try:
+        im2 = ImageModel(FITS_FILE,
+                          schema=im1._schema,
+                          strict_validation=True)
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+        im2.close()
+
+    im1.close()
+    assert caught, "Test of validation while reading image"
+
+def test_validate_required_field():
+    im = ImageModel((10,10), strict_validation=True)
+    schema = im.meta._schema
+    schema['properties']['telescope']['fits_required'] = True
+
+    try:
+        im.validate_required_fields()
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+    assert caught, "Test of validate_required_fields"
+
+    im.meta.telescope = 'JWST'
+    try:
+        im.validate_required_fields()
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+    assert not caught, "Test of validate_required_fields"
+
 def test_multislit_model():
     data = np.arange(24, dtype=np.float32).reshape((6, 4))
     err = np.arange(24, dtype=np.float32).reshape((6, 4)) + 2

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -16,6 +16,7 @@ from ..util import open as open_model
 
 ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
 FITS_FILE = os.path.join(ROOT_DIR, 'test.fits')
+ASDF_FILE = os.path.join(ROOT_DIR, 'collimator_fake.asdf')
 ASN_FILE = os.path.join(ROOT_DIR, 'association.json')
 
 
@@ -354,6 +355,27 @@ def test_initialize_arrays_with_arglist():
     im = ImageModel(shape, zeroframe=thirteen, dq=bitz)
     assert np.array_equal(im.zeroframe, thirteen)
     assert np.array_equal(im.dq, bitz)
+
+def test_open_asdf_model():
+    # Open an empty asdf file, pass extra arguments
+
+    model = DataModel(init=None,
+                     ignore_version_mismatch=False,
+                     ignore_unrecognized_tag=True)
+
+    assert model._asdf._ignore_version_mismatch == False
+    assert model._asdf._ignore_unrecognized_tag == True
+    model.close()
+
+    # Open an existing asdf file
+
+    model = DataModel(ASDF_FILE,
+                     ignore_version_mismatch=False,
+                     ignore_unrecognized_tag=True)
+
+    assert model._asdf._ignore_version_mismatch == False
+    assert model._asdf._ignore_unrecognized_tag == True
+    model.close()
 
 def test_relsens():
     with ImageModel() as im:


### PR DESCRIPTION
Asdf supports two flags, ignore_version_mismatch and ignore_unrecognized_flag, when creating a new asdf file. Part of creating a new datamodel is opening an asdf file, either natively or as embedded in a FITS extension. This update passes these two flags from the DataModel argument list to the call that opens or creates an asdf file. The result is better control of the warning messages produced by asdf.
