### PR TITLE
JP-349 DQ Flagging for IFU cubes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -713,6 +713,8 @@ csv_tools
 cube_build
 ----------
 
+- Added dq flagging [#3804]
+
 cube_skymatch
 -------------
 

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -192,7 +192,7 @@ class CubeData():
 # _______________________________________________________________________________
             for i in range(nchannels):
                 for j in range(nsubchannels):
-                    nfiles = len(master_table.FileMap['MIRI'][valid_channel[i]][valid_subchannel[j]])
+                    nfiles = len(master_table.FileMap['MIRI'][valid_channel[i]][valid_subchannel[j]]['file'])
                     if nfiles > 0:
 # ______________________________________________________________________________
                         # neither parameters are set
@@ -260,7 +260,7 @@ class CubeData():
             if user_glen == 0 and user_flen == 0:
                 for i in range(nbands):
 
-                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]])
+                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]]['file'])
                     if nfiles > 0:
                         self.all_grating.append(valid_gwa[i])
                         self.all_filter.append(valid_fwa[i])
@@ -270,7 +270,7 @@ class CubeData():
 
             else:
                 for i in range(nbands):
-                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]])
+                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]]['file'])
                     if nfiles > 0:
                         # now check if THESE Filter and Grating input parameters were set
                         if (valid_fwa[i] in self.filter and

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -194,13 +194,13 @@ class CubeData():
                 for j in range(nsubchannels):
                     nfiles = len(master_table.FileMap['MIRI'][valid_channel[i]][valid_subchannel[j]])
                     if nfiles > 0:
-# ______________________________________________________________________________
+                        # ______________________________________________________
                         # neither parameters are set
                         if user_clen == 0 and user_slen == 0:
                             self.all_channel.append(valid_channel[i])
                             self.all_subchannel.append(valid_subchannel[j])
-# _______________________________________________________________________________
-# channel was set by user but not sub-channel
+                            # __________________________________________________
+                            # channel was set by user but not sub-channel
                         elif user_clen != 0 and user_slen == 0:
                             # now check if this channel was set by user
                             if (valid_channel[i] in self.channel):

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -192,7 +192,7 @@ class CubeData():
 # _______________________________________________________________________________
             for i in range(nchannels):
                 for j in range(nsubchannels):
-                    nfiles = len(master_table.FileMap['MIRI'][valid_channel[i]][valid_subchannel[j]]['file'])
+                    nfiles = len(master_table.FileMap['MIRI'][valid_channel[i]][valid_subchannel[j]])
                     if nfiles > 0:
 # ______________________________________________________________________________
                         # neither parameters are set
@@ -260,7 +260,7 @@ class CubeData():
             if user_glen == 0 and user_flen == 0:
                 for i in range(nbands):
 
-                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]]['file'])
+                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]])
                     if nfiles > 0:
                         self.all_grating.append(valid_gwa[i])
                         self.all_filter.append(valid_fwa[i])
@@ -270,7 +270,7 @@ class CubeData():
 
             else:
                 for i in range(nbands):
