### PR TITLE
Add filtering/selection by peakmax and brightest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -359,7 +359,7 @@ lastframe
 lib
 ---
 
-- Updated reffiles_utils to no longer issue warnings about mismatch in 
+- Updated reffiles_utils to no longer issue warnings about mismatch in
   data array size params for NIRSpec IRS2 readouts. [#2664]
 
 linearity
@@ -471,6 +471,13 @@ tweakreg
 
 - Updated tweakreg to use `wcs.available_frames` to get the names of the frames in
   a WCS pipeline. [#2590, #2594, #2629]
+
+- Added two new parameters: ``brightest`` to keep the top ``brightest``
+  (based on the flux) objects in the object catalog *after all other
+  filtering has been applied* and ``peakmax`` to exclude sources with
+  peak pixel values larger or equal to ``peakmax``. ``brightest`` can be used
+  to eliminate false detections and ``peakmax`` can be used to filter out
+  saturated sources (instrument-specific value).[#2706]
 
 wfs_combine
 -----------

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -81,7 +81,6 @@ _calculated_suffixes = set([
     'groupscalestep',
     'resamplestep',
     'assign_wcs',
-    'tweakreg',
     'resetstep',
     'klip',
     'straylightstep',

--- a/jwst/pipeline/tweakreg.cfg
+++ b/jwst/pipeline/tweakreg.cfg
@@ -5,6 +5,8 @@ save_catalogs = False
 catalog_format = 'ecsv'
 kernel_fwhm = 2.5
 snr_threshold = 10.
+brightest = None
+peakmax = None
 enforce_user_order = False
 expand_refcat = False
 minobj = 15
@@ -17,4 +19,3 @@ yoffset = 0.0
 fitgeometry = 'general'
 nclip = 3
 sigma = 3.0
-

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -4,7 +4,8 @@ from ..datamodels import ImageModel
 
 
 def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
-                          sharphi=1.0, roundlo=-1.0, roundhi=1.0):
+                          sharphi=1.0, roundlo=-1.0, roundhi=1.0,
+                          brightest=None):
     """
     Create a catalog of point-line sources to be used for image
     alignment in tweakreg.
@@ -37,6 +38,21 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
     roundhi : float, optional
         The upper bound on roundess for object detection.
 
+    brightest : int, None, optional
+        Number of brightest objects to keep after sorting the full object list.
+        If ``brightest`` is set to `None`, all objects will be selected.
+
+    peakmax : float, None, optional
+        Maximum peak pixel value in an object. Only objects whose peak pixel
+        values are *strictly smaller* than ``peakmax`` will be selected.
+        This may be used to exclude saturated sources. By default, when
+        ``peakmax`` is set to `None`, all objects will be selected.
+
+        .. warning::
+            `DAOStarFinder` automatically excludes objects whose peak
+            pixel values are negative. Therefore, setting ``peakmax`` to a
+            non-positive value would result in exclusion of all objects.
+
     Returns
     -------
     catalog : `~astropy.Table`
@@ -52,7 +68,8 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
 
     daofind = DAOStarFinder(fwhm=kernel_fwhm, threshold=threshold,
                             sharplo=sharplo, sharphi=sharphi, roundlo=roundlo,
-                            roundhi=roundhi)
+                            roundhi=roundhi, brightest=brightest,
+                            peakmax=peakmax)
     sources = daofind(model.data)
 
     columns = ['id', 'xcentroid', 'ycentroid', 'flux']

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -5,7 +5,7 @@ from ..datamodels import ImageModel
 
 def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
                           sharphi=1.0, roundlo=-1.0, roundhi=1.0,
-                          brightest=None):
+                          brightest=None, peakmax=None):
     """
     Create a catalog of point-line sources to be used for image
     alignment in tweakreg.

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -31,7 +31,7 @@ class TweakRegStep(Step):
         kernel_fwhm = float(default=2.5) # Gaussian kernel FWHM in pixels
         snr_threshold = float(default=10.0) # SNR threshold above the bkg
         brightest = int(default=None) # Keep top ``brightest`` objects
-        peakmax = float(default=None) # Filter out objects with pixel values >= ``pixmax``
+        peakmax = float(default=None) # Filter out objects with pixel values >= ``peakmax``
 
         # Optimize alignment order:
         enforce_user_order = boolean(default=False) # Align images in user specified order?

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -27,9 +27,11 @@ class TweakRegStep(Step):
     spec = """
         # Source finding parameters:
         save_catalogs = boolean(default=False) # Write out catalogs?
-        catalog_format = string(default='ecsv')   # Catalog output file format
-        kernel_fwhm = float(default=2.5)    # Gaussian kernel FWHM in pixels
-        snr_threshold = float(default=10.0)  # SNR threshold above the bkg
+        catalog_format = string(default='ecsv') # Catalog output file format
+        kernel_fwhm = float(default=2.5) # Gaussian kernel FWHM in pixels
+        snr_threshold = float(default=10.0) # SNR threshold above the bkg
+        brightest = int(default=None) # Keep top ``brightest`` objects
+        peakmax = float(default=None) # Filter out objects with pixel values >= ``pixmax``
 
         # Optimize alignment order:
         enforce_user_order = boolean(default=False) # Align images in user specified order?
@@ -65,8 +67,10 @@ class TweakRegStep(Step):
 
         # Build the catalogs for input images
         for image_model in images:
-            catalog = make_tweakreg_catalog(image_model, self.kernel_fwhm,
-                                            self.snr_threshold)
+            catalog = make_tweakreg_catalog(
+                image_model, self.kernel_fwhm, self.snr_threshold,
+                brightest=self.brightest, peakmax=self.peakmax
+            )
             filename = image_model.meta.filename
             self.log.info('Detected {0} sources in {1}.'.format(len(catalog), filename))
 


### PR DESCRIPTION
This PR adds two new parameters to `tweakreg_step` star object detection algorithm to allow source selection/filtering by:

1. `peakmax` - maximum peak pixel value for selecting stars.
2. `brightest` - number of brightest objects to keep.

The rationale for these parameters is that `peakmax` could allow automatic exclusion of sources that reach a known saturation level of the detector and `brightest` would keep top `brightest` stars thus eliminating the faintest objects that could be false detections.

CC: @hbushouse @larrybradley 