### PR TITLE
WIP: error instead of warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,9 @@ matrix:
 
         # build sphinx documentation with warnings
         - os: linux
-          env: SETUP_CMD='build_sphinx'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_DOC_DEPENDENCIES"
-               PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi'
+          env: SETUP_CMD='build_sphinx -W'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES"
+               PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi sphinxcontrib-programoutput'
         - os: linux
           env: MAIN_CMD='flake8 --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722 --max-line-length=110'
                SETUP_CMD='jwst'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.3'
+#needs_sphinx = '1.3'
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -121,7 +121,8 @@ master_doc = 'index'
 # thus need to ignore those warning. This can be removed once the patch gets
 # released in upstream Sphinx (https://github.com/sphinx-doc/sphinx/pull/1843).
 # Suppress the warnings requires Sphinx v1.4.2
-suppress_warnings = ['app.add_directive', ]
+
+##suppress_warnings = ['app.add_directive', ]
 
 
 # General information about the project

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ source-dir = docs
 build-dir = docs
 all_files = 1
 
+
 [upload_docs]
 upload-dir = docs/_build/html
 show-response = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ exclude = jwst/extern,docs,jwst/associations,jwst/jwpsf,jwst/ramp_fitting, jwst/
 
 [tool:pytest]
 minversion = 3
-addopts = --ignore=build, --doctest-rst
+addopts = --ignore=build, --doctest-rst, -p no:warnings
 norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern scripts
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 doctest_plus = enabled

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,16 @@ try:
         """Build Sphinx documentation after compiling C source files"""
 
         description = 'Build Sphinx documentation'
+        
+        user_options = BuildDoc.user_options[:]
+        
+        user_options.append(
+            ('keep-going', 'k',
+             'Parses the sphinx output and sets the return code to 1 if there '
+             'are any warnings. Note that this will cause the sphinx log to '
+             'only update when it completes, rather than continuously as is '
+             'normally the case.'))
+        
 
         def initialize_options(self):
             BuildDoc.initialize_options(self)
@@ -47,7 +57,10 @@ try:
             build_cmd = self.reinitialize_command('build_ext')
             build_cmd.inplace = 1
             self.run_command('build_ext')
-            build_main(['-b', 'html', './docs', './docs/_build/html'])
+            retcode = build_main(['-W', '--keep-going', '-b', 'html', './docs', './docs/_build/html'])
+            print('retcode', retcode)
+            if retcode != 0:
+                sys.exit(retcode)
 
 except ImportError:
     class BuildSphinx(Command):


### PR DESCRIPTION
This PR is meant to show the problem which a subsequent PR will fix. There are two issues with the current test setup.

- In some case the Travis test jobs issue `Warnings` which are silently passed. These should really be errors. In this case it's a warning about a missing option `--doctest-rst`.
- The other issue is that the sphinx build silently passes although there are many warnings. Some of these warnings are real errors.

This PR changes the test and build configuration and enables reporting warnings as errors. A subsequent PR (#3048) will fix the warnings/errors. Then rebasing this PR after the second one is merged should produce no errors.
