### PR TITLE
Define pytest_plugins in top level conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+"""Project default for pytest"""
+from astropy.tests.helper import enable_deprecations_as_exceptions
+
+enable_deprecations_as_exceptions()
+
+pytest_plugins = [
+    'asdf.tests.schema_tester'
+]

--- a/jwst/conftest.py
+++ b/jwst/conftest.py
@@ -4,10 +4,6 @@ import tempfile
 import pytest
 
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
-from astropy.tests.helper import enable_deprecations_as_exceptions
-
-# Uncomment the following line to treat all DeprecationWarnings as exceptions
-enable_deprecations_as_exceptions()
 
 try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
@@ -15,10 +11,6 @@ try:
     del PYTEST_HEADER_MODULES['h5py']
 except (NameError, KeyError):
     pass
-
-pytest_plugins = [
-    'asdf.tests.schema_tester'
-]
 
 
 @pytest.fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ exclude = jwst/extern,docs,jwst/associations,jwst/jwpsf,jwst/ramp_fitting, jwst/
 [tool:pytest]
 minversion = 3
 addopts = --ignore=build
-norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern
+norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern scripts
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 doctest_plus = enabled
 


### PR DESCRIPTION
Having pytest plugins anywhere except the top level `conftest.py` has been deprecated since `pytest 3.5`.  We've been seeing this warning for a while:
```
conftest.py:0: RemovedInPytest4Warning: Defining pytest_plugins in a non-top-level conftest is deprecated, because it affects the entire directory tree in a non-explicit way.
Please move it to the top level conftest file instead.
```
This PR resolves it.

We currently use the `asdf` schema tester pytest plugin to make sure our datamodel schemas are valid YAML.

I'm also adding the `scripts/` subdir to our pytest ignore directory, as in order to parse the `set_bary_helio_times.py` script, the environment variable JPL_EPHEMERIS needs to be set, and one gets a pytest collection error when one doesn't.  We started seeing this collection error when we started doctesting.