### PR TITLE
Parameterize CRDS "observatory"

### DIFF
--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -49,26 +49,42 @@ from crds.core import crds_cache_locking
 # This is really a testing and debug convenience function,  and notably now
 # the only place in this module that a direct import of datamodels occurs
 # or datamodels open() occurs.
-def get_refpaths_from_filename(filename, reference_file_types):
-    """Test wrapper to open/close data model for get_multiple_reference_paths."""
+def get_refpaths_from_filename(filename, reference_file_types, observatory=None):
+    """Test wrapper to open/close data model for get_multiple_reference_paths.
+
+    See also get_multiple_reference_filepaths().
+    """
     from .. import datamodels
     with datamodels.open(filename) as model:
-        refpaths = get_multiple_reference_paths(model, reference_file_types)
+        refpaths = get_multiple_reference_paths(model, reference_file_types, observatory)
     return refpaths
 
 # ......................
     
 # import memory_profiler
 # @memory_profiler.profile
-def get_multiple_reference_paths(dataset_model, reference_file_types):
+def get_multiple_reference_paths(dataset_model, reference_file_types, observatory=None):
     """Aligns JWST pipeline requirements with CRDS library top level interfaces.
     
     `dataset_model` is an open data model.
 
+    `reference_file_types` is a list of reference file type name strings.
+
+    If `observatory` is not None,  it should be a string naming the 
+    telescope and valid for CRDS, e.g. 'jwst' or 'hst'.
+
+    If `observatory` is None,  the data_model.telescope value will be
+    fetched and used if it is not None.
+
+    If both of the above fail,  observatory defaults to 'jwst'.
+
     Returns best references dict { filetype : filepath or "N/A", ... }
     """
     data_dict = _get_data_dict(dataset_model)
-    refpaths = _get_refpaths(data_dict, tuple(reference_file_types))
+    if observatory is None:
+        observatory = dataset_model.meta.telescope or 'jwst'
+    observatory = observatory.lower()
+    refpaths = _get_refpaths(data_dict, tuple(reference_file_types), observatory)
     return refpaths
 
 # ......................
@@ -88,7 +104,7 @@ def _clean_flat_dict(header):
 
 # ......................
 
-def _get_refpaths(data_dict, reference_file_types):
+def _get_refpaths(data_dict, reference_file_types, observatory):
     """Tailor the CRDS core library getreferences() call to the JWST CAL code by
     adding locking and truncating expected exceptions.   Also simplify 'NOT FOUND n/a' to
     'N/A'.  Re-interpret empty reference_file_types as "no types" instead of core
@@ -96,15 +112,9 @@ def _get_refpaths(data_dict, reference_file_types):
     """
     if not reference_file_types:   # [] interpreted as *all types*.
         return {}
-    try: # catch exceptions to truncate expected tracebacks
-        with crds_cache_locking.get_cache_lock():
-            bestrefs = crds.getreferences(data_dict, reftypes=reference_file_types, observatory="jwst")
-    except crds.CrdsBadRulesError as exc:
-        raise crds.CrdsBadRulesError(str(exc))
-    except crds.CrdsBadReferenceError as exc:
-        raise crds.CrdsBadReferenceError(str(exc))
-    except crds.CrdsLookupError as exc:
-        raise crds.CrdsLookupError(str(exc))
+    with crds_cache_locking.get_cache_lock():
+        bestrefs = crds.getreferences(
+            data_dict, reftypes=reference_file_types, observatory=observatory)
     refpaths = {filetype: filepath if "N/A" not in filepath.upper() else "N/A"
                 for (filetype, filepath) in bestrefs.items()}
     return refpaths
@@ -121,14 +131,14 @@ def check_reference_open(refpath):
         opened.close()
     return refpath
 
-def get_reference_file(dataset, reference_file_type):
+def get_reference_file(dataset, reference_file_type, observatory=None):
     """
     Gets a reference file from CRDS as a readable file-like object.
     The actual file may be optionally overridden.
 
     Parameters
     ----------
-    input_file : jwst.datamodels.ModelBase instance
+    dataset : jwst.datamodels.ModelBase instance
         A model of the input file.  Metadata on this input file will
         be used by the CRDS "bestref" algorithm to obtain a reference
         file.
@@ -137,17 +147,25 @@ def get_reference_file(dataset, reference_file_type):
         The type of reference file to retrieve.  For example, to
         retrieve a flat field reference file, this would be 'flat'.
 
+    observatory: string
+        telescope name used with CRDS,  e.g. 'jwst'.
+
     Returns
     -------
     reference_filepath : string
         The path of the reference in the CRDS file cache.
+
+
+    See also get_multiple_reference_paths().
     """
     if isinstance(dataset, str):
         from jwst import datamodels
         with datamodels.open(dataset) as model:
-            return get_multiple_reference_paths(model, [reference_file_type])[reference_file_type]
+            return get_multiple_reference_paths(
+                model, [reference_file_type], observatory)[reference_file_type]
     else:
