### PR TITLE
fix too strict a requirement on pixel dq - JP-949

### DIFF
--- a/jwst/straylight/straylight.py
+++ b/jwst/straylight/straylight.py
@@ -226,7 +226,7 @@ def correct_mrs_modshepard(input_model, slice_map, roi, power):
     mask_dq = input_model.dq.copy()
     all_flags = (dqflags.pixel['DEAD'] + dqflags.pixel['HOT'] +
                  dqflags.pixel['OPEN'] + dqflags.pixel['ADJ_OPEN'] +
-                 dqflags.pixel['RC'])
+                 dqflags.pixel['RC']+ dqflags.pixel['REFERENCE_PIXEL'])
     testflags = np.bitwise_and(mask_dq, all_flags)
     # where are testflags ne 0 and mask == 1
     bad_flags = np.where((testflags != 0) & (mask == 1))


### PR DESCRIPTION
Too strict a requirement was set on the dqflag for the gap pixels. After flat fielding these gap pixel
can get set to DO _NOT _USE because there is no flat for them. So just do a basic check on
the gap pixels to make sure they are not HOT, DEAD, OPEN, RC or ADJ_OPEN

Once reviewed this should be merged because it is needed to fix the regression test failure: JP-949
