### PR TITLE
Fix regex deprecations in associations

### DIFF
--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -67,8 +67,8 @@ FLAG_TO_EXPTYPE = {
 }
 
 # File templates
-_DMS_POOLNAME_REGEX = 'jw(\d{5})_(\d{3})_(\d{8}[Tt]\d{6})_pool'
-_LEVEL1B_REGEX = '(?P<path>.+)(?P<type>_uncal)(?P<extension>\..+)'
+_DMS_POOLNAME_REGEX = r'jw(\d{5})_(\d{3})_(\d{8}[Tt]\d{6})_pool'
+_LEVEL1B_REGEX = r'(?P<path>.+)(?P<type>_uncal)(?P<extension>\..+)'
 
 # Key that uniquely identfies items.
 KEY = 'expname'

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -73,11 +73,11 @@ logger.addHandler(logging.NullHandler())
 ASN_SCHEMA = RegistryMarker.schema(libpath('asn_schema_jw_level3.json'))
 
 # DMS file name templates
-_LEVEL1B_REGEX = '(?P<path>.+)(?P<type>_uncal)(?P<extension>\..+)'
-_DMS_POOLNAME_REGEX = 'jw(\d{5})_(\d{8}[Tt]\d{6})_pool'
+_LEVEL1B_REGEX = r'(?P<path>.+)(?P<type>_uncal)(?P<extension>\..+)'
+_DMS_POOLNAME_REGEX = r'jw(\d{5})_(\d{8}[Tt]\d{6})_pool'
 
 # Product name regex's
-_REGEX_ACID_VALUE = '(o\d{3}|(c|a)\d{4})'
+_REGEX_ACID_VALUE = r'(o\d{3}|(c|a)\d{4})'
 
 # Exposures that should have received Level2b processing
 LEVEL2B_EXPTYPES = []

--- a/jwst/tests_nightly/general/associations/test_level3_product_names.py
+++ b/jwst/tests_nightly/general/associations/test_level3_product_names.py
@@ -13,22 +13,22 @@ from jwst.associations.lib.dms_base import DMSAttrConstraint
 
 
 LEVEL3_PRODUCT_NAME_REGEX = (
-    'jw'
-    '(?P<program>\d{5})'
-    '-(?P<acid>[a-z]\d{3,4})'
-    '_(?P<target>(?:t\d{3})|(?:\{source_id\}))'
-    '(?:-(?P<epoch>epoch\d+))?'
-    '_(?P<instrument>.+?)'
-    '_(?P<opt_elem>.+)'
+    r'jw'
+    r'(?P<program>\d{5})'
+    r'-(?P<acid>[a-z]\d{3,4})'
+    r'_(?P<target>(?:t\d{3})|(?:\{source_id\}))'
+    r'(?:-(?P<epoch>epoch\d+))?'
+    r'_(?P<instrument>.+?)'
+    r'_(?P<opt_elem>.+)'
 )
 
 LEVEL3_PRODUCT_NAME_NO_OPTELEM_REGEX = (
-    'jw'
-    '(?P<program>\d{5})'
-    '-(?P<acid>[a-z]\d{3,4})'
-    '_(?P<target>(?:t\d{3})|(?:s\d{5}))'
-    '(?:-(?P<epoch>epoch\d+))?'
-    '_(?P<instrument>.+?)'
+    r'jw'
+    r'(?P<program>\d{5})'
+    r'-(?P<acid>[a-z]\d{3,4})'
+    r'_(?P<target>(?:t\d{3})|(?:s\d{5}))'
+    r'(?:-(?P<epoch>epoch\d+))?'
+    r'_(?P<instrument>.+?)'
 )
 
 # Null values


### PR DESCRIPTION
Fix deprecations like the following
```
jwst/tests_nightly/general/associations/test_level3_product_names.py:17: DeprecationWarning: invalid escape sequence \d
    '(?P<program>\d{5})'
```