### PR TITLE
Remove conda from Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "pypy3.6"
+  - "3.6"
 sudo: false
 
 # The apt packages below are needed for sphinx builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: xenial
 language: python
-python: 3.6.8
+python:
+  - 3.6.8
 sudo: false
 
 # The apt packages below are needed for sphinx builds
@@ -12,6 +13,7 @@ addons:
       - graphviz
 
 env:
+  - NUMPY_VERSION=1.15.4
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
@@ -28,20 +30,14 @@ matrix:
            PIP_DEPENDENCIES='.[docs]'
     # PEP8 check
     - env: TEST_COMMAND='flake8 --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722 --max-line-length=110 jwst'
-           PIP_DEPENDENCIES='.'
     # Strict PEP8 check, an allowed failure below
     - env: TEST_COMMAND='flake8 --count jwst'
-           PIP_DEPENDENCIES='.'
-
   allow_failures:
     - env: TEST_COMMAND='flake8 --count jwst'
-           PIP_DEPENDENCIES='.'
 
 install:
-  - pip install numpy~=1.16
-  - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -e $PIP_DEPENDENCIES; fi
+  - pip install numpy~=$NUMPY_VERSION
+  - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -e $PIP_DEPENDENCIES; python setup.py develop; fi
   - pip install flake8
-  - python setup.py develop
 
-script:
-  - $TEST_COMMAND
+script: $TEST_COMMAND

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-language: python
 dist: xenial
-python:
-  - "3.6"
+language: python
+python: 3.6
 sudo: false
 
 # The apt packages below are needed for sphinx builds
@@ -29,15 +28,19 @@ matrix:
            PIP_DEPENDENCIES='.[docs]'
     # PEP8 check
     - env: TEST_COMMAND='flake8 --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722 --max-line-length=110 jwst'
+           PIP_DEPENDENCIES='.'
     # Strict PEP8 check, an allowed failure below
     - env: TEST_COMMAND='flake8 --count jwst'
+           PIP_DEPENDENCIES='.'
 
   allow_failures:
     - env: TEST_COMMAND='flake8 --count jwst'
+           PIP_DEPENDENCIES='.'
 
 install:
   - pip install numpy~=1.16
   - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -e $PIP_DEPENDENCIES; fi
+  - pip install flake8
   - python setup.py develop
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.6"
+  - "3.6.8"
 sudo: false
 
 # The apt packages below are needed for sphinx builds
@@ -15,6 +15,9 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
+    - PIP_INDEX="https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
+    = PIP_INSTALL_ARGS="--index-url ${pip_index} --progress-bar=off"
+
 
 matrix:
   # Don't wait for allowed failures
@@ -36,7 +39,7 @@ matrix:
 
 install:
   - pip install numpy~=1.16
-  - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -q -e $PIP_DEPENDENCIES; fi
+  - if [[ -n $PIP_DEPENDENCIES ]]; then pip install $PIP_INSTALL_ARGS -e $PIP_DEPENDENCIES; fi
   - python setup.py develop
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,79 +1,43 @@
-language: c
-
-os:
-    - linux
-
+language: python
+python:
+  - "pypy3.6"
 sudo: false
 
 # The apt packages below are needed for sphinx builds
 addons:
-    apt:
-        packages:
-            - texlive-latex-extra
-            - dvipng
-            - graphviz
+  apt:
+    packages:
+      - texlive-latex-extra
+      - dvipng
+      - graphviz
 
 env:
-    global:
-        - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda-dev'
-        - CONDA_DEPENDENCIES="asdf
-                              astropy
-                              crds
-                              drizzle
-                              flake8
-                              gwcs
-                              jsonschema
-                              jplephem
-                              matplotlib
-                              photutils
-                              scipy
-                              spherical-geometry
-                              stsci.image
-                              stsci.imagestats
-                              stsci.stimage
-                              verhawk"
-        - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
-        - CRDS_PATH='/tmp/crds_cache'
-        - MC_URL=https://repo.continuum.io/miniconda
-        - PYTHON_VERSION=3.6
+  global:
+    - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
+    - CRDS_PATH='/tmp/crds_cache'
 
 matrix:
+  # Don't wait for allowed failures
+  fast_finish: true
+  include:
+    # Run tests
+    - env: TEST_COMMAND='python setup.py test'
+           PIP_DEPENDENCIES='.[test]'
+    # Build sphinx documentation with warnings
+    - env: TEST_COMMAND='python setup.py build_sphinx -W'
+           PIP_DEPENDENCIES='.[docs]'
+    # PEP8 check
+    - env: TEST_COMMAND='flake8 --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722 --max-line-length=110 jwst'
+    # Strict PEP8 check, an allowed failure below
+    - env: TEST_COMMAND='flake8 --count jwst'
 
