### PR TITLE
Treat RuntimeWarnings from spherical_geometry as RuntimeErrors in tweakreg

### DIFF
--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -115,7 +115,7 @@ class TweakRegStep(Step):
             self.skip = True
             for model in images:
                 model.meta.cal_step.tweakreg = "SKIPPED"
-            return input
+            return images
 
         # create a list of WCS-Catalog-Images Info and/or their Groups:
         imcats = []
@@ -124,7 +124,17 @@ class TweakRegStep(Step):
                 raise AssertionError("Logical error in the pipeline code.")
 
             wcsimlist = list(map(self._imodel2wcsim, g))
-            wgroup = WCSGroupCatalog(wcsimlist, name=wcsimlist[0].name)
+            try:
+                wgroup = WCSGroupCatalog(wcsimlist, name=wcsimlist[0].name)
+            except RuntimeError:
+                self.log.info("There was a problem computing the union "
+                    "of polygons in spherical_geometry.  Aborting.")
+                self.log.info("Step skipped.")
+                self.skip = True
+                for model in images:
+                    model.meta.cal_step.tweakreg = "SKIPPED"
+                return images
+
             imcats.append(wgroup)
 
         # align images:

--- a/jwst/tweakreg/wcsimage.py
+++ b/jwst/tweakreg/wcsimage.py
@@ -12,6 +12,7 @@ of image WCS.
 import logging
 import numpy as np
 from copy import deepcopy
+import warnings
 
 # THIRD-PARTY
 import gwcs
@@ -806,7 +807,12 @@ class WCSGroupCatalog():
         if len(polygons) == 0:
             self._polygon = SphericalPolygon([])
         else:
-            self._polygon = SphericalPolygon.multi_union(polygons)
+            try:
+                warnings.filterwarnings("error", category=RuntimeWarning)
+                self._polygon = SphericalPolygon.multi_union(polygons)
+                warnings.resetwarnings()
+            except RuntimeWarning:
+                raise RuntimeError
 
     def __len__(self):
         return len(self._images)


### PR DESCRIPTION
Resolves #3009.

The dataset from that issue now runs through the pipeline without problems - `tweakreg` is skipped.