### PR TITLE
Fix our RTD documentation builds

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -2,8 +2,8 @@ name: jwst
 dependencies:
   - "python>=3.5"
   - setuptools
-  - numpy
   - pip:
+    - numpy
     - sphinx
     - sphinxcontrib-programoutput
     - sphinx-automodapi

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,7 +1,6 @@
 name: jwst
 dependencies:
   - python=3.6
-  - setuptools
   - numpy=1.15
   - pip:
     - astropy

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,17 +1,19 @@
-
+name: jwst
 dependencies:
-  - python>=3
+  - "python>=3.5"
   - setuptools
-  - astropy
-  - matplotlib
   - numpy
-  - scipy
   - pip:
+    - sphinx
     - sphinxcontrib-programoutput
     - sphinx-automodapi
+    - sphinx_rtd_theme
     - stsci_rtd_theme
+    - matplotlib
+    - "astropy>=3.1"
     - asdf
     - crds
+    - scipy
     - drizzle
     - gwcs
     - jsonschema
@@ -23,7 +25,4 @@ dependencies:
     - stsci.imagestats
     - stsci.stimage
     - stsci.tools
-    - six
     - verhawk
-    - sphinx_rtd_theme
-

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,6 +1,6 @@
 name: jwst
 dependencies:
-  - "python>=3.5"
+  - python=3.6.6
   - setuptools
   - pip:
     - numpy
@@ -10,7 +10,7 @@ dependencies:
     - sphinx_rtd_theme
     - stsci_rtd_theme
     - matplotlib
-    - "astropy>=3.1"
+    - astropy
     - asdf
     - crds
     - scipy

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,15 +1,9 @@
 name: jwst
 dependencies:
-  - python=3.6.6
+  - python=3.6
   - setuptools
+  - numpy=1.15
   - pip:
-    - numpy
-    - sphinx
-    - sphinxcontrib-programoutput
-    - sphinx-automodapi
-    - sphinx_rtd_theme
-    - stsci_rtd_theme
-    - matplotlib
     - astropy
     - asdf
     - crds
@@ -27,3 +21,7 @@ dependencies:
     - stsci.tools
     - verhawk
     - pytest
+    - sphinxcontrib-programoutput
+    - sphinx-automodapi
+    - stsci_rtd_theme
+    - matplotlib

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -26,3 +26,4 @@ dependencies:
     - stsci.stimage
     - stsci.tools
     - verhawk
+    - pytest


### PR DESCRIPTION
So this fixes the build.  Basically, peg `python` and `numpy` in the conda env, and then do all other dependencies via `pip`.

The build results of this PR are here

https://readthedocs.org/projects/jwsttest/builds/8396900/