### PR TITLE
fix -1 px off for NRS2 coordinates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.13.3 (Unreleased)
 ===================
 
+- assign_wcs
+------------
+
+- Fix a one pixel off problem with the Nirspec NRS2 WCS transforms. [#3473]
+
+
 datamodels
 ----------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1076,12 +1076,12 @@ def dms_to_sca(input_model):
         ystart = 1
     # The SCA coordinates are in full frame
     # The inputs are 1-based, remove -1 when'if they are 0-based
-    # The outputs must be 1-based becaause this is what the model expects.
+    # The outputs must be 1-based because this is what the model expects.
     # If xstart was 0-based and the inputs were 0-based ->
     # Shift(+1)
     subarray2full = models.Shift(xstart - 1) & models.Shift(ystart - 1)
     if detector == 'NRS2':
-        model = models.Shift(-2048) & models.Shift(-2048) | models.Scale(-1) & models.Scale(-1)
+        model = models.Shift(-2047) & models.Shift(-2047) | models.Scale(-1) & models.Scale(-1)
     elif detector == 'NRS1':
         model = models.Identity(2)
     return subarray2full | model


### PR DESCRIPTION
Resolves #2957 

It's been a while since this ticket was created and I lost track of the test data.
It would be good to get another NRS2 dataset and the corresponding ESA traces to test this fix.