### PR TITLE
Update gain_scale step to work on variance arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,11 @@ extract_1d
 - Parameters were added to ``ExtractBase.__init__``, and most of the initialization
   is done there rather than in the subclasses. [#3714]
 
+gain_scale
+----------
+
+- Updated to apply gain factor to variance arrays. [#3794]
+
 group_scale
 -----------
 

--- a/docs/jwst/gain_scale/description.rst
+++ b/docs/jwst/gain_scale/description.rst
@@ -32,7 +32,7 @@ reads that keyword value during its execution and stores the value in
 the science data keyword `GAINFACT`, so that the gain reference file
 does not have to be loaded again by the `gain_scale` step. If, however,
 the step does not find that keyword populated in the science data, it
-loads the gain reference file to retreive it. If all attempts to
+loads the gain reference file to retrieve it. If all attempts to
 find the scaling factor fail, the step is skipped.
 
 Gain reference files for instruments or modes that use the standard

--- a/docs/jwst/gain_scale/description.rst
+++ b/docs/jwst/gain_scale/description.rst
@@ -15,26 +15,31 @@ the change was made in the instrument flight software to use gain=2.
 NIRSpec subarray data obtained previous to that time used the
 standard gain=1 setting.
 
-The `gain_scale` step is applied at the end of the `calwebb_detector1`
-pipeline, after the `ramp_fit` step has been applied. It is applied
-to both the `rate` and `rateints` products from `ramp_fit`, if both
-types of products were created. The science (`SCI`) and error (`ERR`)
-arrays are both rescaled.
+The `gain_scale` step is applied at the end of the
+:ref:`calwebb_detector1 <calwebb_detector1>` pipeline, after the
+:ref:`ramp_fit <ramp_fit_step>` step has been applied. It is applied
+to both the `rate` and `rateints` products from
+:ref:`ramp_fit <ramp_fit_step>`, if both
+types of products were created. The science (SCI) and error (ERR)
+arrays are multiplied by the gain factor, and the Poisson
+variance (VAR_POISSON) and read noise variance (VAR_RNOISE) arrays
+are multiplied by the square of the gain factor.
 
 The scaling factor is obtained from the `GAINFACT` keyword in the
-header of the gain reference file. Normally the `ramp_fit` step will
-read that keyword value during its execution and store the value in
+header of the gain reference file. Normally the
+:ref:`ramp_fit <ramp_fit_step>` step
+reads that keyword value during its execution and stores the value in
 the science data keyword `GAINFACT`, so that the gain reference file
 does not have to be loaded again by the `gain_scale` step. If, however,
 the step does not find that keyword populated in the science data, it
-will load the gain reference file to retreive it. If all attempts to
-find the scaling factor fail, the step will be skipped.
+loads the gain reference file to retreive it. If all attempts to
+find the scaling factor fail, the step is skipped.
 
 Gain reference files for instruments or modes that use the standard
 gain setting will typically not have the `GAINFACT` keyword in their
-header, which will cause the `gain_scale` step to be skipped. Alternatively,
+header, which causes the `gain_scale` step to be skipped. Alternatively,
 gain reference files for modes that use the standard gain can have
-`GAINFACT=1.0`, in which case the correction will be benign.
+`GAINFACT=1.0`, in which case the correction is benign.
 
 Upon successful completion of the step, the `S_GANSCL` keyword in the
-science data will be set to "COMPLETE."
+science data is set to "COMPLETE."

--- a/jwst/gain_scale/gain_scale.py
+++ b/jwst/gain_scale/gain_scale.py
@@ -1,7 +1,4 @@
-#
-#  Module for rescaling data for non-standard gain value
-#
-
+import numpy as np
 import logging
 
 log = logging.getLogger(__name__)
@@ -13,29 +10,40 @@ def do_correction(input_model, gain_factor):
     Short Summary
     -------------
     Rescales all integrations in an exposure by gain_factor, to
-    account for non-standard detector gain settings. The SCI
-    and ERR arrays are rescaled.
+    account for non-standard detector gain settings. The SCI,
+    ERR, and variance arrays are rescaled.
 
     Parameters
     ----------
-    input_model: data model object
-        science data to be corrected
+    input_model : `~jwst.datamodels.DataModel`
+        Input datamodel to be corrected
 
     Returns
     -------
-    output_model: data model object
-        rescaled science data
+    output_model : `~jwst.datamodels.DataModel`
+        Output datamodel with rescaled data
 
     """
 
     # Create output as a copy of the input science data model
     output_model = input_model.copy()
 
-    # Apply the rescaling to the entire data array
+    # Apply the gain factor to the SCI and ERR arrays
     log.info('Rescaling by {0}'.format(gain_factor))
     output_model.data *= gain_factor
     output_model.err *= gain_factor
 
+    # Apply the square of the gain factor to the variance arrays,
+    # if they exist
+    if (output_model.var_poisson is not None and
+            np.size(output_model.var_poisson)) > 0:
+                output_model.var_poisson *= gain_factor**2
+
+    if (output_model.var_rnoise is not None and
+            np.size(output_model.var_rnoise)) > 0:
+                output_model.var_rnoise *= gain_factor**2
+
+    # Set step status info
     output_model.meta.exposure.gain_factor = gain_factor
     output_model.meta.cal_step.gain_scale = 'COMPLETE'
 

--- a/jwst/gain_scale/tests/test_gain_scale.py
+++ b/jwst/gain_scale/tests/test_gain_scale.py
@@ -2,52 +2,59 @@
 Unit tests for gain_scale correction
 """
 
-from jwst.datamodels import RampModel
+from jwst.datamodels import CubeModel
 from jwst.gain_scale.gain_scale import do_correction
 from jwst.gain_scale import GainScaleStep
 import numpy as np
 import pytest
 
-def test_correction(make_rampmodel):
+
+def test_correction(make_cubemodel):
     """Make sure correct gain factor is applied
     """
-    datmod = make_rampmodel(2, 50, 50)
-    output = do_correction(datmod, gain_factor=datmod.meta.exposure.gain_factor)
+    datmod = make_cubemodel(2, 50, 50)
+    gf = datmod.meta.exposure.gain_factor
+    output = do_correction(datmod, gain_factor=gf)
 
     assert(output.meta.cal_step.gain_scale == 'COMPLETE')
-    assert np.all(output.err == datmod.err * datmod.meta.exposure.gain_factor)
-    assert np.all(output.data == datmod.data * datmod.meta.exposure.gain_factor)
+    assert np.all(output.data == datmod.data * gf)
+    assert np.all(output.err == datmod.err * gf)
+    assert np.all(output.var_poisson == datmod.var_poisson * gf * gf)
+    assert np.all(output.var_rnoise == datmod.var_rnoise * gf * gf)
 
 
-def test_step(make_rampmodel):
+def test_step(make_cubemodel):
     """Make sure correct gain factor is applied at step level
     """
-    datmod = make_rampmodel(2, 50, 50)
+    datmod = make_cubemodel(2, 50, 50)
+    gf = datmod.meta.exposure.gain_factor
     output = GainScaleStep.call(datmod)
 
     assert(output.meta.cal_step.gain_scale == 'COMPLETE')
-    assert np.all(output.err == datmod.err * datmod.meta.exposure.gain_factor)
-    assert np.all(output.data == datmod.data * datmod.meta.exposure.gain_factor)
+    assert np.all(output.data == datmod.data * gf)
+    assert np.all(output.err == datmod.err * gf)
+    assert np.all(output.var_poisson == datmod.var_poisson * gf * gf)
+    assert np.all(output.var_rnoise == datmod.var_rnoise * gf * gf)
 
 
 @pytest.fixture(scope='function')
-def make_rampmodel():
-    '''Ramp model for testing'''
+def make_cubemodel():
+    '''Cube model for testing'''
 
-    # NRS1 and NRS2 are size  2048x2048 pixels
-    def _dm(ngroups, ysize, xsize):
-        # create the data and groupdq arrays
-        nints = 2
-        csize = (nints, ngroups, ysize, xsize)
+    def _dm(nints, ysize, xsize):
+        # create the data arrays
+        csize = (nints, ysize, xsize)
         data = np.random.randint(low=1, high=50, size=csize)
         err = np.random.randint(low=0.1, high=5.0, size=csize)
+        var_p = err * err
+        var_r = np.ones(csize) * 12
 
-        # create a JWST datamodel for NIRSPEC data
-        dm = RampModel(data=data, err=err)
+        # create a JWST datamodel
+        dm = CubeModel(data=data, err=err, var_poisson=var_p, var_rnoise=var_r)
 
         dm.meta.instrument.name = 'NIRSPEC'
         dm.meta.date = '2018-01-01'
-        dm.meta.instrument.detector= 'NRS1'
+        dm.meta.instrument.detector = 'NRS1'
         dm.meta.observation.date = '2018-01-01'
 
         dm.meta.exposure.gain_factor = 2


### PR DESCRIPTION
Updated the `gain_scale` step to apply the correction to the variance arrays, in addition to SCI and ERR. Also updated the unit test to create CubeModels, instead of RampModels, because when the step is applied in the `calwebb_detector1` flow it's working on countrate images/cubes, not 4-D ramps. Updated docs accordingly.

Fixes #3790.