### PR TITLE
Reprocess all backgrounds for Level2 associations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ associations
 
 - Implemented Level 2 re-sequencing to prevent overwriting of associations [#3674]
 
+- Implemented Level 2 background exposure reprocessing [#3675]
+
 combine_1d
 ----------
 

--- a/jwst/associations/generate.py
+++ b/jwst/associations/generate.py
@@ -85,6 +85,7 @@ def generate(pool, rules, version_id=None):
             process_queue.extend(to_process)
 
     # Finalize found associations
+    logger.debug('# associations before finalization: %s', len(associations))
     try:
         finalized_asns = rules.callback.reduce('finalize', associations)
     except KeyError:

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -235,6 +235,7 @@ class Asn_Lv2Spec(
                     SimpleConstraint(
                         value='science',
                         test=lambda value, item: self.get_exposure_type(item) != value,
+                        force_unique=False,
                     )
                 ],
                 reduce=Constraint.any
@@ -939,3 +940,29 @@ class Asn_Lv2WFSC(
 
         super(Asn_Lv2WFSC, self)._init_hook(item)
         self.data['asn_type'] = 'wfs-image2'
+
+
+@RegistryMarker.rule
+class Asn_Force_Reprocess(DMSLevel2bBase):
+    """Force all backgrounds to reprocess"""
+
+    def __init__(self, *args, **kwargs):
+
+        # Setup constraints
+        self.constraints = Constraint([
+            SimpleConstraint(
+                value='background',
+                sources=self.get_exposure_type,
+                force_unique=False,
+            ),
+            SimpleConstraint(
+                name='force_fail',
+                test=lambda x, y: False,
+                value='anything but None',
+                reprocess_on_fail=True,
+                work_over=ProcessList.EXISTING,
+                reprocess_rules=[]
+            )
+        ])
+
+        super(Asn_Force_Reprocess, self).__init__(*args, **kwargs)


### PR DESCRIPTION
This ensures that associations created after the background
but to which the background should belong becomes a member.

WIP #3434/JP-675