### PR TITLE
Recover and save step configuration parameters

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -58,6 +58,7 @@ from .saturation import SaturationModel
 from .slit import SlitModel, SlitDataModel
 from .source_container import SourceModelContainer
 from .spec import SpecModel
+from .steppars import StepParsModel
 from .straylight import StrayLightModel
 from .superbias import SuperBiasModel
 from .throughput import ThroughputModel
@@ -112,7 +113,7 @@ __all__ = [
     'RegionsModel', 'ResetModel',
     'ResolutionModel', 'MiriResolutionModel',
     'RSCDModel', 'SaturationModel', 'SlitDataModel', 'SlitModel', 'SpecModel',
-    'SourceModelContainer',
+    'SourceModelContainer', 'StepParsModel',
     'StrayLightModel', 'SuperBiasModel', 'SpecwcsModel',
     'ThroughputModel',
     'TrapDensityModel', 'TrapParsModel', 'TrapsFilledModel',

--- a/jwst/datamodels/schemas/steppars.schema.yaml
+++ b/jwst/datamodels/schemas/steppars.schema.yaml
@@ -1,0 +1,77 @@
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      date:
+        title: Date this file was created (UTC)
+        type: string
+      origin:
+        title: Organization responsible for creating file
+        type: string
+      time_sys:
+        title: principal time system for time-related keywords
+        type: string
+      filename:
+        title: Name of the file
+        type: string
+      filetype:
+        title: Type of data in the file
+        type: string
+      model_type:
+        title: Type of data model
+        type: string
+      telescope:
+        title: Telescope used to acquire the data
+        type: string
+        default: JWST
+      reftype:
+        title: Reference file type
+        type: string
+        default: pars-step
+      pedigree:
+        title: The pedigree of the reference file
+        type: string
+        default: SPECIFY pedigree such as "GROUND"
+      description:
+        title: Description of the reference file
+        type: string
+        default: Parameters for calibration step SPECIFY
+      author:
+        title: Author of the reference file
+        type: string
+        default: SPECIFY AUTHOR
+      useafter:
+        title: Use after date of the reference file
+        type: string
+        default: SPECIFY
+      instrument:
+        title: Instrument configuration information
+        type: object
+        properties:
+          name:
+            title: Instrument used to acquire the data
+            type: string
+            enum: [NIRCAM, NIRSPEC, MIRI, TFI, FGS, NIRISS, ANY, N/A]
+          detector:
+            title: Name of detector used to acquire the data
+            type: string
+            enum: [NRCA1, NRCA2, NRCA3, NRCA4, NRCALONG, NRCB1, NRCB2, NRCB3, NRCB4,
+              NRCBLONG, NRS1, NRS2, ANY, MIRIMAGE, MIRIFULONG, MIRIFUSHORT,
+              NIS, GUIDER1, GUIDER2, N/A]
+            description: Detector name.
+        required: [name]
+    required: [date, reftype, pedigree, description, author, instrument]
+  parameters:
+    type: object
+    properties:
+      class:
+        title: Fully qualified Step class
+        type: string
+        default: jwst.stpipe.Step
+      name:
+        title: Nickname for the Step
+        type: string
+        default: step
+    required: [class, name]
+required: [meta, parameters]

--- a/jwst/datamodels/steppars.py
+++ b/jwst/datamodels/steppars.py
@@ -1,8 +1,23 @@
 """Step parameters model"""
-import os
+from copy import copy
+
 from .model_base import DataModel
 
 __all__ = ['StepParsModel']
+
+DEFAULT_META = {
+    'date': 'SPECIFY DATE',
+    'origin': 'STScI',
+    'telescope': 'JWST',
+    'reftype': 'pars-step',
+    'pedigree': 'SPECIFY PEDIGREE',
+    'description': 'Parameters for calibration step SPECIFY',
+    'author': 'SPECIFY AUTHOR',
+    'useafter': 'SPECIFY',
+    'instrument': {
+        'name': 'SPECIFY',
+    },
+}
 
 
 class StepParsModel(DataModel):
@@ -14,3 +29,6 @@ class StepParsModel(DataModel):
 
     def __init__(self, init=None, **kwargs):
         super().__init__(init=init, **kwargs)
+        meta = copy(DEFAULT_META)
+        meta.update(self.meta.instance)
+        self.meta.instance.update(meta)

--- a/jwst/datamodels/steppars.py
+++ b/jwst/datamodels/steppars.py
@@ -1,0 +1,16 @@
+"""Step parameters model"""
+import os
+from .model_base import DataModel
+
+__all__ = ['StepParsModel']
+
+
+class StepParsModel(DataModel):
+    """
+    A data model for `Step` parameters.
+    """
+    schema_url = "steppars.schema"
+    supported_formats = ['yaml', 'json', 'asdf']
+
+    def __init__(self, init=None, **kwargs):
+        super().__init__(init=init, **kwargs)

--- a/jwst/lib/class_property.py
+++ b/jwst/lib/class_property.py
@@ -61,4 +61,4 @@ class ClassProperty:
         return self.fget(obj)
 
     def getter(self, fget):
-        return type(self)(fget, self.fset, self.fdel, self.__doc__)
+        return type(self)(fget, self.__doc__)

--- a/jwst/lib/class_property.py
+++ b/jwst/lib/class_property.py
@@ -1,0 +1,64 @@
+"""Allow property access to both instance and class attributes"""
+
+class ClassProperty:
+    """Allow class-level property descriptors
+
+    This property allows definition of a non-data descriptor to
+    be defined that is accessible from both the class and instances
+    of the class.
+
+    Parameters
+    ----------
+    fget: function
+        The function to use as the `__get__` method.
+
+    Notes
+    -----
+    On class access, only the `__get__` method of a descriptor is used.
+    All other descriptor methods are ignored. As such, allowing the definitions
+    of `__set__` and `__delete__` are not allowed.
+
+    The code is based on the `Property` example descriptor in the python
+    documentation.
+
+    Examples
+    --------
+    Usage is the same as the Python `property` descriptor. However, access
+    is available from both the class and instances.
+
+    >>> class MyClass:
+    ...     @ClassProperty
+    ...     def baz(obj):
+    ...         return obj._baz
+    ...
+    ...     _baz = 'class'
+
+    >>> MyClass.baz
+    'class'
+
+    >>> mc = MyClass()
+    >>> mc.baz
+    'class'
+
+    >>> mc._baz = 'instance'
+    >>> mc.baz
+    'instance'
+
+    >>> MyClass.baz
+    'class'
+    """
+    def __init__(self, fget=None, doc=None):
+        self.fget = fget
+        if doc is None and fget is not None:
+            doc = fget.__doc__
+        self.__doc__ = doc
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            obj = objtype
+        if self.fget is None:
+            raise AttributeError("unreadable attribute")
+        return self.fget(obj)
+
+    def getter(self, fget):
+        return type(self)(fget, self.fset, self.fdel, self.__doc__)

--- a/jwst/stpipe/cmdline.py
+++ b/jwst/stpipe/cmdline.py
@@ -182,6 +182,10 @@ def just_the_step_from_cmdline(args, cls=None):
     parser1.add_argument(
         "--debug", action="store_true",
         help="When an exception occurs, invoke the Python debugger, pdb")
+    parser1.add_argument(
+        '--save-parameters', type=str,
+        help='Save step parameters to specified file.'
+    )
     known, _ = parser1.parse_known_args(args)
 
     try:
@@ -235,6 +239,7 @@ def just_the_step_from_cmdline(args, cls=None):
     del args.logcfg
     del args.verbose
     del args.debug
+    del args.save_parameters
     positional = args.args
     del args.args
 
@@ -263,6 +268,10 @@ def just_the_step_from_cmdline(args, cls=None):
         step._pars_model = config.pars_model
     except AttributeError:
         pass
+
+    # Save the step configuration
+    if known.save_parameters:
+        step.pars_model.save(known.save_parameters)
 
     return step, step_class, positional, debug_on_exception
 

--- a/jwst/stpipe/cmdline.py
+++ b/jwst/stpipe/cmdline.py
@@ -258,6 +258,12 @@ def just_the_step_from_cmdline(args, cls=None):
     log.log.info("Hostname: {0}".format(os.uname()[1]))
     log.log.info("OS: {0}".format(os.uname()[0]))
 
+    # If initialized from a StepParsModel, remember that.
+    try:
+        step._pars_model = config.pars_model
+    except AttributeError:
+        pass
+
     return step, step_class, positional, debug_on_exception
 
 

--- a/jwst/stpipe/config_parser.py
+++ b/jwst/stpipe/config_parser.py
@@ -256,7 +256,7 @@ def config_from_dict(d, spec=None, root_dir=None):
     return config
 
 
-def validate(config, spec, section=None, validator=None, root_dir=None):
+def validate(config, spec, section=None, validator=None, root_dir=None, preserve_errors=True):
     """
     Parse config_file, in INI format, and do validation with the
     provided specfile.
@@ -282,7 +282,7 @@ def validate(config, spec, section=None, validator=None, root_dir=None):
             section = None
 
         errors = config.main.validate(
-            validator, preserve_errors=True,
+            validator, preserve_errors=preserve_errors,
             section=section)
 
         messages = []

--- a/jwst/stpipe/config_parser.py
+++ b/jwst/stpipe/config_parser.py
@@ -42,7 +42,7 @@ from ..extern.configobj.configobj import (
     ConfigObj, Section, flatten_errors, get_extra_values)
 from ..extern.configobj.validate import Validator, ValidateError, VdtTypeError
 
-from ..datamodels.model_base import DataModel
+from ..datamodels import DataModel, StepParsModel
 
 from . import utilities
 
@@ -139,6 +139,7 @@ def load_config_file(config_file):
     # Seems to be ASDF. Create the configobj from that.
     configobj = ConfigObj()
     configobj.merge(cfg['parameters'])
+    configobj.pars_model = StepParsModel(cfg)
     return configobj
 
 

--- a/jwst/stpipe/config_parser.py
+++ b/jwst/stpipe/config_parser.py
@@ -29,6 +29,7 @@
 """
 Our configuration files are ConfigObj/INI files.
 """
+from inspect import isclass
 import logging
 import os
 import os.path
@@ -174,9 +175,24 @@ def get_merged_spec_file(cls, preserve_comments=False):
 def load_spec_file(cls, preserve_comments=False):
     """
     Load the spec file corresponding to the given class.
+
+    Parameters
+    ----------
+    cls: `Step`-derived or `Step` instance
+        A class or instance of a `Step`-based class.
+
+    preserve_comments: bool
+        True to keep comments in the resulting `ConfigObj`
+
+    Returns
+    -------
+    spec_file: ConfigObj
+        The resulting configuration objection.
     """
     # Don't use 'hasattr' here, because we don't want to inherit spec
     # from the base class.
+    if not isclass(cls):
+        cls = cls.__class__
     if 'spec' in cls.__dict__:
         spec = cls.spec.strip()
         spec_file = textwrap.dedent(spec)

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -1119,6 +1119,8 @@ class Step():
             Keys are the parameters and values are the values.
         """
         spec = config_parser.load_spec_file(step)
+        if spec is None:
+            return {}
         instance_pars = {
             key: getattr(step, key)
             for key in spec

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -54,6 +54,9 @@ class Step():
     input_dir          = string(default=None)        # Input directory
     """
 
+    # No parameter model has been created yet.
+    _pars_model = None
+    
     # Reference types for both command line override
     # definition and reference prefetch
     reference_file_types = []
@@ -1144,7 +1147,9 @@ class Step():
         model: `StepParsModel`
             The `StepParsModel`.
         """
-        pars_model = getattr(step, '_pars_model', StepParsModel())
+        pars_model = step._pars_model
+        if pars_model is None:
+            pars_model = StepParsModel()
         pars_model.parameters.instance.update(step.pars)
         step._pars_model = pars_model
         return pars_model

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -56,7 +56,7 @@ class Step():
 
     # No parameter model has been created yet.
     _pars_model = None
-    
+
     # Reference types for both command line override
     # definition and reference prefetch
     reference_file_types = []

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -15,6 +15,7 @@ from os.path import (
     splitext,
 )
 import sys
+from types import MethodType
 
 try:
     from astropy.io import fits
@@ -30,11 +31,10 @@ from .. import __version_commit__, __version__
 from ..associations.load_as_asn import (LoadAsAssociation, LoadAsLevel2Asn)
 from ..associations.lib.format_template import FormatTemplate
 from ..associations.lib.update_path import update_key_value
-from ..datamodels import (DataModel, ModelContainer)
+from ..datamodels import (DataModel, ModelContainer, StepParsModel)
 from ..datamodels import open as dm_open
 from ..lib.class_property import ClassProperty
 from ..lib.suffix import remove_suffix
-
 
 class Step():
     """
@@ -268,7 +268,6 @@ class Step():
             Additional parameters to set.  These will be set as member
             variables on the new Step instance.
         """
-
         # Setup primary input
         self._reference_files_used = []
         self._input_filename = None
@@ -1114,7 +1113,27 @@ class Step():
             if hasattr(step, key)
         }
         pars = config_parser.config_from_dict(instance_pars, spec, allow_missing=True)
+        pars = dict(pars)
         return pars
+
+    @ClassProperty
+    def pars_model(step):
+        """Return Step parameters as StepParsModel
+
+        Parameters
+        ----------
+        step: `Step`-derived class or instance
+            The `Step` or `Step` instance to retrieve the parameters model for.
+
+        Returns
+        -------
+        model: `StepParsModel`
+            The `StepParsModel`.
+        """
+        pars_model = getattr(step, '_pars_model', StepParsModel())
+        pars_model.parameters.instance.update(step.pars)
+        step._pars_model = pars_model
+        return pars_model
 
 
 # #########

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -236,12 +236,18 @@ class Step():
         if 'name' in config:
             del config['name']
 
-        return cls(
+        step = cls(
             name=name,
             parent=parent,
             config_file=config_file,
             _validate_kwds=False,
             **config)
+        try:
+            step._pars_model = config.pars_model
+        except AttributeError:
+            pass
+
+        return step
 
     def __init__(self, name=None, parent=None, config_file=None,
                  _validate_kwds=True, **kws):
@@ -523,6 +529,12 @@ class Step():
                 config, name=name, config_file=config_file)
         else:
             instance = cls(**kwargs)
+
+        try:
+            instance._pars_model = config.pars_model
+        except (AttributeError, UnboundLocalError):
+            pass
+
         return instance.run(*args)
 
     @property

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -15,7 +15,6 @@ from os.path import (
     splitext,
 )
 import sys
-from types import MethodType
 
 try:
     from astropy.io import fits
@@ -1121,11 +1120,12 @@ class Step():
         spec = config_parser.load_spec_file(step)
         if spec is None:
             return {}
-        instance_pars = {
-            key: getattr(step, key)
-            for key in spec
-            if hasattr(step, key)
-        }
+        instance_pars = {}
+        for key in spec:
+            if hasattr(step, key):
+                value = getattr(step, key)
+                if not isinstance(value, property):
+                    instance_pars[key] = value
         pars = config_parser.config_from_dict(instance_pars, spec, allow_missing=True)
         pars = dict(pars)
         return pars

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -32,6 +32,7 @@ from ..associations.lib.format_template import FormatTemplate
 from ..associations.lib.update_path import update_key_value
 from ..datamodels import (DataModel, ModelContainer)
 from ..datamodels import open as dm_open
+from ..lib.class_property import ClassProperty
 from ..lib.suffix import remove_suffix
 
 
@@ -1092,6 +1093,21 @@ class Step():
             datamodel.meta.cal_step._instance[cal_step] = status
 
         # TODO: standardize cal_step naming to point to the offical step name
+
+    @ClassProperty
+    def pars(step):
+        """Retrieve the configuration parameters of a step
+
+        Parameters
+        ----------
+        step: `Step`-derived class or instance
+
+        Returns
+        -------
+        pars: dict
+            Keys are the parameters and values are the values.
+        """
+        return None
 
 
 # #########

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -1113,7 +1113,7 @@ class Step():
             for key in spec
             if hasattr(step, key)
         }
