### PR TITLE
Remove psutil dependency.  Use multiprocessing.cpu_count() instead.

### DIFF
--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -7,7 +7,6 @@ from ..lib import reffile_utils
 from . import twopoint_difference as twopt
 from . import yintercept as yint
 import multiprocessing
-import psutil
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -34,7 +33,7 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     if max_cores is None:
         numslices = 1
     else:
-        num_cores = psutil.cpu_count(logical = True)
+        num_cores = multiprocessing.cpu_count()
         log.info("Found %d possible cores to use for jump detection " % num_cores)
         if max_cores == 'quarter':
             numslices = num_cores // 4 or 1

--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,6 @@ setup(
         'jsonschema>=2.3,<=2.6',
         'numpy>=1.13',
         'photutils>=0.6',
-        'psutil',
         'scipy>=1.0',
         'spherical-geometry>=1.2',
         'stsci.image>=2.3',


### PR DESCRIPTION
This package dependency was added with `jump` multiprocessing support, but is not needed.  Use the built-in functionality of `multiprocessing` in the python core library instead.

This is an issue as `psutil` does not `pip install` properly on older versions of linux.  Tests fail because of a non-existing shared library:
```
E   ImportError: /lib64/libc.so.6: version `GLIBC_2.13' not found (required by /home/jdavies/miniconda3/envs/testtest/lib/python3.6/site-packages/psutil/_psutil_linux.cpython-36m-x86_64-linux-gnu.so)
```