### PR TITLE
fix examples in documentation

### DIFF
--- a/docs/jwst/assign_wcs/asdf-howto.rst
+++ b/docs/jwst/assign_wcs/asdf-howto.rst
@@ -106,7 +106,16 @@ Create the reference file
 The DictortionModel in jwst.datamodels is used as an example of how to create a reference file. Similarly data models should be used to create other types of reference files as this process provides validaiton of the file structure.
 
 >>> from jwst.datamodels import DistortionModel
->>> dist = DistortionModel(model=model)
+>>> dist = DistortionModel(model=model, strict_validation=True)
+>>> dist.meta.description = "New distortion model"
+>>> dist.meta.author = "INS team"
+>>> dist.meta.useafter = "2012/01/21"
+>>> dist.meta.instrument.name = "MIRI"
+>>> dist .meta.instrument.detector = "MIRIMAGE"
+>>> dist.meta.pedigree = "GROUND"
+>>> dist.meta.reftype = "distortion"
+>>> dist.meta.input_units = "pixel"
+>>> dist.meta.output_units = "arcsec"
 >>> dist.validate()
 >>> dist.save("new_distortion.asdf")
 'new_distortion.asdf'

--- a/docs/jwst/assign_wcs/asdf-howto.rst
+++ b/docs/jwst/assign_wcs/asdf-howto.rst
@@ -41,7 +41,7 @@ They are evaluated by passing the inputs directly, similar
 to the way functions are called. For example,
 
 >>> poly_x = astmodels.Polynomial2D(degree=2, c0_0=.2, c1_0=.11, c2_0=2.3, c0_1=.43, c0_2=.1, c1_1=.5)
->>> poly_x(1, 1)
+>>> poly_x(1, 1)   # doctest: +FLOAT_CMP
     3.639999
 
 Models have their analytical inverse defined if it exists and accessible through the ``inverse`` property.
@@ -50,7 +50,7 @@ An inverse model can also be (re)defined by assigning to the ``inverse`` propert
 >>> rotation = astmodels.Rotation2D(angle=23.4)
 >>> rotation.inverse
     <Rotation2D(angle=-23.4)>
->>> poly_x.inverse = astmodels.Polynomial2D(degree=3, **coeffs)
+>>> poly_x.inverse = astmodels.Polynomial2D(degree=3, **coeffs) # doctest: +SKIP
 
 astropy.modeling also provides the means to combine models in various ways.
 
@@ -68,7 +68,7 @@ sum of the number of inputs of all models.
 as input to the next one, so the number of outputs of one model must be equal to the number
 of inputs to the next one.
 
->>> model = poly_x | shift_x | scale_x
+>>> model = poly_x | shift_x | astmodels.Scale(-2.3)
 >>> model = shift_x & shift_y | poly_x
 
 Two models, ``Mapping`` and ``Identity``, are useful for axes manipulation - dropping
@@ -80,8 +80,8 @@ in ``x`` and ``y``, preceded by a shift in both axes:
 
 >>> poly_y = astmodels.Polynomial2D(degree=2, c0_0=.2, c1_0=1.1, c2_0=.023, c0_1=3, c0_2=.01, c1_1=2.2)
 >>> model = shift_x & shift_y | astmodels.Mapping((0, 1, 0, 1)) | poly_x & poly_y
->>> model(1, 1)
-    (5872.03, 29242.892)
+>>> model(1, 1) # doctest: +FLOAT_CMP
+    (5872.03, 8465.401)
 
 ``Identity`` takes an integer which represents the number of inputs to be passed unchanged.
 This can be useful when one of the inputs does not need more processing. As an example,
@@ -109,7 +109,7 @@ The DictortionModel in jwst.datamodels is used as an example of how to create a 
 >>> dist = DistortionModel(model=model)
 >>> dist.validate()
 >>> dist.save("new_distortion.asdf")
-
+'new_distortion.asdf'
 
 Save a transform to an ASDF file
 --------------------------------

--- a/docs/jwst/assign_wcs/main.rst
+++ b/docs/jwst/assign_wcs/main.rst
@@ -48,6 +48,8 @@ Using the WCS interactively
 Once a FITS file is opened as a `DataModel` the WCS can be accessed as an attribute of the meta object. Calling it as a function with detector positions as inputs returns the
 corresponding world coordinates. Using MIRI LRS fixed slit as an example:
 
+.. doctest-skip::
+   
 >>> from jwst.datamodels import ImageModel
 >>> exp = ImageModel('miri_fixedslit_assign_wcs.fits')
 >>> ra, dec, lam = exp.meta.wcs(x, y)
