### PR TITLE
JP-919 Updated associations and tests

### DIFF
--- a/jwst/tests_nightly/general/associations/test_generate.py
+++ b/jwst/tests_nightly/general/associations/test_generate.py
@@ -12,7 +12,7 @@ def test_generate(full_pool_rules):
     """Run a full sized pool using all rules"""
     pool, rules, pool_fname = full_pool_rules
     asns = generate(pool, rules)
-    assert len(asns) == 95
+    assert len(asns) == 96
     for asn in asns:
         asn_name, asn_store = asn.dump()
         asn_table = load_asn(asn_store)


### PR DESCRIPTION
Update the code and test data for the nightly association tests. The failing tests now pass, 
============================= test session starts ==============================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /Users/ddavis/src/JWST/scsb/jwst, inifile: setup.cfg
plugins: openfiles-0.4.0, doctestplus-0.3.0, ci-watson-0.3, requests-mock-1.6.0
collected 25 items

jwst/tests_nightly/general/associations/test_standards.py .............. [ 56%]
..........s                                                              [100%]