### PR TITLE
Change VALUE datatype in dq_def schema to uint

### DIFF
--- a/jwst/datamodels/schemas/dq_def.schema.yaml
+++ b/jwst/datamodels/schemas/dq_def.schema.yaml
@@ -4,7 +4,7 @@ datatype:
 - name: BIT
   datatype: int32
 - name: VALUE
-  datatype: int32
+  datatype: uint32
 - name: NAME
   datatype: [ascii, 40]
 - name: DESCRIPTION


### PR DESCRIPTION
This PR makes a simple change to the datatype of the VALUE in  jwst.datamodels.schemas.dq_def.schema.yaml

Currently this is set to a datatype of `int`. But I believe it should be `uint`. 

I found this while attempting to populate the `dq_def` attribute in a MaskModel instance with the official list of DQ flags in `datamodels.dqflags.pixel`. In this case, the final entry in my dq_def list is the tuple: (31, 2147483648, 'REFERENCE_PIXEL', ''). But when I then set that as the dq_def attribute and print the attribute, the flag value is suddenly negative, and tuple is printed as: (31, -2147483648, 'REFERENCE_PIXEL', ''). I think this is due to the integer datatype.

Here's what I was doing when I found the problem:
```
    from jwst.datamodels import MaskModel, dqflags
    definitions = []
    standard_defs = dqflags.pixel
    for bitname in standard_defs:
        bitvalue = standard_defs[bitname]
        if bitvalue != 0:
            bitnumber = np.uint8(np.log(bitvalue)/np.log(2))
        else:
            bitnumber = 0
        newrow = (bitnumber, bitvalue, bitname, '')
        definitions.append(newrow)

    m = MaskModel()
    m.dq_def = definitions

    print(definitions)
    print(m.dq_def)
```