### PR TITLE
Fix bug in latest photom update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ photom
 ------
 
 - Updated to zero-out pixels outside the wavelength range of flux calibration
-  and set DQ=DO_NOT_USE. [#3475]
+  and set DQ=DO_NOT_USE. [#3475, #3489]
 
 refpix
 ------

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -650,8 +650,9 @@ class DataSet():
         # Get the length of the relative response arrays in this row
         nelem = tabdata['nelem']
 
-        # If the relative response arrays have length > 0, load and include them in
-        # the flux conversion
+        # If the relative response arrays have length > 0,
+        # load and include them in the flux conversion
+        no_cal = None
         if nelem > 0:
             waves = tabdata['wavelength'][:nelem]
             relresps = tabdata['relresponse'][:nelem]
@@ -700,7 +701,13 @@ class DataSet():
                 slit.var_rnoise *= conversion**2
             if slit.var_flat is not None and np.size(slit.var_flat) > 0:
                 slit.var_flat *= conversion**2
-            slit.dq[no_cal] = np.bitwise_or(slit.dq[no_cal], dqflags.pixel['DO_NOT_USE'])
+            if no_cal is not None:
+                    if len(slit.dq.shape) == 3:
+                        slit.dq[:,no_cal] = np.bitwise_or(slit.dq[:,no_cal],
+                            dqflags.pixel['DO_NOT_USE'])
+                    else:
+                        slit.dq[no_cal] = np.bitwise_or(slit.dq[no_cal],
+                            dqflags.pixel['DO_NOT_USE'])
             slit.meta.bunit_data = 'MJy/sr'
             slit.meta.bunit_err = 'MJy/sr'
         else:
@@ -712,7 +719,13 @@ class DataSet():
                 self.input.var_rnoise *= conversion**2
             if self.input.var_flat is not None and np.size(self.input.var_flat) > 0:
                 self.input.var_flat *= conversion**2
-            self.input.dq[no_cal] = np.bitwise_or(self.input.dq[no_cal], dqflags.pixel['DO_NOT_USE'])
+            if no_cal is not None:
+                if len(self.input.dq.shape) == 3:
+                    self.input.dq[:,no_cal] = np.bitwise_or(self.input.dq[:,no_cal],
+                        dqflags.pixel['DO_NOT_USE'])
+                else:
+                    self.input.dq[no_cal] = np.bitwise_or(self.input.dq[no_cal],
+                        dqflags.pixel['DO_NOT_USE'])
             self.input.meta.bunit_data = 'MJy/sr'
             self.input.meta.bunit_err = 'MJy/sr'
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -702,12 +702,8 @@ class DataSet():
             if slit.var_flat is not None and np.size(slit.var_flat) > 0:
                 slit.var_flat *= conversion**2
             if no_cal is not None:
-                    if len(slit.dq.shape) == 3:
-                        slit.dq[:,no_cal] = np.bitwise_or(slit.dq[:,no_cal],
-                            dqflags.pixel['DO_NOT_USE'])
-                    else:
-                        slit.dq[no_cal] = np.bitwise_or(slit.dq[no_cal],
-                            dqflags.pixel['DO_NOT_USE'])
+                slit.dq[..., no_cal] = np.bitwise_or(slit.dq[..., no_cal],
+                                                     dqflags.pixel['DO_NOT_USE'])
             slit.meta.bunit_data = 'MJy/sr'
             slit.meta.bunit_err = 'MJy/sr'
         else:
@@ -720,12 +716,8 @@ class DataSet():
             if self.input.var_flat is not None and np.size(self.input.var_flat) > 0:
                 self.input.var_flat *= conversion**2
             if no_cal is not None:
-                if len(self.input.dq.shape) == 3:
-                    self.input.dq[:,no_cal] = np.bitwise_or(self.input.dq[:,no_cal],
-                        dqflags.pixel['DO_NOT_USE'])
-                else:
-                    self.input.dq[no_cal] = np.bitwise_or(self.input.dq[no_cal],
-                        dqflags.pixel['DO_NOT_USE'])
+                self.input.dq[..., no_cal] = np.bitwise_or(self.input.dq[..., no_cal],
+                                                           dqflags.pixel['DO_NOT_USE'])
             self.input.meta.bunit_data = 'MJy/sr'
             self.input.meta.bunit_err = 'MJy/sr'
 


### PR DESCRIPTION
The updates in #3475 had a couple of flaws. First, image mode exposures failed, because the if-block containing the setting of ``no_cal`` does not get entered, so that it was undefined when used later. Second, the use of ``no_cal`` in setting flags in the DQ array only worked properly when the DQ array is 2-D (same shape as ``no_cal``), which means it crashed on exposures that use ``CubeModel`` where the DQ array is 3-D. The updates here address both of those problems. If any reviewers know of a more elegant (pythonic) way to do this, please make suggestions.