### PR TITLE
Simplify transform_bbox_from_datamodel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ ami
 
 assign_wcs
 ----------
+
+ - Removed ``transform_bbox_from_datamodels`` in favor of
+   ``transform_bbox_from_shape`` which now works by using last two dimensions
+   in the ``shape``. [#3040]
+
  - Added velocity correction model to the WFSS and TSGRISM wcs pipelines [#2801]
 
  - Refactored how the pipeline handles subarrays in the WCS. Fixed a bug

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -8,7 +8,7 @@ from astropy import coordinates as coord
 from gwcs import coordinate_frames as cf
 
 from .util import (not_implemented_mode, subarray_transform,
-                   transform_bbox_from_datamodel, bounding_box_from_subarray)
+                   transform_bbox_from_shape, bounding_box_from_subarray)
 from . import pointing
 from ..datamodels import DistortionModel
 
@@ -94,7 +94,7 @@ def imaging_distortion(input_model, reference_files):
     try:
         transform.bounding_box
     except NotImplementedError:
-        transform.bounding_box = transform_bbox_from_datamodel(input_model)
+        transform.bounding_box = transform_bbox_from_shape(input_model.data.shape)
     dist.close()
     return transform
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -11,7 +11,7 @@ from gwcs import selector
 from . import pointing
 from ..transforms import models as jwmodels
 from .util import (not_implemented_mode, subarray_transform,
-                   velocity_correction, transform_bbox_from_datamodel, bounding_box_from_subarray)
+                   velocity_correction, transform_bbox_from_shape, bounding_box_from_subarray)
 from ..datamodels import (DistortionModel, FilteroffsetModel,
                           DistortionMRSModel, WavelengthrangeModel,
                           RegionsModel, SpecwcsModel)
@@ -114,7 +114,7 @@ def imaging_distortion(input_model, reference_files):
     try:
         distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = transform_bbox_from_datamodel(input_model)
