### PR TITLE
Set default inline threshold for ASDF to 0

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -67,6 +67,7 @@ class ModelContainer(model_base.DataModel):
 
     def __init__(self, init=None, persist=True, **kwargs):
 
+        inline_threshold = kwargs.pop('inline_threshold', 0)
         super(ModelContainer, self).__init__(init=None, **kwargs)
         self._persist = persist
 
@@ -79,7 +80,8 @@ class ModelContainer(model_base.DataModel):
             instance = copy.deepcopy(init._instance)
             self._schema = init._schema
             self._shape = init._shape
-            self._asdf = AsdfFile(instance, extensions=self._extensions)
+            self._asdf = AsdfFile(instance, extensions=self._extensions,
+                                  inline_threshold=inline_threshold)
             self._instance = instance
             self._ctx = self
             self.__class__ = init.__class__
@@ -155,7 +157,7 @@ class ModelContainer(model_base.DataModel):
         self._open_model(index)
         return self._models.pop(index)
 
-    def copy(self, memo=None):
+    def copy(self, memo=None, inline_threshold=0):
         """
         Returns a deep copy of the models in this model container.
         """
@@ -164,7 +166,8 @@ class ModelContainer(model_base.DataModel):
                                 pass_invalid_values=self._pass_invalid_values,
                                 strict_validation=self._strict_validation)
         instance = copy.deepcopy(self._instance, memo=memo)
-        result._asdf = AsdfFile(instance, extensions=self._extensions)
+        result._asdf = AsdfFile(instance, extensions=self._extensions,
+                                inline_threshold=inline_threshold)
         result._instance = instance
         result._iscopy = self._iscopy
         result._schema = result._schema

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -115,15 +115,17 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         is_array = False
         is_shape = False
         shape = None
+        # Set threshold size for inlining data arrays to 0 by default
+        asdf_kwargs = dict(inline_threshold=kwargs.pop('inline_threshold', 0))
 
         if init is None:
-            asdf = AsdfFile(extensions=extensions)
+            asdf = AsdfFile(extensions=extensions, **asdf_kwargs)
 
         elif isinstance(init, dict):
-            asdf = AsdfFile(init, extensions=self._extensions)
+            asdf = AsdfFile(init, extensions=self._extensions, **asdf_kwargs)
 
         elif isinstance(init, np.ndarray):
-            asdf = AsdfFile(extensions=self._extensions)
+            asdf = AsdfFile(extensions=self._extensions, **asdf_kwargs)
             shape = init.shape
             is_array = True
 
@@ -133,7 +135,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                     raise ValueError("shape must be a tuple of ints")
 
             shape = init
-            asdf = AsdfFile()
+            asdf = AsdfFile(**asdf_kwargs)
             is_shape = True
 
         elif isinstance(init, DataModel):
@@ -298,10 +300,11 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return asdf_file_resolver
 
     @staticmethod
-    def clone(target, source, deepcopy=False, memo=None):
+    def clone(target, source, deepcopy=False, memo=None, inline_threshold=0):
         if deepcopy:
             instance = copy.deepcopy(source._instance, memo=memo)
-            target._asdf = AsdfFile(instance, extensions=source._extensions)
+            target._asdf = AsdfFile(instance, extensions=source._extensions,
+                                    inline_threshold=inline_threshold)
             target._instance = instance
             target._iscopy = source._iscopy
         else:
@@ -542,7 +545,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         self.on_save(init)
 
-        AsdfFile(self._instance, extensions=self._extensions).write_to(init, *args, **kwargs)
+        inline_threshold = kwargs.pop('inline_threshold', 0)
+        AsdfFile(self._instance, extensions=self._extensions,
+                 inline_threshold=inline_threshold).write_to(init, *args, **kwargs)
 
     @classmethod
     def from_fits(cls, init, schema=None):


### PR DESCRIPTION
ASDF just introduced new functionality that causes arrays below a particular threshold size to be automatically stored inline rather than in internal blocks (see https://github.com/spacetelescope/asdf/pull/557).

This has potential performance issues for the pipeline, and it also may affect comparisons with existing reference files. This PR updates the pipeline to make use of the new `inline_threshold` parameter introduced by ASDF to ensure that all arrays continue to be stored in internal blocks for now.

**EDIT**: some initial discussion of this took place in #2692.