### PR TITLE
Update CI to test against unmerged ASDF branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ addons:
 env:
     global:
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda-dev'
-        - CONDA_DEPENDENCIES="asdf
-                              astropy
+        - CONDA_DEPENDENCIES="astropy
                               crds
                               dask
                               drizzle
@@ -42,7 +41,7 @@ env:
         - CRDS_PATH='/tmp/crds_cache'
         - MAIN_CMD='python setup.py'
         - MC_URL=https://repo.continuum.io/miniconda
-        - PIP_DEPENDENCIES=''
+        - PIP_DEPENDENCIES='git+git://github.com/drdavella/asdf@inline-threshold'
         - PYTHON_VERSION=3.6
 
     matrix:
@@ -87,9 +86,11 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --set auto_update_conda false
   - for channel in $CONDA_CHANNELS; do conda config --add channels "$channel"; done
-  - conda create -n test -q python=$PYTHON_VERSION $CONDA_DEPENDENCIES
+  - conda create -n test -q python=$PYTHON_VERSION
   - source activate test
+  - pip install "git+git://github.com/drdavella/asdf@inline-threshold"
   - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -q $PIP_DEPENDENCIES; fi
+  - conda install $CONDA_DEPENDENCIES
 
 after_install:
   - conda list astropy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,7 @@ def CONDA_ARGS = "-q -y"
 def CONDA_CREATE = "conda create ${CONDA_ARGS}"
 def CONDA_INST = "conda install ${CONDA_ARGS}"
 def CONDA_CHANNEL = "http://ssb.stsci.edu/astroconda-dev"
-def CONDA_DEPS = "asdf \
-                  astropy \
+def CONDA_DEPS = "astropy \
                   crds \
                   dask \
                   drizzle \
@@ -48,7 +47,7 @@ def CONDA_TEST_DEPS = "pytest"
 // Pip related setup
 def PIP_ARGS = "-q"
 def PIP_INST = "pip install ${PIP_ARGS}"
-def PIP_DEPS = ""
+def PIP_DEPS = "git+git://github.com/drdavella/asdf@inline-threshold"
 def PIP_DOC_DEPS = "sphinx-automodapi"
 def PIP_TEST_DEPS = "requests_mock ci_watson"
 
@@ -107,7 +106,9 @@ for (py in PY_VERSIONS) {
             bc.build_cmds = [
                 "conda config --add channels ${CONDA_CHANNEL}",
                 "${CONDA_CREATE} -n ${NAME} \
-                    python=${py} numpy=${npy} astropy=${apy} ${CONDA_DEPS}",
+                    python=${py} numpy=${npy} astropy=${apy}",
+                "${WRAPPER} ${PIP_INST} ${PIP_DEPS}",
+                "${WRAPPER} ${CONDA_INSTALL} ${CONDA_DEPS}",
                 "${WRAPPER} ${PY_SETUP} install"
             ]
             bc.test_cmds = [


### PR DESCRIPTION
**DO NOT MERGE**

The only purpose of this PR is to test the pipeline against a proposed change to ASDF.  It updates the CI scripts to install ASDF from a topic branch on GitHub.

The proposed change is that arrays below a certain threshold size (50 elements, to be specific) will automatically be inlined rather than stored in binary blocks. While the threshold can be customized, the change makes this new behavior the default. See https://github.com/spacetelescope/asdf/pull/557 for more details.

I'm testing this here since it has the potential to cause comparisons to old reference files to fail. We'll see how the test goes and move forward from there.

Also, feel free to voice and questions/concerns here.