### PR TITLE
Don't use numpy 1.15.3 in testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
                               matplotlib
                               namedlist
                               photutils
+                              pytest=3.8.2
                               scipy
                               six
                               spherical-geometry

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
                               jplephem
                               matplotlib
                               namedlist
-                              numpy
                               photutils
                               scipy
                               six
@@ -42,15 +41,13 @@ env:
         - CRDS_PATH='/tmp/crds_cache'
         - MAIN_CMD='python setup.py'
         - MC_URL=https://repo.continuum.io/miniconda
-        - PIP_DEPENDENCIES='git+https://github.com/spacetelescope/ci_watson.git'
+        - PIP_DEPENDENCIES='ci_watson'
         - PYTHON_VERSION=3.6
+        - NUMPY_VERSION=1.15.2
 
     matrix:
         - SETUP_CMD='install'
         - SETUP_CMD='test'
-        # These will no longer work unless we add an explicit dependency on asdf-1.3.1
-        #- PYTHON_VERSION=2.7 SETUP_CMD='install' ASTROPY_VERSION=stable
-        #- PYTHON_VERSION=2.7 SETUP_CMD='test' ASTROPY_VERSION=stable
 
 matrix:
 
@@ -87,7 +84,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --set auto_update_conda false
   - for channel in $CONDA_CHANNELS; do conda config --add channels "$channel"; done
-  - conda create -n test -q python=$PYTHON_VERSION $CONDA_DEPENDENCIES
+  - conda create -n test -q python=$PYTHON_VERSION numpy=$NUMPY_VERSION $CONDA_DEPENDENCIES
   - source activate test
   - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -q $PIP_DEPENDENCIES; fi
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ def pip_packages_tests = "requests_mock ci_watson"
 dist = new BuildConfig()
 dist.nodetype = 'linux'
 dist.name = 'dist'
