### PR TITLE
Update srctype rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,11 @@ set_telescope_pointing
 - Fix ``populate_model_from_siaf`` to convert SIAF pixel scale from
   arcsec to degress for CDELTn keywords. [#3248]
 
+srctype
+-------
+
+- Updated logic for background targets and nodded exposures. [#3310]
+
 tweakreg
 --------
 

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -3,32 +3,59 @@ import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+
 def set_source_type(input_model):
     """
+    Set the source_type, based on APT input or default values.
+
+    Parameters
+    ----------
+    input_model : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`, or `~jwst.datamodels.MultiSlitModel`
+        The data model to be processed.
+
+    Returns
+    -------
+    input_model :
+        The updated model that has been processed.
     """
 
     # Get the exposure type of the input model
-    try:
-        exptype = input_model.meta.exposure.type
-        log.info('Input EXP_TYPE is %s' % exptype)
-    except:
-        log.error('Failed to access EXP_TYPE value in input')
-        log.error('Step will be skipped')
+    exptype = input_model.meta.exposure.type
+    if exptype is None:
+        log.warning('EXP_TYPE value not found in input')
+        log.warning('Step will be skipped')
         return None
+    else:
+        log.info('Input EXP_TYPE is %s' % exptype)
 
     # For exposure types that use a single source, get the user-supplied
     # source type from the selection they provided in the APT
     if exptype in ['MIR_LRS-FIXEDSLIT', 'MIR_LRS-SLITLESS', 'MIR_MRS',
-                   'NIS_SOSS', 'NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_IFU']:
+                   'NRC_TSGRISM', 'NIS_SOSS', 'NRS_FIXEDSLIT',
+                   'NRS_BRIGHTOBJ', 'NRS_IFU']:
 
-        # Get the value the user specified (if any)
+        bkg_target = input_model.meta.observation.bkgdtarg
+        patttype = input_model.meta.dither.primary_type
         user_type = input_model.meta.target.source_type
 
-        if (user_type is not None) and (user_type in ['POINT', 'EXTENDED']):
+        if (bkg_target is not None) and (bkg_target is True):
+
+            # If this image is flagged as a BACKGROUND target, set the
+            # source type to EXTENDED regardless of any other settings
+            src_type = 'EXTENDED'
+            log.info('Exposure is a background target; setting SRCTYPE = %s' % src_type)
+
+        elif (patttype is not None) and ('NOD' in patttype):
+
+            # Set all nodded exposures to POINT source type
+            src_type = 'POINT'
+            log.info('Exposure is nodded; setting SRCTYPE = %s' % src_type)
+
+        elif (user_type is not None) and (user_type in ['POINT', 'EXTENDED']):
 
             # Use the value supplied by the user
-            log.info('Using input SRCTYPE of %s' % user_type)
             src_type = user_type
+            log.info('Using input SRCTYPE = %s' % src_type)
 
         else:
 
@@ -38,17 +65,7 @@ def set_source_type(input_model):
             else:
                 src_type = 'POINT'
 
-            # Check for background target status
-            if input_model.meta.observation.bkgdtarg:
-
-                # If it's NIRSpec IFU background target exposure, set
-                # the default type to Extended
-                if input_model.meta.exposure.type == 'NRS_IFU':
-                    src_type = 'EXTENDED'
-
-            # Report the type
-            log.info('Input SRCTYPE is unknown. Setting to default ' +
-                     'value of %s' % src_type)
+            log.info('Input SRCTYPE is unknown; setting default SRCTYPE = %s' % src_type)
 
         input_model.meta.target.source_type = src_type
 
@@ -72,7 +89,7 @@ def set_source_type(input_model):
                 slit.source_type = 'EXTENDED'
 
             log.info('source_id=%g, stellarity=%g, type=%s' %
-                      (slit.source_id, stellarity, slit.source_type))
+                     (slit.source_id, stellarity, slit.source_type))
 
         # Set the source type value in the primary header to
         # a harmless default
@@ -80,8 +97,7 @@ def set_source_type(input_model):
 
     # Unrecognized exposure type
     else:
-        log.warning('EXP_TYPE %s not applicable to this operation' %
-                    exptype)
+        log.warning('EXP_TYPE %s not applicable to this operation' % exptype)
         log.warning('Step will be skipped')
         return None
 

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -15,8 +15,8 @@ def set_source_type(input_model):
 
     Returns
     -------
