### PR TITLE
Run doctestsplus items in a tmpdir

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+@pytest.fixture(autouse=True)
+def _docdir(request):
+
+    # Trigger ONLY for doctestplus.
+    doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
+    if isinstance(request.node, doctest_plugin._doctest_textfile_item_cls):
+        tmpdir = request.getfixturevalue('tmpdir')
+        with tmpdir.as_cwd():
+            yield
+    else:
+        yield


### PR DESCRIPTION
Resolves #3053 by running each `doctestplus` item in its own _tmpdir_.

Perhaps this is overkill?  Maybe we should just comment out those offending lines in the documentation?  Or maybe we shouldn't be running the documentation of some of these items as unit tests?  Opinions?  @nden 