### PR TITLE
Fix failing NIRISS SOSS reg test module

### DIFF
--- a/jwst/tests_nightly/general/niriss/test_niriss_steps_single.py
+++ b/jwst/tests_nightly/general/niriss/test_niriss_steps_single.py
@@ -118,12 +118,8 @@ class TestNIRISSPhotom(BaseJWSTTest):
         """
         input_file = self.get_data(self.test_dir,
                                    'jw00034001001_01101_00001_NIRISS_flat_field.fits')
-        override_photom = self.get_data(self.test_dir,
-                                        'jwst_niriss_photom_b7a.fits')
 
-        result = PhotomStep.call(input_file,
-                        override_photom=override_photom
-                        )
+        result = PhotomStep.call(input_file)
         output_file = result.meta.filename
         result.save(output_file)
         result.close()


### PR DESCRIPTION
One of the NIRISS SOSS regression tests of the ``photom`` step was written before the team started including spectral order number in the NIRISS photom ref files, so it was using a hand-crafted ref file as an override. That was a long time ago. Updated photom ref files now exist, which work just fine with the dataset in the test, so I removed the use of the ref file override.