### PR TITLE
Fix mistake in the time to read one detector pixel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -141,6 +141,7 @@ refpix
 ------
 
 - Added a description of processing for IRS2 readout mode data. [#2889]
+- Fixed a mistake in the time to read one pixel. [#2922]
 
 resample
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -141,7 +141,7 @@ refpix
 ------
 
 - Added a description of processing for IRS2 readout mode data. [#2889]
-- Fixed a mistake in the time to read one pixel. [#2922]
+- Fixed a mistake in the time to read one pixel. [#2923]
 
 resample
 --------

--- a/docs/jwst/refpix/description.rst
+++ b/docs/jwst/refpix/description.rst
@@ -83,7 +83,7 @@ reference pixels, but also time for the transition between reading normal
 data and reference pixels, as well as additional overhead at the end of
 each row and between frames.  For example, it takes the same length of time
 to jump from reading normal pixels to reading reference pixels as it does
-to read one pixel value, about one microsecond.
+to read one pixel value, about ten microseconds.
 
 Before subtracting the reference pixel and reference output values from
 the science data, some processing is done on the reference values, and the


### PR DESCRIPTION
In the description of IRS2 readout, I had written that it took one microsecond to read one pixel.  The time is actually closer to 10 microseconds.