### PR TITLE
Update MIRI detector1 step order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,6 +173,8 @@ pipeline
 
 - Added new Image2Pipeline configuration calwebb_wfs-image2.cfg for WFS&C processing [#2599]
 
+- Updated the order of MIRI steps in calwebb_detector1 and calwebb_dark. [#2669]
+
 ramp_fitting
 ------------
 

--- a/jwst/pipeline/calwebb_dark.cfg
+++ b/jwst/pipeline/calwebb_dark.cfg
@@ -17,6 +17,8 @@ suffix = "dark"
         config_file = refpix.cfg
       [[rscd]]
         config_file = rscd.cfg
+      [[firstframe]]
+        config_file = firstframe.cfg
       [[lastframe]]
         config_file = lastframe.cfg
       [[linearity]]

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -12,6 +12,7 @@ from ..ipc import ipc_step
 from ..superbias import superbias_step
 from ..refpix import refpix_step
 from ..rscd import rscd_step
+from ..firstframe import firstframe_step
 from ..lastframe import lastframe_step
 from ..linearity import linearity_step
 
@@ -40,6 +41,7 @@ class DarkPipeline(Pipeline):
                  'superbias': superbias_step.SuperBiasStep,
                  'refpix': refpix_step.RefPixStep,
                  'rscd': rscd_step.RSCD_Step,
+                 'firstframe': firstframe_step.FirstFrameStep,
                  'lastframe': lastframe_step.LastFrameStep,
                  'linearity': linearity_step.LinearityStep,
                  }
@@ -62,9 +64,10 @@ class DarkPipeline(Pipeline):
             input = self.dq_init(input)
             input = self.saturation(input)
             input = self.ipc(input)
+            input = self.firstframe(input)
+            input = self.lastframe(input)
             input = self.linearity(input)
             input = self.rscd(input)
-            input = self.lastframe(input)
 
         else:
 

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import logging
 from ..stpipe import Pipeline
 from .. import datamodels
 
@@ -22,7 +23,6 @@ from ..gain_scale import gain_scale_step
 __all__ = ['Detector1Pipeline']
 
 # Define logging
-import logging
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
@@ -80,10 +80,10 @@ class Detector1Pipeline(Pipeline):
             input = self.dq_init(input)
             input = self.saturation(input)
             input = self.ipc(input)
-            input = self.linearity(input)
-            input = self.rscd(input)
             input = self.firstframe(input)
             input = self.lastframe(input)
+            input = self.linearity(input)
+            input = self.rscd(input)
             input = self.dark_current(input)
             input = self.refpix(input)
 


### PR DESCRIPTION
Updated the order of MIRI steps in level-2a processing to be consistent with JCCWG specs, which boils down to moving `firstframe` and `lastframe` to be ahead of `linearity` and `rscd`. Also updated the `calwebb_dark` pipeline to include the `firstframe` step for MIRI.

Fixes #1454.