### PR TITLE
Force integer division in Python 3 (tweakreg)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -238,6 +238,8 @@ tweakreg
 - Use a more numerically stable ``numpy.linalg.inv`` instead of own matrix
   inversion. [#3033]
 
+- Bug fix: Use integer division in Python 3. [#3072]
+
 wfs_combine
 -----------
 

--- a/jwst/tweakreg/imalign.py
+++ b/jwst/tweakreg/imalign.py
@@ -383,7 +383,7 @@ def max_overlap_pair(images, enforce_user_order):
     m = overlap_matrix(images)
     n = m.shape[0]
     index = m.argmax()
-    i = index / n
+    i = index // n
     j = index % n
     si = np.sum(m[i])
     sj = np.sum(m[:, j])


### PR DESCRIPTION
This PR should fix the crash reported in https://github.com/spacetelescope/jwst/issues/2963#issuecomment-459449539