### PR TITLE
Update MIRI Imager photom data model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ datamodels
   ``http://jwst.stsci.edu/schemas/image.schema.yaml``.  The datamodels
   ``BaseExtension`` is renamed internally to ``DataModelExtension``. [#3437]
 
+- Added the new column "relresperror" to the "MiriImgPhotomModel" data
+  model schema. [#3512]
+
 extract_1d
 ----------
 - An indexing bug was fixed. [#3497]

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -139,6 +139,7 @@ class MiriImgPhotomModel(PhotomModel):
        - nelem: int16
        - wavelength: float32[500]
        - relresponse: float32[500]
+       - relresperror: float32[500]
 
     """
     schema_url = "mirimg_photom.schema"

--- a/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -24,4 +24,7 @@ allOf:
       - name: relresponse
         shape: [500]
         datatype: float32
+      - name: relresperror
+        shape: [500]
+        datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Add the table column "relresperror" to the ``MiriImgPhotomModel`` schema, to accommodate the new column contained in the CDP-7 version of the MIRI Imager photom reference file.

Fixes #3511.