### PR TITLE
Fix usage of ci_watson --env cli arg in BaseJWSTTest class

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -44,7 +44,7 @@ bc.build_cmds = [
 bc.test_cmds = [
     "pytest -r sx -v -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
-    --log-level=WARNING \
+    --log-level=INFO \
     jwst/tests_nightly/general"
 ]
 bc.test_configs = [data_config]

--- a/jwst/associations/tests/helpers.py
+++ b/jwst/associations/tests/helpers.py
@@ -86,7 +86,7 @@ class BasePoolRule():
                 ppars.path + ': n_asns not expected {} {}'.format(len(asns), ppars.n_asns)
             for asn, candidates in zip(asns, ppars.candidates):
                 assert set(asn.candidates) == set(candidates)
-            file_regex = re.compile('.+_(?P<suffix>.+)\..+')
+            file_regex = re.compile(r'.+_(?P<suffix>.+)\..+')
             for asn in asns:
                 for product in asn['products']:
                     for member in product['members']:

--- a/jwst/tests/base_classes.py
+++ b/jwst/tests/base_classes.py
@@ -41,7 +41,9 @@ class BaseJWSTTest:
     ignore_hdus = ['ASDF']
     ignore_keywords = ['DATE', 'CAL_VER', 'CAL_VCS', 'CRDS_VER', 'CRDS_CTX', 'FILENAME']
 
-    env = 'dev'
+    @pytest.fixture(autouse=True)
+    def config_env(self, pytestconfig, envopt):
+        self.env = pytestconfig.getoption('env')
 
     @pytest.fixture(autouse=True)
     def config_access(self, pytestconfig):

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ TESTS_REQUIRE = [
     'pytest-doctestplus',
     'requests_mock',
     'pytest-openfiles',
-    'pytest-faulthandler',
 ]
 
 def get_transforms_data():


### PR DESCRIPTION
Plus:
 - Set --log-level=INFO in JenkinsfileRT
 - Remove pytest-faulthandler dependency; Pytest 5.0 includes it
 - Fix regex deprecation in associations test helpers
 - Fix reffile validation warning in linearity unit tests; speed them up by using smaller arrays