### PR TITLE
Compute var_flat from fflat, sflat and dflat for NIRSpec modes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,14 @@ extract_1d
 ----------
 - An indexing bug was fixed. [#3497]
 
+flatfield
+---------
+
+- Remove flatfield step parameter `flat_suffix`.  Add boolean step parameter
+  `save_interpolated_flat`.  Refactor flatfield internals. [#3493]
+
+- Propagate uncertainty from FFLAT, SFLAT and DFLAT flat fields into science
+  ERR array and VAR_FLAT array for NIRSpec spectroscopic modes.  [#3538]
 
 jump
 ----

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -1596,10 +1596,14 @@ def interpolate_flat(image_flat, image_dq, image_err, image_wl, wl):
     (nz, ysize, xsize) = image_flat.shape
     if nz == 1:
         if len(image_dq.shape) == 2:
-            return (image_flat.reshape((ysize, xsize)), image_dq)
+            # dq and err arrays are the same size, so treat them the same
+            return image_flat.reshape((ysize, xsize)), image_dq, image_err
         else:
-            return (image_flat.reshape((ysize, xsize)),
-                    image_dq.reshape((ysize, xsize)))
+            return (
+                image_flat.reshape((ysize, xsize)),
+                image_dq.reshape((ysize, xsize)),
+                image_err.reshape((ysize, xsize))
+            )
 
     grid = np.indices((ysize, xsize), dtype=np.intp)
     ixpixel = grid[1]

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -252,21 +252,21 @@ def nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model):
 
     Parameters
     ----------
-    output_model : ~jwst.datamodels.MultiSlitModel
+    output_model : `~jwst.datamodels.MultiSlitModel`
         MultiSlitModel, modified (flat fielded) slit-by-slit, in-place.
 
-    f_flat_model : ~jwst.datamodels.NirspecFlatModel or None
+    f_flat_model : `~jwst.datamodels.NirspecFlatModel` or None
         Flat field for the fore optics.
 
-    s_flat_model : ~jwst.datamodels.NirspecFlatModel or None
+    s_flat_model : `~jwst.datamodels.NirspecFlatModel` or None
         Flat field for the spectrograph.
 
-    d_flat_model : ~jwst.datamodels.NirspecFlatModel or None
+    d_flat_model : `~jwst.datamodels.NirspecFlatModel` or None
         Flat field for the detector.
 
     Returns
     -------
-    ~jwst.datamodels.MultiSlitModel
+    interpolated_flats: `~jwst.datamodels.MultiSlitModel`
         The interpolated flat field, one for each slit.
     """
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -194,7 +194,10 @@ def apply_flat_field(science, flat):
 #
 
 def do_nirspec_flat_field(output_model, f_flat_model, s_flat_model, d_flat_model):
-    """Apply flat-fielding for NIRSpec data, updating in-place
+    """Apply flat-fielding for NIRSpec data, updating in-place.
+
+    Calls one of 3 functions depending on whether the data is 1) NIRSpec IFU,
+    2) NIRSpec BRIGHTOBJ or 3) NIRSpec MSA or Fixed-slit.
 
     Parameters
     ----------
@@ -226,9 +229,7 @@ def do_nirspec_flat_field(output_model, f_flat_model, s_flat_model, d_flat_model
                       "don't know how to process it.")
             raise RuntimeError("Input is {}; expected SlitModel"
                                .format(type(output_model)))
-        return nirspec_brightobj(output_model,
-                                 f_flat_model, s_flat_model,
-                                 d_flat_model)
+        return nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model)
 
     # We expect NIRSpec IFU data to be an IFUImageModel, but it's conceivable
     # that the slices have been copied out into a MultiSlitModel, so
@@ -240,13 +241,40 @@ def do_nirspec_flat_field(output_model, f_flat_model, s_flat_model, d_flat_model
                           "don't know how to process it.")
                 raise RuntimeError("Input is {}; expected IFUImageModel"
                                    .format(type(output_model)))
-            return nirspec_ifu(output_model,
-                               f_flat_model, s_flat_model,
-                               d_flat_model)
+            return nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model)
+    # For datamodels with slits, MSA and Fixed slit modes:
+    else:
+        return nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model)
+
+
+def nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model):
+    """Apply flat-fielding for NIRSpec fixed slit and MSA data, in-place
+
+    Parameters
+    ----------
+    output_model : ~jwst.datamodels.MultiSlitModel
+        MultiSlitModel, modified (flat fielded) slit-by-slit, in-place.
+
+    f_flat_model : ~jwst.datamodels.NirspecFlatModel or None
+        Flat field for the fore optics.
+
+    s_flat_model : ~jwst.datamodels.NirspecFlatModel or None
+        Flat field for the spectrograph.
+
+    d_flat_model : ~jwst.datamodels.NirspecFlatModel or None
+        Flat field for the detector.
+
+    Returns
+    -------
+    ~jwst.datamodels.MultiSlitModel
+        The interpolated flat field, one for each slit.
+    """
+
+    exposure_type = output_model.meta.exposure.type
 
     # Create a list to hold the list of slits.  This will eventually be used
     # to extend the MultiSlitModel.slits attribute.  We do it this way to
-    # postpone validation until the end.
+    # postpone validation until the end, which is faster.
     flat_slits = []
 
     # A flag to make sure at least one slit was flatfielded, so we can set
@@ -360,10 +388,19 @@ def do_nirspec_flat_field(output_model, f_flat_model, s_flat_model, d_flat_model
         # Append the SlitDataModel to the list of slits
         flat_slits.append(new_flat)
 
-        # Apply flat to data, err and dq arrays
+        # Now let's apply the correction to science data and error arrays.  Rely
+        # on array broadcasting to handle the cubes
         slit.data /= flat_2d
-        slit.err /= flat_2d
-        slit.dq |= flat_dq_2d.astype(slit.dq.dtype)
+
+        # Update the variances using BASELINE algorithm
+        flat_data_squared = flat_2d**2
+        slit.var_poisson /= flat_data_squared
+        slit.var_rnoise /= flat_data_squared
+        slit.var_flat = slit.data**2 / flat_data_squared * flat_err_2d**2
+        slit.err = np.sqrt(slit.var_poisson + slit.var_rnoise + slit.var_flat)
+
+        # Combine the science and flat DQ arrays
+        slit.dq |= flat_dq_2d
 
         any_updated = True
 
@@ -380,9 +417,7 @@ def do_nirspec_flat_field(output_model, f_flat_model, s_flat_model, d_flat_model
     return interpolated_flats
 
 
-def nirspec_brightobj(output_model,
-                      f_flat_model, s_flat_model,
-                      d_flat_model):
+def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model):
     """Apply flat-fielding for NIRSpec BRIGHTOBJ data, in-place
 
     Parameters
@@ -489,24 +524,24 @@ def nirspec_brightobj(output_model,
                                       dtype=output_model.err.dtype)
     interpolated_flats.wavelength = wl.copy()
 
-    if len(shape) == 3:
-        flat_nd = flat_2d.reshape((1, ysize, xsize))
-        flat_dq_nd = flat_dq_2d.reshape((1, ysize, xsize))
-    else:
-        flat_nd = flat_2d
-        flat_dq_nd = flat_dq_2d
-    output_model.data /= flat_nd
-    output_model.err /= flat_nd
-    output_model.dq |= flat_dq_nd
+    output_model.data /= flat_2d
+    output_model.dq |= flat_dq_2d
+
+    # Update the variances and uncertainty array using BASELINE algorithm
+    flat_data_squared = flat_2d**2
+    output_model.var_poisson /= flat_data_squared
+    output_model.var_rnoise /= flat_data_squared
+    output_model.var_flat = output_model.data**2 / flat_data_squared * flat_err_2d**2
+    output_model.err = np.sqrt(
+        output_model.var_poisson + output_model.var_rnoise + output_model.var_flat
+    )
 
     output_model.meta.cal_step.flat_field = 'COMPLETE'
 
     return interpolated_flats
 
 
-def nirspec_ifu(output_model,
-                f_flat_model, s_flat_model,
-                d_flat_model):
+def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model):
     """Apply flat-fielding for NIRSpec IFU data, in-place
 
     Parameters
@@ -533,6 +568,7 @@ def nirspec_ifu(output_model,
     exposure_type = output_model.meta.exposure.type
     flat = np.ones_like(output_model.data)
     flat_dq = np.zeros_like(output_model.dq)
+    flat_err = np.ones_like(output_model.data)
 
     try:
         list_of_wcs = nirspec.nrs_ifu_wcs(output_model)
@@ -624,14 +660,24 @@ def nirspec_ifu(output_model,
                         .format(flat_dq.dtype, flat_dq_2d.dtype))
             flat_dq[ystart:ystop, xstart:xstop] |= \
                 flat_dq_2d.astype(flat_dq.dtype).copy()
+        flat_err[ystart:ystop, xstart:xstop][good_flag] = flat_err_2d[good_flag]
         del nan_flag, good_flag
 
         any_updated = True
 
     if any_updated:
-        output_model.dq |= flat_dq
         output_model.data /= flat
-        output_model.err /= flat
+        output_model.dq |= flat_dq
+
+        # Update the variances and uncertainty array using BASELINE algorithm
+        flat_data_squared = flat**2
+        output_model.var_poisson /= flat_data_squared
+        output_model.var_rnoise /= flat_data_squared
+        output_model.var_flat = output_model.data**2 / flat_data_squared * flat_err**2
+        output_model.err = np.sqrt(
+            output_model.var_poisson + output_model.var_rnoise + output_model.var_flat
+        )
+
         output_model.meta.cal_step.flat_field = 'COMPLETE'
 
         # Create an output model for the interpolated flat fields.
@@ -719,8 +765,18 @@ def create_flat_field(wl, f_flat_model, s_flat_model, d_flat_model,
     flat_dq = combine_dq(f_flat_dq, s_flat_dq, d_flat_dq,
                          default_shape=flat_2d.shape)
 
-    # Placeholder for the error array
-    flat_err = np.zeros_like(flat_2d)
+    # Combine the uncertainty arrays, excluding the ones that are None
+    sum_var = np.zeros_like(flat_2d)
+    if f_flat_err is not None:
+        np.place(f_flat, f_flat==0, 1.)
+        sum_var += f_flat_err**2 / f_flat**2
+    if s_flat_err is not None:
+        np.place(s_flat, s_flat==0, 1.)
+        sum_var += s_flat_err**2 / s_flat**2
+    if d_flat_err is not None:
+        np.place(d_flat, d_flat==0, 1.)
+        sum_var += d_flat_err**2 / d_flat**2
+    flat_err = flat_2d * np.sqrt(sum_var)
 
     mask1 = np.bitwise_and(flat_dq, dqflags.pixel['UNRELIABLE_FLAT'])
     mask2 = np.bitwise_and(flat_dq, dqflags.pixel['NO_FLAT_FIELD'])
@@ -778,8 +834,7 @@ def fore_optics_flat(wl, f_flat_model, exposure_type,
         Flat field for the fore optics.
 
     exposure_type : str
-        The exposure type refers to fixed_slit, IFU, or using the
-        micro-shutter array.
+        The exposure type refers to fixed_slit, IFU, or MSA.
 
     slit_name : str
         The name of the slit currently being processed.
@@ -825,6 +880,9 @@ def fore_optics_flat(wl, f_flat_model, exposure_type,
     # image flat, so set the variable to 1.
     flat_2d = 1.
 
+    f_flat_dq = None
+    f_flat_err = None
+
     if exposure_type == "NRS_MSASPEC":
         # The MOS "image" is in MSA coordinates (shutter index in x and y),
         # not detector pixel coordinates.
@@ -834,11 +892,14 @@ def fore_optics_flat(wl, f_flat_model, exposure_type,
         msa_y -= 1              # convert to zero indexed
         msa_x -= 1
         full_array_flat = f_flat_model.quadrants[quadrant].data
+        full_array_err = f_flat_model.quadrants[quadrant].err
+
         # Get the wavelength corresponding to each plane in the "image".
         image_wl = read_image_wl(f_flat_model, quadrant)
         if image_wl.max() < MICRONS_100:
             log.warning("Wavelengths in f_flat image appear to be in meters.")
         one_d_flat = full_array_flat[:, msa_y, msa_x]
+        one_d_err = full_array_err[:, msa_y, msa_x]
 
         # The wavelengths and flat-field values read from the reference
         # table are tab_wl and tab_flat respectively.  We need to combine
@@ -852,8 +913,7 @@ def fore_optics_flat(wl, f_flat_model, exposure_type,
         #       left, right:  values to return for out-of-bounds x
         tab_flat *= np.interp(tab_wl, image_wl, one_d_flat, 1., 1.)
 
-    f_flat_dq = None
-    f_flat_err = None
+        f_flat_err = np.interp(tab_wl, image_wl, one_d_err, 1., 1.)
 
     # The shape of the output array is obtained from `wl`.
     f_flat, f_flat_dq = combine_fast_slow(wl, flat_2d, f_flat_dq,
@@ -924,22 +984,23 @@ def spectrograph_flat(wl, s_flat_model,
 
     full_array_flat = s_flat_model.data
     full_array_dq = s_flat_model.dq
+    full_array_err = s_flat_model.err
 
     if len(full_array_flat.shape) == 3:
         # MSA data
         image_flat = full_array_flat[:, ystart:ystop, xstart:xstop]
         image_dq = full_array_dq[:, ystart:ystop, xstart:xstop]
+        image_err = full_array_err[:, ystart:ystop, xstart:xstop]
         # Get the wavelength corresponding to each plane in the image.
         image_wl = read_image_wl(s_flat_model, quadrant)
         if image_wl.max() < MICRONS_100:
             log.warning("Wavelengths in s_flat image appear to be in meters")
-        (flat_2d, s_flat_dq) = interpolate_flat(image_flat, image_dq,
-                                                image_wl, wl)
+        flat_2d, s_flat_dq, s_flat_err = interpolate_flat(image_flat, image_dq,
+                                                          image_err, image_wl, wl)
     else:
         flat_2d = full_array_flat[ystart:ystop, xstart:xstop]
         s_flat_dq = full_array_dq[ystart:ystop, xstart:xstop]
-
-    s_flat_err = None
+        s_flat_err = full_array_err[ystart:ystop, xstart:xstop]
 
     s_flat, s_flat_dq = combine_fast_slow(wl, flat_2d, s_flat_dq,
                                           tab_wl, tab_flat, dispaxis)
@@ -1009,19 +1070,17 @@ def detector_flat(wl, d_flat_model,
 
     full_array_flat = d_flat_model.data
     full_array_dq = d_flat_model.dq
+    full_array_err = d_flat_model.err
     image_flat = full_array_flat[:, ystart:ystop, xstart:xstop]
-    if len(full_array_dq.shape) == 2:
-        image_dq = full_array_dq[ystart:ystop, xstart:xstop]
-    else:
-        image_dq = full_array_dq[:, ystart:ystop, xstart:xstop]
+    image_dq = full_array_dq[..., ystart:ystop, xstart:xstop]
+    image_err = full_array_err[..., ystart:ystop, xstart:xstop]
     # Get the wavelength corresponding to each plane in the image.
     image_wl = read_image_wl(d_flat_model, quadrant)
     if image_wl.max() < MICRONS_100:
         log.warning("Wavelengths in d_flat image appear to be in meters.")
 
-    d_flat_err = None
-
-    flat_2d, d_flat_dq = interpolate_flat(image_flat, image_dq, image_wl, wl)
+    flat_2d, d_flat_dq, d_flat_err = interpolate_flat(image_flat, image_dq,
+                                                      image_err, image_wl, wl)
 
     d_flat, d_flat_dq = combine_fast_slow(wl, flat_2d, d_flat_dq,
                                           tab_wl, tab_flat, dispaxis)
@@ -1128,8 +1187,7 @@ def read_image_wl(flat_model, quadrant=None):
     return wavelength
 
 
-def read_flat_table(flat_model, exposure_type,
-                    slit_name=None, quadrant=None):
+def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
     """Read the table (the "fast" variation).
 
     Parameters
@@ -1493,7 +1551,7 @@ def wl_interpolate(wavelength, tab_wl, tab_flat):
     return q * tab_flat[n0] + p * tab_flat[n0 + 1]
 
 
-def interpolate_flat(image_flat, image_dq, image_wl, wl):
+def interpolate_flat(image_flat, image_dq, image_err, image_wl, wl):
     """Interpolate within the 3-D flat field image to get a 2-D flat.
 
     Parameters
@@ -1505,7 +1563,11 @@ def interpolate_flat(image_flat, image_dq, image_wl, wl):
         (the first axis) of the reference image.
 
     image_dq : ndarray, 2-D or 3-D
-        This is slice [:, ystart:ystop, xstart:xstop] of the data quality
+        This is slice [..., ystart:ystop, xstart:xstop] of the data quality
+        array for the flat field reference image.
+
+    image_err : ndarray, 2-D or 3-D
+        This is slice [..., ystart:ystop, xstart:xstop] of the data quality
         array for the flat field reference image.
 
     image_wl : ndarray, 1-D
@@ -1523,10 +1585,13 @@ def interpolate_flat(image_flat, image_dq, image_wl, wl):
 
     flat_dq : ndarray, 2-D, uint32
         The data quality array corresponding to `flat_2d`.
+
+    flat_err : ndarray, 2-D, float32
+        The error array corresponding to `flat_2d`.
     """
 
     if len(image_flat.shape) < 3:
-        return (image_flat, image_dq)
+        return image_flat, image_dq, image_err
 
     (nz, ysize, xsize) = image_flat.shape
     if nz == 1:
@@ -1572,6 +1637,13 @@ def interpolate_flat(image_flat, image_dq, image_wl, wl):
     q = 1. - p
     flat_2d = q * image_flat[k, iypixel, ixpixel] + \
               p * image_flat[k + 1, iypixel, ixpixel]
+
+    if len(image_err.shape) == 2:
+        flat_err = image_err.copy()
+    else:
+        flat_err = q * image_err[k, iypixel, ixpixel] + \
+                   p * image_err[k + 1, iypixel, ixpixel]
+
     if len(image_dq.shape) == 2:
         flat_dq = image_dq.copy()
     else:
@@ -1592,4 +1664,4 @@ def interpolate_flat(image_flat, image_dq, image_wl, wl):
     # change to the science data.
     flat_2d[:, :] = np.where(flat_dq > 0, 1., flat_2d)
 
-    return (flat_2d.astype(image_flat.dtype), flat_dq)
+    return flat_2d.astype(image_flat.dtype), flat_dq, flat_err

--- a/jwst/flatfield/tests/test_flatfield.py
+++ b/jwst/flatfield/tests/test_flatfield.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from jwst import datamodels
 from jwst.flatfield import FlatFieldStep
-from jwst.flatfield.flat_field_step import NRS_IMAGING_MODES
+from jwst.flatfield.flat_field_step import NRS_IMAGING_MODES, NRS_SPEC_MODES
 
 
 @pytest.mark.parametrize(
@@ -13,14 +13,17 @@ from jwst.flatfield.flat_field_step import NRS_IMAGING_MODES
         ("NIRCAM", "NRC_WFSS"),
         ("MIRI", "MIR_IMAGE"),
         ("MIRI", "MIR_LRS-FIXEDSLIT"),
+        ("MIRI", "MIR_LRS-SLITLESS"),
         ("MIRI", "MIR_MRS"),
         ("NIRISS", "NIS_IMAGE"),
+        ("NIRISS", "NIS_WFSS"),
+        ("NIRISS", "NIS_SOSS"),
+        ("NIRISS", "NIS_AMI"),
         ("FGS", "FGS_IMAGE"),
     ] + [("NIRSPEC", exptype) for exptype in NRS_IMAGING_MODES]
 )
