### PR TITLE
Clean up open file warnings; shorten traceback in regtest failures

### DIFF
--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -80,6 +80,7 @@ def data_file():
     with TemporaryDirectory() as path:
         file_path = os.path.join(path, 'fits.fits')
         model.save(file_path)
+        model.close()
         yield file_path
 
 
@@ -96,6 +97,7 @@ def data_file_nosiaf():
     with TemporaryDirectory() as path:
         file_path = os.path.join(path, 'fits_nosiaf.fits')
         model.save(file_path)
+        model.close()
         yield file_path
 
 

--- a/jwst/tests/compare_outputs.py
+++ b/jwst/tests/compare_outputs.py
@@ -134,6 +134,7 @@ def compare_outputs(outputs, raise_error=True, ignore_keywords=[],
     .. note:: Each ``outputs`` entry in the list gets interpreted and processed
               separately.
     """
+    __tracebackhide__ = True
     default_kwargs = {'rtol': rtol, 'atol': atol,
                       'ignore_keywords': ignore_keywords,
                       'ignore_fields': ignore_fields,


### PR DESCRIPTION
- close 2 FITS files left open in fixtures feeding tests in `set_telescope_pointing`.  Gets rid of the following warnings:
```
jwst/datamodels/schema.py:250
  /Users/jdavies/dev/jwst/jwst/datamodels/schema.py:250: ResourceWarning: unclosed file <_io.FileIO name='/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/tmpltx3gjhn/fits.fits' mode='rb' closefd=True>
    schema = OrderedDict(schema)

jwst/datamodels/schema.py:250
  /Users/jdavies/dev/jwst/jwst/datamodels/schema.py:250: ResourceWarning: unclosed file <_io.FileIO name='/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/tmpq8j0udl9/fits_nosiaf.fits' mode='rb' closefd=True>
    schema = OrderedDict(schema)
```

- shorten the _very long_ tracebacks seen in our regression test failures.  Essentially, this will get rid of having all the code of `compare_outputs` spit out in the test results on Jenkins.  :tada: