### PR TITLE
fix photutils to public release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ setup(
         'gwcs @ git+https://github.com/spacetelescope/gwcs@3e2bc108e#egg=gwcs',
         'jsonschema>=2.3,<=2.6',
         'numpy>=1.13',
-        'photutils @ git+https://github.com/astropy/photutils@99f101be#egg=photutils',
+        'photutils>=0.7',
         'scipy>=1.0',
         'spherical-geometry>=1.2',
         'stsci.image>=2.3.3',


### PR DESCRIPTION
This PR sets the photutils version to the public release of photutils `>=0.7`. This should fix the crash in the nircam image3 regression test. The test fails now with minor differences (possibly due to a different seriazlization in astropy.table).