-        return get_multiple_reference_paths(dataset, [reference_file_type])[reference_file_type]
+        return get_multiple_reference_paths(
+            dataset, [reference_file_type], observatory)[reference_file_type]
         
 
 def get_override_name(reference_file_type):
@@ -177,13 +195,25 @@ def get_svn_version():
     """Return the CRDS s/w version used for determining best references."""
     return crds.__version__
 
-
-def reference_uri_to_cache_path(reference_uri):
+def reference_uri_to_cache_path(reference_uri, observatory=None):
     """Convert an abstract CRDS reference file URI into an absolute path for the
     file as located in the CRDS cache.
 
-    e.g. 'crds://jwst_miri_flat_0177.fits'  -->  
-            '/grp/crds/cache/references/jwst/jwst_miri_flat_0177.fits'
+    Parameters
+    ----------
+
+    reference_uri :  string identifying an abstract CRDS reference file,
+                      .e.g. 'crds://jwst_miri_flat_0177.fits'
+
+    observatory : string naming the telescope/project for CRDS, e.g. 'jwst'
+           `observatory` should be omitted, None,  or defined as a literal string value.
+           Omission and the value None are interpreted as 'jwst'.
+
+    Returns
+    -------
+
+    reference_path : absolute file path to reference_uri in the CRDS cache,
+           .e.g. '/grp/crds/cache/references/jwst/jwst_miri_flat_0177.fits'
 
     Standard CRDS cache paths are typically defined relative to the CRDS_PATH
     environment variable.  See https://jwst-crds.stsci.edu guide and top level
@@ -192,11 +222,19 @@ def reference_uri_to_cache_path(reference_uri):
     The default CRDS_PATH value is /grp/crds/cache, currently on the Central Store.
     """
     if not reference_uri.startswith("crds://"):
-        raise exceptions.CrdsError("CRDS reference URI's should start with 'crds://' but got", repr(reference_uri))
+        raise exceptions.CrdsError(
+            "CRDS reference URI's should start with 'crds://' but got", repr(reference_uri))
+    observatory = (observatory or 'jwst').lower()
     basename = config.pop_crds_uri(reference_uri)
-    return crds.locate_file(basename, "jwst")
+    return crds.locate_file(basename, observatory)
 
-def get_context_used():
-    """Return the context (.pmap) used for determining best references."""
-    _connected, final_context = heavy_client.get_processing_mode("jwst")
+def get_context_used(observatory=None):
+    """Return the context (.pmap) used for determining best references.
+
+    observatory : string naming the telescope/project for CRDS, e.g. 'jwst'
+           `observatory` should be omitted, None,  or defined as a literal string value.
+           Omission and the value None are interpreted as 'jwst'.
+    """
+    observatory = (observatory or 'jwst').lower()
+    _connected, final_context = heavy_client.get_processing_mode(observatory)
     return final_context

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -429,7 +429,8 @@ class Step():
                             if hasattr(result.meta.ref_file, ref_name):
                                 getattr(result.meta.ref_file, ref_name).name = filename
                         result.meta.ref_file.crds.sw_version = crds_client.get_svn_version()
-                        result.meta.ref_file.crds.context_used = crds_client.get_context_used()
+                        result.meta.ref_file.crds.context_used = \
+                            crds_client.get_context_used(result.meta.telescope)
                 self._reference_files_used = []
 
             # Mark versions
@@ -657,6 +658,7 @@ class Step():
                 (reference_file_type, hdr_name))
         return crds_client.check_reference_open(reference_name)
 
+    @classmethod
     def reference_uri_to_cache_path(self, reference_uri):
         """Convert an abstract CRDS reference URI to an absolute file path in the CRDS
         cache.  Reference URI's are typically output to dataset headers to record the

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -659,7 +659,7 @@ class Step():
         return crds_client.check_reference_open(reference_name)
 
     @classmethod
-    def reference_uri_to_cache_path(self, reference_uri):
+    def reference_uri_to_cache_path(cls, reference_uri):
         """Convert an abstract CRDS reference URI to an absolute file path in the CRDS
         cache.  Reference URI's are typically output to dataset headers to record the
         reference files used.


### PR DESCRIPTION
Primarily these are changes to crds_client.py and step.py driven by issue #3050.

Rather than hard coding the CRDS library observatory parameter as 'jwst',  it's exposed in the API so that it can be specified or inferred from data.   In theory this makes it possible for other telescopes to use STPIPE with no customization provided they fork/customize CRDS to add their own telescope.

There are 2 additional changes:

1.  I removed exception handling code in crds_client which is now ineffective because of subtle changes to Python-3 exception handling.   It affects tracebacks when references are not found.  They were horrible,  now they're horrible with less code.  We should add fatal errors if we don't have them and call one instead of a horrible traceback for "reference file not found."   But this is still an
improvement.

2. I made the Step.reference_uri_to_cache_path() method a class method,  so testers can call it relative to a Step or Pipeline class they have handy.    This is a convenience to avoid an import and hide crds_client from test scripts.  I believe adding @classmethod to a method which does not depend on an instance is harmless.

This is a first cut,  it may require tweaks before it satisfies #3050...   but it should be a good starter.
