### PR TITLE
Make coron3 regression test more robust

### DIFF
--- a/jwst/tests_nightly/general/nircam/test_coron3_1.py
+++ b/jwst/tests_nightly/general/nircam/test_coron3_1.py
@@ -7,6 +7,7 @@ from jwst.pipeline import Coron3Pipeline
 @pytest.mark.bigdata
 class TestCoron3Pipeline(BaseJWSTTest):
     rtol = 0.00001
+    atol = 0.00001
     input_loc = 'nircam'
     ref_loc = ['test_coron3', 'truth']
 
@@ -15,7 +16,7 @@ class TestCoron3Pipeline(BaseJWSTTest):
     def test_coron3_1(self):
         """Regression test of calwebb_coron3 pipeline.
 
-        Test will be performed on NIRCam simulated data.
+        Test is performed on NIRCam simulated data.
         """
         asn_name = 'jw99999-a3001_20170327t121212_coron3_001_asn.json'
         override_psfmask = 'jwst_nircam_psfmask_somb.fits'
@@ -30,6 +31,8 @@ class TestCoron3Pipeline(BaseJWSTTest):
         pipe.align_refs.override_psfmask = psfmask_file
         pipe.outlier_detection.resample_data = False
         pipe.run(asn_file)
+
+        self.ignore_keywords += ['NAXIS1', 'TFORM7']
 
         outputs = [( # Compare psfstack product
                     'jw99999-a3001_t1_nircam_f140m-maskbar_psfstack.fits',


### PR DESCRIPTION
The test is currently failing because our CAL_VER changed yesterday.
```
In [7]: hdrtab_new['CAL_VER']
Out[7]: 
chararray(['0.13.1a.dev10+g48b072ec', '0.13.1a.dev10+g48b072ec',
           '0.13.1a.dev10+g48b072ec', '0.13.1a.dev10+g48b072ec',
           '0.13.1a.dev10+g48b072ec', '0.13.1a.dev10+g48b072ec',
           '0.13.1a.dev10+g48b072ec', '0.13.1a.dev10+g48b072ec',
           '0.13.1a.dev10+g48b072ec', '0.13.1a.dev10+g48b072ec'],
          dtype='<U23')

In [10]: hdrtab_ref['CAL_VER']
Out[10]: 
chararray(['0.13.1a.dev5+g7fd654d4', '0.13.1a.dev5+g7fd654d4',
           '0.13.1a.dev5+g7fd654d4', '0.13.1a.dev5+g7fd654d4',
           '0.13.1a.dev5+g7fd654d4', '0.13.1a.dev5+g7fd654d4',
           '0.13.1a.dev5+g7fd654d4', '0.13.1a.dev5+g7fd654d4',
           '0.13.1a.dev5+g7fd654d4', '0.13.1a.dev5+g7fd654d4'],
          dtype='<U22')
```
The new CAL_VER string is 1 character longer than the old one.  And since `blendheaders` builds the `dtype` on the fly, we get different length columns in the output HDRTAB.  That is fragile.  So let's fix it by:

 - Ignore NAXIS1, TFORM7 in `fitsdiff`
 - Add absolute tolerance to coron3 regression test

The addition of `atol` will help for values between 0 and 1 so that the test passes locally in addition to passing on our Jenkins RT build.