### PR TITLE
Loosen the WFSC constraints and only exclude NIS_EXTCAL

### DIFF
--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -926,10 +926,15 @@ class Asn_Lv2WFSC(
             DMSAttrConstraint(
                 name='wfsc',
                 sources=['visitype'],
-                value='prime_wfsc_sensing_control',
+                value='.+wfsc.+',
                 force_unique=True
+            ),
+            DMSAttrConstraint(
+                name='exclude',
+                sources=['exp_type'],
+                value='.+(?!nis_extcal).+',
+                force_unique=False,
             )
-
         ])
 
         # Now check and continue initialization.


### PR DESCRIPTION
Revert an over-strict test on WFSC associations.