### PR TITLE
Remove NRS_BOTA from dms_base

### DIFF
--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -104,7 +104,6 @@ IMAGE2_NONSCIENCE_EXP_TYPES = [
     'nrc_tacq',
     'nrc_taconfirm',
     'nrc_focus',
-    'nrs_bota',
     'nrs_confirm',
     'nrs_focus',
     'nrs_image',


### PR DESCRIPTION
The exptype NRS_BOTA was removed in #2772, but not here.

This was causing a validation warning in one of our unit tests:
```
jwst/lib/tests/test_pipe_utils.py::test_is_tso_from_exptype[nrs_bota-False]
  /Users/jdavies/dev/jwst/jwst/datamodels/validate.py:35: ValidationWarning: While validating type the following error occurred:
  'NRS_BOTA' is not one of ['FGS_DARK', 'FGS_FOCUS', 'FGS_IMAGE', 'FGS_INTFLAT', 'FGS_SKYFLAT', 'FGS_ACQ1', 'FGS_ACQ2', 'FGS_FINEGUIDE', 'FGS_ID-IMAGE', 'FGS_ID-STACK', 'FGS_TRACK', 'MIR_4QPM', 'MIR_CORONCAL', 'MIR_DARKALL', 'MIR_DARKIMG', 'MIR_DARKMRS', 'MIR_FLATALL', 'MIR_FLATIMAGE', 'MIR_FLATIMAGE-EXT', 'MIR_FLATMRS', 'MIR_FLATMRS-EXT', 'MIR_IMAGE', 'MIR_LRS-FIXEDSLIT', 'MIR_LRS-SLITLESS', 'MIR_LYOT', 'MIR_MRS', 'MIR_TACQ', 'NIS_AMI', 'NIS_DARK', 'NIS_EXTCAL', 'NIS_FOCUS', 'NIS_IMAGE', 'NIS_LAMP', 'NIS_SOSS', 'NIS_TACQ', 'NIS_TACONFIRM', 'NIS_WFSS', 'NRC_CORON', 'NRC_DARK', 'NRC_FLAT', 'NRC_FOCUS', 'NRC_IMAGE', 'NRC_WFSS', 'NRC_LED', 'NRC_WFSC', 'NRC_TACONFIRM', 'NRC_TACQ', 'NRC_TSGRISM', 'NRC_TSIMAGE', 'NRS_AUTOFLAT', 'NRS_AUTOWAVE', 'NRS_BRIGHTOBJ', 'NRS_CONFIRM', 'NRS_DARK', 'NRS_FIXEDSLIT', 'NRS_FOCUS', 'NRS_IFU', 'NRS_IMAGE', 'NRS_LAMP', 'NRS_MIMF', 'NRS_MSASPEC', 'NRS_MSATA', 'NRS_TACONFIRM', 'NRS_TACQ', 'NRS_TASLIT', 'NRS_WATA', 'N/A', 'ANY']
  
  Failed validating 'enum' in schema:
      {'$schema': 'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema',
       'blend_table': True,
       'enum': ['FGS_DARK',
                'FGS_FOCUS',
                'FGS_IMAGE',
                'FGS_INTFLAT',
                'FGS_SKYFLAT',
                'FGS_ACQ1',
                'FGS_ACQ2',
                'FGS_FINEGUIDE',
                'FGS_ID-IMAGE',
                'FGS_ID-STACK',
                'FGS_TRACK',
                'MIR_4QPM',
                'MIR_CORONCAL',
                'MIR_DARKALL',
                'MIR_DARKIMG',
                'MIR_DARKMRS',
                'MIR_FLATALL',
                'MIR_FLATIMAGE',
                'MIR_FLATIMAGE-EXT',
                'MIR_FLATMRS',
                'MIR_FLATMRS-EXT',
                'MIR_IMAGE',
                'MIR_LRS-FIXEDSLIT',
                'MIR_LRS-SLITLESS',
                'MIR_LYOT',
                'MIR_MRS',
                'MIR_TACQ',
                'NIS_AMI',
                'NIS_DARK',
                'NIS_EXTCAL',
                'NIS_FOCUS',
          ...
    warnings.warn(errmsg, ValidationWarning)
```