### PR TITLE
Function to convert 1-D spectrum to 2-D

### DIFF
--- a/jwst/master_background/create_master_bkg.py
+++ b/jwst/master_background/create_master_bkg.py
@@ -2,18 +2,15 @@ import numpy as np
 
 from .. import datamodels
 
-def create_background(m_bkg_spec, wavelength, flux):
+def create_background(wavelength, flux):
     """Create a 1-D spectrum table as a MultiSpecModel.
 
     This is the syntax for accessing the data in the columns:
-    wavelength = output_model.spec_table[0]['wavelength'])
-    background = output_model.spec_table[0]['flux'])
+    wavelength = output_model.spec[0].spec_table['wavelength']
+    background = output_model.spec[0].spec_table['flux']
 
     Parameters
     ----------
-    m_bkg_spec : string
-        The name of the file to create.
-
     wavelength : 1-D ndarray
         Array of wavelengths, in nanometers.
 
@@ -26,7 +23,7 @@ def create_background(m_bkg_spec, wavelength, flux):
         A data model containing the 1-D background spectrum.  This can be
         written to disk by calling:
 
-        output_model.save(m_bkg_spec)
+        output_model.save(<filename>)
     """
 
     wl_shape = wavelength.shape

--- a/jwst/master_background/create_master_bkg.py
+++ b/jwst/master_background/create_master_bkg.py
@@ -24,7 +24,7 @@ def create_background(wavelength, flux):
 
     Returns
     -------
-    output_model : datamodels.MultiSpecModel, or None
+    output_model : `~jwst.datamodels.MultiSlitModel`, or None
         A data model containing the 1-D background spectrum.  This can be
         written to disk by calling:
 

