### PR TITLE
Shorten test names so result dirs don't overwrite on Artifactory

### DIFF
--- a/jwst/tests_nightly/general/miri/test_miri_steps.py
+++ b/jwst/tests_nightly/general/miri/test_miri_steps.py
@@ -38,7 +38,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                                      side_gain=1.0),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_bias_drift.fits',
                       output_hdus=[],
-                      id='test_refpix_miri'
+                      id='refpix_miri'
                      ),
                 # test_refpix_miri2: refpix step performed on MIRI data
                  dict(input='jw00025001001_01107_00001_MIRIMAGE_saturation.fits',
@@ -49,7 +49,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                                      side_gain=1.0),
                       output_truth='jw00025001001_01107_00001_MIRIMAGE_bias_drift.fits',
                       output_hdus=[],
-                      id='test_refpix_miri2'
+                      id='refpix_miri2'
                      ),
                 # test_dark_current_miri: dark current step performed on MIRI data
                  dict(input='jw00001001001_01101_00001_MIRIMAGE_bias_drift.fits',
@@ -58,7 +58,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_dark_current.fits',
                       output_hdus=[],
-                      id='test_dark_current_miri'
+                      id='dark_current_miri'
                      ),
                 # test_dark_current_miri2: dark current step performed on MIRI data
                  dict(input='jw80600012001_02101_00003_mirimage_lastframe.fits',
@@ -67,7 +67,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_dark.fits',
                       output_hdus=[],
-                      id='test_dark_current_miri2'
+                      id='dark_current_miri2'
                      ),
                 # test_dq_init_miri: dq_init step performed on uncalibrated MIRI data
                  dict(input='jw00001001001_01101_00001_MIRIMAGE_uncal.fits',
@@ -76,7 +76,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_dq_init.fits',
                       output_hdus=[],
-                      id='test_dq_init_miri'
+                      id='dq_init_miri'
                      ),
                 # test_dq_init_miri2: dq_init step performed on uncalibrated MIRI data
                  dict(input='jw80600012001_02101_00003_mirimage_uncal.fits',
@@ -85,7 +85,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_dqinit.fits',
                       output_hdus=[],
-                      id='test_dq_init_miri2'
+                      id='dq_init_miri2'
                      ),
                 # test_emission_miri: emission step performed on calibrated miri data
                  dict(input='jw00001001001_01101_00001_MIRIMAGE_flat_field.fits',
@@ -94,7 +94,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_emission.fits',
                       output_hdus=[],
-                      id='test_emission_miri'
+                      id='emission_miri'
                      ),
                 # test_extract1d_miri: extract_1d step performed on MIRI LRS fixed-slit data
                  dict(input='jw00035001001_01101_00001_mirimage_photom.fits',
@@ -103,7 +103,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(smoothing_length=0),
                       output_truth='jw00035001001_01101_00001_mirimage_x1d.fits',
                       output_hdus=[],
-                      id='test_extract1d_miri'
+                      id='extract1d_miri'
                      ),
                 # test_extract1d_miri2: extract_1d step performed on MIRI LRS slitless data
                  dict(input='jw80600012001_02101_00003_mirimage_photom.fits',
@@ -112,7 +112,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(smoothing_length=0),
                       output_truth='jw80600012001_02101_00003_mirimage_x1d.fits',
                       output_hdus=['primary',('extract1d',1),('extract1d',2),('extract1d',3),('extract1d',4)],
-                      id='test_extract1d_miri2'
+                      id='extract1d_miri2'
                      ),
                 # test_flat_field_miri: flat_field step performed on MIRI data.
                  dict(input='jw00001001001_01101_00001_MIRIMAGE_assign_wcs.fits',
@@ -121,7 +121,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_flat_field.fits',
                       output_hdus=[],
-                      id='test_flat_field_miri'
+                      id='flat_field_miri'
                      ),
                 # test_flat_field_miri2: flat_field step performed on MIRI data.
                  dict(input='jw80600012001_02101_00003_mirimage_assign_wcs.fits',
@@ -130,7 +130,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_flat_field.fits',
                       output_hdus=[],
-                      id='test_flat_field_miri2'
+                      id='flat_field_miri2'
                      ),
                 # test_fringe_miri: fringe performed on MIRI data.
                  dict(input='fringe1_input.fits',
@@ -139,7 +139,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='baseline_fringe1.fits',
                       output_hdus=['primary','sci','err','dq'],
-                      id='test_fringe_miri'
+                      id='fringe_miri'
                      ),
                 # test_fringe_miri2: fringe performed on MIRI data.
                  dict(input='fringe2_input.fits',
@@ -148,7 +148,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='baseline_fringe2.fits',
                       output_hdus=['primary','sci','err','dq'],
-                      id='test_fringe_miri2'
+                      id='fringe_miri2'
                      ),
                 # test_fringe_miri3: fringe performed on MIRI data.
                  dict(input='fringe3_input.fits',
@@ -157,7 +157,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='baseline_fringe3.fits',
                       output_hdus=['primary','sci','err','dq'],
-                      id='test_fringe_miri3'
+                      id='fringe_miri3'
                      ),
                 # test_jump_miri: jump step performed on MIRI data.
                  dict(input='jw00001001001_01101_00001_MIRIMAGE_linearity.fits',
@@ -166,7 +166,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(rejection_threshold=200.0),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_jump.fits',
                       output_hdus=[],
-                      id='test_jump_miri'
+                      id='jump_miri'
                      ),
                 # test_jump_miri2: jump step performed on MIRI data.
                  dict(input='jw80600012001_02101_00003_mirimage_dark.fits',
@@ -175,7 +175,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(rejection_threshold=25.0),
                       output_truth='jw80600012001_02101_00003_mirimage_jump.fits',
                       output_hdus=[],
-                      id='test_jump_miri2'
+                      id='jump_miri2'
                      ),
                 # test_lastframe_miri2: lastframe step performed on MIRI data
                  dict(input='jw80600012001_02101_00003_mirimage_rscd.fits',
@@ -184,7 +184,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_lastframe.fits',
                       output_hdus=[],
-                      id='test_lastframe_miri2'
+                      id='lastframe_miri2'
                      ),
                 # test_linearity_miri: linearity step performed on MIRI data
                  dict(input='jw00001001001_01101_00001_MIRIMAGE_dark_current.fits',
@@ -193,7 +193,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_linearity.fits',
                       output_hdus=[],
-                      id='test_linearity_miri'
+                      id='linearity_miri'
                      ),
                 # test_linearity_miri2: linearity step performed on MIRI data
                  dict(input='jw80600012001_02101_00003_mirimage_saturation.fits',
@@ -202,7 +202,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_linearity.fits',
                       output_hdus=[],
-                      id='test_linearity_miri2'
+                      id='linearity_miri2'
                      ),
                 # test_photom_miri: photom step performed on MIRI imaging data
                  dict(input='jw00001001001_01101_00001_MIRIMAGE_emission.fits',
@@ -211,7 +211,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_photom.fits',
                       output_hdus=[],
-                      id='test_photom_miri'
+                      id='photom_miri'
                      ),
                  # test_photom_miri2: photom step performed on MIRI LRS slitless data
                  dict(input='jw80600012001_02101_00003_mirimage_srctype.fits',
@@ -220,7 +220,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_photom.fits',
                       output_hdus=[],
-                      id='test_photom_miri2'
+                      id='photom_miri2'
                      ),
                  # test_rscd_miri2: RSCD step performed on MIRI data
                  dict(input='jw80600012001_02101_00003_mirimage_linearity.fits',
@@ -229,7 +229,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_rscd.fits',
                       output_hdus=[],
-                      id='test_rscd_miri2'
+                      id='rscd_miri'
                      ),
                  # test_saturation_miri: saturation step performed on uncalibrated MIRI data
                  dict(input='jw00001001001_01101_00001_MIRIMAGE_dq_init.fits',
@@ -238,7 +238,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00001001001_01101_00001_MIRIMAGE_saturation.fits',
                       output_hdus=['primary','sci','err','pixeldq','groupdq'],
-                      id='test_saturation_miri'
+                      id='saturation_miri'
                      ),
                  # test_saturation_miri2: saturation step performed on uncalibrated MIRI data
                  dict(input='jw80600012001_02101_00003_mirimage_dqinit.fits',
@@ -247,7 +247,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_saturation.fits',
                       output_hdus=[],
-                      id='test_saturation_miri2'
+                      id='saturation_miri2'
                      ),
                  # test_srctype2: srctype step performed on MIRI LRS slitless data
                  dict(input='jw80600012001_02101_00003_mirimage_flat_field.fits',
@@ -256,7 +256,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80600012001_02101_00003_mirimage_srctype.fits',
                       output_hdus=[],
-                      id='test_srctype2'
+                      id='srctype_miri'
                      ),
                  # test_straylight1_miri: straylight performed on MIRI IFUSHORT data
                  dict(input='jw80500018001_02101_00002_MIRIFUSHORT_flatfield.fits',
@@ -265,7 +265,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80500018001_02101_00002_MIRIFUSHORT_straylight.fits',
                       output_hdus=['primary','sci','err','dq'],
-                      id='test_straylight1_miri'
+                      id='straylight_miri'
                      ),
                  # test_straylight2_miri: straylight performed on MIRI IFULONG data
                  dict(input='jw80500018001_02101_00002_MIRIFULONG_flatfield.fits',
@@ -274,7 +274,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw80500018001_02101_00002_MIRIFULONG_straylight.fits',
                       output_hdus=[],
-                      id='test_straylight2_miri'
+                      id='straylight_miri2'
                      ),
                ]
              }

