### PR TITLE
JP-740 Add datetime rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,7 @@ model_blender
 -------------
 
 - Allow blendmodels to ignore attributes in asdf tree not in schema [#3480]
+- Add new rules for dates and times [#3554]
 
 photom
 ------
@@ -1624,4 +1625,3 @@ white_light
 
 wiimatch
 --------
-

--- a/docs/jwst/model_blender/blender_rules.rst
+++ b/docs/jwst/model_blender/blender_rules.rst
@@ -16,17 +16,21 @@ includes
     import numpy as np
     # translation dictionary for function entries from rules files
     blender_funcs = {'first': first,
-                     'last': last,
-                     'float_one': float_one,
-                     'int_one': int_one,
-                     'zero': zero,
-                     'multi': multi,
-                     'multi?': multi1,
-                     'mean': np.mean,
-                     'sum': np.sum,
-                     'max': np.max,
-                     'min': np.min,
-                     'stddev': np.std}
+                      'last': last,
+                      'float_one': float_one,
+                      'int_one': int_one,
+                      'zero': zero,
+                      'multi': multi,
+                      'multi?': multi1,
+                      'mean': np.mean,
+                      'sum': np.sum,
+                      'max': np.max,
+                      'min': np.min,
+                      'stddev': np.std,
+                      'mintime': mintime,
+                      'maxtime': maxtime,
+                      'mindate': mindate,
+                      'maxdate': maxdate}
 
 The rules that should be referenced in the model schema definition are the
 keys defined for `jwst.model_blender.blender_rules.blender_funcs` listed
@@ -35,3 +39,5 @@ numpy array operations, while others are defined internally to `model_blender`.
 
 .. automodapi:: jwst.model_blender.blendrules
    :skip: OrderedDict
+   :skip: Time
+   :skip: time

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -144,7 +144,7 @@ properties:
             title: "[yyyy-mm-dd] UTC date at start of exposure"
             fits_keyword: DATE-OBS
             blend_table: True
-            blend_rule: mintime
+            blend_rule: mindate
           time:
             title: "[hh:mm:ss.sss] UTC time at start of exposure"
             type: string
@@ -156,13 +156,13 @@ properties:
             title: "Date-time start of data acquisition"
             fits_keyword: DATE-BEG
             blend_table: True
-            blend_rule: mintime
+            blend_rule: mindate
           date_end:
             type: string
             title: "[yyyy-mm-dd] UTC date at end of exposure"
             fits_keyword: DATE-END
             blend_table: True
-            blend_rule: maxtime
+            blend_rule: maxdate
           time_end:
             title: "[hh:mm:ss.sss] UTC time at end of exposure"
             type: string

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -144,31 +144,31 @@ properties:
             title: "[yyyy-mm-dd] UTC date at start of exposure"
             fits_keyword: DATE-OBS
             blend_table: True
-            blend_rule: first
+            blend_rule: mintime
           time:
             title: "[hh:mm:ss.sss] UTC time at start of exposure"
             type: string
             fits_keyword: TIME-OBS
             blend_table: True
-            blend_rule: first
+            blend_rule: mintime
           date_beg:
             type: string
             title: "Date-time start of data acquisition"
             fits_keyword: DATE-BEG
             blend_table: True
-            blend_rule: first
+            blend_rule: mintime
           date_end:
             type: string
             title: "[yyyy-mm-dd] UTC date at end of exposure"
             fits_keyword: DATE-END
             blend_table: True
-            blend_rule: last
+            blend_rule: maxtime
           time_end:
             title: "[hh:mm:ss.sss] UTC time at end of exposure"
             type: string
             fits_keyword: TIME-END
             blend_table: True
-            blend_rule: last
+            blend_rule: maxtime
           obs_id:
             title: Programmatic observation identifier
             type: string

--- a/jwst/model_blender/blendrules.py
+++ b/jwst/model_blender/blendrules.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import numpy as np
 from astropy.io import fits
+from astropy.time import Time
 
 from jwst import __version__
 from .. import datamodels
@@ -81,6 +82,16 @@ def last(items):
         return items[-1]
     return None
 
+def mintime(items):
+    """Return the minimum time from a list of time strings."""
+    time_list = Time(items)
+    return time_list.min()
+
+def maxtime(items):
+    """Return the maximum time from a list of time strings."""
+    time_list = Time(items)
+    return time_list.max()
+
 
 # translation dictionary for function entries from rules files
 blender_funcs = {'first': first,
@@ -94,7 +105,9 @@ blender_funcs = {'first': first,
                  'sum': np.sum,
                  'max': np.max,
                  'min': np.min,
-                 'stddev': np.std}
+                 'stddev': np.std,
+                 'mintime': mintime,
+                 'maxtime': maxtime}
 
 
 # Classes for managing keyword rules

--- a/jwst/model_blender/blendrules.py
+++ b/jwst/model_blender/blendrules.py
@@ -5,6 +5,7 @@
 from collections import OrderedDict
 
 import numpy as np
+from datetime import time
 from astropy.io import fits
 from astropy.time import Time
 
@@ -82,16 +83,29 @@ def last(items):
         return items[-1]
     return None
 
-def mintime(items):
+def mindate(items):
     """Return the minimum time from a list of time strings."""
     time_list = Time(items)
     return time_list.min()
 
-def maxtime(items):
+def maxdate(items):
     """Return the maximum time from a list of time strings."""
     time_list = Time(items)
     return time_list.max()
 
+def mintime(items):
+    times = [_isotime(time_str) for time_str in items]
+    return min(times).isoformat()
+
+def maxtime(items):
+    times = [_isotime(time_str) for time_str in items]
+    return max(times).isoformat()
+
+def _isotime(time_str):
+    hms = [float(i) for i in time_str.split(':')]
+    sec_ms = hms[2] - int(hms[2])
+    isotime = time(int(hms[0]), int(hms[1]), int(hms[2]), int(sec_ms * 1000000))
+    return isotime
 
 # translation dictionary for function entries from rules files
 blender_funcs = {'first': first,
@@ -107,7 +121,9 @@ blender_funcs = {'first': first,
                  'min': np.min,
                  'stddev': np.std,
                  'mintime': mintime,
-                 'maxtime': maxtime}
+                 'maxtime': maxtime,
+                 'mindate': mindate,
+                 'maxdate': maxdate}
 
 
 # Classes for managing keyword rules


### PR DESCRIPTION
New model_blender rules have been added for handling dates and times, with initial testing done using:

`strun calwebb_image3.cfg jw87600-o004_20190518t040438_image3_001_asn.json
`

This addresses #3548.