### PR TITLE
Remove soon-to-be-deprecated usage of AsdfFile.open

### DIFF
--- a/docs/jwst/assign_wcs/asdf-howto.rst
+++ b/docs/jwst/assign_wcs/asdf-howto.rst
@@ -117,17 +117,18 @@ Save a transform to an ASDF file
 `asdf <http://asdf.readthedocs.io/en/latest/>`__ is used to read and write reference files in
 `ASDF <http://asdf-standard.readthedocs.org/en/latest/>`__ format. Once the model is create using the rules in the above section, it needs to be assigned to the ASDF tree.
 
+>>> import asdf
 >>> from asdf import AsdfFile
 >>> f = AsdfFile()
 >>> f.tree['model'] = model
 >>> f.write_to('reffile.asdf')
 
-The ``write_to`` command validates the file and writes it to disk. It will catch any errors due to
-inconsistent inputs/outputs or invalid parameters.
+The ``write_to`` command validates the file and writes it to disk. It will
+catch any errors due to inconsistent inputs/outputs or invalid parameters.
 
-To test the file, it can be read in again using the ``AsdfFile.open()`` method:
+To test the file, it can be read in again using the ``asdf.open()`` function:
 
->>> ff = AsdfFile.open('reffile.asdf')
+>>> ff = asdf.open('reffile.asdf')
 >>> model = ff.tree['model']
 >>> model(1, 1)
     -152.2

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -1,6 +1,6 @@
 import logging
 
-from asdf import AsdfFile
+import asdf
 from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling.models import Const1D, Mapping, Identity
@@ -131,7 +131,7 @@ def niriss_soss(input_model, reference_files):
     world = cf.CompositeFrame([sky, spec], name='world')
 
     try:
-        with AsdfFile.open(reference_files['specwcs']) as wl:
+        with asdf.open(reference_files['specwcs']) as wl:
             wl1 = wl.tree[1].copy()
             wl2 = wl.tree[2].copy()
             wl3 = wl.tree[3].copy()

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -15,6 +15,7 @@ from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import WCS
 
+import asdf
 from asdf import AsdfFile
 from asdf import yamlutil
 from asdf import schema as asdf_schema
@@ -119,13 +120,13 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         asdf_kwargs = dict(inline_threshold=kwargs.pop('inline_threshold', 0))
 
         if init is None:
-            asdf = AsdfFile(extensions=extensions, **asdf_kwargs)
+            asdffile = AsdfFile(extensions=extensions, **asdf_kwargs)
 
         elif isinstance(init, dict):
-            asdf = AsdfFile(init, extensions=self._extensions, **asdf_kwargs)
+            asdffile = AsdfFile(init, extensions=self._extensions, **asdf_kwargs)
 
         elif isinstance(init, np.ndarray):
-            asdf = AsdfFile(extensions=self._extensions, **asdf_kwargs)
+            asdffile = AsdfFile(extensions=self._extensions, **asdf_kwargs)
             shape = init.shape
             is_array = True
 
@@ -135,7 +136,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                     raise ValueError("shape must be a tuple of ints")
 
             shape = init
-            asdf = AsdfFile(**asdf_kwargs)
+            asdffile = AsdfFile(**asdf_kwargs)
             is_shape = True
 
         elif isinstance(init, DataModel):
@@ -145,10 +146,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             return
 
         elif isinstance(init, AsdfFile):
-            asdf = init
+            asdffile = init
 
         elif isinstance(init, fits.HDUList):
-            asdf = fits_support.from_fits(init, self._schema,
+            asdffile = fits_support.from_fits(init, self._schema,
                                           self._extensions, self._ctx)
 
         elif isinstance(init, (str, bytes)):
@@ -158,13 +159,13 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             if file_type == "fits":
                 hdulist = fits.open(init)
-                asdf = fits_support.from_fits(hdulist, self._schema,
+                asdffile = fits_support.from_fits(hdulist, self._schema,
                                               self._extensions, self._ctx)
 
                 self._files_to_close.append(hdulist)
 
             elif file_type == "asdf":
-                asdf = AsdfFile.open(init, extensions=self._extensions)
+                asdffile = asdf.open(init, extensions=self._extensions)
 
             else:
                 # TODO handle json files as well
@@ -177,8 +178,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         # Initialize object fields as determined from the code above
         self._shape = shape
-        self._instance = asdf.tree
-        self._asdf = asdf
+        self._instance = asdffile.tree
+        self._asdf = asdffile
 
         # Initalize class dependent hidden fields
         self._no_asdf_extension = False


### PR DESCRIPTION
This will take effect once https://github.com/spacetelescope/asdf/pull/579 is merged, but there's no harm in making this change now.

This closes #2795.