### PR TITLE
Propagate env to association pool paths in regression tests

### DIFF
--- a/jwst/tests_nightly/general/associations/conftest.py
+++ b/jwst/tests_nightly/general/associations/conftest.py
@@ -33,6 +33,7 @@ def pytest_generate_tests(metafunc):
     if 'pool_path' in metafunc.fixturenames:
         SDPPoolsSource.inputs_root = metafunc.config.getini('inputs_root')[0]
         SDPPoolsSource.results_root = metafunc.config.getini('results_root')[0]
+        SDPPoolsSource.env = metafunc.config.getoption('env')
 
         pools = SDPPoolsSource()
 

--- a/jwst/tests_nightly/general/associations/test_sdp_pools.py
+++ b/jwst/tests_nightly/general/associations/test_sdp_pools.py
@@ -64,7 +64,6 @@ class TestSDPPools(SDPPoolsSource):
         generated_path = Path('generate')
         generated_path.mkdir()
         args = special['args'] + [
-            '--no-merge',
             '-p', str(generated_path),
             '--version-id', version_id,
             self.get_data(pool_path)
@@ -103,7 +102,6 @@ class TestSDPPools(SDPPoolsSource):
 
         results = asn_generate([
             '--dry-run',
-            '--no-merge',
             self.get_data(pool_path)
         ])
         asns = results.associations

--- a/jwst/tests_nightly/general/associations/test_standards.py
+++ b/jwst/tests_nightly/general/associations/test_standards.py
@@ -18,15 +18,11 @@ from jwst.associations.main import Main
 # Setup environment
 # #################
 
-# Main test args
-TEST_ARGS = ['--no-merge']
-
 # Produce Level2b only associations
 LV2_ONLY_ARGS = [
     '-r',
     t_path('../lib/rules_level2b.py'),
     '--ignore-default',
-    '--no-merge'
 ]
 
 # Produce Level3 only associations
@@ -34,7 +30,6 @@ LV3_ONLY_ARGS = [
     '-r',
     t_path('../lib/rules_level3.py'),
     '--ignore-default',
-    '--no-merge'
 ]
 
 # Produce general associations
@@ -112,7 +107,7 @@ class TestAgainstStandards(BaseJWSTTest):
         generated_path = Path('generate')
         generated_path.mkdir()
         version_id = standard_pars.pool_root.replace('_', '-')
-        args = TEST_ARGS + standard_pars.main_args + [
+        args = standard_pars.main_args + [
             '-p', str(generated_path),
             '--version-id', version_id,
         ]


### PR DESCRIPTION
This will allow passing `--env` to point to a different tag branch on the Artifactory repo, to get the input and truth data appropriate for that tag.
```
pytest --bigdata --slow jwst/tests_nightly/general/associations/test_sdp_pools.py --env=0.13.7
```

This also fixes `--no-merge` deprecation warning produced in the associations regression tests.
```
201907081253:WARNING:jwst.associations.__call__:The "--no-merge" option is now the default and deprecated. Use "--merge" to force merging.
```