### PR TITLE
Update ami_analyze rotation param default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,6 @@
 0.13.3 (Unreleased)
 ===================
 
-
 ami
 ---
 
@@ -10,6 +9,8 @@ ami
   minor tweaks to more closely match those in the prototype code: changed some of 
   initial values of the estimation parameters, and the filtering routine 
   arguments.  [#3487]
+
+- Updated ami_analyze.cfg to use default value of zero for rotation. [#3520]
 
 assign_wcs
 ------------

--- a/jwst/pipeline/ami_analyze.cfg
+++ b/jwst/pipeline/ami_analyze.cfg
@@ -1,4 +1,4 @@
 name = "ami_analyze"
 class = "jwst.ami.AmiAnalyzeStep"
 oversample=3
-rotation=1.49
+rotation=0.0


### PR DESCRIPTION
Update the ami_analyze.cfg file to set the default value of ``rotation`` to zero, which matches the default value in the step "spec" block.

Fixes #3510.