### PR TITLE
Fix bugs in updated photom

### DIFF
--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -7,9 +7,10 @@ The calibration information is read from a photometric reference file.
 The exact nature of the calibration information loaded from the reference file
 and applied to the science data depends on the instrument mode.
 
-This step relies on having wavelength information available for the input
-image (see below) and therefore the :ref:`assign_wcs <assign_wcs_step>` step
-*must* be applied before executing the photom step.
+This step relies on having wavelength information available when working on
+spectroscopic data (see below) and therefore the
+:ref:`assign_wcs <assign_wcs_step>` step *must* be applied before executing
+the photom step.
 
 Upon successful completion of this step, the status keyword S_PHOTOM will be
 set to COMPLETE.

--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -7,6 +7,10 @@ The calibration information is read from a photometric reference file.
 The exact nature of the calibration information loaded from the reference file
 and applied to the science data depends on the instrument mode.
 
+This step relies on having wavelength information available for the input
+image (see below) and therefore the :ref:`assign_wcs <assign_wcs_step>` step
+*must* be applied before executing the photom step.
+
 Upon successful completion of this step, the status keyword S_PHOTOM will be
 set to COMPLETE.
 Furthermore, the BUNIT keyword value in the SCI and ERR extension

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -187,7 +187,7 @@ class DataSet():
 
                         # Populate the photometry keywords
                         self.input.meta.photometry.conversion_megajanskys = \
-                            conv_factor.value
+                            conv_factor
                         self.input.meta.photometry.conversion_microjanskys = \
                             conv_factor * MJSR_TO_UJA2
 
@@ -421,11 +421,14 @@ class DataSet():
             ftab.dq[where_zero] = np.bitwise_or(ftab.dq[where_zero],
                                                 dqflags.pixel['NON_SCIENCE'])
 
+            # Compute the combined 2D sensitivity factors
+            sens2d = ftab.data * ftab.pixsiz
+
             # Divide the science data and uncertainty arrays by the 2D sensitivity factors
-            self.input.data /= self.input.relsens2d
-            self.input.err /= self.input.relsens2d
-            self.input.var_poisson /= self.input.relsens2d**2
-            self.input.var_rnoise /= self.input.relsens2d**2
+            self.input.data /= sens2d
+            self.input.err /= sens2d
+            self.input.var_poisson /= sens2d**2
+            self.input.var_rnoise /= sens2d**2
 
             # Update the science dq
             self.input.dq = np.bitwise_or(self.input.dq, ftab.dq)

--- a/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
@@ -10,7 +10,6 @@ from jwst.pipeline import Detector1Pipeline, Spec2Pipeline
 from jwst.imprint import ImprintStep
 from jwst.ramp_fitting import RampFitStep
 from jwst.extract_1d import Extract1dStep
-from jwst.resample import ResampleSpecStep
 from jwst.master_background import MasterBackgroundStep
 from jwst.cube_build import CubeBuildStep
 from jwst import datamodels
@@ -345,5 +344,4 @@ class TestNIRSpecMasterBackground_MOS(BaseJWSTTest):
 
         outputs = [(result_file, ref_file)]
         self.compare_outputs(outputs)
-        input_sci.close()
         result.close()

--- a/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
@@ -338,98 +338,10 @@ class TestNIRSpecMasterBackground_MOS(BaseJWSTTest):
                                            user_background=input_1dbkg_file,
                                            save_results=True)
 
