### PR TITLE
Add unit tests for combine_1d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.13.3 (Unreleased)
 ===================
 
+combine_1d
+----------
+
+- Unit tests were added to combine_1d.  [#3489]
+
 datamodels
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 combine_1d
 ----------
 
-- Unit tests were added to combine_1d.  [#3489]
+- Unit tests were added to combine_1d.  [#3490]
 
 datamodels
 ----------

--- a/docs/jwst/combine_1d/arguments.rst
+++ b/docs/jwst/combine_1d/arguments.rst
@@ -14,9 +14,3 @@ the exposure time (FITS keyword EFFEXPTM) is used as the weight.  If
 the string is "unit_weight" or "unit weight", the same weight (1) will
 be used for all input spectra.  If the string is anything else, a warning
 will be logged and unit weight will be used.
-
-*  ``--background``
-
-Set this boolean parameter to True if the input spectra are all just
-background.  The default is False, meaning that the input are science
-spectra.

--- a/docs/jwst/combine_1d/description.rst
+++ b/docs/jwst/combine_1d/description.rst
@@ -12,15 +12,7 @@ spectra have been included, the output is normalized by dividing by
 the sum of the weights.
 
 The weight will typically be the integration time or the exposure time,
-but uniform (unit) weighting can be specified instead.  It is the net
-count rate that uses this weight; that is, the net count rate is multiplied
-by the integration time to get net counts, and it is the net counts that
-are added together and finally divided by the sum of the integration
-times.  The flux weighted by an additional factor of the instrumental
-sensitivity, count rate per unit flux.  The idea is that the quantity
-that is added up should be in units of counts.  If unit weight was
-specified, however, unit weight will be used for both flux and net.
-The data quality (DQ) columns will be combined using bitwise OR.
+but uniform (unit) weighting can be specified instead.
 
 The only part of this step that is not completely straightforward is the
 determination of wavelengths for the output spectrum.  The output
@@ -31,11 +23,9 @@ wavelength would be computed as the average of the wavelengths at the same
 pixel in all the input files.  The combine_1d step is intended to handle a
 more general case where the input wavelength arrays may be offset with
 respect to each other, or they might not align well due to different
-distortions.
-
-All the input wavelength arrays will be concatenated and then sorted.
-The code then looks for "clumps" in wavelength, based on the standard
-deviation of a slice of the concatenated and sorted array of input
+distortions.  All the input wavelength arrays will be concatenated and then
+sorted.  The code then looks for "clumps" in wavelength, based on the
+standard deviation of a slice of the concatenated and sorted array of input
 wavelengths; a small standard deviation implies a clump.  In regions of
 the spectrum where the input wavelengths overlap with somewhat random
 offsets and don't form any clumps, the output wavelengths are computed
@@ -46,9 +36,9 @@ Input
 =====
 An association file specifies which file or files to read for the input
 data.  Each input data file contains one or more 1-D spectra in table
-format, e.g. as written by the extract_1d step.  An input data file can
-be either SpecModel (for one spectrum) or MultiSpecModel format (which
-can contain more than one spectrum).
+format, e.g. as written by the extract_1d step.  Each input data file will
+ordinarily be in MultiSpecModel format (which can contain more than one
+spectrum).
 
 The association file should have an object called "products", which is
 a one-element list containing a dictionary.  This dictionary contains two
@@ -60,8 +50,8 @@ of which contains one input file name, identified by key "expname".
 Output
 ======
 The output will be in CombinedSpecModel format, with a table extension
-having the name COMBINE1D.  This extension will have six columns, giving
-the wavelength, flux, error estimate for the flux, net countrate in
-counts/second, the sum of the weights that were used when combining the
-input spectra, and the number of input spectra that contributed to each
-output pixel.
+having the name COMBINE1D.  This extension will have eight columns, giving
+the wavelength, flux, error estimate for the flux, surface brightness,
+error estimate for the surface brightness, the combined data quality flags,
+the sum of the weights that were used when combining the input spectra,
+and the number of input spectra that contributed to each output pixel.

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -301,7 +301,7 @@ def count_input(input_spectra):
     wl : ndarray
         Sorted list of all the wavelengths in all the input spectra.
 
-    n_input_spectra : 
+    n_input_spectra : ndarray, 1-D
         For each element of `wl`, the corresponding element of
         `n_input_spectra` is the number of input spectra that cover the
         wavelength in `wl`.

--- a/jwst/combine_1d/tests/test_count_input.py
+++ b/jwst/combine_1d/tests/test_count_input.py
@@ -4,8 +4,7 @@ Test for combine1d.count_input
 import numpy as np
 
 # from jwst import datamodels
-from jwst.combine_1d import new_combine1d as combine1d      # xxx temporary
-# xxx from jwst.combine_1d import combine1d
+from jwst.combine_1d import combine1d
 
 class DummySpectra:
     def __init__(self, wavelength):

--- a/jwst/combine_1d/tests/test_count_input.py
+++ b/jwst/combine_1d/tests/test_count_input.py
@@ -1,0 +1,125 @@
+"""
+Test for combine1d.count_input
+"""
+import numpy as np
+
+# from jwst import datamodels
+from jwst.combine_1d import new_combine1d as combine1d      # xxx temporary
+# xxx from jwst.combine_1d import combine1d
+
+class DummySpectra:
+    def __init__(self, wavelength):
+        # The argument to count_input is a list of InputSpectrumModel
+        # objects, but the only attribute we need is wavelength, so this
+        # DummySpectra class will suffice.
+        self.wavelength = wavelength.copy()
+
+
+def test_1a():
+    input_spectra = create_input_spectra_1()
+
+    (wl, n_input_spectra) = combine1d.count_input(input_spectra)
+
+    truth_1a = truth_array_1a()
+
+    # Compare wl with the correct values.
+    assert np.allclose(wl, truth_1a, rtol=1.e-10)
+
+
+def test_1b():
+    input_spectra = create_input_spectra_1()
+    (wl, n_input_spectra) = combine1d.count_input(input_spectra)
+
+    truth_1b = truth_array_1b()
+
+    # Compare n_input_spectra with the correct values.
+    assert np.allclose(n_input_spectra, truth_1b, rtol=1.e-10)
+
+
+def test_1c():
+    input_spectra = create_input_spectra_1()
+    (wl, n_input_spectra) = combine1d.count_input(input_spectra)
+
+    output_wl = combine1d.compute_output_wl(wl, n_input_spectra)
+
+    truth_1c = truth_array_1c()
+
+    assert np.allclose(output_wl, truth_1c, rtol=1.e-10)
+
+
+def create_input_spectra_1():
+
+    input_spectra = []
+
+    # This is for the case that there are four input spectra, each one
+    # six pixels long.  The wavelengths are roughly the same in each
+    # spectrum.  The differences in wavelength between spectra is small
+    # compared to the spacing between wavelengths in any one spectrum.
+    # That is, the union of the wavelengths in all the input spectra
+    # will be clumped.  For this test, first specify the wavelengths in
+    # these clumps.  Then assign the wavelengths for each input spectrum
+    # by picking one element from each clump.
+    clumps = np.array([[1.372, 1.385, 1.391, 1.402],
+                       [1.701, 1.718, 1.719, 1.723],
+                       [1.979, 1.984, 1.991, 2.013],
+                       [2.212, 2.223, 2.228, 2.310],
+                       [2.475, 2.479, 2.487, 2.496],
+                       [2.716, 2.723, 2.729, 2.741]], dtype=np.float64)
+
+    spec = [clumps[0, 3], clumps[1, 0], clumps[2, 2], clumps[3, 1], clumps[4, 2], clumps[5, 1]]
+    input_spectra.append(DummySpectra(np.array(spec)))
+    spec = [clumps[0, 0], clumps[1, 3], clumps[2, 0], clumps[3, 3], clumps[4, 0], clumps[5, 2]]
+    input_spectra.append(DummySpectra(np.array(spec)))
+    spec = [clumps[0, 2], clumps[1, 1], clumps[2, 1], clumps[3, 2], clumps[4, 3], clumps[5, 0]]
+    input_spectra.append(DummySpectra(np.array(spec)))
+    spec = [clumps[0, 1], clumps[1, 2], clumps[2, 3], clumps[3, 0], clumps[4, 1], clumps[5, 3]]
+    input_spectra.append(DummySpectra(np.array(spec)))
+
+    return input_spectra
+
+
+def truth_array_1a():
+    """Merged and sorted wavelengths from all input files."""
+
+    # Wavelengths (merged and sorted) in input files.
+    return np.array([1.372, 1.385, 1.391, 1.402, 1.701, 1.718, 1.719, 1.723,
+                     1.979, 1.984, 1.991, 2.013, 2.212, 2.223, 2.228, 2.31,
+                     2.475, 2.479, 2.487, 2.496, 2.716, 2.723, 2.729, 2.741],
+                    dtype=np.float64)
+
+
+def truth_array_1b():
+    """Number of input models that cover each of the wavelengths in the
+       combined array.
+
+    The first element in the wl array (see function truth_array_1a) has
+    value 1.372, and that's not actually within the array of wavelengths
+    for the first input model, which are (see function
+    create_input_spectra_1):
+        [1.402 1.701 1.991 2.223 2.487 2.723]
+    But the array that we'll return has 4 (the number of input models)
+    for every element.  How can that be correct?  It's because we assume
+    the pixels in the input models have finite width, but the wavelengths
+    in the input models are the values at the centers of the pixels.  So
+    the range of wavelengths that are actually covered by an input model
+    is not just the interval between the first and last wavelengths in
+    the input model's wavelength array, it's the range from the wavelength
+    at the left edge of the first pixel to the wavelength at the right edge
+    of the last pixel.
+    """
+
+    # n_input_spectra
+    return np.array([4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4], dtype=np.int64)
+
+
+def truth_array_1c():
+    """Computed wavelengths for the output.
+
+    These are averages of the input wavelengths within clusters, sets
+    of input wavelengths that are closer together than the spacing
+    between pixels.
+    """
+
+    return np.array([1.3875, 1.71525, 1.99175, 2.24325, 2.48425, 2.72725],
+                    dtype=np.float64)


### PR DESCRIPTION
This PR adds a few unit tests for `combine_1d`.  It also addresses some comments made regarding PR #3412.  The tests are for a simple case.  At some point the algorithm for computing output wavelengths should be improved, and some more realistic unit tests should be written.

Closes #3215.