### PR TITLE
Remove soon-to-be-deprecated usage of AsdfFile.open

### DIFF
--- a/docs/jwst/assign_wcs/asdf-howto.rst
+++ b/docs/jwst/assign_wcs/asdf-howto.rst
@@ -117,17 +117,18 @@ Save a transform to an ASDF file
 `asdf <http://asdf.readthedocs.io/en/latest/>`__ is used to read and write reference files in
 `ASDF <http://asdf-standard.readthedocs.org/en/latest/>`__ format. Once the model is create using the rules in the above section, it needs to be assigned to the ASDF tree.
 
+>>> import asdf
 >>> from asdf import AsdfFile
 >>> f = AsdfFile()
 >>> f.tree['model'] = model
 >>> f.write_to('reffile.asdf')
 
-The ``write_to`` command validates the file and writes it to disk. It will catch any errors due to
-inconsistent inputs/outputs or invalid parameters.
+The ``write_to`` command validates the file and writes it to disk. It will
+catch any errors due to inconsistent inputs/outputs or invalid parameters.
 
-To test the file, it can be read in again using the ``AsdfFile.open()`` method:
+To test the file, it can be read in again using the ``asdf.open()`` function:
 
->>> ff = AsdfFile.open('reffile.asdf')
+>>> ff = asdf.open('reffile.asdf')
 >>> model = ff.tree['model']
 >>> model(1, 1)
     -152.2

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -1,6 +1,6 @@
 import logging
 
-from asdf import AsdfFile
+import asdf
 from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling.models import Const1D, Mapping, Identity
@@ -131,7 +131,7 @@ def niriss_soss(input_model, reference_files):
     world = cf.CompositeFrame([sky, spec], name='world')
 
     try:
-        with AsdfFile.open(reference_files['specwcs']) as wl:
+        with asdf.open(reference_files['specwcs']) as wl:
             wl1 = wl.tree[1].copy()
             wl2 = wl.tree[2].copy()
             wl3 = wl.tree[3].copy()

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -526,7 +526,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         Open an asdf object from a filename or create a new asdf object
         """
         if isinstance(init, str):
-            asdffile = AsdfFile.open(init, extensions=extensions,
+            asdffile = asdf.open(init, extensions=extensions,
                                  ignore_version_mismatch=ignore_version_mismatch,
                                  ignore_unrecognized_tag=ignore_unrecognized_tag)
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -145,6 +145,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                                   **kwargs)
 
         elif isinstance(init, DataModel):
+            asdffile = None
             self.clone(self, init)
             if not isinstance(init, self.__class__):
                 self.validate()

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -14,7 +14,8 @@ from ..util import open
 from .. import (DataModel, ModelContainer, ImageModel, ReferenceFileModel,
                 ReferenceImageModel, ReferenceCubeModel, ReferenceQuadModel,
                 FlatModel, MaskModel, NircamPhotomModel, GainModel,
-                ReadnoiseModel)
+                ReadnoiseModel, DistortionModel)
+from jwst.stpipe.crds_client import get_reference_file
 
 def test_open_fits():
     """Test opening a model from a FITS file"""
@@ -95,6 +96,23 @@ def test_open_reference_files():
         model = klass(file)
         assert isinstance(model, klass)
         model.close()
+
+def test_open_reffile_readonly():
+    """Test opening a reffile from CRDS read-only cache"""
+    model = ImageModel()
+    model.meta.instrument.name = 'NIRCAM'
+    model.meta.instrument.detector = 'NRCA4'
+    model.meta.instrument.channel = 'SHORT'
+    model.meta.observation.date = '2018-01-01'
+    model.meta.observation.time = '12:03:34.176000'
+
+    reffile = get_reference_file(model, 'distortion')
+    try:
+        os.chmod(reffile, 0o444)
+    except PermissionError:
+        pass
+    distortion = DistortionModel(reffile)
+    distortion.close()
 
 # Utilities
 def t_path(partial_path):

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -116,10 +116,6 @@ def test_open_fits_readonly(tmpdir):
     with datamodels.open(tmpfile) as model:
         assert model.meta.telescope == 'JWST'
 
-    # The following *should* fail with a permission error, but it does not.
-    with datamodels.open(tmpfile) as model:
-        model.save(tmpfile)
-
 def test_open_asdf_readonly(tmpdir):
     tmpfile = str(tmpdir.join('readonly.asdf'))
 
@@ -135,10 +131,6 @@ def test_open_asdf_readonly(tmpdir):
 
     with datamodels.open(tmpfile) as model:
         assert model.meta.telescope == 'JWST'
-
-    # The following *should* fail with a permission error, but it does not.
-    with datamodels.open(tmpfile) as model:
-        model.save(tmpfile)
 
 # Utilities
 def t_path(partial_path):


### PR DESCRIPTION
This re-implements #2814 and adds 2 unit tests to make sure read-only files can be read by `datamodels`.