### PR TITLE
Update outlier_detection for photutils>=0.7 non-indexable Apertures

### DIFF
--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -84,7 +84,12 @@ class OutlierDetectionScaled(OutlierDetection):
             radius_outer = 5
 
         apertures = CircularAperture((xcenter, ycenter), r=radius)
-        aperture_mask = apertures.to_mask(method='center')[0]
+        # ApertureMask in photutils<=0.6 is indexable.  In >=0.6 it is scalar
+        # if there is only one Aperture.  Handle both.
+        try:
+            aperture_mask = apertures.to_mask(method='center')[0]
+        except TypeError:
+            aperture_mask = apertures.to_mask(method='center')
         # This mask has 1 for mask region, 0 for outside of mask
         median_mask = aperture_mask.to_image((ny, nx))
         inv_median_mask = np.abs(median_mask - 1)

--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -84,7 +84,7 @@ class OutlierDetectionScaled(OutlierDetection):
             radius_outer = 5
 
         apertures = CircularAperture((xcenter, ycenter), r=radius)
-        # ApertureMask in photutils<=0.6 is indexable.  In >=0.6 it is scalar
+        # ApertureMask in photutils<=0.6 is indexable.  In >=0.7 it is scalar
         # if there is only one Aperture.  Handle both.
         try:
             aperture_mask = apertures.to_mask(method='center')[0]


### PR DESCRIPTION
This came up in testing the released `jwst 0.13.7` SDP-delivered conda spec file on our 0.13.7 Artifactory input and truth data snapshot.

The dev version of `photutils` no longer has indexable ApertureMasks if there is only one Aperture.