### PR TITLE
WIP: FITS file formats documentation

### DIFF
--- a/docs/jwst/data_products/common_features.rst
+++ b/docs/jwst/data_products/common_features.rst
@@ -1,0 +1,17 @@
+Common Features
+---------------
+
+All JWST FITS data products have a few common features in their structure
+and organization:
+
+1. The FITS primary Header Data Unit (HDU) only contains header information,
+   in the form of keyword records, with an empty data array, which is
+   indicated by the occurence of NAXIS=0 in the primary header. Meta
+   data that pertains to the entire product is stored in keywords in the
+   primary header. Meta data related to specific extensions (see below)
+   is stored in keywords in the headers of each extension.
+
+2. All data related to the product are contained in one or more FITS
+   IMAGE or BINTABLE extensions. The header of each extension may contain
+   keywords that pertain uniquely to that extension.
+

--- a/docs/jwst/data_products/file_naming.rst
+++ b/docs/jwst/data_products/file_naming.rst
@@ -1,0 +1,43 @@
+File Naming Scheme
+------------------
+The FITS file naming scheme for Stage 0, 1, and 2 "exposure-based" products is::
+
+ jw<ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>_<detector>_<prodType>.fits
+
+where
+
+ - ppppp: program ID number
+ - ooo: observation number
+ - vvv: visit number
+ - gg: visit group
+ - s: parallel sequence ID (1=prime, 2-5=parallel)
+ - aa: activity number (base 36)
+ - eeeee: exposure number
+ - detector: detector name (e.g. 'nrca1', 'nrcblong', 'mirimage')
+ - prodType: product type identifier (e.g. 'uncal', 'rate', 'cal')
+
+An example Stage 1 product FITS file name is::
+
+ jw93065002001_02101_00001_nrca1_rate.fits
+
+The FITS file naming scheme for Stage 3 "source-based" products is::
+
+ jw<ppppp>-<AC_ID>_[<"t"TargID | "s"SourceID>](-<"epoch"X>)_<instr>_<optElements>(-<subarray>)_<prodType>(-<ACT_ID>).fits
+
+where
+
+ - ppppp: program ID number
+ - AC_ID: association candidate ID
+ - TargID: a 3-digit target ID (either TargID or SourceID must be present)
+ - SourceID: a 5-digit source ID
+ - epochX: the text "epoch" followed by a single digit epoch number
+ - instr: science instrument name (e.g. 'nircam', 'miri')
+ - optElements: a single or hyphen-separated list of optical elements (e.g. filter, grating)
+ - subarray: optional indicator of subarray name
+ - prodType: product type identifier (e.g. 'i2d', 's3d', 'x1d')
+ - ACT_ID: a 2-digit activity ID
+
+An example Stage 3 product FITS file name is::
+
+ jw87600-a3001_t001_niriss_f480m-nrm_amiavg.fits
+

--- a/docs/jwst/data_products/file_naming.rst
+++ b/docs/jwst/data_products/file_naming.rst
@@ -42,6 +42,8 @@ An example Stage 3 product FITS file name is::
 
  jw87600-a3001_t001_niriss_f480m-nrm_amiavg.fits
 
+.. _segmented_files:
+
 Segmented Products
 ^^^^^^^^^^^^^^^^^^
 When the raw data volume for an individual exposure is determined to be large enough to result in

--- a/docs/jwst/data_products/file_naming.rst
+++ b/docs/jwst/data_products/file_naming.rst
@@ -2,7 +2,7 @@ File Naming Scheme
 ------------------
 The FITS file naming scheme for Stage 0, 1, and 2 "exposure-based" products is::
 
- jw<ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>_<detector>_<prodType>.fits
+ jw<ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>(-<"seg"NNN>)_<detector>_<prodType>.fits
 
 where
 
@@ -13,6 +13,7 @@ where
  - s: parallel sequence ID (1=prime, 2-5=parallel)
  - aa: activity number (base 36)
  - eeeee: exposure number
+ - segNNN: the text "seg" followed by a three-digit segment number (optional)
  - detector: detector name (e.g. 'nrca1', 'nrcblong', 'mirimage')
  - prodType: product type identifier (e.g. 'uncal', 'rate', 'cal')
 
@@ -30,7 +31,7 @@ where
  - AC_ID: association candidate ID
  - TargID: a 3-digit target ID (either TargID or SourceID must be present)
  - SourceID: a 5-digit source ID
- - epochX: the text "epoch" followed by a single digit epoch number
+ - epochX: the text "epoch" followed by a single digit epoch number (optional)
  - instr: science instrument name (e.g. 'nircam', 'miri')
  - optElements: a single or hyphen-separated list of optical elements (e.g. filter, grating)
  - subarray: optional indicator of subarray name
@@ -40,4 +41,27 @@ where
 An example Stage 3 product FITS file name is::
 
  jw87600-a3001_t001_niriss_f480m-nrm_amiavg.fits
+
+Segmented Products
+^^^^^^^^^^^^^^^^^^
+When the raw data volume for an individual exposure is determined to be large enough to result in
+Stage 2 products greater than 2 GB in size, all Stage 0-2 products for the exposure are broken into
+multiple segments, so as to keep total file sizes to a reasonable level. This is often the case with
+Time Series Observations (TSO), where individual exposures can have thousands of integrations.
+The detector data are broken along integration boundaries (never within an integration) and stored
+in "segmented" products. The segments are identified by the "segNNN" field in exposure-based file
+names, where NNN is 1-indexed and always includes any leading zeros.
+
+Segmented products contain extra keywords located in their primary headers that help to identify
+the segments and the contents of each segment. The following segment-related keywords are used:
+
+ - EXSEGNUM: The segment number of the current product
+ - EXSEGTOT: The total number of segments
+ - INTSTART: The starting integration number of the data in this segment
+ - INTEND: The ending integration number of the data in this segment
+
+All of the Stage 1 and Stage 2 calibration pipelines will process each segment independently,
+creating the full set of intermediate and calibrated products for each segment. The calibrated data
+for all segments is then combined by one of the Stage 3 pipelines into a source-based Stage 3
+product.
 

