### PR TITLE
Confirm Completion Keyword Assignment for Flat Field Correction

### DIFF
--- a/jwst/flatfield/tests/test_flatfield.py
+++ b/jwst/flatfield/tests/test_flatfield.py
@@ -53,7 +53,7 @@ def test_flatfield_step_interface(instrument, exptype):
 
     assert (result.data == data.data).all()
     assert result.var_flat.shape == shape
-
+    assert result.meta.cal_step.flat_field == 'COMPLETE'
 
 def exptypes():
     """Generate NRS EXPTYPES from the schema enum, removing spec types"""


### PR DESCRIPTION
This PR is a part of the INS migration of unit tests to the pipeline. This test was a request by the NIRSPEC team to check the completion of the flat field step. I added an assertion to an already existing unit test that just confirms the keyword is value `COMPLETE`. If it's necessary, I can make a separate test.

Resolves #3532.