### PR TITLE
Remove DataModel._extensions attribute

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -89,7 +89,7 @@ class ModelContainer(model_base.DataModel):
             instance = copy.deepcopy(init._instance)
             self._schema = init._schema
             self._shape = init._shape
-            self._asdf = AsdfFile(instance, extensions=init._extensions)
+            self._asdf = AsdfFile(instance)
             self._instance = instance
             self._ctx = self
             self.__class__ = init.__class__
@@ -136,11 +136,10 @@ class ModelContainer(model_base.DataModel):
         Returns a deep copy of the models in this model container.
         """
         result = self.__class__(init=None,
-                                extensions=self._extensions,
                                 pass_invalid_values=self._pass_invalid_values,
                                 strict_validation=self._strict_validation)
         instance = copy.deepcopy(self._instance, memo=memo)
-        result._asdf = AsdfFile(instance, extensions=self._extensions)
+        result._asdf = AsdfFile(instance)
         result._instance = instance
         result._iscopy = self._iscopy
         result._schema = result._schema

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -379,7 +379,7 @@ def _save_history(hdulist, tree):
                 history[i] = HistoryEntry({'description': str(history[i])})
         hdulist[0].header['HISTORY'] = history[i]['description']
 
-def to_fits(tree, schema, extensions=None):
+def to_fits(tree, schema):
     hdulist = fits.HDUList()
     hdulist.append(fits.PrimaryHDU())
 
@@ -387,8 +387,7 @@ def to_fits(tree, schema, extensions=None):
     _save_extra_fits(hdulist, tree)
     _save_history(hdulist, tree)
 
-    asdf = fits_embed.AsdfInFits(hdulist, tree,
-                                 extensions=extensions)
+    asdf = fits_embed.AsdfInFits(hdulist, tree)
     return asdf
 
 
@@ -532,9 +531,9 @@ def _load_history(hdulist, tree):
         history['entries'].append(HistoryEntry({'description': entry}))
 
 
-def from_fits(hdulist, schema, extensions, context, **kwargs):
+def from_fits(hdulist, schema, context, **kwargs):
     try:
-        ff = from_fits_asdf(hdulist, extensions=extensions, **kwargs)
+        ff = from_fits_asdf(hdulist, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc
 
@@ -545,7 +544,7 @@ def from_fits(hdulist, schema, extensions, context, **kwargs):
 
     return ff
 
-def from_fits_asdf(hdulist, extensions=None,
+def from_fits_asdf(hdulist,
                   ignore_version_mismatch=True,
                   ignore_unrecognized_tag=False,
                   **kwargs):
@@ -553,7 +552,6 @@ def from_fits_asdf(hdulist, extensions=None,
     Wrap asdf call to extract optional argumentscommet
     """
     return fits_embed.AsdfInFits.open(hdulist,
-                                      extensions=extensions,
                                       ignore_version_mismatch=ignore_version_mismatch,
                                       ignore_unrecognized_tag=ignore_unrecognized_tag)
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -41,7 +41,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     """
     schema_url = "core.schema.yaml"
 
-    def __init__(self, init=None, schema=None, extensions=None,
+    def __init__(self, init=None, schema=None,
                  pass_invalid_values=False, strict_validation=False,
                  **kwargs):
         """
@@ -71,9 +71,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             If not provided, the schema associated with this class
             will be used.
 
-        extensions: classes extending the standard set of extensions, optional.
-            If an extension is defined, the prefix used should be 'url'.
-
         pass_invalid_values: If true, values that do not validate the schema
             will be added to the metadata. If false, they will be set to None
 