--- a/docs/jwst/data_products/guidestar_products.rst
+++ b/docs/jwst/data_products/guidestar_products.rst
@@ -1,0 +1,553 @@
+.. _guidestar_products:
+
+Guide star data products
+------------------------
+The FGS guiding capabilities are provided by 4 guide star functions: Identification, Acquisition,
+Track, and Fine Guide. Data downlinked by these functions is processed by DMS to provide uncalibrated
+and calibrated guide star data products. The uncalibrated products consist of raw pixel value data
+arrays, as well as different kinds of tabular information related to the guide stars and centroid
+locations of the guide star as computed by the on-board FGS Flight Software (FSW). Calibrated
+guide star products are created by the :ref:`calwebb_guider <calwebb_guider>` pipeline. Briefly, the
+processing performed applies bad pixel masks and flat-fields the science data, as well as computing
+countrate images from the multiple groups within each integration contained in a given product. The
+countrate images, which are computed by the :ref:`guider_cds <guider_cds_step>` step, are computed
+for most modes by simply differencing groups 1 and 2 in each integration and dividing by the group
+time.
+
+ID mode
+^^^^^^^
+The "Identification" guiding function images the field of view by reading the detector in a series
+subarray "strips" that, collectively, cover most of the field. A total of 36 subarray strips are
+read out, each of which is 64 x 2048 pixels in size. Each strip has 8 pixels of overlap with its
+adjoining strips, resulting in a total of 2024 unique detector rows that've been read out. ID mode
+uses 2 groups per integration and 2 integrations, resulting in a total of 4 reads. Each subarray
+strip has its 4 reads performed before moving on to the next subarray.
+
+DMS creates 2 different forms of products for ID mode data: one in which an image is constructed
+by simply stacking or butting the data from adjacent subarray strips against one another and the
+other in which the overlap regions of the strips are taken into account by averaging the pixel
+values. The first form is referred to as a "stacked" product and the second as an "image" product.
+
+The file name syntax for ID mode products is as follows::
+
+ jw<pppppooovvv>_gs-id_<m>_<stacked | image>-<uncal | cal>.fits
+
+where:
+
+ - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
+ - gs-id: guide star identification product
+ - m: the number of the identification attempt (0-8) within a visit
+ - stacked: indicates that the subarray strips are stacked (butted) against one another in the image
+ - image: indicates that the subarray strips have been merged in their overlap regions
+ - uncal: indicates the uncalibrated (raw) product
+ - cal: indicates the calibrated product
+
+The FITS file structure for uncalibrated ID "image" products is as follows:
+
++-----+-------------------------+----------+-----------+---------------------+
+| HDU | EXTNAME                 | HDU Type | Data Type | Dimensions          |
++=====+=========================+==========+===========+=====================+
+|  0  | N/A                     | primary  | N/A       | N/A                 |
++-----+-------------------------+----------+-----------+---------------------+
+|  1  | SCI                     | IMAGE    | uint16    | 2024 x 2048 x 2 x 2 |
++-----+-------------------------+----------+-----------+---------------------+
+|  2  | Flight Reference Stars  | BINTABLE | N/A       | 4 cols x nstars     |
++-----+-------------------------+----------+-----------+---------------------+
+|  3  | Planned Reference Stars | BINTABLE | N/A       | 10 cols x nstars    |
++-----+-------------------------+----------+-----------+---------------------+
+
+ - SCI: 4-D data array containing the raw pixel values. The subarray overlaps have been accounted for,
+   resulting in image dimensions of 2024 x 2048 pixels, with the 2 groups and 2 integrations stacked
+   along the 3rd and 4th array axes.
+ - Flight Reference Stars: A table containing information on the actual reference stars
+   used by the FSW. Detailed contents are listed :ref:`below <flight_ref_stars>`.
+ - Planned Reference Stars: A table containing information on the planned reference stars.
+   Detailed contents are listed :ref:`below <planned_ref_stars>`.
+
+The FITS file structure for uncalibrated ID "stacked" products is as follows:
+
++-----+-------------------------+----------+-----------+---------------------+
+| HDU | EXTNAME                 | HDU Type | Data Type | Dimensions          |
++=====+=========================+==========+===========+=====================+
+|  0  | N/A                     | primary  | N/A       | N/A                 |
++-----+-------------------------+----------+-----------+---------------------+
+|  1  | SCI                     | IMAGE    | uint16    | 2304 x 2048 x 2 x 2 |
++-----+-------------------------+----------+-----------+---------------------+
+|  2  | Flight Reference Stars  | BINTABLE | N/A       | 4 cols x nstars     |
++-----+-------------------------+----------+-----------+---------------------+
+|  3  | Planned Reference Stars | BINTABLE | N/A       | 10 cols x nstars    |
++-----+-------------------------+----------+-----------+---------------------+
+
+ - SCI: 4-D data array containing the raw pixel values. The subarray data are butted against one
+   another, resulting in image dimensions of 2304 x 2048 pixels, with the 2 groups and 2 integrations
+   stacked along the 3rd and 4th array axes.
+ - Flight Reference Stars: A table containing information on the actual reference stars
+   used by the FSW. Detailed contents are listed :ref:`below <flight_ref_stars>`.
+ - Planned Reference Stars: A table containing information on the planned reference stars.
+   Detailed contents are listed :ref:`below <planned_ref_stars>`.
+
+The FITS file structure for calibrated ID "image" products is as follows:
+
++-----+-------------------------+----------+-----------+------------------+
+| HDU | EXTNAME                 | HDU Type | Data Type | Dimensions       |
++=====+=========================+==========+===========+==================+
+|  0  | N/A                     | primary  | N/A       | N/A              |
++-----+-------------------------+----------+-----------+------------------+
+|  1  | SCI                     | IMAGE    | float32   | 2024 x 2048 x 1  |
++-----+-------------------------+----------+-----------+------------------+
+|  2  | ERR                     | IMAGE    | float32   | 2024 x 2048 x 1  |
++-----+-------------------------+----------+-----------+------------------+
+|  3  | DQ                      | IMAGE    | uint32    | 2024 x 2048      |
++-----+-------------------------+----------+-----------+------------------+
+|  4  | Flight Reference Stars  | BINTABLE | N/A       | 4 cols x nstars  |
++-----+-------------------------+----------+-----------+------------------+
+|  5  | Planned Reference Stars | BINTABLE | N/A       | 10 cols x nstars |
++-----+-------------------------+----------+-----------+------------------+
+|  6  | ASDF                    | BINTABLE | N/A       | variable         |
++-----+-------------------------+----------+-----------+------------------+
+
+ - SCI: 3-D data array containing the pixel values, in units of DN/s. The data for the 2 integrations
+   has been combined into a single image, as is done by the on-board FSW, resulting in a data array
+   with NAXIS3 = 1.
+ - ERR: 3-D data array containing uncertainty estimates for each pixel.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - Flight Reference Stars: A table containing information on the actual reference stars
+   used by the FSW. Detailed contents are listed :ref:`below <flight_ref_stars>`.
+ - Planned Reference Stars: A table containing information on the planned reference stars.
+   Detailed contents are listed :ref:`below <planned_ref_stars>`.
+ - ADSF: The data model meta data.
+
+The FITS file structure for calibrated ID "stacked" products is as follows:
+
++-----+-------------------------+----------+-----------+------------------+
+| HDU | EXTNAME                 | HDU Type | Data Type | Dimensions       |
++=====+=========================+==========+===========+==================+
+|  0  | N/A                     | primary  | N/A       | N/A              |
++-----+-------------------------+----------+-----------+------------------+
+|  1  | SCI                     | IMAGE    | float32   | 2304 x 2048 x 1  |
++-----+-------------------------+----------+-----------+------------------+
+|  2  | ERR                     | IMAGE    | float32   | 2304 x 2048 x 1  |
++-----+-------------------------+----------+-----------+------------------+
+|  3  | DQ                      | IMAGE    | uint32    | 2304 x 2048      |
++-----+-------------------------+----------+-----------+------------------+
+|  4  | Flight Reference Stars  | BINTABLE | N/A       | 4 cols x nstars  |
++-----+-------------------------+----------+-----------+------------------+
+|  5  | Planned Reference Stars | BINTABLE | N/A       | 10 cols x nstars |
++-----+-------------------------+----------+-----------+------------------+
+|  6  | ASDF                    | BINTABLE | N/A       | variable         |
++-----+-------------------------+----------+-----------+------------------+
+
+ - SCI: 3-D data array containing the pixel values, in units of DN/s. The data for the 2 integrations
+   has been combined into a single image, as is done by the on-board FSW, resulting in a data array
+   with NAXIS3=1.
+ - ERR: 3-D data array containing uncertainty estimates for each pixel.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - Flight Reference Stars: A table containing information on the actual reference stars
+   used by the FSW. Detailed contents are listed :ref:`below <flight_ref_stars>`.
+ - Planned Reference Stars: A table containing information on the planned reference stars.
+   Detailed contents are listed :ref:`below <planned_ref_stars>`.
+ - ADSF: The data model meta data.
+
+.. _flight_ref_stars:
+
+Flight reference stars table
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The structure and content of the Flight Reference Stars table is as follows.
+
++-------------------+-----------+-------------------------------+
+| Column Name       | Data Type | Description                   |
++===================+===========+===============================+
+| reference_star_id | char*2    | Reference star index          |
++-------------------+-----------+-------------------------------+
+| id_x              | float64   | x position in FGS Ideal frame |
++-------------------+-----------+-------------------------------+
+| id_y              | float64   | y position in FGS Ideal frame |
++-------------------+-----------+-------------------------------+
+| count_rate        | float64   | count rate                    |
++-------------------+-----------+-------------------------------+
+
+.. _planned_ref_stars:
+
+Planned reference stars table
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The structure and content of the Planned Reference Stars table is as follows.
+
++-------------------+-----------+-------------------------------+
+| Column Name       | Data Type | Description                   |
++===================+===========+===============================+
+| guide_star_order  | int32     | Guide star index within list  |
++-------------------+-----------+-------------------------------+
+| reference_star_id | char*12   | GSC II identifier             |
++-------------------+-----------+-------------------------------+
+| ra                | float64   | ICRS RA of the star           |
++-------------------+-----------+-------------------------------+
+| dec               | float64   | ICRS Dec of the star          |
++-------------------+-----------+-------------------------------+
+| id_x              | float64   | x position in FGS Ideal frame |
++-------------------+-----------+-------------------------------+
+| id_y              | float64   | y position in FGS Ideal frame |
++-------------------+-----------+-------------------------------+
+| fgs_mag           | float64   | magnitude                     |
++-------------------+-----------+-------------------------------+
+| fgs_mag_uncert    | float64   | magnitude uncertainty         |
++-------------------+-----------+-------------------------------+
+| count_rate        | float64   | count rate                    |
++-------------------+-----------+-------------------------------+
+| count_rate_uncert | float64   | count rate uncertainty        |
++-------------------+-----------+-------------------------------+
+
+ACQ1 mode
+^^^^^^^^^
+The "Acquistion" guiding function ACQ1 performs 128 x 128 pixel subarray readouts of the
+detector, using 2 groups per integration and a total of 6 integrations.
+
+The file name syntax for ACQ1 mode products is as follows::
+
+ jw<pppppooovvv>_gs-acq1_<yyyydddhhmmss>-<uncal | cal>.fits
+
+where:
+
+ - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
+ - gs-acq1: guide star acquisition1 product
+ - yyyydddhhmmss: the time stamp at the *end* of the data contained in the file
+ - uncal: indicates the uncalibrated (raw) product
+ - cal: indicates the calibrated product
+
+The FITS file structure for ACQ1 uncalibrated products is as follows:
+
++-----+---------+----------+-----------+-------------------+
+| HDU | EXTNAME | HDU Type | Data Type | Dimensions        |
++=====+=========+==========+===========+===================+
+|  0  | N/A     | primary  | N/A       | N/A               |
++-----+---------+----------+-----------+-------------------+
+|  1  | SCI     | IMAGE    | uint16    | 128 x 128 x 2 x 6 |
++-----+---------+----------+-----------+-------------------+
+
+ - SCI: 4-D data array containing the raw pixel values.
+
+The FITS file structure for ACQ1 calibrated products is as follows:
+
++-----+---------+----------+-----------+---------------+
+| HDU | EXTNAME | HDU Type | Data Type | Dimensions    |
++=====+=========+==========+===========+===============+
+|  0  | N/A     | primary  | N/A       | N/A           |
++-----+---------+----------+-----------+---------------+
+|  1  | SCI     | IMAGE    | float32   | 128 x 128 x 6 |
++-----+---------+----------+-----------+---------------+
+|  2  | ERR     | IMAGE    | float32   | 128 x 128 x 6 |
++-----+---------+----------+-----------+---------------+
+|  3  | DQ      | IMAGE    | uint32    | 128 x 128     |
++-----+---------+----------+-----------+---------------+
+|  4  | ASDF    | BINTABLE | N/A       | variable      |
++-----+---------+----------+-----------+---------------+
+
+ - SCI: 3-D data array containing the pixel values, in units of DN/s. Count rate images have been
+   computed for each of the 6 integrations by differencing the 2 groups of each integration.
+ - ERR: 3-D data array containing uncertainty estimates for each pixel.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - ADSF: The data model meta data.
+
+ACQ2 mode
+^^^^^^^^^
+The "Acquisition" guiding function ACQ2 performs 32 x 32 pixel subarray readouts of the detector,
+using 2 groups per integration and a total of 5 integrations.
+
+The file name syntax for ACQ2 mode products is as follows::
+
+ jw<pppppooovvv>_gs-acq2_<yyyydddhhmmss>-<uncal | cal>.fits
+
+where:
+
+ - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
+ - gs-acq2: guide star acquisition2 product
+ - yyyydddhhmmss: the time stamp at the *end* of the data contained in the file
+ - uncal: indicates the uncalibrated (raw) product
+ - cal: indicates the calibrated product
+
+The FITS file structure for ACQ2 uncalibrated products is as follows:
+
++-----+---------+----------+-----------+-----------------+
+| HDU | EXTNAME | HDU Type | Data Type | Dimensions      |
++=====+=========+==========+===========+=================+
+|  0  | N/A     | primary  | N/A       | N/A             |
++-----+---------+----------+-----------+-----------------+
+|  1  | SCI     | IMAGE    | uint16    | 32 x 32 x 2 x 5 |
++-----+---------+----------+-----------+-----------------+
+
+ - SCI: 4-D data array containing the raw pixel values.
+
+The FITS file structure for ACQ2 calibrated products is as follows:
+
++-----+---------+----------+-----------+-------------+
+| HDU | EXTNAME | HDU Type | Data Type | Dimensions  |
++=====+=========+==========+===========+=============+
+|  0  | N/A     | primary  | N/A       | N/A         |
++-----+---------+----------+-----------+-------------+
+|  1  | SCI     | IMAGE    | float32   | 32 x 32 x 5 |
++-----+---------+----------+-----------+-------------+
+|  2  | ERR     | IMAGE    | float32   | 32 x 32 x 5 |
++-----+---------+----------+-----------+-------------+
+|  3  | DQ      | IMAGE    | uint32    | 32 x 32     |
++-----+---------+----------+-----------+-------------+
+|  4  | ASDF    | BINTABLE | N/A       | variable    |
++-----+---------+----------+-----------+-------------+
+
+ - SCI: 3-D data array containing the pixel values, in units of DN/s. Count rate images have been
+   computed for each of the 5 integrations by differencing the 2 groups of each integration.
+ - ERR: 3-D data array containing uncertainty estimates for each pixel.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - ADSF: The data model meta data.
+
+Track mode
+^^^^^^^^^^
+The "Track" guiding function performs 32 x 32 pixel subarray readouts, the location of which
+can move on the detector as the FGS FSW tracks the position of the guide star. The subarray
+readouts are performed with a cadence of 16 Hz. Each integration consists of 2 groups, and the
+total number of integrations (NINTS) can be very large (in the thousands).
+
+The file name syntax for TRACK mode products is as follows::
+
+ jw<pppppooovvv>_gs-track_<yyyydddhhmmss>-<uncal | cal>.fits
+
+where:
+
+ - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
+ - gs-track: guide star track product
+ - yyyydddhhmmss: the time stamp at the *end* of the data contained in the file
+ - uncal: indicates the uncalibrated (raw) product
+ - cal: indicates the calibrated product
+
+The FITS file structure for TRACK uncalibrated products is as follows:
+
++-----+----------------------+----------+-----------+---------------------+
+| HDU | EXTNAME              | HDU Type | Data Type | Dimensions          |
++=====+======================+==========+===========+=====================+
+|  0  | N/A                  | primary  | N/A       | N/A                 |
++-----+----------------------+----------+-----------+---------------------+
+|  1  | SCI                  | IMAGE    | uint16    | 32 x 32 x 2 x nints |
++-----+----------------------+----------+-----------+---------------------+
+|  2  | Pointing             | BINTABLE | N/A       | 12 cols x nrows     |
++-----+----------------------+----------+-----------+---------------------+
+|  3  | FGS Centroid Packet  | BINTABLE | N/A       | 17 cols x nrows     |
++-----+----------------------+----------+-----------+---------------------+
+|  4  | Track subarray table | BINTABLE | N/A       | 5 cols x nrows      |
++-----+----------------------+----------+-----------+---------------------+
+
+ - SCI: 4-D data array containing the raw pixel values.
+ - Pointing: A table containing guide star position and jitter information.
+   See :ref:`below <pointing_table>` for details of the contents.
+ - FGS Centroid Packet: A table containing guide star centroiding information.
+   See :ref:`below <centroid_table>` for details of the contents.
+ - Track subarray table: A table containing subarray information over the duration of the product.
+   See :ref:`below <subarray_table>` for details of the contents.
+
+The FITS file structure for TRACK calibrated products is as follows:
+
++-----+----------------------+----------+-----------+-----------------+
+| HDU | EXTNAME              | HDU Type | Data Type | Dimensions      |
++=====+======================+==========+===========+=================+
+|  0  | N/A                  | primary  | N/A       | N/A             |
++-----+----------------------+----------+-----------+-----------------+
+|  1  | SCI                  | IMAGE    | float32   | 32 x 32 x nints |
++-----+----------------------+----------+-----------+-----------------+
+|  2  | ERR                  | IMAGE    | float32   | 32 x 32 x nints |
++-----+----------------------+----------+-----------+-----------------+
+|  3  | DQ                   | IMAGE    | uint32    | 32 x 32         |
++-----+----------------------+----------+-----------+-----------------+
+|  4  | POINTING             | BINTABLE | N/A       | 12 cols x nrows |
++-----+----------------------+----------+-----------+-----------------+
+|  5  | FGS CENTROID PACKET  | BINTABLE | N/A       | 17 cols x nrows |
++-----+----------------------+----------+-----------+-----------------+
+|  6  | TRACK SUBARRAY TABLE | BINTABLE | N/A       | 5 cols x nrows  |
++-----+----------------------+----------+-----------+-----------------+
+|  7  | ASDF                 | BINTABLE | N/A       | variable        |
++-----+----------------------+----------+-----------+-----------------+
+
+ - SCI: 3-D data array containing the pixel values, in units of DN/s. Count rate images for each
+   integration have been computed by differencing the 2 groups in each integration.
+ - ERR: 3-D data array containing uncertainty estimates for each pixel.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - Pointing: A table containing guide star position and jitter information.
+   See :ref:`below <pointing_table>` for details of the contents.
+ - FGS Centroid Packet: A table containing guide star centroiding information.
+   See :ref:`below <centroid_table>` for details of the contents.
+ - Track subarray table: A table containing subarray information over the duration of the product.
+   See :ref:`below <subarray_table>` for details of the contents.
+ - ADSF: The data model meta data.
+
+.. _pointing_table:
+
+Pointing table
+~~~~~~~~~~~~~~
+The structure and content of the Pointing table is as follows.
+
++-------------------+-----------+--------------+----------------------------------------------------+
+| Column Name       | Data Type | Units        | Description                                        |
++===================+===========+==============+====================================================+
+| time              | float64   | milli-sec    | Time since start of data file                      |
++-------------------+-----------+--------------+----------------------------------------------------+
+| jitter            | float64   | milli-arcsec | :math:`sqrt(delta\_ddc\_ra^2 + delta\_ddc\_dec^2)` |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_ddc_ra      | float64   | milli-arcsec | Initial DDC RA - Current                           |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_ddc_dec     | float64   | milli-arcsec | Initial DDC Dec - Current                          |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_aperture_pa | float64   | milli-arcsec | Initial PA - Current                               |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_v1_ra       | float64   | milli-arcsec | Initial V frame RA - Current                       |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_v1_dec      | float64   | milli-arcsec | Initial V frame Dec - Current                      |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_v3_pa       | float64   | milli-arcsec | Initial V frame PA - Current                       |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_j1_ra       | float64   | milli-arcsec | Initial J frame RA - Current                       |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_j1_dec      | float64   | milli-arcsec | Initial J frame Dec - Current                      |
++-------------------+-----------+--------------+----------------------------------------------------+
+| delta_j3_pa       | float64   | milli-arcsec | Initial J frame PA - Current                       |
++-------------------+-----------+--------------+----------------------------------------------------+
+| HGA_motion        | int32     | N/A          | | HGA state: 0 = moving,                           |
+|                   |           |              | | 1 = finished, 2 = offline                        |
++-------------------+-----------+--------------+----------------------------------------------------+
+
+.. _centroid_table:
+
+FGS Centroid Packet table
+~~~~~~~~~~~~~~~~~~~~~~~~~
+The structure and content of the Centroid Packet table is as follows.
+
++------------------------------------------------+-----------+----------------------------------------------+
+| Column Name                                    | Data Type | Description                                  |
++================================================+===========+==============================================+
+| observatory_time                               | char*23   | UTC time when packet was generated           |
++------------------------------------------------+-----------+----------------------------------------------+
+| centroid_time                                  | char*23   | Fine guidance centroid time                  |
++------------------------------------------------+-----------+----------------------------------------------+
+| guide_star_position_x                          | float64   | FGS Ideal Frame (arcsec)                     |
++------------------------------------------------+-----------+----------------------------------------------+
+| guide_star_position_y                          | float64   | FGS Ideal Frame (arcsec)                     |
++------------------------------------------------+-----------+----------------------------------------------+
+| guide_star_instrument_counts_per_sec           | float64   | Instrument counts/sec                        |
++------------------------------------------------+-----------+----------------------------------------------+
+| signal_to_noise_current_frame                  | float64   | For current image frame                      |
++------------------------------------------------+-----------+----------------------------------------------+
+| delta_signal                                   | float64   | Between current and previous frame           |
++------------------------------------------------+-----------+----------------------------------------------+
+| delta_noise                                    | float64   | Between current and previous frame           |
++------------------------------------------------+-----------+----------------------------------------------+
+| psf_width_x                                    | int32     | Bias from ideal guide star position (pixels) |
++------------------------------------------------+-----------+----------------------------------------------+
+| psf_width_y                                    | int32     | Bias from ideal guide star position (pixels) |
++------------------------------------------------+-----------+----------------------------------------------+
+| data_quality                                   | int32     | Centroid data quality                        |
++------------------------------------------------+-----------+----------------------------------------------+
+| bad_pixel_flag                                 | char*4    | Bad pixel status for current subwindow (0/1) |
++------------------------------------------------+-----------+----------------------------------------------+
+| bad_centroid_dq_flag                           | char*50   | Bad centroid for current subwindow (0/1)     |
++------------------------------------------------+-----------+----------------------------------------------+
+| cosmic_ray_hit_flag                            | char*5    | NO/YES                                       |
++------------------------------------------------+-----------+----------------------------------------------+
+| sw_subwindow_loc_change_flag                   | char*5    | NO/YES                                       |
++------------------------------------------------+-----------+----------------------------------------------+
+| guide_star_at_detector_subwindow_boundary_flag | char*5    | NO/YES                                       |
++------------------------------------------------+-----------+----------------------------------------------+
+| subwindow_out_of_FOV_flag                      | char*5    | NO/YES                                       |
++------------------------------------------------+-----------+----------------------------------------------+
+
+.. _subarray_table:
+
+Track Subarray table
+~~~~~~~~~~~~~~~~~~~~
+The Track Subarray table contains location and size information for the detector subarray window
+that is used during the track function to follow the guide star.
+The structure and content of the Track Subarray table is as follows.
+
++------------------+-----------+------------------------------------+
+| Column Name      | Data Type | Description                        |
++==================+===========+====================================+
+| observatory_time | char*23   | UTC time when packet was generated |
++------------------+-----------+------------------------------------+
+| x_corner         | float64   | Subarray x corner (pixels)         |
++------------------+-----------+------------------------------------+
+| y_corner         | float64   | Subarray y corner (pixels)         |
++------------------+-----------+------------------------------------+
+| x_size           | int16     | Subarray x size (pixels)           |
++------------------+-----------+------------------------------------+
+| y_size           | int16     | Subarray y size (pixels)           |
++------------------+-----------+------------------------------------+
+
+FineGuide mode
+^^^^^^^^^^^^^^
+The "FineGuide" guiding function performs 8 x 8 pixel subarray readouts, at a fixed location
+on the detector, and with a cadence of 16 Hz, from which the FGS FSW computes centroids for the
+guide star. To reduce readout noise contribution to the centroid calculation, "Fowler" sampling
+of the readouts is employed. Each integration consists of 4 readouts at the beginning, a
+signal accumulation period, and 4 readouts at the end. The detector is then reset and the
+readout cycle repeats for the next integration. The 4 readouts at the beginning are averaged
+together, the 4 readouts at the end are averaged together, and then the difference of the 2
+averages is computed to form a final countrate image for each integration. This approach to
+creating the countrate images is used both on-board and in the :ref:`calwebb_guider <calwebb_guider>`
+pipeline when the raw data are processed on the ground.
+
+The file name syntax for FineGuide mode products is as follows::
+
+ jw<pppppooovvv>_gs-fg_<yyyydddhhmmss>-<uncal | cal>.fits
+
+where:
+
+ - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
+ - gs-fg: guide star FineGuide product
+ - yyyydddhhmmss: the time stamp at the *end* of the data contained in the file
+ - uncal: indicates the uncalibrated (raw) product
+ - cal: indicates the calibrated product
+
+The FITS file structure for FineGuide uncalibrated products is as follows:
+
++-----+----------------------+----------+-----------+-------------------+
+| HDU | EXTNAME              | HDU Type | Data Type | Dimensions        |
++=====+======================+==========+===========+===================+
+|  0  | N/A                  | primary  | N/A       | N/A               |
++-----+----------------------+----------+-----------+-------------------+
+|  1  | SCI                  | IMAGE    | uint16    | 8 x 8 x 8 x nints |
++-----+----------------------+----------+-----------+-------------------+
+|  2  | Pointing             | BINTABLE | N/A       | 12 cols x nrows   |
++-----+----------------------+----------+-----------+-------------------+
+|  3  | FGS Centroid Packet  | BINTABLE | N/A       | 17 cols x nrows   |
++-----+----------------------+----------+-----------+-------------------+
+
+ - SCI: 4-D data array containing the raw pixel values.
+ - Pointing: A table containing guide star position and jitter information.
+   See :ref:`above <pointing_table>` for details of the contents.
+ - FGS Centroid Packet: A table containing guide star centroiding information.
+   See :ref:`above <centroid_table>` for details of the contents.
+
+The FITS file structure for FineGuide calibrated products is as follows:
+
++-----+----------------------+----------+-----------+-----------------+
+| HDU | EXTNAME              | HDU Type | Data Type | Dimensions      |
++=====+======================+==========+===========+=================+
+|  0  | N/A                  | primary  | N/A       | N/A             |
++-----+----------------------+----------+-----------+-----------------+
+|  1  | SCI                  | IMAGE    | float32   | 8 x 8 x nints   |
++-----+----------------------+----------+-----------+-----------------+
+|  2  | ERR                  | IMAGE    | float32   | 8 x 8 x nints   |
++-----+----------------------+----------+-----------+-----------------+
+|  3  | DQ                   | IMAGE    | uint32    | 8 x 8           |
++-----+----------------------+----------+-----------+-----------------+
+|  4  | POINTING             | BINTABLE | N/A       | 12 cols x nrows |
++-----+----------------------+----------+-----------+-----------------+
+|  5  | FGS CENTROID PACKET  | BINTABLE | N/A       | 17 cols x nrows |
++-----+----------------------+----------+-----------+-----------------+
+|  6  | ASDF                 | BINTABLE | N/A       | variable        |
++-----+----------------------+----------+-----------+-----------------+
+
+ - SCI: 3-D data array containing the pixel values, in units of DN/s. Count rate images for each
+   integration have been computed using the Fowler sampling scheme described above.
+ - ERR: 3-D data array containing uncertainty estimates for each pixel.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - Pointing: A table containing guide star position and jitter information.
+   See :ref:`above <pointing_table>` for details of the contents.
+ - FGS Centroid Packet: A table containing guide star centroiding information.
+   See :ref:`above <centroid_table>` for details of the contents.
+ - ADSF: The data model meta data.
+

