### PR TITLE
Add coverage report and regression test with dev dependencies

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,18 @@
+[run]
+branch = True
+source = jwst
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    conftest.py
+    setup.py
+    docs/*
+    jwst/conftest.py
+    jwst/tests*
+    jwst/*/tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 *.pyc
 *.egg-info/
 *.so
+.coverage
 */version.py
 docs/*/source/*.txt.rst
 docs/generated

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
     - NUMPY_VERSION=1.16
-    - TEST_COMMAND='pytest'
+    - TEST_COMMAND='pytest --cov=./'
 
 matrix:
   # Don't wait for allowed failures
@@ -64,4 +64,8 @@ install:
   - pip install numpy~=$NUMPY_VERSION
   - pip install $PIP_DEPENDENCIES
 
-script: $TEST_COMMAND
+script:
+  - $TEST_COMMAND
+
+after_script:
+  - if [ "${TEST_COMMAND:0:6}" = "pytest" ]; then codecov; fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 if (utils.scm_checkout()) return
 
+withCredentials([string(
+    credentialsId: 'jwst-codecov',
+    variable: 'codecov_token')]) {
+
 env_vars = [
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_PATH=./crds_cache",
@@ -32,7 +36,8 @@ bc1.build_cmds = [
     "pip install -e .[test]",
 ]
 bc1.test_cmds = [
-    "pytest -r sx --junitxml=results.xml"
+    "pytest --cov=./ -r sx --junitxml=results.xml",
+    "codecov --token=${codecov_token}"
 ]
 
 // Generate conda-free build with python 3.7
@@ -44,7 +49,9 @@ bc2.build_cmds = [
     "pip install -e .[test]",
 ]
 bc2.test_cmds = [
-    "pytest -r sx --junitxml=results.xml"
+    "pytest --cov=./ -r sx --junitxml=results.xml",
+    "codecov --token=${codecov_token}"
 ]
 
 utils.run([bc0, bc1, bc2])
+}  // withCredentials

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -46,7 +46,7 @@ bc0.test_cmds = [
     "pytest -r sxf -n 15 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
     --log-level=INFO \
-    jwst/tests_nightly/general"
+    jwst"
 ]
 bc0.test_configs = [data_config]
 
@@ -61,41 +61,4 @@ bc1.build_cmds = ["pip install -e .[test]"]
 bc1.test_cmds = []
 bc1.test_configs = []
 
-
-// Build and test with python 3.6 and unreleased dependencies
-bc2 = new BuildConfig()
-bc2.nodetype = 'jwst'
-bc2.name = 'dev-deps'
-bc2.env_vars = env_vars
-bc2.conda_ver = '4.6.14'
-bc2.conda_packages = [
-    "python=${python_version}",
-]
-bc2.build_cmds = [
-    "pip install -r requirements-dev.txt",
-    "pip install -e .[test]",
-    "pip install pytest-xdist",
-]
-bc2.test_cmds = [
-    "pytest -r sxf -n 15 --bigdata --slow \
-    --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
-    --log-level=INFO \
-    jwst/tests_nightly/general"
-]
-bc2.test_configs = [data_config]
-
-
-// macos-specific buildconfig to cause the creation of counterparts to the linux
-// environment dumps. Packages in a mininmal conda environment differ by OS
-// which is why this is needed.
-bc3 = utils.copy(bc2)
-bc3.nodetype = 'macos'
-bc3.name = 'macos-dev-deps'
-bc3.build_cmds = [
-    "pip install -r requirements-dev.txt",
-    "pip install -e .[test]",
-]
-bc3.test_cmds = []
-bc3.test_configs = []
-
-utils.run([jobconfig, bc0, bc1, bc2, bc3])
+utils.run([jobconfig, bc0, bc1])

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -1,6 +1,10 @@
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return
 
+withCredentials([string(
+    credentialsId: 'jwst-codecov',
+    variable: 'codecov_token')]) {
+
 jobconfig = new JobConfig()
 jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
@@ -43,10 +47,11 @@ bc0.build_cmds = [
     "pip install pytest-xdist",
 ]
 bc0.test_cmds = [
-    "pytest -r sxf -n 15 --bigdata --slow \
+    "pytest --cov=./ -r sxf -n 15 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
     --log-level=INFO \
-    jwst"
+    jwst",
+    "codecov --token=${codecov_token}"
 ]
 bc0.test_configs = [data_config]
 
@@ -62,3 +67,4 @@ bc1.test_cmds = []
 bc1.test_configs = []
 
 utils.run([jobconfig, bc0, bc1])
+}  // withCredentials

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -62,4 +62,40 @@ bc1.test_cmds = []
 bc1.test_configs = []
 
 
-utils.run([jobconfig, bc0, bc1])
+// Build and test with python 3.6 and unreleased dependencies
+bc2 = new BuildConfig()
+bc2.nodetype = 'jwst'
+bc2.name = 'unstable-deps'
+bc2.env_vars = env_vars
+bc2.conda_ver = '4.6.14'
+bc2.conda_packages = [
+    "python=${python_version}",
+]
+bc2.build_cmds = [
+    "pip install -r requirements-dev.txt",
+    "pip install -e .[test]",
+    "pip install pytest-xdist",
+]
+bc2.test_cmds = [
+    "pytest -r sx -v -n 30 --bigdata --slow \
+    --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
+    --log-level=INFO \
+    jwst/tests_nightly/general"
+]
+bc2.test_configs = [data_config]
+
+
+// macos-specific buildconfig to cause the creation of counterparts to the linux
+// environment dumps. Packages in a mininmal conda environment differ by OS
+// which is why this is needed.
+bc3 = utils.copy(bc2)
+bc3.nodetype = 'macos'
+bc3.name = 'macos-unstable-deps'
+bc3.build_cmds = [
+    "pip install -r requirements-dev.txt",
+    "pip install -e .[test]",
+]
+bc3.test_cmds = []
+bc3.test_configs = []
+
+utils.run([jobconfig, bc0, bc1, bc2, bc3])

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -43,7 +43,7 @@ bc0.build_cmds = [
     "pip install pytest-xdist",
 ]
 bc0.test_cmds = [
-    "pytest -r sx -v -n 30 --bigdata --slow \
+    "pytest -r sxf -n 15 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
     --log-level=INFO \
     jwst/tests_nightly/general"
@@ -65,7 +65,7 @@ bc1.test_configs = []
 // Build and test with python 3.6 and unreleased dependencies
 bc2 = new BuildConfig()
 bc2.nodetype = 'jwst'
-bc2.name = 'unstable-deps'
+bc2.name = 'dev-deps'
 bc2.env_vars = env_vars
 bc2.conda_ver = '4.6.14'
 bc2.conda_packages = [
@@ -77,7 +77,7 @@ bc2.build_cmds = [
     "pip install pytest-xdist",
 ]
 bc2.test_cmds = [
-    "pytest -r sx -v -n 30 --bigdata --slow \
+    "pytest -r sxf -n 15 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
     --log-level=INFO \
     jwst/tests_nightly/general"
@@ -90,7 +90,7 @@ bc2.test_configs = [data_config]
 // which is why this is needed.
 bc3 = utils.copy(bc2)
 bc3.nodetype = 'macos'
-bc3.name = 'macos-unstable-deps'
+bc3.name = 'macos-dev-deps'
 bc3.build_cmds = [
     "pip install -r requirements-dev.txt",
     "pip install -e .[test]",

--- a/JenkinsfileRT_Unstable
+++ b/JenkinsfileRT_Unstable
@@ -12,6 +12,10 @@ def PipInject(String reqs) {
     return result
 }
 
+withCredentials([string(
+    credentialsId: 'jwst-codecov',
+    variable: 'codecov_token')]) {
+
 jobconfig = new JobConfig()
 jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
@@ -56,10 +60,11 @@ bc0.build_cmds = [
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
-    "pytest -r sx -v -n 30 --bigdata --slow \
+    "pytest --cov=./ -r sx -v -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
     --log-level=INFO \
-    jwst"
+    jwst",
+    "codecov --token=${codecov_token}"
 ]
 bc0.test_configs = [data_config]
 
@@ -79,3 +84,4 @@ bc1.test_cmds = []
 bc1.test_configs = []
 
 utils.run([jobconfig, bc0, bc1])
+}  // withCredentials

--- a/JenkinsfileRT_Unstable
+++ b/JenkinsfileRT_Unstable
@@ -3,7 +3,7 @@ if (utils.scm_checkout(['skip_disable':true])) return
 
 def PipInject(String reqs) {
     def result = []
-    if (!reqs.trim().isEmpty()) {
+    if (reqs.trim().isEmpty()) {
 	return result
     }
     for (req in reqs.split('\n')) {

--- a/JenkinsfileRT_Unstable
+++ b/JenkinsfileRT_Unstable
@@ -47,11 +47,11 @@ bc0.conda_packages = [
     "python=${python_version}",
 ]
 bc0.build_cmds = [
-    PipInject(env.OVERRIDE_REQUIREMENTS),
     "pip install -r requirements-dev.txt",
     "pip install -e .[test]",
     "pip install pytest-xdist",
 ]
+bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest -r sx -v -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
@@ -68,10 +68,10 @@ bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-unstable-deps'
 bc1.build_cmds = [
-    PipInject(env.OVERRIDE_REQUIREMENTS),
     "pip install -r requirements-dev.txt",
     "pip install -e .[test]",
 ]
+bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
 bc1.test_cmds = []
 bc1.test_configs = []
 

--- a/JenkinsfileRT_Unstable
+++ b/JenkinsfileRT_Unstable
@@ -55,7 +55,7 @@ bc0.conda_packages = [
 ]
 bc0.build_cmds = [
     "pip install -r requirements-dev.txt",
-    "pip install -e .[test]",
+    "pip install -e .[test,ephem]",
     "pip install pytest-xdist",
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds

--- a/JenkinsfileRT_Unstable
+++ b/JenkinsfileRT_Unstable
@@ -3,6 +3,9 @@ if (utils.scm_checkout(['skip_disable':true])) return
 
 def PipInject(String reqs) {
     def result = []
+    if (!reqs.trim().isEmpty()) {
+	return result
+    }
     for (req in reqs.split('\n')) {
         result += "pip install $req"
     }

--- a/JenkinsfileRT_Unstable
+++ b/JenkinsfileRT_Unstable
@@ -1,0 +1,78 @@
+// [skip ci] and [ci skip] have no effect here.
+if (utils.scm_checkout(['skip_disable':true])) return
+
+def PipInject(String reqs) {
+    def result = []
+    for (req in reqs.split('\n')) {
+        result += "pip install $req"
+    }
+    return result
+}
+
+jobconfig = new JobConfig()
+jobconfig.enable_env_publication = true
+jobconfig.publish_env_on_success_only = true
+
+// Define python version for conda
+python_version = '3.6'
+
+// pip related setup
+def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
+def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
+
+// Define environement variables needed for the regression tests
+env_vars = [
+    "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
+    "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
+    "CRDS_CONTEXT=jwst-edit",
+]
+
+// Set pytest basetemp output directory
+pytest_basetemp = "test_outputs"
+
+// Configure artifactory ingest
+data_config = new DataConfig()
+data_config.server_id = 'bytesalad'
+data_config.root = '${PYTEST_BASETEMP}'
+data_config.match_prefix = '(.*)_result' // .json is appended automatically
+
+
+// Build and test with python 3.6 and unreleased dependencies
+bc0 = new BuildConfig()
+bc0.nodetype = 'jwst'
+bc0.name = 'unstable-deps'
+bc0.env_vars = env_vars
+bc0.conda_ver = '4.6.14'
+bc0.conda_packages = [
+    "python=${python_version}",
+]
+bc0.build_cmds = [
+    PipInject(env.OVERRIDE_REQUIREMENTS),
+    "pip install -r requirements-dev.txt",
+    "pip install -e .[test]",
+    "pip install pytest-xdist",
+]
+bc0.test_cmds = [
+    "pytest -r sx -v -n 30 --bigdata --slow \
+    --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
+    --log-level=INFO \
+    jwst"
+]
+bc0.test_configs = [data_config]
+
+
+// macos-specific buildconfig to cause the creation of counterparts to the linux
+// environment dumps. Packages in a mininmal conda environment differ by OS
+// which is why this is needed.
+bc1 = utils.copy(bc0)
+bc1.nodetype = 'macos'
+bc1.name = 'macos-unstable-deps'
+bc1.build_cmds = [
+    PipInject(env.OVERRIDE_REQUIREMENTS),
+    "pip install -r requirements-dev.txt",
+    "pip install -e .[test]",
+]
+bc1.test_cmds = []
+bc1.test_configs = []
+
+utils.run([jobconfig, bc0, bc1])

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ JWST Calibration Pipeline
 =========================
 [![Documentation Status](https://readthedocs.org/projects/jwst-pipeline/badge/?version=latest)](http://jwst-pipeline.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://travis-ci.org/spacetelescope/jwst.svg?branch=master)](https://travis-ci.org/spacetelescope/jwst)
+[![codecov](https://codecov.io/gh/spacetelescope/jwst/branch/master/graph/badge.svg)](https://codecov.io/gh/spacetelescope/jwst)
 [![Powered by STScI Badge](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)
 [![Powered by Astropy Badge](http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat)](http://www.astropy.org/)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-git+https://github.com/numpy/numpy#egg=numpy
+# git+https://github.com/numpy/numpy#egg=numpy
 git+https://github.com/astropy/astropy#a8f496b2#egg=astropy
 git+https://github.com/spacetelescope/asdf#egg=asdf
 git+https://github.com/spacetelescope/gwcs#3e2bc108e#egg=gwcs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-git+https://github.com/numpy/numpy.git#egg=numpy
-git+https://github.com/astropy/astropy.git#egg=astropy
-git+https://github.com/spacetelescope/asdf.git#egg=asdf
-git+https://github.com/spacetelescope/gwcs.git#egg=gwcs
-git+https://github.com/astropy/photutils.git#egg=photutils
+git+https://github.com/numpy/numpy#egg=numpy
+git+https://github.com/astropy/astropy#a8f496b2#egg=astropy
+git+https://github.com/spacetelescope/asdf#egg=asdf
+git+https://github.com/spacetelescope/gwcs#3e2bc108e#egg=gwcs
+git+https://github.com/astropy/photutils#99f101be#egg=photutils

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # git+https://github.com/numpy/numpy#egg=numpy
-git+https://github.com/astropy/astropy#a8f496b2#egg=astropy
-git+https://github.com/spacetelescope/asdf#egg=asdf
-git+https://github.com/spacetelescope/gwcs#3e2bc108e#egg=gwcs
-git+https://github.com/astropy/photutils#99f101be#egg=photutils
+git+https://github.com/astropy/astropy#egg=astropy
+git+https://github.com/spacetelescope#egg=asdf
+git+https://github.com/spacetelescope/gwcs#egg=gwcs
+git+https://github.com/astropy/photutils#egg=photutils

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,8 @@ TESTS_REQUIRE = [
     'pytest-doctestplus',
     'requests_mock',
     'pytest-openfiles',
+    'pytest-cov',
+    'codecov',
 ]
 
 def get_transforms_data():


### PR DESCRIPTION
Implement `codecov`.

~Note: Not sure at the moment how to do this for `.travis.yml` because it uses a wrapper to handle commands.~

Resolves #3893.
Resolves #135.
Resolves #3880.
Closes #3883.