-def test_flatfield_step_interface(tmpdir, instrument, exptype):
+def test_flatfield_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a FLAT reffile"""
-    flat_file = str(tmpdir.join('flat.fits'))
 
     shape = (20, 20)
 
@@ -41,13 +44,44 @@ def test_flatfield_step_interface(tmpdir, instrument, exptype):
     flat.data += 1
     flat.data[0,0] = np.nan
     flat.err = np.random.random(shape) * 0.05
-    flat.save(flat_file)
 
     # override class attribute so only the `flat` type needs to be overriden
     # in the step call.  Otherwise CRDS calls will be made for the other 3
-    # types of flat reference file.
+    # types of flat reference file not used in this test.
     FlatFieldStep.reference_file_types = ["flat"]
-    result = FlatFieldStep.call(data, override_flat=flat_file)
+    result = FlatFieldStep.call(data, override_flat=flat)
 
     assert (result.data == data.data).all()
     assert result.var_flat.shape == shape
+
+
+def exptypes():
+    """Generate NRS EXPTYPES from the schema enum, removing spec types"""
+    model = datamodels.ImageModel()
+    alltypes = set(model.meta.exposure._schema['properties']['type']['enum'])
+    spectypes = set(NRS_SPEC_MODES)
+    return sorted([i for i in (alltypes - spectypes)])
+
+@pytest.mark.parametrize(
+    "exptype",
+    exptypes()
+)
+def test_nirspec_flatfield_step_interface(exptype):
+    """Test that the interface works all NIRSpec types"""
+
+    shape = (20, 20)
+
+    data = datamodels.ImageModel(shape)
+    data.meta.observation.date = "2019-01-01"
+    data.meta.observation.time = "00:00:00"
+    data.meta.instrument.name = "NIRSPEC"
+    data.meta.instrument.detector = "NRS1"
+    data.meta.instrument.filter = "CLEAR"
+    data.meta.instrument.grating = "MIRROR"
+    data.meta.exposure.type = exptype
+    data.meta.subarray.xstart = 1
+    data.meta.subarray.ystart = 1
+    data.meta.subarray.xsize = shape[1]
+    data.meta.subarray.ysize = shape[0]
+
+    FlatFieldStep.call(data)


### PR DESCRIPTION
- Add function `nirspec_fs_msa()` to handle the work done originally by `do_nirspec_flat_field()`.  Now `do_nirspec_flat_field()` calls one of 3 functions:
    - `nirspec_brightobj()`
    - `nirspec_ifu()`
    - `nirspec_fs_msa()`
- Propogate error arrays from the FFLAT, SFLAT and DFLAT reffiles into the `err` and `var_flat` arrays in the science data.

Continues work started on #3493.
Resolves #3460.