### PR TITLE
unit test for background

### DIFF
--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -28,11 +28,6 @@ def background(tmpdir_factory):
 
     image.meta.subarray.xstart = 1
     image.meta.subarray.ystart = 1
-    image.meta.wcsinfo.v2_ref = 0
-    image.meta.wcsinfo.v3_ref = 0
-    image.meta.wcsinfo.roll_ref = 0
-    image.meta.wcsinfo.ra_ref = 0
-    image.meta.wcsinfo.dec_ref = 0
 
     image.meta.instrument.gwa_xtilt = 0.0001
     image.meta.instrument.gwa_ytilt = 0.0001
@@ -59,15 +54,9 @@ def test_background_nirspec_gwa(_jail, background):
 
     image.meta.subarray.xstart = 1
     image.meta.subarray.ystart = 1
-    image.meta.wcsinfo.v2_ref = 0
-    image.meta.wcsinfo.v3_ref = 0
-    image.meta.wcsinfo.roll_ref = 0
-    image.meta.wcsinfo.ra_ref = 0
-    image.meta.wcsinfo.dec_ref = 0
 
     # open the background to read in the GWA values
     back_image = datamodels.open(background)
-
     image.meta.instrument.gwa_xtilt = back_image.meta.instrument.gwa_xtilt
     image.meta.instrument.gwa_ytilt = back_image.meta.instrument.gwa_ytilt
     image.meta.instrument.gwa_tilt = back_image.meta.instrument.gwa_tilt

--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -1,0 +1,108 @@
+"""
+Unit tests for background subtraction
+"""
+import pytest
+from numpy.testing.utils import assert_allclose
+from jwst.background import BackgroundStep
+
+from jwst import datamodels
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+
+
+@pytest.fixture(scope='module')
+def background(tmpdir_factory):
+    """Generate a  background image to feed to background step"""
+
+    filename = tmpdir_factory.mktemp('background_input')
+    filename = str(filename.join('background.fits'))
+    image = datamodels.IFUImageModel((10,10))
+    image.data[:,:] = 10
+    image.meta.instrument.name = 'NIRSPEC'
+    image.meta.instrument.detector = 'NRS1'
+    image.meta.instrument.filter = 'CLEAR'
+    image.meta.instrument.grating = 'PRISM'
+    image.meta.exposure.type = 'NRS_IFU'
+    image.meta.observation.date = '2019-02-27'
+    image.meta.observation.time = '13:37:18.548'
+    image.meta.date = '2019-02-27T13:37:18.548'
+
+    image.meta.subarray.xstart = 1
+    image.meta.subarray.ystart = 1
+    image.meta.wcsinfo.v2_ref = 0
+    image.meta.wcsinfo.v3_ref = 0
+    image.meta.wcsinfo.roll_ref = 0
+    image.meta.wcsinfo.ra_ref = 0
+    image.meta.wcsinfo.dec_ref = 0
+
+    image.meta.instrument.gwa_xtilt = 0.0001
+    image.meta.instrument.gwa_ytilt = 0.0001
+    image.meta.instrument.gwa_tilt = 37.0610
+
+    image.save(filename)
+    return filename
+
+
+def test_background_nirspec_gwa(_jail, background):
+    """Verify NIRSPEC GWA logic for in the science and background"""
+
+    # set up the IFU science image
+    image = datamodels.IFUImageModel((10,10))
+    image.data[:,:] = 100
+    image.meta.instrument.name = 'NIRSPEC'
+    image.meta.instrument.detector = 'NRS1'
+    image.meta.instrument.filter = 'CLEAR'
+    image.meta.instrument.grating = 'PRISM'
+    image.meta.exposure.type = 'NRS_IFU'
+    image.meta.observation.date = '2019-02-27'
+    image.meta.observation.time = '13:37:18.548'
+    image.meta.date = '2019-02-27T13:37:18.548'
+
+    image.meta.subarray.xstart = 1
+    image.meta.subarray.ystart = 1
+    image.meta.wcsinfo.v2_ref = 0
+    image.meta.wcsinfo.v3_ref = 0
+    image.meta.wcsinfo.roll_ref = 0
+    image.meta.wcsinfo.ra_ref = 0
+    image.meta.wcsinfo.dec_ref = 0
+
+    # open the background to read in the GWA values
+    back_image = datamodels.open(background)
+
+    image.meta.instrument.gwa_xtilt = back_image.meta.instrument.gwa_xtilt
+    image.meta.instrument.gwa_ytilt = back_image.meta.instrument.gwa_ytilt
+    image.meta.instrument.gwa_tilt = back_image.meta.instrument.gwa_tilt
+
+    bkg = [background]
+    # Test 1
+    # Run with GWA values the same - confirm it runs
+    # And gives the predicted result
+
+    collect_pipeline_cfgs('./config')
+    result = BackgroundStep.call(
+        image, bkg,
+        config_file='config/background.cfg',
+        )
+
+    test = image.data - back_image.data
+    assert_allclose(result.data, test)
+    assert type(image) is type(result)
+    assert result.meta.cal_step.back_sub == 'COMPLETE'
+
+    # Test 2 - change xtilt
+    image.meta.instrument.gwa_xtilt = image.meta.instrument.gwa_xtilt + 0.00001
+    collect_pipeline_cfgs('./config')
+    result = BackgroundStep.call(
+        image, bkg,
+        config_file='config/background.cfg',
+        )
+    assert result.meta.cal_step.back_sub == 'SKIPPED'
+
+    # Test 3 - change ytilt - set xtilt back to back_image value
+    image.meta.instrument.gwa_xtilt = back_image.meta.instrument.gwa_xtilt
+    image.meta.instrument.gwa_ytilt = image.meta.instrument.gwa_ytilt + 0.00001
+    collect_pipeline_cfgs('./config')
+    result = BackgroundStep.call(
+        image, bkg,
+        config_file='config/background.cfg',
+        )
+    assert result.meta.cal_step.back_sub == 'SKIPPED'

