### PR TITLE
Guide star keyword updates

### DIFF
--- a/jwst/datamodels/schemas/guider_cal.schema.yaml
+++ b/jwst/datamodels/schemas/guider_cal.schema.yaml
@@ -14,13 +14,8 @@ allOf:
           fits_hdu: FGS Centroid Packet
         guide_star_state:
           title: "Guide star state: track or fine_guide"
-          type: number
-          fits_keyword: GUIDESTA
-          fits_hdu: FGS Centroid Packet
-        guide_star_acq_state:
-          title: State of guide star acquisition sequence
           type: string
-          fits_keyword: GS_STATE
+          fits_keyword: GUIDESTA
           fits_hdu: FGS Centroid Packet
         ddc_field_point:
           title: Differential Distortion Compensation field point

--- a/jwst/datamodels/schemas/guider_raw.schema.yaml
+++ b/jwst/datamodels/schemas/guider_raw.schema.yaml
@@ -14,13 +14,8 @@ allOf:
           fits_hdu: FGS Centroid Packet
         guide_star_state:
           title: "Guide star state: track or fine_guide"
-          type: number
-          fits_keyword: GUIDESTA
-          fits_hdu: FGS Centroid Packet
-        guide_star_acq_state:
-          title: State of guide star acquisition sequence
           type: string
-          fits_keyword: GS_STATE
+          fits_keyword: GUIDESTA
           fits_hdu: FGS Centroid Packet
         ddc_field_point:
           title: Differential Distortion Compensation field point


### PR DESCRIPTION
Removed keyword GS_STATE and changed data type of GUIDESTA from number to string in both guide-star data model schemas.

Fixes #3312