### PR TITLE
Reference file doc updates for IPC and Linearity

### DIFF
--- a/docs/jwst/ami/reference_files.rst
+++ b/docs/jwst/ami/reference_files.rst
@@ -6,7 +6,7 @@ and ``ami_normalize`` steps do not use any reference files.
 THROUGHPUT Reference File
 -------------------------
 
-:RETYPE: THROUGHPUT
+:REFTYPE: THROUGHPUT
 :Data model: `~jwst.datamodels.ThroughputModel`
 
 The THROUGHPUT reference file contains throughput data for the filter used

--- a/docs/jwst/coron/reference_files.rst
+++ b/docs/jwst/coron/reference_files.rst
@@ -6,7 +6,7 @@ steps in the ``coron`` package uses a reference file.
 PSFMASK Reference File
 -------------------------
 
-:RETYPE: PSFMASK
+:REFTYPE: PSFMASK
 :Data model: `~jwst.datamodels.PsfMaskModel`
 
 The PSFMASK reference file contains a 2-D mask that's used as a weight

--- a/docs/jwst/cube_build/reference_files.rst
+++ b/docs/jwst/cube_build/reference_files.rst
@@ -8,7 +8,7 @@ CUBEPAR is used for both NIRSpec and MIRI IFU data.
 CUBEPAR reference file
 ----------------------
 
-:RETYPE: CUBEPAR
+:REFTYPE: CUBEPAR
 :Data models: `~jwst.datamodels.MiriIFUCubeParsModel`, `~jwst.datamodels.NirspecIFUCubeParsModel`
 
 The CUBEPAR reference file contains parameter values used to construct
@@ -78,7 +78,7 @@ information to use with each of these types of multi-band cubes.
 RESOL reference file
 --------------------
 
-:RETYPE: RESOL
+:REFTYPE: RESOL
 :Data model: `~jwst.datamodels.MiriResolutionModel`
 
 The RESOL reference file contains the MIRI MRS PSF and LSF widths, per

--- a/docs/jwst/dark_current/reference_files.rst
+++ b/docs/jwst/dark_current/reference_files.rst
@@ -5,7 +5,7 @@ The ``dark`` step uses a DARK reference file.
 DARK Reference File
 -------------------
 
-:RETYPE: DARK
+:REFTYPE: DARK
 :Data models: `~jwst.datamodels.DarkModel`, `~jwst.datamodels.DarkMIRIModel`
 
 The DARK reference file contains pixel-by-pixel and frame-by-frame

--- a/docs/jwst/fringe/reference_files.rst
+++ b/docs/jwst/fringe/reference_files.rst
@@ -6,7 +6,7 @@ The ``fringe`` step uses a FRINGE reference file.
 FRINGE Reference File
 ---------------------
 
-:RETYPE: FRINGE
+:REFTYPE: FRINGE
 :Data model: `~jwst.datamodels.FringeModel`
 
 The FRINGE reference file contains pixel-by-pixel fringing correction

--- a/docs/jwst/imprint/README
+++ b/docs/jwst/imprint/README
@@ -1,1 +1,0 @@
-Please see ticket #251 for build 6 implementation details.

--- a/docs/jwst/ipc/README
+++ b/docs/jwst/ipc/README
@@ -1,1 +1,0 @@
-Please see ticket #105 for build 1 implementation details.

--- a/docs/jwst/ipc/index.rst
+++ b/docs/jwst/ipc/index.rst
@@ -6,7 +6,7 @@ IPC Correction
    :maxdepth: 2
 
    description.rst
-   reference_files.rst
    arguments.rst
+   reference_files.rst
 
 .. automodapi:: jwst.ipc

--- a/docs/jwst/ipc/ipc_selection.rst
+++ b/docs/jwst/ipc/ipc_selection.rst
@@ -1,16 +1,18 @@
+.. _ipc_selectors:
+
 Reference Selection Keywords for IPC
-------------------------------------
+++++++++++++++++++++++++++++++++++++
 CRDS selects appropriate IPC references based on the following keywords.
 IPC is not applicable for instruments not in the table.
-Non-standard keywords used for file selection are *required*.
+All keywords used for file selection are *required*.
 
 ========== ======================================
-Instrument Keywords                               
+Instrument Keywords
 ========== ======================================
-FGS        INSTRUME, DETECTOR, DATE-OBS, TIME-OBS 
-MIRI       INSTRUME, DETECTOR, DATE-OBS, TIME-OBS 
-NIRCAM     INSTRUME, DETECTOR, DATE-OBS, TIME-OBS 
-NIRISS     INSTRUME, DETECTOR, DATE-OBS, TIME-OBS 
-NIRSPEC    INSTRUME, DETECTOR, DATE-OBS, TIME-OBS 
+FGS        INSTRUME, DETECTOR, DATE-OBS, TIME-OBS
+MIRI       INSTRUME, DETECTOR, DATE-OBS, TIME-OBS
+NIRCam     INSTRUME, DETECTOR, DATE-OBS, TIME-OBS
+NIRISS     INSTRUME, DETECTOR, DATE-OBS, TIME-OBS
+NIRSpec    INSTRUME, DETECTOR, DATE-OBS, TIME-OBS
 ========== ======================================
 

