### PR TITLE
JP-741 Customize reffile prefetch

### DIFF
--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -42,6 +42,8 @@ class Coron3Pipeline(Pipeline):
         'resample': resample_step.ResampleStep
     }
 
+    prefetch_references = False
+
     def process(self, input):
         """Primary method for performing pipeline."""
         self.log.info('Starting calwebb_coron3 ...')
@@ -72,6 +74,9 @@ class Coron3Pipeline(Pipeline):
             self.log.error(err_str1)
             self.log.error('Calwebb_coron3 processing will be aborted')
             return
+
+        for member in psf_files + targ_files:
+            self.prefetch(member)
 
         # Assemble all the input psf files into a single ModelContainer
         psf_models = datamodels.ModelContainer()

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -69,12 +69,11 @@ class Pipeline(Step):
 
             setattr(self, key, new_step)
 
-        self.reference_file_types = self._collect_active_reftypes()
-
-    def _collect_active_reftypes(self):
+    @property
+    def reference_file_types(self):
         """Collect the list of all reftypes for child Steps that are not skipped.
-        Overridden reftypes are included but handled normally later by the Pipeline
-        version of the get_ref_override() method defined below.
+        Overridden reftypes are included but handled normally later by the
+        Pipeline version of the get_ref_override() method defined below.
         """
         return [reftype for step in self._unskipped_steps
                 for reftype in step.reference_file_types]

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -363,14 +363,6 @@ class Step():
             self.set_primary_input(args[0])
 
         try:
-            # prefetch truly occurs at the Pipeline (or subclass) level.
-            if (
-                    len(args) and len(self.reference_file_types) and
-                    not self.skip and
-                    self.prefetch_references
-            ):
-                self._precache_references(args[0])
-
             # Default output file configuration
             if self.output_file is not None:
                 self.save_results = True
@@ -396,6 +388,8 @@ class Step():
                 self.log.info('Step skipped.')
                 step_result = args[0]
             else:
+                if self.prefetch_references:
+                    self.prefetch(*args)
                 try:
                     step_result = self.process(*args)
                 except TypeError as e:
@@ -479,6 +473,15 @@ class Step():
         return step_result
 
     __call__ = run
+
+    def prefetch(self, *args):
+        """Prefetch reference files,  nominally called when
+        self.prefetch_references is True.  Can be called explictly
+        when self.prefetch_refences is False.
+        """
+        # prefetch truly occurs at the Pipeline (or subclass) level.
+        if len(args) and len(self.reference_file_types) and not self.skip:
+            self._precache_references(args[0])
 
     def process(self, *args):
         """


### PR DESCRIPTION
Some members of a coron3 association should not be processed / prefetched.

Modified step.py to expose a `.prefetch()` method which is called just prior to
`.process()` IF `.prefetch_references == True`.   This is the default.

If `.prefetch_references == False`,  `.prefetch()` can still be called explicitly
within `.process()` if needed,  as is done here for `calwebb_coron3`.

To improve customization, changed `Pipeline.reference_file_types`, once defined
in __init__() as an attribute, into a `@property` which is deferred until needed.

Resolves #3549.