### PR TITLE
Grism and WCS test validation warnings

### DIFF
--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -1,3 +1,4 @@
+import pytest
 from numpy.testing import utils
 from astropy import units as u
 from astropy import wcs
@@ -112,6 +113,7 @@ def test_frame_from_model(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.filterwarnings("ignore: The WCS transformation has more axes")
 def test_create_fitwcs(tmpdir):
     """ Test GWCS vs FITS WCS results. """
     im = _create_model_3d()

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -163,6 +163,7 @@ def get_reference_files(datamodel):
     return refs
 
 
+@pytest.mark.filterwarnings("ignore: Card is too long")
 def test_create_box_fits():
     """Make sure that a box is created around a source catalog object.
     This version allows use of the FITS WCS to translate the source location
@@ -191,7 +192,7 @@ def test_create_box_fits():
         if sid == 9:
             assert [1] == list(ids[0].order_bounding.keys())
 
-@pytest.mark.xfail()
+@pytest.mark.xfail(reason='NIRCam distortion reffile')
 def test_create_box_gwcs():
     """Make sure that a box is created around a source catalog object.
     This version allows use of the GWCS to translate the source location.
@@ -234,7 +235,7 @@ def setup_image_cat():
     return imwcs, refs
 
 
-@pytest.mark.filterwarnings("ignore: VerifyWarning")
+@pytest.mark.filterwarnings("ignore: Card is too long")
 def test_create_specific_orders():
     """Test that boxes only for the specified orders
     are created.. instead of the default in the reference
@@ -326,6 +327,7 @@ def test_extract_tso_height():
     del outmodel
 
 
+@pytest.mark.filterwarnings("ignore: Card is too long")
 def test_extract_wfss_object():
     """Test extraction of a WFSS object.
 


### PR DESCRIPTION
Some of our unit tests generate warnings when they pass.  These warnings are expected given the structure of the tests and should be filtered.

This PR filters the following warnings:
```
jwst/assign_wcs/tests/test_wcs.py::test_create_fitwcs
  /Users/jdavies/miniconda3/envs/jwst_dev/lib/python3.7/site-packages/astropy/wcs/wcs.py:506: FITSFixedWarning: The WCS transformation has more axes (3) than the image it is associated with (2)
    wcsprm.naxis, header_naxis), FITSFixedWarning)
```
and a few of these:
```
jwst/extract_2d/tests/test_grisms.py::test_create_box_fits
  /Users/jdavies/miniconda3/envs/jwst_dev/lib/python3.7/site-packages/astropy/io/fits/card.py:979: VerifyWarning: Card is too long, comment will be truncated.
    VerifyWarning)
```
so that they no longer appear at the end of every test run.