### PR TITLE
Add test to make sure submodules are importable

### DIFF
--- a/jwst/steps.py
+++ b/jwst/steps.py
@@ -1,47 +1,10 @@
-from . import datamodels
-from . import ami
-from . import assign_wcs
-from . import associations
-from . import background
-from . import combine_1d
-from . import coron
-from . import csv_tools
-from . import cube_build
-from . import cube_skymatch
-from . import dark_current
-from . import dq_init
-from . import emission
-from . import extract_1d
-from . import extract_2d
-from . import fits_generator
-from . import flatfield
-from . import fringe
-from . import guider_cds
-from . import imprint
-from . import ipc
-from . import jump
-from . import jwpsf
-from . import lastframe
-from . import linearity
-from . import mrs_imatch
-from . import outlier_detection
-from . import persistence
-from . import photom
-from . import pipeline
-from . import ramp_fitting
-from . import refpix
-from . import resample
-from . import reset
-from . import rscd
-from . import saturation
-from . import skymatch
-from . import source_catalog
-from . import srctype
-from . import stpipe
-from . import straylight
-from . import superbias
-# Requires non-standard modules and enviroment settings
-#from . import timeconversion
-from . import transforms
-from . import tweakreg
-from . import wfs_combine
+import importlib
+from pkgutil import iter_modules
+
+import jwst
+
+submodules = [mod for _, mod, ispkg in iter_modules(jwst.__path__) if ispkg]
+# timeconversion requires non-standard dependencies and enviroment settings
+submodules.remove('timeconversion')
+for module in submodules:
+    importlib.import_module("jwst." + module)

--- a/jwst/tests/test_infrastructure.py
+++ b/jwst/tests/test_infrastructure.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import importlib
+from pkgutil import iter_modules
+
 import pytest
 
 from .base_classes import (
@@ -110,3 +113,14 @@ class TestBaseJWSTTest(BaseJWSTTest):
         """
         files = self.data_glob('test_bias_drift', glob=glob_filter)
         assert len(files) in nfiles
+
+
+def test_submodules_can_be_imported():
+    """Make sure all package submodules can be imported"""
+    import jwst
+
+    submodules = [mod for _, mod, ispkg in iter_modules(jwst.__path__) if ispkg]
+    # Ignore timeconversion which has non-standard env vars and dependencies
+    submodules.remove('timeconversion')
+    for module in submodules:
+        importlib.import_module("jwst." + module)


### PR DESCRIPTION
Make sure error in #3553 does not happen again.  Putting the check that packages are importable in this repo, not just in the conda package recipe.

Companion to the actual fix #3556.

Also, since `steps.py` is just used as in the conda recipe as a smoke test, and since we are now doing it here as part of our unit tests, can we remove the module and that line in the conda recipe?

https://github.com/astroconda/astroconda-dev/blob/aaad924953d4e608afda22cba7b90f6e6de32a46/jwst/meta.yaml#L76

I would feel more comfortable doing the smoke test in the package instead of in the conda recipe.  @jhunkeler 

Also, it seems the only thing that imports `steps.py` is `cal_ver_steps.py`.  But it seems to do nothing with it (but has a `flake8` override).  And maybe we don't need `cal_ver_steps.py` either?  We are not using this at all in our deployments, are we @hbushouse?