### PR TITLE
Update source_catalog step for non-detections

### DIFF
--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -42,7 +42,7 @@ class SourceCatalogStep(Step):
                 model, kernel_fwhm, kernel_xsize, kernel_ysize, snr_threshold,
                 npixels, deblend=deblend)
 
-            if len(catalog) == 0:
+            if catalog is None:
                 self.log.info('No sources were found.  Source catalog will '
                               'not be written.')
                 return


### PR DESCRIPTION
This PR updates the `source_catalog` step to handle non-detections for both the current and upcoming release of `photutils`.