### PR TITLE
Update datamodels schema title and enum fields to match latest keyword dictionary dump

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1011,22 +1011,22 @@ properties:
           starting_set:
             title: Starting 4-point set number
             type: integer
-            enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             fits_keyword: DSETSTRT
           number_of_sets:
             title: Total number of 4-point sets
             type: integer
-            enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             fits_keyword: NUMDSETS
           direction:
             title: Direction of dither pattern offsets
             type: string
-            enum: [NEGATIVE, POSITIVE]
+            enum: [NEGATIVE, POSITIVE, NONE]
             fits_keyword: DITHDIRC
           optimized_for:
             title: Dither pattern optimization
             type: string
-            enum: ["POINT-SOURCE", "EXTENDED-SOURCE"]
+            enum: ["POINT-SOURCE", "EXTENDED-SOURCE", NONE]
             fits_keyword: DITHOPFR
           sparse_points:
             title: Sparse cycling dither points

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -155,8 +155,7 @@ properties:
             blend_rule: mindatetime
           date_end:
             type: string
-            # 2019-06-12: Title has changed to "Date-time end of data acquisition" in keyword dictionary.
-            title: "[yyyy-mm-dd] UTC date at end of exposure"
+            title: "Date-time end of data acquisition"
             fits_keyword: DATE-END
             blend_table: True
             # Despite what the title might lead you to believe, this keyword
@@ -1012,34 +1011,22 @@ properties:
           starting_set:
             title: Starting 4-point set number
             type: integer
-            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
-            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
-            # for now.
-            # enum: [1, 3, 5]
+            enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             fits_keyword: DSETSTRT
           number_of_sets:
             title: Total number of 4-point sets
             type: integer
-            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
-            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
-            # for now.
-            # enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             fits_keyword: NUMDSETS
           direction:
             title: Direction of dither pattern offsets
             type: string
-            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
-            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
-            # for now.
-            # enum: [NEGATIVE, POSITIVE]
+            enum: [NEGATIVE, POSITIVE]
             fits_keyword: DITHDIRC
           optimized_for:
             title: Dither pattern optimization
             type: string
-            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
-            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
-            # for now.
-            # enum: ["POINT-SOURCE", "EXTENDED-SOURCE"]
+            enum: ["POINT-SOURCE", "EXTENDED-SOURCE"]
             fits_keyword: DITHOPFR
           sparse_points:
             title: Sparse cycling dither points
@@ -1048,10 +1035,7 @@ properties:
           primary_channel:
             title: MRS primary channel
             type: string
-            # 2019-06-12: The keyword dictionary specifies an enum constraint for this field, but
-            # due to discrepancies in the dictionary JSON we're going to leave this unconstrained
-            # for now.
-            # enum: [ALL, CHANNEL1, CHANNEL2, CHANNEL3, CHANNEL4]
+            enum: [ALL, CHANNEL1, CHANNEL2, CHANNEL3, CHANNEL4]
             fits_keyword: MRSPRCHN
           dither_points:
             title: Total number of points in primary dither pattern

--- a/jwst/datamodels/schemas/lev3_prod.schema.yaml
+++ b/jwst/datamodels/schemas/lev3_prod.schema.yaml
@@ -4,18 +4,15 @@ properties:
     type: object
     properties:
       resample:
-        # 2019-06-12: Title has changed to "Resampling parameter information" in keyword dictionary.
-        title: Metadata describing resampling done using this data
+        title: Resampling parameter information
         type: object
         properties:
           pointings:
-            # 2019-06-12: Title has changed to "Number of groups/pointings included in resampled product" in keyword dictionary.
-            title: Number of pointings included in resampled product
+            title: "Number of groups/pointings included in resampled product"
             type: integer
             fits_keyword: NDRIZ
           product_exposure_time:
-            # 2019-06-12: Title has changed to "[s] Total exposure time for product" in keyword dictionary.
-            title: Total exposure time for product
+            title: "[s] Total exposure time for product"
             type: number
             fits_keyword: TEXPTIME
           weight_type:

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -110,8 +110,7 @@ allOf:
             fits_keyword: INT_NUM
             fits_hdu: EXTRACT1D
           time_scale:
-            # 2019-06-12: Title has changed to "principal time system for time-related keywords" in keyword dictionary.
-            title: "Time scale"
+            title: "principal time system for time-related keywords"
             type: string
             default: "UTC"
             fits_keyword: TIMESYS


### PR DESCRIPTION
Addresses #3661 

These are the title and enum field updates that we held back when updating the datamodels schemas in #3653.