### PR TITLE
Split input in master_background into source and background

### DIFF
--- a/jwst/datamodels/filetype.py
+++ b/jwst/datamodels/filetype.py
@@ -16,9 +16,8 @@ def check(init):
 
     if isinstance(init, str):
         if os.path.exists(init):
-            fd = open(init, "rb")
-            magic = fd.read(5)
-            fd.close()
+            with open(init, "rb") as fd:
+                magic = fd.read(5)
         else:
             filename, file_extension = os.path.splitext(init)
             file_type = file_extension[1:]

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -71,11 +71,6 @@ def open(init=None, extensions=None, **kwargs):
         # Copy the object so it knows not to close here
         return init.__class__(init)
 
-    elif is_association(init):
-        from . import container
-        return container.ModelContainer(init, extensions=extensions,
-                                        **kwargs)
-
     elif isinstance(init, (str, bytes)) or hasattr(init, "read"):
         # If given a string, presume its a file path.
         # if it has a read method, assume a file descriptor
@@ -112,6 +107,11 @@ def open(init=None, extensions=None, **kwargs):
 
     elif isinstance(init, fits.HDUList):
         hdulist = init
+
+    elif is_association(init) or isinstance(init, list):
+        from . import container
+        return container.ModelContainer(init, extensions=extensions,
+                                        **kwargs)
 
     # If we have it, determine the shape from the science hdu
     if hdulist:

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -255,7 +255,7 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
     elif input.meta.instrument.name.upper() == "MIRI":
         shape = input.data.shape
         grid = np.indices(shape, dtype=np.float64)
-        wl_array = ifu_wcs(grid[1], grid[0])[2]
+        wl_array = input.meta.wcs(grid[1], grid[0])[2]
 
         wl_array[np.isnan(wl_array)] = -1.
         bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -17,6 +17,7 @@ class MasterBackgroundStep(Step):
         user_background = string(default=None) # Path to user-supplied master background
         save_background = boolean(default=False) # Save computed master background
         force_subtract = boolean(default=False) # Force subtracting master background
+        output_use_model = boolean(default=True)
     """
 
     def process(self, input):
@@ -26,7 +27,7 @@ class MasterBackgroundStep(Step):
         Parameters
         ----------
         input : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`, `~jwst.datamodels.ModelContainer`, association
-            Input target data model(s) to which master background subtraction is
+            Input target datamodel(s) to which master background subtraction is
             to be applied
 
         user_background : None, string, or `~jwst.datamodels.MultiSpecModel`
@@ -34,7 +35,7 @@ class MasterBackgroundStep(Step):
             or opened datamodel
 
         save_background : bool, optional
-            Save master background.
+            Save computed master background.
 
         force_subtract : bool, optional
             Optional user-supplied flag which subtracts the master background overriding the checks
@@ -46,7 +47,7 @@ class MasterBackgroundStep(Step):
         Returns
         -------
         result: `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`, `~jwst.datamodels.ModelContainer`
-            The background-subtracted target data model(s)
+            The background-subtracted science datamodel(s)
         """
 
         # Get association info if available


### PR DESCRIPTION
In addition to implementing the basic master background creation in `MasterBackgroundStep`, it also allows a `ModelContainer` to be initialized by a list of of files, i.e.
```
from glob import glob
from jwst import datamodels

files = glob('*_x1d.fits')
container = datamodels.open(files)
```

Which is useful for testing and general use.

Resolves #3211.

Depends on #3274 being merged first.

To do:

- [x] add regression test for MIRI IFU association with dedicated background exposures.