@@ -61,7 +63,9 @@ the detector) the WCS model also looks for the wavelength and order and returns
 the (x,y) location of that wavelength+order on the dispersed image and the original
 source pixel location, as entered, along with the order that was specified:
 
->>> form jwst.datamodels import ImageModel
+.. doctest-skip::
+   
+>>> from jwst.datamodels import ImageModel
 >>> exp = ImageModel('nircam_wfss_assign_wcs.fits')
 >>> x, y, x0, y0, order = exp.meta.wcs(x0, y0, wavelength, order)
 >>> print(x0, y0, wavelength, order)
@@ -75,7 +79,9 @@ and transforms between any two frames in the WCS pipeline in forward or
 backward direction. For example, for a NIRSpec fixed slits exposure,
 which has been through the extract_2d step:
 
->>> exp = models.MultiSlitModel('nrs1_fixed_assign_wcs_extract_2d.fits')
+.. doctest-skip::
+   
+>>> exp = datamodels.MultiSlitModel('nrs1_fixed_assign_wcs_extract_2d.fits')
 >>> exp.slits[0].meta.wcs.available_frames
     ['detector', 'sca', 'bgwa', 'slit_frame', 'msa_frame', 'ote', 'v2v3', 'world']
 >>> msa2detector = exp.slits[0].meta.wcs.get_transform('msa_frame', 'detector')

--- a/docs/jwst/associations/association_reference.rst
+++ b/docs/jwst/associations/association_reference.rst
@@ -289,6 +289,8 @@ with the ``RegistryMarker.rule`` decorator as follows::
 Then, when the rule file is used to create an ``AssociationRegistry``,
 the class ``MyRule`` will be included as one of the available rules::
 
+.. doctest-skip::
+   
   >>> from jwst.associations import AssociationRegistry
   >>> registry = AssociationRegistry('myrules.py', include_default=False)
   >>> print(registry)

--- a/docs/jwst/datamodels/metadata.rst
+++ b/docs/jwst/datamodels/metadata.rst
@@ -16,7 +16,7 @@ string will raise an exception::
 
     >>> from jwst.datamodels import ImageModel
     >>> model = ImageModel()
-    >>> model.meta.target.ra = "foo"
+    >>> model.meta.target.ra = "foo"    # doctest: +SKIP
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File "site-packages/jwst.datamodels/schema.py", line 672, in __setattr__
@@ -36,16 +36,41 @@ substring in metadata names as well as their documentation.  The
 search is case-insensitive::
 
     >>> from jwst.datamodels import ImageModel
-    # Create a model of the desired type
+    >>> # Create a model of the desired type
     >>> model = ImageModel()
-    # Call `search_schema` on it to find possibly related elements.
+    >>> # Call `search_schema` on it to find possibly related elements.
     >>> model.search_schema('target')
-    target: Information about the target
-    target.dec: DEC of the target
-    target.name: Standard astronomical catalog name for the target
-    target.proposer: Proposer's name for the target
-    target.ra: RA of the target
-    target.type: Fixed target, moving target, or generic target
+    meta.target
+    <BLANKLINE>
+    meta.target.catalog_name
+    <BLANKLINE>
+    meta.target.dec
+    <BLANKLINE>
+    meta.target.dec_uncertainty
+    <BLANKLINE>
+    meta.target.proper_motion_dec
+    <BLANKLINE>
+    meta.target.proper_motion_epoch
+    <BLANKLINE>
+    meta.target.proper_motion_ra
+    <BLANKLINE>
+    meta.target.proposer_dec
+    <BLANKLINE>
+    meta.target.proposer_name
+    <BLANKLINE>
+    meta.target.proposer_ra
+    <BLANKLINE>
+    meta.target.ra
+    <BLANKLINE>
+    meta.target.ra_uncertainty
+    <BLANKLINE>
+    meta.target.source_type
+    <BLANKLINE>
+    meta.target.type
+    <BLANKLINE>
+    meta.visit.internal_target
+    <BLANKLINE>
+
 
 An alternative method to get and set metadata values is to use a
 dot-separated name as a dictionary lookup.  This is useful for
@@ -70,16 +95,19 @@ list of transformation objects, each of which has a `type` (string)
 and a `coeff` (number) member.  We can assign elements to the list in
 the following equivalent ways::
 
+.. doctest-skip::
+
     >>> trans = model.meta.transformations.item()
     >>> trans.type = 'SIN'
     >>> trans.coeff = 42.0
     >>> model.meta.transformations.append(trans)
-
     >>> model.meta.transformations.append({'type': 'SIN', 'coeff': 42.0})
 
 When accessing the items of the list, the result is a normal metadata
 object where the attributes are type-checked::
 
