### PR TITLE
Update README for B7.2.1 patch release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Software vs DMS build version map
 
 | jwst tag | DMS build | CRDS_CONTEXT |   Date     |          Notes                           |
 | -------- | --------- | ------------ | ---------- | -----------------------------------------|
+|  0.12.3  | B7.2.1    | 0500         | 01/15/2019 | DMS Build 7.2.1 patch release            |
 |  0.12.2  | B7.2      | 0495         | 11/07/2018 | Final release candidate for Build 7.2    |
 |  0.12.1  | B7.2rc2   | 0495         | 11/01/2018 | Second release candidate for Build 7.2   |
 |  0.12.0  | B7.2rc1   | 0493*        | 10/09/2018 | First release candidate for Build 7.2    |


### PR DESCRIPTION
Updated the jwst pkg vs. DMS build table to include info for the B7.2.1 (0.12.3) release.