### PR TITLE
Update reg test for new cfg name

### DIFF
--- a/jwst/tests_nightly/general/pipelines/test_nrs_fs_brightobj_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_fs_brightobj_spec2.py
@@ -19,7 +19,7 @@ def test_nrs_fs_brightobj_spec2(_bigdata):
     """
     collect_pipeline_cfgs()
     args = [
-        'calwebb_tso_spec2.cfg',
+        'calwebb_tso-spec2.cfg',
         op.join(
             _bigdata,
             'pipelines/jw84600042001_02101_00001_nrs2_rateints.fits'


### PR DESCRIPTION
Update the test_nrs_fs_brightobj_spec2 regression test module to use the new name of the cfg file, which PR #2639 changed from "calwebb_tso_spec2.cfg" to "calwebb_tso-spec2.cfg".