### PR TITLE
Fix an issue in casting numpy arrays to structured array types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,10 @@ datamodels
   can be used to constrain the dimensionality of data in structured array
   fields. [#3976]
 
+- Fixed an issue with the fix from [#3976] that was affecting "casting" to
+  data types defined by schema of structured arrays when input values are not
+  native Python types (tuples). [#3995]
+
 exp_to_source
 -------------
 

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -2,7 +2,7 @@
 
 import copy
 import numpy as np
-import collections
+from collections.abc import Mapping
 from astropy.io import fits
 
 from astropy.utils.compat.misc import override__dir__
@@ -32,14 +32,17 @@ def _cast(val, schema):
             val = val._make_array()
 
         if (isinstance(schema['datatype'], list) and
-            any('name' in t for t in schema['datatype']) and len(val)):
+            any('name' in t for t in schema['datatype']) and
+            len(val) and
+            ((isinstance(val, list) and isinstance(val[0], tuple)) or
+             isinstance(val, fits.FITS_rec))):
             # we are dealing with a structured array. Because we may
             # modify schema (to add shape), we make a deep copy of the
             # schema here:
             schema = copy.deepcopy(schema)
 
             for t, v in zip(schema['datatype'], val[0]):
-                if not isinstance(t, collections.Mapping):
+                if not isinstance(t, Mapping):
                     continue
 
                 aval = np.asanyarray(v)

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -356,7 +356,6 @@ def test_table_array_shape_ndim():
         assert str(e.value).startswith("Array has wrong number of dimensions.")
 
 
-
 def test_table_array_convert():
     """
     Test that structured arrays are converted when necessary, and
@@ -501,7 +500,7 @@ def test_data_array():
         for hdu in hdulist:
             x.add((hdu.header.get('EXTNAME'),
                    hdu.header.get('EXTVER')))
-        print(x)
+
         assert x == set(
             [('FOO', 2), ('FOO', 1), ('ASDF', None), ('DQ', 2),
              (None, None)])


### PR DESCRIPTION
A fix for https://github.com/spacetelescope/jwst/issues/3991. When structured arrays are NOT initialized from "native Python types", i.e., `[(), (), ...]`, `_cast()` should skip the code introduced in  https://github.com/spacetelescope/jwst/pull/3976