### PR TITLE
Set allow_default=True in set_telescope_pointing regression test

### DIFF
--- a/jwst/tests_nightly/general/miri/test_miri_steps_single.py
+++ b/jwst/tests_nightly/general/miri/test_miri_steps_single.py
@@ -291,7 +291,7 @@ class TestMIRISetPointing(BaseJWSTTest):
                                     docopy=True  # always produce local copy
                               )
 
-        add_wcs(input_file)
+        add_wcs(input_file, allow_default=True)
 
         outputs = [(input_file,
                     'jw80600010001_02101_00001_mirimage_uncal_ref.fits')]


### PR DESCRIPTION
The regression test

https://boyle.stsci.edu:8081/job/RT/job/JWST/93/testReport/junit/jwst.tests_nightly.general.miri.test_miri_steps_single/TestMIRISetPointing/test_miri_setpointing/

was failing because pointing mnemonics are not available in the database for the dates of this observation.  A default pointing will be generated based on the target RA/Dec only if `allow_defaults=True` is set.  It is `False` by default.