### PR TITLE
Fix Step.print_configspec()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,17 +20,21 @@ datamodels
 - Write ``siaf_xref_sci`` and ``siaf_yref_sci`` to FITS keywords ``XREF_SCI``
   and ``YREF_SCI`` for ``NRC_TSGRISM`` exposures. [#3766]
 
+extract_1d
+----------
+
+- Parameters were added to ``ExtractBase.__init__``, and most of the initialization
+  is done there rather than in the subclasses. [#3714]
+
 group_scale
 -----------
 
 - Updates to documentation and log messages. [#3738]
 
+stpipe
+------
 
-extract_1d
-----------
-
-- Parameters were added to ExtractBase.__init__, and most of the initialization
-  is done there rather than in the subclasses. [#3714]
+- Fix ``Step.print_configspec()`` method.  Add test.  [#3768]
 
 0.13.7 (2019-06-21)
 ===================

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -80,18 +80,9 @@ class Step():
         return spec
 
     @classmethod
-    def print_configspec(cls, stream=sys.stdout):
-
-        # Python2/3 issue: Python3 doesn't like bytes
-        # going to stdout directly.
-        if stream == sys.stdout:
-            try:
-                stream = sys.stdout.buffer
-            except AttributeError:
-                pass
-
+    def print_configspec(cls):
         specfile = cls.load_spec_file(preserve_comments=True)
-        specfile.write(stream)
+        specfile.write(sys.stdout.buffer)
 
     @classmethod
     def from_config_file(cls, config_file, parent=None, name=None):

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -5,16 +5,14 @@ from os.path import (
 )
 
 import pytest
-import numpy as np
 
-from ..config_parser import ValidationError
+from jwst import datamodels
+from jwst.stpipe import Step
+from jwst.stpipe.config_parser import ValidationError
 
 
 def test_hook():
     """Test the running of hooks"""
-    from .. import Step
-    from ... import datamodels
-
     step_fn = join(dirname(__file__), 'steps', 'stepwithmodel_hook.cfg')
     step = Step.from_config_file(step_fn)
 
@@ -29,9 +27,6 @@ def test_hook():
 
 def test_hook_with_return():
     """Test the running of hooks"""
-    from .. import Step
-    from ... import datamodels
-
     step_fn = join(dirname(__file__), 'steps', 'stepwithmodel_hookreturn.cfg')
     step = Step.from_config_file(step_fn)
 
@@ -44,8 +39,6 @@ def test_hook_with_return():
 
 
 def test_step():
-    from .. import Step
-
     step_fn = join(dirname(__file__), 'steps', 'some_other_step.cfg')
     step = Step.from_config_file(step_fn)
 
@@ -92,8 +85,6 @@ def test_step_from_python_simple2():
 
 
 def test_step_from_commandline():
-    from .. import Step
-
     args = [
         abspath(join(dirname(__file__), 'steps', 'some_other_step.cfg')),
         '--par1=58', '--par2=hij klm'
@@ -109,8 +100,6 @@ def test_step_from_commandline():
 
 
 def test_step_from_commandline_class():
-    from .. import Step
-
     args = [
         'jwst.stpipe.tests.steps.AnotherDummyStep',
         '--par1=58', '--par2=hij klm'
@@ -126,7 +115,6 @@ def test_step_from_commandline_class():
 
 
 def test_step_from_commandline_invalid():
-    from .. import Step
     args = [
             '__foo__'
         ]
@@ -136,8 +124,6 @@ def test_step_from_commandline_invalid():
 
 
 def test_step_from_commandline_invalid2():
-    from .. import Step
-
     args = [
         '__foo__.__bar__'
         ]
@@ -146,8 +132,6 @@ def test_step_from_commandline_invalid2():
 
 
 def test_step_from_commandline_invalid3():
-    from .. import Step
-
     args = [
         'sys.foo'
         ]
@@ -156,8 +140,6 @@ def test_step_from_commandline_invalid3():
 
 
 def test_step_from_commandline_invalid4():
-    from .. import Step
-
     args = [
         'sys.argv'
         ]
@@ -165,26 +147,11 @@ def test_step_from_commandline_invalid4():
         Step.from_cmdline(args)
 
 
-@pytest.mark.skip(reason="This test does nothing")
-def test_step_print_spec():
-    import io
-    buf = io.BytesIO()
-
-    from .. import subproc
-
-    subproc.SystemCall.print_configspec(buf)
-
-    # content = buf.getvalue()
-    # TODO: Assert some things
-
-
 def test_step_with_local_class():
-    from .. import Step
-
     step_fn = join(dirname(__file__), 'steps', 'local_class.cfg')
     step = Step.from_config_file(step_fn)
 
-    step.run(np.array([[0, 0]]))
+    step.run(datamodels.ImageModel((2, 2)))
 
 
 def test_extra_parameter():
@@ -195,7 +162,6 @@ def test_extra_parameter():
 
 def test_crds_override():
     from .steps import AnotherDummyStep
-    from ... import datamodels
 
     step = AnotherDummyStep(
         "SomeOtherStepOriginal",
@@ -223,3 +189,8 @@ def test_search_attr():
     assert pipeline.stepwithmodel.search_attr('output_dir') == value
     assert pipeline.search_attr('junk') is None
     assert pipeline.stepwithmodel.search_attr('junk') is None
+
+
+def test_print_configspec():
+    step = Step()
+    step.print_configspec()


### PR DESCRIPTION
This `stpipe.Step` method has been broken for a very long time.  It is now fixed with a test.