### PR TITLE
MIRI data to use RampModel instead of MIRIRampModel

### DIFF
--- a/jwst/datamodels/schemas/ramp.schema.yaml
+++ b/jwst/datamodels/schemas/ramp.schema.yaml
@@ -34,6 +34,12 @@ allOf:
       default: 0.0
       ndim: 3
       datatype: float32
+    refout:
+      title: Reference Output
+      fits_hdu: REFOUT
+      default: 0.0
+      ndim: 4
+      datatype: float32
 - $ref: group.schema.yaml
 - $ref: int_times.schema.yaml
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -203,17 +203,8 @@ def _class_from_ramp_type(hdulist, shape):
             try:
                 hdulist['DQ']
             except KeyError:
-                # It's a RampModel or MIRIRampModel
-                try:
-                    hdulist['REFOUT']
-                except KeyError:
-                    # It's a RampModel
-                    from . import ramp
-                    new_class = ramp.RampModel
-                else:
-                    # It's a MIRIRampModel
-                    from . import miri_ramp
-                    new_class = miri_ramp.MIRIRampModel
+                from . import ramp
+                new_class = ramp.RampModel
             else:
                 new_class = None
         else:


### PR DESCRIPTION
Add REFOUT attribute to RampModel so that MIRI data can be opened as a RampModel and retain the REFOUT data.  Change datamodels.open so that data with a REFOUT extension are opened as a RampModel instead of a MIRIRampModel.
MIRIRampModel is still available.