### PR TITLE
remove relsens_2d from image schema

### DIFF
--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -38,11 +38,6 @@ allOf:
       datatype: float32
     relsens:
       $ref: relsens.schema.yaml
-    relsens2d:
-      title: Sensitivity array
-      fits_hdu: RELSENS2D
-      default: 1.0
-      datatype: float32
     var_poisson:
       title: variance due to poisson noise
       fits_hdu: VAR_POISSON


### PR DESCRIPTION
`relsens_2d` is applied only to IFU data.