### PR TITLE
Update masterbg test to use flux column

### DIFF
--- a/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
@@ -244,16 +244,16 @@ class TestNIRSpecMasterBackground_IFU(BaseJWSTTest):
         # read in the valid wavelengths of the user-1d
         user_background_model = datamodels.open(user_background)
         user_wave = user_background_model.spec[0].spec_table['wavelength']
-        user_flux = user_background_model.spec[0].spec_table['net']
+        user_flux = user_background_model.spec[0].spec_table['flux']
         user_wave_valid = np.where(user_flux > 0)
         min_user_wave = np.amin(user_wave[user_wave_valid])
         max_user_wave = np.amax(user_wave[user_wave_valid])
         user_background_model.close()
         # find the waverange covered by both user and science
-        sci_spec_1d = sci_1d.spec[0].spec_table['net']
+        sci_spec_1d = sci_1d.spec[0].spec_table['flux']
         sci_spec_wave = sci_1d.spec[0].spec_table['wavelength']
 
-        result_spec_1d = result_1d.spec[0].spec_table['net']
+        result_spec_1d = result_1d.spec[0].spec_table['flux']
 
         sci_wave_valid = np.where(sci_spec_1d > 0)
         min_wave = np.amin(sci_spec_wave[sci_wave_valid])


### PR DESCRIPTION
One of the regression tests for the ``master_background`` step was using the ``net`` column of x1d files. It's been updated to use the ``flux`` column, now that ``extract_1d`` no longer produces a ``net`` column.