### PR TITLE
JP-974 : temporary fix for crash in cube_build

### DIFF
--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -150,7 +150,7 @@ def fitswcs_transform_from_model(wcsinfo, wavetable=None):
         else :
             # Wave dimension is an array that needs to be converted to a table
             waves = wavetable['wavelength'].flatten()
-            spectral_transform = astmodels.Tabular1D(lookup_table=waves)
+            spectral_transform = astmodels.Tabular1D(lookup_table=waves, bounds_error=False)
 
         transform = transform & spectral_transform
 


### PR DESCRIPTION
This will eliminate the crash in cube_build although there might be some regression tests failing with differences. I suspect there's a deeper reason for the failure and this should be discussed further.