### PR TITLE
make bounding_box clearer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ assign_wcs
  - Refactored how the pipeline handles subarrays in the WCS. Fixed a bug
    where the bounding box was overwritten in full frame mode. [#2980]
 
+ - Rename several functions dealing with calculating bounding boxes for clarity [#3014]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -8,7 +8,7 @@ from astropy import coordinates as coord
 from gwcs import coordinate_frames as cf
 
 from .util import (not_implemented_mode, subarray_transform,
-                   bounding_box_from_model, bounding_box_from_subarray)
+                   transform_bbox_from_datamodel, bounding_box_from_subarray)
 from . import pointing
 from ..datamodels import DistortionModel
 
@@ -94,7 +94,7 @@ def imaging_distortion(input_model, reference_files):
     try:
         transform.bounding_box
     except NotImplementedError:
-        transform.bounding_box = bounding_box_from_model(input_model)
+        transform.bounding_box = transform_bbox_from_datamodel(input_model)
     dist.close()
     return transform
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -11,7 +11,7 @@ from gwcs import selector
 from . import pointing
 from ..transforms import models as jwmodels
 from .util import (not_implemented_mode, subarray_transform,
-                   velocity_correction, bounding_box_from_model, bounding_box_from_subarray)
+                   velocity_correction, transform_bbox_from_model, bounding_box_from_subarray)
 from ..datamodels import (DistortionModel, FilteroffsetModel,
                           DistortionMRSModel, WavelengthrangeModel,
                           RegionsModel, SpecwcsModel)
@@ -114,7 +114,7 @@ def imaging_distortion(input_model, reference_files):
     try:
         distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = bounding_box_from_model(input_model)
+        distortion.bounding_box = transform_bbox_from_model(input_model)
 
     # Add an offset for the filter
     obsfilter = input_model.meta.instrument.filter

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -11,7 +11,7 @@ from gwcs import selector
 from . import pointing
 from ..transforms import models as jwmodels
 from .util import (not_implemented_mode, subarray_transform,
-                   velocity_correction, transform_bbox_from_model, bounding_box_from_subarray)
+                   velocity_correction, transform_bbox_from_datamodel, bounding_box_from_subarray)
 from ..datamodels import (DistortionModel, FilteroffsetModel,
                           DistortionMRSModel, WavelengthrangeModel,
                           RegionsModel, SpecwcsModel)
@@ -114,7 +114,7 @@ def imaging_distortion(input_model, reference_files):
     try:
         distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = transform_bbox_from_model(input_model)