-        # One of out tests is to compare the 1-D extracted spectra from
-        # the science image (no background added) and the masterbackground subtracted
-        # data.
-
-        # run resample_spec  on results from MasterBackground step
-        result_2d = ResampleSpecStep.call(result)
-        # run 1-D extract on results from MasterBackground step
-        result_1d = Extract1dStep.call(result_2d)
-
-        # get input science data with background added
-        input_sci_cal_file = self.get_data(*self.test_dir,
-                                            'nrs_mos_sci_cal.fits')
-        # get 1-D extract on original science data without background
-        # this reference data was also run through ResampleSpec
-        input_sci_1d_file = self.get_data(*self.ref_loc,
-                                            'nrs_mos_sci_extract1dstep.fits')
-
-        input_sci = datamodels.open(input_sci_cal_file)
-        sci_cal_1d = datamodels.open(input_sci_1d_file)
-        num_spec = len(sci_cal_1d.spec)
-
-        # the user 1D spectrum may not cover the entire wavelength range of the
-        # science data.  Find the wavelength range of user 1-D spectra
-
-        input_1dbkg_1d = datamodels.open(input_1dbkg_file)
-        user_wave = input_1dbkg_1d.spec[0].spec_table['wavelength']
-        user_flux = input_1dbkg_1d.spec[0].spec_table['flux']
-        user_wave_valid = np.where(user_flux > 0)
-        min_user_wave = np.amin(user_wave[user_wave_valid])
-        max_user_wave = np.amax(user_wave[user_wave_valid])
-        input_1dbkg_1d.close()
-
-        # loop over each slit and perform 2 tests on each slit
-        for i in range(num_spec):
-            # Test 1 compare extracted spectra data from the science data
-            # to extracted spectra from the output
-            # from MasterBackground subtraction.
-            sci_spec_1d = sci_cal_1d.spec[i].spec_table['flux']
-            sci_wave = sci_cal_1d.spec[i].spec_table['wavelength']
-            result_spec_1d = result_1d.spec[i].spec_table['flux']
-
-            # find the waverange covered by both user 1-D and science slit
-            sci_wave_valid = np.where(sci_spec_1d > 0)
-            min_wave = np.amin(sci_wave[sci_wave_valid])
-            max_wave = np.amax(sci_wave[sci_wave_valid])
-            if min_user_wave > min_wave:
-                min_wave = min_user_wave
-            if max_user_wave < max_wave:
-                max_wave = max_user_wave
-
-            sub_spec = sci_spec_1d - result_spec_1d
-            valid = np.where(np.logical_and(sci_wave > min_wave, sci_wave < max_wave))
-            sub_spec = sub_spec[valid]
-            mean_sub = np.nanmean(sub_spec)
-            atol = 1.5
-            assert_allclose(mean_sub, 0, atol=atol)
-
-            # Test 2  compare the science  data with no background
-            # to the output from the masterBackground Subtraction step
-            # background subtracted science image.
-            bb = input_sci.slits[i].meta.wcs.bounding_box
-            x, y = grid_from_bounding_box(bb)
-            ra, dec, lam = input_sci.slits[i].meta.wcs(x, y)
-            valid = np.isfinite(lam)
-
-            sci = input_sci.slits[i].data
-            result_slit = result.slits[i].data
-
-            # check for outliers in the science image that could cause test
-            # to fail. These could be cosmic ray hits or other yeck that
-            # messes up the science data - ignores these cases
-            sci_mean = np.nanmean(sci[valid])
-            sci_std = np.nanstd(sci[valid])
-            upper = sci_mean + sci_std*5.0
-            lower = sci_mean - sci_std*5.0
-            mask_clean = np.logical_and(sci[valid] < upper, sci[valid] > lower)
-
-            # for this slit subtract the background subtracted data from
-            # the science data with no background added
-            sub = result_slit - sci
-            # do not look at outliers - they confuse things
-            sub_valid = sub[valid]
-            mean_sub = np.mean(sub_valid[mask_clean])
-            atol = 0.1
-            assert_allclose(np.absolute(mean_sub), 0, atol=atol)
-
-        # Test 3 Compare background sutracted science data (results)
-        #  to a truth file. This data is MultiSlit data
-
+        # Compare background subtracted science data (results)
+        # to a truth file. These data are MultiSlit data.
         result_file = result.meta.filename
-        ref_file = self.get_data(*self.ref_loc,
-                                  'nrs_mos_sci+bkg_masterbackgroundstep.fits')
+        ref_file = self.get_data(*self.ref_loc, 'nrs_mos_sci+bkg_masterbackgroundstep.fits')
 
         outputs = [(result_file, ref_file)]
         self.compare_outputs(outputs)


### PR DESCRIPTION
Fix a couple ``photom`` bugs that were in #3359, and update the step docs to indicate that the step now relies on having WCS (wavelength) info available, hence ``assign_wcs`` is a prerequisite.

Also updated one of the NRS MOS ``master_background`` regression tests to only check truth file, with no on-the-fly processing and comparison.