### PR TITLE
Fix DQ flagging in master background for NIRSpec IFU

### DIFF
--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -273,8 +273,9 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
             # mask_limit is indices into each WCS slice grid.  Need them in
             # full frame coordinates, so we use x and y, which are full-frame
             full_frame_ind = y[mask_limit].astype(int), x[mask_limit].astype(int)
-            background.dq[full_frame_ind] |= dqflags.pixel['DO_NOT_USE']
             # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
+            background.dq[full_frame_ind] = np.bitwise_or(background.dq[full_frame_ind],
+                                                          dqflags.pixel['DO_NOT_USE'])
 
             bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
                                  left=0., right=0.)
@@ -292,7 +293,8 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
         wl_array[mask_limit] = -1
 
         # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
-        background.dq[mask_limit] |= dqflags.pixel['DO_NOT_USE']
+        background.dq[mask_limit] = np.bitwise_or(background.dq[mask_limit],
+                                                  dqflags.pixel['DO_NOT_USE'])
         bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
                              left=0., right=0.)
         background.data[:, :] = bkg_flux.copy()

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -265,13 +265,17 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
             x, y = grid_from_bounding_box(ifu_wcs.bounding_box)
             wl_array = ifu_wcs(x, y)[2]
             wl_array[np.isnan(wl_array)] = -1.
-            # flag values outside of the background wavelength table
+
+            # mask wavelengths not covered by the master background
             mask_limit = (wl_array > max_wave) | (wl_array < min_wave)
             wl_array[mask_limit] = -1
 
+            # mask_limit is indices into each WCS slice grid.  Need them in
+            # full frame coordinates, so we use x and y, which are full-frame
+            full_frame_ind = y[mask_limit].astype(int), x[mask_limit].astype(int)
+            background.dq[full_frame_ind] |= dqflags.pixel['DO_NOT_USE']
             # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
-            background.dq[mask_limit] = np.bitwise_or(background.dq[mask_limit],
-                                                      dqflags.pixel['DO_NOT_USE'])
+
             bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
                                  left=0., right=0.)
             background.data[y.astype(int), x.astype(int)] = bkg_flux.copy()
@@ -288,8 +292,7 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
         wl_array[mask_limit] = -1
 
         # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
-        background.dq[mask_limit] = np.bitwise_or(background.dq[mask_limit],
-                                                dqflags.pixel['DO_NOT_USE'])
+        background.dq[mask_limit] |= dqflags.pixel['DO_NOT_USE']
         bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
                              left=0., right=0.)
         background.data[:, :] = bkg_flux.copy()

--- a/jwst/tests_nightly/general/miri/test_miri_steps.py
+++ b/jwst/tests_nightly/general/miri/test_miri_steps.py
@@ -100,7 +100,7 @@ class TestMIRISteps(BaseJWSTTestSteps):
                  dict(input='jw00035001001_01101_00001_mirimage_photom.fits',
                       test_dir='test_extract1d',
                       step_class=Extract1dStep,
-                      step_pars=dict(smoothing_length=0),
+                      step_pars=dict(suffix='x1d'),
                       output_truth='jw00035001001_01101_00001_mirimage_x1d.fits',
                       output_hdus=[],
                       id='extract1d_miri'
@@ -109,9 +109,9 @@ class TestMIRISteps(BaseJWSTTestSteps):
                  dict(input='jw80600012001_02101_00003_mirimage_photom.fits',
                       test_dir='test_extract1d',
                       step_class=Extract1dStep,
-                      step_pars=dict(smoothing_length=0),
+                      step_pars=dict(suffix='x1d'),
                       output_truth='jw80600012001_02101_00003_mirimage_x1d.fits',
-                      output_hdus=['primary',('extract1d',1),('extract1d',2),('extract1d',3),('extract1d',4)],
+                      output_hdus=[],
                       id='extract1d_miri2'
                      ),
                 # test_flat_field_miri: flat_field step performed on MIRI data.

--- a/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
@@ -181,23 +181,20 @@ class TestNIRSpecMasterBackground_FS(BaseJWSTTest):
     ref_loc = ['test_masterbackground', 'nrs-fs', 'truth']
     test_dir = ['test_masterbackground', 'nrs-fs']
 
-    def test_nirspec_masterbackground_fs_user1d(self):
+    def test_nirspec_fs_masterbg_user(self):
         """
-
-        Regression test of master background subtraction for NRS FS when a user 1-D spectrum is provided.
-
+        Regression test of master background subtraction for NRS FS when a
+        user 1-D spectrum is provided.
         """
         # input file has 2-D background image added to it
-        input_file = self.get_data(*self.test_dir,
-                                    'nrs_sci+bkg_cal.fits')
+        input_file = self.get_data(*self.test_dir, 'nrs_sci+bkg_cal.fits')
         # user provided 1-D background was created from the 2-D background image
-        input_1dbkg_file = self.get_data(*self.test_dir,
-                                          'nrs_bkg_user_clean_x1d.fits')
+        input_1dbkg_file = self.get_data(*self.test_dir, 'nrs_bkg_user_clean_x1d.fits')
 
         result = MasterBackgroundStep.call(input_file,
                                            user_background=input_1dbkg_file,
                                            save_results=True)
-        # _________________________________________________________________________
+
         # Test 1 compare 4 FS 1D extracted spectra from science data with
         # no background added to 4 FS 1D extracted spectra from the output
         # from MasterBackground subtraction
@@ -229,7 +226,7 @@ class TestNIRSpecMasterBackground_FS(BaseJWSTTest):
                                             'nrs_sci_cal.fits')
         input_sci = datamodels.open(input_sci_cal_file)
         for i in range(num_spec):