+        distortion.bounding_box = transform_bbox_from_datamodel(input_model)
 
     # Add an offset for the filter
     obsfilter = input_model.meta.instrument.filter

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -7,7 +7,7 @@ import gwcs.coordinate_frames as cf
 
 from . import pointing
 from .util import (not_implemented_mode, subarray_transform, velocity_correction,
-                   bounding_box_from_model, bounding_box_from_subarray)
+                   transform_bbox_from_datamodel, bounding_box_from_subarray)
 from ..datamodels import (ImageModel, NIRCAMGrismModel, DistortionModel,
                           CubeModel)
 from ..transforms.models import (NIRCAMForwardRowGrismDispersion,
@@ -109,7 +109,7 @@ def imaging_distortion(input_model, reference_files):
     except NotImplementedError:
         # Check if the transform in the reference file has a ``bounding_box``.
         # If not set a ``bounding_box`` equal to the size of the image.
-        transform.bounding_box = bounding_box_from_model(input_model)
+        transform.bounding_box = transform_bbox_from_datamodel(input_model)
     dist.close()
     return transform
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -8,7 +8,7 @@ import gwcs.coordinate_frames as cf
 from gwcs import wcs
 
 from .util import (not_implemented_mode, subarray_transform,
-                   velocity_correction, bounding_box_from_subarray, bounding_box_from_model)
+                   velocity_correction, bounding_box_from_subarray, transform_bbox_from_datamodel)
 from . import pointing
 from ..transforms.models import (NirissSOSSModel,
                                  NIRISSForwardRowGrismDispersion,
@@ -249,7 +249,7 @@ def imaging_distortion(input_model, reference_files):
         # Check if the model has a bounding box.
         distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = bounding_box_from_model(input_model)
+        distortion.bounding_box = transform_bbox_from_datamodel(input_model)
 
     dist.close()
     return distortion

--- a/jwst/assign_wcs/tests/test_util.py
+++ b/jwst/assign_wcs/tests/test_util.py
@@ -11,7 +11,7 @@ from astropy.table import QTable
 from ...lib.catalog_utils import SkyObject
 from ... import datamodels
 
-from ..util import (get_object_info, bounding_box_from_shape,
+from ..util import (get_object_info, bounding_box_for_wcs,
                     subarray_transform, bounding_box_from_model,
                     bounding_box_from_subarray)
 
@@ -27,19 +27,19 @@ def get_file_path(filename):
     return os.path.join(data_path, filename)
 
 
-def test_bounding_box_from_shape_2d():
+def test_bounding_box_for_wcs_2d():
     model = datamodels.ImageModel((512, 2048))
-    bb = bounding_box_from_shape(model.data.shape)
+    bb = bounding_box_for_wcs(model.data.shape)
     assert bb == ((-0.5, 2047.5), (-0.5, 511.5))
 
 
-def test_bounding_box_from_shape_3d():
+def test_bounding_box_for_wcs_3d():
     model = datamodels.CubeModel((3, 32, 2048))
-    bb = bounding_box_from_shape(model.data.shape)
+    bb = bounding_box_for_wcs(model.data.shape)
     assert bb == ((-0.5, 2047.5), (-0.5, 31.5))
 
     model = datamodels.IFUCubeModel((750, 45, 50))
-    bb = bounding_box_from_shape(model.data.shape)
+    bb = bounding_box_for_wcs(model.data.shape)
     assert bb == ((-0.5, 49.5), (-0.5, 44.5))
 
 

--- a/jwst/assign_wcs/tests/test_util.py
+++ b/jwst/assign_wcs/tests/test_util.py
@@ -11,9 +11,9 @@ from astropy.table import QTable
 from ...lib.catalog_utils import SkyObject
 from ... import datamodels
 
-from ..util import (get_object_info, bounding_box_for_wcs,
-                    subarray_transform, bounding_box_from_model,
-                    bounding_box_from_subarray)
+from ..util import (get_object_info, wcs_bbox_from_shape,
+                    subarray_transform, transform_bbox_from_datamodel,
+                    bounding_box_from_subarray, transform_bbox_from_shape)
 
 from . import data
 
@@ -27,19 +27,25 @@ def get_file_path(filename):
     return os.path.join(data_path, filename)
 
 
-def test_bounding_box_for_wcs_2d():
+def test_transform_bbox_from_shape_2d():
     model = datamodels.ImageModel((512, 2048))
-    bb = bounding_box_for_wcs(model.data.shape)
+    bb = transform_bbox_from_shape(model.data.shape)
+    assert bb == ((-0.5, 511.5), (-0.5, 2047.5))
+
+
+def test_wcs_bbox_from_shape_2d():
+    model = datamodels.ImageModel((512, 2048))
+    bb = wcs_bbox_from_shape(model.data.shape)
     assert bb == ((-0.5, 2047.5), (-0.5, 511.5))
 
 
-def test_bounding_box_for_wcs_3d():
+def test_wcs_bbox_from_shape_3d():
     model = datamodels.CubeModel((3, 32, 2048))
-    bb = bounding_box_for_wcs(model.data.shape)
+    bb = wcs_bbox_from_shape(model.data.shape)
     assert bb == ((-0.5, 2047.5), (-0.5, 31.5))
 
     model = datamodels.IFUCubeModel((750, 45, 50))
-    bb = bounding_box_for_wcs(model.data.shape)
+    bb = wcs_bbox_from_shape(model.data.shape)
     assert bb == ((-0.5, 49.5), (-0.5, 44.5))
 
 
@@ -85,15 +91,15 @@ def test_subarray_transform():
     assert isinstance(transform[1], Shift) and transform[1].offset == 4
 
 
-def test_bounding_box_from_model():
+def test_transform_bbox_from_datamodel():
     im = datamodels.ImageModel()
     im.data = np.zeros((45, 36))
 
     cube = datamodels.CubeModel()
     cube.data = np.zeros((3, 45, 36))
 
-    assert bounding_box_from_model(im) == ((-.5, 44.5), (-.5, 35.5))
-    assert bounding_box_from_model(cube) == ((-.5, 44.5), (-.5, 35.5))
+    assert transform_bbox_from_datamodel(im) == ((-.5, 44.5), (-.5, 35.5))
+    assert transform_bbox_from_datamodel(cube) == ((-.5, 44.5), (-.5, 35.5))
 
 
 def test_bounding_box_from_subarray():

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -662,8 +662,10 @@ def get_num_msa_open_shutters(shutter_state):
     return num
 
 
-def bounding_box_from_shape(shape):
+def bounding_box_for_transform(shape):
     """Create a bounding box from the shape of the data.
+
+    This is appropriate to attached to a transform.
 
     Parameters
     ----------
@@ -674,6 +676,25 @@ def bounding_box_from_shape(shape):
     -------
     bbox : tuple
         Bounding box in y, x order.
+    """
+    bbox = ((-0.5, shape[0] - 0.5),
+            (-0.5, shape[1] - 0.5))
+    return bbox
+
+
+def bounding_box_for_wcs(shape):
+    """Create a bounding box from the shape of the data.
+
+    This is appropriate to attach to a wcs object
+    Parameters
+    ----------
+    shape : tuple
+        The shape attribute from a `numpy.ndarray` array
+
+    Returns
+    -------
+    bbox : tuple
+        Bounding box in x, y order.
     """
     bbox = ((-0.5, shape[-1] - 0.5),
             (-0.5, shape[-2] - 0.5))
@@ -750,7 +771,7 @@ def update_s_region_imaging(model):
     bbox = model.meta.wcs.bounding_box
 
     if bbox is None:
-        bbox = bounding_box_from_shape(model.data.shape)
+        bbox = bounding_box_for_wcs(model.data.shape)
 
     # footprint is an array of shape (2, 4) as we
     # are interested only in the footprint on the sky
@@ -772,7 +793,7 @@ def update_s_region_spectral(model):
 
     bbox = swcs.bounding_box
     if bbox is None:
-        bbox = bounding_box_from_shape(model.data.shape)
+        bbox = bounding_box_for_wcs(model.data.shape)
 
     x, y = grid_from_bounding_box(bbox)
     ra, dec, lam = swcs(x, y)

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -662,7 +662,7 @@ def get_num_msa_open_shutters(shutter_state):
     return num
 
 
-def bounding_box_for_transform(shape):
+def transform_bbox_from_shape(shape):
     """Create a bounding box from the shape of the data.
 
     This is appropriate to attached to a transform.
@@ -682,7 +682,7 @@ def bounding_box_for_transform(shape):
     return bbox
 
 
-def bounding_box_for_wcs(shape):
+def wcs_bbox_from_shape(shape):
     """Create a bounding box from the shape of the data.
 
     This is appropriate to attach to a wcs object
@@ -701,7 +701,7 @@ def bounding_box_for_wcs(shape):
     return bbox
 
 
-def bounding_box_from_model(input_model):
+def transform_bbox_from_datamodel(input_model):
     """Create a bounding box from the shape of the data base on the model.
 
     Note: The bounding box of a ``CubeModel`` is the bounding_box
@@ -771,7 +771,7 @@ def update_s_region_imaging(model):
     bbox = model.meta.wcs.bounding_box
 
     if bbox is None:
-        bbox = bounding_box_for_wcs(model.data.shape)
+        bbox = wcs_bbox_from_shape(model.data.shape)
 
     # footprint is an array of shape (2, 4) as we
     # are interested only in the footprint on the sky
@@ -793,7 +793,7 @@ def update_s_region_spectral(model):
 
     bbox = swcs.bounding_box
     if bbox is None:
-        bbox = bounding_box_for_wcs(model.data.shape)
+        bbox = wcs_bbox_from_shape(model.data.shape)
 
     x, y = grid_from_bounding_box(bbox)
     ra, dec, lam = swcs(x, y)

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -191,7 +191,7 @@ def extract_tso_object(input_model,
             output_model.err = ext_err
             output_model.dq = ext_dq
             output_model.meta.wcs = subwcs
-            output_model.meta.wcs.bounding_box = util.bounding_box_from_shape(ext_data.shape)
+            output_model.meta.wcs.bounding_box = util.bounding_box_for_wcs(ext_data.shape)
             output_model.meta.wcs.crpix2 = 34  # update for the move, vals are the same
             output_model.meta.wcsinfo.spectral_order = order
             output_model.name = str('TSO object')
@@ -373,7 +373,7 @@ def extract_grism_objects(input_model,
                 ext_err = input_model.err[ymin: ymax + 1, xmin: xmax + 1].copy()
                 ext_dq = input_model.dq[ymin: ymax + 1, xmin: xmax + 1].copy()
 
-                tr.bounding_box = util.bounding_box_from_shape(ext_data.shape)
+                tr.bounding_box = util.bounding_box_for_transform(ext_data.shape)
                 subwcs.set_transform('grism_detector', 'detector', tr)
 
                 new_slit = datamodels.SlitModel(data=ext_data, err=ext_err, dq=ext_dq)

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -191,7 +191,7 @@ def extract_tso_object(input_model,
             output_model.err = ext_err
             output_model.dq = ext_dq
             output_model.meta.wcs = subwcs
-            output_model.meta.wcs.bounding_box = util.bounding_box_for_wcs(ext_data.shape)
+            output_model.meta.wcs.bounding_box = util.wcs_bbox_from_shape(ext_data.shape)
             output_model.meta.wcs.crpix2 = 34  # update for the move, vals are the same
             output_model.meta.wcsinfo.spectral_order = order
             output_model.name = str('TSO object')
@@ -373,7 +373,7 @@ def extract_grism_objects(input_model,
                 ext_err = input_model.err[ymin: ymax + 1, xmin: xmax + 1].copy()
                 ext_dq = input_model.dq[ymin: ymax + 1, xmin: xmax + 1].copy()
 
-                tr.bounding_box = util.bounding_box_for_transform(ext_data.shape)
+                tr.bounding_box = util.transform_bbox_from_shape(ext_data.shape)
                 subwcs.set_transform('grism_detector', 'detector', tr)
 
                 new_slit = datamodels.SlitModel(data=ext_data, err=ext_err, dq=ext_dq)

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -246,7 +246,7 @@ def extract_slit(input_model, slit, exp_type):
         raise ValueError("extract_2d does not work with "
                          "{0} dimensional data".format(ndim))
 
-    slit_wcs.bounding_box = util.bounding_box_from_shape(ext_data.shape)
+    slit_wcs.bounding_box = util.bounding_box_for_wcs(ext_data.shape)
 
     # compute wavelengths
     x, y = wcstools.grid_from_bounding_box(slit_wcs.bounding_box, step=(1, 1))

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -246,7 +246,7 @@ def extract_slit(input_model, slit, exp_type):
         raise ValueError("extract_2d does not work with "
                          "{0} dimensional data".format(ndim))
 
-    slit_wcs.bounding_box = util.bounding_box_for_wcs(ext_data.shape)
+    slit_wcs.bounding_box = util.wcs_bbox_from_shape(ext_data.shape)
 
     # compute wavelengths
     x, y = wcstools.grid_from_bounding_box(slit_wcs.bounding_box, step=(1, 1))

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -178,7 +178,7 @@ class ResampleSpecData:
         # turn the size into a numpy shape in (y, x) order
         self.data_size = tuple(output_array_size[::-1])
 
-        bounding_box = resample_utils.bounding_box_for_wcs(self.data_size)
+        bounding_box = resample_utils.wcs_bbox_from_shape(self.data_size)
         output_wcs.bounding_box = bounding_box
 
         return output_wcs
@@ -215,7 +215,7 @@ class ResampleSpecData:
             output_model = self.blank_output.copy()
             output_model.meta.wcs = self.output_wcs
 
-            bb = resample_utils.bounding_box_for_wcs(output_model.data.shape)
+            bb = resample_utils.wcs_bbox_from_shape(output_model.data.shape)
             output_model.meta.wcs.bounding_box = bb
             output_model.meta.filename = obs_product
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -178,7 +178,7 @@ class ResampleSpecData:
         # turn the size into a numpy shape in (y, x) order
         self.data_size = tuple(output_array_size[::-1])
 
-        bounding_box = resample_utils.bounding_box_from_shape(self.data_size)
+        bounding_box = resample_utils.bounding_box_for_wcs(self.data_size)
         output_wcs.bounding_box = bounding_box
 
         return output_wcs
@@ -215,7 +215,7 @@ class ResampleSpecData:
             output_model = self.blank_output.copy()
             output_model.meta.wcs = self.output_wcs
 
-            bb = resample_utils.bounding_box_from_shape(output_model.data.shape)
+            bb = resample_utils.bounding_box_for_wcs(output_model.data.shape)
             output_model.meta.wcs.bounding_box = bb
             output_model.meta.filename = obs_product
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -8,7 +8,7 @@ from gwcs import WCS, wcstools
 
 from stsci.tools.bitmask import interpret_bit_flags
 
-from ..assign_wcs.util import wcs_from_footprints, bounding_box_from_shape
+from ..assign_wcs.util import wcs_from_footprints, bounding_box_for_wcs
 
 import logging
 log = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ def make_output_wcs(input_models):
     wcslist = [i.meta.wcs for i in input_models]
     for w, i in zip(wcslist, input_models):
         if w.bounding_box is None:
-            w.bounding_box = bounding_box_from_shape(i.data.shape)
+            w.bounding_box = bounding_box_for_wcs(i.data.shape)
     naxes = wcslist[0].output_frame.naxes
 
     if naxes == 3:
@@ -99,7 +99,7 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, shape=None):
     """ Return a pixel grid map from input frame to output frame.
     """
     if shape:
-        bb = bounding_box_from_shape(shape)
+        bb = bounding_box_for_wcs(shape)
         log.debug("Bounding box from data shape: {}".format(bb))
     else:
         bb = in_wcs.bounding_box

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -8,7 +8,7 @@ from gwcs import WCS, wcstools
 
 from stsci.tools.bitmask import interpret_bit_flags
 
-from ..assign_wcs.util import wcs_from_footprints, bounding_box_for_wcs
+from ..assign_wcs.util import wcs_from_footprints, wcs_bbox_from_shape
 
 import logging
 log = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ def make_output_wcs(input_models):
     wcslist = [i.meta.wcs for i in input_models]
     for w, i in zip(wcslist, input_models):
         if w.bounding_box is None:
-            w.bounding_box = bounding_box_for_wcs(i.data.shape)
+            w.bounding_box = wcs_bbox_from_shape(i.data.shape)
     naxes = wcslist[0].output_frame.naxes
 
     if naxes == 3:
@@ -99,7 +99,7 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, shape=None):
     """ Return a pixel grid map from input frame to output frame.
     """
     if shape:
-        bb = bounding_box_for_wcs(shape)
+        bb = wcs_bbox_from_shape(shape)
         log.debug("Bounding box from data shape: {}".format(bb))
     else:
         bb = in_wcs.bounding_box


### PR DESCRIPTION
This PR creates a new function in `assign_wcs.util` called `bounding_box_for_transform` which returns the correctly arranged tuple for attaching to a transform.

It also renames the current `assign_wcs.util.bounding_box_from_shape` to `bounding_box_for_wcs`, which still returns the tuple in (x,y) order.

The names made sense to me, but this is up for discussion.  see #3013