### PR TITLE
Fix calspec2 reg test file saving

### DIFF
--- a/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
@@ -17,8 +17,8 @@ def test_nrs_msa_spec2(_bigdata):
 
     # define step for use in test
     step = Spec2Pipeline()
+    step.output_file = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod_cal.fits'
     step.save_bsub = False
-    step.output_use_model = True
     step.resample_spec.save_results = True
     step.extract_1d.save_results = True
     step.extract_1d.smoothing_length = 0


### PR DESCRIPTION
#2676 changed the behavior for the saving of cal products from the `calwebb_spec2` (and `calwebb_image2`) pipeline, which caused this regression test to no longer produce a _cal product on disk. Added the output file name to the pipeline param list to fix.