### PR TITLE
 Add test that checks if all datamodels can be initialized

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -37,7 +37,7 @@ from .multiextract1d import MultiExtract1dImageModel
 from .multiprod import MultiProductModel
 from .multislit import MultiSlitModel
 from .multispec import MultiSpecModel
-from .nirspec_flat import NRSFlatModel, NirspecFlatModel, NirspecQuadFlatModel
+from .nirspec_flat import NirspecFlatModel, NirspecQuadFlatModel
 from .outlierpars import OutlierParsModel
 from .pathloss import PathlossModel
 from .persat import PersistenceSatModel
@@ -87,7 +87,7 @@ __all__ = [
     'DrizParsModel',
     'Extract1dImageModel',
     'FilteroffsetModel',
-    'FlatModel', 'NRSFlatModel', 'NirspecFlatModel', 'NirspecQuadFlatModel',
+    'FlatModel', 'NirspecFlatModel', 'NirspecQuadFlatModel',
     'FOREModel', 'FPAModel',
     'FringeModel', 'GainModel', 'GLS_RampFitModel',
     'GuiderRawModel', 'GuiderCalModel',

--- a/jwst/datamodels/nirspec_flat.py
+++ b/jwst/datamodels/nirspec_flat.py
@@ -1,15 +1,10 @@
 from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
-__all__ = ['NRSFlatModel']
-
-class NRSFlatModel(ReferenceFileModel):
-    """A base class for NIRSpec flat-field reference file models."""
-
-    schema_url = "nirspec.flat.schema.yaml"
+__all__ = ['NirspecFlatModel', 'NirspecQuadFlatModel']
 
 
-class NirspecFlatModel(NRSFlatModel):
+class NirspecFlatModel(ReferenceFileModel):
     """A data model for NIRSpec flat-field reference files.
 
     Parameters
@@ -49,7 +44,7 @@ class NirspecFlatModel(NRSFlatModel):
         self.err = self.err
 
 
-class NirspecQuadFlatModel(NRSFlatModel):
+class NirspecQuadFlatModel(ReferenceFileModel):
     """A data model for NIRSpec flat-field files that differ by quadrant.
 
     Parameters

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -15,10 +15,20 @@ from astropy.io import fits
 from astropy.modeling import models
 from astropy import time
 
-from .. import util, validate
-from .. import (DataModel, ImageModel, RampModel, MaskModel,
-                MultiSlitModel, AsnModel, CollimatorModel)
-from ..schema import merge_property_trees
+from jwst.datamodels import util, validate
+from jwst.datamodels import _defined_models as defined_models
+from jwst.datamodels import (
+    DataModel,
+    ImageModel,
+    RampModel,
+    MaskModel,
+    MultiSlitModel,
+    AsnModel,
+    CollimatorModel,
+    SourceModelContainer,
+    MultiExposureModel,
+)
+from jwst.datamodels.schema import merge_property_trees
 
 from asdf import schema as mschema
 
@@ -617,3 +627,16 @@ def test_merge_property_trees(combiner):
     # Make sure that merge_property_trees does not destructively modify schemas
     f = merge_property_trees(s)
     assert f == s
+
+
+@pytest.mark.parametrize("model", [m for m in defined_models.values()])
+def test_all_datamodels_init(model):
+    """
+    Test that all current datamodels can be initialized.
+    """
+    if model is SourceModelContainer:
+        # SourceModelContainer cannot have init=None
+        m = model(MultiExposureModel())
+    else:
+        m = model()
+    del m

--- a/jwst/datamodels/tsophot.py
+++ b/jwst/datamodels/tsophot.py
@@ -1,4 +1,6 @@
 import warnings
+import sys
+import traceback
 
 from .reference import ReferenceFileModel
 from .validate import ValidationWarning
@@ -16,15 +18,9 @@ class TsoPhotModel(ReferenceFileModel):
         super(TsoPhotModel, self).__init__(init=init, **kwargs)
         if radii is not None:
             self.radii = radii
-        if init is None:
-            self.populate_meta()
 
     def on_save(self, path=None):
         self.meta.reftype = self.reftype
-
-    def populate_meta(self):
-        self.meta.instrument.name = "MIRI|NIRCAM|"
-        self.meta.exposure.type = "MIR_IMAGE|NRC_TSIMAGE|"
 
     def to_fits(self):
         raise NotImplementedError("FITS format is not supported for this file.")
@@ -37,6 +33,9 @@ class TsoPhotModel(ReferenceFileModel):
             assert self.meta.exposure.type in ["MIR_IMAGE", "NRC_TSIMAGE"]
         except AssertionError as errmsg:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                tb = sys.exc_info()[-1]
+                tb_info = traceback.extract_tb(tb)
+                text = tb_info[-1][-1]
+                warnings.warn(text, ValidationWarning)

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -317,7 +317,7 @@ class RegionsModel(ReferenceFileModel):
     def validate(self):
         super(RegionsModel, self).validate()
         try:
-            assert isinstance(self.regions.copy(), np.ndarray)
+            assert isinstance(self.regions, np.ndarray)
             assert self.meta.instrument.name == "MIRI"
             assert self.meta.exposure.type == "MIR_MRS"
             assert self.meta.instrument.channel in ("12", "34", "1", "2", "3", "4")


### PR DESCRIPTION
Since we ran into some bugs with the `validate()` method and the schema for other datamodels, here is a simple test to verify that at a minimum, all datamodels can be instantiated.

The test caught a bug in `TsoPhotModel` where two keywords were being assigned patterns via `__init__`, but the schema for those keywords do not allow those patterns.

Also removed `NRSFlatModel`, which was an intermediate subclass between `DataModel` and `NirspecFlatModel`.  There was a bug in the schema name, and it added no new features to its subclasses.