### PR TITLE
Add numpy to dev dependencies matrix in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - NUMPY_VERSION=1.16
+    - NUMPY="numpy~=1.16"
     - TEST_COMMAND='pytest'
 
 matrix:
@@ -34,10 +34,12 @@ matrix:
 
     # Test with dev dependencies
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
+           NUMPY="cython git+https://github.com/numpy/numpy"
 
     # Test with python 3.7 and dev dependencies
     - python: 3.7
       env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
+           NUMPY="cython git+https://github.com/numpy/numpy"
 
     # Test with latest delivered CRDS_CONTEXT, as in regressions tests
     - env: CRDS_CONTEXT="jwst-edit"
@@ -53,15 +55,17 @@ matrix:
 
   allow_failures:
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
+           NUMPY="cython git+https://github.com/numpy/numpy"
 
     - python: 3.7
       env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
+           NUMPY="cython git+https://github.com/numpy/numpy"
 
     - env: CRDS_CONTEXT="jwst-edit"
            PIP_DEPENDENCIES=".[test]"
 
 install:
-  - pip install numpy~=$NUMPY_VERSION
+  - pip install $NUMPY
   - pip install $PIP_DEPENDENCIES
 
 script: $TEST_COMMAND

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ addons:
       - texlive-latex-extra
       - dvipng
       - graphviz
+      - libblas3
+      - liblapack3
+      - liblapack-dev
+      - libblas-dev
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,33 +25,32 @@ matrix:
   fast_finish: true
 
   include:
-    # Run tests
-    - env: PIP_DEPENDENCIES='.[test]'
+    - env: PIP_DEPENDENCIES=".[test]"
 
-    # Test with python 3.7
     - python: 3.7
-      env: PIP_DEPENDENCIES='.[test]'
+      env: PIP_DEPENDENCIES=".[test]"
 
-    # Test with dev dependencies
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
            NUMPY="cython git+https://github.com/numpy/numpy"
 
-    # Test with python 3.7 and dev dependencies
     - python: 3.7
       env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
            NUMPY="cython git+https://github.com/numpy/numpy"
+
+    - python: 3.8-dev
+      env: PIP_DEPENDENCIES=".[test]"
 
     # Test with latest delivered CRDS_CONTEXT, as in regressions tests
     - env: CRDS_CONTEXT="jwst-edit"
            PIP_DEPENDENCIES=".[test]"
 
     # Build sphinx documentation with warnings
-    - env: TEST_COMMAND='make --directory=docs html'
-           PIP_DEPENDENCIES='.[docs]'
+    - env: TEST_COMMAND="make --directory=docs html"
+           PIP_DEPENDENCIES=".[docs]"
 
     # PEP8 check
-    - env: TEST_COMMAND='flake8 jwst'
-           PIP_DEPENDENCIES='flake8'
+    - env: TEST_COMMAND="flake8"
+           PIP_DEPENDENCIES="flake8"
 
   allow_failures:
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
@@ -60,6 +59,9 @@ matrix:
     - python: 3.7
       env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
            NUMPY="cython git+https://github.com/numpy/numpy"
+
+    - python: 3.8-dev
+      env: PIP_DEPENDENCIES=".[test]"
 
     - env: CRDS_CONTEXT="jwst-edit"
            PIP_DEPENDENCIES=".[test]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
            NUMPY="cython git+https://github.com/numpy/numpy"
 
     - python: 3.8-dev
-      env: PIP_DEPENDENCIES=".[test]"
+      env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
 
     # Test with latest delivered CRDS_CONTEXT, as in regressions tests
     - env: CRDS_CONTEXT="jwst-edit"
@@ -65,7 +65,7 @@ matrix:
            NUMPY="cython git+https://github.com/numpy/numpy"
 
     - python: 3.8-dev
-      env: PIP_DEPENDENCIES=".[test]"
+      env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
 
     - env: CRDS_CONTEXT="jwst-edit"
            PIP_DEPENDENCIES=".[test]"


### PR DESCRIPTION
Since packages in our `requirements-dev.txt` file depend on `numpy`, if one wants to install the dev version, one has to do it first before installing the requirements.