-    input_model :
-        The updated model that has been processed.
+    input_model : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`, `~jwst.datamodels.MultiSlitModel`, or None
+        The updated model or None if the process couldn't be completed.
     """
 
     # Get the exposure type of the input model
@@ -38,7 +38,7 @@ def set_source_type(input_model):
         patttype = input_model.meta.dither.primary_type
         user_type = input_model.meta.target.source_type
 
-        if (bkg_target is not None) and (bkg_target is True):
+        if bkg_target:
 
             # If this image is flagged as a BACKGROUND target, set the
             # source type to EXTENDED regardless of any other settings
@@ -51,7 +51,7 @@ def set_source_type(input_model):
             src_type = 'POINT'
             log.info('Exposure is nodded; setting SRCTYPE = %s' % src_type)
 
-        elif (user_type is not None) and (user_type in ['POINT', 'EXTENDED']):
+        elif user_type in ['POINT', 'EXTENDED']:
 
             # Use the value supplied by the user
             src_type = user_type

--- a/jwst/srctype/tests/test_srctype.py
+++ b/jwst/srctype/tests/test_srctype.py
@@ -1,0 +1,94 @@
+"""
+Test the srctype step on exposures with various settings
+"""
+from jwst import datamodels
+from jwst.srctype import srctype
+
+def test_background_target_set():
+
+    # An exposure flagged as background target
+    input = datamodels.ImageModel((10,10))
+
+    input.meta.exposure.type = 'NRS_IFU'
+    input.meta.observation.bkgdtarg = True
+    input.meta.dither.primary_type = '2-POINT-NOD'
+    input.meta.target.source_type = 'POINT'
+
+    output = srctype.set_source_type(input)
+
+    # Result should be EXTENDED regardless of other input settings
+    assert output.meta.target.source_type == 'EXTENDED'
+
+def test_background_target_unset():
+
+    # An exposure without BKGDTARG set at all
+    input = datamodels.ImageModel((10,10))
+
+    input.meta.exposure.type = 'NRS_IFU'
+    input.meta.dither.primary_type = '2-POINT-NOD'
+    input.meta.target.source_type = 'EXTENDED'
+
+    output = srctype.set_source_type(input)
+
+    # If BKGDTARG is missing, next test should be based on the
+    # value of PATTTYPE, which in this case should return POINT.
+    assert output.meta.target.source_type == 'POINT'
+
+def test_nodded():
+
+    # An exposure using a NOD dither pattern
+    input = datamodels.ImageModel((10,10))
+
+    input.meta.exposure.type = 'NRS_IFU'
+    input.meta.observation.bkgdtarg = False
+    input.meta.dither.primary_type = '2-POINT-NOD'
+    input.meta.target.source_type = 'EXTENDED'
+
+    output = srctype.set_source_type(input)
+
+    # Result should be POINT regardless of input setting
+    assert output.meta.target.source_type == 'POINT'
+
+def test_user_input():
+
+    # An exposure with the value set upstream by the user
+    input = datamodels.ImageModel((10,10))
+
+    input.meta.exposure.type = 'NRS_IFU'
+    input.meta.observation.bkgdtarg = False
+    input.meta.dither.primary_type = '4-POINT'
+    input.meta.target.source_type = 'POINT'
+
+    output = srctype.set_source_type(input)
+
+    # Result should be POINT regardless of other input settings
+    assert output.meta.target.source_type == 'POINT'
+
+def test_unknown():
+
+    # An exposure with upstream input UNKNOWN
+    input = datamodels.ImageModel((10,10))
+
+    input.meta.exposure.type = 'MIR_MRS'
+    input.meta.observation.bkgdtarg = False
+    input.meta.dither.primary_type = '2-POINT'
+    input.meta.target.source_type = 'UNKNOWN'
+
+    output = srctype.set_source_type(input)
+
+    # Result should be EXTENDED regardless of other input settings
+    assert output.meta.target.source_type == 'EXTENDED'
+
+def test_no_sourcetype():
+
+    # An exposure without the SRCTYPE keyword present at all
+    input = datamodels.ImageModel((10,10))
+
+    input.meta.exposure.type = 'MIR_LRS-FIXEDSLIT'
+    input.meta.observation.bkgdtarg = False
+    input.meta.dither.primary_type = '2-POINT'
+
+    output = srctype.set_source_type(input)
+
+    # Result should be POINT regardless of other input settings
+    assert output.meta.target.source_type == 'POINT'


### PR DESCRIPTION
Updated the srctype step to apply more logic in certain situations. The new hierarchy is:
 - If it's a background target, set SRCTYPE = 'EXTENDED' no matter what (ignore any user input)
 - If it's a nodded exposure, set SRCTYPE = 'POINT' no matter what (ignore any user input)
 - If neither of those situations apply, use the user input, if it exists
 - If all else fails, apply specified defaults

The first 2 allow for correct functioning of down-stream steps, such as `extract_1d`, so that they do the proper thing when deciding how to do their processing.

Note that all of this logic only applies to observing modes that have a single pre-defined target/source, such as MIRI LRS, MIRI MRS, NIRSpec fixed-slit, and NIRSpec IFU. NIRSpec MOS still uses the stellarity values supplied in the MSA meta data file.

Fixes #3294