### PR TITLE
Apply corrections to readnoise variance

### DIFF
--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -99,9 +99,8 @@ def do_correction(input_model, barshadow_model):
                 slitlet.barshadow = correction
 
                 # Apply the correction by dividing into the science and uncertainty arrays:
-                #     var_poission is divided by correction**2, because it's variance,
-                #         while err is standard deviation
-                #     var_rnoise is not changed, because it does not depend on signal level
+                #     var_poission and var_rnoise are divided by correction**2,
+                #     because they're variance, while err is standard deviation
                 slitlet.data /= correction
                 slitlet.err /= correction
                 slitlet.var_poisson /= correction**2

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -105,6 +105,7 @@ def do_correction(input_model, barshadow_model):
                 slitlet.data /= correction
                 slitlet.err /= correction
                 slitlet.var_poisson /= correction**2
+                slitlet.var_rnoise /= correction**2
             else:
                 log.info("Slitlet %d has zero length, correction skipped" % slitlet_number)
 

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -228,6 +228,7 @@ def do_correction(input_model, pathloss_model):
                         slit.data /= pathloss_2d
                         slit.err /= pathloss_2d
                         slit.var_poisson /= pathloss_2d**2
+                        slit.var_rnoise /= pathloss_2d**2
                         slit.pathloss = pathloss_2d
                     else:
                         log.warning("Source is outside slit.  Skipping "
@@ -290,6 +291,7 @@ def do_correction(input_model, pathloss_model):
                     slit.data /= pathloss_2d
                     slit.err /= pathloss_2d
                     slit.var_poisson /= pathloss_2d**2
+                    slit.var_rnoise /= pathloss_2d**2
                     slit.pathloss = pathloss_2d
                 else:
                     log.warning("Source is outside slit.  Skipping "
@@ -349,6 +351,7 @@ def do_correction(input_model, pathloss_model):
         output_model.data /= pathloss_2d
         output_model.err /= pathloss_2d
         output_model.var_poisson /= pathloss_2d**2
+        output_model.var_rnoise /= pathloss_2d**2
         output_model.pathloss = pathloss_2d
 
         # This might be useful to other steps
@@ -422,6 +425,7 @@ def do_correction(input_model, pathloss_model):
         output_model.data /= pathloss_2d
         output_model.err /= pathloss_2d
         output_model.var_poisson /= pathloss_2d**2
+        output_model.var_rnoise /= pathloss_2d**2
         output_model.pathloss = pathloss_2d
 
         output_model.meta.cal_step.pathloss = 'COMPLETE'


### PR DESCRIPTION
Updated the ``pathloss`` and ``barshadow`` steps to apply their corrections to the readnoise variance arrays, same as Poisson variance.

Fixes #3365.