### PR TITLE
Updates to calspec2 background step to check NIRSPEC GWA Tilt values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 0.13.2 (Unreleased)
 ===================
 
+background
+----------
+
+- Verify the exposures to be used as background have the same NIRSpec GWA
+  tilt values as the science exposures. If the background and science
+  exposures do not have matching GWA tilt values, then skip the background
+  subtraction step in calspec2. [#3252]
+
 datamodels
 ----------
 
@@ -8,7 +16,9 @@ datamodels
   http://stsci.edu/schemas/fits-schema/ to map to the correct location
   in the ``jwst`` package. [#3239]
 
-<<<<<<< mod_extract
+- Change ``ModelContainer`` to load and instantiate datamodels from an
+  association on init.  This reverts #1027. [#3264]
+
 extract_1d
 ----------
 
@@ -16,10 +26,6 @@ extract_1d
   image (for IFU) may be either 2-D or 3-D.  When using a reference image
   for non-IFU data, background smoothing is now done after scaling the
   background count rate. [#3258]
-=======
-- Change ``ModelContainer`` to load and instantiate datamodels from an
-  association on init.  This reverts #1027. [#3264]
->>>>>>> master
 
 master_background
 -----------------

--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -3,7 +3,7 @@
 from ..stpipe import Step
 from .. import datamodels
 from . import background_sub
-
+import numpy as np
 __all__ = ["BackgroundStep"]
 
 
@@ -67,15 +67,15 @@ class BackgroundStep(Step):
                     input_xtilt = input_model.meta.instrument.gwa_xtilt
                     input_ytilt = input_model.meta.instrument.gwa_ytilt
                     for bkg_file in bkg_list:
-                        bkg_model = datamodels.open(bkg_file)
-                        bkg_xtilt = bkg_model.meta.instrument.gwa_xtilt
-                        bkg_ytilt = bkg_model.meta.instrument.gwa_ytilt
-                        xdiff = abs(bkg_xtilt - input_xtilt)
-                        ydiff = abs(bkg_ytilt - input_ytilt)
-                        bkg_model.close()
-                        if xdiff > tolerance or ydiff > tolerance:
-                            do_sub = False
-                            break
+                        with datamodels.open(bkg_file) as bkg_model:
+                            bkg_xtilt = bkg_model.meta.instrument.gwa_xtilt
+                            bkg_ytilt = bkg_model.meta.instrument.gwa_ytilt
+                            if np.allclose((input_xtilt, input_ytilt), 
+                                           (bkg_xtilt, bkg_ytilt), atol=tolerance, rtol=0):
+                                pass
+                            else:
+                                do_sub  = False
+                                break
                 # Do the background subtraction
                 if do_sub:
                     result = background_sub.background_sub(input_model,

--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -3,7 +3,6 @@
 from ..stpipe import Step
 from .. import datamodels
 from . import background_sub
-import numpy as np
 
 __all__ = ["BackgroundStep"]
 
@@ -60,20 +59,19 @@ class BackgroundStep(Step):
                 result.meta.cal_step.back_sub = 'COMPLETE'
             else:
                 # check if input data is NRS_IFU
-                tolerance = 1.0e-15
-                result = input_model.copy()
+                tolerance = 1.0e-8
                 do_sub = True
-                if input_model.meta.exposure.type in ["NRS_IFU"]:
-                    # check if GWA_XTILT & GWA_YTILT values of source
+                if input_model.meta.instrument.name in ["NIRSPEC"]:
+                    # check if GWA_XTIL & GWA_YTIL values of source
                     # background are the same. If not skip step
                     input_xtilt = input_model.meta.instrument.gwa_xtilt
                     input_ytilt = input_model.meta.instrument.gwa_ytilt
                     for bkg_file in bkg_list:
-                        bkg_model = datamodels.ImageModel(bkg_file)
+                        bkg_model = datamodels.open(bkg_file)
                         bkg_xtilt = bkg_model.meta.instrument.gwa_xtilt
                         bkg_ytilt = bkg_model.meta.instrument.gwa_ytilt
-                        xdiff = np.absolute(bkg_xtilt - input_xtilt)
-                        ydiff = np.absolute(bkg_ytilt - input_ytilt)
+                        xdiff = abs(bkg_xtilt - input_xtilt)
+                        ydiff = abs(bkg_ytilt - input_ytilt)
                         bkg_model.close()
                         if xdiff > tolerance or ydiff > tolerance:
                             do_sub = False
@@ -83,13 +81,13 @@ class BackgroundStep(Step):
                     result = background_sub.background_sub(input_model,
                                                            bkg_list,
                                                            self.sigma,
-                                                       self.maxiters)
+                                                           self.maxiters)
                     result.meta.cal_step.back_sub = 'COMPLETE'
                 else:
-                    print('skip')
+                    result = input_model.copy()
                     result.meta.cal_step.back_sub = 'SKIPPED'
                     self.log.warning('Skipping background subtraction')
-                    self.log.warning('GWA_XTILT and GWA_YTILT source values '
+                    self.log.warning('GWA_XTIL and GWA_YTIL source values '
                                      'are not the same as bkg values')
 
         return result


### PR DESCRIPTION
This is for #3135 it it covers the checking the calspec2 background step when NIRSPEC data is run.
The GWA_XTILT and GWA_YTILT have to match. 
I did put in a tolerance - of 1e-15. I might need to change that part. 

Fixes #1149.