### PR TITLE
Set pytest caplog to WARNING or greater in JenkinsfileRT

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -44,6 +44,7 @@ bc.build_cmds = [
 bc.test_cmds = [
     "pytest -r sx -v -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
+    --log-level=WARNING \
     jwst/tests_nightly/general"
 ]
 bc.test_configs = [data_config]


### PR DESCRIPTION
Logs are too long when set to DEBUG level as is default in pytest.  Setting the level to WARNING will still print WARNING, ERROR and CRITICAL log messages in the automated runs, but not DEBUG or INFO log messages.

Should make the test results much easier to read, and also for tests that have very verbose DEBUG logging, make the XML results file a reasonable size so Jenkins can slurp it up.