### PR TITLE
Switch regression tests to build with publicly-released dependencies

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -38,15 +38,14 @@ data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
+bc.name = "released dependencies"
 bc.env_vars = test_env
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
     "pip install ${pip_install_args} numpy~=${numpy_version}",
-    "pip install ${pip_install_args} develop",
+    "python setup.py ${pip_install_args} develop",
     "pip install ${pip_install_args} -e .[test]",
     "pip install pytest-xdist",
-    "pip freeze",
-    "conda list",
 ]
 
 bc.test_cmds = ["${pytest_command}"]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -7,7 +7,7 @@ jobconfig.publish_env_on_success_only = true
 
 // Define python and numpy versions
 python_version = '3.6'
-numpy_version = '1.16.1'
+numpy_version = '1.16.*'
 
 // Define environment variables needed for the tests
 def test_env = [
@@ -41,7 +41,7 @@ bc.nodetype = 'jwst'
 bc.env_vars = test_env
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
-    "pip install ${pip_install_args} numpy==${numpy_version}",
+    "pip install --progress-bar=off numpy==${numpy_version}",
     "pip install ${pip_install_args} .[test]",
     "pip install pytest-xdist",
     "pip freeze",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -41,7 +41,6 @@ bc.nodetype = 'jwst'
 bc.env_vars = test_env
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
-    "conda --version",
     "pip install ${pip_install_args} numpy==${numpy_version}",
     "pip install ${pip_install_args} -e .[test]",
     "pip install pytest-xdist",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -35,6 +35,7 @@ data_config.server_id = 'bytesalad'
 data_config.root = '${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
+// Build and test with python 3.6 with released dependencies
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
 bc.name = "released dependencies"

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -42,7 +42,7 @@ bc.env_vars = test_env
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
     "pip install --progress-bar=off numpy==${numpy_version}",
-    "pip install ${pip_install_args} .[test]",
+    "pip install ${pip_install_args} -e .[test]",
     "pip install pytest-xdist",
     "pip freeze",
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -7,7 +7,7 @@ jobconfig.publish_env_on_success_only = true
 
 // Define python and numpy versions
 python_version = '3.6'
-numpy_version = '1.15.*'
+numpy_version = '1.16.1'
 
 // Define environment variables needed for the tests
 def test_env = [
@@ -24,12 +24,11 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Pytest command setup
 def pytest_basetemp = "test_outputs"
 def pytest_command = "pytest -r sx -v \
-                      -n 28 \
+                      -n 30 \
                       --bigdata --slow \
                       --basetemp=${pytest_basetemp} \
                       --junit-xml=results.xml \
                       jwst/tests_nightly/general"
-//                      -k 'not ami_' \
 
 // Configure artifactory ingest
 data_config = new DataConfig()

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -11,7 +11,6 @@ numpy_version = '1.16'
 
 // Define environment variables needed for the tests
 def test_env = [
-    "HOME=./",
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_CONTEXT=jwst_0500.pmap",
@@ -44,8 +43,7 @@ bc.conda_ver = '4.6.7'
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
     "pip install ${pip_install_args} numpy~=${numpy_version}",
-    "pip install ${pip_install_args} -e .[test]",
-    "python setup.py develop",
+    "pip install ${pip_install_args} .[test]",
     "pip install pytest-xdist",
 ]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -40,11 +40,12 @@ bc = new BuildConfig()
 bc.nodetype = 'jwst'
 bc.name = "released dependencies"
 bc.env_vars = test_env
+bc.conda_ver = '4.6.7'
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
     "pip install ${pip_install_args} numpy~=${numpy_version}",
-    "python setup.py develop",
     "pip install ${pip_install_args} -e .[test]",
+    "python setup.py develop",
     "pip install pytest-xdist",
 ]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -7,7 +7,7 @@ jobconfig.publish_env_on_success_only = true
 
 // Define python and numpy versions
 python_version = '3.6'
-numpy_version = '1.16.*'
+numpy_version = '1.15.*'
 
 // Define environment variables needed for the tests
 def test_env = [
@@ -37,11 +37,12 @@ data_config.root = '${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
 bc = new BuildConfig()
+bc.conda_ver = '4.6.7'
 bc.nodetype = 'jwst'
 bc.env_vars = test_env
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
-    "pip install --progress-bar=off numpy==${numpy_version}",
+    "pip install ${pip_install_args} numpy==${numpy_version}",
     "pip install ${pip_install_args} -e .[test]",
     "pip install pytest-xdist",
     "pip freeze",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -7,7 +7,7 @@ jobconfig.publish_env_on_success_only = true
 
 // Define python and numpy versions
 python_version = '3.6'
-numpy_version = '1.16.1'
+numpy_version = '1.16'
 
 // Define environment variables needed for the tests
 def test_env = [
@@ -41,10 +41,12 @@ bc.nodetype = 'jwst'
 bc.env_vars = test_env
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
-    "pip install ${pip_install_args} numpy==${numpy_version}",
+    "pip install ${pip_install_args} numpy~=${numpy_version}",
+    "pip install ${pip_install_args} develop",
     "pip install ${pip_install_args} -e .[test]",
     "pip install pytest-xdist",
     "pip freeze",
+    "conda list",
 ]
 
 bc.test_cmds = ["${pytest_command}"]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -37,11 +37,11 @@ data_config.root = '${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
 bc = new BuildConfig()
-bc.conda_ver = '4.6.7'
 bc.nodetype = 'jwst'
 bc.env_vars = test_env
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
+    "conda --version",
     "pip install ${pip_install_args} numpy==${numpy_version}",
     "pip install ${pip_install_args} -e .[test]",
     "pip install pytest-xdist",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -5,6 +5,11 @@ jobconfig = new JobConfig()
 jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
 
+// Define python and numpy versions
+python_version = '3.6'
+numpy_version = '1.15.*'
+
+// Define environment variables needed for the tests
 def test_env = [
     "HOME=./",
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
@@ -13,60 +18,34 @@ def test_env = [
 ]
 
 // Pip related setup
-def PIP_ARGS = "-q"
-def PIP_INST = "pip install ${PIP_ARGS}"
-def PIP_DEPS = ""
-def PIP_TEST_DEPS = "requests_mock ci_watson"
+def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
+def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 
-// Pytest wrapper
-def PYTEST_BASETEMP = "test_outputs"
-def PYTEST = "pytest \
-              -r s \
-              -v \
-              --bigdata \
-              --slow \
-              --basetemp=${PYTEST_BASETEMP} \
-              --junit-xml=results.xml"
-
-def TEST_ROOT = "jwst/tests_nightly/general"
+// Pytest command setup
+def pytest_basetemp = "test_outputs"
+def pytest_command = "pytest -r s -v \
+                      --bigdata --slow \
+                      --basetemp=${pytest_basetemp} \
+                      --junit-xml=results.xml \
+                      jwst/tests_nightly/general"
 
 // Configure artifactory ingest
 data_config = new DataConfig()
 data_config.server_id = 'bytesalad'
-data_config.root = '${PYTEST_BASETEMP}'
+data_config.root = '${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
 bc.env_vars = test_env
-bc.name = '3.6'
-bc.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-bc.conda_packages = ['asdf',
-                     'astropy',
-                     'crds',
-                     'drizzle',
-                     'flake8',
-                     'gwcs',
-                     'jsonschema',
-                     'jplephem',
-                     'matplotlib',
-                     'numpy',
-                     'photutils',
-                     'python=3.6',
-                     'pytest',
-                     'scipy',
-                     'spherical-geometry',
-                     'stsci.image',
-                     'stsci.imagestats',
-                     'stsci.stimage',
-                     'verhawk'
+bc.conda_packages = ["python=${python_version}"]
+bc.build_cmds = [
+    "pip install ${pip_install_args} numpy==${numpy_version}",
+    "pip install ${pip_install_args} .[test]",
+    "pip freeze",
 ]
 
-bc.test_cmds = ["printenv | sort",
-                "python setup.py develop",
-                "${PIP_INST} ${PIP_TEST_DEPS}",
-                "${PYTEST} ${TEST_ROOT}"
-]
+bc.test_cmds = ["${pytest_command}"]
 
 bc.test_configs = [data_config]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -7,7 +7,7 @@ jobconfig.publish_env_on_success_only = true
 
 // Define python and numpy versions
 python_version = '3.6'
-numpy_version = '1.15.*'
+numpy_version = '1.16.1'
 
 // Define environment variables needed for the tests
 def test_env = [

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -23,11 +23,13 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 
 // Pytest command setup
 def pytest_basetemp = "test_outputs"
-def pytest_command = "pytest -r s -v \
+def pytest_command = "pytest -r sx -v \
+                      -n 28 \
                       --bigdata --slow \
                       --basetemp=${pytest_basetemp} \
                       --junit-xml=results.xml \
                       jwst/tests_nightly/general"
+//                      -k 'not ami_' \
 
 // Configure artifactory ingest
 data_config = new DataConfig()
@@ -42,6 +44,7 @@ bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
     "pip install ${pip_install_args} numpy==${numpy_version}",
     "pip install ${pip_install_args} .[test]",
+    "pip install pytest-xdist",
     "pip freeze",
 ]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -43,7 +43,7 @@ bc.env_vars = test_env
 bc.conda_packages = ["python=${python_version}"]
 bc.build_cmds = [
     "pip install ${pip_install_args} numpy~=${numpy_version}",
-    "python setup.py ${pip_install_args} develop",
+    "python setup.py develop",
     "pip install ${pip_install_args} -e .[test]",
     "pip install pytest-xdist",
 ]

--- a/jwst/tests/base_classes.py
+++ b/jwst/tests/base_classes.py
@@ -30,7 +30,7 @@ class BaseJWSTTest:
     Base test class from which to derive JWST regression tests
     '''
     rtol = 1e-5
-    atol = 1e-8
+    atol = 1e-7
 
     input_loc = ''  # root directory for 'input' files
     ref_loc = []    # root path for 'truth' files: ['test1','truth'] or ['test3']

--- a/jwst/tests/base_classes.py
+++ b/jwst/tests/base_classes.py
@@ -29,8 +29,8 @@ class BaseJWSTTest:
     '''
     Base test class from which to derive JWST regression tests
     '''
-    rtol = 0.00001
-    atol = 0
+    rtol = 1e-5
+    atol = 1e-8
 
     input_loc = ''  # root directory for 'input' files
     ref_loc = []    # root path for 'truth' files: ['test1','truth'] or ['test3']

--- a/jwst/tests_nightly/general/nircam/test_coron3_1.py
+++ b/jwst/tests_nightly/general/nircam/test_coron3_1.py
@@ -32,8 +32,6 @@ class TestCoron3Pipeline(BaseJWSTTest):
         pipe.outlier_detection.resample_data = False
         pipe.run(asn_file)
 
-        self.ignore_keywords += ['NAXIS1', 'TFORM7']
-
         outputs = [( # Compare psfstack product
                     'jw99999-a3001_t1_nircam_f140m-maskbar_psfstack.fits',
                     'jw99999-a3001_t1_nircam_f140m-maskbar_psfstack_ref.fits'
@@ -54,9 +52,13 @@ class TestCoron3Pipeline(BaseJWSTTest):
                     'jw9999947001_02102_00002_nrcb3_a3001_crfints.fits',
                     'jw9999947001_02102_00002_nrcb3_a3001_crfints_ref.fits'
                    ),
-                   ( # Compare i2d product
-                    'jw99999-a3001_t1_nircam_f140m-maskbar_i2d.fits',
-                    'jw99999-a3001_t1_nircam_f140m-maskbar_i2d_ref.fits'
-                   )
+                   {'files':(# Compare i2d product
+                             'jw99999-a3001_t1_nircam_f140m-maskbar_i2d.fits',
+                             'jw99999-a3001_t1_nircam_f140m-maskbar_i2d_ref.fits'),
+                    'pars': {'ignore_keywords':
+                             self.ignore_keywords+['NAXIS1', 'TFORM*'],
+                             'ignore_fields':self.ignore_keywords
+                             }
+                   }
                   ]
         self.compare_outputs(outputs)

--- a/jwst/tests_nightly/general/nircam/test_nircam_steps.py
+++ b/jwst/tests_nightly/general/nircam/test_nircam_steps.py
@@ -34,7 +34,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                                      side_gain=1.0),
                       output_truth='jw00017001001_01101_00001_NRCA1_bias_drift.fits',
                       output_hdus=[],
-                      id='test_refpixt_nircam'
+                      id='test_refpix_nircam'
 
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_saturation.fits',


### PR DESCRIPTION
- use `pip install -e .[test]` to install `jwst` and its released dependencies listed in `setup.py`
- use `numpy` from PyPi instead of from Anaconda, i..e one without `mkl`
- because no `mkl`, use `pytest-xdist` to parallelize our builds (from 5.5 hours down to ~2 hours)

Addresses #3143