--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -15,7 +15,7 @@ def background(tmpdir_factory):
 
     filename = tmpdir_factory.mktemp('background_input')
     filename = str(filename.join('background.fits'))
-    image = datamodels.IFUImageModel((10,10))
+    image = datamodels.IFUImageModel((10, 10))
     image.data[:,:] = 10
     image.meta.instrument.name = 'NIRSPEC'
     image.meta.instrument.detector = 'NRS1'
@@ -37,11 +37,10 @@ def background(tmpdir_factory):
     return filename
 
 
-def test_background_nirspec_gwa(_jail, background):
+def test_nirspec_gwa(_jail, background):
     """Verify NIRSPEC GWA logic for in the science and background"""
-
     # set up the IFU science image
-    image = datamodels.IFUImageModel((10,10))
+    image = datamodels.IFUImageModel((10, 10))
     image.data[:,:] = 100
     image.meta.instrument.name = 'NIRSPEC'
     image.meta.instrument.detector = 'NRS1'
@@ -51,7 +50,6 @@ def test_background_nirspec_gwa(_jail, background):
     image.meta.observation.date = '2019-02-27'
     image.meta.observation.time = '13:37:18.548'
     image.meta.date = '2019-02-27T13:37:18.548'
-
     image.meta.subarray.xstart = 1
     image.meta.subarray.ystart = 1
 
@@ -62,8 +60,7 @@ def test_background_nirspec_gwa(_jail, background):
     image.meta.instrument.gwa_tilt = back_image.meta.instrument.gwa_tilt
 
     bkg = [background]
-    # Test 1
-    # Run with GWA values the same - confirm it runs
+    # Test Run with GWA values the same - confirm it runs
     # And gives the predicted result
 
     collect_pipeline_cfgs('./config')
@@ -77,7 +74,33 @@ def test_background_nirspec_gwa(_jail, background):
     assert type(image) is type(result)
     assert result.meta.cal_step.back_sub == 'COMPLETE'
 
