### PR TITLE
Add exit code to set_bary_helio_times script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ combine_1d
 ----------
 
 - Added parameter ``background``; for background data, scale the flux,
-   error, and net by 1 / NPIXELS, and include NPIXELS in the weight;
-   changed the default for ``exptime_key`` to "exposure_time". [#3180]
+  error, and net by 1 / NPIXELS, and include NPIXELS in the weight;
+  changed the default for ``exptime_key`` to "exposure_time". [#3180]
 
 extract_1d
 ----------
@@ -24,6 +24,11 @@ master_background
 
  - Added unit tests for expand_to_2d.  Support CombinedSpecModel data
    for the 1-D user-supplied background spectrum. [#3188]
+
+set_bary_helio_times
+--------------------
+
+ - Added exit code of 1 when unable to compute converted times. [#3197]
 
 set_telescope_pointing
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ master_background
 set_bary_helio_times
 --------------------
 
- - Added exit code of 1 when unable to compute converted times. [#3197]
+ - Raise an exception when unable to compute converted times. [#3197]
 
 set_telescope_pointing
 ----------------------

--- a/scripts/move_wcs.py
+++ b/scripts/move_wcs.py
@@ -36,7 +36,7 @@ def _collect_wcs_keywords(f):
     # Get keywords to go in SCI header from the datamodels schema
     dm = datamodels.open(f, pass_invalid_values=True)
     stsci_wcs_kw = []
-    for k,v in datamodels.schema.build_schema2fits_dict(dm.meta._schema).items():
+    for k, v in datamodels.schema.build_schema2fits_dict(dm.meta._schema).items():
         if v[1] == 'SCI':
             if v[0] != 'WCSAXES':
                 stsci_wcs_kw.append(v[0])
@@ -96,14 +96,14 @@ def add_default_keywords(new_hdr):
     wcsaxes = new_hdr['WCSAXES']
     if wcsaxes == 3:
         default_pc = {"PC1_1": 1, "PC1_2": 0, "PC1_3": 0,
-                      "PC2_1": 0 , "PC2_2": 1, "PC2_3": 0,
+                      "PC2_1": 0, "PC2_2": 1, "PC2_3": 0,
                       "PC3_1": 0, "PC3_2": 0, "PC3_3": 1
                      }
         default_cunit = {"CUNIT1": "deg", "CUNIT2": "deg", "CUNIT3": "um"}
         default_ctype = {"CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN", "CTYPE3": "WAVE"}
     elif wcsaxes == 2:
         default_pc = {"PC1_1": 1, "PC1_2": 0,
-                      "PC2_1": 0 , "PC2_2": 1,
+                      "PC2_1": 0, "PC2_2": 1,
                      }
         default_cunit = {"CUNIT1": "deg", "CUNIT2": "deg"}
         default_ctype = {"CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN"}
@@ -136,5 +136,3 @@ if __name__ == '__main__':
             files = glob.glob(files)
 
     move_wcs(files)
-
-

--- a/scripts/runjwpsf.py
+++ b/scripts/runjwpsf.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-from __future__ import division, print_function  #confidence high
 import sys
 
 from jwst import jwpsf
+
 
 def run():
     jwpsf.jwpsf()

--- a/scripts/set_bary_helio_times.py
+++ b/scripts/set_bary_helio_times.py
@@ -36,8 +36,7 @@ times. It also updates the extension that contains the times
 for each group by adding the necessary columns to that table.
 '''
 
-from __future__ import print_function, division
-
+import sys
 import argparse
 import logging
 
@@ -90,6 +89,7 @@ def set_bary_helio_times(filename, jwstpos=None):
     pheader['HELIDELT'] = (hstrtime - starttime) * 86400.
 
     # Now modify the table
+    success = False
     try:
         tabhdu = hdul['GROUP']
     except KeyError:
@@ -129,6 +129,8 @@ def set_bary_helio_times(filename, jwstpos=None):
             hcol = fits.Column(
                 name='helio_end_time', format='D', unit='MJD', array=htimes
             )
+            success = True
+
         binhdu = fits.BinTableHDU.from_columns(
             tabhdu.columns + fits.ColDefs([bcol, hcol])
         )
@@ -138,6 +140,9 @@ def set_bary_helio_times(filename, jwstpos=None):
     hdul.flush()
     hdul.close()
     logging.info('Completed set_bary_helio_times task')
+
+    if not success:
+        sys.exit(1)
 
 
 def main(args):

--- a/scripts/set_velocity_aberration.py
+++ b/scripts/set_velocity_aberration.py
@@ -49,8 +49,6 @@ It does not currently place the new keywords in any particular location
 in the header other than what is required by the standard.
 '''
 
-from __future__ import print_function, division
-
 import astropy.io.fits as fits
 import logging
 import math
@@ -103,9 +101,9 @@ def aberration_scale(velocity_x, velocity_y, velocity_z,
     targ_y = r_xy * math.sin(targ_ra * d_to_r)
     targ_z = math.sin(targ_dec * d_to_r)
 
-    dot_prod = velocity_x * targ_x + \
-               velocity_y * targ_y + \
-               velocity_z * targ_z
+    dot_prod = (velocity_x * targ_x +
+                velocity_y * targ_y +
+                velocity_z * targ_z)
     cos_theta = dot_prod / speed
     # This sin_theta is only valid over the range [0, pi], but so is the
     # angle between the velocity vector and the direction toward the target.
@@ -114,8 +112,8 @@ def aberration_scale(velocity_x, velocity_y, velocity_z,
     tan_theta_p = sin_theta / (gamma * (cos_theta + beta))
     theta_p = math.atan(tan_theta_p)
 
-    scale_factor = gamma * (cos_theta + beta)**2 / \
-                   (math.cos(theta_p)**2 * (1. + beta * cos_theta))
+    scale_factor = (gamma * (cos_theta + beta)**2 /
+                    (math.cos(theta_p)**2 * (1. + beta * cos_theta)))
 
     return scale_factor
 
@@ -153,9 +151,9 @@ def aberration_offset(velocity_x, velocity_y, velocity_z,
     cos_delta = math.cos(targ_dec * d_to_r)
 
     delta_ra = (-xdot * sin_alpha + ydot * cos_alpha) / cos_delta
-    delta_dec = -xdot * cos_alpha * sin_delta - \
-                ydot * sin_alpha * sin_delta + \
-                zdot * cos_delta
+    delta_dec = (-xdot * cos_alpha * sin_delta -
+                 ydot * sin_alpha * sin_delta +
+                 zdot * cos_delta)
 
     return delta_ra, delta_dec
 

--- a/scripts/stspec
+++ b/scripts/stspec
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import argparse
 import sys
 


### PR DESCRIPTION
This adds a call to "sys.exit(1)" if the script fails to be able to compute the converted times. If everything goes OK, it exits with no explicit code, which is assumed to default to 0. Python experts, please comment on whether plain "exit" or "sys.exit" is preferred.

Also includes minor updates to other scripts in the package to remove future import statements (should've been taken out long ago, now that we're requiring Python 3.x for the jwst package), as well as random pep8 updates to other scripts.

Fixes #3196