### PR TITLE
Changed good_bits from 4 to 6 to exclude SATURATION and JUMP_DET flags (JP-765)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,11 @@ exp_to_source
 
 - Removed the enum list for the SUBPXPAT keyword to allow validation of any value. [#3616]
 
+outlier_detection
+-----------------
+
+- Changed default value of good_pixel from 4 to 6 [#3638]
+
 pipeline
 --------
 
@@ -38,6 +43,13 @@ pipeline
 - ``calwebb_tso3`` was changed to allow processing of exposures
   with ``EXP_TYPE=MIR_IMAGE.`` [#3633]
 
+- Changed the default value of good_pixel from 4 to 6 for all outlier
+  detection steps and both resample steps [#3638]
+
+resample
+--------
+
+- Changed default value of good_pixel from 4 to 6 [#3638]
 
 0.13.3 (2019-06-04)
 ===================

--- a/jwst/outlier_detection/outlier_detection_scaled_step.py
+++ b/jwst/outlier_detection/outlier_detection_scaled_step.py
@@ -31,7 +31,7 @@ class OutlierDetectionScaledStep(Step):
         scale = string(default='0.5 0.4')
         backg = float(default=0.0)
         save_intermediate_results = boolean(default=False)
-        good_bits = integer(default=4)
+        good_bits = integer(default=6)
     """
 
     def process(self, input):

--- a/jwst/outlier_detection/outlier_detection_stack_step.py
+++ b/jwst/outlier_detection/outlier_detection_stack_step.py
@@ -41,7 +41,7 @@ class OutlierDetectionStackStep(Step):
         backg = float(default=0.0)
         save_intermediate_results = boolean(default=False)
         resample_data = boolean(default=False)
-        good_bits = integer(default=4)
+        good_bits = integer(default=6)
     """
 
     def process(self, input):

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -59,7 +59,7 @@ class OutlierDetectionStep(Step):
         backg = float(default=0.0)
         save_intermediate_results = boolean(default=False)
         resample_data = boolean(default=True)
-        good_bits = integer(default=4)
+        good_bits = integer(default=6)
         scale_detection = boolean(default=False)
         search_output_file = boolean(default=False)
     """

--- a/jwst/pipeline/outlier_detection.cfg
+++ b/jwst/pipeline/outlier_detection.cfg
@@ -14,4 +14,4 @@ scale = '0.5 0.4'
 backg = 0.0        
 save_intermediate_results = False
 resample_data = True
-good_bits = 4
+good_bits = 6

--- a/jwst/pipeline/outlier_detection_scaled.cfg
+++ b/jwst/pipeline/outlier_detection_scaled.cfg
@@ -13,4 +13,4 @@ snr = '4.0 3.0'
 scale = '0.5 0.4'
 backg = 0.0        
 save_intermediate_results = False
-good_bits = 4
+good_bits = 6

--- a/jwst/pipeline/outlier_detection_stack.cfg
+++ b/jwst/pipeline/outlier_detection_stack.cfg
@@ -14,4 +14,4 @@ scale = '0.5 0.4'
 backg = 0.0        
 save_intermediate_results = False
 resample_data = False
-good_bits = 4
+good_bits = 6

--- a/jwst/pipeline/outlier_detection_tso.cfg
+++ b/jwst/pipeline/outlier_detection_tso.cfg
@@ -14,4 +14,4 @@ scale = '0.5 0.4'
 backg = 0.0        
 save_intermediate_results = False
 resample_data = False
-good_bits = 4
+good_bits = 6

--- a/jwst/pipeline/resample.cfg
+++ b/jwst/pipeline/resample.cfg
@@ -6,6 +6,6 @@ weight_type = 'exptime'
 pixfrac = 1.0
 kernel = 'square'
 fillval = 'INDEF'
-good_bits = 4
+good_bits = 6
 blendheaders = True
 suffix = 'i2d'

--- a/jwst/pipeline/resample_spec.cfg
+++ b/jwst/pipeline/resample_spec.cfg
@@ -6,6 +6,6 @@ weight_type = 'exptime'
 pixfrac = 1.0
 kernel = 'square'
 fillval = 'INDEF'
-good_bits = 4
+good_bits = 6
 blendheaders = True
 suffix = 's2d'

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -30,7 +30,7 @@ class ResampleStep(Step):
         kernel = string(default=None)
         fillval = string(default=None)
         weight_type = option('exptime', default=None)
-        good_bits = integer(min=0, default=4)
+        good_bits = integer(min=0, default=6)
         single = boolean(default=False)
         blendheaders = boolean(default=True)
     """


### PR DESCRIPTION
Pixels with just either of these flags set won't be excluded from weight calculation.