### PR TITLE
Fix a bug in casting of structured arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,10 @@ datamodels
   data types defined by schema of structured arrays when input values are not
   native Python types (tuples). [#3995]
 
+- Fixed an issue with the fix from [#3995] that was affecting "casting" to
+  data types defined by schema of structured arrays when input values are
+  already structured arrays. [#4030]
+
 exp_to_source
 -------------
 


### PR DESCRIPTION
Fixes a bug described in https://github.com/spacetelescope/jwst/issues/3999#issuecomment-532276865 This bug was introduced in a bug fix to a bug fix in #3995. Essentially the structured array schema validation AND type coercion code was (incorrectly) skipped when input is already a structured array.

CC: @stscicrawford @jemorrison 