### PR TITLE
JP-665 - fix spec2 processing of NRS_LAMP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ datamodels
 
 - Removed the enum list for the SUBPXPAT keyword to allow validation of any value. [#3616]
 
+pipeline
+--------
+
+- ``calwebb_spec2`` was changed to allow processing of exposures
+  with ``EXP_TYPE=NRS_LAMP.`` [#3603]
+
 
 0.13.3 (2019-06-04)
 ===================

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -4,10 +4,6 @@ from ..stpipe import Step
 from .. import datamodels
 from . import extract_2d
 
-import logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 
 __all__ = ["Extract2dStep"]
 
@@ -30,7 +26,6 @@ class Extract2dStep(Step):
 
     def process(self, input_model, *args, **kwargs):
         reference_file_names = {}
-        log.info('reference_file_names {}'.format(reference_file_names))
         for reftype in self.reference_file_types:
             reffile = self.get_reference_file(input_model, reftype)
             reference_file_names[reftype] = reffile if reffile else ""

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -4,6 +4,10 @@ from ..stpipe import Step
 from .. import datamodels
 from . import extract_2d
 
+import logging
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
 
 __all__ = ["Extract2dStep"]
 
@@ -26,6 +30,7 @@ class Extract2dStep(Step):
 
     def process(self, input_model, *args, **kwargs):
         reference_file_names = {}
+        log.info('reference_file_names {}'.format(reference_file_names))
         for reftype in self.reference_file_types:
             reffile = self.get_reference_file(input_model, reftype)
             reference_file_names[reftype] = reffile if reffile else ""

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -45,6 +45,7 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
             apply_wavecorr = False
             warnings.warn("WAVECORR reference file missing - skipping correction")
     else:
+        reffile = None
         apply_wavecorr = False
         log.info("Skipping wavecorr correction for EXP_TYPE {0}".format(exp_type))
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -233,7 +233,7 @@ class Spec2Pipeline(Pipeline):
             input = self.extract_2d(input)
         else:
             # Extract 2D sub-windows for NIRSpec slit and MSA
-            if exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_MSASPEC']:
+            if exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_MSASPEC', 'NRS_LAMP']:
                 input = self.extract_2d(input)
 
             # Apply flat-field correction


### PR DESCRIPTION
Resolves #3422 
Tested on the failing exposures.

`NRS_LAMP` exposures are supposed to be processed like NRS Fixed Slits. This means the zero-point wavelength correction can be applied as well using the `wavecorr` reference file for FS. Currently it is skipped because `NRS_LAMP` is not in the `rmap` for `wavecorr`.