### PR TITLE
Move MASTERBG keyword to background section of schema

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -2132,8 +2132,8 @@ properties:
                 channel:
                   title: Channel ID
                   type: string
-      master_background_file:
-        title: Master background file used
-        type: string
-        fits_keyword: MASTERBG
+          master_background_file:
+            title: Master background file used
+            type: string
+            fits_keyword: MASTERBG
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -86,9 +86,9 @@ class MasterBackgroundStep(Step):
                 # Record name of user-supplied master background spectrum
                 if isinstance(result, datamodels.ModelContainer):
                     for model in result:
-                        model.meta.master_background_file = basename(self.user_background)
+                        model.meta.background.master_background_file = basename(self.user_background)
                 else:
-                    result.meta.master_background_file = basename(self.user_background)
+                    result.meta.background.master_background_file = basename(self.user_background)
 
             # Save the computed background if requested by user
             if self.save_background and self.user_background is None:

--- a/jwst/master_background/tests/test_master_background.py
+++ b/jwst/master_background/tests/test_master_background.py
@@ -99,10 +99,10 @@ def test_master_background_init(input_data, status, _jail, user_background):
     if isinstance(result, datamodels.ModelContainer):
         for model in result:
             if model.meta.cal_step.master_background == 'COMPLETE':
-                assert model.meta.master_background_file == 'user_background.fits'
+                assert model.meta.background.master_background_file == 'user_background.fits'
     else:
         if result.meta.cal_step.master_background == 'COMPLETE':
-            assert result.meta.master_background_file == 'user_background.fits'
+            assert result.meta.background.master_background_file == 'user_background.fits'
 
     # Make sure saving the computed background works
     result = MasterBackgroundStep.call(input_data, save_background=True)


### PR DESCRIPTION
Change
```
meta.master_background_file
```
to
```
meta.background.master_background_file
```
in the core schema, as the `meta.background` block already exists and is a natural place to put this property.