### PR TITLE
Jp 482

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ assign_wcs
 
 associations
 ------------
+- asn_from_list fills the level2  member exptype correctly if the input is a tuple [#2942]
 
 - Update rules to make level 3 associations for slitless LRS mode [#3940]
 

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -146,15 +146,15 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
             result = self.data['asn_type'] == other.data['asn_type']
             result = result and (self.member_ids == other.member_ids)
             return result
-        else:
-            return NotImplemented
+
+        return NotImplemented
 
     def __ne__(self, other):
         """Compare inequality of two associations"""
         if isinstance(other, DMSLevel2bBase):
             return not self.__eq__(other)
-        else:
-            return NotImplemented
+
+        return NotImplemented
 
     def dms_product_name(self):
         """Define product name."""
@@ -299,12 +299,24 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
             )
         self._acid = ACID((acid, ac_type))
 
+        #set the default exptype
+        exptype = 'science'
+
         for idx, item in enumerate(items, start=1):
             self.new_product()
             members = self.current_product['members']
+            if isinstance(item, tuple):
+                expname = item[0]
+            else:
+                expname = item
+
+            #check to see if kwargs are passed and if exptype is given
+            if kwargs:
+                if 'with_exptype' in kwargs:
+                    exptype = item[1]
             member = Member({
-                'expname': item,
-                'exptype': 'science'
+                'expname': expname,
+                'exptype': exptype
             }, item=item)
             members.append(member)
             self.update_validity(member)
@@ -352,8 +364,8 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         # If a background, check that there is a background
         # exposure
         if self.acid.type.lower() == 'background':
-            for member in self.current_product['members']:
-                if member['exptype'].lower() == 'background':
+            for entry in self.current_product['members']:
+                if entry['exptype'].lower() == 'background':
                     return True
 
         # If not background member, or some other candidate type,
@@ -557,7 +569,7 @@ class Utility():
         for asn in asns:
             product_name = asn['products'][0]['name']
             if product_name in dups:
-                    to_prune[product_name].append(asn)
+                to_prune[product_name].append(asn)
 
         for product_name, asns_to_prune in to_prune.items():
             asns_to_prune = Utility.sort_by_candidate(asns_to_prune)
@@ -608,6 +620,7 @@ class Utility():
 
     @staticmethod
     def resequence(*args, **kwargs):
+        """Resquence the numbers to conform to level 3 asns"""
         return Utility_Level3.resequence(*args, **kwargs)
 
     @staticmethod

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -313,7 +313,10 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
             #check to see if kwargs are passed and if exptype is given
             if kwargs:
                 if 'with_exptype' in kwargs:
-                    exptype = item[1]
+                    if item[1]:
+                        exptype = item[1]
+                    else:
+                        exptype='science'
             member = Member({
                 'expname': expname,
                 'exptype': exptype

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -1,5 +1,6 @@
 """Tests for asn_from_list"""
 
+import os
 import pytest
 
 from .. import (Association, AssociationRegistry, load_asn)
@@ -27,6 +28,24 @@ def test_level2():
     assert name.startswith('jwnoprogram-o999_none')
     assert isinstance(serialized, str)
 
+def test_level2_tuple():
+    """Test level 2 association when passing in a tuple"""
+    items = [('file_1.fits', 'science'), ('file_2.fits', 'background'),
+             ('file_3.fits', 'target_aquisition')]
+    asn = asn_from_list(items, rule=DMSLevel2bBase)
+    assert asn['asn_rule'] == 'DMSLevel2bBase'
+    assert asn['asn_type'] == 'None'
+    products = asn['products']
+    assert len(products) == len(items)
+    for product in products:
+        assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
+        members = product['members']
+        assert len(members) == 1
+        member = members[0]
+        #assert member['expname'] == product['name']
+        assert os.path.splitext(member['expname'])[0] == product['name']
+        assert member['exptype'] == product['members'][0]['exptype']
+
 def test_file_ext():
     """check that the filename extension is correctly appended"""
     items = ['a', 'b', 'c']
@@ -40,7 +59,7 @@ def test_file_ext():
     #check that extension with format = 'yaml'  returns yaml
     name, serialized = asn.dump(format='yaml')
     assert name.endswith('yaml')
-   
+
 
 def test_level2_from_cmdline(tmpdir):
     """Create a level2 assocaition from the command line"""

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -39,12 +38,10 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
-        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1
         member = members[0]
-        #assert member['expname'] == product['name']
         assert os.path.splitext(member['expname'])[0] == product['name']
         assert member['exptype'] == product['members'][0]['exptype']
         # make sure '' defaults to 'science'

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -31,13 +32,14 @@ def test_level2():
 def test_level2_tuple():
     """Test level 2 association when passing in a tuple"""
     items = [('file_1.fits', 'science'), ('file_2.fits', 'background'),
-             ('file_3.fits', 'target_aquisition')]
+             ('file_3.fits', 'target_acquisition'),('file_4.fits', '')]
     asn = asn_from_list(items, rule=DMSLevel2bBase)
     assert asn['asn_rule'] == 'DMSLevel2bBase'
     assert asn['asn_type'] == 'None'
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
+        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1
@@ -45,6 +47,9 @@ def test_level2_tuple():
         #assert member['expname'] == product['name']
         assert os.path.splitext(member['expname'])[0] == product['name']
         assert member['exptype'] == product['members'][0]['exptype']
+        # make sure '' defaults to 'science'
+        if not items[3][1]:
+            assert product['members'][0]['exptype'] == 'science'
 
 def test_file_ext():
     """check that the filename extension is correctly appended"""


### PR DESCRIPTION
Update for asn_from_list to have the correct exptype in the level2 associations. 

Unit Tests:
`
pytest --pdb ../../scsb/jwst/jwst/associations/tests/test_asn_from_list.py
================================================================ test session starts ================================================================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /Users/ddavis/src/JWST/scsb/jwst, inifile: setup.cfg
plugins: xdist-1.29.0, forked-1.0.2, openfiles-0.4.0, doctestplus-0.3.0, ci-watson-0.3, requests-mock-1.6.0
collected 16 items

../../scsb/jwst/jwst/associations/tests/test_asn_from_list.py ................                                                                [100%]

============================================================= 16 passed in 0.25 seconds =============================================================
`
Regression tests:
`pytest -n 3 -ra --bigdata --basetemp=/Users/ddavis/Data/JWST/CTeam/test_JP-482_Sep09 ~/src/JWST/scsb/jwst/jwst/tests_nightly/general/associations
...
============= 106 passed, 14 skipped, 2 xfailed in 2128.28 seconds =============
`