### PR TITLE
Apply pathloss correction to NIRSpec and NIRISS SOSS data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,11 @@ outlier_detection
 - Fixed a bug that was causing the step to crash when calling the
   ``cube_build`` step for MIRI MRS data. [#3296]
 
+pathloss
+--------
+
+- Updated to apply the correction to the science data and err arrays. [#3323]
+
 reffile_utils
 -------------
 

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -36,7 +36,7 @@ It creates 2 pairs of 1-d arrays, a wavelength array (calculated from the WCS ap
 the index of the plane in the wavelength direction) and a pathloss array
 calculated by interpolating each plane of the pathloss cube at the position of
 the source (which is taken from datamodel).  There are pairs of these arrays for
-both pointsource and uniformsource data types.
+both point source and uniform source data types.
 
 For the uniform source pathloss calculation, there is no dependence on position
 in the aperture, so the array of pathlosses and calculated wavelengths are attached

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -50,6 +50,7 @@ allOf:
       ndim: 2
       default: 0.0
       datatype: float32
+- $ref: pathlosscorr.schema.yaml
 - type: object
   properties:
     meta:

--- a/jwst/datamodels/schemas/pathlosscorr.schema.yaml
+++ b/jwst/datamodels/schemas/pathlosscorr.schema.yaml
@@ -1,7 +1,7 @@
 type: object
 properties:
   pathloss:
-    title: 2D array for pathloss
+    title: Path loss correction
     fits_hdu: PATHLOSS
     ndim: 2
     datatype: float32

--- a/jwst/datamodels/schemas/pathlosscorr.schema.yaml
+++ b/jwst/datamodels/schemas/pathlosscorr.schema.yaml
@@ -1,34 +1,8 @@
 type: object
 properties:
-  pathloss_pointsource2d:
-    title: 2-d array for pathloss (point source)
-    fits_hdu: PATHLOSS_POINTSOURCE2D
+  pathloss:
+    title: 2D array for pathloss
+    fits_hdu: PATHLOSS
     ndim: 2
     datatype: float32
-  pathloss_pointsource:
-    title: pathloss array for point sources
-    fits_hdu: PATHLOSS_POINTSOURCE
-    ndim: 1
-    datatype: float32
-  wavelength_pointsource:
-    title: wavelength array for point sources
-    fits_hdu: WAVELENGTH_POINTSOURCE
-    ndim: 1
-    datatype: float32
-  pathloss_uniformsource2d:
-    title: 2-d array for pathloss (uniform source)
-    fits_hdu: PATHLOSS_UNIFORMSOURCE2D
-    ndim: 2
-    datatype: float32
-  pathloss_uniformsource:
-    title: pathloss_array for uniform sources
-    fits_hdu: PATHLOSS_UNIFORMSOURCE
-    ndim: 1
-    datatype: float32
-  wavelength_uniformsource:
-    title: wavelength array for uniform sources
-    fits_hdu: WAVELENGTH_UNIFORMSOURCE
-    ndim: 1
-    datatype: float32
-
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -586,14 +586,14 @@ def test_slit_from_image():
     im.meta.instrument.name = "MIRI"
     slit_dm = SlitDataModel(im)
     assert_allclose(im.data, slit_dm.data)
-    assert hasattr(slit_dm, 'pathloss_pointsource')
+    assert hasattr(slit_dm, 'wavelength')
     # this should be enabled after gwcs starts using non-coordinate inputs
     #assert not hasattr(slit_dm, 'meta')
 
     slit = SlitModel(im)
     assert_allclose(im.data, slit.data)
     assert_allclose(im.err, slit.err)
-    assert hasattr(slit, 'pathloss_pointsource')
+    assert hasattr(slit, 'wavelength')
     assert slit.meta.instrument.name == "MIRI"
 
     im = ImageModel(slit)

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -419,7 +419,6 @@ def do_correction(input_model, pathloss_model):
                                       dx * pathloss_array[refrow_index, ix + 1]
 
         pathloss_2d = np.broadcast_to(correction, input_model.data.shape)
-        print(pathloss_2d.mean())
         output_model.data /= pathloss_2d
         output_model.err /= pathloss_2d
         output_model.var_poisson /= pathloss_2d**2

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -10,6 +10,7 @@ from gwcs import wcstools
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+
 # There are 30 slices in the NIRSPEC IFU, numbered from
 # 0 to 29
 NIRSPEC_IFU_SLICES = np.arange(30)
@@ -49,14 +50,17 @@ def get_aperture_from_model(input_model, match):
     """
     if input_model.meta.exposure.type == 'NRS_MSASPEC':
         for aperture in input_model.apertures:
-            if aperture.shutters == match: return aperture
+            if aperture.shutters == match:
+                return aperture
     elif input_model.meta.exposure.type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ',
                                             'NIS_SOSS']:
         for aperture in input_model.apertures:
             log.debug(aperture.name)
-            if aperture.name == match: return aperture
+            if aperture.name == match:
+                return aperture
     else:
-        log.warning('Unable to get aperture from model type {0}'.format(input_model.meta.exposure.type))
+        log.warning("Unable to get aperture from "
+            "model type {0}".format(input_model.meta.exposure.type))
 
     # If nothing matches, return None
     return None
@@ -140,8 +144,8 @@ def calculate_pathloss_vector(pathloss_refdata,
         cdelt2 = pathloss_wcs.cdelt2
         object_colindex = crpix1 + (xcenter - crval1) / cdelt1 - 1
         object_rowindex = crpix2 + (ycenter - crval2) / cdelt2 - 1
-        if (object_colindex < 0 or object_colindex >= (ncols-1) or 
-            object_rowindex < 0 or object_rowindex >= (nrows-1)):
+        if (object_colindex < 0 or object_colindex >= (ncols - 1) or
+            object_rowindex < 0 or object_rowindex >= (nrows - 1)):
             is_inside_slitlet = False
         else:
 
@@ -237,15 +241,16 @@ def do_correction(input_model, pathloss_model):
                         slit.var_poisson /= pathloss_2d**2
                         slit.pathloss = pathloss_2d
                     else:
-                        log.warning("Source is outside slitlet, \
-                        skipping pathloss correction for this slitlet")
+                        log.warning("Source is outside slit.  Skipping "
+                        "pathloss correction for slit {}".format(slit_number))
                 else:
-                    log.warning("Cannot find matching pathloss model for slit with size {}, \
-                    skipping pathloss correction for this slitlet".format(nshutters))
+                    log.warning("Cannot find matching pathloss model for slit "
+                        "with {} shutters, skipping pathloss correction for this "
+                        "slit".format(nshutters))
                     continue
             else:
-                log.warning("Slit has data size = {}, \
-                skipping pathloss correction for this slitlet".format(size))
+                log.warning("Slit has data size = {}, skipping "
+                    "pathloss correction for this slitlet".format(size))
         output_model.meta.cal_step.pathloss = 'COMPLETE'
     elif exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
         slit_number = 0
@@ -261,7 +266,7 @@ def do_correction(input_model, pathloss_model):
             # Get the aperture from the reference file that matches the slit
             aperture = get_aperture_from_model(pathloss_model, slit.name)
             if aperture is not None:
-                log.info("Using aperture {0}".format(aperture.name))
+                log.info("Using aperture {}".format(aperture.name))
                 (wavelength_pointsource,
                  pathloss_pointsource_vector,
                  is_inside_slit) = calculate_pathloss_vector(aperture.pointsource_data,
@@ -298,10 +303,11 @@ def do_correction(input_model, pathloss_model):
                     slit.var_poisson /= pathloss_2d**2
                     slit.pathloss = pathloss_2d
                 else:
-                    log.warning("Source is outside slit, skipping pathloss correction for this slit")
+                    log.warning("Source is outside slit.  Skipping "
+                        "pathloss correction for slit {}".format(slit.name))
             else:
-                log.warning("Cannot find matching pathloss model for aperture {}, \
-                skipping pathloss correction for this slit".format(slit.name))
+                log.warning("Cannot find matching pathloss model for aperture {} "
+                    "skipping pathloss correction for this slit".format(slit.name))
                 continue
         output_model.meta.cal_step.pathloss = 'COMPLETE'
     elif exp_type == 'NRS_IFU':
@@ -379,7 +385,8 @@ def do_correction(input_model, pathloss_model):
         # Get the aperture from the reference file that matches the subarray
         aperture = get_aperture_from_model(pathloss_model, subarray)
         if aperture is None:
-            log.warning("Unable to get Aperture from reference file for subarray {}".format(subarray))
+            log.warning("Unable to get Aperture from reference file "
+                "for subarray {}".format(subarray))
             log.warning("Pathloss correction skipped")
             output_model.meta.cal_step.pathloss = 'SKIPPED'
             return output_model

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -220,23 +220,22 @@ def do_correction(input_model, pathloss_model):
 
                         wavelength_array = slit.wavelength
 
-                        # Compute and apply the 2D correction
+                        # Compute the pathloss 2D correction
                         if is_pointsource(slit.source_type):
-                            pathloss_pointsource_2d = interpolate_onto_grid(
+                            pathloss_2d = interpolate_onto_grid(
                                 wavelength_array,
                                 wavelength_pointsource,
                                 pathloss_pointsource_vector)
-                            slit.data /= pathloss_pointsource_2d
-                            slit.err /= pathloss_pointsource_2d
-                            slit.var_poisson /= pathloss_pointsource_2d**2
                         else:
-                            pathloss_uniformsource_2d = interpolate_onto_grid(
+                            pathloss_2d = interpolate_onto_grid(
                                 wavelength_array,
                                 wavelength_uniformsource,
                                 pathloss_uniform_vector)
-                            slit.data /= pathloss_uniformsource_2d
-                            slit.err /= pathloss_uniformsource_2d
-                            slit.var_poisson /= pathloss_uniformsource_2d**2
+                        # Apply the pathloss 2D correction and attach to datamodel
+                        slit.data /= pathloss_2d
+                        slit.err /= pathloss_2d
+                        slit.var_poisson /= pathloss_2d**2
+                        slit.pathloss = pathloss_2d
                     else:
                         log.warning("Source is outside slitlet, \
                         skipping pathloss correction for this slitlet")
@@ -282,23 +281,22 @@ def do_correction(input_model, pathloss_model):
 
                     wavelength_array = slit.wavelength
 
-                    # Compute and apply the 2D correction
+                    # Compute the pathloss 2D correction
                     if is_pointsource(slit.source_type):
-                        pathloss_pointsource_2d = interpolate_onto_grid(
+                        pathloss_2d = interpolate_onto_grid(
                             wavelength_array,
                             wavelength_pointsource,
                             pathloss_pointsource_vector)
-                        slit.data /= pathloss_pointsource_2d
-                        slit.err /= pathloss_pointsource_2d
-                        slit.var_poisson /= pathloss_pointsource_2d**2
                     else:
-                        pathloss_uniformsource_2d = interpolate_onto_grid(
+                        pathloss_2d = interpolate_onto_grid(
                             wavelength_array,
                             wavelength_uniformsource,
                             pathloss_uniform_vector)
-                        slit.data /= pathloss_uniformsource_2d
-                        slit.err /= pathloss_uniformsource_2d
-                        slit.var_poisson /= pathloss_uniformsource_2d**2
+                    # Apply the pathloss 2D correction and attach to datamodel
+                    slit.data /= pathloss_2d
+                    slit.err /= pathloss_2d
+                    slit.var_poisson /= pathloss_2d**2
+                    slit.pathloss = pathloss_2d
                 else:
                     log.warning("Source is outside slit, skipping pathloss correction for this slit")
             else:
@@ -341,23 +339,22 @@ def do_correction(input_model, pathloss_model):
             ra, dec, wavelength = slice_wcs(x, y)
             wavelength_array[ymin:ymax+1, xmin:xmax+1] = wavelength
 
-        # Compute and apply the 2D correction
+        # Compute the pathloss 2D correction
         if is_pointsource(input_model.meta.target.source_type):
-            pathloss_pointsource_2d = interpolate_onto_grid(
+            pathloss_2d = interpolate_onto_grid(
                 wavelength_array,
                 wavelength_pointsource,
                 pathloss_pointsource_vector)
-            output_model.data /= pathloss_pointsource_2d
-            output_model.err /= pathloss_pointsource_2d
-            output_model.var_poisson /= pathloss_pointsource_2d**2
         else:
-            pathloss_uniformsource_2d = interpolate_onto_grid(
+            pathloss_2d = interpolate_onto_grid(
                 wavelength_array,
                 wavelength_uniformsource,
                 pathloss_uniform_vector)
-            output_model.data /= pathloss_uniformsource_2d
-            output_model.err /= pathloss_uniformsource_2d
-            output_model.var_poisson /= pathloss_uniformsource_2d**2
+        # Apply the pathloss 2D correction and attach to datamodel
+        output_model.data /= pathloss_2d
+        output_model.err /= pathloss_2d
+        output_model.var_poisson /= pathloss_2d**2
+        output_model.pathloss = pathloss_2d
 
         # This might be useful to other steps
         output_model.wavelength = wavelength_array
@@ -413,7 +410,13 @@ def do_correction(input_model, pathloss_model):
                     correction[row] = (1.0 - dx) * pathloss_array[refrow_index, ix] + \
                                       dx * pathloss_array[refrow_index, ix + 1]
 
-        output_model.pathloss_pointsource = correction
+        # How do we apply for NIRISS?
+        # output_model.data /= pathloss_2d
+        # output_model.err /= pathloss_2d
+        # output_model.var_poisson /= pathloss_2d**2
+        # output_model.pathloss = pathloss_2d
+
+        output_model.pathloss = correction
         output_model.meta.cal_step.pathloss = 'COMPLETE'
 
     return output_model

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -10,19 +10,18 @@ from gwcs import wcstools
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-#
 # There are 30 slices in the NIRSPEC IFU, numbered from
 # 0 to 29
 NIRSPEC_IFU_SLICES = np.arange(30)
 
-def getCenter(exp_type, input):
+def get_center(exp_type, input):
     """
     Get the center of the target in the aperture.
     (0.0, 0.0) is the aperture center.  Coordinates go
     from -0.5 to 0.5.
     """
     if exp_type == "NRS_IFU":
-        #
+
         # Currently assume IFU sources are centered
         return (0.0, 0.0)
     elif exp_type in ["NRS_MSASPEC", "NRS_FIXEDSLIT", "NRS_BRIGHTOBJ"]:
@@ -43,7 +42,7 @@ def getCenter(exp_type, input):
         log.warning("Using (0.0, 0.0)")
         return (0.0, 0.0)
 
-def getApertureFromModel(input_model, match):
+def get_aperture_from_model(input_model, match):
     """Figure out the correct aperture based on the value of the 'match'
     parameter.  For MSA, match is the number of shutters, for fixed slit,
     match is the name of the slit
@@ -58,7 +57,7 @@ def getApertureFromModel(input_model, match):
             if aperture.name == match: return aperture
     else:
         log.warning('Unable to get aperture from model type {0}'.format(input_model.meta.exposure.type))
-    #
+
     # If nothing matches, return None
     return None
 
@@ -112,7 +111,7 @@ def calculate_pathloss_vector(pathloss_refdata,
         wavesize = pathloss_refdata.shape[0]
     wavelength = np.zeros(wavesize, dtype=np.float32)
     pathloss_vector = np.zeros(wavesize, dtype=np.float32)
-    #
+
     # uniformsource.data is 1-d, we just return it, along with
     # a vector of wavelengths calculated using the WCS
     # Uniform source is always inside the slitlet
@@ -123,7 +122,7 @@ def calculate_pathloss_vector(pathloss_refdata,
         for i in np.arange(wavesize):
             wavelength[i] = crval1 +(float(i+1) - crpix1)*cdelt1
         return wavelength, pathloss_refdata, True
-    #
+
     # pointsource.data is 3-d, so we have to extract a wavelength vector
     # at the specified location.  We do this using bilinear interpolation
     else:
@@ -145,7 +144,7 @@ def calculate_pathloss_vector(pathloss_refdata,
             object_rowindex < 0 or object_rowindex >= (nrows-1)):
             is_inside_slitlet = False
         else:
-            #
+
             # Do bilinear interpolation to get the array of
             # path loss vs wavelength
             dx1 = object_colindex - int(object_colindex)
@@ -185,22 +184,22 @@ def do_correction(input_model, pathloss_model):
     """
     exp_type = input_model.meta.exposure.type
     log.info(exp_type)
+    output_model = input_model.copy()
     if exp_type == 'NRS_MSASPEC':
         slit_number = 0
-        # For each slit
-        for slit in input_model.slits:
+        for slit in output_model.slits:
             slit_number = slit_number + 1
             log.info('Working on slit {}'.format(slit_number))
             size = slit.data.size
             # That has data.size > 0
             if size > 0:
                 # Get centering
-                xcenter, ycenter = getCenter(exp_type, slit)
+                xcenter, ycenter = get_center(exp_type, slit)
                 # Calculate the 1-d wavelength and pathloss vectors
                 # for the source position
                 # Get the aperture from the reference file that matches the slit
                 nshutters = util.get_num_msa_open_shutters(slit.shutter_state)
-                aperture = getApertureFromModel(pathloss_model, nshutters)
+                aperture = get_aperture_from_model(pathloss_model, nshutters)
                 if aperture is not None:
                     (wavelength_pointsource,
                      pathloss_pointsource_vector,
@@ -213,26 +212,31 @@ def do_correction(input_model, pathloss_model):
                                                         aperture.uniform_wcs,
                                                         xcenter, ycenter)
                     if is_inside_slitlet:
-                        #
+
                         # Wavelengths in the reference file are in meters,
                         #need them to be in microns
                         wavelength_pointsource *= 1.0e6
                         wavelength_uniformsource *= 1.0e6
-                        slit.pathloss_pointsource = pathloss_pointsource_vector
-                        slit.wavelength_pointsource =  wavelength_pointsource
-                        slit.pathloss_uniformsource = pathloss_uniform_vector
-                        slit.wavelength_uniformsource = wavelength_uniformsource
-                        #
-                        # Create the 2-d pathloss arrays
+
                         wavelength_array = slit.wavelength
-                        pathloss_pointsource_2d = interpolate_onto_grid(wavelength_array,
-                                                                        wavelength_pointsource,
-                                                                        pathloss_pointsource_vector)
-                        pathloss_uniformsource_2d = interpolate_onto_grid(wavelength_array,
-                                                                          wavelength_uniformsource,
-                                                                          pathloss_uniform_vector)
-                        slit.pathloss_pointsource2d = pathloss_pointsource_2d
-                        slit.pathloss_uniformsource2d = pathloss_uniformsource_2d
+
+                        # Compute and apply the 2D correction
+                        if is_pointsource(slit.source_type):
+                            pathloss_pointsource_2d = interpolate_onto_grid(
+                                wavelength_array,
+                                wavelength_pointsource,
+                                pathloss_pointsource_vector)
+                            slit.data /= pathloss_pointsource_2d
+                            slit.err /= pathloss_pointsource_2d
+                            slit.var_poisson /= pathloss_pointsource_2d**2
+                        else:
+                            pathloss_uniformsource_2d = interpolate_onto_grid(
+                                wavelength_array,
+                                wavelength_uniformsource,
+                                pathloss_uniform_vector)
+                            slit.data /= pathloss_uniformsource_2d
+                            slit.err /= pathloss_uniformsource_2d
+                            slit.var_poisson /= pathloss_uniformsource_2d**2
                     else:
                         log.warning("Source is outside slitlet, \
                         skipping pathloss correction for this slitlet")
@@ -243,20 +247,20 @@ def do_correction(input_model, pathloss_model):
             else:
                 log.warning("Slit has data size = {}, \
                 skipping pathloss correction for this slitlet".format(size))
-        input_model.meta.cal_step.pathloss = 'COMPLETE'
+        output_model.meta.cal_step.pathloss = 'COMPLETE'
     elif exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
         slit_number = 0
         is_inside_slit = True
         # For each slit
-        for slit in input_model.slits:
+        for slit in output_model.slits:
             log.info(slit.name)
             slit_number = slit_number + 1
             # Get centering
-            xcenter, ycenter = getCenter(exp_type, slit)
+            xcenter, ycenter = get_center(exp_type, slit)
             # Calculate the 1-d wavelength and pathloss vectors
             # for the source position
             # Get the aperture from the reference file that matches the slit
-            aperture = getApertureFromModel(pathloss_model, slit.name)
+            aperture = get_aperture_from_model(pathloss_model, slit.name)
             if aperture is not None:
                 log.info("Using aperture {0}".format(aperture.name))
                 (wavelength_pointsource,
@@ -270,37 +274,42 @@ def do_correction(input_model, pathloss_model):
                                                     aperture.uniform_wcs,
                                                     xcenter, ycenter)
                 if is_inside_slit:
-                    #
+
                     # Wavelengths in the reference file are in meters, need them to be
                     # in microns
                     wavelength_pointsource *= 1.0e6
                     wavelength_uniformsource *= 1.0e6
-                    slit.pathloss_pointsource = pathloss_pointsource_vector
-                    slit.wavelength_pointsource =  wavelength_pointsource
-                    slit.pathloss_uniformsource = pathloss_uniform_vector
-                    slit.wavelength_uniformsource = wavelength_uniformsource
-                    #
-                    # Create the 2-d pathloss arrays
+
                     wavelength_array = slit.wavelength
-                    pathloss_pointsource_2d = interpolate_onto_grid(wavelength_array,
-                                                                    wavelength_pointsource,
-                                                                    pathloss_pointsource_vector)
-                    pathloss_uniformsource_2d = interpolate_onto_grid(wavelength_array,
-                                                                      wavelength_uniformsource,
-                                                                      pathloss_uniform_vector)
-                    slit.pathloss_pointsource2d = pathloss_pointsource_2d
-                    slit.pathloss_uniformsource2d = pathloss_uniformsource_2d
+
+                    # Compute and apply the 2D correction
+                    if is_pointsource(slit.source_type):
+                        pathloss_pointsource_2d = interpolate_onto_grid(
+                            wavelength_array,
+                            wavelength_pointsource,
+                            pathloss_pointsource_vector)
+                        slit.data /= pathloss_pointsource_2d
+                        slit.err /= pathloss_pointsource_2d
+                        slit.var_poisson /= pathloss_pointsource_2d**2
+                    else:
+                        pathloss_uniformsource_2d = interpolate_onto_grid(
+                            wavelength_array,
+                            wavelength_uniformsource,
+                            pathloss_uniform_vector)
+                        slit.data /= pathloss_uniformsource_2d
+                        slit.err /= pathloss_uniformsource_2d
+                        slit.var_poisson /= pathloss_uniformsource_2d**2
                 else:
                     log.warning("Source is outside slit, skipping pathloss correction for this slit")
             else:
                 log.warning("Cannot find matching pathloss model for aperture {}, \
                 skipping pathloss correction for this slit".format(slit.name))
                 continue
-        input_model.meta.cal_step.pathloss = 'COMPLETE'
+        output_model.meta.cal_step.pathloss = 'COMPLETE'
     elif exp_type == 'NRS_IFU':
         # IFU targets are always inside slit
         # Get centering
-        xcenter, ycenter = getCenter(exp_type, None)
+        xcenter, ycenter = get_center(exp_type, None)
         # Calculate the 1-d wavelength and pathloss vectors
         # for the source position
         aperture = pathloss_model.apertures[0]
@@ -318,11 +327,7 @@ def do_correction(input_model, pathloss_model):
         # in microns
         wavelength_pointsource *= 1.0e6
         wavelength_uniformsource *= 1.0e6
-        input_model.wavelength_pointsource = wavelength_pointsource
-        input_model.pathloss_pointsource = pathloss_pointsource_vector
-        input_model.wavelength_uniformsource = wavelength_uniformsource
-        input_model.pathloss_uniformsource = pathloss_uniform_vector
-        #
+
         # Create the 2-d pathloss arrays, initialize with NaNs
         wavelength_array = np.zeros(input_model.shape, dtype=np.float32)
         wavelength_array.fill(np.nan)
@@ -335,18 +340,29 @@ def do_correction(input_model, pathloss_model):
             ymax = int(y.max())
             ra, dec, wavelength = slice_wcs(x, y)
             wavelength_array[ymin:ymax+1, xmin:xmax+1] = wavelength
-        pathloss_pointsource_2d = interpolate_onto_grid(wavelength_array,
-                                                        wavelength_pointsource,
-                                                        pathloss_pointsource_vector)
-        pathloss_uniformsource_2d = interpolate_onto_grid(wavelength_array,
-                                                          wavelength_uniformsource,
-                                                          pathloss_uniform_vector)
-        input_model.pathloss_pointsource2d = pathloss_pointsource_2d
-        input_model.pathloss_uniformsource2d = pathloss_uniformsource_2d
-        #
+
+        # Compute and apply the 2D correction
+        if is_pointsource(input_model.meta.target.source_type):
+            pathloss_pointsource_2d = interpolate_onto_grid(
+                wavelength_array,
+                wavelength_pointsource,
+                pathloss_pointsource_vector)
+            output_model.data /= pathloss_pointsource_2d
+            output_model.err /= pathloss_pointsource_2d
+            output_model.var_poisson /= pathloss_pointsource_2d**2
+        else:
+            pathloss_uniformsource_2d = interpolate_onto_grid(
+                wavelength_array,
+                wavelength_uniformsource,
+                pathloss_uniform_vector)
+            output_model.data /= pathloss_uniformsource_2d
+            output_model.err /= pathloss_uniformsource_2d
+            output_model.var_poisson /= pathloss_uniformsource_2d**2
+
         # This might be useful to other steps
-        input_model.wavelength = wavelength_array
-        input_model.meta.cal_step.pathloss = 'COMPLETE'
+        output_model.wavelength = wavelength_array
+
+        output_model.meta.cal_step.pathloss = 'COMPLETE'
 
     elif exp_type == 'NIS_SOSS':
         """NIRISS SOSS pathloss correction is basically a correction for the
@@ -359,15 +375,17 @@ def do_correction(input_model, pathloss_model):
         # Omit correction if this is a TSO observation
         if input_model.meta.visit.tsovisit:
             log.warning("NIRISS SOSS TSO observations skip the pathloss step")
-            return input_model
+            output_model.meta.cal_step.pathloss = 'SKIPPED'
+            return output_model
         pupil_wheel_position = input_model.meta.instrument.pupil_position
         subarray = input_model.meta.subarray.name
         # Get the aperture from the reference file that matches the subarray
-        aperture = getApertureFromModel(pathloss_model, subarray)
+        aperture = get_aperture_from_model(pathloss_model, subarray)
         if aperture is None:
             log.warning("Unable to get Aperture from reference file for subarray {}".format(subarray))
             log.warning("Pathloss correction skipped")
-            return input_model
+            output_model.meta.cal_step.pathloss = 'SKIPPED'
+            return output_model
         else:
             log.info("Aperture {} selected from reference file".format(aperture.name))
         pathloss_array = aperture.pointsource_data[0]
@@ -394,8 +412,11 @@ def do_correction(input_model, pathloss_model):
                 else:
                     correction[row] = (1.0 - dx) * pathloss_array[refrow_index, ix] + \
                                       dx * pathloss_array[refrow_index, ix + 1]
-        input_model.pathloss_pointsource = correction
-    return input_model.copy()
+
+        output_model.pathloss_pointsource = correction
+        output_model.meta.cal_step.pathloss = 'COMPLETE'
+
+    return output_model
 
 def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
     """
@@ -425,7 +446,7 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
     grid of pathloss corrections for each non-Nan pixel
 
     """
-    #
+
     # Need to set the pathloss correction of pixels whose wavelength is outside
     # the wavelength range of the reference file to NaN.  This trick will acomplish
     # that while still allowing the use of array linear interpolation
@@ -442,7 +463,6 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
     extended_wavelength_vector[0] = wavelength_vector[0] - 0.1
     extended_wavelength_vector[-1] = wavelength_vector[-1] + 0.1
 
-    #
     # Find the indices in the original wavelength array that correspond
     # to the lower of 2 adjacent wavelength values spanning the wavelength
     # values in the wavelength grid.  NaNs and values > max wavelength will
@@ -450,11 +470,11 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
     # will return 0
     upper_indices = np.searchsorted(wavelength_vector,
                                     wavelength_grid)
-    #
+
     # Move these indices so they correspond to the extended arrays
     lower_indices = upper_indices
     upper_indices = upper_indices + 1
-    #
+
     # Now we can just proceed without worrying about values outside the wavelength
     # array
     numerator = wavelength_grid - extended_wavelength_vector[lower_indices]
@@ -469,3 +489,12 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
                                  - extended_pathloss_vector[lower_indices]))
 
     return pathloss_grid
+
+def is_pointsource(srctype):
+    """Returns True if srctype is POINT"""
+    if srctype is None:
+        return False
+    elif srctype.upper() == 'POINT':
+        return True
+    else:
+        return False

--- a/jwst/pathloss/pathloss_step.py
+++ b/jwst/pathloss/pathloss_step.py
@@ -11,20 +11,7 @@ class PathLossStep(Step):
     into the data.
 
     Pathloss depends on the centering of the source in the aperture if the
-    source is a point source. This step fills the following attributes in the
-    datamodel:
-
-    - for exposure type `NRS_IFU`, the 1-d arrays .wavelength_pointsource,
-      .pathloss_pointsource, .wavelength_uniformsource and
-      .pathloss_uniformsource
-
-    - for exposure types NRS_FIXEDSLIT, NRS_BRIGHTOBJ, and NRS_MSASPEC, the
-      1-d arrays .slits[n].wavelength_pointsource,
-      .slits[n].pathloss_pointsource, .slits[n].wavelength_uniformsource and
-      .slits[n].pathloss_uniformsource
-
-    In all of these `EXP_TYPES`, these arrays are added to each
-    member of the `slits` attribute.
+    source is a point source.
     """
 
     spec = """

--- a/jwst/pathloss/pathloss_step.py
+++ b/jwst/pathloss/pathloss_step.py
@@ -1,6 +1,6 @@
 from ..stpipe import Step
 from .. import datamodels
-from . import path_loss
+from . import pathloss
 
 __all__ = ["PathLossStep"]
 
@@ -55,7 +55,7 @@ class PathLossStep(Step):
             pathloss_model = datamodels.PathlossModel(self.pathloss_name)
 
             # Do the pathloss correction
-            result = path_loss.do_correction(input_model, pathloss_model)
+            result = pathloss.do_correction(input_model, pathloss_model)
 
             pathloss_model.close()
 

--- a/jwst/tests/base_classes.py
+++ b/jwst/tests/base_classes.py
@@ -171,10 +171,9 @@ class BaseJWSTTestSteps(BaseJWSTTest):
 
         input_file = self.get_data(self.test_dir, input)
 
-        result = step_class.call(input_file, **step_pars)
+        result = step_class.call(input_file, save_results=True, **step_pars)
 
         output_file = result.meta.filename
-        result.save(output_file)
         result.close()
 
         output_pars = None

--- a/jwst/tests_nightly/general/niriss/test_niriss_steps.py
+++ b/jwst/tests_nightly/general/niriss/test_niriss_steps.py
@@ -11,6 +11,7 @@ from jwst.flatfield import FlatFieldStep
 from jwst.jump import JumpStep
 from jwst.linearity import LinearityStep
 from jwst.saturation import SaturationStep
+from jwst.pathloss import PathLossStep
 
 
 # Parameterized regression tests for NIRISS processing
@@ -91,6 +92,14 @@ class TestNIRISSSteps(BaseJWSTTestSteps):
                       output_truth='jw00034001001_01101_00001_NIRISS_saturation.fits',
                       output_hdus=[],
                       id='saturation_niriss'
+                      ),
+                 dict(input='soss_2AB_results_int_assign_wcs.fits',
+                      test_dir='test_pathloss',
+                      step_class=PathLossStep,
+                      step_pars=dict(),
+                      output_truth='soss_2AB_results_int_pathloss.fits',
+                      output_hdus=[],
+                      id='pathloss_niriss'
                       ),
                 ]
               }

