### PR TITLE
Fix DB source logging issue and update default DB url

### DIFF
--- a/jwst/lib/engdb_tools.py
+++ b/jwst/lib/engdb_tools.py
@@ -17,10 +17,10 @@ logger.addHandler(logging.NullHandler())
 # #############################################
 # Where is the engineering service? Its HERE!!!
 # #############################################
-ENGDB_HOST = 'http://iwjwdmscemweb.stsci.edu/'
+ENGDB_HOST = 'http://iwjwdmsbemweb.stsci.edu/'
 ENGDB_BASE_URL = ''.join([
     ENGDB_HOST,
-    'JWDMSEngFqAccB72/',
+    'JWDMSEngFqAcc/',
     'TlmMnemonicDataSrv.svc/',
 ])
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -1227,10 +1227,6 @@ def get_mnemonics(obsstart, obsend, tolerance, engdb_url=None):
         Cannot retrieve engineering information
 
     """
-    logger.info(
-        'Querying engineering DB: {}'.format(ENGDB_BASE_URL)
-    )
-
     try:
         engdb = ENGDB_Service(base_url=engdb_url)
     except Exception as exception:
@@ -1240,6 +1236,10 @@ def get_mnemonics(obsstart, obsend, tolerance, engdb_url=None):
                 exception
             )
         )
+    logger.info(
+        'Querying engineering DB: {}'.format(engdb.base_url)
+    )
+
     mnemonics = {
         'SA_ZATTEST1':  None,
         'SA_ZATTEST2':  None,

--- a/jwst/lib/tests/test_engdb_tools.py
+++ b/jwst/lib/tests/test_engdb_tools.py
@@ -28,8 +28,8 @@ BAD_MNEMONIC = 'No_Such_MNEMONIC'
 NODATA_STARTIME = '2014-01-01'
 NODATA_ENDTIME = '2014-01-02'
 
-ALTERNATE_HOST = 'http://iwjwdmsbemweb.stsci.edu'
-ALTERNATE_URL = ALTERNATE_HOST + '/JWDMSEngFqAccB71/TlmMnemonicDataSrv.svc/'
+ALTERNATE_HOST = 'http://twjwdmsemweb.stsci.edu'
+ALTERNATE_URL = ALTERNATE_HOST + '/JWDMSEngFqAcc/TlmMnemonicDataSrv.svc/'
 
 
 def is_alive(url):

--- a/jwst/lib/tests/test_engdb_tools.py
+++ b/jwst/lib/tests/test_engdb_tools.py
@@ -62,15 +62,13 @@ def engdb():
         yield engdb
 
 
-@pytest.mark.skipif(
-    not is_alive(ALTERNATE_HOST),
-    reason='Alternate test host not available.'
-)
 def test_environmetal():
     old = os.environ.get('ENG_BASE_URL', None)
     try:
         os.environ['ENG_BASE_URL'] = ALTERNATE_URL
         engdb = engdb_tools.ENGDB_Service()
+    except Exception:
+        pytest.skip('Alternate engineering db not available for test.')
     finally:
         if old is None:
             del os.environ['ENG_BASE_URL']

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -1,7 +1,6 @@
 """
 Test suite for set_telescope_pointing
 """
-import copy
 import logging
 import numpy as np
 import os
@@ -9,9 +8,6 @@ import sys
 import pytest
 from tempfile import TemporaryDirectory
 
-import requests_mock
-
-from astropy.table import Table
 from astropy.time import Time
 
 from .. import engdb_tools
@@ -183,6 +179,17 @@ def test_get_pointing(eng_db_ngas):
     assert np.isclose(j2fgs_matrix, J2FGS_MATRIX_EXPECTED).all()
     assert np.isclose(fsmcorr, FSMCORR_EXPECTED).all()
     assert STARTTIME <= obstime <= ENDTIME
+
+
+def test_logging(eng_db_ngas, caplog):
+    (q,
+     j2fgs_matrix,
+     fsmcorr,
+     obstime) = stp.get_pointing(STARTTIME.mjd, ENDTIME.mjd)
+    assert 'Determining pointing between observations times' in caplog.text
+    assert 'Telemetry search tolerance' in caplog.text
+    assert 'Reduction function' in caplog.text
+    assert 'Querying engineering DB' in caplog.text
 
 
 def test_get_pointing_list(eng_db_ngas):


### PR DESCRIPTION
A previous PR updated how the engineering database URL can be specified. However, that PR neglected to update the logging of the source URL properly. This fixes that oversight.

Also added is the change of the default database to coincide with the new organization of the strings, moving towards a constant db location.