--- a/jwst/tests_nightly/general/nircam/test_nircam_steps.py
+++ b/jwst/tests_nightly/general/nircam/test_nircam_steps.py
@@ -34,7 +34,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                                      side_gain=1.0),
                       output_truth='jw00017001001_01101_00001_NRCA1_bias_drift.fits',
                       output_hdus=[],
-                      id='test_refpixt_nircam'
+                      id='refpix_nircam'
 
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_saturation.fits',
@@ -43,7 +43,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA1_dark_current.fits',
                       output_hdus=[],
-                      id='test_dark_current_nircam'
+                      id='dark_current_nircam'
 
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_uncal.fits',
@@ -52,7 +52,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA1_dq_init.fits',
                       output_hdus=[],
-                      id='test_dq_init_nircam'
+                      id='dq_init_nircam'
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_persistence.fits',
                       test_dir='test_emission',
@@ -60,7 +60,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA1_emission.fits',
                       output_hdus=[],
-                      id='test_emission_nircam'
+                      id='emission_nircam'
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_ramp_fit.fits',
                       test_dir='test_flat_field',
@@ -68,7 +68,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA1_flat_field.fits',
                       output_hdus=[],
-                      id='test_flat_field_nircam'
+                      id='flat_field_nircam'
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA3_uncal.fits',
                       test_dir='test_ipc_step',
