### PR TITLE
JP-858 Close intermediate files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ exp_to_source
 
 - Updated the documentation and added some logging to the step. [#3803]
 
+- Close input files after creating the new outputs. [#3828]
+
 extract_1d
 ----------
 

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -36,12 +36,13 @@ def exp_to_source(inputs):
     for exposure in inputs:
         log.info('Reorganizing data from exposure {}'.format(exposure.meta.filename))
         for slit in exposure.slits:
-            log.debug('Copying slit {}'.format(slit.source_id))
+            log.debug('Copying source {}'.format(slit.source_id))
             result[str(slit.source_id)].exposures.append(slit)
             merge_tree(
                 result[str(slit.source_id)].exposures[-1].meta.instance,
                 exposure.meta.instance
             )
+        exposure.close()
 
     # Turn off the default factory
     result.default_factory = None


### PR DESCRIPTION
Update the `exp_to_source` to close the input exposures after it's done rearranging the data into new models, with a minor change to a logging message too.

Fixes #3802.