### PR TITLE
Master background regression tests for MIRI MRS and LRS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,8 +132,8 @@ srctype
 
 tests
 -----
-- Removed set do_copy = True for get_data [#3370] 
-- Removed auto_toggle_do_copy  [#3370]
+- in base_classes.py forced do_copy = True for def get_data [#3370] 
+- in base_classes.py removed auto_toggle_do_copy  [#3370]
 tweakreg
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,10 +130,6 @@ srctype
 
 - Updated logic for background targets and nodded exposures. [#3310]
 
-tests
------
-- in base_classes.py forced do_copy = True for def get_data [#3370] 
-- in base_classes.py removed auto_toggle_do_copy  [#3370]
 tweakreg
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,6 +130,10 @@ srctype
 
 - Updated logic for background targets and nodded exposures. [#3310]
 
+tests
+-----
+- Removed set do_copy = True for get_data [#3370] 
+- Removed auto_toggle_do_copy  [#3370]
 tweakreg
 --------
 

--- a/jwst/tests/base_classes.py
+++ b/jwst/tests/base_classes.py
@@ -59,16 +59,21 @@ class BaseJWSTTest:
     def repo_path(self):
         return [self.inputs_root, self.env, self.input_loc]
 
-    def get_data(self, *pathargs, docopy=True):
+    def get_data(self, *pathargs, docopy=None):
         """
         Download `filename` into working directory using
         `artifactory_helpers/get_bigdata()`.
         This will then return the full path to the local copy of the file.
         """
-        # If user has specified action for no_copy, apply it with
+        # If user has specified action for docopy use it, If none
         # default behavior being whatever was defined in the base class.
-        local_file = get_bigdata(*self.repo_path, *pathargs, docopy=self.docopy)
-
+        if docopy is None: 
+            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=self.docopy)
+        elif docopy:
+            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=True)
+        else:
+            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=False)
+            
         return local_file
 
     def compare_outputs(self, outputs, raise_error=True, **kwargs):
@@ -160,6 +165,7 @@ class BaseJWSTTestSteps(BaseJWSTTest):
         Template method for parameterizing all the tests of JWST pipeline
         processing steps.
         """
+
         if test_dir is None:
             return
 
@@ -170,7 +176,6 @@ class BaseJWSTTestSteps(BaseJWSTTest):
         self.ignore_keywords += ['FILENAME']
 
         input_file = self.get_data(self.test_dir, input)
-
         result = step_class.call(input_file, save_results=True, **step_pars)
 
         output_file = result.meta.filename

--- a/jwst/tests/base_classes.py
+++ b/jwst/tests/base_classes.py
@@ -47,19 +47,19 @@ class BaseJWSTTest:
         self.inputs_root = pytestconfig.getini('inputs_root')[0]
         self.results_root = pytestconfig.getini('results_root')[0]
 
-    @pytest.fixture(autouse=True)
-    def auto_toggle_docopy(self):
-        bigdata_root = get_bigdata_root()
-        if bigdata_root and check_url(bigdata_root):
-            self.docopy = True
-        else:
-            self.docopy = False
+#    @pytest.fixture(autouse=True)
+#    def auto_toggle_docopy(self):
+#        bigdata_root = get_bigdata_root()
+#        if bigdata_root and check_url(bigdata_root):
+#            self.docopy = True
+#        else:
+#            self.docopy = False
 
     @property
     def repo_path(self):
         return [self.inputs_root, self.env, self.input_loc]
 
-    def get_data(self, *pathargs, docopy=None):
+    def get_data(self, *pathargs, docopy=True):
         """
         Download `filename` into working directory using
         `artifactory_helpers/get_bigdata()`.
@@ -67,12 +67,12 @@ class BaseJWSTTest:
         """
         # If user has specified action for docopy use it, If none
         # default behavior being whatever was defined in the base class.
-        if docopy is None: 
-            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=self.docopy)
-        elif docopy:
-            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=True)
-        else:
-            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=False)
+#        if docopy is None: 
+#            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=self.docopy)
+#        elif docopy:
+        local_file = get_bigdata(*self.repo_path, *pathargs, docopy=True)
+#        else:
+#            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=False)
             
         return local_file
 
@@ -93,7 +93,7 @@ class BaseJWSTTest:
 
         return compare_outputs(outputs,
                                input_path=input_path,
-                               docopy=self.docopy,
+                               docopy=True,
                                results_root=self.results_root,
                                **compare_kws)
 

--- a/jwst/tests/base_classes.py
+++ b/jwst/tests/base_classes.py
@@ -47,14 +47,6 @@ class BaseJWSTTest:
         self.inputs_root = pytestconfig.getini('inputs_root')[0]
         self.results_root = pytestconfig.getini('results_root')[0]
 
-#    @pytest.fixture(autouse=True)
-#    def auto_toggle_docopy(self):
-#        bigdata_root = get_bigdata_root()
-#        if bigdata_root and check_url(bigdata_root):
-#            self.docopy = True
-#        else:
-#            self.docopy = False
-
     @property
     def repo_path(self):
         return [self.inputs_root, self.env, self.input_loc]
@@ -65,15 +57,7 @@ class BaseJWSTTest:
         `artifactory_helpers/get_bigdata()`.
         This will then return the full path to the local copy of the file.
         """
-        # If user has specified action for docopy use it, If none
-        # default behavior being whatever was defined in the base class.
-#        if docopy is None: 
-#            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=self.docopy)
-#        elif docopy:
-        local_file = get_bigdata(*self.repo_path, *pathargs, docopy=True)
-#        else:
-#            local_file = get_bigdata(*self.repo_path, *pathargs, docopy=False)
-            
+        local_file = get_bigdata(*self.repo_path, *pathargs, docopy=docopy)
         return local_file
 
     def compare_outputs(self, outputs, raise_error=True, **kwargs):
@@ -282,4 +266,3 @@ def _data_glob_url(url, glob='*'):
         url_paths = [a['uri'].replace('api/storage/', '') for a in r.json()['results']]
 
     return url_paths
-

--- a/jwst/tests_nightly/general/miri/test_miri_steps_single.py
+++ b/jwst/tests_nightly/general/miri/test_miri_steps_single.py
@@ -213,8 +213,8 @@ class TestMIRIWCSIFU(BaseJWSTTest):
 @pytest.mark.bigdata
 class TestMIRIWCSImage(BaseJWSTTest):
     input_loc = 'miri'
-    ref_loc = ['test_wcs','image','truth']
-    test_dir = os.path.join('test_wcs','image')
+    ref_loc = ['test_wcs', 'image', 'truth']
+    test_dir = os.path.join('test_wcs', 'image')
 
     def test_miri_image_wcs(self):
         """
@@ -243,8 +243,8 @@ class TestMIRIWCSImage(BaseJWSTTest):
 @pytest.mark.bigdata
 class TestMIRIWCSSlitless(BaseJWSTTest):
     input_loc = 'miri'
-    ref_loc = ['test_wcs','slitless','truth']
-    test_dir = os.path.join('test_wcs','slitless')
+    ref_loc = ['test_wcs', 'slitless', 'truth']
+    test_dir = os.path.join('test_wcs', 'slitless')
 
     def test_miri_slitless_wcs(self):
         """
@@ -359,26 +359,184 @@ class TestMIRIMasterBackgroundLRS(BaseJWSTTest):
         input_sci.close()
 
 
-class TestMIRIMasterBackgroundMRS(BaseJWSTTest):
+@pytest.mark.bigdata
+class TestMIRIMasterBackgroundMRSDedicated(BaseJWSTTest):
     input_loc = 'miri'
-    ref_loc = ['test_masterbackground', 'mrs', 'truth']
-    test_dir = ['test_masterbackground', 'mrs']
+    ref_loc = ['test_masterbackground', 'mrs', 'dedicated', 'truth']
+    test_dir = ['test_masterbackground', 'mrs', 'dedicated']
 
     rtol = 0.000001
 
-    def test_miri_mrs_masterbg(self):
-        """Run masterbackground step on MIRI LRS association"""
+    def test_miri_masterbg_mrs_dedicated(self):
+        """Run masterbackground step on MIRI MRS association"""
         asn_file = self.get_data(*self.test_dir,
-                                   'miri_mrs_mbkg_0304_spec3_asn.json')
+                                  'miri_mrs_mbkg_0304_spec3_asn.json',
+                                  docopy=True)
         for file in raw_from_asn(asn_file):
-            self.get_data(*self.test_dir, file)
+            self.get_data(*self.test_dir, file, docopy=True)
 
         collect_pipeline_cfgs('./config')
         result = MasterBackgroundStep.call(
             asn_file,
             config_file='config/master_background.cfg',
-            save_background=True
+            save_background=True,
+            save_results=True
             )
 
+        # test 1
+        # loop over the background subtracted data and compare to truth files
+        # check that the  cal_step master_background ran to complete
         for model in result:
             assert model.meta.cal_step.master_background == 'COMPLETE'
+
+            result_file = model.meta.filename.replace('cal','master_background')
+            truth_file = self.get_data(*self.ref_loc,
+                                        result_file)
+
+            outputs = [(result_file, truth_file)]
+            self.compare_outputs(outputs)
+
+        
+        # test 2
+        # compare the master background combined file to truth file
+        master_combined_bkg_file = 'MIRI_MRS_seq1_MIRIFULONG_34LONGexp1_bkg_o002_masterbg.fits'
+        truth_background = self.get_data(*self.ref_loc,
+                                          master_combined_bkg_file)
+        outputs = [(master_combined_bkg_file, truth_background)]
+        self.compare_outputs(outputs)
+
+
+@pytest.mark.bigdata
+class TestMIRIMasterBackgroundMRSNodded(BaseJWSTTest):
+    input_loc = 'miri'
+    ref_loc = ['test_masterbackground', 'mrs', 'nodded', 'truth']
+    test_dir = ['test_masterbackground', 'mrs', 'nodded']
+
+    rtol = 0.000001
+
+    def test_miri_masterbg_mrs_nodded(self):
+        """Run masterbackground step on MIRI MRS association"""
+        asn_file = self.get_data(*self.test_dir,
+                                  'miri_mrs_mbkg_spec3_asn.json',
+                                  docopy=True)
+        for file in raw_from_asn(asn_file):
+            self.get_data(*self.test_dir, file,docopy=True)
+
+        collect_pipeline_cfgs('./config')
+        result = MasterBackgroundStep.call(
+            asn_file,
+            config_file='config/master_background.cfg',
+            save_background=True,
+            save_results=True
+            )
+
+        # test 1
+        # loop over the background subtracted data and compare to truth files
+        # check that the  cal_step master_background ran to complete
+        for model in result:
+            assert model.meta.cal_step.master_background == 'COMPLETE'
+
+            result_file = model.meta.filename.replace('cal','master_background')
+            truth_file = self.get_data(*self.ref_loc,
+                                        result_file)
+
+            outputs = [(result_file, truth_file)]
+            self.compare_outputs(outputs)
+
+        # test 2
+        # compare the master background combined file to truth file
+        master_combined_bkg_file = 'MIRI_MRS_nod_seq1_MIRIFUSHORT_12SHORTexp1_o001_masterbg.fits'
+        truth_background = self.get_data(*self.ref_loc,
+                                          master_combined_bkg_file)
+        outputs = [(master_combined_bkg_file, truth_background)]
+        self.compare_outputs(outputs)
+
+
+@pytest.mark.bigdata
+class TestMIRIMasterBackgroundLRSNodded(BaseJWSTTest):
+    input_loc = 'miri'
+    ref_loc = ['test_masterbackground', 'lrs', 'nodded', 'truth']
+    test_dir = ['test_masterbackground', 'lrs', 'nodded']
+
+    rtol = 0.000001
+
+    def test_miri_masterbg_lrs_nodded(self):
+        """Run masterbackground step on MIRI LRS association"""
+        asn_file = self.get_data(*self.test_dir,
+                                  'miri_lrs_mbkg_nodded_spec3_asn.json',
+                                  docopy=True)
+        for file in raw_from_asn(asn_file):
+            self.get_data(*self.test_dir, file,docopy=True)
+
+        collect_pipeline_cfgs('./config')
+        result = MasterBackgroundStep.call(
+            asn_file,
+            config_file='config/master_background.cfg',
+            save_background=True,
+            save_results=True
+            )
+
+        # test 1
+        # loop over the background subtracted data and compare to truth files
+        for model in result:
+            assert model.meta.cal_step.master_background == 'COMPLETE'
+
+            result_file = model.meta.filename.replace('cal','master_background')
+            truth_file = self.get_data(*self.ref_loc,
+                                        result_file)
+
+            outputs = [(result_file, truth_file)]
+            self.compare_outputs(outputs)
+
+        # test 2
+        # compare the master background combined file to truth file
+        master_combined_bkg_file = 'MIRI_LRS_nod_seq1_MIRIMAGE_P750Lexp1_o002_masterbg.fits'
+        truth_background = self.get_data(*self.ref_loc,
+                                          master_combined_bkg_file)
+        outputs = [(master_combined_bkg_file, truth_background)]
+        self.compare_outputs(outputs)
+
+
+@pytest.mark.bigdata
+class TestMIRIMasterBackgroundLRSDedicated(BaseJWSTTest):
+    input_loc = 'miri'
+    ref_loc = ['test_masterbackground', 'lrs', 'dedicated', 'truth']
+    test_dir = ['test_masterbackground', 'lrs', 'dedicated']
+
+    rtol = 0.000001
+
+    def test_miri_masterbg_lrs_dedicated(self):
+        """Run masterbackground step on MIRI LRS association"""
+        asn_file = self.get_data(*self.test_dir,
+                                  'miri_lrs_mbkg_dedicated_spec3_asn.json',
+                                  docopy = True)
+        for file in raw_from_asn(asn_file):
+            self.get_data(*self.test_dir, file, docopy=True)
+
+        collect_pipeline_cfgs('./config')
+        result = MasterBackgroundStep.call(
+            asn_file,
+            config_file='config/master_background.cfg',
+            save_background = True,
+            save_results = True
+            )
+
+        # test 1
+        # loop over the background subtracted data and compare to truth files
+        for model in result:
+            assert model.meta.cal_step.master_background == 'COMPLETE'
+
+            result_file = model.meta.filename.replace('cal','master_background')
+            truth_file = self.get_data(*self.ref_loc,
+                                        result_file)
+
+            outputs = [(result_file, truth_file)]
+            self.compare_outputs(outputs)
+
+        # test 2
+        # compare the master background combined file to truth file
+        master_combined_bkg_file = 'MIRI_LRS_seq1_MIRIMAGE_P750Lexp1_o001_masterbg.fits'
+        truth_background = self.get_data(*self.ref_loc,
+                                          master_combined_bkg_file)
+        outputs = [(master_combined_bkg_file, truth_background)]
+        self.compare_outputs(outputs)

--- a/jwst/tests_nightly/general/miri/test_miri_steps_single.py
+++ b/jwst/tests_nightly/general/miri/test_miri_steps_single.py
@@ -284,9 +284,7 @@ class TestMIRISetPointing(BaseJWSTTest):
 
         # Copy original version of file to test file, which will get overwritten by test
         input_file = self.get_data(self.test_dir,
-                                    'jw80600010001_02101_00001_mirimage_uncal_orig.fits',
-                                    docopy=True  # always produce local copy
-                              )
+                                    'jw80600010001_02101_00001_mirimage_uncal_orig.fits')
         # Get SIAF PRD database file
         siaf_prd_loc = ['jwst-pipeline', self.env, 'common', 'prd.db']
         siaf_path = get_bigdata(*siaf_prd_loc)
@@ -370,10 +368,9 @@ class TestMIRIMasterBackgroundMRSDedicated(BaseJWSTTest):
     def test_miri_masterbg_mrs_dedicated(self):
         """Run masterbackground step on MIRI MRS association"""
         asn_file = self.get_data(*self.test_dir,
-                                  'miri_mrs_mbkg_0304_spec3_asn.json',
-                                  docopy=True)
+                                  'miri_mrs_mbkg_0304_spec3_asn.json')
         for file in raw_from_asn(asn_file):
-            self.get_data(*self.test_dir, file, docopy=True)
+            self.get_data(*self.test_dir, file)
 
         collect_pipeline_cfgs('./config')
         result = MasterBackgroundStep.call(
@@ -389,10 +386,9 @@ class TestMIRIMasterBackgroundMRSDedicated(BaseJWSTTest):
         for model in result:
             assert model.meta.cal_step.master_background == 'COMPLETE'
 
-            result_file = model.meta.filename.replace('cal','master_background')
+            result_file = model.meta.filename.replace('cal', 'master_background')
             truth_file = self.get_data(*self.ref_loc,
                                         result_file)
-
             outputs = [(result_file, truth_file)]
             self.compare_outputs(outputs)
 
@@ -416,10 +412,9 @@ class TestMIRIMasterBackgroundMRSNodded(BaseJWSTTest):
     def test_miri_masterbg_mrs_nodded(self):
         """Run masterbackground step on MIRI MRS association"""
         asn_file = self.get_data(*self.test_dir,
-                                  'miri_mrs_mbkg_spec3_asn.json',
-                                  docopy=True)
+                                  'miri_mrs_mbkg_spec3_asn.json')
         for file in raw_from_asn(asn_file):
-            self.get_data(*self.test_dir, file, docopy=True)
+            self.get_data(*self.test_dir, file)
 
         collect_pipeline_cfgs('./config')
         result = MasterBackgroundStep.call(
@@ -462,10 +457,9 @@ class TestMIRIMasterBackgroundLRSNodded(BaseJWSTTest):
     def test_miri_masterbg_lrs_nodded(self):
         """Run masterbackground step on MIRI LRS association"""
         asn_file = self.get_data(*self.test_dir,
-                                  'miri_lrs_mbkg_nodded_spec3_asn.json',
-                                  docopy=True)
+                                  'miri_lrs_mbkg_nodded_spec3_asn.json')
         for file in raw_from_asn(asn_file):
-            self.get_data(*self.test_dir, file, docopy=True)
+            self.get_data(*self.test_dir, file)
 
         collect_pipeline_cfgs('./config')
         result = MasterBackgroundStep.call(
@@ -507,10 +501,9 @@ class TestMIRIMasterBackgroundLRSDedicated(BaseJWSTTest):
     def test_miri_masterbg_lrs_dedicated(self):
         """Run masterbackground step on MIRI LRS association"""
         asn_file = self.get_data(*self.test_dir,
-                                  'miri_lrs_mbkg_dedicated_spec3_asn.json',
-                                  docopy = True)
+                                  'miri_lrs_mbkg_dedicated_spec3_asn.json')
         for file in raw_from_asn(asn_file):
-            self.get_data(*self.test_dir, file, docopy=True)
+            self.get_data(*self.test_dir, file)
 
         collect_pipeline_cfgs('./config')
         result = MasterBackgroundStep.call(

--- a/jwst/tests_nightly/general/miri/test_miri_steps_single.py
+++ b/jwst/tests_nightly/general/miri/test_miri_steps_single.py
@@ -396,7 +396,6 @@ class TestMIRIMasterBackgroundMRSDedicated(BaseJWSTTest):
             outputs = [(result_file, truth_file)]
             self.compare_outputs(outputs)
 
-        
         # test 2
         # compare the master background combined file to truth file
         master_combined_bkg_file = 'MIRI_MRS_seq1_MIRIFULONG_34LONGexp1_bkg_o002_masterbg.fits'
@@ -420,7 +419,7 @@ class TestMIRIMasterBackgroundMRSNodded(BaseJWSTTest):
                                   'miri_mrs_mbkg_spec3_asn.json',
                                   docopy=True)
         for file in raw_from_asn(asn_file):
-            self.get_data(*self.test_dir, file,docopy=True)
+            self.get_data(*self.test_dir, file, docopy=True)
 
         collect_pipeline_cfgs('./config')
         result = MasterBackgroundStep.call(
@@ -436,7 +435,7 @@ class TestMIRIMasterBackgroundMRSNodded(BaseJWSTTest):
         for model in result:
             assert model.meta.cal_step.master_background == 'COMPLETE'
 
-            result_file = model.meta.filename.replace('cal','master_background')
+            result_file = model.meta.filename.replace('cal', 'master_background')
             truth_file = self.get_data(*self.ref_loc,
                                         result_file)
 
@@ -466,7 +465,7 @@ class TestMIRIMasterBackgroundLRSNodded(BaseJWSTTest):
                                   'miri_lrs_mbkg_nodded_spec3_asn.json',
                                   docopy=True)
         for file in raw_from_asn(asn_file):
-            self.get_data(*self.test_dir, file,docopy=True)
+            self.get_data(*self.test_dir, file, docopy=True)
 
         collect_pipeline_cfgs('./config')
         result = MasterBackgroundStep.call(
@@ -481,7 +480,7 @@ class TestMIRIMasterBackgroundLRSNodded(BaseJWSTTest):
         for model in result:
             assert model.meta.cal_step.master_background == 'COMPLETE'
 
-            result_file = model.meta.filename.replace('cal','master_background')
+            result_file = model.meta.filename.replace('cal', 'master_background')
             truth_file = self.get_data(*self.ref_loc,
                                         result_file)
 
@@ -518,15 +517,14 @@ class TestMIRIMasterBackgroundLRSDedicated(BaseJWSTTest):
             asn_file,
             config_file='config/master_background.cfg',
             save_background = True,
-            save_results = True
-            )
+            save_results = True)
 
         # test 1
         # loop over the background subtracted data and compare to truth files
         for model in result:
             assert model.meta.cal_step.master_background == 'COMPLETE'
 
-            result_file = model.meta.filename.replace('cal','master_background')
+            result_file = model.meta.filename.replace('cal', 'master_background')
             truth_file = self.get_data(*self.ref_loc,
                                         result_file)
 


### PR DESCRIPTION
Added four regression tests for masterbackground subtractions.
1. mrs nodded
2. mrs dedicated background
3. lrs nodded
4. lrs dedicated background
These test are done. I might need to reproduce the data once all the changes to extract1d have been finished for the nodded and dedicated background cases. Then I will put the data onto byesalad.

@jdavies-st I did not remove the auto_toggle_docopy because I really do not understand what it is 
trying to do when you run the tests locally. It seems it should always fail. Instead I changed the way
get_data works. Please look at the logical for docopy. I think it is what we want - do exactly what
the user wants and if nothing is given (docopy = None) then default back to the way it worked before
and use self.docopy.
