### PR TITLE
Filter resample RuntimeWarnings due to NaNs in spectral WCS transforms

### DIFF
--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -1,5 +1,6 @@
 import logging
 from collections import OrderedDict
+import warnings
 
 import numpy as np
 
@@ -103,7 +104,10 @@ class ResampleSpecData:
         tan = Pix2Sky_TAN()
         native2celestial = RotateNative2Celestial(lon, lat, 180)
         undist2sky = tan | native2celestial
+        # Filter out RuntimeWarnings due to computed NaNs in the WCS
+        warnings.simplefilter("ignore")
         x_tan, y_tan = undist2sky.inverse(ra, dec)
+        warnings.resetwarnings()
 
         spectral_axis = find_dispersion_axis(lam)
         spatial_axis = spectral_axis ^ 1

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -1,16 +1,16 @@
-import numpy as np
+import logging
+import warnings
 
+import numpy as np
 from astropy import wcs as fitswcs
 from astropy.coordinates import SkyCoord
 from astropy.modeling.models import Scale, AffineTransformation2D
 from astropy.modeling import Model
 from gwcs import WCS, wcstools
-
 from astropy.nddata.bitmask import interpret_bit_flags
 
 from ..assign_wcs.util import wcs_from_footprints, wcs_bbox_from_shape
 
-import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -156,7 +156,10 @@ def reproject(wcs1, wcs2):
         flat_sky = []
         for axis in sky:
             flat_sky.append(axis.flatten())
+        # Filter out RuntimeWarnings due to computed NaNs in the WCS
+        warnings.simplefilter("ignore")
         det = backward_transform(*tuple(flat_sky))
+        warnings.resetwarnings()
         det_reshaped = []
         for axis in det:
             det_reshaped.append(axis.reshape(x.shape))


### PR DESCRIPTION
Get rid of these expected warnings due to NaNs in the spectral gWCS transforms:
```
$ pytest --bigdata --slow --basetemp=/Users/jdavies/scratch jwst/tests_nightly/ -k test_run_msaflagging
======================================================================== test session starts ========================================================================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /Users/jdavies/dev/jwst, inifile: setup.cfg
plugins: openfiles-0.3.2, xdist-1.29.0, forked-1.0.2, doctestplus-0.3.0, ci-watson-0.3, requests-mock-1.6.0
collected 262 items / 261 deselected / 1 selected                                                                                                                   

jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py .                                                                                            [100%]

========================================================================= warnings summary ==========================================================================
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
  /Users/jdavies/miniconda3/envs/jwst/lib/python3.7/site-packages/astropy/modeling/rotations.py:186: RuntimeWarning: invalid value encountered in less
    mask = alpha < 0

jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
  /Users/jdavies/miniconda3/envs/jwst/lib/python3.7/site-packages/scipy/interpolate/interpolate.py:2531: RuntimeWarning: invalid value encountered in less
    out_of_bounds += x < grid[0]

jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
jwst/tests_nightly/general/nirspec/test_calwebb_spec2_nrs_msa.py::TestSpec2NRSMSA::test_run_msaflagging
  /Users/jdavies/miniconda3/envs/jwst/lib/python3.7/site-packages/scipy/interpolate/interpolate.py:2532: RuntimeWarning: invalid value encountered in greater
    out_of_bounds += x > grid[-1]
```