### PR TITLE
Don't use pixels with wavelength = NaN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,10 @@ datamodels
 
 extract_1d
 ----------
+
 - An indexing bug was fixed. [#3497]
+
+- Pixels with wavelength = NaN are no longer used. [#3539]
 
 
 jump


### PR DESCRIPTION
The `master_background/expand_to_2d.get_wavelengths` function is now used to get the 2-D array of wavelengths from the input file, instead of explicitly checking for the existence of the wavelength attribute (an extension in the input file), and evaluating the WCS function if the attribute does not exist or is not populated.

The replace_bad_values function has been modified.  Instead of setting the science data to a fill value (zero) for pixels where the data value was NaN or the data quality flag included DO_NOT_USE, the science data are now set to NaN wherever the wavelength is NaN or the DQ flag includes DO_NOT_USE.

Closes #3223.