### PR TITLE
refactor subarray transform

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ assign_wcs
 ----------
  - Added velocity correction model to the WFSS and TSGRISM wcs pipelines [#2801]
 
+ - Refactored how the pipeline handles subarrays in the WCS. Fixed a bug
+   where the bounding box was overwritten in full frame mode. [#2980]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -92,7 +92,7 @@ def imaging_distortion(input_model, reference_files):
     # Check if the transform in the reference file has a ``bounding_box``.
     # If not set a ``bounding_box`` equal to the size of the image.
     try:
-        bb = transform.bounding_box
+        transform.bounding_box
     except NotImplementedError:
         transform.bounding_box = bounding_box_from_model(input_model)
     dist.close()

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -12,7 +12,7 @@ from gwcs.utils import _toindex
 from . import pointing
 from ..transforms import models as jwmodels
 from .util import (not_implemented_mode, subarray_transform,
-                   velocity_correction)
+                   velocity_correction, bounding_box_from_model, bounding_box_from_subarray)
 from ..datamodels import (DistortionModel, FilteroffsetModel,
                           DistortionMRSModel, WavelengthrangeModel,
                           RegionsModel, SpecwcsModel)
@@ -67,19 +67,23 @@ def imaging(input_model, reference_files):
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
     # Create the transforms
+    distortion = imaging_distortion(input_model, reference_files)
     subarray2full = subarray_transform(input_model)
-    imdistortion = imaging_distortion(input_model, reference_files)
-    distortion = subarray2full | imdistortion
+    if subarray2full is not None:
+        distortion = subarray2full | distortion
+        distortion.bounding_box = bounding_box_from_subarray(input_model)
+    else:
+        # TODO: remove setting the bounding box when it is set in the new ref file.
+        try:
+            bb = distortion.bounding_box
+        except NotImplementedError:
+            shape = input_model.data.shape
+            # Note: Since bounding_box is attached to the model here it's in reverse order.
+            bb = ((-0.5, shape[0] - 0.5), (3.5, shape[1] - 4.5))
+            distortion.bounding_box = bb
+
     tel2sky = pointing.v23tosky(input_model)
 
-    # TODO: remove setting the bounding box when it is set in the new ref file.
-    try:
-        bb = distortion.bounding_box
-    except NotImplementedError:
-        shape = input_model.data.shape
-        # Note: Since bounding_box is attached to the model here it's in reverse order.
-        bb = ((-0.5, shape[0] - 0.5), (3.5, shape[1] - 4.5))
-    distortion.bounding_box = bb
     # Create the pipeline
     pipeline = [(detector, distortion),
                 (v2v3, tel2sky),
@@ -105,11 +109,19 @@ def imaging_distortion(input_model, reference_files):
     # Read in the distortion.
     with DistortionModel(reference_files['distortion']) as dist:
         distortion = dist.model
-    obsfilter = input_model.meta.instrument.filter
+
+    # Check if the transform in the reference file has a ``bounding_box``.
+    # If not set a ``bounding_box`` equal to the size of the image.
+    try:
+        distortion.bounding_box
+    except NotImplementedError:
+        distortion.bounding_box = bounding_box_from_model(input_model)
 
     # Add an offset for the filter
+    obsfilter = input_model.meta.instrument.filter
     with FilteroffsetModel(reference_files['filteroffset']) as filter_offset:
         filters = filter_offset.filters
+
     col_offset = None
     row_offset = None
     for f in filters:
@@ -132,7 +144,6 @@ def lrs(input_model, reference_files):
     Uses the "specwcs" and "distortion" reference files.
 
     """
-
     # Setup the frames.
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
     spec = cf.SpectralFrame(name='wavelength', axes_order=(2,), unit=(u.micron,),
@@ -147,7 +158,8 @@ def lrs(input_model, reference_files):
     with DistortionModel(reference_files['distortion']) as dist:
         distortion = dist.model
 
-    full_distortion = subarray2full | distortion
+    if subarray2full is not None:
+        distortion = subarray2full | distortion
 
     # Load and process the reference data.
     with fits.open(reference_files['specwcs']) as ref:
@@ -180,8 +192,7 @@ def lrs(input_model, reference_files):
     # x.shape will be something like (1, 388)
     y, x = np.mgrid[row_zero_point:row_zero_point + 1, 0:input_model.data.shape[1]]
 
-    #spatial_transform = full_distortion | tel2sky
-    spatial_transform = full_distortion
+    spatial_transform = distortion
     radec = np.array(spatial_transform(x, y))[:, 0, :]
 
     ra_full = np.matlib.repmat(radec[0], _toindex(bb[1][1]) + 1 - _toindex(bb[1][0]), 1)

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -6,7 +6,8 @@ from astropy.modeling.models import Identity, Const1D, Mapping
 import gwcs.coordinate_frames as cf
 
 from . import pointing
-from .util import not_implemented_mode, subarray_transform, velocity_correction
+from .util import (not_implemented_mode, subarray_transform, velocity_correction,
+                   bounding_box_from_model, bounding_box_from_subarray)
 from ..datamodels import (ImageModel, NIRCAMGrismModel, DistortionModel,
                           CubeModel)
 from ..transforms.models import (NIRCAMForwardRowGrismDispersion,
@@ -70,11 +71,12 @@ def imaging(input_model, reference_files):
     v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
+    distortion = imaging_distortion(input_model, reference_files)
     subarray2full = subarray_transform(input_model)
-    imdistortion = imaging_distortion(input_model, reference_files)
-    distortion = subarray2full | imdistortion
-    distortion.bounding_box = imdistortion.bounding_box
-    del imdistortion.bounding_box
+    if subarray2full is not None:
+        distortion = subarray2full | distortion
+        distortion.bounding_box = bounding_box_from_subarray(input_model)
+
     tel2sky = pointing.v23tosky(input_model)
     pipeline = [(detector, distortion),
                 (v2v3, tel2sky),
@@ -103,26 +105,11 @@ def imaging_distortion(input_model, reference_files):
     transform = dist.model
 
     try:
-        bb = transform.bounding_box
+        transform.bounding_box
     except NotImplementedError:
-        shape = input_model.data.shape
-        # Note: Since bounding_box is attached to the model here
-        # it's in reverse order.
-        """
-        A CubeModel is always treated as a stack (in dimension 1)
-        of 2D images, as opposed to actual 3D data. In this case
-        the bounding box is set to the 2nd and 3rd dimension.
-        """
-        if isinstance(input_model, CubeModel):
-            bb = ((-0.5, shape[1] - 0.5),
-                  (-0.5, shape[2] - 0.5))
-        elif isinstance(input_model, ImageModel):
-            bb = ((-0.5, shape[0] - 0.5),
-                  (-0.5, shape[1] - 0.5))
-        else:
-            raise TypeError("Input is not an ImageModel or CubeModel")
-
-        transform.bounding_box = bb
+        # Check if the transform in the reference file has a ``bounding_box``.
+        # If not set a ``bounding_box`` equal to the size of the image.
+        transform.bounding_box = bounding_box_from_model(input_model)
     dist.close()
     return transform
 
@@ -227,10 +214,15 @@ def tsgrism(input_model, reference_files):
 
     # x, y, order in goes to transform to full array location and order
     # get the shift to full frame coordinates
-    sub2full = subarray_transform(input_model) & Identity(1)
-    sub2direct = (sub2full | Mapping((0, 1, 0, 1, 2)) |
-                  (Identity(2) & xcenter & ycenter & Identity(1)) |
-                  det2det)
+    sub_trans = subarray_transform(input_model)
+    if sub_trans is not None:
+        sub2direct = (sub_trans & Identity(1) | Mapping((0, 1, 0, 1, 2)) |
+                      (Identity(2) & xcenter & ycenter & Identity(1)) |
+                      det2det)
+    else:
+        sub2direct = (Mapping((0, 1, 0, 1, 2)) |
+                      (Identity(2) & xcenter & ycenter & Identity(1)) |
+                      det2det)
 
     # take us from full frame detector to v2v3
     distortion = imaging_distortion(input_model, reference_files) & Identity(2)

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -8,14 +8,13 @@ import gwcs.coordinate_frames as cf
 from gwcs import wcs
 
 from .util import (not_implemented_mode, subarray_transform,
-                   velocity_correction)
+                   velocity_correction, bounding_box_from_subarray, bounding_box_from_model)
 from . import pointing
 from ..transforms.models import (NirissSOSSModel,
                                  NIRISSForwardRowGrismDispersion,
                                  NIRISSBackwardGrismDispersion,
                                  NIRISSForwardColumnGrismDispersion)
-from ..datamodels import (ImageModel, NIRISSGrismModel, DistortionModel,
-                          CubeModel)
+from ..datamodels import ImageModel, NIRISSGrismModel, DistortionModel
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -150,19 +149,29 @@ def niriss_soss(input_model, reference_files):
             wl2 = wl3 | velocity_corr
             log.info("Applied Barycentric velocity correction: {}".format(velocity_corr[1].amplitude.value))
 
-    subarray2full = subarray_transform(input_model)
-
     # Reverse the order of inputs passed to Tabular because it's in python order in modeling.
     # Consider changing it in modelng ?
-    cm_order1 = subarray2full | (Mapping((0, 1, 1, 0)) | \
-                                 (Const1D(target_ra) & Const1D(target_dec) & wl1)
-                                 ).rename('Order1')
-    cm_order2 = subarray2full | (Mapping((0, 1, 1, 0)) | \
-                                 (Const1D(target_ra) & Const1D(target_dec) & wl2)
-                                 ).rename('Order2')
-    cm_order3 = subarray2full | (Mapping((0, 1, 1, 0)) | \
-                                 (Const1D(target_ra) & Const1D(target_dec) & wl3)
-                                 ).rename('Order3')
+    cm_order1 = (Mapping((0, 1, 1, 0)) | \
+                 (Const1D(target_ra) & Const1D(target_dec) & wl1)
+                 ).rename('Order1')
+    cm_order2 = (Mapping((0, 1, 1, 0)) | \
+                 (Const1D(target_ra) & Const1D(target_dec) & wl2)
+                 ).rename('Order2')
+    cm_order3 = (Mapping((0, 1, 1, 0)) | \
+                 (Const1D(target_ra) & Const1D(target_dec) & wl3)
+                 ).rename('Order3')
+
+    subarray2full = subarray_transform(input_model)
+    if subarray2full is not None:
+        cm_order1 = subarray2full | cm_order1
+        cm_order2 = subarray2full | cm_order2
+        cm_order3 = subarray2full | cm_order3
+
+        bbox = ((0, input_model.meta.subarray.ysize),
+                (0, input_model.meta.subarray.xsize))
+        cm_order1.bounding_box = bbox
+        cm_order2.bounding_box = bbox
+        cm_order3.bounding_box = bbox
 
     # Define the transforms, they should accept (x,y) and return (ra, dec, lambda)
     soss_model = NirissSOSSModel([1, 2, 3],
@@ -199,18 +208,19 @@ def imaging(input_model, reference_files):
     -----
     It includes three coordinate frames -
     "detector" "v2v3" and "world".
-
     It uses the "distortion" reference file.
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
     v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
+    distortion = imaging_distortion(input_model, reference_files)
+
     subarray2full = subarray_transform(input_model)
-    imdistortion = imaging_distortion(input_model, reference_files)
-    distortion = subarray2full | imdistortion
-    distortion.bounding_box = imdistortion.bounding_box
-    del imdistortion.bounding_box
+    if subarray2full is not None:
+        distortion = subarray2full | distortion
+        distortion.bounding_box = bounding_box_from_subarray(input_model)
+
     tel2sky = pointing.v23tosky(input_model)
     pipeline = [(detector, distortion),
                 (v2v3, tel2sky),
@@ -239,23 +249,7 @@ def imaging_distortion(input_model, reference_files):
         # Check if the model has a bounding box.
         distortion.bounding_box
     except NotImplementedError:
-        shape = input_model.data.shape
-        # Note: Since bounding_box is attached to the model here
-        # it's in reverse order.
-        """
-        A CubeModel is always treated as a stack (in dimension 1)
-        of 2D images, as opposed to actual 3D data. In this case
-        the bounding box is set to the 2nd and 3rd dimension.
-        """
-        if isinstance(input_model, CubeModel):
-            bb = ((-0.5, shape[1] - 0.5),
-                  (-0.5, shape[2] - 0.5))
-        elif isinstance(input_model, ImageModel):
-            bb = ((-0.5, shape[0] - 0.5),
-                  (-0.5, shape[1] - 0.5))
-        else:
-            raise TypeError("Input is not an ImageModel or CubeModel")
-        distortion.bounding_box = bb
+        distortion.bounding_box = bounding_box_from_model(input_model)
 
     dist.close()
     return distortion

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -21,7 +21,7 @@ from gwcs import utils as gwutils
 from . import pointing
 from ..lib.catalog_utils import SkyObject
 from ..transforms.models import GrismObject
-from ..datamodels import WavelengthrangeModel, DataModel
+from ..datamodels import WavelengthrangeModel, DataModel, ImageModel, CubeModel
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -275,18 +275,39 @@ def is_fits(input):
 
 def subarray_transform(input_model):
     """
-    Inputs are in full frame coordinates.
-    If a subarray observation - shift the inputs.
+    Return an offset model if the observation uses a subarray.
 
+    Parameters
+    ----------
+    input_model : `~jwst.datamodels.DataModel`
+        Data model.
+
+    Returns
+    -------
+    subarray2full : `~astropy.modeling.core.Model` or ``None``
+        Returns a (combination of ) ``Shift`` models is a subarray is used.
+        Returns ``None`` if a full frame observation.
     """
+    tr_xstart = astmodels.Identity(1)
+    tr_ystart = astmodels.Identity(1)
+
+    # These quanities are 1-based
     xstart = input_model.meta.subarray.xstart
     ystart = input_model.meta.subarray.ystart
-    if xstart is None:
-        xstart = 1
-    if ystart is None:
-        ystart = 1
-    subarray2full = astmodels.Shift(xstart - 1) & astmodels.Shift(ystart - 1)
-    return subarray2full
+
+    if xstart is not None and xstart != 1:
+        tr_xstart = astmodels.Shift(xstart -1)
+
+    if ystart is not None and ystart != 1:
+        tr_ystart = astmodels.Shift(ystart -1)
+
+    if (isinstance(tr_xstart, astmodels.Identity) and
+        isinstance(tr_ystart, astmodels.Identity)):
+        # the case of a full frame observation
+        return None
+    else:
+        subarray2full = tr_xstart & tr_ystart
+        return subarray2full
 
 
 def not_implemented_mode(input_model, ref):
@@ -649,11 +670,75 @@ def bounding_box_from_shape(shape):
     shape : tuple
         The shape attribute from a `numpy.ndarray` array
 
-    Note: The bounding box of a ``CubeModel`` is the bounding_box of one
-    of the stacked images.
+    Returns
+    -------
+    bbox : tuple
+        Bounding box in y, x order.
     """
     bbox = ((-0.5, shape[-1] - 0.5),
             (-0.5, shape[-2] - 0.5))
+    return bbox
+
+
+def bounding_box_from_model(input_model):
+    """Create a bounding box from the shape of the data base on the model.
+
+    Note: The bounding box of a ``CubeModel`` is the bounding_box
+    of one of the stacked images. A CubeModel is always treated as
+    a stack (in dimension 1) of 2D images, as opposed to actual 3D data.
+    In this case the bounding box is set to the 2nd and 3rd dimension.
+
+    Parameters
+    ----------
+    input_model : `~jwst.datamodels.DataModel`
+        The data model.
+
+    Returns
+    -------
+    bbox : tuple
+        Bounding box in y, x order.
+    """
+    shape = input_model.data.shape
+    if isinstance(input_model, CubeModel):
+        bbox = ((-0.5, shape[1] - 0.5),
+              (-0.5, shape[2] - 0.5))
+    elif isinstance(input_model, ImageModel):
+        bbox = ((-0.5, shape[0] - 0.5),
+              (-0.5, shape[1] - 0.5))
+    else:
+        raise TypeError("Input is not an ImageModel or CubeModel")
+    return bbox
+
+
+def bounding_box_from_subarray(input_model):
+    """Create a bounding box from the subarray size.
+
+    Note: The bounding_box assumes full frame coordinates.
+    It is set to ((ystart, ystart + xsize), (xstart, xstart + xsize)).
+    It is in 0-based coordinates.
+
+    Parameters
+    ----------
+    input_model : `~jwst.datamodels.DataModel`
+        The data model.
+
+    Returns
+    -------
+    bbox : tuple
+        Bounding box in y, x order.
+    """
+    bb_xstart = -0.5
+    bb_xend = -0.5
+    bb_ystart = -0.5
+    bb_yend = -0.5
+
+    if input_model.meta.subarray.xsize is not None:
+        # Implicitely there's bb_xstart + 0.5 and xsize -1 - 0.5
+        bb_xend = input_model.meta.subarray.xsize - 1 - 0.5
+    if input_model.meta.subarray.ysize is not None:
+        bb_yend = input_model.meta.subarray.ysize - 1 - 0.5
+
+    bbox = ((bb_ystart, bb_yend), (bb_xstart, bb_xend))
     return bbox
 
 

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -285,7 +285,7 @@ def subarray_transform(input_model):
     Returns
     -------
     subarray2full : `~astropy.modeling.core.Model` or ``None``
-        Returns a (combination of ) ``Shift`` models is a subarray is used.
+        Returns a (combination of ) ``Shift`` models if a subarray is used.
         Returns ``None`` if a full frame observation.
     """
     tr_xstart = astmodels.Identity(1)


### PR DESCRIPTION
Currently `assign_wcs.util.subarray_transform` returns a `Shift(xstart) & Shift(ystart)` transform  even for full frame observations (`Shift(0) & Shift(0)`. This transform is prepended to the WCS forward transform, e.g. the distortion. In the case of full frame observations this becomes a problem when the bounding box is attached to the transform in the reference file because then it is overwritten. In addition there are two unnecessary transforms prepended to the pipeline. 

This PR changes the logic to:
- if `subarray.xstart` and `subarray.ystart` are not `None` or `1`
  - prepend a transofrm (shift(xtsrat) & Shft(ystart)
  - change the bounding box to ((0, xstart), (0, ystart))
- if one of `xstart` or `ystart` is not None or `1` (e.g. `ystart`
  - prepend Identity(1) & Shift(ystart)
  - change the bounding box to be ((0, xstart), (0, ystart))
- if both are None or `1`:
  - do not prepend transform
  - do not change the bounding box


Related to #1604 