### PR TITLE
Update set_telescope_pointing to convert FSMCORR units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,8 @@ set_telescope_pointing
 - Updates to prevent crashes when SIAF values needed for crpix or
   cdelt keywords are missing. [#3316]
 
+- Convert FSM correction values from arcsec to radians. [#3367]
+
 srctype
 -------
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -573,7 +573,7 @@ def calc_wcs(pointing, siaf, **transform_kwargs):
     return (wcsinfo, vinfo)
 
 
-def calc_transforms(pointing, siaf, fsmcorr_version='latest', j2fgs_transpose=True):
+def calc_transforms(pointing, siaf, fsmcorr_version='latest', fsmcorr_units='arcsec', j2fgs_transpose=True):
     """Calculate transforms from pointing to SIAF
 
     Given the spacecraft pointing parameters and the
@@ -582,17 +582,21 @@ def calc_transforms(pointing, siaf, fsmcorr_version='latest', j2fgs_transpose=Tr
 
     Parameters
     ----------
-    pointing: Pointing
+    pointing : Pointing
         Observatory pointing information
 
-    siaf: SIAF
+    siaf : SIAF
         Aperture information
 
-    fsmcorr_version: str
+    fsmcorr_version : str
         The version of the FSM correction calculation to use.
         See :ref:`calc_sifov_fsm_delta_matrix`
 
-    j2fgs_transpose: bool
+    fsmcorr_units : str
+        Units of the FSM correction values. Default is 'arcsec'.
+        See :ref:`calc_sifov_fsm_delta_matrix`
+
+    j2fgs_transpose : bool
         Transpose the `j2fgs1` matrix.
 
     Returns
@@ -623,7 +627,7 @@ def calc_transforms(pointing, siaf, fsmcorr_version='latest', j2fgs_transpose=Tr
 
     # Calculate the FSM corrections to the SI_FOV frame
     m_sifov_fsm_delta = calc_sifov_fsm_delta_matrix(
-        pointing.fsmcorr, fsmcorr_version=fsmcorr_version
+        pointing.fsmcorr, fsmcorr_version=fsmcorr_version, fsmcorr_units=fsmcorr_units
     )
 
     # Calculate the FGS1 ICS to SI-FOV matrix
@@ -828,22 +832,25 @@ def calc_j2fgs1_matrix(j2fgs_matrix, transpose=False):
     return transform
 
 
-def calc_sifov_fsm_delta_matrix(fsmcorr, fsmcorr_version='latest'):
+def calc_sifov_fsm_delta_matrix(fsmcorr, fsmcorr_version='latest', fsmcorr_units='arcsec'):
     """Calculate Fine Steering Mirror correction matrix
 
     Parameters
     ----------
-    fsmcorr: np.array((2,))
+    fsmcorr : np.array((2,))
         The FSM correction parameters:
             0: SA_ZADUCMDX
             1: SA_ZADUCMDY
 
-    fsmcorr_version: str
+    fsmcorr_version : str
         The version of the FSM correction calculation to use.
         Versions available:
             latest: The state-of-art. Currently `v2`
             v2: Update 201708 to use actual spherical calculations
             v1: Original linear approximation
+
+    fsmcorr_units : str
+        The units of the FSM correction values. Default is `arcsec`.
 
     Returns
     -------
@@ -851,12 +858,19 @@ def calc_sifov_fsm_delta_matrix(fsmcorr, fsmcorr_version='latest'):
         The transformation matrix
     """
     version = fsmcorr_version.lower()
+    units = fsmcorr_units.lower()
     logger.debug('Using version {}'.format(version))
+    logger.debug('Using units {}'.format(units))
 
     x = fsmcorr[0]  # SA_ZADUCMDX
     y = fsmcorr[1]  # SA_ZADUCMDY
 
-    # `V1`: Linear approximation calcuation
+    # If FSMCORR values are in arcsec, convert to radians
+    if units == 'arcsec':
+        x *= D2R / 3600.
+        y *= D2R / 3600.
+
+    # `V1`: Linear approximation calculation
     if version == 'v1':
         transform = np.array(
             [

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -264,6 +264,7 @@ def update_wcs(model, default_pa_v3=0., siaf_path=None, engdb_url=None,
     else:
         logger.warning("Aperture name is set to 'UNKNOWN'. "
                        "WCS keywords will not be populated from SIAF.")
+        siaf = SIAF()
 
     if exp_type in FGS_GUIDE_EXP_TYPES:
         update_wcs_from_fgs_guiding(

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -266,34 +266,10 @@ def test_add_wcs_default(data_file):
 
 def test_add_wcs_default_nosiaf(data_file_nosiaf, caplog):
     """Handle when no pointing exists and the default is used and no SIAF specified."""
-    try:
+    with pytest.raises(ValueError):
         stp.add_wcs(
             data_file_nosiaf, siaf_path=siaf_db, tolerance=0, allow_default=True
         )
-    except ValueError:
-        pass  # This is what we want for the test.
-    except Exception as e:
-        pytest.skip(
-            'Live ENGDB service is not accessible.'
-            '\nException={}'.format(e)
-        )
-
-    model = datamodels.Level1bModel(data_file_nosiaf)
-    assert model.meta.pointing.ra_v1 == TARG_RA
-    assert model.meta.pointing.dec_v1 == TARG_DEC
-    assert model.meta.pointing.pa_v3 == 0.
-    assert model.meta.wcsinfo.crval1 == TARG_RA
-    assert model.meta.wcsinfo.crval2 == TARG_DEC
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 1.0)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 1.0)
-    assert model.meta.wcsinfo.ra_ref == TARG_RA
-    assert model.meta.wcsinfo.dec_ref == TARG_DEC
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 360.)
-    assert model.meta.wcsinfo.wcsaxes == 2
-
-    assert 'Insufficient SIAF information found in header' in caplog.text
 
 
 @pytest.mark.skipif(sys.version_info.major<3,


### PR DESCRIPTION
Updated ``set_telescope_pointing`` to convert the input FSM correction values from units of arcsec to radians. Added the switch ``fsmcorr_units`` to allow for the possibility of processing older data that still had these values in radians to begin with.

Fixes #3300.