### PR TITLE
Initialize PyArrayObject in carrutils.c

### DIFF
--- a/src/tweakreg/carrutils.c
+++ b/src/tweakreg/carrutils.c
@@ -83,6 +83,7 @@ arrxyzero(PyObject *obj, PyObject *args)
   dimensions[0] = (integer_t)(searchrad*2) + 1;
   dimensions[1] = (integer_t)(searchrad*2) + 1;
   ozpmat = (PyArrayObject *)PyArray_SimpleNew(2, dimensions, NPY_DOUBLE);
+  PyArray_FILLWBYTE(ozpmat, 0);
   if (!ozpmat) {
     goto _exit;
   }


### PR DESCRIPTION
This should fix the problems seen in the following regression test:

https://boyle.stsci.edu:8081/job/RT/job/JWST/lastCompletedBuild/testReport/jwst.tests_nightly.general.nircam.test_nrc_image3_1/TestImage3Pipeline1/test_image3_pipeline2/

Fixes #2982.