### PR TITLE
Update README for 0.13.1 delivery [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Software vs DMS build version map
 
 | jwst tag | DMS build | CRDS_CONTEXT |   Date     |          Notes                           |
 | -------- | --------- | ------------ | ---------- | -----------------------------------------|
+|  0.13.1  |           | 0500         | 03/08/2019 | DMS test, no delivery to I&T             |
 |  0.13.0  |           | 0500         | 02/15/2019 | DMS test, no delivery to I&T             |
 |  0.12.3  | B7.2.1    | 0500         | 01/15/2019 | DMS Build 7.2.1 patch release            |
 |  0.12.2  | B7.2      | 0495         | 11/07/2018 | Final release candidate for Build 7.2    |


### PR DESCRIPTION
Update the DMS deliveries table in the README to include 0.13.1.