### PR TITLE
Remove trailing spaces and fix indentation issues in schema files

### DIFF
--- a/jwst/datamodels/schemas/container.schema.yaml
+++ b/jwst/datamodels/schemas/container.schema.yaml
@@ -4,7 +4,7 @@ properties:
     type: object
     properties:
       table_name:
-        title: Name of ASN table 
+        title: Name of ASN table
         type: string
         fits_keyword: ASNTAB
       pool_name:

--- a/jwst/datamodels/schemas/extract1dimage.schema.yaml
+++ b/jwst/datamodels/schemas/extract1dimage.schema.yaml
@@ -11,7 +11,7 @@ allOf:
     name:
       title: Name of the slit
       type: string
-      fits_keyword: SLTNAME 
+      fits_keyword: SLTNAME
       fits_hdu: SCI
     spectral_order:
       title: Spectral order number

--- a/jwst/datamodels/schemas/guider_cal.schema.yaml
+++ b/jwst/datamodels/schemas/guider_cal.schema.yaml
@@ -106,7 +106,7 @@ allOf:
       default: 0
       ndim: 2
       datatype: uint32
-    planned_star_table: 
+    planned_star_table:
       title: Planned reference star table
       fits_hdu: Planned Reference Stars
       datatype:
@@ -130,7 +130,7 @@ allOf:
         datatype: float64
       - name: count_rate_uncert
         datatype: float64
-    flight_star_table: 
+    flight_star_table:
       title: Flight reference star table
       fits_hdu: Flight Reference Stars
       datatype:
@@ -170,13 +170,13 @@ allOf:
         datatype: float64
       - name: HGA_motion
         datatype: int16
-    centroid_table: 
+    centroid_table:
       title: Centroid packet table
       fits_hdu: FGS Centroid Packet
       datatype:
-      - name: observatory_time   
+      - name: observatory_time
         datatype: [ascii, 23]
-      - name: centroid_time   
+      - name: centroid_time
         datatype: [ascii, 23]
       - name: guide_star_position_x
         datatype: float64
@@ -212,7 +212,7 @@ allOf:
       title: Track subarray data table
       fits_hdu: Track subarray table
       datatype:
-      - name: observatory_time   
+      - name: observatory_time
         datatype: [ascii, 23]
       - name: x_corner
         datatype: float64

--- a/jwst/datamodels/schemas/guider_raw.schema.yaml
+++ b/jwst/datamodels/schemas/guider_raw.schema.yaml
@@ -106,7 +106,7 @@ allOf:
       default: 0
       ndim: 2
       datatype: uint32
-    planned_star_table: 
+    planned_star_table:
       title: Planned reference star table
       fits_hdu: Planned Reference Stars
       datatype:
@@ -130,7 +130,7 @@ allOf:
         datatype: float64
       - name: count_rate_uncert
         datatype: float64
-    flight_star_table: 
+    flight_star_table:
       title: Flight reference star table
       fits_hdu: Flight Reference Stars
       datatype:
@@ -170,13 +170,13 @@ allOf:
         datatype: float64
       - name: HGA_motion
         datatype: int16
-    centroid_table: 
+    centroid_table:
       title: Centroid packet table
       fits_hdu: FGS Centroid Packet
       datatype:
-      - name: observatory_time   
+      - name: observatory_time
         datatype: [ascii, 23]
-      - name: centroid_time   
+      - name: centroid_time
         datatype: [ascii, 23]
       - name: guide_star_position_x
         datatype: float64
@@ -212,7 +212,7 @@ allOf:
       title: Track subarray data table
       fits_hdu: Track subarray table
       datatype:
-      - name: observatory_time   
+      - name: observatory_time
         datatype: [ascii, 23]
       - name: x_corner
         datatype: float64

--- a/jwst/datamodels/schemas/lev3_prod.schema.yaml
+++ b/jwst/datamodels/schemas/lev3_prod.schema.yaml
@@ -4,34 +4,34 @@ properties:
     type: object
     properties:
       resample:
-          title: Metadata describing resampling done using this data
-          type: object
-          properties:
-            pointings:
-              title: Number of pointings included in resampled product
-              type: integer
-              fits_keyword:  NDRIZ
-            product_exposure_time:
-              title: Total exposure time for product
-              type: number
-              fits_keyword: TEXPTIME
-            weight_type:
-              title: Type of drizzle weighting to use in resampling input
-              type: string
-              enum: ['exptime','error']
-              fits_keyword: WHT_TYPE
+        title: Metadata describing resampling done using this data
+        type: object
+        properties:
+          pointings:
+            title: Number of pointings included in resampled product
+            type: integer
+            fits_keyword: NDRIZ
+          product_exposure_time:
+            title: Total exposure time for product
+            type: number
+            fits_keyword: TEXPTIME
+          weight_type:
+            title: Type of drizzle weighting to use in resampling input
+            type: string
+            enum: [exptime, error]
+            fits_keyword: WHT_TYPE
       tweakreg_catalog:
-          type: object
-          properties:
-            filename:
-              title: Output tweakreg catalog filename
-              type: string
-              fits_keyword: TCATFILE
+        type: object
+        properties:
+          filename:
+            title: Output tweakreg catalog filename
+            type: string
+            fits_keyword: TCATFILE
       source_catalog:
-          type: object
-          properties:
-            filename:
-              title: Output source catalog filename
-              type: string
-              fits_keyword: SCATFILE
+        type: object
+        properties:
+          filename:
+            title: Output source catalog filename
+            type: string
+            fits_keyword: SCATFILE
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/multiextract1d.schema.yaml
+++ b/jwst/datamodels/schemas/multiextract1d.schema.yaml
@@ -15,7 +15,7 @@ allOf:
           name:
             title: Name of the slit
             type: string
-            fits_keyword: SLTNAME 
+            fits_keyword: SLTNAME
             fits_hdu: SCI
           spectral_order:
             title: Spectral order number


### PR DESCRIPTION
This removes trailing spaces and fixes some indentation inconsistencies in the schema files.  The schema editor produces YAML without these quirks, so fixing them in a separate PR will make the diff of schema changes due to the keyword dictionary sync a little cleaner.