### PR TITLE
JP-326 Improve error message for AMI _calints input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ ami
 
 - Updated ami_analyze.cfg to use default value of zero for rotation. [#3520]
 
+- ``ami_analyze`` now emits a RuntimeError if the input is _calints or if a
+  throughput reference file cannot be found.  [#3567]
+
 assign_wcs
 ------------
 

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -38,31 +38,35 @@ class AmiAnalyzeStep(Step):
         self.log.info('Initial rotation guess = %g deg', rotate)
 
         # Open the input data model
-        with datamodels.ImageModel(input) as input_model:
+        try:
+            with datamodels.ImageModel(input) as input_model:
 
-            # Get the name of the filter throughput reference file to use
-            self.filter_ref_name = self.get_reference_file(input_model,
-                                   'throughput')
-            self.log.info('Using filter throughput reference file %s',
-                           self.filter_ref_name)
+                # Get the name of the filter throughput reference file to use
+                throughput_reffile = self.get_reference_file(input_model,
+                                       'throughput')
+                self.log.info('Using filter throughput reference file %s',
+                               throughput_reffile)
 
-            # Check for a valid reference file
-            if self.filter_ref_name == 'N/A':
-                self.log.warning('No THROUGHPUT reference file found')
-                self.log.warning('AMI analyze step will be skipped')
-                result = input_model.copy()
-                result.meta.cal_step.ami_analyze = 'SKIPPED'
-                return result
+                # Check for a valid reference file
+                if throughput_reffile == 'N/A':
+                    self.log.warning('No THROUGHPUT reference file found')
+                    self.log.warning('AMI analyze step will be skipped')
+                    raise RuntimeError("No throughput reference file found. "
+                                       "ami_analyze cannot continue.")
 
-            # Open the filter throughput reference file
-            filter_model = datamodels.ThroughputModel(self.filter_ref_name)
+                # Open the filter throughput reference file
+                throughput_model = datamodels.ThroughputModel(throughput_reffile)
 
-            # Do the LG analysis on the input image
-            result = ami_analyze.apply_LG(input_model, filter_model,
-                                          oversample, rotate)
+                # Do the LG analysis on the input image
+                result = ami_analyze.apply_LG(input_model, throughput_model,
+                                              oversample, rotate)
 
-            # Close the reference file and update the step status
-            filter_model.close()
-            result.meta.cal_step.ami_analyze = 'COMPLETE'
+                # Close the reference file and update the step status
+                throughput_model.close()
+                result.meta.cal_step.ami_analyze = 'COMPLETE'
 
-        return result
+            return result
+
+        # If _calints CubeModel input, handle as RuntimeError
+        except ValueError as err:
+            raise RuntimeError("Only 2D ImageModel data can be processed.") from err

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -40,7 +40,8 @@ class AmiAnalyzeStep(Step):
         # Open the input data model
         try:
             with datamodels.ImageModel(input) as input_model:
-
+                if len(input_model.data.shape) != 2:
+                    raise RuntimeError("Only 2D ImageModel data can be processed.")
                 # Get the name of the filter throughput reference file to use
                 throughput_reffile = self.get_reference_file(input_model,
                                        'throughput')

--- a/jwst/ami/tests/test_ami_interface.py
+++ b/jwst/ami/tests/test_ami_interface.py
@@ -1,0 +1,45 @@
+import pytest
+
+from jwst import datamodels
+from jwst.ami import AmiAnalyzeStep
+import jwst
+
+
+def test_ami_analyze_calints_fail(tmpdir):
+    """Make sure ami_analyze fails if input is CubeModel (_calints)"""
+    input_file = str(tmpdir.join("ami_analyze_input.fits"))
+    model = datamodels.CubeModel((25, 19, 19))
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.filter = "F277W"
+    model.meta.observation.date = "2019-01-01"
+    model.meta.observation.time = "00:00:00"
+    model.save(input_file)
+    with pytest.raises(RuntimeError):
+        AmiAnalyzeStep.call(input_file)
+
+
+def test_ami_analyze_cube_fail():
+    """Make sure ami_analyze fails if input is CubeModel (_calints)"""
+    model = datamodels.ImageModel((25, 19, 19))
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.filter = "F277W"
+    model.meta.observation.date = "2019-01-01"
+    model.meta.observation.time = "00:00:00"
+    with pytest.raises(RuntimeError):
+        AmiAnalyzeStep.call(model)
+
+
+def test_ami_analyze_no_reffile_fail(monkeypatch):
+    """Make sure that ami_analyze fails if no throughput reffile is available"""
+    model = datamodels.ImageModel((19, 19))
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.filter = "F277W"
+    model.meta.observation.date = "2019-01-01"
+    model.meta.observation.time = "00:00:00"
+
+    def mockreturn(input_model, reftype):
+        return("N/A")
+    monkeypatch.setattr(jwst.stpipe.crds_client, 'get_reference_file', mockreturn)
+
+    with pytest.raises(RuntimeError):
+        AmiAnalyzeStep.call(model)


### PR DESCRIPTION
Resolves #2138.

It would be nice to have a more generalized Error class for `stpipe` steps and pipelines, but will require going through step-by-step and pipeline-by-pipeline and coming up with a consistent way of emitting errors by steps and handling them (if possible) in pipelines.  I will file an issue for this.