### PR TITLE
Add optional asdf arguments to model_base

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -531,9 +531,10 @@ def _load_history(hdulist, tree):
         history['entries'].append(HistoryEntry({'description': entry}))
 
 
-def from_fits(hdulist, schema, extensions, context):
+def from_fits(hdulist, schema, extensions, context, **kwargs):
     try:
-        ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions)
+        ##ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions, **kwargs)
+        ff = from_fits_asdf(hdulist, extensions=extensions, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc
 
@@ -543,6 +544,17 @@ def from_fits(hdulist, schema, extensions, context):
     _load_history(hdulist, ff.tree)
 
     return ff
+
+def from_fits_asdf(hdulist, extensions=None,
+                  ignore_version_mismatch=True,
+                  ignore_unrecognized_tag=False,
+                  **kwargs):
+    kwargs = None
+    return fits_embed.AsdfInFits.open(hdulist,
+                                      extensions=extensions,
+                                      ignore_version_mismatch=ignore_version_mismatch,
+                                      ignore_unrecognized_tag=ignore_unrecognized_tag)
+
 
 def from_fits_hdu(hdu, schema):
     """

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -533,7 +533,6 @@ def _load_history(hdulist, tree):
 
 def from_fits(hdulist, schema, extensions, context, **kwargs):
     try:
-        ##ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions, **kwargs)
         ff = from_fits_asdf(hdulist, extensions=extensions, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -495,8 +495,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             path_head = dir_path
         output_path = os.path.join(path_head, path_tail)
 
-        self.validate_required_fields()
-
         # TODO: Support gzip-compressed fits
         if ext == '.fits':
             # TODO: remove 'clobber' check once depreciated fully in astropy

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -74,6 +74,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         strict_validation: if true, an schema validation errors will generate
             an excption. If false, they will generate a warning.
+
+        kwargs: Aadditional arguments passed to lower level functions
         """
         # Set the extensions
         self._extensions = extensions
@@ -535,7 +537,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return asdf
 
     @classmethod
-    def from_asdf(cls, init, schema=None):
+    def from_asdf(cls, init, schema=None, **kwargs):
         """
         Load a data model from a ASDF file.
 
@@ -550,11 +552,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         schema :
             Same as for `__init__`
 
+
+        kwargs:
+            Aadditional arguments passed to lower level functions
+
         Returns
         -------
         model : DataModel instance
         """
-        return cls(init, schema=schema)
+        return cls(init, schema=schema, **kwargs)
 
     def to_asdf(self, init, *args, **kwargs):
         """
@@ -575,7 +581,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                  inline_threshold=inline_threshold).write_to(init, *args, **kwargs)
 
     @classmethod
-    def from_fits(cls, init, schema=None):
+    def from_fits(cls, init, schema=None, **kwargs):
         """
         Load a model from a FITS file.
 
@@ -590,11 +596,14 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         schema :
             Same as for `__init__`
 
+        kwargs:
+            Aadditional arguments passed to lower level functions
+
         Returns
         -------
         model : DataModel instance
         """
-        return cls(init, schema=schema)
+        return cls(init, schema=schema, **kwargs)
 
     def to_fits(self, init, *args, **kwargs):
         """

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -349,6 +349,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             # Get the value pointed at by the path to the node,
             # or None in case there is no entry for the node
+
             node = ctx
             for attr in path:
                 node = getattr(node, attr)

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -483,46 +483,6 @@ def test_info():
                 assert words[2] == "float32", "Correct type for err"
     assert matches== 3, "Check all extensions are described"
 
-def test_validate_on_read():
-    im1 = ImageModel((10,10))
-    schema = im1.meta._schema
-    schema['properties']['calibration_software_version']['fits_required'] = True
-
-    try:
-        im2 = ImageModel(FITS_FILE,
-                          schema=im1._schema,
-                          strict_validation=True)
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-        im2.close()
-
-    im1.close()
-    assert caught, "Test of validation while reading image"
-
-def test_validate_required_field():
-    im = ImageModel((10,10), strict_validation=True)
-    schema = im.meta._schema
-    schema['properties']['telescope']['fits_required'] = True
-
-    try:
-        im.validate_required_fields()
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-    assert caught, "Test of validate_required_fields"
-
-    im.meta.telescope = 'JWST'
-    try:
-        im.validate_required_fields()
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-    assert not caught, "Test of validate_required_fields"
-
 def test_multislit_model():
     data = np.arange(24, dtype=np.float32).reshape((6, 4))
     err = np.arange(24, dtype=np.float32).reshape((6, 4)) + 2

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -17,6 +17,7 @@ from ..util import open as open_model
 
 ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
 FITS_FILE = os.path.join(ROOT_DIR, 'test.fits')
+ASDF_FILE = os.path.join(ROOT_DIR, 'collimator_fake.asdf')
 ASN_FILE = os.path.join(ROOT_DIR, 'association.json')
 
 
@@ -361,6 +362,27 @@ def test_initialize_arrays_with_arglist():
     im = ImageModel(shape, zeroframe=thirteen, dq=bitz)
     assert np.array_equal(im.zeroframe, thirteen)
     assert np.array_equal(im.dq, bitz)
+
+def test_open_asdf_model():
+    # Open an empty asdf file, pass extra arguments
+
+    model = DataModel(init=None,
+                     ignore_version_mismatch=False,
+                     ignore_unrecognized_tag=True)
+
+    assert model._asdf._ignore_version_mismatch == False
+    assert model._asdf._ignore_unrecognized_tag == True
+    model.close()
+
+    # Open an existing asdf file
+
+    model = DataModel(ASDF_FILE,
+                     ignore_version_mismatch=False,
+                     ignore_unrecognized_tag=True)
+
+    assert model._asdf._ignore_version_mismatch == False
+    assert model._asdf._ignore_unrecognized_tag == True
+    model.close()
 
 def test_relsens():
     with ImageModel() as im:


### PR DESCRIPTION
This update adds support for the optional arguments at asdf creation ignore_version_mismatch and ignore_unrecognized_tag. These two arguments can be added when creating any datamodel and will be passed on to asdf. This is a rebase of the branch asdf_arguments onto jwst upstream that resolves merge conflicts.