### PR TITLE
Use released versions of astropy, asdf and gwcs for Jenkins builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ relic/
 *wpu
 .pytest_cache
 results.xml
+pip-wheel-metadata/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ if (utils.scm_checkout()) return
 matrix_python = ['3.6']
 matrix_numpy = ['1.15']
 matrix_astropy = ['4']
+matrix_astropy_pip = ['3.1']
 matrix = []
 
 def test_env = [
@@ -46,10 +47,10 @@ dist.build_cmds = [
 ]
 matrix += dist
 
-// Generate pip build and test matrix
+// Generate pip build and test matrix with released upstream dependencies
 for (python_ver in matrix_python) {
     for (numpy_ver in matrix_numpy) {
-        for (astropy_ver in matrix_astropy) {
+        for (astropy_ver in matrix_astropy_pip) {
             def name = "pip_py${python_ver}np${numpy_ver}ap${astropy_ver}"
             bc = new BuildConfig()
             bc.nodetype = 'linux'
@@ -58,7 +59,7 @@ for (python_ver in matrix_python) {
             bc.conda_packages = ["python=${python_ver}"]
             bc.build_cmds = [
                 "pip install ${pip_install_args} numpy==${matrix_numpy[0]}",
-                "pip install ${pip_install_args} -r requirements-dev.txt .[test]",
+                "pip install ${pip_install_args} .[test]",
             ]
             bc.test_cmds = ["pytest -r s --basetemp=test_results --junitxml=results.xml"]
             matrix += bc
@@ -66,7 +67,7 @@ for (python_ver in matrix_python) {
     }
 }
 
-// Generate conda build and test matrix
+// Generate conda build and test matrix with astroconda-dev dependencies
 for (python_ver in matrix_python) {
     for (numpy_ver in matrix_numpy) {
         for (astropy_ver in matrix_astropy) {

--- a/setup.py
+++ b/setup.py
@@ -204,11 +204,11 @@ setup(
                   define_macros=[('NUMPY', '1')]),
     ],
     install_requires=[
-        'asdf>=2.3',
+        'asdf>=2.3.2',
         'astropy>=3.1',
         'crds>=7.2.7',
         'drizzle>=1.12',
-        'gwcs>=0.9',
+        'gwcs>=0.10',
         'jsonschema>=2.3,<=2.6',
         'numpy>=1.13',
         'photutils>=0.4',


### PR DESCRIPTION
This changes the `pip`  build/test matrix element for `jwst` on Jenkins to use only released dependencies of `astropy`, `asdf` and `gwcs`.

Addresses #3143.