### PR TITLE
Add multi-processing option to jump step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@ dist/
 *.egg-info/
 *.so
 *.prof
-.*
-.gitignore
+.idea
 */version.py
 docs/*/source/*.txt.rst
 docs/generated

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ dist/
 *.pyc
 *.egg-info/
 *.so
-*.prof
-.idea
 */version.py
 docs/*/source/*.txt.rst
 docs/generated

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist/
 *.pyc
 *.egg-info/
 *.so
+*.prof
+.*
+.gitignore
 */version.py
 docs/*/source/*.txt.rst
 docs/generated

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,11 @@ extract_1d
 ----------
 - An indexing bug was fixed. [#3497]
 
+jump
+----
+
+- Add multiprocessing capability to JumpStep [#3440]
+
 master_background
 -----------------
 

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -38,9 +38,9 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     elif max_cores == 'quarter':
         numslices = np.int(np.floor(num_cores/4))
     elif max_cores == 'half':
-        numslices = np.int(np.floor(num_cores/2))
+        numslices = np.int(np.floor(num_cores/2)) - 1 # leave room for the main thread
     elif max_cores == 'all':
-        numslices = np.int(num_cores)
+        numslices = np.int(num_cores) - 1 # leave room for the main thread
     log.info("Creating %d processes for jump detection " % numslices)
     pool = multiprocessing.Pool(processes=numslices)
 
@@ -122,6 +122,8 @@ def detect_jumps (input_model, gain_model, readnoise_model,
                 gdq[:, :, k * yincrement:(k + 1) * yincrement, :] = resultslice[1]
             k += 1
 
+    pool.terminate()
+    pool.close()
     elapsed = time.time() - start
     log.debug('Elapsed time = %g sec' %elapsed)
 

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 def detect_jumps (input_model, gain_model, readnoise_model,
-                  rejection_threshold, do_yint, signal_threshold, max_cores):
+                  rejection_threshold, do_yint, signal_threshold, max_cores=None):
     """
     This is the high-level controlling routine for the jump detection process.
     It loads and sets the various input data and parameters needed by each of
@@ -31,17 +31,18 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     image.  Also, a 2-dimensional read noise array with appropriate values for
     each pixel is passed to the detection methods.
     """
-    num_cores = psutil.cpu_count(logical = True)
-    log.info("Found %d possible cores to use for jump detection " % num_cores)
-    if max_cores == 'one':
-        numslices = np.int(1)
-    elif max_cores == 'quarter':
-        numslices = np.int(np.floor(num_cores/4))
-    elif max_cores == 'half':
-        numslices = np.int(np.floor(num_cores/2))
-    elif max_cores == 'all':
-        numslices = np.int(num_cores)
-    log.info("Creating %d processes for jump detection " % numslices)
+    if max_cores is None:
+        numslices = 1
+    else:
+        num_cores = psutil.cpu_count(logical = True)
+        log.info("Found %d possible cores to use for jump detection " % num_cores)
+        if max_cores == 'quarter':
+            numslices = num_cores // 4
+        elif max_cores == 'half':
+            numslices = num_cores // 2
+        elif max_cores == 'all':
+            numslices = num_cores
+        log.info("Creating %d processes for jump detection " % numslices)
     pool = multiprocessing.Pool(processes=numslices)
 
     # Load the data arrays that we need from the input model

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -79,7 +79,7 @@ def detect_jumps (input_model, gain_model, readnoise_model,
         pdq[wh_g] = np.bitwise_or( pdq[wh_g], dqflags.pixel['NO_GAIN_VALUE'] )
         pdq[wh_g] = np.bitwise_or( pdq[wh_g], dqflags.pixel['DO_NOT_USE'] )
 
-    # Apply gain to the SCI, ERR, and readnoise arrays so they're in units 
+    # Apply gain to the SCI, ERR, and readnoise arrays so they're in units
     # of electrons
 
     data *= gain_2d

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -37,9 +37,9 @@ def detect_jumps (input_model, gain_model, readnoise_model,
         num_cores = psutil.cpu_count(logical = True)
         log.info("Found %d possible cores to use for jump detection " % num_cores)
         if max_cores == 'quarter':
-            numslices = num_cores // 4
+            numslices = num_cores // 4 or 1
         elif max_cores == 'half':
-            numslices = num_cores // 2
+            numslices = num_cores // 2 or 1
         elif max_cores == 'all':
             numslices = num_cores
         else:

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -42,6 +42,8 @@ def detect_jumps (input_model, gain_model, readnoise_model,
             numslices = num_cores // 2
         elif max_cores == 'all':
             numslices = num_cores
+        else:
+            numslices = 1
         log.info("Creating %d processes for jump detection " % numslices)
     pool = multiprocessing.Pool(processes=numslices)
 
@@ -79,8 +81,8 @@ def detect_jumps (input_model, gain_model, readnoise_model,
         pdq[wh_g] = np.bitwise_or( pdq[wh_g], dqflags.pixel['NO_GAIN_VALUE'] )
         pdq[wh_g] = np.bitwise_or( pdq[wh_g], dqflags.pixel['DO_NOT_USE'] )
 
-    # Apply gain to the SCI, ERR, and readnoise arrays so they're in units
-    #   of electrons
+    # Apply gain to the SCI, ERR, and readnoise arrays so they're in units 
+    # of electrons
 
     data *= gain_2d
     err  *= gain_2d
@@ -124,7 +126,7 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     pool.terminate()
     pool.close()
     elapsed = time.time() - start
-    log.debug('Elapsed time = %g sec' %elapsed)
+    log.debug('Elapsed time = %g sec' % elapsed)
 
     # Apply the y-intercept method as a second pass, if requested
     if do_yint:
@@ -140,7 +142,7 @@ def detect_jumps (input_model, gain_model, readnoise_model,
         yint.find_crs(data, err, gdq, times, readnoise_2d,
                         rejection_threshold, signal_threshold, median_slopes)
         elapsed = time.time() - start
-        log.debug('Elapsed time = %g sec' %elapsed)
+        log.debug('Elapsed time = %g sec' % elapsed)
 
     # Update the DQ arrays of the output model with the jump detection results
     output_model.groupdq = gdq

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -38,9 +38,9 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     elif max_cores == 'quarter':
         numslices = np.int(np.floor(num_cores/4))
     elif max_cores == 'half':
-        numslices = np.int(np.floor(num_cores/2)) - 1 # leave room for the main thread
+        numslices = np.int(np.floor(num_cores/2))
     elif max_cores == 'all':
-        numslices = np.int(num_cores) - 1 # leave room for the main thread
+        numslices = np.int(num_cores)
     log.info("Creating %d processes for jump detection " % numslices)
     pool = multiprocessing.Pool(processes=numslices)
 

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -91,8 +91,6 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     scisize = data.shape
     numx = int(scisize[3])
     numy = int(scisize[2])
-    numz = int(scisize[1])
-    numints = int(scisize[0])
     median_slopes = np.zeros((numy, numx), dtype=np.float32)
     yincrement = int(numy / numslices)
     slices = []

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -16,7 +16,7 @@ class JumpStep(Step):
 
     spec = """
         rejection_threshold = float(default=4.0,min=0) # CR rejection threshold
-        maximum_cores = option('one', 'quarter', 'half', 'all', default='half') # max number of processes to create
+        maximum_cores = option('one', 'quarter', 'half', 'all', default='one') # max number of processes to create
     """
 
     # Prior to 04/26/17, the following were also in the spec above:

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -48,7 +48,8 @@ class JumpStep(Step):
             do_yint = self.do_yintercept
             sig_thresh = self.yint_threshold
             self.log.info('CR rejection threshold = %g sigma', rej_thresh)
-            self.log.info('Maximum cores to use = %s', max_cores)
+            if self.maximum_cores is not None:
+                self.log.info('Maximum cores to use = %s', max_cores)
             if do_yint:
                 self.log.info('Y-intercept signal threshold = %g', sig_thresh)
 

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -16,7 +16,7 @@ class JumpStep(Step):
 
     spec = """
         rejection_threshold = float(default=4.0,min=0) # CR rejection threshold
-        maximum_cores = option('one', 'quarter', 'half', 'all', default='one') # max number of processes to create
+        maximum_cores = option('quarter', 'half', 'all', default=None) # max number of processes to create
     """
 
     # Prior to 04/26/17, the following were also in the spec above:

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -91,8 +91,6 @@ def test_oneCR_100_groups_fullarray():
 
 def setup_inputs(ngroups=10, readnoise=10, nints=1,
                  nrows=1032, ncols=1024, nframes=1, grouptime=1.0, gain=1, deltatime=1):
-    print('readnoise', readnoise)
-    print('gain', gain)
     times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
     gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
     err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -1,17 +1,19 @@
 import numpy as np
-from jwst.jump.jump import detect_jumps
-from jwst.datamodels import MIRIRampModel
+import pytest
+
 from jwst.datamodels import GainModel, ReadnoiseModel
+from jwst.datamodels import MIRIRampModel
+from jwst.jump.jump import detect_jumps
 
 
-def test_nocrs_noflux():
+def test_nocrs_noflux(setup_inputs):
     # all pixel values are zero. So slope should be zero
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
     out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
     assert (0 == np.max(out_model.groupdq))
 
 
-def test_oneCR_10_groups():
+def test_onecr_10_groups(setup_inputs):
     grouptime = 3.0
     ingain = 200  # use large gain to show that Poisson noise doesn't affect the recombination
     inreadnoise = np.float64(7)
@@ -19,20 +21,20 @@ def test_oneCR_10_groups():
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
                                                           gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
     # two segments perfect fit, second segment has twice the slope
-    model1.data[0, 0, 500, 500] = 15.0
-    model1.data[0, 1, 500, 500] = 20.0
-    model1.data[0, 2, 500, 500] = 25.0
-    model1.data[0, 3, 500, 500] = 30.0
-    model1.data[0, 4, 500, 500] = 35.0
-    model1.data[0, 5, 500, 500] = 140.0
-    model1.data[0, 6, 500, 500] = 150.0
-    model1.data[0, 7, 500, 500] = 160.0
-    model1.data[0, 8, 500, 500] = 170.0
-    model1.data[0, 9, 500, 500] = 180.0
+    model1.data[0, 0, 5, 5] = 15.0
+    model1.data[0, 1, 5, 5] = 20.0
+    model1.data[0, 2, 5, 5] = 25.0
+    model1.data[0, 3, 5, 5] = 30.0
+    model1.data[0, 4, 5, 5] = 35.0
+    model1.data[0, 5, 5, 5] = 140.0
+    model1.data[0, 6, 5, 5] = 150.0
+    model1.data[0, 7, 5, 5] = 160.0
+    model1.data[0, 8, 5, 5] = 170.0
+    model1.data[0, 9, 5, 5] = 180.0
     out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
-    assert (4 == np.max(out_model.groupdq[0, 5, 500, 500]))
+    assert (4 == np.max(out_model.groupdq[0, 5, 5, 5]))
 
-def test_oneCR_10_groups_fullarray():
+def test_onecr_10_groups_fullarray(setup_inputs):
     grouptime = 3.0
     ingain = 5  # use large gain to show that Poisson noise doesn't affect the recombination
     inreadnoise = np.float64(7)
@@ -40,134 +42,95 @@ def test_oneCR_10_groups_fullarray():
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
                                                           gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
     # two segments perfect fit, second segment has twice the slope
-    model1.data[0, 0, :, :] = 15.0
-    model1.data[0, 1, :, :] = 20.0
-    model1.data[0, 2, :, :] = 25.0
-    model1.data[0, 3, :, :] = 30.0
-    model1.data[0, 4, :, :] = 35.0
-    model1.data[0, 5, :, :] = 140.0
-    model1.data[0, 6, :, :] = 150.0
-    model1.data[0, 7, :, :] = 160.0
-    model1.data[0, 8, :, :] = 170.0
-    model1.data[0, 9, :, :] = 180.0
-    # move the CR to group 3 for row 102 and make difference be 30
-    model1.data[0, 3, :, 102] = 100
-    model1.data[0, 4, :, 102] = 130
-    model1.data[0, 5, :, 102] = 160
-    model1.data[0, 6, :, 102] = 190
-    model1.data[0, 7, :, 102] = 220
-    model1.data[0, 8, :, 102] = 250
-    model1.data[0, 9, :, 102] = 280
+    model1.data[0, 0, 5, :] = 15.0
+    model1.data[0, 1, 5, :] = 20.0
+    model1.data[0, 2, 5, :] = 25.0
+    model1.data[0, 3, 5, :] = 30.0
+    model1.data[0, 4, 5, :] = 35.0
+    model1.data[0, 5, 5, :] = 140.0
+    model1.data[0, 6, 5, :] = 150.0
+    model1.data[0, 7, 5, :] = 160.0
+    model1.data[0, 8, 5, :] = 170.0
+    model1.data[0, 9, 5, :] = 180.0
+    # move the CR to group 3 for row 10 and make difference be 30
+    model1.data[0, 3, 5, 10] = 100
+    model1.data[0, 4, 5, 10] = 130
+    model1.data[0, 5, 5, 10] = 160
+    model1.data[0, 6, 5, 10] = 190
+    model1.data[0, 7, 5, 10] = 220
+    model1.data[0, 8, 5, 10] = 250
+    model1.data[0, 9, 5, 10] = 280
     out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
     assert (4 == np.max(out_model.groupdq[0, 5, :, :]))
 
 
-def test_oneCR_100_groups_fullarray():
+def test_onecr_50_groups(setup_inputs):
     grouptime = 3.0
     ingain = 5  # use large gain to show that Poisson noise doesn't affect the recombination
     inreadnoise = np.float64(7)
-    ngroups = 10
+    ngroups = 50
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
                                                           gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
     # two segments perfect fit, second segment has twice the slope
-    model1.data[0, 0, :, :] = 15.0
-    model1.data[0, 1, :, :] = 20.0
-    model1.data[0, 2, :, :] = 25.0
-    model1.data[0, 3, :, :] = 30.0
-    model1.data[0, 4, :, :] = 35.0
-    model1.data[0, 5, :, :] = 140.0
-    model1.data[0, 6, :, :] = 150.0
-    model1.data[0, 7, :, :] = 160.0
-    model1.data[0, 8, :, :] = 170.0
-    model1.data[0, 9, :, :] = 180.0
-    model1.data[0, 10:99, :, :] =190.0
-    model1.data[0, 30:99, :, :] = 490.0
+    model1.data[0, 0, 5, 5] = 15.0
+    model1.data[0, 1, 5, 5] = 20.0
+    model1.data[0, 2, 5, 5] = 25.0
+    model1.data[0, 3, 5, 5] = 30.0
+    model1.data[0, 4, 5, 5] = 35.0
+    model1.data[0, 5, 5, 5] = 140.0
+    model1.data[0, 6, 5, 5] = 150.0
+    model1.data[0, 7, 5, 5] = 160.0
+    model1.data[0, 8, 5, 5] = 170.0
+    model1.data[0, 9, 5, 5] = 180.0
+    model1.data[0, 10:29, 5, 5] = 190.0
+    model1.data[0, 30:49, 5, 5] = 490.0
     out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
-    assert (4 == np.max(out_model.groupdq[0, 5, :, :]))
-    outdqcr = out_model.groupdq[0, 5, :, :]
+    assert (4 == np.max(out_model.groupdq[0, 5, 5, 5]))
+    outdqcr = out_model.groupdq[0, 5, 5, 5]
     np.testing.assert_allclose(4, outdqcr)
 
 # Need test for multi-ints near zero with positive and negative slopes
 
-def setup_inputs(ngroups=10, readnoise=10, nints=1,
+@pytest.fixture
+def setup_inputs():
+    def _setup(ngroups=10, readnoise=10, nints=1,
                  nrows=1032, ncols=1024, nframes=1, grouptime=1.0, gain=1, deltatime=1):
-    times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
-    gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-    pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
-    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
-    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
-    model1 = MIRIRampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
-    model1.meta.instrument.name = 'MIRI'
-    model1.meta.instrument.detector = 'MIRIMAGE'
-    model1.meta.instrument.filter = 'F480M'
-    model1.meta.observation.date = '2015-10-13'
-    model1.meta.exposure.type = 'MIR_IMAGE'
-    model1.meta.exposure.group_time = deltatime
-    model1.meta.subarray.name = 'FULL'
-    model1.meta.subarray.xstart = 1
-    model1.meta.subarray.ystart = 1
-    model1.meta.subarray.xsize = 1024
-    model1.meta.subarray.ysize = 1032
-    model1.meta.exposure.frame_time = deltatime
-    model1.meta.exposure.ngroups = ngroups
-    model1.meta.exposure.group_time = deltatime
-    model1.meta.exposure.nframes = 1
-    model1.meta.exposure.groupgap = 0
-    gain = GainModel(data=gain)
-    gain.meta.instrument.name = 'MIRI'
-    gain.meta.subarray.xstart = 1
-    gain.meta.subarray.ystart = 1
-    gain.meta.subarray.xsize = 1024
-    gain.meta.subarray.ysize = 1032
-    rnModel = ReadnoiseModel(data=read_noise)
-    rnModel.meta.instrument.name = 'MIRI'
-    rnModel.meta.subarray.xstart = 1
-    rnModel.meta.subarray.ystart = 1
-    rnModel.meta.subarray.xsize = 1024
-    rnModel.meta.subarray.ysize = 1032
-    return model1, gdq, rnModel, pixdq, err, gain
+        times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
+        gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
+        err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+        data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+        pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
+        read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
+        gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
+        model1 = MIRIRampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
+        model1.meta.instrument.name = 'MIRI'
+        model1.meta.instrument.detector = 'MIRIMAGE'
+        model1.meta.instrument.filter = 'F480M'
+        model1.meta.observation.date = '2015-10-13'
+        model1.meta.exposure.type = 'MIR_IMAGE'
+        model1.meta.exposure.group_time = deltatime
+        model1.meta.subarray.name = 'FULL'
+        model1.meta.subarray.xstart = 1
+        model1.meta.subarray.ystart = 1
+        model1.meta.subarray.xsize = 20
+        model1.meta.subarray.ysize = 20
+        model1.meta.exposure.frame_time = deltatime
+        model1.meta.exposure.ngroups = ngroups
+        model1.meta.exposure.group_time = deltatime
+        model1.meta.exposure.nframes = 1
+        model1.meta.exposure.groupgap = 0
+        gain = GainModel(data=gain)
+        gain.meta.instrument.name = 'MIRI'
+        gain.meta.subarray.xstart = 1
+        gain.meta.subarray.ystart = 1
+        gain.meta.subarray.xsize = 20
+        gain.meta.subarray.ysize = 20
+        rnModel = ReadnoiseModel(data=read_noise)
+        rnModel.meta.instrument.name = 'MIRI'
+        rnModel.meta.subarray.xstart = 1
+        rnModel.meta.subarray.ystart = 1
+        rnModel.meta.subarray.xsize = 20
+        rnModel.meta.subarray.ysize = 20
+        return model1, gdq, rnModel, pixdq, err, gain
 
-
-def setup_subarray_inputs(ngroups=10, readnoise=10, nints=1,
-                          nrows=1032, ncols=1024, subxstart=1, subystart=1,
-                          subxsize=1024, subysize=1032, nframes=1,
-                          gain=1, deltatime=1.0):
-    times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
-    gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-    data = np.zeros(shape=(nints, ngroups, subysize, subxsize), dtype=np.float64)
-    pixdq = np.zeros(shape=(subysize, subxsize), dtype=np.float64)
-    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
-    gdq = np.zeros(shape=(nints, ngroups, subysize, subxsize), dtype=np.int32)
-    model1 = MIRIRampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
-    model1.meta.instrument.name = 'MIRI'
-    model1.meta.instrument.detector = 'MIRIMAGE'
-    model1.meta.instrument.filter = 'F480M'
-    model1.meta.observation.date = '2015-10-13'
-    model1.meta.exposure.type = 'MIR_IMAGE'
-    model1.meta.exposure.group_time = deltatime
-    model1.meta.subarray.name = 'FULL'
-    model1.meta.subarray.xstart = subxstart
-    model1.meta.subarray.ystart = subystart
-    model1.meta.subarray.xsize = subxsize
-    model1.meta.subarray.ysize = subysize
-    model1.meta.exposure.frame_time = deltatime
-    model1.meta.exposure.ngroups = ngroups
-    model1.meta.exposure.group_time = deltatime
-    model1.meta.exposure.nframes = nframes
-    model1.meta.exposure.groupgap = 0
-    gain = GainModel(data=gain)
-    gain.meta.instrument.name = 'MIRI'
-    gain.meta.subarray.xstart = 1
-    gain.meta.subarray.ystart = 1
-    gain.meta.subarray.xsize = 1024
-    gain.meta.subarray.ysize = 1032
-    rnModel = ReadnoiseModel(data=read_noise)
-    rnModel.meta.instrument.name = 'MIRI'
-    rnModel.meta.subarray.xstart = 1
-    rnModel.meta.subarray.ystart = 1
-    rnModel.meta.subarray.xsize = 1024
-    rnModel.meta.subarray.ysize = 1032
-    return model1, gdq, rnModel, pixdq, err, gain
+    return _setup

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -1,0 +1,185 @@
+import pytest
+import numpy as np
+
+from jwst.jump.jump import detect_jumps
+from jwst.datamodels import dqflags
+from jwst.datamodels import MIRIRampModel
+from jwst.datamodels import GainModel, ReadnoiseModel
+
+
+def test_nocrs_noflux():
+    # all pixel values are zero. So slope should be zero
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
+    assert (0 == np.max(out_model.groupdq))
+
+
+
+def test_oneCR_10_groups():
+    grouptime = 3.0
+    deltaDN = 5
+    ingain = 200  # use large gain to show that Poisson noise doesn't affect the recombination
+    inreadnoise = np.float64(7)
+    ngroups = 10
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
+                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    # two segments perfect fit, second segment has twice the slope
+    model1.data[0, 0, 500, 500] = 15.0
+    model1.data[0, 1, 500, 500] = 20.0
+    model1.data[0, 2, 500, 500] = 25.0
+    model1.data[0, 3, 500, 500] = 30.0
+    model1.data[0, 4, 500, 500] = 35.0
+    model1.data[0, 5, 500, 500] = 140.0
+    model1.data[0, 6, 500, 500] = 150.0
+    model1.data[0, 7, 500, 500] = 160.0
+    model1.data[0, 8, 500, 500] = 170.0
+    model1.data[0, 9, 500, 500] = 180.0
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
+    assert (4 == np.max(out_model.groupdq[0, 5, 500, 500]))
+
+def test_oneCR_10_groups_fullarray():
+    grouptime = 3.0
+    deltaDN = 5
+    ingain = 5  # use large gain to show that Poisson noise doesn't affect the recombination
+    inreadnoise = np.float64(7)
+    ngroups = 10
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
+                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    # two segments perfect fit, second segment has twice the slope
+    model1.data[0, 0, :, :] = 15.0
+    model1.data[0, 1, :, :] = 20.0
+    model1.data[0, 2, :, :] = 25.0
+    model1.data[0, 3, :, :] = 30.0
+    model1.data[0, 4, :, :] = 35.0
+    model1.data[0, 5, :, :] = 140.0
+    model1.data[0, 6, :, :] = 150.0
+    model1.data[0, 7, :, :] = 160.0
+    model1.data[0, 8, :, :] = 170.0
+    model1.data[0, 9, :, :] = 180.0
+    # move the CR to group 3 for row 102 and make difference be 30
+    model1.data[0, 3, :, 102] = 100
+    model1.data[0, 4, :, 102] = 130
+    model1.data[0, 5, :, 102] = 160
+    model1.data[0, 6, :, 102] = 190
+    model1.data[0, 7, :, 102] = 220
+    model1.data[0, 8, :, 102] = 250
+    model1.data[0, 9, :, 102] = 280
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
+    assert (4 == np.max(out_model.groupdq[0, 5, :, :]))
+
+def test_oneCR_100_groups_fullarray():
+    grouptime = 3.0
+    deltaDN = 5
+    ingain = 5  # use large gain to show that Poisson noise doesn't affect the recombination
+    inreadnoise = np.float64(7)
+    ngroups = 10
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
+                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    # two segments perfect fit, second segment has twice the slope
+    model1.data[0, 0, :, :] = 15.0
+    model1.data[0, 1, :, :] = 20.0
+    model1.data[0, 2, :, :] = 25.0
+    model1.data[0, 3, :, :] = 30.0
+    model1.data[0, 4, :, :] = 35.0
+    model1.data[0, 5, :, :] = 140.0
+    model1.data[0, 6, :, :] = 150.0
+    model1.data[0, 7, :, :] = 160.0
+    model1.data[0, 8, :, :] = 170.0
+    model1.data[0, 9, :, :] = 180.0
+    model1.data[0, 10:99, :, :] =190.0
+    model1.data[0, 30:99, :, :] = 490.0
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
+    assert (4 == np.max(out_model.groupdq[0, 5, :, :]))
+    outdqcr = out_model.groupdq[0, 5, :, :]
+ #   np.testing.assert_equal(4,out_model.groupdq[0, 5, :, :])
+    badpixel = np.where(outdqcr != 4)
+    np.testing.assert_allclose(4, outdqcr)
+
+
+
+# Need test for multi-ints near zero with positive and negative slopes
+
+def setup_inputs(ngroups=10, readnoise=10, nints=1,
+                 nrows=1032, ncols=1024, nframes=1, grouptime=1.0, gain=1, deltatime=1):
+    print('readnoise', readnoise)
+    print('gain', gain)
+    times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
+    gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
+    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+    pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
+    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
+    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
+    model1 = MIRIRampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
+    model1.meta.instrument.name = 'MIRI'
+    model1.meta.instrument.detector = 'MIRIMAGE'
+    model1.meta.instrument.filter = 'F480M'
+    model1.meta.observation.date = '2015-10-13'
+    model1.meta.exposure.type = 'MIR_IMAGE'
+    model1.meta.exposure.group_time = deltatime
+    model1.meta.subarray.name = 'FULL'
+    model1.meta.subarray.xstart = 1
+    model1.meta.subarray.ystart = 1
+    model1.meta.subarray.xsize = 1024
+    model1.meta.subarray.ysize = 1032
+    model1.meta.exposure.frame_time = deltatime
+    model1.meta.exposure.ngroups = ngroups
+    model1.meta.exposure.group_time = deltatime
+    model1.meta.exposure.nframes = 1
+    model1.meta.exposure.groupgap = 0
+    gain = GainModel(data=gain)
+    gain.meta.instrument.name = 'MIRI'
+    gain.meta.subarray.xstart = 1
+    gain.meta.subarray.ystart = 1
+    gain.meta.subarray.xsize = 1024
+    gain.meta.subarray.ysize = 1032
+    rnModel = ReadnoiseModel(data=read_noise)
+    rnModel.meta.instrument.name = 'MIRI'
+    rnModel.meta.subarray.xstart = 1
+    rnModel.meta.subarray.ystart = 1
+    rnModel.meta.subarray.xsize = 1024
+    rnModel.meta.subarray.ysize = 1032
+    return model1, gdq, rnModel, pixdq, err, gain
+
+
+def setup_subarray_inputs(ngroups=10, readnoise=10, nints=1,
+                          nrows=1032, ncols=1024, subxstart=1, subystart=1,
+                          subxsize=1024, subysize=1032, nframes=1,
+                          grouptime=1.0, gain=1, deltatime=1):
+    times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
+    gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
+    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+    data = np.zeros(shape=(nints, ngroups, subysize, subxsize), dtype=np.float64)
+    pixdq = np.zeros(shape=(subysize, subxsize), dtype=np.float64)
+    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
+    gdq = np.zeros(shape=(nints, ngroups, subysize, subxsize), dtype=np.int32)
+    model1 = MIRIRampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
+    model1.meta.instrument.name = 'MIRI'
+    model1.meta.instrument.detector = 'MIRIMAGE'
+    model1.meta.instrument.filter = 'F480M'
+    model1.meta.observation.date = '2015-10-13'
+    model1.meta.exposure.type = 'MIR_IMAGE'
+    model1.meta.exposure.group_time = deltatime
+    model1.meta.subarray.name = 'FULL'
+    model1.meta.subarray.xstart = subxstart
+    model1.meta.subarray.ystart = subystart
+    model1.meta.subarray.xsize = subxsize
+    model1.meta.subarray.ysize = subysize
+    model1.meta.exposure.frame_time = deltatime
+    model1.meta.exposure.ngroups = ngroups
+    model1.meta.exposure.group_time = deltatime
+    model1.meta.exposure.nframes = 1
+    model1.meta.exposure.groupgap = 0
+    gain = GainModel(data=gain)
+    gain.meta.instrument.name = 'MIRI'
+    gain.meta.subarray.xstart = 1
+    gain.meta.subarray.ystart = 1
+    gain.meta.subarray.xsize = 1024
+    gain.meta.subarray.ysize = 1032
+    rnModel = ReadnoiseModel(data=read_noise)
+    rnModel.meta.instrument.name = 'MIRI'
+    rnModel.meta.subarray.xstart = 1
+    rnModel.meta.subarray.ystart = 1
+    rnModel.meta.subarray.xsize = 1024
+    rnModel.meta.subarray.ysize = 1032
+    return model1, gdq, rnModel, pixdq, err, gain

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -7,7 +7,7 @@ from jwst.datamodels import GainModel, ReadnoiseModel
 def test_nocrs_noflux():
     # all pixel values are zero. So slope should be zero
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
-    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0, 'one')
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
     assert (0 == np.max(out_model.groupdq))
 
 
@@ -29,7 +29,7 @@ def test_oneCR_10_groups():
     model1.data[0, 7, 500, 500] = 160.0
     model1.data[0, 8, 500, 500] = 170.0
     model1.data[0, 9, 500, 500] = 180.0
-    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0, 'one')
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
     assert (4 == np.max(out_model.groupdq[0, 5, 500, 500]))
 
 def test_oneCR_10_groups_fullarray():
@@ -58,7 +58,7 @@ def test_oneCR_10_groups_fullarray():
     model1.data[0, 7, :, 102] = 220
     model1.data[0, 8, :, 102] = 250
     model1.data[0, 9, :, 102] = 280
-    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0, 'one')
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
     assert (4 == np.max(out_model.groupdq[0, 5, :, :]))
 
 
@@ -82,7 +82,7 @@ def test_oneCR_100_groups_fullarray():
     model1.data[0, 9, :, :] = 180.0
     model1.data[0, 10:99, :, :] =190.0
     model1.data[0, 30:99, :, :] = 490.0
-    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0, 'one')
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
     assert (4 == np.max(out_model.groupdq[0, 5, :, :]))
     outdqcr = out_model.groupdq[0, 5, :, :]
     np.testing.assert_allclose(4, outdqcr)

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -88,7 +88,7 @@ def test_oneCR_100_groups_fullarray():
     model1.data[0, 9, :, :] = 180.0
     model1.data[0, 10:99, :, :] =190.0
     model1.data[0, 30:99, :, :] = 490.0
-    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0)
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, False, 4.0, 'one')
     assert (4 == np.max(out_model.groupdq[0, 5, :, :]))
     outdqcr = out_model.groupdq[0, 5, :, :]
  #   np.testing.assert_equal(4,out_model.groupdq[0, 5, :, :])

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -1,9 +1,7 @@
-import os
 from itertools import cycle
 
 import pytest
 import numpy as np
-from astropy.io import fits
 
 from jwst.datamodels import MIRIRampModel
 from jwst.datamodels import GainModel, ReadnoiseModel

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -2,8 +2,6 @@ import pytest
 import numpy as np
 import os
 from astropy.io import fits
-from jwst.jump.jump import detect_jumps
-from jwst.datamodels import dqflags
 from jwst.datamodels import MIRIRampModel
 from jwst.datamodels import GainModel, ReadnoiseModel
 from jwst.jump import JumpStep

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -1,0 +1,306 @@
+import pytest
+import numpy as np
+from astropy.io import fits
+from jwst.jump.jump import detect_jumps
+from jwst.datamodels import dqflags
+from jwst.datamodels import MIRIRampModel
+from jwst.datamodels import GainModel, ReadnoiseModel
+from jwst.jump import JumpStep
+from itertools import cycle
+
+def test_one_core():
+    grouptime = 3.0
+    deltaDN = 5
+    ingain = 6
+    inreadnoise = np.float64(7)
+    ngroups = 100
+    CR_fraction = 2
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
+                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    for i in range(ngroups):
+        model1.data[0, i, :, :] = deltaDN * i
+    first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
+    CR_locs = [x for x in range(1032*1024) if x % CR_fraction == 0]
+    CR_x_locs = [x % 1032 for x in CR_locs]
+    CR_y_locs = [np.int(x / 1032) for x in CR_locs]
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        model1.data[0,CR_group:,CR_y_locs[i], CR_x_locs[i]] = \
+            model1.data[0,CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500
+
+    print("number of CRs "+ len(CR_x_locs).__str__())
+    gain = np.ones(shape=(1024, 1032), dtype=np.float64) * ingain
+    hdr = fits.Header()
+    hdr['INSTRUME'] = 'MIRI'
+    hdr['SUBARRAY'] = 'FULL'
+    hdr['SUBSTRT1'] = 1
+    hdr['SUBSIZE1'] = 1032
+    hdr['SUBSTRT2'] = 1
+    hdr['SUBSIZE2'] = 1024
+    hdu = fits.PrimaryHDU(gain,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=gain))
+    hdul.writeto('gain.fits', overwrite=True)
+
+    rnoise = np.ones(shape=(1024, 1032), dtype=np.float64) * inreadnoise
+    hdu = fits.PrimaryHDU(rnoise,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=rnoise))
+    hdul.writeto('readnoise.fits', overwrite=True)
+
+
+    out_model = JumpStep.call(model1, override_gain='gain.fits', override_readnoise = 'readnoise.fits',
+                              maximum_cores='one')
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        print,CR_group
+        assert (4 == np.max(out_model.groupdq[0, CR_group, CR_y_locs[i], CR_x_locs[i]]))
+
+def test_one_core_NIRCAM():
+    grouptime = 3.0
+    deltaDN = 5
+    ingain = 6
+    inreadnoise = np.float64(7)
+    ngroups = 100
+    CR_fraction = 2
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,nrows=2048, ncols=2048,
+                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    for i in range(ngroups):
+        model1.data[0, i, :, :] = deltaDN * i
+    first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
+    CR_locs = [x for x in range(2048*2048) if x % CR_fraction == 0]
+    CR_x_locs = [x % 2048 for x in CR_locs]
+    CR_y_locs = [np.int(x / 2048) for x in CR_locs]
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        model1.data[0,CR_group:,CR_y_locs[i], CR_x_locs[i]] = \
+            model1.data[0,CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500
+
+    print("number of CRs "+ len(CR_x_locs).__str__())
+    gain = np.ones(shape=(2048, 2048), dtype=np.float64) * ingain
+    hdr = fits.Header()
+    hdr['INSTRUME'] = 'MIRI'
+    hdr['SUBARRAY'] = 'FULL'
+    hdr['SUBSTRT1'] = 1
+    hdr['SUBSIZE1'] = 2048
+    hdr['SUBSTRT2'] = 1
+    hdr['SUBSIZE2'] = 2048
+    hdu = fits.PrimaryHDU(gain,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=gain))
+    hdul.writeto('gain.fits', overwrite=True)
+
+    rnoise = np.ones(shape=(2048, 2048), dtype=np.float64) * inreadnoise
+    hdu = fits.PrimaryHDU(rnoise,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=rnoise))
+    hdul.writeto('readnoise.fits', overwrite=True)
+
+
+    out_model = JumpStep.call(model1, override_gain='gain.fits', override_readnoise = 'readnoise.fits',
+                              maximum_cores='one')
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        print,CR_group
+        assert (4 == np.max(out_model.groupdq[0, CR_group, CR_y_locs[i], CR_x_locs[i]]))
+
+def test_all_cores_NIRCAM():
+    grouptime = 3.0
+    deltaDN = 5
+    ingain = 6
+    inreadnoise = np.float64(7)
+    ngroups = 100
+    CR_fraction = 2
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,nrows=2048, ncols=2048,
+                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    for i in range(ngroups):
+        model1.data[0, i, :, :] = deltaDN * i
+    first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
+    CR_locs = [x for x in range(2048*2048) if x % CR_fraction == 0]
+    CR_x_locs = [x % 2048 for x in CR_locs]
+    CR_y_locs = [np.int(x / 2048) for x in CR_locs]
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        model1.data[0,CR_group:,CR_y_locs[i], CR_x_locs[i]] = \
+            model1.data[0,CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500
+
+    print("number of CRs "+ len(CR_x_locs).__str__())
+    gain = np.ones(shape=(2048, 2048), dtype=np.float64) * ingain
+    hdr = fits.Header()
+    hdr['INSTRUME'] = 'MIRI'
+    hdr['SUBARRAY'] = 'FULL'
+    hdr['SUBSTRT1'] = 1
+    hdr['SUBSIZE1'] = 2048
+    hdr['SUBSTRT2'] = 1
+    hdr['SUBSIZE2'] = 2048
+    hdu = fits.PrimaryHDU(gain,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=gain))
+    hdul.writeto('gain.fits', overwrite=True)
+
+    rnoise = np.ones(shape=(2048, 2048), dtype=np.float64) * inreadnoise
+    hdu = fits.PrimaryHDU(rnoise,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=rnoise))
+    hdul.writeto('readnoise.fits', overwrite=True)
+
+
+    out_model = JumpStep.call(model1, override_gain='gain.fits', override_readnoise = 'readnoise.fits',
+                              maximum_cores='all')
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        print,CR_group
+        assert (4 == np.max(out_model.groupdq[0, CR_group, CR_y_locs[i], CR_x_locs[i]]))
+
+def test_half_cores():
+    grouptime = 3.0
+    deltaDN = 5
+    ingain = 6
+    inreadnoise = np.float64(7)
+    ngroups = 100
+    CR_fraction = 2
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
+                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    for i in range(ngroups):
+        model1.data[0, i, :, :] = deltaDN * i
+    first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
+    CR_locs = [x for x in range(1032*1024) if x % CR_fraction == 0]
+    CR_x_locs = [x % 1032 for x in CR_locs]
+    CR_y_locs = [np.int(x / 1032) for x in CR_locs]
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        model1.data[0,CR_group:,CR_y_locs[i], CR_x_locs[i]] = \
+            model1.data[0,CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500
+
+    print("number of CRs "+ len(CR_x_locs).__str__())
+    gain = np.ones(shape=(1024, 1032), dtype=np.float64) * ingain
+    hdr = fits.Header()
+    hdr['INSTRUME'] = 'MIRI'
+    hdr['SUBARRAY'] = 'FULL'
+    hdr['SUBSTRT1'] = 1
+    hdr['SUBSIZE1'] = 1032
+    hdr['SUBSTRT2'] = 1
+    hdr['SUBSIZE2'] = 1024
+    hdu = fits.PrimaryHDU(gain,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=gain))
+    hdul.writeto('gain.fits', overwrite=True)
+
+    rnoise = np.ones(shape=(1024, 1032), dtype=np.float64) * inreadnoise
+    hdu = fits.PrimaryHDU(rnoise,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=rnoise))
+    hdul.writeto('readnoise.fits', overwrite=True)
+
+
+    out_model = JumpStep.call(model1, override_gain='gain.fits', override_readnoise = 'readnoise.fits',
+                              maximum_cores='all')
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        print,CR_group
+        assert (4 == np.max(out_model.groupdq[0, CR_group, CR_y_locs[i], CR_x_locs[i]]))
+
+def test_one_core_two_CRs():
+    grouptime = 3.0
+    deltaDN = 5
+    ingain = 6
+    inreadnoise = np.float64(7)
+    ngroups = 100
+    CR_fraction = 3
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
+                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    for i in range(ngroups):
+        model1.data[0, i, :, :] = deltaDN * i
+    first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
+    CR_locs = [x for x in range(1032*1024) if x % CR_fraction == 0]
+    CR_x_locs = [x % 1032 for x in CR_locs]
+    CR_y_locs = [np.int(x / 1032) for x in CR_locs]
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        model1.data[0,CR_group:,CR_y_locs[i], CR_x_locs[i]] = \
+            model1.data[0,CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500
+        model1.data[0, CR_group+8:, CR_y_locs[i], CR_x_locs[i]] = \
+            model1.data[0, CR_group+8:, CR_y_locs[i], CR_x_locs[i]] + 700
+
+
+    print("number of CRs "+ len(CR_x_locs).__str__())
+    gain = np.ones(shape=(1024, 1032), dtype=np.float64) * ingain
+    hdr = fits.Header()
+    hdr['INSTRUME'] = 'MIRI'
+    hdr['SUBARRAY'] = 'FULL'
+    hdr['SUBSTRT1'] = 1
+    hdr['SUBSIZE1'] = 1032
+    hdr['SUBSTRT2'] = 1
+    hdr['SUBSIZE2'] = 1024
+    hdu = fits.PrimaryHDU(gain,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=gain))
+    hdul.writeto('gain.fits', overwrite=True)
+
+    rnoise = np.ones(shape=(1024, 1032), dtype=np.float64) * inreadnoise
+    hdu = fits.PrimaryHDU(rnoise,header=hdr)
+    hdul = fits.HDUList([hdu])
+    hdul.append(fits.ImageHDU(name="SCI", data=rnoise))
+    hdul.writeto('readnoise.fits', overwrite=True)
+
+
+    out_model = JumpStep.call(model1, override_gain='gain.fits', override_readnoise = 'readnoise.fits',
+                              maximum_cores='one')
+    CR_pool = cycle(first_CR_group_locs)
+    for i in range(len(CR_x_locs)):
+        CR_group = next(CR_pool)
+        assert (4 == np.max(out_model.groupdq[0, CR_group, CR_y_locs[i], CR_x_locs[i]]))
+        assert (4 == np.max(out_model.groupdq[0, CR_group+8, CR_y_locs[i], CR_x_locs[i]]))
+
+
+
+def setup_inputs(ngroups=10, readnoise=10, nints=1,
+                 nrows=1024, ncols=1032, nframes=1, grouptime=1.0, gain=1, deltatime=1):
+    print('readnoise', readnoise)
+    print('gain', gain)
+    times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
+    gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
+    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+    pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
+    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
+    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
+    model1 = MIRIRampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
+    model1.meta.instrument.name = 'MIRI'
+    model1.meta.instrument.detector = 'MIRIMAGE'
+    model1.meta.instrument.filter = 'F480M'
+    model1.meta.observation.date = '2015-10-13'
+    model1.meta.exposure.type = 'MIR_IMAGE'
+    model1.meta.exposure.group_time = deltatime
+    model1.meta.subarray.name = 'FULL'
+    model1.meta.subarray.xstart = 1
+    model1.meta.subarray.ystart = 1
+    model1.meta.subarray.xsize = 1032
+    model1.meta.subarray.ysize = 1024
+    model1.meta.exposure.frame_time = deltatime
+    model1.meta.exposure.ngroups = ngroups
+    model1.meta.exposure.group_time = deltatime
+    model1.meta.exposure.nframes = 1
+    model1.meta.exposure.groupgap = 0
+    gain = GainModel(data=gain)
+    gain.meta.instrument.name = 'MIRI'
+    gain.meta.subarray.xstart = 1
+    gain.meta.subarray.ystart = 1
+    gain.meta.subarray.xsize = 1032
+    gain.meta.subarray.ysize = 1024
+    rnModel = ReadnoiseModel(data=read_noise)
+    rnModel.meta.instrument.name = 'MIRI'
+    rnModel.meta.subarray.xstart = 1
+    rnModel.meta.subarray.ystart = 1
+    rnModel.meta.subarray.xsize = 1032
+    rnModel.meta.subarray.ysize = 1024
+    return model1, gdq, rnModel, pixdq, err, gain

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -1,149 +1,220 @@
+import os
+from itertools import cycle
+
 import pytest
 import numpy as np
-import os
 from astropy.io import fits
+
 from jwst.datamodels import MIRIRampModel
 from jwst.datamodels import GainModel, ReadnoiseModel
 from jwst.jump import JumpStep
-from itertools import cycle
 
-@pytest.fixture(params=['one','quarter','half','all'])
-def get_max_cores(request):
-    return request.param
+MAXIMUM_CORES = [None, 'quarter','half','all']
+
+@pytest.fixture(scope="module")
+def generate_miri_reffiles(tmpdir_factory):
+    gainfile = str(tmpdir_factory.mktemp("data").join("gain.fits"))
+    readnoisefile = str(tmpdir_factory.mktemp("data").join('readnoise.fits'))
+
+    ingain = 6
+    xsize = 103
+    ysize = 102
+    gain = np.ones(shape=(ysize, xsize), dtype=np.float64) * ingain
+    gain_model = GainModel(data=gain)
+    gain_model.meta.instrument.name = "MIRI"
+    gain_model.meta.subarray.name = "FULL"
+    gain_model.meta.subarray.xstart = 1
+    gain_model.meta.subarray.ystart = 1
+    gain_model.meta.subarray.xsize = xsize
+    gain_model.meta.subarray.ysize = ysize
+    gain_model.save(gainfile)
+
+    inreadnoise = 5
+    rnoise = np.ones(shape=(ysize, xsize), dtype=np.float64) * inreadnoise
+    readnoise_model = ReadnoiseModel(data=rnoise)
+    readnoise_model.meta.instrument.name = "MIRI"
+    readnoise_model.meta.subarray.xstart = 1
+    readnoise_model.meta.subarray.ystart = 1
+    readnoise_model.meta.subarray.xsize = xsize
+    readnoise_model.meta.subarray.ysize = ysize
+    readnoise_model.save(readnoisefile)
+
+    return gainfile, readnoisefile
 
 
 @pytest.fixture(scope="module")
-def add_reffiles(request):
+def generate_nircam_reffiles(tmpdir_factory):
+    gainfile = str(tmpdir_factory.mktemp("ndata").join("gain.fits"))
+    readnoisefile = str(tmpdir_factory.mktemp("ndata").join('readnoise.fits'))
+
     ingain = 6
+    xsize = 20
+    ysize = 20
+    gain = np.ones(shape=(ysize, xsize), dtype=np.float64) * ingain
+    gain_model = GainModel(data=gain)
+    gain_model.meta.instrument.name = "NIRCAM"
+    gain_model.meta.subarray.name = "FULL"
+    gain_model.meta.subarray.xstart = 1
+    gain_model.meta.subarray.ystart = 1
+    gain_model.meta.subarray.xsize = xsize
+    gain_model.meta.subarray.ysize = ysize
+    gain_model.save(gainfile)
+
     inreadnoise = 5
-    gain = np.ones(shape=(1024, 1032), dtype=np.float64) * ingain
-    hdr = fits.Header()
-    hdr['INSTRUME'] = 'MIRI'
-    hdr['SUBARRAY'] = 'FULL'
-    hdr['SUBSTRT1'] = 1
-    hdr['SUBSIZE1'] = 1032
-    hdr['SUBSTRT2'] = 1
-    hdr['SUBSIZE2'] = 1024
-    hdu = fits.PrimaryHDU(gain, header=hdr)
-    hdul = fits.HDUList([hdu])
-    hdul.append(fits.ImageHDU(name="SCI", data=gain))
-    hdul.writeto('gain.fits', overwrite=True)
+    rnoise = np.ones(shape=(ysize, xsize), dtype=np.float64) * inreadnoise
+    readnoise_model = ReadnoiseModel(data=rnoise)
+    readnoise_model.meta.instrument.name = "NIRCAM"
+    readnoise_model.meta.subarray.xstart = 1
+    readnoise_model.meta.subarray.ystart = 1
+    readnoise_model.meta.subarray.xsize = xsize
+    readnoise_model.meta.subarray.ysize = ysize
+    readnoise_model.save(readnoisefile)
 
-    rnoise = np.ones(shape=(1024, 1032), dtype=np.float64) * inreadnoise
-    hdu = fits.PrimaryHDU(rnoise, header=hdr)
-    hdul = fits.HDUList([hdu])
-    hdul.append(fits.ImageHDU(name="SCI", data=rnoise))
-    hdul.writeto('readnoise.fits', overwrite=True)
-    def fin():
-        os.remove('gain.fits')
-        os.remove('readnoise.fits')
+    return gainfile, readnoisefile
 
-    request.addfinalizer(fin)
 
-@pytest.fixture(scope="module")
+@pytest.fixture
+def setup_inputs():
 
-def add_NIRCAM_reffiles(request):
-    ingain = 6
-    inreadnoise = 5
-    gain = np.ones(shape=(2048, 2048), dtype=np.float64) * ingain
-    hdr = fits.Header()
-    hdr['INSTRUME'] = 'MIRI'
-    hdr['SUBARRAY'] = 'FULL'
-    hdr['SUBSTRT1'] = 1
-    hdr['SUBSIZE1'] = 2048
-    hdr['SUBSTRT2'] = 1
-    hdr['SUBSIZE2'] = 2048
-    hdu = fits.PrimaryHDU(gain, header=hdr)
-    hdul = fits.HDUList([hdu])
-    hdul.append(fits.ImageHDU(name="SCI", data=gain))
-    hdul.writeto('gain.NIRCAM.fits', overwrite=True)
+    def _setup(ngroups=10, readnoise=10, nints=1, nrows=1024, ncols=1032,
+                                nframes=1, grouptime=1.0, gain=1, deltatime=1):
+        times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
+        gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
+        err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+        data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+        pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
+        read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
+        gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
 
-    rnoise = np.ones(shape=(2048, 2048), dtype=np.float64) * inreadnoise
-    hdu = fits.PrimaryHDU(rnoise, header=hdr)
-    hdul = fits.HDUList([hdu])
-    hdul.append(fits.ImageHDU(name="SCI", data=rnoise))
-    hdul.writeto('readnoise.NIRCAM.fits', overwrite=True)
-    def fin():
-        os.remove('gain.NIRCAM.fits')
-        os.remove('readnoise.NIRCAM.fits')
+        rampmodel = MIRIRampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
+        rampmodel.meta.instrument.name = 'MIRI'
+        rampmodel.meta.instrument.detector = 'MIRIMAGE'
+        rampmodel.meta.instrument.filter = 'F480M'
+        rampmodel.meta.observation.date = '2015-10-13'
+        rampmodel.meta.exposure.type = 'MIR_IMAGE'
+        rampmodel.meta.exposure.group_time = deltatime
+        rampmodel.meta.subarray.name = 'FULL'
+        rampmodel.meta.subarray.xstart = 1
+        rampmodel.meta.subarray.ystart = 1
+        rampmodel.meta.subarray.xsize = ncols
+        rampmodel.meta.subarray.ysize = nrows
+        rampmodel.meta.exposure.frame_time = deltatime
+        rampmodel.meta.exposure.ngroups = ngroups
+        rampmodel.meta.exposure.group_time = deltatime
+        rampmodel.meta.exposure.nframes = 1
+        rampmodel.meta.exposure.groupgap = 0
 
-    request.addfinalizer(fin)
+        gain = GainModel(data=gain)
+        gain.meta.instrument.name = 'MIRI'
+        gain.meta.subarray.xstart = 1
+        gain.meta.subarray.ystart = 1
+        gain.meta.subarray.xsize = ncols
+        gain.meta.subarray.ysize = nrows
 
-def test_one_CR(add_reffiles,get_max_cores):
+        rnmodel = ReadnoiseModel(data=read_noise)
+        rnmodel.meta.instrument.name = 'MIRI'
+        rnmodel.meta.subarray.xstart = 1
+        rnmodel.meta.subarray.ystart = 1
+        rnmodel.meta.subarray.xsize = ncols
+        rnmodel.meta.subarray.ysize = nrows
+
+        return rampmodel, gdq, rnmodel, pixdq, err, gain
+
+    return _setup
+
+
+@pytest.mark.parametrize("max_cores", MAXIMUM_CORES)
+def test_one_CR(generate_miri_reffiles, max_cores, setup_inputs):
+    override_gain, override_readnoise = generate_miri_reffiles
     grouptime = 3.0
     deltaDN = 5
     ingain = 6
     inreadnoise = np.float64(7)
     ngroups = 100
     CR_fraction = 3
+    xsize = 103
+    ysize = 102
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
-                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+        nrows=ysize, ncols=xsize,
+        gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
     for i in range(ngroups):
         model1.data[0, i, :, :] = deltaDN * i
     first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
-    CR_locs = [x for x in range(1032*1024) if x % CR_fraction == 0]
-    CR_x_locs = [x % 1032 for x in CR_locs]
-    CR_y_locs = [np.int(x / 1032) for x in CR_locs]
+    CR_locs = [x for x in range(xsize*ysize) if x % CR_fraction == 0]
+    CR_x_locs = [x % ysize for x in CR_locs]
+    CR_y_locs = [np.int(x / xsize) for x in CR_locs]
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
         model1.data[0,CR_group:,CR_y_locs[i], CR_x_locs[i]] = \
             model1.data[0,CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500
 
-    print("number of CRs "+ len(CR_x_locs).__str__())
+    print("number of CRs {}".format(len(CR_x_locs)))
 
-    out_model = JumpStep.call(model1, override_gain='gain.fits', override_readnoise = 'readnoise.fits',
-                              maximum_cores=get_max_cores)
+    out_model = JumpStep.call(model1, override_gain=override_gain,
+        override_readnoise=override_readnoise, maximum_cores=max_cores)
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
         assert (4 == np.max(out_model.groupdq[0, CR_group, CR_y_locs[i], CR_x_locs[i]]))
 
-def test_half_NIRCAM(add_NIRCAM_reffiles):
+
+@pytest.mark.parametrize("max_cores", MAXIMUM_CORES)
+def test_nircam(generate_nircam_reffiles, setup_inputs, max_cores):
+    override_gain, override_readnoise = generate_nircam_reffiles
+
     grouptime = 3.0
     deltaDN = 5
     ingain = 6
     inreadnoise = np.float64(7)
     ngroups = 100
     CR_fraction = 5
-    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,nrows=2048, ncols=2048,
-                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+    nrows = 20
+    ncols = 20
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
+        nrows=nrows, ncols=ncols, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
     for i in range(ngroups):
         model1.data[0, i, :, :] = deltaDN * i
     first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
-    CR_locs = [x for x in range(2048*2048) if x % CR_fraction == 0]
-    CR_x_locs = [x % 2048 for x in CR_locs]
-    CR_y_locs = [np.int(x / 2048) for x in CR_locs]
+    CR_locs = [x for x in range(nrows*ncols) if x % CR_fraction == 0]
+    CR_x_locs = [x % ncols for x in CR_locs]
+    CR_y_locs = [np.int(x / nrows) for x in CR_locs]
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
         model1.data[0,CR_group:,CR_y_locs[i], CR_x_locs[i]] = \
             model1.data[0,CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500
 
-    print("number of CRs "+ len(CR_x_locs).__str__())
+    print("number of CRs {}".format(len(CR_x_locs)))
 
-    out_model = JumpStep.call(model1, override_gain='gain.NIRCAM.fits', override_readnoise = 'readnoise.NIRCAM.fits',
-                              maximum_cores='half')
+    out_model = JumpStep.call(model1, override_gain=override_gain,
+        override_readnoise=override_readnoise, maximum_cores=max_cores)
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
         assert (4 == np.max(out_model.groupdq[0, CR_group, CR_y_locs[i], CR_x_locs[i]]))
 
-def test_two_CRs(add_reffiles,get_max_cores):
+
+@pytest.mark.parametrize("max_cores", MAXIMUM_CORES)
+def test_two_CRs(generate_miri_reffiles, max_cores, setup_inputs):
+    override_gain, override_readnoise = generate_miri_reffiles
     grouptime = 3.0
     deltaDN = 5
     ingain = 6
     inreadnoise = np.float64(7)
     ngroups = 100
     CR_fraction = 5
+    xsize = 103
+    ysize = 102
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
-                                                          gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+        nrows=ysize, ncols=xsize,
+        gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
     for i in range(ngroups):
         model1.data[0, i, :, :] = deltaDN * i
     first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
-    CR_locs = [x for x in range(1032*1024) if x % CR_fraction == 0]
-    CR_x_locs = [x % 1032 for x in CR_locs]
-    CR_y_locs = [np.int(x / 1032) for x in CR_locs]
+    CR_locs = [x for x in range(xsize*ysize) if x % CR_fraction == 0]
+    CR_x_locs = [x % ysize for x in CR_locs]
+    CR_y_locs = [np.int(x / xsize) for x in CR_locs]
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
@@ -151,54 +222,10 @@ def test_two_CRs(add_reffiles,get_max_cores):
             model1.data[0,CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500
         model1.data[0, CR_group+8:, CR_y_locs[i], CR_x_locs[i]] = \
             model1.data[0, CR_group+8:, CR_y_locs[i], CR_x_locs[i]] + 700
-    out_model = JumpStep.call(model1, override_gain='gain.fits', override_readnoise = 'readnoise.fits',
-                              maximum_cores=get_max_cores)
+    out_model = JumpStep.call(model1, override_gain=override_gain,
+        override_readnoise=override_readnoise, maximum_cores=max_cores)
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
         assert (4 == np.max(out_model.groupdq[0, CR_group, CR_y_locs[i], CR_x_locs[i]]))
         assert (4 == np.max(out_model.groupdq[0, CR_group+8, CR_y_locs[i], CR_x_locs[i]]))
-
-
-
-def setup_inputs(ngroups=10, readnoise=10, nints=1,
-                 nrows=1024, ncols=1032, nframes=1, grouptime=1.0, gain=1, deltatime=1):
-    print('readnoise', readnoise)
-    print('gain', gain)
-    times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
-    gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-    pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
-    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
-    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
-    model1 = MIRIRampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
-    model1.meta.instrument.name = 'MIRI'
-    model1.meta.instrument.detector = 'MIRIMAGE'
-    model1.meta.instrument.filter = 'F480M'
-    model1.meta.observation.date = '2015-10-13'
-    model1.meta.exposure.type = 'MIR_IMAGE'
-    model1.meta.exposure.group_time = deltatime
-    model1.meta.subarray.name = 'FULL'
-    model1.meta.subarray.xstart = 1
-    model1.meta.subarray.ystart = 1
-    model1.meta.subarray.xsize = 1032
-    model1.meta.subarray.ysize = 1024
-    model1.meta.exposure.frame_time = deltatime
-    model1.meta.exposure.ngroups = ngroups
-    model1.meta.exposure.group_time = deltatime
-    model1.meta.exposure.nframes = 1
-    model1.meta.exposure.groupgap = 0
-    gain = GainModel(data=gain)
-    gain.meta.instrument.name = 'MIRI'
-    gain.meta.subarray.xstart = 1
-    gain.meta.subarray.ystart = 1
-    gain.meta.subarray.xsize = 1032
-    gain.meta.subarray.ysize = 1024
-    rnModel = ReadnoiseModel(data=read_noise)
-    rnModel.meta.instrument.name = 'MIRI'
-    rnModel.meta.subarray.xstart = 1
-    rnModel.meta.subarray.ystart = 1
-    rnModel.meta.subarray.xsize = 1032
-    rnModel.meta.subarray.ysize = 1024
-    return model1, gdq, rnModel, pixdq, err, gain

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -445,7 +445,7 @@ def test_6grps_satat6_crat1_flagadjpixels(setup_cube):
     data[0, 5, 100, 101] = 35015
     gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
     median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
-   # assert(4 == np.max(out_gdq))  # no CR was found
+    # assert(4 == np.max(out_gdq))  # no CR was found
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 99, 100]))
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 101, 100]))
@@ -468,7 +468,7 @@ def test_10grps_satat8_crsat3and6(setup_cube):
     data[0, 7:11, 100, 100] = 61000
     gdq[0, 7:11, 100, 100] = dqflags.group['SATURATED']
     median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
-   # assert(4 == np.max(out_gdq))  # no CR was found
+    # assert(4 == np.max(out_gdq))  # no CR was found
     assert np.array_equal(
         [0, 0, dqflags.group['JUMP_DET'], 0, 0, dqflags.group['JUMP_DET'], 0,
             dqflags.group['SATURATED'], dqflags.group['SATURATED'], dqflags.group['SATURATED']],

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -8,7 +8,7 @@ from jwst.datamodels import dqflags
 def test_nocrs_noflux(setup_cube):
     ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(out_gdq)) # no CR found
 
 
@@ -18,7 +18,7 @@ def test_5grps_cr3_noflux(setup_cube):
 
     data[0, 0:2, 100, 100] = 10.0
     data[0, 2:5, 100, 100] = 1000
-    median_diff, out_gdq =find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq =find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(2 == np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
 
@@ -29,7 +29,7 @@ def test_5grps_cr2_noflux(setup_cube):
 
     data[0, 0, 100, 100] = 10.0
     data[0, 1:6, 100, 100] = 1000
-    median_diff, out_gdq =find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq =find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(1 == np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
 
@@ -44,7 +44,7 @@ def test_6grps_negative_differences_zeromedian(setup_cube):
     data[0, 3, 100, 100] = 105
     data[0, 4, 100, 100] = 100
     data[0, 5, 100, 100] = 100
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(out_gdq)) #no CR was found
     assert(0 == median_diff[0,100,100]) #Median difference is zero
 
@@ -55,7 +55,7 @@ def test_5grps_cr2_negjumpflux(setup_cube):
 
     data[0, 0, 100, 100] = 1000.0
     data[0, 1:6, 100, 100] = 10
-    median_diff, out_gdq =find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq =find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(1 == np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
 
@@ -65,11 +65,8 @@ def test_3grps_cr2_noflux(setup_cube):
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     data[0, 0, 100, 100] = 10.0
     data[0, 1:4, 100, 100] = 1000
-    print("test data "+repr(data[0,:,100,100]))
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print(repr(out_gdq[0, :, 100, 100]))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
-    assert(4 == np.max(out_gdq)) #a CR was found
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(out_gdq)) # a CR was found
     #    assert(1,np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
     assert(np.array_equal([0, 4, 0], out_gdq[0, :, 100, 100]))
 
@@ -79,7 +76,7 @@ def test_4grps_cr2_noflux(setup_cube):
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     data[0, 0, 100, 100] = 10.0
     data[0, 1:4, 100, 100] = 1000
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(1 == np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
 
@@ -93,9 +90,7 @@ def test_5grps_cr2_nframe2(setup_cube):
     data[0, 2, 100, 100] = 1002
     data[0, 3, 100, 100] = 1001
     data[0, 4, 100, 100] = 1005
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
-    print(repr(out_gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,4,0,0], out_gdq[0, :, 100, 100]) )
 
@@ -109,9 +104,7 @@ def test_4grps_twocrs_2nd_4th(setup_cube):
     data[0, 1, 100, 100] = 60
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
-    print(repr(out_gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,0,4] , out_gdq[0, :, 100, 100]) )
 
@@ -125,8 +118,7 @@ def test_5grps_twocrs_2nd_5th(setup_cube):
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4] ,out_gdq[0, :, 100, 100]) )
 
@@ -140,8 +132,7 @@ def test_5grps_twocrs_2nd_5thbig(setup_cube):
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 2115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4] , out_gdq[0, :, 100, 100]) )
 
@@ -160,8 +151,7 @@ def test_10grps_twocrs_2nd_8th_big(setup_cube):
     data[0, 7, 100, 100] = 2115
     data[0, 8, 100, 100] = 2115
     data[0, 9, 100, 100] = 2115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , out_gdq[0, :, 100, 100]) )
 
@@ -180,8 +170,7 @@ def test_10grps_twocrs_10percenthit(setup_cube):
     data[0:200, 7, 100, 100] = 2115
     data[0:200, 8, 100, 100] = 2115
     data[0:200, 9, 100, 100] = 2115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , out_gdq[0, :, 100, 100]) )
 
@@ -195,8 +184,7 @@ def test_5grps_twocrs_2nd_5thbig_nframes2(setup_cube):
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 2115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4] , out_gdq[0, :, 100, 100]) )
 
@@ -211,8 +199,7 @@ def test_6grps_twocrs_2nd_5th(setup_cube):
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
     data[0, 5, 100, 100] = 115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ",median_diff[0,100,100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4,0] , out_gdq[0, :, 100, 100]) )
 
@@ -227,7 +214,7 @@ def test_6grps_twocrs_2nd_5th_nframes2(setup_cube):
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
     data[0, 5, 100, 100] = 115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
     assert(np.array_equal([0,4,0,0,4,0] , out_gdq[0, :, 100, 100]) )
 
@@ -248,10 +235,8 @@ def test_6grps_twocrs_twopixels_nframes2(setup_cube):
     data[0, 3, 200, 100] = 60
     data[0, 4, 200, 100] = 115
     data[0, 5, 200, 100] = 115
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
-    print("100 100 dq",repr(out_gdq[0,:,100,100]))
-    print("200 100 dq",repr(out_gdq[0,:,200,100]))
     assert(np.array_equal([0,4,0,0,4,0] , out_gdq[0, :, 100, 100]) )
     assert(np.array_equal([0, 0, 4, 0, 4, 0] , out_gdq[0, :, 200, 100]))
 
@@ -265,8 +250,7 @@ def test_5grps_cr2_negslope(setup_cube):
     data[0, 2, 100, 100] = -200
     data[0, 3, 100, 100] = -260
     data[0, 4, 100, 100] = -360
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq))  # a CR was found
     assert(np.array_equal([0, 0, 4, 0, 0] , out_gdq[0, :, 100, 100]))
 
@@ -281,8 +265,7 @@ def test_6grps_1cr(setup_cube):
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 1146
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert (4 == out_gdq[0, 5, 100, 100])
     assert(11 == median_diff[0, 100, 100])
 
@@ -298,8 +281,7 @@ def test_7grps_1cr(setup_cube):
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 60
     data[0, 6, 100, 100] = 1160
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == out_gdq[0, 6,100,100])
     assert(11.5 == median_diff[0, 100, 100])
 
@@ -312,8 +294,7 @@ def test_5grps_nocr(setup_cube):
     data[0, 2, 100, 100] = 21
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(11 == median_diff[0, 100, 100])
 
 
@@ -327,8 +308,7 @@ def test_6grps_nocr(setup_cube):
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 60
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
-    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(11.5 == median_diff[0, 100, 100])
 
 
@@ -339,7 +319,7 @@ def test_10grps_cr2_gt3sigma(setup_cube):
     nframes = 1
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq))  # a CR was found
     assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , out_gdq[0, :, 100, 100]))
 
@@ -351,7 +331,7 @@ def test_10grps_cr2_3sigma_nocr(setup_cube):
     nframes = 1
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(out_gdq))  # a CR was found
     assert(np.array_equal([0, 0, 0, 0, 0,0,0,0,0,0] , out_gdq[0, :, 100, 100]))
 
@@ -363,7 +343,7 @@ def test_10grps_cr2_gt3sigma_2frames(setup_cube):
     nframes = 2
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq))  # a CR was found
     assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , out_gdq[0, :, 100, 100]))
 
@@ -374,7 +354,7 @@ def test_10grps_cr2_gt3sigma_2frames_offdiag(setup_cube):
     nframes = 2
     data[0, 0, 100, 110] = 0
     data[0, 1:11, 100, 110] = crmag
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq))  # a CR was found
     assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , out_gdq[0, :, 100, 110]))
 
@@ -385,7 +365,7 @@ def test_10grps_cr2_3sigma_2frames_nocr(setup_cube):
     nframes = 2
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(out_gdq))  # a CR was found
     assert(np.array_equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0] , out_gdq[0, :, 100, 100]))
 
@@ -397,9 +377,9 @@ def test_10grps_nocr_2pixels_sigma0(setup_cube):
     nframes=1
     data[0, 0, 100, 100] = crmag
     data[0, 1:11, 100, 100] = crmag
-    read_noise[500, 500] = 0.0
-    read_noise[600, 600] = 0.0
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    read_noise[50, 50] = 0.0
+    read_noise[60, 60] = 0.0
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(out_gdq))  # no CR was found
 
 
@@ -414,7 +394,7 @@ def test_5grps_satat4_crat3(setup_cube):
     data[0, 4, 100, 100] = 61000
     gdq[0, 3, 100, 100] = dqflags.group['SATURATED']
     gdq[0, 4, 100, 100] = dqflags.group['SATURATED']
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     # assert(4 == np.max(out_gdq))  # no CR was found
     assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'],dqflags.group['SATURATED'], dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
 
@@ -437,7 +417,7 @@ def test_6grps_satat6_crat1(setup_cube):
     data[0, 4, 100, 101] = 30010
     data[0, 5, 100, 101] = 35015
     gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     # assert(4 == np.max(out_gdq))  # no CR was found
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
 
@@ -461,7 +441,7 @@ def test_6grps_satat6_crat1_flagadjpixels(setup_cube):
     data[0, 4, 100, 101] = 30010
     data[0, 5, 100, 101] = 35015
     gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
    # assert(4 == np.max(out_gdq))  # no CR was found
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 99, 100]))
@@ -484,7 +464,7 @@ def test_10grps_satat8_crsat3and6(setup_cube):
     data[0, 6, 100, 100] = 45000
     data[0, 7:11, 100, 100] = 61000
     gdq[0, 7:11, 100, 100] = dqflags.group['SATURATED']
-    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
    # assert(4 == np.max(out_gdq))  # no CR was found
     assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'], 0, 0, dqflags.group['JUMP_DET'],
                             0,dqflags.group['SATURATED'],dqflags.group['SATURATED'],dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -349,6 +349,16 @@ def test_10grps_cr2_gt3sigma_2frames(setup_cube):
     assert(4 == np.max(gdq))  # a CR was found
     assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
 
+def test_10grps_cr2_gt3sigma_2frames_offdiag(setup_cube):
+    ngroups = 10
+    crmag=16
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5*np.sqrt(2))
+    nframes = 2
+    data[0, 0, 100, 110] = 0
+    data[0, 1:11, 100, 110] = crmag
+    find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq))  # a CR was found
+    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 110]))
 
 def test_10grps_cr2_3sigma_2frames_nocr(setup_cube):
     ngroups = 10

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -201,7 +201,7 @@ def test_6grps_twocrs_2nd_5th(setup_cube):
     data[0, 5, 100, 100] = 115
     median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(out_gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,4,0] , out_gdq[0, :, 100, 100]) )
+    assert np.array_equal([0,4,0,0,4,0] , out_gdq[0, :, 100, 100])
 
 
 def test_6grps_twocrs_2nd_5th_nframes2(setup_cube):
@@ -396,7 +396,10 @@ def test_5grps_satat4_crat3(setup_cube):
     gdq[0, 4, 100, 100] = dqflags.group['SATURATED']
     median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
     # assert(4 == np.max(out_gdq))  # no CR was found
-    assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'],dqflags.group['SATURATED'], dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
+    assert np.array_equal(
+        [0, 0, dqflags.group['JUMP_DET'], dqflags.group['SATURATED'], dqflags.group['SATURATED']],
+        out_gdq[0, :, 100, 100]
+        )
 
 
 def test_6grps_satat6_crat1(setup_cube):
@@ -448,8 +451,8 @@ def test_6grps_satat6_crat1_flagadjpixels(setup_cube):
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 101, 100]))
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 99]))
     assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 101]))
-    
-    
+
+
 def test_10grps_satat8_crsat3and6(setup_cube):
     ngroups = 10
     #crmag = 1000
@@ -466,8 +469,10 @@ def test_10grps_satat8_crsat3and6(setup_cube):
     gdq[0, 7:11, 100, 100] = dqflags.group['SATURATED']
     median_diff, out_gdq = find_crs(data, gdq, read_noise, rej_threshold, nframes)
    # assert(4 == np.max(out_gdq))  # no CR was found
-    assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'], 0, 0, dqflags.group['JUMP_DET'],
-                            0,dqflags.group['SATURATED'],dqflags.group['SATURATED'],dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
+    assert np.array_equal(
+        [0, 0, dqflags.group['JUMP_DET'], 0, 0, dqflags.group['JUMP_DET'], 0,
+            dqflags.group['SATURATED'], dqflags.group['SATURATED'], dqflags.group['SATURATED']],
+        out_gdq[0, :, 100, 100])
 
 
 @pytest.fixture(scope='function')

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -8,7 +8,8 @@ from jwst.datamodels import dqflags
 def test_nocrs_noflux(setup_cube):
     ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
-    assert(0 == np.max(find_crs(data, gdq, read_noise, rej_threshold, nframes))) # no CR found
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(0 == np.max(out_gdq)) # no CR found
 
 
 def test_5grps_cr3_noflux(setup_cube):
@@ -17,9 +18,9 @@ def test_5grps_cr3_noflux(setup_cube):
 
     data[0, 0:2, 100, 100] = 10.0
     data[0, 2:5, 100, 100] = 1000
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(2 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+    median_diff, out_gdq =find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(2 == np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
 
 
 def test_5grps_cr2_noflux(setup_cube):
@@ -28,9 +29,9 @@ def test_5grps_cr2_noflux(setup_cube):
 
     data[0, 0, 100, 100] = 10.0
     data[0, 1:6, 100, 100] = 1000
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+    median_diff, out_gdq =find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(1 == np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
 
 
 def test_6grps_negative_differences_zeromedian(setup_cube):
@@ -43,8 +44,8 @@ def test_6grps_negative_differences_zeromedian(setup_cube):
     data[0, 3, 100, 100] = 105
     data[0, 4, 100, 100] = 100
     data[0, 5, 100, 100] = 100
-    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(0 == np.max(gdq)) #no CR was found
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(0 == np.max(out_gdq)) #no CR was found
     assert(0 == median_diff[0,100,100]) #Median difference is zero
 
 
@@ -54,9 +55,9 @@ def test_5grps_cr2_negjumpflux(setup_cube):
 
     data[0, 0, 100, 100] = 1000.0
     data[0, 1:6, 100, 100] = 10
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+    median_diff, out_gdq =find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(1 == np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
 
 
 def test_3grps_cr2_noflux(setup_cube):
@@ -64,11 +65,13 @@ def test_3grps_cr2_noflux(setup_cube):
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     data[0, 0, 100, 100] = 10.0
     data[0, 1:4, 100, 100] = 1000
-    # print("test data "+repr(data[0,:,100,100]))
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    # assert(1,np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
-    assert(np.array_equal([0, 4, 0], gdq[0, :, 100, 100]))
+    print("test data "+repr(data[0,:,100,100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print(repr(out_gdq[0, :, 100, 100]))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(4 == np.max(out_gdq)) #a CR was found
+    #    assert(1,np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
+    assert(np.array_equal([0, 4, 0], out_gdq[0, :, 100, 100]))
 
 
 def test_4grps_cr2_noflux(setup_cube):
@@ -76,9 +79,9 @@ def test_4grps_cr2_noflux(setup_cube):
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     data[0, 0, 100, 100] = 10.0
     data[0, 1:4, 100, 100] = 1000
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(1 == np.argmax(out_gdq[0,:,100,100])) #find the CR in the expected group
 
 
 def test_5grps_cr2_nframe2(setup_cube):
@@ -90,9 +93,11 @@ def test_5grps_cr2_nframe2(setup_cube):
     data[0, 2, 100, 100] = 1002
     data[0, 3, 100, 100] = 1001
     data[0, 4, 100, 100] = 1005
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,4,0,0], gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    print(repr(out_gdq[0, :, 100, 100]))
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,4,0,0], out_gdq[0, :, 100, 100]) )
 
 
 @pytest.mark.xfail
@@ -104,9 +109,11 @@ def test_4grps_twocrs_2nd_4th(setup_cube):
     data[0, 1, 100, 100] = 60
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,4] , gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    print(repr(out_gdq[0, :, 100, 100]))
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,4] , out_gdq[0, :, 100, 100]) )
 
 
 def test_5grps_twocrs_2nd_5th(setup_cube):
@@ -118,9 +125,10 @@ def test_5grps_twocrs_2nd_5th(setup_cube):
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,4] ,gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4] ,out_gdq[0, :, 100, 100]) )
 
 
 def test_5grps_twocrs_2nd_5thbig(setup_cube):
@@ -132,9 +140,10 @@ def test_5grps_twocrs_2nd_5thbig(setup_cube):
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 2115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,4] , gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4] , out_gdq[0, :, 100, 100]) )
 
 
 def test_10grps_twocrs_2nd_8th_big(setup_cube):
@@ -151,9 +160,10 @@ def test_10grps_twocrs_2nd_8th_big(setup_cube):
     data[0, 7, 100, 100] = 2115
     data[0, 8, 100, 100] = 2115
     data[0, 9, 100, 100] = 2115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , out_gdq[0, :, 100, 100]) )
 
 
 def test_10grps_twocrs_10percenthit(setup_cube):
@@ -170,9 +180,10 @@ def test_10grps_twocrs_10percenthit(setup_cube):
     data[0:200, 7, 100, 100] = 2115
     data[0:200, 8, 100, 100] = 2115
     data[0:200, 9, 100, 100] = 2115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , out_gdq[0, :, 100, 100]) )
 
 
 def test_5grps_twocrs_2nd_5thbig_nframes2(setup_cube):
@@ -184,9 +195,10 @@ def test_5grps_twocrs_2nd_5thbig_nframes2(setup_cube):
     data[0, 2, 100, 100] = 60
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 2115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,4] , gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4] , out_gdq[0, :, 100, 100]) )
 
 
 def test_6grps_twocrs_2nd_5th(setup_cube):
@@ -199,9 +211,10 @@ def test_6grps_twocrs_2nd_5th(setup_cube):
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
     data[0, 5, 100, 100] = 115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ",median_diff[0,100,100])
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4,0] , out_gdq[0, :, 100, 100]) )
 
 
 def test_6grps_twocrs_2nd_5th_nframes2(setup_cube):
@@ -214,9 +227,9 @@ def test_6grps_twocrs_2nd_5th_nframes2(setup_cube):
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
     data[0, 5, 100, 100] = 115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4,0] , out_gdq[0, :, 100, 100]) )
 
 
 def test_6grps_twocrs_twopixels_nframes2(setup_cube):
@@ -235,10 +248,12 @@ def test_6grps_twocrs_twopixels_nframes2(setup_cube):
     data[0, 3, 200, 100] = 60
     data[0, 4, 200, 100] = 115
     data[0, 5, 200, 100] = 115
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq)) #a CR was found
-    assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
-    assert(np.array_equal([0, 0, 4, 0, 4, 0] , gdq[0, :, 200, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq)) #a CR was found
+    print("100 100 dq",repr(out_gdq[0,:,100,100]))
+    print("200 100 dq",repr(out_gdq[0,:,200,100]))
+    assert(np.array_equal([0,4,0,0,4,0] , out_gdq[0, :, 100, 100]) )
+    assert(np.array_equal([0, 0, 4, 0, 4, 0] , out_gdq[0, :, 200, 100]))
 
 
 def test_5grps_cr2_negslope(setup_cube):
@@ -250,9 +265,10 @@ def test_5grps_cr2_negslope(setup_cube):
     data[0, 2, 100, 100] = -200
     data[0, 3, 100, 100] = -260
     data[0, 4, 100, 100] = -360
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq))  # a CR was found
-    assert(np.array_equal([0, 0, 4, 0, 0] , gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(4 == np.max(out_gdq))  # a CR was found
+    assert(np.array_equal([0, 0, 4, 0, 0] , out_gdq[0, :, 100, 100]))
 
 
 def test_6grps_1cr(setup_cube):
@@ -265,9 +281,9 @@ def test_6grps_1cr(setup_cube):
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 1146
-    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
     print("calculated median diff of pixel is ", median_diff[0, 100, 100])
-    assert (4 == gdq[0, 5, 100, 100])
+    assert (4 == out_gdq[0, 5, 100, 100])
     assert(11 == median_diff[0, 100, 100])
 
 
@@ -282,9 +298,9 @@ def test_7grps_1cr(setup_cube):
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 60
     data[0, 6, 100, 100] = 1160
-    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
     print("calculated median diff of pixel is ", median_diff[0, 100, 100])
-    assert(4 == gdq[0, 6,100,100])
+    assert(4 == out_gdq[0, 6,100,100])
     assert(11.5 == median_diff[0, 100, 100])
 
 def test_5grps_nocr(setup_cube):
@@ -296,7 +312,8 @@ def test_5grps_nocr(setup_cube):
     data[0, 2, 100, 100] = 21
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
-    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(11 == median_diff[0, 100, 100])
 
 
@@ -310,7 +327,8 @@ def test_6grps_nocr(setup_cube):
     data[0, 3, 100, 100] = 33
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 60
-    median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
     assert(11.5 == median_diff[0, 100, 100])
 
 
@@ -321,9 +339,9 @@ def test_10grps_cr2_gt3sigma(setup_cube):
     nframes = 1
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq))  # a CR was found
-    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq))  # a CR was found
+    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , out_gdq[0, :, 100, 100]))
 
 
 def test_10grps_cr2_3sigma_nocr(setup_cube):
@@ -333,9 +351,9 @@ def test_10grps_cr2_3sigma_nocr(setup_cube):
     nframes = 1
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(0 == np.max(gdq))  # a CR was found
-    assert(np.array_equal([0, 0, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(0 == np.max(out_gdq))  # a CR was found
+    assert(np.array_equal([0, 0, 0, 0, 0,0,0,0,0,0] , out_gdq[0, :, 100, 100]))
 
 
 def test_10grps_cr2_gt3sigma_2frames(setup_cube):
@@ -345,9 +363,9 @@ def test_10grps_cr2_gt3sigma_2frames(setup_cube):
     nframes = 2
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq))  # a CR was found
-    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq))  # a CR was found
+    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , out_gdq[0, :, 100, 100]))
 
 def test_10grps_cr2_gt3sigma_2frames_offdiag(setup_cube):
     ngroups = 10
@@ -356,9 +374,9 @@ def test_10grps_cr2_gt3sigma_2frames_offdiag(setup_cube):
     nframes = 2
     data[0, 0, 100, 110] = 0
     data[0, 1:11, 100, 110] = crmag
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(4 == np.max(gdq))  # a CR was found
-    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 110]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(4 == np.max(out_gdq))  # a CR was found
+    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , out_gdq[0, :, 100, 110]))
 
 def test_10grps_cr2_3sigma_2frames_nocr(setup_cube):
     ngroups = 10
@@ -367,9 +385,9 @@ def test_10grps_cr2_3sigma_2frames_nocr(setup_cube):
     nframes = 2
     data[0, 0, 100, 100] = 0
     data[0, 1:11, 100, 100] = crmag
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(0 == np.max(gdq))  # a CR was found
-    assert(np.array_equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0] , gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(0 == np.max(out_gdq))  # a CR was found
+    assert(np.array_equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0] , out_gdq[0, :, 100, 100]))
 
 
 def test_10grps_nocr_2pixels_sigma0(setup_cube):
@@ -379,8 +397,10 @@ def test_10grps_nocr_2pixels_sigma0(setup_cube):
     nframes=1
     data[0, 0, 100, 100] = crmag
     data[0, 1:11, 100, 100] = crmag
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    assert(0 == np.max(gdq))  # no CR was found
+    read_noise[500, 500] = 0.0
+    read_noise[600, 600] = 0.0
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    assert(0 == np.max(out_gdq))  # no CR was found
 
 
 def test_5grps_satat4_crat3(setup_cube):
@@ -394,11 +414,9 @@ def test_5grps_satat4_crat3(setup_cube):
     data[0, 4, 100, 100] = 61000
     gdq[0, 3, 100, 100] = dqflags.group['SATURATED']
     gdq[0, 4, 100, 100] = dqflags.group['SATURATED']
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    # assert(4 == np.max(gdq))  # no CR was found
-    assert (np.array_equal(
-        [0, 0, dqflags.group['JUMP_DET'],dqflags.group['SATURATED'], dqflags.group['SATURATED']],
-        gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    # assert(4 == np.max(out_gdq))  # no CR was found
+    assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'],dqflags.group['SATURATED'], dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
 
 
 def test_6grps_satat6_crat1(setup_cube):
@@ -419,9 +437,9 @@ def test_6grps_satat6_crat1(setup_cube):
     data[0, 4, 100, 101] = 30010
     data[0, 5, 100, 101] = 35015
     gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    # assert(4 == np.max(gdq))  # no CR was found
-    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+    # assert(4 == np.max(out_gdq))  # no CR was found
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
 
 
 @pytest.mark.xfail
@@ -443,15 +461,15 @@ def test_6grps_satat6_crat1_flagadjpixels(setup_cube):
     data[0, 4, 100, 101] = 30010
     data[0, 5, 100, 101] = 35015
     gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    # assert(4 == np.max(gdq))  # no CR was found
-    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
-    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 99, 100]))
-    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 101, 100]))
-    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 100, 99]))
-    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 100, 101]))
-
-
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+   # assert(4 == np.max(out_gdq))  # no CR was found
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 99, 100]))
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 101, 100]))
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 99]))
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], out_gdq[0, :, 100, 101]))
+    
+    
 def test_10grps_satat8_crsat3and6(setup_cube):
     ngroups = 10
     #crmag = 1000
@@ -466,12 +484,10 @@ def test_10grps_satat8_crsat3and6(setup_cube):
     data[0, 6, 100, 100] = 45000
     data[0, 7:11, 100, 100] = 61000
     gdq[0, 7:11, 100, 100] = dqflags.group['SATURATED']
-    find_crs(data, gdq, read_noise, rej_threshold, nframes)
-    # assert(4 == np.max(gdq))  # no CR was found
-    assert (np.array_equal(
-        [0, 0, dqflags.group['JUMP_DET'], 0, 0, dqflags.group['JUMP_DET'], 0,
-        dqflags.group['SATURATED'], dqflags.group['SATURATED'], dqflags.group['SATURATED']],
-        gdq[0, :, 100, 100]))
+    median_diff, out_gdq = find_crs((data, gdq, read_noise, rej_threshold, nframes))
+   # assert(4 == np.max(out_gdq))  # no CR was found
+    assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'], 0, 0, dqflags.group['JUMP_DET'],
+                            0,dqflags.group['SATURATED'],dqflags.group['SATURATED'],dqflags.group['SATURATED']], out_gdq[0, :, 100, 100]))
 
 
 @pytest.fixture(scope='function')

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -266,6 +266,8 @@ def test_6grps_1cr(setup_cube):
     data[0, 4, 100, 100] = 46
     data[0, 5, 100, 100] = 1146
     median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert (4 == gdq[0, 5, 100, 100])
     assert(11 == median_diff[0, 100, 100])
 
 
@@ -281,8 +283,9 @@ def test_7grps_1cr(setup_cube):
     data[0, 5, 100, 100] = 60
     data[0, 6, 100, 100] = 1160
     median_diff = find_crs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", median_diff[0, 100, 100])
+    assert(4 == gdq[0, 6,100,100])
     assert(11.5 == median_diff[0, 100, 100])
-
 
 def test_5grps_nocr(setup_cube):
     ngroups = 6

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -203,7 +203,7 @@ def get_clipped_median(num_differences, diffs_to_ignore, differences, sorted_ind
                                                             pixel_med_index2[even_group_rows, even_group_cols]
                                                             - ((diffs_to_ignore[even_group_rows, even_group_cols])
                                                                / 2).astype(int)]) / 2.0
-    # The 1-D array case is a lot simplier.    
+    # The 1-D array case is a lot simplier.
     else:
         pixel_med_index = sorted_index[int(((num_differences - 1 - diffs_to_ignore) / 2))]
         pixel_med_diff = differences[pixel_med_index]

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -20,22 +20,14 @@ log.setLevel(logging.DEBUG)
 HUGE_NUM = np.finfo(np.float32).max
 
 
-#def find_crs(indata, ingdq, read_noise, rej_threshold, nframes):
-def find_crs(indata):
-
+def find_crs(data, group_dq, read_noise, rej_threshold, nframes):
     """
     Find CRs/Jumps in each integration within the input data array.
     The input data array is assumed to be in units of electrons, i.e. already
     multiplied by the gain. We also assume that the read noise is in units of
     electrons.
     """
-    if isinstance(indata, tuple):
-        read_noise = indata[2]
-        rej_threshold = indata[3]
-        nframes = indata[4]
-        data = indata[0]
-        ingdq = indata[1]
-    gdq = ingdq.copy()
+    gdq = group_dq.copy()
     # Get data characteristics
     (nints, ngroups, nrows, ncols) = data.shape
 
@@ -43,7 +35,7 @@ def find_crs(indata):
     median_slopes = np.zeros((nints, nrows, ncols), dtype=np.float32)
 
     # Square the read noise values, for use later
-    read_noise_2 = read_noise * read_noise
+    read_noise_2 = read_noise**2
 
     # Reset saturated values in input data array to NaN, so they don't get
     # used in any of the subsequent calculations
@@ -170,7 +162,7 @@ def find_crs(indata):
 
             # Save the CR-cleaned median slope for this pixel
             if not new_CR_found:  # the while loop ran at least one time
-                 median_slopes[integration, row1[j], col1[j]] = pixel_med_diff
+                median_slopes[integration, row1[j], col1[j]] = pixel_med_diff
 
         # Next pixel with an outlier (j loop)
     # Next integration (integration loop)

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -127,7 +127,7 @@ def find_crs(indata):
         r, c = np.indices(max_index1.shape)
         # Get the row and column indices of pixels whose largest non-saturated ratio is above the threshold
         row1, col1 = np.where(ratio[r, c, max_index1] > rej_threshold)
-        log.debug('From highest outlier Twopt found %d pixels with at least one CR' % (len(row1)))
+        log.info('From highest outlier Two point found %d pixels with at least one CR' % (len(row1)))
         number_pixels_with_cr = len(row1)
         # Loop over all pixels that we found the first CR in
         for j in range(number_pixels_with_cr):

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -19,6 +19,7 @@ log.setLevel(logging.DEBUG)
 
 HUGE_NUM = np.finfo(np.float32).max
 
+
 def find_crs(data, gdq, read_noise, rej_threshold, nframes):
 
     """
@@ -39,8 +40,8 @@ def find_crs(data, gdq, read_noise, rej_threshold, nframes):
 
     # Reset saturated values in input data array to NaN, so they don't get
     # used in any of the subsequent calculations
-    wh_sat = np.where(np.bitwise_and(gdq, dqflags.group['SATURATED']))
-    data[wh_sat] = np.NaN
+    saturated_pixels = np.where(np.bitwise_and(gdq, dqflags.group['SATURATED']))
+    data[saturated_pixels] = np.NaN
 
     # Loop over multiple integrations
     for integration in range(nints):
@@ -49,12 +50,13 @@ def find_crs(data, gdq, read_noise, rej_threshold, nframes):
 
         # Roll the ngroups axis of data arrays to the end, to make
         # memory access to the values for a given pixel faster
-        rdata = np.rollaxis(data[integration], 0, 3)
+        # new array has dimensions of [nrows, ncols, ngroups]
+        rolled_data = np.rollaxis(data[integration], 0, 3)
 
         # Compute first differences of adjacent groups up the ramp
-        first_diffs = np.diff(rdata, axis=2)
-        nans = np.where(np.isnan(first_diffs))
-        first_diffs[nans] = 100000.
+        first_diffs = np.diff(rolled_data, axis=2)
+        nan_pixels = np.where(np.isnan(first_diffs))
+        first_diffs[nan_pixels] = 100000.
 
         positive_first_diffs = np.abs(first_diffs)
 
@@ -63,54 +65,68 @@ def find_crs(data, gdq, read_noise, rej_threshold, nframes):
         matching_array = np.ones(shape=(positive_first_diffs.shape[0],
                                         positive_first_diffs.shape[1],
                                         positive_first_diffs.shape[2])) * 100000
+        #sat_groups is a 3D array that is true when the group is saturated
         sat_groups = (positive_first_diffs == matching_array)
+        #number_sat_groups is a 2D array with the count of saturated groups for each pixel
         number_sat_groups = (sat_groups * 1).sum(axis=2)
         ndiffs = ngroups - 1
+        #Here we sort the 3D array along the last axis which is the group axis.
+        #np.argsort returns a 3D array with the last axis containing the indexes that would yield the groups in
+        #order.
         sort_index = np.argsort(positive_first_diffs)
-        med_diffs = return_clipped_median(ndiffs, number_sat_groups, first_diffs, sort_index)
+        #median_diffs is a 2D array with the clipped median of each pixel
+        median_diffs = get_clipped_median(ndiffs, number_sat_groups, first_diffs, sort_index)
 
         # Save initial estimate of the median slope for all pixels
-        median_slopes[integration] = med_diffs
+        median_slopes[integration] = median_diffs
 
         # Compute uncertainties as the quadrature sum of the poisson noise
         # in the first difference signal and read noise. Because the first
         # differences can be biased by CRs/jumps, we use the median signal
-        # for computing the poisson noise. Here sigma correctly has the
-        # read noise taking into account the fact that multiple frames were
-        # averaged into each group.
-        poisson_noise = np.sqrt(np.abs(med_diffs))
+        # for computing the poisson noise. Here we lower the read noise
+        # by the square root of number of frames in the group.
+        # Sigma is a 2D array.
+        poisson_noise = np.sqrt(np.abs(median_diffs))
         sigma = np.sqrt(poisson_noise * poisson_noise + read_noise_2 / nframes)
 
         # Reset sigma to exclude pixels with both readnoise and signal=0
-        wh_sig = np.where(sigma == 0.)
-        if len(wh_sig[0] > 0):
-            log.debug('Twopt found %d pixels with sigma=0' % (len(wh_sig[0])))
+        sigma_0_pixels = np.where(sigma == 0.)
+        if len(sigma_0_pixels[0] > 0):
+            log.debug('Twopt found %d pixels with sigma=0' % (len(sigma_0_pixels[0])))
             log.debug('which will be reset so that no jump will be detected')
-            sigma[wh_sig] = HUGE_NUM
+            sigma[sigma_0_pixels] = HUGE_NUM
 
         # Compute distance of each sample from the median in units of sigma;
         # note that the use of "abs" means we'll detect both positive and
-        # negative outliers
-        ratio = np.abs(first_diffs - med_diffs[:, :, np.newaxis]) / sigma[:, :, np.newaxis]
+        # negative outliers.
+        #ratio is a 2D array with the units of sigma deviation of the difference from the median.
+        ratio = np.abs(first_diffs - median_diffs[:, :, np.newaxis]) / sigma[:, :, np.newaxis]
 
         # get the rows and columns of pixels of all pixels
+        # This seems like an obtuse way to set row and column.
         row, col = np.where(number_sat_groups >= 0)
         # Get the group index for each pixel of the largest non-saturated group, assuming the indicies are sorted.
+        # 2 is subtracted from ngroups because we are using differences and there is one less difference than the
+        # number of groups.
         # This is a 2-D array.
         max_value_index = ngroups - 2 - number_sat_groups
 
-        # Extract from the sorted group index the index of the largest non-saturated group
+        # Extract from the sorted group index the index of the largest non-saturated group.
         max_index1d = sort_index[row, col, max_value_index[row, col]]
         # Reshape the list of max indicies to be a 2-day array
-        max_index1 = np.reshape(max_index1d, (nrows,ncols))
+        max_index1 = np.reshape(max_index1d, (nrows, ncols))
 
+        #Is this redundant? Are r and c different than row and column?
         r, c = np.indices(max_index1.shape)
         # Get the row and column indices of pixels whose largest non-saturated ratio is above the threshold
         row1, col1 = np.where(ratio[r, c, max_index1] > rej_threshold)
         log.debug('From highest outlier Twopt found %d pixels with at least one CR' % (len(row1)))
         number_pixels_with_cr = len(row1)
+        # Loop over all pixels that we found the first CR in
         for j in range(number_pixels_with_cr):
+            # Extract the first diffs for the this pixel with at least one CR yielding a 1D array
             pixel_masked_diffs = first_diffs[row1[j], col1[j]]
+            # Get the scalar readnoise^2 and number of saturated groups for this pixel.
             pixel_rn2 = read_noise_2[row1[j], col1[j]]
             pixel_sat_groups = number_sat_groups[row1[j], col1[j]]
 
@@ -119,32 +135,35 @@ def find_crs(data, gdq, read_noise, rej_threshold, nframes):
             pixel_cr_mask = np.ones(pixel_masked_diffs.shape, dtype=bool)
             number_CRs_found = 1
             pixel_sorted_index = sort_index[row1[j], col1[j], :]
-            pixel_cr_mask[pixel_sorted_index[ndiffs - pixel_sat_groups - 1]] = 0
+            pixel_cr_mask[pixel_sorted_index[ndiffs - pixel_sat_groups - 1]] = 0  #setting largest diff to be a CR
             new_CR_found = True
 
-            # Loop over all the found CRs and see if there is more than one CR, setting the mask as you go
+            # Loop and see if there is more than one CR, setting the mask as you go
             while new_CR_found and ((ndiffs - number_CRs_found - pixel_sat_groups) > 1):
                 new_CR_found = False
-                pixel_med_diff = return_clipped_median(ndiffs, number_CRs_found + pixel_sat_groups,
+                # For this pixel get a new median difference excluding the number of CRs found and
+                # the number of saturated groups
+                pixel_med_diff = get_clipped_median(ndiffs, number_CRs_found + pixel_sat_groups,
                                                        pixel_masked_diffs, pixel_sorted_index)
-                poisson_noise = np.sqrt(np.abs(pixel_med_diff))
-                sigma = np.sqrt(poisson_noise * poisson_noise + pixel_rn2 / nframes)
-                ratio = np.abs(pixel_masked_diffs - pixel_med_diff) / sigma
+                #recalculate the noise and ratio for this pixel now that we have rejected a CR
+                pixel_poisson_noise = np.sqrt(np.abs(pixel_med_diff))
+                pixel_sigma = np.sqrt(pixel_poisson_noise * pixel_poisson_noise + pixel_rn2 / nframes)
+                pixel_ratio = np.abs(pixel_masked_diffs - pixel_med_diff) / pixel_sigma
 
                 # Check if largest remaining difference is above threshold
-                if ratio[pixel_sorted_index[ndiffs - number_CRs_found - pixel_sat_groups - 1]] > rej_threshold:
+                if pixel_ratio[pixel_sorted_index[ndiffs - number_CRs_found - pixel_sat_groups - 1]] > rej_threshold:
                     new_CR_found = True
                     pixel_cr_mask[pixel_sorted_index[ndiffs - number_CRs_found - pixel_sat_groups - 1]] = 0
                     number_CRs_found += 1
 
-            # Found all CRs. Set CR flags in input DQ array for this pixel
+            # Found all CRs for this pixel. Set CR flags in input DQ array for this pixel
             gdq[integration, 1:, row1[j], col1[j]] = \
                 np.bitwise_or(gdq[integration, 1:, row1[j], col1[j]],
                               dqflags.group['JUMP_DET'] * np.invert(pixel_cr_mask))
 
             # Save the CR-cleaned median slope for this pixel
-            if not new_CR_found: # the loop ran at least one time
-                median_slopes[integration, row1[j], col1[j]] = pixel_med_diff
+            if not new_CR_found:  # the while loop ran at least one time
+                 median_slopes[integration, row1[j], col1[j]] = pixel_med_diff
 
         # Next pixel with an outlier (j loop)
     # Next integration (integration loop)
@@ -152,7 +171,7 @@ def find_crs(data, gdq, read_noise, rej_threshold, nframes):
     return median_slopes
 
 
-def return_clipped_median(num_differences, diffs_to_ignore, differences, sorted_index):
+def get_clipped_median(num_differences, diffs_to_ignore, differences, sorted_index):
     """
     This routine will return the clipped median for the input array or pixel.
     It will ignore the input number of largest differences. At a minimum this
@@ -164,30 +183,32 @@ def return_clipped_median(num_differences, diffs_to_ignore, differences, sorted_
     # Check to see if this is a 2-D array or 1-D
     if sorted_index.ndim > 1:
 
-        # always exclude the highest value
+        # Get the index of the median value always excluding the highest value
         pixel_med_index = sorted_index[:, :, int((num_differences - 1) / 2)]
+        # Get the row and column of each pixel.
         row, col = np.indices(pixel_med_index.shape)
 
         # In addition, decrease the index by 1 for every two diffs_to_ignore,
         # these will be saturated values in this case
-        pixel_med_diff = differences[row, col, pixel_med_index - ((diffs_to_ignore) / 2).astype(int)]
-        # For pixels with an even number of groups the median is the mean of the two central values
-        even_group_rows,even_group_cols = np.where((num_differences - diffs_to_ignore - 1)% 2 == 0)
+        pixel_med_diff = differences[row, col, pixel_med_index - (diffs_to_ignore / 2).astype(int)]
+        # For pixels with an even number of differences the median is the mean of the two central values
+        # So we need to get the
+        even_group_rows, even_group_cols = np.where((num_differences - diffs_to_ignore - 1) % 2 == 0)
         pixel_med_index2 = np.zeros_like(pixel_med_index)
         pixel_med_index2[even_group_rows, even_group_cols] = sorted_index[even_group_rows,
-        even_group_cols, int((num_differences - 1) / 2 ) - 1]
+                                                                          even_group_cols,
+                                                                          int((num_differences - 1) / 2) - 1]
         # Average together the two central values
-        pixel_med_diff[even_group_rows,even_group_cols] = (
-            pixel_med_diff[even_group_rows, even_group_cols]
-            + differences[even_group_rows, even_group_cols,
-            pixel_med_index2[even_group_rows, even_group_cols]
-            - ((diffs_to_ignore[even_group_rows, even_group_cols]) / 2).astype(int)]
-            ) / 2.0
-    # The 1-D array case is a lot simplier.
+        pixel_med_diff[even_group_rows, even_group_cols] = (pixel_med_diff[even_group_rows, even_group_cols] +
+                                                            differences[even_group_rows, even_group_cols,
+                                                            pixel_med_index2[even_group_rows, even_group_cols]
+                                                            - ((diffs_to_ignore[even_group_rows, even_group_cols])
+                                                               / 2).astype(int)]) / 2.0
+    # The 1-D array case is a lot simplier.    
     else:
         pixel_med_index = sorted_index[int(((num_differences - 1 - diffs_to_ignore) / 2))]
         pixel_med_diff = differences[pixel_med_index]
-        if (num_differences - diffs_to_ignore - 1) % 2 == 0:  # even number of groups
+        if (num_differences - diffs_to_ignore - 1) % 2 == 0:  # even number of differences
             pixel_med_index2 = sorted_index[int((num_differences - 1 - diffs_to_ignore) / 2) - 1]
             pixel_med_diff = (pixel_med_diff + differences[pixel_med_index2]) / 2.0
 

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -20,7 +20,8 @@ log.setLevel(logging.DEBUG)
 HUGE_NUM = np.finfo(np.float32).max
 
 
-def find_crs(data, gdq, read_noise, rej_threshold, nframes):
+#def find_crs(indata, ingdq, read_noise, rej_threshold, nframes):
+def find_crs(indata):
 
     """
     Find CRs/Jumps in each integration within the input data array.
@@ -28,7 +29,13 @@ def find_crs(data, gdq, read_noise, rej_threshold, nframes):
     multiplied by the gain. We also assume that the read noise is in units of
     electrons.
     """
-
+    if isinstance(indata, tuple):
+        read_noise = indata[2]
+        rej_threshold = indata[3]
+        nframes = indata[4]
+        data = indata[0]
+        ingdq = indata[1]
+    gdq = ingdq.copy()
     # Get data characteristics
     (nints, ngroups, nrows, ncols) = data.shape
 
@@ -168,7 +175,7 @@ def find_crs(data, gdq, read_noise, rej_threshold, nframes):
         # Next pixel with an outlier (j loop)
     # Next integration (integration loop)
 
-    return median_slopes
+    return median_slopes, gdq
 
 
 def get_clipped_median(num_differences, diffs_to_ignore, differences, sorted_index):

--- a/jwst/pipeline/jump.cfg
+++ b/jwst/pipeline/jump.cfg
@@ -1,3 +1,4 @@
 name = "jump"
 class = "jwst.jump.JumpStep"
 rejection_threshold = 4.0
+maximum_cores = 'half'

--- a/jwst/pipeline/jump.cfg
+++ b/jwst/pipeline/jump.cfg
@@ -1,4 +1,4 @@
 name = "jump"
 class = "jwst.jump.JumpStep"
 rejection_threshold = 4.0
-maximum_cores = 'half'
+maximum_cores = 'one'

--- a/jwst/pipeline/jump.cfg
+++ b/jwst/pipeline/jump.cfg
@@ -1,4 +1,3 @@
 name = "jump"
 class = "jwst.jump.JumpStep"
 rejection_threshold = 4.0
-maximum_cores = 'one'

--- a/jwst/pipeline/jump.cfg
+++ b/jwst/pipeline/jump.cfg
@@ -1,3 +1,4 @@
 name = "jump"
 class = "jwst.jump.JumpStep"
+
 rejection_threshold = 4.0

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ TESTS_REQUIRE = [
     'pytest-doctestplus',
     'requests_mock',
     'pytest-astropy',
+    'pytest-faulthandler',
 ]
 
 def get_transforms_data():
@@ -194,6 +195,7 @@ setup(
         'jsonschema>=2.3,<=2.6',
         'numpy>=1.13',
         'photutils>=0.6',
+        'psutil',
         'scipy>=1.0',
         'spherical-geometry>=1.2',
         'stsci.image>=2.3',


### PR DESCRIPTION
This PR makes a few changes to @mwregan2's very nice #3021.

- Remove `maximum_cores='one'` and make `maximum_cores=None` as the default behavior that SDP expects.  I.e. if `maximum_cores` is not set, no multiprocessing pool is created. 
- Use smaller in the unit test fixtures (instead of full frame) to reduce memory usage and runtime, as is standard for a number of the other pipeline step unit tests where appropriate.  Runtime is reduced because of the `assert` statements in a `for` loop and scales by the number of pixels in the array.
- Parametrize the tests instead of the test fixtures for the multiprocessing tests.  Makes it clearer what is going on.
- Change test fixtures to use `GainModel` and `ReadnoiseModel` instead of custom FITS versions of these to reduce future maintenance.
- Add `psutil` and `pytest-faulthandler` as new package dependencies.

@mwregan2, feel free to look at my commits one-at-a-time below to see the changes.  Let me know what you think.  Hopefully these changes will get us closer to merging this.

Closes #3021.