### PR TITLE
JP-832 Row and column were interchanged for NIRISS WFSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ assign_wcs
 
 - This step populates keyword DISPAXIS. [#3799]
 
+- For NIRISS WFSS data, the wavelengths were incorrect because the function
+  for horizontally oriented spectra was called for GR150R, and the function
+  for vertically oriented spectra was called for GR150C. [#3891]
+
 
 associations
 ------------

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -350,18 +350,24 @@ def wfss(input_model, reference_files):
         raise ValueError('FWCPOS keyword value not found in input image')
 
     # sep the row and column grism models
-    if 'R' in input_model.meta.instrument.filter[-1]:
+    # In "DMS" orientation (same parity as the sky), the GR150C spectra
+    # are aligned more closely with the rows, and the GR150R spectra are
+    # aligned more closely with the columns.
+    if input_model.meta.instrument.filter.endswith('C'):
         det2det = NIRISSForwardRowGrismDispersion(orders,
                                                   lmodels=displ,
                                                   xmodels=dispx,
                                                   ymodels=dispy,
                                                   theta=fwcpos_ref - fwcpos)
-    else:
+    elif input_model.meta.instrument.filter.endswith('R'):
         det2det = NIRISSForwardColumnGrismDispersion(orders,
                                                      lmodels=displ,
                                                      xmodels=dispx,
                                                      ymodels=dispy,
                                                      theta=fwcpos_ref - fwcpos)
+    else:
+        raise ValueError("FILTER keyword {} is not valid."
+                         .format(input_model.meta.instrument.filter))
 
     backward = NIRISSBackwardGrismDispersion(orders,
                                              lmodels=invdispl,


### PR DESCRIPTION
Function `wfss` in assign_wcs/niriss.py called `NIRISSForwardRowGrismDispersion` for GR150R data, and it called `NIRISSForwardColumnGrismDispersion` for GR150C data.  Our data are in DMS ("sky") orientation, however, and the spectra for GR150R are oriented vertically, while the spectra for GR150C are oriented horizontally.

Closes #3760.