@@ -82,12 +79,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         kwargs: Aadditional arguments passed to lower level functions
         """
-        # Set attributes used to hold information for asdf
-        if extensions is None:
-            extensions = [BaseExtension()]
-        else:
-            extensions.extend([BaseExtension()])
-        self._extensions = extensions
 
         # Override value of validation parameters
         # if environment value set
@@ -119,16 +110,13 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         shape = None
 
         if init is None:
-            asdffile = self.open_asdf(init=None, extensions=self._extensions,
-                                  **kwargs)
+            asdffile = self.open_asdf(init=None, **kwargs)
 
         elif isinstance(init, dict):
-            asdffile = self.open_asdf(init=init, extensions=self._extensions,
-                                  **kwargs)
+            asdffile = self.open_asdf(init=init, **kwargs)
 
         elif isinstance(init, np.ndarray):
-            asdffile = self.open_asdf(init=None, extensions=self._extensions,
-                                  **kwargs)
+            asdffile = self.open_asdf(init=None, **kwargs)
 
             shape = init.shape
             is_array = True
@@ -140,8 +128,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             shape = init
             is_shape = True
-            asdffile = self.open_asdf(init=None, extensions=self._extensions,
-                                  **kwargs)
+            asdffile = self.open_asdf(init=None, **kwargs)
 
         elif isinstance(init, DataModel):
             asdffile = None
@@ -154,8 +141,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             asdffile = init
 
         elif isinstance(init, fits.HDUList):
-            asdffile = fits_support.from_fits(init, self._schema,
-                                          self._extensions, self._ctx)
+            asdffile = fits_support.from_fits(init, self._schema, self._ctx)
 
         elif isinstance(init, (str, bytes)):
             if isinstance(init, bytes):
@@ -166,14 +152,12 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                 hdulist = fits.open(init)
                 asdffile = fits_support.from_fits(hdulist,
                                               self._schema,
-                                              self._extensions,
                                               self._ctx,
                                               **kwargs)
                 self._files_to_close.append(hdulist)
 
             elif file_type == "asdf":
-                asdffile = self.open_asdf(init=init, extensions=self._extensions,
-                                      **kwargs)
+                asdffile = self.open_asdf(init=init, **kwargs)
 
             else:
                 # TODO handle json files as well
@@ -306,8 +290,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     def clone(target, source, deepcopy=False, memo=None):
         if deepcopy:
             instance = copy.deepcopy(source._instance, memo=memo)
-            target._asdf = AsdfFile(instance,
-                                    extensions=source._extensions)
+            target._asdf = AsdfFile(instance)
             target._instance = instance
             target._iscopy = source._iscopy
         else:
@@ -325,7 +308,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         Returns a deep copy of this model.
         """
         result = self.__class__(init=None,
-                                extensions=self._extensions,
                                 pass_invalid_values=self._pass_invalid_values,
                                 strict_validation=self._strict_validation)
         self.clone(result, self, deepcopy=True, memo=memo)
@@ -512,7 +494,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return output_path
 
     @staticmethod
