### PR TITLE
Update photom to handle NIRISS SOSS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - CRDS_CONTEXT="jwst_0503.pmap"
+    - CRDS_CONTEXT="jwst_0504.pmap"
     - NUMPY_VERSION=1.16
 
 matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,6 +99,9 @@ photom
 - Updated to apply the flux calibration to the science data and err arrays.
   [#3359]
 
+- Updated to compute a wavelength array for NIRISS SOSS exposures using
+  spectral order 1. [#3387]
+
 reffile_utils
 -------------
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ python_version = '3.6'
 env_vars = [
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_PATH=./crds_cache",
-    "CRDS_CONTEXT=jwst_0503.pmap",
+    "CRDS_CONTEXT=jwst_0504.pmap",
 ]
 
 // Pip related setup

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -13,7 +13,7 @@ numpy_version = '1.16'
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
-    "CRDS_CONTEXT=jwst_0503.pmap",
+    "CRDS_CONTEXT=jwst_0504.pmap",
 ]
 
 // Set pytest basetemp output directory

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -4,7 +4,8 @@ import numpy as np
 
 from gwcs.wcstools import grid_from_bounding_box
 from .. import datamodels
-from .. assign_wcs import nirspec               # for NIRSpec IFU data
+from .. assign_wcs import nirspec   # For NIRSpec IFU data
+from .. assign_wcs import niriss    # For NIRISS SOSS data
 from .. datamodels import dqflags
 
 log = logging.getLogger(__name__)
@@ -305,7 +306,7 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
     return background
 
 
-def get_wavelengths(model):
+def get_wavelengths(model, order=None):
     """Read or compute wavelengths.
 
     Parameters
@@ -313,12 +314,16 @@ def get_wavelengths(model):
     model : `~jwst.datamodels.DataModel`
         The input science data.
 
+    order : int
+        Spectral order number, for NIRISS SOSS only.
+
     Returns
     -------
     wl_array : 2-D ndarray
         An array of wavelengths corresponding to the data in `model`.
     """
 
+    # Use the existing wavelength array, if there is one
     if hasattr(model, "wavelength"):
         wl_array = model.wavelength.copy()
         got_wavelength = True                   # may be reset below
@@ -329,8 +334,13 @@ def get_wavelengths(model):
             got_wavelength = False
             wl_array = None
 
+    # If no existing wavelength array, compute one
     if hasattr(model.meta, "wcs") and not got_wavelength:
-        wcs = model.meta.wcs
+        if hasattr(model.meta, "exposure") and model.meta.exposure.type == "NIS_SOSS":
+            transform = niriss.niriss_soss_set_input(model, order)
+            wcs = transform
+        else:
+            wcs = model.meta.wcs
         shape = model.data.shape
         grid = np.indices(shape[-2:], dtype=np.float64)
         wl_array = wcs(grid[1], grid[0])[2]

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -336,11 +336,15 @@ def get_wavelengths(model, order=None):
 
     # If no existing wavelength array, compute one
     if hasattr(model.meta, "wcs") and not got_wavelength:
+
+        # Set up an appropriate WCS object
         if hasattr(model.meta, "exposure") and model.meta.exposure.type == "NIS_SOSS":
-            transform = niriss.niriss_soss_set_input(model, order)
-            wcs = transform
+            wcs = niriss.niriss_soss_set_input(model, order)
         else:
             wcs = model.meta.wcs
+
+        # Evaluate the WCS on the grid of pixel indexes, capturing only the
+        # resulting wavelength values
         shape = model.data.shape
         grid = np.indices(shape[-2:], dtype=np.float64)
         wl_array = wcs(grid[1], grid[0])[2]

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -614,8 +614,8 @@ class DataSet():
         """
         Short Summary
         -------------
-        Read the conversion photom factor, and attach the relative sensitivity
-        table if the number of rows in the table > 0.
+        Combine photometric scalar and wavelength-dependent conversion factors
+        and apply to the science dataset.
 
         Parameters
         ----------
@@ -787,7 +787,7 @@ class DataSet():
         a scalar factor and an array of wavelength-dependent factors. The combination
         of both factors are applied to the input model. The scalar factor is also
         written to the PHOTMJSR and PHOTUJA2 keywords in the model. If a pixel area
-        map reference file exists for the instrument mode, it is also attached to
+        map reference file exists for the instrument mode, it is attached to
         the input model.
 
         Parameters

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -281,12 +281,11 @@ class DataSet():
         # Handle MultiSlit models separately, which are used for NIRISS WFSS
         if isinstance(self.input, datamodels.MultiSlitModel):
 
-            # We have to find and attach a separate set of flux cal
+            # We have to find and apply a separate set of flux cal
             # data for each of the slits/orders in the input
             for slit in self.input.slits:
 
-                # Initialize the output conversion factor and
-                # increment slit number
+                # Initialize the output conversion factor and increment slit number
                 match = False
                 self.slitnum += 1
 
@@ -324,12 +323,12 @@ class DataSet():
                 ref_pupil = tabdata['pupil'].strip().upper()
                 ref_order = tabdata['order']
 
-                # Spectroscopic mode
-                if self.exptype in ['NIS_SOSS', 'NIS_WFSS']:
+                # SOSS mode
+                if self.exptype in ['NIS_SOSS']:
 
                     # Find matching values of FILTER, PUPIL, and ORDER
                     if (self.filter == ref_filter and self.pupil == ref_pupil and order == ref_order):
-                        self.photom_io(tabdata)
+                        self.photom_io(tabdata, order)
                         match = True
                         break
 
@@ -611,7 +610,7 @@ class DataSet():
 
         return wave2d, area2d, dqmap
 
-    def photom_io(self, tabdata):
+    def photom_io(self, tabdata, order=None):
         """
         Short Summary
         -------------
@@ -622,6 +621,9 @@ class DataSet():
         ----------
         tabdata : FITS record
             Single row of data from reference table
+
+        order : int
+            Spectral order number
 
         Returns
         -------
@@ -663,9 +665,9 @@ class DataSet():
 
             # Compute a 2-D grid of conversion factors, as a function of wavelength
             if isinstance(self.input, datamodels.MultiSlitModel):
-                wl_array = expand_to_2d.get_wavelengths(self.input.slits[self.slitnum])
+                wl_array = expand_to_2d.get_wavelengths(self.input.slits[self.slitnum], order)
             else:
-                wl_array = expand_to_2d.get_wavelengths(self.input)
+                wl_array = expand_to_2d.get_wavelengths(self.input, order)
 
             wl_array[np.isnan(wl_array)] = -1.
             conv_2d = np.interp(wl_array, waves, relresps, left=1., right=1.)


### PR DESCRIPTION
Update the ``photom`` step to use the spectral order number when calling the ``get_wavelengths`` function for NIRISS SOSS mode, because the SOSS mode WCS is order-dependent. Also update the ``get_wavelengths`` function to make use of the ``order`` parameter when building the WCS transform for SOSS exposures.

Addresses some of the photom-related issues in #3301.