### PR TITLE
Support asdf flags when creating a new datamodel

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -82,7 +82,10 @@ class ModelContainer(model_base.DataModel):
             instance = copy.deepcopy(init._instance)
             self._schema = init._schema
             self._shape = init._shape
-            self._asdf = AsdfFile(instance, extensions=self._extensions)
+            self._asdf = AsdfFile(instance,
+                                  extensions=init._extensions,
+                                  inline_threshold=init._inline_threshold
+                                  )
             self._instance = instance
             self._ctx = self
             self.__class__ = init.__class__

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -82,10 +82,7 @@ class ModelContainer(model_base.DataModel):
             instance = copy.deepcopy(init._instance)
             self._schema = init._schema
             self._shape = init._shape
-            self._asdf = AsdfFile(instance,
-                                  extensions=init._extensions,
-                                  inline_threshold=init._inline_threshold
-                                  )
+            self._asdf = AsdfFile(instance, extensions=init._extensions)
             self._instance = instance
             self._ctx = self
             self.__class__ = init.__class__
@@ -161,7 +158,7 @@ class ModelContainer(model_base.DataModel):
         self._open_model(index)
         return self._models.pop(index)
 
-    def copy(self, memo=None, inline_threshold=0):
+    def copy(self, memo=None):
         """
         Returns a deep copy of the models in this model container.
         """
@@ -170,8 +167,7 @@ class ModelContainer(model_base.DataModel):
                                 pass_invalid_values=self._pass_invalid_values,
                                 strict_validation=self._strict_validation)
         instance = copy.deepcopy(self._instance, memo=memo)
-        result._asdf = AsdfFile(instance, extensions=self._extensions,
-                                inline_threshold=inline_threshold)
+        result._asdf = AsdfFile(instance, extensions=self._extensions)
         result._instance = instance
         result._iscopy = self._iscopy
         result._schema = result._schema

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -70,7 +70,6 @@ class ModelContainer(model_base.DataModel):
 
     def __init__(self, init=None, persist=True, **kwargs):
 
-        inline_threshold = kwargs.pop('inline_threshold', 0)
         super(ModelContainer, self).__init__(init=None, **kwargs)
         self._persist = persist
 
@@ -83,8 +82,7 @@ class ModelContainer(model_base.DataModel):
             instance = copy.deepcopy(init._instance)
             self._schema = init._schema
             self._shape = init._shape
-            self._asdf = AsdfFile(instance, extensions=self._extensions,
-                                  inline_threshold=inline_threshold)
+            self._asdf = AsdfFile(instance, extensions=self._extensions)
             self._instance = instance
             self._ctx = self
             self.__class__ = init.__class__

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -531,9 +531,10 @@ def _load_history(hdulist, tree):
         history['entries'].append(HistoryEntry({'description': entry}))
 
 
-def from_fits(hdulist, schema, extensions, context):
+def from_fits(hdulist, schema, extensions, context, **kwargs):
     try:
