### PR TITLE
Add relresperror column to MIRI photom schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,10 @@ datamodels
 - Updated EXP_TYPE allowed values to include "MIR_DARKALL", "MIR_DARKIMG",
   "MIR_DARKMRS", "MIR_FLATALL", "MIR_FLATIMAGE-EXT", and "MIR_FLATMRS-EXT" [#2709]
 
+- Added the new column "relresperror" to the MIRI Imager/LRS photom reference
+  file schema for data model "MiriImgPhotomModel", to allow for uncertainty
+  in the relative response values [#2721]
+
 dq_init
 -------
 

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -144,6 +144,7 @@ class MiriImgPhotomModel(PhotomModel):
         - nelem: int16
         - wavelength: float32[500]
         - relresponse: float32[500]
+        - relresperror: float32[500]
 
     """
     schema_url = "mirimg_photom.schema.yaml"

--- a/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -24,4 +24,7 @@ allOf:
       - name: relresponse
         shape: [500]
         datatype: float32
+      - name: relresperror
+        shape: [500]
+        datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Added a new column "relresperror" to the MIRI Imager/LRS photom reference file schema, to accommodate uncertainties in the wavelength-dependent response values, as requested by the MIRI IDT. They need this update in order to create ref files for their CDP-7 delivery in Nov. 2018. So it should be included in the next available B7.2 patch.
 
Fixes #2712.