### PR TITLE
Pull test data inputs_root and results_root values from pytest config.

### DIFF
--- a/jwst/tests/base_classes.py
+++ b/jwst/tests/base_classes.py
@@ -40,9 +40,12 @@ class BaseJWSTTest:
     ignore_hdus = ['ASDF']
     ignore_keywords = ['DATE', 'CAL_VER', 'CAL_VCS', 'CRDS_VER', 'CRDS_CTX', 'FILENAME']
 
-    input_repo = 'jwst-pipeline'
-    results_root = 'jwst-pipeline-results'
     env = 'dev'
+
+    @pytest.fixture(autouse=True)
+    def config_access(self, pytestconfig):
+        self.inputs_root = pytestconfig.getini('inputs_root')[0]
+        self.results_root = pytestconfig.getini('results_root')[0]
 
     @pytest.fixture(autouse=True)
     def auto_toggle_docopy(self):
@@ -54,7 +57,7 @@ class BaseJWSTTest:
 
     @property
     def repo_path(self):
-        return [self.input_repo, self.env, self.input_loc]
+        return [self.inputs_root, self.env, self.input_loc]
 
     def get_data(self, *pathargs, docopy=True):
         """
@@ -81,7 +84,7 @@ class BaseJWSTTest:
                         ignore_keywords=ignore_keywords,
                         rtol=rtol, atol=atol)
 
-        input_path = [self.input_repo, self.env, self.input_loc, *self.ref_loc]
+        input_path = [self.inputs_root, self.env, self.input_loc, *self.ref_loc]
 
         return compare_outputs(outputs,
                                input_path=input_path,

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern sc
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 doctest_plus = enabled
 junit_family=xunit2
+inputs_root = jwst-pipeline
+results_root = jwst-pipeline-results
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ DOCS_REQUIRE = [
     'sphinx-astropy',
 ]
 TESTS_REQUIRE = [
-    'ci-watson',
+    'ci-watson>=0.3.0',
     'pytest',
     'pytest-doctestplus',
     'requests_mock',


### PR DESCRIPTION
This standardizes the location for Artifactory/local data root locations for test inputs and results. It will facilitate in a general manner a request for incremental environment snapshot artifacts to be published at the conclusion of selected regression test runs.

The pytest config items `inputs_root` and `results_root` are supported by `ci-watson` starting in version `0.3`, released recently.