-                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]]['file'])
+                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]])
                     if nfiles > 0:
                         # now check if THESE Filter and Grating input parameters were set
                         if (valid_fwa[i] in self.filter and

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -56,7 +56,7 @@ class CubeBuildStep (Step):
          output_use_model = boolean(default=true) # Use filenames in the output models
        """
 
-    reference_file_types = ['cubepar', 'resol']
+    reference_file_types = ['cubepar', 'resol', 'regions']
 
 # ________________________________________________________________________________
     def process(self, input):
@@ -225,6 +225,16 @@ class CubeBuildStep (Step):
                 self.log.warning('No spectral resolution reference file found')
                 self.log.warning('Run again and turn off miripsf')
                 return
+
+# ________________________________________________________________________________
+# Read in regions reference file - only needed for MIRI Data
+
+#        regions_filename = self.get_reference_file(self.input_models[0], 'regions')
+
+#        if regions_filename == 'N/A':
+#            self.log.warning('No regions reference file found')
+#            self.log.warning('This must be NIRSPEC data')
+#            return
 # ________________________________________________________________________________
 # shove the input parameters in to pars to pull out in general cube_build.py
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -37,6 +37,7 @@ class CubeBuildStep (Step):
          band = option('short','medium','long','all',default='all') # Band
          grating   = option('prism','g140m','g140h','g235m','g235h',g395m','g395h','all',default='all') # Grating
          filter   = option('clear','f100lp','f070lp','f170lp','f290lp','all',default='all') # Filter
+         output_type = option('band','channel','grating','multi',default='band') # Type IFUcube to create.
          scale1 = float(default=0.0) # cube sample size to use for axis 1, arc seconds
          scale2 = float(default=0.0) # cube sample size to use for axis 2, arc seconds
          scalew = float(default=0.0) # cube sample size to use for axis 3, microns
@@ -51,12 +52,12 @@ class CubeBuildStep (Step):
          xdebug = integer(default=None) # debug option, x spaxel value to report information on
          ydebug = integer(default=None) # debug option, y spaxel value to report information on
          zdebug = integer(default=None) # debug option, z spaxel value to report  information on
-         output_type = option('band','channel','grating','multi',default='band') # Type IFUcube to create.
+         debug_write = boolean(default=false) # Open and write information on FOV on sky for each file
          search_output_file = boolean(default=false)
          output_use_model = boolean(default=true) # Use filenames in the output models
        """
 
-    reference_file_types = ['cubepar', 'resol', 'regions']
+    reference_file_types = ['cubepar', 'resol']
 
 # ________________________________________________________________________________
     def process(self, input):
@@ -225,16 +226,6 @@ class CubeBuildStep (Step):
                 self.log.warning('No spectral resolution reference file found')
                 self.log.warning('Run again and turn off miripsf')
                 return
-
-# ________________________________________________________________________________
-# Read in regions reference file - only needed for MIRI Data
-
-#        regions_filename = self.get_reference_file(self.input_models[0], 'regions')
-
-#        if regions_filename == 'N/A':
-#            self.log.warning('No regions reference file found')
-#            self.log.warning('This must be NIRSPEC data')
-#            return
 # ________________________________________________________________________________
 # shove the input parameters in to pars to pull out in general cube_build.py
 
@@ -249,6 +240,7 @@ class CubeBuildStep (Step):
 
 # shove the input parameters in to pars_cube to pull out ifu_cube.py
 # these parameters are related to the building a single ifucube_model
+
         pars_cube = {
             'scale1': self.scale1,
             'scale2': self.scale2,
@@ -261,6 +253,7 @@ class CubeBuildStep (Step):
             'roiw': self.roiw,
             'wavemin': self.wavemin,
             'wavemax': self.wavemax,
+            'debug_write': self.debug_write,
             'xdebug': self.xdebug,
             'ydebug': self.ydebug,
             'zdebug': self.zdebug,

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -52,7 +52,7 @@ class CubeBuildStep (Step):
          xdebug = integer(default=None) # debug option, x spaxel value to report information on
          ydebug = integer(default=None) # debug option, y spaxel value to report information on
          zdebug = integer(default=None) # debug option, z spaxel value to report  information on
-         debug_write = boolean(default=false) # Open and write information on FOV on sky for each file
+         skip_dqflag = boolean(default=false) # skip setting the DQ plane of the IFU  
          search_output_file = boolean(default=false)
          output_use_model = boolean(default=true) # Use filenames in the output models
        """
@@ -253,7 +253,7 @@ class CubeBuildStep (Step):
             'roiw': self.roiw,
             'wavemin': self.wavemin,
             'wavemax': self.wavemax,
-            'debug_write': self.debug_write,
+            'skip_dqflag': self.skip_dqflag,
             'xdebug': self.xdebug,
             'ydebug': self.ydebug,
             'zdebug': self.zdebug,

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -150,6 +150,7 @@ class CubeBuildStep (Step):
         if self.coord_system == 'world':
             self.interpolation = 'pointcloud'  # can not be area
 
+
         self.log.info('Input interpolation: %s', self.interpolation)
         self.log.info('Coordinate system to use: %s', self.coord_system)
         if self.interpolation == 'pointcloud':

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -52,7 +52,7 @@ class CubeBuildStep (Step):
          xdebug = integer(default=None) # debug option, x spaxel value to report information on
          ydebug = integer(default=None) # debug option, y spaxel value to report information on
          zdebug = integer(default=None) # debug option, z spaxel value to report  information on
-         skip_dqflag = boolean(default=false) # skip setting the DQ plane of the IFU  
+         skip_dqflag = boolean(default=false) # skip setting the DQ plane of the IFU
          search_output_file = boolean(default=false)
          output_use_model = boolean(default=true) # Use filenames in the output models
        """
@@ -150,7 +150,6 @@ class CubeBuildStep (Step):
         # 2. miripsf - weighting for MIRI based on PSF and LSF
         if self.coord_system == 'world':
             self.interpolation = 'pointcloud'  # can not be area
-
 
         self.log.info('Input interpolation: %s', self.interpolation)
         self.log.info('Coordinate system to use: %s', self.coord_system)

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -52,7 +52,7 @@ class CubeBuildStep (Step):
          xdebug = integer(default=None) # debug option, x spaxel value to report information on
          ydebug = integer(default=None) # debug option, y spaxel value to report information on
          zdebug = integer(default=None) # debug option, z spaxel value to report  information on
-         skip_dqflag = boolean(default=false) # skip setting the DQ plane of the IFU
+         skip_dqflagging = boolean(default=false) # skip setting the DQ plane of the IFU
          search_output_file = boolean(default=false)
          output_use_model = boolean(default=true) # Use filenames in the output models
        """
@@ -252,7 +252,7 @@ class CubeBuildStep (Step):
             'roiw': self.roiw,
             'wavemin': self.wavemin,
             'wavemax': self.wavemax,
-            'skip_dqflag': self.skip_dqflag,
+            'skip_dqflagging': self.skip_dqflagging,
             'xdebug': self.xdebug,
             'ydebug': self.ydebug,
             'zdebug': self.zdebug,

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -269,7 +269,8 @@ class CubeBuildStep (Step):
 # cubeinfo.setup:
 # read in all the input files, information from cube_pars, read in input data
 # and fill in master_table holding what files are associationed with each
-# ch/sub-ch or grating/filter.
+# ch/sub-ch or grating/filter. Also the footprint on the sky and wavelength range
+# of each file is stored in file_map.
 # Fill in all_channel, all_subchannel,all_filter, all_grating, instrument and
 # detector
 

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -262,7 +262,6 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
             istart = zz * nplane
             for ir, rr in enumerate(indexr[0]):
 # ______________________________________________________________________________
-# ______________________________________________________________________________
 # if weight is miripsf -distances determined in alpha-beta coordinate system
 
                 weights = FindNormalizationWeights(wave[ipt],

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -103,7 +103,7 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
         indexz = np.where(abs(zcoord - wave[ipt]) <= roiw_pixel[ipt])
 
         # on the wavelength boundaries the point cloud may not be in the IFUCube
-        # the edge cases are skipped and not included in final IFUcube.
+        # the edge cases are skipped and not included in final IFUcube to avoid noisy results
         # Left commented code for checking later for NIRSPEC the spectral size
         # in the reference file may be too small
 #        if len(indexz[0]) == 0:

--- a/jwst/cube_build/cube_overlap.py
+++ b/jwst/cube_build/cube_overlap.py
@@ -258,7 +258,7 @@ def addpoint(x, y, xnew, ynew, nvertices2):
 # ________________________________________________________________________________
 
 
-def SH_FindOverlap(xcenter, ycenter, xlength, ylength, xp_corner, yp_corner):
+def sh_find_overlap(xcenter, ycenter, xlength, ylength, xp_corner, yp_corner):
     """ Find overlap between pixel and spaxel
 
     Using the Sutherland_hedgeman Polygon Clipping Algorithm to solve the
@@ -493,12 +493,12 @@ def match_det2cube(x, y, sliceno, start_slice, input_model, transform,
             for xx in range(ix1, ix2 + 1):
                 cube_index = istart + yy * naxis1 + xx  # yy = slice # -1
                 xcenter = xcoord[xx]
-                AreaOverlap = SH_FindOverlap(xcenter, zcenter,
+                area_overlap = sh_find_overlap(xcenter, zcenter,
                                              cdelt1, cdelt3,
                                              alpha_corner, wave_corner)
 
-                if AreaOverlap > 0.0:
-                    AreaRatio = AreaOverlap / Area
+                if area_overlap > 0.0:
+                    AreaRatio = area_overlap / Area
                     spaxel_flux[cube_index] = spaxel_flux[cube_index] + \
                         (AreaRatio * pixel_flux[ipixel])
                     spaxel_weight[cube_index] = spaxel_weight[cube_index] + \

--- a/jwst/cube_build/cube_overlap.py
+++ b/jwst/cube_build/cube_overlap.py
@@ -410,10 +410,8 @@ def match_det2cube(x, y, sliceno, start_slice, input_model, transform,
 
     pixel_dq = input_model.dq[y, x]
 
-    all_flags = (dqflags.pixel['DO_NOT_USE'] + dqflags.pixel['DROPOUT'] +
-                 dqflags.pixel['NON_SCIENCE'] +
-                 dqflags.pixel['DEAD'] + dqflags.pixel['HOT'] +
-                 dqflags.pixel['RC'] + dqflags.pixel['NONLINEAR'])
+    all_flags = (dqflags.pixel['DO_NOT_USE']  +
+                 dqflags.pixel['NON_SCIENCE'] )
     # find the location of all the values to reject in cube building
     good_data = np.where((np.bitwise_and(pixel_dq, all_flags) == 0))
 

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -172,8 +172,8 @@ class FileTable():
 
                     self.FileMap['NIRSPEC'][gwa][fwa]['file'].append(input_model)
                     self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(None)
-                    instrument = input_model.meta.instrument.name.lower()
-                    mod = importlib.import_module('.' + instrument, 'jwst.assign_wcs')
+#                    instrument = input_model.meta.instrument.name.lower()
+#                    mod = importlib.import_module('.' + instrument, 'jwst.assign_wcs')
                 else:
 
                     log.info('Instrument not valid for cube')

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -2,7 +2,6 @@
 """
 from .. import datamodels
 from .. assign_wcs.util import  wcs_bbox_from_shape
-from .. assign_wcs.util import 
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -149,7 +148,6 @@ class FileTable():
                 detector = input_model.meta.instrument.detector
                 instrument = input_model.meta.instrument.name
                 assign_wcs = input_model.meta.cal_step.assign_wcs
-#                sfootprint =  input_model.meta.wcsinfo.s_region
 
                 if(assign_wcs != 'COMPLETE'):
                     raise ErrorNoAssignWCS("Assign WCS has not been run on file %s",
@@ -160,12 +158,11 @@ class FileTable():
                 if instrument == 'MIRI':
                     channel = input_model.meta.instrument.channel
                     subchannel = input_model.meta.instrument.band.lower()
-#                    footprint = find_footprint_spectral(input_model) 
             #________________________________________________________________________________
                     clenf = len(channel)
                     for k in range(clenf):
                         self.FileMap['MIRI'][channel[k]][subchannel]['file'].append(input_model)
-#                        self.FileMap['MIRI'][channel[k]][subchannel]['footprint'].append(footprint)
+                        self.FileMap['MIRI'][channel[k]][subchannel]['footprint'].append(None)
             #________________________________________________________________________________
             #NIRSPEC instrument
             #________________________________________________________________________________
@@ -174,10 +171,9 @@ class FileTable():
                     gwa = input_model.meta.instrument.grating.lower()
 
                     self.FileMap['NIRSPEC'][gwa][fwa]['file'].append(input_model)
+                    self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(None)
                     instrument = input_model.meta.instrument.name.lower()
                     mod = importlib.import_module('.' + instrument, 'jwst.assign_wcs')
-#                    footprint = find_footprint_nrs_ifu(input_model, mod)
-#                    self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(footprint)
                 else:
 
                     log.info('Instrument not valid for cube')

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -2,6 +2,7 @@
 """
 from .. import datamodels
 from .. assign_wcs.util import  wcs_bbox_from_shape
+from .. assign_wcs.util import 
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -148,9 +149,7 @@ class FileTable():
                 detector = input_model.meta.instrument.detector
                 instrument = input_model.meta.instrument.name
                 assign_wcs = input_model.meta.cal_step.assign_wcs
-                sfootprint =  input_model.meta.wcsinfo.s_region
-                print('sfootprint',sfootprint)
-
+#                sfootprint =  input_model.meta.wcsinfo.s_region
 
                 if(assign_wcs != 'COMPLETE'):
                     raise ErrorNoAssignWCS("Assign WCS has not been run on file %s",
@@ -161,12 +160,12 @@ class FileTable():
                 if instrument == 'MIRI':
                     channel = input_model.meta.instrument.channel
                     subchannel = input_model.meta.instrument.band.lower()
-                    footprint = find_footprint_spectral(input_model) 
+#                    footprint = find_footprint_spectral(input_model) 
             #________________________________________________________________________________
                     clenf = len(channel)
                     for k in range(clenf):
                         self.FileMap['MIRI'][channel[k]][subchannel]['file'].append(input_model)
-                        self.FileMap['MIRI'][channel[k]][subchannel]['footprint'].append(footprint)
+#                        self.FileMap['MIRI'][channel[k]][subchannel]['footprint'].append(footprint)
             #________________________________________________________________________________
             #NIRSPEC instrument
             #________________________________________________________________________________
@@ -177,12 +176,11 @@ class FileTable():
                     self.FileMap['NIRSPEC'][gwa][fwa]['file'].append(input_model)
                     instrument = input_model.meta.instrument.name.lower()
                     mod = importlib.import_module('.' + instrument, 'jwst.assign_wcs')
-                    footprint = find_footprint_nrs_ifu(input_model, mod)
-                    self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(footprint)
+#                    footprint = find_footprint_nrs_ifu(input_model, mod)
+#                    self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(footprint)
                 else:
 
                     log.info('Instrument not valid for cube')
-
         return instrument, detector
 
 class ErrorNoAssignWCS(Exception):

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -20,94 +20,48 @@ class FileTable():
 #        self.FileMap['MIRI']['1']['medium'] = []
 #        self.FileMap['MIRI']['1']['long'] = []
         self.FileMap['MIRI']['1'] = {}
-        self.FileMap['MIRI']['1']['short'] = {}
-        self.FileMap['MIRI']['1']['short']['footprint'] = []
-        self.FileMap['MIRI']['1']['short']['file'] = []
-        self.FileMap['MIRI']['1']['medium'] = {}
-        self.FileMap['MIRI']['1']['medium']['footprint'] = []
-        self.FileMap['MIRI']['1']['medium']['file'] = []
-        self.FileMap['MIRI']['1']['long'] = {}
-        self.FileMap['MIRI']['1']['long']['footprint'] = []
-        self.FileMap['MIRI']['1']['long']['file'] = []
+        self.FileMap['MIRI']['1']['short'] = []
+        self.FileMap['MIRI']['1']['medium'] = []
+        self.FileMap['MIRI']['1']['long'] = []
 
         self.FileMap['MIRI']['2'] = {}
-        self.FileMap['MIRI']['2']['short'] = {}
-        self.FileMap['MIRI']['2']['short']['footprint'] = []
-        self.FileMap['MIRI']['2']['short']['file'] = []
-        self.FileMap['MIRI']['2']['medium'] = {}
-        self.FileMap['MIRI']['2']['medium']['footprint'] = []
-        self.FileMap['MIRI']['2']['medium']['file'] = []
-        self.FileMap['MIRI']['2']['long'] = {}
-        self.FileMap['MIRI']['2']['long']['footprint'] = []
-        self.FileMap['MIRI']['2']['long']['file'] = []
+        self.FileMap['MIRI']['2']['short'] = []
+        self.FileMap['MIRI']['2']['medium'] = []
+        self.FileMap['MIRI']['2']['long'] = []
 
         self.FileMap['MIRI']['3'] = {}
-        self.FileMap['MIRI']['3']['short'] = {}
-        self.FileMap['MIRI']['3']['short']['footprint'] = []
-        self.FileMap['MIRI']['3']['short']['file'] = []
-        self.FileMap['MIRI']['3']['medium'] = {}
-        self.FileMap['MIRI']['3']['medium']['footprint'] = []
-        self.FileMap['MIRI']['3']['medium']['file'] = []
-        self.FileMap['MIRI']['3']['long'] = {}
-        self.FileMap['MIRI']['3']['long']['footprint'] = []
-        self.FileMap['MIRI']['3']['long']['file'] = []
+        self.FileMap['MIRI']['3']['short'] = []
+        self.FileMap['MIRI']['3']['medium'] = []
+        self.FileMap['MIRI']['3']['long'] = []
 
         self.FileMap['MIRI']['4'] = {}
-        self.FileMap['MIRI']['4']['short'] = {}
-        self.FileMap['MIRI']['4']['short']['footprint'] = []
-        self.FileMap['MIRI']['4']['short']['file'] = []
-        self.FileMap['MIRI']['4']['medium'] = {}
-        self.FileMap['MIRI']['4']['medium']['footprint'] = []
-        self.FileMap['MIRI']['4']['medium']['file'] = []
-        self.FileMap['MIRI']['4']['long'] = {}
-        self.FileMap['MIRI']['4']['long']['footprint'] = []
-        self.FileMap['MIRI']['4']['long']['file'] = []
+        self.FileMap['MIRI']['4']['short'] = []
+        self.FileMap['MIRI']['4']['medium'] = []
+        self.FileMap['MIRI']['4']['long'] = []
 
         self.FileMap['NIRSPEC'] = {}
         self.FileMap['NIRSPEC']['prism'] = {}
-        self.FileMap['NIRSPEC']['prism']['clear'] = {}
-        self.FileMap['NIRSPEC']['prism']['clear']['footprint'] = []
-        self.FileMap['NIRSPEC']['prism']['clear']['file'] = []
+        self.FileMap['NIRSPEC']['prism']['clear'] = []
 
         self.FileMap['NIRSPEC']['g140m'] = {}
-        self.FileMap['NIRSPEC']['g140m']['f070lp'] = {}
-        self.FileMap['NIRSPEC']['g140m']['f070lp']['footprint'] = []
-        self.FileMap['NIRSPEC']['g140m']['f070lp']['file'] = []
-
-#        self.FileMap['NIRSPEC']['g140m']['f100lp'] = []
-        self.FileMap['NIRSPEC']['g140m']['f100lp'] = {}
-        self.FileMap['NIRSPEC']['g140m']['f100lp']['file'] = []
-        self.FileMap['NIRSPEC']['g140m']['f100lp']['footprint'] = []
+        self.FileMap['NIRSPEC']['g140m']['f070lp'] = []
+        self.FileMap['NIRSPEC']['g140m']['f100lp'] = []
 
         self.FileMap['NIRSPEC']['g140h'] = {}
-        self.FileMap['NIRSPEC']['g140h']['f070lp'] = {}
-        self.FileMap['NIRSPEC']['g140h']['f070lp']['footprint'] = []
-        self.FileMap['NIRSPEC']['g140h']['f070lp']['file'] = []
-
-        self.FileMap['NIRSPEC']['g140h']['f100lp'] = {}
-        self.FileMap['NIRSPEC']['g140h']['f100lp']['footprint'] = []
-        self.FileMap['NIRSPEC']['g140h']['f100lp']['file'] = []
+        self.FileMap['NIRSPEC']['g140h']['f070lp'] = []
+        self.FileMap['NIRSPEC']['g140h']['f100lp'] = []
 
         self.FileMap['NIRSPEC']['g235m'] = {}
-        self.FileMap['NIRSPEC']['g235m']['f170lp'] = {}
-        self.FileMap['NIRSPEC']['g235m']['f170lp']['footprint'] = []
-        self.FileMap['NIRSPEC']['g235m']['f170lp']['file'] = []
+        self.FileMap['NIRSPEC']['g235m']['f170lp'] = []
 
         self.FileMap['NIRSPEC']['g235h'] = {}
-        self.FileMap['NIRSPEC']['g235h']['f170lp'] = {}
-        self.FileMap['NIRSPEC']['g235h']['f170lp']['footprint'] = []
-        self.FileMap['NIRSPEC']['g235h']['f170lp']['file'] = []
+        self.FileMap['NIRSPEC']['g235h']['f170lp'] = []
 
         self.FileMap['NIRSPEC']['g395m'] = {}
-        self.FileMap['NIRSPEC']['g395m']['f290lp'] = {}
-        self.FileMap['NIRSPEC']['g395m']['f290lp']['footprint'] = []
-        self.FileMap['NIRSPEC']['g395m']['f290lp']['file'] = []
+        self.FileMap['NIRSPEC']['g395m']['f290lp'] = []
 
         self.FileMap['NIRSPEC']['g395h'] = {}
-        self.FileMap['NIRSPEC']['g395h']['f290lp'] = {}
-        self.FileMap['NIRSPEC']['g395h']['f290lp']['footprint'] = []
-        self.FileMap['NIRSPEC']['g395h']['f290lp']['file'] = []
-
+        self.FileMap['NIRSPEC']['g395h']['f290lp'] = []
 #********************************************************************************
     def set_file_table(self,
                        input_models,
@@ -161,8 +115,7 @@ class FileTable():
             #________________________________________________________________________________
                     clenf = len(channel)
                     for k in range(clenf):
-                        self.FileMap['MIRI'][channel[k]][subchannel]['file'].append(input_model)
-                        self.FileMap['MIRI'][channel[k]][subchannel]['footprint'].append(None)
+                        self.FileMap['MIRI'][channel[k]][subchannel].append(input_model)
             #________________________________________________________________________________
             #NIRSPEC instrument
             #________________________________________________________________________________
@@ -170,10 +123,7 @@ class FileTable():
                     fwa = input_model.meta.instrument.filter.lower()
                     gwa = input_model.meta.instrument.grating.lower()
 
-                    self.FileMap['NIRSPEC'][gwa][fwa]['file'].append(input_model)
-                    self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(None)
-#                    instrument = input_model.meta.instrument.name.lower()
-#                    mod = importlib.import_module('.' + instrument, 'jwst.assign_wcs')
+                    self.FileMap['NIRSPEC'][gwa][fwa].append(input_model)
                 else:
 
                     log.info('Instrument not valid for cube')

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -96,7 +96,6 @@ class FileTable():
 
                 detector = input_model.meta.instrument.detector
                 instrument = input_model.meta.instrument.name.upper()
-                print('file_table:',instrument)
 
                 assign_wcs = input_model.meta.cal_step.assign_wcs
 

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -1,6 +1,7 @@
 """ Dictionary holding defaults for cube_build
 """
 from .. import datamodels
+from .. assign_wcs.util import  wcs_bbox_from_shape
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -14,49 +15,98 @@ class FileTable():
         self.FileMap = {}
         self.FileMap['MIRI'] = {}
 
+#        self.FileMap['MIRI']['1'] = {}
+#        self.FileMap['MIRI']['1']['short'] = []
+#        self.FileMap['MIRI']['1']['medium'] = []
+#        self.FileMap['MIRI']['1']['long'] = []
         self.FileMap['MIRI']['1'] = {}
-        self.FileMap['MIRI']['1']['short'] = []
-        self.FileMap['MIRI']['1']['medium'] = []
-        self.FileMap['MIRI']['1']['long'] = []
+        self.FileMap['MIRI']['1']['short'] = {}
+        self.FileMap['MIRI']['1']['short']['footprint'] = []
+        self.FileMap['MIRI']['1']['short']['file'] = []
+        self.FileMap['MIRI']['1']['medium'] = {}
+        self.FileMap['MIRI']['1']['medium']['footprint'] = []
+        self.FileMap['MIRI']['1']['medium']['file'] = []
+        self.FileMap['MIRI']['1']['long'] = {}
+        self.FileMap['MIRI']['1']['long']['footprint'] = []
+        self.FileMap['MIRI']['1']['long']['file'] = []
 
         self.FileMap['MIRI']['2'] = {}
-        self.FileMap['MIRI']['2']['short'] = []
-        self.FileMap['MIRI']['2']['medium'] = []
-        self.FileMap['MIRI']['2']['long'] = []
+        self.FileMap['MIRI']['2']['short'] = {}
+        self.FileMap['MIRI']['2']['short']['footprint'] = []
+        self.FileMap['MIRI']['2']['short']['file'] = []
+        self.FileMap['MIRI']['2']['medium'] = {}
+        self.FileMap['MIRI']['2']['medium']['footprint'] = []
+        self.FileMap['MIRI']['2']['medium']['file'] = []
+        self.FileMap['MIRI']['2']['long'] = {}
+        self.FileMap['MIRI']['2']['long']['footprint'] = []
+        self.FileMap['MIRI']['2']['long']['file'] = []
 
         self.FileMap['MIRI']['3'] = {}
-        self.FileMap['MIRI']['3']['short'] = []
-        self.FileMap['MIRI']['3']['medium'] = []
-        self.FileMap['MIRI']['3']['long'] = []
+        self.FileMap['MIRI']['3']['short'] = {}
+        self.FileMap['MIRI']['3']['short']['footprint'] = []
+        self.FileMap['MIRI']['3']['short']['file'] = []
+        self.FileMap['MIRI']['3']['medium'] = {}
+        self.FileMap['MIRI']['3']['medium']['footprint'] = []
+        self.FileMap['MIRI']['3']['medium']['file'] = []
+        self.FileMap['MIRI']['3']['long'] = {}
+        self.FileMap['MIRI']['3']['long']['footprint'] = []
+        self.FileMap['MIRI']['3']['long']['file'] = []
 
         self.FileMap['MIRI']['4'] = {}
-        self.FileMap['MIRI']['4']['short'] = []
-        self.FileMap['MIRI']['4']['medium'] = []
-        self.FileMap['MIRI']['4']['long'] = []
+        self.FileMap['MIRI']['4']['short'] = {}
+        self.FileMap['MIRI']['4']['short']['footprint'] = []
+        self.FileMap['MIRI']['4']['short']['file'] = []
+        self.FileMap['MIRI']['4']['medium'] = {}
+        self.FileMap['MIRI']['4']['medium']['footprint'] = []
+        self.FileMap['MIRI']['4']['medium']['file'] = []
+        self.FileMap['MIRI']['4']['long'] = {}
+        self.FileMap['MIRI']['4']['long']['footprint'] = []
+        self.FileMap['MIRI']['4']['long']['file'] = []
 
         self.FileMap['NIRSPEC'] = {}
         self.FileMap['NIRSPEC']['prism'] = {}
-        self.FileMap['NIRSPEC']['prism']['clear'] = []
+        self.FileMap['NIRSPEC']['prism']['clear'] = {}
+        self.FileMap['NIRSPEC']['prism']['clear']['footprint'] = []
+        self.FileMap['NIRSPEC']['prism']['clear']['file'] = []
 
         self.FileMap['NIRSPEC']['g140m'] = {}
-        self.FileMap['NIRSPEC']['g140m']['f070lp'] = []
-        self.FileMap['NIRSPEC']['g140m']['f100lp'] = []
+        self.FileMap['NIRSPEC']['g140m']['f070lp'] = {}
+        self.FileMap['NIRSPEC']['g140m']['f070lp']['footprint'] = []
+        self.FileMap['NIRSPEC']['g140m']['f070lp']['file'] = []
+
+#        self.FileMap['NIRSPEC']['g140m']['f100lp'] = []
+        self.FileMap['NIRSPEC']['g140m']['f100lp'] = {}
+        self.FileMap['NIRSPEC']['g140m']['f100lp']['file'] = []
+        self.FileMap['NIRSPEC']['g140m']['f100lp']['footprint'] = []
 
         self.FileMap['NIRSPEC']['g140h'] = {}
-        self.FileMap['NIRSPEC']['g140h']['f070lp'] = []
-        self.FileMap['NIRSPEC']['g140h']['f100lp'] = []
+        self.FileMap['NIRSPEC']['g140h']['f070lp'] = {}
+        self.FileMap['NIRSPEC']['g140h']['f070lp']['footprint'] = []
+        self.FileMap['NIRSPEC']['g140h']['f070lp']['file'] = []
+
+        self.FileMap['NIRSPEC']['g140h']['f100lp'] = {}
+        self.FileMap['NIRSPEC']['g140h']['f100lp']['footprint'] = []
+        self.FileMap['NIRSPEC']['g140h']['f100lp']['file'] = []
 
         self.FileMap['NIRSPEC']['g235m'] = {}
-        self.FileMap['NIRSPEC']['g235m']['f170lp'] = []
+        self.FileMap['NIRSPEC']['g235m']['f170lp'] = {}
+        self.FileMap['NIRSPEC']['g235m']['f170lp']['footprint'] = []
+        self.FileMap['NIRSPEC']['g235m']['f170lp']['file'] = []
 
         self.FileMap['NIRSPEC']['g235h'] = {}
-        self.FileMap['NIRSPEC']['g235h']['f170lp'] = []
+        self.FileMap['NIRSPEC']['g235h']['f170lp'] = {}
+        self.FileMap['NIRSPEC']['g235h']['f170lp']['footprint'] = []
+        self.FileMap['NIRSPEC']['g235h']['f170lp']['file'] = []
 
         self.FileMap['NIRSPEC']['g395m'] = {}
-        self.FileMap['NIRSPEC']['g395m']['f290lp'] = []
+        self.FileMap['NIRSPEC']['g395m']['f290lp'] = {}
+        self.FileMap['NIRSPEC']['g395m']['f290lp']['footprint'] = []
+        self.FileMap['NIRSPEC']['g395m']['f290lp']['file'] = []
 
         self.FileMap['NIRSPEC']['g395h'] = {}
-        self.FileMap['NIRSPEC']['g395h']['f290lp'] = []
+        self.FileMap['NIRSPEC']['g395h']['f290lp'] = {}
+        self.FileMap['NIRSPEC']['g395h']['f290lp']['footprint'] = []
+        self.FileMap['NIRSPEC']['g395h']['f290lp']['file'] = []
 
 #********************************************************************************
     def set_file_table(self,
@@ -98,7 +148,23 @@ class FileTable():
                 detector = input_model.meta.instrument.detector
                 instrument = input_model.meta.instrument.name
                 assign_wcs = input_model.meta.cal_step.assign_wcs
+                footprint =  input_model.meta.wcsinfo.s_region
+                bbox = input_model.meta.wcs.bounding_box
+                if bbox is None:
+                    bbox = wcs_bbox_from_shape(input_model.data.shape)
+                print('bbox', bbox) 
+                #wcslist = [input_model.meta.wcs]
+                #footprints = [w.footprint().T for w in wcslist]
+                footprint = input_model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T<
 
+                print('footprint',footprint)
+                sys.exit()
+
+                
+
+                #footprint = input_model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T
+                #print('footprint',footprint)
+                #print(type(footprint))
                 if(assign_wcs != 'COMPLETE'):
                     raise ErrorNoAssignWCS("Assign WCS has not been run on file %s",
                                            ifile)
@@ -111,7 +177,8 @@ class FileTable():
             #________________________________________________________________________________
                     clenf = len(channel)
                     for k in range(clenf):
-                        self.FileMap['MIRI'][channel[k]][subchannel].append(input_model)
+                        self.FileMap['MIRI'][channel[k]][subchannel]['file'].append(input_model)
+                        self.FileMap['MIRI'][channel[k]][subchannel]['footprint'].append(footprint)
             #________________________________________________________________________________
             #NIRSPEC instrument
             #________________________________________________________________________________
@@ -119,7 +186,10 @@ class FileTable():
                     fwa = input_model.meta.instrument.filter.lower()
                     gwa = input_model.meta.instrument.grating.lower()
 
-                    self.FileMap['NIRSPEC'][gwa][fwa].append(input_model)
+                    self.FileMap['NIRSPEC'][gwa][fwa]['file'].append(input_model)
+
+
+                    #self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(footprint)
                 else:
 
                     log.info('Instrument not valid for cube')

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -95,7 +95,9 @@ class FileTable():
             with datamodels.IFUImageModel(input) as input_model:
 
                 detector = input_model.meta.instrument.detector
-                instrument = input_model.meta.instrument.name
+                instrument = input_model.meta.instrument.name.upper()
+                print('file_table:',instrument)
+
                 assign_wcs = input_model.meta.cal_step.assign_wcs
 
                 if(assign_wcs != 'COMPLETE'):

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -148,23 +148,10 @@ class FileTable():
                 detector = input_model.meta.instrument.detector
                 instrument = input_model.meta.instrument.name
                 assign_wcs = input_model.meta.cal_step.assign_wcs
-                footprint =  input_model.meta.wcsinfo.s_region
-                bbox = input_model.meta.wcs.bounding_box
-                if bbox is None:
-                    bbox = wcs_bbox_from_shape(input_model.data.shape)
-                print('bbox', bbox) 
-                #wcslist = [input_model.meta.wcs]
-                #footprints = [w.footprint().T for w in wcslist]
-                footprint = input_model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T<
+                sfootprint =  input_model.meta.wcsinfo.s_region
+                print('sfootprint',sfootprint)
 
-                print('footprint',footprint)
-                sys.exit()
 
-                
-
-                #footprint = input_model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T
-                #print('footprint',footprint)
-                #print(type(footprint))
                 if(assign_wcs != 'COMPLETE'):
                     raise ErrorNoAssignWCS("Assign WCS has not been run on file %s",
                                            ifile)
@@ -174,6 +161,7 @@ class FileTable():
                 if instrument == 'MIRI':
                     channel = input_model.meta.instrument.channel
                     subchannel = input_model.meta.instrument.band.lower()
+                    footprint = find_footprint_spectral(input_model) 
             #________________________________________________________________________________
                     clenf = len(channel)
                     for k in range(clenf):
@@ -187,9 +175,10 @@ class FileTable():
                     gwa = input_model.meta.instrument.grating.lower()
 
                     self.FileMap['NIRSPEC'][gwa][fwa]['file'].append(input_model)
-
-
-                    #self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(footprint)
+                    instrument = input_model.meta.instrument.name.lower()
+                    mod = importlib.import_module('.' + instrument, 'jwst.assign_wcs')
+                    footprint = find_footprint_nrs_ifu(input_model, mod)
+                    self.FileMap['NIRSPEC'][gwa][fwa]['footprint'].append(footprint)
                 else:
 
                     log.info('Instrument not valid for cube')

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -1,7 +1,6 @@
 """ Dictionary holding defaults for cube_build
 """
 from .. import datamodels
-from .. assign_wcs.util import  wcs_bbox_from_shape
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -15,10 +14,6 @@ class FileTable():
         self.FileMap = {}
         self.FileMap['MIRI'] = {}
 
-#        self.FileMap['MIRI']['1'] = {}
-#        self.FileMap['MIRI']['1']['short'] = []
-#        self.FileMap['MIRI']['1']['medium'] = []
-#        self.FileMap['MIRI']['1']['long'] = []
         self.FileMap['MIRI']['1'] = {}
         self.FileMap['MIRI']['1']['short'] = []
         self.FileMap['MIRI']['1']['medium'] = []
@@ -62,11 +57,11 @@ class FileTable():
 
         self.FileMap['NIRSPEC']['g395h'] = {}
         self.FileMap['NIRSPEC']['g395h']['f290lp'] = []
-#********************************************************************************
+# ********************************************************************************
+
     def set_file_table(self,
                        input_models,
                        input_filenames):
-#********************************************************************************
         """
         Short Summary
         -------------
@@ -87,7 +82,7 @@ class FileTable():
         """
         num = 0
         num = len(input_filenames)
-#________________________________________________________________________________
+# ________________________________________________________________________________
 # Loop over input list of files and assign fill in the MasterTable with filename
 # for the correct (channel-subchannel) or (grating-subchannel)
         for i in range(num):
@@ -106,19 +101,16 @@ class FileTable():
                 if(assign_wcs != 'COMPLETE'):
                     raise ErrorNoAssignWCS("Assign WCS has not been run on file %s",
                                            ifile)
-            #________________________________________________________________________________
-            #MIRI instrument
-            #________________________________________________________________________________
+            # _____________________________________________________________________
+            # MIRI instrument
                 if instrument == 'MIRI':
                     channel = input_model.meta.instrument.channel
                     subchannel = input_model.meta.instrument.band.lower()
-            #________________________________________________________________________________
                     clenf = len(channel)
                     for k in range(clenf):
                         self.FileMap['MIRI'][channel[k]][subchannel].append(input_model)
-            #________________________________________________________________________________
-            #NIRSPEC instrument
-            #________________________________________________________________________________
+            # _____________________________________________________________________
+            # NIRSPEC instrument
                 elif instrument == 'NIRSPEC':
                     fwa = input_model.meta.instrument.filter.lower()
                     gwa = input_model.meta.instrument.grating.lower()
@@ -128,6 +120,7 @@ class FileTable():
 
                     log.info('Instrument not valid for cube')
         return instrument, detector
+
 
 class ErrorNoAssignWCS(Exception):
     pass

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1169,10 +1169,8 @@ class IFUCubeData():
 # using the DQFlags from the input_image find pixels that should be excluded
 # from the cube mapping
             all_flags = (dqflags.pixel['DO_NOT_USE'] +
-                         dqflags.pixel['DROPOUT'] +
-                         dqflags.pixel['NON_SCIENCE'] +
-                         dqflags.pixel['DEAD'] + dqflags.pixel['HOT'] +
-                         dqflags.pixel['RC'] + dqflags.pixel['NONLINEAR'])
+                         dqflags.pixel['NON_SCIENCE'])
+
             # find the location of all the values to reject in cube building
             good_data = np.where((np.bitwise_and(dq_all, all_flags) == 0) & (valid2 == True))
             # good data holds the location of pixels we want to map to cube

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -5,7 +5,7 @@ import time
 import numpy as np
 import logging
 import math
-import pysiaf
+#import pysiaf
 #from shapely.geometry import box, Polygon
 from ..model_blender import blendmeta
 from .. import datamodels
@@ -46,21 +46,16 @@ class IFUCubeData():
         self.input_filenames = input_filenames
         self.pipeline = pipeline
         
-#        dq_file = 'cube_spaxel_dq'+str(list_par1[0]) +'.results'
-#        self.spaxel_dq_file =  open(dq_file, 'w')
-#        print('dq file',dq_file)
+        self.debug_write = True
+        if self.debug_write:
+            dq_wave_file = 'cube_spaxel_wave2_dq'+str(list_par1[0]) +'.results'
+            self.spaxel_wave_dq_file =  open(dq_wave_file, 'w')
+            print('dq wave file',dq_wave_file)
 
-        dq_wave_file = 'cube_spaxel_wave_dq'+str(list_par1[0]) +'.results'
-        self.spaxel_wave_dq_file =  open(dq_wave_file, 'w')
-        print('dq wave file',dq_wave_file)
+            dq_wave_footprint_file = 'cube_spaxel_wave2_footprint_dq'+str(list_par1[0]) +'.results'
+            self.spaxel_wave_footprint_dq_file =  open(dq_wave_footprint_file, 'w')
+            print('dq wave file',dq_wave_footprint_file)
 
-        dq_wave_footprint_file = 'cube_spaxel_wave_footprint_dq'+str(list_par1[0]) +'.results'
-        self.spaxel_wave_footprint_dq_file =  open(dq_wave_footprint_file, 'w')
-        print('dq wave file',dq_wave_footprint_file)
-
-        dq_wave_siaf_file = 'cube_spaxel_wave_siaf_dq'+str(list_par1[0]) +'.results'
-        self.spaxel_wave_siaf_dq_file =  open(dq_wave_siaf_file, 'w')
-        print('dq siaf file',dq_wave_siaf_file)
 
         self.input_models = input_models  # needed when building single mode IFU cubes
         self.output_name_base = output_name_base
@@ -87,6 +82,7 @@ class IFUCubeData():
         self.wavemax = pars_cube.get('wavemax')
         self.weighting = pars_cube.get('weighting')
         self.weight_power = pars_cube.get('weight_power')
+        self.debug = pars_cube.get('debug')
         self.xdebug = pars_cube.get('xdebug')
         self.ydebug = pars_cube.get('ydebug')
         self.zdebug = pars_cube.get('zdebug')
@@ -156,7 +152,7 @@ class IFUCubeData():
             this_a = self.list_par1[i]
             this_b = self.list_par2[i]
 
-            n = len(self.master_table.FileMap[self.instrument][this_a][this_b]['file'])
+            n = len(self.master_table.FileMap[self.instrument][this_a][this_b])
             num_files = num_files + n
         self.num_files = num_files
 # do some basic checks on the cubes
@@ -339,13 +335,14 @@ class IFUCubeData():
             self.lambda_max = self.lambda_min + (self.naxis3) * self.cdelt3
 
             self.zcoord = np.zeros(self.naxis3)
-            self.crval3 = self.lambda_min
+            # CRPIX3 for FITS is 1 (center of first pixel)
+            # CRVAL3 then is lambda_min + self.cdelt3/ 2.0, which is also zcoord[0]
+            self.crval3 = self.lambda_min + self.cdelt3 / 2.0
             self.crpix3 = 1.0
             zstart = self.lambda_min + self.cdelt3 / 2.0
             for i in range(self.naxis3):
                 self.zcoord[i] = zstart
                 zstart = zstart + self.cdelt3
-
         else:
             self.naxis3 = len(self.wavelength_table)
             self.zcoord = np.asarray(self.wavelength_table)
@@ -405,10 +402,10 @@ class IFUCubeData():
         self.lambda_max = self.lambda_min + (self.naxis3) * self.cdelt3
 
         self.zcoord = np.zeros(self.naxis3)
-        self.crval3 = self.lambda_min
-        self.crpix3 = 1.0
         zstart = self.lambda_min + self.cdelt3 / 2.0
-
+#        self.crval3 = self.lambda_min
+        self.crval3 = zstart
+        self.crpix3 = 1.0
         for i in range(self.naxis3):
             self.zcoord[i] = zstart
             zstart = zstart + self.cdelt3
@@ -551,42 +548,32 @@ class IFUCubeData():
         for i in range(number_bands):
             this_par1 = self.list_par1[i]
             this_par2 = self.list_par2[i]
-            nfiles = len(self.master_table.FileMap[self.instrument][this_par1][this_par2]['file'])
+            nfiles = len(self.master_table.FileMap[self.instrument][this_par1][this_par2])
 # ________________________________________________________________________________
 # loop over the files that cover the spectral range the cube is for
             for k in range(nfiles):
-                ifile = self.master_table.FileMap[self.instrument][this_par1][this_par2]['file'][k]
+                ifile = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
                 self.this_cube_filenames.append(ifile)
                 log.debug("Working on Band defined by: %s %s ", this_par1, this_par2)
 # --------------------------------------------------------------------------------
                 if self.interpolation == 'pointcloud':
                     t0 = time.time()
                     pixelresult = self.map_detector_to_outputframe(this_par1,
-                                                                   this_par2,
                                                                    subtract_background,
                                                                    ifile)
 
-                    coord1, coord2, wave, flux, rois_pixel, roiw_pixel, weight_pixel,\
-                        softrad_pixel, alpha_det, beta_det, footprint = pixelresult
+                    coord1, coord2, wave, flux, slice, rois_pixel, roiw_pixel, weight_pixel,\
+                        softrad_pixel, alpha_det, beta_det  = pixelresult
                     t1 = time.time()
                     log.info("Time to transform pixels to output frame = %.1f.s" % (t1 - t0,))
 
-                    min_wave_band = np.amin(wave)
-                    max_wave_band = np.amax(wave)
-                    
-                    footprint_wave = self.compute_four_corners(coord1, coord2, wave)
-                    footprint_siaf = self.compute_four_corners_siaf(this_par1,this_par2, ifile)
 
-                    print('footprint siaf',footprint_siaf)
-#                    self.master_table.FileMap[self.instrument][this_par1][this_par2]['footprint'][k]=footprint_siaf
-                    # send footprint of file on sky -spatial and wavelength
-                    # set the spaxel_dq values, need the roiw and self.zcoord - defines wavelengths
+                    t0 = time.time()
+                    roiw_ave = np.mean(roiw_pixel)
+                    self.map_fov_to_dqplane(this_par1, coord1, coord2, wave, roiw_ave,slice)
+                    t1 = time.time()
 
-                    #self.map_siaf_projection_to_dqframe(footprint_siaf, min_wave_band, max_wave_band)
-
-                    self.map_fov_wave_projection_to_dqframe(footprint_wave)
-
-                    
+                    log.info("Time to compute four corners & map to dq frame = %.1f.s" % (t1 - t0,))                    
                     if self.weighting == 'msm':
                         t0 = time.time()
 #                        if self.new_code:
@@ -690,7 +677,7 @@ class IFUCubeData():
         t0 = time.time()
         self.find_spaxel_flux()
 
-        self.set_final_dq_flags()
+#        self.set_final_dq_flags()
         t1 = time.time()
         log.info("Time to find Cube Flux = %.1f.s" % (t1 - t0,))
 
@@ -733,11 +720,11 @@ class IFUCubeData():
 
             subtract_background = False
 
-            pixelresult = self.map_detector_to_outputframe(this_par1, this_par2,
+            pixelresult = self.map_detector_to_outputframe(this_par1,
                                                            subtract_background,
                                                            self.input_models[j])
 
-            coord1, coord2, wave, flux, rois_pixel, roiw_pixel, weight_pixel, \
+            coord1, coord2, wave, flux, slice,rois_pixel, roiw_pixel, weight_pixel, \
                 softrad_pixel, alpha_det, beta_det = pixelresult
 
             cube_cloud.match_det2cube_msm(self.naxis1,
@@ -805,6 +792,7 @@ class IFUCubeData():
                 par1 = self.list_par1[i]
                 par2 = self.list_par2[i]
 
+            # pull out the values from the cube pars reference file
             roiw[i] = self.instrument_info.GetWaveRoi(par1, par2)
             rois[i] = self.instrument_info.GetSpatialRoi(par1, par2)
 
@@ -950,8 +938,6 @@ class IFUCubeData():
         parameter1 = self.list_par1
         parameter2 = self.list_par2
 
-#        print('parameter 1',parameter1)
-#        print('parameter 2',parameter2)
         a_min = []
         a_max = []
         b_min = []
@@ -966,7 +952,7 @@ class IFUCubeData():
             this_a = parameter1[i]
             this_b = parameter2[i]
             log.debug('Working on data from %s, %s', this_a, this_b)
-            n = len(self.master_table.FileMap[self.instrument][this_a][this_b]['file'])
+            n = len(self.master_table.FileMap[self.instrument][this_a][this_b])
             log.debug('number of files %d', n)
             for k in range(n):
                 amin = 0.0
@@ -976,8 +962,7 @@ class IFUCubeData():
                 lmin = 0.0
                 lmax = 0.0
 
-                ifile = self.master_table.FileMap[self.instrument][this_a][this_b]['file'][k]
-                print(ifile)
+                ifile = self.master_table.FileMap[self.instrument][this_a][this_b][k]
 # ______________________________________________________________________________
 # Open the input data model
 # Find the footprint of the image
@@ -1008,8 +993,6 @@ class IFUCubeData():
                     b_max.append(bmax)
                     lambda_min.append(lmin)
                     lambda_max.append(lmax)
-# store footprint for later need it for setting up DQ flags to help find holdes
-#                self.master_table.FileMap[self.instrument][this_a][this_b].append(ch_footprint)
 # ________________________________________________________________________________
     # done looping over files determine final size of cube
 
@@ -1017,9 +1000,10 @@ class IFUCubeData():
         final_a_max = max(a_max)
         final_b_min = min(b_min)
         final_b_max = max(b_max)
-        final_lambda_min = min(lambda_min)
-        final_lambda_max = max(lambda_max)
+#        final_lambda_min = min(lambda_min)
+#        final_lambda_max = max(lambda_max)
 
+        # wavelength range read in from cube pars reference file
         final_lambda_min = self.wavemin
         final_lambda_max = self.wavemax
 # ________________________________________________________________________________
@@ -1041,6 +1025,7 @@ class IFUCubeData():
 # ________________________________________________________________________________
         cube_footprint = (final_a_min, final_a_max, final_b_min, final_b_max,
                           final_lambda_min, final_lambda_max)
+
 # ________________________________________________________________________________
     # Based on Scaling and Min and Max values determine naxis1, naxis2, naxis3
     # set cube CRVALs, CRPIXs
@@ -1052,7 +1037,7 @@ class IFUCubeData():
         self.print_cube_geometry()
 # **************************************************************************
                                                             
-    def map_detector_to_outputframe(self, this_par1, this_par2,
+    def map_detector_to_outputframe(self, this_par1,
                                     subtract_background,
                                     ifile):
         from ..mrs_imatch.mrs_imatch_step import apply_background_2d
@@ -1070,9 +1055,7 @@ class IFUCubeData():
         ----------
         this_par1 : str
            for MIRI this is the channel # for NIRSPEC this is the grating name
-        this_par2 : str
-           for MIRI this is the subchannel type for NIRSPEC this is the filter
-           name
+           only need for MIRI to distinguish which channel on the detector we have
         subtract_background : boolean
            if TRUE then subtract the background found in the mrs_imatch step
         ifile : datamodel
@@ -1110,7 +1093,7 @@ class IFUCubeData():
         coord2 = None
         flux = None
         wave = None
-        footprint = None
+        slice = None # Slice number
 # Open the input data model
         with datamodels.IFUImageModel(ifile) as input_model:
             # check if background sky matching as been done
@@ -1127,10 +1110,28 @@ class IFUCubeData():
                         apply_background_2d(input_model, poly_ch, subtract=True)
 # --------------------------------------------------------------------------------
             if self.instrument == 'MIRI':
+
+                # find the slice number of each pixel and fill in slice_det 
+                slice_det = np.zeros((1024, 1032)) 
+                det2ab_transform = input_model.meta.wcs.get_transform('detector',
+                                                        'alpha_beta') 
+                start_region = self.instrument_info.GetStartSlice(this_par1)
+                end_region = self.instrument_info.GetEndSlice(this_par1)
+                regions = list(range(start_region, end_region + 1))
+                for i in regions:
+                    ys, xs = (det2ab_transform.label_mapper.mapper == i).nonzero()
+                    xind = _toindex(xs)
+                    yind = _toindex(ys)
+                    xind = np.ndarray.flatten(xind)
+                    yind = np.ndarray.flatten(yind)                                   
+                    slice_det[yind,xind] = i
+
+                # define the x,y detector values of channel to be mapped to desired coordinate system
                 xstart, xend = self.instrument_info.GetMIRISliceEndPts(this_par1)
                 y, x = np.mgrid[:1024, xstart:xend]
                 y = np.reshape(y, y.size)
                 x = np.reshape(x, x.size)
+
                 if self.coord_system == 'world':
                     ra, dec, wave = input_model.meta.wcs(x, y)
                     valid1 = ~np.isnan(ra)
@@ -1140,13 +1141,15 @@ class IFUCubeData():
                     x = x[valid1]
                     y = y[valid1]
 
+                    xind = _toindex(x)
+                    yind = _toindex(y)
+                    xind = np.ndarray.flatten(xind)
+                    yind = np.ndarray.flatten(yind)                                   
+                    slice = slice_det[yind,xind]
+
                     if self.weighting == 'miripsf':
-                        det2ab_transform = input_model.meta.wcs.get_transform('detector',
-                                                                              'alpha_beta')
                         alpha, beta, lam = det2ab_transform(x, y)
                 elif self.coord_system == 'alpha-beta':
-                    det2ab_transform = input_model.meta.wcs.get_transform('detector',
-                                                                          'alpha_beta')
                     alpha, beta, wave = det2ab_transform(x, y)
                     valid1 = ~np.isnan(coord1)
                     alpha = alpha[valid1]
@@ -1165,6 +1168,7 @@ class IFUCubeData():
                 lam_det = np.zeros((2048, 2048))
                 flag_det = np.zeros((2048, 2048))
 
+                slice_det = np.zeros((2048, 2048))
                 # for NIRSPEC each file has 30 slices
                 # wcs information access seperately for each slice
                 nslices = 30
@@ -1194,29 +1198,59 @@ class IFUCubeData():
                     dec_det[yind, xind] = dec
                     lam_det[yind, xind] = lam
                     flag_det[yind, xind] = 1
-                    # done looping  - pull out valid values
+                    slice_det[yind, xind] = ii+1
+
+                # after looping over slices  - pull out valid values
                 valid_data = np.where(flag_det == 1)
                 y, x = valid_data
                 ra = ra_det[valid_data]
                 dec = dec_det[valid_data]
                 wave = lam_det[valid_data]
+                slice = slice_det[valid_data]
+
 # ______________________________________________________________________________
 # The following is for both MIRI and NIRSPEC
 # grab the flux and DQ values for these pixles
             flux_all = input_model.data[y, x]
             dq_all = input_model.dq[y, x]
             valid2 = np.isfinite(flux_all)
+#            min_wave_tolerance = self.crval3 - self.roiw
+#            max_wave_tolerance = self.zcoord[-1] + self.roiw
+
+            min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0])
+            max_wave_tolerance = self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2])
+
+            valid_min = np.where(wave >= min_wave_tolerance)
+            not_mapped_low = wave.size - len(valid_min[0])
+
+            valid_max = np.where(wave <= max_wave_tolerance)
+            not_mapped_high = wave.size - len(valid_max[0])
+            if not_mapped_low > 0: 
+                log.info('# of detector pixels not mapped to output plane: %i with wavelength below %f', 
+                         not_mapped_low, min_wave_tolerance)
+                
+            if not_mapped_high > 0: 
+                log.info('# of detector pixels not mapped to output plane: %i with wavelength above  %f', 
+                         not_mapped_high, max_wave_tolerance)
+
 # ______________________________________________________________________________
 # using the DQFlags from the input_image find pixels that should be excluded
 # from the cube mapping
             all_flags = (dqflags.pixel['DO_NOT_USE'] +
                          dqflags.pixel['NON_SCIENCE'])
 
+
+
+            valid3 = np.bitwise_and( (wave >= min_wave_tolerance), 
+                                     (wave <= max_wave_tolerance))
             # find the location of all the values to reject in cube building
-            good_data = np.where((np.bitwise_and(dq_all, all_flags) == 0) & (valid2 == True))
+            good_data = np.where((np.bitwise_and(dq_all, all_flags) == 0) & 
+                                 (valid2 == True) & (valid3 == True))
+
             # good data holds the location of pixels we want to map to cube
             flux = flux_all[good_data]
             wave = wave[good_data]
+            slice = slice[good_data]
 # based on the wavelength define the sroi, wroi, weight_power and
 # softrad to use in matching detector to spaxel values
             rois_det = np.zeros(wave.shape)
@@ -1251,28 +1285,165 @@ class IFUCubeData():
                 coord1 = alpha[good_data]
                 coord2 = beta[good_data]
 
-        return coord1, coord2, wave, flux, rois_det, roiw_det, weight_det, \
-            softrad_det, alpha_det, beta_det, footprint
+        return coord1, coord2, wave, flux, slice, rois_det, roiw_det, weight_det, \
+            softrad_det, alpha_det, beta_det
 # ********************************************************************************
 
-                                                            
-    def map_siaf_projection_to_dqframe(self, footprint,
-                                       min_wave_band, max_wave_band):
 
+    def map_fov_to_dqplane(self, this_par1, coord1, coord2, wave, roiw_ave, slice):
+        """ Compute the four corners of the FOV of band on the sky. """
 
-        """Set an intermdediate dq_flag baded on the footprint
+        # map the FOV of channel (MIRI) or slice (NIRSPEC) to the DQ plane
+        # and set an initial DQ flagging 
+
+        # computation of 4 corners is not the same as the wcs.footprint
+        # all four corners have different coord1 and coord2 values
+        # the wcs footprint consists of only 4 values ra min, ra max, dec min, dec max
         
-        The intermediate spaxel dq has a default value of 0
-        For each wavelength plane  of a data model (for MIRI of a selected
-        band) this intermediate spaxel dq is fill in with 1 (overlap partial),
-        2 overlap_full, or a bit_wise combination of these.
+        # The routine defines the four corners as
+        # corner 1: location of min coord2
+        # corner 2: location of min coord1
+        # corner 3: location of max coord2
+        # corner 4: location of max coord1
+        
+        # The FOV of the MIRI channel is the same across all the wavelengths.
+        # The FOV of each NIRSpec slice varies across the wavelength range -
+        # we need to map to each wavelength slice in the IFU. To accuracy do this
+        # use the roiw to set the wavlength range for the slice.
 
-        return spaxel_dq updated for this input file 
+        if self.instrument == 'MIRI':
 
+            # find the wavelength boundaries of the band - use two extreme slices 
+            wavemin = np.amin(wave)
+            wavemax = np.amax(wave)
+            iwavemin = np.absolute(np.array(wavemin - self.zcoord) / (self.cdelt3_normal/2.0) )
+            iwavemax = np.absolute(np.array(wavemax - self.zcoord) / (self.cdelt3_normal/2.0) )
+            imin = np.where(iwavemin == np.amin(iwavemin))[0]
+            imax = np.where(iwavemax == np.amin(iwavemax))[0]
+        
+#            print('wavemin',wavemin,imin[0],self.zcoord[imin[0]])
+#            print('wavemax',wavemax,imax[0],self.zcoord[imax[0]])
+
+            # pull out the two extreme slices in the FOV.
+            # use these points to set the FOV 
+            start_region = self.instrument_info.GetStartSlice(this_par1)
+            end_region = self.instrument_info.GetEndSlice(this_par1)
+
+            coord1_start = coord1[slice == start_region]
+            coord2_start = coord2[slice == start_region]
+            slice_start = slice[slice == start_region]
+            wave_start = wave[slice == start_region]
+
+            nstart = coord1_start.shape
+            for i in range(nstart[0]):
+                self.spaxel_wave_dq_file.write('%i %f %f %f ' %
+                                               (slice_start[i],wave_start[i],
+                                                coord1_start[i],coord2_start[i])+ '\n')
+
+            coord1_end = coord1[slice == end_region]
+            coord2_end = coord2[slice == end_region]
+            slice_end = slice[slice == end_region]
+            wave_end = wave[slice == end_region]
+            nstart = coord1_end.shape
+            for i in range(nstart[0]):
+                self.spaxel_wave_dq_file.write('%i %f %f %f ' %
+                                               (slice_end[i],wave_end[i],
+                                                coord1_end[i],coord2_end[i])+ '\n')
+
+            coord1_total = np.concatenate((coord1_start,coord1_end), axis = 0)
+            coord2_total = np.concatenate((coord2_start,coord2_end), axis = 0)
+            footprint = self.four_corners(coord1_total, coord2_total)
+
+
+            self.spaxel_wave_footprint_dq_file.write('%i %f %f %f %f %f %f %f %f %f %f' %
+                                                     (self.naxis3,np.amin(wave), np.max(wave),
+                                                      footprint[0],footprint[1],
+                                                      footprint[2], footprint[3], 
+                                                      footprint[4], footprint[5],
+                                                      footprint[6], footprint[7],)+ '\n')
+            #loop over the wavelength ranges of the IFU cube and map to DQ plane 
+
+            wmin = imin[0]
+            wmax = imax[0]
+            (xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4) = footprint
+
+            # find the overlap with IFU Cube
+            xi_corner=np.array([xi1,xi2,xi3,xi4])
+            eta_corner=np.array([eta1,eta2,eta3,eta4])
+            self.overlap_fov_with_spaxels(xi_corner, eta_corner, wmin,wmax)
+
+        elif self.instrument == 'NIRSPEC':
+            print('going to map fov to dq frame')
+            # for each of the 30 slices - find the FOV of each slice per wavelength bin
+            for islice in range(30):
+                t0 = time.time()
+                print('on slice ',islice)
+                # find wave min and max for slice
+                index_slice = np.where(slice == islice+1)
+                
+                # find the smaller set of wavelengths to search over for this slice
+                wavemin = np.amin(wave[index_slice])
+                wavemax = np.amax(wave[index_slice])
+                iwavemin = np.absolute(np.array(wavemin - self.zcoord) / (self.cdelt3_normal/2.0) )
+                iwavemax = np.absolute(np.array(wavemax - self.zcoord) / (self.cdelt3_normal/2.0) )
+                imin = np.where(iwavemin == np.amin(iwavemin))[0]
+                imax = np.where(iwavemax == np.amin(iwavemax))[0]
+        
+#                print('wavemin',wavemin,imin[0],self.zcoord[imin[0]])
+#                print('wavemax',wavemax,imax[0],self.zcoord[imax[0]])
+
+                # loop over valid wavelengths for slice and find the FOV of the slice at the
+                # wavelength plane of the IFU cube
+
+                for w in range(imin[0], imax[0]):
+                    wave_distance = np.absolute(self.zcoord[w] - wave)
+                    index_use = np.where((wave_distance < roiw_ave) & (slice == islice+1))
+                    if len(index_use[0]) > 0:
+                        coord2_use = coord2[index_use]
+                        coord1_use = coord1[index_use]
+                        wave_use = wave[index_use] # only used to print to file below
+
+                        for i in range(len(index_use[0])):
+                            self.spaxel_wave_dq_file.write('%i %i %f %f %f ' %
+                                                           (w,islice,wave_use[i],
+                                                            coord1_use[i],coord2_use[i])+ '\n')
+        
+                        isline, footprint = self.four_corners(coord1_use, coord2_use)
+                        self.spaxel_wave_footprint_dq_file.write('%c %i %i  %f %f %f %f %f %f %f %f' %
+                                                                 (isline,w,islice,footprint[0],footprint[1],
+                                                                  footprint[2], footprint[3], 
+                                                                  footprint[4], footprint[5],
+                                                                  footprint[6], footprint[7],)+ '\n')
+
+                        (xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4) = footprint
+                        # find the overlap with IFU Cube
+                        xi_corner=np.array([xi1,xi2,xi3,xi4])
+                        eta_corner=np.array([eta1,eta2,eta3,eta4])
+                        self.overlap_fov_with_spaxels(xi_corner, eta_corner, w, w,islice)
+                t1 = time.time()
+                print('time to map slice across wavelength regions',t1-t0)
+
+# ********************************************************************************
+
+
+    def overlap_fov_with_spaxels(self, xi_corner, eta_corner, wmin, wmax, islice):
+
+        """find the amount of overlap of FOV with each spaxel 
+        
+        Given the corners of the FOV (per slice for NIRSPEC) find the spaxel
+        that overlap with this FOV.  Set the intermediate spaxel  to
+        a value based on the overlap between the FOV for each exposure 
+        and the spaxel area. The values assigned are: 
+        a. self.overlap_partial = overlap partial
+        b  self.overlap_full = overlap_full
+        bit_wise combination of these values is allowed to account for
+        dithered FOVs.
 
         Parameter
         ----------
-        footprint spatial and wavelength footprint of input model
+        xi_corner: xi coordinates of the 4 corners of the FOV on the cube plane 
+        eta_corner: xi coordinates of the 4 corners of the FOV on the cube plane 
+        w: wavelength bin in the IFU cube. 
 
         Returns
         -------
@@ -1280,25 +1451,18 @@ class IFUCubeData():
            
 
         """
+        ximin  = np.amin(xi_corner)
+        ximax = np.amax(xi_corner)
+        etamin  = np.amin(eta_corner)
+        etamax  = np.amax(eta_corner)
+#        print('for slice',islice,wmin,ximin,ximax,etamin,etamax)
+        index = np.where( (self.xcenters > ximin) & (self.xcenters < ximax) &
+                          (self.ycenters > etamin) & (self.ycenters < etamax) )
+#        print(' length',len(index[0]), self.xcenters.size)
 
-        # first find the wavelength planes this slice overlaps. Min and max wavelength
-        # input values are set for MIRI for the entire band. 
-        t0 = time.time()
-
-        # footprint of input model on the sky (band for MIRI) 
-        [xi1, eta1], [xi2, eta2], [xi3, eta3], [xi4, eta4] = footprint
-        
-        xi_corner=np.array([xi1,xi2,xi3,xi4])
-        eta_corner=np.array([eta1,eta2,eta3,eta4])
-
-        id_min = np.abs(self.zcoord - min_wave_band).argmin()
-        id_max = np.abs(self.zcoord - max_wave_band).argmin()
-        print(id_min,id_max,min_wave_band, max_wave_band,self.zcoord[id_min], self.zcoord[id_max])
-
-        slice_dq = np.zeros(self.naxis2 * self.naxis1 ,dtype=np.int32)
-        nxy = self.xcenters.size
-        nz = self.zcoord.size
-
+        wave_slice_dq = np.zeros(self.naxis2 * self.naxis1 ,dtype=np.int32)
+        nxy = self.xcenters.size # size of spatial plane
+        # loop over spaxels in the spatial plane and set slice_dq
         for ixy in range(nxy):
             area_box = self.cdelt1 * self.cdelt2
             area_overlap = cube_overlap.sh_find_overlap(self.xcenters[ixy], 
@@ -1307,145 +1471,70 @@ class IFUCubeData():
                                                         xi_corner, eta_corner)
                         
             overlap_coverage = area_overlap/area_box
+
+
             if overlap_coverage > 0:
-#                self.spaxel_dq_file.write('%f %f %f %f  %f %f %f %f %f %f %f %f %f' %
-#                                          (self.xcenters[ixy], self.ycenters[ixy],
-#                                           self.cdelt1, self.cdelt3, xi_corner[0], eta_corner[0],
-#                                           xi_corner[1], eta_corner[1],xi_corner[2],eta_corner[2],
-#                                           xi_corner[3], eta_corner[3], overlap_coverage) + '\n')
-
+                if(islice == 28 and wmin ==0):
+                    yy = int(ixy/self.naxis1)
+                    xx  = ixy - (yy * self.naxis1)
+                    print(self.xcenters[ixy],self.ycenters[ixy], overlap_coverage,ixy,xx,yy)
                 if overlap_coverage > 0.95:
-                    slice_dq[ixy] = self.overlap_full
+                    wave_slice_dq[ixy] = self.overlap_full
                 else:
-                    slice_dq[ixy] = self.overlap_partial
+                    wave_slice_dq[ixy] = self.overlap_partial
                             
-        for iz in range(id_min, id_max):
-            self.spaxel_dq[iz,:] = np.bitwise_or(self.spaxel_dq[iz,:] , slice_dq)
-# ________________________________________________________________________________
-                                                            
-        t1 = time.time()
-        print('time to map file projection to cube',t1 - t0) 
+        # set for a range of wavelengths
+        if wmin != wmax:
+            self.spaxel_dq[wmin:wmax,:] = np.bitwise_or(self.spaxel_dq[wmin:wmax,:] , wave_slice_dq)
 
+        # set for a single wavelength
+        else: 
+            self.spaxel_dq[wmin,:] = np.bitwise_or(self.spaxel_dq[wmin,:] , wave_slice_dq)
+#            print('testing',self.spaxel_dq[0,518])
 # ********************************************************************************
-
-
-    def map_fov_wave_projection_to_dqframe(self, footprint_wave):
-
-        """Set an intermdediate dq_flag baded on the footprint
         
-        The intermediate spaxel dq has a default value of 0
-        For each wavelength plane  of a data model (for MIRI of a selected
-        band) this intermediate spaxel dq is fill in with 1 (overlap partial),
-        2 overlap_full, or a bit_wise combination of these.
-
-        return spaxel_dq updated for this input file 
 
 
-        Parameter
-        ----------
-        footprint spatial and wavelength footprint of input model
+    def four_corners(self, coord1, coord2, isline):
+        """ helper function to compute the four corners of the FOV  """
 
-        Returns
-        -------
-        self.spaxel_dq : numpy.ndarray. Module updates spaxel_dq for each file 
-           
+        isline = False
+        index = np.where(coord2 == np.amin(coord2))
+        xi_corner1 = coord1[index[0]]
+        eta_corner1 = coord2[index[0]]
 
-        """
-                                                            
-        # first find the wavelength planes this slice overlaps. Min and max wavelength
-        # input values are set for MIRI for the entire band. 
-        for w in range(self.naxis3):
-                                                           
-        # footprint of input model on the sky (band for MIRI) 
-            (xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4) = footprint_wave[w,:]
-        
-            xi_corner=np.array([xi1,xi2,xi3,xi4])
-            eta_corner=np.array([eta1,eta2,eta3,eta4])
+        index = np.where(coord1 == np.amax(coord1))
+        xi_corner2 = coord1[index[0]]
+        eta_corner2 = coord2[index[0]]
 
-            slice_dq = np.zeros(self.naxis2 * self.naxis1 ,dtype=np.int32)
-            nxy = self.xcenters.size
-            for ixy in range(nxy):
-                area_box = self.cdelt1 * self.cdelt2
-                area_overlap = cube_overlap.sh_find_overlap(self.xcenters[ixy], 
-                                                        self.ycenters[ixy],
-                                                        self.cdelt1, self.cdelt2,
-                                                        xi_corner, eta_corner)
-                        
-                overlap_coverage = area_overlap/area_box
-                if overlap_coverage > 0:
-#                    self.spaxel_dq_file.write('%f %f %f %f  %f %f %f %f %f %f %f %f %f' %
-#                                              (self.xcenters[ixy], self.ycenters[ixy],
-#                                               self.cdelt1, self.cdelt3, xi_corner[0], eta_corner[0],
-#                                               xi_corner[1], eta_corner[1],xi_corner[2],eta_corner[2],
-#                                               xi_corner[3], eta_corner[3], overlap_coverage) + '\n')
-
-                    if overlap_coverage > 0.95:
-                        slice_dq[ixy] = self.overlap_full
-                    else:
-                        slice_dq[ixy] = self.overlap_partial
-                            
-                        
-            self.spaxel_dq[w,:] = np.bitwise_or(self.spaxel_dq[w,:] , slice_dq)
-
-# ********************************************************************************
-
-    def compute_four_corners(self, coord1, coord2, wave):
-        """ Compute te four corners of the FOV of band on the sky. """
-
-        # computation of 4 corners is not the same as the wcs.footprint
-        # all four corners and different coord1 and coord2 values
-        # the footprint consists of only 4 values ra min, ra max, dec min, dec max
-        
-        # The routine defines the four corners as
-        # corner 1: location of min coord2
-        # corner 2: location of min coord1
-        # corner 3: location of max coord2
-        # corner 4: location of max coord1
-        
-        # find the wavelength dependent footprint
-        footprint_wave = np.zeros((self.naxis3,8))
-
-        for w in range(self.naxis3):
-            wave1 = self.zcoord[w] - self.cdelt3/2.0
-            wave2 = wave1 + self.cdelt3
-
-            index_use = np.where((wave <= wave2)  & (wave >= wave1))
-
-            if len(index_use[0]) > 1:
-                coord2_use = coord2[index_use]
-                coord1_use = coord1[index_use]
-                for i in range(len(index_use[0])):
+        index = np.where(coord2 == np.amax(coord2))
+        xi_corner3 = coord1[index[0]]
+        eta_corner3 = coord2[index[0]]
                 
-                    self.spaxel_wave_dq_file.write('%i %f %f ' %
-                                                   (w,coord1_use[i],coord2_use[i])+ '\n')
-
-                index = np.where(coord2_use == np.amin(coord2_use))
-                xi_corner1 = coord1_use[index[0]]
-                eta_corner1 = coord2_use[index[0]]
-
-                index = np.where(coord1_use == np.amax(coord1_use))
-                xi_corner2 = coord1_use[index[0]]
-                eta_corner2 = coord2_use[index[0]]
-
-                index = np.where(coord2_use == np.amax(coord2_use))
-                xi_corner3 = coord1_use[index[0]]
-                eta_corner3 = coord2_use[index[0]]
-                
-                index = np.where(coord1_use == np.amin(coord1_use))
-                xi_corner4 = coord1_use[index[0]]
-                eta_corner4 = coord2_use[index[0]]
+        index = np.where(coord1 == np.amin(coord1))
+        xi_corner4 = coord1[index[0]]
+        eta_corner4 = coord2[index[0]]
             
-                footprint_wave[w,:] = (xi_corner1[0], eta_corner1[0],xi_corner2[0], eta_corner2[0], 
-                                       xi_corner3[0], eta_corner3[0], xi_corner4[0], eta_corner4[0])
+        footprint = (xi_corner1[0], eta_corner1[0],xi_corner2[0], eta_corner2[0], 
+                     xi_corner3[0], eta_corner3[0], xi_corner4[0], eta_corner4[0])
 
-                self.spaxel_wave_footprint_dq_file.write('%i %f %f %f %f %f %f %f %f %f %f' %
-                                          (w,wave1,wave2,xi_corner1[0],eta_corner1[0],
-                                           xi_corner2[0],eta_corner2[0],xi_corner3[0],eta_corner3[0],
-                                           xi_corner4[0],eta_corner4[0],)+ '\n')
-        return footprint_wave
+        distance_min_points = math.sqrt((xi_corner1 - xi_corner4)**2 +
+                                        (eta_corner1 - eta_corner4)**2)
+
+        distance_max_points = math.sqrt((xi_corner2 - xi_corner3)**2 +
+                                        (eta_corner2 - eta_corner3)**2)
         
-# ********************************************************************************
+        dist_tolerance = 0.0001
+        if ( (distance_min_points < dist_tolerance) and 
+             (distance_max_points < dist_tolerance)):
+            isline = True
+        footprint_all = (isline, footprint) 
 
+        return footprint
+
+# function may not be needed anymore, it uses the siaf library 
+# Kept the code (for now) until we decide the best way to determine
+# the corners of the FOV. 
 
     def compute_four_corners_siaf(self, this_par1, this_par2,ifile):
 
@@ -1568,12 +1657,14 @@ class IFUCubeData():
         #self.overlap_partial = 4  # intermediate flag
         #self.overlap_full  = 2    # intermediate flag
         #self.overlap_hole = dqflags.pixel['DO_NOT_USE'] 
-        #self.overlap_no_coverage = dqflags.pixel['NON_SCIENCE'] 
+        #self.overlap_no_coverage = dqflags.pixel['NON_SCIENCE'] (also bitwise and with 
+        # dqflags.pixel['DO_NOT_USE'] )
 
-       # first convert all the value of spaxel_dq of 0 to NON_SCIENCE
+       # first convert all the value of spaxel_dq of 0 to NON_SCIENCE + DO_NOT_USE
         non_science = self.spaxel_dq == 0
         self.spaxel_dq[non_science] = self.overlap_no_coverage
-
+        self.spaxel_dq[non_science] = np.bitwise_or(self.spaxel_dq[non_science],
+                                                    dqflags.pixel['DO_NOT_USE'])
 
         # refine where good data should be
         ind_full = self.spaxel_dq == self.overlap_full
@@ -1584,7 +1675,7 @@ class IFUCubeData():
         # flatten to match the size of spaxel_weight
         self.spaxel_dq = np.ndarray.flatten(self.spaxel_dq)
         location_holes = np.where(( self.spaxel_dq == 0) & (self.spaxel_weight==0))
-#        print( 'number of holes',len(location_holes[0]))
+        log.info('Number of holes: %i', len(location_holes[0]))
 
         self.spaxel_dq[location_holes]  = self.overlap_hole
 
@@ -1800,9 +1891,37 @@ class IFUCubeData():
         temp_wmap = self.spaxel_iflux.reshape((self.naxis3,
                                                self.naxis2, self.naxis1))
 
+        print('test',self.spaxel_dq[0,518])
         temp_dq = self.spaxel_dq.reshape((self.naxis3,
                                           self.naxis2, self.naxis1))
 
+        print('test',temp_dq[0,11,12])
+
+
+        temp_dq = np.zeros((self.naxis3,self.naxis2, self.naxis1),dtype=np.int32)
+        m = 0 
+        for i in range(self.naxis3):
+            jk = 0 
+            for j in range(self.naxis2):
+                for k in range(self.naxis1):
+                    temp_dq[i,j,k] = self.spaxel_dq[i,jk]
+                    jk = jk + 1
+                    m = m + 1
+
+            
+        print('test',temp_dq[0,11,12])
+
+
+#        temp_dq2 = np.zeros((self.naxis3, self.naxis2,self.naxis1),dtype=np.int32)
+
+#        for i in range(self.naxis3):
+#            jk = 0 
+#            for j in range(self.naxis1):
+#                for k in range(self.naxis2):
+#                    temp_dq2[i,k,j] = self.spaxel_dq[i,jk]
+#                    jk = jk + 1
+
+#        print('test',temp_dq2[0,11,12])
         ifucube_model.data = temp_flux
         ifucube_model.weightmap = temp_wmap
         ifucube_model.dq = temp_dq

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -46,9 +46,9 @@ class IFUCubeData():
         self.input_filenames = input_filenames
         self.pipeline = pipeline
         
-        dq_file = 'cube_spaxel_dq'+str(list_par1[0]) +'.results'
-        self.spaxel_dq_file =  open(dq_file, 'w')
-        print('dq file',dq_file)
+#        dq_file = 'cube_spaxel_dq'+str(list_par1[0]) +'.results'
+#        self.spaxel_dq_file =  open(dq_file, 'w')
+#        print('dq file',dq_file)
 
         dq_wave_file = 'cube_spaxel_wave_dq'+str(list_par1[0]) +'.results'
         self.spaxel_wave_dq_file =  open(dq_wave_file, 'w')
@@ -58,7 +58,7 @@ class IFUCubeData():
         self.spaxel_wave_footprint_dq_file =  open(dq_wave_footprint_file, 'w')
         print('dq wave file',dq_wave_footprint_file)
 
-        dq_wave_siaf_file = 'cube_spaxel_wave_saif_dq'+str(list_par1[0]) +'.results'
+        dq_wave_siaf_file = 'cube_spaxel_wave_siaf_dq'+str(list_par1[0]) +'.results'
         self.spaxel_wave_siaf_dq_file =  open(dq_wave_siaf_file, 'w')
         print('dq siaf file',dq_wave_siaf_file)
 
@@ -574,17 +574,17 @@ class IFUCubeData():
                     min_wave_band = np.amin(wave)
                     max_wave_band = np.amax(wave)
                     
-#                    footprint_wave = self.compute_four_corners(coord1, coord2, wave)
+                    footprint_wave = self.compute_four_corners(coord1, coord2, wave)
                     footprint_siaf = self.compute_four_corners_siaf(this_par1,this_par2, ifile)
 
                     print('footprint siaf',footprint_siaf)
-                    self.master_table.FileMap[self.instrument][this_par1][this_par2]['footprint'][k]=footprint_siaf
+#                    self.master_table.FileMap[self.instrument][this_par1][this_par2]['footprint'][k]=footprint_siaf
                     # send footprint of file on sky -spatial and wavelength
                     # set the spaxel_dq values, need the roiw and self.zcoord - defines wavelengths
 
-                    self.map_siaf_projection_to_dqframe(footprint_siaf, min_wave_band, max_wave_band)
+                    #self.map_siaf_projection_to_dqframe(footprint_siaf, min_wave_band, max_wave_band)
 
-                    #self.map_fov_wave_projection_to_dqframe(footprint_wave)
+                    self.map_fov_wave_projection_to_dqframe(footprint_wave)
 
                     
                     if self.weighting == 'msm':
@@ -1308,11 +1308,11 @@ class IFUCubeData():
                         
             overlap_coverage = area_overlap/area_box
             if overlap_coverage > 0:
-                self.spaxel_dq_file.write('%f %f %f %f  %f %f %f %f %f %f %f %f %f' %
-                                          (self.xcenters[ixy], self.ycenters[ixy],
-                                           self.cdelt1, self.cdelt3, xi_corner[0], eta_corner[0],
-                                           xi_corner[1], eta_corner[1],xi_corner[2],eta_corner[2],
-                                           xi_corner[3], eta_corner[3], overlap_coverage) + '\n')
+#                self.spaxel_dq_file.write('%f %f %f %f  %f %f %f %f %f %f %f %f %f' %
+#                                          (self.xcenters[ixy], self.ycenters[ixy],
+#                                           self.cdelt1, self.cdelt3, xi_corner[0], eta_corner[0],
+#                                           xi_corner[1], eta_corner[1],xi_corner[2],eta_corner[2],
+#                                           xi_corner[3], eta_corner[3], overlap_coverage) + '\n')
 
                 if overlap_coverage > 0.95:
                     slice_dq[ixy] = self.overlap_full
@@ -1373,11 +1373,11 @@ class IFUCubeData():
                         
                 overlap_coverage = area_overlap/area_box
                 if overlap_coverage > 0:
-                    self.spaxel_dq_file.write('%f %f %f %f  %f %f %f %f %f %f %f %f %f' %
-                                              (self.xcenters[ixy], self.ycenters[ixy],
-                                               self.cdelt1, self.cdelt3, xi_corner[0], eta_corner[0],
-                                               xi_corner[1], eta_corner[1],xi_corner[2],eta_corner[2],
-                                               xi_corner[3], eta_corner[3], overlap_coverage) + '\n')
+#                    self.spaxel_dq_file.write('%f %f %f %f  %f %f %f %f %f %f %f %f %f' %
+#                                              (self.xcenters[ixy], self.ycenters[ixy],
+#                                               self.cdelt1, self.cdelt3, xi_corner[0], eta_corner[0],
+#                                               xi_corner[1], eta_corner[1],xi_corner[2],eta_corner[2],
+#                                               xi_corner[3], eta_corner[3], overlap_coverage) + '\n')
 
                     if overlap_coverage > 0.95:
                         slice_dq[ixy] = self.overlap_full
@@ -1410,36 +1410,35 @@ class IFUCubeData():
             wave2 = wave1 + self.cdelt3
 
             index_use = np.where((wave <= wave2)  & (wave >= wave1))
-            coord2_use = coord2[index_use]
-            coord1_use = coord1[index_use]
 
-#            print(w, coord2_use.shape) 
-            for i in range(len(index_use[0])):
+            if len(index_use[0]) > 1:
+                coord2_use = coord2[index_use]
+                coord1_use = coord1[index_use]
+                for i in range(len(index_use[0])):
                 
-                self.spaxel_wave_dq_file.write('%i %f %f ' %
-                                          (w,coord1_use[i],coord2_use[i])+ '\n')
+                    self.spaxel_wave_dq_file.write('%i %f %f ' %
+                                                   (w,coord1_use[i],coord2_use[i])+ '\n')
 
+                index = np.where(coord2_use == np.amin(coord2_use))
+                xi_corner1 = coord1_use[index[0]]
+                eta_corner1 = coord2_use[index[0]]
 
-            index = np.where(coord2_use == np.amin(coord2_use))
-            xi_corner1 = coord1_use[index[0]]
-            eta_corner1 = coord2_use[index[0]]
+                index = np.where(coord1_use == np.amax(coord1_use))
+                xi_corner2 = coord1_use[index[0]]
+                eta_corner2 = coord2_use[index[0]]
 
-            index = np.where(coord1_use == np.amax(coord1_use))
-            xi_corner2 = coord1_use[index[0]]
-            eta_corner2 = coord2_use[index[0]]
-
-            index = np.where(coord2_use == np.amax(coord2_use))
-            xi_corner3 = coord1_use[index[0]]
-            eta_corner3 = coord2_use[index[0]]
-
-            index = np.where(coord1_use == np.amin(coord1_use))
-            xi_corner4 = coord1_use[index[0]]
-            eta_corner4 = coord2_use[index[0]]
+                index = np.where(coord2_use == np.amax(coord2_use))
+                xi_corner3 = coord1_use[index[0]]
+                eta_corner3 = coord2_use[index[0]]
+                
+                index = np.where(coord1_use == np.amin(coord1_use))
+                xi_corner4 = coord1_use[index[0]]
+                eta_corner4 = coord2_use[index[0]]
             
-            footprint_wave[w,:] = (xi_corner1[0], eta_corner1[0],xi_corner2[0], eta_corner2[0], 
-                                   xi_corner3[0], eta_corner3[0], xi_corner4[0], eta_corner4[0])
+                footprint_wave[w,:] = (xi_corner1[0], eta_corner1[0],xi_corner2[0], eta_corner2[0], 
+                                       xi_corner3[0], eta_corner3[0], xi_corner4[0], eta_corner4[0])
 
-            self.spaxel_wave_footprint_dq_file.write('%i %f %f %f %f %f %f %f %f %f %f' %
+                self.spaxel_wave_footprint_dq_file.write('%i %f %f %f %f %f %f %f %f %f %f' %
                                           (w,wave1,wave2,xi_corner1[0],eta_corner1[0],
                                            xi_corner2[0],eta_corner2[0],xi_corner3[0],eta_corner3[0],
                                            xi_corner4[0],eta_corner4[0],)+ '\n')
@@ -1489,7 +1488,6 @@ class IFUCubeData():
                     subchannel_name = 'C'
 
                 siaf_channel_band   = 'MIRIFU_CHANNEL'+str(this_par1)+subchannel_name
-                print('siaf name',siaf_channel_band)
                 this_band = siaf[siaf_channel_band]
 
                 v2ref,v3ref = this_band.V2Ref, this_band.V3Ref

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -43,7 +43,7 @@ class IFUCubeData():
         self.new_code = 0
         self.input_filenames = input_filenames
         self.pipeline = pipeline
-        
+
         self.input_models = input_models  # needed when building single mode IFU cubes
         self.output_name_base = output_name_base
         self.num_files = None
@@ -693,7 +693,7 @@ class IFUCubeData():
         n = len(self.input_models)
         log.info("Number of Single IFU cubes to create = %i" % n)
         this_par1 = self.list_par1[0]  # only one channel is used in this approach
-        this_par2 = None  # not important for this type of mapping
+#        this_par2 = None  # not important for this type of mapping
 
         self.weighting == 'msm'
 
@@ -1356,8 +1356,8 @@ class IFUCubeData():
                 footprint_all = self.four_corners(coord1_total, coord2_total)
                 isline, footprint = footprint_all
 
-                wmin = imin[0]
-                wmax = imax[0]
+#                wmin = imin[0]
+#                wmax = imax[0]
                 (xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4) = footprint
 
             # find the overlap of FOV footprint and with IFU Cube
@@ -1399,9 +1399,6 @@ class IFUCubeData():
 
                         footprint_all = self.four_corners(coord1_use, coord2_use)
                         isline, footprint = footprint_all
-                        line = 0
-                        if isline:
-                            line = 1
 
                         (xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4) = footprint
                         # find the overlap with IFU Cube
@@ -1536,17 +1533,21 @@ class IFUCubeData():
 
         """
 
-        ximin = np.amin(xi_corner)
-        ximax = np.amax(xi_corner)
-        etamin = np.amin(eta_corner)
-        etamax = np.amax(eta_corner)
-        index = np.where((self.xcenters > ximin) & (self.xcenters < ximax) &
-                          (self.ycenters > etamin) & (self.ycenters < etamax))
+#        ximin = np.amin(xi_corner)
+#        ximax = np.amax(xi_corner)
+#        etamin = np.amin(eta_corner)
+#        etamax = np.amax(eta_corner)
+#        index = np.where((self.xcenters > ximin) & (self.xcenters < ximax) &
+#                          (self.ycenters > etamin) & (self.ycenters < etamax))
 
         wave_slice_dq = np.zeros(self.naxis2 * self.naxis1, dtype=np.int32)
-        nxy = self.xcenters.size  # size of spatial plane
         # loop over spaxels in the spatial plane and set slice_dq
+        nxy = self.xcenters.size  # size of spatial plane
         for ixy in range(nxy):
+#        num = len(index[0])
+#        for inum in range(num):
+#            ixy = index[0][inum]
+
             area_box = self.cdelt1 * self.cdelt2
             area_overlap = cube_overlap.sh_find_overlap(self.xcenters[ixy],
                                                         self.ycenters[ixy],
@@ -1670,7 +1671,7 @@ class IFUCubeData():
         self.spaxel_dq[under_data] = self.overlap_partial
 
         # convert all remaining spaxel_dq of 0 to NON_SCIENCE + DO_NOT_USE
-        # these pixel should have no overlap with the data 
+        # these pixel should have no overlap with the data
         non_science = self.spaxel_dq == 0
         self.spaxel_dq[non_science] = np.bitwise_or(self.overlap_no_coverage,
                                                     dqflags.pixel['DO_NOT_USE'])
@@ -1678,10 +1679,6 @@ class IFUCubeData():
         # refine where good data should be
         ind_full = np.where(np.bitwise_and(self.spaxel_dq, self.overlap_full))
         ind_partial = np.where(np.bitwise_and(self.spaxel_dq, self.overlap_partial))
-                            
-#        ind_full = self.spaxel_dq == self.overlap_full
-#        ind_partial = self.spaxel_dq == self.overlap_partial
-        
 
         self.spaxel_dq[ind_full] = 0
         self.spaxel_dq[ind_partial] = 0

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1102,7 +1102,7 @@ class IFUCubeData():
             if self.instrument == 'MIRI':
 
                 # find the slice number of each pixel and fill in slice_det
-                slice_det = np.zeros((1024, 1032))
+                slice_det = np.zeros((1024, 1032), dtype=int)
                 det2ab_transform = input_model.meta.wcs.get_transform('detector',
                                                                       'alpha_beta')
                 start_region = self.instrument_info.GetStartSlice(this_par1)
@@ -1158,7 +1158,7 @@ class IFUCubeData():
                 lam_det = np.zeros((2048, 2048))
                 flag_det = np.zeros((2048, 2048))
 
-                slice_det = np.zeros((2048, 2048))
+                slice_det = np.zeros((2048, 2048), dtype = int)
                 # for NIRSPEC each file has 30 slices
                 # wcs information access seperately for each slice
                 nslices = 30
@@ -1197,7 +1197,6 @@ class IFUCubeData():
                 dec = dec_det[valid_data]
                 wave = lam_det[valid_data]
                 slice_no = slice_det[valid_data]
-
 # ______________________________________________________________________________
 # The following is for both MIRI and NIRSPEC
 # grab the flux and DQ values for these pixles
@@ -1207,6 +1206,7 @@ class IFUCubeData():
 
             min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0])
             max_wave_tolerance = self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2])
+
 
             valid_min = np.where(wave >= min_wave_tolerance)
             not_mapped_low = wave.size - len(valid_min[0])
@@ -1386,13 +1386,12 @@ class IFUCubeData():
             # for each of the 30 slices - find the projection of this slice
             # onto each of the IFU wavelength planes.
             for islice in range(30):
-                index_slice = np.where(slice == islice+1)
+                index_slice = np.where(slice_no == islice+1)
 
                 # find the smaller set of wavelengths to search over for this slice
                 wavemin = np.amin(wave[index_slice])
                 wavemax = np.amax(wave[index_slice])
-#                iwavemin = np.absolute(np.array(wavemin - self.zcoord) / (self.cdelt3_normal/2.0))
-#                iwavemax = np.absolute(np.array(wavemax - self.zcoord) / (self.cdelt3_normal/2.0))
+
                 iwavemin = np.absolute(np.array(wavemin - self.zcoord) / (self.cdelt3_normal))
                 iwavemax = np.absolute(np.array(wavemax - self.zcoord) / (self.cdelt3_normal))
                 imin = np.where(iwavemin == np.amin(iwavemin))[0]
@@ -1752,7 +1751,7 @@ class IFUCubeData():
         self.spaxel_dq = spaxel_dq_temp
         location_holes = np.where(self.spaxel_dq == self.overlap_hole)
         ave_holes = len(location_holes[0])/self.naxis3
-        print(ave_holes)
+
         if ave_holes < 1:
             log.info('Average # of holes/wavelength plane is < 1')
         else:

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1323,7 +1323,7 @@ class IFUCubeData():
             imin = np.where(iwavemin == np.amin(iwavemin))[0]
             imax = np.where(iwavemax == np.amin(iwavemax))[0]
 
-            # for each wavelength plane - find the 2 extreme slices to set the FOV 
+            # for each wavelength plane - find the 2 extreme slices to set the FOV
             for w in range(imin[0], imax[0]):
                 wave_distance = np.absolute(self.zcoord[w] - wave)
 
@@ -1700,24 +1700,24 @@ class IFUCubeData():
         # one last check. Remove pixels flagged as hole but have 1 adjacent spaxel
         # that has no coverage (NON_SCIENCE).  If NON_SCIENCE flag is next to pixel
         # flagged as hole then set the Hole flag to NON_SCIENCE
-        spaxel_dq_temp = self.spaxel_dq 
+        spaxel_dq_temp = self.spaxel_dq
         nxy = self.naxis1 * self.naxis2
         index = np.where(self.spaxel_dq == self.overlap_hole)
         for i in range(len(index[0])):
             iwave = int(index[0][i]/nxy)
             rem = index[0][i] - iwave*nxy
             yrem = int(rem/self.naxis1)
-            xrem = rem - yrem * self.naxis1 
+            xrem = rem - yrem * self.naxis1
 
             found  = 0
             ij = 0
-            # do not allow holes to occur at the edge of IFU cube 
-            if (yrem == 0 or yrem == (self.naxis2-1) or 
+            # do not allow holes to occur at the edge of IFU cube
+            if (yrem == 0 or yrem == (self.naxis2-1) or
                 xrem == 0 or xrem == (self.naxis1-1)):
                 spaxel_dq_temp[index[0][i]] = np.bitwise_or(self.overlap_no_coverage,
                                                             dqflags.pixel['DO_NOT_USE'])
                 found = 1
-            # flag as NON_SCIENCE instead of hole if left, right, top, bottom pixel 
+            # flag as NON_SCIENCE instead of hole if left, right, top, bottom pixel
             # is NON_SCIENCE
             xcheck = np.zeros(4,dtype = int)
             ycheck = np.zeros(4,dtype = int)
@@ -1728,14 +1728,14 @@ class IFUCubeData():
             xcheck[1] = xrem + 1
             ycheck[1] = yrem
             # bottom
-            xcheck[2] = xrem 
+            xcheck[2] = xrem
             ycheck[2] = yrem -1
             # top
-            xcheck[3] = xrem 
+            xcheck[3] = xrem
             ycheck[3] = yrem +1
-            
-            while ((ij < 4) and (found ==0)):  
-                if(xcheck[ij] > 0 and xcheck[ij] < self.naxis1 and 
+
+            while ((ij < 4) and (found ==0)):
+                if(xcheck[ij] > 0 and xcheck[ij] < self.naxis1 and
                    ycheck[ij] > 0 and ycheck[ij] < self.naxis2):
                     index_check = iwave*nxy + ycheck[ij]*self.naxis1 + xcheck[ij]
                     # If the nearby spaxel_dq contains overlap_no_covrage
@@ -1748,7 +1748,7 @@ class IFUCubeData():
                                                                     dqflags.pixel['DO_NOT_USE'])
                         found = 1
                 ij = ij + 1
-        
+
         self.spaxel_dq = spaxel_dq_temp
         location_holes = np.where(self.spaxel_dq == self.overlap_hole)
         ave_holes = len(location_holes[0])/self.naxis3

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1141,6 +1141,8 @@ class IFUCubeData():
                     wave = wave[valid1]
                     x = x[valid1]
                     y = y[valid1]
+                    #TODO add footprint determation
+
                     if self.weighting == 'miripsf':
                         det2ab_transform = input_model.meta.wcs.get_transform('detector',
                                                                               'alpha_beta')
@@ -1165,6 +1167,9 @@ class IFUCubeData():
                 dec_det = np.zeros((2048, 2048))
                 lam_det = np.zeros((2048, 2048))
                 flag_det = np.zeros((2048, 2048))
+
+                #TODO add footprint determination
+
                 # for NIRSPEC each file has 30 slices
                 # wcs information access seperately for each slice
                 nslices = 30

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1315,8 +1315,8 @@ class IFUCubeData():
             # find the wavelength boundaries of the band - use two extreme slices
             wavemin = np.amin(wave)
             wavemax = np.amax(wave)
-            
-            # self.zcoord holds the center of the wavelength bin 
+
+            # self.zcoord holds the center of the wavelength bin
             iwavemin = np.absolute(np.array(wavemin - self.zcoord) / self.cdelt3_normal)
             iwavemax = np.absolute(np.array(wavemax - self.zcoord) / self.cdelt3_normal)
 

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -38,10 +38,11 @@ class InstrumentInfo():
         self.high_wroi = []
         self.high_power = []
         self.high_softrad = []
-#_______________________________________________________________________
+# _______________________________________________________________________
         # This is basic information on the MIRI channels
         # information that will not change:
-        #   number of slices, starting slice number, ending # slice number and default scales
+        # number of slices, starting slice number,
+        # ending # slice number and default scales
         self.Info = {}
         self.Info['psf_alpha_cuttoff'] = None
         self.Info['psf_alpha_a_short'] = None
@@ -53,7 +54,7 @@ class InstrumentInfo():
         self.Info['psf_beta_b_short'] = None
         self.Info['psf_beta_a_long'] = None
         self.Info['psf_beta_b_long'] = None
-#________________________________________________________________________________
+# _____________________________________________________________________
 # channel 1 parameters
         self.Info['1'] = {}
         self.Info['1']['nslices'] = 21
@@ -124,7 +125,7 @@ class InstrumentInfo():
         self.Info['1']['long']['rp_a_ave'] = None
         self.Info['1']['long']['rp_b_ave'] = None
         self.Info['1']['long']['rp_c_ave'] = None
-#________________________________________________________________________________
+# _______________________________________________________________________
 # channel 2 parameters
         self.Info['2'] = {}
         self.Info['2']['nslices'] = 17
@@ -195,7 +196,7 @@ class InstrumentInfo():
         self.Info['2']['long']['rp_a_ave'] = None
         self.Info['2']['long']['rp_b_ave'] = None
         self.Info['2']['long']['rp_c_ave'] = None
-#________________________________________________________________________________
+# ________________________________________________________________
 # channel 3 parameters
         self.Info['3'] = {}
         self.Info['3']['nslices'] = 16
@@ -266,7 +267,7 @@ class InstrumentInfo():
         self.Info['3']['long']['rp_a_ave'] = None
         self.Info['3']['long']['rp_b_ave'] = None
         self.Info['3']['long']['rp_c_ave'] = None
-#________________________________________________________________________________
+# _________________________________________________________________
 # channel 4 parameters
         self.Info['4'] = {}
         self.Info['4']['nslices'] = 12
@@ -338,8 +339,8 @@ class InstrumentInfo():
         self.Info['4']['long']['rp_b_ave'] = None
         self.Info['4']['long']['rp_c_ave'] = None
 
-#################################################################################
-#NIRSPEC Paramters
+# ####################################################################
+# NIRSPEC Paramters
         self.Info['prism'] = {}
         self.Info['prism']['clear'] = {}
         self.Info['prism']['clear']['nslices'] = 30
@@ -404,7 +405,6 @@ class InstrumentInfo():
         self.Info['g395m']['f290lp']['softrad'] = None
         self.Info['g395m']['f290lp']['msm_power'] = None
 
-
         self.Info['g140h'] = {}
         self.Info['g140h']['f070lp'] = {}
         self.Info['g140h']['f070lp']['nslices'] = 30
@@ -456,7 +456,7 @@ class InstrumentInfo():
         self.Info['g395h']['f290lp']['softrad'] = None
         self.Info['g395h']['f290lp']['msm_power'] = None
 
-#********************************************************************************
+# ******************************************************************
 # Functions
 
     def SetMultiChannelTable(self, wave, sroi, wroi, power, softrad):
@@ -494,7 +494,6 @@ class InstrumentInfo():
         else:
             self.Info[parameter1][parameter2]['ascale'] = value
             self.Info[parameter1][parameter2]['bscale'] = value
-
 
     def SetSpectralStep(self, value, parameter1, parameter2):
         self.Info[parameter1][parameter2]['wscale'] = value
@@ -550,7 +549,8 @@ class InstrumentInfo():
         self.Info['psf_beta_b_short'] = b_short
         self.Info['psf_beta_a_long'] = a_long
         self.Info['psf_beta_b_long'] = b_long
-#______________________________________________________________________
+# ______________________________________________________________________
+
     def Get_RP_ave_Wave(self, this_channel, this_band):
         w = self.Info[this_channel][this_band]['rp_wave_cuttoff']
         a = self.Info[this_channel][this_band]['rp_a_ave']
@@ -638,7 +638,6 @@ class InstrumentInfo():
                  self.high_power,
                  self.high_softrad)
         return table
-
 
     def GetMIRISliceEndPts(self, parameter1):
         slice_xstart = self.Info[parameter1]['xstart']


### PR DESCRIPTION
The PR sets the DQ plane of the IFU cube. The values it sets are:

- 0: good data
- 1: DO_NOT_USE (Hole - should have data but does not)
- 1 + 512 (NON_SCIENCE): no overlapping data with IFU cube

The number of holes for each IFU cube is printed in the logging.
This PR also fixed an error in CRVAL3 (it was off by 1/2 a pixel).

Messages are now printed if data falls outside the min and max wavelength (which is set by the cubepars reference file).

Note: A future update for NIRSpec will use the min and max wavelength of data to set the IFU wavelength ranges. 
