### PR TITLE
Fix a failure in tweakreg when catalogs contain sources outside WCS domain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ tweakreg
 - Fixed a bug in handling situations when no useable sources are
   detected in any of the input images. [#3286]
 
+- Enhanced source catalog extraction algorithm to filer out sources outside
+  the WCS domain of definition (when available). [#3292]
+
 0.13.1 (2019-03-07)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,7 @@ tweakreg
 - Fixed a bug in handling situations when no useable sources are
   detected in any of the input images. [#3286]
 
-- Enhanced source catalog extraction algorithm to filer out sources outside
+- Enhanced source catalog extraction algorithm to filter out sources outside
   the WCS domain of definition (when available). [#3292]
 
 0.13.1 (2019-03-07)

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -75,7 +75,7 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
     sources = daofind(model.data)
 
     columns = ['id', 'xcentroid', 'ycentroid', 'flux']
-    if len(sources) > 0:
+    if sources:
         catalog = sources[columns]
     else:
         catalog = Table(names=columns, dtype=(np.int_, np.float_, np.float_,

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -71,6 +71,19 @@ class TweakRegStep(Step):
                 image_model, self.kernel_fwhm, self.snr_threshold,
                 brightest=self.brightest, peakmax=self.peakmax
             )
+
+            # filter out sources outside the image array if WCS validity
+            # region is provided:
+            wcs_bounds = image_model.meta.wcs.pixel_bounds
+            if wcs_bounds is not None:
+                ((xmin, xmax), (ymin, ymax)) = wcs_bounds
+                xname = 'xcentroid' if 'xcentroid' in catalog.colnames else 'x'
+                yname = 'ycentroid' if 'ycentroid' in catalog.colnames else 'y'
+                x = catalog[xname]
+                y = catalog[yname]
+                mask = (x > xmin) & (x < xmax) & (y > ymin) & (y < ymax)
+                catalog = catalog[mask]
+
             filename = image_model.meta.filename
             nsources = len(catalog)
             if nsources == 0:


### PR DESCRIPTION
This PR fixes the crash described in https://github.com/spacetelescope/jwst/issues/3287 by adding code to weed out sources that lie outside of the domain of definition of data model's WCS.