### PR TITLE
Use reference image for IFU data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ datamodels
   http://stsci.edu/schemas/fits-schema/ to map to the correct location
   in the ``jwst`` package. [#3239]
 
+extract_1d
+----------
+
+- This step can now use a reference image for IFU data. [#3258]
+
 master_background
 -----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,10 @@ datamodels
 extract_1d
 ----------
 
-- This step can now use a reference image for IFU data. [#3258]
+- This step can now use a reference image for IFU data.  The reference
+  image (for IFU) may be either 2-D or 3-D.  When using a reference image
+  for non-IFU data, background smoothing is now done after scaling the
+  background count rate. [#3258]
 
 master_background
 -----------------

--- a/docs/jwst/extract_1d/index.rst
+++ b/docs/jwst/extract_1d/index.rst
@@ -9,6 +9,7 @@ Extract 1D Spectra
 
    description.rst
    reference_files.rst
+   reference_image.rst
    arguments.rst
 
 .. automodapi:: jwst.extract_1d

--- a/docs/jwst/extract_1d/reference_image.rst
+++ b/docs/jwst/extract_1d/reference_image.rst
@@ -1,0 +1,56 @@
+Reference Image Format
+======================
+An alternative reference format, an image, is also supported.  There are
+no files of this type in CRDS (there would be a conflict with the current
+JSON-format reference files), but a user can create a file in this format
+and specify that it be used as an override for the default reference file.
+
+This format is a `~jwst.datamodels.MultiExtract1dImageModel`, which is
+loosely based on `~jwst.datamodels.MultiSlitModel`.  The file should
+contain keyword DATAMODL, with value 'MultiExtract1dImageModel'; this is
+not required, but it makes it possible to open the file simply with
+`datamodels.open`.  The reference image file contains one or more images,
+which are of type `~jwst.datamodels.Extract1dImageModel`, and one can
+iterate over the list of these images to find one that matches the
+observing configuration.  This iterable is the ``images`` attribute of
+the model (``ref_model``, for purposes of discussion).  Each element of
+``ref_model.images`` can contain a ``name`` attribute (FITS keyword
+SLTNAME) and a ``spectral_order`` attribute (FITS keyword SPORDER), which
+can be compared with the slit name and spectral order respectively in the
+science data model in order to select the matching reference image.  The
+wildcard for SLTNAME is "ANY", and any integer value for SPORDER greater
+than or equal to 1000 is a wildcard for spectral order (SPORDER is an
+integer, and an integer keyword may not be assigned a string value such as
+"ANY").  For IFU data, the image to use is selected only on ``name``.
+
+For non-IFU data, the shape of the reference image should match the shape
+of the science data, although the step can either trim the reference image
+or pad it with zeros to match the size of the science data, pinned at
+pixel [0, 0].  For IFU data, the shape of the reference image can be 3-D,
+exactly matching the shape of the IFU data, or it can be 2-D, matching
+the shape of one plane of the IFU data.  If the reference image is 2-D,
+it will be applied equally to each plane of the IFU data, i.e. it will be
+broadcast over the dispersion direction.
+
+The data type of each image is float32, but the data values may only
+be +1, 0, or -1.  A value of +1 means that the matching pixel in the
+science data will be included when accumulating data for the source
+(target) region.  A value of 0 means the pixel will not be used for
+anything.  A value of -1 means the pixel will be included for the
+background; if there are no pixels with value -1, no background will be
+subtracted.  A pixel will either be included or not; there is no option
+to include only a fraction of a pixel.
+
+For non-IFU data, values will be extracted column by column (if the
+dispersion direction is horizontal, else row by row).  The gross count
+rate will be the sum of the source pixels in a column (or row).  If
+background region(s) were specified, the sum of those pixels will be
+scaled by the ratio of the number of source pixels to the number of
+background pixels (with possibly a different ratio for each column (row))
+before being subtracted from the gross count rate.  The scaled background
+is what will be saved in the output table.
+
+For IFU data, the values will be summed over each plane in the dispersion
+direction, giving one value of flux and optionally one value of background
+per plane.  The background value will be scaled by the ratio of source
+pixels to background pixels before being subtracted from the flux.

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2187,12 +2187,13 @@ class ImageExtractModel(ExtractBase):
             # -1 is used as a flag, and also to avoid dividing by zero.
             n_bkg = np.where(n_bkg == 0., -1., n_bkg)
             background = (data * mask_bkg).sum(axis=axis, dtype=np.float)
-            # Boxcar smoothing.
-            if self.smoothing_length > 1:
-                background = extract1d.bxcar(background, self.smoothing_length)
             scalefactor = n_target / n_bkg
             scalefactor = np.where(n_bkg > 0., scalefactor, 0.)
             background *= scalefactor
+            # Boxcar smoothing.
+            if self.smoothing_length > 1:
+                background = extract1d.bxcar(background, self.smoothing_length)
+                background = np.where(n_bkg > 0., background, 0.)
             net = gross - background
         else:
             background = np.zeros_like(gross)

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -627,24 +627,25 @@ def separate_target_and_background(ref):
 
     Parameters
     ----------
-    ref : ndarray, 2-D
+    ref : ndarray, 2-D or 3-D
         This is the reference image data array.  This should be the same
-        shape as one plane of the science data.  A value of 1 in a pixel
-        indicates that the pixel should be included when computing the
-        target spectrum.  A value of 0 means the pixel is not part of
-        either the target or background.  A value of -1 means the pixel
-        should be included as part of the background region.
+        shape as one plane of the science data (or the same shape as the
+        entire 3-D science data array).  A value of 1 in a pixel indicates
+        that the pixel should be included when computing the target
+        spectrum.  A value of 0 means the pixel is not part of either the
+        target or background.  A value of -1 means the pixel should be
+        included as part of the background region.
 
     Returns
     -------
-    mask_target : ndarray, 2-D
+    mask_target : ndarray, 2-D or 3-D
         This is an array of the same type and shape as the reference
         image, but with values of only 0 or 1.  A value of 1 indicates
-        that the corresponding pixel in each plane of the science data
-        array should be included when adding up values to make the 1-D
-        spectrum, and a value of 0 means that it should not be included.
+        that the corresponding pixel of the science data array should be
+        included when adding up values to make the 1-D spectrum, and a
+        value of 0 means that it should not be included.
 
-    mask_bkg : ndarray, 2-D, or None.
+    mask_bkg : ndarray, 2-D or 3-D, or None.
         This is like `mask_target` (i.e. values are 0 or 1) but for
         background regions.  A value of 1 in `mask_bkg` indicates a pixel
         that should be included as part of the background.  If there is no
@@ -667,13 +668,14 @@ def im_centroid(data, mask_target):
 
     Parameters
     ----------
-    data : ndarray, 2-D
+    data : ndarray, 3-D
         This is the science image data array.
 
-    mask_target : ndarray, 2-D
+    mask_target : ndarray, 2-D or 3-D
         This is an array of the same type and shape as one plane of the
-        science image, but with values of 0 or 1, where 1 indicates a pixel
-        within the source.
+        science image (or the same type and shape of the entire 3-D science
+        image), but with values of 0 or 1, where 1 indicates a pixel within
+        the source.
 
     Returns
     -------
@@ -685,7 +687,10 @@ def im_centroid(data, mask_target):
     # 2-D image of the IFU field of view.  Multiplying by mask_target
     # zeros out all pixels that are not regarded as part of the target
     # (or targets).
-    data_2d = data.sum(axis=0, dtype=np.float64) * mask_target
+    if len(mask_target.shape) == 2:
+        data_2d = data.sum(axis=0, dtype=np.float64) * mask_target
+    else:
+        data_2d = (data * mask_target).sum(axis=0, dtype=np.float64)
     if data_2d.sum() == 0.:
         log.warning("Couldn't compute image centroid.")
         shape = data_2d.shape


### PR DESCRIPTION
The `extract_1d` step can now use a reference image to define the source and optional background regions for IFU data.  The format of this reference image is the same as has been supported for other modes.
Resolves #3213.
Closes #3213.