### PR TITLE
Add subarray keyword(s) to new Miri imaging photom model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,9 @@ datamodels
 - Add EXP_TYPE and P_EXP_TY keywords to new imaging photom reference file
   data model schemas. [#4068]
 
+- Add SUBARRAY (and related) keywords to the new MIRI imaging photom reference file
+  data model schema. [#4081]
+
 exp_to_source
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,15 @@ datamodels
 - Add EXP_TYPE and P_EXP_TY keywords to new imaging photom reference file
   data model schemas. [#4068]
 
+- Introduced a flag ``ignore_missing_extensions=True`` to the `DataModel` initializer
+  which is propagated to the ``asdf.open`` function. It allows control over a warning
+  asdf issues when opening files written with an extension version older than the
+  extension version the file was written with. An example message is
+
+  ``asdf/asdf.py:202: UserWarning: File was created with extension
+  'astropy.io.misc.asdf.extension.AstropyAsdfExtension' from package astropy-4.0.dev24515,
+  but older version astropy-3.2.1 is installed``. [#4070]
+
 - Add SUBARRAY (and related) keywords to the new MIRI imaging photom reference file
   data model schema. [#4081]
 

--- a/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -4,6 +4,7 @@ allOf:
 - $ref: keyword_exptype.schema.yaml
 - $ref: keyword_pexptype.schema.yaml
 - $ref: keyword_band.schema.yaml
+- $ref: subarray.schema.yaml
 - $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:


### PR DESCRIPTION
Yet another update to the new MIRI photom ref file data model for imaging mode, to include the subarray-related keywords in the schema, because subarray is used as a CRDS selector for MIRI photom ref files. In continued support of JP-1004 and JP-1014.