### PR TITLE
rework spatial transform for the LRS modes

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -66,11 +66,12 @@ def load_wcs(input_model, reference_files={}):
         exclude_types = ['nrc_wfss', 'nrc_tsgrism', 'nis_wfss',
                          'nrs_fixedslit', 'nrs_msaspec',
                          'nrs_autowave', 'nrs_autoflat', 'nrs_lamp',
-                         'nrs_brightobj', 'mir_lrs-fixedslit', 'mir_lrs-slitless',
-                         'nis_soss']
+                         'nrs_brightobj', 'nis_soss']
 
         if output_model.meta.exposure.type.lower() not in exclude_types:
-            if output_model.meta.exposure.type.lower() in IMAGING_TYPES:
+            imaging_types = IMAGING_TYPES.copy()
+            imaging_types.update(['mir_lrs-fixedslit', 'mir_lrs-slitless'])
+            if output_model.meta.exposure.type.lower() in imaging_types:
                 try:
                     update_s_region_imaging(output_model)
                 except Exception as exc:

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -187,9 +187,6 @@ def lrs(input_model, reference_files):
     bb = ((x0.min() - 0.5 + zero_point[0], x1.max() + 0.5 + zero_point[0]),
           (y0.min() - 0.5 + zero_point[1], y0.max() + 0.5 + zero_point[1]))
 
-    # Find the ROW of the zero point which should be the [1] of zero_point
-    row_zero_point = zero_point[1]
-
     # Compute the v2v3 to sky.
     tel2sky = pointing.v23tosky(input_model)
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -161,6 +161,11 @@ def lrs(input_model, reference_files):
     if subarray2full is not None:
         distortion = subarray2full | distortion
 
+    # Incorporate the small rotation
+    angle = np.arctan(0.00421924)
+    rotation = models.Rotation2D(angle)
+    distortion = distortion | rotation
+
     # Load and process the reference data.
     with fits.open(reference_files['specwcs']) as ref:
         lrsdata = np.array([l for l in ref[1].data])
@@ -182,28 +187,27 @@ def lrs(input_model, reference_files):
 
     bb = ((x0.min() - 0.5 + zero_point[0], x1.max() + 0.5 + zero_point[0]),
           (y0.min() - 0.5 + zero_point[1], y0.max() + 0.5 + zero_point[1]))
+
     # Find the ROW of the zero point which should be the [1] of zero_point
     row_zero_point = zero_point[1]
 
     # Compute the v2v3 to sky.
     tel2sky = pointing.v23tosky(input_model)
 
-    # Compute the V2/V3 for each pixel in this row
-    # x.shape will be something like (1, 388)
-    y, x = np.mgrid[row_zero_point:row_zero_point + 1, 0:input_model.data.shape[1]]
+    # Compute the spatial detector to V2V3 transform
+    # Take a row centered on zero_point_y and convert it to v2, v3.
+    # The forward transform uses constant ``y`` values for each ``x``.
+    # The inverse transform uses constant ``v3`` values for each ``v2``.
+    x = np.arange(0, input_model.data.shape[1], dtype=np.float)
+    y = np.zeros(x.shape, dtype=np.float) + row_zero_point
 
-    spatial_transform = distortion
-    radec = np.array(spatial_transform(x, y))[:, 0, :]
+    zero_point_v2v3 = distortion(*zero_point)
 
-    ra_full = np.matlib.repmat(radec[0], _toindex(bb[1][1]) + 1 - _toindex(bb[1][0]), 1)
-    dec_full = np.matlib.repmat(radec[1], _toindex(bb[1][1]) + 1 - _toindex(bb[1][0]), 1)
+    spatial_forward = models.Identity(1) & models.Const1D(zero_point[1]) | distortion
+    spatial_forward.inverse = (models.Identity(1) & models.Const1D(zero_point_v2v3[1]) |
+                               distortion.inverse)
 
-    ra_t2d = models.Tabular2D(lookup_table=ra_full, name='xtable',
-        bounds_error=False, fill_value=np.nan)
-    dec_t2d = models.Tabular2D(lookup_table=dec_full, name='ytable',
-        bounds_error=False, fill_value=np.nan)
-
-    # Create the model transforms.
+    # Create the spectral transforms.
     lrs_wav_model = jwmodels.LRSWavelength(lrsdata, zero_point)
 
     try:
@@ -216,24 +220,12 @@ def lrs(input_model, reference_files):
             lrs_wav_model = lrs_wav_model | velocity_corr
             log.info("Applied Barycentric velocity correction : {}".format(velocity_corr[1].amplitude.value))
 
-    # Incorporate the small rotation
-    angle = np.arctan(0.00421924)
-    rot = models.Rotation2D(angle)
-    radec_t2d = ra_t2d & dec_t2d | rot
-
-    # Account for the subarray when computing spatial coordinates.
-    xshift = -bb[0][0]
-    yshift = -bb[1][0]
-
-    det_to_v23 = models.Mapping((1, 0, 1, 0, 0, 1)) | models.Shift(yshift, name='yshift1') & \
-              models.Shift(xshift, name='xshift1') & \
-              models.Shift(yshift, name='yshift2') & models.Shift(xshift, name='xshift2') & \
-              models.Identity(2) | radec_t2d & lrs_wav_model
+    det_to_v2v3 = models.Mapping((0, 1, 0, 1)) | spatial_forward & lrs_wav_model
+    det_to_v2v3.bounding_box = bb[::-1]
     v23_to_world = tel2sky & models.Identity(1)
-    det_to_v23.bounding_box = bb[::-1]
-    # Now the actual pipeline.
 
-    pipeline = [(detector, det_to_v23),
+    # Now the actual pipeline.
+    pipeline = [(detector, det_to_v2v3),
                 (v2v3, v23_to_world),
                 (world, None)
                 ]

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -8,7 +8,6 @@ from astropy.io import fits
 
 import gwcs.coordinate_frames as cf
 from gwcs import selector
-from gwcs.utils import _toindex
 from . import pointing
 from ..transforms import models as jwmodels
 from .util import (not_implemented_mode, subarray_transform,
@@ -194,13 +193,10 @@ def lrs(input_model, reference_files):
     # Compute the v2v3 to sky.
     tel2sky = pointing.v23tosky(input_model)
 
-    # Compute the spatial detector to V2V3 transform
+    # To compute the spatial detector to V2V3 transform:
     # Take a row centered on zero_point_y and convert it to v2, v3.
     # The forward transform uses constant ``y`` values for each ``x``.
     # The inverse transform uses constant ``v3`` values for each ``v2``.
-    x = np.arange(0, input_model.data.shape[1], dtype=np.float)
-    y = np.zeros(x.shape, dtype=np.float) + row_zero_point
-
     zero_point_v2v3 = distortion(*zero_point)
 
     spatial_forward = models.Identity(1) & models.Const1D(zero_point[1]) | distortion


### PR DESCRIPTION
The MIRI LRS spatial transform is computed for one row,  `x, zero_point_y`, and replicated for all other rows. It was represented as a `Tabular2D` model. This PR changes the representation to use analytical models. It uses the distortion model but passes `zero_point_y` for all y values in the forward transform, e.g.
```
forward = Identity(1) & Const1D(zero_point_y) | distortion
``` 
It assigns a similar inverse which uses `Const1D(zero_point_v3)` as second input.

Note: This assigns an inverse to the spatial transform but not to the spectral. @drlaw1558 has an upcoming PR which changes the representation of the wavelength solution from a lookup table to an analytical model and introduces an inverse of the spectral part of the WCS.

Anyone want to review this?