### PR TITLE
Update ref file docs for straylight and superbias

### DIFF
--- a/docs/jwst/saturation/reference_files.rst
+++ b/docs/jwst/saturation/reference_files.rst
@@ -6,7 +6,7 @@ SATURATION Reference File
 -------------------------
 
 :REFTYPE: SATURATION
-:Data model: `SaturationModel`
+:Data model: `jwst.datamodels.SaturationModel`
 
 The SATURATION reference file contains pixel-by-pixel saturation threshold
 values.
@@ -34,7 +34,7 @@ PUPIL      model.meta.instrument.pupil
 Reference File Format
 +++++++++++++++++++++
 SATURATION reference files are FITS format, with 2 IMAGE extensions
-and 1 BINTABLE extension. The FITS primary data array is assumed to be empty.
+and 1 BINTABLE extension. The FITS primary HDU does not contain a data array.
 The format and content of the file is as follows:
 
 =======  ========  =====  ==============  =========

--- a/docs/jwst/straylight/reference_files.rst
+++ b/docs/jwst/straylight/reference_files.rst
@@ -1,27 +1,57 @@
-Reference File Types
-====================
-The default algorithm in the MIRI MRS stray-light correction step uses
-information contained in the meta data of the input image which maps each
-pixels to a slice or the region between the slices, also known as the slice
-gaps. This information was previously loaded from a reference file into the
-meta data by the assign_wcs step.  There is an option to use a more simplistic
-algorithm that uses STRAYMASK reference file.
+Reference Files
+===============
 
-.. include:: ../includes/standard_keywords.rst
+By default the ``straylight`` step does not use a reference file.
+It instead uses meta information added by the ``assign_wcs`` step that
+maps each pixel to an IFU slice number or the regions between slices
+within the 2-D slice image.
+
+If the step option ``method`` is set to "Nearest", a more simplistic
+algorithm is used to compute the correction, which requires the use of
+the ``STRAYMASK`` reference file. It contains a simple mask indicating
+which pixels lie within the inter-slice regions of the image.
+
+STRAYMASK Reference File
+------------------------
+
+:REFTYPE: STRAYMASK
+:Data model: `~jwst.datamodels.StrayLightModel`
+
+The STRAYMASK reference file contains a simple mask that indicates
+which pixels lie within IFU slices and which ones lie between slices.
 
 .. include:: straymask_selection.rst
 
+.. include:: ../includes/standard_keywords.rst
 
-If --method = "Nearest" option is used then the MIRI MRS stray-light reference
-file is selected on the basis of INSTRUME, DETECTOR, and BAND values of the
-input science data set.
+Type Specific Keywords for STRAYMASK
+++++++++++++++++++++++++++++++++++++
+In addition to the standard reference file keywords listed above,
+the following keywords are *required* in STRAYMASK reference files,
+because they are used as CRDS selectors
+(see :ref:`straymask_selectors`):
 
-MIRI MRS stray-light  Reference File Format
--------------------------------------------
-The STRAYMASK reference files are FITS files with and empty primary data array
-and one IMAGE extension named MASK. This IMAGE extension is a 2-D integer image
-mask file of size 1032 X 1024. The mask contains values of 1 for pixels that
-fall in the slice gaps and values of 0 for science pixels. The stray-light
-algorithm only uses pixels that fall in the slice gaps to determine the
-correction.
+=========  ==============================
+Keyword    Data Model Name
+=========  ==============================
+DETECTOR   model.meta.instrument.detector
+BAND       model.meta.instrument.band  
+=========  ==============================
+
+Reference File Format
++++++++++++++++++++++
+STRAYMASK reference files are FITS format with 1 IMAGE extension.
+The FITS primary HDU does not contain a data array.
+The characteristics of the extension is as follows:
+
+=======  ========  =====  ==============  =========
+EXTNAME  XTENSION  NAXIS  Dimensions      Data type
+=======  ========  =====  ==============  =========
+MASK     IMAGE       2    ncols x nrows   integer
+=======  ========  =====  ==============  =========
+
+The ``MASK`` array provides a simple 0 or 1 mapping to indicate which pixels
+fall in IFU slice gaps, with 1 indicating a gap pixel and 0 for non-gap pixels.
+The simple form of the ``straylight`` correction step will use only the pixels
+flagged with a 1.
 

--- a/docs/jwst/straylight/straymask_selection.rst
+++ b/docs/jwst/straylight/straymask_selection.rst
@@ -1,8 +1,10 @@
+.. _straymask_selectors:
+
 Reference Selection Keywords for STRAYMASK
-------------------------------------------
+++++++++++++++++++++++++++++++++++++++++++
 CRDS selects appropriate STRAYMASK references based on the following keywords.
 STRAYMASK is not applicable for instruments not in the table.
-Non-standard keywords used for file selection are *required*.
+All keywords used for file selection are *required*.
 
 ========== ============================================
 Instrument Keywords                                     

