### PR TITLE
Clean up pytest bigdata marks

### DIFF
--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -21,12 +21,6 @@ DATAPATH = abspath(
 EXPFILE = 'jw00001001001_01101_00001_mirimage_rate.fits'
 CALFILE = 'jw00001001001_01101_00001_mirimage_cal.fits'
 
-# Skip if the data is not available
-pytestmark = pytest.mark.skipif(
-    not path.exists(DATAPATH),
-    reason='Test data not accessible'
-)
-
 
 @pytest.mark.bigdata
 def test_result_return(mk_tmp_dirs):

--- a/jwst/pipeline/tests/test_calwebb_spec2.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2.py
@@ -26,12 +26,6 @@ CALFILE = EXPFILE.replace('_rate', '_cal')
 BSUBFILE = EXPFILE.replace('_rate', '_bsub')
 EXTRACT1DFILE = EXPFILE.replace('_rate', '_x1d')
 
-# Skip if the data is not available
-pytestmark = pytest.mark.skipif(
-    not path.exists(DATAPATH),
-    reason='Test data not accessible'
-)
-
 
 @pytest.mark.bigdata
 def test_result_return(mk_tmp_dirs):
@@ -42,6 +36,7 @@ def test_result_return(mk_tmp_dirs):
     assert isinstance(results[0], DataModel)
 
 
+@pytest.mark.bigdata
 def test_full_run(mk_tmp_dirs):
     """Make a full run with the default configuraiton"""
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
@@ -57,6 +52,7 @@ def test_full_run(mk_tmp_dirs):
     assert path.isfile(EXTRACT1DFILE)
 
 
+@pytest.mark.bigdata
 def test_asn_with_bkg(mk_tmp_dirs):
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
 
@@ -100,6 +96,7 @@ def test_asn_with_bkg(mk_tmp_dirs):
     assert path.isfile(BSUBFILE)
 
 
+@pytest.mark.bigdata
 def test_asn_with_bkg_bsub(mk_tmp_dirs):
     """Test background saving using the bsub flag"""
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
@@ -129,6 +126,7 @@ def test_asn_with_bkg_bsub(mk_tmp_dirs):
     assert path.isfile(BSUBFILE)
 
 
+@pytest.mark.bigdata
 def test_asn(mk_tmp_dirs):
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
     exppath = path.join(DATAPATH, EXPFILE)
@@ -152,6 +150,7 @@ def test_asn(mk_tmp_dirs):
     assert path.isfile(CALFILE)
 
 
+@pytest.mark.bigdata
 def test_asn_multiple_products(mk_tmp_dirs):
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
     exppath = path.join(DATAPATH, EXPFILE)
@@ -178,6 +177,7 @@ def test_asn_multiple_products(mk_tmp_dirs):
     assert path.isfile('product2_cal.fits')
 
 
+@pytest.mark.bigdata
 def test_datamodel(mk_tmp_dirs):
     model = dm_open(path.join(DATAPATH, EXPFILE))
     cfg = path.join(SCRIPT_DATA_PATH, 'calwebb_spec2_save.cfg')
@@ -185,6 +185,7 @@ def test_datamodel(mk_tmp_dirs):
     assert path.isfile(CALFILE)
 
 
+@pytest.mark.bigdata
 def test_file(mk_tmp_dirs):
     exppath = path.join(DATAPATH, EXPFILE)
     cfg = path.join(SCRIPT_DATA_PATH, 'calwebb_spec2_save.cfg')

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -165,7 +165,7 @@ def test_step_from_commandline_invalid4():
         Step.from_cmdline(args)
 
 
-@pytest.mark.skip(reason="No test here")
+@pytest.mark.skip(reason="This test does nothing")
 def test_step_print_spec():
     import io
     buf = io.BytesIO()

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author = STScI
 author_email = help@stsci.edu
 license = BSD
 edit_on_github = False
-github_project = STScI-JWST/jwst
+github_project = spacetelescope/jwst
 
 [build-sphinx]
 source-dir = docs


### PR DESCRIPTION
Make our usage of `@pytest.mark.bigdata` consistent through all our tests.  These were a few we missed.