### PR TITLE
Update photom to handle pixels with no flux cal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ master_background
 - Fix bug in master_background where the flux from the input x1d files
   was being combined instead of the background columns.  [#3468]
 
+photom
+------
+
+- Updated to zero-out pixels outside the wavelength range of flux calibration
+  and set DQ=DO_NOT_USE. [#3475]
+
 
 0.13.2 (2019-05-14)
 ===================
@@ -163,9 +169,6 @@ photom
   spectral order 1. [#3387]
 
 - Updated to apply the square of the correction to VAR_FLAT [#3427]
-
-- Updated to zero-out pixels outside the wavelength range of flux calibration
-  and set DQ=DO_NOT_USE. [#3475]
 
 reffile_utils
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,6 +164,9 @@ photom
 
 - Updated to apply the square of the correction to VAR_FLAT [#3427]
 
+- Updated to zero-out pixels outside the wavelength range of flux calibration
+  and set DQ=DO_NOT_USE. [#3475]
+
 reffile_utils
 -------------
 

--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -5,12 +5,15 @@ The photom step applies flux (photometric) calibrations to a data product
 to convert the data from units of countrate to surface brightness.
 The calibration information is read from a photometric reference file.
 The exact nature of the calibration information loaded from the reference file
-and applied to the science data depends on the instrument mode.
+and applied to the science data depends on the instrument mode, as
+described below.
 
 This step relies on having wavelength information available when working on
-spectroscopic data (see below) and therefore the
+spectroscopic data and therefore the
 :ref:`assign_wcs <assign_wcs_step>` step *must* be applied before executing
-the photom step.
+the photom step. Pixels with wavelengths that are outside of the range
+covered by the calibration reference data are set to zero and flagged
+in the DQ array as "DO_NOT_USE."
 
 Upon successful completion of this step, the status keyword S_PHOTOM will be
 set to COMPLETE.

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -239,9 +239,8 @@ class DataSet():
                         self.input.err /= sens2d
                         self.input.var_poisson /= sens2d**2
                         self.input.var_rnoise /= sens2d**2
-                        if (self.input.var_flat is not None and
-                            np.size(self.input.var_flat) > 0):
-                                self.input.var_flat /= sens2d**2
+                        if (self.input.var_flat is not None and np.size(self.input.var_flat) > 0):
+                            self.input.var_flat /= sens2d**2
 
                         # Update BUNIT values for the science data and err
                         self.input.meta.bunit_data = 'mJy/arcsec^2'
@@ -681,40 +680,39 @@ class DataSet():
                                 order)
 
             wl_array[np.isnan(wl_array)] = -1.
-            conv_2d = np.interp(wl_array, waves, relresps, left=1., right=1.)
+            conv_2d = np.interp(wl_array, waves, relresps, left=np.NaN, right=np.NaN)
+            no_cal = np.isnan(conv_2d)
 
             # Combine the scalar and 2-D conversions
             # NOTE: the 2-D conversion is divided into the data for now, until the
             # instrument teams deliver multiplicative conversions in photom ref files
             conversion = conversion / conv_2d
+            conversion[no_cal] = 0.
 
         # Apply the conversion to the data and all uncertainty arrays
         if isinstance(self.input, datamodels.MultiSlitModel):
-            self.input.slits[self.slitnum].data *= conversion
-            self.input.slits[self.slitnum].err *= conversion
-            if (self.input.slits[self.slitnum].var_poisson is not None and
-                np.size(self.input.slits[self.slitnum].var_poisson) > 0):
-                    self.input.slits[self.slitnum].var_poisson *= conversion**2
-            if (self.input.slits[self.slitnum].var_rnoise is not None and
-                np.size(self.input.slits[self.slitnum].var_rnoise) > 0):
-                    self.input.slits[self.slitnum].var_rnoise *= conversion**2
-            if (self.input.slits[self.slitnum].var_flat is not None and
-                np.size(self.input.slits[self.slitnum].var_flat) > 0):
-                    self.input.slits[self.slitnum].var_flat *= conversion**2
-            self.input.slits[self.slitnum].meta.bunit_data = 'MJy/sr'
-            self.input.slits[self.slitnum].meta.bunit_err = 'MJy/sr'
+            slit = self.input.slits[self.slitnum]
+            slit.data *= conversion
+            slit.err *= conversion
+            if (slit.var_poisson is not None and np.size(slit.var_poisson) > 0):
+                slit.var_poisson *= conversion**2
+            if (slit.var_rnoise is not None and np.size(slit.var_rnoise) > 0):
+                slit.var_rnoise *= conversion**2
+            if (slit.var_flat is not None and np.size(slit.var_flat) > 0):
+                slit.var_flat *= conversion**2
+            slit.dq[no_cal] = np.bitwise_or(slit.dq[no_cal], dqflags.pixel['DO_NOT_USE'])
+            slit.meta.bunit_data = 'MJy/sr'
+            slit.meta.bunit_err = 'MJy/sr'
         else:
             self.input.data *= conversion
             self.input.err *= conversion
-            if (self.input.var_poisson is not None and
-                np.size(self.input.var_poisson) > 0):
-                    self.input.var_poisson *= conversion**2
-            if (self.input.var_rnoise is not None and
-                np.size(self.input.var_rnoise) > 0):
-                    self.input.var_rnoise *= conversion**2
-            if (self.input.var_flat is not None and
-                np.size(self.input.var_flat) > 0):
-                    self.input.var_flat *= conversion**2
+            if (self.input.var_poisson is not None and np.size(self.input.var_poisson) > 0):
+                self.input.var_poisson *= conversion**2
+            if (self.input.var_rnoise is not None and np.size(self.input.var_rnoise) > 0):
+                self.input.var_rnoise *= conversion**2
+            if (self.input.var_flat is not None and np.size(self.input.var_flat) > 0):
+                self.input.var_flat *= conversion**2
+            self.input.dq[no_cal] = np.bitwise_or(self.input.dq[no_cal], dqflags.pixel['DO_NOT_USE'])
             self.input.meta.bunit_data = 'MJy/sr'
             self.input.meta.bunit_err = 'MJy/sr'
 
@@ -784,7 +782,7 @@ class DataSet():
         # Compute the relative difference between the pixel area values from
         # the two different sources, if they exist
         if (tab_a2 is not None) and (area_a2 is not None):
-            a2_tol = abs(tab_a2 - area_a2) / (tab_a2 + area_a2)
+            a2_tol = abs(tab_a2 - area_a2) / ((tab_a2 + area_a2) / 2)
 
             # If the difference is greater than the defined tolerance,
             # issue a warning

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -239,7 +239,7 @@ class DataSet():
                         self.input.err /= sens2d
                         self.input.var_poisson /= sens2d**2
                         self.input.var_rnoise /= sens2d**2
-                        if (self.input.var_flat is not None and np.size(self.input.var_flat) > 0):
+                        if self.input.var_flat is not None and np.size(self.input.var_flat) > 0:
                             self.input.var_flat /= sens2d**2
 
                         # Update BUNIT values for the science data and err
@@ -431,7 +431,7 @@ class DataSet():
             self.input.var_poisson /= sens2d**2
             self.input.var_rnoise /= sens2d**2
             if self.input.var_flat is not None and np.size(self.input.var_flat) > 0:
-                    self.input.var_flat /= sens2d**2
+                self.input.var_flat /= sens2d**2
 
             # Update the science dq
             self.input.dq = np.bitwise_or(self.input.dq, ftab.dq)

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -694,11 +694,11 @@ class DataSet():
             slit = self.input.slits[self.slitnum]
             slit.data *= conversion
             slit.err *= conversion
-            if (slit.var_poisson is not None and np.size(slit.var_poisson) > 0):
+            if slit.var_poisson is not None and np.size(slit.var_poisson) > 0:
                 slit.var_poisson *= conversion**2
-            if (slit.var_rnoise is not None and np.size(slit.var_rnoise) > 0):
+            if slit.var_rnoise is not None and np.size(slit.var_rnoise) > 0:
                 slit.var_rnoise *= conversion**2
-            if (slit.var_flat is not None and np.size(slit.var_flat) > 0):
+            if slit.var_flat is not None and np.size(slit.var_flat) > 0:
                 slit.var_flat *= conversion**2
             slit.dq[no_cal] = np.bitwise_or(slit.dq[no_cal], dqflags.pixel['DO_NOT_USE'])
             slit.meta.bunit_data = 'MJy/sr'
@@ -706,11 +706,11 @@ class DataSet():
         else:
             self.input.data *= conversion
             self.input.err *= conversion
-            if (self.input.var_poisson is not None and np.size(self.input.var_poisson) > 0):
+            if self.input.var_poisson is not None and np.size(self.input.var_poisson) > 0:
                 self.input.var_poisson *= conversion**2
-            if (self.input.var_rnoise is not None and np.size(self.input.var_rnoise) > 0):
+            if self.input.var_rnoise is not None and np.size(self.input.var_rnoise) > 0:
                 self.input.var_rnoise *= conversion**2
-            if (self.input.var_flat is not None and np.size(self.input.var_flat) > 0):
+            if self.input.var_flat is not None and np.size(self.input.var_flat) > 0:
                 self.input.var_flat *= conversion**2
             self.input.dq[no_cal] = np.bitwise_or(self.input.dq[no_cal], dqflags.pixel['DO_NOT_USE'])
             self.input.meta.bunit_data = 'MJy/sr'


### PR DESCRIPTION
The photom step has been updated to handle pixels in spectroscopic mode exposures that have wavelengths outside the range of the wavelengths of the calibration reference data. Previously the calibration value for such pixels had been set to 1, by the numpy interpolation routine that's used to interpolate the 1-D reference data into the 2-D space of the exposure. That's been changed to set the conversion values to NaN, and the locations of the NaN's are given a calibration value of zero, so that the pixels end up with a value of zero in the output. That set of pixels is also flagged with DO_NOT_USE in the DQ array. Updated the docs to add this info.

Also fixed a minor bug in the ``save_area_info`` function where it computes the difference between the nominal pixel area values given in the PHOTOM and AREA reference files.