### PR TITLE
Fix crashes in skymatch when some footprints almost entirely overlap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,10 @@
 ami
 ---
 
-- Fixed indentation bug in ami_analyze, so now all results are sufficiently 
-  close to the results of the stand-alone prototype. Other modifications include 
-  minor tweaks to more closely match those in the prototype code: changed some of 
-  initial values of the estimation parameters, and the filtering routine 
+- Fixed indentation bug in ami_analyze, so now all results are sufficiently
+  close to the results of the stand-alone prototype. Other modifications include
+  minor tweaks to more closely match those in the prototype code: changed some of
+  initial values of the estimation parameters, and the filtering routine
   arguments.  [#3487]
 
 - Updated ami_analyze.cfg to use default value of zero for rotation. [#3520]
@@ -93,6 +93,11 @@ refpix
 - Fixed a bug where pixeldq arrays were being transformed from DMS to detector
   coordinates for every group instead of just once
 
+skymatch
+--------
+
+- Improved reliability when matching sky in images with very close sky
+  footprints. [#3557]
 
 stpipe
 ------

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -681,15 +681,24 @@ class SkyGroup:
 
         Returns
         -------
-        polygon : SphericalPolygon
+        intersect_poly : SphericalPolygon
             A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `SkyImage` and `skyimage`.
 
         """
         if isinstance(skyimage, (SkyImage, SkyGroup)):
-            return self._polygon.intersection(skyimage.polygon)
+            other = skyimage.polygon
         else:
-            return self._polygon.intersection(skyimage)
+            other = skyimage
+
+        pts1 = np.sort(list(self._polygon.points)[0], axis=0)
+        pts2 = np.sort(list(other.points)[0], axis=0)
+        if np.allclose(pts1, pts2, rtol=0, atol=5e-9):
+            intersect_poly = self._polygon.copy()
+        else:
+            intersect_poly = self._polygon.intersection(other)
+        return intersect_poly
+
 
     def _update_bounding_polygon(self):
         polygons = [im.polygon for im in self._images]


### PR DESCRIPTION
This PR essentially re-implements enhancement in `stsci.skypac` in https://github.com/spacetelescope/stsci.skypac/pull/49 