-dist.conda_packages = ["numpy=${matrix_numpy[0]}"]
+dist.conda_packages = ['numpy=${matrix_numpy[0]}']
 dist.build_cmds = [
     "python setup.py sdist",
     "python setup.py bdist_egg",
@@ -62,7 +62,7 @@ docs = new BuildConfig()
 docs.nodetype = 'linux'
 docs.name = 'docs'
 docs.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-docs.conda_packages = conda_packages + conda_packages_docs + ["numpy=${matrix_numpy[0]}"]
+docs.conda_packages = conda_packages + conda_packages_docs + ['numpy=${matrix_numpy[0]}']
 docs.build_cmds = [
     "pip install -q ${pip_packages_docs}",
     "python setup.py build_sphinx"
@@ -80,7 +80,7 @@ for (python_ver in matrix_python) {
             bc.env_vars = test_env
             bc.name = name
             bc.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-            bc.conda_packages = conda_packages + ["python=${python_ver}"] + ["numpy=${numpy_ver}"]
+            bc.conda_packages = conda_packages + ['python=${python_ver}'] + ['numpy=${numpy_ver}']
             bc.build_cmds = [
                 "pip install -q ${pip_packages_tests}",
                 "python setup.py install"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 if (utils.scm_checkout()) return
 
 matrix_python = ['3.6']
-matrix_numpy = ['1.14']
+matrix_numpy = ['1.15.2']
 matrix_astropy = ['4']
 matrix = []
 
@@ -42,14 +42,13 @@ def conda_packages_docs = [
 
 // Pip related setup
 def pip_packages_docs = "sphinx-automodapi"
-def pip_packages_tests = "requests_mock \
-                          git+https://github.com/spacetelescope/ci_watson.git"
+def pip_packages_tests = "requests_mock ci_watson"
 
 // Generate distributions
 dist = new BuildConfig()
 dist.nodetype = 'linux'
 dist.name = 'dist'
-dist.conda_packages = ["numpy"]
+dist.conda_packages = ["numpy=${matrix_numpy[0]}"]
 dist.build_cmds = [
     "python setup.py sdist",
     "python setup.py bdist_egg",
@@ -63,7 +62,7 @@ docs = new BuildConfig()
 docs.nodetype = 'linux'
 docs.name = 'docs'
 docs.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-docs.conda_packages = conda_packages + conda_packages_docs
+docs.conda_packages = conda_packages + conda_packages_docs + ["numpy=${matrix_numpy[0]}"]
 docs.build_cmds = [
     "pip install -q ${pip_packages_docs}",
     "python setup.py build_sphinx"
@@ -81,7 +80,7 @@ for (python_ver in matrix_python) {
             bc.env_vars = test_env
             bc.name = name
             bc.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-            bc.conda_packages = conda_packages + ["python=${python_ver}"]
+            bc.conda_packages = conda_packages + ["python=${python_ver}"] + ["numpy=${numpy_ver}"]
             bc.build_cmds = [
                 "pip install -q ${pip_packages_tests}",
                 "python setup.py install"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 if (utils.scm_checkout()) return
 
 matrix_python = ['3.6']
-matrix_numpy = ['1.15.2']
+matrix_numpy = ['1.14']
 matrix_astropy = ['4']
 matrix = []
 
@@ -48,7 +48,7 @@ def pip_packages_tests = "requests_mock ci_watson"
 dist = new BuildConfig()
 dist.nodetype = 'linux'
 dist.name = 'dist'
-dist.conda_packages = ['numpy=1.15.2']
+dist.conda_packages = ["numpy=${matrix_numpy[0]}"]
 dist.build_cmds = [
     "python setup.py sdist",
     "python setup.py bdist_egg",
@@ -62,7 +62,7 @@ docs = new BuildConfig()
 docs.nodetype = 'linux'
 docs.name = 'docs'
 docs.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-docs.conda_packages = conda_packages + conda_packages_docs + ['numpy=1.15.2']
+docs.conda_packages = conda_packages + conda_packages_docs + ["numpy=${matrix_numpy[0]}"]
 docs.build_cmds = [
     "pip install -q ${pip_packages_docs}",
     "python setup.py build_sphinx"
@@ -80,7 +80,7 @@ for (python_ver in matrix_python) {
             bc.env_vars = test_env
             bc.name = name
             bc.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-            bc.conda_packages = conda_packages + ['python=${python_ver}'] + ['numpy=${numpy_ver}']
+            bc.conda_packages = conda_packages + ["python=${python_ver}"] + ["numpy=${numpy_ver}"]
             bc.build_cmds = [
                 "pip install -q ${pip_packages_tests}",
                 "python setup.py install"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ def pip_packages_tests = "requests_mock ci_watson"
 dist = new BuildConfig()
 dist.nodetype = 'linux'
 dist.name = 'dist'
-dist.conda_packages = ['numpy=${matrix_numpy[0]}']
+dist.conda_packages = ['numpy=1.15.2']
 dist.build_cmds = [
     "python setup.py sdist",
     "python setup.py bdist_egg",
@@ -62,7 +62,7 @@ docs = new BuildConfig()
 docs.nodetype = 'linux'
 docs.name = 'docs'
 docs.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-docs.conda_packages = conda_packages + conda_packages_docs + ['numpy=${matrix_numpy[0]}']
+docs.conda_packages = conda_packages + conda_packages_docs + ['numpy=1.15.2']
 docs.build_cmds = [
     "pip install -q ${pip_packages_docs}",
     "python setup.py build_sphinx"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 if (utils.scm_checkout()) return
 
 matrix_python = ['3.6']
-matrix_numpy = ['1.14']
+matrix_numpy = ['1.15.2']
 matrix_astropy = ['4']
 matrix = []
 
@@ -48,7 +48,7 @@ def pip_packages_tests = "requests_mock ci_watson"
 dist = new BuildConfig()
 dist.nodetype = 'linux'
 dist.name = 'dist'
-dist.conda_packages = ["numpy=${matrix_numpy[0]}"]
+dist.conda_packages = ["numpy=${matrix_numpy[0]}"] + ["python=${matrix_python[0]}"]
 dist.build_cmds = [
     "python setup.py sdist",
     "python setup.py bdist_egg",
@@ -62,7 +62,7 @@ docs = new BuildConfig()
 docs.nodetype = 'linux'
 docs.name = 'docs'
 docs.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-docs.conda_packages = conda_packages + conda_packages_docs + ["numpy=${matrix_numpy[0]}"]
+docs.conda_packages = conda_packages + conda_packages_docs + ["numpy=${matrix_numpy[0]}"] + ["python=${matrix_python[0]}"]
 docs.build_cmds = [
     "pip install -q ${pip_packages_docs}",
     "python setup.py build_sphinx"

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -12,7 +12,7 @@ def test_env = [
 def PIP_ARGS = "-q"
 def PIP_INST = "pip install ${PIP_ARGS}"
 def PIP_DEPS = ""
-def PIP_TEST_DEPS = "requests_mock git+https://github.com/spacetelescope/ci_watson.git"
+def PIP_TEST_DEPS = "requests_mock ci_watson"
 
 // Pytest wrapper
 def PYTEST_BASETEMP = "test_outputs"
@@ -41,14 +41,15 @@ bc.conda_packages = ['asdf',
                      'dask',
                      'drizzle',
                      'flake8',
-                     'pytest=3.8.2',
                      'gwcs',
                      'jsonschema',
                      'jplephem',
                      'matplotlib',
                      'namedlist',
-                     'numpy',
+                     'numpy=1.15.2',
                      'photutils',
+                     'python=3.6',
+                     'pytest=3.8.2',
                      'scipy',
                      'six',
                      'spherical-geometry',

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -135,7 +135,7 @@ def niriss_soss(input_model, reference_files):
             wl1 = wl.tree[1].copy()
             wl2 = wl.tree[2].copy()
             wl3 = wl.tree[3].copy()
-    except Exception as e:
+    except Exception:
         raise IOError('Error reading wavelength correction from {}'.format(reference_files['specwcs']))
 
     try:

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -389,7 +389,7 @@ def get_msa_metadata(input_model, reference_files):
     """
     try:
         msa_config = reference_files['msametafile']
-    except (KeyError, TypeError) as error:
+    except (KeyError, TypeError):
         log.info('MSA metadata file not in reference files dict')
         log.info('Getting MSA metadata file from MSAMETFL keyword')
         msa_config = input_model.meta.instrument.msa_metadata_file

--- a/jwst/csv_tools/csvconvert.py
+++ b/jwst/csv_tools/csvconvert.py
@@ -68,7 +68,7 @@ class CSVConvertScript():
             self.output = table_to_hdulist(self.table)
             self.output.writeto(parsed.outfile, clobber=True)
         else:
-            raise NotImplemented('Format {} is not implemented.'.format(parsed.format))
+            raise NotImplementedError('Format {} is not implemented.'.format(parsed.format))
         self.format = parsed.format
 
 #*********

--- a/jwst/datamodels/schema_editor.py
+++ b/jwst/datamodels/schema_editor.py
@@ -415,7 +415,7 @@ class Keyword_db:
                     subschema = aschema.load_schema(suburl_path,
                                                     resolver,
                                                     True)
-                except IOError as err:
+                except IOError:
                     print("Could not read " + suburl_path)
                     subschema = OrderedDict()
 

--- a/jwst/datamodels/tsophot.py
+++ b/jwst/datamodels/tsophot.py
@@ -31,7 +31,7 @@ class TsoPhotModel(ReferenceFileModel):
             assert len(self.radii) > 0
             assert self.meta.instrument.name in ["MIRI", "NIRCAM"]
             assert self.meta.exposure.type in ["MIR_IMAGE", "NRC_TSIMAGE"]
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
                 raise
             else:

--- a/jwst/emission/emission.py
+++ b/jwst/emission/emission.py
@@ -34,7 +34,7 @@ class DataSet():
 
         try:
             model = datamodels.open(input_dm)
-        except Exception as errmess:
+        except Exception:
             log.info('Error opening: %s ', input_dm)
             model = None
 

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -81,6 +81,7 @@ _calculated_suffixes = set([
     'groupscalestep',
     'resamplestep',
     'assign_wcs',
+    'tweakreg',
     'resetstep',
     'klip',
     'straylightstep',

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -95,7 +95,7 @@ class Spec2Pipeline(Pipeline):
                 # status if run from the command line.
                 # Bump it up now.
                 raise exception
-            except Exception as exception:
+            except Exception:
                 traceback.print_exc()
                 has_exceptions = True
             else:

--- a/jwst/tests_nightly/general/nircam/test_nrc_image3_1.py
+++ b/jwst/tests_nightly/general/nircam/test_nrc_image3_1.py
@@ -1,7 +1,6 @@
 import pytest
 
 from jwst.tests.base_classes import BaseJWSTTest, raw_from_asn
-from jwst.pipeline import Image3Pipeline
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -827,7 +827,7 @@ class NirissSOSSModel(Model):
         # So, we are going to just take the 0'th element and use that as the index.
         try:
             order_number = int(spectral_order[0])
-        except Exception as e:
+        except Exception:
             raise ValueError('Spectral order is not between 1 and 3, {}'.format(spectral_order))
 
         return self.models[order_number](x, y)


### PR DESCRIPTION
It seems masked arrays are broken in some way in `numpy 1.15.3`.  Seeing if this will fix our CI tests.