### PR TITLE
Jp946 Process non-science exposures taken during WFS&C observations

### DIFF
--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -95,7 +95,6 @@ class Asn_Lv2ImageNonScience(
         # Setup constraints
         self.constraints = Constraint([
             Constraint_Base(),
-            Constraint_Mode(),
             Constraint_Image_Nonscience(),
             Constraint_Single_Science(self.has_science),
         ])
@@ -876,16 +875,17 @@ class Asn_Lv2WFSC(
         # Setup constraints
         self.constraints = Constraint([
             Constraint_Base(),
+            Constraint_Image_Science(),
             Constraint_Single_Science(self.has_science),
             Constraint_ExtCal(),
             Constraint(
                 [
-                        DMSAttrConstraint(
-                            name='wfsc',
-                            sources=['visitype'],
-                            value='.+wfsc.+',
-                            force_unique=True
-                        )
+                    DMSAttrConstraint(
+                        name='wfsc',
+                        sources=['visitype'],
+                        value='.+wfsc.+',
+                        force_unique=True
+                    )
                 ]
             )
         ])

--- a/jwst/tests_nightly/general/associations/test_sdp_pools.py
+++ b/jwst/tests_nightly/general/associations/test_sdp_pools.py
@@ -33,6 +33,10 @@ SPECIAL_DEFAULT = {
     'xfail': None,
 }
 SPECIAL_POOLS = {
+    'jw00632_20190819t190005_pool': {
+        'args': [],
+        'xfail': 'JSOCINT-TDB: WFSC ROUTINE VISIT issue'
+    },
     'jw80600_20171108T041522_pool': {
         'args': [],
         'xfail': 'PR #3450',

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -25,10 +25,15 @@ class WfsCombineStep(Step):
         self.log.info('The number of pairs of input files: %g', num_sets)
 
         # Process each pair of input images listed in the association table
-        for which_set in range(num_sets):
-            infile_1 = asn_table['products'][which_set]['members'][0]['expname']
-            infile_2 = asn_table['products'][which_set]['members'][1]['expname']
-            outfile = asn_table['products'][which_set]['name']
+        for which_set in asn_table['products']:
+            science_members = [
+                member
+                for member in which_set['members']
+                if member['exptype'].lower() == 'science'
+            ]
+            infile_1 = science_members[0]['expname']
+            infile_2 = science_members[1]['expname']
+            outfile = which_set['name']
 
             wfs = wfs_combine.DataSet(
                 infile_1, infile_2, outfile, self.do_refine


### PR DESCRIPTION
Resolves JP-946/#3938.

Any non-science exposures, such as target acquisitions, taken during WFS&C observations, will be processed as they would be during any other observation mode.

Also resolved the issue `WfsCombineStep` being able to handle non-science members in the associations.