### PR TITLE
fix holes in ifu cube

### DIFF
--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -801,11 +801,19 @@ class IFUCubeData():
 
 # now check spectral step
         all_same_spectral = np.all(spectralsize == spectralsize[0])
-        if all_same_spectral:
+
+# check if scalew has been set - if yes then linear scale
+        if self.scalew != 0:
+            self.spectral_size = self.scalew
+            self.linear_wavelength = True
+            wave_roi = np.amin(roiw)
+            weight_power = np.amin(power)
+            self.soft_rad = np.amin(softrad)            
+        elif all_same_spectral:
             self.spectral_size = spectralsize[0]
             wave_roi = roiw[0]
-            self.soft_rad = softrad[0]
             weight_power = power[0]
+            self.soft_rad = softrad[0]
         else:
             self.linear_wavelength = False
             if self.instrument == 'MIRI':
@@ -840,9 +848,13 @@ class IFUCubeData():
 
             self.roiw_table = table_wroi[imin:imax]
             self.rois_table = table_sroi[imin:imax]
+            if self.num_files < 4: 
+                self.rois_table = [i*1.5 for i in self.rois_table]
+
             self.softrad_table = table_softrad[imin:imax]
             self.weight_power_table = table_power[imin:imax]
             self.wavelength_table = table_wavelength[imin:imax]
+            
 
         # check if the user has set the cube parameters to use
         if self.rois == 0:
@@ -853,24 +865,21 @@ class IFUCubeData():
                      'default value set for 4 dithers %f', self.rois)
         if self.scale1 != 0:
             self.spatial_size = self.scale1
-        if self.scalew != 0:
-            self.spectral_size = self.scalew
-            self.linear_wavelength = True
+
             # set wave_roi, weight_power, soft_rad to same values if they are in  list
         if self.roiw == 0:
             self.roiw = wave_roi
         if self.weight_power == 0:
             self.weight_power = weight_power
 
-#        print('spatial size', self.spatial_size)
-#        print('spectral size', self.spectral_size)
-#        print('spatial roi', self.rois)
-#        print('wave min and max', self.wavemin, self.wavemax)
-#        print('linear wavelength', self.linear_wavelength)
-#        print('roiw', self.roiw)
+        print('spatial size', self.spatial_size)
+        print('spectral size', self.spectral_size)
+        print('spatial roi', self.rois)
+        print('wave min and max', self.wavemin, self.wavemax)
+        print('linear wavelength', self.linear_wavelength)
+        print('roiw', self.roiw)
+        print('output_type',self.output_type)
 
-#        if self.interpolation == 'pointcloud':
-#            log.info('Region of interest spatial, wavelength  %f %f', self.rois, self.roiw)
 # ******************************************************************************
 
     def setup_ifucube_wcs(self):


### PR DESCRIPTION
The cube pars reference files contains the default cube pixel size and wavelength sampling to use.
It was created assuming  4 pt dither. For the CALSPEC2 pipeline the the ifucube is create with a single
exposures so the wavelength sampling needs to be larger than what is in the default table.
Currently if there are less than 4 files the wavelength plane is increased by 1.5 We need to move
this 1.5 factor out of the code and into a parameters, but that will be done with a different PR.

