### PR TITLE
JP-764 : write siaf_x/yref_sci to FITS keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,13 +17,14 @@ datamodels
 
 - Fixed missing TUNITn keywords caused by changes for unsigned int columns. [#3753]
 
+- Write ``siaf_xref_sci`` and ``siaf_yref_sci`` to FITS keywords ``XREF_SCI``
+  and ``YREF_SCI`` for ``NRC_TSGRISM`` exposures. [#3766]
+
 group_scale
 -----------
 
 - Updates to documentation and log messages. [#3738]
 
-0.13.8 (Unreleased)
-===================
 
 extract_1d
 ----------

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -301,6 +301,10 @@ properties:
           siaf_xref_sci:
             title: Aperture X reference point in SCI frame from SIAF (NRC_TSGRISM mode)
             type: number
-          siaf_xref_sci:
+            fits_keyword: XREF_SCI
+            fits_hdu: SCI
+          siaf_yref_sci:
             title: Aperture Y reference point in SCI frame from SIAF (NRC_TSGRISM mode)
             type: number
+            fits_keyword: YREF_SCI
+            fits_hdu: SCI


### PR DESCRIPTION
This works around the issue of `DataModel.update` updating only attributes that have a corresponding FITS keyword.

Resolves #3594