### PR TITLE
Convert CDELTn to degrees

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ master_background
 
 - Modified the unit tests for ``expand_to_2d``. [#3242]
 
+set_telescope_pointing
+----------------------
+
+ - Fix ``populate_model_from_siaf`` to convert SIAF pixel scale from
+   arcsec to degress for CDELTn keywords. [#3248]
+
 0.13.1 (2019-03-07)
 ===================
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -80,7 +80,7 @@ Transforms = namedtuple("Transforms",
 Transforms.__new__.__defaults__ = (None, None, None, None, None,
                                    None, None, None, None)
 # WCS reference container
-WCSRef = namedtuple( 'WCSRef', ['ra', 'dec', 'pa'])
+WCSRef = namedtuple('WCSRef', ['ra', 'dec', 'pa'])
 WCSRef.__new__.__defaults__ = (None, None, None)
 
 
@@ -476,8 +476,8 @@ def update_s_region(model, siaf):
     )
     # Execute IdealToV2V3, followed by V23ToSky
     from ..transforms.models import IdealToV2V3, V23ToSky
-    v2_ref_deg = model.meta.wcsinfo.v2_ref / 3600 # in deg
-    v3_ref_deg = model.meta.wcsinfo.v3_ref / 3600 # in deg
+    v2_ref_deg = model.meta.wcsinfo.v2_ref / 3600  # in deg
+    v3_ref_deg = model.meta.wcsinfo.v3_ref / 3600  # in deg
     roll_ref = model.meta.wcsinfo.roll_ref
     ra_ref = model.meta.wcsinfo.ra_ref
     dec_ref = model.meta.wcsinfo.dec_ref
@@ -493,8 +493,8 @@ def update_s_region(model, siaf):
     v2, v3 = idltov23(xvert, yvert)  # in arcsec
 
     # Convert to deg
-    v2 = v2 / 3600 # in deg
-    v3 = v3 / 3600 # in deg
+    v2 = v2 / 3600  # in deg
+    v3 = v3 / 3600  # in deg
     angles = [-v2_ref_deg, v3_ref_deg, -roll_ref, -dec_ref, ra_ref]
     axes = "zyxyz"
     v23tosky = V23ToSky(angles, axes_order=axes)
@@ -738,7 +738,7 @@ def calc_aperture_wcs(m_eci2siaf):
     # The VyPA @ xref,yref is given by
     y = cos(vy_dec) * sin(vy_ra-wcs_ra)
     x = sin(vy_dec) * cos(wcs_dec) - \
-      cos(vy_dec) * sin(wcs_dec) * cos((vy_ra - wcs_ra))
+        cos(vy_dec) * sin(wcs_dec) * cos((vy_ra - wcs_ra))
     wcs_pa = np.arctan2(y, x)
 
     # Convert all WCS to degrees
@@ -973,7 +973,7 @@ def calc_position_angle(v1, v3):
     """
     y = cos(v3.dec) * sin(v3.ra-v1.ra)
     x = sin(v3.dec) * cos(v1.dec) - \
-      cos(v3.dec) * sin(v1.dec) * cos((v3.ra - v1.ra))
+        cos(v3.dec) * sin(v1.dec) * cos((v3.ra - v1.ra))
     v3_pa = np.arctan2(y, x)
 
     return v3_pa
@@ -1100,8 +1100,8 @@ def compute_local_roll(pa_v3, ra_ref, dec_ref, v2_ref, v3_ref):
 
 def _roll_angle_from_matrix(matrix, v2, v3):
     X = -(matrix[2, 0] * np.cos(v2) + matrix[2, 1] * np.sin(v2)) * np.sin(v3) + matrix[2, 2] * np.cos(v3)
-    Y = (matrix[0, 0] *  matrix[1, 2] - matrix[1, 0] * matrix[0, 2]) * np.cos(v2) + \
-      (matrix[0, 1] * matrix[1, 2] - matrix[1, 1] * matrix[0, 2]) * np.sin(v2)
+    Y = (matrix[0, 0] * matrix[1, 2] - matrix[1, 0] * matrix[0, 2]) * np.cos(v2) + \
+        (matrix[0, 1] * matrix[1, 2] - matrix[1, 1] * matrix[0, 2]) * np.sin(v2)
     new_roll = np.rad2deg(np.arctan2(Y, X))
     if new_roll < 0:
         new_roll += 360
@@ -1332,7 +1332,6 @@ def get_mnemonics(obsstart, obsend, tolerance, engdb_url=None):
                 )
             mnemonics[mnemonic] = allowed
 
-
     # All mnemonics must have some values.
     if not all([len(mnemonic) for mnemonic in mnemonics.values()]):
         raise ValueError('Incomplete set of pointing mnemonics')
@@ -1360,8 +1359,8 @@ def all_pointings(mnemonics):
             for mnemonic in mnemonics
         ]
         if any(values):
-            # The tagged obstime will come from the SA_ZATTEST1 mneunonic
-            #pointing.
+            # The tagged obstime will come from the SA_ZATTEST1 mnemonic
+            # pointing.
             obstime = mnemonics['SA_ZATTEST1'][idx].obstime
 
             # Fill out the matricies
@@ -1399,7 +1398,6 @@ def all_pointings(mnemonics):
     return pointings
 
 
-
 def populate_model_from_siaf(model, siaf):
     """
     Populate the WCS keywords of a Level1bModel from the SIAF.
@@ -1426,8 +1424,8 @@ def populate_model_from_siaf(model, siaf):
         model.meta.wcsinfo.cunit2 = "deg"
         model.meta.wcsinfo.crpix1 = siaf.crpix1
         model.meta.wcsinfo.crpix2 = siaf.crpix2
-        model.meta.wcsinfo.cdelt1 = siaf.cdelt1
-        model.meta.wcsinfo.cdelt2 = siaf.cdelt2
+        model.meta.wcsinfo.cdelt1 = siaf.cdelt1 / 3600  # in deg
+        model.meta.wcsinfo.cdelt2 = siaf.cdelt2 / 3600  # in deg
         model.meta.coordinates.reference_frame = "ICRS"
 
 

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -227,23 +227,32 @@ def test_add_wcs_default(data_file):
         )
 
     model = datamodels.Level1bModel(data_file)
+    model.save('test_add_wcs_default.fits')
     assert model.meta.pointing.ra_v1 == TARG_RA
     assert model.meta.pointing.dec_v1 == TARG_DEC
     assert model.meta.pointing.pa_v3 == 0.
+    assert model.meta.wcsinfo.wcsaxes == 2
+    assert model.meta.wcsinfo.crpix1 == 693.5
+    assert model.meta.wcsinfo.crpix2 == 512.5
     assert model.meta.wcsinfo.crval1 == TARG_RA
     assert model.meta.wcsinfo.crval2 == TARG_DEC
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -1.0)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 1.0)
-    assert model.meta.wcsinfo.ra_ref == TARG_RA
-    assert model.meta.wcsinfo.dec_ref == TARG_DEC
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 358.9045979379)
-    assert model.meta.wcsinfo.wcsaxes == 2
     assert model.meta.wcsinfo.ctype1 == "RA---TAN"
     assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
     assert model.meta.wcsinfo.cunit1 == 'deg'
     assert model.meta.wcsinfo.cunit2 == 'deg'
