### PR TITLE
Use PyArray_SimpleNew instead of deprecated PyArray_FromDims

### DIFF
--- a/src/tweakreg/carrutils.c
+++ b/src/tweakreg/carrutils.c
@@ -12,7 +12,7 @@
 
 static PyObject *gl_Error;
 
-typedef int integer_t;
+typedef npy_intp integer_t;
 
 /* ==== Allocate a double *vector (vec of pointers) ======================
     Memory is Allocated!  See void free_Carray(double ** )                  */
@@ -61,7 +61,7 @@ arrxyzero(PyObject *obj, PyObject *args)
   double **zpmat = NULL;
 
   long imgnum, refnum;
-  npy_intp dimensions[2];
+  integer_t dimensions[2];
   integer_t xind, yind;
   double dx, dy;
   long j, k;

--- a/src/tweakreg/carrutils.c
+++ b/src/tweakreg/carrutils.c
@@ -61,7 +61,7 @@ arrxyzero(PyObject *obj, PyObject *args)
   double **zpmat = NULL;
 
   long imgnum, refnum;
-  integer_t dimensions[2];
+  npy_intp dimensions[2];
   integer_t xind, yind;
   double dx, dy;
   long j, k;
@@ -82,7 +82,7 @@ arrxyzero(PyObject *obj, PyObject *args)
 
   dimensions[0] = (integer_t)(searchrad*2) + 1;
   dimensions[1] = (integer_t)(searchrad*2) + 1;
-  ozpmat = (PyArrayObject *)PyArray_FromDims(2, dimensions, NPY_DOUBLE);
+  ozpmat = (PyArrayObject *)PyArray_SimpleNew(2, dimensions, NPY_DOUBLE);
   if (!ozpmat) {
     goto _exit;
   }


### PR DESCRIPTION
Fixes a `DeprecationWarning` seen in python 3.7:
```
jwst/tests_nightly/general/nircam/test_nrc_image3_1.py::TestImage3Pipeline1::test_image3_pipeline2
  /Users/jdavies/dev/jwst/jwst/tweakreg/matchutils.py:74: DeprecationWarning: PyArray_FromDims: use PyArray_SimpleNew.
    refxy.astype(np.float32), searchrad)
```