### PR TITLE
Fix a typo in branching by number of points

### DIFF
--- a/jwst/tweakreg/wcsimage.py
+++ b/jwst/tweakreg/wcsimage.py
@@ -1448,7 +1448,7 @@ class RefCatalog():
             xv = [x[0] - 0.5, x[0] - 0.5, x[0] + 0.5, x[0] + 0.5, x[0] - 0.5]
             yv = [y[0] - 0.5, y[0] + 0.5, y[0] + 0.5, y[0] - 0.5, y[0] - 0.5]
 
-        elif len(xv) == 3:
+        elif len(xv) == 2:
             # two points. build a small box around them:
             x, y = convex_hull(x, y, wcs=None)
 


### PR DESCRIPTION
This is an obvious typo that needs to be fixed. I am not sure though whether this is going to fix https://github.com/spacetelescope/jwst/issues/2746 by itself (though it might, depending on detected points).

CC: @stscieisenhamer 