### PR TITLE
Remove schema time format specs

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -152,17 +152,13 @@ properties:
             blend_table: True
             blend_rule: first
           date_beg:
-            anyOf:
-              - $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
-              - type: string
+            type: string
             title: "Date-time start of data acquisition"
             fits_keyword: DATE-BEG
             blend_table: True
             blend_rule: first
           date_end:
-            anyOf:
-              - $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
-              - type: string
+            type: string
             title: "[yyyy-mm-dd] UTC date at end of exposure"
             fits_keyword: DATE-END
             blend_table: True


### PR DESCRIPTION
Ever since #2595 was merged, the regression test "test_mrs_spec3" has been throwing schema validation warnings concerning the DATE-BEG keyword, which is really odd, because that keyword doesn't even exist yet in any of our data products. Somehow the schema validation problem is also causing a failure later in the pipeline run itself. Removing the "anyOf" block in the definitions of the DATE-BEG and DATE-END keywords and instead defining their data types as just plain string fixes the problem. So those data type defs are being updated in order to avoid the spec3 error. We don't use or need the datetime format specification right now anyway for those 2 keywords.