### PR TITLE
Mask non-imaging regions in tweakreg and source_catalog

### DIFF
--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -2,7 +2,7 @@ from astropy.table import Table
 import numpy as np
 from photutils import detect_threshold, DAOStarFinder
 
-from ..datamodels import ImageModel
+from ..datamodels import dqflags, ImageModel
 
 
 def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
@@ -71,7 +71,11 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
                             sharplo=sharplo, sharphi=sharphi, roundlo=roundlo,
                             roundhi=roundhi, brightest=brightest,
                             peakmax=peakmax)
-    sources = daofind(model.data)
+
+    # Mask the non-imaging area (e.g. MIRI)
+    mask = (dqflags.pixel['NON_SCIENCE'] & model.dq).astype(np.bool)
+
+    sources = daofind(model.data, mask=mask)
 
     columns = ['id', 'xcentroid', 'ycentroid', 'flux']
     if sources:

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(
         'gwcs>=0.10',
         'jsonschema>=2.3,<=2.6',
         'numpy>=1.13',
-        'photutils>=0.4',
+        'photutils>=0.6',
         'scipy>=1.0',
         'spherical-geometry>=1.2',
         'stsci.image>=2.3',


### PR DESCRIPTION
This PR adds masks for non-imaging regions in the `tweakreg` and `source_catalog` steps based on the `NON_SCIENCE` DQ flag (e.g. MIRI images).

I updated the `photutils` version dependency because the `photutils.DAOStarFinder` `mask` keyword requires `photutils >= 0.6`.

Closes #2062 and #3287.