### PR TITLE
Updates to dark step reffile docs

### DIFF
--- a/docs/jwst/dark_current/arguments.rst
+++ b/docs/jwst/dark_current/arguments.rst
@@ -7,5 +7,5 @@ The dark current step has one step-specific argument:
 
 If the ``dark_output`` argument is given with a filename for its value,
 the frame-averaged dark data that are created within the step will be
-be saved to that file.
+saved to that file.
 

--- a/docs/jwst/dark_current/dark_selection.rst
+++ b/docs/jwst/dark_current/dark_selection.rst
@@ -1,5 +1,7 @@
+.. _dark_selectors:
+
 Reference Selection Keywords for DARK
--------------------------------------
++++++++++++++++++++++++++++++++++++++
 CRDS selects appropriate DARK references based on the following keywords.
 DARK is not applicable for instruments not in the table.
 
@@ -8,8 +10,8 @@ Instrument Keywords
 ========== ==================================================================================================
 FGS        INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
 MIRI       INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
-NIRCAM     INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS                                                   
+NIRCam     INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS                                                   
 NIRISS     INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
-NIRSPEC    INSTRUME, DETECTOR, READPATT, SUBARRAY, SUBSTRT1, SUBSTRT2, SUBSIZE1, SUBSIZE2, DATE-OBS, TIME-OBS 
+NIRSpec    INSTRUME, DETECTOR, READPATT, SUBARRAY, SUBSTRT1, SUBSTRT2, SUBSIZE1, SUBSIZE2, DATE-OBS, TIME-OBS 
 ========== ==================================================================================================
 

--- a/docs/jwst/dark_current/dark_specific.rst
+++ b/docs/jwst/dark_current/dark_specific.rst
@@ -1,17 +1,19 @@
 Type Specific Keywords for DARK
-++++++++++++++++++++++++++++++++++
-The following additional keywords are required for the DARK reference
-type:
++++++++++++++++++++++++++++++++
+In addition to the standard reference file keywords listed above,
+the following keywords are *required* in DARK reference files,
+because they are used as CRDS selectors
+(see :ref:`dark_selectors`):
 
-=========  ========================  ==========================
-Keyword    Model Name                Instruments
-=========  ========================  ==========================
-DETECTOR   meta.instrument.detector  all
-READPATT   meta.exposure.readpatt    FGS, NIRISS, MIRI, NIRSPEC       
-SUBARRAY   meta.subarray.name        all
-SUBSTRT1   meta.subarray.xstart      NIRSPEC
-SUBSTRT2   meta.subarray.ystart      NIRSPEC
-SUBSIZE1   meta.subarray.xsize       NIRSPEC
-SUBSIZE2   meta.subarray.ysize       NIRSPEC
-=========  ========================  ==========================
+=========  ==============================  ==========================
+Keyword    Data Model Name                 Instruments
+=========  ==============================  ==========================
+DETECTOR   model.meta.instrument.detector  All
+READPATT   model.meta.exposure.readpatt    FGS, MIRI, NIRISS, NIRSpec
+SUBARRAY   model.meta.subarray.name        All
+SUBSTRT1   model.meta.subarray.xstart      NIRSpec
+SUBSTRT2   model.meta.subarray.ystart      NIRSpec
+SUBSIZE1   model.meta.subarray.xsize       NIRSpec
+SUBSIZE2   model.meta.subarray.ysize       NIRSpec
+=========  ==============================  ==========================
 

--- a/docs/jwst/dark_current/reference_files.rst
+++ b/docs/jwst/dark_current/reference_files.rst
@@ -1,23 +1,33 @@
 Reference File
 ==============
-The dark current step uses a DARK reference file.
+The `dark` step uses a DARK reference file.
+
+DARK Reference File
+-------------------
+
+:RETYPE: DARK
+:Data model: `DarkModel', `DarkMIRIModel`
+
+The DARK reference file contains pixel-by-pixel and frame-by-frame
+dark current values for a given detector readout mode.
 
 .. include:: dark_selection.rst
-             
+
 .. include:: ../includes/standard_keywords.rst
 
 .. include:: dark_specific.rst
              
-DARK Reference File Format
---------------------------
+Reference File Format
++++++++++++++++++++++
+DARK reference files are FITS format, with 3 IMAGE extensions
+and 1 BINTABLE extension. The FITS primary data array is assumed to be empty.
+The format and content of the files is different for MIRI than the
+near-IR instruments, as shown below.
 
-NIR Detectors
-+++++++++++++
-
-Dark reference files are FITS files with 3 IMAGE extensions and 1 BINTABLE
-extension. The FITS primary data array is assumed to be empty. The 
-characteristics of the three image extensions for darks used with the
-Near-IR instruments are as follows:
+Near-IR Detectors
+~~~~~~~~~~~~~~~~~
+Characteristics of the three IMAGE extensions for DARK files used with
+the Near-IR instruments are as follows:
 
 =======  =====  =======================  =========
 EXTNAME  NAXIS  Dimensions               Data type
@@ -28,18 +38,15 @@ DQ       2      ncols x nrows            integer
 DQ_DEF   2      TFIELDS = 4              N/A
 =======  =====  =======================  =========
 
-.. include:: ../includes/dq_def.rst
-
 MIRI Detectors
-++++++++++++++
-
-The dark reference files for the MIRI detectors depend on the integration number,  
+~~~~~~~~~~~~~~
+The DARK reference files for the MIRI detectors depend on the integration number,  
 because the first integration of MIRI exposures contains effects from the detector
 reset and are slightly different from subsequent integrations. Currently the MIRI
-dark reference files contain a correction for only two integrations: the first
-integration of the dark is subtracted from the first integration of the science data,
-while the second dark integration is subtracted from all subsequent science integrations.
-The format of the MIRI dark reference files is as follows:
+DARK reference files contain a correction for only two integrations: the first
+integration of the DARK is subtracted from the first integration of the science data,
+while the second DARK integration is subtracted from all subsequent science integrations.
+The format of the MIRI DARK reference files is as follows:
 
 =======  =====  ===============================  =========
 EXTNAME  NAXIS  Dimensions                       Data type


### PR DESCRIPTION
Updated reference file info in the `dark_current` step docs.
In partial fulfillment of #2675.