--- a/docs/jwst/ipc/reference_files.rst
+++ b/docs/jwst/ipc/reference_files.rst
@@ -5,7 +5,7 @@ The IPC deconvolution step uses an IPC reference file.
 IPC Reference File
 ------------------
 
-:RETYPE: IPC
+:REFTYPE: IPC
 :Data model: `~jwst.datamodels.IPCModel`
 
 The IPC reference file contains a deconvolution kernel.

--- a/docs/jwst/ipc/reference_files.rst
+++ b/docs/jwst/ipc/reference_files.rst
@@ -1,26 +1,56 @@
-Reference File Types
-====================
-The IPC deconvolution current step uses an IPC reference file.
+Reference Files
+===============
+The IPC deconvolution step uses an IPC reference file.
 
-.. include:: ../includes/standard_keywords.rst
+IPC Reference File
+------------------
+
+:RETYPE: IPC
+:Data model: `~jwst.datamodels.IPCModel`
+
+The IPC reference file contains a deconvolution kernel.
 
 .. include:: ipc_selection.rst
 
-IPC Reference File Format
---------------------------
-IPC reference files are FITS files with one IMAGE extension, with EXTNAME
-value of 'SCI'.  The FITS primary data array is assumed to be empty.
-The SCI extension contains a floating-point data array.
+.. include:: ../includes/standard_keywords.rst
 
-Two formats are currently supported for the IPC kernel, a small 2-D array
+Type Specific Keywords for IPC
+++++++++++++++++++++++++++++++
+In addition to the standard reference file keywords listed above,
+the following keywords are *required* in IPC reference files,
+because they are used as CRDS selectors
+(see :ref:`ipc_selectors`):
+
+=========  ==============================
+Keyword    Data Model Name
+=========  ==============================
+DETECTOR   model.meta.instrument.detector
+=========  ==============================
+
+Reference File Format
++++++++++++++++++++++
+IPC reference files are FITS format, with 1 IMAGE extension.
+The FITS primary HDU does not contain a data array.
+The format and content of the file can be one of two forms,
+as described below:
+
+=======  ========  =====  =============================  =========
+EXTNAME  XTENSION  NAXIS  Dimensions                     Data type
+=======  ========  =====  =============================  =========
+SCI      IMAGE       2    nkern x nkern                  float
+or
+SCI      IMAGE       4    ncols x nrows x nkern x nkern  float
+=======  ========  =====  =============================  =========
+
+Two formats are currently supported for the IPC kernel: a small 2-D array
 or a 4-D array.  If the kernel is 2-D, its dimensions should be odd,
-perhaps 3 x 3 or 5 x 5 pixels.  The value at the center pixel will be
-larger than 1 (e.g. 1.02533), and the sum of all pixel values will be
+for example 3 x 3 or 5 x 5 pixels.  The value at the center pixel will be
+larger than 1 (e.g. 1.02533) and the sum of all pixel values will be
 equal to 1.
 
-A 4-D kernel may be used to allow the IPC correction to vary from point
-to point across the image.  In this case, the axes that are most rapidly
-varying (the last two, in Python notation; the first two, in IRAF notation)
+A 4-D kernel may be used to allow the IPC correction to vary from pixel
+to pixel across the image.  In this case, the axes that are most rapidly
+varying (the last two in Python notation; the first two in IRAF/FITS notation)
 have dimensions equal to those of a full-frame image.  At each point in
 that image, there will be a small, 2-D kernel as described in the previous
 paragraph.

--- a/docs/jwst/linearity/README
+++ b/docs/jwst/linearity/README
@@ -1,1 +1,0 @@
-Please see ticket #19 for build 1 implementation details.

--- a/docs/jwst/linearity/index.rst
+++ b/docs/jwst/linearity/index.rst
@@ -6,7 +6,7 @@ Linearity Correction
    :maxdepth: 2
 
    description.rst
-   reference_files.rst
    arguments.rst
+   reference_files.rst
 
 .. automodapi:: jwst.linearity

--- a/docs/jwst/linearity/linearity_selection.rst
+++ b/docs/jwst/linearity/linearity_selection.rst
@@ -1,16 +1,18 @@
+.. _linearity_selectors:
+
 Reference Selection Keywords for LINEARITY
-------------------------------------------
+++++++++++++++++++++++++++++++++++++++++++
 CRDS selects appropriate LINEARITY references based on the following keywords.
 LINEARITY is not applicable for instruments not in the table.
