### PR TITLE
Update MIRI WCS regression tests to not overwrite their input

### DIFF
--- a/jwst/tests_nightly/general/miri/test_miri_steps_single.py
+++ b/jwst/tests_nightly/general/miri/test_miri_steps_single.py
@@ -166,8 +166,7 @@ class TestMIRIWCSIFU(BaseJWSTTest):
         region = RegionsModel(crds_client.get_reference_file(result, 'regions'))
 
         # inputs
-        shape = region.regions.shape
-        y, x = np.mgrid[ : shape[0], : shape[1]]
+        x, y = grid_from_bounding_box(result.meta.wcs.bounding_box)
 
         # Get indices where pixels == 0. These should be NaNs in the output.
         ind_zeros = region.regions == 0


### PR DESCRIPTION
This update is to enable the `test_miri_slitless_wcs` regression test to pass after #3063.

Also general cleanup of other WCS regression tests:
 - Use `grid_from_bounding_box` convenience function instead of `np.mgrid`
 - Get truth file after `assign_wcs` is run, and segregate it in a `truth` subdir
 - Run `assign_wcs` with `save_results=True` so as not to overwrite the input file
 - Clarify test result and truth file variable names

Addresses #2941.