### PR TITLE
Remove IRS2 data size warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,9 @@ lastframe
 lib
 ---
 
+- Updated reffiles_utils to no longer issue warnings about mismatch in 
+  data array size params for NIRSpec IRS2 readouts. [#2664]
+
 linearity
 ---------
 

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -132,8 +132,7 @@ def ref_matches_sci(sci_model, ref_model):
     # a mismatch in the y-size.
     if (ysize_ref == 2048) and (ysize_data == 3200):
         ysize_ref = ysize_data
-
-    elif (xsize_ref != xsize_data) or (ysize_ref != ysize_data):
+    if (xsize_ref != xsize_data) or (ysize_ref != ysize_data):
         log.warning("Reference file data array size doesn't match subarray params")
         log.warning("Using actual array size")
         xsize_ref = xsize_data
@@ -173,9 +172,8 @@ def ref_matches_sci(sci_model, ref_model):
     # a mismatch in the y-size.
     if (ysize_sci == 2048) and (sci_model.shape[-2] == 3200):
         ysize_sci = sci_model.shape[-2]
-
-    elif (xsize_sci != sci_model.shape[-1]) or \
-         (ysize_sci != sci_model.shape[-2]):
+    if (xsize_sci != sci_model.shape[-1]) or \
+       (ysize_sci != sci_model.shape[-2]):
         log.warning("Science file data array size doesn't match subarray params")
         log.warning("Using actual array size")
         xsize_sci = sci_model.shape[-1]

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -127,15 +127,17 @@ def ref_matches_sci(sci_model, ref_model):
         xsize_data = ref_model.shape[-1]
         ysize_data = ref_model.shape[-2]
 
-    if (xsize_ref != xsize_data) or (ysize_ref != ysize_data):
-        # Check for NIRSpec IRS2 mode, which is allowed to have a mismatch
-        if (ysize_ref == 2048) and (ysize_data == 3200):
-            ysize_ref = ysize_data
-        else:
-            log.warning("Reference file data array size doesn't match subarray params")
-            log.warning("Using actual array size")
-            xsize_ref = xsize_data
-            ysize_ref = ysize_data
+    # Make sure the size attributes are consistent with data array.
+    # NIRSpec IRS2 is a special mode, where it's allowed to have
+    # a mismatch in the y-size.
+    if (ysize_ref == 2048) and (ysize_data == 3200):
+        ysize_ref = ysize_data
+
+    elif (xsize_ref != xsize_data) or (ysize_ref != ysize_data):
+        log.warning("Reference file data array size doesn't match subarray params")
+        log.warning("Using actual array size")
+        xsize_ref = xsize_data
+        ysize_ref = ysize_data
 
     # Get the science model subarray parameters
     try:
@@ -166,18 +168,18 @@ def ref_matches_sci(sci_model, ref_model):
         log.error("Science file subarray corners are invalid")
         raise ValueError("Bad subarray corners")
 
-    # Make sure the size attributes are consistent with data array
-    if (xsize_sci != sci_model.shape[-1]) or \
-       (ysize_sci != sci_model.shape[-2]):
+    # Make sure the size attributes are consistent with data array.
+    # NIRSpec IRS2 is a special mode, where it's allowed to have
+    # a mismatch in the y-size.
+    if (ysize_sci == 2048) and (sci_model.shape[-2] == 3200):
+        ysize_sci = sci_model.shape[-2]
 
-        # Check for NIRSpec IRS2 mode, which is allowed to have a mismatch
-        if (ysize_sci == 2048) and (sci_model.shape[-2] == 3200):
-            ysize_sci = sci_model.shape[-2]
-        else:
-            log.warning("Science file data array size doesn't match subarray params")
-            log.warning("Using actual array size")
-            xsize_sci = sci_model.shape[-1]
-            ysize_sci = sci_model.shape[-2]
+    elif (xsize_sci != sci_model.shape[-1]) or \
+         (ysize_sci != sci_model.shape[-2]):
+        log.warning("Science file data array size doesn't match subarray params")
+        log.warning("Using actual array size")
+        xsize_sci = sci_model.shape[-1]
+        ysize_sci = sci_model.shape[-2]
 
     # Finally, see if all of the science file subarray params match those
     # of the reference file
@@ -214,8 +216,8 @@ def get_subarray_data(sci_model, ref_model):
 
         # If the science file is full-frame, set the missing params to
         # default values
-        if (sci_model.data.shape[-1] == 2048) and \
-           (sci_model.data.shape[-2] == 2048):
+        if (sci_model.data.shape[-1] == 2048 and
+            sci_model.data.shape[-2] == 2048):
             sci_model.meta.subarray.xstart = 1
             sci_model.meta.subarray.ystart = 1
             sci_model.meta.subarray.xsize = 2048

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -128,10 +128,14 @@ def ref_matches_sci(sci_model, ref_model):
         ysize_data = ref_model.shape[-2]
 
     if (xsize_ref != xsize_data) or (ysize_ref != ysize_data):
-        log.warning("Reference file data array size doesn't match subarray params")
-        log.warning("Using actual array size")
-        xsize_ref = xsize_data
-        ysize_ref = ysize_data
+        # Check for NIRSpec IRS2 mode, which is allowed to have a mismatch
+        if (ysize_ref == 2048) and (ysize_data == 3200):
+            ysize_ref = ysize_data
+        else:
+            log.warning("Reference file data array size doesn't match subarray params")
+            log.warning("Using actual array size")
+            xsize_ref = xsize_data
+            ysize_ref = ysize_data
 
     # Get the science model subarray parameters
     try:
@@ -165,10 +169,15 @@ def ref_matches_sci(sci_model, ref_model):
     # Make sure the size attributes are consistent with data array
     if (xsize_sci != sci_model.shape[-1]) or \
        (ysize_sci != sci_model.shape[-2]):
-        log.warning("Science file data array size doesn't match subarray params")
-        log.warning("Using actual array size")
-        xsize_sci = sci_model.shape[-1]
-        ysize_sci = sci_model.shape[-2]
+
+        # Check for NIRSpec IRS2 mode, which is allowed to have a mismatch
+        if (ysize_sci == 2048) and (sci_model.shape[-2] == 3200):
+            ysize_sci = sci_model.shape[-2]
+        else:
+            log.warning("Science file data array size doesn't match subarray params")
+            log.warning("Using actual array size")
+            xsize_sci = sci_model.shape[-1]
+            ysize_sci = sci_model.shape[-2]
 
     # Finally, see if all of the science file subarray params match those
     # of the reference file

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -79,7 +79,7 @@ def ref_matches_sci(sci_model, ref_model):
         # If the ref file is full-frame, set the missing params to
         # default values
         if ref_model.meta.instrument.name.upper() == 'MIRI':
-            if (ref_model.data.shape[-1] == 1032 and \
+            if (ref_model.data.shape[-1] == 1032 and
                 ref_model.data.shape[-2] == 1024):
                 log.warning('Missing subarray corner/size keywords in reference file')
                 log.warning('Setting them to full-frame default values')
@@ -95,8 +95,8 @@ def ref_matches_sci(sci_model, ref_model):
                 log.error('Missing subarray corner/size keywords in reference file')
                 raise ValueError("Can't determine ref file subarray properties")
         else:
-            if (ref_model.data.shape[-1] == 2048) and \
-               (ref_model.data.shape[-2] == 2048):
+            if (ref_model.data.shape[-1] == 2048 and
+                ref_model.data.shape[-2] == 2048):
                 log.warning('Missing subarray corner/size keywords in reference file')
                 log.warning('Setting them to full-frame default values')
                 xstart_ref = 1
@@ -111,8 +111,8 @@ def ref_matches_sci(sci_model, ref_model):
                 log.error('Missing subarray corner/size keywords in reference file')
                 raise ValueError("Can't determine ref file subarray properties")
 
-    log.debug(" ref xstart=%d, xsize=%d, ystart=%d, ysize=%d" % \
-        (xstart_ref, xsize_ref, ystart_ref, ysize_ref))
+    log.debug(" ref xstart=%d, xsize=%d, ystart=%d, ysize=%d" %
+              (xstart_ref, xsize_ref, ystart_ref, ysize_ref))
 
     # Make sure the starting corners are valid
     if (xstart_ref < 1) or (ystart_ref < 1):
@@ -158,8 +158,8 @@ def ref_matches_sci(sci_model, ref_model):
         log.error('Missing subarray corner/size keywords in science file')
         raise ValueError("Can't determine science file subarray properties")
     else:
-        log.debug(" sci xstart=%d, xsize=%d, ystart=%d, ysize=%d" % \
-            (xstart_sci, xsize_sci, ystart_sci, ysize_sci))
+        log.debug(" sci xstart=%d, xsize=%d, ystart=%d, ysize=%d" %
+                  (xstart_sci, xsize_sci, ystart_sci, ysize_sci))
 
     # Make sure the starting corners are valid
     if (xstart_sci < 1) or (ystart_sci < 1):
@@ -221,8 +221,8 @@ def get_subarray_data(sci_model, ref_model):
             sci_model.meta.subarray.xsize = 2048
             sci_model.meta.subarray.ysize = 2048
         else:
-            raise ValueError('xstart or ystart metadata values ' \
-                             + 'not found in input model')
+            raise ValueError('xstart or ystart metadata values ' +
+                             'not found in input model')
 
     # Make sure xstart/ystart exist in reference data model
     if (ref_model.meta.subarray.xstart is None or
@@ -231,25 +231,25 @@ def get_subarray_data(sci_model, ref_model):
         # If the ref file is full-frame, set the missing params to
         # default values
         if ref_model.meta.instrument.name.upper() == 'MIRI':
-            if (ref_model.data.shape[-1] == 1032 and \
+            if (ref_model.data.shape[-1] == 1032 and
                 ref_model.data.shape[-2] == 1024):
                 ref_model.meta.subarray.xstart = 1
                 ref_model.meta.subarray.ystart = 1
                 ref_model.meta.subarray.xsize = 1032
                 ref_model.meta.subarray.ysize = 1024
             else:
-                raise ValueError('xstart or ystart metadata values ' \
-                                 + 'not found in reference model')
+                raise ValueError('xstart or ystart metadata values ' +
+                                 'not found in reference model')
         else:
-            if (ref_model.data.shape[-1] == 2048) and \
-               (ref_model.data.shape[-2] == 2048):
+            if (ref_model.data.shape[-1] == 2048 and
+                ref_model.data.shape[-2] == 2048):
                 ref_model.meta.subarray.xstart = 1
                 ref_model.meta.subarray.ystart = 1
                 ref_model.meta.subarray.xsize = 2048
                 ref_model.meta.subarray.ysize = 2048
             else:
-                raise ValueError('xstart or ystart metadata values ' \
-                                 + 'not found in reference model')
+                raise ValueError('xstart or ystart metadata values ' +
+                                 'not found in reference model')
 
     # Get subarray limits from metadata of input model
     xstart_sci = sci_model.meta.subarray.xstart
@@ -284,8 +284,8 @@ def get_subarray_data(sci_model, ref_model):
     if (xstart < 0 or ystart < 0 or
         xstop > ref_model.meta.subarray.xsize or
         ystop > ref_model.meta.subarray.ysize):
-        log.error('Computed reference file slice indexes are ' \
-                  + 'incompatible with size of reference data array')
+        log.error('Computed reference file slice indexes are ' +
+                  'incompatible with size of reference data array')
         log.error('xstart=%d, xstop=%d, ystart=%d, ystop=%d',
                    xstart, xstop, ystart, ystop)
         log.error('Reference xsize=%d, ysize=%d',
@@ -326,9 +326,7 @@ def get_subarray_model(sci_model, ref_model):
 
     # Get the reference model subarray params
     xstart_ref = ref_model.meta.subarray.xstart
-    xsize_ref = ref_model.meta.subarray.xsize
     ystart_ref = ref_model.meta.subarray.ystart
-    ysize_ref = ref_model.meta.subarray.ysize
 
     # Compute the slice indexes, in 0-indexed python frame
     xstart = xstart_sci - xstart_ref
@@ -343,8 +341,8 @@ def get_subarray_model(sci_model, ref_model):
     if (xstart < 0 or ystart < 0 or
         xstop > ref_model.meta.subarray.xsize or
         ystop > ref_model.meta.subarray.ysize):
-        log.error('Computed reference file slice indexes are ' \
-                  + 'incompatible with size of reference data array')
+        log.error('Computed reference file slice indexes are ' +
+                  'incompatible with size of reference data array')
         log.error('xstart=%d, xstop=%d, ystart=%d, ystop=%d',
                    xstart, xstop, ystart, ystop)
         log.error('Reference xsize=%d, ysize=%d',


### PR DESCRIPTION
Updated the reffiles library utilities to NOT issue a warning when SUBSIZE2 != data.shape[-2] for the case of NIRSpec IRS2 readouts. It's expected that in this situation SUBSIZE2=2048 while the actual data array is 3200 pixels.