-        ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions)
+        ##ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions, **kwargs)
+        ff = from_fits_asdf(hdulist, extensions=extensions, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc
 
@@ -543,6 +544,17 @@ def from_fits(hdulist, schema, extensions, context):
     _load_history(hdulist, ff.tree)
 
     return ff
+
+def from_fits_asdf(hdulist, extensions=None,
+                  ignore_version_mismatch=True,
+                  ignore_unrecognized_tag=False,
+                  **kwargs):
+    kwargs = None
+    return fits_embed.AsdfInFits.open(hdulist,
+                                      extensions=extensions,
+                                      ignore_version_mismatch=ignore_version_mismatch,
+                                      ignore_unrecognized_tag=ignore_unrecognized_tag)
+
 
 def from_fits_hdu(hdu, schema):
     """

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -379,7 +379,7 @@ def _save_history(hdulist, tree):
                 history[i] = HistoryEntry({'description': str(history[i])})
         hdulist[0].header['HISTORY'] = history[i]['description']
 
-def to_fits(tree, schema, extensions=None, inline_threshold=None):
+def to_fits(tree, schema, extensions=None):
     hdulist = fits.HDUList()
     hdulist.append(fits.PrimaryHDU())
 
@@ -388,7 +388,6 @@ def to_fits(tree, schema, extensions=None, inline_threshold=None):
     _save_history(hdulist, tree)
 
     asdf = fits_embed.AsdfInFits(hdulist, tree,
-                                 inline_threshold=inline_threshold,
                                  extensions=extensions)
     return asdf
 

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -550,7 +550,9 @@ def from_fits_asdf(hdulist, extensions=None,
                   ignore_version_mismatch=True,
                   ignore_unrecognized_tag=False,
                   **kwargs):
-    kwargs = None
+    """
+    Wrap asdf call to extract optional argumentscommet
+    """
     return fits_embed.AsdfInFits.open(hdulist,
                                       extensions=extensions,
                                       ignore_version_mismatch=ignore_version_mismatch,

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -379,7 +379,7 @@ def _save_history(hdulist, tree):
                 history[i] = HistoryEntry({'description': str(history[i])})
         hdulist[0].header['HISTORY'] = history[i]['description']
 
-def to_fits(tree, schema, extensions=None):
+def to_fits(tree, schema, extensions=None, inline_threshold=None):
     hdulist = fits.HDUList()
     hdulist.append(fits.PrimaryHDU())
 
@@ -387,7 +387,9 @@ def to_fits(tree, schema, extensions=None):
     _save_extra_fits(hdulist, tree)
     _save_history(hdulist, tree)
 
-    asdf = fits_embed.AsdfInFits(hdulist, tree, extensions=extensions)
+    asdf = fits_embed.AsdfInFits(hdulist, tree,
+                                 inline_threshold=inline_threshold,
+                                 extensions=extensions)
     return asdf
 
 

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -533,7 +533,6 @@ def _load_history(hdulist, tree):
 
 def from_fits(hdulist, schema, extensions, context, **kwargs):
     try:
-        ##ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions, **kwargs)
         ff = from_fits_asdf(hdulist, extensions=extensions, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -495,8 +495,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             path_head = dir_path
         output_path = os.path.join(path_head, path_tail)
 
-        self.validate_required_fields()
-
         # TODO: Support gzip-compressed fits
         if ext == '.fits':
             # TODO: remove 'clobber' check once depreciated fully in astropy

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -38,7 +38,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
     def __init__(self, init=None, schema=None, extensions=None,
                  pass_invalid_values=False, strict_validation=False,
-                 inline_threshold=None, **kwargs):
+                 **kwargs):
         """
         Parameters
         ----------
@@ -74,14 +74,11 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         strict_validation: if true, an schema validation errors will generate
             an excption. If false, they will generate a warning.
-        inline_threshold: a flag passed to asdf that determines the size
-            below which an array is written inline as ascii instead of
-            as a binary block.
+
         kwargs: Aadditional arguments passed to lower level functions
         """
-        # Set attributes used to hold information for Asdf
+        # Set attributes used to hold information for asdf
         self._extensions = extensions
-        self._inline_threshold = inline_threshold
 
         # Override value of validation parameters
         # if environment value set
@@ -123,17 +120,14 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         if init is None:
             asdf = self.open_asdf(init=None, extensions=self._extensions,
-                                  inline_threshold=self._inline_threshold,
                                   **kwargs)
 
         elif isinstance(init, dict):
             asdf = self.open_asdf(init=init, extensions=self._extensions,
-                                  inline_threshold=self._inline_threshold,
                                   **kwargs)
 
         elif isinstance(init, np.ndarray):
             asdf = self.open_asdf(init=None, extensions=self._extensions,
-                                  inline_threshold=self._inline_threshold,
                                   **kwargs)
 
             shape = init.shape
@@ -147,7 +141,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             shape = init
             is_shape = True
             asdf = self.open_asdf(init=None, extensions=self._extensions,
-                                  inline_threshold=self._inline_threshold,
                                   **kwargs)
 
         elif isinstance(init, DataModel):
@@ -179,7 +172,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             elif file_type == "asdf":
                 asdf = self.open_asdf(init=init, extensions=self._extensions,
-                                      inline_threshold=self._inline_threshold,
                                       **kwargs)
 
             else:
@@ -319,8 +311,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     def clone(target, source, deepcopy=False, memo=None):
         if deepcopy:
             instance = copy.deepcopy(source._instance, memo=memo)
-            target._asdf = AsdfFile(instance, extensions=source._extensions,
-                                    inline_threshold=source._inline_threshold)
+            target._asdf = AsdfFile(instance,
+                                    extensions=source._extensions)
             target._instance = instance
             target._iscopy = source._iscopy
         else:
@@ -528,12 +520,11 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     def open_asdf(init=None, extensions=None,
                   ignore_version_mismatch=True,
                   ignore_unrecognized_tag=False,
-                  inline_threshold=None, **kwargs):
+                  **kwargs):
         """
         Open an asdf object from a filename or create a new asdf object
         """
         if isinstance(init, str):
-            # TODO: add inline_threshold when the code supports it
             asdf = AsdfFile.open(init, extensions=extensions,
                                  ignore_version_mismatch=ignore_version_mismatch,
                                  ignore_unrecognized_tag=ignore_unrecognized_tag)
@@ -541,8 +532,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         else:
             asdf = AsdfFile(init, extensions=extensions,
                             ignore_version_mismatch=ignore_version_mismatch,
-                            ignore_unrecognized_tag=ignore_unrecognized_tag,
-                            inline_threshold=inline_threshold
+                            ignore_unrecognized_tag=ignore_unrecognized_tag
                             )
         return asdf
 
@@ -586,7 +576,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         self.on_save(init)
         asdf = self.open_asdf(self._instance, extensions=self._extensions,
-                              inline_threshold=self._inline_threshold,
                               **kwargs)
         asdf.write_to(init, *args, **kwargs)
 
@@ -630,8 +619,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         self.on_save(init)
 
         with fits_support.to_fits(self._instance, self._schema,
-                                  extensions=self._extensions,
-                                  inline_threshold=self._inline_threshold) as ff:
+                                  extensions=self._extensions) as ff:
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore', message='Card is too long')
                 if self._no_asdf_extension:

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -547,7 +547,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return asdf
 
     @classmethod
-    def from_asdf(cls, init, schema=None, **kwargs):
+    def from_asdf(cls, init, schema=None, extensions=None, **kwargs):
         """
         Load a data model from a ASDF file.
 
@@ -558,11 +558,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             - readable file object: Initialize from the given file object
             - asdf.AsdfFile: Initialize from the given
               `~asdf.AsdfFile`.
-
         schema :
             Same as for `__init__`
-
-
+        extensions :
+            Same as for `__init__`
         kwargs:
             Aadditional arguments passed to lower level functions
 
@@ -570,8 +569,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         -------
         model : DataModel instance
         """
-        return cls(init, schema=schema, extensions=self._extensions,
-                   inline_threshold=self._inline_threshold, **kwargs)
+        return cls(init, schema=schema, extensions=extensions, **kwargs)
+
 
     def to_asdf(self, init, *args, **kwargs):
         """

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -15,7 +15,6 @@ from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import WCS
 
-import asdf as asdf_pkg
 from asdf import AsdfFile
 from asdf import yamlutil
 from asdf import schema as asdf_schema
@@ -535,7 +534,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         if isinstance(init, str):
             # TODO: add inline_threshold when the code supports it
-            asdf = asdf_pkg.open(init, extensions=extensions,
+            asdf = AsdfFile.open(init, extensions=extensions,
                                  ignore_version_mismatch=ignore_version_mismatch,
                                  ignore_unrecognized_tag=ignore_unrecognized_tag)
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -349,6 +349,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             # Get the value pointed at by the path to the node,
             # or None in case there is no entry for the node
+
             node = ctx
             for attr in path:
                 node = getattr(node, attr)

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -119,13 +119,17 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         asdf_kwargs = dict(inline_threshold=kwargs.pop('inline_threshold', 0))
 
         if init is None:
-            asdf = AsdfFile(extensions=extensions, **asdf_kwargs)
+            asdf = self.open_asdf(init=None, extensions=self._extensions,
+                                  **kwargs)
 
         elif isinstance(init, dict):
-            asdf = AsdfFile(init, extensions=self._extensions, **asdf_kwargs)
+            asdf = self.open_asdf(init=init, extensions=self._extensions,
+                                 **kwargs)
 
         elif isinstance(init, np.ndarray):
-            asdf = AsdfFile(extensions=self._extensions, **asdf_kwargs)
+            asdf = self.open_asdf(init=None, extensions=self._extensions,
+                                 **kwargs)
+
             shape = init.shape
             is_array = True
 
@@ -135,7 +139,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                     raise ValueError("shape must be a tuple of ints")
 
             shape = init
-            asdf = AsdfFile(**asdf_kwargs)
+            asdf = self.open_asdf(init=None)
             is_shape = True
 
         elif isinstance(init, DataModel):
@@ -158,13 +162,16 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             if file_type == "fits":
                 hdulist = fits.open(init)
-                asdf = fits_support.from_fits(hdulist, self._schema,
-                                              self._extensions, self._ctx)
-
+                asdf = fits_support.from_fits(hdulist,
+                                              self._schema,
+                                              self._extensions,
+                                              self._ctx,
+                                              **kwargs)
                 self._files_to_close.append(hdulist)
 
             elif file_type == "asdf":
-                asdf = AsdfFile.open(init, extensions=self._extensions)
+                asdf = self.open_asdf(init=init, extensions=self._extensions,
+                                      **kwargs)
 
             else:
                 # TODO handle json files as well
@@ -507,6 +514,28 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             raise ValueError("unknown filetype {0}".format(ext))
 
         return output_path
+
+    @staticmethod
+    def open_asdf(init=None, extensions=None,
+                  ignore_version_mismatch=True,
+                  ignore_unrecognized_tag=False,
+                  **kwargs):
+        """
+        Open an asdf object from a filename or create a new asdf object
+        """
+        # Drop arguments not explicitly mentioned in the arg list
+        kwargs = None
+
+        if isinstance(init, str):
+            asdf = AsdfFile.open(init, extensions=extensions,
+                                 ignore_version_mismatch=ignore_version_mismatch,
+                                 ignore_unrecognized_tag=ignore_unrecognized_tag)
+
+        else:
+            asdf = AsdfFile(init, extensions=extensions,
+                            ignore_version_mismatch=ignore_version_mismatch,
+                            ignore_unrecognized_tag=ignore_unrecognized_tag)
+        return asdf
 
     @classmethod
     def from_asdf(cls, init, schema=None):

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -525,8 +525,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         Open an asdf object from a filename or create a new asdf object
         """
-        # Drop arguments not explicitly mentioned in the arg list
-        kwargs = None
+
 
         if isinstance(init, str):
             asdf = AsdfFile.open(init, extensions=extensions,

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -74,6 +74,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         strict_validation: if true, an schema validation errors will generate
             an excption. If false, they will generate a warning.
+
+        kwargs: Aadditional arguments passed to lower level functions
         """
         # Set the extensions
         self._extensions = extensions
@@ -538,7 +540,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return asdf
 
     @classmethod
-    def from_asdf(cls, init, schema=None):
+    def from_asdf(cls, init, schema=None, **kwargs):
         """
         Load a data model from a ASDF file.
 
@@ -553,11 +555,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         schema :
             Same as for `__init__`
 
+
+        kwargs:
+            Aadditional arguments passed to lower level functions
+
         Returns
         -------
         model : DataModel instance
         """
-        return cls(init, schema=schema)
+        return cls(init, schema=schema, **kwargs)
 
     def to_asdf(self, init, *args, **kwargs):
         """
@@ -578,7 +584,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                  inline_threshold=inline_threshold).write_to(init, *args, **kwargs)
 
     @classmethod
-    def from_fits(cls, init, schema=None):
+    def from_fits(cls, init, schema=None, **kwargs):
         """
         Load a model from a FITS file.
 
@@ -593,11 +599,14 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         schema :
             Same as for `__init__`
 
+        kwargs:
+            Aadditional arguments passed to lower level functions
+
         Returns
         -------
         model : DataModel instance
         """
-        return cls(init, schema=schema)
+        return cls(init, schema=schema, **kwargs)
 
     def to_fits(self, init, *args, **kwargs):
         """

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -483,46 +483,6 @@ def test_info():
                 assert words[2] == "float32", "Correct type for err"
     assert matches== 3, "Check all extensions are described"
 
-def test_validate_on_read():
-    im1 = ImageModel((10,10))
-    schema = im1.meta._schema
-    schema['properties']['calibration_software_version']['fits_required'] = True
-
-    try:
-        im2 = ImageModel(FITS_FILE,
-                          schema=im1._schema,
-                          strict_validation=True)
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-        im2.close()
-
-    im1.close()
-    assert caught, "Test of validation while reading image"
-
-def test_validate_required_field():
-    im = ImageModel((10,10), strict_validation=True)
-    schema = im.meta._schema
-    schema['properties']['telescope']['fits_required'] = True
-
-    try:
-        im.validate_required_fields()
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-    assert caught, "Test of validate_required_fields"
-
-    im.meta.telescope = 'JWST'
-    try:
-        im.validate_required_fields()
-    except jsonschema.ValidationError:
-        caught = True
-    else:
-        caught = False
-    assert not caught, "Test of validate_required_fields"
-
 def test_multislit_model():
     data = np.arange(24, dtype=np.float32).reshape((6, 4))
     err = np.arange(24, dtype=np.float32).reshape((6, 4)) + 2

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -17,6 +17,7 @@ from ..util import open as open_model
 
 ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
 FITS_FILE = os.path.join(ROOT_DIR, 'test.fits')
+ASDF_FILE = os.path.join(ROOT_DIR, 'collimator_fake.asdf')
 ASN_FILE = os.path.join(ROOT_DIR, 'association.json')
 
 
@@ -361,6 +362,27 @@ def test_initialize_arrays_with_arglist():
     im = ImageModel(shape, zeroframe=thirteen, dq=bitz)
     assert np.array_equal(im.zeroframe, thirteen)
     assert np.array_equal(im.dq, bitz)
+
+def test_open_asdf_model():
+    # Open an empty asdf file, pass extra arguments
+
+    model = DataModel(init=None,
+                     ignore_version_mismatch=False,
+                     ignore_unrecognized_tag=True)
+
+    assert model._asdf._ignore_version_mismatch == False
+    assert model._asdf._ignore_unrecognized_tag == True
+    model.close()
+
+    # Open an existing asdf file
+
+    model = DataModel(ASDF_FILE,
+                     ignore_version_mismatch=False,
+                     ignore_unrecognized_tag=True)
+
+    assert model._asdf._ignore_version_mismatch == False
+    assert model._asdf._ignore_unrecognized_tag == True
+    model.close()
 
 def test_relsens():
     with ImageModel() as im:

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -505,6 +505,46 @@ def test_info():
                 assert words[2] == "float32", "Correct type for err"
     assert matches== 3, "Check all extensions are described"
 
+def test_validate_on_read():
+    im1 = ImageModel((10,10))
+    schema = im1.meta._schema
+    schema['properties']['calibration_software_version']['fits_required'] = True
+
+    try:
+        im2 = ImageModel(FITS_FILE,
+                          schema=im1._schema,
+                          strict_validation=True)
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+        im2.close()
+
+    im1.close()
+    assert caught, "Test of validation while reading image"
+
+def test_validate_required_field():
+    im = ImageModel((10,10), strict_validation=True)
+    schema = im.meta._schema
+    schema['properties']['telescope']['fits_required'] = True
+
+    try:
+        im.validate_required_fields()
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+    assert caught, "Test of validate_required_fields"
+
+    im.meta.telescope = 'JWST'
+    try:
+        im.validate_required_fields()
+    except jsonschema.ValidationError:
+        caught = True
+    else:
+        caught = False
+    assert not caught, "Test of validate_required_fields"
+
 def test_multislit_model():
     data = np.arange(24, dtype=np.float32).reshape((6, 4))
     err = np.arange(24, dtype=np.float32).reshape((6, 4)) + 2


### PR DESCRIPTION
Asdf supports two flags, ignore_version_mismatch and gnore_unrecognized_flag, when creating a new asdf file. Part of creating a new datamodel is opening an asdf file, either natively or as embedded in a FITS extension. This update passes these two flags from the DataModel argument list to the call that opens or creates an asdf file. The result is better control of the warning messages produced by asdf.

Resolves #1215.