### PR TITLE
JP-842 Update exp_to_source docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ datamodels
 - Write ``siaf_xref_sci`` and ``siaf_yref_sci`` to FITS keywords ``XREF_SCI``
   and ``YREF_SCI`` for ``NRC_TSGRISM`` exposures. [#3766]
 
+exp_to_source
+-------------
+
+- Updated the documentation and added some logging to the step. [#3803]
+
 extract_1d
 ----------
 

--- a/docs/jwst/data_products/file_naming.rst
+++ b/docs/jwst/data_products/file_naming.rst
@@ -1,5 +1,10 @@
-File Naming Scheme
-------------------
+File Naming Schemes
+-------------------
+
+.. _exp_file_names:
+
+Stage 0 - 2 Naming
+^^^^^^^^^^^^^^^^^^
 The FITS file naming scheme for Stage 0, 1, and 2 "exposure-based" products is::
 
  jw<ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>(-<"seg"NNN>)_<detector>_<prodType>.fits
@@ -21,6 +26,10 @@ An example Stage 1 product FITS file name is::
 
  jw93065002001_02101_00001_nrca1_rate.fits
 
+.. _src_file_names:
+
+Stage 3 Naming
+^^^^^^^^^^^^^^
 The FITS file naming scheme for Stage 3 "source-based" products is::
 
  jw<ppppp>-<AC_ID>_[<"t"TargID | "s"SourceID>](-<"epoch"X>)_<instr>_<optElements>(-<subarray>)_<prodType>(-<ACT_ID>).fits

--- a/docs/jwst/exp_to_source/main.rst
+++ b/docs/jwst/exp_to_source/main.rst
@@ -1,8 +1,90 @@
 Description
 ============
 
-Overview
---------
-The ``exp_to_source`` is a Stage 2 -> Stage 3 data reorganization tool.
-It will take a list of Stage 2 MultiSlit exposures and reorganize the data to produce files that
-are source-centric.
+``exp_to_source`` is a data reorganization tool that is used to convert
+Stage 2 exposure-based data products to Stage 3 source-based data products.
+It is only used when there is a known source list for the exposure data,
+which is required in order to reorganize the data by source. Hence it is
+only useable for NIRSpec MOS, NIRSpec fixed-slit, NIRCam WFSS, and NIRISS
+WFSS data. Details on the operation for each mode are given below.
+
+The tool is run near the beginning of the :ref:`calwebb_spec3 <calwebb_spec3>`
+pipeline, immediately after the :ref:`master background <master_background_step>`
+step.
+
+In general, the tool takes as input multiple exposure-based "cal" products
+created during Stage 2 spectroscopic (:ref:`calwebb_spec2 <calwebb_spec2>`)
+processing and reorganizes the data in them to create a set of output
+source-based "cal" products, which are then processed through the remaining
+steps of the :ref:`calwebb_spec3 <calwebb_spec3>` pipeline. For example,
+if the input consists of a set of 3 exposure-based "cal" files (from a
+3-point nod dither pattern, for example), each one of which contains data
+for 5 defined sources, then the output consists of a set of 5
+source-based "cal" products (one per source), each of which contains the
+data from the 3 exposures for each source. This is done as a convenience,
+in order to have all the data for a given source contained in a single
+product. All data arrays associated with a given source, e.g. SCI, ERR, DQ,
+WAVELENGTH, VAR_POISSON, etc., are copied from each input product into
+the corresponding output product.
+
+NIRSpec MOS
+^^^^^^^^^^^
+NIRSpec MOS observations are created at the APT level by defining a
+configuration of MSA slitlets with a source assigned to each slitlet.
+The source-to-slitlet linkage is carried along in the information contained
+in the MSA metadata file used during :ref:`calwebb_spec2 <calwebb_spec2>`
+processing. Each slitlet instance created by the :ref:`extract_2d <extract_2d_step>`
+step stores the source ID (a simple integer number) in the SOURCEID keyword of
+the SCI extension header for the slitlet. The ``exp_to_source`` tool uses
+the SOURCEID values to sort the data from each input product into an
+appropriate source-based output product.
+
+NIRSpec Fixed-Slit
+^^^^^^^^^^^^^^^^^^
+NIRSpec fixed-slit observations do not have sources identified with each
+slit, so the slit names, e.g. S200A1, S1600A1, etc., are mapped to predefined
+source ID values, as follows:
+
+=========  =========
+Slit Name  Source ID
+=========  =========
+S200A1         1
+S200A2         2
+S400A1         3
+S1600A1        4
+S200B1         5
+=========  =========
+
+The assigned source ID values are used by ``exp_to_source`` to sort the data
+from each slit into the appropriate source-based output product.
+
+NIRCam and NIRISS WFSS
+^^^^^^^^^^^^^^^^^^^^^^
+Wide-Field Slitless Spectroscopy (WFSS) modes do not have a predefined
+source list, but a source list is created by the
+:ref:`calwebb_image3 <calwebb_image3>` pipeline when it processes the
+direct image exposures that are included in a WFSS observation. That
+source catalog is then used during :ref:`calwebb_spec2 <calwebb_spec2>`
+processing of the grism exposures to define and create cutouts for each
+identified source. Like NIRSpec MOS mode, each "slit" instance is identified
+by the source ID number from the catalog and is used by the ``exp_to_source``
+tool to reorganize exposures into source-based products.
+
+File Name Syntax
+^^^^^^^^^^^^^^^^
+The input exposure-based "cal" products have file names that follow the
+standard Stage 2 exposure syntax, such as::
+
+ jw93065002001_02101_00001_nrs1_cal.fits
+
+See :ref:`exposure-based file names <exp_file_names>` for more details
+on the meaning of each field in the file names.
+
+The FITS file naming scheme for the source-based "cal" products follows
+the standard Stage 3 syntax, such as::
+
+ jw10006-o010_s00061_nirspec_f170lp-g235m_cal.fits
+
+where "s00061" in this example is the source ID.
+See :ref:`source-based file names <src_file_names>` for more details
+on the meaning of each field in this type of file name.

--- a/docs/jwst/gain_scale/description.rst
+++ b/docs/jwst/gain_scale/description.rst
@@ -17,9 +17,9 @@ standard gain=1 setting.
 
 The `gain_scale` step is applied at the end of the
 :ref:`calwebb_detector1 <calwebb_detector1>` pipeline, after the
-:ref:`ramp_fit <ramp_fit_step>` step has been applied. It is applied
+:ref:`ramp_fit <ramp_fitting_step>` step has been applied. It is applied
 to both the `rate` and `rateints` products from
-:ref:`ramp_fit <ramp_fit_step>`, if both
+:ref:`ramp_fit <ramp_fitting_step>`, if both
 types of products were created. The science (SCI) and error (ERR)
 arrays are multiplied by the gain factor, and the Poisson
 variance (VAR_POISSON) and read noise variance (VAR_RNOISE) arrays
@@ -27,7 +27,7 @@ are multiplied by the square of the gain factor.
 
 The scaling factor is obtained from the `GAINFACT` keyword in the
 header of the gain reference file. Normally the
-:ref:`ramp_fit <ramp_fit_step>` step
+:ref:`ramp_fit <ramp_fitting_step>` step
 reads that keyword value during its execution and stores the value in
 the science data keyword `GAINFACT`, so that the gain reference file
 does not have to be loaded again by the `gain_scale` step. If, however,

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -1,5 +1,7 @@
-"""exp_to_source: Reformat Level2b MSA data to be source-based.
+"""exp_to_source: Reformat Level2b multi-source data to be source-based.
 """
+import logging
+
 from collections import OrderedDict
 from collections.abc import Callable
 
@@ -10,6 +12,9 @@ from ..datamodels import (
 from ..datamodels.properties import merge_tree
 
 __all__ = ['exp_to_source', 'multislit_to_container']
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 
 def exp_to_source(inputs):
@@ -29,7 +34,9 @@ def exp_to_source(inputs):
     """
     result = DefaultOrderedDict(MultiExposureModel)
     for exposure in inputs:
+        log.info('Reorganizing data from exposure {}'.format(exposure.meta.filename))
         for slit in exposure.slits:
+            log.debug('Copying slit {}'.format(slit.source_id))
             result[str(slit.source_id)].exposures.append(slit)
             merge_tree(
                 result[str(slit.source_id)].exposures[-1].meta.instance,


### PR DESCRIPTION
Updated the `exp_to_source` docs to give a lot more details as to how things work for various modes, and examples of reorganized file names. Also fixed some broken internal references in the `gain_scale` doc. Also added a little bit of logging info to the `exp_to_source` step itself (it's nice to be able to see what's happening, instead of just staring at a blank screen).

Fixes #3773 