### PR TITLE
JP-737 Don't use PATTTYPE to check for IRS2 mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,9 +89,6 @@ datamodels
   data types defined by schema of structured arrays when input values are
   already structured arrays. [#4030]
 
-- Added "MIR_TACONFIRM" to the list of allowed EXP_TYPE values in the
-  keyword schemas. [#4039]
-
 exp_to_source
 -------------
 
@@ -141,10 +138,19 @@ group_scale
 
 - Updates to documentation and log messages. [#3738]
 
+ipc
+---
+
+Function is_irs2 has been removed from x_irs2.py.  The version of this funtion
+that is now in lib/pipe_utils.py is used instead. [#4054]
+
 lib
 ---
 
 - A function to determine the dispersion direction has been added. [#3756]
+
+- Function is_irs2 has been added to pipe_utils.py, and unit tests were
+  added to tests/test_pipe_utils.py. [#4054]
 
 master_background
 -----------------
@@ -156,10 +162,22 @@ photom
 
 - Add unit tests [#4022]
 
+refpix
+------
+
+- Call is_irs2 from lib/pipe_utils.py instead of using PATTTYPE keyword to
+  check for IRS2 readout mode. [#4054]
+
 resample_spec
 -------------
 
 - This step uses keyword DISPAXIS and also copies it to output. [#3799]
+
+saturation
+----------
+
+Function is_irs2 has been removed from x_irs2.py.  The version of this funtion
+that is now in lib/pipe_utils.py is used instead. [#4054]
 
 stpipe
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,9 @@ datamodels
   data types defined by schema of structured arrays when input values are
   already structured arrays. [#4030]
 
+- Added "MIR_TACONFIRM" to the list of allowed EXP_TYPE values in the
+  keyword schemas. [#4039]
+
 exp_to_source
 -------------
 

--- a/jwst/ipc/ipc_corr.py
+++ b/jwst/ipc/ipc_corr.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 import logging
 import numpy as np
 
+from ..lib import pipe_utils
 from . import x_irs2
 
 log = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ def ipc_correction(input_model, ipc_model):
     output = input_model.copy()
 
     # Was IRS2 readout used?
-    is_irs2_format = x_irs2.is_irs2(input_model)
+    is_irs2_format = pipe_utils.is_irs2(input_model)
     if is_irs2_format:
         irs2_mask = x_irs2.make_mask(input_model)
 

--- a/jwst/ipc/x_irs2.py
+++ b/jwst/ipc/x_irs2.py
@@ -2,10 +2,9 @@ from collections import namedtuple
 
 import numpy as np
 
+from ..lib import pipe_utils
+
 """ This is the interface:
-    bool = is_irs2(input_model)
-        True if the data in input_model were taken using the IRS2 readout
-         pattern.
     mask = make_mask(input_model)
         Create a mask for extracting normal pixels; used by `from_irs2` and
         `to_irs2`.
@@ -92,40 +91,6 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     return param
 
 
-def is_irs2(input_model):
-    """Check whether the data are in IRS2 format.
-
-    Parameters
-    ----------
-    input_model : JWST data model
-        The input science data model.
-
-    Returns
-    -------
-    bool
-        True if `input_model` is in IRS2 format; False otherwise.
-    """
-
-    if isinstance(input_model, np.ndarray):
-        shape = input_model.shape
-        can_check_for_MIRI = False
-    else:
-        # use:  if input_model.meta.exposure.readpatt.find("IRS2") >= 0
-        shape = input_model.data.shape
-        can_check_for_MIRI = True
-
-    if can_check_for_MIRI and input_model.meta.instrument.name == 'MIRI':
-        max_height = 1032                       # perhaps should use 1024
-    else:
-        max_height = 2048
-
-    y_axis_length = max(shape[-1], shape[-2])
-
-    if y_axis_length > max_height:
-        return True
-    else:
-        return False
-
 
 def normal_shape(input_model, n=None, r=None, detector=None):
     """Determine the shape of the 'normal' pixel data.
@@ -166,7 +131,7 @@ def normal_shape(input_model, n=None, r=None, detector=None):
         if detector is None:
             detector = input_model.meta.instrument.detector
 
-    if not is_irs2(input_model):                # not IRS2 format
+    if not pipe_utils.is_irs2(input_model):     # not IRS2 format
         return shape
 
     param = _get_irs2_parameters(input_model, n=n, r=r)

--- a/jwst/lib/pipe_utils.py
+++ b/jwst/lib/pipe_utils.py
@@ -1,5 +1,7 @@
 """Pipeline utilities objects"""
 
+import numpy as np
+
 from ..associations.lib.dms_base import TSO_EXP_TYPES
 from ..datamodels import CubeModel
 
@@ -12,12 +14,12 @@ def is_tso(model):
 
     Parameters
     ----------
-    model: datamodels.DataModel
+    model : `~jwst.datamodels.DataModel`
         Data to check
 
     Returns
     -------
-    is_tso: bool
+    is_tso : bool
        `True` if the model represents TSO data
     """
     is_tso = False
@@ -39,3 +41,38 @@ def is_tso(model):
 
     # We've checked everything.
     return is_tso
+
+
+def is_irs2(model):
+    """Check whether the data are in IRS2 format.
+
+    This currently assumes that only full-frame, near-infrared data can be
+    taken using the IRS2 readout pattern.
+
+    Parameters
+    ----------
+    model : `~jwst.datamodels.DataModel` or ndarray
+        Data to check
+
+    Returns
+    -------
+    bool
+       `True` if the data are in IRS2 format
+    """
+
+    if isinstance(model, np.ndarray):
+        shape = model.shape
+    else:
+        try:
+            shape = model.data.shape
+        except AttributeError:
+            return False
+
+    max_length = 2048
+
+    irs2_axis_length = max(shape[-1], shape[-2])
+
+    if irs2_axis_length > max_length:
+        return True
+    else:
+        return False

--- a/jwst/lib/tests/test_pipe_utils.py
+++ b/jwst/lib/tests/test_pipe_utils.py
@@ -2,6 +2,8 @@
 import inspect
 import pytest
 
+import numpy as np
+
 from .. import pipe_utils
 from ... import datamodels
 from ...associations.lib import dms_base
@@ -78,3 +80,21 @@ def test_is_tso_from_tsoflag(tsovisit, expected):
     model = datamodels.DataModel()
     model.meta.visit.tsovisit = tsovisit
     assert pipe_utils.is_tso(model) is expected
+
+
+def test_is_irs2_1():
+    """Test is_irs2 using a numpy array"""
+    x = np.ones((2048, 2), dtype=np.float32)
+    assert not pipe_utils.is_irs2(x)
+    x = np.ones((3200, 2), dtype=np.float32)
+    assert pipe_utils.is_irs2(x)
+
+
+def test_is_irs2_2():
+    """Test is_irs2 using a jwst data model"""
+    x = np.ones((2048, 2), dtype=np.float32)
+    model = datamodels.ImageModel(data=x)
+    assert not pipe_utils.is_irs2(model)
+    x = np.ones((3200, 2), dtype=np.float32)
+    model = datamodels.ImageModel(data=x)
+    assert pipe_utils.is_irs2(model)

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from ..stpipe import Step
+from ..lib import pipe_utils
 from .. import datamodels
 from . import reference_pixels
 from . import irs2_subtract_reference
@@ -29,8 +30,8 @@ class RefPixStep(Step):
     def process(self, input):
 
         with datamodels.RampModel(input) as input_model:
-            if input_model.meta.exposure.readpatt is not None and \
-               input_model.meta.exposure.readpatt.find("IRS2") >= 0:
+            # shape[-2] will be 3200 for IRS2 data.
+            if pipe_utils.is_irs2(input_model):
                 self.irs2_name = self.get_reference_file(input_model, 'refpix')
                 self.log.info('Using refpix reference file: %s' %
                               self.irs2_name)

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -5,6 +5,7 @@ import logging
 
 from ..datamodels import dqflags
 from ..lib import reffile_utils
+from ..lib import pipe_utils
 from . import x_irs2
 
 import numpy as np
@@ -37,7 +38,7 @@ def do_correction(input_model, ref_model):
 
     ramparr = input_model.data
     # Was IRS2 readout used?
-    is_irs2_format = x_irs2.is_irs2(input_model)
+    is_irs2_format = pipe_utils.is_irs2(input_model)
     if is_irs2_format:
         irs2_mask = x_irs2.make_mask(input_model)
 

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -2,10 +2,9 @@ from collections import namedtuple
 
 import numpy as np
 
+from ..lib import pipe_utils
+
 """ This is the interface:
-    bool = is_irs2(input_model)
-        True if the data in input_model were taken using the IRS2 readout
-         pattern.
     mask = make_mask(input_model)
         Create a mask for extracting normal pixels; used by from_irs2 and
         to_irs2.
@@ -81,29 +80,6 @@ def _get_irs2_parameters(input_model, n=None, r=None):
 
     return param
 
-def is_irs2(input_model):
-    """Check whether the data are in IRS2 format."""
-
-    if isinstance(input_model, np.ndarray):
-        shape = input_model.shape
-        can_check_for_MIRI = False
-    else:
-        # use:  if input_model.meta.exposure.readpatt.find("IRS2") >= 0
-        shape = input_model.data.shape
-        can_check_for_MIRI = True
-
-    if can_check_for_MIRI and input_model.meta.instrument.name == 'MIRI':
-        max_height = 1032                       # perhaps should use 1024
-    else:
-        max_height = 2048
-
-    y_axis_length = max(shape[-1], shape[-2])
-
-    if y_axis_length > max_height:
-        return True
-    else:
-        return False
-
 def normal_shape(input_model, n=None, r=None, detector=None):
     """Determine the shape of the 'normal' pixel data."""
 
@@ -114,7 +90,7 @@ def normal_shape(input_model, n=None, r=None, detector=None):
         if detector is None:
             detector = input_model.meta.instrument.detector
 
-    if not is_irs2(input_model):                # not IRS2 format
+    if not pipe_utils.is_irs2(input_model):     # not IRS2 format
         return shape
 
     param = _get_irs2_parameters(input_model, n=n, r=r)


### PR DESCRIPTION
For science data, the value of the PATTTYPE keyword will contain "IRS2" if and only if the data were read out using IRS2.  Target acquisition data are never read out using IRS2, but PATTTYPE can still contain "IRS2".  Some but not all tests for IRS2 mode already use the image shape rather than the PATTTYPE keyword.

A new `is_irs2` function has been added to lib/pipe_utils.py, and the nearly identical function of the same name has been removed from the x_irs2.py files in ipc and saturation.  This function returns True if one axis of the input image is larger than 2048 (it will be 3200, for the current IRS2 parameters).  Files in refpix, ipc, and saturation have been modified to call the version of `is_irs2` in lib.