### PR TITLE
Jp 868: Background target exposures need to create their own science ASN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ assign_wcs
 associations
 ------------
 
+- Update rules to have NRS_IFU backgrounds in science associations [#3824]
+
 - Return filename with extensions based on file type [#2671]
 
 - Ensured that all target acqs are processed by Level 2 [#3765]

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -364,7 +364,8 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
                     DMSAttrConstraint(
                         name='allowed_bkgdtarg',
                         sources=['exp_type'],
-                        value=['mir_mrs','nrs_ifu'],)
+                        value=['mir_mrs','nrs_ifu','mir_lrs-fixedslit',
+                               'nrs_fixedslit'],)
                 ],
             reduce=Constraint.any
                     ),

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -352,21 +352,21 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
             ),
             Constraint(
                 [
-                DMSAttrConstraint(
-                name='bkgdtarg',
-                sources=['bkgdtarg'],
-                value=['T'],)
-                    ],
-                    reduce=Constraint.any
-                    ),
+                    DMSAttrConstraint(
+                        name='bkgdtarg',
+                        sources=['bkgdtarg'],
+                        value=['T'],)
+                ],
+                reduce=Constraint.any
+                                    ),
             Constraint(
                 [
-                DMSAttrConstraint(
-                name='mir_bkgdtarg',
-                sources=['exp_type'],
-                value=['mir_mrs'],)
-                    ],
-                    reduce=Constraint.any
+                    DMSAttrConstraint(
+                        name='allowed_bkgdtarg',
+                        sources=['exp_type'],
+                        value=['mir_mrs','nrs_ifu'],)
+                ],
+            reduce=Constraint.any
                     ),
                 ])
 

--- a/jwst/associations/tests/test_level3_basics.py
+++ b/jwst/associations/tests/test_level3_basics.py
@@ -47,9 +47,11 @@ def test_targacq(pool_file):
     asns = generate(pool, rules)
     assert len(asns) > 0
     for asn in asns:
-        for product in asn['products']:
-            exptypes = [
-                member['exptype'].lower()
-                for member in product['members']
-            ]
-            assert 'target_acquisition' in exptypes
+        # Ignore reprocessed asn's with only science
+        if asn['asn_rule'] != "Asn_Lv3SpecAux":
+            for product in asn['products']:
+                exptypes = [
+                    member['exptype'].lower()
+                    for member in product['members']
+                    ]
+                assert 'target_acquisition' in exptypes


### PR DESCRIPTION
NIS_IFU bkg observations as level3 spec association. 
Fix unit tests where target acquisitions were left out of associations. test_level3_basics.py  expects at least one member to be a target acquisition.  

Fixes #3824.