### PR TITLE
Skip really slow FGS detector1 regtest

### DIFF
--- a/jwst/tests_nightly/general/fgs/test_fgs_sloper_1.py
+++ b/jwst/tests_nightly/general/fgs/test_fgs_sloper_1.py
@@ -4,6 +4,7 @@ from jwst.pipeline.calwebb_detector1 import Detector1Pipeline
 from jwst.tests.base_classes import BaseJWSTTest
 
 
+@pytest.mark.skip
 @pytest.mark.bigdata
 class TestSloperPipeline(BaseJWSTTest):
     input_loc = 'fgs'


### PR DESCRIPTION
One `calwebb_detector1` regression test using an FGS image-mode exposure as input consistently takes ~3 hours to execute, which is 1-2 hours longer than all of the remaining regression tests combined. This test needs to be reworked or we need to find better data to use, so that our regression test runs are not hostage to this one test. I'm marking it to be skipped for now, until something can be done to fix or replace it.