### PR TITLE
Use sphinx-asdf to automatically generate schema documentation for transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 *.so
 */version.py
 docs/*/source/*.txt.rst
+docs/generated
 docs/fits_generator/source/templates.rst
 docs/jwst_git/
 docs/_build/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,8 @@ extensions = [
     'sphinx_automodapi.automodsumm',
     'sphinx_automodapi.autodoc_enhancements',
     'sphinx_automodapi.smart_resolver',
-    'sphinx_astropy.ext.doctest'
+    'sphinx_astropy.ext.doctest',
+    'sphinx_asdf',
     ]
 
 
@@ -213,6 +214,11 @@ pygments_style = 'default'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
+# Mapping for links to the ASDF Standard in ASDF schema documentation
+asdf_schema_reference_mappings = [
+    ('tag:stsci.edu:asdf',
+     'http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/'),
+]
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/jwst/transforms/index.rst
+++ b/docs/jwst/transforms/index.rst
@@ -7,5 +7,35 @@ Transforms
 
    tpcorr
 
+ASDF Schema Definitions
+-----------------------
+
+This package defines `ASDF <http://asdf-standard.readthedocs.io>`__ schemas
+that are used for validating the representation of transforms in the ASDF
+format. These schemas contain useful documentation about the associated types,
+and can also be used by other implementations that wish to interoperate with
+these transform definitions.
+
+.. asdf-autoschemas::
+   :schema_root: ../jwst/transforms/schemas
+   :standard_prefix: stsci.edu/jwst_pipeline
+
+   coords-0.7.0
+   grating_equation-0.7.0
+   gwa_to_slit-0.7.0
+   logical-0.7.0
+   lrs_wavelength-0.7.0
+   miri_ab2slice-0.7.0
+   nircam_grism_dispersion-0.7.0
+   niriss_grism_dispersion-0.7.0
+   niriss_soss-0.7.0
+   refraction_index_from_prism-0.7.0
+   rotation_sequence-0.7.0
+   slit_to_msa-0.7.0
+   snell-0.7.0
+   tpcorr-0.7.0
+   v23tosky-0.7.0
+
+
 .. automodapi:: jwst.transforms
 .. automodapi:: jwst.transforms.models

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/grating_equation-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/grating_equation-0.7.0.yaml
@@ -31,7 +31,7 @@ examples:
           output: wavelength
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       groove_density:

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/gwa_to_slit-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/gwa_to_slit-0.7.0.yaml
@@ -12,7 +12,7 @@ description: |
   the slit.
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       slits:
@@ -28,12 +28,12 @@ allOf:
               anyOf:
                 - type: array
                 - type: number
-          - $ref: ../asdf/core/ndarray-1.0.0
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
       models:
         description: |
           A compound model transferring positions at the GWA to
           position in the slit frame.
         type: array
         items:
-          $ref: "../asdf/transform/transform-1.1.0"
+          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
     required: [slits, models]

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/logical-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/logical-0.7.0.yaml
@@ -17,7 +17,7 @@ examples:
           value: .nan
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       condition:
@@ -30,11 +30,11 @@ allOf:
           A number or ndarray to compare to using the condition.
           If ndarray then the input array, compareto and value should have the same shape.
         anyOf:
-          - $ref: ../asdf/core/ndarray-1.0.0
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
           - type: number
       value:
         description: |
           Value to substitute where condition is True.
         anyOf:
-          - $ref: ../asdf/core/ndarray-1.0.0
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
           - type: number

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/lrs_wavelength-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/lrs_wavelength-0.7.0.yaml
@@ -11,14 +11,14 @@ description: |
   MIRI LRS fixed slit.
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       wavetable:
         description: |
           An array with columns of:
           xcenter, ycenter, wavelength, x0, y0, x1, y1, x2, y2, x3, y3
-        $ref: ../asdf/core/ndarray-1.0.0
+        $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
       zero_point:
         description: |
           An array of size 2 - the zero point of the wavelength solution.

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/miri_ab2slice-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/miri_ab2slice-0.7.0.yaml
@@ -12,7 +12,7 @@ description: |
   that the coordinate belongs to in detector coordinates.
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       beta_zero:

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-0.7.0.yaml
@@ -10,7 +10,7 @@ description: |
    - given x,y,wave,order in effective direct image return x,y,wave,order in dispersed
    - given x,y,x0,y0,order in dispersed image returns x,y,wave,order in effective direct
 anyOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       xmodels:
@@ -18,19 +18,19 @@ anyOf:
          NIRCAM row dispersion models
         type: array
         items:
-          $ref: ../asdf/transform/transform-1.1.0
+          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
       ymodels:
         description: |
           NIRCAM column dispersion models
         type: array
         items:
-          $ref: ../asdf/transform/transform-1.1.0
+          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
       lmodels:
         description: |
           NIRCAM wavelength dispersion models
         type: array
         items:
-          $ref: ../asdf/transform/transform-1.1.0
+          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
       orders:
         description: |
           NIRCAM available grism orders, in-sync with the model arrays

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/niriss_grism_dispersion-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/niriss_grism_dispersion-0.7.0.yaml
@@ -10,7 +10,7 @@ description: |
    - given x,y,wave,order in effective direct image return x,y,wave,order in dispersed
    - given x,y,x0,y0,order in dispersed image returns x,y,wave,order in effective direct
 anyOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       theta:
@@ -24,7 +24,7 @@ anyOf:
         items:
           type: array
           items:
-            $ref: ../asdf/transform/transform-1.1.0
+            $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
       ymodels:
         description: |
           NIRISS Grism column dispersion model
@@ -32,13 +32,13 @@ anyOf:
         items:
           type: array
           items:
-            $ref: ../asdf/transform/transform-1.1.0
+            $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
       lmodels:
         description: |
           NIRISS wavelength-models for dispersion
         type: array
         items:
-          $ref: ../asdf/transform/transform-1.1.0
+          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
       orders:
         description: |
           NIRISS available grism orders, in-sync with the model arrays

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/niriss_soss-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/niriss_soss-0.7.0.yaml
@@ -9,7 +9,7 @@ description: |
   It maps spectral orderto to transform
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       spectral_orders:
@@ -23,5 +23,5 @@ allOf:
           A compound model transferring pixel to worlds coordinates.
         type: array
         items:
-          $ref: ../asdf/transform/transform-1.1.0
+          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
     required: [spectral_orders, models]

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/refraction_index_from_prism-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/refraction_index_from_prism-0.7.0.yaml
@@ -11,7 +11,7 @@ description: |
   index of refraction.
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       prism_angle:

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/rotation_sequence-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/rotation_sequence-0.7.0.yaml
@@ -10,7 +10,7 @@ description: |
   A sequence of 3D rotations around different axes.
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       angles:

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/slit_to_msa-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/slit_to_msa-0.7.0.yaml
@@ -10,7 +10,7 @@ description: |
   It maps a slit to its position in the MSA plane.
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       slits:
@@ -20,12 +20,12 @@ allOf:
               anyOf:
                 - type: array
                 - type: number
-          - $ref: ../asdf/core/ndarray-1.0.0
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
       models:
         description: |
           A compound model transferring positions in the slit frame to
           positions in the MSA frame.
         type: array
         items:
-          $ref: ../asdf/transform/transform-1.1.0
+          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
     required: [slits, models]

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/snell-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/snell-0.7.0.yaml
@@ -16,7 +16,7 @@ description: |
   - Applies Snell's law through fromt surface.
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       prism_angle:

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/tpcorr-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/tpcorr-0.7.0.yaml
@@ -14,7 +14,7 @@ description: |
   Ouput of this model are corrected (V2, V3) coordinates.
 
 anyOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       v2ref:
@@ -38,7 +38,7 @@ anyOf:
               type: array
               items:
                 type: number
-          - $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
       shift:
         description: |
           Translational correction.
@@ -46,5 +46,5 @@ anyOf:
           - type: array
             items:
               type: number
-          - $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
     required: [v2ref, v3ref, roll, matrix, shift]

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/v23tosky-0.7.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/v23tosky-0.7.0.yaml
@@ -21,7 +21,7 @@ examples:
           axes_order: zyxyz
 
 allOf:
-  - $ref: ../asdf/transform/transform-1.1.0
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
       angles:

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ DOCS_REQUIRE = [
     'sphinx-rtd-theme',
     'stsci-rtd-theme',
     'sphinx-astropy',
+    'sphinx-asdf',
 ]
 TESTS_REQUIRE = [
     'ci-watson>=0.3.0',


### PR DESCRIPTION
This PR adds a section to the `transforms` submodule documentation that links to new documentation for each of the transform schemas. The schema documentation is automatically generated using the [sphinx-asdf](https://github.com/spacetelescope/sphinx-asdf) plugin.