### PR TITLE
Changed the handling of zero wavelengths for NIRSpec data.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,7 +96,7 @@ flatfield
 ---------
 
 - Modified the code to find the dispersion direction. [#2492]
-- Changed the handling of zero wavelengths for NIRSpec data. [#xxx]
+- Changed the handling of zero wavelengths for NIRSpec data. [#2659]
 
 fringe
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,7 @@ flatfield
 ---------
 
 - Modified the code to find the dispersion direction. [#2492]
+- Changed the handling of zero wavelengths for NIRSpec data. [#xxx]
 
 fringe
 ------

--- a/jwst/flatfield/tests/test_clean_wl.py
+++ b/jwst/flatfield/tests/test_clean_wl.py
@@ -1,0 +1,45 @@
+"""
+Test for flat_field.clean_wl
+"""
+import numpy as np
+
+from jwst.flatfield import flat_field
+
+def test_clean_wl():
+
+    # The dispersion direction is horizontal.
+    wl_h = np.zeros((5, 9), dtype=np.float32)
+    wl_h[1, 3:7] = np.arange(3, 7, dtype=np.float32)
+    wl_h[2, 2:8] = np.arange(2, 8, dtype=np.float32) + 0.01
+    wl_h[3, 4] = 4.02
+
+    # The dispersion direction is vertical.
+    wl_v = np.rot90(wl_h)
+
+    # These are the "cleaned" arrays that we expect.
+    wl_h_clean = np.array(
+                [[2.01, 2.01, 2.01, 3.005, 4.01, 5.005, 6.005, 7.01, 7.01 ],
+                 [2.01, 2.01, 2.01, 3.,    4.,   5.,    6.,    7.01, 7.01 ],
+                 [2.01, 2.01, 2.01, 3.01,  4.01, 5.01,  6.01,  7.01, 7.01 ],
+                 [2.01, 2.01, 2.01, 3.005, 4.02, 5.005, 6.005, 7.01, 7.01 ],
+                 [2.01, 2.01, 2.01, 3.005, 4.01, 5.005, 6.005, 7.01, 7.01 ]],
+                dtype=np.float64)
+
+    wl_v_clean = np.array([[7.01,  7.01, 7.01, 7.01,  7.01 ],
+                           [7.01,  7.01, 7.01, 7.01,  7.01 ],
+                           [6.005, 6.,   6.01, 6.005, 6.005],
+                           [5.005, 5.,   5.01, 5.005, 5.005],
+                           [4.01,  4.,   4.01, 4.02,  4.01 ],
+                           [3.005, 3.,   3.01, 3.005, 3.005],
+                           [2.01,  2.01, 2.01, 2.01,  2.01 ],
+                           [2.01,  2.01, 2.01, 2.01,  2.01 ],
+                           [2.01,  2.01, 2.01, 2.01,  2.01 ]],
+                          dtype=np.float64)
+
+    # 1 means horizontal dispersion
+    wl_hc = flat_field.clean_wl(wl_h, 1)
+    assert np.allclose(wl_hc, wl_h_clean, atol=0., rtol=1.e-6)
+
+    # 2 means vertical dispersion
+    wl_vc = flat_field.clean_wl(wl_v, 2)
+    assert np.allclose(wl_vc, wl_v_clean, atol=0., rtol=1.e-6)


### PR DESCRIPTION
Function `combine_fast_slow` now calls a new function `clean_wl`, which returns a copy of the wavelength array with zero or NaN values replaced with an average.  The width of a pixel in wavelength units is computed by subtracting the wavelengths of adjacent pixels, but now this gives better results for pixels that are near the border between good wavelength values and NaN values.  Before calling `g_average`, there's a check that the wavelength is positive.

A check was added to verify that the wavelengths read from the fast-variation table are increasing, and a warning is logged if they are not.

Function `wl_interpolate` (used when computing the fast-variation flat) now returns the first or last element of the flat array if the wavelength is outside the range of the wavelength array.

Function `interpolate_flat` (used when computing the slow-variation flat) now only adds NO_FLAT_FIELD to the flat DQ array if the wavelength is less than or equal to zero.

See issue #2621.