### PR TITLE
Specify pip<19.1 to avoid PEP 517 breakage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,10 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'linux'
 bc0.name = 'wheel-sdist'
 bc0.conda_ver = '4.6.8'
-bc0.conda_packages = ["python=${python_version}"]
+bc0.conda_packages = [
+    "python=${python_version}",
+    "pip<19.1"
+]
 bc0.build_cmds = [
     "pip install ${pip_install_args} numpy",
     "pip wheel ${pip_install_args} .",
@@ -47,6 +50,7 @@ bc2.conda_packages = [
     "numpy",
     "nomkl",
     "jwst",
+    "pip<19.1",
 ]
 bc2.build_cmds = [
     "python setup.py develop",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -42,6 +42,7 @@ bc.conda_packages = [
     "numpy=${numpy_version}",
     "nomkl",
     "jwst",
+    "pip<19.1",
 ]
 bc.build_cmds = [
     "python setup.py develop",


### PR DESCRIPTION
This is because of

https://github.com/pypa/pip/issues/6434

Closes #3409