### PR TITLE
Remove enum list for SUBPXPAT keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ datamodels
 
 - Changed PATTSIZE keyword data type from float to string. [#3606]
 
+- Removed the enum list for the SUBPXPAT keyword to allow validation of any value. [#3616]
+
 
 0.13.3 (2019-06-04)
 ===================

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -952,7 +952,6 @@ properties:
           subpixel_dither_pattern:
             title: subpixel dither pattern
             type: string
-            enum: [BOTH, SPATIAL, SPECTRAL, NONE]
             fits_keyword: SUBPXPAT
             blend_table: True
           spectral_position_number:


### PR DESCRIPTION
Removed the enum list in the core schema for the SUBPXPAT keyword. Many new values have been implemented in the front-ends recently and are still in flux. Hence the safest way to achieve validation for now is to have any enum list at all.

This addresses https://jira.stsci.edu/browse/JP-772

Resolves #3617.