### PR TITLE
Change MRS throughput threshold for assign_wcs

### DIFF
--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -422,8 +422,8 @@ def detector_to_abl(input_model, reference_files):
 
     with RegionsModel(reference_files['regions']) as f:
         allregions = f.regions.copy()
-        # Use the 50% throughput slice mask
-        regions=allregions[4,:,:]
+        # Use the 80% throughput slice mask
+        regions=allregions[7,:,:]
 
     label_mapper = selector.LabelMapperArray(regions)
     transforms = {}

--- a/jwst/tests_nightly/general/miri/test_miri_steps_single.py
+++ b/jwst/tests_nightly/general/miri/test_miri_steps_single.py
@@ -171,7 +171,7 @@ class TestMIRIWCSIFU(BaseJWSTTest):
         # Get the region file
         region = RegionsModel(crds_client.get_reference_file(result, 'regions'))
         # Choose the same plane as in the miri.py file (hardcoded for now).
-        regions = region.regions[4, :, :]
+        regions = region.regions[7, :, :]
 
         # inputs
         x, y = grid_from_bounding_box(result.meta.wcs.bounding_box)


### PR DESCRIPTION
Continued testing with simulated data and the new CDP-7 photometric reference files indicates that an 80% throughput threshold gives better performance for mosaiced data than the 50% threshold.  This pull request changes that default.