### PR TITLE
Only overwrite FITS_rec dtypes for signed int columns that should be unsigned

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ datamodels
 
 - Fixed corruption of FITS tables with unsigned int columns. [#3736]
 
+- Fixed missing TUNITn keywords caused by changes for unsigned int columns. [#3753]
+
 group_scale
 -----------
 


### PR DESCRIPTION
This addresses the problem in the regression tests where TUNITn keywords are being dropped from the output.  There are a couple of underlying problems in astropy (casting a FITS_rec to a new dtype drops column fields like unit, columns with character data disagree with FITS_rec on their dtypes) that may need to be resolved, but this PR at least gets us back to where we were.

The fix is to be more surgical about replacing table dtypes with the individual field dtypes.  Previously I was always recreating the table dtype from the fields, now I'm only recreating them if necessary, and even then only replacing signed int with unsigned int.

I ran the following regression tests successfully:

jwst/tests_nightly/general/miri/test_miri_steps.py dark_current_miri2
(to confirm that missing TUNITn keywords came back)

jwst/tests_nightly/general/miri/test_miri_steps_single.py test_miri_masterbg_mrs_dedicated
(to confirm that the unsigned int columns are still fixed)