### PR TITLE
Update aperture area for photutils API change

### DIFF
--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -1,8 +1,10 @@
+from distutils.version import LooseVersion
 import logging
 import math
 
 import numpy as np
 from astropy import units as u
+import photutils
 from photutils import CircularAperture, CircularAnnulus, \
                       RectangularAperture, aperture_photometry
 
@@ -393,15 +395,24 @@ def extract_ifu(input_model, source_type, extract_params):
     phot_table = aperture_photometry(temp, aperture,
                                      method=method, subpixels=subpixels)
     aperture_area = float(phot_table['aperture_sum'][0])
-    log.debug("aperture.area() = %g; aperture_area = %g",
-              aperture.area(), aperture_area)
+    if LooseVersion(photutils.__version__) >= '0.7':
+        log.debug("aperture.area = %g; aperture_area = %g",
+                  aperture.area, aperture_area)
+    else:
+        log.debug("aperture.area() = %g; aperture_area = %g",
+                  aperture.area(), aperture_area)
+
     if subtract_background and annulus is not None:
         # Compute the area of the annulus.
         phot_table = aperture_photometry(temp, annulus,
                                          method=method, subpixels=subpixels)
         annulus_area = float(phot_table['aperture_sum'][0])
-        log.debug("annulus.area() = %g; annulus_area = %g",
-                  annulus.area(), annulus_area)
+        if LooseVersion(photutils.__version__) >= '0.7':
+            log.debug("annulus.area = %g; annulus_area = %g",
+                      annulus.area, annulus_area)
+        else:
+            log.debug("annulus.area() = %g; annulus_area = %g",
+                      annulus.area(), annulus_area)
         if annulus_area > 0.:
             normalization = aperture_area / annulus_area
         else:

--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -1,8 +1,10 @@
 """Class definition for performing outlier detection with scaling."""
 
 from copy import deepcopy
+from distutils.version import LooseVersion
 import numpy as np
 
+import photutils
 from photutils import aperture_photometry, CircularAperture, CircularAnnulus
 import astropy.units as u
 
@@ -125,8 +127,13 @@ class OutlierDetectionScaled(OutlierDetection):
 
         aperture_sum = u.Quantity(tbl1['aperture_sum'][0])
         annulus_sum = u.Quantity(tbl2['aperture_sum'][0])
-        annulus_mean = annulus_sum / aper2.area()
-        aperture_bkg = annulus_mean * apertures.area()
+        if LooseVersion(photutils.__version__) >= '0.7':
+            annulus_mean = annulus_sum / aper2.area
+            aperture_bkg = annulus_mean * apertures.area
+        else:
+            annulus_mean = annulus_sum / aper2.area()
+            aperture_bkg = annulus_mean * apertures.area()
+
         median_phot_value = aperture_sum - aperture_bkg
 
         if save_intermediate_results:

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -1,10 +1,12 @@
 from collections import OrderedDict
+from distutils.version import LooseVersion
 
 import logging
 
 import numpy as np
 from astropy.table import QTable
 from astropy.time import Time, TimeDelta
+import photutils
 from photutils import CircularAperture, CircularAnnulus
 
 from ..datamodels import CubeModel
@@ -167,13 +169,22 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
         tbl['annulus_sum'] = annulus_sum
         tbl['annulus_sum_err'] = annulus_sum_err
 
-        annulus_mean = annulus_sum / bkg_aper.area()
-        annulus_mean_err = annulus_sum_err / bkg_aper.area()
+        if LooseVersion(photutils.__version__) >= '0.7':
+            annulus_mean = annulus_sum / bkg_aper.area
+            annulus_mean_err = annulus_sum_err / bkg_aper.area
+
+            aperture_bkg = annulus_mean * phot_aper.area
+            aperture_bkg_err = annulus_mean_err * phot_aper.area
+        else:
+            annulus_mean = annulus_sum / bkg_aper.area()
+            annulus_mean_err = annulus_sum_err / bkg_aper.area()
+
+            aperture_bkg = annulus_mean * phot_aper.area()
+            aperture_bkg_err = annulus_mean_err * phot_aper.area()
+
         tbl['annulus_mean'] = annulus_mean
         tbl['annulus_mean_err'] = annulus_mean_err
 
-        aperture_bkg = annulus_mean * phot_aper.area()
-        aperture_bkg_err = annulus_mean_err * phot_aper.area()
         tbl['aperture_bkg'] = aperture_bkg
         tbl['aperture_bkg_err'] = aperture_bkg_err
 


### PR DESCRIPTION
In `photutils 0.6` the aperture objects have an `area()` method, but in `photutils 0.7` this was changed to an attribute.  This PR updates the `extract_1d`, `tso_photometry`, and `outlier_detection` steps to work with both `photutils` 0.6 and >= 0.7 (including 0.7dev) versions.

Fixes https://github.com/spacetelescope/jwst/issues/3534.