### PR TITLE
Document usage of ASDF as a configuration file format.

### DIFF
--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -433,6 +433,7 @@ logging level designations of ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, and
 ``CRITICAL``. Only messages at or above the specified level
 will be displayed.
 
+.. _`Configuration Files`:
 
 Configuration Files
 ===================

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -404,10 +404,6 @@ of the stpipe-log.cfg file is:
     handler = file:pipeline.log
     level = INFO
 
-which specifies that all log messages will be directed to a file called
-"pipeline.log" and messages at a severity level of INFO and above will be
-recorded.
-
 If there's no ``stpipe-log.cfg`` file in the working directory, which specifies
 how to handle process log information, the default is to display log messages
 to stdout. If you want log information saved to a file, you can specify the
@@ -433,6 +429,14 @@ logging level designations of ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, and
 ``CRITICAL``. Only messages at or above the specified level
 will be displayed.
 
+.. note::
+
+   Setting up ``stpipe-log.cfg`` can lead to confusion, especially if it is
+   forgotten about. If one has not run a pipeline in awhile, and then sees no
+   logging information, most likely it is because ``stpipe-log.cfg`` is
+   present. Consider using a different name and specifying it explicitly on the
+   command line.
+
 .. _`Configuration Files`:
 
 Configuration Files
@@ -446,9 +450,8 @@ overridden either by the command line options, as previously described, and by a
 local configuration file.
 
 A configuration file should be used when there are parameters a user wishes to
-change from the default/CRDS version, but will not be changed on every run of
-the step. To create a configuration file with the default
-values, use the command: ::
+change from the default/CRDS version for a custom run of the step. To create a
+configuration file with the default values, use the command: ::
 
  strun <step.class> --save-parameters <filename.asdf>
 

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -85,17 +85,13 @@ referencing their class names is done as follows:
   $ strun jwst.dq_init.DQInitStep jw00017001001_01101_00001_nrca1_uncal.fits
 
 When a pipeline or step is executed in this manner (i.e. by referencing the
-class name), it will be run using all default parameter values. The same thing
-can be accomplished by using the default configuration file corresponding to
-each:
-::
-
-  $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.fits
-  $ strun dq_init.cfg jw00017001001_01101_00001_nrca1_uncal.fits
+class name), it will be run using a CRDS-supplied configuration merged with
+default values
 
 If you want to use non-default parameter values, you can specify them as
 keyword arguments on the command line or set them in the appropriate
-cfg file.
+configuration file.
+
 To specify parameter values for an individual step when running a pipeline
 use the syntax ``--steps.<step_name>.<parameter>=value``.
 For example, to override the default selection of a dark current reference
@@ -114,14 +110,12 @@ step by using the '-h' (help) argument to strun:
     $ strun dq_init.cfg -h
     $ strun jwst.pipeline.Detector1Pipeline -h
 
-If you want to consistently override the default values of certain arguments
-and don't want to specify them on the command line every time you
-execute ``strun``, you can specify them in the configuration (.cfg) file for
-the pipeline or the individual step.
-For example, to always run ``Detector1Pipeline`` using the override in the
-previous example, you could edit your ``calwebb_detector1.cfg`` file to
-contain the following:
-::
+If you want to consistently override the default values of certain arguments and
+don't want to specify them on the command line every time you execute ``strun``,
+you can specify them in the configuration (.cfg or .asdf) file for the pipeline
+or the individual step. For example, to always run ``Detector1Pipeline`` using
+the override in the previous example, you could edit your
+``calwebb_detector1.cfg`` file to contain the following: ::
 
  name = "Detector1Pipeline"
  class = "jwst.pipeline.Detector1Pipeline"
@@ -154,6 +148,17 @@ where ``my_dark_current.cfg`` contains:
  class = "jwst.dark_current.DarkCurrentStep"
  override_dark = 'my_dark.fits'
 
