### PR TITLE
Pin jsonschema<=2.6 in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def conda_packages = [
     "drizzle",
     "flake8",
     "gwcs",
-    "jsonschema",
+    "jsonschema<=2.6",
     "jplephem",
     "matplotlib",
     "photutils",


### PR DESCRIPTION
Fixes the same issue in our CI.  Related to #3254.