### PR TITLE
Allow variable shape arrays in schemas for structured array fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,12 @@ calwebb_tso3
 
 - Update to exclude target_acquisitions from processing in the calwebb_tso3 pipeline [#3759]
 
+cube_build
+----------
+
+- Schema for the ``WAVE-TAB`` WCS no longer requires fixed-length arrays for
+  the wavelength "coordinates". The ``'nelem'`` field therefore is no longer
+  necessary and has been removed. [#3976]
 
 datamodels
 ----------
@@ -68,6 +74,11 @@ datamodels
 
 - Updated multiexposure.schema to just import slitdata.schema instead of explicitly
   specifying all of its attributes. [#3809]
+
+- Improved ``properties._cast()`` to be able to handle structured arrays
+  schemas without a specified (in schema) shape. In addition, ``ndim``
+  can be used to constrain the dimensionality of data in structured array
+  fields. [#3976]
 
 exp_to_source
 -------------

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1782,26 +1782,12 @@ class IFUCubeData():
                                                     err=err_cube,
                                                     weightmap=idata)
         else:
-            nelem = np.array([])
             wave = np.asarray(self.wavelength_table, dtype=np.float32)
-            # for now we need to pad wavelength to fix datamodel size
             num = len(wave)
-            nn = 10420   # This number needs to match the shape of the
-            # wavetable['wavelength'] value in the ifucube.schema.
-            # In the future it would be good to remove that we have to
-            # set the size of this value in the schema.
-
-            wave = np.pad(wave, (0, nn - num), 'constant')
-            newnum = len(wave)
-            allwave = np.zeros((1, 1, newnum))
-            allwave[0, 0, :] = wave
-
-            nelem = np.append(nelem, num)
-# to get the data in the correct format:
-#  (an array in a single cell in the fit table)
-# need to zip data.
-            alldata = np.array(list(zip(np.array(nelem), np.array(allwave))),
-                               dtype=datamodels.IFUCubeModel().wavetable.dtype)
+            alldata = np.array(
+                [(wave[None].T, )],
+                dtype=[('wavelength', '<f4', (num, 1))]
+            )
 
             ifucube_model = datamodels.IFUCubeModel(data=data, dq=dq_cube,
                                                     err=err_cube,
@@ -1863,7 +1849,7 @@ class IFUCubeData():
             ifucube_model.meta.wcsinfo.crpix3 = 1.0
             ifucube_model.meta.wcsinfo.cdelt3 = None
             ifucube_model.meta.ifu.roi_wave = np.mean(self.roiw_table)
-            ifucube_model.wavedim = '(1,10420)'
+            ifucube_model.wavedim = '(1,{:d})'.format(num)
 
         ifucube_model.meta.wcsinfo.ctype1 = 'RA---TAN'
         ifucube_model.meta.wcsinfo.ctype2 = 'DEC--TAN'

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -76,11 +76,9 @@ allOf:
       title: Wavelength value for slices
       fits_hdu: WCS-TABLE
       datatype:
-      - name: nelem
-        datatype: int16
       - name: wavelength
         datatype: float32
-        shape: [10420]
+        ndim: 2
     wavedim:
       title: Wavetable dimension
       type: string


### PR DESCRIPTION
This PR improves the logic in the `datamodels.properties._cast()` function so that now it can handle structured arrays who's fields can be arbitrarily shaped arrays. Previously schemas for structured arrays required a fixed shape to be defined which in turn led to issues such as https://github.com/spacetelescope/jwst/issues/3750

In addition, the new logic also allows specifying the ``ndim`` constrain in the schemas for the fields of structured arrays.

Finally, this PR modified the code for the ``cube_build`` so that wavetables are saved using arrays of appropriate length `=>` DS9 "frame matching by WCS" now should work with cubes.