### PR TITLE
Update MultiExposure model to include all slit arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ datamodels
 - Added the new column "relresperror" to the "MiriImgPhotomModel" data
   model schema. [#3512]
 
+- Added all ``SlitModel`` data arrays to ``MultiExposureModel``, so that all input
+  arrays appear in the output of ``exp_to_source``. [#3572]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/multiexposure.py
+++ b/jwst/datamodels/multiexposure.py
@@ -62,7 +62,13 @@ class MultiExposureModel(DataModel):
             self.exposures[0].data = init.data
             self.exposures[0].dq = init.dq
             self.exposures[0].err = init.err
+            self.exposures[0].wavelength = init.wavelength
+            self.exposures[0].barshadow = init.barshadow
             self.exposures[0].area = init.area
+            self.exposures[0].var_poisson = init.var_poisson
+            self.exposures[0].var_rnoise = init.var_rnoise
+            self.exposures[0].var_flat = init.var_flat
+            self.exposures[0].pathloss = init.pathloss
             return
 
         super(MultiExposureModel, self).__init__(

--- a/jwst/datamodels/schemas/multiexposure.schema.yaml
+++ b/jwst/datamodels/schemas/multiexposure.schema.yaml
@@ -26,9 +26,27 @@ allOf:
               fits_hdu: ERR
               default: 0.0
               datatype: float32
+            wavelength:
+              fits_hdu: WAVELENGTH
+              datatype: float32
+            barshadow:
+              fits_hdu: BARSHADOW
+              datatype: float32
             area:
               fits_hdu: AREA
               default: 0.0
+              datatype: float32
+            var_poisson:
+              fits_hdu: VAR_POISSON
+              datatype: float32
+            var_rnoise:
+              fits_hdu: VAR_RNOISE
+              datatype: float32
+            var_flat:
+              fits_hdu: VAR_FLAT
+              datatype: float32
+            pathloss:
+              fits_hdu: PATHLOSS
               datatype: float32
             name:
               title: Name of the slit


### PR DESCRIPTION
Updated the MultiExposure model to include all possible Slit arrays, not just SCI, DQ, and ERR. The lack of arrays like WAVELENGTH in the output was causing problems in downstream steps in ``calwebb_spec3``.

Fixes #3521.