### PR TITLE
Update master_background docs

### DIFF
--- a/docs/jwst/master_background/arguments.rst
+++ b/docs/jwst/master_background/arguments.rst
@@ -18,7 +18,7 @@ The master background subtraction step uses the following optional arguments.
   Defaults to ``False``.
 
 ``--force_subtract``
-  A boolean indicating whether or not to override the steps' built-in logic for determining
+  A boolean indicating whether or not to override the step's built-in logic for determining
   if the step should be applied. By default, the step will be skipped if the
   :ref:`calwebb_spec2 <calwebb_spec2>` :ref:`background <background_step>` step has
   already been applied. If ``--force_subtract = True``, the master background will be

--- a/docs/jwst/master_background/arguments.rst
+++ b/docs/jwst/master_background/arguments.rst
@@ -2,7 +2,7 @@
 
 Step Arguments
 ==============
-The master spectroscopic background subtraction step has two optional arguments.
+The master background subtraction step uses the following optional arguments.
 
 ``--user_background``
   The file name of a user-supplied 1-D master background spectrum. Must be in the form
@@ -13,7 +13,13 @@ The master spectroscopic background subtraction step has two optional arguments.
   Defaults to ``None``.
 
 ``--save_background``
-  A boolean indicating whether the computed master background spectrum should be saved
+  A boolean indicating whether the computed 1-D master background spectrum should be saved
   to a file. If a user-supplied background is specified, this argument is ignored.
   Defaults to ``False``.
 
+``--force_subtract``
+  A boolean indicating whether or not to override the steps' built-in logic for determining
+  if the step should be applied. By default, the step will be skipped if the
+  :ref:`calwebb_spec2 <calwebb_spec2>` :ref:`background <background_step>` step has
+  already been applied. If ``--force_subtract = True``, the master background will be
+  applied.

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -87,7 +87,7 @@ Creating the 1-D master background spectrum
 -------------------------------------------
 The 1-D master background spectrum is created by combining data contained in the
 :ref:`x1d <x1d>` products listed in the input ASN as being "exptype: background" members.
-As noted above, the background members can be exposures obtained of dedicated background targets
+As noted above, the background members can be exposures of dedicated background targets
 or can be a collection of exposures of a point-like source observed in a nod pattern
 (e.g. MIRI LRS fixed-slit "ALONG-SLIT-NOD" or NIRSpec IFU "2-POINT-NOD" dither patterns).
 

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -1,6 +1,6 @@
 Description
 ===========
-The master spectroscopic background subtraction step subtracts background signal from
+The master background subtraction step subtracts background signal from
 2-D spectroscopic data using a 1-D master background spectrum. The 1-D master background
 spectrum is computed from one or more input exposures, or can alternatively be supplied
 by the user. The 1-D background spectrum - flux versus wavelength - is projected into the
@@ -11,22 +11,88 @@ Upon successful completion of the step, the S_MSBSUB keyword is set to 'COMPLETE
 output product. The background-subtracted results are returned as a new data model, leaving
 the input model unchanged.
 
+Inputs and Outputs
+------------------
+The primary driver of the master background step is a "spec3" type Association (ASN) file
+or a ``ModelContainer`` populated from an ASN file. This is the ASN file used as input to
+the :ref:`calwebb_spec3 <calwebb_spec3>` pipeline, which defines a stage 3 combined product
+and its input members. The list of input members includes both "science" and "background"
+exposure types. The master background subtraction step uses the input members designated
+with "exptype: background" as the data from which to create the master background spectrum.
+These should be :ref:`x1d <x1d>` products created for individual exposures at the end of
+the :ref:`calwebb_spec2 <calwebb_spec2>` pipeline.
+The master background will be subtracted from all input members designated as
+"exptype: science" in the ASN, resulting in a new version of each such input. These inputs
+should be :ref:`cal <cal>` products created for individual exposures by the
+:ref:`calwebb_spec2 <calwebb_spec2>` pipeline.
+
+For observing scenarios that use exposures of dedicated background targets, the "background"
+members in the ASN will be the exposures from those background targets. For scenarios that
+use source nodding within the field to sample the background, the lists of "science" and
+"background" members in the ASN will use the same exposures. The only difference is that
+the "science" members will refer to :ref:`cal <cal>` products, while the "background"
+members will refer to :ref:`x1d <x1d>` products.
+
+For example, the ASN file for a simple 2-point nodded observation consisting of two
+exposures looks like the following::
+
+  {
+      "asn_type": "spec3",
+      "asn_rule": "candidate_Asn_IFU",
+      "program": "00626",
+      "asn_id": "c1003",
+      "target": "t001",
+      "asn_pool": "jw00626_20190128T194403_pool",
+      "products": [
+          {"name": "jw00626-c1003_t001_nrs",
+              "members": [
+                  {"expname": "jw00626009001_02101_00001_nrs1_cal.fits",
+                    "exptype": "science",
+                    "asn_candidate": "('c1003', 'background')"
+                  },
+                  {"expname": "jw00626009001_02102_00001_nrs1_cal.fits",
+                   "exptype": "science", 
+                   "asn_candidate": "('c1003', 'background')"
+                  },
+                  {"expname": "jw00626009001_02101_00001_nrs1_x1d.fits",
+                   "exptype": "background",
+                   "asn_candidate": "('c1003', 'background')"
+                  },
+                  {"expname": "jw00626009001_02102_00001_nrs1_x1d.fits",
+                   "exptype": "background",
+                   "asn_candidate": "('c1003', 'background')"
+                  }
+              ]
+          }
+      ]
+  }
+
+As you can see from the above ASN list, the same two exposures are defined as
+being both "science" and "background" members, because they both contain the target
+of interest and a region of background. The "science" members, which are the
+:ref:`cal <cal>` products created by the :ref:`calwebb_spec2 <calwebb_spec2>`
+pipeline, are the data files that will have the master background subtraction
+applied, while the "background" members are :ref:`x1d <x1d>` 1-D spectral
+products from which the master background spectrum will be created.
+
 Creating the 1-D master background spectrum
 -------------------------------------------
