### PR TITLE
fix nirspec cubepars schema

### DIFF
--- a/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
@@ -7,7 +7,7 @@ allOf:
       title: default IFU cube  parameters table
       fits_hdu: CUBEPAR
       datatype:
-      - name: grating
+      - name: disperser
         datatype: [ascii,5]
       - name: filter
         datatype: [ascii, 6]
@@ -23,7 +23,7 @@ allOf:
       title: default IFU cube msn parameters table
       fits_hdu: CUBEPAR_MSM
       datatype:
-      - name: grating
+      - name: disperser
         datatype: [ascii,5]
       - name: filter
         datatype: [ascii,6]


### PR DESCRIPTION
Updated the nirspec_cubepars schema to have the correct name associated with DISPERSER.
The code for reading in the reference file already was updated with DISPERSER.
