### PR TITLE
Combine1DStep needed arrays of right ascension and declination

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.13.2 (Unreleased)
 ===================
 
+combine_1d
+----------
+
+- Fix call to wcs.invert, and don't weight flux by sensitivity if the net
+  column is all zeros. [#3274]
+
 datamodels
 ----------
 
@@ -8,7 +14,9 @@ datamodels
   http://stsci.edu/schemas/fits-schema/ to map to the correct location
   in the ``jwst`` package. [#3239]
 
-<<<<<<< mod_extract
+- Change ``ModelContainer`` to load and instantiate datamodels from an
+  association on init.  This reverts #1027. [#3264]
+
 extract_1d
 ----------
 
@@ -16,10 +24,6 @@ extract_1d
   image (for IFU) may be either 2-D or 3-D.  When using a reference image
   for non-IFU data, background smoothing is now done after scaling the
   background count rate. [#3258]
-=======
-- Change ``ModelContainer`` to load and instantiate datamodels from an
-  association on init.  This reverts #1027. [#3264]
->>>>>>> master
 
 master_background
 -----------------


### PR DESCRIPTION
The `combine_1d` step failed in the call to wcs.invert because two of the arguments (right ascension and declination) were scalars, but the wavelength was an array.  Right ascension and declination are now stored as arrays, even though their values are constant.

Another bug was that in the files for the test case, the net column was all zeros (because the spectra had been extracted from flux-calibrated data).  The flux was being weighted by the sensitivity (so that the quantity that was accumulated would be in units of counts), but the sensitivity was gotten as the ratio of net to flux; therefore, the weight was being set to zero.  A test has been added to disable including the sensitivity in the weight for flux if the net is zero.

Closes #3270.