### PR TITLE
Apply barshadow, pathloss, and photom correction to VAR_FLAT

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ barshadow
 - Updated to apply the correction to the science data arrays, in addition
   to attaching as an extension. [#3319]
 
+- Updated to apply the square of the correction to VAR_FLAT [#3427]
+
 calwebb_spec3
 -------------
 
@@ -120,6 +122,8 @@ pathloss
 
 - Updated to apply the correction to the science data and err arrays. [#3323]
 
+- Updated to apply the square of the correction to VAR_FLAT [#3427]
+
 photom
 ------
 
@@ -128,6 +132,8 @@ photom
 
 - Updated to compute a wavelength array for NIRISS SOSS exposures using
   spectral order 1. [#3387]
+
+- Updated to apply the square of the correction to VAR_FLAT [#3427]
 
 reffile_utils
 -------------

--- a/docs/jwst/barshadow/description.rst
+++ b/docs/jwst/barshadow/description.rst
@@ -41,9 +41,10 @@ heights to shutter spacings, and then the Y and wavelength values are interpolat
 into the model to determine the correction for each pixel.
 
 Once the 2-D correction array for a slit has been computed, it is applied to the
-science (SCI), error (ERR), and Poisson variance (VAR_POISSON) data arrays of the slit.
+science (SCI), error (ERR), and variance (VAR_POISSON, VAR_RNOISE, and
+VAR_FLAT) data arrays of the slit.
 The correction values are divided into the SCI and ERR arrays, and the square of the
-correction values are divided into the VAR_POISSON array.
+correction values are divided into the variance arrays.
 
 Output product
 --------------

--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -44,7 +44,9 @@ on the wavelength at each pixel.
 
 The combination of the scalar conversion factor and the 2-D response values are
 then applied to the science data, including the SCI and ERR arrays, as well as
-the variance (VAR_POISSON and VAR_RNOISE) arrays.
+the variance (VAR_POISSON, VAR_RNOISE, and VAR_FLAT) arrays.
+The correction values are divided into the SCI and ERR arrays, and the square
+of the correction values are divided into the variance arrays.
 
 The scalar conversion constant is copied to the header keyword PHOTMJSR, which
 gives the conversion from DN/s to MegaJy/steradian that was applied to the data.

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -105,6 +105,8 @@ def do_correction(input_model, barshadow_model):
                 slitlet.err /= correction
                 slitlet.var_poisson /= correction**2
                 slitlet.var_rnoise /= correction**2
+                if slitlet.var_flat is not None and np.size(slitlet.var_flat) > 0:
+                    slitlet.var_flat /= correction**2
             else:
                 log.info("Slitlet %d has zero length, correction skipped" % slitlet_number)
 

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -229,6 +229,8 @@ def do_correction(input_model, pathloss_model):
                         slit.err /= pathloss_2d
                         slit.var_poisson /= pathloss_2d**2
                         slit.var_rnoise /= pathloss_2d**2
+                        if slit.var_flat is not None and np.size(slit.var_flat) > 0:
+                            slit.var_flat /= pathloss_2d**2
                         slit.pathloss = pathloss_2d
                     else:
                         log.warning("Source is outside slit.  Skipping "
@@ -292,6 +294,8 @@ def do_correction(input_model, pathloss_model):
                     slit.err /= pathloss_2d
                     slit.var_poisson /= pathloss_2d**2
                     slit.var_rnoise /= pathloss_2d**2
+                    if slit.var_flat is not None and np.size(slit.var_flat) > 0:
+                        slit.var_flat /= pathloss_2d**2
                     slit.pathloss = pathloss_2d
                 else:
                     log.warning("Source is outside slit.  Skipping "
@@ -352,6 +356,8 @@ def do_correction(input_model, pathloss_model):
         output_model.err /= pathloss_2d
         output_model.var_poisson /= pathloss_2d**2
         output_model.var_rnoise /= pathloss_2d**2
+        if output_model.var_flat is not None and np.size(output_model.var_flat) > 0:
+            output_model.var_flat /= pathloss_2d**2
         output_model.pathloss = pathloss_2d
 
         # This might be useful to other steps
@@ -426,6 +432,8 @@ def do_correction(input_model, pathloss_model):
         output_model.err /= pathloss_2d
         output_model.var_poisson /= pathloss_2d**2
         output_model.var_rnoise /= pathloss_2d**2
+        if output_model.var_flat is not None and np.size(output_model.var_flat) > 0:
+            output_model.var_flat /= pathloss_2d**2
         output_model.pathloss = pathloss_2d
 
         output_model.meta.cal_step.pathloss = 'COMPLETE'

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -239,6 +239,9 @@ class DataSet():
                         self.input.err /= sens2d
                         self.input.var_poisson /= sens2d**2
                         self.input.var_rnoise /= sens2d**2
+                        if (self.input.var_flat is not None and
+                            np.size(self.input.var_flat) > 0):
+                                self.input.var_flat /= sens2d**2
 
                         # Update BUNIT values for the science data and err
                         self.input.meta.bunit_data = 'mJy/arcsec^2'
@@ -428,6 +431,8 @@ class DataSet():
             self.input.err /= sens2d
             self.input.var_poisson /= sens2d**2
             self.input.var_rnoise /= sens2d**2
+            if self.input.var_flat is not None and np.size(self.input.var_flat) > 0:
+                    self.input.var_flat /= sens2d**2
 
             # Update the science dq
             self.input.dq = np.bitwise_or(self.input.dq, ftab.dq)
@@ -693,6 +698,9 @@ class DataSet():
             if (self.input.slits[self.slitnum].var_rnoise is not None and
                 np.size(self.input.slits[self.slitnum].var_rnoise) > 0):
                     self.input.slits[self.slitnum].var_rnoise *= conversion**2
+            if (self.input.slits[self.slitnum].var_flat is not None and
+                np.size(self.input.slits[self.slitnum].var_flat) > 0):
+                    self.input.slits[self.slitnum].var_flat *= conversion**2
             self.input.slits[self.slitnum].meta.bunit_data = 'MJy/sr'
             self.input.slits[self.slitnum].meta.bunit_err = 'MJy/sr'
         else:
@@ -704,6 +712,9 @@ class DataSet():
             if (self.input.var_rnoise is not None and
                 np.size(self.input.var_rnoise) > 0):
                     self.input.var_rnoise *= conversion**2
+            if (self.input.var_flat is not None and
+                np.size(self.input.var_flat) > 0):
+                    self.input.var_flat *= conversion**2
             self.input.meta.bunit_data = 'MJy/sr'
             self.input.meta.bunit_err = 'MJy/sr'
 
@@ -849,7 +860,7 @@ class DataSet():
             self.calc_fgs(ftab)
 
         # Load the pixel area reference file, if it exists, and attach the
-        # the reference data to the science model
+        # reference data to the science model
         if area_fname:
             if 'IMAGE' in self.exptype and area_fname != 'N/A':
                 self.save_area_info(ftab, area_fname)


### PR DESCRIPTION
The correction factors (squared) are applied to the VAR_POISSON and VAR_RNOISE variances in the `barshadow`, `pathloss`, and `photom` steps.  These correction factors (also squared) are now also applied to the VAR_FLAT variance array.

Note that this PR does not close issue #3414, because there are other steps that can follow `flat_field`.