-    def open_asdf(init=None, extensions=None,
+    def open_asdf(init=None,
                   ignore_version_mismatch=True,
                   ignore_unrecognized_tag=False,
                   **kwargs):
@@ -520,19 +502,19 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         Open an asdf object from a filename or create a new asdf object
         """
         if isinstance(init, str):
-            asdffile = asdf.open(init, extensions=extensions,
+            asdffile = asdf.open(init,
                                  ignore_version_mismatch=ignore_version_mismatch,
                                  ignore_unrecognized_tag=ignore_unrecognized_tag)
 
         else:
-            asdffile = AsdfFile(init, extensions=extensions,
+            asdffile = AsdfFile(init,
                             ignore_version_mismatch=ignore_version_mismatch,
                             ignore_unrecognized_tag=ignore_unrecognized_tag
                             )
         return asdffile
 
     @classmethod
-    def from_asdf(cls, init, schema=None, extensions=None, **kwargs):
+    def from_asdf(cls, init, schema=None, **kwargs):
         """
         Load a data model from a ASDF file.
 
@@ -545,8 +527,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
               `~asdf.AsdfFile`.
         schema :
             Same as for `__init__`
-        extensions :
-            Same as for `__init__`
         kwargs:
             Aadditional arguments passed to lower level functions
 
@@ -554,7 +534,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         -------
         model : DataModel instance
         """
-        return cls(init, schema=schema, extensions=extensions, **kwargs)
+        return cls(init, schema=schema, **kwargs)
 
 
     def to_asdf(self, init, *args, **kwargs):
@@ -570,8 +550,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             `asdf.AsdfFile.write_to`.
         """
         self.on_save(init)
-        asdffile = self.open_asdf(self._instance, extensions=self._extensions,
-                              **kwargs)
+        asdffile = self.open_asdf(self._instance, **kwargs)
         asdffile.write_to(init, *args, **kwargs)
 
     @classmethod
@@ -613,8 +592,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         self.on_save(init)
 
-        with fits_support.to_fits(self._instance, self._schema,
-                                  extensions=self._extensions) as ff:
+        with fits_support.to_fits(self._instance, self._schema) as ff:
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore', message='Card is too long')
                 if self._no_asdf_extension:
@@ -1042,9 +1020,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             The type will depend on what libraries are installed on
             this system.
         """
-        extensions = self._asdf._extensions
-        ff = fits_support.to_fits(self._instance, self._schema,
-                                  extensions=extensions)
+        ff = fits_support.to_fits(self._instance, self._schema)
         hdu = fits_support.get_hdu(ff._hdulist, hdu_name, index=hdu_ver-1)
         header = hdu.header
         return WCS(header, key=key, relax=True, fix=True)
@@ -1074,8 +1050,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             hdu = fits.ImageHDU(name=hdu_name, header=header)
         hdulist = fits.HDUList([hdu])
 
-        ff = fits_support.from_fits(hdulist, self._schema,
-                                    self._extensions, self._ctx)
+        ff = fits_support.from_fits(hdulist, self._schema, self._ctx)
 
         self._instance = properties.merge_tree(self._instance, ff.tree)
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -30,7 +30,6 @@ from . import validate
 from .history import HistoryList
 
 from .extension import (
-    BaseExtension,
     URL_PREFIX,
 )
 

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -17,7 +17,7 @@ log.addHandler(logging.NullHandler())
 class NoTypeWarning(Warning):
     pass
 
-def open(init=None, extensions=None, **kwargs):
+def open(init=None, **kwargs):
     """
     Creates a DataModel from a number of different types
 
@@ -41,10 +41,6 @@ def open(init=None, extensions=None, **kwargs):
           to what was passed in.
 
         - dict: The object model tree for the data model
-
-    extensions : list of AsdfExtension
-        A list of extensions to the ASDF to support when reading
-        and writing ASDF files.
 
     Returns
     -------
@@ -88,13 +84,11 @@ def open(init=None, extensions=None, **kwargs):
         elif file_type == "asn":
             # Read the file as an association / model container
             from . import container
-            return container.ModelContainer(init, extensions=extensions,
-                                            **kwargs)
+            return container.ModelContainer(init, **kwargs)
 
         elif file_type == "asdf":
             # Read the file as asdf, no need for a special class
-            return model_base.DataModel(init, extensions=extensions,
-                                        **kwargs)
+            return model_base.DataModel(init, **kwargs)
 
     elif isinstance(init, tuple):
         for item in init:
@@ -110,8 +104,7 @@ def open(init=None, extensions=None, **kwargs):
 
     elif is_association(init) or isinstance(init, list):
         from . import container
-        return container.ModelContainer(init, extensions=extensions,
-                                        **kwargs)
+        return container.ModelContainer(init, **kwargs)
 
     # If we have it, determine the shape from the science hdu
     if hdulist:
@@ -158,7 +151,7 @@ def open(init=None, extensions=None, **kwargs):
         log.debug('Opening as {0}'.format(new_class))
 
     # Actually open the model
-    model = new_class(init, extensions=extensions, **kwargs)
+    model = new_class(init, **kwargs)
 
     # Close the hdulist if we opened it
     if file_to_close is not None:


### PR DESCRIPTION
We no longer have to pass around our ASDF extensions internally in the `datamodels` code.  They are always available via `entry_points`.  Following from our discussion in https://github.com/spacetelescope/jwst/pull/3227#pullrequestreview-211491661

Fixes #3231