### PR TITLE
correct bounding box for subarray in MIRI LRS observations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,12 +11,14 @@ assign_wcs
    ``transform_bbox_from_shape`` which now works by using last two dimensions
    in the ``shape``. [#3040]
 
- - Added velocity correction model to the WFSS and TSGRISM wcs pipelines [#2801]
+ - Added velocity correction model to the WFSS and TSGRISM wcs pipelines. [#2801]
 
  - Refactored how the pipeline handles subarrays in the WCS. Fixed a bug
    where the bounding box was overwritten in full frame mode. [#2980]
 
- - Rename several functions dealing with calculating bounding boxes for clarity [#3014]
+ - Rename several functions dealing with calculating bounding boxes for clarity. [#3014]
+
+ - The bounding box of the MIRI LRS WCS is now in "image" coordinates, not full frame. [#3063]
 
 associations
 ------------

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -184,8 +184,13 @@ def lrs(input_model, reference_files):
     y0 = lrsdata[:, 4]
     x1 = lrsdata[:, 5]
 
-    bb = ((x0.min() - 0.5 + zero_point[0], x1.max() + 0.5 + zero_point[0]),
-          (y0.min() - 0.5 + zero_point[1], y0.max() + 0.5 + zero_point[1]))
+    subarray_xstart = input_model.meta.subarray.xstart - 1
+    subarray_ystart = input_model.meta.subarray.ystart - 1
+
+    # The bounding box is computed from the data in the wavelength solution
+    # and corrected for subarray.
+    bb = ((x0.min() - 0.5 + zero_point[0] - subarray_xstart, x1.max() + 0.5 + zero_point[0] - subarray_xstart),
+          (y0.min() - 0.5 + zero_point[1] - subarray_ystart, y0.max() + 0.5 + zero_point[1] - subarray_ystart))
 
     # Compute the v2v3 to sky.
     tel2sky = pointing.v23tosky(input_model)

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -157,9 +157,6 @@ def lrs(input_model, reference_files):
     with DistortionModel(reference_files['distortion']) as dist:
         distortion = dist.model
 
-    #if subarray2full is not None:
-    #    distortion = subarray2full | distortion
-
     # Incorporate the small rotation
     angle = np.arctan(0.00421924)
     rotation = models.Rotation2D(angle)
@@ -177,7 +174,6 @@ def lrs(input_model, reference_files):
             zero_point = ref[1].header['imx'], ref[1].header['imy']
         elif input_model.meta.exposure.type.lower() == 'mir_lrs-slitless':
             zero_point = ref[1].header['imxsltl'], ref[1].header['imysltl']
-            #zero_point = [35, 442]  # [35, 763] # account for subarray
 
     # Create the bounding_box
     x0 = lrsdata[:, 3]

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -157,8 +157,8 @@ def lrs(input_model, reference_files):
     with DistortionModel(reference_files['distortion']) as dist:
         distortion = dist.model
 
-    if subarray2full is not None:
-        distortion = subarray2full | distortion
+    #if subarray2full is not None:
+    #    distortion = subarray2full | distortion
 
     # Incorporate the small rotation
     angle = np.arctan(0.00421924)
@@ -219,6 +219,11 @@ def lrs(input_model, reference_files):
             log.info("Applied Barycentric velocity correction : {}".format(velocity_corr[1].amplitude.value))
 
     det_to_v2v3 = models.Mapping((0, 1, 0, 1)) | spatial_forward & lrs_wav_model
+
+    # Correction for subarray is done here so that it applies to the input coordinates
+    # to the spatial as well as the spectral transform
+    if subarray2full is not None:
+        det_to_v2v3 = subarray2full | det_to_v2v3
     det_to_v2v3.bounding_box = bb[::-1]
     v23_to_world = tel2sky & models.Identity(1)
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -167,8 +167,8 @@ def niriss_soss(input_model, reference_files):
         cm_order2 = subarray2full | cm_order2
         cm_order3 = subarray2full | cm_order3
 
-        bbox = ((0, input_model.meta.subarray.ysize),
-                (0, input_model.meta.subarray.xsize))
+        bbox = ((-0.5, input_model.meta.subarray.ysize - 0.5),
+                (-0.5, input_model.meta.subarray.xsize - 0.5))
         cm_order1.bounding_box = bbox
         cm_order2.bounding_box = bbox
         cm_order3.bounding_box = bbox


### PR DESCRIPTION
The bounding box of MIRI LRS observations is determined by the wavelength solution in the `specwcs` reference file, in full frame coordinates. This adjust the bounding box when the observation is a subarray.

There's also a minor correction for the NIRISS SOSS mode from the center to the edge of the pixel.