-        pars = config_parser.config_from_dict(instance_pars, spec)
+        pars = config_parser.config_from_dict(instance_pars, spec, allow_missing=True)
         return pars
 
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -1107,7 +1107,14 @@ class Step():
         pars: dict
             Keys are the parameters and values are the values.
         """
-        return None
+        spec = config_parser.load_spec_file(step)
+        instance_pars = {
+            key: getattr(step, key)
+            for key in spec
+            if hasattr(step, key)
+        }
+        pars = config_parser.config_from_dict(instance_pars, spec)
+        return pars
 
 
 # #########

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -43,9 +43,6 @@ class MakeListStep(Step):
     par2 = string() # Reticulate the splines
 
     par3 = boolean(default=False) # Does it blend?
-
-    [foo]
-
     """
 
     def process(self, a=None, b=None):

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -10,6 +10,20 @@ from jwst import datamodels
 from jwst.stpipe import Step
 from jwst.stpipe.config_parser import ValidationError
 
+from .steps import MakeListStep
+
+
+@pytest.mark.parametrize(
+    'step_obj, expected',
+    [
+        (MakeListStep, {'par1': None, 'par2': None, 'par3': False}),
+        (MakeListStep(par1=0., par2='from args'), {'par1': 0., 'par2': 'from args', 'par3': False}),
+    ]
+)
+def test_getpars(step_obj, expected):
+    """Test retreiving of configuration parameters"""
+    assert step_obj.pars == expected
+
 
 def test_hook():
     """Test the running of hooks"""

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -11,8 +11,11 @@ from jwst.stpipe import Step
 from jwst.stpipe.config_parser import ValidationError
 
 from .steps import MakeListStep
