### PR TITLE
Add back datamodels BaseExtension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ combine_1d
   error, and net by 1 / NPIXELS, and include NPIXELS in the weight;
   changed the default for ``exptime_key`` to "exposure_time". [#3180]
 
+datamodels
+----------
+
+- Add back BaseExtension class so url-to-schema mapping works again [#3227]
+
 extract_1d
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -815,7 +815,6 @@ datamodels
 
 - Removed BaseExtension class, it was not being used [#2430]
 
-
 dq_init
 -------
 

--- a/jwst/__init__.py
+++ b/jwst/__init__.py
@@ -6,8 +6,4 @@ except ImportError:  # Not available for RTD
 import sys
 
 if sys.version_info < (3, 5):
-    raise ImportError("JWST does not support Python 2.x, 3.0, 3.1, 3.2, 3.3 or 3.4."
-                      "Beginning with JWST 0.9, Python 3.5 and above is required.")
-
-from .transforms.jwextension import JWSTExtension
-from .datamodels.extension import BaseExtension
+    raise ImportError("JWST requires Python 3.5 and above.")

--- a/jwst/__init__.py
+++ b/jwst/__init__.py
@@ -9,4 +9,5 @@ if sys.version_info < (3, 5):
     raise ImportError("JWST does not support Python 2.x, 3.0, 3.1, 3.2, 3.3 or 3.4."
                       "Beginning with JWST 0.9, Python 3.5 and above is required.")
 
-
+from .transforms.jwextension import JWSTExtension
+from .datamodels.extension import BaseExtension

--- a/jwst/datamodels/extension.py
+++ b/jwst/datamodels/extension.py
@@ -1,0 +1,30 @@
+import os.path
+from asdf.extension import AsdfExtension
+from asdf import util
+
+SCHEMA_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), 'schemas'))
+
+URL_PREFIX = 'http://jwst.stsci.edu/schemas/'
+
+
+class BaseExtension(AsdfExtension):
+    """
+    This asdf extension provides url mapping for the asdf resolver
+
+    This is needed so that the asdf resolver can find the datamodel schemas
+    in the jwst package.  This base extension needs to be imported in the
+    jwst package __init__ and have an entry_points entry in setup.py
+    """
+    @property
+    def types(self):
+        return []
+
+    @property
+    def tag_mapping(self):
+        return []
+
+    @property
+    def url_mapping(self):
+        return [(URL_PREFIX,
+                 util.filepath_to_url(SCHEMA_PATH) + '/{url_suffix}')]

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -4,7 +4,6 @@ Data model class heirarchy
 
 import copy
 import datetime
-import inspect
 import os
 import sys
 import warnings

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -30,6 +30,11 @@ from . import validate
 
 from .history import HistoryList
 
+from .extension import (
+    BaseExtension,
+    URL_PREFIX,
+)
+
 
 class DataModel(properties.ObjectNode, ndmodel.NDModel):
     """
@@ -79,6 +84,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         kwargs: Aadditional arguments passed to lower level functions
         """
         # Set attributes used to hold information for asdf
+        if extensions is None:
+            extensions = [BaseExtension()]
+        else:
+            extensions.extend([BaseExtension()])
         self._extensions = extensions
 
         # Override value of validation parameters
@@ -88,22 +97,13 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         self._strict_validation = self.get_envar("STRICT_VALIDATION",
                                                  strict_validation)
 
-        # Construct the path to the schema files
-        filename = os.path.abspath(inspect.getfile(self.__class__))
-        base_url = os.path.join(
-            os.path.dirname(filename), 'schemas', '')
-
         # Load the schema files
         if schema is None:
-            schema_path = os.path.join(base_url, self.schema_url)
+            schema_path = os.path.join(URL_PREFIX, self.schema_url)
             # Create an AsdfFile so we can use its resolver for loading schemas
-            asdf_file = AsdfFile(extensions=self._extensions)
-            if hasattr(asdf_file, 'resolver'):
-                file_resolver = asdf_file.resolver
-            else:
-                file_resolver = self.get_resolver(asdf_file)
+            asdf_file = AsdfFile()
             schema = asdf_schema.load_schema(schema_path,
-                                             resolver=file_resolver,
+                                             resolver=asdf_file.resolver,
                                              resolve_references=True)
 
         self._schema = mschema.merge_property_trees(schema)
@@ -302,12 +302,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             except ValueError:
                 value = True
         return value
-
-    def get_resolver(self, asdf_file):
-        extensions = asdf_file._extensions
-        def asdf_file_resolver(uri):
-            return extensions._url_mapping(extensions._tag_mapping(uri))
-        return asdf_file_resolver
 
     @staticmethod
     def clone(target, source, deepcopy=False, memo=None):

