### PR TITLE
Use target coordinates to shift extraction location

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,11 @@ extract_1d
 
 - Unit tests were added for IFU data. [#3285]
 
+- The target coordinates are used (for some modes) to determine the
+  extraction location, i.e. correcting for nod/dither offset.  For IFU,
+  the areas of the source aperture and background annulus are computed
+  differently. [#3362]
+
 master_background
 -----------------
 

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -47,7 +47,7 @@ extract_1d reference file.
 
 *  ``--apply_nod_offset``
 
-This is a boolean flag to specify whether the source and target positions
+This is a boolean flag to specify whether the target and background positions
 specified in the reference file should be shifted to account for nod
 and/or dither offset.  If None (the default), the value in the reference
 file will be used, or it will be set to True if it is not specified in

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -1,8 +1,7 @@
 Step Arguments
 ==============
 
-The extract_1d step has three step-specific arguments.  Currently none of
-these is used for IFU data.
+The extract_1d step has five step-specific arguments.
 
 *  ``--smoothing_length``
 
@@ -38,3 +37,24 @@ let the user know that the step is still running.
 ``log_increment`` is an integer, with default value 50.  If it is greater
 than 0, an INFO message will be printed every ``log_increment``
 integrations, e.g. "... 150 integrations done".
+
+*  ``--subtract_background``
+
+This is a boolean flag to specify whether the background should be
+subtracted.  If None, the value in the extract_1d reference file (if any)
+will be used.  If not None, this parameter overrides the value in the
+extract_1d reference file.
+
+*  ``--apply_nod_offset``
+
+This is a boolean flag to specify whether the source and target positions
+specified in the reference file should be shifted to account for nod
+and/or dither offset.  If None (the default), the value in the reference
+file will be used, or it will be set to True if it is not specified in
+the reference file.  The offset is determined by finding the location in
+the data corresponding to the target position (as given by keywords
+TARG_RA and TARG_DEC).
+
+At the time of writing, a nod/dither offset will not be applied if the
+source is extended.  It will also not be applied for wide-field slitless
+spectroscopy data, or NIRSpec fixed-slit, or NIRSpec MOS (MSA) data.

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -43,6 +43,21 @@ class Extract1dStep(Step):
         If None, the value in the extract_1d reference file will be used.
         If not None, this parameter overrides the value in the
         extract_1d reference file.
+
+    apply_nod_offset : bool or None
+        If True, the source and background positions specified in the
+        reference file (or the default position, if there is no reference
+        file) will be shifted to account for nod and/or dither offset.  If
+        None (the default), the value in the reference file will be used,
+        or it will be set to True if it is not specified in the reference
+        file.  This offset is determined by finding the location in the data
+        corresponding to the target position (keywords TARG_RA and TARG_DEC).
+        For NIRSpec fixed-slit or MOS data, there must be different target
+        coordinates for each slit for which a nod correction might be
+        needed, and this is not implemented yet in extract_1d.
+        It also doesn't make sense to apply a nod/dither offset for an
+        extended target, so this flag can internally be overridden (set to
+        False) for extended targets.
     """
 
     spec = """
@@ -55,6 +70,11 @@ class Extract1dStep(Step):
     log_increment = integer(default=50)
     # Flag indicating whether the background should be subtracted.
     subtract_background = boolean(default=None)
+    # If True, the locations of the target and background regions will be
+    # shifted to correct for the computed nod/dither offset.
+    # Currently this offset is not applied for NIRSpec fixed-slit or
+    # MOS (MSA) data), or for WFSS data.
+    apply_nod_offset = boolean(default=None)
     """
 
     reference_file_types = ['extract1d']
@@ -123,7 +143,8 @@ class Extract1dStep(Step):
                                                  self.smoothing_length,
                                                  self.bkg_order,
                                                  self.log_increment,
-                                                 self.subtract_background)
+                                                 self.subtract_background,
+                                                 self.apply_nod_offset)
                     # Set the step flag to complete in each MultiSpecModel
                     temp.meta.cal_step.extract_1d = 'COMPLETE'
                     result.append(temp)
@@ -142,7 +163,8 @@ class Extract1dStep(Step):
                                                self.smoothing_length,
                                                self.bkg_order,
                                                self.log_increment,
-                                               self.subtract_background)
+                                               self.subtract_background,
+                                               self.apply_nod_offset)
                 # Set the step flag to complete
                 result.meta.cal_step.extract_1d = 'COMPLETE'
             else:
@@ -163,7 +185,8 @@ class Extract1dStep(Step):
                                            self.smoothing_length,
                                            self.bkg_order,
                                            self.log_increment,
-                                           self.subtract_background)
+                                           self.subtract_background,
+                                           self.apply_nod_offset)
             # Set the step flag to complete
             result.meta.cal_step.extract_1d = 'COMPLETE'
 

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -47,9 +47,9 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
         extract_1d reference file.
 
     apply_nod_offset : bool or None
-        If True, the source and target positions specified in the reference
-        file (or the default position, if there is no reference file) will
-        be shifted to account for nod and/or dither offset.
+        If True, the target and background positions specified in the
+        reference file (or the default position, if there is no reference
+        file) will be shifted to account for nod and/or dither offset.
 
     Returns
     -------
@@ -784,7 +784,7 @@ def nans_in_wavelength(wavelength, net, background, npixels, dq):
 
 
 def separate_target_and_background(ref):
-    """Create masks for source and background.
+    """Create masks for target and background.
 
     Parameters
     ----------

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -443,9 +443,9 @@ def locn_from_wcs(input_model, ra_targ, dec_targ):
         # The arguments are the X, Y, and Z pixel coordinates, and the
         # output arrays will be 2-D.
         (ra_i, dec_i, wl) = input_model.meta.wcs(grid[1], grid[0], z)
-        rect = sph_to_rect(ra_i, dec_i)
-        v = sph_to_rect(ra_targ, dec_targ)
-        diff = rect - v
+        cart = celestial_to_cartesian(ra_i, dec_i)
+        v = celestial_to_cartesian(ra_targ, dec_targ)   # a single vector
+        diff = cart - v
         # We want the pixel with the minimum distance from v, but the pixel
         # with the minimum value of distance squared will be the same.
         dist2 = (diff**2).sum(axis=-1)
@@ -465,8 +465,8 @@ def locn_from_wcs(input_model, ra_targ, dec_targ):
     return locn
 
 
-def sph_to_rect(ra, dec):
-    """Convert celestial coordinates to rectangular.
+def celestial_to_cartesian(ra, dec):
+    """Convert celestial coordinates to Cartesian.
 
     Parameters
     ----------
@@ -476,13 +476,13 @@ def sph_to_rect(ra, dec):
 
     Returns
     -------
-    rect : ndarray
-        If `ra` and `dec` are float, `rect` with be a 3-element array.
-        If `ra` and `dec` are arrays, `rect` will be an array with shape
+    cart : ndarray
+        If `ra` and `dec` are float, `cart` with be a 3-element array.
+        If `ra` and `dec` are arrays, `cart` will be an array with shape
         ra.shape + (3,).
-        For each element of `ra` (or `dec`), the last axis of `rect` will
-        give the rectangular coordinates of a unit vector in the direction
-        `ra`, `dec`.  The elements of the vector in rectangular coordinates
+        For each element of `ra` (or `dec`), the last axis of `cart` will
+        give the Cartesian coordinates of a unit vector in the direction
+        `ra`, `dec`.  The elements of the vector in Cartesian coordinates
         are in the order x, y, z, where x is the direction toward the
         vernal equinox, y is the direction toward right ascension = 90
         degrees (6 hours) and declination = 0, and z is toward the north
@@ -494,13 +494,13 @@ def sph_to_rect(ra, dec):
     else:
         shape = (3,)
 
-    rect = np.zeros(shape, dtype=np.float64)
-    rect[..., 2] = np.sin(dec * np.pi / 180.)
+    cart = np.zeros(shape, dtype=np.float64)
+    cart[..., 2] = np.sin(dec * np.pi / 180.)
     r_xy = np.cos(dec * np.pi / 180.)
-    rect[..., 1] = r_xy * np.sin(ra * np.pi / 180.)
-    rect[..., 0] = r_xy * np.cos(ra * np.pi / 180.)
+    cart[..., 1] = r_xy * np.sin(ra * np.pi / 180.)
+    cart[..., 0] = r_xy * np.cos(ra * np.pi / 180.)
 
-    return rect
+    return cart
 
 
 def image_extract_ifu(input_model, source_type, extract_params):


### PR DESCRIPTION
The right ascension and declination of the target are now gotten from keywords TARG_RA and TARG_DEC, and the inverse WCS is used to find the location of that celestial point in the input image.  For a 2-D input image (or a stack of such images), that point is assumed to be the location of the spectrum in the cross-dispersion direction.  For an IFU cube, the forward WCS is evaluated at each pixel in one plane to compute the right ascension and declination (and wavelength), and the location of the target is taken to be the pixel with celestial coordinates that are closest to TARG_RA and TARG_DEC.  The extraction location will actually be shifted to the computed point, except for extended sources, WFSS modes, or (currently) NIRSpec fixed-slit or MOS.

For IFU, the computation of the areas of the source and background regions has been changed.  Instead of calling `aperture.area()` or `annulus.area()`, a temporary array filled with ones is created, and the aperture and annulus are applied to that array.  The 'aperture_sum' in the photometry table is then the actual area, i.e. accounting for the possibility that the aperture or annulus extends beyond the borders of the IFU image.

See JP-597 and JP-644.

Closes #3284.  Closes #3361.