+The configuration parameters for each step can be saved to an ASDF file using
+the ``--save-parameters <filename>`` option. For example, to save the
+configuration for the `tweakreg` step, one would do the following:
+::
+
+ strun jwst.tweakreg.PersistenceStep --save-parameters persistence.asdf
+
+This file can be edited and then used to run the step with the new configuration:
+::
+
+ strun persistence.asdf jw00017001001_01101_00001_nrca1_uncal.fits
 
 Exit Status
 -----------
@@ -387,6 +392,22 @@ Alternatively you can specify the ``skip`` argument on the command line:
 Logging Configuration
 ---------------------
 
+The name of a file in which to save log information, as well as the desired
+level of logging messages, can be specified in an optional configuration file
+"stpipe-log.cfg". This file must be in the same directory in which you run the
+pipeline in order for it to be used. If this file does not exist, the default
+logging mechanism is STDOUT, with a level of INFO. An example of the contents
+of the stpipe-log.cfg file is:
+::
+
+    [*]
+    handler = file:pipeline.log
+    level = INFO
+
+which specifies that all log messages will be directed to a file called
+"pipeline.log" and messages at a severity level of INFO and above will be
+recorded.
+
 If there's no ``stpipe-log.cfg`` file in the working directory, which specifies
 how to handle process log information, the default is to display log messages
 to stdout. If you want log information saved to a file, you can specify the
@@ -416,56 +437,34 @@ will be displayed.
 Configuration Files
 ===================
 
-Configuration (.cfg) files can be used to specify parameter values
-when running a pipeline or individual steps, as well as for
-specifying logging options.
+Configuration files can be used to specify parameter values when running a
+pipeline or individual steps. For JWST, configuration files are retrieved from
+CRDS, just as with other reference files. If there is no match between a step,
+the input data, and CRDS, the coded defaults are used. These values can be
+overridden either by the command line options, as previously described, and by a
+local configuration file.
 
-You can use the ``collect_pipeline_cfgs`` task to get copies of all the cfg
-files currently in use by the jwst pipeline software. The task takes a single
-argument, which is the name of the directory to which you want the cfg files
-copied. Use '.' to specify the current working directory, e.g.
+A configuration file should be used when there are parameters a user wishes to
+change from the default/CRDS version, but will not be changed on every run of
+the step. To create a configuration file with the default
+values, use the command: ::
+
+ strun <step.class> --save-parameters <filename.asdf>
+
+For example, to get the parameters for the jump step, use:
 ::
 
- $ collect_pipeline_cfgs .
+ strun jwst.jump.JumpStep --save-parameters jump_pars.asdf
 
-Each step and pipeline has their own cfg file, which are used to specify
-relevant parameter values. For each step in a pipeline, the pipeline cfg file
-specifies either the step's arguments or the cfg file containing the step's
-arguments.
+Once retrieved, the file can be edited, removing parameters that should be left
+at their default/CRDS values, and setting the remaining parameters to the
+desired values. 
 
-The name of a file in which to save log information, as well as the desired
-level of logging messages, can be specified in an optional configuration file
-"stpipe-log.cfg". This file must be in the same directory in which you run the
-pipeline in order for it to be used. If this file does not exist, the default
-logging mechanism is STDOUT, with a level of INFO. An example of the contents
-of the stpipe-log.cfg file is:
-::
+For more information, see :ref:`config_asdf_files`. Note that the older
+:ref:`config_cfg_files` format is still an option, understanding that this
+format will be deprecated.
 
-    [*]
-    handler = file:pipeline.log
-    level = INFO
 