-            # ______________________________________________________________________
+
             # Test 1 compare extracted spectra data from the science data
             # to extracted spectra from the output
             # from MasterBackground subtraction.
@@ -252,7 +249,7 @@ class TestNIRSpecMasterBackground_FS(BaseJWSTTest):
             mean_sub = np.absolute(np.nanmean(sub_spec))
             atol = 4.0
             assert_allclose(mean_sub, 0, atol=atol)
-            # ______________________________________________________________________
+
             # Test 2  compare the science  data with no background
             # to the output from the masterBackground Subtraction step
             # background subtracted science image.
@@ -282,7 +279,7 @@ class TestNIRSpecMasterBackground_FS(BaseJWSTTest):
             atol = 0.5
             assert_allclose(np.absolute(mean_sub), 0, atol=atol)
         input_sci.close()
-        # ______________________________________________________________________
+
         # Test 3 Compare background sutracted science data (results)
         #  to a truth file. This data is MultiSlit data
         result_file = result.meta.filename
@@ -301,30 +298,25 @@ class TestNIRSpecMasterBackground_IFU(BaseJWSTTest):
     ref_loc = ['test_masterbackground', 'nrs-ifu', 'truth']
     test_dir = ['test_masterbackground', 'nrs-ifu']
 
-    def test_nirspec_masterbackground_ifu_user1d(self):
+    def test_nirspec_ifu_masterbg_user(self):
         """
-
-        Regression test of master background subtraction for NRS IFU when a user 1-D spectrum is provided.
-
+        Regression test of master background subtraction for NRS IFU when a
+        user 1-D spectrum is provided.
         """
         # input file has 2-D background image added to it
+        input_file = self.get_data(*self.test_dir, 'prism_sci_bkg_cal.fits')
 
-        input_file = self.get_data(*self.test_dir,
-                                    'prism_sci_bkg_cal.fits')
-        # user provide 1-D background was created from the 2-D background image
-        input_1dbkg_file = self.get_data(*self.test_dir,
-                                          'prism_bkg_x1d.fits')
+        # user-provided 1-D background was created from the 2-D background image
+        user_background = self.get_data(*self.test_dir, 'prism_bkg_x1d.fits')
 
         result = MasterBackgroundStep.call(input_file,
-                                           user_background=input_1dbkg_file,
+                                           user_background=user_background,
                                            save_results=True)
 
-        # _________________________________________________________________________
         # Test 1 compare extracted spectra data with
         # no background added to extracted spectra from the output
         # from MasterBackground subtraction. First cube_build has to be run
         # on the data.
-
         result_s3d = CubeBuildStep.call(result)
         # run 1-D extract on results from MasterBackground step
         result_1d = Extract1dStep.call(result_s3d, subtract_background=False)
@@ -334,13 +326,13 @@ class TestNIRSpecMasterBackground_IFU(BaseJWSTTest):
         sci_1d = datamodels.open(input_sci_1d_file)
 
         # read in the valid wavelengths of the user-1d