+.. doctest-skip::
+  
     >>> trans = model.meta.transformations[0]
     >>> print(trans)
     <jwst.datamodels.schema.Transformations object at 0x123a810>

--- a/docs/jwst/datamodels/models.rst
+++ b/docs/jwst/datamodels/models.rst
@@ -228,7 +228,7 @@ There is a convenience method, `find_fits_keyword` to find where a
 FITS keyword is used in the metadata tree::
 
     >>> from jwst.datamodels import DataModel
-    # First, create a model of the desired type
+    >>> # First, create a model of the desired type
     >>> model = DataModel()
     >>> model.find_fits_keyword('DATE-OBS')
     [u'meta.observation.date']

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -41,7 +41,7 @@ in the case of NIRSpec FS exposure or any of the slitlet names in the case of th
 To find out what slits are available for extraction:
 
   >>> from jwst.assign_wcs import nirspec
-  >>> nirspec.get_open_slits(input_model)
+  >>> nirspec.get_open_slits(input_model) # doctest: +SKIP
 
 
 The corner locations of the regions to be extracted are determined from the

--- a/docs/jwst/references_general/photom_reffile.rst
+++ b/docs/jwst/references_general/photom_reffile.rst
@@ -238,17 +238,17 @@ which contains the columns of information unique to that instrument.
 A NIRISS photom reference file, for example, could be constructed as follows
 from within the python environment::
 
- >>> from jwst import models
+ >>> from jwst import datamodels
  >>> import numpy as np
- >>> output=models.NirissPhotomModel()
- >>> filter=np.array(['F277W','F356W','CLEAR'])
- >>> pupil=np.array(['CLEARP','CLEARP','F090W'])
- >>> photf=np.array([1.e-15,2.e-15,3.e-15])
- >>> uncer=np.array([1.e-17,2.e-17,3.e-17])
- >>> nelem=np.zeros(3)
- >>> wave=np.zeros(3)
- >>> resp=np.zeros(3)
- >>> data=np.array(list(zip(filter,pupil,photf,uncer,nelem,wave,resp)),dtype=output.phot_table.dtype)
+ >>> output = datamodels.NirissPhotomModel()
+ >>> filter = np.array(['F277W','F356W','CLEAR'])
+ >>> pupil = np.array(['CLEARP','CLEARP','F090W'])
+ >>> photf = np.array([1.e-15,2.e-15,3.e-15])
+ >>> uncer = np.array([1.e-17,2.e-17,3.e-17])
+ >>> nelem = np.zeros(3)
+ >>> wave = np.zeros(3)
+ >>> resp = np.zeros(3)
+ >>> data = np.array(list(zip(filter,pupil,photf,uncer,nelem,wave,resp)),dtype=output.phot_table.dtype)
  >>> output.phot_table=data
  >>> output.save('niriss_photom_0001.fits')
 

--- a/docs/jwst/references_general/photom_reffile.rst
+++ b/docs/jwst/references_general/photom_reffile.rst
@@ -245,10 +245,12 @@ from within the python environment::
  >>> pupil = np.array(['CLEARP','CLEARP','F090W'])
  >>> photf = np.array([1.e-15,2.e-15,3.e-15])
  >>> uncer = np.array([1.e-17,2.e-17,3.e-17])
- >>> nelem = np.zeros(3)
- >>> wave = np.zeros(3)
- >>> resp = np.zeros(3)
- >>> data = np.array(list(zip(filter,pupil,photf,uncer,nelem,wave,resp)),dtype=output.phot_table.dtype)
- >>> output.phot_table=data
+ >>> nelem = np.zeros(3, dtype=np.int16)
+ >>> wave = np.zeros((3, 5000))
+ >>> resp = np.zeros((3, 5000))
+ >>> order = np.array([1, 2, 3], dtype=np.int16)
+ >>> data = np.array(list(zip(filter, pupil, order, photf, uncer, nelem, wave, resp)), dtype=output.phot_table.dtype)
+ >>> output.phot_table = data
  >>> output.save('niriss_photom_0001.fits')
+ 'niriss_photom_0001.fits'
 

--- a/docs/jwst/stpipe/devel_io_design.rst
+++ b/docs/jwst/stpipe/devel_io_design.rst
@@ -96,16 +96,16 @@ the result will be saved in a file called::
 Similarly, the same code can be used in a Python script or interactive
 environment as follows::
 
+.. doctest-skip:: 
+  >>> import jwst
   >>> input = jwst.datamodels.open('input_data.fits')
   >>> result = MyStep.call(input)
-
       # `result` contains the resulting data
       # which can then be used by further `Steps`'s or
       # other functions.
       #
       # when done, the data can be saved with the `DataModel.save`
       # method