@@ -76,7 +76,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA3_ipc.fits',
                       output_hdus=['primary', 'sci'],
-                      id='test_ipc_nircam'
+                      id='ipc_nircam'
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_linearity.fits',
                       test_dir='test_jump',
@@ -84,7 +84,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(rejection_threshold=25.0),
                       output_truth='jw00017001001_01101_00001_NRCA1_jump.fits',
                       output_hdus=[],
-                      id='test_jump_nircam'
+                      id='jump_nircam'
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_dark_current.fits',
                       test_dir='test_linearity',
@@ -92,7 +92,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA1_linearity.fits',
                       output_hdus=[],
-                      id='test_linearity_nircam'
+                      id='linearity_nircam'
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_ramp.fits',
                       test_dir='test_persistence',
@@ -100,7 +100,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA1_persistence.fits',
                       output_hdus=[],
-                      id='test_persistence_nircam'
+                      id='persistence_nircam'
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_emission.fits',
                       test_dir='test_photom',
@@ -108,7 +108,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA1_photom.fits',
                       output_hdus=[],
-                      id='test_photom_nircam'
+                      id='photom_nircam'
                       ),
                  dict(input='jw00017001001_01101_00001_NRCA1_bias_drift.fits',
                       test_dir='test_saturation',
@@ -116,7 +116,7 @@ class TestNIRCamSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00017001001_01101_00001_NRCA1_saturation.fits',
                       output_hdus=[],
-                      id='test_saturation_nircam'
+                      id='saturation_nircam'
                       ),
                 ]
               }