-which specifies that all log messages will be directed to a file called
-"pipeline.log" and messages at a severity level of INFO and above will be
-recorded.
-
-For a given step, the step's cfg file specifies parameters and their default
-values; it includes parameters that are typically not changed between runs.
-Parameters that are usually reset for each run are not included in the cfg file,
-but instead specified on the command line. An example of a cfg file for the
-jump detection step is:
-::
-
-    name = "jump"
-    class = "jwst.jump.JumpStep"
-    rejection_threshold = 4.0
-
-You can list all of the parameters for this step using:
-::
-
- $ strun jump.cfg -h
-
-which gives the usage, the positional arguments, and the optional arguments.
 More information on configuration files can be found in the ``stpipe`` User's
 Guide at :ref:`stpipe-user-steps`.
 

--- a/docs/jwst/references_general/explain_rmaps.rst
+++ b/docs/jwst/references_general/explain_rmaps.rst
@@ -14,6 +14,9 @@ required for running the calibration step.  Note that for some Steps the
 reference file types actually used vary so the minimal list of required types
 may not be known if no science data is defined.
 
+Note that the ``Step`` parameter reference files do not need to be specified.
+These are automatically requested in the ``Step`` architecture.
+
 CRDS Prefetch
 -------------
 

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -265,7 +265,7 @@ Step Parameters Reference Types
 
 When each ``Step`` is instantiated, a CRDS look-up, based on the ``Step`` class
 name and input data, is made to retrieve a configuration file. The ``reftype``
-for such configuration files is ``pars-<class name``. For example, for the step
+for such configuration files is ``pars-<class name>``. For example, for the step
 ``jwst.persistence.PersistenceStep``, the ``reftype`` would be
 ``pars-persistencestep``.
 

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -35,6 +35,7 @@ undergone by the files before being ingested in CRDS.
 Reference File Types
 ====================
 
+
 Most reference files have a one-to-one relationship with calibration steps, e.g.
 there is one step that uses one type of reference file. Some steps, however, use
 several types of reference files and some reference file types are used by more
@@ -258,6 +259,17 @@ documentation on each reference file.
 +--------------------------------------------------+---------------------------------------------+
 | :ref:`WFSSBKG <wfssbkg_reffile>`                 | :ref:`background <background_step>`         |
 +--------------------------------------------------+---------------------------------------------+
+
+Step Parameters Reference Types
++++++++++++++++++++++++++++++++
+
+When each ``Step`` is instantiated, a CRDS look-up, based on the ``Step`` class
+name and input data, is made to retrieve a configuration file. The ``reftype``
+for such configuration files is ``pars-<class name``. For example, for the step
+``jwst.persistence.PersistenceStep``, the ``reftype`` would be
+``pars-persistencestep``.
+
+For more information, see :ref:`Configuration Files`.
 
 .. _`Standard Required Keywords`:
 

--- a/docs/jwst/stpipe/config_asdf.rst
+++ b/docs/jwst/stpipe/config_asdf.rst
@@ -3,7 +3,12 @@
 ASDF Configuration Files
 ========================
 
-The format of choice to use to configure steps.
+The format of choice to use for step configuration files. `ASDF <https://asdf-standard.readthedocs.io/>`_ stands for "Advanced Scientific Data Format", a general purpose, non-proprietary, and system-agnostic format for the dissemination of data. Built on `YAML <https://yaml.org/>`_, the most basic file is text-based requiring minimal formatting.
+
+ASDF replaces the original :ref:`CFG <config_cfg_files>` format for step
+configuration. Using ASDF allows the configurations to be stored and retrieved
+from CRDS, selecting the best configuration for a given set of criteria, such as
+instrument and observation mode.
 
 .. _asdf_minimal_file:
 
@@ -22,3 +27,51 @@ All configuration files must have at least the following:
    parameters:
      class: jwst.stpipe.tests.steps.MakeListStep
    ...
