### PR TITLE
Only list numpy once in Jenkinsfile conda dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ def conda_packages = [
     "jplephem",
     "matplotlib",
     "namedlist",
-    "numpy",
     "photutils",
     "scipy",
     "six",


### PR DESCRIPTION
This is to resolve the couple of ssbjenkins CI failures we were seeing on Nov 5, where it was still, for some reason trying to pull in `numpy 1.15.3`.  It seems conda resolving is a moving target.