--- a/jwst/tests_nightly/general/niriss/test_niriss_steps.py
+++ b/jwst/tests_nightly/general/niriss/test_niriss_steps.py
@@ -31,7 +31,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       output_hdus=['primary','fit','resid','closure_amp',
                                          'closure_pha','fringe_amp','fringe_pha',
                                          'pupil_pha','solns'],
-                      id='test_ami_analyze'
+                      id='ami_analyze_niriss'
                       ),
                  dict(input='jw00034001001_01101_00001_NIRISS_dq_init.fits',
                       test_dir='test_bias_drift',
@@ -42,7 +42,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                                      side_gain=1.0),
                       output_truth='jw00034001001_01101_00001_NIRISS_bias_drift.fits',
                       output_hdus=[],
-                      id='test_refpix_niriss'
+                      id='refpix_niriss'
                       ),
                  dict(input='jw00034001001_01101_00001_NIRISS_saturation.fits',
                       test_dir='test_dark_step',
@@ -50,7 +50,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00034001001_01101_00001_NIRISS_dark_current.fits',
                       output_hdus=[],
-                      id='test_dark_current_niriss'
+                      id='dark_current_niriss'
                       ),
                  dict(input='jw00034001001_01101_00001_NIRISS_uncal.fits',
                       test_dir='test_dq_init',
@@ -58,7 +58,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00034001001_01101_00001_NIRISS_dq_init.fits',
                       output_hdus=[],
-                      id='test_dq_init_niriss'
+                      id='dq_init_niriss'
                       ),
                  dict(input='jw00034001001_01101_00001_NIRISS_ramp_fit.fits',
                       test_dir='test_flat_field',
@@ -66,7 +66,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00034001001_01101_00001_NIRISS_flat_field.fits',
                       output_hdus=[],
-                      id='test_flat_field_niriss'
+                      id='flat_field_niriss'
                       ),
                  dict(input='jw00034001001_01101_00001_NIRISS_linearity.fits',
                       test_dir='test_jump',
@@ -74,7 +74,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       step_pars=dict(rejection_threshold=20.0),
                       output_truth='jw00034001001_01101_00001_NIRISS_jump.fits',
                       output_hdus=[],
-                      id='test_jump_niriss'
+                      id='jump_niriss'
                       ),
                  dict(input='jw00034001001_01101_00001_NIRISS_dark_current.fits',
                       test_dir='test_linearity',
@@ -82,7 +82,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00034001001_01101_00001_NIRISS_linearity.fits',
                       output_hdus=[],
-                      id='test_linearity_niriss'
+                      id='linearity_niriss'
                       ),
                  dict(input='jw00034001001_01101_00001_NIRISS_bias_drift.fits',
                       test_dir='test_saturation',
@@ -90,7 +90,7 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00034001001_01101_00001_NIRISS_saturation.fits',
                       output_hdus=[],
-                      id='test_saturation_niriss'
+                      id='saturation_niriss'
                       ),
                 ]
               }

