### PR TITLE
Exclude GuiderCalModel from flatfield error propogation

### DIFF
--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -188,22 +188,16 @@ def apply_flat_field(science, flat):
 
     # Now let's apply the correction to science data and error arrays.  Rely
     # on array broadcasting to handle the cubes
-
-    # Flatten data and error arrays
     science.data /= flat_data
 
     # Update the variances using BASELINE algorithm
-    flat_data_squared = flat_data**2
-    science.var_poisson /= flat_data_squared
-    science.var_rnoise /= flat_data_squared
-    science.var_flat = science.data**2 / flat_data_squared * flat_err**2
-
-    # Propogate flat and flat variance into the science err array
-    science.err = np.sqrt(
-        science.var_poisson +
-        science.var_rnoise +
-        science.var_flat
-        )
+    # Skip for guider data, as it has not gone through ramp fitting
+    if not isinstance(science, datamodels.GuiderCalModel):
+        flat_data_squared = flat_data**2
+        science.var_poisson /= flat_data_squared
+        science.var_rnoise /= flat_data_squared
+        science.var_flat = science.data**2 / flat_data_squared * flat_err**2
+        science.err = np.sqrt(science.var_poisson + science.var_rnoise + science.var_flat)
 
     # Combine the science and flat DQ arrays
     science.dq = np.bitwise_or(science.dq, flat_dq)


### PR DESCRIPTION
Follow-on to #3384 to exclude `GuiderCalModel` from error propogation from `FlatFieldStep`.

The guider pipeline currently does not do anything with errors.  The `err` attribute is not populated and `var_rnoise` and `var_poisson` don't exist in the schema for `GuiderCalModel`.  So there's no way to properly add in the variance due to the flat field.  So we skip it for now.

Tested against the 3 guider pipeline regression tests.  And they all will pass with this PR.