### PR TITLE
[skip ci] Change to alternative VCS syntax in requirements-sdp.txt

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,5 +1,5 @@
 asdf==2.4.2
-astropy @ git+https://github.com/astropy/astropy@5f7c192
+-e git+https://github.com/astropy/astropy@5f7c192#egg=astropy
 atomicwrites==1.3.0
 attrs==19.1.0
 certifi==2019.9.11
@@ -11,7 +11,7 @@ crds==7.4.1.1
 Cython==0.29.13
 drizzle==1.13.1
 filelock==3.0.12
-gwcs @ git+https://github.com/spacetelescope/gwcs@3e2bc108e
+-e git+https://github.com/spacetelescope/gwcs@3e2bc108e#egg=gwcs
 idna==2.8
 importlib-metadata==0.23
 jsonschema==3.0.2


### PR DESCRIPTION
This simplifies the logic required to create an environment snapshot after regression test runs.