### PR TITLE
add error message

### DIFF
--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -100,7 +100,7 @@ class DataTypes():
                 self.filenames.append(model.meta.filename)
 
         else:
-            raise TypeError
+            raise TypeError("Failed to process file type {}".format(type(input_try)))
 
 # if the user has set the output name - strip out *.fits
 # later suffixes will be added to this name to designate the


### PR DESCRIPTION
I ran into this a few times - cube_build failed with `TypeError` but it doesn't say what the type is. In all cases the input files had `ImageModel` recorded instead of `IFUImageModel`. This is a simple PR to add a message to the error.