### PR TITLE
Synchronize datamodels core schema with JWST Keyword Dictionary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,33 @@ datamodels
 
 - Added enumeration of allowed values of ``FXD_SLIT`` to the core schema. [#3584]
 
+- Changed ``WHT_TYPE`` keyword to ``RESWHT``. [#3653]
+
+- Add missing pattern/enum values to keyword_pband, keyword_pfilter, keyword_channel [#3653]
+
+- New keywords [#3653]
+   - ``DSETSTRT``
+   - ``NUMDSETS``
+   - ``DITHDIRC``
+   - ``DITHOPFR``
+   - ``DITHPNTS``
+   - ``MRSPRCHN``
+   - ``NDITHPTS``
+   - ``DWTSCL``
+   - ``DOUTUN``
+   - ``RESBITS``
+   - ``DFVAL``
+   - ``DPIXFR``
+   - ``DKERN``
+   - ``SCIEXT``
+   - ``CONEXT``
+   - ``WHTEXT``
+
+extract_1d
+----------
+
+- Checks for input from a SourceModelContainer. [#3649]
+
 exp_to_source
 -------------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -155,6 +155,7 @@ properties:
             blend_rule: mindatetime
           date_end:
             type: string
+            # 2019-06-12: Title has changed to "Date-time end of data acquisition" in keyword dictionary.
             title: "[yyyy-mm-dd] UTC date at end of exposure"
             fits_keyword: DATE-END
             blend_table: True
@@ -1008,6 +1009,54 @@ properties:
             type: number
             fits_keyword: YOFFSET
             blend_table: True
+          starting_set:
+            title: Starting 4-point set number
+            type: integer
+            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
+            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
+            # for now.
+            # enum: [1, 3, 5]
+            fits_keyword: DSETSTRT
+          number_of_sets:
+            title: Total number of 4-point sets
+            type: integer
+            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
+            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
+            # for now.
+            # enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            fits_keyword: NUMDSETS
+          direction:
+            title: Direction of dither pattern offsets
+            type: string
+            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
+            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
+            # for now.
+            # enum: [NEGATIVE, POSITIVE]
+            fits_keyword: DITHDIRC
+          optimized_for:
+            title: Dither pattern optimization
+            type: string
+            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
+            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
+            # for now.
+            # enum: ["POINT-SOURCE", "EXTENDED-SOURCE"]
+            fits_keyword: DITHOPFR
+          sparse_points:
+            title: Sparse cycling dither points
+            type: string
+            fits_keyword: DITHPNTS
+          primary_channel:
+            title: MRS primary channel
+            type: string
+            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
+            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
+            # for now.
+            # enum: [ALL, CHANNEL1, CHANNEL2, CHANNEL3, CHANNEL4]
+            fits_keyword: MRSPRCHN
+          dither_points:
+            title: Total number of points in primary dither pattern
+            type: string
+            fits_keyword: NDITHPTS
       ephemeris:
         title: JWST ephemeris information
         type: object

--- a/jwst/datamodels/schemas/keyword_channel.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_channel.schema.yaml
@@ -9,5 +9,5 @@ properties:
           channel:
             title: NIRCAM or MIRI channel name.
             type: string
-            enum: [LONG, SHORT, '12', '34', '1', '2', '3', '4', ANY, N/A]
+            enum: [LONG, SHORT, '1234', '123', '234', '12', '34', '1', '2', '3', '4', ANY, N/A]
             fits_keyword: CHANNEL

--- a/jwst/datamodels/schemas/keyword_pband.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pband.schema.yaml
@@ -9,6 +9,6 @@ properties:
           p_band:
             title: MRS wavelength band
             type: string
-            pattern: ^((ANY|SHORT|MEDIUM|LONG|SHORT-MEDIUM|SHORT-LONG|\
+            pattern: ^((ANY|MULTIPLE|SHORT|MEDIUM|LONG|SHORT-MEDIUM|SHORT-LONG|\
                         MEDIUM-SHORT|MEDIUM-LONG|LONG-SHORT|LONG-MEDIUM|N/A)\s*\|\s*)+$
             fits_keyword: P_BAND

--- a/jwst/datamodels/schemas/keyword_pchannel.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pchannel.schema.yaml
@@ -9,5 +9,5 @@ properties:
           p_channel:
             title: Channel name.
             type: string
-            pattern: ^((LONG|SHORT|12|34|1|2|3|4|ANY|N/A)\s*\|\s*)+$
+            pattern: ^((LONG|SHORT|1234|123|234|12|34|1|2|3|4|ANY|N/A)\s*\|\s*)+$
             fits_keyword: P_CHANNE

--- a/jwst/datamodels/schemas/keyword_pfilter.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pfilter.schema.yaml
@@ -16,5 +16,5 @@ properties:
               F212N|F2300C|F250M|F2550W|F2550WR|F277W|F290LP|F300M|\
               F322W2|F335M|F356W|F360M|F380M|F410M|F430M|F444W|\
               F460M|F480M|F560W|F770W|FLENS|FND|GR150C|\
-              GR150R|OPAQUE|P750L|WLP4|N/A|ANY)\\s*\\|\\s*)+$"
+              GR150R|OPAQUE|P750L|WLP4|F070W|MULTIPLE|N/A|ANY)\\s*\\|\\s*)+$"
             fits_keyword: P_FILTER

--- a/jwst/datamodels/schemas/lev3_prod.schema.yaml
+++ b/jwst/datamodels/schemas/lev3_prod.schema.yaml
@@ -4,14 +4,17 @@ properties:
     type: object
     properties:
       resample:
+        # 2019-06-12: Title has changed to "Resampling parameter information" in keyword dictionary.
         title: Metadata describing resampling done using this data
         type: object
         properties:
           pointings:
+            # 2019-06-12: Title has changed to "Number of groups/pointings included in resampled product" in keyword dictionary.
             title: Number of pointings included in resampled product
             type: integer
             fits_keyword: NDRIZ
           product_exposure_time:
+            # 2019-06-12: Title has changed to "[s] Total exposure time for product" in keyword dictionary.
             title: Total exposure time for product
             type: number
             fits_keyword: TEXPTIME
@@ -19,7 +22,44 @@ properties:
             title: Type of drizzle weighting to use in resampling input
             type: string
             enum: [exptime, error]
-            fits_keyword: WHT_TYPE
+            fits_keyword: RESWHT
+          drizzle_weight_scale:
+            title: Drizzle weight scale used to created resampled product
+            type: string
+            fits_keyword: DWTSCL
+          drizzle_output_units:
+            title: Units for resampled output product
+            type: string
+            enum: [counts, cps]
+            fits_keyword: DOUTUN
+          resample_bits:
+            title: Bit values to consider good when interpreting input DQ arrays
+            type: integer
+            fits_keyword: RESBITS
+          drizzle_fill_value:
+            title: Value used in pixels without any valid input data
+            type: string
+            fits_keyword: DFVAL
+          drizzle_pixel_fraction:
+            title: Drizzle pixel fraction used to create resampled product
+            type: number
+            fits_keyword: DPIXFR
+          drizzle_kernel:
+            title: Drizzle kernel used to create resampled product
+            type: string
+            fits_keyword: DKERN
+          product_data_extname:
+            title: Extname of the SCI extension
+            type: string
+            fits_keyword: SCIEXT
+          product_context_extname:
+            title: Extname of the CON extension
+            type: string
+            fits_keyword: CONEXT
+          product_weight_extname:
+            title: Extname of the WHT extension
+            type: string
+            fits_keyword: WHTEXT
       tweakreg_catalog:
         type: object
         properties:

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -110,6 +110,7 @@ allOf:
             fits_keyword: INT_NUM
             fits_hdu: EXTRACT1D
           time_scale:
+            # 2019-06-12: Title has changed to "principal time system for time-related keywords" in keyword dictionary.
             title: "Time scale"
             type: string
             default: "UTC"


### PR DESCRIPTION
Resolves #3624 

This updates the datamodels schema files with new keywords that appeared in the 2019-06-11 dump of the dev keyword dictionary.  I didn't change any titles, but left notes showing where they need an update.  I have some questions about what I did but I'll comment directly on the relevant lines.