+    assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
+    assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, -1.0)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.0)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.0)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, 1.0)
+    assert model.meta.wcsinfo.v2_ref == 200.0
+    assert model.meta.wcsinfo.v3_ref == -350.0
+    assert model.meta.wcsinfo.vparity == -1
+    assert model.meta.wcsinfo.v3yangle == 42.0
+    assert model.meta.wcsinfo.ra_ref == TARG_RA
+    assert model.meta.wcsinfo.dec_ref == TARG_DEC
+    assert np.isclose(model.meta.wcsinfo.roll_ref, 358.9045979379)
     assert word_precision_check(
         model.meta.wcsinfo.s_region,
         (
@@ -308,20 +317,28 @@ def test_add_wcs_fsmcorr_v1(data_file):
     assert model.meta.pointing.ra_v1 == TARG_RA
     assert model.meta.pointing.dec_v1 == TARG_DEC
     assert model.meta.pointing.pa_v3 == 0.
+    assert model.meta.wcsinfo.wcsaxes == 2
+    assert model.meta.wcsinfo.crpix1 == 693.5
+    assert model.meta.wcsinfo.crpix2 == 512.5
     assert model.meta.wcsinfo.crval1 == TARG_RA
     assert model.meta.wcsinfo.crval2 == TARG_DEC
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -1.0)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 1.0)
-    assert model.meta.wcsinfo.ra_ref == TARG_RA
-    assert model.meta.wcsinfo.dec_ref == TARG_DEC
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 358.9045979379)
-    assert model.meta.wcsinfo.wcsaxes == 2
     assert model.meta.wcsinfo.ctype1 == "RA---TAN"
     assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
     assert model.meta.wcsinfo.cunit1 == 'deg'
     assert model.meta.wcsinfo.cunit2 == 'deg'
