### PR TITLE
Remove the Lv2NRSLAMPImage rule

### DIFF
--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -412,51 +412,6 @@ class Asn_Lv2MIRLRSFixedSlitNod(
 
 
 @RegistryMarker.rule
-class Asn_Lv2NRSLAMPImage(
-        AsnMixin_Lv2Special,
-        DMSLevel2bBase
-):
-    """Level2b NIRSpec Image Lamp calibrations Association
-
-    Characteristics:
-        - Association type: ``nrslamp-image2``
-        - Pipeline: ``calwebb_nrslamp-image2``
-        - Image-based NRS calibrations
-        - Single science exposure
-    """
-
-    def __init__(self, *args, **kwargs):
-
-        self.constraints = Constraint([
-            Constraint_Base(),
-            Constraint_Single_Science(self.has_science),
-            DMSAttrConstraint(
-                name='opt_elem2',
-                sources=['grating'],
-                value='mirror'
-            ),
-            DMSAttrConstraint(
-                name='instrument',
-                sources=['instrume'],
-                value='nirspec'
-            ),
-            DMSAttrConstraint(
-                name='opt_elem',
-                sources=['filter'],
-                value='opaque'
-            ),
-        ])
-
-        super(Asn_Lv2NRSLAMPImage, self).__init__(*args, **kwargs)
-
-    def _init_hook(self, item):
-        """Post-check and pre-add initialization"""
-
-        super(Asn_Lv2NRSLAMPImage, self)._init_hook(item)
-        self.data['asn_type'] = 'nrslamp-image2'
-
-
-@RegistryMarker.rule
 class Asn_Lv2NRSLAMPSpectral(
         AsnMixin_Lv2Special,
         DMSLevel2bBase


### PR DESCRIPTION
As per new information in JP-473/JP-282, the image processing of NRS_LAMP should be removed. This removes the association rule that would have setup for NRS_LAMP.