### PR TITLE
spec3 pipeline for WFSS modes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,10 +37,17 @@ extract_1d
 ----------
 - An indexing bug was fixed. [#3497]
 
+
 jump
 ----
 
 - Add multiprocessing capability to JumpStep [#3440]
+
+extract_2d
+----------
+
+- A space was removed from the names of grism objects in a MultiSlit model. [#3517]
+
 
 master_background
 -----------------
@@ -60,6 +67,11 @@ photom
 
 - Updated to zero-out pixels outside the wavelength range of flux calibration
   and set DQ=DO_NOT_USE. [#3475, #3489]
+
+pipeline
+--------
+
+- calwebb_spec3 was changed to allow processing of WFSS modes. [#3517]
 
 refpix
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,7 @@ jump
 extract_2d
 ----------
 
-- Replaced a white space in the names of grism objects with an upderscore. [#3517]
+- Replaced a white space in the names of grism objects with an underscore. [#3517]
 
 
 master_background

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,7 @@ jump
 extract_2d
 ----------
 
-- A space was removed from the names of grism objects in a MultiSlit model. [#3517]
+- Replaced a white space in the names of grism objects with an upderscore. [#3517]
 
 
 master_background

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -617,7 +617,6 @@ def get_aperture(im_shape, wcs, verbose, extract_params):
 
     if extract_params['ref_file_type'] == FILE_TYPE_IMAGE:
         return {}
-
     ap_ref = aperture_from_ref(extract_params, im_shape)
 
     (ap_ref, truncated) = update_from_shape(ap_ref, im_shape)
@@ -2739,7 +2738,6 @@ def run_extract1d(input_model, refname, smoothing_length, bkg_order,
     # we'll set S_EXTR1D to 'COMPLETE'.
     if ref_dict is not None:
         ref_dict['need_to_set_to_complete'] = False
-
     output_model = do_extract1d(input_model, ref_dict,
                                 smoothing_length, bkg_order,
                                 log_increment, subtract_background,
@@ -3046,7 +3044,6 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                                       datamodels.SlitModel)):
 
             slit = None
-
             # NRS_BRIGHTOBJ exposures are instances of SlitModel.
             prev_offset = OFFSET_NOT_ASSIGNED_YET
             for sp_order in spectral_order_list:
@@ -3080,12 +3077,14 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
 
                 # Loop over each integration in the input model
                 verbose = True          # for just the first integration
-                if input_model.data.shape[0] == 1:
+                shape = input_model.data.shape
+                if len(shape) == 3 and shape[0] == 1 or len(shape) == 2:
                     log.info("Beginning loop, just 1 integration ...")
+                    num_integrations = [-1]
                 else:
-                    log.info("Beginning loop over %d integrations ...",
-                             input_model.data.shape[0])
-                for integ in range(input_model.data.shape[0]):
+                    log.info("Beginning loop over {} integrations ...".format(shape[0]))
+                    num_integrations = range(shape[0])
+                for integ in num_integrations:
                     # Extract spectrum
                     try:
                         (ra, dec, wavelength, temp_flux, background,

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -3080,11 +3080,11 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 shape = input_model.data.shape
                 if len(shape) == 3 and shape[0] == 1 or len(shape) == 2:
                     log.info("Beginning loop, just 1 integration ...")
-                    num_integrations = [-1]
+                    integrations = [-1]
                 else:
                     log.info("Beginning loop over {} integrations ...".format(shape[0]))
-                    num_integrations = range(shape[0])
-                for integ in num_integrations:
+                    integrations = range(shape[0])
+                for integ in integrations:
                     # Extract spectrum
                     try:
                         (ra, dec, wavelength, temp_flux, background,

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -383,7 +383,7 @@ def extract_grism_objects(input_model,
                 # set x/ystart values relative to the image (screen) frame.
                 # The overall subarray offset is recorded in model.meta.subarray.
                 # nslit = obj.sid - 1  # catalog id starts at zero
-                new_slit.name = "Object {0}".format(obj.sid)
+                new_slit.name = "Object_{0}".format(obj.sid)
                 new_slit.xstart = 1  # fits pixels
                 new_slit.xsize = ext_data.shape[1]
                 new_slit.ystart = 1  # fits pixels

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -118,8 +118,8 @@ class Spec3Pipeline(Pipeline):
             self.log.info('Convert from exposure-based to source-based data.')
             sources = [
                 (name, model)
-                for name, model in multislit_to_container(source_models).items()
-            ]
+                        for name, model in multislit_to_container(source_models).items()
+                ]
 
         # Process each source
         for source in sources:

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -14,13 +14,15 @@ from ..master_background import master_background_step
 from ..mrs_imatch import mrs_imatch_step
 from ..outlier_detection import outlier_detection_step
 from ..resample import resample_spec_step
+from ..combine_1d import combine_1d_step
+
 
 __all__ = ['Spec3Pipeline']
 
 # Group exposure types
 MULTISOURCE_MODELS = ['MultiSlitModel']
 IFU_EXPTYPES = ['MIR_MRS', 'NRS_IFU']
-SLITLESS_TYPES = ['NIS_WFSS', 'NRC_WFSS'] #, 'NRC_TSGRISM']
+SLITLESS_TYPES = ['NIS_WFSS', 'NRC_WFSS']
 
 
 class Spec3Pipeline(Pipeline):
@@ -45,7 +47,8 @@ class Spec3Pipeline(Pipeline):
         'outlier_detection': outlier_detection_step.OutlierDetectionStep,
         'resample_spec': resample_spec_step.ResampleSpecStep,
         'cube_build': cube_build_step.CubeBuildStep,
-        'extract_1d': extract_1d_step.Extract1dStep
+        'extract_1d': extract_1d_step.Extract1dStep,
+        'combine_1d': combine_1d_step.Combine1dStep
     }
 
     # Main processing
@@ -165,6 +168,7 @@ class Spec3Pipeline(Pipeline):
             # Do 1-D spectral extraction
             if exptype in SLITLESS_TYPES:
                 result = self.extract_1d(result)
+                result = self.combine_1d(result)
             elif resample_complete is not None and \
                resample_complete.upper() == 'COMPLETE':
                 if exptype in IFU_EXPTYPES:

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -20,6 +20,7 @@ __all__ = ['Spec3Pipeline']
 # Group exposure types
 MULTISOURCE_MODELS = ['MultiSlitModel']
 IFU_EXPTYPES = ['MIR_MRS', 'NRS_IFU']
+SLITLESS_TYPES = ['NIS_WFSS', 'NRC_WFSS'] #, 'NRC_TSGRISM']
 
 
 class Spec3Pipeline(Pipeline):
@@ -142,26 +143,29 @@ class Spec3Pipeline(Pipeline):
                 result = self.mrs_imatch(result)
 
             # Call outlier detection
-            result = self.outlier_detection(result)
+            if exptype not in SLITLESS_TYPES:
+                result = self.outlier_detection(result)
 
-            # Resample time. Dependent on whether the data is IFU or
-            # not.
-            resample_complete = None
-            if exptype in IFU_EXPTYPES:
-                result = self.cube_build(result)
-                try:
-                    resample_complete = result[0].meta.cal_step.cube_build
-                except AttributeError:
-                    pass
-            else:
-                result = self.resample_spec(result)
-                try:
-                    resample_complete = result.meta.cal_step.resample
-                except AttributeError:
-                    pass
+                # Resample time. Dependent on whether the data is IFU or
+                # not.
+                resample_complete = None
+                if exptype in IFU_EXPTYPES:
+                    result = self.cube_build(result)
+                    try:
+                        resample_complete = result[0].meta.cal_step.cube_build
+                    except AttributeError:
+                        pass
+                else:
+                    result = self.resample_spec(result)
+                    try:
+                        resample_complete = result.meta.cal_step.resample
+                    except AttributeError:
+                        pass
 
             # Do 1-D spectral extraction
-            if resample_complete is not None and \
+            if exptype in SLITLESS_TYPES:
+                result = self.extract_1d(result)
+            elif resample_complete is not None and \
                resample_complete.upper() == 'COMPLETE':
                 if exptype in IFU_EXPTYPES:
                     self.extract_1d.search_output_file = False


### PR DESCRIPTION
Change the calwebb_spec3 pipeline to allow processing of WFSS modes.

Also fixed a bug in extract_1d where the shape of the input data was not passed correctly to the extraction code in the case of a single 2D slit.

This was tested on one file from the regression tests - NIS-WFSS. More testing necessary.

Resolves #3415.