### PR TITLE
Adding imprint unit test

### DIFF
--- a/jwst/imprint/tests/test_imprint.py
+++ b/jwst/imprint/tests/test_imprint.py
@@ -1,0 +1,31 @@
+"""
+Unit tests for imprint correction
+"""
+
+from jwst.datamodels import ImageModel
+from jwst.imprint import ImprintStep
+import numpy as np
+import pytest
+
+
+def test_step(make_imagemodel):
+    """Assert that the results should be all zeros.
+    """
+    im = make_imagemodel(10, 10)
+    result = ImprintStep.call(im, im)
+
+    assert(result.meta.cal_step.imprint == 'COMPLETE')
+    assert result.data.sum() == 0
+
+
+@pytest.fixture(scope='function')
+def make_imagemodel():
+    '''Image model for testing'''
+    def _im(ysize, xsize):
+        # create the data arrays
+        im = ImageModel((ysize, xsize))
+        im.data = np.random.rand(ysize, xsize)
+
+        return im
+
+    return _im


### PR DESCRIPTION
Adding unit test for the imprint step. This take an image model as the input and imprint model so when the correction is applied the result is zero. Also checks that the correction keyword is added to the metadata.