### PR TITLE
Allow blendmodels to ignore attributes in asdf tree not in schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ master_background
 
 - Use the surf_bright column instead of flux in master_background.  [#3476]
 
+model_blender
+-------------
+
+- Allow blendmodels to ignore attributes in asdf tree not in schema [#3480]
+
 photom
 ------
 
@@ -28,6 +33,12 @@ refpix
 
 - Fixed a bug where pixeldq arrays were being transformed from DMS to detector
   coordinates for every group instead of just once
+
+tweakreg
+--------
+
+- Mask and do not use NON-SCIENCE regions in tweakreg source detection. [#3461]
+
 
 0.13.2 (2019-05-14)
 ===================

--- a/jwst/model_blender/blendmeta.py
+++ b/jwst/model_blender/blendmeta.py
@@ -12,10 +12,8 @@ from .. import associations
 from ..datamodels import fits_support
 from ..datamodels import schema as dm_schema
 
-
 from .blendrules import KeywordRules
 
-__vdate__ = '11-May-2018'
 
 EMPTY_LIST = [None, '', ' ', 'INDEF', 'None']
 
@@ -135,7 +133,11 @@ def blendmodels(product, inputs=None, output=None, verbose=False):
     for attr in flat_new_metadata:
         attr_use = not [attr.startswith(i) for i in ignore_list].count(True)
         if attr.startswith('meta') and attr_use:
-            output_model[attr] = newmeta[attr]
+            try:
+                output_model[attr] = newmeta[attr]
+            except KeyError:
+                # Ignore keys that are in the asdf tree but not in the schema
+                pass
 
     # Apply any user-specified filename for output product
     if output:


### PR DESCRIPTION
This bug came up when testing #3461.

It is possible to have attributes in a JWST datamodel ASDF tree that are not in the current schema.  Perhaps these attributes have been removed from the schema or the datamodel was created from a schema that referenced our schema and added more attributes.

If this is the case, then `blendmodels` will fail.  This fix allows it to just ignore items that are not the in schema.

If items in the tree are not in the schema, then they won't have a blend rule anyway.