### PR TITLE
In support of JP-862: Fetch ASDF Step configurations from CRDS.

### DIFF
--- a/jwst/stpipe/class_dict.py
+++ b/jwst/stpipe/class_dict.py
@@ -1,0 +1,2 @@
+c_dict = {"jwst.tweakreg.TweakRegStep": "tweakreg",
+       "jwst.ramp_fitting.ramp_fit_step.RampFitStep": "rampfit" }

--- a/jwst/stpipe/cmdline.py
+++ b/jwst/stpipe/cmdline.py
@@ -201,16 +201,13 @@ def just_the_step_from_cmdline(args, cls=None):
     try:
         if config_0.endswith('asdf'): # asdf config file
             config = config_parser.load_config_file(config_0)
-            class_name = config['class'].split('.')[2]
-            ref_type = 'pars-'+ class_name #  pars-TweakRegStep, 
-            ref_type = ref_type.split('Step')[0] #  pars-TweakReg; remove trailing 'Step' for now
-
+            ref_type = config.pars_model.meta.instance['reftype']
             input_model = datamodels.open(positional_0)
+            pars_model = Step.pars_model
             pars_step_ref_file = crds_client.get_reference_file( input_model, ref_type )
             step_model = datamodels.open( pars_step_ref_file )
-            step_parameters = step_model.instance
-            pars_model = Step.pars_model
-            full_params = pars_model.update( step_parameters)
+            step_parameters = step_model.instance['parameters']
+            full_pars_model = pars_model.update( step_parameters )
         elif cls is None: 
             step_class, config, name, config_file = \
                 _get_config_and_class(known.cfg_file_or_class[0])

--- a/jwst/stpipe/cmdline.py
+++ b/jwst/stpipe/cmdline.py
@@ -193,31 +193,25 @@ def just_the_step_from_cmdline(args, cls=None):
     )
     known, _ = parser1.parse_known_args(args)
 
-    # Retrieve config file from CRDS and merge (should redo using argparse)
+
+    # Retrieve config file from CRDS
     config_0 = known.cfg_file_or_class[0]  # local_config_file, or full class name
     positional_0 = args[1] # input data file
 
-    if config_0.endswith('asdf'): # asdf config file given on command line
-        temp_0 = config_0.split('.asdf')[0]  # i.e. 'jwst_generic_pars-tweakreg_0001'
-        temp_1 = temp_0.split('_pars-') # i.e., ['jwst_generic', 'tweakreg_0001']
-        temp_2 = temp_1[1].split('_')  # i.e., ['tweakreg', '0001']
-        class_name = temp_2[0] 
-
-        if class_name not in class_dict_c_dict.values() # verify that name is valid
-             raise ValueError("Unsupported value for class name: %s" % class_name)
-
-    else: # from the full class Step name given, look up the class name
-        class_name = class_dict.c_dict[ config_0 ]
-
-    input_model = datamodels.open(positional_0)
-    config_crds = crds_client.get_reference_file( input_model, class_name )
-    config_from_files = config_crds.update( config_0 )
-    config_new = ConfObj()
-    config_new.update( config_crds )
-    config_final = config_new.update( config_0 ) # What do I do with this now ? 
- 
     try:
-        if cls is None:
+        if config_0.endswith('asdf'): # asdf config file
+            config = config_parser.load_config_file(config_0)
+            class_name = config['class'].split('.')[2]
+            ref_type = 'pars-'+ class_name #  pars-TweakRegStep, 
+            ref_type = ref_type.split('Step')[0] #  pars-TweakReg; remove trailing 'Step' for now
+
+            input_model = datamodels.open(positional_0)
+            pars_step_ref_file = crds_client.get_reference_file( input_model, ref_type )
+            step_model = datamodels.open( pars_step_ref_file )
+            step_parameters = step_model.instance
+            pars_model = Step.pars_model
+            full_params = pars_model.update( step_parameters)
+        elif cls is None: 
             step_class, config, name, config_file = \
                 _get_config_and_class(known.cfg_file_or_class[0])
         else:


### PR DESCRIPTION
 Added prototype code to retrieve the config file from CRDS, using look-up of step name from the step class. Still need: to more fully test all strun use cases (including for overrides),  include code to actually retrieve config file from CRDS,  continue work to incorporate/merge config info retrieved from CRDS,  improve code by additional use of argparse, to consider rework in light or Jonathan's recent related PR. This should not be merged.