--- a/jwst/datamodels/schema.py
+++ b/jwst/datamodels/schema.py
@@ -3,12 +3,6 @@
 import re
 from collections import OrderedDict
 
-from asdf import AsdfFile
-from asdf import schema as asdf_schema
-
-from .extension import BaseExtension
-from jwst.transforms.jwextension import JWSTExtension
-from gwcs.extension import GWCSExtension
 
 # return_result included for backward compatibility
 def find_fits_keyword(schema, keyword, return_result=False):
@@ -266,37 +260,6 @@ def merge_property_trees(schema):
     walk_schema(schema, callback)
 
     return newschema
-
-def read_schema(schema_file, extensions=None):
-    """
-    Read a schema file from disk in order to pass it as an argument
-    to a new datamodel.
-    """
-    def get_resolver(asdf_file):
-        extensions = asdf_file._extensions
-        def asdf_file_resolver(uri):
-            return extensions._url_mapping(extensions._tag_mapping(uri))
-        return asdf_file_resolver
-
-    default_extensions = [GWCSExtension(), JWSTExtension()]
-
-    if extensions is None:
-        extensions = default_extensions[:]
-    else:
-        extensions.extend(default_extensions)
-    asdf_file = AsdfFile(extensions=extensions)
-
-    if hasattr(asdf_file, 'resolver'):
-        file_resolver = asdf_file.resolver
-    else:
-        file_resolver = get_resolver(asdf_file)
-
-    schema = asdf_schema.load_schema(schema_file,
-                                     resolver=file_resolver,
-                                     resolve_references=True)
-
-    schema = merge_property_trees(schema)
-    return schema
 
 
 def build_docstring(klass, template):

--- a/jwst/datamodels/schema.py
+++ b/jwst/datamodels/schema.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from asdf import AsdfFile
 from asdf import schema as asdf_schema
 
+from .extension import BaseExtension
 from jwst.transforms.jwextension import JWSTExtension
 from gwcs.extension import GWCSExtension
 

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -644,5 +644,5 @@ def test_all_datamodels_init(model):
 def test_datamodel_schema_entry_points():
     """Test that entry points for datamodels BaseExtension work with asdf"""
     resolver = asdf.AsdfFile().resolver
-    schema = mschema.load_schema('http://jwst.stsci.edu/schemas/image.schema.yaml',
+    mschema.load_schema('http://jwst.stsci.edu/schemas/image.schema.yaml',
         resolver=resolver, resolve_references=True)

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -22,6 +22,7 @@ from .. import (DataModel, ImageModel, RampModel, MaskModel,
                 SourceModelContainer, MultiExposureModel)
 from ..schema import merge_property_trees, build_docstring
 
+import asdf
 from asdf import schema as mschema
 
 FITS_FILE = None
@@ -639,3 +640,9 @@ def test_all_datamodels_init(model):
         m = model()
     del m
 
+
+def test_datamodel_schema_entry_points():
+    """Test that entry points for datamodels BaseExtension work with asdf"""
+    resolver = asdf.AsdfFile().resolver
+    schema = mschema.load_schema('http://jwst.stsci.edu/schemas/image.schema.yaml',
+        resolver=resolver, resolve_references=True)

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,7 @@ except ImportError:
 
 if sys.version_info < (3, 5):
     error = """
-    JWST 0.9+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3 or 3.4.
     Beginning with JWST 0.9, Python 3.5 and above is required.
-
-    This may be due to an out of date pip
-
-    Make sure you have pip >= 9.0.1.
-
     """
     sys.exit(error)
 
@@ -171,7 +165,8 @@ import relic.release
 version = relic.release.get_info()
 relic.release.write_template(version, NAME)
 
-entry_points = dict(asdf_extensions=['jwst_pipeline = jwst.transforms.jwextension:JWSTExtension'])
+entry_points = dict(asdf_extensions=['jwst_pipeline = jwst.transforms.jwextension:JWSTExtension',
+                                     'model_extensions = jwst.datamodels.extension:BaseExtension'])
 
 setup(
     name=NAME,


### PR DESCRIPTION
Revert #2430 with a few modifications:
- Add back `BaseExtension` to allow the URL mapping of `http://jwst.stsci.edu/schemas/core.schema.yaml` --> the location of `core.schema.yaml` in this package.  And all the other schemas.
-  Define the URL_PREFIX of `http://jwst.stsci.edu/schemas/` in one location in the package.
- Add this extension to `entry_points` in `setup.py` so `asdf` and other packages can access the schemas.
- Use the `entry_points` internally so it gets tested.
- Add a test to test the `entry_points` access from `asdf`, so we don't break this again in the future.

Resolves #3224.