-    # Test 2 - change xtilt
+
+def test_nirspec_gwa_xtilt(_jail, background):
+    """Verify NIRSPEC GWA Xtilt must be the same in the science and background image"""
+
+    # set up the IFU science image
+    image = datamodels.IFUImageModel((10, 10))
+    image.data[:,:] = 100
+    image.meta.instrument.name = 'NIRSPEC'
+    image.meta.instrument.detector = 'NRS1'
+    image.meta.instrument.filter = 'CLEAR'
+    image.meta.instrument.grating = 'PRISM'
+    image.meta.exposure.type = 'NRS_IFU'
+    image.meta.observation.date = '2019-02-27'
+    image.meta.observation.time = '13:37:18.548'
+    image.meta.date = '2019-02-27T13:37:18.548'
+    image.meta.subarray.xstart = 1
+    image.meta.subarray.ystart = 1
+
+    # open the background to read in the GWA values
+    back_image = datamodels.open(background)
+    image.meta.instrument.gwa_xtilt = back_image.meta.instrument.gwa_xtilt
+    image.meta.instrument.gwa_ytilt = back_image.meta.instrument.gwa_ytilt
+    image.meta.instrument.gwa_tilt = back_image.meta.instrument.gwa_tilt
+
+    bkg = [background]
+
+    # Test change xtilt
     image.meta.instrument.gwa_xtilt = image.meta.instrument.gwa_xtilt + 0.00001
     collect_pipeline_cfgs('./config')
     result = BackgroundStep.call(
@@ -86,8 +109,33 @@ def test_background_nirspec_gwa(_jail, background):
         )
     assert result.meta.cal_step.back_sub == 'SKIPPED'
 
-    # Test 3 - change ytilt - set xtilt back to back_image value
+
+def test_nirspec_gwa_ytitl(_jail, background):
+    """Verify NIRSPEC GWA Ytilt must be the same in the science and background image"""
+
+    # set up the IFU science image
+    image = datamodels.IFUImageModel((10, 10))
+    image.data[:,:] = 100
+    image.meta.instrument.name = 'NIRSPEC'
+    image.meta.instrument.detector = 'NRS1'
+    image.meta.instrument.filter = 'CLEAR'
+    image.meta.instrument.grating = 'PRISM'
+    image.meta.exposure.type = 'NRS_IFU'
+    image.meta.observation.date = '2019-02-27'
+    image.meta.observation.time = '13:37:18.548'
+    image.meta.date = '2019-02-27T13:37:18.548'
+    image.meta.subarray.xstart = 1
+    image.meta.subarray.ystart = 1
+
+    # open the background to read in the GWA values
+    back_image = datamodels.open(background)
     image.meta.instrument.gwa_xtilt = back_image.meta.instrument.gwa_xtilt
