### PR TITLE
Improve support for WFSS data.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,9 @@ exp_to_source
 
 extract_1d
 ----------
+- Updated to recognize NRC_TSGRISM as WFSS data.  SlitDataModel schema now
+  specifies that the wavelength attribute should be 2-D, with a default
+  value of 0. [#2911]
 
 extract_2d
 ----------

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -107,6 +107,8 @@ allOf:
     wavelength:
       title: Wavelength array, corrected for zero-point
       fits_hdu: WAVELENGTH
+      ndim: 2
+      default: 0.0
       datatype: float32
     barshadow:
       title: Bar shadow correction

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -18,7 +18,7 @@ from . import spec_wcs
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_GRISM', 'NRC_WFSS']
+WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
 """Exposure types to be regarded as wide-field slitless spectroscopy."""
 
 # These values are used to indicate whether the input reference file


### PR DESCRIPTION
'NRC_TSGRISM' was added to `WFSS_EXPTYPES`, the list of exposure types that are WFSS/GRISM types.

The `SlitDataModel` schema was modified to specify that the wavelength attribute should be two-dimensional, and that the default value is zero.

See issue #2898.