### PR TITLE
Revert "Merge pull request #1027 from bernie-simon/jit_container"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ datamodels
   http://stsci.edu/schemas/fits-schema/ to map to the correct location
   in the ``jwst`` package. [#3239]
 
+- Change ``ModelContainer`` to load and instantiate datamodels from an
+  association on init.  This reverts #1027. [#3264]
+
 master_background
 -----------------
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -42,10 +42,6 @@ class ModelContainer(model_base.DataModel):
         - None: initializes an empty `ModelContainer` instance, to which
           DataModels can be added via the ``append()`` method.
 
-    persist : bool
-        If True, do not close model after opening it.
-
-
     Examples
     --------
     >>> container = ModelContainer('example_asn.json')
@@ -70,16 +66,17 @@ class ModelContainer(model_base.DataModel):
     # does not describe the data contents of the container.
     schema_url = "container.schema.yaml"
 
-    def __init__(self, init=None, persist=True, **kwargs):
+    def __init__(self, init=None, **kwargs):
 
         super(ModelContainer, self).__init__(init=None, **kwargs)
-        self._persist = persist
 
         if init is None:
             self._models = []
         elif isinstance(init, list):
-            self._validate_model(init)
-            self._models = init[:]
+            for item in init:
+                if not isinstance(item, model_base.DataModel):
+                    raise ValueError('list must contain only DataModels')
+            self._models = init
         elif isinstance(init, self.__class__):
             instance = copy.deepcopy(init._instance)
             self._schema = init._schema
@@ -98,65 +95,33 @@ class ModelContainer(model_base.DataModel):
             raise TypeError('Input {0!r} is not a list of DataModels or '
                             'an ASN file'.format(init))
 
-    def _open_model(self, index):
-        model = self._models[index]
-        if isinstance(model, str):
-            model = datamodel_open(
-                model,
-                extensions=self._extensions,
-                pass_invalid_values=self._pass_invalid_values
-            )
-            self._models[index] = model
-
-        return model
-
-    def _close_model(self, filename, index):
-        if not self._persist:
-            self._models[index].close()
-            self._models[index] = filename
-
-    def _validate_model(self, models):
-        if not isinstance(models, list):
-            models = [models]
-        for model in models:
-            if isinstance(model, ModelContainer):
-                raise ValueError(
-                    "ModelContainer cannot contain ModelContainer"
-                )
-            if not isinstance(model, (str, model_base.DataModel)):
-                raise ValueError('model must be string or DataModel')
-
     def __len__(self):
         return len(self._models)
 
     def __getitem__(self, index):
-        return self._open_model(index)
+        return self._models[index]
 
     def __setitem__(self, index, model):
-        self._validate_model(model)
         self._models[index] = model
 
     def __delitem__(self, index):
         del self._models[index]
 
     def __iter__(self):
-        return ModelContainerIterator(self)
+        for model in self._models:
+            yield model
 
     def insert(self, index, model):
-        self._validate_model(model)
         self._models.insert(index, model)
 
     def append(self, model):
-        self._validate_model(model)
         self._models.append(model)
 
-    def extend(self, models):
-        self._validate_model(models)
-        self._models.extend(models)
+    def extend(self, model):
+        self._models.extend(model)
 
     def pop(self, index=-1):
-        self._open_model(index)
-        return self._models.pop(index)
+        self._models.pop(index)
 
     def copy(self, memo=None):
         """
@@ -212,7 +177,13 @@ class ModelContainer(model_base.DataModel):
         # make a list of all the input files
         infiles = [member['expname'] for member
                    in asn_data['products'][0]['members']]
-        self._models = infiles
+        if asn_file_path:
+            asn_dir = op.dirname(asn_file_path)
+            infiles = [op.join(asn_dir, f) for f in infiles]
+        try:
+            self._models = [datamodel_open(infile) for infile in infiles]
+        except IOError:
+            raise IOError('Cannot open {}'.format(infiles))
 
         # Pull the whole association table into meta.asn_table
         self.meta.asn_table = {}
@@ -288,10 +259,9 @@ class ModelContainer(model_base.DataModel):
 
         return output_paths
 
-    @property
-    def models_grouped(self):
+    def _assign_group_ids(self):
         """
-        Returns a list of a list of datamodels grouped by exposure.
+        Assign an ID grouping by exposure.
 
         Data from different detectors of the same exposure will have the
         same group id, which allows grouping by exposure.  The following
@@ -316,8 +286,7 @@ class ModelContainer(model_base.DataModel):
             ]
         group_dict = OrderedDict()
 
-        for i in range(len(self)):
-            model = self._open_model(i)
+        for i, model in enumerate(self._models):
             params = []
             for param in unique_exposure_parameters:
                 params.append(getattr(model.meta.observation, param))
@@ -334,12 +303,20 @@ class ModelContainer(model_base.DataModel):
                     )
                 model.meta.group_id = 'exposure{0:04d}'.format(i + 1)
 
