### PR TITLE
Fix assign_wcs error handling in calspec2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,10 @@ ami
 assign_wcs
 ------------
 
-- Fix a one pixel off problem with the Nirspec NRS2 WCS transforms. [#3473]
+- Fix a one pixel off problem with the NIRSpec NRS2 WCS transforms. [#3473]
+
+- Raise a ``ValueError`` if the FWCPOS keyword isn't found in input NIRISS
+  WFSS images. [#3574]
 
 combine_1d
 ----------
@@ -86,6 +89,9 @@ pipeline
 
 - ``calwebb_image2`` was changed to prevent 3D data from being sent to
   ``resample``. [#3544]
+
+- ``calwebb_spec2`` was changed to check for an error in ``assign_wcs`` processing
+  before executing the ``background`` step. [#3574]
 
 refpix
 ------

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -346,6 +346,8 @@ def wfss(input_model, reference_files):
 
     # This is the actual rotation from the input model
     fwcpos = input_model.meta.instrument.filter_position
+    if fwcpos is None:
+        raise ValueError('FWCPOS keyword value not found in input image')
 
     # sep the row and column grism models
     if 'R' in input_model.meta.instrument.filter[-1]:


### PR DESCRIPTION
Updated the ``calwebb_spec2`` flow so that errors in ``assign_wcs`` are checked and acted on before calling the ``background`` step, because for WFSS data the ``background`` step needs WCS info (which won't be there if ``assign_wcs`` aborted).

Also added a check for the presence of the FWCPOS keyword in the NIRISS WFSS processing and raise an error if it isn't there.

Fixes #3558 