### PR TITLE
Bump CRDS context to 502 for all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - CRDS_CONTEXT="jwst_0501.pmap"
+    - CRDS_CONTEXT="jwst_0502.pmap"
     - NUMPY_VERSION=1.16
 
 matrix:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ python_version = '3.6'
 env_vars = [
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_PATH=./crds_cache",
-    "CRDS_CONTEXT=jwst_0501.pmap",
+    "CRDS_CONTEXT=jwst_0502.pmap",
 ]
 
 // Pip related setup

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -13,7 +13,7 @@ numpy_version = '1.16'
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
-    "CRDS_CONTEXT=jwst_0501.pmap",
+    "CRDS_CONTEXT=jwst_0502.pmap",
 ]
 
 // Set pytest basetemp output directory


### PR DESCRIPTION
Bump up CRDS_CONTEXT from 501 to 502 in all test setup files, now that the new MIRI ref files in 501 have been completely verified. Time to test the next set of new ref files.