--- a/docs/jwst/superbias/reference_files.rst
+++ b/docs/jwst/superbias/reference_files.rst
@@ -1,23 +1,58 @@
-Reference File Types
-====================
-The superbias subtraction step uses a SUPERBIAS reference file.
+Reference Files
+===============
+The ``superbias`` subtraction step uses a SUPERBIAS reference file.
 
-.. include:: ../includes/standard_keywords.rst
+SUPERBIAS Reference File
+------------------------
+
+:REFTYPE: SUPERBIAS
+:Data model: `~jwst.datamodels.SuperBiasModel`
+
+The SUPERBIAS reference file contains a 2-D image of the detector bias
+("zeroth" read) structure.
 
 .. include:: superbias_selection.rst
 
-SUPERBIAS Reference File Format
--------------------------------
-Superbias reference files are FITS files with 3 IMAGE extensions and 1 BINTABLE
-extension. The FITS primary data array is assumed to be empty. The 
-characteristics of the three image extension are as follows:
+.. include:: ../includes/standard_keywords.rst
 
-=======  =====  =============  =========
-EXTNAME  NAXIS  Dimensions     Data type
-=======  =====  =============  =========
-SCI      2      ncols x nrows  float
-ERR      2      ncols x nrows  float
-DQ       2      ncols x nrows  integer
-=======  =====  =============  =========
+Type Specific Keywords for SUPERBIAS
+++++++++++++++++++++++++++++++++++++
+In addition to the standard reference file keywords listed above,
+the following keywords are *required* in SUPERBIAS reference files,
+because they are used as CRDS selectors
+(see :ref:`superbias_selectors`):
+
+=========  ==============================  ============================
+Keyword    Data Model Name                 Instruments
+=========  ==============================  ============================
+DETECTOR   model.meta.instrument.detector  FGS, NIRCam, NIRISS, NIRSpec
+READPATT   model.meta.exposure.readpatt    FGS, NIRCam, NIRISS, NIRSpec
+SUBARRAY   model.meta.subarray.name        FGS, NIRCam, NIRISS, NIRSpec
+SUBSTRT1   model.meta.subarray.xstart      NIRSpec only
+SUBSTRT2   model.meta.subarray.ystart      NIRSpec only
+SUBSIZE1   model.meta.subarray.xsize       NIRSpec only
+SUBSIZE2   model.meta.subarray.ysize       NIRSpec only
+=========  ==============================  ============================
+
+Reference File Format
++++++++++++++++++++++
+SUPERBIAS reference files are FITS format, with 3 IMAGE extensions
+and 1 BINTABLE extension. The FITS primary HDU does not contain a data array.
+The format and content of the file is as follows:
+
+=======  ========  =====  ==============  =========
+EXTNAME  XTENSION  NAXIS  Dimensions      Data type
+=======  ========  =====  ==============  =========
+SCI      IMAGE       2    ncols x nrows   float
+ERR      IMAGE       2    ncols x nrows   float
+DQ       IMAGE       2    ncols x nrows   integer
+DQ_DEF   BINTABLE    2    TFIELDS = 4     N/A
+=======  ========  =====  ==============  =========
+
+The ``SCI`` array contains the super-bias image of the detector. The
+``ERR`` array contains uncertainties in the super-bias values and the
+``DQ`` array contains data quality flags associated with the super-bias
+image.
 
 .. include:: ../includes/dq_def.rst
+

--- a/docs/jwst/superbias/superbias_selection.rst
+++ b/docs/jwst/superbias/superbias_selection.rst
@@ -1,15 +1,17 @@
+.. _superbias_selectors:
+
 Reference Selection Keywords for SUPERBIAS
-------------------------------------------
+++++++++++++++++++++++++++++++++++++++++++
 CRDS selects appropriate SUPERBIAS references based on the following keywords.
 SUPERBIAS is not applicable for instruments not in the table.
-Non-standard keywords used for file selection are *required*.
+All keywords used for file selection are *required*.
 
 ========== ==================================================================================================
 Instrument Keywords                                                                                           
 ========== ==================================================================================================
 FGS        INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
-NIRCAM     INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
+NIRCam     INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
 NIRISS     INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
-NIRSPEC    INSTRUME, DETECTOR, READPATT, SUBARRAY, SUBSTRT1, SUBSTRT2, SUBSIZE1, SUBSIZE2, DATE-OBS, TIME-OBS 
+NIRSpec    INSTRUME, DETECTOR, READPATT, SUBARRAY, SUBSTRT1, SUBSTRT2, SUBSIZE1, SUBSIZE2, DATE-OBS, TIME-OBS 
 ========== ==================================================================================================
 


### PR DESCRIPTION
Update the reference file docs for the `straylight` and `superbias` steps, for #2675. Also contains a minor fix for the previous updates to `saturation` reffile docs. Reviewers: feel free to only review the docs for your steps.