### PR TITLE
Fix wfs-image2 regression test

### DIFF
--- a/jwst/tests_nightly/general/nircam/test_nircam_steps_single.py
+++ b/jwst/tests_nightly/general/nircam/test_nircam_steps_single.py
@@ -44,6 +44,8 @@ class TestWFSImage2(BaseJWSTTest):
             output_files.remove(input_name)
         if output_name in output_files:
             output_files.remove(output_name)
+        if "truth" in output_files:
+            output_files.remove("truth")
 
         assert cal_name in output_files
         output_files.remove(cal_name)


### PR DESCRIPTION
PR #2984 caused this test to fail because now the truth files in the test output dir are in a `truth` subdir.  This fixes that.