### PR TITLE
Add pytest.ini file to select correct junit test report family 

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-junit_family=xunit2

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ addopts = --ignore=build, --doctest-rst
 norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern scripts
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 doctest_plus = enabled
+junit_family=xunit2
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
The Jenkins test reporting plugin requires a correctly constructed schema of the report produced by pytest. This `pytest.ini` directive provides that.
Honored as of pytest 2.4.