### PR TITLE
NRS grating=MIRROR should trigger the imaging pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ assign_wcs
 
 - Added unit tests for grism modes [#2649]
 
+- Augmented the logic for choosing a Nirspec WCS mode to include a check for the value
+  of ``GRATING``. If ``GRATING=MIRROR`` imaging mode is chosen reegardless of ``EXP_TYPE``. [#2761]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -49,8 +49,11 @@ def create_pipeline(input_model, reference_files):
     reference_files : dict
         {reftype: reference_file_name} mapping.
     """
-    exp_type = input_model.meta.exposure.type.lower()
-    pipeline = exp_type2transform[exp_type](input_model, reference_files)
+    if input_model.meta.grating.lower() == "mirror":
+        pipeline = imaging(input_model, reference_files)
+    else:
+        exp_type = input_model.meta.exposure.type.lower()
+        pipeline = exp_type2transform[exp_type](input_model, reference_files)
     if pipeline:
         log.info("Created a NIRSPEC {0} pipeline with references {1}".format(
                 exp_type, reference_files))
@@ -345,7 +348,7 @@ def get_open_slits(input_model, reference_files=None):
         log.info("Slits projected on detector {0}: {1}".format(input_model.meta.instrument.detector,
                                                                [sl.name for sl in slits]))
     if not slits:
-        log_message = "No open slits fall on detector {0}.".format(input_model.meta.instrument.detector) 
+        log_message = "No open slits fall on detector {0}.".format(input_model.meta.instrument.detector)
         log.critical(log_message)
         raise NoDataOnDetectorError(log_message)
     return slits

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -49,7 +49,7 @@ def create_pipeline(input_model, reference_files):
     reference_files : dict
         {reftype: reference_file_name} mapping.
     """
-    if input_model.meta.grating.lower() == "mirror":
+    if input_model.meta.instrument.grating.lower() == "mirror":
         pipeline = imaging(input_model, reference_files)
     else:
         exp_type = input_model.meta.exposure.type.lower()

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -49,10 +49,10 @@ def create_pipeline(input_model, reference_files):
     reference_files : dict
         {reftype: reference_file_name} mapping.
     """
+    exp_type = input_model.meta.exposure.type.lower()    
     if input_model.meta.instrument.grating.lower() == "mirror":
         pipeline = imaging(input_model, reference_files)
     else:
-        exp_type = input_model.meta.exposure.type.lower()
         pipeline = exp_type2transform[exp_type](input_model, reference_files)
     if pipeline:
         log.info("Created a NIRSPEC {0} pipeline with references {1}".format(

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -52,6 +52,11 @@ def extract2d(input_model,
     log.info('EXP_TYPE is {0}'.format(exp_type))
 
     if exp_type in nrs_modes:
+        if input_model.meta.grating.lower() == "mirror":
+            # Catch the case of EXP_TYPE=NRS_LAMP and grating=MIRROR
+            log.info("'EXP_TYPE {} with grating=MIRROR not supported for extract 2D".format(exp_type))
+            input_model.meta.cal_step.extract_2d = 'SKIPPED'
+            return input_model
         output_model = nrs_extract2d(input_model,
                                      slit_name=slit_name,
                                      apply_wavecorr=apply_wavecorr,

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -52,7 +52,7 @@ def extract2d(input_model,
     log.info('EXP_TYPE is {0}'.format(exp_type))
 
     if exp_type in nrs_modes:
-        if input_model.meta.grating.lower() == "mirror":
+        if input_model.meta.instrument.grating.lower() == "mirror":
             # Catch the case of EXP_TYPE=NRS_LAMP and grating=MIRROR
             log.info("'EXP_TYPE {} with grating=MIRROR not supported for extract 2D".format(exp_type))
             input_model.meta.cal_step.extract_2d = 'SKIPPED'


### PR DESCRIPTION
assign_wcs should run the imaging WCS pipeline when grating=MIRROR. The specific case in DMS is
```
EXP_TYPE=NRS_LAMP
GRATING=MIRRROR
```
This was processed as a spectral WCS based on EXP_TYPE only.

Related to #2745.