### PR TITLE
Revert "Add relresperror column to MIRI photom schema"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,10 +102,6 @@ datamodels
 - Updated EXP_TYPE allowed values to include "MIR_DARKALL", "MIR_DARKIMG",
   "MIR_DARKMRS", "MIR_FLATALL", "MIR_FLATIMAGE-EXT", and "MIR_FLATMRS-EXT" [#2709]
 
-- Added the new column "relresperror" to the MIRI Imager/LRS photom reference
-  file schema for data model "MiriImgPhotomModel", to allow for uncertainty
-  in the relative response values [#2721]
-
 dq_init
 -------
 

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -144,7 +144,6 @@ class MiriImgPhotomModel(PhotomModel):
         - nelem: int16
         - wavelength: float32[500]
         - relresponse: float32[500]
-        - relresperror: float32[500]
 
     """
     schema_url = "mirimg_photom.schema.yaml"

--- a/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -24,7 +24,4 @@ allOf:
       - name: relresponse
         shape: [500]
         datatype: float32
-      - name: relresperror
-        shape: [500]
-        datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Reverts spacetelescope/jwst#2721. Backing this out for now, because it's causing errors with all the current MIRI PHOTOM ref files in CRDS, which don't have the extra column in the table. Don't need it for 0.12.1. Will reinstate later after B7.2 delivery and we figure out how to get the existing MIRI PHOTOM ref files updated (they may get updated naturally through the team's upcoming CDP-7 delivery).