### PR TITLE
Remove python 2 exception .message references

### DIFF
--- a/jwst/associations/exceptions.py
+++ b/jwst/associations/exceptions.py
@@ -8,12 +8,6 @@ __all__ = [
 class AssociationError(Exception):
     """Basic errors related to Associations"""
 
-    def __init__(self, message='No explanation given'):
-        self.message = message
-
-    def __str__(self):
-        return 'Association Exception: {}'.format(self.message)
-
 
 class AssociationNotAConstraint(AssociationError):
     """No matching constraint found"""

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -80,9 +80,7 @@ class Extract1dError(Exception):
 
 class InvalidSpectralOrderNumberError(Extract1dError):
     """The spectral order number was invalid or off the detector."""
-    def __init__(self, message=None):
-        super().__init__()
-        self.message = message
+    pass
 
 
 def load_ref_file(refname):


### PR DESCRIPTION
Exceptions in Python 3 no longer have a `self.message` attribute.  Use `self.args` instead.