### PR TITLE
Filter out reffile keyword validation warnings out of dq_init tests

### DIFF
--- a/jwst/dq_init/tests/test_dq_init.py
+++ b/jwst/dq_init/tests/test_dq_init.py
@@ -1,7 +1,9 @@
+import warnings
 import pytest
 from jwst.dq_init import DQInitStep
 from jwst.dq_init.dq_initialization import do_dqinit
 from jwst.datamodels import MIRIRampModel, MaskModel, GuiderRawModel, RampModel, dqflags
+from jwst.datamodels.validate import ValidationWarning
 import numpy as np
 
 
@@ -129,6 +131,9 @@ def test_err():
     ref_data.meta.subarray.ystart = ystart
     ref_data.meta.subarray.ysize = ysize
 
+    # Filter out validation warnings from ref_data
+    warnings.filterwarnings("ignore", category=ValidationWarning)
+
     # run correction step
     outfile = do_dqinit(dm_ramp, ref_data)
 
@@ -189,6 +194,9 @@ def test_dq_subarray():
     ref_data.meta.subarray.xsize = fullxsize
     ref_data.meta.subarray.ystart = 1
     ref_data.meta.subarray.ysize = fullysize
+
+    # Filter out validation warnings from ref_data
+    warnings.filterwarnings("ignore", category=ValidationWarning)
 
     # run correction step
     outfile = do_dqinit(im, ref_data)


### PR DESCRIPTION
Since a `MaskModel` reffile is generated on the fly in 2 of the `dq_init` tests, and it's required keywords such as
```
meta.description
meta.telescope
meta.reftype
meta.author
meta.pedigree
meta.useafter
```
are not populated, we get validation warnings.  These keywords are there for CRDS purposes and are not needed in the test, so let's just filter out these warnings.