### PR TITLE
move get_wavelengths to lib

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -11,7 +11,7 @@ from ..datamodels import dqflags
 from ..assign_wcs import niriss         # for specifying spectral order number
 from ..assign_wcs.util import wcs_bbox_from_shape
 from ..lib import pipe_utils
-from ..master_background.expand_to_2d import get_wavelengths
+from ..lib.wcs_utils import get_wavelengths
 from . import extract1d
 from . import ifu
 from . import spec_wcs

--- a/jwst/lib/wcs_utils.py
+++ b/jwst/lib/wcs_utils.py
@@ -1,4 +1,6 @@
 import numpy as np
+from ..assign_wcs import niriss
+
 
 
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']

--- a/jwst/lib/wcs_utils.py
+++ b/jwst/lib/wcs_utils.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+
+WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
+
+
+def get_wavelengths(model, exp_type="", order=None):
+    """Read or compute wavelengths.
+
+    Parameters
+    ----------
+    model : `~jwst.datamodels.DataModel`
+        The input science data, or a slit from a
+        `~jwst.datamodels.MultiSlitModel`.
+
+    exp_type : str
+        The exposure type.  This is only needed to check whether the input
+        data are WFSS.
+
+    order : int
+        Spectral order number, for NIRISS SOSS only.
+
+    Returns
+    -------
+    wl_array : 2-D ndarray
+        An array of wavelengths corresponding to the data in `model`.
+    """
+
+    # Use the existing wavelength array, if there is one
+    if hasattr(model, "wavelength"):
+        wl_array = model.wavelength.copy()
+        got_wavelength = True                   # may be reset below
+    else:
+        wl_array = None
+    if (wl_array is None or len(wl_array) == 0 or
+        np.nanmin(wl_array) == 0. and np.nanmax(wl_array) == 0.):
+            got_wavelength = False
+            wl_array = None
+
+    # If no existing wavelength array, compute one
+    if hasattr(model.meta, "wcs") and not got_wavelength:
+
+        # Set up an appropriate WCS object
+        if hasattr(model.meta, "exposure") and model.meta.exposure.type == "NIS_SOSS":
+            wcs = niriss.niriss_soss_set_input(model, order)
+        else:
+            wcs = model.meta.wcs
+
+        # Evaluate the WCS on the grid of pixel indexes, capturing only the
+        # resulting wavelength values
+        shape = model.data.shape
+        grid = np.indices(shape[-2:], dtype=np.float64)
+
+        if exp_type in WFSS_EXPTYPES:
+            # We currently have to loop over pixels for WFSS data.
+            wl_array = np.zeros(shape[-2:], dtype=np.float64)
+            for j in range(shape[-2]):
+                for i in range(shape[-1]):
+                    # Keep wavelength; ignore RA and Dec
+                    wl_array[..., j, i] = wcs(i, j)[2]
+        else:
+            wl_array = wcs(grid[1], grid[0])[2]
+
+    return wl_array

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -5,7 +5,6 @@ import numpy as np
 from gwcs.wcstools import grid_from_bounding_box
 from .. import datamodels
 from .. assign_wcs import nirspec   # For NIRSpec IFU data
-from .. assign_wcs import niriss    # For NIRISS SOSS data
 from .. datamodels import dqflags
 from ..lib.wcs_utils import get_wavelengths
 

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -7,6 +7,7 @@ from .. import datamodels
 from .. assign_wcs import nirspec   # For NIRSpec IFU data
 from .. assign_wcs import niriss    # For NIRISS SOSS data
 from .. datamodels import dqflags
+from ..lib.wcs_utils import get_wavelengths
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -297,63 +298,3 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
                            .format(input.meta.exposure.type))
 
     return background
-
-
-def get_wavelengths(model, exp_type="", order=None):
-    """Read or compute wavelengths.
-
-    Parameters
-    ----------
-    model : `~jwst.datamodels.DataModel`
-        The input science data, or a slit from a
-        `~jwst.datamodels.MultiSlitModel`.
-
-    exp_type : str
-        The exposure type.  This is only needed to check whether the input
-        data are WFSS.
-
-    order : int
-        Spectral order number, for NIRISS SOSS only.
-
-    Returns
-    -------
-    wl_array : 2-D ndarray
-        An array of wavelengths corresponding to the data in `model`.
-    """
-
-    # Use the existing wavelength array, if there is one
-    if hasattr(model, "wavelength"):
-        wl_array = model.wavelength.copy()
-        got_wavelength = True                   # may be reset below
-    else:
-        wl_array = None
-    if (wl_array is None or len(wl_array) == 0 or
-        np.nanmin(wl_array) == 0. and np.nanmax(wl_array) == 0.):
-            got_wavelength = False
-            wl_array = None
-
-    # If no existing wavelength array, compute one
-    if hasattr(model.meta, "wcs") and not got_wavelength:
-
-        # Set up an appropriate WCS object
-        if hasattr(model.meta, "exposure") and model.meta.exposure.type == "NIS_SOSS":
-            wcs = niriss.niriss_soss_set_input(model, order)
-        else:
-            wcs = model.meta.wcs
-
-        # Evaluate the WCS on the grid of pixel indexes, capturing only the
-        # resulting wavelength values
-        shape = model.data.shape
-        grid = np.indices(shape[-2:], dtype=np.float64)
-
-        if exp_type in WFSS_EXPTYPES:
-            # We currently have to loop over pixels for WFSS data.
-            wl_array = np.zeros(shape[-2:], dtype=np.float64)
-            for j in range(shape[-2]):
-                for i in range(shape[-1]):
-                    # Keep wavelength; ignore RA and Dec
-                    wl_array[..., j, i] = wcs(i, j)[2]
-        else:
-            wl_array = wcs(grid[1], grid[0])[2]
-
-    return wl_array

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -4,7 +4,7 @@ from astropy import units as u
 
 from .. import datamodels
 from .. datamodels import dqflags
-from .. master_background import expand_to_2d
+from .. lib.wcs_utils import get_wavelengths
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -670,15 +670,13 @@ class DataSet():
 
             # Compute a 2-D grid of conversion factors, as a function of wavelength
             if isinstance(self.input, datamodels.MultiSlitModel):
-                wl_array = expand_to_2d.get_wavelengths(
-                                self.input.slits[self.slitnum],
-                                self.input.meta.exposure.type,
-                                order)
+                wl_array = get_wavelengths(self.input.slits[self.slitnum],
+                                           self.input.meta.exposure.type,
+                                           order)
             else:
-                wl_array = expand_to_2d.get_wavelengths(
-                                self.input,
-                                self.input.meta.exposure.type,
-                                order)
+                wl_array = get_wavelengths(self.input,
+                                           self.input.meta.exposure.type,
+                                           order)
 
             wl_array[np.isnan(wl_array)] = -1.
             conv_2d = np.interp(wl_array, waves, relresps, left=np.NaN, right=np.NaN)


### PR DESCRIPTION
Resolves #3553

This PR copies the `get_wavelength` function verbatim to `lib/wcs_utils.py` in order to fix an import error and allow tests to run. It may need to be cleaned and generalized in a later PR.