### PR TITLE
Array should be filled after pointer validity check, not before

### DIFF
--- a/src/tweakreg/carrutils.c
+++ b/src/tweakreg/carrutils.c
@@ -83,10 +83,9 @@ arrxyzero(PyObject *obj, PyObject *args)
   dimensions[0] = (integer_t)(searchrad*2) + 1;
   dimensions[1] = (integer_t)(searchrad*2) + 1;
   ozpmat = (PyArrayObject *)PyArray_SimpleNew(2, dimensions, NPY_DOUBLE);
-  PyArray_FILLWBYTE(ozpmat, 0);
-  if (!ozpmat) {
+  if (!ozpmat)
     goto _exit;
-  }
+  PyArray_FILLWBYTE(ozpmat, 0);
   /* Allocate memory for return matrix */
   zpmat=pymatrix_to_Carrayptrs(ozpmat);
 


### PR DESCRIPTION
The fix in #2948 and #2982 fills the newly allocated arrays before checking the returned pointer thus making the check pointless and the code less reliable.

Pointer check should be moved before array fill operation. 