+
+The first 5 lines define the file as an ASDF file. The rest of the file is
+formatted as one would format YAML data. Being YAML, the last line, containing
+the three ``...`` is essential.
+
+A step configuration requires one key, called ``parameters``, which
+contains all the parameters to pass onto the step. All parameters should be
+indented. The amount of indentation does not matter, as long as they are all
+indented equally.
+
+See `Running a Step from a configuration file`_ for a full discussion of required and optional parameters that will be found in the ``parameters`` block.
+
+Configuration as Reference File
+-------------------------------
+
+When a configuration file is to be ingested into CRDS, there is another key
+required, ``meta``, which defines the information needed by CRDS to select a
+configuration file. A basic reference configuration will look as follows:
+
+.. code-block::
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.3.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   meta:
+      author: Alfred E. Neuman
+      date: '2019-07-17T10:56:23.456'
+      description: MakeListStep parameters
+      instrument: {name: GENERIC}
+      pedigree: GROUND
+      reftype: pars-makeliststep
+      telescope: JWST
+      title: MakeListStep default parameters
+      useafter: '1990-04-24T00:00:00'
+   parameters:
+      class: jwst.stpipe.tests.steps.MakeListStep
+   ...
+
+All of the keys found under ``meta`` are required, most of which are
+self-explanatory. For more information, refer to the `CRDS documentation
+<https://jwst-crds.stsci.edu/static/users_guide/>`_.
+
+The one keyword to explain further is ``reftype``. This is what CRDS uses to
+determine which reference file is being sought after. For step configurations,
+this has the format ``pars-<step_name>`` where ``<step_name>`` will be the Python
+class name, in lowercase.

--- a/docs/jwst/stpipe/config_asdf.rst
+++ b/docs/jwst/stpipe/config_asdf.rst
@@ -67,7 +67,7 @@ configuration file. A basic reference configuration will look as follows:
       class: jwst.stpipe.tests.steps.MakeListStep
    ...
 
-All of the keys found under ``meta`` are required, most of which are
+All of the keys under ``meta`` are required, most of which are
 self-explanatory. For more information, refer to the `CRDS documentation
 <https://jwst-crds.stsci.edu/static/users_guide/>`_.
 

--- a/docs/jwst/stpipe/config_asdf.rst
+++ b/docs/jwst/stpipe/config_asdf.rst
@@ -37,7 +37,7 @@ contains all the parameters to pass onto the step. All parameters should be
 indented. The amount of indentation does not matter, as long as they are all
 indented equally.
 
-See `Running a Step from a configuration file`_ for a full discussion of required and optional parameters that will be found in the ``parameters`` block.
+See :ref:`Running a Step from a configuration file<running_a_step_from_a_configuration_file>` for a full discussion of required and optional parameters that will be found in the ``parameters`` block.
 
 Configuration as Reference File
 -------------------------------

--- a/docs/jwst/stpipe/config_asdf.rst
+++ b/docs/jwst/stpipe/config_asdf.rst
@@ -1,0 +1,24 @@
+.. _config_asdf_files:
+
+ASDF Configuration Files
+========================
+
+The format of choice to use to configure steps.
+
+.. _asdf_minimal_file:
+
+Minimal File
+------------
+
+All configuration files must have at least the following:
+
+.. code-block::
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.3.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   parameters:
+     class: jwst.stpipe.tests.steps.MakeListStep
+   ...

--- a/docs/jwst/stpipe/config_cfg.rst
+++ b/docs/jwst/stpipe/config_cfg.rst
@@ -1,0 +1,37 @@
+.. _config_cfg_files:
+
+Configuration (CFG) Files
+=========================
+
+The ``cfg`` format for configuration files uses the well-known ini-file format.
+
+You can use the ``collect_pipeline_cfgs`` task to get copies of all the cfg
+files currently in use by the jwst pipeline software. The task takes a single
+argument, which is the name of the directory to which you want the cfg files
+copied. Use '.' to specify the current working directory, e.g.
+::
+
+ $ collect_pipeline_cfgs .
+
+Each step and pipeline has their own cfg file, which are used to specify
+relevant parameter values. For each step in a pipeline, the pipeline cfg file
+specifies either the step's arguments or the cfg file containing the step's
+arguments.
+
+For a given step, the step's cfg file specifies parameters and their default
+values; it includes parameters that are typically not changed between runs.
+Parameters that are usually reset for each run are not included in the cfg file,
+but instead specified on the command line. An example of a cfg file for the
+jump detection step is:
+::
+
+    name = "jump"
+    class = "jwst.jump.JumpStep"
+    rejection_threshold = 4.0
+
+You can list all of the parameters for this step using:
+::
+
+ $ strun jump.cfg -h
+
+which gives the usage, the positional arguments, and the optional arguments.

