### PR TITLE
Reinstate FGS guider subarray names

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -786,7 +786,8 @@ properties:
             anyOf:
               # FGS
               - enum:
-                 [SUB128CNTR, SUB128DIAG, SUB128LL,
+                 [8X8, 32X32, 128X128, 2048X64,
+                  SUB128CNTR, SUB128DIAG, SUB128LL,
                   SUB32CNTR, SUB32DIAG, SUB32LL,
                   SUB8CNTR, SUB8DIAG, SUB8LL]
               # MIRI

--- a/jwst/datamodels/schemas/keyword_psubarray.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_psubarray.schema.yaml
@@ -9,7 +9,8 @@ properties:
           p_subarray:
             type: string
             pattern: "\
-              ^((SUB128CNTR|SUB128DIAG|SUB128LL|SUB32CNTR|SUB32DIAG|\
+              ^((8X8|32X32|128X128|2048X64|\
+              SUB128CNTR|SUB128DIAG|SUB128LL|SUB32CNTR|SUB32DIAG|\
               SUB32LL|SUB8CNTR|SUB8DIAG|SUB8LL|\
               BRIGHTSKY|MASK1065|MASK1140|MASK1550|MASKLYOT|\
               SLITLESSPRISM|SUB128|SUB256|SUB64|SUBPRISM|\

--- a/jwst/datamodels/schemas/subarray.schema.yaml
+++ b/jwst/datamodels/schemas/subarray.schema.yaml
@@ -13,7 +13,8 @@ properties:
             anyOf:
               # FGS
               - enum:
-                 [SUB128CNTR, SUB128DIAG, SUB128LL,
+                 [8X8, 32X32, 128X128, 2048X64,
+                  SUB128CNTR, SUB128DIAG, SUB128LL,
                   SUB32CNTR, SUB32DIAG, SUB32LL,
                   SUB8CNTR, SUB8DIAG, SUB8LL]
               # MIRI


### PR DESCRIPTION
#2667 removed the FGS subarray names "8X8", "32X32", "128X128", and "2048X64" from the allowed values lists in our schemas, because those names are not in the latest list of "official" subarray names for the PRD. But it turns out the FGS values included in that list only cover the science exposure modes. The names listed above are used for the guiding modes and hence need to be reinstated.

Fixes #2560.