### PR TITLE
Make master background step actually work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,15 @@ lib
 linearity
 ---------
 
+master_background
+-----------------
+
+- Implement the basic step scaffolding for `MasterBackgroundStep`. [#3090]
+
+- Record user-supplied master background in MSTRBKGD keyword [#3101]
+
+- Add step documentation for master background subtraction [#3102]
+
 model_blender
 -------------
 

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -2,7 +2,6 @@ import logging
 
 import numpy as np
 
-from gwcs.utils import _toindex
 from gwcs.wcstools import grid_from_bounding_box
 from .. import datamodels
 from .. assign_wcs import nirspec               # for NIRSpec IFU data
@@ -241,16 +240,13 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
     if input.meta.instrument.name.upper() == "NIRSPEC":
         list_of_wcs = nirspec.nrs_ifu_wcs(input)
         for ifu_wcs in list_of_wcs:
-
-            ((xstart, xstop), (ystart, ystop)) = _toindex(ifu_wcs.bounding_box)
-
             x, y = grid_from_bounding_box(ifu_wcs.bounding_box)
             wl_array = ifu_wcs(x, y)[2]
 
             wl_array[np.isnan(wl_array)] = -1.
             bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
                                  left=0., right=0.)
-            background.data[ystop:ystart, xstop:xstart] = bkg_flux.copy()
+            background.data[y.astype(int), x.astype(int)] = bkg_flux.copy()
 
     elif input.meta.instrument.name.upper() == "MIRI":
         shape = input.data.shape

--- a/jwst/master_background/tests/test_master_background.py
+++ b/jwst/master_background/tests/test_master_background.py
@@ -2,10 +2,18 @@
 Unit tests for master background subtraction
 """
 import pytest
+import numpy as np
 
 from jwst.master_background import MasterBackgroundStep
+from jwst.assign_wcs import AssignWcsStep
+# from jwst.assign_wcs.tests.test_nirspec import (
+#     create_nirspec_fs_file,
+#     create_nirspec_ifu_file,
+#     )
+from jwst.master_background.create_master_bkg import create_background
 from jwst import datamodels
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+# from jwst.extract_2d import Extract2dStep
 
 
 @pytest.fixture(scope='module')
@@ -14,7 +22,10 @@ def user_background(tmpdir_factory):
 
     filename = tmpdir_factory.mktemp('master_background_user_input')
     filename = str(filename.join('user_background.fits'))
-    data = datamodels.SlitModel()
+    wavelength = np.linspace(0.5, 25, num=100)
+    flux = np.linspace(2.0, 2.2, num=100)
+    data = create_background(wavelength, flux)
+    data.meta.model_type = 'MultiSpecModel'
     data.save(filename)
 
     return filename
@@ -24,22 +35,45 @@ def _generate_data():
     """Generate data of each type of input for master background step"""
 
     image = datamodels.ImageModel((10, 10))
-    multislit = datamodels.MultiSlitModel()
-    multislit.slits.append(datamodels.SlitModel((10, 10)))
-    ifu_image = datamodels.IFUImageModel((10, 10))
+    image.meta.instrument.name = 'MIRI'
+    image.meta.instrument.detector = 'MIRIMAGE'
+    image.meta.exposure.type = 'MIR_LRS-FIXEDSLIT'
+    image.meta.observation.date = '2018-01-01'
+    image.meta.observation.time = '00:00:00'
+    image.meta.subarray.xstart = 1
+    image.meta.subarray.ystart = 1
+    image.meta.wcsinfo.v2_ref = 0
+    image.meta.wcsinfo.v3_ref = 0
+    image.meta.wcsinfo.roll_ref = 0
+    image.meta.wcsinfo.ra_ref = 0
+    image.meta.wcsinfo.dec_ref = 0
+    image = AssignWcsStep.call(image)
+
+    # hdulist = create_nirspec_fs_file(grating="G140M", filter="F100LP")
+    # hdulist[1].data = np.zeros((2048, 2048))
+    # fs = datamodels.ImageModel(hdulist)
+    # fs = AssignWcsStep.call(fs)
+    # multislit = Extract2dStep.call(fs)
+
+    # hdulist = create_nirspec_ifu_file("OPAQUE", "G140M")
+    # hdulist[1].data = np.zeros((2048, 2048))
+    # ifu_image = datamodels.IFUImageModel(hdulist)
+    # ifu_image = AssignWcsStep.call(ifu_image)
+    
     container = datamodels.ModelContainer([image])
+    
     cube = datamodels.CubeModel((2, 10, 10))
 
     # Return the data and a status dependent on whether the step can process it
     return [(image, 'COMPLETE'),
-            (multislit, 'COMPLETE'),
-            (ifu_image, 'COMPLETE'),
+            # (multislit, 'COMPLETE'),
+            # (ifu_image, 'COMPLETE'),
             (container, 'COMPLETE'),
             (cube, 'SKIPPED'),
             ]
 
 @pytest.mark.parametrize('input_data, status', _generate_data())
-def test_master_background_init(input_data, status, _jail):
+def test_master_background_init(input_data, status, _jail, user_background):
     """Verify data can run through the step"""
 
     result = MasterBackgroundStep.call(input_data)
@@ -58,11 +92,7 @@ def test_master_background_init(input_data, status, _jail):
         for model in result:
             assert model.meta.cal_step.master_back_sub == status
 
-
-@pytest.mark.parametrize('input_data, status', _generate_data())
-def test_master_background_optional_args(input_data, status, _jail, user_background):
-    """Verify data can run through the step with optional arguments"""
-
+    # Run with a user-supplied background and verify this is recorded in header
     result = MasterBackgroundStep.call(input_data, user_background=user_background)
 
     try:
@@ -73,12 +103,5 @@ def test_master_background_optional_args(input_data, status, _jail, user_backgro
             if model.meta.cal_step.master_back_sub == 'COMPLETE':
                 assert model.meta.master_background == 'user_background.fits'
 
+    # Make sure saving the computed background works
     result = MasterBackgroundStep.call(input_data, save_background=True)
-
-    assert type(input_data) is type(result)
-
-    try:
-        assert result.meta.cal_step.master_back_sub == status
-    except AttributeError:
-        for model in result:
-            assert model.meta.cal_step.master_back_sub == status

--- a/jwst/pipeline/master_background.cfg
+++ b/jwst/pipeline/master_background.cfg
@@ -1,5 +1,4 @@
 name = "master_background" 
 class = "jwst.master_background.MasterBackgroundStep"
 
-user_background = None
 save_background = False

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -1064,6 +1064,34 @@ class Step():
                 # Not a file-checkable object. Ignore.
                 pass
 
+    @staticmethod
+    def record_step_status(datamodel, cal_step, success=True):
+        """Record whether or not a step completed in meta.cal_step
+
+        Parameters
+        ----------
+        datamodel : `~jwst.datamodels.Datamodel` instance
+            This is the datamodel or container of datamodels to modify in place
+
+        cal_step : str
+            The attribute in meta.cal_step for recording the status of the step
+
+        success : bool
+            If True, then 'COMPLETE' is recorded.  If False, then 'SKIPPED'
+        """
+        if success:
+            status = 'COMPLETE'
+        else:
+            status = 'SKIPPED'
+
+        if isinstance(datamodel, ModelContainer):
+            for model in datamodel:
+                model.meta.cal_step._instance[cal_step] = status
+        else:
+            datamodel.meta.cal_step._instance[cal_step] = status
+
+        # TODO: standardize cal_step naming to point to the offical step name
+
 
 # #########
 # Utilities


### PR DESCRIPTION
- Make `MasterBackgroundStep` call `expand_to_2d` function.  Now it will actually subtract a user-supplied background.
- Fix indexing bug in NIRSpec IFU master background
- Add `Step.record_step_status()` method for use by this step (and any other step)
- Update the unit tests.  The tests for IFU and MultiSpec files pass, but they've been commented out as they take too long to run (65 seconds vs 2 seconds).  I will deal with these in a future PR.