### PR TITLE
Change exception type for incorrect input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ tweakreg
 - Enhanced source catalog extraction algorithm to filter out sources outside
   the WCS domain of definition (when available). [#3292]
 
+- Changed the type of exception raised when input has incorrect type. [#3297]
+
 0.13.1 (2019-03-07)
 ===================
 

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -60,9 +60,8 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
     catalog : `~astropy.Table`
         An astropy Table containing the source catalog.
     """
-
     if not isinstance(model, ImageModel):
-        raise ValueError('The input model must be a ImageModel.')
+        raise TypeError('The input model must be an ImageModel.')
 
     threshold_img = detect_threshold(model.data, snr=snr_threshold)
     # TODO:  use threshold image based on error array


### PR DESCRIPTION
I think the most appropriate exception type here is `TypeError`. Also corrected a typo.