### PR TITLE
EXP: See if ci skip directive prevents merging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools>=38.2.5", "wheel", "numpy"]
+requires = ["python>=3.5", "setuptools>=38.2.5", "wheel", "numpy"]


### PR DESCRIPTION
This is an experiment for @nden for my claim that the merge button will be grayed out if there is a `[ci skip]` directive in the commit and the repo requires passing test before merge.