### PR TITLE
JP-934 Generate level 3 assoc for dedicated background target, update …

### DIFF
--- a/jwst/associations/association_io.py
+++ b/jwst/associations/association_io.py
@@ -86,7 +86,9 @@ class json():
             Name for the JSON file.
             Second item is the string containing the JSON serialization.
         """
-        asn_filename = asn.asn_name+'.json'
+        asn_filename = asn.asn_name
+        if not asn_filename.endswith('.json'):
+            asn_filename = asn_filename+'.json'
         return (
             asn_filename,
             json_lib.dumps(asn.data, cls=AssociationEncoder, indent=4, separators=(',', ': '))
@@ -150,7 +152,9 @@ class yaml():
             Name for the YAML file.
             Second item is the string containing the YAML serialization.
         """
-        asn_filename = asn.asn_name+'.yaml'
+        asn_filename = asn.asn_name
+        if not asn.asn_name.endswith('.yaml'):
+            asn_filename = asn.asn_name+'.yaml'
         return (
             asn_filename,
             yaml_lib.dump(asn.data, default_flow_style=False)

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -209,9 +209,10 @@ class Asn_SpectralTarget(AsnMixin_Spectrum):
                     DMSAttrConstraint(
                         name='patttype_spectarg',
                         sources=['patttype'],
+                        value=['2-point-nod|4-point-nod|along-slit-nod'],
                     ),
                 ],
-                reduce=Constraint.notany
+                reduce=Constraint.any
             )
         ])
 
@@ -343,7 +344,7 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
         # Setup for checking.
         self.constraints = Constraint([
             Constraint_Target(association=self),
-            Constraint_IFU(),
+            #Constraint_IFU(),
             Constraint(
                 [
                     Constraint_TSO(),

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -303,7 +303,8 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
 
         # check to see if these are nodded backgrounds, if they are setup
         # the background members, otherwise return the original association
-        if "nod" not in self.constraints['patttype_spectarg']:
+        # to test for the string 'nod' we need to copy and pop the value out of the set
+        if 'nod' not in self.constraints['patttype_spectarg'].found_values.copy().pop():
             results = []
             results.append(self)
             return results

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -325,7 +325,7 @@ class Main():
         """
         for asn in self.associations:
             (fname, serialized) = asn.dump(format=format)
-            with open(os.path.join(path, fname + '.' + format), 'w') as f:
+            with open(os.path.join(path, fname), 'w') as f:
                 f.write(serialized)
 
         if save_orphans:


### PR DESCRIPTION
…for .json file extension
20 new spec3 associations are created for mir_lrs-fixedslit observations. Need to file a ticket for observation 26 in the pool file jw00623_20190625t115752_pool.csv. o0026 has PATTTYPE = NULL, the APT requires(?) a dither pattern here so this does not appear to be a valid observation. 
Unit tests: all pass
Regression tests: 7 tests will need updated/ additional truth files. 

Also added fix for the extra .json extension that was appearing in the output association files. 