### PR TITLE
Use the surf_bright column in master_background

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ master_background
 - Fix bug in master_background where the flux from the input x1d files
   was being combined instead of the background columns.  [#3468]
 
+- Use the surf_bright column instead of flux in master_background.  [#3476]
+
 
 0.13.2 (2019-05-14)
 ===================

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -3,7 +3,8 @@ Description
 The master background subtraction step subtracts background signal from
 2-D spectroscopic data using a 1-D master background spectrum. The 1-D master background
 spectrum is computed from one or more input exposures, or can alternatively be supplied
-by the user. The 1-D background spectrum - flux versus wavelength - is projected into the
+by the user. The 1-D background spectrum - surfact brightness
+versus wavelength - is projected into the
 2-D space of source data based on the wavelength of each pixel in the 2-D data. The resulting
 2-D background signal is then subtracted directly from the 2-D source data.
 
@@ -92,7 +93,7 @@ or can be a collection of exposures of a point-like source observed in a nod pat
 (e.g. MIRI LRS fixed-slit "ALONG-SLIT-NOD" or NIRSpec IFU "2-POINT-NOD" dither patterns).
 
 For the case of dedicated background target exposures, the 1-D spectrum contained in the
-"FLUX" column of the background :ref:`x1d <x1d>` products will be used for creating the
+"SURF_BRIGHT" column of the background :ref:`x1d <x1d>` products will be used for creating the
 master background spectrum. For the case of nodded exposures, the 1-D spectrum contained
 in the "BACKGROUND" column of the :ref:`x1d <x1d>` products will be used.
 
@@ -121,4 +122,3 @@ source data instances and for each one it does the following:
    the 1-D master background spectrum as a function of wavelength.
 
  - Subtract the resulting 2-D background image from the 2-D source data.
-

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -3,7 +3,7 @@ Description
 The master background subtraction step subtracts background signal from
 2-D spectroscopic data using a 1-D master background spectrum. The 1-D master background
 spectrum is computed from one or more input exposures, or can alternatively be supplied
-by the user. The 1-D background spectrum - surfact brightness
+by the user. The 1-D background spectrum - surface brightness
 versus wavelength - is projected into the
 2-D space of source data based on the wavelength of each pixel in the 2-D data. The resulting
 2-D background signal is then subtracted directly from the 2-D source data.

--- a/docs/jwst/master_background/reference_files.rst
+++ b/docs/jwst/master_background/reference_files.rst
@@ -1,4 +1,3 @@
 Reference Files
 ===============
 The master spectroscopic background subtraction step does not use any reference files.
-

--- a/jwst/master_background/create_master_bkg.py
+++ b/jwst/master_background/create_master_bkg.py
@@ -20,7 +20,7 @@ def create_background(wavelength, surf_bright):
         Array of wavelengths, in micrometers.
 
     surf_bright : 1-D ndarray
-        Array of background fluxes.
+        Array of background surface brightness values.
 
     Returns
     -------

--- a/jwst/master_background/create_master_bkg.py
+++ b/jwst/master_background/create_master_bkg.py
@@ -7,19 +7,19 @@ from .. import datamodels
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-def create_background(wavelength, flux):
+def create_background(wavelength, surf_bright):
     """Create a 1-D spectrum table as a MultiSpecModel.
 
     This is the syntax for accessing the data in the columns:
     wavelength = output_model.spec[0].spec_table['wavelength']
-    background = output_model.spec[0].spec_table['flux']
+    background = output_model.spec[0].spec_table['surf_bright']
 
     Parameters
     ----------
     wavelength : 1-D ndarray
         Array of wavelengths, in micrometers.
 
-    flux : 1-D ndarray
+    surf_bright : 1-D ndarray
         Array of background fluxes.
 
     Returns
@@ -32,23 +32,23 @@ def create_background(wavelength, flux):
     """
 
     wl_shape = wavelength.shape
-    flux_shape = flux.shape
+    sb_shape = surf_bright.shape
     bad = False
     if len(wl_shape) > 1:
         bad = True
         log.error("The wavelength array has shape {}; expected "
               "a 1-D array".format(wl_shape))
-    if len(flux_shape) > 1:
+    if len(sb_shape) > 1:
         bad = True
-        log.error("The background flux array has shape {}; expected "
-              "a 1-D array".format(flux_shape))
+        log.error("The background surf_bright array has shape {}; expected "
+              "a 1-D array".format(sb_shape))
     if bad:
         return None
 
-    if wl_shape[0] != flux_shape[0]:
+    if wl_shape[0] != sb_shape[0]:
         log.error("wavelength array has length {}, "
-                  "but background flux array has length {}."
-                  .format(wl_shape[0], flux_shape[0]))
+                  "but background surf_bright array has length {}."
+                  .format(wl_shape[0], sb_shape[0]))
         log.error("The arrays must be the same size.")
         return None
 
@@ -61,8 +61,8 @@ def create_background(wavelength, flux):
 
     spec_dtype = datamodels.SpecModel().spec_table.dtype
 
-    otab = np.array(list(zip(wavelength, flux,
-                             dummy, dq, dummy, dummy, dummy, dummy, npixels)),
+    otab = np.array(list(zip(wavelength, dummy, dummy,
+                             surf_bright, dummy, dq, dummy, dummy, npixels)),
                     dtype=spec_dtype)
 
     spec = datamodels.SpecModel(spec_table=otab)

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -41,7 +41,7 @@ def expand_to_2d(input, m_bkg_spec):
         else:                                   # CombinedSpecModel
             spec_table = bkg.spec_table
         tab_wavelength = spec_table['wavelength'].copy()
-        tab_background = spec_table['flux']
+        tab_background = spec_table['surf_bright']
 
     # We're going to use np.interp, so tab_wavelength must be strictly
     # increasing.
@@ -72,7 +72,7 @@ def bkg_for_container(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table.
+        The surf_bright column read from the 1-D background table.
 
     Returns
     -------
@@ -101,7 +101,7 @@ def create_bkg(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table.
+        The surf_bright column read from the 1-D background table.
 
     Returns
     -------
@@ -142,7 +142,7 @@ def bkg_for_multislit(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table.
+        The surf_bright column read from the 1-D background table.
 
     Returns
     -------
@@ -192,7 +192,7 @@ def bkg_for_image(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table.
+        The surf_bright column read from the 1-D background table.
 
     Returns
     -------
@@ -236,7 +236,7 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
         The wavelength column read from the 1-D background table.
 
     tab_background : 1-D ndarray
-        The flux column read from the 1-D background table.
+        The surf_bright column read from the 1-D background table.
 
     Returns
     -------

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -161,19 +161,19 @@ def bkg_for_multislit(input, tab_wavelength, tab_background):
             raise RuntimeError("Can't determine wavelengths for {}"
                                .format(type(slit)))
 
-        # Wherever the wavelength is NaN, the background flux should to be set
-        # to 0.  We replace NaN elements in wl_array with -1, so that np.interp
-        # will detect that those values are out of range (note the `left`
-        # argument to np.interp) and set the output to 0.
+        # Wherever the wavelength is NaN, the background surface brightness
+        # should to be set to 0.  We replace NaN elements in wl_array with
+        # -1, so that np.interp will detect that those values are out of range
+        # (note the `left` argument to np.interp) and set the output to 0.
         wl_array[np.isnan(wl_array)] = -1.
         # flag values outside of background wavelength table
         mask_limit = (wl_array > max_wave) | (wl_array < min_wave)
         wl_array[mask_limit] = -1
-        # bkg_flux will be a 2-D array, because wl_array is 2-D.
-        bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
-                             left=0., right=0.)
+        # bkg_surf_bright will be a 2-D array, because wl_array is 2-D.
+        bkg_surf_bright = np.interp(wl_array, tab_wavelength, tab_background,
+                                    left=0., right=0.)
 
-        background.slits[k].data[:] = bkg_flux.copy()
+        background.slits[k].data[:] = bkg_surf_bright.copy()
         background.slits[k].dq[mask_limit] = np.bitwise_or(background.slits[k].dq[mask_limit],
                                                            dqflags.pixel['DO_NOT_USE'])
 
@@ -213,11 +213,11 @@ def bkg_for_image(input, tab_wavelength, tab_background):
     # flag values outside of background wavelength table
     mask_limit = (wl_array > max_wave) | (wl_array < min_wave)
     wl_array[mask_limit] = -1
-    # bkg_flux will be a 2-D array, because wl_array is 2-D.
-    bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
-                         left=0., right=0.)
+    # bkg_surf_bright will be a 2-D array, because wl_array is 2-D.
+    bkg_surf_bright = np.interp(wl_array, tab_wavelength, tab_background,
+                                left=0., right=0.)
 
-    background.data[:] = bkg_flux.copy()
+    background.data[:] = bkg_surf_bright.copy()
     background.dq[mask_limit] = np.bitwise_or(background.dq[mask_limit],
                                               dqflags.pixel['DO_NOT_USE'])
 
@@ -271,9 +271,9 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
             background.dq[full_frame_ind] = np.bitwise_or(background.dq[full_frame_ind],
                                                           dqflags.pixel['DO_NOT_USE'])
 
-            bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
-                                 left=0., right=0.)
-            background.data[y.astype(int), x.astype(int)] = bkg_flux.copy()
+            bkg_surf_bright = np.interp(wl_array, tab_wavelength,
+                                        tab_background, left=0., right=0.)
+            background.data[y.astype(int), x.astype(int)] = bkg_surf_bright.copy()
 
     elif input.meta.instrument.name.upper() == "MIRI":
         shape = input.data.shape
@@ -289,9 +289,9 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
         # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
         background.dq[mask_limit] = np.bitwise_or(background.dq[mask_limit],
                                                   dqflags.pixel['DO_NOT_USE'])
-        bkg_flux = np.interp(wl_array, tab_wavelength, tab_background,
-                             left=0., right=0.)
-        background.data[:, :] = bkg_flux.copy()
+        bkg_surf_bright = np.interp(wl_array, tab_wavelength, tab_background,
+                                    left=0., right=0.)
+        background.data[:, :] = bkg_surf_bright.copy()
     else:
         raise RuntimeError("Exposure type {} is not supported."
                            .format(input.meta.exposure.type))

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -106,6 +106,8 @@ class MasterBackgroundStep(Step):
                         # for simulated data that didn't bother populating this
                         # keyword
                         if model.meta.observation.bkgdtarg == False:
+                            self.log.debug("Copying BACKGROUND column "
+                                           "to SURF_BRIGHT")
                             copy_background_to_flux(model)
 
                     master_background = combine_1d_spectra(
@@ -189,14 +191,14 @@ class MasterBackgroundStep(Step):
 
 
 def copy_background_to_flux(spectrum):
-    """Copy the background column to the flux column in a MultiSpecModel in-place"""
+    """Copy the background column to the surf_bright column in a MultiSpecModel in-place"""
     for spec in spectrum.spec:
-        spec.spec_table['FLUX'] = spec.spec_table['BACKGROUND'].copy()
-        spec.spec_table['ERROR'] = spec.spec_table['BERROR'].copy()
+        spec.spec_table['SURF_BRIGHT'][:] = spec.spec_table['BACKGROUND'].copy()
+        spec.spec_table['SB_ERROR'][:] = spec.spec_table['BERROR'].copy()
         # Zero out the background column for safety
         spec.spec_table['BACKGROUND'][:] = 0
-        # Set BERROR to dummy val of 1.0, as in extract_1d currently
-        spec.spec_table['BERROR'][:] = 1
+        # Set BERROR to dummy val of 0.0, as in extract_1d currently
+        spec.spec_table['BERROR'][:] = 0.
 
 
 def split_container(container):

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -108,7 +108,7 @@ class MasterBackgroundStep(Step):
                         if model.meta.observation.bkgdtarg == False:
                             self.log.debug("Copying BACKGROUND column "
                                            "to SURF_BRIGHT")
-                            copy_background_to_flux(model)
+                            copy_background_to_surf_bright(model)
 
                     master_background = combine_1d_spectra(
                         background_data,
@@ -190,7 +190,7 @@ class MasterBackgroundStep(Step):
         return do_sub
 
 
-def copy_background_to_flux(spectrum):
+def copy_background_to_surf_bright(spectrum):
     """Copy the background column to the surf_bright column in a MultiSpecModel in-place"""
     for spec in spectrum.spec:
         spec.spec_table['SURF_BRIGHT'][:] = spec.spec_table['BACKGROUND'].copy()

--- a/jwst/master_background/tests/test_create_master_bkg.py
+++ b/jwst/master_background/tests/test_create_master_bkg.py
@@ -8,18 +8,18 @@ from jwst.master_background import create_master_bkg
 def test_create_master_bkg():
 
     wl = np.arange(37, dtype=np.float64) * 0.1 + 3.
-    flux = np.ones(37, dtype=np.float64) * 7
+    surf_bright = np.ones(37, dtype=np.float64) * 7
 
-    model = create_master_bkg.create_background(wl, flux[0:5])
+    model = create_master_bkg.create_background(wl, surf_bright[0:5])
     assert model is None
 
     dummy = np.zeros((5, 7), dtype=np.float64) + 3
-    model = create_master_bkg.create_background(dummy, flux)
+    model = create_master_bkg.create_background(dummy, surf_bright)
     assert model is None
 
-    model = create_master_bkg.create_background(wl, flux)
+    model = create_master_bkg.create_background(wl, surf_bright)
 
     tab_wavelength = model.spec[0].spec_table['wavelength']
-    tab_flux = model.spec[0].spec_table['flux']
+    tab_surf_bright = model.spec[0].spec_table['surf_bright']
     assert np.allclose(wl, tab_wavelength, rtol=1.e-10)
-    assert np.allclose(flux, tab_flux, rtol=1.e-10)
+    assert np.allclose(surf_bright, tab_surf_bright, rtol=1.e-10)

--- a/jwst/master_background/tests/test_expand_to_2d.py
+++ b/jwst/master_background/tests/test_expand_to_2d.py
@@ -146,15 +146,17 @@ def user_bkg_spec_a():
     m_bkg_spec = datamodels.MultiSpecModel()
     wavelength = np.geomspace(1.5, 4.5, num=25, endpoint=True,
                               dtype=np.float64)
-    flux = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
-                       dtype=np.float64)
+    flux = np.zeros_like(wavelength)
     error = np.ones_like(wavelength)
-    dq = np.zeros(wavelength.shape, dtype=np.uint32)
-    surf_bright = np.zeros_like(wavelength)
+    surf_bright = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
+                              dtype=np.float64)
     sb_error = np.ones_like(wavelength)
+    dq = np.zeros(wavelength.shape, dtype=np.uint32)
     background = np.ones_like(wavelength)
     berror = np.ones_like(wavelength)
-    npixels = np.ones_like(wavelength)
+    # The npixels column should no longer be used.  Set it to a large value
+    # to make it more obvious in case it actually is still used.
+    npixels = np.zeros_like(wavelength) + 2000.
     otab = np.array(list(zip(wavelength, flux, error,
                              surf_bright, sb_error, dq, background, berror,
                              npixels)),
@@ -187,12 +189,12 @@ def user_bkg_spec_b():
     m_bkg_spec = datamodels.MultiSpecModel()
     wavelength = np.geomspace(1.5, 4.5, num=25, endpoint=True,
                               dtype=np.float64)[::-1]
-    flux = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
-                       dtype=np.float64)[::-1]
+    flux = np.zeros_like(wavelength)
     error = np.ones_like(wavelength)
-    dq = np.zeros(wavelength.shape, dtype=np.uint32)
-    surf_bright = np.zeros_like(wavelength)
+    surf_bright = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
+                              dtype=np.float64)[::-1]
     sb_error = np.ones_like(wavelength)
+    dq = np.zeros(wavelength.shape, dtype=np.uint32)
     background = np.ones_like(wavelength)
     berror = np.ones_like(wavelength)
     npixels = np.ones_like(wavelength)
@@ -219,10 +221,10 @@ def user_bkg_spec_c():
 
     wavelength = np.geomspace(1.5, 4.5, num=25, endpoint=True,
                               dtype=np.float64)
-    flux = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
-                       dtype=np.float64)
+    flux = np.zeros_like(wavelength)
     error = np.ones_like(wavelength)
-    surf_bright = np.zeros_like(wavelength)
+    surf_bright = np.linspace(13., 25., num=25, endpoint=True, retstep=False,
+                              dtype=np.float64)
     sb_error = np.ones_like(wavelength)
     dq = np.zeros(wavelength.shape, dtype=np.uint32)
     weight = np.ones_like(wavelength)

--- a/jwst/master_background/tests/test_master_background.py
+++ b/jwst/master_background/tests/test_master_background.py
@@ -96,18 +96,18 @@ def test_copy_background_to_flux():
     """Test the copy_background_to_flux function"""
 
     wavelength = np.linspace(0.5, 25, num=100)
-    flux = np.linspace(2.0, 2.2, num=100) + (np.random.random(100) - 0.5) * 0.001
-    error = np.random.random(100) * 0.01
+    surf_bright = np.linspace(2.0, 2.2, num=100) + (np.random.random(100) - 0.5) * 0.001
+    sb_error = np.random.random(100) * 0.01 + 17.       # different from berror
     background = np.random.random(100) * 0.01 + 1
     berror = np.random.random(100) * 0.01
-    data = create_background(wavelength, flux)
-    data.spec[0].spec_table['error'] = error
+    data = create_background(wavelength, surf_bright)
+    data.spec[0].spec_table['sb_error'] = sb_error
     data.spec[0].spec_table['background'] = background
     data.spec[0].spec_table['berror'] = berror
 
     newdata = data.copy()
     copy_background_to_flux(newdata)
 
-    assert (newdata.spec[0].spec_table['flux'] == background).all()
-    assert (newdata.spec[0].spec_table['error'] == berror).all()
+    assert (newdata.spec[0].spec_table['surf_bright'] == background).all()
+    assert (newdata.spec[0].spec_table['sb_error'] == berror).all()
     assert (newdata.spec[0].spec_table['background'] == 0).all()

--- a/jwst/master_background/tests/test_master_background.py
+++ b/jwst/master_background/tests/test_master_background.py
@@ -8,7 +8,7 @@ from jwst import datamodels
 from jwst.assign_wcs import AssignWcsStep
 from jwst.master_background import MasterBackgroundStep
 from jwst.master_background.create_master_bkg import create_background
-from jwst.master_background.master_background_step import copy_background_to_flux
+from jwst.master_background.master_background_step import copy_background_to_surf_bright
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 
 
@@ -92,8 +92,8 @@ def test_master_background_logic(_jail, user_background, science_image):
     assert type(science_image) is type(result)
 
 
-def test_copy_background_to_flux():
-    """Test the copy_background_to_flux function"""
+def test_copy_background_to_surf_bright():
+    """Test the copy_background_to_surf_bright function"""
 
     wavelength = np.linspace(0.5, 25, num=100)
     surf_bright = np.linspace(2.0, 2.2, num=100) + (np.random.random(100) - 0.5) * 0.001
@@ -106,7 +106,7 @@ def test_copy_background_to_flux():
     data.spec[0].spec_table['berror'] = berror
 
     newdata = data.copy()
-    copy_background_to_flux(newdata)
+    copy_background_to_surf_bright(newdata)
 
     assert (newdata.spec[0].spec_table['surf_bright'] == background).all()
     assert (newdata.spec[0].spec_table['sb_error'] == berror).all()


### PR DESCRIPTION
The `master_background` step now uses the SURF_BRIGHT column instead of the FLUX column of the 1-D background spectrum.  The `create_background` function in create_master_bkg.py now populates the SURF_BRIGHT column instead of the FLUX column.