### PR TITLE
JP-785 Modify extract_1d to correctly handle SourceModelContainer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ datamodels
 
 extract_1d
 ----------
-- Checks for input from a SourceModelContainer. [#3648]
+- Checks for input from a SourceModelContainer. [#3649]
 
 exp_to_source
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,13 +16,17 @@ associations
 - Generate will no longer merge Level2 associations by default [#3631]
 
 - Prevent inclusion of data files with exp_type="NIS_EXTCAL" in the association files [#3611]
-=======
+
 datamodels
 ----------
 
 - Changed PATTSIZE keyword data type from float to string. [#3606]
 
 - Added enumeration of allowed values of ``FXD_SLIT`` to the core schema. [#3584]
+
+extract_1d
+----------
+- Checks for input from a SourceModelContainer. [#3648]
 
 exp_to_source
 -------------

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2684,7 +2684,8 @@ class ImageExtractModel(ExtractBase):
 
 
 def run_extract1d(input_model, refname, smoothing_length, bkg_order,
-                  log_increment, subtract_background, apply_nod_offset):
+                  log_increment, subtract_background, apply_nod_offset,
+                  was_source_model=False):
     """Extract 1-D spectra.
 
     This just reads the reference file (if any) and calls do_extract1d.
@@ -2721,6 +2722,11 @@ def run_extract1d(input_model, refname, smoothing_length, bkg_order,
         reference file (or the default position, if there is no reference
         file) will be shifted to account for nod and/or dither offset.
 
+    was_source_model : bool
+        True if and only if `input_model` is actually one SlitModel
+        obtained by iterating over a SourceModelContainer.  The default
+        is False.
+
     Returns
     -------
     output_model : data model
@@ -2740,7 +2746,7 @@ def run_extract1d(input_model, refname, smoothing_length, bkg_order,
     output_model = do_extract1d(input_model, ref_dict,
                                 smoothing_length, bkg_order,
                                 log_increment, subtract_background,
-                                apply_nod_offset)
+                                apply_nod_offset, was_source_model)
 
     return output_model
 
@@ -2782,7 +2788,8 @@ def ref_dict_sanity_check(ref_dict):
 
 def do_extract1d(input_model, ref_dict, smoothing_length=None,
                  bkg_order=None, log_increment=50,
-                 subtract_background=None, apply_nod_offset=None):
+                 subtract_background=None, apply_nod_offset=None,
+                 was_source_model=False):
     """Extract 1-D spectra.
 
     Parameters
@@ -2817,6 +2824,11 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
         If True, the target and background positions specified in the
         reference file (or the default position, if there is no reference
         file) will be shifted to account for nod and/or dither offset.
+
+    was_source_model : bool
+        True if and only if `input_model` is actually one SlitModel
+        obtained by iterating over a SourceModelContainer.  The default
+        is False.
 
     Returns
     -------
@@ -2854,10 +2866,13 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                         "so apply_nod_offset will be set to False",
                         input_model.meta.target.source_type)
 
-    if isinstance(input_model, datamodels.MultiSlitModel) or \
-       isinstance(input_model, datamodels.MultiProductModel):
+    if (was_source_model or
+        isinstance(input_model, datamodels.MultiSlitModel) or
+        isinstance(input_model, datamodels.MultiProductModel)):
 
-        if isinstance(input_model, datamodels.MultiSlitModel):
+        if was_source_model:            # from a SourceModelContainer?
+            slits = [input_model]
+        elif isinstance(input_model, datamodels.MultiSlitModel):
             slits = input_model.slits
         else:                           # MultiProductModel
             slits = input_model.products

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -92,16 +92,23 @@ class Extract1dStep(Step):
         # Open the input and figure out what type of model it is
         input_model = datamodels.open(input)
 
+        was_source_model = False                 # default value
         if isinstance(input_model, datamodels.CubeModel):
             # It's a 3-D multi-integration model
             self.log.debug('Input is a CubeModel for a multiple integ. file')
         elif isinstance(input_model, datamodels.ImageModel):
             # It's a single 2-D image
             self.log.debug('Input is an ImageModel')
+        elif isinstance(input_model, datamodels.SourceModelContainer):
+            self.log.debug('Input is a SourceModelContainer')
+            was_source_model = True
         elif isinstance(input_model, datamodels.ModelContainer):
             self.log.debug('Input is a ModelContainer')
         elif isinstance(input_model, datamodels.MultiSlitModel):
             self.log.debug('Input is a MultiSlitModel')
+        elif isinstance(input_model, datamodels.MultiExposureModel):
+            self.log.warning('Input is a MultiExposureModel, '
+                             'which is not currently supported')
         elif isinstance(input_model, datamodels.MultiProductModel):
             self.log.debug('Input is a MultiProductModel')
         elif isinstance(input_model, datamodels.IFUCubeModel):
@@ -125,6 +132,7 @@ class Extract1dStep(Step):
                 self.log.debug("Input contains %d items", len(input_model))
                 result = datamodels.ModelContainer()
                 for model in input_model:
+                    # This is a flag for do_extract1d.
                     if model.meta.exposure.type in extract.WFSS_EXPTYPES:
                         ref_file = 'N/A'
                         self.log.info('No EXTRACT1D reference file '
@@ -139,7 +147,8 @@ class Extract1dStep(Step):
                                                  self.bkg_order,
                                                  self.log_increment,
                                                  self.subtract_background,
-                                                 self.apply_nod_offset)
+                                                 self.apply_nod_offset,
+                                                 was_source_model=was_source_model)
                     # Set the step flag to complete in each MultiSpecModel
                     temp.meta.cal_step.extract_1d = 'COMPLETE'
                     result.append(temp)
@@ -159,7 +168,8 @@ class Extract1dStep(Step):
                                                self.bkg_order,
                                                self.log_increment,
                                                self.subtract_background,
-                                               self.apply_nod_offset)
+                                               self.apply_nod_offset,
+                                               was_source_model=was_source_model)
                 # Set the step flag to complete
                 result.meta.cal_step.extract_1d = 'COMPLETE'
             else:
@@ -179,7 +189,8 @@ class Extract1dStep(Step):
                                            self.bkg_order,
                                            self.log_increment,
                                            self.subtract_background,
-                                           self.apply_nod_offset)
+                                           self.apply_nod_offset,
+                                           was_source_model=False)
             # Set the step flag to complete
             result.meta.cal_step.extract_1d = 'COMPLETE'
 


### PR DESCRIPTION
`extract_1d` now treats each `SlitModel` from an input `SourceModelContainer` as a one-element list of `SlitModels`.  These are then processed by the section of extract.py as for `MultiSlitModels`.

Note that this PR does not close the issue, #3639, because currently `combine_1d` still cannot process the output of `extract_1d`. This problem appears to be related to incorrect handling of FITS bintable columns of type `uint32`.