### PR TITLE
JP-795 Temporarily overwrite DQ column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ associations
 
 - Prevent inclusion of data files with exp_type="NIS_EXTCAL" in the association files [#3611]
 
+combine_1d
+----------
+
+The input DQ column is temporarily replaced by a zero-filled array of
+the right data type. [#3666]
+
 datamodels
 ----------
 

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -58,7 +58,11 @@ class InputSpectrumModel:
             self.surf_bright = np.zeros_like(self.flux)
             self.sb_error = np.zeros_like(self.flux)
             log.warning("There is no SURF_BRIGHT column in the input.")
-        self.dq = spec.spec_table.field("dq").copy()
+        # xxx temporary self.dq = spec.spec_table.field("dq").copy()
+        # xxx This is a workaround which should be deleted after the
+        # bug described in JP-789, GitHub issues #3655 and #3179 have
+        # been fixed.
+        self.dq = np.zeros(self.wavelength.shape, dtype=np.uint32)  # xxx
         self.nelem = self.wavelength.shape[0]
         self.unit_weight = False        # may be reset below
         self.right_ascension = np.zeros_like(self.wavelength)


### PR DESCRIPTION
The DQ column in the input table is now (temporarily) ignored, and a zero-filled array of the correct data type is used instead.

Closes #3665.