+    image.meta.instrument.gwa_ytilt = back_image.meta.instrument.gwa_ytilt
+    image.meta.instrument.gwa_tilt = back_image.meta.instrument.gwa_tilt
+
+    bkg = [background]
+
+    # Test different ytilt
     image.meta.instrument.gwa_ytilt = image.meta.instrument.gwa_ytilt + 0.00001
     collect_pipeline_cfgs('./config')
     result = BackgroundStep.call(

--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -37,9 +37,12 @@ def background(tmpdir_factory):
     return filename
 
 
-def test_nirspec_gwa(_jail, background):
-    """Verify NIRSPEC GWA logic for in the science and background"""
-    # set up the IFU science image
+@pytest.fixture(scope='module')
+def science_image(tmpdir_factory):
+    """Generate science image"""
+
+    filename = tmpdir_factory.mktemp('background_input')
+    filename = str(filename.join('science_image.fits'))
     image = datamodels.IFUImageModel((10, 10))
     image.data[:,:] = 100
     image.meta.instrument.name = 'NIRSPEC'
@@ -53,6 +56,18 @@ def test_nirspec_gwa(_jail, background):
     image.meta.subarray.xstart = 1
     image.meta.subarray.ystart = 1
 
+    image.meta.instrument.gwa_xtilt = 0.0001
+    image.meta.instrument.gwa_ytilt = 0.0001
+    image.meta.instrument.gwa_tilt = 37.0610
+
+    image.save(filename)
+    return filename
+
+
+def test_nirspec_gwa(_jail, background, science_image):
+    """Verify NIRSPEC GWA logic for in the science and background"""
+
+    image = datamodels.open(science_image)
     # open the background to read in the GWA values
     back_image = datamodels.open(background)
     image.meta.instrument.gwa_xtilt = back_image.meta.instrument.gwa_xtilt
@@ -73,24 +88,15 @@ def test_nirspec_gwa(_jail, background):
     assert_allclose(result.data, test)
     assert type(image) is type(result)
     assert result.meta.cal_step.back_sub == 'COMPLETE'
+    back_image.close()
+    image.close()
 
 
-def test_nirspec_gwa_xtilt(_jail, background):
+def test_nirspec_gwa_xtilt(_jail, background, science_image):
     """Verify NIRSPEC GWA Xtilt must be the same in the science and background image"""
 
     # set up the IFU science image
-    image = datamodels.IFUImageModel((10, 10))
-    image.data[:,:] = 100
-    image.meta.instrument.name = 'NIRSPEC'
-    image.meta.instrument.detector = 'NRS1'
-    image.meta.instrument.filter = 'CLEAR'
-    image.meta.instrument.grating = 'PRISM'
-    image.meta.exposure.type = 'NRS_IFU'
-    image.meta.observation.date = '2019-02-27'
-    image.meta.observation.time = '13:37:18.548'
-    image.meta.date = '2019-02-27T13:37:18.548'
-    image.meta.subarray.xstart = 1
-    image.meta.subarray.ystart = 1
+    image = datamodels.open(science_image)
 
     # open the background to read in the GWA values
     back_image = datamodels.open(background)
@@ -108,24 +114,15 @@ def test_nirspec_gwa_xtilt(_jail, background):
         config_file='config/background.cfg',
         )
     assert result.meta.cal_step.back_sub == 'SKIPPED'
+    image.close()
+    back_image.close()
 
 
-def test_nirspec_gwa_ytitl(_jail, background):
+def test_nirspec_gwa_ytitl(_jail, background, science_image):
     """Verify NIRSPEC GWA Ytilt must be the same in the science and background image"""
 
     # set up the IFU science image
-    image = datamodels.IFUImageModel((10, 10))
-    image.data[:,:] = 100
-    image.meta.instrument.name = 'NIRSPEC'
-    image.meta.instrument.detector = 'NRS1'
-    image.meta.instrument.filter = 'CLEAR'
-    image.meta.instrument.grating = 'PRISM'
-    image.meta.exposure.type = 'NRS_IFU'
-    image.meta.observation.date = '2019-02-27'
-    image.meta.observation.time = '13:37:18.548'
-    image.meta.date = '2019-02-27T13:37:18.548'
-    image.meta.subarray.xstart = 1
-    image.meta.subarray.ystart = 1
+    image = datamodels.open(science_image)
 
     # open the background to read in the GWA values
     back_image = datamodels.open(background)
@@ -143,3 +140,6 @@ def test_nirspec_gwa_ytitl(_jail, background):
         config_file='config/background.cfg',
         )
     assert result.meta.cal_step.back_sub == 'SKIPPED'
+
+    back_image.close()
+    image.close()


### PR DESCRIPTION
Unit test for calspec2 background subtraction - testing logic when the data is NISPEC. The GWA x,y values have to be the same between science image and background.

I was not sure if I had to run assign_wcs on the data. I had this in the code at first but when I took
it out it did not seem to matter that is was not run. If I need it for some reason  let me know. If I don't need it I can probably take out all the setting of the wcs values. 

I used the _jail  for the background image since the input to background step is a list of background
filenames - at least I think that is correct. 
