### PR TITLE
Make skymatch not fail in match mode when images do not overlap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -286,6 +286,8 @@ saturation
 skymatch
 --------
 
+- Made skymatch to not fail in 'match' mode when images do not overlap [#2803]
+
 source_catalog
 --------------
 

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -112,6 +112,7 @@ class SkyImage:
 
         # initial sky value:
         self._sky = 0.0
+        self._sky_is_valid = False
 
         # check that mask has the same shape as image:
         if mask is None:
@@ -181,6 +182,19 @@ class SkyImage:
     @sky.setter
     def sky(self, sky):
         self._sky = sky
+
+
+    @property
+    def is_sky_valid(self):
+        """
+        Indicates whether sky value was successfully computed.
+        Must be set externally.
+        """
+        return self._sky_is_valid
+
+    @is_sky_valid.setter
+    def is_sky_valid(self, valid):
+        self._sky_is_valid = valid
 
     @property
     def radec(self):

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -101,10 +101,18 @@ class SkyMatchStep(Step):
         # set sky background value in each image's meta:
         for im in images:
             if isinstance(im, SkyImage):
-                self._set_sky_background(im.meta['imagemodel'], im.sky)
+                if im.is_sky_valid:
+                    self._set_sky_background(im.meta['imagemodel'], im.sky)
+                    im.meta.cal_step.skymatch = "COMPLETE"
+                else:
+                    im.meta.cal_step.skymatch = "SKIPPED"
             else:
                 for gim in im:
-                    self._set_sky_background(gim.meta['imagemodel'], gim.sky)
+                    if gim.is_sky_valid:
+                        self._set_sky_background(gim.meta['imagemodel'], gim.sky)
+                        gim.meta.cal_step.skymatch = "COMPLETE"
+                    else:
+                        gim.meta.cal_step.skymatch = "SKIPPED"
 
         return img
 

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -102,17 +102,20 @@ class SkyMatchStep(Step):
         for im in images:
             if isinstance(im, SkyImage):
                 if im.is_sky_valid:
-                    self._set_sky_background(im.meta['imagemodel'], im.sky)
-                    im.meta.cal_step.skymatch = "COMPLETE"
+                    self._set_sky_background(im.meta['image_model'], im.sky)
+                    im.meta['image_model'].meta.cal_step.skymatch = "COMPLETE"
                 else:
-                    im.meta.cal_step.skymatch = "SKIPPED"
+                    im.meta['image_model'].meta.cal_step.skymatch = "SKIPPED"
             else:
                 for gim in im:
                     if gim.is_sky_valid:
-                        self._set_sky_background(gim.meta['imagemodel'], gim.sky)
-                        gim.meta.cal_step.skymatch = "COMPLETE"
+                        self._set_sky_background(
+                            gim.meta['image_model'],
+                            gim.sky
+                        )
+                        gim.meta['image_model'].meta.cal_step.skymatch = "COMPLETE"
                     else:
-                        gim.meta.cal_step.skymatch = "SKIPPED"
+                        gim.meta['image_model'].meta.cal_step.skymatch = "SKIPPED"
 
         return img
 
@@ -185,7 +188,7 @@ class SkyMatchStep(Step):
             id=image_model.meta.filename, # file name?
             skystat=self._skystat,
             stepsize=self.stepsize,
-            meta={'imagemodel': image_model}
+            meta={'image_model': image_model}
         )
 
         if self.subtract:


### PR DESCRIPTION
This PR makes `skymatch` not to fail when images do not overlap. This addresses the failure in `skymatch` reported in  https://github.com/spacetelescope/jwst/pull/2796#issue-226360537 likely occurring either because images have all pixels flagged as bad or the parts that are "good" do not overlap.

After this PR, `skymatch` will "succeed" but it will set `meta.cal_step.skymatch = "SKIPPED"` for images for which sky could not have been computed.

