### PR TITLE
Add a requirements-sdp.txt file and new Jenkinsfiles to run on weekends

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -28,7 +28,7 @@ data_config.server_id = 'bytesalad'
 data_config.root = '${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
-// Build and test with python 3.6 and released dependencies from astroconda
+// Build and test
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
 bc.name = 'stable'

--- a/JenkinsfileRT-dev
+++ b/JenkinsfileRT-dev
@@ -28,7 +28,7 @@ data_config.server_id = 'bytesalad'
 data_config.root = '${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
-// Build and test with python 3.6 and released dependencies from astroconda
+// Build and test
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
 bc.name = 'dev'

--- a/JenkinsfileRT-dev
+++ b/JenkinsfileRT-dev
@@ -31,7 +31,7 @@ data_config.match_prefix = '(.*)_result' // .json is appended automatically
 // Build and test with python 3.6 and released dependencies from astroconda
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
-bc.name = 'stable'
+bc.name = 'dev'
 bc.env_vars = env_vars
 bc.conda_ver = '4.7.5'
 bc.conda_packages = [
@@ -39,6 +39,7 @@ bc.conda_packages = [
 ]
 bc.build_cmds = [
     "pip install numpy",
+    "pip install -r requirements-dev.txt",
     "pip install -e .[test]",
     "pip install pytest-xdist",
 ]

--- a/JenkinsfileRT-sdp
+++ b/JenkinsfileRT-sdp
@@ -6,7 +6,7 @@ jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
 
 // Define python version for conda
-python_version = '3.7'
+python_version = '3.6'
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
@@ -28,7 +28,7 @@ data_config.server_id = 'bytesalad'
 data_config.root = '${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
-// Build and test with python 3.6 and released dependencies from astroconda
+// Build and test
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
 bc.name = 'sdp'

--- a/JenkinsfileRT-sdp
+++ b/JenkinsfileRT-sdp
@@ -3,7 +3,7 @@ if (utils.scm_checkout(['skip_disable':true])) return
 
 jobconfig = new JobConfig()
 jobconfig.enable_env_publication = true
-jobconfig.publish_env_on_success_only = false
+jobconfig.publish_env_on_success_only = true
 
 // Define python version for conda
 python_version = '3.7'
@@ -31,7 +31,7 @@ data_config.match_prefix = '(.*)_result' // .json is appended automatically
 // Build and test with python 3.6 and released dependencies from astroconda
 bc = new BuildConfig()
 bc.nodetype = 'jwst'
-bc.name = 'stable'
+bc.name = 'sdp'
 bc.env_vars = env_vars
 bc.conda_ver = '4.7.5'
 bc.conda_packages = [
@@ -39,6 +39,7 @@ bc.conda_packages = [
 ]
 bc.build_cmds = [
     "pip install numpy",
+    "pip install -r requirements-sdp.txt",
     "pip install -e .[test]",
     "pip install pytest-xdist",
 ]

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,0 +1,14 @@
+asdf==2.3.3
+astropy==3.2.1
+crds==7.3.4
+drizzle==1.13.1
+gwcs==0.10.0
+jplephem==2.9
+jsonschema==2.6.0
+numpy==1.16.4
+photutils==0.6
+scipy==1.3.0
+spherical-geometry==1.2.11
+stsci.image==2.3.2
+stsci.imagestats==1.6.2
+stsci.stimage==0.2.3

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,6 @@ setup(
         'stsci.image>=2.3',
         'stsci.imagestats>=1.4',
         'stsci.stimage>=0.2',
-        'verhawk',
     ],
     extras_require={
         'docs': DOCS_REQUIRE,


### PR DESCRIPTION
- Run both unit and regression tests in our `JenkinsfileRT` runs.  This will eventually enable us to track joint test coverage.
- Add `requirements-sdp.txt` with pinned dependencies.  The purpose of this is to run our main regression tests from it eventually and to keep our dependencies stable during the development cycle for in-house SDP processing.
- Add `JenkinsfileRT-dev` for regression testing against dev dependencies on the weekends
- Add `JenkinsfileRT-sdp` for regression testing using `requirements-sdp.txt` as either our daily test run or another weekend test run.
- Remove `verhawk` as a package dependency.  It is not used.
- Use `python 3.7` in regression testing.