### PR TITLE
Update model blender to return strings instead of astropy Time objects

### DIFF
--- a/docs/jwst/model_blender/blender_rules.rst
+++ b/docs/jwst/model_blender/blender_rules.rst
@@ -30,7 +30,9 @@ includes
                       'mintime': mintime,
                       'maxtime': maxtime,
                       'mindate': mindate,
-                      'maxdate': maxdate}
+                      'maxdate': maxdate,
+		      'mindatetime': mindatetime,
+		      'maxdatetime': maxdatetime}
 
 The rules that should be referenced in the model schema definition are the
 keys defined for `jwst.model_blender.blender_rules.blender_funcs` listed

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -158,7 +158,9 @@ properties:
             title: "[yyyy-mm-dd] UTC date at end of exposure"
             fits_keyword: DATE-END
             blend_table: True
-            blend_rule: maxdate
+            # Despite what the title might lead you to believe, this keyword
+            # actually contains a full datetime string.
+            blend_rule: maxdatetime
           time_end:
             title: "[hh:mm:ss.sss] UTC time at end of exposure"
             type: string

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -4,10 +4,8 @@ properties:
     type: object
     properties:
       date:
-        anyOf:
-          - $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
-          - type: string
         title: "[yyyy-mm-ddThh:mm:ss.ss] UTC date file created"
+        type: string
         fits_keyword: DATE
         blend_table: True
       origin:
@@ -138,10 +136,8 @@ properties:
         type: object
         properties:
           date:
-            anyOf:
-              - $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
-              - type: string
             title: "[yyyy-mm-dd] UTC date at start of exposure"
+            type: string
             fits_keyword: DATE-OBS
             blend_table: True
             blend_rule: mindate
@@ -156,7 +152,7 @@ properties:
             title: "Date-time start of data acquisition"
             fits_keyword: DATE-BEG
             blend_table: True
-            blend_rule: mindate
+            blend_rule: mindatetime
           date_end:
             type: string
             title: "[yyyy-mm-dd] UTC date at end of exposure"

--- a/jwst/model_blender/blendrules.py
+++ b/jwst/model_blender/blendrules.py
@@ -84,14 +84,24 @@ def last(items):
     return None
 
 def mindate(items):
-    """Return the minimum time from a list of time strings."""
-    time_list = Time(items)
-    return time_list.min()
+    """Return the minimum date from a list of date strings in yyyy-mm-dd format."""
+    time_list = Time(items, format="iso", in_subfmt="date", out_subfmt="date")
+    return str(time_list.min())
 
 def maxdate(items):
-    """Return the maximum time from a list of time strings."""
-    time_list = Time(items)
-    return time_list.max()
+    """Return the maximum date from a list of date strings in yyyy-mm-dd format."""
+    time_list = Time(items, format="iso", in_subfmt="date", out_subfmt="date")
+    return str(time_list.max())
+
+def mindatetime(items):
+    """Return the minimum datetime from a list of datetime strings in ISO-8601 format."""
+    time_list = Time(items, format="isot")
+    return str(time_list.min())
+
+def maxdatetime(items):
+    """Return the maximum datetime from a list of datetime strings in ISO-8601 format."""
+    time_list = Time(items, format="isot")
+    return str(time_list.max())
 
 def mintime(items):
     times = [_isotime(time_str) for time_str in items]
@@ -123,7 +133,9 @@ blender_funcs = {'first': first,
                  'mintime': mintime,
                  'maxtime': maxtime,
                  'mindate': mindate,
-                 'maxdate': maxdate}
+                 'maxdate': maxdate,
+                 'mindatetime': mindatetime,
+                 'maxdatetime': maxdatetime}
 
 
 # Classes for managing keyword rules

--- a/jwst/model_blender/tests/test_blend.py
+++ b/jwst/model_blender/tests/test_blend.py
@@ -12,8 +12,9 @@ start_times = [57877.00359994354, 57877.0168373584, 57877.03126958496]
 exp_times = [107.3676, 107.3676, 107.3676]
 end_times = [57877.0048426241, 57877.01808003896, 57877.03251226551]
 filenames = ['image1_cal.fits', 'image2_cal.fits', 'image3_cal.fits']
-dates = ['2017-11-30T13:52:20.367', '2017-11-11T15:14:29.176',
-         '2017-11-11T15:15:06.118']
+datetimes = ['2017-11-30T13:52:20.367', '2017-11-11T15:14:29.176',
+             '2017-11-11T15:15:06.118']
+dates = ['2017-11-30', '2017-11-11', '2017-12-10']
 instrument_names = ['NIRCAM'] * 3
 
 
@@ -28,13 +29,17 @@ def setup():
                     'meta.exposure.end_time': end_times,
                     'meta.filename': filenames,
                     'meta.instrument.name': instrument_names,
-                    'meta.date': dates}
+                    'meta.date': datetimes,
+                    'meta.observation.date': dates,
+                    'meta.observation.date_beg': datetimes}
     OUTPUT_VALUES = {'meta.exposure.start_time': start_times[0],
                     'meta.exposure.exposure_time': np.sum(exp_times),
                     'meta.exposure.end_time': end_times[-1],
                     'meta.filename': filenames[0],
                     'meta.instrument.name': instrument_names[0],
-                    'meta.date': dates[0]}
+                    'meta.date': datetimes[0],
+                    'meta.observation.date': dates[1],
+                    'meta.observation.date_beg': datetimes[1]}
 
     for i, tfile in enumerate(TMP_FILES):
         for attr in INPUT_VALUES:


### PR DESCRIPTION
https://jira.stsci.edu/browse/JP-778

This PR introduces two additional blender rules, `mindatetime` and `maxdatetime`, and has all of the date/time rules return strings in the appropriate format instead of astropy Time objects.

This may be controversial, but I'm also dropping support for the asdf time schema in meta.date and meta.observation.date.  As far as I know there is only one permissible format, so I'm not sure why the schema needs to allow everything in asdf/time/time-1.0.0.  This is relevant because the model blender sees that meta.observation.date can be an object with its own nested fields, so it ignores the blend_* settings (like it does with any object).

Anyway, with these changes the test_ami_pipeline regression test no longer crashes -- it still doesn't pass, but that doesn't seem related.

Resolves #3621.