### PR TITLE
MNT: Unpin jsonschema<=2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(
         'crds>=7.2.7',
         'drizzle>=1.13',
         'gwcs @ git+http://github.com/spacetelescope/gwcs#3e2bc108e#egg=gwcs',
-        'jsonschema>=2.3,<=2.6',
+        'jsonschema>=2.3',
         'numpy>=1.13',
         'photutils @ git+http://github.com/astropy/photutils#99f101be#egg=photutils',
         'scipy>=1.0',


### PR DESCRIPTION
`asdf` already supports `jsonschema` 3, so why pin it still?

Backstory: I am trying to load your pipeline Level 2 data in a notebook. All the other dependencies need `jsonschema` 3, so when GWCS accesses the data models shipped with this pipeline, things crash because of this pinning. This patch works for my use case.