+        distortion.bounding_box = transform_bbox_from_shape(input_model.data.shape)
 
     # Add an offset for the filter
     obsfilter = input_model.meta.instrument.filter

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -7,7 +7,7 @@ import gwcs.coordinate_frames as cf
 
 from . import pointing
 from .util import (not_implemented_mode, subarray_transform, velocity_correction,
-                   transform_bbox_from_datamodel, bounding_box_from_subarray)
+                   transform_bbox_from_shape, bounding_box_from_subarray)
 from ..datamodels import (ImageModel, NIRCAMGrismModel, DistortionModel,
                           CubeModel)
 from ..transforms.models import (NIRCAMForwardRowGrismDispersion,
@@ -109,7 +109,7 @@ def imaging_distortion(input_model, reference_files):
     except NotImplementedError:
         # Check if the transform in the reference file has a ``bounding_box``.
         # If not set a ``bounding_box`` equal to the size of the image.
-        transform.bounding_box = transform_bbox_from_datamodel(input_model)
+        transform.bounding_box = transform_bbox_from_shape(input_model.data.shape)
     dist.close()
     return transform
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -249,7 +249,7 @@ def imaging_distortion(input_model, reference_files):
         # Check if the model has a bounding box.
         distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = transform_bbox_from_shape(input_model)
+        distortion.bounding_box = transform_bbox_from_shape(input_model.data.shape)
 
     dist.close()
     return distortion

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -8,7 +8,7 @@ import gwcs.coordinate_frames as cf
 from gwcs import wcs
 
 from .util import (not_implemented_mode, subarray_transform,
-                   velocity_correction, bounding_box_from_subarray, transform_bbox_from_datamodel)
+                   velocity_correction, bounding_box_from_subarray, transform_bbox_from_shape)
 from . import pointing
 from ..transforms.models import (NirissSOSSModel,
                                  NIRISSForwardRowGrismDispersion,
@@ -249,7 +249,7 @@ def imaging_distortion(input_model, reference_files):
         # Check if the model has a bounding box.
         distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = transform_bbox_from_datamodel(input_model)
+        distortion.bounding_box = transform_bbox_from_shape(input_model)
 
     dist.close()
     return distortion

--- a/jwst/assign_wcs/tests/test_util.py
+++ b/jwst/assign_wcs/tests/test_util.py
@@ -11,8 +11,7 @@ from astropy.table import QTable
 from ...lib.catalog_utils import SkyObject
 from ... import datamodels
 
-from ..util import (get_object_info, wcs_bbox_from_shape,
-                    subarray_transform, transform_bbox_from_datamodel,
+from ..util import (get_object_info, wcs_bbox_from_shape, subarray_transform,
                     bounding_box_from_subarray, transform_bbox_from_shape)
 
 from . import data
@@ -31,6 +30,12 @@ def test_transform_bbox_from_shape_2d():
     model = datamodels.ImageModel((512, 2048))
     bb = transform_bbox_from_shape(model.data.shape)
     assert bb == ((-0.5, 511.5), (-0.5, 2047.5))
+
+
+def test_transform_bbox_from_shape_3d():
+    model = datamodels.CubeModel((3, 32, 2048))
+    bb = transform_bbox_from_shape(model.data.shape)
+    assert bb == ((-0.5, 31.5), (-0.5, 2047.5))
 
 
 def test_wcs_bbox_from_shape_2d():
@@ -89,17 +94,6 @@ def test_subarray_transform():
     transform = subarray_transform(im)
     assert isinstance(transform[0], Identity)
     assert isinstance(transform[1], Shift) and transform[1].offset == 4
-
-
-def test_transform_bbox_from_datamodel():
-    im = datamodels.ImageModel()
-    im.data = np.zeros((45, 36))
-
-    cube = datamodels.CubeModel()
-    cube.data = np.zeros((3, 45, 36))
-
-    assert transform_bbox_from_datamodel(im) == ((-.5, 44.5), (-.5, 35.5))
-    assert transform_bbox_from_datamodel(cube) == ((-.5, 44.5), (-.5, 35.5))
 
 
 def test_bounding_box_from_subarray():

--- a/jwst/assign_wcs/tests/test_util.py
+++ b/jwst/assign_wcs/tests/test_util.py
@@ -4,7 +4,6 @@ Test the utility functions
 
 import os
 
-import numpy as np
 from astropy.modeling.models import Shift, Identity
 from astropy.table import QTable
 

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -677,8 +677,8 @@ def transform_bbox_from_shape(shape):
     bbox : tuple
         Bounding box in y, x order.
     """
-    bbox = ((-0.5, shape[0] - 0.5),
-            (-0.5, shape[1] - 0.5))
+    bbox = ((-0.5, shape[-2] - 0.5),
+            (-0.5, shape[-1] - 0.5))
     return bbox
 
 
@@ -698,29 +698,6 @@ def wcs_bbox_from_shape(shape):
     """
     bbox = ((-0.5, shape[-1] - 0.5),
             (-0.5, shape[-2] - 0.5))
-    return bbox
-
-
-def transform_bbox_from_datamodel(input_model):
-    """Create a bounding box from the shape of the data base on the model.
-
-    Note: The bounding box of a ``CubeModel`` is the bounding_box
-    of one of the stacked images. A CubeModel is always treated as
-    a stack (in dimension 1) of 2D images, as opposed to actual 3D data.
-    In this case the bounding box is set to the 2nd and 3rd dimension.
-
-    Parameters
-    ----------
-    input_model : `~jwst.datamodels.DataModel`
-        The data model.
-
-    Returns
-    -------
-    bbox : tuple
-        Bounding box in y, x order.
-    """
-    shape = input_model.data.shape
-    bbox = ((-0.5, shape[-2] - 0.5), (-0.5, shape[-1] - 0.5))
     return bbox
 
 

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -21,7 +21,7 @@ from gwcs import utils as gwutils
 from . import pointing
 from ..lib.catalog_utils import SkyObject
 from ..transforms.models import GrismObject
-from ..datamodels import WavelengthrangeModel, DataModel, ImageModel, CubeModel
+from ..datamodels import WavelengthrangeModel, DataModel
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -720,14 +720,7 @@ def transform_bbox_from_datamodel(input_model):
         Bounding box in y, x order.
     """
     shape = input_model.data.shape
-    if isinstance(input_model, CubeModel):
-        bbox = ((-0.5, shape[1] - 0.5),
-              (-0.5, shape[2] - 0.5))
-    elif isinstance(input_model, ImageModel):
-        bbox = ((-0.5, shape[0] - 0.5),
-              (-0.5, shape[1] - 0.5))
-    else:
-        raise TypeError("Input is not an ImageModel or CubeModel")
+    bbox = ((-0.5, shape[-2] - 0.5), (-0.5, shape[-1] - 0.5))
     return bbox
 
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/spacetelescope/jwst/pull/3014#issuecomment-454909182 and simplifies the code for `transform_bbox_from_datamodel`.

However, I would suggest a further simplification: combine three functions into a single one:
```python
def to_bbox(a, order='yx'):
    if order not in ('xy', 'yx'):
        raise ValueError("Unsupported 'order' value")
    try:
        a = a.data.shape
    except AttributeError:
        pass

    bbox = ((-0.5, a[-2] - 0.5), (-0.5, a[-1] - 0.5))

    return bbox if order == 'yx' else bbox[::-1]
```
The `try-except` block above can be replaced with an `if isinstance()`.