### PR TITLE
Improve subarray slice error messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ datamodels
 - Change ``ModelContainer`` to load and instantiate datamodels from an
   association on init.  This reverts #1027. [#3264]
 
+- Keyword updates to data model schemas, including OBSFOLDR, MIRNGRPS,
+  MIRNFRMS, and new PATTTYPE values. [#3266]
+
 extract_1d
 ----------
 
@@ -42,11 +45,17 @@ master_background
   was already run on the data.  A new ``force_subtract`` parameter is
   added to override this logic.  [#3263]
 
+reffile_utils
+-------------
+
+- Improved error messages when problems are encountered in extracting
+  subarrays from reference files. [#3268]
+
 set_telescope_pointing
 ----------------------
 
- - Fix ``populate_model_from_siaf`` to convert SIAF pixel scale from
-   arcsec to degress for CDELTn keywords. [#3248]
+- Fix ``populate_model_from_siaf`` to convert SIAF pixel scale from
+  arcsec to degress for CDELTn keywords. [#3248]
 
 0.13.1 (2019-03-07)
 ===================
@@ -54,14 +63,14 @@ set_telescope_pointing
 combine_1d
 ----------
 
- - Added parameter ``background``; for background data, scale the flux,
-   error, and net by 1 / NPIXELS, and include NPIXELS in the weight;
-   changed the default for ``exptime_key`` to "exposure_time". [#3180]
+- Added parameter ``background``; for background data, scale the flux,
+  error, and net by 1 / NPIXELS, and include NPIXELS in the weight;
+  changed the default for ``exptime_key`` to "exposure_time". [#3180]
 
- - There is now a direct interface for calling the step.  This function,
-   ``combine_1d_spectra``, may be passed either a ModelContainer or a
-   MultiSpecModel object.  Previously this function expected the name of
-   an association file. [#3220]
+- There is now a direct interface for calling the step.  This function,
+  ``combine_1d_spectra``, may be passed either a ModelContainer or a
+  MultiSpecModel object.  Previously this function expected the name of
+  an association file. [#3220]
 
 datamodels
 ----------
@@ -71,36 +80,36 @@ datamodels
 extract_1d
 ----------
 
- - If flux conversion is done, the FLUX is now set to zero (instead of
-   copying the NET) if the wavelength of a pixel is outside the range of
-   the RELSENS array. [#3190]
+- If flux conversion is done, the FLUX is now set to zero (instead of
+  copying the NET) if the wavelength of a pixel is outside the range of
+  the RELSENS array. [#3190]
 
- - Added a parameter ``subtract_background`` to ``extract_1d`` indicating
-   whether the local background should be subtracted. If None, the value
-   in the extract_1d reference file is used. [#3157, #3186]
+- Added a parameter ``subtract_background`` to ``extract_1d`` indicating
+  whether the local background should be subtracted. If None, the value
+  in the extract_1d reference file is used. [#3157, #3186]
 
- - ``extract_1d`` can be run by calling ``extract.do_extract1d`` and
-   passing a dictionary of reference file information. [#3202]
+- ``extract_1d`` can be run by calling ``extract.do_extract1d`` and
+  passing a dictionary of reference file information. [#3202]
 
- - ``ref_dict`` was None in ``run_extract1d``, and a check for that was
-   missing. [#3233]
+- ``ref_dict`` was None in ``run_extract1d``, and a check for that was
+  missing. [#3233]
 
 master_background
 -----------------
 
- - Added unit tests for expand_to_2d.  Support CombinedSpecModel data
-   for the 1-D user-supplied background spectrum. [#3188]
+- Added unit tests for expand_to_2d.  Support CombinedSpecModel data
+  for the 1-D user-supplied background spectrum. [#3188]
 
 set_bary_helio_times
 --------------------
 
- - Raise an exception when unable to compute converted times. [#3197]
+- Raise an exception when unable to compute converted times. [#3197]
 
 set_telescope_pointing
 ----------------------
 
- - Added population of CDELTn keywords based on SIAF values and fixed bug in calculation
-   of S_REGION corners. [#3184]
+- Added population of CDELTn keywords based on SIAF values and fixed bug in calculation
+  of S_REGION corners. [#3184]
 
 0.13.0 (2019-02-15)
 ===================
@@ -111,20 +120,20 @@ ami
 assign_wcs
 ----------
 
- - Removed ``transform_bbox_from_datamodels`` in favor of
-   ``transform_bbox_from_shape`` which now works by using last two dimensions
-   in the ``shape``. [#3040]
+- Removed ``transform_bbox_from_datamodels`` in favor of
+  ``transform_bbox_from_shape`` which now works by using last two dimensions
+  in the ``shape``. [#3040]
 
- - Added velocity correction model to the WFSS and TSGRISM wcs pipelines. [#2801]
+- Added velocity correction model to the WFSS and TSGRISM wcs pipelines. [#2801]
 
- - Refactored how the pipeline handles subarrays in the WCS. Fixed a bug
-   where the bounding box was overwritten in full frame mode. [#2980]
+- Refactored how the pipeline handles subarrays in the WCS. Fixed a bug
+  where the bounding box was overwritten in full frame mode. [#2980]
 
- - Rename several functions dealing with calculating bounding boxes for clarity. [#3014]
+- Rename several functions dealing with calculating bounding boxes for clarity. [#3014]
 
- - The bounding box of the MIRI LRS WCS is now in "image" coordinates, not full frame. [#3063]
+- The bounding box of the MIRI LRS WCS is now in "image" coordinates, not full frame. [#3063]
 
- - FITS WCS keywords are written out only if the observation is one of the IMAGING_MODES. [#3066]
+- FITS WCS keywords are written out only if the observation is one of the IMAGING_MODES. [#3066]
 
 associations
 ------------
@@ -136,7 +145,6 @@ background
 
 barshadow
 ---------
-
 
 combine_1d
 ----------

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -79,8 +79,7 @@ def ref_matches_sci(sci_model, ref_model):
         # If the ref file is full-frame, set the missing params to
         # default values
         if ref_model.meta.instrument.name.upper() == 'MIRI':
-            if (ref_model.data.shape[-1] == 1032 and
-                ref_model.data.shape[-2] == 1024):
+            if (ref_model.data.shape[-1] == 1032 and ref_model.data.shape[-2] == 1024):
                 log.warning('Missing subarray corner/size keywords in reference file')
                 log.warning('Setting them to full-frame default values')
                 xstart_ref = 1
@@ -95,8 +94,7 @@ def ref_matches_sci(sci_model, ref_model):
                 log.error('Missing subarray corner/size keywords in reference file')
                 raise ValueError("Can't determine ref file subarray properties")
         else:
-            if (ref_model.data.shape[-1] == 2048 and
-                ref_model.data.shape[-2] == 2048):
+            if (ref_model.data.shape[-1] == 2048 and ref_model.data.shape[-2] == 2048):
                 log.warning('Missing subarray corner/size keywords in reference file')
                 log.warning('Setting them to full-frame default values')
                 xstart_ref = 1
@@ -219,67 +217,55 @@ def get_subarray_data(sci_model, ref_model):
     """
 
     # Make sure xstart/ystart exist in science data model
-    if (sci_model.meta.subarray.xstart is None or
-        sci_model.meta.subarray.ystart is None):
+    if (sci_model.meta.subarray.xstart is None or sci_model.meta.subarray.ystart is None):
 
         # If the science file is full-frame, set the missing params to
         # default values
-        if (sci_model.data.shape[-1] == 2048 and
-            sci_model.data.shape[-2] == 2048):
+        if (sci_model.data.shape[-1] == 2048 and sci_model.data.shape[-2] == 2048):
             sci_model.meta.subarray.xstart = 1
             sci_model.meta.subarray.ystart = 1
             sci_model.meta.subarray.xsize = 2048
             sci_model.meta.subarray.ysize = 2048
         else:
-            raise ValueError('xstart or ystart metadata values ' +
-                             'not found in input model')
+            raise ValueError('xstart or ystart metadata values not found in input model')
 
     # Make sure xstart/ystart exist in reference data model
-    if (ref_model.meta.subarray.xstart is None or
-        ref_model.meta.subarray.ystart is None):
+    if (ref_model.meta.subarray.xstart is None or ref_model.meta.subarray.ystart is None):
 
         # If the ref file is full-frame, set the missing params to
         # default values
         if ref_model.meta.instrument.name.upper() == 'MIRI':
-            if (ref_model.data.shape[-1] == 1032 and
-                ref_model.data.shape[-2] == 1024):
+            if (ref_model.data.shape[-1] == 1032 and ref_model.data.shape[-2] == 1024):
                 ref_model.meta.subarray.xstart = 1
                 ref_model.meta.subarray.ystart = 1
                 ref_model.meta.subarray.xsize = 1032
                 ref_model.meta.subarray.ysize = 1024
             else:
-                raise ValueError('xstart or ystart metadata values ' +
-                                 'not found in reference model')
+                raise ValueError('xstart or ystart metadata values not found in reference model')
         else:
-            if (ref_model.data.shape[-1] == 2048 and
-                ref_model.data.shape[-2] == 2048):
+            if (ref_model.data.shape[-1] == 2048 and ref_model.data.shape[-2] == 2048):
                 ref_model.meta.subarray.xstart = 1
                 ref_model.meta.subarray.ystart = 1
                 ref_model.meta.subarray.xsize = 2048
                 ref_model.meta.subarray.ysize = 2048
             else:
-                raise ValueError('xstart or ystart metadata values ' +
-                                 'not found in reference model')
+                raise ValueError('xstart or ystart metadata values not found in reference model')
 
     # Get subarray limits from metadata of input model
     xstart_sci = sci_model.meta.subarray.xstart
     xsize_sci = sci_model.meta.subarray.xsize
-    xstop_sci = xstart_sci + xsize_sci - 1
     ystart_sci = sci_model.meta.subarray.ystart
     ysize_sci = sci_model.meta.subarray.ysize
-    ystop_sci = ystart_sci + ysize_sci - 1
-    log.debug('science xstart=%d, xstop=%d, ystart=%d, ystop=%d',
-              xstart_sci, xstop_sci, ystart_sci, ystop_sci)
+    log.debug('science xstart=%d, xsize=%d, ystart=%d, ysize=%d',
+              xstart_sci, xsize_sci, ystart_sci, ysize_sci)
 
     # Get subarray limits from metadata of reference model
     xstart_ref = ref_model.meta.subarray.xstart
     xsize_ref = ref_model.meta.subarray.xsize
-    xstop_ref = xstart_ref + xsize_ref - 1
     ystart_ref = ref_model.meta.subarray.ystart
     ysize_ref = ref_model.meta.subarray.ysize
-    ystop_ref = ystart_ref + ysize_ref - 1
-    log.debug('reference xstart=%d, xstop=%d, ystart=%d, ystop=%d',
-              xstart_ref, xstop_ref, ystart_ref, ystop_ref)
+    log.debug('reference xstart=%d, xsize=%d, ystart=%d, ysize=%d',
+              xstart_ref, xsize_ref, ystart_ref, ysize_ref)
 
     # Compute slice limits, in 0-indexed python notation
     xstart = xstart_sci - xstart_ref
@@ -292,15 +278,15 @@ def get_subarray_data(sci_model, ref_model):
     # Make sure that the slice limits are within the bounds of
     # the reference file data array
     if (xstart < 0 or ystart < 0 or
-        xstop > ref_model.meta.subarray.xsize or
-        ystop > ref_model.meta.subarray.ysize):
+        xstop > ref_model.meta.subarray.xsize or ystop > ref_model.meta.subarray.ysize):
         log.error('Computed reference file slice indexes are ' +
                   'incompatible with size of reference data array')
-        log.error('xstart=%d, xstop=%d, ystart=%d, ystop=%d',
+        log.error('Science: SUBSTRT1=%d, SUBSTRT2=%d, SUBSIZE1=%d, SUBSIZE2=%d',
+                   xstart_sci+1, ystart_sci+1, xsize_sci, ysize_sci)
+        log.error('Reference: SUBSTRT1=%d, SUBSTRT2=%d, SUBSIZE1=%d, SUBSIZE2=%d',
+                   xstart_ref+1, ystart_ref+1, xsize_ref, ysize_ref)
+        log.error('Slice indexes: xstart=%d, xstop=%d, ystart=%d, ystop=%d',
                    xstart, xstop, ystart, ystop)
-        log.error('Reference xsize=%d, ysize=%d',
-                   ref_model.meta.subarray.xsize,
-                   ref_model.meta.subarray.ysize)
         raise ValueError('Bad reference file slice indexes')
 
     return ref_model.data[ystart:ystop, xstart:xstop]
@@ -310,7 +296,7 @@ def get_subarray_model(sci_model, ref_model):
 
     """
     Create a subarray version of a reference file model that matches
-    the subarray characteristics of a science data model. An new
+    the subarray characteristics of a science data model. A new
     model is created that contains subarrays of all data arrays
     contained in the reference file model.
 
@@ -337,27 +323,26 @@ def get_subarray_model(sci_model, ref_model):
     # Get the reference model subarray params
     xstart_ref = ref_model.meta.subarray.xstart
     ystart_ref = ref_model.meta.subarray.ystart
+    xsize_ref = ref_model.meta.subarray.xsize
+    ysize_ref = ref_model.meta.subarray.ysize
 
     # Compute the slice indexes, in 0-indexed python frame
     xstart = xstart_sci - xstart_ref
     ystart = ystart_sci - ystart_ref
     xstop = xstart + xsize_sci
     ystop = ystart + ysize_sci
-    log.debug("slice xstart=%d, xstop=%d, ystart=%d, ystop=%d",
-              xstart, xstop, ystart, ystop)
+    log.debug("slice xstart=%d, xstop=%d, ystart=%d, ystop=%d", xstart, xstop, ystart, ystop)
 
     # Make sure that the slice limits are within the bounds of
     # the reference file data array
     if (xstart < 0 or ystart < 0 or
-        xstop > ref_model.meta.subarray.xsize or
-        ystop > ref_model.meta.subarray.ysize):
-        log.error('Computed reference file slice indexes are ' +
-                  'incompatible with size of reference data array')
-        log.error('xstart=%d, xstop=%d, ystart=%d, ystop=%d',
-                   xstart, xstop, ystart, ystop)
-        log.error('Reference xsize=%d, ysize=%d',
-                   ref_model.meta.subarray.xsize,
-                   ref_model.meta.subarray.ysize)
+        xstop > ref_model.meta.subarray.xsize or ystop > ref_model.meta.subarray.ysize):
+        log.error('Computed reference file slice indexes are incompatible with size of reference data array')
+        log.error('Science: SUBSTRT1=%d, SUBSTRT2=%d, SUBSIZE1=%d, SUBSIZE2=%d',
+                   xstart_sci+1, ystart_sci+1, xsize_sci, ysize_sci)
+        log.error('Reference: SUBSTRT1=%d, SUBSTRT2=%d, SUBSIZE1=%d, SUBSIZE2=%d',
+                   xstart_ref+1, ystart_ref+1, xsize_ref, ysize_ref)
+        log.error('Slice indexes: xstart=%d, xstop=%d, ystart=%d, ystop=%d', xstart, xstop, ystart, ystop)
         raise ValueError('Bad reference file slice indexes')
 
     # Extract subarrays from each data attribute in the particular

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -282,9 +282,9 @@ def get_subarray_data(sci_model, ref_model):
         log.error('Computed reference file slice indexes are ' +
                   'incompatible with size of reference data array')
         log.error('Science: SUBSTRT1=%d, SUBSTRT2=%d, SUBSIZE1=%d, SUBSIZE2=%d',
-                   xstart_sci+1, ystart_sci+1, xsize_sci, ysize_sci)
+                   xstart_sci, ystart_sci, xsize_sci, ysize_sci)
         log.error('Reference: SUBSTRT1=%d, SUBSTRT2=%d, SUBSIZE1=%d, SUBSIZE2=%d',
-                   xstart_ref+1, ystart_ref+1, xsize_ref, ysize_ref)
+                   xstart_ref, ystart_ref, xsize_ref, ysize_ref)
         log.error('Slice indexes: xstart=%d, xstop=%d, ystart=%d, ystop=%d',
                    xstart, xstop, ystart, ystop)
         raise ValueError('Bad reference file slice indexes')
@@ -339,9 +339,9 @@ def get_subarray_model(sci_model, ref_model):
         xstop > ref_model.meta.subarray.xsize or ystop > ref_model.meta.subarray.ysize):
         log.error('Computed reference file slice indexes are incompatible with size of reference data array')
         log.error('Science: SUBSTRT1=%d, SUBSTRT2=%d, SUBSIZE1=%d, SUBSIZE2=%d',
-                   xstart_sci+1, ystart_sci+1, xsize_sci, ysize_sci)
+                   xstart_sci, ystart_sci, xsize_sci, ysize_sci)
         log.error('Reference: SUBSTRT1=%d, SUBSTRT2=%d, SUBSIZE1=%d, SUBSIZE2=%d',
-                   xstart_ref+1, ystart_ref+1, xsize_ref, ysize_ref)
+                   xstart_ref, ystart_ref, xsize_ref, ysize_ref)
         log.error('Slice indexes: xstart=%d, xstop=%d, ystart=%d, ystop=%d', xstart, xstop, ystart, ystop)
         raise ValueError('Bad reference file slice indexes')
 


### PR DESCRIPTION
Updated the reference file utility routines that extract subarrays from reference files so that when errors are encountered due to bad subarray keyword values (e.g. SUBSTRTn, SUBSIZEn) in either the science or reference file, the resulting error messages are more explicit about giving all the 1-indexed SUBSTRTn and SUBSIZEn values for both the science and reference file, and list the computed array slice indexes as python 0-indexed values.

Fixes #3160 