-Non-standard keywords used for file selection are *required*.
+All keywords used for file selection are *required*.
 
 ========== ==============================================================
 Instrument Keywords                                                       
 ========== ==============================================================
 FGS        INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS               
 MIRI       INSTRUME, DETECTOR, SUBARRAY, BAND, FILTER, DATE-OBS, TIME-OBS 
-NIRCAM     INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS               
+NIRCam     INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS               
 NIRISS     INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS               
-NIRSPEC    INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS               
+NIRSpec    INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS               
 ========== ==============================================================
 

--- a/docs/jwst/linearity/reference_files.rst
+++ b/docs/jwst/linearity/reference_files.rst
@@ -6,7 +6,7 @@ The ``linearity`` step uses a LINEARITY reference file.
 LINEARITY Reference File
 -------------------------
 
-:RETYPE: LINEARITY
+:REFTYPE: LINEARITY
 :Data model: `~jwst.datamodels.LinearityModel`
 
 The LINEARITY reference file contains pixel-by-pixel polynomial correction

--- a/docs/jwst/linearity/reference_files.rst
+++ b/docs/jwst/linearity/reference_files.rst
@@ -1,28 +1,53 @@
 Reference File Types
 ====================
 
-The linearity correction step uses a LINEARITY reference file.
+The ``linearity`` step uses a LINEARITY reference file.
 
-.. include:: ../includes/standard_keywords.rst
+LINEARITY Reference File
+-------------------------
+
+:RETYPE: LINEARITY
+:Data model: `~jwst.datamodels.LinearityModel`
+
+The LINEARITY reference file contains pixel-by-pixel polynomial correction
+coefficients.
 
 .. include:: linearity_selection.rst
 
-Reference File Format
----------------------
-Linearity reference files are FITS format with 2 IMAGE extensions and 1
-BINTABLE extension. The primary data array is assumed to be empty. The 2
-IMAGE extensions have the following characteristics:
+.. include:: ../includes/standard_keywords.rst
 
-=======  =====  =======================  =========
-EXTNAME  NAXIS  Dimensions               Data type
-=======  =====  =======================  =========
-COEFFS   3      ncols x nrows x ncoeffs  float
-DQ       2      ncols x nrows            integer
-=======  =====  =======================  =========
+Type Specific Keywords for LINEARITY
++++++++++++++++++++++++++++++++++++++
+In addition to the standard reference file keywords listed above,
+the following keywords are *required* in LINEARITY reference files,
+because they are used as CRDS selectors
+(see :ref:`linearity_selectors`):
+
+=========  ==============================  ===========
+Keyword    Data Model Name                 Instruments
+=========  ==============================  ===========
+DETECTOR   model.meta.instrument.detector  All
+SUBARRAY   model.meta.subarray.name        All
+FILTER     model.meta.instrument.filter    MIRI only
+BAND       model.meta.instrument.band      MIRI only
+=========  ==============================  ===========
+
+Reference File Format
++++++++++++++++++++++
+LINEARITY reference files are FITS format, with 2 IMAGE extensions
+and 1 BINTABLE extension. The FITS primary HDU does not contain a data array.
+The format and content of the file is as follows:
+
+=======  ========  =====  =======================  =========
+EXTNAME  XTENSION  NAXIS  Dimensions               Data type
+=======  ========  =====  =======================  =========
+COEFFS   IMAGE       3    ncols x nrows x ncoeffs  float
+DQ       IMAGE       2    ncols x nrows            integer
+DQ_DEF   BINTABLE    2    TFIELDS = 4              N/A
+=======  ========  =====  =======================  =========
 
 Each plane of the COEFFS data cube contains the pixel-by-pixel coefficients for
 the associated order of the polynomial. There can be any number of planes to
 accommodate a polynomial of any order.
 
 .. include:: ../includes/dq_def.rst
-

--- a/docs/jwst/saturation/reference_files.rst
+++ b/docs/jwst/saturation/reference_files.rst
@@ -5,7 +5,7 @@ The saturation step uses a SATURATION reference file.
 SATURATION Reference File
 -------------------------
 
-:RETYPE: SATURATION
+:REFTYPE: SATURATION
 :Data model: `SaturationModel`
 
 The SATURATION reference file contains pixel-by-pixel saturation threshold
@@ -47,7 +47,5 @@ DQ_DEF   BINTABLE    2    TFIELDS = 4     N/A
 
 The values in the ``SCI`` array give the saturation threshold in units of DN
 for each pixel.
-The ``DQ_DEF`` table extension lists the bit assignments for the flag conditions
-used in the DQ array.
 
 .. include:: ../includes/dq_def.rst


### PR DESCRIPTION
Updated the reference file info in the `ipc` and `linearity` step docs, for the new consistent formatting of reffile docs.