--- a/docs/jwst/data_products/guidestar_products.rst
+++ b/docs/jwst/data_products/guidestar_products.rst
@@ -14,6 +14,41 @@ countrate images, which are computed by the :ref:`guider_cds <guider_cds_step>` 
 for most modes by simply differencing groups 1 and 2 in each integration and dividing by the group
 time.
 
+File naming
+^^^^^^^^^^^
+Guide star product file names contain identifiers related to the function in use and the time at
+which the data were obtained. The table below lists the file name syntax used for each of the
+guiding functions and the related value of the EXP_TYPE keyword.
+
++----------------+---------------+-----------------------------------------------------+
+| Function       | EXP_TYPE      | File name                                           |
++================+===============+=====================================================+
+| Identification | FGS_ID-IMAGE  | jw<pppppooovvv>_gs-id_<m>_image-uncal.fits          |
++                +---------------+-----------------------------------------------------+
+|                | FGS_ID-STACK  | jw<pppppooovvv>_gs-id_<m>_stacked-uncal.fits        |
++----------------+---------------+-----------------------------------------------------+
+| Acquistion     | FGS_ACQ1      | jw<pppppooovvv>_gs-acq1_<yyyydddhhmmss>_uncal.fits  |
++                +---------------+-----------------------------------------------------+
+|                | FGS_ACQ2      | jw<pppppooovvv>_gs-acq2_<yyyydddhhmmss>_uncal.fits  |
++----------------+---------------+-----------------------------------------------------+
+| Track          | FGS_TRACK     | jw<pppppooovvv>_gs-track_<yyyydddhhmmss>_uncal.fits |
++----------------+---------------+-----------------------------------------------------+
+| Fine Guide     | FGS_FINEGUIDE | jw<pppppooovvv>_gs-fg_<yyyydddhhmmss>_uncal.fits    |
++----------------+---------------+-----------------------------------------------------+
+
+where the file name fields are:
+
+:jw: mission identifier
+:ppppp: program id
+:ooo: observation number
+:vvv: visit number
+:m: ID attempt counter (1-8)
+:yyyydddhhmmss: time stamp at the end of the data in the file
+
+Uncalibrated products use the "uncal" file name suffix as shown above, while calibrated
+products use a "cal" suffix. The relevance of the "image" and "stacked" designations for the
+Identification mode products is described below.
+
 ID mode
 ^^^^^^^
 The "Identification" guiding function images the field of view by reading the detector in a series
@@ -27,20 +62,6 @@ DMS creates 2 different forms of products for ID mode data: one in which an imag
 by simply stacking or butting the data from adjacent subarray strips against one another and the
 other in which the overlap regions of the strips are taken into account by averaging the pixel
 values. The first form is referred to as a "stacked" product and the second as an "image" product.
-
-The file name syntax for ID mode products is as follows::
-
- jw<pppppooovvv>_gs-id_<m>_<stacked | image>-<uncal | cal>.fits
-
-where:
-
- - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
- - gs-id: guide star identification product
- - m: the number of the identification attempt (0-8) within a visit
- - stacked: indicates that the subarray strips are stacked (butted) against one another in the image
- - image: indicates that the subarray strips have been merged in their overlap regions
- - uncal: indicates the uncalibrated (raw) product
- - cal: indicates the calibrated product
 
 The FITS file structure for uncalibrated ID "image" products is as follows:
 
@@ -200,19 +221,6 @@ ACQ1 mode
 ^^^^^^^^^
 The "Acquistion" guiding function ACQ1 performs 128 x 128 pixel subarray readouts of the
 detector, using 2 groups per integration and a total of 6 integrations.
-
-The file name syntax for ACQ1 mode products is as follows::
-
- jw<pppppooovvv>_gs-acq1_<yyyydddhhmmss>-<uncal | cal>.fits
-
-where:
-
- - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
- - gs-acq1: guide star acquisition1 product
- - yyyydddhhmmss: the time stamp at the *end* of the data contained in the file
- - uncal: indicates the uncalibrated (raw) product
- - cal: indicates the calibrated product
-
 The FITS file structure for ACQ1 uncalibrated products is as follows:
 
 +-----+---------+----------+-----------+-------------------+
@@ -251,19 +259,6 @@ ACQ2 mode
 ^^^^^^^^^
 The "Acquisition" guiding function ACQ2 performs 32 x 32 pixel subarray readouts of the detector,
 using 2 groups per integration and a total of 5 integrations.
-
-The file name syntax for ACQ2 mode products is as follows::
-
- jw<pppppooovvv>_gs-acq2_<yyyydddhhmmss>-<uncal | cal>.fits
-
-where:
-
- - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
- - gs-acq2: guide star acquisition2 product
- - yyyydddhhmmss: the time stamp at the *end* of the data contained in the file
- - uncal: indicates the uncalibrated (raw) product
- - cal: indicates the calibrated product
-
 The FITS file structure for ACQ2 uncalibrated products is as follows:
 
 +-----+---------+----------+-----------+-----------------+
@@ -304,19 +299,6 @@ The "Track" guiding function performs 32 x 32 pixel subarray readouts, the locat
 can move on the detector as the FGS FSW tracks the position of the guide star. The subarray
 readouts are performed with a cadence of 16 Hz. Each integration consists of 2 groups, and the
 total number of integrations (NINTS) can be very large (in the thousands).
-
-The file name syntax for TRACK mode products is as follows::
-
- jw<pppppooovvv>_gs-track_<yyyydddhhmmss>-<uncal | cal>.fits
-
-where:
-
- - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
- - gs-track: guide star track product
- - yyyydddhhmmss: the time stamp at the *end* of the data contained in the file
- - uncal: indicates the uncalibrated (raw) product
- - cal: indicates the calibrated product
-
 The FITS file structure for TRACK uncalibrated products is as follows:
 
 +-----+----------------------+----------+-----------+---------------------+
@@ -488,18 +470,6 @@ together, the 4 readouts at the end are averaged together, and then the differen
 averages is computed to form a final countrate image for each integration. This approach to
 creating the countrate images is used both on-board and in the :ref:`calwebb_guider <calwebb_guider>`
 pipeline when the raw data are processed on the ground.
-
-The file name syntax for FineGuide mode products is as follows::
-
- jw<pppppooovvv>_gs-fg_<yyyydddhhmmss>-<uncal | cal>.fits
-
-where:
-
- - pppppooovvv: the visit id, consisting of program id, obervation number, and visit number
- - gs-fg: guide star FineGuide product
- - yyyydddhhmmss: the time stamp at the *end* of the data contained in the file
- - uncal: indicates the uncalibrated (raw) product
- - cal: indicates the calibrated product
 
 The FITS file structure for FineGuide uncalibrated products is as follows:
 

--- a/docs/jwst/data_products/index.rst
+++ b/docs/jwst/data_products/index.rst
@@ -1,0 +1,16 @@
+.. _data_products:
+
+Data Products Information
+=========================
+
+.. toctree::
+   :maxdepth: 3
+   
+   stages.rst
+   file_naming.rst
+   product_types.rst
+   common_features.rst
+   science_products.rst
+   nonscience_products.rst
+   guidestar_products.rst
+

--- a/docs/jwst/data_products/nonscience_products.rst
+++ b/docs/jwst/data_products/nonscience_products.rst
@@ -6,7 +6,7 @@ Non-science products
 Dark exposure: ``dark``
 ^^^^^^^^^^^^^^^^^^^^^^^
 Dark exposures processed by the :ref:`calwebb_dark <calwebb_dark>` pipeline result in a
-product that has the same structure and content as the ramp_ product described above.
+product that has the same structure and content as the :ref:`ramp <ramp>` product described above.
 The details are as follows:
 
 +-----+------------+----------+-----------+---------------------------------+
@@ -58,7 +58,7 @@ Charge trap state data: ``trapsfilled``
 The :ref:`persistence <persistence_step>` step in the :ref:`calwebb_detector1 <calwebb_detector1>`
 pipeline produces an image containing information on the number of filled charge traps in each
 pixel at the end of an exposure. Internally these data exist as a `~jwst.datamodels.TrapsFilledModel`
