### PR TITLE
Jp 833

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,10 +28,14 @@ associations
 
 - Fixed the number of inputs to the spectral WCS - one expetced, two were passed. [#3827]
 
-datamodels
-----------
+calwebb_tso3
+-------------
 
 - Update to exclude target_acquisitions from processing in the calwebb_tso3 pipeline [#3759]
+
+
+datamodels
+----------
 
 - Update to prevent target_acquisitions from processing in the spec3 pipeline [#3777]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ associations
 datamodels
 ----------
 
+- Update to exclude target_acquisitions from processing in the calwebb_tso3 pipeline [#3759]
+
 - Update to prevent target_acquisitions from processing in the spec3 pipeline [#3777]
 
 - Use public API of jsonschema to ease upgrade to 3.x. [#3705]

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -50,7 +50,9 @@ class Tso3Pipeline(Pipeline):
         """
 
         self.log.info('Starting calwebb_tso3...')
-        input_models = datamodels.open(input)
+        asn_exptypes = ['science']
+
+        input_models = datamodels.open(input, asn_exptypes=asn_exptypes)
 
         if self.output_file is None:
             self.output_file = input_models.meta.asn_table.products[0].name


### PR DESCRIPTION
After restricting the asn_exptypes to ['science'] in calwebb_tso3.py and adding the DISPAXIS keyword to the input FITS files,  the tso3 pipeline runs to completion. 

`strun --debug --input_dir=/Users/ddavis/src/JWST/develop/JP-833/ ~/src/JWST/scsb/jwst/jwst/pipeline/calwebb_tso3.cfg jw00625-o023_20190625t121711_tso3_001_asn.json`

`2019-07-31 11:53:11,543 - stpipe - WARNING - /Users/ddavis/miniconda3/envs/jwst_dev/lib/python3.7/site-packages/astropy/modeling/core.py:77: AstropyDeprecationWarning: Composition of model classes will be removed in 4.0 (but composition of model instances is not affected)`

...

`2019-07-31 12:23:22,565 - stpipe.Tso3Pipeline - INFO - Writing Level 3 photometry catalog` `jw00625-o023_t001_niriss_clear-gr700xd-substrip256_whtlt.ecsv...`
`2019-07-31 12:23:22,578 - stpipe.Tso3Pipeline - INFO - Step Tso3Pipeline done
`