-        input_1d_bkg_model = datamodels.open(input_1dbkg_file)
-        user_wave = input_1d_bkg_model.spec[0].spec_table['wavelength']
-        user_flux = input_1d_bkg_model.spec[0].spec_table['net']
+        user_background_model = datamodels.open(user_background)
+        user_wave = user_background_model.spec[0].spec_table['wavelength']
+        user_flux = user_background_model.spec[0].spec_table['net']
         user_wave_valid = np.where(user_flux > 0)
         min_user_wave = np.amin(user_wave[user_wave_valid])
         max_user_wave = np.amax(user_wave[user_wave_valid])
-        input_1d_bkg_model.close()
+        user_background_model.close()
         # find the waverange covered by both user and science
         sci_spec_1d = sci_1d.spec[0].spec_table['net']
         sci_spec_wave = sci_1d.spec[0].spec_table['wavelength']
@@ -363,7 +355,7 @@ class TestNIRSpecMasterBackground_IFU(BaseJWSTTest):
         mean_sub = np.absolute(np.nanmean(sub_spec))
         atol = 5.0
         assert_allclose(mean_sub, 0, atol=atol)
-        # ______________________________________________________________________
+
         # Test 2  compare the science  data with no background
         # to the output from the masterBackground Subtraction step
         # background subtracted science image.
@@ -395,7 +387,7 @@ class TestNIRSpecMasterBackground_IFU(BaseJWSTTest):
             sub_mean = np.absolute(np.nanmean(sub[mask_clean]))
             atol = 2.0
             assert_allclose(sub_mean, 0, atol=atol)
-        # ______________________________________________________________________
+
         # Test 3 Compare background sutracted science data (results)
         #  to a truth file. This data is MultiSlit data
 
@@ -416,22 +408,20 @@ class TestNIRSpecMasterBackground_MOS(BaseJWSTTest):
     ref_loc = ['test_masterbackground', 'nrs-mos', 'truth']
     test_dir = ['test_masterbackground', 'nrs-mos']
 
-    def test_nirspec_masterbackground_mos_user1d(self):
+    def test_nirspec_mos_masterbg_user(self):
         """
-        Regression test of master background subtraction for NRS MOS when a user 1-D spectrum is provided.
-
+        Regression test of master background subtraction for NRS MOS when
+        a user 1-D spectrum is provided.
         """
         # input file has 2-D background image added to it
-        input_file = self.get_data(*self.test_dir,
-                                    'nrs_mos_sci+bkg_cal.fits')
+        input_file = self.get_data(*self.test_dir, 'nrs_mos_sci+bkg_cal.fits')
         # user provide 1-D background was created from the 2-D background image
-        input_1dbkg_file = self.get_data(*self.test_dir,
-                                          'nrs_mos_bkg_x1d.fits')
+        input_1dbkg_file = self.get_data(*self.test_dir, 'nrs_mos_bkg_x1d.fits')
 
         result = MasterBackgroundStep.call(input_file,
                                            user_background=input_1dbkg_file,
                                            save_results=True)
-        # _________________________________________________________________________
+
         # One of out tests is to compare the 1-D extracted spectra from
         # the science image (no background added) and the masterbackground subtracted
         # data.
@@ -466,7 +456,6 @@ class TestNIRSpecMasterBackground_MOS(BaseJWSTTest):
 
         # loop over each slit and perform 2 tests on each slit
         for i in range(num_spec):
-            # ______________________________________________________________________
             # Test 1 compare extracted spectra data from the science data
             # to extracted spectra from the output
             # from MasterBackground subtraction.
@@ -489,7 +478,7 @@ class TestNIRSpecMasterBackground_MOS(BaseJWSTTest):
             mean_sub = np.nanmean(sub_spec)
             atol = 1.5
             assert_allclose(mean_sub, 0, atol=atol)
-            # ______________________________________________________________________
+
             # Test 2  compare the science  data with no background
             # to the output from the masterBackground Subtraction step
             # background subtracted science image.
@@ -518,7 +507,7 @@ class TestNIRSpecMasterBackground_MOS(BaseJWSTTest):
             mean_sub = np.mean(sub_valid[mask_clean])
             atol = 0.1
             assert_allclose(np.absolute(mean_sub), 0, atol=atol)
-        # ______________________________________________________________________
+
         # Test 3 Compare background sutracted science data (results)
         #  to a truth file. This data is MultiSlit data
 


### PR DESCRIPTION
Fixes a bug found in a regression test (see traceback below).  The DQ indices being flagged were those in a single IFU slice, but the indices need to be in the full detector frame.  So we use the slice boolean mask to pick out the indices in `x` and `y`, which are in full-frame coordinates.

