### PR TITLE
Remove stsci.tools dependency; use astropy.nddata.bitmask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ env:
                               stsci.image
                               stsci.imagestats
                               stsci.stimage
-                              stsci.tools
                               verhawk"
         - CONDA_DOCS_DEPENDENCIES='sphinx graphviz'
         - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,6 @@ def conda_packages = [
     "stsci.image",
     "stsci.imagestats",
     "stsci.stimage",
-    "stsci.tools",
     "verhawk",
     "pytest"
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -55,7 +55,6 @@ bc.conda_packages = ['asdf',
                      'stsci.image',
                      'stsci.imagestats',
                      'stsci.stimage',
-                     'stsci.tools',
                      'verhawk'
 ]
 

--- a/jwst/cube_skymatch/cube_skymatch_step.py
+++ b/jwst/cube_skymatch/cube_skymatch_step.py
@@ -11,16 +11,14 @@ import numpy as np
 from ..stpipe import Step
 from .. import datamodels
 
-try:
-    from stsci.tools.bitmask import bitfield_to_boolean_mask
-    from stsci.tools.bitmask import interpret_bit_flags
-except ImportError:
-    from stsci.tools.bitmask import bitmask2mask as bitfield_to_boolean_mask
-    from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
+from astropy.nddata.bitmask import (
+    bitfield_to_boolean_mask,
+    interpret_bit_flags,
+)
 
 #LOCAL:
-from . skymatch import match
-from . skycube import SkyCube
+from .skymatch import match
+from .skycube import SkyCube
 from ..skymatch.skystatistics import SkyStats
 
 __all__ = ['CubeSkyMatchStep']

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -6,7 +6,7 @@ from astropy.modeling.models import Scale, AffineTransformation2D
 from astropy.modeling import Model
 from gwcs import WCS, wcstools
 
-from stsci.tools.bitmask import interpret_bit_flags
+from astropy.nddata.bitmask import interpret_bit_flags
 
 from ..assign_wcs.util import wcs_from_footprints, wcs_bbox_from_shape
 

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -14,17 +14,15 @@ import logging
 from ..stpipe import Step
 from .. import datamodels
 
-try:
-    from stsci.tools.bitmask import bitfield_to_boolean_mask
-    from stsci.tools.bitmask import interpret_bit_flags
-except ImportError:
-    from stsci.tools.bitmask import bitmask2mask as bitfield_to_boolean_mask
-    from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
+from astropy.nddata.bitmask import (
+    bitfield_to_boolean_mask,
+    interpret_bit_flags,
+)
 
 #LOCAL:
-from . skymatch import match
-from . skyimage import SkyImage, SkyGroup
-from . skystatistics import SkyStats
+from .skymatch import match
+from .skyimage import SkyImage, SkyGroup
+from .skystatistics import SkyStats
 
 __all__ = ['SkyMatchStep']
 

--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,6 @@ setup(
         'stsci.image>=2.3',
         'stsci.imagestats>=1.4',
         'stsci.stimage>=0.2',
-        'stsci.tools>=3.4',
         'verhawk',
     ],
     extras_require={


### PR DESCRIPTION
The `image3pipeline` and MIRI MRS `spec3pipeline` regression tests pass with this change.

Resolves #3144.