### PR TITLE
 Propagate flatfield uncertainties into science error and variance arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,12 @@ extract_1d
   the areas of the source aperture and background annulus are computed
   differently. [#3362]
 
+flatfield
+---------
+
+- Propagate uncertainty from flat field into science ERR array and new
+  VAR_FLAT array which holds the variance due to the flat field.  [#3384]
+
 master_background
 -----------------
 

--- a/jwst/datamodels/schemas/cube.schema.yaml
+++ b/jwst/datamodels/schemas/cube.schema.yaml
@@ -52,4 +52,10 @@ allOf:
       default: 0.0
       ndim: 3
       datatype: float32
+    var_flat:
+      title: Integration-specific variances due to flat field
+      fits_hdu: VAR_FLAT
+      default: 0.0
+      ndim: 3
+      datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifuimage.schema.yaml
+++ b/jwst/datamodels/schemas/ifuimage.schema.yaml
@@ -29,23 +29,13 @@ allOf:
       title: Pixel area map array
       fits_hdu: AREA
       datatype: float32
-    var_poisson:
-      title: variance due to poisson noise
-      fits_hdu: VAR_POISSON
-      ndim: 2
-      default: 0.0
-      datatype: float32
-    var_rnoise:
-      title: variance due to read noise
-      fits_hdu: VAR_RNOISE
-      ndim: 2
-      default: 0.0
-      datatype: float32
+- $ref: variance.schema.yaml
+- type: object
+  properties:
     wavelength:
       title: wavelength
       fits_hdu: WAVELENGTH
       datatype: float32
       default: 0.0
 - $ref: pathlosscorr.schema.yaml
-
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -31,18 +31,7 @@ allOf:
       fits_hdu: AREA
       default: 0.0
       datatype: float32
-    var_poisson:
-      title: variance due to poisson noise
-      fits_hdu: VAR_POISSON
-      ndim: 2
-      default: 0.0
-      datatype: float32
-    var_rnoise:
-      title: variance due to read noise
-      fits_hdu: VAR_RNOISE
-      ndim: 2
-      default: 0.0
-      datatype: float32
+- $ref: variance.schema.yaml
 - $ref: pathlosscorr.schema.yaml
 - type: object
   properties:

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -121,16 +121,7 @@ allOf:
       fits_hdu: AREA
       default: 0.0
       datatype: float32
-    var_poisson:
-      title: variance due to poisson noise
-      fits_hdu: VAR_POISSON
-      default: 0.0
-      datatype: float32
-    var_rnoise:
-      title: variance due to read noise
-      fits_hdu: VAR_RNOISE
-      default: 0.0
-      datatype: float32
+- $ref: variance.schema.yaml
 - $ref: pathlosscorr.schema.yaml
 - $ref: bunit.schema.yaml
 - $ref: photometry.schema.yaml

--- a/jwst/datamodels/schemas/variance.schema.yaml
+++ b/jwst/datamodels/schemas/variance.schema.yaml
@@ -1,0 +1,21 @@
+type: object
+properties:
+    var_poisson:
+      title: variance due to poisson noise
+      fits_hdu: VAR_POISSON
+      ndim: 2
+      default: 0.0
+      datatype: float32
+    var_rnoise:
+      title: variance due to read noise
+      fits_hdu: VAR_RNOISE
+      ndim: 2
+      default: 0.0
+      datatype: float32
+    var_flat:
+      title: variance due to flat field
+      fits_hdu: VAR_FLAT
+      ndim: 2
+      default: 0.0
+      datatype: float32
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -27,9 +27,7 @@ class FlatFieldStep(Step):
     """
 
     spec = """
-        # Suffix for optional output file for interpolated flat fields.
-        # Note that this is only used for NIRSpec spectrographic data.
-        flat_suffix = string(default=None)
+        flat_suffix = string(default=None) #Suffix for optional NIRSpec interpolated flat output file
     """
 
     reference_file_types = ["flat", "fflat", "sflat", "dflat"]


### PR DESCRIPTION
This propagates flat field reference file uncertainties to the science data via VAR_FLAT and ERR in `FlatFieldStep` for all modes except NIRSpec spectral modes.

Algorithm is below:

- ur = raw slope
- ff = flat field
- s = slope = ur / ff
- sigma_s^2 = (s^2/ur^2)sigma_r^2 + (s^2/ur^2)sigma_p^2 + (s^2/ff^2)sigma_ff^2
- Hence, the four uncertainties tracked are:
    - (s^2/ur^2)sigma_r^2 = sigma_r^2/ff^2
    - (s^2/ur^2)sigma_p^2 = sigma_p^2/ff^2
    - (s^2/ff^2)sigma_ff^2
    - sigma_s^2

Resolves #3307.