### PR TITLE
Add missing reference file keywords to reffile schemas

### DIFF
--- a/jwst/datamodels/reference.py
+++ b/jwst/datamodels/reference.py
@@ -1,4 +1,7 @@
 import warnings
+import sys
+import traceback
+
 from .model_base import DataModel
 from .dynamicdq import dynamic_mask
 from .validate import ValidationWarning
@@ -29,17 +32,20 @@ class ReferenceFileModel(DataModel):
         """
         try:
             assert self.meta.description is not None
-            assert (self.meta.telescope == 'JWST')
+            assert self.meta.telescope == 'JWST'
             assert self.meta.reftype is not None
             assert self.meta.author is not None
             assert self.meta.pedigree is not None
             assert self.meta.useafter is not None
             assert self.meta.instrument.name is not None
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                tb = sys.exc_info()[-1]
+                tb_info = traceback.extract_tb(tb)
+                text = tb_info[-1][-1]
+                warnings.warn(text, ValidationWarning)
 
         super(ReferenceFileModel, self).validate()
 

--- a/jwst/datamodels/schemas/nirspec_flat.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_flat.schema.yaml
@@ -1,6 +1,7 @@
 allOf:
 - $ref: referencefile.schema.yaml
 - $ref: subarray.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/nirspec_flat.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_flat.schema.yaml
@@ -1,7 +1,9 @@
 allOf:
 - $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: keyword_filter.schema.yaml
+- $ref: keyword_grating.schema.yaml
 - $ref: keyword_pexptype.schema.yaml
+- $ref: subarray.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/superbias.schema.yaml
+++ b/jwst/datamodels/schemas/superbias.schema.yaml
@@ -2,6 +2,7 @@ allOf:
 - $ref: referencefile.schema.yaml
 - $ref: subarray.schema.yaml
 - $ref: keyword_readpatt.schema.yaml
+- $ref: keyword_preadpatt.schema.yaml
 - $ref: keyword_gainfact.schema.yaml
 - type: object
   properties:


### PR DESCRIPTION
- Adds P_EXP_TY to NIRSpec Flat reffile
- Adds P_READPA to SuperBias reffile
- cleans up the `self.validate()` method so the warning is useful and the error message is not emitted twice.

Resolves #2684.