### PR TITLE
Fix url_mapper for fits-schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 0.13.2 (Unreleased)
 ===================
 
+datamodels
+----------
+
+- Fix ``url_mapper`` for fits-schema to allow URLs with of the format
+  http://stsci.edu/schemas/fits-schema/ to map to the correct location
+  in the ``jwst`` package. [#3239]
+
 0.13.1 (2019-03-07)
 ===================
 

--- a/jwst/datamodels/extension.py
+++ b/jwst/datamodels/extension.py
@@ -4,6 +4,8 @@ from asdf import util
 
 SCHEMA_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), 'schemas'))
+METASCHEMA_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), 'metaschema'))
 
 URL_PREFIX = 'http://jwst.stsci.edu/schemas/'
 
@@ -26,5 +28,8 @@ class BaseExtension(AsdfExtension):
 
     @property
     def url_mapping(self):
-        return [(URL_PREFIX,
-                 util.filepath_to_url(SCHEMA_PATH) + '/{url_suffix}')]
+        return [
+            (URL_PREFIX, util.filepath_to_url(SCHEMA_PATH) + '/{url_suffix}'),
+            ('http://stsci.edu/schemas/fits-schema/',
+                util.filepath_to_url(METASCHEMA_PATH) + '/{url_suffix}.yaml'),
+        ]

--- a/jwst/datamodels/metaschema/fits-schema.yaml
+++ b/jwst/datamodels/metaschema/fits-schema.yaml
@@ -7,7 +7,7 @@ description: |
   to converting models to and from FITS files.
 
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema"
+  - $ref: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
   - type: object
     properties:
       fits_keyword:


### PR DESCRIPTION
This fixes our current failures of schema validation seen in #3234 when testing this package using `asdf-2.4.0.dev1720`.  This resolves the bugs in this package.  Changes on `asdf` will be required to fully resolve it.

Resolves #3238.