### PR TITLE
set source_id correctly in extract_2d

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -361,7 +361,7 @@ def get_open_slits(input_model, reference_files=None, slit_y_range=[-.55, .55]):
     elif exp_type == "nrs_fixedslit":
         slits = get_open_fixed_slits(input_model, slit_y_range)
     elif exp_type == "nrs_brightobj":
-        slits = [Slit('S1600A1', 3, 0, 0, 0, slit_y_range[0], slit_y_range[1], 5)]
+        slits = [Slit('S1600A1', 3, 0, 0, 0, slit_y_range[0], slit_y_range[1], 5, 4)]
     elif exp_type == "nrs_lamp":
         slits = get_open_fixed_slits(input_model, slit_y_range)
     else:

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -160,8 +160,9 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
     output_model.xsize = (xhi - xlo)
     output_model.ystart = ylo + 1 # FITS 1-indexed
     output_model.ysize = (yhi - ylo)
+    output_model.source_id = int(slit.source_id)
     if output_model.meta.exposure.type.lower() in ['nrs_msaspec', 'nrs_autoflat']:
-        output_model.source_id = int(slit.source_id)
+        #output_model.source_id = int(slit.source_id)
         output_model.source_name = slit.source_name
         output_model.source_alias = slit.source_alias
         output_model.stellarity = float(slit.stellarity)


### PR DESCRIPTION
This fixes an issue discovered in testing #3643 - the source_id of a fixed slit is lost in extract_2d and reset to the default value of 0.