-    # Don't wait for allowed failures
-    fast_finish: true
+  allow_failures:
+    - env: TEST_COMMAND='flake8 --count jwst'
 
-    include:
-
-        # Run tests
-        - env: TEST_COMMAND='python setup.py test'
-               PIP_DEPENDENCIES='.[test]'
-
-        # Build sphinx documentation with warnings
-        - env: TEST_COMMAND='python setup.py build_sphinx -W'
-               PIP_DEPENDENCIES='.[docs]'
-
-        # PEP8 check
-        - env: TEST_COMMAND='flake8 --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722 --max-line-length=110 jwst'
-
-        # Strict PEP8 check, an allowed failure below
-        - env: TEST_COMMAND='flake8 --count jwst'
-
-    allow_failures:
-        - env: TEST_COMMAND='flake8 --count jwst'
-
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then MC_INST=Miniconda3-latest-Linux-x86_64.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then MC_INST=Miniconda3-latest-MacOSX-x86_64.sh; fi
-  - curl -LO "$MC_URL/$MC_INST"
-  - bash $MC_INST -b -p $HOME/miniconda
-  - export PATH=$HOME/miniconda/bin:$PATH
-  - conda config --set always_yes yes --set changeps1 no
-  - for channel in $CONDA_CHANNELS; do conda config --add channels "$channel"; done
-  - conda update -y conda
-  - conda create -n test -q python=$PYTHON_VERSION numpy $CONDA_DEPENDENCIES
-  - source activate test
-  - python setup.py develop
+install:
+  - pip install numpy~=1.16
   - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -q -e $PIP_DEPENDENCIES; fi
+  - python setup.py develop
 
 script:
   - $TEST_COMMAND

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
            PIP_DEPENDENCIES='.'
 
 install:
+  - pip install -U pip
+  - pip install -U python~=3.6
   - pip install numpy~=1.16
   - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -e $PIP_DEPENDENCIES; fi
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
     - PIP_INDEX="https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
-    = PIP_INSTALL_ARGS="--index-url ${pip_index} --progress-bar=off"
+    - PIP_INSTALL_ARGS="--index-url ${pip_index} --progress-bar=off"
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - PIP_INDEX="https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
-    - PIP_INSTALL_ARGS=" --index-url ${pip_index} --progress-bar=off "
-
 
 matrix:
   # Don't wait for allowed failures
@@ -40,7 +37,7 @@ matrix:
 
 install:
   - pip install numpy~=1.16
-  - if [[ -n $PIP_DEPENDENCIES ]]; then pip install $PIP_INSTALL_ARGS -e $PIP_DEPENDENCIES; fi
+  - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -e $PIP_DEPENDENCIES; fi
   - python setup.py develop
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: python
-python: 3.6
+python: 3.6.8
 sudo: false
 
 # The apt packages below are needed for sphinx builds
@@ -38,8 +38,6 @@ matrix:
            PIP_DEPENDENCIES='.'
 
 install:
-  - pip install -U pip
-  - pip install -U python~=3.6
   - pip install numpy~=1.16
   - if [[ -n $PIP_DEPENDENCIES ]]; then pip install -e $PIP_DEPENDENCIES; fi
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
     - PIP_INDEX="https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
-    - PIP_INSTALL_ARGS="--index-url ${pip_index} --progress-bar=off"
+    - PIP_INSTALL_ARGS=" --index-url ${pip_index} --progress-bar=off "
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
+dist: xenial
 python:
-  - "3.6.8"
+  - "3.6"
 sudo: false
 
 # The apt packages below are needed for sphinx builds

--- a/jwst/ami/nrm_model.py
+++ b/jwst/ami/nrm_model.py
@@ -184,9 +184,9 @@ class NrmModel:
             self.fov_sim = fov
 
         if hasattr(centering, '__iter__'):
-            if centering is 'PIXELCENTERED':
+            if centering == 'PIXELCENTERED':
                 centering=(0.5, 0.5)
-            elif centering is 'PIXELCORNER':
+            elif centering == 'PIXELCORNER':
                 centering=(0.0, 0.0)
 
         self.bandpass = bandpass


### PR DESCRIPTION
- Rely on publicly-released dependencies
- Don't use `conda` in Travis CI build/test matrix
- New version of `flake8` founda  bug in the ami code