### PR TITLE
Update reg tests to compare ecsv files

### DIFF
--- a/jwst/tests_nightly/general/nircam/test_nrc_image3_1.py
+++ b/jwst/tests_nightly/general/nircam/test_nrc_image3_1.py
@@ -43,7 +43,8 @@ class TestImage3Pipeline1(BaseJWSTTest):
                              self.ignore_keywords+['NAXIS1', 'TFORM*'],
                              'ignore_fields':self.ignore_keywords,
                              'rtol': 0.0001}
-                   }
+                   },
+                   ('mosaic_long_cat.ecsv', 'mosaic_long_cat_ref.ecsv'),
                   ]
         self.compare_outputs(outputs)
 
@@ -79,6 +80,8 @@ class TestImage3Pipeline1(BaseJWSTTest):
                     'pars':{'ignore_keywords':self.ignore_keywords+['NAXIS1','TFORM*'],
                             'ignore_fields':self.ignore_keywords,
                             'rtol':0.0001}
-                   }
+                   },
+                   ('jw10002-o001_t002_nircam_f444w_cat.ecsv',
+                    'jw10002-o001_t002_nircam_f444w_cat_ref.ecsv'),
                   ]
         self.compare_outputs(outputs)

--- a/jwst/tests_nightly/general/nircam/test_tso3.py
+++ b/jwst/tests_nightly/general/nircam/test_tso3.py
@@ -41,10 +41,16 @@ class TestTso3Pipeline(BaseJWSTTest):
 
         step.run(asn_file)
 
-        outputs = [('jw93065002001_02101_00001_nrca1_a3001_crfints.fits',
-                    'jw93065002001_02101_00001_nrca1_a3001_crfints_ref.fits',
-                    ['primary', 'sci', 'dq', 'err'])
-                   ]
+        outputs = [
+            # Compare level-2c product
+            ('jw93065002001_02101_00001_nrca1_a3001_crfints.fits',
+             'jw93065002001_02101_00001_nrca1_a3001_crfints_ref.fits',
+             ['primary', 'sci', 'dq', 'err']),
+
+            # Compare level-3 product
+            ('jw93065-a3001_t1_nircam_f150w-wlp8_phot.ecsv',
+             'jw93065-a3001_t1_nircam_f150w-wlp8_phot_ref.ecsv'),
+        ]
         self.compare_outputs(outputs)
 
 
@@ -78,8 +84,14 @@ class TestTso3Pipeline(BaseJWSTTest):
         step.extract_1d.bkg_order = 0
 
         step.run(asn_file)
-        outputs = [('jw93065002002_02101_00001_nrca1_a3002_crfints.fits',
-                    'jw93065002002_02101_00001_nrca1_a3002_crfints_ref.fits',
-                    ['primary', 'sci', 'dq', 'err'])
-                  ]
+        outputs = [
+            # Compare level-2c product
+            ('jw93065002002_02101_00001_nrca1_a3002_crfints.fits',
+             'jw93065002002_02101_00001_nrca1_a3002_crfints_ref.fits',
+             ['primary', 'sci', 'dq', 'err']),
+
+            # Compare level-3 product
+            ('jw93065-a3002_t1_nircam_f150w-wlp8_phot.ecsv',
+             'jw93065-a3002_t1_nircam_f150w-wlp8_phot_ref.ecsv'),
+        ]
         self.compare_outputs(outputs)


### PR DESCRIPTION
Updated 4 NIRCam regression tests - 2 for `calwebb_image3` and 2 for `calwebb_tso3` - to include comparison of the cat.ecsv and phot.ecsv products that they create.