### PR TITLE
Bump CRDS context for tests to 508

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - CRDS_CONTEXT="jwst_0504.pmap"
+    - CRDS_CONTEXT="jwst_0508.pmap"
     - NUMPY_VERSION=1.16
 
 matrix:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ python_version = '3.6'
 env_vars = [
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_PATH=./crds_cache",
-    "CRDS_CONTEXT=jwst_0504.pmap",
+    "CRDS_CONTEXT=jwst_0508.pmap",
 ]
 
 // Pip related setup

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -13,7 +13,7 @@ numpy_version = '1.16'
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
-    "CRDS_CONTEXT=jwst_0504.pmap",
+    "CRDS_CONTEXT=jwst_0508.pmap",
 ]
 
 // Set pytest basetemp output directory


### PR DESCRIPTION
Increment CRDS context for CI and regression tests from 504 to 508. 508 is the current default, although new ref files have been submitted in even later contexts.