### PR TITLE
Fix Jenkins RT MacOS build

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -57,7 +57,7 @@ bc0.test_configs = [data_config]
 bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-stable-deps'
-bc1.build_cmds = ["pip install -e .[test,ephem]"]
+bc1.build_cmds = ["pip install -e .[test]"]
 bc1.test_cmds = []
 bc1.test_configs = []
 


### PR DESCRIPTION
Fixes the problem seen in our Jenkins RT MacOS build:

https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST/detail/JWST/350/pipeline/26#step-161-log-66
```
Collecting jplephem>=2.8; extra == "ephem" (from jwst==0.13.8a0.dev142+gda86e52f)
  Downloading https://files.pythonhosted.org/packages/14/6f/354fd50e625a66c7be3f08095c0e1fa389c75453858acf2689ffa9c4fc54/jplephem-2.9.tar.gz
Collecting pymssql>=2.1; extra == "ephem" (from jwst==0.13.8a0.dev142+gda86e52f)
  Downloading https://files.pythonhosted.org/packages/2e/81/99562b93d75f3fc5956fa65decfb35b38a4ee97cf93c1d0d3cb799fffb99/pymssql-2.1.4.tar.gz (691kB)
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: /Users/iraf/build/pembry/workspace/RT/JWST/miniconda/envs/tmp_env1/lib/python3.6/site-packages/setuptools/dist.py:45: DistDeprecationWarning: Do not call this function
      warnings.warn("Do not call this function", DistDeprecationWarning)
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/fy/_s99d0l14k598wxq803bjjr800000g/T/pip-install-v510df5b/pymssql/setup.py", line 88, in <module>
        from Cython.Distutils import build_ext as _build_ext
    ModuleNotFoundError: No module named 'Cython'
```
Even if `cython` is installed, it errors out on `freetds`.
```
  Building wheel for pymssql (setup.py): started
  Building wheel for pymssql (setup.py): finished with status 'error'
  ERROR: Complete output from command /Users/iraf/build/pembry/workspace/RT/jdavies-dev/miniconda/envs/tmp_env1/bin/python -u -c 'import setuptools, tokenize;__file__='"'"'/private/var/folders/fy/_s99d0l14k598wxq803bjjr800000g/T/pip-install-qo9p09vm/pymssql/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /private/var/folders/fy/_s99d0l14k598wxq803bjjr800000g/T/pip-wheel-4r47tg6u --python-tag cp36:
  ERROR: /Users/iraf/build/pembry/workspace/RT/jdavies-dev/miniconda/envs/tmp_env1/lib/python3.6/site-packages/setuptools/dist.py:45: DistDeprecationWarning: Do not call this function
    warnings.warn("Do not call this function", DistDeprecationWarning)
  setup.py: platform.system() => 'Darwin'
  setup.py: platform.architecture() => ('64bit', '')
  setup.py: platform.libc_ver() => ('', '')
  setup.py: Detected Darwin/Mac OS X.
      You can install FreeTDS with Homebrew or MacPorts, or by downloading
      and compiling it yourself.
  
      Homebrew (http://brew.sh/)
      --------------------------
      brew install freetds
  
      MacPorts (http://www.macports.org/)
      -----------------------------------
      sudo port install freetds
  
  setup.py: Not using bundled FreeTDS
  setup.py: include_dirs = ['/usr/local/include', '/sw/include', '/opt/local/include']
  setup.py: library_dirs = ['/usr/local/lib', '/sw/lib', '/opt/local/lib']
  running bdist_wheel
  running build
  running build_ext
  cythoning src/_mssql.pyx to src/_mssql.c
  /Users/iraf/build/pembry/workspace/RT/jdavies-dev/miniconda/envs/tmp_env1/lib/python3.6/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /private/var/folders/fy/_s99d0l14k598wxq803bjjr800000g/T/pip-install-qo9p09vm/pymssql/src/_mssql.pxd
    tree = Parsing.p_module(s, pxd, full_module_name)
  warning: src/_mssql.pyx:150:4: Exception already a builtin Cython type
  building '_mssql' extension
  creating build
  creating build/temp.macosx-10.7-x86_64-3.6
  creating build/temp.macosx-10.7-x86_64-3.6/src
  gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/iraf/build/pembry/workspace/RT/jdavies-dev/miniconda/envs/tmp_env1/include -arch x86_64 -I/Users/iraf/build/pembry/workspace/RT/jdavies-dev/miniconda/envs/tmp_env1/include -arch x86_64 -I/usr/local/include -I/sw/include -I/opt/local/include -I/Users/iraf/build/pembry/workspace/RT/jdavies-dev/miniconda/envs/tmp_env1/include/python3.6m -c src/_mssql.c -o build/temp.macosx-10.7-x86_64-3.6/src/_mssql.o -DMSDBLIB
  src/_mssql.c:599:10: fatal error: 'sqlfront.h' file not found
  #include "sqlfront.h"
           ^~~~~~~~~~~~
  1 error generated.
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for pymssql
```
Until we have a better solution to `pymssql` and `freetds` on MacOS, we just won't install it in the MacOS builds.  I suspect the solution will be using something other than `pymssql` to access the JWST ephemeris.  It seems to be basically unmaintained.

https://github.com/pymssql/pymssql

Perhaps we can push for an API can be built for this database?  That would allow us to test the code as well.  @stscicrawford 