--- a/docs/jwst/stpipe/devel_step.rst
+++ b/docs/jwst/stpipe/devel_step.rst
@@ -337,6 +337,6 @@ For example::
 
     > ExampleStep
 
-    > ExampleStep --config-file=example_step.cfg
+    > ExampleStep --config-file=example_step.asdf
 
     > ExampleStep --parameter1=42.0 input_file.fits

--- a/docs/jwst/stpipe/index.rst
+++ b/docs/jwst/stpipe/index.rst
@@ -12,6 +12,8 @@ For Users
    user_step.rst
    user_pipeline.rst
    user_logging.rst
+   config_asdf.rst
+   config_cfg.rst 
 
 
 .. _stpipe-devel-steps:

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -30,9 +30,9 @@ format. Refer to the :ref:`minimal example<asdf_minimal_file>` for a complete
 description of the contents. The rest of this documented will focus on the step
 parameters themselves.
 
-All step parameters appear under the ``parameters:`` section and indented. The
-amount of indentation does not matter, as long as all parameters are indented
-equally.
+All step parameters appear under the ``parameters:`` section, and they must be
+indented. The amount of indentation does not matter, as long as all parameters
+are indented equally.
 
 Every step configuration file must contain the parameter ``class``, followed by
 the optional ``name`` followed by any parameters that are specific to the step

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -15,6 +15,8 @@ Steps can be configured by either:
     - Writing a configuration file
     - Instantiating the Step directly from Python
 
+.. _running_a_step_from_a_configuration_file:
+
 Running a Step from a configuration file
 ========================================
 

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -13,27 +13,28 @@ parameters on it.
 Steps can be configured by either:
 
     - Writing a configuration file
-
     - Instantiating the Step directly from Python
 
 Running a Step from a configuration file
 ========================================
 
-A Step configuration file is in the well-known ini-file format.
-stpipe uses the `ConfigObj
-<https://configobj.readthedocs.io/en/latest/>`_ library to parse
-them.
+A Step configuration file contains one or more of a ``Step``'s parameters. Any
+parameter not specified in the file will take its value from the CRDS-retrieved
+configuration or the defaults coded directly into the ``Step``. Note that any
+parameter specified on the command line overrides all other values.
 
-Every step configuration file must contain the ``name`` and ``class``
-of the step, followed by parameters that are specific to the step
+The preferred format of configuration files is the :ref:`config_asdf_files`
+format. Refer to the :ref:`minimal example<asdf_minimal_file>` for a complete
+description of the contents. The rest of this documented will focus on the step
+parameters themselves.
+
+All step parameters appear under the ``parameters:`` section and indented. The
+amount of indentation does not matter, as long as all parameters are indented
+equally.
+
+Every step configuration file must contain the parameter ``class``, followed by
+the optional ``name`` followed by any parameters that are specific to the step
 being run.
-
-``name`` defines the name of the step.  This is distinct from the
-class of the step, since the same class of Step may be configured in
-different ways, and it is useful to be able to have a way of
-distinguishing between them.  For example, when Steps are combined
-into :ref:`stpipe-user-pipelines`, a Pipeline may use the same Step class
-multiple times, each with different configuration parameters.
 
 ``class`` specifies the Python class to run.  It should be a
 fully-qualified Python path to the class.  Step classes can ship with