-data model, which is saved to a ``trapsfilled` FITS product. The FITS file has the following
+data model, which is saved to a ``trapsfilled`` FITS product. The FITS file has the following
 format:
 
 +-----+---------+----------+-----------+-------------------+
@@ -82,8 +82,8 @@ WFS&C combined image: ``wfscmb``
 The :ref:`wfs_combine <wfs_combine_step>` step in the :ref:`calwebb_wfs-image3 <calwebb_wfs-image3>`
 pipeline combines dithered pairs of Wavefront Sensing and Control (WFS&C) images, with the
 result being stored in a ``wfscmb`` product. Unlike the drizzle methods used to combine and resample
-science images, resulting in an i2d_ product, the WFS&C combination is a simple shift and add technique
-that results in a standard imaging FITS file structure, as shown below.
+science images, resulting in an :ref:`i2d <i2d>` product, the WFS&C combination is a simple shift and add
+technique that results in a standard imaging FITS file structure, as shown below.
 
 +-----+---------+----------+-----------+---------------+
 | HDU | EXTNAME | HDU Type | Data Type | Dimensions    |

--- a/docs/jwst/data_products/nonscience_products.rst
+++ b/docs/jwst/data_products/nonscience_products.rst
@@ -1,0 +1,106 @@
+Non-science products
+--------------------
+
+.. _dark:
+
+Dark exposure: ``dark``
+^^^^^^^^^^^^^^^^^^^^^^^
+Dark exposures processed by the :ref:`calwebb_dark <calwebb_dark>` pipeline result in a
+product that has the same structure and content as the ramp_ product described above.
+The details are as follows:
+
++-----+------------+----------+-----------+---------------------------------+
+| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                      |
++=====+============+==========+===========+=================================+
+|  0  | N/A        | primary  | N/A       | N/A                             |
++-----+------------+----------+-----------+---------------------------------+
+|  1  | SCI        | IMAGE    | float32   | ncols x nrows x ngroups x nints |
++-----+------------+----------+-----------+---------------------------------+
+|  2  | PIXELDQ    | IMAGE    | uint32    | ncols x nrows                   |
++-----+------------+----------+-----------+---------------------------------+
+|  3  | GROUPDQ    | IMAGE    | uint8     | ncols x nrows x ngroups x nints |
++-----+------------+----------+-----------+---------------------------------+
+|  4  | ERR        | IMAGE    | float32   | ncols x nrows x ngroups x nints |
++-----+------------+----------+-----------+---------------------------------+
+|  5  | GROUP      | BINTABLE | N/A       | variable                        |
++-----+------------+----------+-----------+---------------------------------+
+|  6  | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols           |
++-----+------------+----------+-----------+---------------------------------+
+|     | ZEROFRAME* | IMAGE    | float32   | ncols x nrows x nints           |
++-----+------------+----------+-----------+---------------------------------+
+|     | REFOUT*    | IMAGE    | uint16    | ncols x 256 x ngroups x nints   |
++-----+------------+----------+-----------+---------------------------------+
+|     | ASDF       | BINTABLE | N/A       | variable                        |
++-----+------------+----------+-----------+---------------------------------+
+
+ - SCI: 4-D data array containing the pixel values. The first two dimensions are equal to
+   the size of the detector readout, with the data from multiple groups (NGROUPS) within each
+   integration stored along the 3rd axis, and the multiple integrations (NINTS) stored along
+   the 4th axis.
+ - PIXELDQ: 2-D data array containing DQ flags that apply to all groups and all integrations
+   for a given pixel (e.g. a hot pixel is hot in all groups and integrations).
+ - GROUPDQ: 4-D data array containing DQ flags that pertain to individual groups within individual
+   integrations, such as the point at which a pixel becomes saturated within a given integration.
+ - ERR: 4-D data array containing uncertainty estimates on a per-group and per-integration basis.
+ - GROUP: A table of meta data for some (or all) of the data groups.
+ - INT_TIMES: A table of begining, middle, and end time stamps for each integration in the
+   exposure.
+ - ZEROFRAME: 3-D data array containing the pixel values of the zero-frame for each
+   integration in the exposure, where each plane of the cube corresponds to a given integration.
+   Only appears if the zero-frame data were requested to be downlinked separately.
+ - REFOUT: The MIRI detector reference output values. Only appears in MIRI exposures.
+ - ADSF: The data model meta data.
+
+.. _trfld:
+
+Charge trap state data: ``trapsfilled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The :ref:`persistence <persistence_step>` step in the :ref:`calwebb_detector1 <calwebb_detector1>`
+pipeline produces an image containing information on the number of filled charge traps in each
+pixel at the end of an exposure. Internally these data exist as a `~jwst.datamodels.TrapsFilledModel`
+data model, which is saved to a ``trapsfilled` FITS product. The FITS file has the following
+format:
+
++-----+---------+----------+-----------+-------------------+
+| HDU | EXTNAME | HDU Type | Data Type | Dimensions        |
++=====+=========+==========+===========+===================+
+|  0  | N/A     | primary  | N/A       | N/A               |
++-----+---------+----------+-----------+-------------------+
+|  1  | SCI     | IMAGE    | float32   | ncols x nrows x 3 |
++-----+---------+----------+-----------+-------------------+
+|  2  | ASDF    | BINTABLE | N/A       | variable          |
++-----+---------+----------+-----------+-------------------+
+
+ - SCI: 3-D data array giving the number of charge traps per pixel, with each plane
+   corresponding to a different trap family.
+ - ADSF: The data model meta data.
+
+.. _wfscmb:
+
+WFS&C combined image: ``wfscmb``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The :ref:`wfs_combine <wfs_combine_step>` step in the :ref:`calwebb_wfs-image3 <calwebb_wfs-image3>`
+pipeline combines dithered pairs of Wavefront Sensing and Control (WFS&C) images, with the
+result being stored in a ``wfscmb`` product. Unlike the drizzle methods used to combine and resample
+science images, resulting in an i2d_ product, the WFS&C combination is a simple shift and add technique
+that results in a standard imaging FITS file structure, as shown below.
+
++-----+---------+----------+-----------+---------------+
+| HDU | EXTNAME | HDU Type | Data Type | Dimensions    |
++=====+=========+==========+===========+===============+
+|  0  | N/A     | primary  | N/A       | N/A           |
++-----+---------+----------+-----------+---------------+
+|  1  | SCI     | IMAGE    | float32   | ncols x nrows |
++-----+---------+----------+-----------+---------------+
+|  2  | ERR     | IMAGE    | float32   | ncols x nrows |
++-----+---------+----------+-----------+---------------+
+|  3  | DQ      | IMAGE    | uint32    | ncols x nrows |
++-----+---------+----------+-----------+---------------+
+|  4  | ASDF    | BINTABLE | N/A       | variable      |
++-----+---------+----------+-----------+---------------+
+
+ - SCI: 2-D data array containing the pixel values, in units of surface brightness.
+ - ERR: 2-D data array containing uncertainty estimates for each pixel.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - ADSF: The data model meta data.
+

--- a/docs/jwst/data_products/product_types.rst
+++ b/docs/jwst/data_products/product_types.rst
@@ -1,0 +1,81 @@
+Data Product Types
+------------------
+The following table contains a list of all data product types, as given by their file name suffix,
+the pipeline and stage of processing that creates each type, and an indication of whether the file naming
+is exposure-based or source-based. The product name suffixes are active links to detailed descriptions
+in the following sections.
+
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| Pipeline           | Type Suffix                | Stage | Exp/Source | Description                         |
++====================+============================+=======+============+=====================================+
+| N/A                | :ref:`uncal <uncal>`       |   0   | Exposure   | Uncalibrated 4-D exposure           |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_dark       | :ref:`dark <dark>`         |   1   | Exposure   | 4-D corrected dark exposure         |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_detector1  | :ref:`trapsfilled <trfld>` |   1   | Exposure   | Charge trap state data              |
+|                    |                            |       |            |                                     |
+|                    | :ref:`ramp <ramp>`         |   1   | Exposure   | 4-D corrected ramp data             |
+|                    |                            |       |            |                                     |
+|                    | :ref:`rateints <rate>`     |   1   | Exposure   | 3-D countrate data, per integration |
+|                    |                            |       |            |                                     |
+|                    | :ref:`rate <rate>`         |   1   | Exposure   | 2-D countrate data, per exposure    |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_spec2      | :ref:`bsubints <bsub>`     |   2   | Exposure   | 3-D background-subtracted data      |
+|                    |                            |       |            |                                     |
+|                    | :ref:`bsub <bsub>`         |   2   | Exposure   | 2-D background-subtracted data      |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_image2     | :ref:`calints <cal>`       |   2   | Exposure   | 3-D calibrated data                 |
+|                    |                            |       |            |                                     |
+| calwebb_tso-image2 | :ref:`cal <cal>`           |   2   | Exposure   | 2-D calibrated data                 |
+|                    |                            |       |            |                                     |
+| calwebb_wfs-image2 | :ref:`i2d <i2d>`           |   2   | Exposure   | 2-D resampled imaging data          |
+|                    |                            |       |            |                                     |
+| calwebb_spec2      | :ref:`s2d <s2d>`           |   2   | Exposure   | 2-D resampled spectroscopic data    |
+|                    |                            |       |            |                                     |
+| calwebb_tso-spec2  | :ref:`s3d <s3d>`           |   2   | Exposure   | 3-D resampled spectroscopic data    |
+|                    |                            |       |            |                                     |
+|                    | :ref:`x1dints <x1d>`       |   2   | Exposure   | 1-D spectral data, per integration  |
+|                    |                            |       |            |                                     |
+|                    | :ref:`x1d <x1d>`           |   2   | Exposure   | 1-D extracted spectral data         |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_image3     | :ref:`crf <crf>`           |   2   | Exposure   | 2-D CR-flagged calibrated data      |
+|                    |                            |       |            |                                     |
+|                    | :ref:`i2d <i2d>`           |   3   | Source     | 2-D resampled imaging data          |
+|                    |                            |       |            |                                     |
+|                    | :ref:`cat <cat>`           |   3   | Source     | Source catalog                      |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_spec3      | :ref:`crf <crf>`           |   2   | Exposure   | 2-D CR-flagged calibrated data      |
+|                    |                            |       |            |                                     |
+|                    | :ref:`s2d <s2d>`           |   3   | Source     | 2-D resampled spectroscopic data    |
+|                    |                            |       |            |                                     |
+|                    | :ref:`s3d <s3d>`           |   3   | Source     | 3-D resampled spectroscopic data    |
+|                    |                            |       |            |                                     |
+|                    | :ref:`x1d <x1d>`           |   3   | Source     | 1-D extracted spectroscopic data    |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_ami3       | :ref:`ami <ami>`           |   3   | Source     | Fringe parameters                   |
+|                    |                            |       |            |                                     |
+|                    | :ref:`amiavg <ami>`        |   3   | Source     | Averaged fringe parameters          |
+|                    |                            |       |            |                                     |
+|                    | :ref:`aminorm <ami>`       |   3   | Source     | Normalized fringe parameters        |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_coron3     | :ref:`crfints <crf>`       |   2   | Exposure   | 3-D CR-flagged calibrated data      |
+|                    |                            |       |            |                                     |
+|                    | :ref:`psfstack <psfstack>` |   3   | Source     | PSF library images                  |
+|                    |                            |       |            |                                     |
+|                    | :ref:`psfalign <psfalign>` |   3   | Exposure   | Aligned PSF images                  |
+|                    |                            |       |            |                                     |
+|                    | :ref:`psfsub <psfsub>`     |   3   | Exposure   | PSF-subtracted images               |
+|                    |                            |       |            |                                     |
+|                    | :ref:`i2d <i2d>`           |   3   | Source     | 2-D resampled PSF-subtracted image  |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_tso3       | :ref:`crfints <crfints>`   |   2   | Exposure   | 3-D CR-flagged calibrated data      |
+|                    |                            |       |            |                                     |
+|                    | :ref:`phot <phot>`         |   3   | Source     | TSO imaging photometry catalog      |
+|                    |                            |       |            |                                     |
+|                    | :ref:`x1dints <x1dints>`   |   3   | Source     | TSO 1-D extracted spectra           |
+|                    |                            |       |            |                                     |
+|                    | :ref:`whtlt <whtlt>`       |   3   | Source     | TSO spectral white-light catalog    |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+| calwebb_wfs-image3 | :ref:`wfscmb <wfscmb>`     |   3   | Source     | 2-D combined WFS&C image            |
++--------------------+----------------------------+-------+------------+-------------------------------------+
+

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -567,7 +567,7 @@ The structure of the "EXTRACT1D" table extension is as follows:
 The table is constructed using a simple 2-D layout, using one row per extracted spectral
 element in the dispersion direction of the data (i.e. one row per wavelength bin).
 For some spectroscopic modes, such as MIRI MRS and NIRSpec IFU, the data that are used
-as input to the :ref:`extract_1d` step are already in calibrated units of surface
+as input to the :ref:`extract_1d <extract_1d_step>` step are already in calibrated units of surface
 brightness and therefore it's not possible to present 1-D extracted results for the net
 and background spectral data in units of DN/s. In these cases the NET, NERROR, BACKGROUND,
 and BERROR table columns will be zero-filled and only the WAVELENGTH, FLUX, ERROR, and DQ

--- a/docs/jwst/data_products/stages.rst
+++ b/docs/jwst/data_products/stages.rst
@@ -1,0 +1,55 @@
+Processing Levels and Product Stages
+====================================
+Here we describe the structure and content of the most frequently used forms of files for
+JWST science data products, the vast majority of which are in FITS format. Each type of FITS
+file is the result of serialization of a corresponding data model. All
+JWST pipeline input and output products, with the exception of a few
+reference files and catalogs, are serialized as FITS files.
+The `ASDF <https://asdf-standard.readthedocs.io/en/stable/>`_ representation
+of the data model is serialized as a FITS BINTABLE extension
+within the FITS file, with EXTNAME="ASDF". The ASDF extension is essentially a
+text character serialization in `YAML <https://yaml.org>`_ format of the
+data model. The ASDF representation is read from the extension when a FITS file
+is loaded into a data model to provide the initial instance of the data model.
+Values in the other FITS extensions then either override this initial model or are added to it.
+
+Within the various STScI internal data processing and archiving systems that are used for
+routine processing of JWST data, there are some different uses of terminology to refer to
+different levels or stages of processing and products. For those who are interested or
+need to know, the table below gives high-level translations between those naming conventions.
+
++--------------------------------+-------------------------------------+------------------------------------+
+| Data Processing Levels         | User Data Product Stages            | MAST/CAOM Data Levels              |
++================================+=====================================+====================================+
+| N/A                            | N/A                                 | -1 = Planned, but not yet executed |
++--------------------------------+-------------------------------------+------------------------------------+
+| Level 0 = Science telemetry    | Not available to users              | Not available to users             |
++--------------------------------+-------------------------------------+------------------------------------+
+| Level 0.5 = POD files          | Not available to users              | Not available to users             |
++--------------------------------+-------------------------------------+------------------------------------+
+| Level 1a = Original FITS file  | Stage 0 = Original FITS file        | 0 = raw                            |
++--------------------------------+-------------------------------------+------------------------------------+
+| Level 1b = Uncal FITS file     | Stage 0 = Fully-populated FITS file | 1 = uncalibrated                   |
++--------------------------------+-------------------------------------+------------------------------------+
+| Level 2a = Countrate exposure  | Stage 1 = Countrate FITS file       | 2 = calibrated                     |
++--------------------------------+-------------------------------------+------------------------------------+
+| Level 2b = Calibrated exposure | Stage 2 = Calibrated exposure       | 2 = calibrated                     |
+|                                |                                     |                                    |
+| Level 2c = CR-flagged exposure |                                     |                                    |
++--------------------------------+-------------------------------------+------------------------------------+
+| Level 3 = Combined data        | Stage 3 = Combined data             | 3 = Science product                |
++--------------------------------+-------------------------------------+------------------------------------+
+| Level 4 = Analysis results     | Stage 4 = High-level product        | 4 = Contributed product            |
++--------------------------------+-------------------------------------+------------------------------------+
+
+Throughout this document, we will use the "Stage" terminology to refer to data products.
+Stage 0, 1, and 2 products are always files containing the data from a single exposure and a
+single detector. A NIRCam exposure that uses all 10 detectors will therefore result in 10 separate
+FITS files for the Stage 0, 1, and 2 products. Because these stages contain the data for a single
+exposure, they are refered to as "exposure-based" products and use an "exposure-based" file naming
+syntax. Stage 3 and 4 products, on the other hand, are constructed from the combined data of
+multiple exposures for a given source or target. They are referred to as "source-based" products
+and use a "source-based" file naming syntax. Observing modes that include multiple defined sources
+within a single exposure or observation, such as NIRSpec MOS and NIRCam/NIRISS WFSS, will result in
+multiple Stage 3 products, one for each defined or identifiable source.
+

