### PR TITLE
Remove editable install from Jenkins CI conda build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,8 @@ bc1 = utils.copy(bc0)
 bc1.name = "stable-deps"
 bc1.env_vars = env_vars
 bc1.build_cmds = [
-    "pip install -e .[test]",
+    "pip install numpy",
+    "pip install .[test]",
 ]
 bc1.test_cmds = [
     "pytest -r sx --junitxml=results.xml"
@@ -41,6 +42,7 @@ bc2.nodetype = 'python3.7'
 bc2.name = 'conda-free'
 bc2.env_vars = env_vars
 bc2.build_cmds = [
+    "pip install numpy",
     "pip install -e .[test]",
 ]
 bc2.test_cmds = [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,9 @@ bc1 = utils.copy(bc0)
 bc1.name = "stable-deps"
 bc1.env_vars = env_vars
 bc1.build_cmds = [
+    "pip install pytest==4.6.2",
     "pip install numpy",
-    "pip install .[test]",
+    "pip install -e .[test]",
 ]
 bc1.test_cmds = [
     "pytest -r sx --junitxml=results.xml"


### PR DESCRIPTION
Hopefully this fixes the problems we're seeing with `astropy` defining `pytest_plugins` in a non-top-level `conftest.py`.