@@ -43,6 +44,13 @@ example, to use the ``SystemCall`` step included with ``stpipe``, set
 ``class`` to ``stpipe.subprocess.SystemCall``.  To use a class called
 ``Custom`` defined in a file ``mysteps.py`` in the same directory as
 the configuration file, set ``class`` to ``mysteps.Custom``.
+
+``name`` defines the name of the step.  This is distinct from the
+class of the step, since the same class of Step may be configured in
+different ways, and it is useful to be able to have a way of
+distinguishing between them.  For example, when Steps are combined
+into :ref:`stpipe-user-pipelines`, a Pipeline may use the same Step class
+multiple times, each with different configuration parameters.
 
 Below ``name`` and ``class`` in the configuration file are parameters
 specific to the Step.  The set of accepted parameters is defined in
@@ -75,17 +83,22 @@ configspec for an imaginary step called `stpipe.cleanup`::
   >>> scale = float()
 
 Using this information, one can write a configuration file to use this
-step.  For example, here is a configuration file (``do_cleanup.cfg``)
+step.  For example, here is a configuration file (``do_cleanup.asdf``)
 that runs the ``stpipe.cleanup`` step to clean up an image.
 
-.. code-block:: ini
+.. code-block::
 
-    name = "MyCleanup"
-    class = "stpipe.cleanup"
-
-    threshold = 42.0
-    scale = 0.01
-
+    #ASDF 1.0.0
+    #ASDF_STANDARD 1.3.0
+    %YAML 1.1
+    %TAG ! tag:stsci.edu:asdf/
+    --- !core/asdf-1.1.0
+    parameters:
+      class = "stpipe.cleanup"
+      name = "MyCleanup"
+      threshold = 42.0
+      scale = 0.01
+    ...
 
 .. _strun:
 
@@ -107,13 +120,13 @@ to the step's process method.  This will often be input filenames.
 For example, to use an existing configuration file from above, but
 override it so the threshold parameter is different::
 
-    $ strun do_cleanup.cfg input.fits --threshold=86
+    $ strun do_cleanup.asdf input.fits --threshold=86
 
 To display a list of the parameters that are accepted for a given Step
 class, pass the ``-h`` parameter, and the name of a Step class or
 configuration file::
 
-    $ strun -h do_cleanup.cfg
+    $ strun -h do_cleanup.asdf
     usage: strun [--logcfg LOGCFG] cfg_file_or_class [-h] [--pre_hooks]
                  [--post_hooks] [--skip] [--scale] [--extname]
 
@@ -133,6 +146,22 @@ Every step has an `--output_file` parameter.  If one is not provided,
 the output filename is determined based on the input file by appending
 the name of the step.  For example, in this case, `foo.fits` is output
 to `foo_cleanup.fits`.
+
+Finally, the parameters a ``Step`` actually ran with can be saved to a new
+configuration file using the `--save-parameters` option. This file will have all
+the parameters, specific to the step, and the final values used.
+
+Parameter Precedence
+````````````````````
+
+There are a number of places where the value of a parameter can be specified.
+The order of precedence, from most to least significant, for parameter value
+assignment is as follows:
+
+    1. Value specified on the command-line: ``strun step.asdf --par=value_that_will_be_used``
+    2. Value found in the user-specified configuration file
+    3. CRDS-retrieved configuration
+    4. ``Step``-coded default, determined by the parameter definition ``Step.spec``
 
 Debugging
 `````````
@@ -182,7 +211,7 @@ such overriding the sflat.
 
 The nice thing about call() is that it can take a configuration file, so::
 
-    output = mystep.call(input, config_file=’my_flatfield.cfg’)
+    output = mystep.call(input, config_file=’my_flatfield.asdf’)
 
 and it will take all the configuration from the config file.
 
@@ -197,5 +226,3 @@ arguments.  Any remaining positional arguments are passed along to the step's
 
 So use call() if you’re passing a config file or passing along args or kwargs.
 Otherwise use run().
-
-


### PR DESCRIPTION
Update the documentation to include ASDF as a configuration file format.