### PR TITLE
Jp 947

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ assign_wcs
 associations
 ------------
 
+- Update rules to make level 3 associations for slitless LRS mode [#3940]
+
+- Update rules so that nOPS5 observations with "ALONG-SLIT-NOD" dither
+   pattern generates level 3 associations [#3912]
+
 - Update rules to have NRS_IFU backgrounds in science associations [#3824]
 
 - Return filename with extensions based on file type [#2671]

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -19,6 +19,7 @@ __all__ = [
     'Asn_Image',
     'Asn_SpectralSource',
     'Asn_SpectralTarget',
+    'Asn_SlitlessSpectral',
     'Asn_TSO',
     'Asn_WFSCMB',
     'Asn_WFSS_NIS',
@@ -235,8 +236,52 @@ class Asn_SpectralTarget(AsnMixin_Spectrum):
         """
         if self.is_valid:
             return self.make_fixedslit_bkg()
-        else:
-            return None
+
+        return None
+
+@RegistryMarker.rule
+class Asn_SlitlessSpectral(AsnMixin_Spectrum):
+    """Level 3 slitless, target-based or single-object spectrographic Association
+
+    Characteristics:
+        - Association type: ``spec3``
+        - Pipeline: ``calwebb_spec3``
+        - Single target
+        - Non-TSO
+    """
+
+    def __init__(self, *args, **kwargs):
+
+        # Setup for checking.
+        self.constraints = Constraint([
+            Constraint(
+                [Constraint_TSO()],
+                reduce=Constraint.notany
+            ),
+            Constraint_Optical_Path(),
+            Constraint_Target(association=self),
+            DMSAttrConstraint(
+                name='exp_type',
+                sources=['exp_type'],
+                value=(
+                    'mir_lrs-slitless'
+                    '|nis_soss'
+                ),
+                force_unique=False
+            ),
+            Constraint(
+                [
+                    DMSAttrConstraint(
+                        name='patttype_spectarg',
+                        sources=['patttype'],
+                    ),
+                ],
+                reduce=Constraint.notany
+            )
+        ])
+
+        # Check and continue initialization.
+        super(Asn_SlitlessSpectral, self).__init__(*args, **kwargs)
 
 @RegistryMarker.rule
 class Asn_SpectralSource(AsnMixin_Spectrum):
@@ -344,7 +389,6 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
         # Setup for checking.
         self.constraints = Constraint([
             Constraint_Target(association=self),
-            #Constraint_IFU(),
             Constraint(
                 [
                     Constraint_TSO(),
@@ -359,7 +403,7 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
                         value=['T'],)
                 ],
                 reduce=Constraint.any
-                                    ),
+                ),
             Constraint(
                 [
                     DMSAttrConstraint(
@@ -368,8 +412,8 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
                         value=['mir_mrs','nrs_ifu','mir_lrs-fixedslit',
                                'nrs_fixedslit'],)
                 ],
-            reduce=Constraint.any
-                    ),
+                reduce=Constraint.any
+                ),
                 ])
 
         # Check and continue initialization.

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -1,6 +1,6 @@
 """Base classes which define the Level3 Associations"""
 from collections import defaultdict
-import copy
+#import copy
 import logging
 from os.path import (
     basename,
@@ -11,7 +11,7 @@ import re
 
 from jwst.associations import (
     Association,
-    AssociationRegistry,
+    #AssociationRegistry,
     ProcessList,
     libpath
 )
@@ -21,7 +21,7 @@ from jwst.associations.lib.utilities import (
     is_iterable
 )
 from jwst.associations.exceptions import (
-    AssociationNotAConstraint,
+    #AssociationNotAConstraint,
     AssociationNotValidError,
 )
 from jwst.associations.lib.acid import ACID
@@ -39,8 +39,7 @@ from jwst.associations.lib.dms_base import (
     IMAGE2_SCIENCE_EXP_TYPES,
     IMAGE2_NONSCIENCE_EXP_TYPES,
     SPEC2_SCIENCE_EXP_TYPES,
-    TSO_EXP_TYPES,
-)
+    )
 from jwst.associations.lib.format_template import FormatTemplate
 from jwst.associations.lib.member import Member
 
@@ -136,8 +135,8 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
             result = self.data['asn_type'] == other.data['asn_type']
             result = result and (self.member_ids == other.member_ids)
             return result
-        else:
-            return NotImplemented
+
+        return NotImplemented
 
     def __ne__(self, other):
         """Compare inequality of two associations"""
@@ -178,11 +177,11 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
         opt_elem = association._get_opt_element()
 
         exposure = association._get_exposure()
-        if len(exposure):
+        if exposure:
             exposure = '-' + exposure
 
         subarray = association._get_subarray()
-        if len(subarray):
+        if subarray:
             subarray = '-' + subarray
 
         product_name = (
@@ -320,7 +319,7 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
             # if there is only one science observation it cannot be the background
             # return with original association.
             if len(science_exps) < 2:
-                return
+                return results
 
             # Create new members for each science exposure in the association,
             # using the the base name + _x1d as background.
@@ -639,7 +638,7 @@ def dms_product_name_sources(asn):
     opt_elem = asn._get_opt_element()
 
     subarray = asn._get_subarray()
-    if len(subarray):
+    if subarray:
         subarray = '-' + subarray
 
     product_name_format = (
@@ -838,8 +837,8 @@ class AsnMixin_Science(DMS_Level3_Base):
                     name='acq_obsnum',
                     sources=['obs_num'],
                     value=lambda: '('
-                             + '|'.join(self.constraints['obs_num'].found_values)
-                             + ')',
+                    + '|'.join(self.constraints['obs_num'].found_values)
+                    + ')',
                     force_unique=False,
                 )
             ],
@@ -893,8 +892,8 @@ class AsnMixin_BkgScience(DMS_Level3_Base):
                     name='acq_obsnum',
                     sources=['obs_num'],
                     value=lambda: '('
-                             + '|'.join(self.constraints['obs_num'].found_values)
-                             + ')',
+                    + '|'.join(self.constraints['obs_num'].found_values)
+                    + ')',
                     force_unique=False,
                 )
             ],
@@ -940,7 +939,7 @@ class AsnMixin_Spectrum(AsnMixin_Science):
         self.data['asn_type'] = 'spec3'
         super(AsnMixin_Spectrum, self)._init_hook(item)
 
-class AsnMixin_AuxData:
+class AsnMixin_AuxData(AsnMixin_Science):
     """Process special and non-science exposures as science.
     """
     def get_exposure_type(self, item, default='science'):


### PR DESCRIPTION
This is to fix the issue where fixed-slit spectra with a nod pattern excluded observations with PATTYPE=NULL from the level 3 associations. A new level 3 rule was put in place to capture these observations. 
From the tests, 
pytest -n 3 -ra --bigdata --basetemp=/Users/ddavis/Data/JWST/CTeam/test_JP-947 ~/src/JWST/scsb/jwst/jwst/tests_nightly/general/associations/  --junit-xml=results.xml
...
============= 106 passed, 14 skipped, 2 xfailed in 2230.92 seconds =============

