### PR TITLE
works with new modeling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ assign_wcs
 
 - This step populates keyword DISPAXIS. [#3799]
 
+
 associations
 ------------
 
@@ -21,6 +22,11 @@ associations
 - Add a check that backgrounds are included in level 3 associations [#3678]
 
 - Will not constrain on uniqueness of the MSACONFIG keyword [#3770]
+
+- combine_1d
+------------
+
+- Fixed the number of inputs to the spectral WCS - one expetced, two were passed. [#3827]
 
 datamodels
 ----------
@@ -49,6 +55,8 @@ extract_1d
   is done there rather than in the subclasses. [#3714]
 
 - This step uses keyword DISPAXIS. [#3799]
+
+- Fixed a bug in ``pixel_area`` when th einput is a ``CubeModel``. [#3827]
 
 extract_2d
 ----------

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -115,7 +115,11 @@ def imaging(input_model, reference_files):
         # MSA to OTEIP transform
         msa2ote = msa_to_oteip(reference_files)
         msa2oteip = msa2ote | Mapping((0, 1), n_inputs=3)
-        msa2oteip.inverse = Mapping((0, 1, 0, 1)) | msa2ote.inverse | Mapping((0, 1), n_inputs=3)
+        map1 = Mapping((0, 1, 0, 1))
+        minv = msa2ote.inverse
+        del minv.inverse
+        msa2oteip.inverse = map1 | minv | Mapping((0, 1), n_inputs=3)
+
         # OTEIP to V2,V3 transform
         with OTEModel(reference_files['ote']) as f:
             oteip2v23 = f.model

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -79,7 +79,7 @@ class InputSpectrumModel:
                                exptime_key)
 
         try:
-            self.right_ascension[:], self.declination[:], _ = spec.meta.wcs(0., 0.)
+            self.right_ascension[:], self.declination[:], _ = spec.meta.wcs(0.)
         except AttributeError:
             self.right_ascension[:] = ms.meta.target.ra
             self.declination[:] = ms.meta.target.dec

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2769,7 +2769,12 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             del npixels_temp
 
             # Convert to flux density (for a point source).
-            pixel_solid_angle = util.pixel_area(slit.meta.wcs, slit.data.shape)
+            wcs_shape = slit.data.shape
+            wcs = slit.meta.wcs
+            if len(wcs_shape) > 2:
+                # CubeModel
+                wcs_shape = wcs_shape[1:]
+            pixel_solid_angle = util.pixel_area(wcs, wcs_shape)
             if pixel_solid_angle is None:
                 log.warning("Pixel solid angle could not be determined")
                 pixel_solid_angle = 1.
@@ -2869,8 +2874,13 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                     wcs = niriss.niriss_soss_set_input(input_model, sp_order)
                 else:
                     wcs = input_model.meta.wcs
-                pixel_solid_angle = util.pixel_area(wcs,
-                                                    input_model.data.shape)
+
+                wcs_shape = input_model.data.shape
+                if len(wcs_shape) > 2:
+                    # CubeModel
+                    wcs_shape = wcs_shape[1:]
+
+                pixel_solid_angle = util.pixel_area(wcs, wcs_shape)
                 if pixel_solid_angle is None:
                     log.warning("Pixel solid angle could not be determined")
                     pixel_solid_angle = 1.
@@ -2971,8 +2981,13 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                                                            sp_order)
                     else:
                         wcs = input_model.meta.wcs
+
+                    wcs_shape = input_model.data.shape
+                    if len(wcs_shape) > 2:
+                        # CubeModel
+                        wcs_shape = wcs_shape[1:]
                     pixel_solid_angle = util.pixel_area(wcs,
-                                                        input_model.data.shape,
+                                                        wcs_shape,
                                                         verbose)
                     if pixel_solid_angle is None:
                         if verbose:

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -123,8 +123,10 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
         background = bkg.to(u.MJy / u.steradian).value
 
     # Compute the solid angle of a pixel in steradians.
-    pixel_solid_angle = util.pixel_area(input_model.meta.wcs,
-                                        input_model.data.shape)
+    wcs_shape = input_model.data.shape
+    wcs = input_model.meta.wcs
+
+    pixel_solid_angle = util.pixel_area(wcs, wcs_shape)
     if pixel_solid_angle is None:
         log.warning("Pixel solid angle could not be determined")
         pixel_solid_angle = 1.

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -123,10 +123,8 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
         background = bkg.to(u.MJy / u.steradian).value
 
     # Compute the solid angle of a pixel in steradians.
-    wcs_shape = input_model.data.shape
-    wcs = input_model.meta.wcs
-
-    pixel_solid_angle = util.pixel_area(wcs, wcs_shape)
+    pixel_solid_angle = util.pixel_area(input_model.meta.wcs,
+                                        input_model.data.shape)
     if pixel_solid_angle is None:
         log.warning("Pixel solid angle could not be determined")
         pixel_solid_angle = 1.

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -100,7 +100,8 @@ class ResampleStep(Step):
         used a resample.cfg file or run ResampleStep using command line args,
         then these will overwerite the defaults pulled from the reference file.
         """
-        drizpars_table = datamodels.DrizParsModel(ref_filename).data
+        with datamodels.DrizParsModel(ref_filename) as drpt:
+            drizpars_table =drpt.data
 
         num_groups = len(input_models.group_names)
         filtname = input_models[0].meta.instrument.filter

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -101,7 +101,7 @@ class ResampleStep(Step):
         then these will overwerite the defaults pulled from the reference file.
         """
         with datamodels.DrizParsModel(ref_filename) as drpt:
-            drizpars_table =drpt.data
+            drizpars_table = drpt.data
 
         num_groups = len(input_models.group_names)
         filtname = input_models[0].meta.instrument.filter


### PR DESCRIPTION
The changes in this PR are necessary (except the one in resample) for the code to run with the new modeling.

- assign_wcs.nirspec:
 Deleted the inverse of a model `M1` which is to be assigned as inverse to a model `M` because modeling checks recursively for "correct" inverses and raises an error even if they are not needed.

- combine_1d:
  There's only one  input to the WCS transform and it defines the wavelength. Spatial coordinates are constants.

- extract_1d:
  `util.pixel_area` takes as input the shape of the data, constructs input arrays from it and evaluates the WCS. In the case of a `CubeModel` a shape of length 3 was passed in but the WCS takes 2 inputs.
  
- resample:
 Fixed an unclosed file `Warning`.  