--- a/jwst/tests_nightly/general/nirspec/test_nirspec_steps.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_steps.py
@@ -35,7 +35,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                                      side_gain=1.0),
                       output_truth='jw00023001001_01101_00001_NRS1_bias_drift.fits',
                       output_hdus=[],
-                      id='test_refpix_nirspec'
+                      id='refpix_nirspec'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_saturation.fits',
                       test_dir='test_dark_step',
@@ -43,7 +43,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00023001001_01101_00001_NRS1_dark_current.fits',
                       output_hdus=[],
-                      id='test_dark_current_nirspec'
+                      id='dark_current_nirspec'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_uncal.fits',
                       test_dir='test_dq_init',
@@ -51,7 +51,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00023001001_01101_00001_NRS1_dq_init.fits',
                       output_hdus=[],
-                      id='test_dq_init_nirspec'
+                      id='dq_init_nirspec'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_cal.fits',
                       test_dir='test_extract_1d',
@@ -60,7 +60,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       output_truth='jw00023001001_01101_00001_NRS1_spec.fits',
                       output_hdus=['primary',('extract1d',1),('extract1d',2),
                                    ('extract1d',3),('extract1d',4)],
-                      id='test_extract1d_nirspec'
+                      id='extract1d_nirspec'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_assign_wcs.fits',
                       test_dir='test_extract_2d',
@@ -72,7 +72,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                                          ('sci', 3), ('err', 3), ('dq', 3),
                                          ('sci', 4), ('err', 4), ('dq', 4),
                                          ('sci', 5), ('err', 5), ('dq', 5)],
-                      id='test_extract2d_nirspec'
+                      id='extract2d_nirspec'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_extract_2d.fits',
                       test_dir='test_flat_field',
@@ -83,7 +83,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                                          ('sci', 2), ('err', 2), ('dq', 2),
                                          ('sci', 3), ('err', 3), ('dq', 3),
                                          ('sci', 4), ('err', 4), ('dq', 4)],
-                      id='test_flat_field_nirspec'
+                      id='flat_field_nirspec'
                       ),
                  dict(input='NRSIRS2_230_491_uncal.fits',
                       test_dir='test_group_scale',
@@ -91,7 +91,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='NRSIRS2_230_491_groupscale.fits',
                       output_hdus=[],
-                      id='test_group_scale_nirspec'
+                      id='group_scale_nirspec'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_linearity.fits',
                       test_dir='test_jump',
@@ -99,7 +99,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       step_pars=dict(rejection_threshold=50.0),
                       output_truth='jw00023001001_01101_00001_NRS1_jump.fits',
                       output_hdus=[],
-                      id='test_jump_nirspec'
+                      id='jump_nirspec'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_dark_current.fits',
                       test_dir='test_linearity',
@@ -107,7 +107,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00023001001_01101_00001_NRS1_linearity.fits',
                       output_hdus=[],
-                      id='test_linearity_nirspec'
+                      id='linearity_nirspec'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_flat_field.fits',
                       test_dir='test_photom',
@@ -118,7 +118,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                                               ('sci',2),('err',2),('dq',2),('relsens',2),
                                               ('sci',3),('err',3),('dq',3),('relsens',3),
                                               ('sci',4),('err',4),('dq',4),('relsens',4)],
-                      id='test_photom_nirspec'
+                      id='photom_nirspec'
                       ),
                  dict(input='jw84600007001_02101_00001_nrs1_superbias.fits',
                       test_dir='test_bias_drift',
@@ -126,7 +126,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw84600007001_02101_00001_nrs1_refpix.fits',
                       output_hdus=[],
-                      id='test_refpix_nirspec_irs2'
+                      id='refpix_nirspec_irs2'
                       ),
                  dict(input='jw00023001001_01101_00001_NRS1_bias_drift.fits',
                       test_dir='test_saturation',
@@ -134,7 +134,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00023001001_01101_00001_NRS1_saturation.fits',
                       output_hdus=[],
-                      id='test_saturation_nirspec'
+                      id='saturation_nirspec'
                       ),
                  dict(input='jw00011001001_01106_00001_NRS2_saturation.fits',
                       test_dir='test_superbias',
@@ -142,7 +142,7 @@ class TestNIRSpecSteps(BaseJWSTTestSteps):
                       step_pars=dict(),
                       output_truth='jw00011001001_01106_00001_NRS2_superbias.fits',
                       output_hdus=[],
-                      id='test_superbias_nirspec'
+                      id='superbias_nirspec'
                       )
                 ]
               }

--- a/jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
+++ b/jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
@@ -13,7 +13,7 @@ class TestSpec2Pipeline(BaseJWSTTest):
     test_dir = 'test_pipelines'
 
     # Specification of parameters for Spec2Pipeline tests
-    params = {'test_nrs_fs_multi_spec2' :
+    params = {'test_spec2':
                 # test_nrs_fs_multi_spec2_1: NIRSpec fixed-slit data
                 [dict(input='jw00023001001_01101_00001_NRS1_rate.fits',
                       outputs=[('jw00023001001_01101_00001_NRS1_cal.fits',
@@ -23,7 +23,7 @@ class TestSpec2Pipeline(BaseJWSTTest):
                                  ('jw00023001001_01101_00001_NRS1_x1d.fits',
                                   'jw00023001001_01101_00001_NRS1_x1d_ref.fits')
                                  ],
-                       id="test_nrs_fs_multi_spec2_1"
+                       id="nirspec_fs_multi_1"
                       ),
                 # test_nrs_fs_multi_spec2_2: NIRSpec fixed-slit data
                  dict(input= 'jwtest1013001_01101_00001_NRS1_rate.fits',
@@ -34,7 +34,7 @@ class TestSpec2Pipeline(BaseJWSTTest):
                                ('jwtest1013001_01101_00001_NRS1_x1d.fits',
                                 'jwtest1013001_01101_00001_NRS1_x1d_ref.fits')
                               ],
-                      id="test_nrs_fs_multi_spec2_2"
+                      id="nirspec_fs_multi_2"
                      ),
                 # test_nrs_fs_multi_spec2_3:
                 # NIRSpec fixed-slit data using the ALLSLITS subarray and detector NRS2
@@ -47,7 +47,7 @@ class TestSpec2Pipeline(BaseJWSTTest):
                                ('jw84600002001_02101_00001_nrs2_x1d.fits',
                                 'jw84600002001_02101_00001_nrs2_x1d_ref.fits')
                               ],
-                      id="test_nrs_fs_multi_spec2_3"
+                      id="nirspec_fs_multi_3"
                      ),
                 # test_nrs_ifu_spec2: NIRSpec IFU data
                  dict(input= 'jw95175001001_02104_00001_nrs1_rate.fits',
@@ -63,16 +63,16 @@ class TestSpec2Pipeline(BaseJWSTTest):
                                 'jw95175001001_02104_00001_nrs1_x1d_ref.fits',
                                 ['primary','extract1d'])
                               ],
-                      id = "test_nrs_ifu_spec2"
+                      id = "nirspec_ifu"
                       )
                 ]
             }
 
-    def test_nrs_fs_multi_spec2(self, input, outputs):
+    def test_spec2(self, input, outputs):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec data.
         """
-        input_file = self.get_data(self.test_dir,input)
+        input_file = self.get_data(self.test_dir, input)
 
         step = Spec2Pipeline()
         step.save_bsub = True


### PR DESCRIPTION
Tests in
```
jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
```
were producing the same output directory names
```
test_nrs_fs_multi_spec2_test_n0
```
when run using `pytest-xdist` and so when uploaded to Artifactory, one would overwrite the other.

This PR shortens names so that each test output dir gets a unique name.  Also, one of the IFU tests was being labeled as a NIRSpec FS test.  Fixes that too.  Shortens test IDs elsewhere too to remove the word "test" redundancy in the output directories.