### PR TITLE
MultiSpec model now uses different keywords for saving time values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ extract_1d
 - Fix issue regarding mixing of the syntax for Boolean arrays and for
   integer index arrays. [#3045]
 
+- Changed the names of time-related keywords for extracted spectra. [#3057]
+
 extract_2d
 ----------
 - Moved the update of meta information to the MultiSlitModel instead of the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,7 +77,7 @@ extract_1d
 - Fix issue regarding mixing of the syntax for Boolean arrays and for
   integer index arrays. [#3045]
 
-- Changed the names of time-related keywords for extracted spectra. [#3057]
+- Changed the names of time-related keywords for extracted spectra. [#3058]
 
 extract_2d
 ----------

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -108,34 +108,40 @@ allOf:
             type: integer
             fits_keyword: INT_NUM
             fits_hdu: EXTRACT1D
+          time_scale:
+            title: "Time scale"
+            type: string
+            default: "UTC"
+            fits_keyword: TIMESYS
+            fits_hdu: EXTRACT1D
           start_utc:
             title: "UTC at start of integration [MJD]"
             type: number
-            fits_keyword: STRT_UTC
+            fits_keyword: MJD-BEG
             fits_hdu: EXTRACT1D
           mid_utc:
             title: "UTC at middle of integration [MJD]"
             type: number
-            fits_keyword: MID_UTC
+            fits_keyword: MJD-AVG
             fits_hdu: EXTRACT1D
           end_utc:
             title: "UTC at end of integration [MJD]"
             type: number
-            fits_keyword: END_UTC
+            fits_keyword: MJD-END
             fits_hdu: EXTRACT1D
           start_tdb:
             title: "TDB at start of integration [MJD]"
             type: number
-            fits_keyword: STRT_TDB
+            fits_keyword: TDB-BEG
             fits_hdu: EXTRACT1D
           mid_tdb:
             title: "TDB at middle of integration [MJD]"
             type: number
-            fits_keyword: MID_TDB
+            fits_keyword: TDB-MID
             fits_hdu: EXTRACT1D
           end_tdb:
             title: "TDB at end of integration [MJD]"
             type: number
-            fits_keyword: END_TDB
+            fits_keyword: TDB-END
             fits_hdu: EXTRACT1D
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2944,6 +2944,7 @@ def populate_time_keywords(input_model, output_model):
             row = k + offset
             spec = output_model.spec[n]             # n is incremented below
             spec.int_num = int_num[row]
+            spec.time_scale = "UTC"
             spec.start_utc = start_utc[row]
             spec.mid_utc = mid_utc[row]
             spec.end_utc = end_utc[row]


### PR DESCRIPTION
The schema for `MultiSpecModel` was modified to change the names of the extension-header keywords for the beginning, middle, and end of an integration.  Closes issue #2274 .