### PR TITLE
Add exptype keywords to new imaging photom data models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,9 @@ datamodels
 - Added new imaging-specific photom reference file data models ``FgsImgPhotomModel``,
   ``MirImgPhotomModel``, ``NrcImgPhotomModel``, and ``NisImgPhotomModel``. [#4052]
 
+- Add EXP_TYPE and P_EXP_TY keywords to new imaging photom reference file
+  data model schemas. [#4068]
+
 exp_to_source
 -------------
 

--- a/jwst/datamodels/schemas/fgsimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/fgsimg_photom.schema.yaml
@@ -1,6 +1,8 @@
 title: FGS photometric flux conversion data model
 allOf:
 - $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
 - $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:

--- a/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -1,6 +1,9 @@
 title: MIRI imaging photometric flux conversion data model
 allOf:
 - $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_band.schema.yaml
 - $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:

--- a/jwst/datamodels/schemas/nisimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nisimg_photom.schema.yaml
@@ -1,6 +1,8 @@
 title: NIRISS imaging photometric flux conversion data model
 allOf:
 - $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
 - $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:

--- a/jwst/datamodels/schemas/nrcimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrcimg_photom.schema.yaml
@@ -1,6 +1,8 @@
 title: NIRCam imaging photometric flux conversion data model
 allOf:
 - $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
 - $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:


### PR DESCRIPTION
#4052 created new data models for imaging-mode photom reference files, in support of JP-1014. That PR, however, forgot to include the CRDS selector keywords - EXP_TYPE, P_EXP_TY, and BAND - the schema, so that they're available in the data models. This PR fixes that omission.

It's likely the case that only the P_EXP_TY keyword is needed in the reference file headers, but it can't hurt to have both EXP_TYPE and P_EXP_TY defined, in case anyone wants to populate EXP_TYPE too.