### PR TITLE
Speed up test_extract_wfss_object unit test

### DIFF
--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -120,8 +120,7 @@ def create_wfss_image(pupil, filtername='F444W'):
                        pupil=pupil, wcskeys=wcs_wfss_kw)
     hdul['sci'].data = np.ones((hdul[0].header['SUBSIZE1'], hdul[0].header['SUBSIZE2']))
     im = ImageModel(hdul)
-    aswcs = AssignWcsStep()
-    return aswcs.process(im)
+    return AssignWcsStep.call(im)
 
 
 def create_tso_wcsimage(filtername="F277W", subarray=False):
@@ -339,7 +338,8 @@ def test_extract_wfss_object():
     refs = get_reference_files(wcsimage)
     outmodel = extract_grism_objects(wcsimage,
                                      use_fits_wcs=True,
-                                     reference_files=refs)
+                                     reference_files=refs,
+                                     compute_wavelength=False)
     assert isinstance(outmodel, MultiSlitModel)
     assert len(outmodel.slits) == 3
     ids = [slit.source_id for slit in outmodel.slits]
@@ -347,6 +347,3 @@ def test_extract_wfss_object():
 
     names = [slit.name for slit in outmodel.slits]
     assert names == ['9', '19', '19']
-
-    # check that bounding boxes exist
-    del outmodel


### PR DESCRIPTION
Due to the addition of computing a wavelength array for each extracted grism cutout in `extract_2d` in #3664 , the runtime of `test_extract_wfss_object()` test increased from ~3 secs to ~5 min.

Before:
```
$ pytest -v jwst/extract_2d/tests/test_grisms.py::test_extract_wfss_object
========================== test session starts ===========================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0 -- /Users/jdavies/miniconda3/envs/jwst/bin/python
cachedir: .pytest_cache
rootdir: /Users/jdavies/dev/jwst, inifile: setup.cfg
plugins: openfiles-0.3.2, xdist-1.29.0, forked-1.0.2, doctestplus-0.3.0, ci-watson-0.3, requests-mock-1.6.0
collected 1 item                                                         

jwst/extract_2d/tests/test_grisms.py::test_extract_wfss_object PASSED [100%]

======================== 1 passed in 2.53 seconds ========================
```
After:
```
$ pytest -v jwst/extract_2d/tests/test_grisms.py::test_extract_wfss_object
========================== test session starts ===========================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0 -- /Users/jdavies/miniconda3/envs/jwst/bin/python
cachedir: .pytest_cache
rootdir: /Users/jdavies/dev/jwst, inifile: setup.cfg
plugins: openfiles-0.3.2, xdist-1.29.0, forked-1.0.2, doctestplus-0.3.0, ci-watson-0.3, requests-mock-1.6.0
collected 1 item                                                         

jwst/extract_2d/tests/test_grisms.py::test_extract_wfss_object PASSED [100%]

======================== 1 passed in 287.72 seconds =======================
```
This PR adds a `compute_wavelength=True` option to the `extract_grism_objects()` function.  For our unit test, we can set it to `False` and get back a reasonable runtime for the unit test, and keep our test coverage the same as before.