### PR TITLE
JP-865 Updated association rules to exclude NIS_EXTCAL eposures

### DIFF
--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -897,7 +897,7 @@ class Constraint_Target(DMSAttrConstraint):
 
 class Constraint_ExtCal(Constraint):
     """Remove any nis_extcals from the associations, they
-       are NOT to be processed in the pipline!"""
+       are NOT to receive level-2b or level-3 processing!"""
 
     def __init__(self):
         super(Constraint_ExtCal, self).__init__(

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -46,6 +46,7 @@ __all__ = [
     'AsnMixin_Lv2Special',
     'AsnMixin_Lv2Spectral',
     'Constraint_Base',
+    'Constraint_ExtCal',
     'Constraint_Image_Nonscience',
     'Constraint_Image_Science',
     'Constraint_Mode',
@@ -894,6 +895,21 @@ class Constraint_Target(DMSAttrConstraint):
             sources=['targetid'],
         )
 
+class Constraint_ExtCal(Constraint):
+    """Remove any nis_extcals from the associations, they
+       are NOT to be processed in the pipline!"""
+
+    def __init__(self):
+        super(Constraint_ExtCal, self).__init__(
+            [
+                DMSAttrConstraint(
+                    name='exp_type',
+                    sources=['exp_type'],
+                    value='nis_extcal'
+                )
+            ],
+            reduce=Constraint.notany
+        )
 
 # ---------------------------------------------
 # Mixins to define the broad category of rules.

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -877,17 +877,16 @@ class Asn_Lv2WFSC(
         self.constraints = Constraint([
             Constraint_Base(),
             Constraint_Single_Science(self.has_science),
-            DMSAttrConstraint(
-                name='wfsc',
-                sources=['visitype'],
-                value='.+wfsc.+',
-                force_unique=True
-            ),
-            DMSAttrConstraint(
-                name='exclude',
-                sources=['exp_type'],
-                value='.+(?!nis_extcal).+',
-                force_unique=False,
+            Constraint_ExtCal(),
+            Constraint(
+                [
+                        DMSAttrConstraint(
+                            name='wfsc',
+                            sources=['visitype'],
+                            value='.+wfsc.+',
+                            force_unique=True
+                        )
+                ]
             )
         ])
 


### PR DESCRIPTION
The association rules are updated to exclude NIS_EXTCAL exposures. In JWSTDMS-31 the example given is for jw00629 where observation number 9 & 10 are listed as exptype='NIS_EXTCAL'. The new rules exclude those files and is shown in the difference between the updated associations for jw00629_20190624t200638_pool.csv,

grep Only diffs_output_July22.log
121:Only in output: jw00629-o009_wfs-image2_001_asn.json
122:Only in output: jw00629-o009_wfs-image2_002_asn.json
123:Only in output: jw00629-o010_wfs-image2_001_asn.json
124:Only in output: jw00629-o010_wfs-image2_002_asn.json

All the other associations remain the same.

 
