### PR TITLE
Fix asdf_schema_tester for dev version of asdf

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,8 @@
-"""Project default for pytest"""
-from astropy.tests.helper import enable_deprecations_as_exceptions
+import pkg_resources
 
-enable_deprecations_as_exceptions()
+entry_points = []
+for entry_point in pkg_resources.iter_entry_points('pytest11'):
+    entry_points.append(entry_point.name)
 
-pytest_plugins = [
-    'asdf.tests.schema_tester'
-]
+if "asdf_schema_tester" not in entry_points:
+    pytest_plugins = ['asdf.tests.schema_tester']

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ exclude = jwst/extern,docs,jwst/associations,jwst/jwpsf,jwst/ramp_fitting, jwst/
 minversion = 3.6
 addopts = --ignore=build, -p no:warnings
 norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern scripts
+asdf_schema_tests_enabled = true
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 doctest_plus = enabled
 junit_family=xunit2


### PR DESCRIPTION
Currently, our builds against the dev version of `asdf` are failing because the schema tester has become an `entry_points` plugin.  This fixes the `jwst` package so it can get the plugin the old or new way.