### PR TITLE
JP-843 Updates to exclude TA's from calwebb_spec3 processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ assign_wcs
 associations
 ------------
 
+- Update to prevent target_acquisitions from processing in the spec3 pipeline [#3777]
+
 - Return filename with extensions based on file type [#2671]
 
 - Ensured that all target acqs are processed by Level 2 [#3765]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,6 @@ assign_wcs
 associations
 ------------
 
-- Update to prevent target_acquisitions from processing in the spec3 pipeline [#3777]
-
 - Return filename with extensions based on file type [#2671]
 
 - Ensured that all target acqs are processed by Level 2 [#3765]
@@ -32,6 +30,8 @@ associations
 
 datamodels
 ----------
+
+- Update to prevent target_acquisitions from processing in the spec3 pipeline [#3777]
 
 - Use public API of jsonschema to ease upgrade to 3.x. [#3705]
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 import os.path as op
 import warnings
 import re
+import logging
 
 from asdf import AsdfFile
 from astropy.io import fits
@@ -19,6 +20,9 @@ __doctest_skip__ = ['ModelContainer']
 
 __all__ = ['ModelContainer']
 
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 class ModelContainer(model_base.DataModel):
     """
@@ -65,15 +69,12 @@ class ModelContainer(model_base.DataModel):
     # does not describe the data contents of the container.
     schema_url = "container.schema"
 
-    def __init__(self, init=None, **kwargs):
+    def __init__(self, init=None, allowed_exptypes=None, **kwargs):
 
-        super(ModelContainer, self).__init__(init=None, **kwargs)
+        super(ModelContainer, self).__init__(init=None, allowed_exptypes=None  , **kwargs)
 
         self._models = []
-        self.allowed_exptypes = None
-        for key in kwargs.keys():
-            if key == 'allowed_exptypes':
-                self.allowed_exptypes = kwargs.get('allowed_exptypes')
+        self.allowed_exptypes = allowed_exptypes
 
         if init is None:
             # Don't populate the container with models
@@ -191,11 +192,11 @@ class ModelContainer(model_base.DataModel):
         # grab all the files
         if self.allowed_exptypes:
             infiles = []
-            print("Filtering datasets based on allowed exptypes:", self.allowed_exptypes)
+            logger.debug("Filtering datasets based on allowed exptypes:", self.allowed_exptypes)
             for member in asn_data['products'][0]['members']:
                 if any([x for x in self.allowed_exptypes if re.match(member['exptype'], x, re.IGNORECASE)]):
                         infiles.append(member['expname'])
-                        print("Files accepted for processing:", member['expname'])
+                        logger.debug("Files accepted for processing:", member['expname'])
         else:
             infiles = [member['expname'] for member
             in asn_data['products'][0]['members']]

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -71,7 +71,7 @@ class ModelContainer(model_base.DataModel):
 
     def __init__(self, init=None, allowed_exptypes=None, **kwargs):
 
-        super(ModelContainer, self).__init__(init=None, allowed_exptypes=None  , **kwargs)
+        super(ModelContainer, self).__init__(init=None, allowed_exptypes=None, **kwargs)
 
         self._models = []
         self.allowed_exptypes = allowed_exptypes

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -45,6 +45,9 @@ class ModelContainer(model_base.DataModel):
         - None: initializes an empty `ModelContainer` instance, to which
           DataModels can be added via the ``append()`` method.
 
+       - asn_exptypes: list of exposure types from the asn file to read
+         into the pipeline, if None read all the given files.
+
     Examples
     --------
     >>> container = ModelContainer('example_asn.json')
@@ -69,12 +72,12 @@ class ModelContainer(model_base.DataModel):
     # does not describe the data contents of the container.
     schema_url = "container.schema"
 
-    def __init__(self, init=None, allowed_exptypes=None, **kwargs):
+    def __init__(self, init=None, asn_exptypes=None, **kwargs):
 
-        super(ModelContainer, self).__init__(init=None, allowed_exptypes=None, **kwargs)
+        super().__init__(init=None, asn_exptypes=None, **kwargs)
 
         self._models = []
-        self.allowed_exptypes = allowed_exptypes
+        self.asn_exptypes = asn_exptypes
 
         if init is None:
             # Don't populate the container with models
@@ -187,19 +190,21 @@ class ModelContainer(model_base.DataModel):
         asn_file_path: str
             Filepath of the association, if known.
         """
-        # match the allowed_exptypes to the exptype in the association and retain
-        # only those file that match, as a list, if allowed_exptypes is set to none
+        # match the asn_exptypes to the exptype in the association and retain
+        # only those file that match, as a list, if asn_exptypes is set to none
         # grab all the files
-        if self.allowed_exptypes:
+        if self.asn_exptypes:
             infiles = []
-            logger.debug("Filtering datasets based on allowed exptypes:", self.allowed_exptypes)
+            logger.debug('Filtering datasets based on allowed exptypes {}:'
+                         .format(self.asn_exptypes))
             for member in asn_data['products'][0]['members']:
-                if any([x for x in self.allowed_exptypes if re.match(member['exptype'], x, re.IGNORECASE)]):
-                        infiles.append(member['expname'])
-                        logger.debug("Files accepted for processing:", member['expname'])
+                if any([x for x in self.asn_exptypes if re.match(member['exptype'],
+                                                                 x, re.IGNORECASE)]):
+                    infiles.append(member['expname'])
+                    logger.debug('Files accepted for processing {}:'.format(member['expname']))
         else:
             infiles = [member['expname'] for member
-            in asn_data['products'][0]['members']]
+                       in asn_data['products'][0]['members']]
 
         if asn_file_path:
             asn_dir = op.dirname(asn_file_path)
@@ -315,7 +320,7 @@ class ModelContainer(model_base.DataModel):
                 params.append(getattr(model.meta.observation, param))
             try:
                 group_id = ('jw' + '_'.join([''.join(params[:3]),
-                        ''.join(params[3:6]), params[6]]))
+                                             ''.join(params[3:6]), params[6]]))
                 model.meta.group_id = group_id
             except TypeError:
                 params_dict = dict(zip(unique_exposure_parameters, params))

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -61,13 +61,13 @@ class Spec3Pipeline(Pipeline):
             The exposure or association of exposures to process
         """
         self.log.info('Starting calwebb_spec3 ...')
-        self.allowed_exptypes = ['science','background']
+        asn_exptypes = ['science','background']
 
         # Retrieve the inputs:
         # could either be done via LoadAsAssociation and then manually
         # load input members into models and ModelContainer, or just
         # do a direct open of all members in ASN file, e.g.
-        input_models = datamodels.open(input, allowed_exptypes=self.allowed_exptypes)
+        input_models = datamodels.open(input, asn_exptypes=asn_exptypes)
 
         # For the first round of development we will assume that the input
         # is ALWAYS an ASN. There's no use case for anyone ever running a

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -61,12 +61,13 @@ class Spec3Pipeline(Pipeline):
             The exposure or association of exposures to process
         """
         self.log.info('Starting calwebb_spec3 ...')
+        self.allowed_exptypes = ['science']
 
         # Retrieve the inputs:
         # could either be done via LoadAsAssociation and then manually
         # load input members into models and ModelContainer, or just
         # do a direct open of all members in ASN file, e.g.
-        input_models = datamodels.open(input)
+        input_models = datamodels.open(input, allowed_exptypes=self.allowed_exptypes)
 
         # For the first round of development we will assume that the input
         # is ALWAYS an ASN. There's no use case for anyone ever running a

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -61,7 +61,7 @@ class Spec3Pipeline(Pipeline):
             The exposure or association of exposures to process
         """
         self.log.info('Starting calwebb_spec3 ...')
-        self.allowed_exptypes = ['science']
+        self.allowed_exptypes = ['science','background']
 
         # Retrieve the inputs:
         # could either be done via LoadAsAssociation and then manually


### PR DESCRIPTION
Updated `datamodels` to allow for specification of an allowed list of ASN `exptypes` to keep when loading an ASN into a `ModelContainer`, and update `calwebb_spec3` to make use of this feature to keep TA's from processing.