### PR TITLE
Check for constant wavelengths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,8 @@ extract_1d
 - Reverse order of RELSENS wavelength and response if the wavelengths are
   not increasing. [#3005]
 
+- Add a test for constant wavelengths (or constant slope). [#3032]
+
 extract_2d
 ----------
 - Moved the update of meta information to the MultiSlitModel instead of the

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -458,10 +458,16 @@ def find_dispaxis(input_model, slit, spectral_order, extract_params):
             wl_10 = stuff[2]
         dwlx = wl_10 - wl_00
         dwly = wl_01 - wl_00
-        if (np.isnan(dwlx) or np.isnan(dwly) or
+        if (np.isnan(dwlx) or np.isnan(dwly) or dwlx == dwly or
             wl_00 == 0 or wl_01 == 0 or wl_10 == 0):
-                log.warning("wavelength from WCS is NaN or 0 "
-                            "within the bounding box")
+                if dwlx == dwly:
+                    log.warning("One-pixel offset gives dwlx = {}, dwly = {}"
+                                .format(dwlx, dwly))
+                else:
+                    log.warning("wavelength from WCS is NaN or 0 "
+                                "within the bounding box")
+                log.warning("    computing differences over "
+                            "the whole bounding box ...")
                 if input_model.meta.exposure.type in WFSS_EXPTYPES:
                     wl_wcs = np.zeros(shape, dtype=np.float64)
                     log.debug("Starting to compute wavelengths ...")


### PR DESCRIPTION
Function find_dispaxis in extract.py was modified to also test whether the difference in wavelengths in the horizontal direction was exactly equal to the difference in wavelengths in the vertical direction.  Closes #3031.