### PR TITLE
JP-457 Prevent calwebb_image2 from sending 3D data to resample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,7 +79,10 @@ photom
 pipeline
 --------
 
-- calwebb_spec3 was changed to allow processing of WFSS modes. [#3517]
+- ``calwebb_spec3`` was changed to allow processing of WFSS modes. [#3517]
+
+- ``calwebb_image2`` was changed to prevent 3D data from being sent to
+  ``resample``. [#3544]
 
 refpix
 ------

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -145,8 +145,9 @@ class Image2Pipeline(Pipeline):
         input = self.photom(input)
 
         # Resample individual exposures, but only if it's one of the
-        # regular science image types.
-        if input.meta.exposure.type.upper() in self.image_exptypes:
+        # regular 2D science image types
+        if input.meta.exposure.type.upper() in self.image_exptypes and \
+        len(input.data.shape) == 2:
             self.resample(input)
 
         # That's all folks


### PR DESCRIPTION
This fixes the issue where 3D `_rateints` products that had normal imaging EXP_TYPES were being sent to `resample` in `calwebb_image2`.

Resolves #2899.