### PR TITLE
Use publicly released dependencies for regression tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,33 +1,10 @@
 if (utils.scm_checkout()) return
 
-python_ver = '3.6'
-pip_numpy_ver = '1.16'
-conda_numpy_ver = '1.15'
+python_version = '3.6'
 
-def test_env = [
+test_env = [
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_PATH=./crds_cache",
-]
-
-// Define conda packages needed for build bc2.  Some come from astroconda-dev
-def conda_packages = [
-    "asdf",
-    "astropy",
-    "crds",
-    "drizzle",
-    "flake8",
-    "gwcs",
-    "jsonschema",
-    "jplephem",
-    "matplotlib",
-    "photutils",
-    "scipy",
-    "spherical-geometry",
-    "stsci.image",
-    "stsci.imagestats",
-    "stsci.stimage",
-    "verhawk",
-    "pytest",
 ]
 
 // Pip related setup
@@ -39,9 +16,10 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 bc0 = new BuildConfig()
 bc0.nodetype = 'linux'
 bc0.name = 'wheel sdist'
-bc0.conda_packages = ["python=${python_ver}"]
+bc0.conda_ver = '4.6.8'
+bc0.conda_packages = ["python=${python_version}"]
 bc0.build_cmds = [
-    "pip install ${pip_install_args} numpy==${pip_numpy_ver}",
+    "pip install ${pip_install_args} numpy",
     "pip wheel ${pip_install_args} .",
     "python setup.py sdist",
 ]
@@ -51,7 +29,7 @@ bc1 = utils.copy(bc0)
 bc1.name = "released dependencies"
 bc1.env_vars = test_env
 bc1.build_cmds = [
-    "pip install ${pip_install_args} numpy~=${pip_numpy_ver}",
+    "pip install ${pip_install_args} numpy",
     "pip install ${pip_install_args} -e .[test]",
     "python setup.py develop",
 ]
@@ -61,11 +39,18 @@ bc1.test_cmds = ["pytest -r sx --basetemp=test_results --junitxml=results.xml"]
 bc2 = utils.copy(bc0)
 bc2.name = "astroconda-dev"
 bc2.env_vars = test_env
-bc2.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-bc2.conda_packages += conda_packages + ["numpy=${conda_numpy_ver}"]
+bc2.conda_channels = [
+    "http://ssb.stsci.edu/astroconda-dev"
+]
+bc2.conda_packages = [
+    "python=${python_version}",
+    "numpy",
+    "nomkl",
+    "jwst",
+]
 bc2.build_cmds = [
     "python setup.py develop",
-    "pip install ${pip_install_args} -e .[test]",
+    "pip install -e .[test]",
 ]
 bc2.test_cmds = ["pytest -r sx --basetemp=test_results --junitxml=results.xml"]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -5,30 +5,19 @@ jobconfig = new JobConfig()
 jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
 
-def test_env = [
-    "HOME=./",
+// Define python and numpy versions for conda
+python_version = '3.6'
+numpy_version = '1.16'
+
+// Define environement variables needed for the regression tests
+test_env = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_CONTEXT=jwst_0500.pmap",
 ]
 
-// Pip related setup
-def PIP_ARGS = "-q"
-def PIP_INST = "pip install ${PIP_ARGS}"
-def PIP_DEPS = ""
-def PIP_TEST_DEPS = "requests_mock ci_watson"
-
-// Pytest wrapper
-def PYTEST_BASETEMP = "test_outputs"
-def PYTEST = "pytest \
-              -r s \
-              -v \
-              --bigdata \
-              --slow \
-              --basetemp=${PYTEST_BASETEMP} \
-              --junit-xml=results.xml"
-
-def TEST_ROOT = "jwst/tests_nightly/general"
+// Set pytest basetemp output directory
+pytest_basetemp = "test_outputs"
 
 // Configure artifactory ingest
 data_config = new DataConfig()
@@ -36,38 +25,34 @@ data_config.server_id = 'bytesalad'
 data_config.root = '${PYTEST_BASETEMP}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
+// Build and test with python 3.6 and released dependencies from astroconda
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
+bc.name = 'released dependencies'
 bc.env_vars = test_env
-bc.name = '3.6'
-bc.conda_channels = ['http://ssb.stsci.edu/astroconda-dev']
-bc.conda_packages = ['asdf',
-                     'astropy',
-                     'crds',
-                     'drizzle',
-                     'flake8',
-                     'gwcs',
-                     'jsonschema',
-                     'jplephem',
-                     'matplotlib',
-                     'numpy',
-                     'photutils',
-                     'python=3.6',
-                     'pytest',
-                     'scipy',
-                     'spherical-geometry',
-                     'stsci.image',
-                     'stsci.imagestats',
-                     'stsci.stimage',
-                     'verhawk'
+bc.conda_ver = '4.6.8'
+bc.conda_override_channels = true
+bc.conda_channels = [
+    'http://ssb.stsci.edu/astroconda',
+    'defaults',
+    'http://ssb.stsci.edu/astroconda-dev',
 ]
-
-bc.test_cmds = ["printenv | sort",
-                "python setup.py develop",
-                "${PIP_INST} ${PIP_TEST_DEPS}",
-                "${PYTEST} ${TEST_ROOT}"
+bc.conda_packages = [
+    "python=${python_version}",
+    "numpy=${numpy_version}",
+    "nomkl",
+    "jwst",
 ]
-
+bc.build_cmds = [
+    "python setup.py develop",
+    "pip install -e .[test]",
+    "pip install pytest-xdist",
+]
+bc.test_cmds = [
+    "pytest -r sx -v -n 30 --bigdata --slow \
+    --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
+    jwst/tests_nightly/general"
+]
 bc.test_configs = [data_config]
 
 utils.run([jobconfig, bc])


### PR DESCRIPTION
- Continue using `conda` in our Jenkins RT builds, but avoid using the astroconda-dev channel for the dependencies.  Use astroconda and default channels for released versions of dependencies.  This has the advantage of still allowing a spec file via `conda list --explicit` at the end of the run to be generated.

- Use Anaconda's `numpy nomkl` packages, which allow more efficient parallelization of the test run.  Should be similar to normal `numpy` available via `pip install` which doesn't have on-chip parallelization enabled.  This should be beneficial for DMS in their runs on HT Condor as well.

- The kicker: instead of having our dependencies in 3 places

    - setup.py
    - astroconda-dev recipe for `jwst`
    - Jenkinsfile/JenkinsfileRT
    
    We now only have them in two places.  This PR enables the Jenkinsfile to use the astroconda-dev recipe's dependencies, so it does not have to list them itself.

Closes #3183 

Closes #3256 

Resolves #3143