### PR TITLE
Spec2Pipeline and Image2Pipeline returns results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,6 +181,9 @@ pipeline
 
 - Updated the order of MIRI steps in calwebb_detector1 and calwebb_dark. [#2669]
 
+- Update Image2Pipeline and Spec2Pipeline to properly return results. [#2676]
+
+
 ramp_fitting
 ------------
 

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -51,6 +51,7 @@ class Image2Pipeline(Pipeline):
 
         # Each exposure is a product in the association.
         # Process each exposure.
+        results = []
         for product in asn['products']:
             self.log.info('Processing product {}'.format(product['name']))
             if self.save_results:
@@ -65,11 +66,14 @@ class Image2Pipeline(Pipeline):
             suffix = 'cal'
             if isinstance(result, datamodels.CubeModel):
                 suffix = 'calints'
-            self.save_model(result, suffix)
-
-            self.closeout(to_close=[result])
+            result.meta.filename = self.make_output_path(suffix=suffix)
+            results.append(result)
 
         self.log.info('... ending calwebb_image2')
+
+        self.output_use_model = True
+        self.suffix = False
+        return results
 
     # Process each exposure
     def process_exposure_product(

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -79,6 +79,7 @@ class Spec2Pipeline(Pipeline):
 
         # Each exposure is a product in the association.
         # Process each exposure.
+        results = []
         has_exceptions = False
         for product in asn['products']:
             self.log.info('Processing product {}'.format(product['name']))
@@ -99,8 +100,7 @@ class Spec2Pipeline(Pipeline):
                 has_exceptions = True
             else:
                 if result is not None:
-                    self.save_model(result)
-                    self.closeout(to_close=[result])
+                    results.append(result)
 
         if has_exceptions and self.fail_on_exception:
             raise RuntimeError(
@@ -109,6 +109,10 @@ class Spec2Pipeline(Pipeline):
 
         # We're done
         self.log.info('Ending calwebb_spec2')
+
+        self.output_use_model = True
+        self.suffix = False
+        return results
 
     # Process each exposure
     def process_exposure_product(
@@ -262,9 +266,10 @@ class Spec2Pipeline(Pipeline):
 
         # Setup to save the calibrated exposure at end of step.
         if tso_mode:
-            self.suffix = 'calints'
+            suffix = 'calints'
         else:
-            self.suffix = 'cal'
+            suffix = 'cal'
+        result.meta.filename = self.make_output_path(suffix=suffix)
 
         # Produce a resampled product, either via resample_spec for
         # "regular" spectra or cube_build for IFU data. No resampled

--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -33,8 +33,8 @@ def test_result_return(mk_tmp_dirs):
     """Ensure that a result is returned programmatically"""
     exppath = path.join(DATAPATH, EXPFILE)
     cfg = path.join(SCRIPT_DATA_PATH, 'calwebb_image2_save.cfg')
-    result = Image2Pipeline.call(exppath, config_file=cfg)
-    assert isinstance(result, DataModel)
+    results = Image2Pipeline.call(exppath, config_file=cfg)
+    assert isinstance(results[0], DataModel)
 
 
 @pytest.mark.bigdata

--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -10,6 +10,7 @@ from .helpers import (
 
 from ...associations.asn_from_list import asn_from_list
 from ...associations.lib.rules_level2_base import DMSLevel2bBase
+from ...datamodels import DataModel
 from ...datamodels import open as dm_open
 from ...stpipe.step import Step
 from ..calwebb_image2 import Image2Pipeline
@@ -25,6 +26,15 @@ pytestmark = pytest.mark.skipif(
     not path.exists(DATAPATH),
     reason='Test data not accessible'
 )
+
+
+@pytest.mark.bigdata
+def test_result_return(mk_tmp_dirs):
+    """Ensure that a result is returned programmatically"""
+    exppath = path.join(DATAPATH, EXPFILE)
+    cfg = path.join(SCRIPT_DATA_PATH, 'calwebb_image2_save.cfg')
+    result = Image2Pipeline.call(exppath, config_file=cfg)
+    assert isinstance(result, DataModel)
 
 
 @pytest.mark.bigdata

--- a/jwst/pipeline/tests/test_calwebb_spec2.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2.py
@@ -12,9 +12,11 @@ from .helpers import (
 
 from ...associations.asn_from_list import asn_from_list
 from ...associations.lib.rules_level2_base import DMSLevel2bBase
+from ...datamodels import DataModel
 from ...datamodels import open as dm_open
-from ..calwebb_spec2 import Spec2Pipeline
 from ...stpipe.step import Step
+from ..calwebb_spec2 import Spec2Pipeline
+from ..collect_pipeline_cfgs import collect_pipeline_cfgs
 
 DATAPATH = abspath(
     '$TEST_BIGDATA/pipelines'
@@ -29,6 +31,15 @@ pytestmark = pytest.mark.skipif(
     not path.exists(DATAPATH),
     reason='Test data not accessible'
 )
+
+
+@pytest.mark.bigdata
+def test_result_return(mk_tmp_dirs):
+    """Ensure that a result is returned programmatically"""
+    exppath = path.join(DATAPATH, EXPFILE)
+    collect_pipeline_cfgs('./cfgs')
+    results = Spec2Pipeline.call(exppath, config_file='./cfgs/calwebb_spec2.cfg')
+    assert isinstance(results[0], DataModel)
 
 
 def test_full_run(mk_tmp_dirs):

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -821,6 +821,11 @@ class Step():
             The extension to use. If none, `output_ext` is used.
             Can include the leading period or not.
 
+        suffix: str or None or False
+            Suffix to append to the filename.
+            If None, the `Step` default will be used.
+            If False, no suffix replacement will be done.
+
         name_format: str or None
             The format string to use to form the base name.
 
@@ -864,26 +869,37 @@ class Step():
         if ext.startswith('.'):
             ext = ext[1:]
 
-        suffix = _get_suffix(suffix, step=step)
-        suffix_sep = None
-        if suffix is not None:
-            basename, suffix_sep = remove_suffix(basename)
-        if suffix_sep is None:
-            suffix_sep = separator
-
         if len(components):
             component_str = formatter(component_format, **components)
         else:
             component_str = ''
 
-        basename = formatter(
-            name_format,
-            basename=basename,
-            suffix=suffix,
-            suffix_sep=suffix_sep,
-            ext=ext,
-            components=component_str
-        )
+        # Suffix check. An explicit check on `False` is necessary
+        # because `None` is also allowed.
+        suffix = _get_suffix(suffix, step=step)
+        if suffix is not False:
+            suffix_sep = None
+            if suffix is not None:
+                basename, suffix_sep = remove_suffix(basename)
+            if suffix_sep is None:
+                suffix_sep = separator
+
+            basename = formatter(
+                name_format,
+                basename=basename,
+                suffix=suffix,
+                suffix_sep=suffix_sep,
+                ext=ext,
+                components=component_str
+            )
+
+        else:
+            basename = formatter(
+                name_format,
+                basename=basename,
+                ext=ext,
+                components=component_str
+            )
 
         output_dir = step.search_attr('output_dir', default='')
         output_dir = expandvars(expanduser(output_dir))


### PR DESCRIPTION
A regression was reported, [JP-440](https://jira.stsci.edu/browse/JP-440), where `Image2Pipeline` no longer returned its primary, or `cal` result, when called programmatically.

This occurred when `Image2Pipeline`, along with `Spec2Pipeline`, was modified to handle associations with multiple products; returning results was removed.

Initial consideration was to remove multi-product handling, #2674. However, this would cause other inconsistencies in interface, usage, etc. In particular, multiple product handling is in use and works as expected when all results are written to files.

So, this PR takes the more direct tack: Before, `Image2Pipeline`, for an input, returned an output. Hence, now that `Image2Pipeline` handles multiple inputs, it should return a list of results.

`Spec2Pipeline` never returned anything. However, it has been modified to mimic `Image2Pipeline` behavior.