-
   >>> result.save('my_final_results.fits')
 
 

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -65,6 +65,8 @@ configspec for an imaginary step called `stpipe.cleanup`::
     Configspec information can also be displayed from Python, just
     call ``print_configspec`` on any Step class::
 
+.. doctest-skip::
+   
     >>> from jwst.stpipe import cleanup
     >>> cleanup.print_configspec()
     # The threshold below which to apply cleanup

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -65,13 +65,13 @@ configspec for an imaginary step called `stpipe.cleanup`::
     Configspec information can also be displayed from Python, just
     call ``print_configspec`` on any Step class::
 
-        >>> from jwst.stpipe import cleanup
-        >>> cleanup.print_configspec()
-        # The threshold below which to apply cleanup
-        threshold = float()
+    >>> from jwst.stpipe import cleanup
+    >>> cleanup.print_configspec()
+    # The threshold below which to apply cleanup
+    threshold = float()
 
-        # A scale factor
-        scale = float()
+    # A scale factor
+    scale = float()
 
 Using this information, one can write a configuration file to use this
 step.  For example, here is a configuration file (``do_cleanup.cfg``)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ exclude = jwst/extern,docs,jwst/associations,jwst/jwpsf,jwst/ramp_fitting, jwst/
 
 [tool:pytest]
 minversion = 3
-addopts = --ignore=build
+addopts = --ignore=build, --doctest-rst
 norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern scripts
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 doctest_plus = enabled


### PR DESCRIPTION
Fixes #2806 
 I am not familiar enough with the code to fix the remaining issues.

Perhaps @jdavies-st or @stscieisenhamer 
```
067 
068     >>> from jwst.stpipe import cleanup
UNEXPECTED EXCEPTION: ImportError("cannot import name 'cleanup'",)
Traceback (most recent call last):
  File "/anaconda3/envs/jwstdev/lib/python3.6/doctest.py", line 1330, in __run
    compileflags, 1), test.globs
  File "<doctest user_step.rst[0]>", line 1, in <module>
ImportError: cannot import name 'cleanup'

/Users/dencheva/dev/jwst/docs/jwst/stpipe/user_step.rst:68: UnexpectedException
```

@hbushouse or @philhodge for this one? I think an `order` field is missing. What would be 
correct values in this case?

```
__________ [doctest] docs/jwst/references_general/photom_reffile.rst ___________
242  >>> import numpy as np
243  >>> output = datamodels.NirissPhotomModel()
244  >>> filter = np.array(['F277W','F356W','CLEAR'])
245  >>> pupil = np.array(['CLEARP','CLEARP','F090W'])
246  >>> photf = np.array([1.e-15,2.e-15,3.e-15])
247  >>> uncer = np.array([1.e-17,2.e-17,3.e-17])
248  >>> nelem = np.zeros(3)
249  >>> wave = np.zeros(3)
250  >>> resp = np.zeros(3)
251  >>> data = np.array(list(zip(filter,pupil,photf,uncer,nelem,wave,resp)),dtype=output.phot_table.dtype)
UNEXPECTED EXCEPTION: ValueError('could not assign tuple of length 7 to structure with 8 fields.',)
Traceback (most recent call last):
  File "<doctest photom_reffile.rst[10]>", line 1, in <module>
ValueError: could not assign tuple of length 7 to structure with 8 fields.
/Users/dencheva/dev/jwst/docs/jwst/references_general/photom_reffile.rst:251: UnexpectedException
```

@stscieisenhamer Has the signature changed? Or should we skip testing this code piece?
```
289 Then, when the rule file is used to create an ``AssociationRegistry``,
290 the class ``MyRule`` will be included as one of the available rules::
291 
292   >>> from jwst.associations import AssociationRegistry
293   >>> registry = AssociationRegistry('myrules.py', include_default=False)
UNEXPECTED EXCEPTION: ModuleNotFoundError("No module named 'm'",)
Traceback (most recent call last):
  File "/anaconda3/envs/jwstdev/lib/python3.6/doctest.py", line 1330, in __run
    compileflags, 1), test.globs)
  File "<doctest association_reference.rst[1]>", line 1, in <module>
  File "/Users/dencheva/dev/jwst/jwst/associations/registry.py", line 125, in __init__
    module = import_from_file(fname)
  File "/Users/dencheva/dev/jwst/jwst/associations/registry.py", line 496, in import_from_file
    module = import_module(module_name)
  File "/anaconda3/envs/jwstdev/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'm'
/Users/dencheva/dev/jwst/docs/jwst/associations/association_reference.rst:293: UnexpectedException
```