--- a/jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
+++ b/jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
@@ -52,16 +52,11 @@ class TestSpec2Pipeline(BaseJWSTTest):
                 # test_nrs_ifu_spec2: NIRSpec IFU data
                  dict(input= 'jw95175001001_02104_00001_nrs1_rate.fits',
                       outputs=[('jw95175001001_02104_00001_nrs1_cal.fits',
-                                'jw95175001001_02104_00001_nrs1_cal_ref.fits',
-                                ['primary','sci','err','dq','relsens2d',
-                                    'pathloss_pointsource','wavelength_pointsource',
-                                    'pathloss_uniformsource','wavelength_uniformsource']),
+                                'jw95175001001_02104_00001_nrs1_cal_ref.fits'),
                                ('jw95175001001_02104_00001_nrs1_s3d.fits',
-                                'jw95175001001_02104_00001_nrs1_s3d_ref.fits',
-                                ['primary','sci','err','dq','wmap']),
+                                'jw95175001001_02104_00001_nrs1_s3d_ref.fits'),
                                ('jw95175001001_02104_00001_nrs1_x1d.fits',
-                                'jw95175001001_02104_00001_nrs1_x1d_ref.fits',
-                                ['primary','extract1d'])
+                                'jw95175001001_02104_00001_nrs1_x1d_ref.fits')
                               ],
                       id = "nirspec_ifu"
                       )


### PR DESCRIPTION
- Applies the computed pathloss correction to the `data, err, var_poisson` members of the datamodel
- Applies the `pathloss_pointsource2D` array if `SRCTYPE == "POINT"`, `pathloss_uniformsource2D` if `SRCTYPE == "EXTENDED"` or `None`.
- No longer attaches the various `pathloss_xxx` extensions.  Only a single `pathloss` extension representing the 2D correction applied.

### Questions:

1) ~~For NIRSpec IFU, is the distinction between point source and uniform source meaningful?  I.e. for a point source in the field, some slits will contain it and some won't.  Is this taken care of in the pathloss reffile?~~ This is taken care of in the reffile.

2) ~~It seems like the NIRISS SOSS (non-TSO) version of this step only computes a point source correction.  Should we be checking to make sure SRCTYPE == "POINT" before even computing the correction, and then apply it?~~ Instead of keying off SRCTYPE, this keys off aperture name.  It only gets applied for `SUBSTRIP96` aperture.  More info [here](https://jwst-docs.stsci.edu/display/JTI/NIRISS+Single+Object+Slitless+Spectroscopy#NIRISSSingleObjectSlitlessSpectroscopy-SOSSsubarrays)


Resolves #1152