### PR TITLE
Use pip install .[test] and [docs] in travis for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
                               jplephem
                               matplotlib
                               photutils
-                              pytest
                               scipy
                               spherical-geometry
                               stsci.image
@@ -40,7 +39,7 @@ env:
         - CRDS_PATH='/tmp/crds_cache'
         - MAIN_CMD='python setup.py'
         - MC_URL=https://repo.continuum.io/miniconda
-        - PIP_DEPENDENCIES='ci_watson pytest-doctestplus pytest-astropy'
+        - PIP_DEPENDENCIES='.[test]'
         - PYTHON_VERSION=3.6
 
     matrix:
@@ -57,13 +56,14 @@ matrix:
         # PEP8 check with flake8 (only once, i.e. "os: linux")
         - os: linux
           env: MAIN_CMD='flake8 --count'
-               SETUP_CMD='jwst' TEST_CMD='flake8 --version'
+               SETUP_CMD='jwst'
+               PIP_DEPENDENCIES='.'
 
         # build sphinx documentation with warnings
         - os: linux
           env: SETUP_CMD='build_sphinx -W'
                CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES"
-               PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-astropy'
+               PIP_DEPENDENCIES='.[docs]'
         - os: linux
           env: MAIN_CMD='flake8 --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722 --max-line-length=110'
                SETUP_CMD='jwst'
@@ -71,7 +71,8 @@ matrix:
     allow_failures:
         # PEP8 will fail for numerous reasons. Ignore it.
         - env: MAIN_CMD='flake8 --count'
-               SETUP_CMD='jwst' TEST_CMD='flake8 --version'
+               SETUP_CMD='jwst'
+               PIP_DEPENDENCIES='.'
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then MC_INST=Miniconda3-4.4.10-Linux-x86_64.sh; fi
@@ -84,7 +85,7 @@ before_install:
   - for channel in $CONDA_CHANNELS; do conda config --add channels "$channel"; done
   - conda create -n test -q python=$PYTHON_VERSION numpy $CONDA_DEPENDENCIES
   - source activate test
-  - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -q $PIP_DEPENDENCIES; fi
+  - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -q -e $PIP_DEPENDENCIES; fi
 
 after_install:
   - conda list astropy


### PR DESCRIPTION
This removes yet another copy of our `test` and `docs` dependencies from the `.travis.yml` file and instead uses the ones centrally defined in `setup.py`.  We do this by doing a
```
pip install -e .[test]
pip install -e .[docs]
```
in the repo after all the install dependencies have been installed by `conda` for the `test` and `build_sphinx` matrix elements, respectively.  Eventually we may want to do those install dependencies the same way and remove `conda` altogether.  Baby steps.