### PR TITLE
Fix issues with calspec3 use of split_container

### DIFF
--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -177,9 +177,9 @@ def split_container(container):
     science = datamodels.ModelContainer()
     for product in asn['products']:
         for member in product['members']:
-            if member['exptype'] == 'science':
+            if member['exptype'].lower() == 'science':
                 science.append(datamodels.open(member['expname']))
-            if member['exptype'] == 'background':
+            if member['exptype'].lower() == 'background':
                 background.append(datamodels.open(member['expname']))
 
     science.meta.asn_table = {}
@@ -187,7 +187,7 @@ def split_container(container):
         science.meta.asn_table._instance, asn
     )
     for p in science.meta.asn_table.instance['products']:
-        p['members'] = [m for m in p['members'] if m['exptype'] != 'background']
+        p['members'] = [m for m in p['members'] if m['exptype'].lower() != 'background']
     return science, background
 
 

--- a/jwst/pipeline/calwebb_spec3.cfg
+++ b/jwst/pipeline/calwebb_spec3.cfg
@@ -2,6 +2,8 @@ name = "Spec3Pipeline"
 class = "jwst.pipeline.Spec3Pipeline"
 
     [steps]
+      [[master_background]]
+        suffix = 'mbsub'
       [[mrs_imatch]]
         suffix = 'mrs_imatch'
       [[outlier_detection]]

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -83,7 +83,7 @@ class Spec3Pipeline(Pipeline):
             members_by_type[member['exptype'].lower()].append(member['expname'])
 
         # If background data are present, call the master background step
-        if len(members_by_type['background']) > 0:
+        if members_by_type['background']:
             source_models = self.master_background(input_models)
             source_models.meta.asn_table = input_models.meta.asn_table
 

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from collections import defaultdict
 
 from .. import datamodels
 from ..associations.lib.rules_level3_base import format_product
@@ -75,17 +76,26 @@ class Spec3Pipeline(Pipeline):
         output_file = input_models.meta.asn_table.products[0].name
         self.output_file = output_file
 
-        # Split the inputs into science and background
-        science_data, background_data = split_container(input_models)
+        # Find all the member types in the product
+        members_by_type = defaultdict(list)
+        product = input_models.meta.asn_table.products[0].instance
+        for member in product['members']:
+            members_by_type[member['exptype'].lower()].append(member['expname'])
 
         # If background data are present, call the master background step
-        if len(background_data) > 0:
+        if len(members_by_type['background']) > 0:
             source_models = self.master_background(input_models)
-            if self.master_background.skip:
-                source_models = science_data
             source_models.meta.asn_table = input_models.meta.asn_table
+
+            # If the step is skipped, do the container splitting that
+            # would've been done in master_background
+            if self.master_background.skip:
+                source_models, bkg_models = split_container(input_models)
+                del bkg_models  # we don't need the background members
         else:
-            source_models = science_data
+            # The input didn't contain any background members,
+            # so we use all the inputs in subsequent steps
+            source_models = input_models
 
         # `sources` is the list of astronomical sources that need be
         # processed. Each element is a ModelContainer, which contains


### PR DESCRIPTION
Fix some issues uncovered after merging PR #3296. The updates eliminate the use of ``split_container`` in ``calwebb_spec3`` if ``master_background`` is called, so that it only gets used once and hence avoids file handle and memory issues. Instead of calling ``split_container`` it simply looks at the ASN member info to see if there are any background members present.

Also updated the ``split_container`` function to use the ``lower()`` method on all string comparisons. This problem was revealed by one of the regression tests that used upper-case "SCIENCE" in an ASN file.