Also, some test cleanup:
 - shorten test function names so that the output dirs don't overwrite each other on Artifactory
 - make sure that truth files are being pulled to the `truth/` dir in `_jail`.


https://plwishmaster.stsci.edu:8081/job/RT/job/JWST/192/testReport/junit/jwst.tests_nightly.general.nirspec.test_nirspec_steps_single/TestNIRSpecMasterBackground_IFU/_stable_deps__test_nirspec_masterbackground_ifu_user1d/
```
self = <general.nirspec.test_nirspec_steps_single.TestNIRSpecMasterBackground_IFU object at 0x7f75d869fcf8>

    def test_nirspec_masterbackground_ifu_user1d(self):
        """
    
        Regression test of master background subtraction for NRS IFU when a user 1-D spectrum is provided.
    
        """
        # input file has 2-D background image added to it
    
        input_file = self.get_data(*self.test_dir,
                                    'prism_sci_bkg_cal.fits')
        # user provide 1-D background was created from the 2-D background image
        input_1dbkg_file = self.get_data(*self.test_dir,
                                          'prism_bkg_x1d.fits')
    
        result = MasterBackgroundStep.call(input_file,
                                           user_background=input_1dbkg_file,
>                                          save_results=True)

../../../jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py:320: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../jwst/stpipe/step.py:532: in call
    return instance.run(*args)
../../../jwst/stpipe/step.py:400: in run
    step_result = self.process(*args)
../../../jwst/master_background/master_background_step.py:93: in process
    background_2d = expand_to_2d(input_data, self.user_background)
../../../jwst/master_background/expand_to_2d.py:59: in expand_to_2d
    background = create_bkg(input, tab_wavelength, tab_background)
../../../jwst/master_background/expand_to_2d.py:126: in create_bkg
    background = bkg_for_ifu_image(input, tab_wavelength, tab_background)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

input = <IFUImageModel(2048, 2048) from prism_sci_bkg_cal.fits>
tab_wavelength = array([0.59750016, 0.60250016, 0.60750016, 0.61250016, 0.61750016,
       0.62250016, 0.62750016, 0.63250016, 0.637500...5750006, 5.26250006, 5.26750006,
       5.27250006, 5.27750006, 5.28250006, 5.28750006, 5.29250005,
       5.29750005])
tab_background = array([24.83188907, 24.9029581 , 25.08349353, 25.20144958, 25.15045092,
       24.79923282, 24.8765032 , 24.92175471, ... 24.89426234, 24.99367225,
       25.03802228, 25.02380728, 25.0395386 , 24.92713958, 24.96919575,
       25.10638608])

    def bkg_for_ifu_image(input, tab_wavelength, tab_background):
        """Create a 2-D background for an IFUImageModel
    
        Parameters
        ----------
        input : `~jwst.datamodels.IFUImageModel`
            The input science data.
    
        tab_wavelength : 1-D ndarray
            The wavelength column read from the 1-D background table.
    
        tab_background : 1-D ndarray
            The flux column read from the 1-D background table, divided by
            the npixels column.
    
        Returns
        -------
        background : `~jwst.datamodels.IFUImageModel`
            A copy of `input` but with the data replaced by the background,
            "expanded" from 1-D to 2-D. The dq flags are set to DO_NOT_USE
            for the pixels outside the region provided in the X1D background
            wavelength table.
    
        """
    
        background = input.copy()
        background.data[:, :] = 0.
        min_wave = np.amin(tab_wavelength)
        max_wave = np.amax(tab_wavelength)
    
        if input.meta.instrument.name.upper() == "NIRSPEC":
            list_of_wcs = nirspec.nrs_ifu_wcs(input)
            for ifu_wcs in list_of_wcs:
                x, y = grid_from_bounding_box(ifu_wcs.bounding_box)
                wl_array = ifu_wcs(x, y)[2]
                wl_array[np.isnan(wl_array)] = -1.
                # flag values outside of the background wavelength table
                mask_limit = (wl_array > max_wave) | (wl_array < min_wave)
                wl_array[mask_limit] = -1
    
                # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
>               background.dq[mask_limit] = np.bitwise_or(background.dq[mask_limit],
                                                          dqflags.pixel['DO_NOT_USE'])
E               IndexError: boolean index did not match indexed array along dimension 0; dimension is 2048 but corresponding boolean dimension is 38

../../../jwst/master_background/expand_to_2d.py:273: IndexError
```