### PR TITLE
Remove references to deprecated ABCs that will be removed in Python 3.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.14.0 (Unreleased)
 ===================
 
+- Remove references to deprecated collections.* ABCs that will be removed in
+  Python 3.8. [#3732]
+
 datamodels
 ----------
 

--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from copy import deepcopy
 from datetime import datetime
 import json

--- a/jwst/datamodels/ndmodel.py
+++ b/jwst/datamodels/ndmodel.py
@@ -211,7 +211,7 @@ class NDModel(nddata_base.NDDataBase):
 # for the NDData interface to Datamodels
 #---------------------------------------------
 
-class MetaNode(properties.ObjectNode, collections.MutableMapping):
+class MetaNode(properties.ObjectNode, collections.abc.MutableMapping):
     """
     NDData compatibility class for meta node
     """

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -1,6 +1,7 @@
 """exp_to_source: Reformat Level2b MSA data to be source-based.
 """
-from collections import OrderedDict, Callable
+from collections import OrderedDict
+from collections.abc import Callable
 
 from ..datamodels import (
     MultiExposureModel,

--- a/jwst/fits_generator/util.py
+++ b/jwst/fits_generator/util.py
@@ -99,7 +99,7 @@ if sys.hexversion >= 0x02060000:
         """
         Returns True if object quacks like a callable.
         """
-        return isinstance(obj, collections.Callable)
+        return isinstance(obj, collections.abc.Callable)
 else:
     def iscallable(obj):
         """


### PR DESCRIPTION
This was originally merged in #3709 and reverted in #3718 to allow us to tag an uncontaminated release from master.  Now it's back!