### PR TITLE
Remove dask dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
         - CONDA_DEPENDENCIES="asdf
                               astropy
                               crds
-                              dask
                               drizzle
                               flake8
                               gwcs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@ def conda_packages = [
     "asdf",
     "astropy",
     "crds",
-    "dask",
     "drizzle",
     "flake8",
     "gwcs",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -38,7 +38,6 @@ bc.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
 bc.conda_packages = ['asdf',
                      'astropy',
                      'crds',
-                     'dask',
                      'drizzle',
                      'flake8',
                      'gwcs',


### PR DESCRIPTION
`dask` is not a dependency of `jwst`, yet it is listed as one in our CI scripts.  As such, it brings in a bunch of its own dependencies and probably makes our CI builds take longer.  Any ideas why it was added @jhunkeler?

This PR removes it.