### PR TITLE
Change the strings that describe the units for flux.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,6 +87,9 @@ extract_1d
   be surface brightness.  This step no longer looks for a RELSENS
   extension. [#3412]
 
+- The keywords that describe the units for the FLUX and ERROR columns
+  have been corrected; the units are now specified as "Jy". [#3447]
+
 
 flatfield
 ---------

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2912,8 +2912,8 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             spec = datamodels.SpecModel(spec_table=otab)
             spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
             spec.spec_table.columns['wavelength'].unit = 'um'
-            spec.spec_table.columns['flux'].unit = 'mJy'
-            spec.spec_table.columns['error'].unit = 'mJy'
+            spec.spec_table.columns['flux'].unit = 'Jy'
+            spec.spec_table.columns['error'].unit = 'Jy'
             spec.spec_table.columns['surf_bright'].unit = 'MJy/sr'
             spec.spec_table.columns['sb_error'].unit = 'MJy/sr'
             spec.spec_table.columns['background'].unit = 'MJy/sr'
@@ -3013,8 +3013,8 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 spec.meta.wcs = spec_wcs.create_spectral_wcs(
                                         ra, dec, wavelength)
                 spec.spec_table.columns['wavelength'].unit = 'um'
-                spec.spec_table.columns['flux'].unit = 'mJy'
-                spec.spec_table.columns['error'].unit = 'mJy'
+                spec.spec_table.columns['flux'].unit = 'Jy'
+                spec.spec_table.columns['error'].unit = 'Jy'
                 spec.spec_table.columns['surf_bright'].unit = 'MJy/sr'
                 spec.spec_table.columns['sb_error'].unit = 'MJy/sr'
                 spec.spec_table.columns['background'].unit = 'MJy/sr'


### PR DESCRIPTION
For some types of input data, `extract_1d` sets the keywords that describe the units for output columns FLUX and ERROR to "mJy", but the units are actually "Jy".  Keywords TUNIT2 and TUNIT3 have been corrected.
Closes #3445.