### PR TITLE
Modify extract_1d and combine_1d for change in units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,7 @@ combine_1d
 
 - Modified to use the same columns as now written by extract_1d.
   The background parameter has been removed, since dividing by npixels
-  is now done in extract_1d. [#3409]
+  is now done in extract_1d. [#3412]
 
 datamodels
 ----------
@@ -83,7 +83,7 @@ extract_1d
 - This now writes columns SURF_BRIGHT and SB_ERROR instead of NET and
   NERROR.  The BACKGROUND column is divided by NPIXELS, so the units will
   be surface brightness.  This step no longer looks for a RELSENS
-  extension. [#3409]
+  extension. [#3412]
 
 
 flatfield

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,10 @@ combine_1d
 - Fix call to wcs.invert, and don't weight flux by sensitivity if the net
   column is all zeros. [#3274]
 
+- Modified to use the same columns as now written by extract_1d.
+  The background parameter has been removed, since dividing by npixels
+  is now done in extract_1d. [#3409]
+
 datamodels
 ----------
 
@@ -75,6 +79,11 @@ extract_1d
   background subtraction.  For non-IFU data, a try/except block was added
   to check for a WCS that does not have an inverse.  Some code (but not
   all) for the now-obsolete RELSENS extension has been deleted. [#3390]
+
+- This now writes columns SURF_BRIGHT and SB_ERROR instead of NET and
+  NERROR.  The BACKGROUND column is divided by NPIXELS, so the units will
+  be surface brightness.  This step no longer looks for a RELSENS
+  extension. [#3409]
 
 
 flatfield

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -18,7 +18,8 @@ class InputSpectrumModel:
         wavelength
         flux
         error
-        net
+        surf_bright
+        sb_error
         dq
         nelem
         weight
@@ -27,16 +28,16 @@ class InputSpectrumModel:
         declination
     """
 
-    def __init__(self, ms, spec, exptime_key, background):
+    def __init__(self, ms, spec, exptime_key):
         """Create an InputSpectrumModel object.
 
         Parameters
         ----------
-        ms : MultiSpecModel or SpecModel object
+        ms : `~jwst.datamodels.DataModel`, MultiSpecModel or SpecModel
             This is used to get the integration time.
 
-        spec : SpecModel table
-            The table containing columns "wavelength" and "net".
+        spec : `~jwst.datamodels.DataModel`, SpecModel table
+            The table containing columns "wavelength" and "flux".
             The `ms` object may contain more than one spectrum, but `spec`
             should be just one of those.
 
@@ -44,32 +45,19 @@ class InputSpectrumModel:
             A string identifying which keyword to use to get the exposure
             time, which is used as a weight; or "unit_weight", which means
             to use weight = 1.
-
-        background : bool
-            If the flux data are actually background rather than a target
-            spectrum, `background` should be set to True.  In this case, the
-            values read from the flux column of each input spectrum will be
-            divided by the npixels column (if that column exists).  This is
-            to convert the values to background per pixel.
         """
 
         self.wavelength = spec.spec_table.field("wavelength").copy()
 
-        if background:
-            try:
-                npixels = spec.spec_table.field("npixels").copy()
-            except KeyError:
-                npixels = np.ones_like(self.wavelength)
-
-        if background:
-            # Convert to background value per pixel.
-            self.flux = spec.spec_table.field("flux") / npixels
-            self.error = spec.spec_table.field("error") / npixels
-            self.net = spec.spec_table.field("net") / npixels
-        else:
-            self.flux = spec.spec_table.field("flux").copy()
-            self.error = spec.spec_table.field("error").copy()
-            self.net = spec.spec_table.field("net").copy()
+        self.flux = spec.spec_table.field("flux").copy()
+        self.error = spec.spec_table.field("error").copy()
+        try:
+            self.surf_bright = spec.spec_table.field("surf_bright").copy()
+            self.sb_error = spec.spec_table.field("sb_error").copy()
+        except KeyError:
+            self.surf_bright = np.zeros_like(self.flux)
+            self.sb_error = np.zeros_like(self.flux)
+            log.warning("There is no SURF_BRIGHT column in the input.")
         self.dq = spec.spec_table.field("dq").copy()
         self.nelem = self.wavelength.shape[0]
         self.unit_weight = False        # may be reset below
@@ -86,8 +74,6 @@ class InputSpectrumModel:
         else:
             raise RuntimeError("Don't understand exptime_key = '%s'" %
                                exptime_key)
-        if background and exptime_key != "unit_weight":
-            self.weight *= npixels
 
         got_wcs = True
         try:
@@ -101,12 +87,12 @@ class InputSpectrumModel:
             self.declination[:] = ms.meta.target.dec
             log.warning("There is no WCS in the input.")
 
-
     def close(self):
         self.wavelength = None
         self.flux = None
         self.error = None
-        self.net = None
+        self.surf_bright = None
+        self.sb_error = None
         self.dq = None
         self.nelem = 0
         self.weight = 1.
@@ -120,14 +106,14 @@ class OutputSpectrumModel:
         wavelength
         flux
         error
-        net
+        surf_bright
+        sb_error
         dq
-        flux_weight
         weight
         count
         wcs
         wavelength_dtype
-        net_dtype
+        flux_dtype
         dq_dtype
         normalized
     """
@@ -137,17 +123,16 @@ class OutputSpectrumModel:
         self.wavelength = None
         self.flux = None
         self.error = None
-        self.net = None
+        self.surf_bright = None
+        self.sb_error = None
         self.dq = None
-        self.flux_weight = None
         self.weight = None
         self.count = None
         self.wcs = None
         self.wavelength_dtype = None
-        self.net_dtype = None
+        self.flux_dtype = None
         self.dq_dtype = None
         self.normalized = False
-
 
     def assign_wavelengths(self, input_spectra):
         """Create an array of wavelengths to use for the output spectrum.
@@ -166,7 +151,7 @@ class OutputSpectrumModel:
         # The types used for accumulating sums and taking averages may not
         # be the same as these types.
         self.wavelength_dtype = input_spectra[0].wavelength.dtype
-        self.net_dtype = input_spectra[0].net.dtype
+        self.flux_dtype = input_spectra[0].flux.dtype
         self.dq_dtype = input_spectra[0].dq.dtype
 
         nwl = 0
@@ -175,7 +160,7 @@ class OutputSpectrumModel:
 
         # Create an array with all the input wavelengths (i.e. the union
         # of the input wavelengths).
-        wl = np.zeros(nwl, dtype=np.float)
+        wl = np.zeros(nwl, dtype=np.float64)
         i = 0
         for in_spec in input_spectra:
             nelem = in_spec.nelem
@@ -212,7 +197,6 @@ class OutputSpectrumModel:
         self.wcs = create_spectral_wcs(input_spectra[0].right_ascension[0],
                                        input_spectra[0].declination[0],
                                        self.wavelength)
-
 
     def compute_output_wl(self, wl, count_input):
         """Compute output wavelengths.
@@ -260,19 +244,19 @@ class OutputSpectrumModel:
         # of wl, over count_input elements.  A small value implies that
         # there's a clump, i.e. several elements of wl with nearly the
         # same wavelength.
-        sigma = np.zeros(nwl, dtype=np.float) + 9999.
+        sigma = np.zeros(nwl, dtype=np.float64) + 9999.
 
         # mean_wl is the mean wavelength over the same slice of wl that we
         # used to compute sigma.  If sigma is small enough that it looks
         # as if there's a clump, we'll copy the mean_wl value to temp_wl
         # to be one element of the output wavelengths.
-        mean_wl = np.zeros(nwl, dtype=np.float) - 99.
+        mean_wl = np.zeros(nwl, dtype=np.float64) - 99.
 
         # temp_wl has the same number of elements as wl, but we expect the
         # array of output wavelengths to be significantly smaller, so
         # temp_wl is initialized to a negative value as a flag.  Positive
         # elements will be copied to the array of output wavelengths.
-        temp_wl = np.zeros(nwl, dtype=np.float) - 99.
+        temp_wl = np.zeros(nwl, dtype=np.float64) - 99.
 
         for k in range(nwl):
             n = count_input[k]
@@ -328,7 +312,6 @@ class OutputSpectrumModel:
 
         return temp_wl[np.where(temp_wl > 0.)].copy()
 
-
     def accumulate_sums(self, input_spectra):
         """Compute a weighted sum of all the input spectra.
 
@@ -348,13 +331,6 @@ class OutputSpectrumModel:
         input pixel is flagged with a non-zero value other than DO_NOT_USE,
         the value will be propagated to the output DQ array via bitwise OR.
 
-        The net will be weighted by the exposure (or integration) time.
-        The flux will also be weighted by the sensitivity.  The ratio of
-        net to flux is the sensitivity.  For both net and flux, the idea
-        is that it is counts that should be added up when accumulating
-        sums.  If unit weight was specified, however, both net and flux
-        will be weighted by one.
-
         Parameters
         ----------
         input_spectra : list of InputSpectrumModel objects
@@ -363,30 +339,15 @@ class OutputSpectrumModel:
 
         nelem = self.wavelength.shape[0]
 
-        self.flux = np.zeros(nelem, dtype=np.float)
-        self.error = np.zeros(nelem, dtype=np.float)
-        self.flux_weight = np.zeros(nelem, dtype=np.float)
+        self.flux = np.zeros(nelem, dtype=np.float64)
+        self.error = np.zeros(nelem, dtype=np.float64)
+        self.surf_bright = np.zeros(nelem, dtype=np.float64)
+        self.sb_error = np.zeros(nelem, dtype=np.float64)
         self.dq = np.zeros(nelem, dtype=self.dq_dtype)
-        self.net = np.zeros(nelem, dtype=np.float)
-        self.weight = np.zeros(nelem, dtype=np.float)
-        self.count = np.zeros(nelem, dtype=np.float)
-
-        # The flux should be weighted by sensitivity (as well as exposure
-        # time), but if the input net columns are not populated, we can't
-        # compute the sensitivity.
-        weight_flux_by_sensitivity = True
-        for in_spec in input_spectra:
-            if in_spec.net.min() == 0. and in_spec.net.max() == 0.:
-                weight_flux_by_sensitivity = False
-                log.warning("The NET column is all zero in one or more "
-                            "input tables, so FLUX will not be weighted by "
-                            "sensitivity.")
-                break
+        self.weight = np.zeros(nelem, dtype=np.float64)
+        self.count = np.zeros(nelem, dtype=np.float64)
 
         for in_spec in input_spectra:
-            if weight_flux_by_sensitivity:
-                # Replace zeros so we can divide by the flux.
-                temp_flux = np.where(in_spec.flux == 0., 1., in_spec.flux)
             # Get the pixel numbers in the output corresponding to the
             # wavelengths of the current input spectrum.
             out_pixel = self.wcs.invert(in_spec.right_ascension,
@@ -399,21 +360,13 @@ class OutputSpectrumModel:
                     continue
                 # Round to the nearest pixel.
                 k = round(float(out_pixel[i]))
-                self.net[k] += (in_spec.net[i] * in_spec.weight[i])
-                self.weight[k] += in_spec.weight[i]
+                weight = in_spec.weight[i]
                 self.dq[k] |= in_spec.dq[i]
-                if in_spec.unit_weight:
-                    flux_wgt = 1.
-                elif weight_flux_by_sensitivity:
-                    # net / flux is the sensitivity
-                    flux_wgt = (in_spec.weight[i] *
-                                in_spec.net[i] / temp_flux[i])
-                    flux_wgt = max(flux_wgt, 0.)
-                else:
-                    flux_wgt = in_spec.weight[i]
-                self.flux[k] += in_spec.flux[i] * flux_wgt
-                self.error[k] += (in_spec.error[i] * flux_wgt)**2
-                self.flux_weight[k] += flux_wgt
+                self.flux[k] += in_spec.flux[i] * weight
+                self.error[k] += (in_spec.error[i] * weight)**2
+                self.surf_bright[k] += (in_spec.surf_bright[i] * weight)
+                self.sb_error[k] += (in_spec.sb_error[i] * weight)**2
+                self.weight[k] += weight
                 self.count[k] += 1.
 
         # Since the output wavelengths will not usually be exactly the same
@@ -428,10 +381,11 @@ class OutputSpectrumModel:
             log.warning("    these elements will be omitted.")
             self.wavelength = self.wavelength[index]
             self.flux = self.flux[index]
-            self.net = self.net[index]
-            self.weight = self.weight[index]
-            self.flux_weight = self.flux_weight[index]
             self.error = self.error[index]
+            self.surf_bright = self.surf_bright[index]
+            self.sb_error = self.error[index]
+            self.dq = self.dq[index]
+            self.weight = self.weight[index]
             self.count = self.count[index]
         del index
 
@@ -442,20 +396,18 @@ class OutputSpectrumModel:
 
         if not self.normalized:
             sum_weight = np.where(self.weight > 0., self.weight, 1.)
-            sum_flux_wgt = np.where(self.flux_weight > 0.,
-                                    self.flux_weight, 1.)
-            self.net /= sum_weight
-            self.flux /= sum_flux_wgt
-            self.error = np.sqrt(self.error / sum_flux_wgt)
+            self.surf_bright /= sum_weight
+            self.flux /= sum_weight
+            self.error = np.sqrt(self.error / sum_weight)
+            self.sb_error = np.sqrt(self.sb_error / sum_weight)
             self.normalized = True
-
 
     def create_output(self):
         """Create the output model.
 
         Returns
         -------
-        output_model : CombinedSpecModel object
+        output_model : `~jwst.datamodels.DataModel`, CombinedSpecModel object
             A table of combined spectral data.
         """
 
@@ -463,18 +415,20 @@ class OutputSpectrumModel:
             log.warning("Data have not been divided by"
                         " the sum of the weights.")
 
-        dtype = [('wavelength', self.wavelength_dtype),
-                 ('flux', self.net_dtype),
-                 ('error', self.net_dtype),
-                 ('net', self.net_dtype),
-                 ('dq', self.dq_dtype),
-                 ('weight', self.wavelength_dtype),
-                 ('n_input', np.float)]
+        dtype = [('WAVELENGTH', self.wavelength_dtype),
+                 ('FLUX', self.flux_dtype),
+                 ('ERROR', self.flux_dtype),
+                 ('SURF_BRIGHT', self.flux_dtype),
+                 ('SB_ERROR', self.flux_dtype),
+                 ('DQ', self.dq_dtype),
+                 ('WEIGHT', self.wavelength_dtype),
+                 ('N_INPUT', np.float64)]
 
         data = np.array(list(zip(self.wavelength,
                                  self.flux,
                                  self.error,
-                                 self.net,
+                                 self.surf_bright,
+                                 self.sb_error,
                                  self.dq,
                                  self.weight,
                                  self.count)), dtype=dtype)
@@ -482,19 +436,18 @@ class OutputSpectrumModel:
 
         return output_model
 
-
     def close(self):
         self.wavelength = None
         self.flux = None
         self.error = None
-        self.net = None
+        self.surf_bright = None
+        self.sb_error = None
         self.dq = None
-        self.flux_weight = None
         self.weight = None
         self.count = None
         self.wcs = None
         self.wavelength_dtype = None
-        self.net_dtype = None
+        self.flux_dtype = None
         self.dq_dtype = None
         self.normalized = False
 
@@ -544,7 +497,7 @@ def check_exptime(exptime_key):
     return exptime_key
 
 
-def combine_1d_spectra(input_model, exptime_key, background=False):
+def combine_1d_spectra(input_model, exptime_key):
     """Combine the input spectra.
 
     Parameters
@@ -558,13 +511,6 @@ def combine_1d_spectra(input_model, exptime_key, background=False):
         be one of:  "exposure_time" (the default), "integration_time",
         or "unit_weight".
 
-    background : bool, default=False
-        If the flux data are actually background rather than a target
-        spectrum, `background` should be set to True.  In this case, the
-        values read from the flux column of each input spectrum will be
-        divided by the npixels column (if that column exists).  This is
-        to convert the values to background per pixel.
-
     Returns
     -------
     output_model : `~jwst.datamodels.DataModel`
@@ -572,8 +518,6 @@ def combine_1d_spectra(input_model, exptime_key, background=False):
     """
 
     log.debug("Using exptime_key = {}.".format(exptime_key))
-    if background:
-        log.debug("The FLUX data will be treated as background data.")
 
     exptime_key = check_exptime(exptime_key)
 
@@ -582,11 +526,11 @@ def combine_1d_spectra(input_model, exptime_key, background=False):
         for ms in input_model:
             for in_spec in ms.spec:
                 input_spectra.append(InputSpectrumModel(
-                                ms, in_spec, exptime_key, background))
+                                ms, in_spec, exptime_key))
     else:
         for in_spec in input_model.spec:
             input_spectra.append(InputSpectrumModel(
-                                input_model, in_spec, exptime_key, background))
+                                input_model, in_spec, exptime_key))
 
     output_spec = OutputSpectrumModel()
     output_spec.assign_wavelengths(input_spectra)

--- a/jwst/combine_1d/combine_1d_step.py
+++ b/jwst/combine_1d/combine_1d_step.py
@@ -17,14 +17,12 @@ class Combine1dStep(Step):
 
     spec = """
     exptime_key = string(default="exposure_time") # use for weight
-    background = boolean(default=False) # True if the input are all background
     """
 
     def process(self, input_file):
 
         with datamodels.open(input_file) as input_model:
             result = combine1d.combine_1d_spectra(input_model,
-                                                  self.exptime_key,
-                                                  self.background)
+                                                  self.exptime_key)
 
         return result

--- a/jwst/datamodels/schemas/combinedspec.schema.yaml
+++ b/jwst/datamodels/schemas/combinedspec.schema.yaml
@@ -7,18 +7,20 @@ allOf:
       title: Combined, extracted spectral data table
       fits_hdu: COMBINE1D
       datatype:
-        - name: WAVELENGTH
-          datatype: float64
-        - name: FLUX
-          datatype: float64
-        - name: ERROR
-          datatype: float64
-        - name: NET
-          datatype: float64
-        - name: DQ
-          datatype: uint32
-        - name: WEIGHT
-          datatype: float64
-        - name: N_INPUT
-          datatype: float64
+      - name: WAVELENGTH
+        datatype: float64
+      - name: FLUX
+        datatype: float64
+      - name: ERROR
+        datatype: float64
+      - name: SURF_BRIGHT
+        datatype: float64
+      - name: SB_ERROR
+        datatype: float64
+      - name: DQ
+        datatype: uint32
+      - name: WEIGHT
+        datatype: float64
+      - name: N_INPUT
+        datatype: float64
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -19,12 +19,12 @@ allOf:
               datatype: float64
             - name: ERROR
               datatype: float64
+            - name: SURF_BRIGHT
+              datatype: float64
+            - name: SB_ERROR
+              datatype: float64
             - name: DQ
               datatype: uint32
-            - name: NET
-              datatype: float64
-            - name: NERROR
-              datatype: float64
             - name: BACKGROUND
               datatype: float64
             - name: BERROR

--- a/jwst/datamodels/schemas/spec.schema.yaml
+++ b/jwst/datamodels/schemas/spec.schema.yaml
@@ -13,12 +13,12 @@ allOf:
         datatype: float64
       - name: ERROR
         datatype: float64
+      - name: SURF_BRIGHT
+        datatype: float64
+      - name: SB_ERROR
+        datatype: float64
       - name: DQ
         datatype: uint32
-      - name: NET
-        datatype: float64
-      - name: NERROR
-        datatype: float64
       - name: BACKGROUND
         datatype: float64
       - name: BERROR

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -14,6 +14,7 @@ from ..lib import pipe_utils
 from . import extract1d
 from . import ifu
 from . import spec_wcs
+from . import util
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -157,7 +158,8 @@ def get_extract_parameters(ref_dict,
     sp_order : int
         The spectral order number.
 
-    meta : metadata for current slit.
+    meta : metadata for the actual input model, i.e. not just for the
+        current slit.
         Not currently used.
 
     smoothing_length : int or None
@@ -254,36 +256,55 @@ def get_extract_parameters(ref_dict,
                         raise ValueError('dispaxis must be 1 or 2.')
                     else:
                         extract_params['dispaxis'] = disp
-                    extract_params['src_coeff'] = aper.get('src_coeff')
-                    extract_params['bkg_coeff'] = aper.get('bkg_coeff')
-                    extract_params['independent_var'] = \
-                          aper.get('independent_var', 'pixel').lower()
+                    if meta.target.source_type.upper() == "EXTENDED":
+                        log.info("Target is extended, so the entire region "
+                                 "will be extracted.")
+                        shape = input_model.data.shape
+                        extract_params['src_coeff'] = None
+                        extract_params['bkg_coeff'] = None
+                        extract_params['bkg_order'] = 0
+                        extract_params['apply_nod_offset'] = False
+                        extract_params['xstart'] = 0
+                        extract_params['xstop'] = shape[-1] - 1
+                        extract_params['ystart'] = 0
+                        extract_params['ystop'] = shape[-2] - 1
+                        extract_params['extract_width'] = None
+                        extract_params['independent_var'] = 'pixel'
+                        extract_params['nod_correction'] = 0    # default value
+                    else:
+                        extract_params['src_coeff'] = aper.get('src_coeff')
+                        extract_params['bkg_coeff'] = aper.get('bkg_coeff')
+                        extract_params['independent_var'] = \
+                              aper.get('independent_var', 'pixel').lower()
+                        if bkg_order is None:
+                            extract_params['bkg_order'] = aper.get('bkg_order', 0)
+                        else:
+                            # If the user supplied a value, use that value.
+                            extract_params['bkg_order'] = bkg_order
+                        if apply_nod_offset is None:
+                            extract_params['apply_nod_offset'] = \
+                                  aper.get('apply_nod_offset', True)
+                        else:
+                            # If the user supplied a value, use that value.
+                            extract_params['apply_nod_offset'] = apply_nod_offset
+                        extract_params['xstart'] = aper.get('xstart')
+                        extract_params['xstop'] = aper.get('xstop')
+                        extract_params['ystart'] = aper.get('ystart')
+                        extract_params['ystop'] = aper.get('ystop')
+                        extract_params['extract_width'] = aper.get('extract_width')
+                        extract_params['nod_correction'] = 0    # default value
                     if smoothing_length is None:
                         extract_params['smoothing_length'] = \
                               aper.get('smoothing_length', 0)
                     else:
                         # If the user supplied a value, use that value.
                         extract_params['smoothing_length'] = smoothing_length
-                    if bkg_order is None:
-                        extract_params['bkg_order'] = aper.get('bkg_order', 0)
-                    else:
-                        # If the user supplied a value, use that value.
-                        extract_params['bkg_order'] = bkg_order
-                    if apply_nod_offset is None:
-                        extract_params['apply_nod_offset'] = \
-                              aper.get('apply_nod_offset', True)
-                    else:
-                        # If the user supplied a value, use that value.
-                        extract_params['apply_nod_offset'] = apply_nod_offset
-                    extract_params['xstart'] = aper.get('xstart')
-                    extract_params['xstop'] = aper.get('xstop')
-                    extract_params['ystart'] = aper.get('ystart')
-                    extract_params['ystop'] = aper.get('ystop')
-                    extract_params['extract_width'] = aper.get('extract_width')
-                    extract_params['nod_correction'] = 0        # default value
                     break
 
     elif ref_dict['ref_file_type'] == FILE_TYPE_IMAGE:
+        # Note that we will use the supplied image-format reference file,
+        # without regard for the distinction between point source and
+        # extended source.
         extract_params['ref_file_type'] = ref_dict['ref_file_type']
         foundit = False
         for im in ref_dict['ref_model'].images:
@@ -1226,8 +1247,7 @@ class ExtractBase:
         Parameters
         ----------
         input_model : data model
-            The input science model.  This will only be used if `slit`
-            is None
+            The input science model.
 
         slit : one slit from a MultiSlitModel (or similar), or None
             The WCS and target coordinates will be gotten from `slit`
@@ -1376,6 +1396,9 @@ class ExtractModel(ExtractBase):
             For MultiSlit or MultiProduct data, `slit` is one slit from
             a list of slits in the input.  For other types of data, `slit`
             will not be used.
+
+        verbose : bool
+            If True, log messages.
 
         ref_file_type : str
             This indicates whether the reference file (if any) was a JSON
@@ -1891,15 +1914,23 @@ class ExtractModel(ExtractBase):
         wavelength : ndarray, 1-D, float64
             The wavelength in micrometers at each pixel.
 
-        net : ndarray, 1-D
-            The count rate (counts / s) minus the background at each pixel.
+        temp_flux : ndarray, 1-D
+            The sum of the data values in the extraction region minus the
+            sum of the data values in the background regions (scaled by the
+            ratio of the numbers of pixels), for each pixel.
+            The data values are in units of surface brightness, so this
+            value isn't really the flux, it's an intermediate value.
+            Dividing by `npixels` (to compute the average) will give the
+            array for the `surf_bright` (surface brightness) output column,
+            and multiplying by the solid angle of a pixel will give the
+            flux for a point source.
 
         background : ndarray, 1-D, float64
-            The background count rate that was subtracted from the total
-            source count rate to get `net`.
+            The background count rate that was subtracted from the sum of
+            the source data values to get `temp_flux`.
 
         npixels : ndarray, 1-D, float64
-            The number of pixels that were added together to get `net`.
+            The number of pixels that were added together to get `temp_flux`.
 
         dq : ndarray, 1-D, uint32
             The data quality array.
@@ -2043,24 +2074,35 @@ class ExtractModel(ExtractBase):
             temp_wl[nan_mask] = 0.01            # because NaNs cause problems
 
         # src total flux, area, total weight
-        (net, background, npixels) = \
+        (temp_flux, background, npixels) = \
         extract1d.extract1d(image, temp_wl, disp_range,
                             self.p_src, self.p_bkg, self.independent_var,
                             self.smoothing_length, self.bkg_order,
                             weights=None)
         del temp_wl
 
-        dq = np.zeros(net.shape, dtype=np.uint32)
+        dq = np.zeros(temp_flux.shape, dtype=np.uint32)
         if n_nan > 0:
-            (wavelength, net, background, npixels, dq) = \
-                nans_at_endpoints(wavelength, net, background, npixels, dq,
-                                  verbose)
+            (wavelength, temp_flux, background, npixels, dq) = \
+                nans_at_endpoints(wavelength, temp_flux, background,
+                                  npixels, dq, verbose)
 
-        return (ra, dec, wavelength, net, background, npixels, dq)
+        return (ra, dec, wavelength, temp_flux, background, npixels, dq)
 
 
 class ImageExtractModel(ExtractBase):
-    """This uses an image that specifies the extraction region."""
+    """This uses an image that specifies the extraction region.
+
+    Extended summary
+    ----------------
+    One of the requirements for this step is that for an extended target,
+    the entire aperture is supposed to be extracted (with no background
+    subtraction).  It doesn't make any sense to use an image reference file
+    to extract the entire aperture; a trivially simple JSON reference file
+    would do.  Therefore, we assume that if the user specified a reference
+    file in image format, the user actually wanted that reference file
+    to be used, so we will ignore the requirement in this case.
+    """
 
     def __init__(self, input_model, slit, verbose,
                  ref_file_type=None,
@@ -2085,6 +2127,9 @@ class ImageExtractModel(ExtractBase):
             a list of slits in the input.  For other types of data, `slit`
             will not be used.
 
+        verbose : bool
+            If True, log messages.
+
         ref_file_type : str
             This indicates whether the reference file (if any) was a JSON
             file or an image.
@@ -2098,11 +2143,11 @@ class ImageExtractModel(ExtractBase):
             "partial match" if only the slit name matches.  If neither
             match, `match` will be "no match".
 
-        ref_image : data model
-            The reference image.
-
         spectral_order : int
             Spectral order number.
+
+        ref_image : data model
+            The reference image.
 
         dispaxis : int
             Dispersion direction:  1 is horizontal, 2 is vertical.
@@ -2118,6 +2163,12 @@ class ImageExtractModel(ExtractBase):
             will be moved to [y0 + nod, x0], where `nod` is
             int(round(nod_correction)), if the dispersion direction is
             horizontal.
+
+        subtract_background : bool or None
+            A flag which indicates whether the background should be subtracted.
+            If None, the value in the extract_1d reference file will be used.
+            If not None, this parameter overrides the value in the
+            extract_1d reference file.
 
         apply_nod_offset : bool or None
             If True, the reference image will be shifted by an integral
@@ -2308,15 +2359,23 @@ class ImageExtractModel(ExtractBase):
         wavelength : ndarray, 1-D
             The wavelength in micrometers at each pixel.
 
-        net : ndarray, 1-D
-            The count rate (counts / s) minus the background at each pixel.
+        temp_flux : ndarray, 1-D
+            The sum of the data values in the extraction region minus the
+            sum of the data values in the background regions (scaled by the
+            ratio of the numbers of pixels), for each pixel.
+            The data values are in units of surface brightness, so this
+            value isn't really the flux, it's an intermediate value.
+            Multiply `temp_flux` by the solid angle of a pixel to get the
+            flux for a point source (column "flux").  Divide `temp_flux` by
+            `npixels` (to compute the average) to get the array for the
+            "surf_bright" (surface brightness) output column.  
 
         background : ndarray, 1-D
-            The background count rate that was subtracted from the total
-            source count rate to get `net`.
+            The background count rate that was subtracted from the sum of
+            the source data values to get `temp_flux`.
 
         npixels : ndarray, 1-D, float64
-            The number of pixels that were added together to get `net`.
+            The number of pixels that were added together to get `temp_flux`.
 
         dq : ndarray, 1-D, uint32
         """
@@ -2369,10 +2428,10 @@ class ImageExtractModel(ExtractBase):
             if self.smoothing_length > 1:
                 background = extract1d.bxcar(background, self.smoothing_length)
                 background = np.where(n_bkg > 0., background, 0.)
-            net = gross - background
+            temp_flux = gross - background
         else:
             background = np.zeros_like(gross)
-            net = gross.copy()
+            temp_flux = gross.copy()
         del gross
 
         if wl_array is None or len(wl_array) == 0:
@@ -2417,9 +2476,10 @@ class ImageExtractModel(ExtractBase):
         mask = np.where(n_target > 0.)
         if len(mask[0]) > 0:
             trim_slc = slice(mask[0][0], mask[0][-1] + 1)
-            net = net[trim_slc]
+            temp_flux = temp_flux[trim_slc]
             background = background[trim_slc]
             n_target = n_target[trim_slc]
+            npixels = npixels[trim_slc]
             x_array = x_array[trim_slc]
             y_array = y_array[trim_slc]
 
@@ -2513,17 +2573,17 @@ class ImageExtractModel(ExtractBase):
                 wavelength = np.arange(shape[0], dtype=np.float)
             wavelength = wavelength[trim_slc]
 
-        dq = np.zeros(net.shape, dtype=np.uint32)
+        dq = np.zeros(temp_flux.shape, dtype=np.uint32)
         nan_mask = np.isnan(wavelength)
         n_nan = nan_mask.sum(dtype=np.intp)
         if n_nan > 0:
             if verbose:
                 log.warning("%d NaNs in wavelength array", n_nan)
-            (wavelength, net, background, npixels, dq) = \
-                nans_at_endpoints(wavelength, net, background, npixels, dq,
-                                  verbose)
+            (wavelength, temp_flux, background, npixels, dq) = \
+                nans_at_endpoints(wavelength, temp_flux, background,
+                                  npixels, dq, verbose)
 
-        return (ra, dec, wavelength, net, background, npixels, dq)
+        return (ra, dec, wavelength, temp_flux, background, npixels, dq)
 
 
     def match_shape(self, shape):
@@ -2600,79 +2660,6 @@ class ImageExtractModel(ExtractBase):
             mask_bkg = None
 
         return (mask_target, mask_bkg)
-
-
-def interpolate_response(wavelength, relsens, verbose):
-    """Interpolate within the relative response table.
-
-    Parameters
-    ----------
-    wavelength : ndarray, 1-D
-        Wavelengths in the science data
-
-    relsens : record array
-        Contains two columns, 'wavelength' and 'response'.
-
-    verbose : bool
-        If True, write log messages.
-
-    Returns
-    -------
-    rr_factor : ndarray, 1-D
-        The reciprocal of the response, interpolated at `wavelength`, with
-        extrapolated elements and zero or negative response values set to 0.
-        Multiply the net count rate by rr_factor to obtain the flux.
-    """
-
-    # "_relsens" indicates that the values were read from the RELSENS table.
-    wl_relsens = relsens['wavelength']
-    resp_relsens = relsens['response']
-    MICRONS_100 = 1.e-4                 # 100 microns, in meters
-    if wl_relsens.max() > 0. and wl_relsens.max() < MICRONS_100:
-        if verbose:
-            log.warning("Converting RELSENS wavelengths to microns.")
-        wl_relsens *= 1.e6
-
-    bad = False
-    if np.any(np.isnan(wl_relsens)):
-        log.error("In RELSENS, the 'wavelength' column contains NaNs.")
-        bad = True
-    if np.any(np.isnan(resp_relsens)):
-        log.error("In RELSENS, the 'response' column contains NaNs.")
-        bad = True
-    if bad:
-        raise ValueError("Found NaNs in RELSENS table.")
-
-    # np.interp requires that wl_relsens be increasing.
-    if wl_relsens[-1] < wl_relsens[0]:
-        if verbose:
-            log.warning("The wavelength column in RELSENS was decreasing.")
-        wl_relsens = wl_relsens[::-1].copy()
-        resp_relsens = resp_relsens[::-1].copy()
-
-    # `r_factor` is the response, interpolated at the wavelengths in the
-    # science data.  -2048 is a flag value, to check for extrapolation.
-    r_factor = np.interp(wavelength, wl_relsens, resp_relsens, -2048., -2048.)
-    mask2048 = np.where(r_factor == -2048.)
-    if len(mask2048[0]) > 0:
-        if verbose:
-            log.warning("Using RELSENS, %d elements were extrapolated; the "
-                        "corresponding flux will be set to 0.",
-                        len(mask2048[0]))
-        r_factor[mask2048] = 1.                 # temporary
-    mask_neg = np.where(r_factor <= 0.)
-    if len(mask_neg[0]) > 0:
-        if verbose:
-            log.warning("Using RELSENS, %d interpolated response values "
-                        "were <= 0; the corresponding flux will be set to 0.",
-                        len(mask_neg[0]))
-        r_factor[mask_neg] = 1.                 # temporary
-
-    rr_factor = 1. / r_factor
-    rr_factor[mask2048] = 0.
-    rr_factor[mask_neg] = 0.
-
-    return rr_factor
 
 
 def run_extract1d(input_model, refname, smoothing_length, bkg_order,
@@ -2886,42 +2873,41 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 continue
 
             try:
-                (ra, dec, wavelength, net, background, npixels, dq,
-                 prev_offset) = extract_one_slit(
+                (ra, dec, wavelength, temp_flux, background,
+                 npixels, dq, prev_offset) = extract_one_slit(
                                         input_model, slit, -1,
                                         prev_offset, True, extract_params)
             except InvalidSpectralOrderNumberError as e:
                 log.info(str(e) + ", skipping ...")
                 continue
-            got_relsens = True
-            try:
-                relsens = slit.relsens
-            except AttributeError:
-                got_relsens = False
-            if got_relsens:
-                # reciprocal of the response
-                rr_factor = interpolate_response(wavelength, relsens, True)
-                flux = net * rr_factor
-            else:
-                log.warning("No relsens for current slit, "
-                            "so can't compute flux.")
-                flux = np.zeros_like(net)
-            fl_error = np.ones_like(net)
-            nerror = np.ones_like(net)
-            berror = np.ones_like(net)
-            otab = np.array(list(zip(wavelength, flux, fl_error, dq,
-                                     net, nerror, background, berror,
-                                     npixels)),
+
+            # Convert the sum to an average, for surface brightness.
+            surf_bright = temp_flux / npixels
+            background /= npixels
+
+            # Convert to flux density (for a point source).
+            pixel_solid_angle = util.pixel_area(slit.meta.wcs, slit.data.shape)
+            if pixel_solid_angle is None:
+                log.warning("Pixel solid angle could not be determined")
+                pixel_solid_angle = 1.
+            flux = temp_flux * pixel_solid_angle
+            del temp_flux
+            error = np.zeros_like(flux) * pixel_solid_angle
+            sb_error = np.zeros_like(flux)
+            berror = np.zeros_like(flux)
+            otab = np.array(list(zip(wavelength,
+                                     flux, error, surf_bright, sb_error,
+                                     dq, background, berror, npixels)),
                             dtype=spec_dtype)
             spec = datamodels.SpecModel(spec_table=otab)
             spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
             spec.spec_table.columns['wavelength'].unit = 'um'
             spec.spec_table.columns['flux'].unit = 'mJy'
             spec.spec_table.columns['error'].unit = 'mJy'
-            spec.spec_table.columns['net'].unit = 'DN/s'
-            spec.spec_table.columns['nerror'].unit = 'DN/s'
-            spec.spec_table.columns['background'].unit = 'DN/s'
-            spec.spec_table.columns['berror'].unit = 'DN/s'
+            spec.spec_table.columns['surf_bright'].unit = 'MJy/sr'
+            spec.spec_table.columns['sb_error'].unit = 'MJy/sr'
+            spec.spec_table.columns['background'].unit = 'MJy/sr'
+            spec.spec_table.columns['berror'].unit = 'MJy/sr'
             spec.slit_ra = ra
             spec.slit_dec = dec
             spec.spectral_order = sp_order
@@ -2971,8 +2957,8 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                                     "determined, so skipping ...")
                         continue
                     try:
-                        (ra, dec, wavelength, net, background, npixels, dq,
-                         prev_offset) = extract_one_slit(
+                        (ra, dec, wavelength, temp_flux, background,
+                         npixels, dq, prev_offset) = extract_one_slit(
                                         input_model, slit, -1,
                                         prev_offset, True, extract_params)
                     except InvalidSpectralOrderNumberError as e:
@@ -2985,25 +2971,30 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 else:
                     log.critical('Missing extraction parameters.')
                     raise ValueError('Missing extraction parameters.')
-                got_relsens = True
-                try:
-                    relsens = input_model.relsens
-                except AttributeError:
-                    got_relsens = False
-                if got_relsens:
-                    # reciprocal of the response
-                    rr_factor = interpolate_response(wavelength, relsens, True)
-                    flux = net * rr_factor
+
+                # Convert the sum to an average, for surface brightness.
+                surf_bright = temp_flux / npixels
+                background /= npixels
+
+                # Convert to flux density (for a point source).
+                if input_model.meta.exposure.type == "NIS_SOSS":
+                    wcs = niriss.niriss_soss_set_input(input_model, sp_order)
                 else:
-                    log.warning("No relsens for input file, "
-                                "so can't compute flux.")
-                    flux = np.zeros_like(net)
-                fl_error = np.ones_like(net)
-                nerror = np.ones_like(net)
-                berror = np.ones_like(net)
-                otab = np.array(list(zip(wavelength, flux, fl_error, dq,
-                                         net, nerror, background, berror,
-                                         npixels)),
+                    wcs = input_model.meta.wcs
+                pixel_solid_angle = util.pixel_area(wcs,
+                                                    input_model.data.shape)
+                if pixel_solid_angle is None:
+                    log.warning("Pixel solid angle could not be determined")
+                    pixel_solid_angle = 1.
+                flux = temp_flux * pixel_solid_angle
+                del temp_flux
+                error = np.zeros_like(flux) * pixel_solid_angle
+                sb_error = np.zeros_like(flux)
+                berror = np.zeros_like(flux)
+                otab = np.array(list(zip(wavelength,
+                                         flux, error,
+                                         surf_bright, sb_error,
+                                         dq, background, berror, npixels)),
                                 dtype=spec_dtype)
                 spec = datamodels.SpecModel(spec_table=otab)
                 spec.meta.wcs = spec_wcs.create_spectral_wcs(
@@ -3011,10 +3002,10 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 spec.spec_table.columns['wavelength'].unit = 'um'
                 spec.spec_table.columns['flux'].unit = 'mJy'
                 spec.spec_table.columns['error'].unit = 'mJy'
-                spec.spec_table.columns['net'].unit = 'DN/s'
-                spec.spec_table.columns['nerror'].unit = 'DN/s'
-                spec.spec_table.columns['background'].unit = 'DN/s'
-                spec.spec_table.columns['berror'].unit = 'DN/s'
+                spec.spec_table.columns['surf_bright'].unit = 'MJy/sr'
+                spec.spec_table.columns['sb_error'].unit = 'MJy/sr'
+                spec.spec_table.columns['background'].unit = 'MJy/sr'
+                spec.spec_table.columns['berror'].unit = 'MJy/sr'
                 spec.slit_ra = ra
                 spec.slit_dec = dec
                 spec.spectral_order = sp_order
@@ -3058,15 +3049,6 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                                 "determined, so skipping ...")
                     continue
 
-                got_relsens = True
-                try:
-                    relsens = input_model.relsens
-                except AttributeError:
-                    got_relsens = False
-                if not got_relsens:
-                    log.warning("No relsens for input file, "
-                                "so can't compute flux.")
-
                 # Loop over each integration in the input model
                 verbose = True          # for just the first integration
                 if input_model.data.shape[0] == 1:
@@ -3077,38 +3059,53 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 for integ in range(input_model.data.shape[0]):
                     # Extract spectrum
                     try:
-                        (ra, dec, wavelength, net, background, npixels, dq,
-                         prev_offset) = extract_one_slit(
+                        (ra, dec, wavelength, temp_flux, background,
+                         npixels, dq, prev_offset) = extract_one_slit(
                                         input_model, slit, integ,
                                         prev_offset, verbose, extract_params)
                     except InvalidSpectralOrderNumberError as e:
                         log.info(str(e) + ", skipping ...")
                         break
-                    if got_relsens:
-                        # reciprocal of the response
-                        rr_factor = interpolate_response(
-                                        wavelength, input_model.relsens,
-                                        verbose)
-                        flux = net * rr_factor
+
+                    # Convert the sum to an average, for surface brightness.
+                    surf_bright = temp_flux / npixels
+                    background /= npixels
+
+                    # Convert to flux density (for a point source).
+                    if input_model.meta.exposure.type == "NIS_SOSS":
+                        wcs = niriss.niriss_soss_set_input(input_model,
+                                                           sp_order)
                     else:
-                        flux = np.zeros_like(net)
-                    fl_error = np.ones_like(net)
-                    nerror = np.ones_like(net)
-                    berror = np.ones_like(net)
-                    otab = np.array(list(zip(wavelength, flux, fl_error, dq,
-                                             net, nerror, background, berror,
+                        wcs = input_model.meta.wcs
+                    pixel_solid_angle = util.pixel_area(wcs,
+                                                        input_model.data.shape,
+                                                        verbose)
+                    if pixel_solid_angle is None:
+                        if verbose:
+                            log.warning("Pixel solid angle could not "
+                                        "be determined")
+                        pixel_solid_angle = 1.
+                    flux = temp_flux * pixel_solid_angle
+                    del temp_flux
+                    error = np.zeros_like(flux) * pixel_solid_angle
+                    sb_error = np.zeros_like(flux)
+                    berror = np.zeros_like(flux)
+                    otab = np.array(list(zip(wavelength,
+                                             flux, error,
+                                             surf_bright, sb_error,
+                                             dq, background, berror,
                                              npixels)),
-                                             dtype=spec_dtype)
+                                    dtype=spec_dtype)
                     spec = datamodels.SpecModel(spec_table=otab)
                     spec.meta.wcs = spec_wcs.create_spectral_wcs(
                                         ra, dec, wavelength)
                     spec.spec_table.columns['wavelength'].unit = 'um'
-                    spec.spec_table.columns['flux'].unit = 'mJy'
-                    spec.spec_table.columns['error'].unit = 'mJy'
-                    spec.spec_table.columns['net'].unit = 'DN/s'
-                    spec.spec_table.columns['nerror'].unit = 'DN/s'
-                    spec.spec_table.columns['background'].unit = 'DN/s'
-                    spec.spec_table.columns['berror'].unit = 'DN/s'
+                    spec.spec_table.columns['flux'].unit = 'Jy'
+                    spec.spec_table.columns['error'].unit = 'Jy'
+                    spec.spec_table.columns['surf_bright'].unit = 'MJy/sr'
+                    spec.spec_table.columns['sb_error'].unit = 'MJy/sr'
+                    spec.spec_table.columns['background'].unit = 'MJy/sr'
+                    spec.spec_table.columns['berror'].unit = 'MJy/sr'
                     spec.slit_ra = ra
                     spec.slit_dec = dec
                     spec.spectral_order = sp_order
@@ -3474,15 +3471,23 @@ def extract_one_slit(input_model, slit, integ,
     wavelength : ndarray, 1-D, float64
         The wavelength in micrometers at each pixel.
 
-    net : ndarray, 1-D, float64
-        The count rate (counts / s) minus the background at each pixel.
+    temp_flux : ndarray, 1-D, float64
+        The sum of the data values in the extraction region minus the sum
+        of the data values in the background regions (scaled by the ratio
+        of the numbers of pixels), for each pixel.
+        The data values are in units of surface brightness, so this value
+        isn't really the flux, it's an intermediate value.  Multiply
+        `temp_flux` by the solid angle of a pixel to get the flux for a
+        point source (column "flux").  Divide `temp_flux` by `npixels` (to
+        compute the average) to get the array for the "surf_bright"
+        (surface brightness) output column.  
 
     background : ndarray, 1-D, float64
         The background count rate that was subtracted from the total
-        source count rate to get `net`.
+        source count rate to get `temp_flux`.
 
     npixels : ndarray, 1-D, float64
-        The number of pixels that were added together to get `net`.
+        The number of pixels that were added together to get `temp_flux`.
 
     dq : ndarray, 1-D, uint32
         The data quality array.
@@ -3561,10 +3566,10 @@ def extract_one_slit(input_model, slit, integ,
         extract_model.log_extraction_parameters()
 
     extract_model.assign_polynomial_limits(verbose)
-    (ra, dec, wavelength, net, background, npixels, dq) = \
+    (ra, dec, wavelength, temp_flux, background, npixels, dq) = \
                 extract_model.extract(data, wl_array, verbose)
 
-    return (ra, dec, wavelength, net, background, npixels, dq, offset)
+    return (ra, dec, wavelength, temp_flux, background, npixels, dq, offset)
 
 
 def replace_bad_values(data, input_dq, fill=0.):
@@ -3600,7 +3605,8 @@ def replace_bad_values(data, input_dq, fill=0.):
     else:
         return data
 
-def nans_at_endpoints(wavelength, net, background, npixels, dq, verbose):
+def nans_at_endpoints(wavelength, temp_flux, background,
+                      npixels, dq, verbose):
     """Flag NaNs in the wavelength array.
 
     Extended summary
@@ -3616,14 +3622,14 @@ def nans_at_endpoints(wavelength, net, background, npixels, dq, verbose):
     wavelength : ndarray
         Array of wavelengths, possibly containing NaNs.
 
-    net : ndarray
-        Array of net count rates.
+    temp_flux : ndarray
+        Array of sums of data values (scaled background has been subtracted).
 
     background : ndarray
-        Array of background values that were subtracted to get `net`.
+        Array of background values that were subtracted to get `temp_flux`.
 
     npixels : ndarray, float64
-        The number of pixels that were added together to get `net`.
+        The number of pixels that were added together to get `temp_flux`.
 
     dq : ndarray
         Data quality array.
@@ -3633,14 +3639,14 @@ def nans_at_endpoints(wavelength, net, background, npixels, dq, verbose):
 
     Returns
     -------
-    wavelength, net, background, npixels, dq : ndarray
+    wavelength, temp_flux, background, npixels, dq : ndarray
         The returned `dq` array may have NaNs flagged with DO_NOT_USE,
         and all five arrays may have been trimmed at either or both ends.
     """
 
     # The input arrays will not be modified in-place.
     new_wl = wavelength.copy()
-    new_net = net.copy()
+    new_temp_flux = temp_flux.copy()
     new_bkg = background.copy()
     new_npixels = npixels.copy()
     new_dq = dq.copy()
@@ -3660,11 +3666,11 @@ def nans_at_endpoints(wavelength, net, background, npixels, dq, verbose):
                          n_trimmed)
             slc = slice(flag[0][0], flag[0][-1] + 1)
             new_wl = new_wl[slc]
-            new_net = new_net[slc]
+            new_temp_flux = new_temp_flux[slc]
             new_bkg = new_bkg[slc]
             new_npixels = new_npixels[slc]
             new_dq = new_dq[slc]
     else:
         new_dq |= dqflags.pixel['DO_NOT_USE']
 
-    return (new_wl, new_net, new_bkg, new_npixels, new_dq)
+    return (new_wl, new_temp_flux, new_bkg, new_npixels, new_dq)

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2891,8 +2891,10 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 continue
 
             # Convert the sum to an average, for surface brightness.
-            surf_bright = temp_flux / npixels
-            background /= npixels
+            npixels_temp = np.where(npixels > 0., npixels, 1.)
+            surf_bright = temp_flux / npixels_temp
+            background /= npixels_temp
+            del npixels_temp
 
             # Convert to flux density (for a point source).
             pixel_solid_angle = util.pixel_area(slit.meta.wcs, slit.data.shape)
@@ -3079,8 +3081,10 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                         break
 
                     # Convert the sum to an average, for surface brightness.
-                    surf_bright = temp_flux / npixels
-                    background /= npixels
+                    npixels_temp = np.where(npixels > 0., npixels, 1.)
+                    surf_bright = temp_flux / npixels_temp
+                    background /= npixels_temp
+                    del npixels_temp
 
                     # Convert to flux density (for a point source).
                     if input_model.meta.exposure.type == "NIS_SOSS":

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2901,9 +2901,10 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             if pixel_solid_angle is None:
                 log.warning("Pixel solid angle could not be determined")
                 pixel_solid_angle = 1.
-            flux = temp_flux * pixel_solid_angle
+            # MJy / steradian --> Jy
+            flux = temp_flux * pixel_solid_angle * 1.e6
             del temp_flux
-            error = np.zeros_like(flux) * pixel_solid_angle
+            error = np.zeros_like(flux) * pixel_solid_angle * 1.e6
             sb_error = np.zeros_like(flux)
             berror = np.zeros_like(flux)
             otab = np.array(list(zip(wavelength,
@@ -2999,9 +3000,10 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 if pixel_solid_angle is None:
                     log.warning("Pixel solid angle could not be determined")
                     pixel_solid_angle = 1.
-                flux = temp_flux * pixel_solid_angle
+                # MJy / steradian --> Jy
+                flux = temp_flux * pixel_solid_angle * 1.e6
                 del temp_flux
-                error = np.zeros_like(flux) * pixel_solid_angle
+                error = np.zeros_like(flux) * pixel_solid_angle * 1.e6
                 sb_error = np.zeros_like(flux)
                 berror = np.zeros_like(flux)
                 otab = np.array(list(zip(wavelength,
@@ -3100,9 +3102,10 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                             log.warning("Pixel solid angle could not "
                                         "be determined")
                         pixel_solid_angle = 1.
-                    flux = temp_flux * pixel_solid_angle
+                    # MJy / steradian --> Jy
+                    flux = temp_flux * pixel_solid_angle * 1.e6
                     del temp_flux
-                    error = np.zeros_like(flux) * pixel_solid_angle
+                    error = np.zeros_like(flux) * pixel_solid_angle * 1.e6
                     sb_error = np.zeros_like(flux)
                     berror = np.zeros_like(flux)
                     otab = np.array(list(zip(wavelength,

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2982,8 +2982,10 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                     raise ValueError('Missing extraction parameters.')
 
                 # Convert the sum to an average, for surface brightness.
-                surf_bright = temp_flux / npixels
-                background /= npixels
+                npixels_temp = np.where(npixels > 0., npixels, 1.)
+                surf_bright = temp_flux / npixels_temp
+                background /= npixels_temp
+                del npixels_temp
 
                 # Convert to flux density (for a point source).
                 if input_model.meta.exposure.type == "NIS_SOSS":
@@ -3562,9 +3564,9 @@ def extract_one_slit(input_model, slit, integ,
                 offset = 0.
         else:
             offset = prev_offset
-        extract_model.nod_correction = offset
     else:
-        extract_model.nod_correction = 0.
+        offset = 0.
+    extract_model.nod_correction = offset
 
     # Add the nod/dither offset to the polynomial coefficients, or shift
     # the reference image (depending on the type of reference file).

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -11,10 +11,6 @@ class Extract1dStep(Step):
 
     Attributes
     ----------
-    ref_file : str
-        Name of the reference file.  This can be "N/A" if there is no
-        reference file for the current instrument mode.
-
     smoothing_length : int or None
         If not None, the background regions (if any) will be smoothed
         with a boxcar function of this width along the dispersion
@@ -130,16 +126,15 @@ class Extract1dStep(Step):
                 result = datamodels.ModelContainer()
                 for model in input_model:
                     if model.meta.exposure.type in extract.WFSS_EXPTYPES:
-                        self.ref_file = 'N/A'
+                        ref_file = 'N/A'
                         self.log.info('No EXTRACT1D reference file '
                                       'will be used')
                     else:
                         # Get the reference file name
-                        self.ref_file = self.get_reference_file(
-                                        model, 'extract1d')
+                        ref_file = self.get_reference_file(model, 'extract1d')
                         self.log.info('Using EXTRACT1D reference file %s',
-                                      self.ref_file)
-                    temp = extract.run_extract1d(model, self.ref_file,
+                                      ref_file)
+                    temp = extract.run_extract1d(model, ref_file,
                                                  self.smoothing_length,
                                                  self.bkg_order,
                                                  self.log_increment,
@@ -151,15 +146,15 @@ class Extract1dStep(Step):
                     del temp
             elif len(input_model) == 1:
                 if input_model[0].meta.exposure.type in extract.WFSS_EXPTYPES:
-                    self.ref_file = 'N/A'
+                    ref_file = 'N/A'
                     self.log.info('No EXTRACT1D reference file will be used')
                 else:
                     # Get the reference file name for the one model in input
-                    self.ref_file = self.get_reference_file(input_model[0],
+                    ref_file = self.get_reference_file(input_model[0],
                                                             'extract1d')
                     self.log.info('Using EXTRACT1D reference file %s',
-                                  self.ref_file)
-                result = extract.run_extract1d(input_model[0], self.ref_file,
+                                  ref_file)
+                result = extract.run_extract1d(input_model[0], ref_file,
                                                self.smoothing_length,
                                                self.bkg_order,
                                                self.log_increment,
@@ -174,14 +169,12 @@ class Extract1dStep(Step):
         else:
             # Get the reference file name
             if input_model.meta.exposure.type in extract.WFSS_EXPTYPES:
-                self.ref_file = 'N/A'
+                ref_file = 'N/A'
                 self.log.info('No EXTRACT1D reference file will be used')
             else:
-                self.ref_file = self.get_reference_file(input_model,
-                                                        'extract1d')
-                self.log.info('Using EXTRACT1D reference file %s',
-                              self.ref_file)
-            result = extract.run_extract1d(input_model, self.ref_file,
+                ref_file = self.get_reference_file(input_model, 'extract1d')
+                self.log.info('Using EXTRACT1D reference file %s', ref_file)
+            result = extract.run_extract1d(input_model, ref_file,
                                            self.smoothing_length,
                                            self.bkg_order,
                                            self.log_increment,

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -2,12 +2,14 @@ import logging
 import math
 
 import numpy as np
+from astropy import units as u
 from photutils import CircularAperture, CircularAnnulus, \
                       RectangularAperture, aperture_photometry
 
 from .. import datamodels
-from .. datamodels import dqflags
+from ..datamodels import dqflags
 from . import spec_wcs
+from . import util
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -61,7 +63,8 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
         log.error("Expected an IFU cube.")
         raise RuntimeError("Expected an IFU cube.")
 
-    if source_type.lower() != "point" and source_type.lower() != "extended":
+    source_type = source_type.lower()
+    if source_type != "point" and source_type != "extended":
         log.warning("source_type was '%s', setting to 'point'.", source_type)
         source_type = "point"
     else:
@@ -76,7 +79,7 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
 
     extract_params = get_extract_parameters(ref_dict, slitname)
     if subtract_background is not None:
-        if subtract_background and source_type.lower() == "extended":
+        if subtract_background and source_type == "extended":
             subtract_background = False
             log.info("Turning off background subtraction because "
                      "the source is extended.")
@@ -84,60 +87,67 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
 
     if extract_params:
         if extract_params['ref_file_type'] == FILE_TYPE_JSON:
-            (ra, dec, wavelength, net, background, npixels, dq) = \
+            (ra, dec, wavelength, temp_flux, background, npixels, dq) = \
                     extract_ifu(input_model, source_type, extract_params)
         else:                                   # FILE_TYPE_IMAGE
-            (ra, dec, wavelength, net, background, npixels, dq) = \
+            (ra, dec, wavelength, temp_flux, background, npixels, dq) = \
                     image_extract_ifu(input_model, source_type, extract_params)
     else:
         log.critical('Missing extraction parameters.')
         raise ValueError('Missing extraction parameters.')
 
-    # Check whether the data have been converted to flux density.
-    fluxcorr_complete = True                    # initial values
-    missing = False
+    # Check the units.  We expect either "MJy / sr" or "mJy / arcsec^2".
     try:
         bunit = input_model.meta.bunit_data
     except AttributeError:
         bunit = None
-    if bunit is None:
-        fluxcorr_complete = False
-        missing = True
-    elif (bunit.find("Jy") < 0 and
-          bunit.find("jansky") < 0 and bunit.find("Jansky") < 0):
-        fluxcorr_complete = False
-    if missing:
-        log.warning("No BUNIT found in input science data header.")
+    megajanskys = True                          # initial value
+    if bunit is not None:
+        if bunit.find("M") < 0 or bunit.find("arcsec") >= 0:
+            megajanskys = False
 
-    # If the data have already been converted to flux density, `net`
-    # contains fluxes, so move that column to `flux`.  If not, it's
-    # too late to do flux correction.
-    if fluxcorr_complete:
-        flux = net.copy()
-        net[:] = 0.
-        log.info("Data have been flux calibrated; setting net to 0.")
-        data_units = 'mJy'
-    else:
-        flux = np.zeros_like(net)
-        log.info("Data have NOT been flux calibrated; setting flux to 0.")
-        data_units = 'DN/s'
+    # Convert the sum to an average, for surface brightness.
+    surf_bright = temp_flux / npixels
+    background /= npixels
+    if not megajanskys:
+        # Not MJy / sr?  Then assume the units are mJy / arcsec^2.
+        # Target spectrum in units of surface brightness.
+        sb = surf_bright * u.mJy / (u.arcsec**2)
+        surf_bright = sb.to(u.MJy / u.steradian).value
+        # Background spectrum.
+        bkg = background * u.mJy / (u.arcsec**2)
+        background = bkg.to(u.MJy / u.steradian).value
 
-    fl_error = np.ones_like(net)
-    nerror = np.ones_like(net)
-    berror = np.ones_like(net)
+    # Convert surface brightness to flux density (for a point source).
+    pixel_solid_angle = util.pixel_area(input_model.meta.wcs,
+                                        input_model.data.shape)
+    if pixel_solid_angle is None:
+        log.warning("Pixel solid angle could not be determined")
+        pixel_solid_angle = 1.
+    if not megajanskys:
+        psa = pixel_solid_angle * u.mJy / (u.arcsec**2)
+        pixel_solid_angle = psa.to(u.MJy / u.steradian).value
+    # The factor 1.e-6 is to get the flux in janskys, rather than MJy.
+    flux = temp_flux * pixel_solid_angle * 1.e-6
+    del temp_flux
+
+    error = np.zeros_like(flux)
+    sb_error = np.zeros_like(flux)
+    berror = np.zeros_like(flux)
     spec_dtype = datamodels.SpecModel().spec_table.dtype
-    otab = np.array(list(zip(wavelength, flux, fl_error, dq,
-                         net, nerror, background, berror, npixels)),
+    otab = np.array(list(zip(wavelength,
+                             flux, error, surf_bright, sb_error,
+                             dq, background, berror, npixels)),
                     dtype=spec_dtype)
     spec = datamodels.SpecModel(spec_table=otab)
     spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
     spec.spec_table.columns['wavelength'].unit = 'um'
-    spec.spec_table.columns['flux'].unit = data_units
-    spec.spec_table.columns['error'].unit = data_units
-    spec.spec_table.columns['net'].unit = data_units
-    spec.spec_table.columns['nerror'].unit = data_units
-    spec.spec_table.columns['background'].unit = data_units
-    spec.spec_table.columns['berror'].unit = data_units
+    spec.spec_table.columns['flux'].unit = "Jy"
+    spec.spec_table.columns['error'].unit = "Jy"
+    spec.spec_table.columns['surf_bright'].unit = "MJy/sr"
+    spec.spec_table.columns['sb_error'].unit = "MJy/sr"
+    spec.spec_table.columns['background'].unit = "MJy/sr"
+    spec.spec_table.columns['berror'].unit = "MJy/sr"
     spec.slit_ra = ra
     spec.slit_dec = dec
     if slitname is not None and slitname != "ANY":
@@ -236,18 +246,25 @@ def extract_ifu(input_model, source_type, extract_params):
         at the nominal center of the image.
 
     wavelength : ndarray, 1-D
-        The wavelength in micrometers at each pixel.
+        The wavelength in micrometers at each plane of the IFU cube.
 
-    net : ndarray, 1-D
-        The count rate (or flux) minus the background at each pixel.
+    temp_flux : ndarray, 1-D
+        The sum of the data values in the extraction aperture minus the
+        sum of the data values in the background region (scaled by the
+        ratio of areas), for each plane.
+        The data values are in units of surface brightness, so this value
+        isn't really the flux, it's an intermediate value.  Dividing by
+        `npixels` (to compute the average) will give the value for the
+        `surf_bright` (surface brightness) column, and multiplying by
+        the solid angle of a pixel will give the flux for a point source.
 
     background : ndarray, 1-D
         The background count rate that was subtracted from the total
-        source count rate to get `net`.
+        source data values to get `temp_flux`.
 
     npixels : ndarray, 1-D, float64
         For each slice, this is the number of pixels that were added
-        together to get `net`.
+        together to get `temp_flux`.
 
     dq : ndarray, 1-D, uint32
         The data quality array.
@@ -259,10 +276,10 @@ def extract_ifu(input_model, source_type, extract_params):
         log.error("Expected a 3-D IFU cube; dimension is %d.", len(shape))
         raise RuntimeError("The IFU cube should be 3-D.")
 
-    # We need to allocate net, background, npixels, and dq arrays
+    # We need to allocate temp_flux, background, npixels, and dq arrays
     # no matter what.  We may need to divide by npixels, so the default
     # is 1 rather than 0.
-    net = np.zeros(shape[0], dtype=np.float64)
+    temp_flux = np.zeros(shape[0], dtype=np.float64)
     background = np.zeros(shape[0], dtype=np.float64)
     npixels = np.ones(shape[0], dtype=np.float64)
 
@@ -270,7 +287,7 @@ def extract_ifu(input_model, source_type, extract_params):
 
     # For an extended target, the entire aperture will be extracted, so
     # it makes no sense to shift the extraction location.
-    if source_type.lower() != "extended":
+    if source_type != "extended":
         ra_targ = input_model.meta.target.ra
         dec_targ = input_model.meta.target.dec
         locn = locn_from_wcs(input_model, ra_targ, dec_targ)
@@ -392,20 +409,20 @@ def extract_ifu(input_model, source_type, extract_params):
     for k in range(shape[0]):
         phot_table = aperture_photometry(data[k, :, :], aperture,
                                          method=method, subpixels=subpixels)
-        net[k] = float(phot_table['aperture_sum'][0])
+        temp_flux[k] = float(phot_table['aperture_sum'][0])
         if subtract_background:
             bkg_table = aperture_photometry(data[k, :, :], annulus,
                                             method=method, subpixels=subpixels)
             background[k] = float(bkg_table['aperture_sum'][0])
-            net[k] = net[k] - background[k] * normalization
+            temp_flux[k] = temp_flux[k] - background[k] * normalization
 
     # Check for NaNs in the wavelength array, flag them in the dq array,
     # and truncate the arrays if NaNs are found at endpoints (unless the
     # entire array is NaN).
-    (wavelength, net, background, npixels, dq) = \
-                nans_in_wavelength(wavelength, net, background, npixels, dq)
+    (wavelength, temp_flux, background, npixels, dq) = \
+        nans_in_wavelength(wavelength, temp_flux, background, npixels, dq)
 
-    return (ra, dec, wavelength, net, background, npixels, dq)
+    return (ra, dec, wavelength, temp_flux, background, npixels, dq)
 
 
 def locn_from_wcs(input_model, ra_targ, dec_targ):
@@ -501,6 +518,16 @@ def celestial_to_cartesian(ra, dec):
 def image_extract_ifu(input_model, source_type, extract_params):
     """Extraction using a reference image.
 
+    Extended summary
+    ----------------
+    One of the requirements for this step is that for an extended target,
+    the entire aperture is supposed to be extracted (with no background
+    subtraction).  It doesn't make any sense to use an image reference file
+    to extract the entire aperture; a trivially simple JSON reference file
+    would do.  Therefore, we assume that if the user specified a reference
+    file in image format, the user actually wanted that reference file
+    to be used, so we will ignore the requirement in this case.
+
     Parameters
     ----------
     input_model : IFUCubeModel
@@ -510,7 +537,7 @@ def image_extract_ifu(input_model, source_type, extract_params):
         "point" or "extended"
 
     extract_params : dict
-        The extraction parameters.  One of these is a open file handle
+        The extraction parameters.  One of these is an open file handle
         for an image that specifies which pixels should be included as
         source and which (if any) should be used as background.
 
@@ -521,18 +548,25 @@ def image_extract_ifu(input_model, source_type, extract_params):
         at the centroid of the target region in the reference image.
 
     wavelength : ndarray, 1-D
-        The wavelength in micrometers at each pixel.
+        The wavelength in micrometers at each plane of the IFU cube.
 
-    net : ndarray, 1-D
-        The count rate (or flux) minus the background at each pixel.
+    temp_flux : ndarray, 1-D
+        The sum of the data values in the extraction aperture minus the
+        sum of the data values in the background region (scaled by the
+        ratio of areas), for each plane.
+        The data values are in units of surface brightness, so this value
+        isn't really the flux, it's an intermediate value.  Dividing by
+        `npixels` (to compute the average) will give the value for the
+        `surf_bright` (surface brightness) column, and multiplying by
+        the solid angle of a pixel will give the flux for a point source.
 
     background : ndarray, 1-D
         The background count rate that was subtracted from the total
-        source count rate to get `net`.
+        source data values to get `temp_flux`.
 
     npixels : ndarray, 1-D, float64
         For each slice, this is the number of pixels that were added
-        together to get `net`.
+        together to get `temp_flux`.
 
     dq : ndarray, 1-D, uint32
         The data quality array.
@@ -545,7 +579,7 @@ def image_extract_ifu(input_model, source_type, extract_params):
     shape = data.shape
 
     # The dispersion direction is the first axis.
-    net = np.zeros(shape[0], dtype=np.float64)
+    temp_flux = np.zeros(shape[0], dtype=np.float64)
     background = np.zeros(shape[0], dtype=np.float64)
     npixels = np.ones(shape[0], dtype=np.float64)
     n_bkg = np.ones(shape[0], dtype=np.float64)
@@ -572,47 +606,40 @@ def image_extract_ifu(input_model, source_type, extract_params):
                          "- skipping it.")
             mask_bkg = None
 
-    if source_type.lower() == "extended":
-        # For an extended target, the entire aperture is supposed to be
-        # extracted, so it makes no sense to shift the reference file.
-        log.info("Target is extended, so not shifting to target location")
-        x0 = float(shape[-1]) / 2. - 0.5
-        y0 = float(shape[-2]) / 2. - 0.5
+    ra_targ = input_model.meta.target.ra
+    dec_targ = input_model.meta.target.dec
+    locn = locn_from_wcs(input_model, ra_targ, dec_targ)
+    if locn is not None:
+        log.info("Target location is x_center = %g, y_center = %g, "
+                 "based on TARG_RA and TARG_DEC.", locn[0], locn[1])
+
+    # Use the centroid of mask_target as the point where the target
+    # would be without any nod/dither correction.
+    (y0, x0) = im_centroid(data, mask_target)
+    log.debug("Target location based on reference image is X = %g, Y = %g",
+              x0, y0)
+
+    if locn is None or np.isnan(locn[0]):
+        log.warning("Couldn't determine pixel location from WCS, so "
+                    "nod/dither correction will not be applied.")
     else:
-        ra_targ = input_model.meta.target.ra
-        dec_targ = input_model.meta.target.dec
-        locn = locn_from_wcs(input_model, ra_targ, dec_targ)
-        if locn is not None:
-            log.info("Target location is x_center = %g, y_center = %g, "
-                     "based on TARG_RA and TARG_DEC.", locn[0], locn[1])
-
-        # Use the centroid of mask_target as the point where the target
-        # would be without any nod/dither correction.
-        (y0, x0) = im_centroid(data, mask_target)
-        log.debug("Target location based on reference image is X = %g, Y = %g",
-                  x0, y0)
-
-        if locn is None or np.isnan(locn[0]):
-            log.warning("Couldn't determine pixel location from WCS, so "
-                        "nod/dither correction will not be applied.")
-        else:
-            (x_center, y_center) = locn
-            # Shift the reference image so it will be centered at locn.
-            # Only shift by a whole number of pixels.
-            delta_x = int(round(x_center - x0))         # must be integer
-            delta_y = int(round(y_center - y0))
-            log.debug("Shifting reference image by %g in X and %g in Y",
-                      delta_x, delta_y)
-            temp = shift_ref_image(mask_target, delta_y, delta_x)
-            if temp is not None:
-                mask_target = temp
-                del temp
-                if mask_bkg is not None:
-                    mask_bkg = shift_ref_image(mask_bkg, delta_y, delta_x)
-                # Since we have shifted mask_target and mask_bkg to
-                # x_center and y_center, update x0 and y0.
-                x0 = x_center
-                y0 = y_center
+        (x_center, y_center) = locn
+        # Shift the reference image so it will be centered at locn.
+        # Only shift by a whole number of pixels.
+        delta_x = int(round(x_center - x0))         # must be integer
+        delta_y = int(round(y_center - y0))
+        log.debug("Shifting reference image by %g in X and %g in Y",
+                  delta_x, delta_y)
+        temp = shift_ref_image(mask_target, delta_y, delta_x)
+        if temp is not None:
+            mask_target = temp
+            del temp
+            if mask_bkg is not None:
+                mask_bkg = shift_ref_image(mask_bkg, delta_y, delta_x)
+            # Since we have shifted mask_target and mask_bkg to
+            # x_center and y_center, update x0 and y0.
+            x0 = x_center
+            y0 = y_center
 
     # Extract the data.
     # First add up the values along the x direction, then add up the
@@ -633,10 +660,10 @@ def image_extract_ifu(input_model, source_type, extract_params):
     if mask_bkg is not None:
         background = (data * mask_bkg).sum(axis=2, dtype=np.float64).sum(axis=1)
         background *= normalization
-        net = gross - background
+        temp_flux = gross - background
     else:
         background = np.zeros_like(gross)
-        net = gross.copy()
+        temp_flux = gross.copy()
 
     # Compute the ra, dec, and wavelength at the pixels of a column through
     # the IFU cube at the target location.  ra and dec should be constant
@@ -656,10 +683,10 @@ def image_extract_ifu(input_model, source_type, extract_params):
     # Check for NaNs in the wavelength array, flag them in the dq array,
     # and truncate the arrays if NaNs are found at endpoints (unless the
     # entire array is NaN).
-    (wavelength, net, background, npixels, dq) = \
-                nans_in_wavelength(wavelength, net, background, npixels, dq)
+    (wavelength, temp_flux, background, npixels, dq) = \
+        nans_in_wavelength(wavelength, temp_flux, background, npixels, dq)
 
-    return (ra, dec, wavelength, net, background, npixels, dq)
+    return (ra, dec, wavelength, temp_flux, background, npixels, dq)
 
 
 def get_coordinates(input_model, x0, y0):
@@ -711,7 +738,7 @@ def get_coordinates(input_model, x0, y0):
     return (ra, dec, wavelength)
 
 
-def nans_in_wavelength(wavelength, net, background, npixels, dq):
+def nans_in_wavelength(wavelength, flux, background, npixels, dq):
     """Check for NaNs in the wavelength array.
 
     If NaNs are found in the wavelength array, flag them in the dq array,
@@ -723,16 +750,16 @@ def nans_in_wavelength(wavelength, net, background, npixels, dq):
     wavelength : ndarray, 1-D, float64
         The wavelength in micrometers at each pixel.
 
-    net : ndarray, 1-D, float64
-        The count rate (or flux) minus the background at each pixel.
+    flux : ndarray, 1-D, float64
+        The flux minus the background at each pixel.
 
     background : ndarray, 1-D, float64
         The background count rate that was subtracted from the total
-        source count rate to get `net`.
+        source count rate to get `flux`.
 
     npixels : ndarray, 1-D, float64
         For each slice, this is the number of pixels that were added
-        together to get `net`.
+        together to get `flux`.
 
     dq : ndarray, 1-D, uint32
         The data quality array.
@@ -741,7 +768,7 @@ def nans_in_wavelength(wavelength, net, background, npixels, dq):
     -------
     wavelength : ndarray, 1-D, float64
 
-    net : ndarray, 1-D, float64
+    flux : ndarray, 1-D, float64
 
     background : ndarray, 1-D, float64
 
@@ -753,14 +780,14 @@ def nans_in_wavelength(wavelength, net, background, npixels, dq):
     nelem = np.size(wavelength)
     if nelem == 0:
         log.warning("Output arrays are empty!")
-        return (wavelength, net, background, npixels, dq)
+        return (wavelength, flux, background, npixels, dq)
 
     nan_mask = np.isnan(wavelength)
     n_nan = nan_mask.sum(dtype=np.intp)
     if n_nan == nelem:
         log.warning("Wavelength array is all NaN!")
         dq = np.bitwise_or(dq[:], dqflags.pixel['DO_NOT_USE'])
-        return (wavelength, net, background, npixels, dq)
+        return (wavelength, flux, background, npixels, dq)
 
     if n_nan > 0:
         log.warning("%d NaNs in wavelength array.", n_nan)
@@ -772,14 +799,14 @@ def nans_in_wavelength(wavelength, net, background, npixels, dq):
             if n_trimmed > 0:
                 slc = slice(flag[0][0], flag[0][-1] + 1)
                 wavelength = wavelength[slc]
-                net = net[slc]
+                flux = flux[slc]
                 background = background[slc]
                 npixels = npixels[slc]
                 dq = dq[slc]
                 log.info("Output arrays have been trimmed by %d elements",
                          n_trimmed)
 
-    return (wavelength, net, background, npixels, dq)
+    return (wavelength, flux, background, npixels, dq)
 
 
 def separate_target_and_background(ref):

--- a/jwst/extract_1d/tests/test_ifu_image_ref.py
+++ b/jwst/extract_1d/tests/test_ifu_image_ref.py
@@ -74,9 +74,9 @@ def test_ifu_2d():
     """
     assert np.allclose(wavelength, true_wl, rtol=1.e-14, atol=1.e-14)
 
-    assert np.allclose(flux, true_flux, atol=150.)
+    assert np.allclose(flux, true_flux, rtol=0.05)
 
-    assert np.allclose(background, true_bkg, atol=150.)
+    assert np.allclose(background, true_bkg, rtol=0.05)
 
     input.close()
     truth.close()
@@ -190,7 +190,7 @@ def test_ifu_no_background():
 
     assert np.allclose(wavelength, true_wl, rtol=1.e-14, atol=1.e-14)
 
-    assert np.allclose(flux, true_flux, atol=150.)
+    assert np.allclose(flux, true_flux, rtol=0.03)
 
     assert np.allclose(background, true_bkg, atol=1.)
 

--- a/jwst/extract_1d/tests/test_ifu_image_ref.py
+++ b/jwst/extract_1d/tests/test_ifu_image_ref.py
@@ -76,7 +76,7 @@ def test_ifu_2d():
 
     assert np.allclose(flux, true_flux, rtol=0.05)
 
-    assert np.allclose(background, true_bkg, rtol=0.05)
+    assert np.allclose(background, true_bkg, rtol=0.1)
 
     input.close()
     truth.close()

--- a/jwst/extract_1d/util.py
+++ b/jwst/extract_1d/util.py
@@ -1,0 +1,85 @@
+import logging
+
+import numpy as np
+
+from gwcs.wcstools import grid_from_bounding_box
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+def pixel_area(wcs, shape, verbose=True):
+    """Compute the solid angle of a pixel.
+
+    Parameters
+    ----------
+    wcs : function
+        This takes a pair of pixel coordinates (`x`, `y`) and returns
+        the right ascension, declination, and wavelength at that pixel
+        (or array of pixels).
+
+    shape : tuple
+        The shape of the data array.  The bounding box from the wcs will be
+        used instead, if it exists.
+
+    verbose : bool
+        If True, log messages.
+
+    Returns
+    -------
+    pixel_solid_angle : float or None
+        The average solid angle of a pixel, in steradians.  None will be
+        returned if this value could not be determined.
+    """
+
+    if shape is not None and len(shape) != 2 and len(shape) != 3:
+        if verbose:
+            log.warning("shape = {}, should be 2-D or 3-D".format(shape))
+        return None
+
+    three_d = (len(shape) == 3)
+
+    if three_d:
+        grid = np.indices(shape[-2:])
+        z = np.zeros(shape[-2:], dtype=np.float64) + shape[0] // 2
+        # The arguments are the X, Y, and Z pixel coordinates, and the
+        # output arrays will be 2-D.
+        (ra, dec, _) = wcs(grid[1], grid[0], z)
+    else:
+        if hasattr(wcs, 'bounding_box') and wcs.bounding_box is not None:
+            grid2 = grid_from_bounding_box(wcs.bounding_box)
+            # Note that the elements of grid2 are reversed wrt grid.
+            (ra, dec, _) = wcs(grid2[0], grid2[1])
+        else:
+            grid = np.indices(shape)
+            (ra, dec, _) = wcs(grid[1], grid[0])
+
+    cos_dec = np.cos(dec[0:-1, 0:-1] * np.pi / 180.)
+    dra1 = (ra[0:-1, 1:] - ra[0:-1, 0:-1]) * cos_dec
+    dra2 = (ra[1:, 0:-1] - ra[0:-1, 0:-1]) * cos_dec
+    ddec1 = dec[0:-1, 1:] - dec[0:-1, 0:-1]
+    ddec2 = dec[1:, 0:-1] - dec[0:-1, 0:-1]
+
+    cdelt1 = np.sqrt(dra1**2 + ddec1**2)
+    cdelt2 = np.sqrt(dra2**2 + ddec2**2)
+    cdelt1 = np.nanmean(cdelt1)
+    cdelt2 = np.nanmean(cdelt2)
+    if verbose:
+        log.debug("Pixel dimensions in arcsec:  {:.5g} x {:.5g}"
+                  .format(cdelt1 * 3600., cdelt2 * 3600.))
+
+    if cdelt1 == 0. and cdelt2 == 0:
+        pixel_solid_angle = None
+    else:
+        if cdelt1 < 0.01 * cdelt2:
+            if verbose:
+                log.warning("Using cdelt2 = {:.4g} arcsec for both dimensions "
+                            "of a pixel".format(cdelt2 * 3600.))
+            cdelt1 = cdelt2
+        elif cdelt2 < 0.01 * cdelt1:
+            if verbose:
+                log.warning("Using cdelt1 = {:.4g} arcsec for both dimensions "
+                            "of a pixel".format(cdelt1 * 3600.))
+            cdelt2 = cdelt1
+        pixel_solid_angle = (cdelt1 * cdelt2) * (np.pi / 180.)**2
+
+    return pixel_solid_angle

--- a/jwst/extract_1d/util.py
+++ b/jwst/extract_1d/util.py
@@ -95,6 +95,28 @@ def pixel_area(wcs, shape, verbose=True):
 
 
 def temp_wcs(wcs, x, y, z=None):
+    """Call the wcs function in a loop over pixels.
+
+    Parameters
+    ----------
+    wcs : function
+        This takes a pair of pixel coordinates and returns the right
+        ascension, declination, and wavelength at that pixel.
+
+    x, y : 2-D ndarray
+        The arrays of pixel coordinates.
+
+    z : 2-D ndarray, or None
+        If the data are 3-D, e.g. IFU or CubeModel, this is an array of
+        values for axis 0 (wavelength for IFU, multiple exposures for
+        CubeModel).
+
+    verbose : bool
+        If True, log messages.
+
+    Returns
+    -------
+    pixel_solid_angle : float or None
 
     ra = np.zeros_like(x)
     dec = np.zeros_like(x)
@@ -103,10 +125,11 @@ def temp_wcs(wcs, x, y, z=None):
     if z is None:
         for j in range(shape[-2]):
             for i in range(shape[-1]):
-                stuff = wcs(i, j)
+                (ra[j, i], dec[j, i], wl[j, i]) = wcs(x[j, i], y[j, i])
     else:
         for j in range(shape[-2]):
             for i in range(shape[-1]):
-                stuff = wcs(i, j, z[j, i])
+                (ra[j, i], dec[j, i], wl[j, i]) = wcs(x[j, i], y[j, i],
+                                                      z[j, i])
 
     return (ra, dec, wl)

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -41,11 +41,7 @@ def expand_to_2d(input, m_bkg_spec):
         else:                                   # CombinedSpecModel
             spec_table = bkg.spec_table
         tab_wavelength = spec_table['wavelength'].copy()
-        try:
-            tab_npixels = spec_table['npixels'].copy()
-        except KeyError:
-            tab_npixels = np.ones_like(tab_wavelength)
-        tab_background = spec_table['flux'] / tab_npixels
+        tab_background = spec_table['flux']
 
     # We're going to use np.interp, so tab_wavelength must be strictly
     # increasing.
@@ -76,8 +72,7 @@ def bkg_for_container(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table, divided by
-        the npixels column.
+        The flux column read from the 1-D background table.
 
     Returns
     -------
@@ -106,8 +101,7 @@ def create_bkg(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table, divided by
-        the npixels column.
+        The flux column read from the 1-D background table.
 
     Returns
     -------
@@ -148,8 +142,7 @@ def bkg_for_multislit(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table, divided by
-        the npixels column.
+        The flux column read from the 1-D background table.
 
     Returns
     -------
@@ -199,8 +192,7 @@ def bkg_for_image(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table, divided by
-        the npixels column.
+        The flux column read from the 1-D background table.
 
     Returns
     -------
@@ -244,8 +236,7 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table, divided by
-        the npixels column.
+        The flux column read from the 1-D background table.
 
     Returns
     -------

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -111,7 +111,6 @@ class MasterBackgroundStep(Step):
                     master_background = combine_1d_spectra(
                         background_data,
                         exptime_key='exposure_time',
-                        background=True,
                         )
 
                     result = datamodels.ModelContainer()

--- a/jwst/master_background/tests/test_expand_to_2d.py
+++ b/jwst/master_background/tests/test_expand_to_2d.py
@@ -148,15 +148,15 @@ def user_bkg_spec_a():
                               dtype=np.float64)
     flux = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
                        dtype=np.float64)
-    fl_error = np.ones_like(wavelength)
+    error = np.ones_like(wavelength)
     dq = np.zeros(wavelength.shape, dtype=np.uint32)
-    net = np.zeros_like(wavelength)
-    nerror = np.ones_like(wavelength)
+    surf_bright = np.zeros_like(wavelength)
+    sb_error = np.ones_like(wavelength)
     background = np.ones_like(wavelength)
     berror = np.ones_like(wavelength)
     npixels = np.ones_like(wavelength)
-    otab = np.array(list(zip(wavelength, flux, fl_error, dq,
-                             net, nerror, background, berror,
+    otab = np.array(list(zip(wavelength, flux, error,
+                             surf_bright, sb_error, dq, background, berror,
                              npixels)),
                     dtype=spec_dtype)
     spec = datamodels.SpecModel(spec_table=otab)
@@ -189,15 +189,15 @@ def user_bkg_spec_b():
                               dtype=np.float64)[::-1]
     flux = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
                        dtype=np.float64)[::-1]
-    fl_error = np.ones_like(wavelength)
+    error = np.ones_like(wavelength)
     dq = np.zeros(wavelength.shape, dtype=np.uint32)
-    net = np.zeros_like(wavelength)
-    nerror = np.ones_like(wavelength)
+    surf_bright = np.zeros_like(wavelength)
+    sb_error = np.ones_like(wavelength)
     background = np.ones_like(wavelength)
     berror = np.ones_like(wavelength)
     npixels = np.ones_like(wavelength)
-    otab = np.array(list(zip(wavelength, flux, fl_error, dq,
-                             net, nerror, background, berror,
+    otab = np.array(list(zip(wavelength, flux, error,
+                             surf_bright, sb_error, dq, background, berror,
                              npixels)),
                     dtype=spec_dtype)
     spec = datamodels.SpecModel(spec_table=otab)
@@ -221,13 +221,14 @@ def user_bkg_spec_c():
                               dtype=np.float64)
     flux = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
                        dtype=np.float64)
-    fl_error = np.ones_like(wavelength)
+    error = np.ones_like(wavelength)
+    surf_bright = np.zeros_like(wavelength)
+    sb_error = np.ones_like(wavelength)
     dq = np.zeros(wavelength.shape, dtype=np.uint32)
-    net = np.zeros_like(wavelength)
     weight = np.ones_like(wavelength)
     n_input = np.ones_like(wavelength)                  # yes, float64
-    data = np.array(list(zip(wavelength, flux, fl_error, net,
-                             dq, weight, n_input)),
+    data = np.array(list(zip(wavelength, flux, error, surf_bright,
+                             sb_error, dq, weight, n_input)),
                     dtype=spec_table_dtype)
     m_bkg_spec = datamodels.CombinedSpecModel(spec_table=data)
 

--- a/jwst/pipeline/combine_1d.cfg
+++ b/jwst/pipeline/combine_1d.cfg
@@ -2,4 +2,3 @@ name = "combine_1d"
 class = "jwst.combine_1d.Combine1dStep"
 
 exptime_key = "exposure_time"
-background = False


### PR DESCRIPTION
The `photom` step now applies the photometric correction, and `extract_1d` and combine_1d have been updated to accept an input file in units of surface brightness.  `extract_1d` no longer checks for a PHOTOM extension, and the output table has new columns SURF_BRIGHT and SB_ERROR rather than NET and NERROR.  In addition, the BACKGOUND column has been divided by NPIXELS, so the units will be surface brightness.  Previously, the BACKGROUND column contained the values that were subtracted from the gross count rate to get the net count rate.  The `ref_file` attribute has been removed from the step class, `Extract1dStep`; `ref_file` is now a local variable.
The `background` parameter has been removed from the `combine_1d` step.  This is no longer needed, since `extract_1d` divides the background by npixels.  `combine_1d` reads the SURF_BRIGHT and SB_ERROR columns (if they exist) from the input file(s), ignoring NET.  The weight no longer includes NPIXELS for averaging background, under the assumption that the input files will be similar to each other if it is the background that is of interest.  When averaging the FLUX and its error, the sensitivity is no longer included as a factor in the weight, because determining the sensitivity required the net count rate, which is no longer available.