### PR TITLE
Use double-precision in AMI analyze and pipeline

### DIFF
--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -7,7 +7,7 @@ import warnings
 import numpy as np
 from .. import datamodels
 
-from .NRM_Model import NRM_Model
+from .nrm_model import NrmModel
 from . import webb_psf
 from . import leastsqnrm
 
@@ -61,7 +61,7 @@ def apply_LG(input_model, filter_model, oversample, rotation):
     rotation = rotation * np.pi / 180.0
 
     # Instantiate the NRM model object
-    jwnrm = NRM_Model(mask='JWST', holeshape='hex',
+    jwnrm = NrmModel(mask='JWST', holeshape='hex',
                 pixscale=leastsqnrm.mas2rad(63.52554816773347),
                 rotate=rotation, rotlist_deg=rots_deg,
                 scallist=relpixscales)
@@ -74,6 +74,7 @@ def apply_LG(input_model, filter_model, oversample, rotation):
     # Now fit the data in the science exposure
     # (pixguess is a guess at the pixel scale of the data)
     #  produces a 19x19 image of the fit
+    input_data = input_model.data.astype(np.float64)
 
     subarray = input_model.meta.subarray.name.upper()
     if subarray == 'FULL':
@@ -86,10 +87,9 @@ def apply_LG(input_model, filter_model, oversample, rotation):
         xstop = xstart + xsize - 1
         ystop = ystart + ysize - 1
 
-        jwnrm.fit_image(input_model.data[ ystart-1:ystop, xstart-1:xstop ],
-                        pixguess=jwnrm.pixel)
+        jwnrm.fit_image(input_data[ystart-1:ystop, xstart-1:xstop], pixguess=jwnrm.pixel)
     else:
-        jwnrm.fit_image(input_model.data, pixguess=jwnrm.pixel)
+        jwnrm.fit_image(input_data, pixguess=jwnrm.pixel)
 
     # Construct model image from fitted PSF
     jwnrm.create_modelpsf()

--- a/jwst/ami/nrm_consts.py
+++ b/jwst/ami/nrm_consts.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-# Constants used in NRM_Model.py
+# Constants used in nrm_model.py
 # piston array, in waves
 phi_nb = np.array([0.028838669455909766, -0.061516214504502634, \
                     0.12390958557781348, -0.020389361461019516, \

--- a/jwst/ami/nrm_model.py
+++ b/jwst/ami/nrm_model.py
@@ -25,13 +25,13 @@ from . import leastsqnrm as leastsqnrm
 from . import analyticnrm2
 from . import utils
 from . import hexee
-from . import NRM_consts
+from . import nrm_consts
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-class NRM_Model():
+class NrmModel:
 
     def __init__(self, mask=None, holeshape="circ", pixscale=hexee.mas2rad(65),
                  rotate=False, over=1, flip=False, pixweight=None, scallist=None,
@@ -39,7 +39,7 @@ class NRM_Model():
         """
         Short Summary
         -------------
-        Set attributes of NRM_Model object.
+        Set attributes of NrmModel class.
 
         Parameters
         ----------
@@ -96,7 +96,7 @@ class NRM_Model():
                 raise AttributeError("mask must be either 'jwst' \
                                                       or NRM_mask_geometry object")
 
-        log.debug('NRM_Model: ctrs flipped in init for CV1, CV2')
+        log.debug('NrmModel: ctrs flipped in init for CV1, CV2')
 
         if rotate:
             log.info('Providing additional rotation %s degrees',
@@ -129,7 +129,7 @@ class NRM_Model():
         if phi == "perfect":
             self.phi = np.zeros(len(self.ctrs))
         elif phi == 'nb':
-            self.phi = NRM_consts.phi_nb
+            self.phi = nrm_consts.phi_nb
         else:
             self.phi = phi
 
@@ -477,7 +477,7 @@ class NRM_Model():
         Short Summary
         -------------
         Make an image from the object's model and fit solutions, by setting the
-        NRM_Model object's modelpsf attribute
+        NrmModel object's modelpsf attribute
 
         Parameters
         ----------

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -67,7 +67,7 @@ def makeA(nh):
 
     To change the convention just reverse the signs of the 'ones'.
 
-    When tested against Alex'' NRM_Model.py 'piston_phase' text output
+    When tested against Alex'' nrm_model.py 'piston_phase' text output
     of fringe phases, these signs appear to be correct -
     anand@stsci.edu 12 Nov 2014
 
@@ -110,7 +110,7 @@ def fringes2pistons(fringephases, nholes):
     """
     Short Summary
     -------------
-    For NRM_Model.py to use to extract pistons out of fringes, given
+    For nrm_model.py to use to extract pistons out of fringes, given
     its hole bookkeeping, which apparently matches that of this module,
     and is the same as Noah Gamper's.
 

--- a/jwst/ami/webb_psf.py
+++ b/jwst/ami/webb_psf.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 
 from . import utils
-from . import NRM_consts
+from . import nrm_consts
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -75,7 +75,7 @@ def get_webbpsf_filter(filter_model, specbin=None, trim=False):
 
     log.debug(' final filter shape %s', spec.shape)
     log.debug(' %d filter samples between %.3f and %.3f um',
-              len(spec[:, 0]), spec[0, W] / NRM_consts.um_,
-              spec[-1, W] / NRM_consts.um_)
+              len(spec[:, 0]), spec[0, W] / nrm_consts.um_,
+              spec[-1, W] / nrm_consts.um_)
 
     return spec

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -100,6 +100,8 @@ class Ami3Pipeline(Pipeline):
         if len(psf_files) > 0:
             self.log.debug('Calling ami_average for PSF results ...')
             psf_avg = self.ami_average(psf_files)
+            for f in psf_files:
+                f.close()
 
             # Save the results to a file, if requested
             if self.save_averages:
@@ -129,6 +131,8 @@ class Ami3Pipeline(Pipeline):
         if len(targ_files) > 0:
             self.log.debug('Calling ami_average for target results ...')
             targ_avg = self.ami_average(targ_files)
+            for f in targ_files:
+                f.close()
 
             # Save the results to a file, if requested
             if self.save_averages:
@@ -159,9 +163,9 @@ class Ami3Pipeline(Pipeline):
             self.log.info(
                 'Blending metadata for PSF normalized target...'
             )
-            input_list = [targ_avg, psf_avg]
-            blendmeta.blendmodels(result, inputs=input_list)
+            blendmeta.blendmodels(result, inputs=[targ_avg, psf_avg])
             self.save_model(result, suffix='aminorm')
+            result.close()
 
         # We're done
         log.info('... ending calwebb_ami3')

--- a/jwst/tests_nightly/general/niriss/test_niriss_steps.py
+++ b/jwst/tests_nightly/general/niriss/test_niriss_steps.py
@@ -27,7 +27,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       step_class=AmiAnalyzeStep,
                       step_pars=dict(oversample=3, rotation=1.49),
                       output_truth=('ami_analyze_ref_output_16.fits',
-                                    dict(rtol = 0.001)),
+                                    dict(rtol = 0.00001)),
                       output_hdus=['primary','fit','resid','closure_amp',
                                          'closure_pha','fringe_amp','fringe_pha',
                                          'pupil_pha','solns'],

--- a/jwst/tests_nightly/general/niriss/test_niriss_steps_single.py
+++ b/jwst/tests_nightly/general/niriss/test_niriss_steps_single.py
@@ -37,7 +37,7 @@ class TestAMIPipeline(BaseJWSTTest):
         outputs = [('test_targ_aminorm.fits',
                     'ami_pipeline_targ_lgnorm.fits'),
                   ]
-        self.compare_outputs(outputs, rtol=0.001,
+        self.compare_outputs(outputs, rtol=0.00001,
                              ignore_hdus=['ASDF', 'HDRTAB'])
 
 


### PR DESCRIPTION
Also:
-  PEP8 cleanup of the AMI class and module names
- close datamodels in the ami3 pipeline

Addresses #1988 and #2893.