+    assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
+    assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, -1.0)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.0)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.0)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, 1.0)
+    assert model.meta.wcsinfo.v2_ref == 200.0
+    assert model.meta.wcsinfo.v3_ref == -350.0
+    assert model.meta.wcsinfo.vparity == -1
+    assert model.meta.wcsinfo.v3yangle == 42.0
+    assert model.meta.wcsinfo.ra_ref == TARG_RA
+    assert model.meta.wcsinfo.dec_ref == TARG_DEC
+    assert np.isclose(model.meta.wcsinfo.roll_ref, 358.9045979379)
     assert word_precision_check(
         model.meta.wcsinfo.s_region,
         (
@@ -344,20 +361,28 @@ def test_add_wcs_with_db(eng_db_ngas, data_file, siaf_file=siaf_db):
     assert np.isclose(model.meta.pointing.ra_v1, 348.9278669)
     assert np.isclose(model.meta.pointing.dec_v1, -38.749239)
     assert np.isclose(model.meta.pointing.pa_v3, 50.1767077)
+    assert model.meta.wcsinfo.wcsaxes == 2
+    assert model.meta.wcsinfo.crpix1 == 693.5
+    assert model.meta.wcsinfo.crpix2 == 512.5
     assert np.isclose(model.meta.wcsinfo.crval1, 348.8776709)
     assert np.isclose(model.meta.wcsinfo.crval2, -38.854159)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.0385309)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992574)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992574)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.0385309)
-    assert np.isclose(model.meta.wcsinfo.ra_ref, 348.8776709)
-    assert np.isclose(model.meta.wcsinfo.dec_ref, -38.854159)
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 50.20832726650)
-    assert model.meta.wcsinfo.wcsaxes == 2
     assert model.meta.wcsinfo.ctype1 == "RA---TAN"
     assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
     assert model.meta.wcsinfo.cunit1 == 'deg'
     assert model.meta.wcsinfo.cunit2 == 'deg'
+    assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
+    assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.0385309)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992574)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992574)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.0385309)
+    assert model.meta.wcsinfo.v2_ref == 200.0
+    assert model.meta.wcsinfo.v3_ref == -350.0
+    assert model.meta.wcsinfo.vparity == -1
+    assert model.meta.wcsinfo.v3yangle == 42.0
+    assert np.isclose(model.meta.wcsinfo.ra_ref, 348.8776709)
+    assert np.isclose(model.meta.wcsinfo.dec_ref, -38.854159)
+    assert np.isclose(model.meta.wcsinfo.roll_ref, 50.20832726650)
     assert word_precision_check(
         model.meta.wcsinfo.s_region,
         (
@@ -380,20 +405,28 @@ def test_add_wcs_with_db_fsmcorr_v1(eng_db_ngas, data_file):
     assert np.isclose(model.meta.pointing.ra_v1, 348.9278669)
     assert np.isclose(model.meta.pointing.dec_v1, -38.749239)
     assert np.isclose(model.meta.pointing.pa_v3, 50.1767077)
+    assert model.meta.wcsinfo.wcsaxes == 2
+    assert model.meta.wcsinfo.crpix1 == 693.5
+    assert model.meta.wcsinfo.crpix2 == 512.5
     assert np.isclose(model.meta.wcsinfo.crval1, 348.8776709)
     assert np.isclose(model.meta.wcsinfo.crval2, -38.854159)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.0385309)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992574)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992574)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.0385309)
-    assert np.isclose(model.meta.wcsinfo.ra_ref, 348.8776709)
-    assert np.isclose(model.meta.wcsinfo.dec_ref, -38.854159)
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 50.20832726650)
-    assert model.meta.wcsinfo.wcsaxes == 2
     assert model.meta.wcsinfo.ctype1 == "RA---TAN"
     assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
     assert model.meta.wcsinfo.cunit1 == 'deg'
     assert model.meta.wcsinfo.cunit2 == 'deg'
+    assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
+    assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.0385309)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992574)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992574)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.0385309)
+    assert model.meta.wcsinfo.v2_ref == 200.0
+    assert model.meta.wcsinfo.v3_ref == -350.0
+    assert model.meta.wcsinfo.vparity == -1
+    assert model.meta.wcsinfo.v3yangle == 42.0
+    assert np.isclose(model.meta.wcsinfo.ra_ref, 348.8776709)
+    assert np.isclose(model.meta.wcsinfo.dec_ref, -38.854159)
+    assert np.isclose(model.meta.wcsinfo.roll_ref, 50.20832726650)
     assert word_precision_check(
         model.meta.wcsinfo.s_region,
         (

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -227,7 +227,6 @@ def test_add_wcs_default(data_file):
         )
 
     model = datamodels.Level1bModel(data_file)
-    model.save('test_add_wcs_default.fits')
     assert model.meta.pointing.ra_v1 == TARG_RA
     assert model.meta.pointing.dec_v1 == TARG_DEC
     assert model.meta.pointing.pa_v3 == 0.


### PR DESCRIPTION
Modified `set_telescope_pointing` to convert the pixel scale values loaded from the SIAF from units of arcsec to degrees when storing the values in the CDELTn keywords. Also some random PEP8/flake8 cleanup.

Fixes #3247