### PR TITLE
JP-345 support data models as reference file overrides

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@ datamodels
   ``http://jwst.stsci.edu/schemas/image.schema.yaml``.  The datamodels
   ``BaseExtension`` is renamed internally to ``DataModelExtension``. [#3437]
 
+reference file overrides
+------------------------
+
+- Capability to define reference overrides using a ``DataModel`` instead of
+  a file path was added.  [#3514]
+
 master_background
 -----------------
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -244,6 +244,17 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         return "".join(buf)
 
+    @property
+    def override_handle(self):
+        """override_handle identifies in-memory models in place of filepath for 
+        dataset headers, i.e. in place of CRDS references recorded as:
+            crds://<reference_basename> 
+        or overrides recorded as:
+          <reference_basename>.
+        """
+        # Arbitrary choice to look something like crds://
+        return "override://" + self.__class__.__name__
+
     def __enter__(self):
         return self
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -246,11 +246,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
     @property
     def override_handle(self):
-        """override_handle identifies in-memory models in place of filepath for 
-        dataset headers, i.e. in place of CRDS references recorded as:
-            crds://<reference_basename> 
-        or overrides recorded as:
-          <reference_basename>.
+        """override_handle identifies in-memory models where a filepath
+        would normally be used.
         """
         # Arbitrary choice to look something like crds://
         return "override://" + self.__class__.__name__

--- a/jwst/extern/configobj/validate.py
+++ b/jwst/extern/configobj/validate.py
@@ -1348,10 +1348,10 @@ def is_string_or_datamodel(value, default=None):
     """Verify that value is either a string (nominally a reference file path)
     or a DataModel (possibly one with no corresponding file.)
     """
-    if is_datamodel(value):
-        return is_datamodel(value)
-    elif is_string(value):
-        return is_string(value)
+    if isinstance(value, DataModel):
+        return value
+    elif isinstance(value, string_type):
+        return value
     else:
         raise VdtTypeError(value)
 

--- a/jwst/extern/configobj/validate.py
+++ b/jwst/extern/configobj/validate.py
@@ -157,8 +157,6 @@ __all__ = (
     'is_string_list',
     'is_ip_addr_list',
     'is_mixed_list',
-    'is_datamodel',
-    'is_string_or_datamodel',
     'is_option',
     '__docformat__',
 )
@@ -585,8 +583,6 @@ class Validator(object):
             'pass': self._pass,
             'option': is_option,
             'force_list': force_list,
-            'is_datamodel' : is_datamodel,
-            'is_string_or_datamodel': is_string_or_datamodel,
         }
         if functions is not None:
             self.functions.update(functions)
@@ -1336,24 +1332,6 @@ def is_option(value, *options):
     if not value in options:
         raise VdtValueError(value)
     return value
-
-def is_datamodel(value, default=None):
-    """Verify that value is either is a DataModel."""
-    if isinstance(value, DataModel):
-        return value
-    else:
-        raise VdtTypeError(value)
-    
-def is_string_or_datamodel(value, default=None):
-    """Verify that value is either a string (nominally a reference file path)
-    or a DataModel (possibly one with no corresponding file.)
-    """
-    if isinstance(value, DataModel):
-        return value
-    elif isinstance(value, string_type):
-        return value
-    else:
-        raise VdtTypeError(value)
 
 def _test(value, *args, **keywargs):
     """

--- a/jwst/extern/configobj/validate.py
+++ b/jwst/extern/configobj/validate.py
@@ -157,14 +157,17 @@ __all__ = (
     'is_string_list',
     'is_ip_addr_list',
     'is_mixed_list',
+    'is_datamodel',
+    'is_string_or_datamodel',
     'is_option',
     '__docformat__',
 )
 
-
 import re
 import sys
 from pprint import pprint
+
+from jwst.datamodels import DataModel
 
 #TODO - #21 - six is part of the repo now, but we didn't switch over to it here
 # this could be replaced if six is used for compatibility, or there are no
@@ -582,6 +585,8 @@ class Validator(object):
             'pass': self._pass,
             'option': is_option,
             'force_list': force_list,
+            'is_datamodel' : is_datamodel,
+            'is_string_or_datamodel': is_string_or_datamodel,
         }
         if functions is not None:
             self.functions.update(functions)
@@ -1332,6 +1337,23 @@ def is_option(value, *options):
         raise VdtValueError(value)
     return value
 
+def is_datamodel(value, default=None):
+    """Verify that value is either is a DataModel."""
+    if isinstance(value, DataModel):
+        return value
+    else:
+        raise VdtTypeError(value)
+    
+def is_string_or_datamodel(value, default=None):
+    """Verify that value is either a string (nominally a reference file path)
+    or a DataModel (possibly one with no corresponding file.)
+    """
+    if is_datamodel(value):
+        return is_datamodel(value)
+    elif is_string(value):
+        return is_string(value)
+    else:
+        raise VdtTypeError(value)
 
 def _test(value, *args, **keywargs):
     """

--- a/jwst/stpipe/config_parser.py
+++ b/jwst/stpipe/config_parser.py
@@ -100,7 +100,8 @@ def _is_datamodel(value, default=None):
         return value
     else:
         raise VdtTypeError(value)
-    
+
+
 def _is_string_or_datamodel(value, default=None):
     """Verify that value is either a string (nominally a reference file path)
     or a DataModel (possibly one with no corresponding file.)
@@ -111,6 +112,7 @@ def _is_string_or_datamodel(value, default=None):
         return value
     else:
         raise VdtTypeError(value)
+
 
 def load_config_file(config_file):
     """

--- a/jwst/stpipe/config_parser.py
+++ b/jwst/stpipe/config_parser.py
@@ -35,7 +35,9 @@ import textwrap
 
 from ..extern.configobj.configobj import (
     ConfigObj, Section, flatten_errors, get_extra_values)
-from ..extern.configobj.validate import Validator, ValidateError
+from ..extern.configobj.validate import Validator, ValidateError, VdtTypeError
+
+from ..datamodels.model_base import DataModel
 
 from . import utilities
 
@@ -91,6 +93,24 @@ def _get_output_file_check(root_dir):
 
     return _output_file_check
 
+
+def _is_datamodel(value, default=None):
+    """Verify that value is either is a DataModel."""
+    if isinstance(value, DataModel):
+        return value
+    else:
+        raise VdtTypeError(value)
+    
+def _is_string_or_datamodel(value, default=None):
+    """Verify that value is either a string (nominally a reference file path)
+    or a DataModel (possibly one with no corresponding file.)
+    """
+    if isinstance(value, DataModel):
+        return value
+    elif isinstance(value, str):
+        return value
+    else:
+        raise VdtTypeError(value)
 
 def load_config_file(config_file):
     """
@@ -213,6 +233,8 @@ def validate(config, spec, section=None, validator=None, root_dir=None):
         validator = Validator()
         validator.functions['input_file'] = _get_input_file_check(root_dir)
         validator.functions['output_file'] = _get_output_file_check(root_dir)
+        validator.functions['is_datamodel'] = _is_datamodel
+        validator.functions['is_string_or_datamodel'] = _is_string_or_datamodel
 
     orig_configspec = config.main.configspec
     config.main.configspec = spec

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -73,7 +73,7 @@ class Step():
         # Add arguments for all of the expected reference files
         for reference_file_type in cls.reference_file_types:
             override_name = crds_client.get_override_name(reference_file_type)
-            spec[override_name] = 'string(default=None)'
+            spec[override_name] = 'is_string_or_datamodel(default=None)'
             spec.inline_comments[override_name] = (
                 '# Override the {0} reference file'.format(
                     reference_file_type))
@@ -614,7 +614,10 @@ class Step():
         """
         override_name = crds_client.get_override_name(reference_file_type)
         path = getattr(self, override_name, None)
-        return abspath(path) if path else path
+        if isinstance(path, DataModel):
+            return path
+        else:
+            return abspath(path) if path else path
 
     def get_reference_file(self, input_file, reference_file_type):
         """
@@ -641,7 +644,11 @@ class Step():
         """
         override = self.get_ref_override(reference_file_type)
         if override is not None:
-            if override.strip() != "":
+            if isinstance(override, DataModel):
+              self._reference_files_used.append(
+                  (reference_file_type, override.override_handle))
+              return override
+            elif override.strip() != "":
                 self._reference_files_used.append(
                     (reference_file_type, basename(override)))
                 reference_name = override

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -645,9 +645,9 @@ class Step():
         override = self.get_ref_override(reference_file_type)
         if override is not None:
             if isinstance(override, DataModel):
-              self._reference_files_used.append(
-                  (reference_file_type, override.override_handle))
-              return override
+                self._reference_files_used.append(
+                    (reference_file_type, override.override_handle))
+                return override
             elif override.strip() != "":
                 self._reference_files_used.append(
                     (reference_file_type, basename(override)))

--- a/jwst/stpipe/tests/test_model_override.py
+++ b/jwst/stpipe/tests/test_model_override.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# coding: utf-8
+import numpy as np
+
+from jwst import datamodels
+from jwst.datamodels.miri_ramp import MIRIRampModel
+from jwst.datamodels.mask import MaskModel
+from jwst.datamodels import dqflags
+
+from jwst.dq_init import DQInitStep
+from jwst.dq_init.dq_initialization import do_dqinit
+
+from jwst.stpipe.config_parser import ValidationError
+
+# Tests derived from example code from Jira JP-345
+# Tests are for override functionality only,  not DQ init.
+
+def create_models():
+    """Returns  MIRIRampModel(), MaskModel()."""
+    
+    # size of integration
+    nints = 1
+    ngroups = 5
+    xsize = 1032
+    ysize = 1024
+
+    # create raw input data for step
+    dm_ramp = make_rawramp(nints, ngroups, ysize, xsize)
+
+    # create a MaskModel to create baseline arrays for
+    # dq and dq_def to be modified afterwards to create
+    # a test case mask model.
+    dq, dq_def = make_maskmodel(ysize, xsize)
+
+    # Construct a MaskModel on the fly for use as override.
+    ref_data = MaskModel(dq=dq, dq_def=dq_def)
+    ref_data.meta.instrument.name = 'MIRI'
+    ref_data.meta.subarray.xstart = 1
+    ref_data.meta.subarray.xsize = xsize
+    ref_data.meta.subarray.ystart = 1
+    ref_data.meta.subarray.ysize = ysize
+
+    return dm_ramp, ref_data
+
+def make_maskmodel(ysize, xsize):
+    # create a mask model for the dq_init step
+    csize = (ysize, xsize)
+    dq = np.zeros(csize, dtype=int)
+    # how do we define a dq_def extension?
+    mask = MaskModel()
+
+    dqdef = [(0, 1, 'DO_NOT_USE', 'Bad Pixel do not use'),
+             (1, 2, 'DEAD', 'Dead Pixel'),
+             (2, 4, 'HOT', 'Hot pixel'),
+             (3, 8, 'UNRELIABLE_SLOPE', 'Large slope variance'),
+             (4, 16, 'RC', 'RC pixel'),
+             (5, 32, 'REFERENCE_PIXEL', 'Reference Pixel')]
+
+    dq_def = np.array((dqdef), dtype=mask.dq_def.dtype)
+
+    return dq, dq_def
+
+def make_rawramp(nints, ngroups, ysize, xsize):
+    # create the data and groupdq arrays
+    csize = (nints, ngroups, ysize, xsize)
+    data = np.full(csize, 1.0)
+
+    # create a JWST datamodel for MIRI data
+    dm_ramp = MIRIRampModel(data=data)
+    dm_ramp.meta.subarray.xstart = 1
+    dm_ramp.meta.subarray.xsize = xsize
+    dm_ramp.meta.subarray.ystart = 1
+    dm_ramp.meta.subarray.ysize = ysize
+
+    return dm_ramp
+
+def test_invalid_override():
+    """Test that a bogus override type is caught."""
+    dm_ramp, ref_data = create_models()
+    try:
+        step = DQInitStep(override_mask = DQInitStep)
+    except ValidationError:
+        pass
+    else:
+        assert 0, "Expected validator type exception didn't occur."
+
+def test_valid_model_override():
+    dm_ramp, ref_data = create_models()
+    
+    step = DQInitStep(override_mask = ref_data)
+
+    # Verify get_reference_file() returns an override model.
+    fetched_reference = step.get_reference_file(dm_ramp, 'mask')
+    assert isinstance(fetched_reference, MaskModel), \
+        "get_reference_file() should return a model for model overrides."
+                      
+    # Verify no exceptions occur during DQ processing.
+    outfile = step.process(dm_ramp)
+
+if __name__ == "__main__":
+    test_valid_model_override()
+    test_invalid_override()
+

--- a/jwst/stpipe/tests/test_overrides.py
+++ b/jwst/stpipe/tests/test_overrides.py
@@ -14,9 +14,9 @@ from jwst.stpipe.config_parser import ValidationError
 # Tests derived from example code from Jira JP-345
 # Tests are for override functionality only,  not DQ init.
 
+
 def create_models():
     """Returns  MIRIRampModel(), MaskModel()."""
-    
     # size of integration
     nints = 1
     ngroups = 5
@@ -41,6 +41,7 @@ def create_models():
 
     return dm_ramp, ref_data
 
+
 def make_maskmodel(ysize, xsize):
     # create a mask model for the dq_init step
     csize = (ysize, xsize)
@@ -59,6 +60,7 @@ def make_maskmodel(ysize, xsize):
 
     return dq, dq_def
 
+
 def make_rawramp(nints, ngroups, ysize, xsize):
     # create the data and groupdq arrays
     csize = (nints, ngroups, ysize, xsize)
@@ -73,6 +75,7 @@ def make_rawramp(nints, ngroups, ysize, xsize):
 
     return dm_ramp
 
+
 def test_invalid_override():
     """Test that a bogus override type is caught."""
     dm_ramp, ref_data = create_models()
@@ -80,25 +83,26 @@ def test_invalid_override():
     with pytest.raises(ValidationError):
         step = DQInitStep(override_mask = DQInitStep)
 
+
 def test_valid_model_override():
     dm_ramp, ref_data = create_models()
-    
+
     step = DQInitStep(override_mask = ref_data)
 
     # Verify get_reference_file() returns an override model.
     fetched_reference = step.get_reference_file(dm_ramp, 'mask')
     assert isinstance(fetched_reference, MaskModel), \
         "get_reference_file() should return a model for this override."
-                      
+
     # Verify no exceptions occur during DQ processing.
     outfile = step.process(dm_ramp)
 
+
 def test_string_override():
     dm_ramp, ref_data = create_models()
-    
+
     step = DQInitStep(override_mask = "some_file.fits")
 
     # Verify stpipe treats string as filename and attempts to open
     with pytest.raises(FileNotFoundError):
         fetched_reference = step.get_reference_file(dm_ramp, 'mask')
-

--- a/jwst/stpipe/tests/test_overrides.py
+++ b/jwst/stpipe/tests/test_overrides.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 # coding: utf-8
 import numpy as np
+import pytest
 
-from jwst import datamodels
 from jwst.datamodels.miri_ramp import MIRIRampModel
 from jwst.datamodels.mask import MaskModel
 from jwst.datamodels import dqflags
 
 from jwst.dq_init import DQInitStep
-from jwst.dq_init.dq_initialization import do_dqinit
 
 from jwst.stpipe.config_parser import ValidationError
 
@@ -77,12 +76,9 @@ def make_rawramp(nints, ngroups, ysize, xsize):
 def test_invalid_override():
     """Test that a bogus override type is caught."""
     dm_ramp, ref_data = create_models()
-    try:
+
+    with pytest.raises(ValidationError):
         step = DQInitStep(override_mask = DQInitStep)
-    except ValidationError:
-        pass
-    else:
-        assert 0, "Expected validator type exception didn't occur."
 
 def test_valid_model_override():
     dm_ramp, ref_data = create_models()
@@ -102,16 +98,7 @@ def test_string_override():
     
     step = DQInitStep(override_mask = "some_file.fits")
 
-    try:
-        # Verify get_reference_file() returns an override model.
+    # Verify stpipe treats string as filename and attempts to open
+    with pytest.raises(FileNotFoundError):
         fetched_reference = step.get_reference_file(dm_ramp, 'mask')
-    except FileNotFoundError:
-        pass
-    else:
-        assert 0, "override string wasn't treated as a file."
-
-if __name__ == "__main__":
-    test_valid_model_override()
-    test_invalid_override()
-    test_string_override()
 

--- a/jwst/stpipe/tests/test_overrides.py
+++ b/jwst/stpipe/tests/test_overrides.py
@@ -5,7 +5,6 @@ import pytest
 
 from jwst.datamodels.miri_ramp import MIRIRampModel
 from jwst.datamodels.mask import MaskModel
-from jwst.datamodels import dqflags
 
 from jwst.dq_init import DQInitStep
 
@@ -81,7 +80,7 @@ def test_invalid_override():
     dm_ramp, ref_data = create_models()
 
     with pytest.raises(ValidationError):
-        step = DQInitStep(override_mask = DQInitStep)
+        DQInitStep(override_mask = DQInitStep)
 
 
 def test_valid_model_override():
@@ -95,7 +94,7 @@ def test_valid_model_override():
         "get_reference_file() should return a model for this override."
 
     # Verify no exceptions occur during DQ processing.
-    outfile = step.process(dm_ramp)
+    step.process(dm_ramp)
 
 
 def test_string_override():
@@ -105,4 +104,4 @@ def test_string_override():
 
     # Verify stpipe treats string as filename and attempts to open
     with pytest.raises(FileNotFoundError):
-        fetched_reference = step.get_reference_file(dm_ramp, 'mask')
+        step.get_reference_file(dm_ramp, 'mask')

--- a/jwst/stpipe/tests/test_overrides.py
+++ b/jwst/stpipe/tests/test_overrides.py
@@ -92,12 +92,26 @@ def test_valid_model_override():
     # Verify get_reference_file() returns an override model.
     fetched_reference = step.get_reference_file(dm_ramp, 'mask')
     assert isinstance(fetched_reference, MaskModel), \
-        "get_reference_file() should return a model for model overrides."
+        "get_reference_file() should return a model for this override."
                       
     # Verify no exceptions occur during DQ processing.
     outfile = step.process(dm_ramp)
 
+def test_string_override():
+    dm_ramp, ref_data = create_models()
+    
+    step = DQInitStep(override_mask = "some_file.fits")
+
+    try:
+        # Verify get_reference_file() returns an override model.
+        fetched_reference = step.get_reference_file(dm_ramp, 'mask')
+    except FileNotFoundError:
+        pass
+    else:
+        assert 0, "override string wasn't treated as a file."
+
 if __name__ == "__main__":
     test_valid_model_override()
     test_invalid_override()
+    test_string_override()
 


### PR DESCRIPTION
Added an stpipe configuration validator function which accepts a string or a datamodel.

Used new validator to enable reference file overrides to accept datamodels.

Added tests.

This PR  is expected enable the usage of DataModels for most steps.   This PR is expected not to affect classic use of filepath strings as overrides.  
