### PR TITLE
JP-878 Don't try to compute pixel solid angle for WFSS data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,12 +58,19 @@ extract_1d
 
 - This step uses keyword DISPAXIS. [#3799]
 
-- Fixed a bug in ``pixel_area`` when th einput is a ``CubeModel``. [#3827]
+- Fixed a bug in ``pixel_area`` when the input is a ``CubeModel``. [#3827]
+
+- Computing the solid angle of a pixel is only done for the first integration
+  of a multi-integration exposure, and it's not done at all for WFSS data
+  [#3863]
 
 extract_2d
 ----------
 
-For grism data, this step copies keyword DISPAXIS from input to output. [#3799]
+- For grism data, this step copies keyword DISPAXIS from input to output. [#3799]
+
+- For NIRCam TSO data, wavelengths are computed and assigned to the
+  wavelength attribute. [#3863]
 
 flat_field
 ----------

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -124,7 +124,8 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
 
     # Compute the solid angle of a pixel in steradians.
     pixel_solid_angle = util.pixel_area(input_model.meta.wcs,
-                                        input_model.data.shape)
+                                        input_model.data.shape,
+                                        False)
     if pixel_solid_angle is None:
         log.warning("Pixel solid angle could not be determined")
         pixel_solid_angle = 1.

--- a/jwst/extract_1d/util.py
+++ b/jwst/extract_1d/util.py
@@ -7,7 +7,7 @@ from gwcs.wcstools import grid_from_bounding_box
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-def pixel_area(wcs, shape, verbose=True):
+def pixel_area(wcs, shape, is_wfss, verbose=True):
     """Compute the solid angle of a pixel.
 
     Parameters
@@ -21,6 +21,9 @@ def pixel_area(wcs, shape, verbose=True):
         The shape of the data array.  The bounding box from the wcs will be
         used instead, if it exists.
 
+    is_wfss : bool
+        True if the input file contains WFSS data.
+
     verbose : bool
         If True, log messages.
 
@@ -30,6 +33,12 @@ def pixel_area(wcs, shape, verbose=True):
         The average solid angle of a pixel, in steradians.  None will be
         returned if this value could not be determined.
     """
+
+    if is_wfss:
+        if verbose:
+            log.warning("The solid angle of a pixel cannot currently "
+                        "be determined for WFSS data.")
+        return None
 
     if shape is not None and len(shape) != 2 and len(shape) != 3:
         if verbose:
@@ -81,6 +90,8 @@ def pixel_area(wcs, shape, verbose=True):
                   .format(cdelt1 * 3600., cdelt2 * 3600.))
 
     if cdelt1 == 0. and cdelt2 == 0:
+        if verbose:
+            log.warning("Pixel solid angle could not be determined")
         pixel_solid_angle = None
     else:
         if cdelt1 < 0.01 * cdelt2:
@@ -114,9 +125,6 @@ def temp_wcs(wcs, x, y, z=None):
         If the data are 3-D, e.g. IFU or CubeModel, this should be an array
         of values for one plane in axis 0 (wavelength for IFU, multiple
         exposures for CubeModel).
-
-    verbose : bool
-        If True, log messages.
 
     Returns
     -------

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -21,7 +21,8 @@ log.setLevel(logging.DEBUG)
 def extract_tso_object(input_model,
                        reference_files=None,
                        extract_height=None,
-                       extract_orders=None):
+                       extract_orders=None,
+                       compute_wavelength=True):
     """
     Extract the spectrum for a NIRCAM TSO observation.
 
@@ -44,6 +45,10 @@ def extract_tso_object(input_model,
         This is an optional parameter that will override the
         orders specified for extraction in the wavelengthrange
         reference file.
+
+    compute_wavelength : bool
+        Compute a wavelength array for the datamodel.  Computationally
+        expensive, but saves doing it repeatedly later on in pipeline.
 
     Returns
     -------
@@ -202,6 +207,8 @@ def extract_tso_object(input_model,
             output_model.meta.wcsinfo.spectral_order = order
             output_model.meta.wcsinfo.dispersion_direction = \
                         input_model.meta.wcsinfo.dispersion_direction
+            if compute_wavelength:
+                output_model.wavelength = compute_wavelength_array(output_model)
             output_model.name = str('TSO object')
             output_model.xstart = 1  # fits pixels
             output_model.xsize = ext_data.shape[2]

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -41,6 +41,8 @@ data_path = os.path.split(os.path.abspath(data.__file__))[0]
 # Default wcs information
 # This is set for a standard nircam image just as an example
 # It does not test the validity of the absolute results
+# for create_tso_wcsimage, set the width of the output image to this value:
+NIRCAM_TSO_WIDTH = 10
 wcs_image_kw = {'wcsaxes': 2, 'ra_ref': 53.1490299775, 'dec_ref': -27.8168745624,
                 'v2_ref': 86.103458, 'v3_ref': -493.227512, 'roll_ref': 45.04234459270135,
                 'crpix1': 1024.5, 'crpix2': 1024.5,
@@ -132,7 +134,7 @@ def create_tso_wcsimage(filtername="F277W", subarray=False):
     hdul = create_hdul(exptype='NRC_TSGRISM', pupil='GRISMR',
                        filtername=filtername, detector='NRCALONG',
                        subarray=subarray, wcskeys=wcs_tso_kw)
-    hdul['sci'].header['SUBSIZE1'] = 2048
+    hdul['sci'].header['SUBSIZE1'] = NIRCAM_TSO_WIDTH
 
     if subarray:
         hdul['sci'].header['SUBSIZE2'] = 256
@@ -141,7 +143,7 @@ def create_tso_wcsimage(filtername="F277W", subarray=False):
         hdul['sci'].header['SUBSIZE2'] = 2048
         subsize = 2048
 
-    hdul['sci'].data = np.ones((2, subsize, 2048))
+    hdul['sci'].data = np.ones((2, subsize, NIRCAM_TSO_WIDTH))
     im = CubeModel(hdul)
     im.meta.wcsinfo.siaf_xref_sci = 887.0
     im.meta.wcsinfo.siaf_yref_sci = 35.0
@@ -318,7 +320,7 @@ def test_extract_tso_height():
     num, ysize, xsize = outmodel.data.shape
     assert num == wcsimage.data.shape[0]
     assert ysize == 50
-    assert xsize == 2048
+    assert xsize == NIRCAM_TSO_WIDTH
     del outmodel
 
 


### PR DESCRIPTION
The `extract_1d` step was modified to only call `util.pixel_area()` for the first integration of multi-integration data.  Also, that function immediately returns `pixel_solid_angle = None` for WFSS data; for these data the WCS function returns constant values for right ascension and declination, so the angular size of a pixel cannot be determined by this function.

The extract_2d step was modified to compute and populate the `wavelength` attribute for NIRCam TSO data.  This partially addresses JP-845, GitHub #3784, Compute wavelengths for NIRCam TSO data, but only the wavelength attribute is populated, not the variance arrays.  To close this issue, the variance arrays need to be copied from input to output.