### PR TITLE
Don't rename failed test outputs; segregate truth files in test dir

### DIFF
--- a/jwst/tests/compare_outputs.py
+++ b/jwst/tests/compare_outputs.py
@@ -1,7 +1,6 @@
 import copy
 from datetime import datetime
 import os
-import shutil
 from difflib import unified_diff
 from io import StringIO
 

--- a/jwst/tests/compare_outputs.py
+++ b/jwst/tests/compare_outputs.py
@@ -193,9 +193,15 @@ def compare_outputs(outputs, raise_error=True, ignore_keywords=[],
             desired_name = desired
             desired_extn = None
 
+        actual = os.path.abspath(actual)
+
         # Get "truth" image
         try:
+            os.makedirs('truth', exist_ok=True)
+            os.chdir('truth')
             desired = get_bigdata(*input_path, desired_name, docopy=docopy)
+            desired = os.path.abspath(desired)
+            os.chdir('..')
         except BigdataError:
             all_okay = False
             creature_report += '\nERROR: Cannot find {} in {}\n'.format(
@@ -207,7 +213,7 @@ def compare_outputs(outputs, raise_error=True, ignore_keywords=[],
             desired = "{}[{}]".format(desired, desired_extn)
 
         if verbose:
-            print("\nComparing:\n {} \nto\n {}".format(actual, desired))
+            print("\nComparing:\n {}\n {}".format(actual, desired))
 
         if actual.endswith('.fits') and desired.endswith('.fits'):
             # Build HDULists for comparison based on user-specified extensions
@@ -216,8 +222,10 @@ def compare_outputs(outputs, raise_error=True, ignore_keywords=[],
                     with fits.open(desired) as f_des:
                         actual_hdu = fits.HDUList(
                             [f_act[extn] for extn in extn_list])
+                        actual_hdu.filename = lambda: os.path.basename(actual)
                         desired_hdu = fits.HDUList(
                             [f_des[extn] for extn in extn_list])
+                        desired_hdu.filename = lambda: os.path.basename(desired)
                         fdiff = FITSDiff(actual_hdu, desired_hdu,
                                          **diff_kwargs)
                         creature_report += '\na: {}\nb: {}\n'.format(
@@ -245,7 +253,7 @@ def compare_outputs(outputs, raise_error=True, ignore_keywords=[],
                     desired_hdu = f_des[desired_extn]
                     fdiff = HDUDiff(actual_hdu, desired_hdu, **diff_kwargs)
 
-            creature_report += '\na: {}\nb: {}\n'.format(actual, desired)
+            creature_report += 'a: {}\nb: {}\n'.format(actual, desired)
             creature_report += fdiff.report()
 
             if not fdiff.identical:
@@ -331,11 +339,10 @@ def generate_upload_params(results_root, updated_outputs, verbose=True):
     # Write out JSON file to enable retention of different results.
     # Also rename outputs as new truths.
     for test_result, truth in updated_outputs:
-        new_truth = os.path.basename(truth)
-        shutil.move(test_result, new_truth)
-        schema_pattern.append(os.path.abspath(new_truth))
+        schema_pattern.append(test_result)
         if verbose:
-            print("Renamed {} as new 'truth' file: {}".format(
-                os.path.abspath(test_result), os.path.abspath(new_truth)))
+            print("\nFailed comparison:")
+            print("    {}".format(test_result))
+            print("    {}".format(truth))
 
     return schema_pattern, tree, testname


### PR DESCRIPTION
This changes the behavior of our regression tests by turning off renaming the test output to be the new truth file (which currently overwrites the actual truth file).  This also adds a segregated `truth` directory inside the test output dir.

This will make comparing the test output with the truth much easier, as both will be located in the test output directory for failed tests.

Also cleans up the test log to give abspaths to output and truth files, so they can easily be found in the output traceback.