### PR TITLE
Fix bug in okify script when fitsdiff fails to write version description

### DIFF
--- a/scripts/okify_regression_tests.py
+++ b/scripts/okify_regression_tests.py
@@ -108,7 +108,23 @@ def main():
         elif FITSDIFF_RE.match(lines[i]):
             block = [lines[i]]
             j = i + 1
+            result_found = False
+            truth_found = False
             while lines[j].startswith("E   ") and not FITSDIFF_RE.match(lines[j]):
+                if RESULT_PATH_RE.match(lines[j]):
+                    if result_found:
+                        # Sometimes if there is no diff, the fitsdiff output will
+                        # omit the "fitsdiff: x.y.z" line that we're using to delineate
+                        # file comparisons.  This just says: stop if we have already seen
+                        # a result path and another one appears.
+                        break
+                    else:
+                        result_found = True
+                elif TRUTH_PATH_RE.match(lines[j]):
+                    if truth_found:
+                        break
+                    else:
+                        truth_found = True
                 block.append(lines[j])
                 j += 1
 


### PR DESCRIPTION
https://jira.stsci.edu/browse/JP-856

I noticed that one of the regression tests was not okified by the new script.  It turns out fitsdiff may omit the version description line that I used to break up the output by file, and when that happens the script was failing to query the user about one of the files.

This PR fixes that issue.  I tested it on last night's test output and it was able to recognize the busted file.

