### PR TITLE
change indexing of model parameters

### DIFF
--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -881,8 +881,7 @@ class V23ToSky(Rotation3D):
         inputs, format_info = self.prepare_inputs(v2, v3)
         parameters = self._param_sets(raw=True)
 
-        outputs = self.evaluate(*chain([v2, v3], parameters))
-
+        outputs = self.evaluate(*chain(inputs, parameters))
         if self.n_outputs == 1:
             outputs = (outputs,)
 

--- a/jwst/transforms/tpcorr.py
+++ b/jwst/transforms/tpcorr.py
@@ -253,7 +253,7 @@ class TPCorr(Model):
         # convert cartesian to spherical coordinates:
         v2c, v3c = self.cartesian2spherical(zcr, xcr, ycr)
 
-        return v2c, v3c
+        return v2c.reshape(v2.shape), v3c.reshape(v3.shape)
 
 
     @property


### PR DESCRIPTION
Instead of indexing model.Parameter index the value of the parameter.
This removes ambiguity in the current code where indexing is of a Parameter instance returns one parameter in a model set. With this changes the code works with current astropy.modeling master and the future refactored modeling.

In addition the prepare_inputs/outputs calls were removed as they are not necessary in this case.

A bug in models.V23ToSky was fixed.
Similar to spacetelescope/tweakwcs#85