### PR TITLE
Remove redundant requests_mock from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,6 @@ setup(
         'jsonschema>=2.3,<=2.6',
         'namedlist>=1.7',
         'numpy>=1.13',
-        'requests_mock',
         'scipy>=1.0',
         'spherical-geometry>=1.2',
         'stsci.tools>=3.4',


### PR DESCRIPTION
Having `requests_mock` in `install_requires` prevents the conda package from being built.