### PR TITLE
JP-656: Minor updates for group_scale step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ datamodels
 
 - Use public API of jsonschema to ease upgrade to 3.x.
 
+group_scale
+-----------
+
+- Updates to documentation and log messages. [#3738]
 
 0.13.8 (Unreleased)
 ===================

--- a/docs/jwst/group_scale/description.rst
+++ b/docs/jwst/group_scale/description.rst
@@ -5,9 +5,9 @@ The `group_scale` step rescales pixel values in raw JWST science
 data products to correct for instances where on-board frame averaging 
 did not result in the proper values.
 
-When multiple frames are averaged together on board into a single
+When multiple frames are averaged together on-board into a single
 group, the sum of the frames is computed and then the sum is
-divided by the number of frames to compute an average. Division by
+divided by the number of frames to compute the average. Division by
 the number of frames is accomplished by simply bit-shifting the
 sum by an appropriate number of bits, corresponding to the 
 decimal value of the number of frames. For example, when 2 frames

--- a/docs/jwst/pipeline/calwebb_detector1.rst
+++ b/docs/jwst/pipeline/calwebb_detector1.rst
@@ -34,7 +34,7 @@ the steps are applied in a different order than for Near-IR (NIR) instrument exp
 +--------------------------------------------+---------+-----------------------------------------+---------+
 | calwebb_detector1                          | tso1    | calwebb_detector1                       | tso1    |
 +============================================+=========+=========================================+=========+
-| :ref:`group_scale <group_scale_step>`      | |check| | :ref:`group_scale <group_scale_step>`   | |check| |
+| :ref:`group_scale <group_scale_step>`      | |check| | :ref:`group_scale <group_scale_step>`   |         |
 +--------------------------------------------+---------+-----------------------------------------+---------+
 | :ref:`dq_init <dq_init_step>`              | |check| | :ref:`dq_init <dq_init_step>`           | |check| |
 +--------------------------------------------+---------+-----------------------------------------+---------+

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -44,6 +44,7 @@ def do_correction(input_model):
     # Create output as a copy of the input science data model
     output_model = input_model.copy()
 
+    log.info('NFRAMES={}, FRMDIVSR={}'.format(nframes, frame_divisor))
     log.info('Rescaling all groups by {}/{}'.format(frame_divisor, nframes))
 
     # Apply the rescaling to the entire data array

--- a/jwst/group_scale/group_scale_step.py
+++ b/jwst/group_scale/group_scale_step.py
@@ -9,7 +9,7 @@ __all__ = ["GroupScaleStep"]
 class GroupScaleStep(Step):
     """
     GroupScaleStep: Rescales group data to account for on-board
-    frame averaging that did not use NFRAMES that is a power of two.
+    frame averaging that did not use FRMDIVSR = NFRAMES.
     All groups in the exposure are rescaled by FRMDIVSR/NFRAMES.
     """
 
@@ -35,8 +35,7 @@ class GroupScaleStep(Step):
             # is a power of 2. If it is, rescaling isn't needed.
             if frame_divisor is None:
                 if (nframes & (nframes - 1) == 0):
-                    self.log.info('NFRAMES={} is a power of 2; ' +
-                                  'correction not needed'.format(nframes))
+                    self.log.info('NFRAMES={} is a power of 2; correction not needed'.format(nframes))
                     self.log.info('Step will be skipped')
                     input_model.meta.cal_step.group_scale = 'SKIPPED'
                     return input_model
@@ -44,8 +43,7 @@ class GroupScaleStep(Step):
             # Compare NFRAMES and FRMDIVSR. If they're equal,
             # rescaling isn't needed.
             elif (nframes == frame_divisor):
-                self.log.info('NFRAMES and FRMDIVSR are equal; ' +
-                              'correction not needed')
+                self.log.info('NFRAMES and FRMDIVSR are equal; correction not needed')
                 self.log.info('Step will be skipped')
                 input_model.meta.cal_step.group_scale = 'SKIPPED'
                 return input_model


### PR DESCRIPTION
A few minor updates to the `group_scale` step code, to fix formatting of info in log messages, and the step docs (including indicating that the step is not used for TSO exposures), just to try to make everything as clear as possible.