### PR TITLE
fixed error in writting self.roiw to header

### DIFF
--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -69,8 +69,12 @@ class CubeBuildStep (Step):
         if(self.wavemax is not None): self.log.info('Setting Maximum wavelength of spectral cube to: %f',
                                                self.wavemax)
 
-        if(self.rois != 0.0): self.log.info('Input Spatial ROI size %f', self.rois)
-        if(self.roiw != 0.0): self.log.info('Input Wave ROI size %f', self.roiw)
+        if(self.rois != 0.0): 
+            self.log.info('Input Spatial ROI size %f', self.rois)
+            self.rois = float(self.rois)
+        if(self.roiw != 0.0): 
+            self.log.info('Input Wave ROI size %f', self.roiw)
+            self.roiw = float(self.roiw)
 
         self.debug_pixel = 0
         self.spaxel_debug = None

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1332,6 +1332,8 @@ class IFUCubeData():
             ifucube_model.meta.wcsinfo.cdelt3 = self.cdelt3
             ifucube_model.meta.wcsinfo.ctype3 = 'WAVE'
             ifucube_model.meta.wcsinfo.crpix3 = self.crpix3
+            ifucube_model.meta.ifu.roi_spatial = float(self.rois)
+            ifucube_model.meta.ifu.roi_wave = float(self.roiw)
         else:
             ifucube_model.meta.wcsinfo.ctype3 = 'WAVE-TAB'
             ifucube_model.meta.wcsinfo.ps3_0 = 'WCS-TABLE'
@@ -1339,6 +1341,7 @@ class IFUCubeData():
             ifucube_model.meta.wcsinfo.crval3 = 1.0
             ifucube_model.meta.wcsinfo.crpix3 = 1.0
             ifucube_model.meta.wcsinfo.cdelt3 = None
+            ifucube_model.meta.ifu.roi_wave = np.mean(self.roiw_table)
             ifucube_model.wavedim = '(1,10420)'
 
 
@@ -1365,8 +1368,9 @@ class IFUCubeData():
         ifucube_model.meta.ifu.error_extension = 'ERR'
         ifucube_model.meta.ifu.error_type = 'ERR'
         ifucube_model.meta.ifu.dq_extension = 'DQ'
-        ifucube_model.meta.ifu.roi_spatial = float(self.rois)
-        ifucube_model.meta.ifu.roi_wave = float(self.roiw)
+
+
+
         ifucube_model.meta.ifu.weighting = str(self.weighting)
 
         # weight_power is needed for single cubes. Linear Wavelengths


### PR DESCRIPTION
When the wavelength dimension  is non-linear the roiw value is actually a table of values and not
a single value. When the wavelength dimension is non-linear self.roiw = None and writing
this value to the header as float(self.roiw) resulted in an error. 
This value is needed in the header when running in 'single' mode to
support background matching and outlier detector (blotting). Single mode will always
produce linear wavelength dimension ifucubes which have a single value in roiw.
This PR populates self.roiw with the mean of the roiw array when the wavelength dimension is non-linear. 