+from .util import t_path
 
 
+ParsModelWithPar3 = datamodels.StepParsModel(t_path('data/step_parameters/jwst_generic_pars-makeliststep_0002.asdf'))
+ParsModelWithPar3.parameters.instance.update({'par3': False})
 @pytest.mark.parametrize(
     'step_obj, expected',
     [
@@ -22,6 +25,9 @@ from .steps import MakeListStep
         (MakeListStep(par1=0., par2='from args'),
          datamodels.StepParsModel({'parameters': {'par1': 0., 'par2': 'from args', 'par3': False}})
         ),
+        (Step.from_config_file(t_path('data/step_parameters/jwst_generic_pars-makeliststep_0002.asdf')),
+         ParsModelWithPar3
+        )
     ]
 )
 def test_getpars_model(step_obj, expected):

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -16,6 +16,22 @@ from .steps import MakeListStep
 @pytest.mark.parametrize(
     'step_obj, expected',
     [
+        (MakeListStep,
+         datamodels.StepParsModel({'parameters': {'par1': 'float() # Control the frobulization', 'par2': 'string() # Reticulate the splines', 'par3': False}})
+        ),
+        (MakeListStep(par1=0., par2='from args'),
+         datamodels.StepParsModel({'parameters': {'par1': 0., 'par2': 'from args', 'par3': False}})
+        ),
+    ]
+)
+def test_getpars_model(step_obj, expected):
+    """Test retreiving of configuration parameters"""
+    assert step_obj.pars_model.parameters == expected.parameters
+
+
+@pytest.mark.parametrize(
+    'step_obj, expected',
+    [
         (MakeListStep, {'par1': 'float() # Control the frobulization', 'par2': 'string() # Reticulate the splines', 'par3': False}),
         (MakeListStep(par1=0., par2='from args'), {'par1': 0., 'par2': 'from args', 'par3': False}),
     ]

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -16,7 +16,7 @@ from .steps import MakeListStep
 @pytest.mark.parametrize(
     'step_obj, expected',
     [
-        (MakeListStep, {'par1': None, 'par2': None, 'par3': False}),
+        (MakeListStep, {'par1': 'float() # Control the frobulization', 'par2': 'string() # Reticulate the splines', 'par3': False}),
         (MakeListStep(par1=0., par2='from args'), {'par1': 0., 'par2': 'from args', 'par3': False}),
     ]
 )

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -35,7 +35,13 @@ def test_saving_pars(tmpdir):
     'step_obj, expected',
     [
         (MakeListStep,
-         datamodels.StepParsModel({'parameters': {'par1': 'float() # Control the frobulization', 'par2': 'string() # Reticulate the splines', 'par3': False}})
+         datamodels.StepParsModel(
+             {'parameters': {
+                 'par1': 'float() # Control the frobulization',
+                 'par2': 'string() # Reticulate the splines',
+                 'par3': False
+             }}
+         )
         ),
         (MakeListStep(par1=0., par2='from args'),
          datamodels.StepParsModel({'parameters': {'par1': 0., 'par2': 'from args', 'par3': False}})
@@ -53,7 +59,11 @@ def test_getpars_model(step_obj, expected):
 @pytest.mark.parametrize(
     'step_obj, expected',
     [
-        (MakeListStep, {'par1': 'float() # Control the frobulization', 'par2': 'string() # Reticulate the splines', 'par3': False}),
+        (MakeListStep, {
+            'par1': 'float() # Control the frobulization',
+            'par2': 'string() # Reticulate the splines',
+            'par3': False
+        }),
         (MakeListStep(par1=0., par2='from args'), {'par1': 0., 'par2': 'from args', 'par3': False}),
     ]
 )

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -17,6 +17,12 @@ ParsModelWithPar3 = datamodels.StepParsModel(t_path('data/step_parameters/jwst_g
 ParsModelWithPar3.parameters.instance.update({'par3': False})
 
 
+def test_noproperty_pars():
+    """Ensure that property parameters are excluded"""
+    pars = Step.pars
+    assert pars['input_dir'] is None
+
+
 def test_saving_pars(tmpdir):
     """Save the step parameters from the commandline"""
     cfg_path = t_path('data/step_parameters/jwst_generic_pars-makeliststep_0002.asdf')

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -13,9 +13,24 @@ from jwst.stpipe.config_parser import ValidationError
 from .steps import MakeListStep
 from .util import t_path
 
-
 ParsModelWithPar3 = datamodels.StepParsModel(t_path('data/step_parameters/jwst_generic_pars-makeliststep_0002.asdf'))
 ParsModelWithPar3.parameters.instance.update({'par3': False})
+
+
+def test_saving_pars(tmpdir):
+    """Save the step parameters from the commandline"""
+    cfg_path = t_path('data/step_parameters/jwst_generic_pars-makeliststep_0002.asdf')
+    saved_path = tmpdir.join('savepars.asdf')
+    Step.from_cmdline([
+        cfg_path,
+        '--save-parameters',
+        str(saved_path)
+    ])
+    assert saved_path.check()
+    saved = datamodels.StepParsModel(str(saved_path))
+    assert saved.parameters == ParsModelWithPar3.parameters
+
+
 @pytest.mark.parametrize(
     'step_obj, expected',
     [


### PR DESCRIPTION
Resolves JP-875/#3834
WIP JP-876/#3835
Add the API necessary to retrieve and save a `Step`s parameters as an ASDF object.

Main code is to recover the parameters, since the current architecture did not support this. The API adds two new attributes to `Step`:

- `Step.pars`: `dict` of the parameters
- `Step.pars_model`: `StepParsModel` of the configuration.

As a convenience, a new data model, `StepParsModel`, has also been implemented. Using the datamodel provides the convenience of the defining schema for validation. It should also help in the CRDS interface, which usually takes a `DateModel` as input for searching.

Finally, a new command-line option `--save-parameters <filename.asdf>` is implemented, allowing saving of the `Step`s parameters.