### PR TITLE
Enable environment snapshot creation for macos

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -28,25 +28,37 @@ data_config.server_id = 'bytesalad'
 data_config.root = '${PYTEST_BASETEMP}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
+
 // Build and test with python 3.6 and released dependencies from astroconda
-bc = new BuildConfig()
-bc.nodetype = 'jwst'
-bc.name = 'stable-deps'
-bc.env_vars = env_vars
-bc.conda_ver = '4.6.14'
-bc.conda_packages = [
+bc0 = new BuildConfig()
+bc0.nodetype = 'jwst'
+bc0.name = 'stable-deps'
+bc0.env_vars = env_vars
+bc0.conda_ver = '4.6.14'
+bc0.conda_packages = [
     "python=${python_version}",
 ]
-bc.build_cmds = [
+bc0.build_cmds = [
     "pip install -e .[test]",
     "pip install pytest-xdist",
 ]
-bc.test_cmds = [
+bc0.test_cmds = [
     "pytest -r sx -v -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
     --log-level=INFO \
     jwst/tests_nightly/general"
 ]
-bc.test_configs = [data_config]
+bc0.test_configs = [data_config]
 
-utils.run([jobconfig, bc])
+
+# macos-specific buildconfig to cause the creation of counterparts to the linux
+# environment dumps. Packages in a mininmal conda environment differ by OS
+# which is why this is needed.
+bc1 = utils.copy(bc0)
+bc1.nodetype = 'macos'
+bc1.name = 'macos-stable-deps'
+bc1.build_cmds = ["pip install -e .[test]"]
+bc1.test_configs = []
+
+
+utils.run([jobconfig, bc0, bc1])

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -58,6 +58,7 @@ bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-stable-deps'
 bc1.build_cmds = ["pip install -e .[test]"]
+bc1.test_cmds = []
 bc1.test_configs = []
 
 


### PR DESCRIPTION
Adds a second `BuildConfig` assigned to an OSX host which simply installs the package along with its testing dependencies as is done on Linux so that an environment snapshot can be created which includes the OS-specific differences in the minimal conda environment that serves as a base.