### PR TITLE
Add master_background step to calspec3 pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ background
   exposures do not have matching GWA tilt values, then skip the background
   subtraction step in calspec2. [#3252]
 
+calwebb_spec3
+-------------
+
+- Add the ``master_background`` subtraction step to the pipeline. [#3296]
+
 combine_1d
 ----------
 
@@ -46,6 +51,12 @@ master_background
 - Modified ``MasterBackgroundStep`` to be skipped if ``BackgroundStep``
   was already run on the data.  A new ``force_subtract`` parameter is
   added to override this logic.  [#3263]
+
+outlier_detection
+-----------------
+
+- Fixed a bug that was causing the step to crash when calling the
+  ``cube_build`` step for MIRI MRS data. [#3296]
 
 reffile_utils
 -------------

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -203,7 +203,7 @@ class IFUCubeData():
                     newname = self.output_name_base + fg_name + 'single_s3d.fits'
 # ______________________________________________________________________________
         if self.output_type != 'single':
-            log.info('Output Name %s', newname)
+            log.info('Output Name: %s', newname)
         return newname
 # _______________________________________________________________________
 
@@ -230,7 +230,7 @@ class IFUCubeData():
         # astropy circmean assumes angles are in radians,
         # we have angles in degrees
         ra_ave = circmean(ravalues * u.deg).value
-#       log.info('Ra average %f12.8', ra_ave)
+#       log.info('RA average %f12.8', ra_ave)
 
         self.crval1 = ra_ave
         self.crval2 = dec_ave
@@ -414,9 +414,9 @@ class IFUCubeData():
 
         log.info('Cube Geometry:')
         if self.coord_system == 'alpha-beta':
-            log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(arc sec)  MIN & Max (alpha,beta arc sec)')
+            log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(arcsec)  Min & Max (alpha, beta arcsec)')
         else:
-            log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(arc sec)  MIN & Max (xi,eta arc sec)')
+            log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(arcsec)  Min & Max (xi, eta arcsec)')
             log.info('Axis 1 %5d  %5.2f %12.8f %12.8f %12.8f %12.8f',
                      self.naxis1, self.crpix1, self.crval1, self.cdelt1,
                      self.a_min, self.a_max)
@@ -424,14 +424,14 @@ class IFUCubeData():
                      self.naxis2, self.crpix2, self.crval2, self.cdelt2,
                      self.b_min, self.b_max)
             if self.linear_wavelength:
-                log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(microns)  MIN & Max (microns)')
+                log.info('axis#  Naxis  CRPIX    CRVAL      CDELT(microns)  Min & Max (microns)')
                 log.info('Axis 3 %5d  %5.2f %12.8f %12.8f %12.8f %12.8f',
                          self.naxis3, self.crpix3, self.crval3, self.cdelt3,
                          self.lambda_min, self.lambda_max)
 
             if not self.linear_wavelength:
-                log.info('Non-linear wavelength dimension, CDELT3 variable')
-                log.info('axis#  Naxis  CRPIX    CRVAL     MIN & Max (microns)')
+                log.info('Non-linear wavelength dimension; CDELT3 variable')
+                log.info('axis#  Naxis  CRPIX    CRVAL     Min & Max (microns)')
                 log.info('Axis 3 %5d  %5.2f %12.8f %12.8f %12.8f',
                          self.naxis3, self.crpix3, self.crval3,
                          self.wavelength_table[0], self.wavelength_table[self.naxis3 - 1])
@@ -442,14 +442,14 @@ class IFUCubeData():
             for i in range(number_bands):
                 this_channel = self.list_par1[i]
                 this_subchannel = self.list_par2[i]
-                log.info('Cube covers channel, subchannel: %s %s ', this_channel, this_subchannel)
+                log.info('Cube covers channel, subchannel: %s, %s ', this_channel, this_subchannel)
         elif self.instrument == 'NIRSPEC':
             # number of filters and gratings are the same
             number_bands = len(self.list_par1)
             for i in range(number_bands):
                 this_fwa = self.list_par2[i]
                 this_gwa = self.list_par1[i]
-                log.info('Cube covers grating, filter: %s %s ', this_gwa, this_fwa)
+                log.info('Cube covers grating, filter: %s, %s ', this_gwa, this_fwa)
 # ________________________________________________________________________________
 
     def build_ifucube(self):
@@ -533,7 +533,7 @@ class IFUCubeData():
             for k in range(nfiles):
                 ifile = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
                 self.this_cube_filenames.append(ifile)
-                log.debug("Working on Band defined by:%s %s ", this_par1, this_par2)
+                log.debug("Working on Band defined by: %s %s ", this_par1, this_par2)
 # --------------------------------------------------------------------------------
                 if self.interpolation == 'pointcloud':
                     t0 = time.time()
@@ -641,7 +641,7 @@ class IFUCubeData():
                                                         self.naxis1, self.naxis2)
                         t1 = time.time()
 
-                        log.info("Time Map All slices on Detector to Cube = %.1f.s" % (t1 - t0,))
+                        log.info("Time to Map All slices on Detector to Cube = %.1f.s" % (t1 - t0,))
 # _______________________________________________________________________
 # Mapped all data to cube or Point Cloud
 # now determine Cube Spaxel flux
@@ -650,7 +650,7 @@ class IFUCubeData():
         self.find_spaxel_flux()
 
         t1 = time.time()
-        log.info("Time to find Cube Flux= %.1f.s" % (t1 - t0,))
+        log.info("Time to find Cube Flux = %.1f.s" % (t1 - t0,))
 
         ifucube_model = self.setup_ifucube(0)
 # _______________________________________________________________________
@@ -674,14 +674,14 @@ class IFUCubeData():
         # loop over input models
         single_ifucube_container = datamodels.ModelContainer()
         n = len(self.input_models)
-        log.info("Number of Single IFU cubes creating  = %i" % n)
+        log.info("Number of Single IFU cubes to create = %i" % n)
         this_par1 = self.list_par1[0]  # only one channel is used in this approach
         this_par2 = None  # not important for this type of mapping
 
         self.weighting == 'msm'
 
         for j in range(n):
-            log.info("Working on next Single IFU Cube  = %i" % (j + 1))
+            log.info("Working on next Single IFU Cube = %i" % (j + 1))
             t0 = time.time()
 # for each new data model create a new spaxel
             total_num = self.naxis1 * self.naxis2 * self.naxis3
@@ -721,7 +721,7 @@ class IFUCubeData():
             ifucube_model = self.setup_ifucube(j)
             self.update_ifucube(ifucube_model)
             t1 = time.time()
-            log.info("Time Create Single ifucube  = %.1f.s" % (t1 - t0,))
+            log.info("Time to Create Single ifucube = %.1f.s" % (t1 - t0,))
 # _______________________________________________________________________
             single_ifucube_container.append(ifucube_model)
 
@@ -860,7 +860,7 @@ class IFUCubeData():
             self.rois = spatial_roi
         if self.output_type == 'single' or self.num_files < 4:
             self.rois = self.rois * 1.5
-            log.info('Increasing spatial region of interest' +
+            log.info('Increasing spatial region of interest ' +
                      'default value set for 4 dithers %f', self.rois)
         if self.scale1 != 0:
             self.spatial_size = self.scale1
@@ -917,14 +917,14 @@ class IFUCubeData():
         lambda_max = []
 
         self.num_bands = len(self.list_par1)
-        log.info('Number of bands in cube  %i', self.num_bands)
+        log.info('Number of bands in cube: %i', self.num_bands)
 
         for i in range(self.num_bands):
             this_a = parameter1[i]
             this_b = parameter2[i]
-            log.debug('Working on data  from %s,%s', this_a, this_b)
+            log.debug('Working on data from %s, %s', this_a, this_b)
             n = len(self.master_table.FileMap[self.instrument][this_a][this_b])
-            log.debug('number of files %d ', n)
+            log.debug('number of files %d', n)
             for k in range(n):
                 amin = 0.0
                 amax = 0.0
@@ -992,7 +992,7 @@ class IFUCubeData():
             log.info('Beta Scale %f ', self.cdelt2)
             self.cdelt2 = (final_b_max - final_b_min) / nslice
             final_b_max = final_b_min + (nslice) * self.cdelt2
-            log.info('Changed the Beta Scale dimension so we have 1 -1 mapping between beta and slice #')
+            log.info('Changed the Beta Scale dimension so we have 1-1 mapping between beta and slice #')
             log.info('New Beta Scale %f ', self.cdelt2)
 # ________________________________________________________________________________
 # Test that we have data (NIRSPEC NRS2 only has IFU data for 3 configurations)
@@ -1128,7 +1128,7 @@ class IFUCubeData():
                 # for NIRSPEC each file has 30 slices
                 # wcs information access seperately for each slice
                 nslices = 30
-                log.info("Mapping each NIRSPEC slice to sky, this takes a while for NIRSPEC data")
+                log.info("Mapping each NIRSpec slice to sky; this takes a while for NIRSpec data")
                 for ii in range(nslices):
                     slice_wcs = nirspec.nrs_wcs_set_input(input_model, ii)
                     x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -38,11 +38,11 @@ class MasterBackgroundStep(Step):
             Save computed master background.
 
         force_subtract : bool, optional
-            Optional user-supplied flag which subtracts the master background overriding the checks
-            on whether the background in calspec2 has already been subtracted.
-            Default is set to false. The step logic determines if the master background should be
-            subtracted. If set to true then the step logic is bypassed and the master background is
-            subtracted.
+            Optional user-supplied flag that overrides step logic to force subtraction of the
+            master background.
+            Default is False, in which case the step logic determines if the calspec2 background step
+            has already been applied and, if so, the master background step is skipped.
+            If set to True, the step logic is bypassed and the master background is subtracted.
 
         Returns
         -------
@@ -82,17 +82,16 @@ class MasterBackgroundStep(Step):
                 self.record_step_status(result, 'master_background', success=False)
 
                 return result
-            # Check if background was subtracted in calspec 2 and force_subtract is False
-            # first check if input is a model container
 
-            do_sub = True  # flag if set to False then no master background subtraction is done
+            # Check if background was subtracted in calspec2 and force_subtract is False
+            do_sub = True  # If False, then no master background subtraction is done
             if not self.force_subtract:  # default mode
 
-                # check if the input data is a model container. If it is then loop over
+                # Check if the input data is a model container. If it is, then loop over the
                 # container and see if the background was subtracted in calspec2.
-                # If all data was  background subtracted. Print log.info and skip master bgk subtrction
-                # If there is a mixture of some being background subtracted print, warning
-                # and message to user to use force_subtract to force the master background
+                # If all data was background subtracted, print log info and skip master bkg subtraction.
+                # If there is a mixture of some being background subtracted, print warning
+                # message to user to use force_subtract to force the master background
                 # to be subtracted.
                 if isinstance(input_data, datamodels.ModelContainer):
                     isub = 0
@@ -103,26 +102,27 @@ class MasterBackgroundStep(Step):
 
                     if not do_sub and isub == len(input_data):
                         self.log.info(
-                            "Not subtracting master background, background was subtracted in calspec2")
-                        self.log.info("To force the master background to be subtracted from this data, "
+                            "Not subtracting master background, because background was subtracted in calspec2")
+                        self.log.info("To force master background subtraction for these data, "
                             "run again and set force_subtract = True.")
 
                     if not do_sub and isub != len(input_data):
-                        self.log.warning("Not subtracting master background.")
-                        self.log.warning("Input data contains a mixture of data with and without "
+                        self.log.warning("Not subtracting master background, because")
+                        self.log.warning("input data contains a mixture of data with and without "
                             "background subtraction done in calspec2.")
-                        self.log.warning("To force the master background to be subtracted from this data, "
+                        self.log.info("To force master background subtraction for these data, "
                             "run again and set force_subtract = True.")
-                # input data is a single file
+
+                # Input is a single model
                 else:
                     if input_data.meta.cal_step.back_sub == 'COMPLETE':
                         do_sub = False
                         self.log.info(
-                            "Not subtracting master background, background was subtracted in calspec2")
-                        self.log.info("To force the master background to be subtracted from this data, "
+                            "Not subtracting master background, because background was subtracted in calspec2")
+                        self.log.info("To force master background subtraction for these data, "
                             "run again and set force_subtract = True.")
 
-            # checked all the input data - do we subtract (continue) or not (return)
+            # Checked all the input data - do we subtract (continue) or not (return)?
             if not do_sub:
                 result = input_data.copy()
                 self.record_step_status(result, 'master_background', success=False)

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -70,7 +70,7 @@ class OutlierDetectionIFU(OutlierDetection):
         # NOTE:  Need to confirm that this attribute accurately reports the
         #        channel 'names' for both types of IFU data; MIRI and NRS
         try:
-            self.channels = self.input_models[0].meta.instrument.channel
+            self.channels = input_models[0].meta.instrument.channel
             if self.channels is None:  # account for NIRSpec IFU data
                 self.channels = '1'
         except AttributeError:

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -76,11 +76,10 @@ class Spec3Pipeline(Pipeline):
         self.output_file = output_file
 
         # Split the inputs into science and background
-        background_data = None
         science_data, background_data = split_container(input_models)
 
         # If background data are present, call the master background step
-        if background_data is not None:
+        if len(background_data) > 0:
             source_models = self.master_background(input_models)
             source_models.meta.asn_table = input_models.meta.asn_table
         else:

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -81,6 +81,8 @@ class Spec3Pipeline(Pipeline):
         # If background data are present, call the master background step
         if len(background_data) > 0:
             source_models = self.master_background(input_models)
+            if self.master_background.skip:
+                source_models = science_data
             source_models.meta.asn_table = input_models.meta.asn_table
         else:
             source_models = science_data

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -3,11 +3,13 @@
 from .. import datamodels
 from ..associations.lib.rules_level3_base import format_product
 from ..exp_to_source import multislit_to_container
+from ..master_background.master_background_step import split_container
 from ..stpipe import Pipeline
 
 # step imports
 from ..cube_build import cube_build_step
 from ..extract_1d import extract_1d_step
+from ..master_background import master_background_step
 from ..mrs_imatch import mrs_imatch_step
 from ..outlier_detection import outlier_detection_step
 from ..resample import resample_spec_step
@@ -36,6 +38,7 @@ class Spec3Pipeline(Pipeline):
 
     # Define aliases to steps
     step_defs = {
+        'master_background': master_background_step.MasterBackgroundStep,
         'mrs_imatch': mrs_imatch_step.MRSIMatchStep,
         'outlier_detection': outlier_detection_step.OutlierDetectionStep,
         'resample_spec': resample_spec_step.ResampleSpecStep,
@@ -72,6 +75,17 @@ class Spec3Pipeline(Pipeline):
         output_file = input_models.meta.asn_table.products[0].name
         self.output_file = output_file
 
+        # Split the inputs into science and background
+        background_data = None
+        science_data, background_data = split_container(input_models)
+
+        # If background data are present, call the master background step
+        if background_data is not None:
+            source_models = self.master_background(input_models)
+            source_models.meta.asn_table = input_models.meta.asn_table
+        else:
+            source_models = science_data
+
         # `sources` is the list of astronomical sources that need be
         # processed. Each element is a ModelContainer, which contains
         # models for all exposures that belong to a single source.
@@ -87,12 +101,12 @@ class Spec3Pipeline(Pipeline):
         # source into its own ModelContainer. This produces a list of
         # sources, each represented by a MultiExposureModel instead of
         # a single ModelContainer.
-        sources = [input_models]
+        sources = [source_models]
         if model_type in MULTISOURCE_MODELS:
             self.log.info('Convert from exposure-based to source-based data.')
             sources = [
                 (name, model)
-                for name, model in multislit_to_container(input_models).items()
+                for name, model in multislit_to_container(source_models).items()
             ]
 
         # Process each source


### PR DESCRIPTION
This is a first-cut, crude attempt to add the `master_background` subtraction step to the `calwebb_spec3` pipeline. For sake of simplicity I've put it before the point in the flow where `MultiSlitModel` data get rearranged from exposure-based models to source-based models. We may need to revisit this when attempting to apply to NIRSpec MOS observations.

I noticed that at least the `cube_build` step needs access to the model.meta.asn_table meta info, which apparently is not preserved when using `split_container` or in the `ModelContainer` coming back from `master_background`, so I've got a line in there to copy it manually to the models passed to subsequent steps.

Fixes #3288