--- a/docs/jwst/datamodels/fits_files.rst
+++ b/docs/jwst/datamodels/fits_files.rst
@@ -1,45 +1,42 @@
-FITS file structures and contents
-=================================
+JWST FITS data product formats
+==============================
 
 Here we describe the structure and content of the most frequently used
 forms of FITS files for JWST science data products. Each type of FITS
 file is the result of serialization of a corresponding data model. All
-JWST pipeline input and output images, with the exception of a few
-reference files, are serialized as FITS files. The ASDF representation
-of the datamodel is serialized as the final extension of the FITS
-file, in the ASDF extension, as eight bit unsigned ints, essentialy a
-text character serialization in yaml format.  The ASDF representation
-is read from the extension when the FITS file is read to provide the
-initial datamodel. Values in the other FITS extensions then either
-override this initial model or are added to it.
-
+JWST pipeline input and output products, with the exception of a few
+reference files and catalogs, are serialized as FITS files. The ASDF
+representation of the data model is serialized as a FITS BINTABLE extension
+within the FITS file, with EXTNAME="ASDF" (essentialy a text character
+serialization in yaml format.  The ASDF representation
+is read from the extension when a FITS file is loaded into a data model,
+to provide the initial instance of the data model. Values in the other
+FITS extensions then either override this initial model or are added to it.
 
 Common Features
 ---------------
 
-All FITS science products have a few common features to their structure
+All JWST FITS science products have a few common features in their structure
 and organization:
 
-1. The primary Header-Data Unit (HDU) only contains header information,
+1. The FITS primary Header-Data Unit (HDU) only contains header information,
    in the form of keyword records, with an empty data array, which is
    indicated by the occurence of NAXIS=0 in the primary header. Meta
    data that pertains to the entire product is stored in keywords in the
    primary header. Meta data related to specific extensions (see below)
-   should be stored in keywords in the headers of those extensions.
+   is stored in keywords in the headers of each extension.
 
 2. All data related to the product are contained in one or more FITS
-   Image or Table extensions. The header of each extension may contain
+   IMAGE or BINTABLE extensions. The header of each extension may contain
    keywords that pertain uniquely to that extension.
 
- 3.
- 
-Level-1 and Level-2 exposure-based products, which contain the data
+Stage 1 and 2 exposure-based products, which contain the data
 from an individual exposure on an individual detector, use the
-following file naming scheme::
+following FITS file naming scheme::
 
-    jw{ppppp}{ooo}{vvv}_{gg}{s}{aa}_{eeeee}_{detector}_{suffix}.fits
+    jw<ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>_<detector>_<prodType>.fits
 
-where:
+where
 
    - ppppp: program ID number
    - ooo: observation number
@@ -49,166 +46,359 @@ where:
    - aa: activity number (base 36)
    - eeeee: exposure number
    - detector: detector name (e.g. 'nrca1', 'nrcblong', 'mirimage')
-   - suffix: product type identifier (e.g. 'uncal', 'rate', 'cal')
+   - prodType: product type identifier (e.g. 'uncal', 'rate', 'cal')
 
-An example Level-2a product FITS file name is::
+An example Stage 1 product FITS file name is::
 
    jw93065002001_02101_00001_nrca1_rate.fits
+
+Stage 3 products, which consist of data from multiple exposures and/or
+detectors, use a source-based file naming scheme::
+
+jw<ppppp>-<AC_ID>_[<"t"TargID | "s"SourceID">](-<"epoch"X>)_<instr>_<optElements>(-<subarray>)_<prodType>(-<ACT_ID>).fits
+
+where
+
+   - ppppp: program ID number
+   - AC_ID: association candidate ID
+   - TargID: a 3-digit target ID (either TargID or SourceID must be present)
+   - SourceID: a 5-digit source ID
+   - epochX: the text "epoch" followed by a single digit epoch number
+   - instr: science instrument name (e.g. 'nircam', 'miri')
+   - optElements: a single or hyphen-separated list of optical elements (e.g. filter, grating)
+   - subarray: optional indicator of subarray name
+   - prodType: product type identifier (e.g. 'i2d', 's3d', 'x1d')
+   - ACT_ID: a 2-digit activity ID
+
+An example Stage 3 product FITS file name is::
+
+   jw87600-a3001_t001_niriss_f480m-nrm_amiavg.fits
 
 Specific products
 -----------------
 
-This section lists the organization and contents of each type of
-science product in FITS form.
+The following sections describe the format and contents of each of the JWST FITS science
+products. Things to note in the descriptions include:
 
-Raw Level-1b (suffix = `uncal`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ - Not all FITS extensions occur in every data product of a given type. Many are either
+   optional or dependent on the instrument or observing mode. Such optional extensions are
+   noted with an asterisk in the tables below.
 
-Exposure raw data (level-1b) products are designated with a file name
-suffix of "uncal." These files usually contain only the raw pixel values
-from an exposure, with the addition of a table extension that contains
-some downlinked meta data pertaining to individual groups. Additional
-extensions can be included for certain instruments and readout types.
-If the zero-frame was requested to be downlinked, an additional image
-extension is included that contains those data.
-MIRI exposures also contain an additional image extension with the values
-from the reference output. The FITS file structure is as follows.
+ - Because some extensions are optional, as well as the fact that the exact ordering of the
+   extensions is not guaranteed, the FITS HDU index numbers of a given extension type can
+   vary from one product to another. The only guarantee is that the ``SCI`` extension,
+   containing the actual pixel values, will always be the first FITS extension (HDU=1).
+   Other common extensions, like ``DQ`` and ``ERR``, usually immediately follow the ``SCI``,
+   but the order is not guaranteed. Hence HDU index numbers are not listed for many
+   extension types, because they can vary.
 
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-| HDU | Content           | EXTNAME   | HDU Type | Data Type | Dimensions                      |
-+=====+===================+===========+==========+===========+=================================+
-|  0  | Primary header    | N/A       | N/A      | N/A       | N/A                             |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-|  1  | Pixel values      | SCI       | IMAGE    | uint16    | ncols x nrows x ngroups x nints |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-|  2  | Group meta        | GROUP     | BINTABLE | N/A       | variable                        |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-|  3  | Zero frame images | ZEROFRAME | IMAGE    | uint16    | ncols x nrows x nints           |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-|  4  | Reference output  | REFOUT    | IMAGE    | uint16    | ncols x 256 x ngroups x nints   |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
+Uncalibrated raw data: ``uncal``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Exposure raw data products are designated by a file name
+suffix of "uncal." These files usually contain only the raw detector pixel values
+from an exposure, with the addition of some table extensions containing various types of
+meta data associated with the exposure.
+Additional extensions can be included for certain instruments and readout types, as noted
+below.
+The FITS file structure is as follows.
 
-The raw pixel values in the SCI extension are stored as a 4-D data array,
-having dimensions equal to the 2-D size of the detector readout, with
-the data from the multiple groups (ngroups) within each integration stored
-along the 3rd axis, and the multiple integrations (nints) stored along the
-4th axis.
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+| HDU | Content            | EXTNAME   | HDU Type | Data Type | Dimensions                      |
++=====+====================+===========+==========+===========+=================================+
+|  0  | Primary header     | N/A       | N/A      | N/A       | N/A                             |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|  1  | Pixel values       | SCI       | IMAGE    | uint16    | ncols x nrows x ngroups x nints |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|  2  | Group meta data    | GROUP     | BINTABLE | N/A       | variable                        |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|  3  | Integration times  | INT_TIMES | BINTABLE | N/A       | nints (rows) x 7 cols           |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|     | Zero-frame images* | ZEROFRAME | IMAGE    | uint16    | ncols x nrows x nints           |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|     | Reference output*  | REFOUT    | IMAGE    | uint16    | ncols x 256 x ngroups x nints   |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|     | Data model meta    | ASDF      | BINTABLE | N/A       | variable                        |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
 
-If zero-frame data are downlinked, there will be one zero-frame image
-for each integration, stored as a 3-D cube (each cube plane corresponds
-to an integration).
+ - SCI: 4-D data array containing the raw pixel values. The first two dimensions are equal to
+   the size of the detector readout, with the data from multiple groups (NGROUPS) within each
+   integration stored along the 3rd axis, and the multiple integrations (NINTS) stored along
+   the 4th axis.
+ - GROUP: A table of meta data for some (or all) of the data groups.
+ - INT_TIMES: A table of begining, middle, and end time stamps for each integration in the
+   exposure.
+ - ZEROFRAME: 3-D data array containing the pixel values of the zero-frame for each
+   integration in the exposure, where each plane of the cube corresponds to a given integration.
+   Only appears if the zero-frame data were requested to be downlinked separately.
+ - REFOUT: The MIRI detector reference output values. Only appears in MIRI exposures.
+ - ADSF: The data model meta data.
 
-Level-2 ramp data (suffix = `ramp`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-As soon as raw level-1b products are loaded into the calibration
-pipeline the contents of the product is modified to include
-additional data extensions, as well as converting the raw SCI
-(and ZEROFRAME and REFOUT, if present) array values from integer to
-floating-point data type. New data arrays that are added include an
-ERR extension and two types of data quality flag extensions. There
-is a 2-D `PIXELDQ` extension that will contain flags that pertain
-to all groups and all integrations, and there is also a 4-D
-`GROUPDQ` extension for containing flags that pertain to individual
-groups within individual integrations. The FITS file layout is as
-follows:
+This FITS file structure is the result of serializing a `~jwst.datamodels.Level1bModel`, but
+can also be read into a `~jwst.datamodels.RampModel`, in which case zero-filled
+ERR, GROUPDQ, and PIXELDQ data arrays will be created and stored in the model, having array
+dimensions based on the shape of the SCI array (see `~jwst.datamodels.RampModel`).
 
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-| HDU | Content           | EXTNAME   | HDU Type | Data Type | Dimensions                      |
-+=====+===================+===========+==========+===========+=================================+
-|  0  | Primary header    | N/A       | N/A      | N/A       | N/A                             |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-|  1  | Pixel values      | SCI       | IMAGE    | float32   | ncols x nrows x ngroups x nints |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-|  2  | 2-D data quality  | PIXELDQ   | IMAGE    | uint32    | ncols x nrows                   |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-|  3  | 4-D data quality  | GROUPDQ   | IMAGE    | uint8     | ncols x nrows x ngroups x nints |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
-|  4  | Error values      | ERR       | IMAGE    | float32   | ncols x nrows x ngroups x nints |
-+-----+-------------------+-----------+----------+-----------+---------------------------------+
+Ramp data: ``ramp``
+^^^^^^^^^^^^^^^^^^^
+As raw data progress through the :ref:`calwebb_detector1 <calwebb_detector1>` pipeline
+they are stored internally in a `~jwst.datamodels.RampModel` (or `~jwst.datamodels.MIRIRampModel`
+for MIRI exposures). This type of data model is serialized to a ``ramp`` type FITS
+file on disk. The original detector pixel values (in the SCI extension) are converted
+from integer to floating-point data type. The same is true for the ZEROFRAME and REFOUT
+data extensions, if they are present. An ERR array and two types of data quality arrays are
+also added to the product. The FITS file layout is as follows:
 
-Any additional extensions that were present in the raw level-1b
-file (e.g. GROUP, ZEROFRAME, REFOUT) will be carried along and
-will also appear in the level-2 ramp product.
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+| HDU | Content            | EXTNAME   | HDU Type | Data Type | Dimensions                      |
++=====+====================+===========+==========+===========+=================================+
+|  0  | Primary header     | N/A       | N/A      | N/A       | N/A                             |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|  1  | Pixel values       | SCI       | IMAGE    | float32   | ncols x nrows x ngroups x nints |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|  2  | 2-D data quality   | PIXELDQ   | IMAGE    | uint32    | ncols x nrows                   |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|  3  | 4-D data quality   | GROUPDQ   | IMAGE    | uint8     | ncols x nrows x ngroups x nints |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|  4  | Error values       | ERR       | IMAGE    | float32   | ncols x nrows x ngroups x nints |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|     | Zero-frame images* | ZEROFRAME | IMAGE    | float32   | ncols x nrows x nints           |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|     | Group meta data    | GROUP     | BINTABLE | N/A       | variable                        |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|     | Integration times  | INT_TIMES | BINTABLE | N/A       | nints (rows) x 7 cols           |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|     | Reference output*  | REFOUT    | IMAGE    | uint16    | ncols x 256 x ngroups x nints   |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
+|     | Data model meta    | ASDF      | BINTABLE | N/A       | variable                        |
++-----+--------------------+-----------+----------+-----------+---------------------------------+
 
-Level-2a countrate products (suffix = `rate` and `rateints`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Countrate products are produced by applying ramp-fitting to the
-integrations within an exposure, in order to compute count rates
-from the original accumulating signal. For exposures that
-contain multiple integrations (nints > 1) this is done in two ways,
-which results in two separate products that are produced. First,
-countrates are computed for each integration within the exposure,
-the resuls of which are stored in a `rateints` product. These
-products will contain 3-D science data arrays, where each plane
-of the data cube contains the countrate image for an integration.
+ - SCI: 4-D data array containing the pixel values. The first two dimensions are equal to
+   the size of the detector readout, with the data from multiple groups (NGROUPS) within each
+   integration stored along the 3rd axis, and the multiple integrations (NINTS) stored along
+   the 4th axis.
+ - PIXELDQ: 2-D data array containing DQ flags that apply to all groups and all integrations
+   for a given pixel (e.g. a hot pixel is hot in all groups and integrations).
+ - GROUPDQ: 4-D data array containing DQ flags that pertain to individual groups within individual
+   integrations, such as the point at which a pixel becomes saturated within a given integration.
+ - ERR: 4-D data array containing uncertainty estimates on a per-group and per-integration basis.
+ - ZEROFRAME: 3-D data array containing the pixel values of the zero-frame for each
+   integration in the exposure, where each plane of the cube corresponds to a given integration.
+   Only appears if the zero-frame data were requested to be downlinked separately.
+ - GROUP: A table of meta data for some (or all) of the data groups.
+ - INT_TIMES: A table of begining, middle, and end time stamps for each integration in the
+   exposure.
+ - REFOUT: The MIRI detector reference output values. Only appears in MIRI exposures.
+ - ADSF: The data model meta data.
 
-The results for each integration are also averaged together to
-form a single 2-D countrate image for the entire exposure. These
-resuls are stored in a `rate` product.
+Countrate data: ``rate`` and ``rateints``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Countrate products are produced by applying the :ref:`ramp_fitting <ramp_fitting_step>` step to
+the integrations within an exposure, in order to compute count rates from the original
+accumulating signal ramps. For exposures that contain multiple integrations (NINTS > 1) this
+is done in two ways, which results in two separate products. First, countrates are computed
+for each integration within the exposure, the results of which are stored in a ``rateints`` product.
+These products contain 3-D data arrays, where each plane of the data cube contains the
+countrate image for a given integration.
 
-The FITS file structure for a `rateints` product is as follows:
+The results for each integration are also averaged together to form a single 2-D countrate
+image for the entire exposure. These resuls are stored in a ``rate`` product.
 
-+-----+----------------+---------+----------+-----------+-----------------------+
-| HDU | Content        | EXTNAME | HDU Type | Data Type | Dimensions            |
-+=====+================+=========+==========+===========+=======================+
-|  0  | Primary header | N/A     | N/A      | N/A       | N/A                   |
-+-----+----------------+---------+----------+-----------+-----------------------+
-|  1  | Pixel values   | SCI     | IMAGE    | float32   | ncols x nrows x nints |
-+-----+----------------+---------+----------+-----------+-----------------------+
-|  2  | Data quality   | DQ      | IMAGE    | uint32    | ncols x nrows x nints |
-+-----+----------------+---------+----------+-----------+-----------------------+
-|  3  | Error values   | ERR     | IMAGE    | float32   | ncols x nrows x nints |
-+-----+----------------+---------+----------+-----------+-----------------------+
+The FITS file structure for a ``rateints`` product is as follows:
 
-The FITS file structure for a `rate` product is as follows:
++-----+---------------------+-------------+----------+-----------+-----------------------+
+| HDU | Content             | EXTNAME     | HDU Type | Data Type | Dimensions            |
++=====+=====================+=============+==========+===========+=======================+
+|  0  | Primary header      | N/A         | N/A      | N/A       | N/A                   |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  1  | Pixel values        | SCI         | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  2  | Error values        | ERR         | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  3  | Data quality        | DQ          | IMAGE    | uint32    | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  4  | Integration times   | INT_TIMES   | BINTABLE | N/A       | nints (rows) x 7 cols |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  5  | Poisson variance    | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  6  | Read noise variance | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  7  | Data model meta     | ASDF        | BINTABLE | N/A       | variable              |
++-----+---------------------+-------------+----------+-----------+-----------------------+
 
-+-----+----------------+---------+----------+-----------+---------------+
-| HDU | Content        | EXTNAME | HDU Type | Data Type | Dimensions    |
-+=====+================+=========+==========+===========+===============+
-|  0  | Primary header | N/A     | N/A      | N/A       | N/A           |
-+-----+----------------+---------+----------+-----------+---------------+
-|  1  | Pixel values   | SCI     | IMAGE    | float32   | ncols x nrows |
-+-----+----------------+---------+----------+-----------+---------------+
-|  2  | Data quality   | DQ      | IMAGE    | uint32    | ncols x nrows |
-+-----+----------------+---------+----------+-----------+---------------+
-|  3  | Error values   | ERR     | IMAGE    | float32   | ncols x nrows |
-+-----+----------------+---------+----------+-----------+---------------+
+ - SCI: 3-D data array containing the pixel values, in units of DN/s. The first two dimensions are equal to
+   the size of the detector readout, with the data from multiple integrations stored along the 3rd axis.
+ - ERR: 3-D data array containing uncertainty estimates on a per-integration basis. These values
+   are based on the combined VAR_POISSON and VAR_RNOISE data (see below), given as
+   standard deviation.
+ - DQ: 3-D data array containing DQ flags. Each plane of the cube corresponds to a given integration.
+ - INT_TIMES: A table of begining, middle, and end time stamps for each integration in the
+   exposure.
+ - VAR_POISSON: 3-D data array containing the per-integration variance estimates for each pixel,
+   based on Poisson noise only.
+ - VAR_RNOISE: 3-D data array containing the per-integration variance estimates for each pixel,
+   based on read noise only.
+ - ADSF: The data model meta data.
 
-Note that the two separate forms of PIXELDQ and GROUPDQ flags from the
-previous types of products have been combined into a single DQ extension
-with the same dimensions as the SCI and ERR components.
+These FITS files are compatitable with the `~jwst.datamodels.CubeModel` data model.
 
-Level-2b calibrated products (suffix = `cal` and `calints`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Single exposure calibrated products duplicate the format and content of
-level-2a products. As with level-2a, there are two different forms of
-calibrated products: one containing results for individual integrations
-(`calints`) and one for exposure-wide results (`cal`).
+The FITS file structure for a ``rate`` product is as follows:
 
-The FITS file structure for a `calints` product is as follows:
++-----+---------------------+-------------+----------+-----------+-----------------------+
+| HDU | Content             | EXTNAME     | HDU Type | Data Type | Dimensions            |
++=====+=====================+=============+==========+===========+=======================+
+|  0  | Primary header      | N/A         | N/A      | N/A       | N/A                   |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  1  | Pixel values        | SCI         | IMAGE    | float32   | ncols x nrows         |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  2  | Error values        | ERR         | IMAGE    | float32   | ncols x nrows         |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  3  | Data quality        | DQ          | IMAGE    | uint32    | ncols x nrows         |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  4  | Poisson variance    | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  5  | Read noise variance | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  6  | Data model meta     | ASDF        | BINTABLE | N/A       | variable              |
++-----+---------------------+-------------+----------+-----------+-----------------------+
 
-+-----+----------------+---------+----------+-----------+-----------------------+
-| HDU | Content        | EXTNAME | HDU Type | Data Type | Dimensions            |
-+=====+================+=========+==========+===========+=======================+
-|  0  | Primary header | N/A     | N/A      | N/A       | N/A                   |
-+-----+----------------+---------+----------+-----------+-----------------------+
-|  1  | Pixel values   | SCI     | IMAGE    | float32   | ncols x nrows x nints |
-+-----+----------------+---------+----------+-----------+-----------------------+
-|  2  | Data quality   | DQ      | IMAGE    | uint32    | ncols x nrows x nints |
-+-----+----------------+---------+----------+-----------+-----------------------+
-|  3  | Error values   | ERR     | IMAGE    | float32   | ncols x nrows x nints |
-+-----+----------------+---------+----------+-----------+-----------------------+
+ - SCI: 2-D data array containing the pixel values, in units of DN/s.
+ - ERR: 2-D data array containing uncertainty estimates for each pixel. These values
+   are based on the combined VAR_POISSON and VAR_RNOISE data (see below), given as
+   standard deviation.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - VAR_POISSON: 2-D data array containing the variance estimate for each pixel,
+   based on Poisson noise only.
+ - VAR_RNOISE: 2-D data array containing the variance estimate for each pixel,
+   based on read noise only.
+ - ADSF: The data model meta data.
+
+These FITS files are compatible with the `~jwst.datamodels.ImageModel` data model.
+
+Note that the ``INT_TIMES`` table does not appear in ``rate`` products, because the
+data have been averaged over all integrations and hence the per-integration time stamps
+are no longer relevant.
+
+Calibrated data: ``cal`` and ``calints``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Single exposure calibrated products duplicate a lot of the format and content of
+countrate products. There are two different high-level forms of calibrated products:
+one containing results for all integrations in an exposure (``calints``) and one for
+results averaged over all integrations (``cal``). These products are the main result of
+Stage 2 pipelines like :ref:`calwebb_image2 <calwebb_image2>` and
+:ref:`calwebb_spec2 <calwebb_spec2>`.
+
+The FITS file structure for a ``calints`` product is as follows:
+
++-----+---------------------+-------------+----------+-----------+-----------------------+
+| HDU | Content             | EXTNAME     | HDU Type | Data Type | Dimensions            |
++=====+=====================+=============+==========+===========+=======================+
+|  0  | Primary header      | N/A         | N/A      | N/A       | N/A                   |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  1  | Pixel values        | SCI         | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  2  | Error values        | ERR         | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|  3  | Data quality        | DQ          | IMAGE    | uint32    | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|     | Integration times   | INT_TIMES   | BINTABLE | N/A       | nints (rows) x 7 cols |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|     | Poisson variance    | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|     | Read noise variance | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|     | Pixel area values*  | AREA        | IMAGE    |           | ncols x nrows         |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|     | Sensitivity values* | RELSENS     | BINTABLE | N/A       | variable              |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|     | Wavelength values*  | WAVELENGTH  | IMAGE    | float32   | ncols x nrows         |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+|     | Data model meta     | ASDF        | BINTABLE | N/A       | variable              |
++-----+---------------------+-------------+----------+-----------+-----------------------+
+
+ - SCI: 3-D data array containing the pixel values, in units of surface brightness, for
+   each integration.
+ - ERR: 3-D data array containing uncertainty estimates for each pixel, for each integration.
+   These values are based on the combined VAR_POISSON and VAR_RNOISE data (see below),
+   given as standard deviation.
+ - DQ: 3-D data array containing DQ flags for each pixel, for each integration.
+ - INT_TIMES: A table of begining, middle, and end time stamps for each integration in the
+   exposure.
+ - VAR_POISSON: 3-D data array containing the variance estimate for each pixel,
+   based on Poisson noise only, for each integration.
+ - VAR_RNOISE: 3-D data array containing the variance estimate for each pixel,
+   based on read noise only, for each integration.
+ - AREA: 2-D data array containing pixel area values, added by the :ref:`photom <photom_step>`
+   step, for imaging modes.
+ - RELSENS: A table of sensitivity values as a function of wavelength, added by the
+   :ref:`photom <photom_step>` step, for some spectroscopic modes.
+ - WAVELENGTH: 2-D data array of wavelength values for each pixel, for some spectroscopic modes.
+ - ADSF: The data model meta data.
 
 The FITS file structure for a `cal` product is as follows:
 
-+-----+----------------+---------+----------+-----------+---------------+
-| HDU | Content        | EXTNAME | HDU Type | Data Type | Dimensions    |
-+=====+================+=========+==========+===========+===============+
-|  0  | Primary header | N/A     | N/A      | N/A       | N/A           |
-+-----+----------------+---------+----------+-----------+---------------+
-|  1  | Pixel values   | SCI     | IMAGE    | float32   | ncols x nrows |
-+-----+----------------+---------+----------+-----------+---------------+
-|  2  | Data quality   | DQ      | IMAGE    | uint32    | ncols x nrows |
-+-----+----------------+---------+----------+-----------+---------------+
-|  3  | Error values   | ERR     | IMAGE    | float32   | ncols x nrows |
-+-----+----------------+---------+----------+-----------+---------------+
++-----+------------------------+--------------------------+----------+-----------+---------------+
+| HDU | Content                | EXTNAME                  | HDU Type | Data Type | Dimensions    |
++=====+========================+==========================+==========+===========+===============+
+|  0  | Primary header         | N/A                      | N/A      | N/A       | N/A           |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|  1  | Pixel values           | SCI                      | IMAGE    | float32   | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|  2  | Error values           | ERR                      | IMAGE    | float32   | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|  3  | Data quality           | DQ                       | IMAGE    | uint32    | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Poisson variance       | VAR_POISSON              | IMAGE    | float32   | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Read noise variance    | VAR_RNOISE               | IMAGE    | float32   | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Pixel area values*     | AREA                     | IMAGE    | float32   | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Sensitivity values*    | RELSENS                  | BINTABLE | N/A       | variable      |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Sensitivity values*    | RELSENS2D                | BINTABLE | N/A       | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Pathloss correction*   | PATHLOSS_POINTSOURCE     | IMAGE    | float32   | ncols         |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Wavelength values*     | WAVELENGTH_POINTSOURCE   | IMAGE    | float32   | ncols         |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Pathloss correction*   | PATHLOSS_UNIFORMSOURCE   | IMAGE    | float32   | ncols         |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Wavelength values*     | WAVELENGTH_UNIFORMSOURCE | IMAGE    | float32   | ncols         |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Bar shadow correction* | BARSHADOW                | IMAGE    | float32   | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Wavelength values*     | WAVELENGTH               | IMAGE    | float32   | ncols x nrows |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+|     | Data model meta        | ASDF                     | BINTABLE | N/A       | variable      |
++-----+------------------------+--------------------------+----------+-----------+---------------+
+
+ - SCI: 2-D data array containing the pixel values, in units of surface brightness.
+ - ERR: 2-D data array containing uncertainty estimates for each pixel.
+   These values are based on the combined VAR_POISSON and VAR_RNOISE data (see below),
+   given as standard deviation.
+ - DQ: 2-D data array containing DQ flags for each pixel.
+ - VAR_POISSON: 2-D data array containing the variance estimate for each pixel,
+   based on Poisson noise only.
+ - VAR_RNOISE: 2-D data array containing the variance estimate for each pixel,
+   based on read noise only.
+ - AREA: 2-D data array containing pixel area values, added by the :ref:`photom <photom_step>`
+   step, for imaging modes.
+ - RELSENS: A table of sensitivity values as a function of wavelength, added by the
+   :ref:`photom <photom_step>` step, for some spectroscopic modes.
+ - RELSENS2D: 2-D data array of sensitivity values per pixel, added by the
+   :ref:`photom <photom_step>` step, for IFU spectroscopic modes.
+ - PATHLOSS_POINTSOURCE: 1-D data array of point-source pathloss correction factors, added by
+   the :ref:`pathloss <pathloss_step>` step, for some spectroscopic modes.
+ - WAVELENGTH_POINTSOURCE: 1-D data array of wavelength values associated with the
+   PATHLOSS_POINTSOURCE correction factors, added by the :ref:`pathloss <pathloss_step>` step,
+   for some spectroscopic modes.
+ - PATHLOSS_UNIFORMSOURCE: 1-D data array of uniform-source pathloss correction factors, added by
+   the :ref:`pathloss <pathloss_step>` step, for some spectroscopic modes.
+ - WAVELENGTH_UNIFORMSOURCE: 1-D data array of wavelength values associated with the
+   PATHLOSS_UNIFORMSOURCE correction factors, added by the :ref:`pathloss <pathloss_step>` step,
+   for some spectroscopic modes.
+ - BARSHADOW: 2-D data array of NIRSpec MSA bar shadow correction factors, added by the
+   :ref:`barshadow <barshadow_step>` step, for NIRSpec MSA exposures only.
+ - WAVELENGTH: 2-D data array of wavelength values for each pixel, for some spectroscopic modes.
+ - ADSF: The data model meta data.
+

--- a/docs/jwst/datamodels/fits_files.rst
+++ b/docs/jwst/datamodels/fits_files.rst
@@ -34,45 +34,45 @@ Stage 1 and 2 exposure-based products, which contain the data
 from an individual exposure on an individual detector, use the
 following FITS file naming scheme::
 
-    jw<ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>_<detector>_<prodType>.fits
+ jw<ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>_<detector>_<prodType>.fits
 
 where
 
-   - ppppp: program ID number
-   - ooo: observation number
-   - vvv: visit number
-   - gg: visit group
-   - s: parallel sequence ID (1=prime, 2-5=parallel)
-   - aa: activity number (base 36)
-   - eeeee: exposure number
-   - detector: detector name (e.g. 'nrca1', 'nrcblong', 'mirimage')
-   - prodType: product type identifier (e.g. 'uncal', 'rate', 'cal')
+ - ppppp: program ID number
+ - ooo: observation number
+ - vvv: visit number
+ - gg: visit group
+ - s: parallel sequence ID (1=prime, 2-5=parallel)
+ - aa: activity number (base 36)
+ - eeeee: exposure number
+ - detector: detector name (e.g. 'nrca1', 'nrcblong', 'mirimage')
+ - prodType: product type identifier (e.g. 'uncal', 'rate', 'cal')
 
 An example Stage 1 product FITS file name is::
 
-   jw93065002001_02101_00001_nrca1_rate.fits
+ jw93065002001_02101_00001_nrca1_rate.fits
 
 Stage 3 products, which consist of data from multiple exposures and/or
 detectors, use a source-based file naming scheme::
 
-jw<ppppp>-<AC_ID>_[<"t"TargID | "s"SourceID">](-<"epoch"X>)_<instr>_<optElements>(-<subarray>)_<prodType>(-<ACT_ID>).fits
+ jw<ppppp>-<AC_ID>_[<"t"TargID | "s"SourceID">](-<"epoch"X>)_<instr>_<optElements>(-<subarray>)_<prodType>(-<ACT_ID>).fits
 
 where
 
-   - ppppp: program ID number
-   - AC_ID: association candidate ID
-   - TargID: a 3-digit target ID (either TargID or SourceID must be present)
-   - SourceID: a 5-digit source ID
-   - epochX: the text "epoch" followed by a single digit epoch number
-   - instr: science instrument name (e.g. 'nircam', 'miri')
-   - optElements: a single or hyphen-separated list of optical elements (e.g. filter, grating)
-   - subarray: optional indicator of subarray name
-   - prodType: product type identifier (e.g. 'i2d', 's3d', 'x1d')
-   - ACT_ID: a 2-digit activity ID
+ - ppppp: program ID number
+ - AC_ID: association candidate ID
+ - TargID: a 3-digit target ID (either TargID or SourceID must be present)
+ - SourceID: a 5-digit source ID
+ - epochX: the text "epoch" followed by a single digit epoch number
+ - instr: science instrument name (e.g. 'nircam', 'miri')
+ - optElements: a single or hyphen-separated list of optical elements (e.g. filter, grating)
+ - subarray: optional indicator of subarray name
+ - prodType: product type identifier (e.g. 'i2d', 's3d', 'x1d')
+ - ACT_ID: a 2-digit activity ID
 
 An example Stage 3 product FITS file name is::
 
-   jw87600-a3001_t001_niriss_f480m-nrm_amiavg.fits
+ jw87600-a3001_t001_niriss_f480m-nrm_amiavg.fits
 
 Specific products
 -----------------
@@ -102,23 +102,23 @@ Additional extensions can be included for certain instruments and readout types,
 below.
 The FITS file structure is as follows.
 
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-| HDU | Content            | EXTNAME   | HDU Type | Data Type | Dimensions                      |
-+=====+====================+===========+==========+===========+=================================+
-|  0  | Primary header     | N/A       | N/A      | N/A       | N/A                             |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|  1  | Pixel values       | SCI       | IMAGE    | uint16    | ncols x nrows x ngroups x nints |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|  2  | Group meta data    | GROUP     | BINTABLE | N/A       | variable                        |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|  3  | Integration times  | INT_TIMES | BINTABLE | N/A       | nints (rows) x 7 cols           |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|     | Zero-frame images* | ZEROFRAME | IMAGE    | uint16    | ncols x nrows x nints           |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|     | Reference output*  | REFOUT    | IMAGE    | uint16    | ncols x 256 x ngroups x nints   |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|     | Data model meta    | ASDF      | BINTABLE | N/A       | variable                        |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
++-----+------------+----------+-----------+---------------------------------+
+| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                      |
++=====+============+==========+===========+=================================+
+|  0  | N/A        | primary  | N/A       | N/A                             |
++-----+------------+----------+-----------+---------------------------------+
+|  1  | SCI        | IMAGE    | uint16    | ncols x nrows x ngroups x nints |
++-----+------------+----------+-----------+---------------------------------+
+|  2  | GROUP      | BINTABLE | N/A       | variable                        |
++-----+------------+----------+-----------+---------------------------------+
+|  3  | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols           |
++-----+------------+----------+-----------+---------------------------------+
+|     | ZEROFRAME* | IMAGE    | uint16    | ncols x nrows x nints           |
++-----+------------+----------+-----------+---------------------------------+
+|     | REFOUT*    | IMAGE    | uint16    | ncols x 256 x ngroups x nints   |
++-----+------------+----------+-----------+---------------------------------+
+|     | ASDF       | BINTABLE | N/A       | variable                        |
++-----+------------+----------+-----------+---------------------------------+
 
  - SCI: 4-D data array containing the raw pixel values. The first two dimensions are equal to
    the size of the detector readout, with the data from multiple groups (NGROUPS) within each
@@ -148,29 +148,29 @@ from integer to floating-point data type. The same is true for the ZEROFRAME and
 data extensions, if they are present. An ERR array and two types of data quality arrays are
 also added to the product. The FITS file layout is as follows:
 
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-| HDU | Content            | EXTNAME   | HDU Type | Data Type | Dimensions                      |
-+=====+====================+===========+==========+===========+=================================+
-|  0  | Primary header     | N/A       | N/A      | N/A       | N/A                             |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|  1  | Pixel values       | SCI       | IMAGE    | float32   | ncols x nrows x ngroups x nints |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|  2  | 2-D data quality   | PIXELDQ   | IMAGE    | uint32    | ncols x nrows                   |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|  3  | 4-D data quality   | GROUPDQ   | IMAGE    | uint8     | ncols x nrows x ngroups x nints |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|  4  | Error values       | ERR       | IMAGE    | float32   | ncols x nrows x ngroups x nints |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|     | Zero-frame images* | ZEROFRAME | IMAGE    | float32   | ncols x nrows x nints           |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|     | Group meta data    | GROUP     | BINTABLE | N/A       | variable                        |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|     | Integration times  | INT_TIMES | BINTABLE | N/A       | nints (rows) x 7 cols           |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|     | Reference output*  | REFOUT    | IMAGE    | uint16    | ncols x 256 x ngroups x nints   |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
-|     | Data model meta    | ASDF      | BINTABLE | N/A       | variable                        |
-+-----+--------------------+-----------+----------+-----------+---------------------------------+
++-----+------------+----------+-----------+---------------------------------+
+| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                      |
++=====+============+==========+===========+=================================+
+|  0  | N/A        | primary  | N/A       | N/A                             |
++-----+------------+----------+-----------+---------------------------------+
+|  1  | SCI        | IMAGE    | float32   | ncols x nrows x ngroups x nints |
++-----+------------+----------+-----------+---------------------------------+
+|  2  | PIXELDQ    | IMAGE    | uint32    | ncols x nrows                   |
++-----+------------+----------+-----------+---------------------------------+
+|  3  | GROUPDQ    | IMAGE    | uint8     | ncols x nrows x ngroups x nints |
++-----+------------+----------+-----------+---------------------------------+
+|  4  | ERR        | IMAGE    | float32   | ncols x nrows x ngroups x nints |
++-----+------------+----------+-----------+---------------------------------+
+|     | ZEROFRAME* | IMAGE    | float32   | ncols x nrows x nints           |
++-----+------------+----------+-----------+---------------------------------+
+|     | GROUP      | BINTABLE | N/A       | variable                        |
++-----+------------+----------+-----------+---------------------------------+
+|     | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols           |
++-----+------------+----------+-----------+---------------------------------+
+|     | REFOUT*    | IMAGE    | uint16    | ncols x 256 x ngroups x nints   |
++-----+------------+----------+-----------+---------------------------------+
+|     | ASDF       | BINTABLE | N/A       | variable                        |
++-----+------------+----------+-----------+---------------------------------+
 
  - SCI: 4-D data array containing the pixel values. The first two dimensions are equal to
    the size of the detector readout, with the data from multiple groups (NGROUPS) within each
@@ -205,25 +205,25 @@ image for the entire exposure. These resuls are stored in a ``rate`` product.
 
 The FITS file structure for a ``rateints`` product is as follows:
 
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-| HDU | Content             | EXTNAME     | HDU Type | Data Type | Dimensions            |
-+=====+=====================+=============+==========+===========+=======================+
-|  0  | Primary header      | N/A         | N/A      | N/A       | N/A                   |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  1  | Pixel values        | SCI         | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  2  | Error values        | ERR         | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  3  | Data quality        | DQ          | IMAGE    | uint32    | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  4  | Integration times   | INT_TIMES   | BINTABLE | N/A       | nints (rows) x 7 cols |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  5  | Poisson variance    | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  6  | Read noise variance | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  7  | Data model meta     | ASDF        | BINTABLE | N/A       | variable              |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
++-----+-------------+----------+-----------+-----------------------+
+| HDU | EXTNAME     | HDU Type | Data Type | Dimensions            |
++=====+=============+==========+===========+=======================+
+|  0  | N/A         | primary  | N/A       | N/A                   |
++-----+-------------+----------+-----------+-----------------------+
+|  1  | SCI         | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  2  | ERR         | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  3  | DQ          | IMAGE    | uint32    | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  4  | INT_TIMES   | BINTABLE | N/A       | nints (rows) x 7 cols |
++-----+-------------+----------+-----------+-----------------------+
+|  5  | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  6  | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  7  | ASDF        | BINTABLE | N/A       | variable              |
++-----+-------------+----------+-----------+-----------------------+
 
  - SCI: 3-D data array containing the pixel values, in units of DN/s. The first two dimensions are equal to
    the size of the detector readout, with the data from multiple integrations stored along the 3rd axis.
@@ -243,23 +243,23 @@ These FITS files are compatitable with the `~jwst.datamodels.CubeModel` data mod
 
 The FITS file structure for a ``rate`` product is as follows:
 
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-| HDU | Content             | EXTNAME     | HDU Type | Data Type | Dimensions            |
-+=====+=====================+=============+==========+===========+=======================+
-|  0  | Primary header      | N/A         | N/A      | N/A       | N/A                   |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  1  | Pixel values        | SCI         | IMAGE    | float32   | ncols x nrows         |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  2  | Error values        | ERR         | IMAGE    | float32   | ncols x nrows         |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  3  | Data quality        | DQ          | IMAGE    | uint32    | ncols x nrows         |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  4  | Poisson variance    | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  5  | Read noise variance | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  6  | Data model meta     | ASDF        | BINTABLE | N/A       | variable              |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
++-----+-------------+----------+-----------+-----------------------+
+| HDU | EXTNAME     | HDU Type | Data Type | Dimensions            |
++=====+=============+==========+===========+=======================+
+|  0  | N/A         | primary  | N/A       | N/A                   |
++-----+-------------+----------+-----------+-----------------------+
+|  1  | SCI         | IMAGE    | float32   | ncols x nrows         |
++-----+-------------+----------+-----------+-----------------------+
+|  2  | ERR         | IMAGE    | float32   | ncols x nrows         |
++-----+-------------+----------+-----------+-----------------------+
+|  3  | DQ          | IMAGE    | uint32    | ncols x nrows         |
++-----+-------------+----------+-----------+-----------------------+
+|  4  | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  5  | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  6  | ASDF        | BINTABLE | N/A       | variable              |
++-----+-------------+----------+-----------+-----------------------+
 
  - SCI: 2-D data array containing the pixel values, in units of DN/s.
  - ERR: 2-D data array containing uncertainty estimates for each pixel. These values
@@ -285,35 +285,37 @@ countrate products. There are two different high-level forms of calibrated produ
 one containing results for all integrations in an exposure (``calints``) and one for
 results averaged over all integrations (``cal``). These products are the main result of
 Stage 2 pipelines like :ref:`calwebb_image2 <calwebb_image2>` and
-:ref:`calwebb_spec2 <calwebb_spec2>`.
+:ref:`calwebb_spec2 <calwebb_spec2>`. There are many additional types of extensions
+that only appear for certain observing modes or instruments, especially for spectroscopic
+exposures.
 
 The FITS file structure for a ``calints`` product is as follows:
 
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-| HDU | Content             | EXTNAME     | HDU Type | Data Type | Dimensions            |
-+=====+=====================+=============+==========+===========+=======================+
-|  0  | Primary header      | N/A         | N/A      | N/A       | N/A                   |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  1  | Pixel values        | SCI         | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  2  | Error values        | ERR         | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|  3  | Data quality        | DQ          | IMAGE    | uint32    | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|     | Integration times   | INT_TIMES   | BINTABLE | N/A       | nints (rows) x 7 cols |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|     | Poisson variance    | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|     | Read noise variance | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|     | Pixel area values*  | AREA        | IMAGE    |           | ncols x nrows         |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|     | Sensitivity values* | RELSENS     | BINTABLE | N/A       | variable              |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|     | Wavelength values*  | WAVELENGTH  | IMAGE    | float32   | ncols x nrows         |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
-|     | Data model meta     | ASDF        | BINTABLE | N/A       | variable              |
-+-----+---------------------+-------------+----------+-----------+-----------------------+
++-----+-------------+----------+-----------+-----------------------+
+| HDU | EXTNAME     | HDU Type | Data Type | Dimensions            |
++=====+=============+==========+===========+=======================+
+|  0  | N/A         | primary  | N/A       | N/A                   |
++-----+-------------+----------+-----------+-----------------------+
+|  1  | SCI         | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  2  | ERR         | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|  3  | DQ          | IMAGE    | uint32    | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|     | INT_TIMES   | BINTABLE | N/A       | nints (rows) x 7 cols |
++-----+-------------+----------+-----------+-----------------------+
+|     | VAR_POISSON | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|     | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
++-----+-------------+----------+-----------+-----------------------+
+|     | AREA*       | IMAGE    |           | ncols x nrows         |
++-----+-------------+----------+-----------+-----------------------+
+|     | RELSENS*    | BINTABLE | N/A       | variable              |
++-----+-------------+----------+-----------+-----------------------+
+|     | WAVELENGTH* | IMAGE    | float32   | ncols x nrows         |
++-----+-------------+----------+-----------+-----------------------+
+|     | ASDF        | BINTABLE | N/A       | variable              |
++-----+-------------+----------+-----------+-----------------------+
 
  - SCI: 3-D data array containing the pixel values, in units of surface brightness, for
    each integration.
@@ -334,43 +336,43 @@ The FITS file structure for a ``calints`` product is as follows:
  - WAVELENGTH: 2-D data array of wavelength values for each pixel, for some spectroscopic modes.
  - ADSF: The data model meta data.
 
-The FITS file structure for a `cal` product is as follows:
+The FITS file structure for a ``cal`` product is as follows:
 
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-| HDU | Content                | EXTNAME                  | HDU Type | Data Type | Dimensions    |
-+=====+========================+==========================+==========+===========+===============+
-|  0  | Primary header         | N/A                      | N/A      | N/A       | N/A           |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|  1  | Pixel values           | SCI                      | IMAGE    | float32   | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|  2  | Error values           | ERR                      | IMAGE    | float32   | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|  3  | Data quality           | DQ                       | IMAGE    | uint32    | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Poisson variance       | VAR_POISSON              | IMAGE    | float32   | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Read noise variance    | VAR_RNOISE               | IMAGE    | float32   | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Pixel area values*     | AREA                     | IMAGE    | float32   | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Sensitivity values*    | RELSENS                  | BINTABLE | N/A       | variable      |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Sensitivity values*    | RELSENS2D                | BINTABLE | N/A       | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Pathloss correction*   | PATHLOSS_POINTSOURCE     | IMAGE    | float32   | ncols         |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Wavelength values*     | WAVELENGTH_POINTSOURCE   | IMAGE    | float32   | ncols         |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Pathloss correction*   | PATHLOSS_UNIFORMSOURCE   | IMAGE    | float32   | ncols         |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Wavelength values*     | WAVELENGTH_UNIFORMSOURCE | IMAGE    | float32   | ncols         |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Bar shadow correction* | BARSHADOW                | IMAGE    | float32   | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Wavelength values*     | WAVELENGTH               | IMAGE    | float32   | ncols x nrows |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
-|     | Data model meta        | ASDF                     | BINTABLE | N/A       | variable      |
-+-----+------------------------+--------------------------+----------+-----------+---------------+
++-----+---------------------------+----------+-----------+---------------+
+| HDU | EXTNAME                   | HDU Type | Data Type | Dimensions    |
++=====+===========================+==========+===========+===============+
+|  0  | N/A                       | primary  | N/A       | N/A           |
++-----+---------------------------+----------+-----------+---------------+
+|  1  | SCI                       | IMAGE    | float32   | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|  2  | ERR                       | IMAGE    | float32   | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|  3  | DQ                        | IMAGE    | uint32    | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|     | VAR_POISSON               | IMAGE    | float32   | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|     | VAR_RNOISE                | IMAGE    | float32   | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|     | AREA*                     | IMAGE    | float32   | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|     | RELSENS*                  | BINTABLE | N/A       | variable      |
++-----+---------------------------+----------+-----------+---------------+
+|     | RELSENS2D*                | BINTABLE | N/A       | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|     | PATHLOSS_POINTSOURCE*     | IMAGE    | float32   | ncols         |
++-----+---------------------------+----------+-----------+---------------+
+|     | WAVELENGTH_POINTSOURCE*   | IMAGE    | float32   | ncols         |
++-----+---------------------------+----------+-----------+---------------+
+|     | PATHLOSS_UNIFORMSOURCE*   | IMAGE    | float32   | ncols         |
++-----+---------------------------+----------+-----------+---------------+
+|     | WAVELENGTH_UNIFORMSOURCE* | IMAGE    | float32   | ncols         |
++-----+---------------------------+----------+-----------+---------------+
+|     | BARSHADOW*                | IMAGE    | float32   | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|     | WAVELENGTH*               | IMAGE    | float32   | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|     | ASDF                      | BINTABLE | N/A       | variable      |
++-----+---------------------------+----------+-----------+---------------+
 
  - SCI: 2-D data array containing the pixel values, in units of surface brightness.
  - ERR: 2-D data array containing uncertainty estimates for each pixel.
@@ -402,3 +404,197 @@ The FITS file structure for a `cal` product is as follows:
  - WAVELENGTH: 2-D data array of wavelength values for each pixel, for some spectroscopic modes.
  - ADSF: The data model meta data.
 
+For spectroscopic modes that contain data for multiple sources, such as NIRSpec MOS,
+NIRCam WFSS, and NIRISS WFSS, there will be multiple tuples of the SCI, ERR, DQ, VAR_POISSON,
+VAR_RNOISE, RELSENS, etc. extensions, where each tuple contains the data for a given source or
+slit, as created by the :ref:`extract_2d <extract_2d_step>` step. FITS "EXTVER" keywords are
+used in each extension header to segregate the multiple instances of each extension type by
+source.
+
+Resampled 2-D data: ``i2d`` and ``s2d``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Images and spectra that have been resampled by the :ref:`resample <resample_step>` step use a
+different set of data arrays than other science products. Resampled 2-D images are stored in
+``i2d`` products and resampled 2-D spectra are stored in ``s2d`` products.
+The FITS file structure for ``i2d`` products is as follows:
+
++-----+-------------+----------+-----------+---------------+
+| HDU | EXTNAME     | HDU Type | Data Type | Dimensions    |
++=====+=============+==========+===========+===============+
+|  0  | N/A         | primary  | N/A       | N/A           |
++-----+-------------+----------+-----------+---------------+
+|  1  | SCI         | IMAGE    | float32   | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  2  | CON         | IMAGE    | int32     | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  3  | WHT         | IMAGE    | float32   | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|     | HDRTAB*     | BINTABLE | N/A       | variable      |
++-----+-------------+----------+-----------+---------------+
+|     | ASDF        | BINTABLE | N/A       | variable      |
++-----+-------------+----------+-----------+---------------+
+
+ - SCI: 2-D data array containing the pixel values, in units of surface brightness.
+ - CON: 2-D context image, which encodes information about which input images contribute
+   to a specific output pixel.
+ - WHT: 2-D weight image giving the relative weight of the output pixels (effectively a
+   relative exposure time map).
+ - HDRTAB: A table containing meta data (FITS keyword values) for all of the input images
+   that were combined to produce the output image. Only appears when multiple inputs are used.
+ - ADSF: The data model meta data.
+ 
+The FITS file structure for ``s2d`` products is as follows:
+
++-----+-------------+----------+-----------+---------------+
+| HDU | EXTNAME     | HDU Type | Data Type | Dimensions    |
++=====+=============+==========+===========+===============+
+|  0  | N/A         | primary  | N/A       | N/A           |
++-----+-------------+----------+-----------+---------------+
+|  1  | SCI         | IMAGE    | float32   | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  2  | CON         | IMAGE    | int32     | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  3  | WHT         | IMAGE    | float32   | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  4  | RELSENS     | BINTABLE | N/A       | variable      |
++-----+-------------+----------+-----------+---------------+
+|     | HDRTAB*     | BINTABLE | N/A       | variable      |
++-----+-------------+----------+-----------+---------------+
+|     | ASDF        | BINTABLE | N/A       | variable      |
++-----+-------------+----------+-----------+---------------+
+
+ - SCI: 2-D data array containing the pixel values, in units of surface brightness.
+ - CON: 2-D context image, which encodes information about which input images contribute
+   to a specific output pixel.
+ - WHT: 2-D weight image giving the relative weight of the output pixels (effectively a
+   relative exposure time map).
+ - RELSENS: A table of sensitivity values as a function of wavelength, carried along from the
+   input calibrated product.
+ - HDRTAB: A table containing meta data (FITS keyword values) for all of the input images
+   that were combined to produce the output image. Only appears when multiple inputs are used.
+ - ADSF: The data model meta data.
+
+For exposure-based products that contain spectra for more than one source or slit
+(e.g. NIRSpec MOS) there will be multiple tuples of the SCI, CON, WHT, and RELSENS
+extensions, one set for each source or slit. FITS "EXTVER" keywords are used in each
+extension header to segregate the multiple instances of each extension type by
+source.
+
+Resampled 3-D (IFU) data: ``s3d``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3-D IFU cubes created by the :ref:`cube_build <cube_build_step>` step are stored in FITS
+files with the following structure:
+
++-----+-------------+----------+-----------+------------------------+
+| HDU | EXTNAME     | HDU Type | Data Type | Dimensions             |
++=====+=============+==========+===========+========================+
+|  0  | N/A         | primary  | N/A       | N/A                    |
++-----+-------------+----------+-----------+------------------------+
+|  1  | SCI         | IMAGE    | float32   | ncols x nrows x nwaves |
++-----+-------------+----------+-----------+------------------------+
+|  2  | ERR         | IMAGE    | float32   | ncols x nrows x nwaves |
++-----+-------------+----------+-----------+------------------------+
+|  3  | DQ          | IMAGE    | int32     | ncols x nrows x nwaves |
++-----+-------------+----------+-----------+------------------------+
+|  4  | WMAP        | IMAGE    | float32   | ncols x nrows x nwaves |
++-----+-------------+----------+-----------+------------------------+
+|     | WCS-TABLE   | BINTABLE | N/A       | 2 cols x 1 row         |
++-----+-------------+----------+-----------+------------------------+
+|     | HDRTAB*     | BINTABLE | N/A       | variable               |
++-----+-------------+----------+-----------+------------------------+
+|     | ASDF        | BINTABLE | N/A       | variable               |
++-----+-------------+----------+-----------+------------------------+
+
+ - SCI: 3-D data array containing the spaxel values, in units of surface brightness.
+ - DQ: 3-D data array containing DQ flags for each spaxel.
+ - ERR: 3-D data array containing uncertainty estimates for each spaxel.
+ - WMAP: 3-D weight image giving the relative weight of the output spaxels.
+ - WCS-TABLE: A table listing the wavelength to be associated with each plane of the
+   third axis in the SCI, DQ, ERR, and WMAP arrays, in a format that conforms to the
+   FITS spectroscopic WCS standards. Column 1 of the table ("nelem") gives the number of
+   wavelength elements listed in the table and column 2 ("wavelength") is a 1-D array
+   giving the wavelength values.
+ - HDRTAB: A table containing meta data (FITS keyword values) for all of the input images
+   that were combined to produce the output image. Only appears when multiple inputs are used.
+ - ADSF: The data model meta data.
+
+``s3d`` products contain several unique meta data elements intended to aid in the use
+of these products in data analysis tools. This includes the following keywords located in
+the header of the FITS primary HDU:
+
+ - FLUXEXT: A string value containing the EXTNAME of the extension containing the IFU flux
+   data. Normally set to "SCI" for JWST IFU cube products.
+ - ERREXT: A string value containing the EXTNAME of the extension containing error estimates
+   for the IFU cube. Normally set to "ERR" for JWST IFU cube products.
+ - ERRTYPE: A string value giving the type of error estimates contained in ERREXT, with
+   possible values of "ERR" (error = standard deviation), "IERR" (inverse error),
+   "VAR" (variance), and "IVAR" (inverse variance). Normally set to "ERR" for JWST IFU
+   cube products.
+ - MASKEXT: A string value containing the EXTNAME of the extension containing the Data Quality
+   mask for the IFU cube. Normally set to "DQ" for JWST IFU cube products.
+
+In addition, the following WCS-related keywords are included in the header of the "SCI"
+extension to support the use of the wavelength table contained in the "WCS-TABLE" extension.
+These keywords allow data analysis tools that are compliant with the FITS spectroscopic WCS
+standards to automatically recognize and load the wavelength information in the "WCS-TABLE"
+and assign wavelengths to the IFU cube data.
+
+ - PS3_0 = 'WCS-TABLE': The name of the extension containing coordinate data for axis 3.
+ - PS3_1 = 'wavelength': The name of the table column containing the coordinate data.
+
+The coordinate data (wavelength values in this case) contained in the "WCS-TABLE" override
+any coordinate information normally computed from FITS WCS keywords like CRPIX3, CRVAL3,
+and CDELT3 for coordinate axis 3.
+
+Extracted 1-D spectroscopic data: ``x1d`` and ``x1dints``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Extracted spectral data produced by the :ref:`extract_1d <extract_1d_step>` step are stored
+in binary table extensions of FITS files. The overall layout of the FITS file is as follows:
+
++-----+-------------+----------+-----------+---------------+
+| HDU | EXTNAME     | HDU Type | Data Type | Dimensions    |
++=====+=============+==========+===========+===============+
+|  0  | N/A         | primary  | N/A       | N/A           |
++-----+-------------+----------+-----------+---------------+
+|  1  | EXTRACT1D   | BINTABLE | N/A       | variable      |
++-----+-------------+----------+-----------+---------------+
+|  2  | ASDF        | BINTABLE | N/A       | variable      |
++-----+-------------+----------+-----------+---------------+
+
+ - EXTRACT1D: A 2-D table containing the extracted spectral data.
+ - ADSF: The data model meta data.
+
+Multiple "EXTRACT1D" extensions can be present if there is data for more than one source or
+if the file is an ``x1dints`` product. For ``x1dints`` products, there is one "EXTRACT1D"
+extension for each integration in the exposure.
+
+The structure of the "EXTRACT1D" table extension is as follows:
+
++-------------+-----------+-------------------+----------------+
+| Column Name | Data Type | Contents          | Units          |
++=============+===========+===================+================+
+| WAVELENGTH  | float64   | Wavelength values | :math:`\mu` m  |
++-------------+-----------+-------------------+----------------+
+| FLUX        | float64   | Flux values       | mJy            |
++-------------+-----------+-------------------+----------------+
+| ERROR       | float64   | Error values      | mJy            |
++-------------+-----------+-------------------+----------------+
+| DQ          | int32     | DQ flags          | N/A            |
++-------------+-----------+-------------------+----------------+
+| NET         | float64   | Net flux          | DN/s           |
++-------------+-----------+-------------------+----------------+
+| NERROR      | float64   | Net error         | DN/s           |
++-------------+-----------+-------------------+----------------+
+| BACKGROUND  | float64   | Background signal | DN/s           |
++-------------+-----------+-------------------+----------------+
+| BERROR      | float64   | Background error  | DN/s           |
++-------------+-----------+-------------------+----------------+
+
+The table is constructed using a simple 2-D layout, using one row per extracted spectral
+element in the dispersion direction of the data (i.e. one row per wavelength bin).
+For some spectroscopic modes, such as MIRI MRS and NIRSpec IFU, the data that are used
+as input to the :ref:`extract_1d` step are already in calibrated units of surface
+brightness and therefore it's not possible to present 1-D extracted results for the net
+and background spectral data in units of DN/s. In these cases the NET, NERROR, BACKGROUND,
+and BERROR table columns will be zero-filled and only the WAVELENGTH, FLUX, ERROR, and DQ
+columns will be populated.

--- a/docs/jwst/datamodels/index.rst
+++ b/docs/jwst/datamodels/index.rst
@@ -11,8 +11,6 @@ Data Models
    attributes.rst
    metadata.rst
    new_model.rst
-   fits_files.rst
    structure.rst
-
 
 .. automodapi:: jwst.datamodels

--- a/docs/jwst/package_index.rst
+++ b/docs/jwst/package_index.rst
@@ -15,6 +15,7 @@ Package Index
    cube_build/index.rst
    dark_current/index.rst
    datamodels/index.rst
+   data_products/index.rst
    dq_init/index.rst
    emission/index.rst
    exp_to_source/index.rst

--- a/docs/jwst/pipeline/calwebb_tso3.rst
+++ b/docs/jwst/pipeline/calwebb_tso3.rst
@@ -42,6 +42,16 @@ or :ref:`calwebb_spec2 <calwebb_spec2>` processing. These products contain 3D st
 per-integration images. Each pipeline step will loop over all of the integrations in each
 input.
 
+Many TSO exposures may contain a sufficiently large number of integrations (NINTS) so as to make
+their individual exposure products too large (in terms of file size on disk) to be able to handle
+conveniently. In these cases, the uncalibrated raw data for a given exposure are split into
+multiple "segmented" products, each of which is identified with a segment number
+(see :ref:`segmented products <segmented_files>`). The ``calwebb_tso3`` input ASN file includes
+all "_calints" exposure segments. The :ref:`outlier_detection <outlier_detection_step>` step will
+process a single segment at a time, creating one output "_crfints" product per segment. The
+remaining ``calwebb_tso3`` steps, will process each segment and concatenate the results into a
+single output product, containing the results for all exposures and segments listed in the ASN.
+
 Outputs
 -------
 


### PR DESCRIPTION
Update the docs with more detailed info on the FITS data product formats and contents. First commit includes descriptions of uncal, ramp, rate, rateints, cal, and calints.