### PR TITLE
Use float64 in coron3 pipeline

### DIFF
--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -222,12 +222,17 @@ def align_models(reference, target, mask):
         # Compute the shifts of the PSF ("target") images relative to
         # the science ("reference") image in this integration, and apply
         # the shifts to the PSF images
-        d, shifts = align_array(reference.data[k], target.data, mask.data)
+        d, shifts = align_array(
+            reference.data[k].astype(np.float64),
+            target.data.astype(np.float64),
+            mask.data)
         output_model.data[k] = d
 
         # Apply the same shifts to the PSF error arrays, if they exist
         if target.err is not None:
-            output_model.err[k] = fourier_imshift(target.err, -shifts)
+            output_model.err[k] = fourier_imshift(
+                target.err.astype(np.float64),
+                -shifts)
 
         # TODO: in the future we need to add shifts and other info (such as
         # slice ID from the reference image to which target was aligned)

--- a/jwst/coron/klip.py
+++ b/jwst/coron/klip.py
@@ -43,14 +43,12 @@ def klip(target_model, refs_model, truncate):
     for i in range(target_model.data.shape[0]):
 
         # Load the target data array and flatten it from 2-D to 1-D
-        target = target_model.data[i]
-        target = target.astype(np.float64)
+        target = target_model.data[i].astype(np.float64)
         tshape = target.shape
         target = target.reshape(-1)
 
         # Load the reference psf arrays and flatten them from 3-D to 2-D
-        refs = refs_model.data[i]
-        refs = refs.astype(np.float64)
+        refs = refs_model.data[i].astype(np.float64)
         rshape = refs.shape
         nrefs = rshape[0]
         refs = refs.reshape(nrefs, rshape[1] * rshape[2])
@@ -69,8 +67,8 @@ def klip(target_model, refs_model, truncate):
         psfimg = np.dot(klvect.T, np.dot(target, klvect.T))
 
         # Subtract the PSF fit from the target image
-        outimg = target - np.mean(target, dtype=np.float64)
-        outimg = outimg - psfimg
+        outimg = target - target.mean()
+        outimg -= psfimg
 
         # Unflatten the PSF and subtracted target images from 1-D to 2-D
         # and copy them to the output models

--- a/jwst/coron/klip_step.py
+++ b/jwst/coron/klip_step.py
@@ -33,7 +33,7 @@ class KlipStep(Step):
             refs_model = datamodels.open(psfrefs)
 
             # Call the KLIP routine
-            (psf_sub, psf_fit) = klip.klip(target_model, refs_model, truncate)
+            psf_sub, psf_fit = klip.klip(target_model, refs_model, truncate)
 
         # Update the step completion status
         psf_sub.meta.cal_step.klip = 'COMPLETE'

--- a/jwst/coron/stack_refs.py
+++ b/jwst/coron/stack_refs.py
@@ -32,7 +32,7 @@ def make_cube(input_models):
             raise ValueError('All PSF exposures must have the same x/y dimensions!')
 
     # Create empty output data arrays of the appropriate dimensions
-    outdata = np.zeros((nints, nrows, ncols), dtype=np.float32)
+    outdata = np.zeros((nints, nrows, ncols), dtype=np.float64)
     outerr = outdata.copy()
     outdq = np.zeros((nints, nrows, ncols), dtype=np.uint32)
 

--- a/jwst/tests_nightly/general/nircam/test_coron3_1.py
+++ b/jwst/tests_nightly/general/nircam/test_coron3_1.py
@@ -6,9 +6,11 @@ from jwst.pipeline import Coron3Pipeline
 
 @pytest.mark.bigdata
 class TestCoron3Pipeline(BaseJWSTTest):
-    rtol = 0.001
+    rtol = 0.00001
     input_loc = 'nircam'
     ref_loc = ['test_coron3', 'truth']
+
+    ignore_fields = ['CAL_VCS', 'CAL_VER']
 
     def test_coron3_1(self):
         """Regression test of calwebb_coron3 pipeline.
@@ -49,18 +51,9 @@ class TestCoron3Pipeline(BaseJWSTTest):
                     'jw9999947001_02102_00002_nrcb3_a3001_crfints.fits',
                     'jw9999947001_02102_00002_nrcb3_a3001_crfints_ref.fits'
                    ),
-                   {'files':( # Compare i2d product
-                            'jw99999-a3001_t1_nircam_f140m-maskbar_i2d.fits',
-                            'jw99999-a3001_t1_nircam_f140m-maskbar_i2d_ref.fits'
-                     ),
-                     'pars': {'ignore_hdus':self.ignore_hdus+['HDRTAB']}
-                   },
-                   {'files':( # Compare the HDRTAB in the i2d product
-                    'jw99999-a3001_t1_nircam_f140m-maskbar_i2d.fits[hdrtab]',
-                    'jw99999-a3001_t1_nircam_f140m-maskbar_i2d_ref.fits[hdrtab]'
-                   ),
-                    'pars': {'ignore_keywords':self.ignore_keywords+['NAXIS1', 'TFORM*'],
-                             'ignore_fields':self.ignore_keywords}
-                   }
+                   ( # Compare i2d product
+                    'jw99999-a3001_t1_nircam_f140m-maskbar_i2d.fits',
+                    'jw99999-a3001_t1_nircam_f140m-maskbar_i2d_ref.fits'
+                   )
                   ]
         self.compare_outputs(outputs)


### PR DESCRIPTION
This is a small change to use double-precision floats where they might be needed in key areas of `Coron3Pipeline`.

This also updates the regression test for this module (which is currently failing).

Hopefully the changes here will make the code more robust to upstream changes in numpy, and make the test more reliable.

Seems to resolve #2893.