### PR TITLE
Pin CRDS_CONTEXT=jwst_0500.pmap

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -5,7 +5,7 @@ def test_env = [
     "HOME=./",
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
-    "CRDS_CONTEXT=jwst-edit",
+    "CRDS_CONTEXT=jwst_0500.pmap",
 ]
 
 // Pip related setup


### PR DESCRIPTION
Temporarily pin the CRDS_CONTEXT for our regression tests until #3106 is merged.  This is to avoid using the new MIRI LRS reference files before the code handling them is merged.