### PR TITLE
Switch back to xdist n 30 for regtests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -47,7 +47,7 @@ bc0.build_cmds = [
     "pip install pytest-xdist",
 ]
 bc0.test_cmds = [
-    "pytest --cov=./ -r sxf -n 15 --bigdata --slow \
+    "pytest --cov=./ -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
     --log-level=INFO \
     jwst",


### PR DESCRIPTION
Tests are taking almost 7 hours.  We had dialed back the number of cores from 30 to 15 thinking we would run the dev ones at the same time.  We are not doing that. So let's bump them back up to 30.