### PR TITLE
Switch engineering database to D-string

### DIFF
--- a/jwst/lib/engdb_tools.py
+++ b/jwst/lib/engdb_tools.py
@@ -17,7 +17,9 @@ logger.addHandler(logging.NullHandler())
 # #############################################
 # Where is the engineering service? Its HERE!!!
 # #############################################
-ENGDB_HOST = 'http://iwjwdmsbemweb.stsci.edu/'
+
+# This is currently set to the D-string hostname:
+ENGDB_HOST = 'http://twjwdmsemweb.stsci.edu/'
 ENGDB_BASE_URL = ''.join([
     ENGDB_HOST,
     'JWDMSEngFqAcc/',


### PR DESCRIPTION
Addresses #3742 

The B string engineering database seems to have been wiped out, which is causing tests that depend on live data to fail.  This PR switches the default db to D string.