+
+    @property
+    def models_grouped(self):
+        """
+        Returns a list of a list of datamodels grouped by exposure.
+        """
+        self._assign_group_ids()
+        group_dict = OrderedDict()
+        for model in self._models:
             group_id = model.meta.group_id
             if group_id in group_dict:
                 group_dict[group_id].append(model)
             else:
                 group_dict[group_id] = [model]
-
         return group_dict.values()
 
     @property
@@ -352,66 +329,34 @@ class ModelContainer(model_base.DataModel):
             result.append(group[0].meta.group_id)
         return result
 
-    def __get_recursively(self, field, search_dict):
-        """
-        Takes a dict with nested lists and dicts, and searches all dicts for
-        a key of the field provided.
-        """
-        values_found = []
-        for key, value in search_dict.items():
-            if key == field:
-                values_found.append(value)
-            elif isinstance(value, dict):
-                results = self.__get_recursively(field, value)
-                for result in results:
-                    values_found.append(result)
-            elif isinstance(value, list):
-                for item in value:
-                    if isinstance(item, dict):
-                        more_results = self.__get_recursively(field, item)
-                        for another_result in more_results:
-                            values_found.append(another_result)
-        return values_found
-
     def get_recursively(self, field):
         """
         Returns a list of values of the specified field from meta.
         """
-        return self.__get_recursively(field, self.meta._instance)
+        def _get_recursively(self, field, search_dict):
+            """
+            Takes a dict with nested lists and dicts, and searches all dicts for
+            a key of the field provided.
+            """
+            values_found = []
+            for key, value in search_dict.items():
+                if key == field:
+                    values_found.append(value)
+                elif isinstance(value, dict):
+                    results = self.__get_recursively(field, value)
+                    for result in results:
+                        values_found.append(result)
+                elif isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, dict):
+                            more_results = self.__get_recursively(field, item)
+                            for another_result in more_results:
+                                values_found.append(another_result)
+            return values_found
+
+        return self._get_recursively(field, self.meta._instance)
 
 
-class ModelContainerIterator:
-    """
-    An iterator for model containers that opens one model at a time
-    """
-    def __init__(self, container):
-        self.index = -1
-        self.open_filename = None
-        self.container = container
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self.open_filename is not None:
-            self.container._close_model(self.open_filename, self.index)
-            self.open_filename = None
-
-        self.index += 1
-        if self.index < len(self.container._models):
-            model = self.container._models[self.index]
-            if isinstance(model, str):
-                name = model
-                model = self.container._open_model(self.index)
-                self.open_filename = name
-            return model
-        else:
-            raise StopIteration
-
-
-# #########
-# Utilities
-# #########
 def make_file_with_index(file_path, idx):
     """Append an index to a filename
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -1,6 +1,7 @@
 import copy
 from collections import OrderedDict
 import os.path as op
+import warnings
 
 from asdf import AsdfFile
 
@@ -11,10 +12,6 @@ from ..associations import (
 from . import model_base
 from .util import open as datamodel_open
 from .util import is_association
-
-import logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __doctest_skip__ = ['ModelContainer']
 
@@ -284,7 +281,6 @@ class ModelContainer(model_base.DataModel):
             'activity_id',
             'exposure_number'
             ]
-        group_dict = OrderedDict()
 
         for i, model in enumerate(self._models):
             params = []
@@ -297,7 +293,7 @@ class ModelContainer(model_base.DataModel):
             except TypeError:
                 params_dict = dict(zip(unique_exposure_parameters, params))
                 bad_params = {'meta.observation.'+k:v for k, v in params_dict.items() if not v}
-                log.warning(
+                warnings.warn(
                     'Cannot determine grouping of exposures: '
                     '{}'.format(bad_params)
                     )

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -33,7 +33,7 @@ class MRSIMatchStep(Step):
     reference_file_types = []
 
     def process(self, images):
-        all_models2d = datamodels.ModelContainer(images, persist=True)
+        all_models2d = datamodels.ModelContainer(images)
 
         chm = {}
 

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -59,7 +59,7 @@ class TweakRegStep(Step):
     def process(self, input):
 
         try:
-            images = datamodels.ModelContainer(input, persist=True)
+            images = datamodels.ModelContainer(input)
         except TypeError as te:
             raise te("Input to tweakreg must be a list of DataModels, an "
                 "association, or an already open ModelContainer containing "


### PR DESCRIPTION
This reverts the complexity in `ModelContainer` introduced in #1027.

 - It added complexity to the code with no speed or memory usage benefit.  See discussion in #1027.  The data arrays in opened `DataModels` are memory mapped, so this is expected.
 - It made determining the state of `ModelContainer._models` difficult.  Instead of it always being a list of `DataModels`, sometimes it was a list of strings of FITS files, but that depended on the operations done to the `ModelContainer`, i.e. if one had tried to read one of the models.  One could end up in a state were `_models` was a mixed list of strings and open `DataModels`.  Not good.
 - Removes the `persist` arg to `ModelContainer`.  When `True`, it just delayed when the model was actually opened and could lead to the half-open list state described above.  When `False`, it didn't allow iterating through items in `meta`, which was always an important use case.

Regression test build on this branch is here:

https://boyle.stsci.edu:8081/job/RT/job/jdavies-dev/103/