### PR TITLE
Changes necessary to support jsonschema 3.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.14.0 (Unreleased)
+===================
+
+datamodels
+----------
+
+- Use public API of jsonschema to ease upgrade to 3.x.
+
+
 0.13.8 (Unreleased)
 ===================
 
@@ -29,7 +38,7 @@ datamodels
 
 - Fixed corruption of FITS tables wiht unsigned int columns. [#3680]
 
-  
+
 0.13.5 (2019-06-19)
 ===================
 
@@ -242,7 +251,7 @@ extract_2d
 
 - Replaced a white space in the names of grism objects with an underscore. [#3517]
 
-- Update WFSS slit names to use simple integer value, and add accompanying unit 
+- Update WFSS slit names to use simple integer value, and add accompanying unit
   test for NIRCAM grism extract_2d [#3632].
 
 master_background

--- a/jwst/associations/lib/asn_schema_jw_level2b.json
+++ b/jwst/associations/lib/asn_schema_jw_level2b.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Association: JWST DMS Level2a->Level2b",
     "description": "The data structure that, within the JWST DMS processing system, defines how to group level2a exposures to produce Level2b data products.",
     "type": "object",

--- a/jwst/associations/lib/asn_schema_jw_level3.json
+++ b/jwst/associations/lib/asn_schema_jw_level3.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Association: JWST DMS Level2b->Level3",
     "description": "The data structure that, within the JWST DMS processing system, defines how to group level2b exposures to produce Level3 data products.",
     "type": "object",

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -293,7 +293,7 @@ def _fits_item_recurse(validator, items, instance, schema):
 def _fits_type(validator, items, instance, schema):
     if instance in ('N/A', '#TODO', '', None):
         return
-    return validators._validators.type_draft4(validator, items, instance, schema)
+    return validators.Draft4Validator.VALIDATORS["type"](validator, items, instance, schema)
 
 
 FITS_VALIDATORS = HashableDict(asdf_schema.YAML_VALIDATORS)


### PR DESCRIPTION
It's been [pointed out](https://github.com/spacetelescope/asdf/issues/530#issuecomment-503811670) that jsonschema 2.6 is incompatible with Python 3.8, so at some point we'll need to upgrade.  These changes make jwst compatible with both jsonschema 2.6 and 3.0.