--- a/jwst/master_background/create_master_bkg.py
+++ b/jwst/master_background/create_master_bkg.py
@@ -1,6 +1,11 @@
+import logging
+
 import numpy as np
 
 from .. import datamodels
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 def create_background(wavelength, flux):
     """Create a 1-D spectrum table as a MultiSpecModel.
@@ -12,7 +17,7 @@ def create_background(wavelength, flux):
     Parameters
     ----------
     wavelength : 1-D ndarray
-        Array of wavelengths, in nanometers.
+        Array of wavelengths, in micrometers.
 
     flux : 1-D ndarray
         Array of background fluxes.
@@ -31,19 +36,20 @@ def create_background(wavelength, flux):
     bad = False
     if len(wl_shape) > 1:
         bad = True
-        print("ERROR:  The wavelength array has shape {}; expected "
+        log.error("The wavelength array has shape {}; expected "
               "a 1-D array".format(wl_shape))
     if len(flux_shape) > 1:
         bad = True
-        print("ERROR:  The background flux array has shape {}; expected "
+        log.error("The background flux array has shape {}; expected "
               "a 1-D array".format(flux_shape))
     if bad:
         return None
 
     if wl_shape[0] != flux_shape[0]:
-        print("ERROR:  wavelength array has length {},".format(wl_shape[0]))
-        print("but background flux array has length {}.".format(flux_shape[0]))
-        print("The arrays must be the same size.")
+        log.error("wavelength array has length {}, "
+                  "but background flux array has length {}."
+                  .format(wl_shape[0], flux_shape[0]))
+        log.error("The arrays must be the same size.")
         return None
 
     # Create arrays for columns that we won't need.
@@ -52,18 +58,14 @@ def create_background(wavelength, flux):
 
     output_model = datamodels.MultiSpecModel()
 
-    # This is temporary, just to give us spec.spec_table.dtype
-    spec = datamodels.SpecModel()
+    spec_dtype = datamodels.SpecModel().spec_table.dtype
 
     # xxx Include one more argument at the end, after column NPIXELS has
     # xxx been added to the x1d table.  The new argument should be float64
     # xxx and with values of 1 (i.e. not dummy).
     otab = np.array(list(zip(wavelength, flux,
                              dummy, dq, dummy, dummy, dummy, dummy)),
-                    dtype=spec.spec_table.dtype)
-
-    # We're done with the temporary one.
-    spec.close()
+                    dtype=spec_dtype)
 
     spec = datamodels.SpecModel(spec_table=otab)
     output_model.spec.append(spec)

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -1,5 +1,4 @@
 import logging
-import math
 
 import numpy as np
 

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -301,7 +301,7 @@ def get_wavelengths(model):
     else:
         wl_array = None
     if (wl_array is None or len(wl_array) == 0 or
-        wl_array.min() == 0. and wl_array.max() == 0.):
+        np.nanmin(wl_array) == 0. and np.nanmax(wl_array) == 0.):
             got_wavelength = False
             wl_array = None
 

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -31,7 +31,7 @@ def expand_to_2d(input, m_bkg_spec):
         try:
             tab_npixels = bkg.spec[0].spec_table['npixels'].copy()
         except KeyError:
-            tab_npixels = np.ones_like(wavelength)
+            tab_npixels = np.ones_like(tab_wavelength)
         tab_background = bkg.spec[0].spec_table['flux'] / tab_npixels
 
     # We're going to use np.interp, so tab_wavelength must be strictly

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -1,0 +1,314 @@
+import math
+
+import numpy as np
+
+from .. import datamodels
+from .. assign_wcs import nirspec               # for NIRSpec IFU data
+
+def expand_to_2d(input, m_bkg_spec):
+    """Expand a 1-D background to 2-D.
+
+    Parameters
+    ----------
+    input : JWST data model
+        The input science data.
+
+    m_bkg_spec : string or JWST data model
+        Either the name of a file containing a 1-D background spectrum,
+        or a data model containing such a spectrum.
+
+    Returns
+    -------
+    background : JWST data model
+        A copy of `input` but with the data replaced by the background,
+        "expanded" from 1-D to 2-D.
+    """
+
+    with datamodels.open(m_bkg_spec) as bkg:
+        if len(bkg.spec) > 1:
+            print("Warning:  The input 1-D spectrum contains multiple spectra")
+        tab_wavelength = bkg.spec[0].spec_table['wavelength'].copy()
+        try:
+            tab_npixels = bkg.spec[0].spec_table['npixels'].copy()
+        except KeyError:
+            tab_npixels = np.ones_like(wavelength)
+        tab_background = bkg.spec[0].spec_table['flux'] / tab_npixels
+
+    # We're going to use np.interp, so tab_wavelength must be strictly
+    # increasing.
+    if not np.all(np.diff(tab_wavelength) > 0):
+        index = np.argsort(tab_wavelength)
+        tab_wavelength = tab_wavelength[index].copy()
+        tab_background = tab_background[index].copy()
+
+    # Handle associations, or input ModelContainers
+    if isinstance(input, datamodels.ModelContainer):
+        background = bkg_for_container(input, tab_wavelength, tab_background)
+
+    else:
+        background = create_bkg(input, tab_wavelength, tab_background)
+
+    return background
+
+
+def bkg_for_container(input, tab_wavelength, tab_background):
+    """Create a 2-D background for a container object.
+
+    Parameters
+    ----------
+    input : JWST association or ModelContainer
+        The input science data.
+
+    tab_wavelength : 1-D ndarray
+        The wavelength column read from the 1-D background table.
+
+    tab_background : 1-D ndarray
+        The flux column read from the 1-D background table, divided by
+        the npixels column.
+
+    Returns
+    -------
+    background : JWST ModelContainer
+        A copy of `input` but with the data replaced by the background,
+        "expanded" from 1-D to 2-D.
+    """
+
+    background = datamodels.ModelContainer()
+    for input_model in input:
+        temp = create_bkg(input_model, tab_wavelength, tab_background)
+        background.append(temp)
+
+    return background
+
+
+def create_bkg(input, tab_wavelength, tab_background):
+    """Create a 2-D background.
+
+    Parameters
+    ----------
+    input : JWST data model
+        The input science data.
+
+    tab_wavelength : 1-D ndarray
+        The wavelength column read from the 1-D background table.
+
+    tab_background : 1-D ndarray
+        The flux column read from the 1-D background table, divided by
+        the npixels column.
+
+    Returns
+    -------
+    background : JWST data model
+        A copy of `input` but with the data replaced by the background,
+        "expanded" from 1-D to 2-D.
+    """
+
+    # Handle individual NIRSpec FS, NIRSpec MOS
+    if isinstance(input, datamodels.MultiSlitModel):
+        background = bkg_for_multislit(input, tab_wavelength, tab_background)
+
+    # Handle MIRI LRS
+    elif isinstance(input, datamodels.ImageModel):
+        background = bkg_for_image(input, tab_wavelength, tab_background)
+
+    # Handle MIRI MRS and NIRSpec IFU
+    elif isinstance(input, datamodels.IFUImageModel):
+        background = bkg_for_IFUimage(input, tab_wavelength, tab_background)
+
+    else:
+        # Shouldn't get here.
+        raise RuntimeError("Input type {} is not supported."
+                           .format(type(input)))
+
+    return background
+
+
+def bkg_for_multislit(input, tab_wavelength, tab_background):
+    """Create a 2-D background for a MultiSlitModel.
+
+    Parameters
+    ----------
+    input : JWST MultiSlitModel
+        The input science data.
+
+    tab_wavelength : 1-D ndarray
+        The wavelength column read from the 1-D background table.
+
+    tab_background : 1-D ndarray
+        The flux column read from the 1-D background table, divided by
+        the npixels column.
+
+    Returns
+    -------
+    background : JWST MultiSlitModel
+        A copy of `input` but with the data replaced by the background,
+        "expanded" from 1-D to 2-D.
+    """
+
+    background = input.copy()
+
+    for (k, slit) in enumerate(input.slits):
+        wl_array = get_wavelengths(slit)
+        if wl_array is None:
+            raise RuntimeError("Can't determine wavelengths for {}"
+                               .format(type(slit)))
+
+        # Wherever the wavelength is NaN, the background flux should to be set
+        # to 0.  We replace NaN elements in wl_array with -1, so that np.interp
+        # will detect that those values are out of range (note the `left`
+        # argument to np.interp) and set the output to 0.
+        wl_array[np.isnan(wl_array)] = -1.
+
+        # bkg_flux will be a 2-D array, because wl_array is 2-D.
+        bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
+                             left=0., right=0.)
+
+        background.slits[k].data[:] = bkg_flux.copy()
+
+    return background
+
+
+def bkg_for_image(input, tab_wavelength, tab_background):
+    """Create a 2-D background for an ImageModel.
+
+    Parameters
+    ----------
+    input : JWST ImageModel
+        The input science data.
+
+    tab_wavelength : 1-D ndarray
+        The wavelength column read from the 1-D background table.
+
+    tab_background : 1-D ndarray
+        The flux column read from the 1-D background table, divided by
+        the npixels column.
+
+    Returns
+    -------
+    background : JWST ImageModel
+        A copy of `input` but with the data replaced by the background,
+        "expanded" from 1-D to 2-D.
+    """
+
+    background = input.copy()
+
+    wl_array = get_wavelengths(input)
+    if wl_array is None:
+        raise RuntimeError("Can't determine wavelengths for {}"
+                           .format(type(input)))
+
+    wl_array[np.isnan(wl_array)] = -1.
+
+    # bkg_flux will be a 2-D array, because wl_array is 2-D.
+    bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
+                         left=0., right=0.)
+
+    background.data[:] = bkg_flux.copy()
+
+    return background
+
+
+def bkg_for_IFUimage(input, tab_wavelength, tab_background):
+    """Create a 2-D background for an IFUImageModel
+
+    Parameters
+    ----------
+    input : JWST IFUImageModel
+        The input science data.
+
+    tab_wavelength : 1-D ndarray
+        The wavelength column read from the 1-D background table.
+
+    tab_background : 1-D ndarray
+        The flux column read from the 1-D background table, divided by
+        the npixels column.
+
+    Returns
+    -------
+    background : JWST IFUImageModel
+        A copy of `input` but with the data replaced by the background,
+        "expanded" from 1-D to 2-D.
+    """
+
+    background = input.copy()
+    background.data[:, :] = 0.
+
+    if input.meta.instrument.name == "NIRSPEC":
+        list_of_wcs = nirspec.nrs_ifu_wcs(input)
+        for ifu_wcs in list_of_wcs:
+
+            xstart = ifu_wcs.bounding_box[0][0]
+            xstop = ifu_wcs.bounding_box[0][1]
+            ystart = ifu_wcs.bounding_box[1][0]
+            ystop = ifu_wcs.bounding_box[1][1]
+
+            # Convert to integers, and add one to the upper limits,
+            # because we want to use these as slice limits.
+            xstart = math.floor(xstart)
+            xstop = math.ceil(xstop) + 1
+            ystart = math.floor(ystart)
+            ystop = math.ceil(ystop) + 1
+            xstart = max(xstart, 0)
+            ystart = max(ystart, 0)
+            xstop = min(xstop, 2048)
+            ystop = min(ystop, 2048)
+
+            shape = (ystop - ystart, xstop - xstart)
+            grid = np.indices(shape, dtype=np.float64)
+            grid[0] += ystart
+            grid[1] += xstart
+            wl_array = ifu_wcs(grid[1], grid[0])[2]
+
+            wl_array[np.isnan(wl_array)] = -1.
+            bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
+                                 left=0., right=0.)
+            background.data[ystop:ystart, xstop:xstart] = bkg_flux.copy()
+
+    elif input.meta.instrument.name == "MIRI":
+        shape = input.data.shape
+        grid = np.indices(shape, dtype=np.float64)
+        wl_array = ifu_wcs(grid[1], grid[0])[2]
+
+        wl_array[np.isnan(wl_array)] = -1.
+        bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
+                             left=0., right=0.)
+        background.data[:, :] = bkg_flux.copy()
+
+    else:
+        raise RuntimeError("Exposure type {} is not supported."
+                           .format(input.meta.exposure.type))
+
+    return background
+
+
+def get_wavelengths(model):
+    """Read or compute wavelengths.
+
+    Parameters
+    ----------
+    model : JWST data model
+        The input science data.
+
+    Returns
+    -------
+    wl_array : 2-D ndarray
+        An array of wavelengths corresponding to the data in `model`.
+    """
+
+    if hasattr(model, "wavelength"):
+        wl_array = model.wavelength.copy()
+        got_wavelength = True                   # may be reset below
+    else:
+        wl_array = None
+    if (wl_array is None or len(wl_array) == 0 or
+        wl_array.min() == 0. and wl_array.max() == 0.):
+            got_wavelength = False
+            wl_array = None
+
+    if hasattr(model, "wcs") and not got_wavelength:
+        wcs = model.wcs.forward_transform
+        shape = model.data.shape
+        grid = np.indices(shape[-2:], dtype=np.float64)
+        wl_array = wcs(grid[1], grid[0])[2]
+
+    return wl_array

--- a/jwst/master_background/tests/test_create_master_bkg.py
+++ b/jwst/master_background/tests/test_create_master_bkg.py
@@ -1,0 +1,25 @@
+"""
+Test for master_background.create_master_bkg
+"""
+import numpy as np
+
+from jwst.master_background import create_master_bkg
+
+def test_create_master_bkg():
+
+    wl = np.arange(37, dtype=np.float64) * 0.1 + 3.
+    flux = np.ones(37, dtype=np.float64) * 7
+
+    model = create_master_bkg.create_background(wl, flux[0:5])
+    assert model is None
+
+    dummy = np.zeros((5, 7), dtype=np.float64) + 3
+    model = create_master_bkg.create_background(dummy, flux)
+    assert model is None
+
+    model = create_master_bkg.create_background(wl, flux)
+
+    tab_wavelength = model.spec[0].spec_table['wavelength']
+    tab_flux = model.spec[0].spec_table['flux']
+    assert np.allclose(wl, tab_wavelength, rtol=1.e-10)
+    assert np.allclose(flux, tab_flux, rtol=1.e-10)


### PR DESCRIPTION
Function `expand_to_2d` was added, to expand a 1-D background file to 2-D.  A utility function `create_background` was also added; this takes 1-D arrays of wavelength and background flux, and copies those values to a table in the appropriate format for a 1-D master background spectrum.
See issue #2308.