-The 1-D master background spectrum is created by combining the data contained in the
-:ref:`x1d <x1d>` products created by the :ref:`calwebb_spec2 <calwebb_spec2>` pipeline. The
-collection of exposure products to be used as background is designated in the input ASN file,
-by setting 'exptype=background' for the appropriate product members. The background members
-could be exposures obtained of dedicated background targets or could be a collection of
-on-target exposures for a point-source observed in a nod pattern (e.g. MIRI LRS fixed-slit
-2-point nods).
+The 1-D master background spectrum is created by combining data contained in the
+:ref:`x1d <x1d>` products listed in the input ASN as being "exptype: background" members.
+As noted above, the background members can be exposures obtained of dedicated background targets
+or can be a collection of exposures of a point-like source observed in a nod pattern
+(e.g. MIRI LRS fixed-slit "ALONG-SLIT-NOD" or NIRSpec IFU "2-POINT-NOD" dither patterns).
 
-The flux versus wavelength data in the :ref:`x1d <x1d>` products for the designated background members
-is combined using the :ref:`combine_1d <combine_1d_step>` step to produce the 1-D master
-background spectrum.
+For the case of dedicated background target exposures, the 1-D spectrum contained in the
+"FLUX" column of the background :ref:`x1d <x1d>` products will be used for creating the
+master background spectrum. For the case of nodded exposures, the 1-D spectrum contained
+in the "BACKGROUND" column of the :ref:`x1d <x1d>` products will be used.
 
-[Need a brief description here of how the multiple spectra are resampled/combined in
-wavelength space to form the final MSB spectrum, once that's been decided.]
+When all the input background spectra have been collected, they are combined using the
+:ref:`combine_1d <combine_1d_step>` step to produce the 1-D master background spectrum.
+Because each input spectrum was originally created as the sum over a number of pixels
+at a given wavelength, each spectrum is properly rescaled to yield background per
+pixel before being combined.
 
 Subtracting the master background
 ---------------------------------
@@ -37,9 +103,9 @@ nodded MIRI LRS fixed-slit exposures. The subtraction process performs a loop ov
 source data instances and for each one it does the following:
 
  - Compute a 2-D wavelength grid corresponding to the 2-D source data. For some observing modes,
-   such as NIRSpec MOS and fixed-slit, a 2-D wavelength is computed and attached to the data during
-   the :ref:`extract_2d <extract_2d_step>` step in the :ref:`calwebb_spec2 <calwebb_spec2>` pipeline.
-   If such a 2-D wavelength array is present, it is used. For other modes that don't have a 2-D
+   such as NIRSpec MOS and fixed-slit, a 2-D wavelength array is computed and attached to the data
+   in the :ref:`calwebb_spec2 <calwebb_spec2>` pipeline :ref:`extract_2d <extract_2d_step>` step.
+   If such a wavelength array is present, it is used. For modes that don't have a 2-D
    wavelength array contained in the data product, it is computed on the fly using the WCS object
    for each source data instance.
 

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -7,6 +7,14 @@ by the user. The 1-D background spectrum - flux versus wavelength - is projected
 2-D space of source data based on the wavelength of each pixel in the 2-D data. The resulting
 2-D background signal is then subtracted directly from the 2-D source data.
 
+Logic built into the step checks to see if the exposure-based :ref:`background <background_step>`
+subtraction step in the :ref:`calwebb_spec2 <calwebb_spec2>` pipeline has already been
+performed on the input images, based on the value of the S_BKDSUB keyword. If S_BKGSUB is
+set to 'COMPLETE', the master background step is skipped. The user can override this logic,
+if desired, by setting the step argument ``--force_subtract`` to ``True``, in which case master
+background subtraction will be applied regardless of the value of S_BKDSUB (see
+:ref:`msb_step_args`).
+
 Upon successful completion of the step, the S_MSBSUB keyword is set to 'COMPLETE' in the
 output product. The background-subtracted results are returned as a new data model, leaving
 the input model unchanged.

--- a/docs/jwst/master_background/index.rst
+++ b/docs/jwst/master_background/index.rst
@@ -1,8 +1,8 @@
 .. _master_background_step:
 
-===========================================
-Master Spectroscopic Background Subtraction
-===========================================
+=============================
+Master Background Subtraction
+=============================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Updated the `master_background` step docs to include more descriptions of how things work for cases of dedicated background target exposures and nodded exposures, including descriptions of the ASN file inputs and what data are used from the input `x1d` products for the different scenarios. Details of exactly how the bkg spectra are combined in `combine_1d` is left to that step's docs.

Fixes #3137