### PR TITLE
Jp 1000 Have NRS_MIMF exposures processed as WFS observations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ assign_wcs
 
 associations
 ------------
+- Update association rules so that MIMF exposures are processed as WFS observations [#4034]
+
 - asn_from_list fills the level2  member exptype correctly if the input is a tuple [#2942]
 
 - Update rules to make level 3 associations for slitless LRS mode [#3940]

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -86,6 +86,7 @@ IMAGE2_SCIENCE_EXP_TYPES = [
     'nrc_image',
     'nrc_coron',
     'nrc_tsimage',
+    'nrs_mimf',
 ]
 
 IMAGE2_NONSCIENCE_EXP_TYPES = [
@@ -94,7 +95,6 @@ IMAGE2_NONSCIENCE_EXP_TYPES = [
     'nrc_focus',
     'nrs_focus',
     'nrs_image',
-    'nrs_mimf',
 ]
 IMAGE2_NONSCIENCE_EXP_TYPES.extend(ACQ_EXP_TYPES)
 

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -707,6 +707,7 @@ class Constraint_Image(DMSAttrConstraint):
                 '|mir_image'
                 '|nis_image'
                 '|fgs_image'
+                '|nrs_mimf'
             ),
         )
 

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -39,7 +38,6 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
-        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -38,6 +39,7 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
+        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1


### PR DESCRIPTION
Updated rules to have NRS_MIMF exposures processed as WFSC data. The unit tests pass, 
```
pytest ~/src/JWST/scsb/jwst/jwst/associations/tests/ | tee ASN_unittests_Sept30.log
...
-- Docs: https://docs.pytest.org/en/latest/warnings.html
== 133 passed, 2 xfailed, 1 warnings in 395.83s (0:06:35) ==========
```
The regression tests will need truth file updates. 
`====== 3 failed, 103 passed, 14 skipped, 2 xfailed in 2497.03s (0:41:37) =======
`
There are 88 total files to be updated, mainly removing the image2 associations and replacing them with the wfs-image2 and adding the wfs-image3 products for programs jw00629 & jw84600. Example files for jw00629-o004 are shown, 

jw00629-o004_wfs-image2_001_asn.json
```
{
    "asn_type": "wfs-image2",
    "asn_rule": "candidate_Asn_Lv2WFSC",
    "version_id": null,
    "code_version": "0.13.8a.dev219+gda0603d2",
    "degraded_status": "No known degraded exposures in association.",
    "program": "00629",
    "target": "1",
    "asn_pool": "jw00629_20190605t025157_pool",
    "constraints": "DMSAttrConstraint({'name': 'program', 'sources': ['program'], 'value': '629'})\nDMSAttrConstraint({'name': 'is_tso', 'sources': ['tsovisit'], 'value': None})\nConstraint_Image_Science({'name': 'exp_type', 'sources': ['exp_type'], 'value': 'nrc_image'})\nConstraint_Single_Science({'name': 'single_science', 'value': False})\nDMSAttrConstraint({'name': 'exp_type', 'sources': ['exp_type'], 'value': 'nis_extcal'})\nDMSAttrConstraint({'name': 'wfsc', 'sources': ['visitype'], 'value': 'prime_wfsc_sensing_only'})\nDMSAttrConstraint({'name': 'asn_candidate', 'sources': ['asn_candidate'], 'value': \"\\\\('o004',\\\\ 'observation'\\\\)\"})",
    "asn_id": "o004",
    "products": [
        {
            "name": "jw00629004001_02101_00002_nrcblong",
            "members": [
                {
                    "expname": "jw00629004001_02101_00002_nrcblong_rate.fits",
                    "exptype": "science",
                    "exposerr": "null"
                }
            ]
        }
    ]
}
```

jw00629-o004_wfs-image3_001_asn.json

```{
    "asn_type": "wfs-image3",
    "asn_rule": "candidate_Asn_WFSCMB",
    "version_id": null,
    "code_version": "0.13.8a.dev219+gda0603d2",
    "degraded_status": "No known degraded exposures in association.",
    "program": "00629",
    "constraints": "DMSAttrConstraint({'name': 'program', 'sources': ['program'], 'value': '629'})\nDMSAttrConstraint({'name': 'instrument', 'sources': ['instrume'], 'value': 'nircam'})\nDMSAttrConstraint({'name': 'opt_elem', 'sources': ['filter'], 'value': 'f480m'})\nDMSAttrConstraint({'name': 'opt_elem2', 'sources': ['pupil'], 'value': 'clear'})\nDMSAttrConstraint({'name': 'opt_elem3', 'sources': ['fxd_slit'], 'value': None})\nDMSAttrConstraint({'name': 'subarray', 'sources': ['subarray'], 'value': 'full'})\nConstraint_Target({'name': 'target', 'sources': ['targetid'], 'value': '1'})\nConstraint_Image({'name': 'exp_type', 'sources': ['exp_type'], 'value': 'nrc_image'})\nDMSAttrConstraint({'name': 'patttype', 'sources': ['patttype'], 'value': 'wfsc'})\nDMSAttrConstraint({'name': 'detector', 'sources': ['detector'], 'value': 'nrcblong'})\nDMSAttrConstraint({'name': 'obs_id', 'sources': ['obs_id'], 'value': 'v00629004001p0000000002101'})\nDMSAttrConstraint({'name': 'act_id', 'sources': ['act_id'], 'value': '01'})\nConstraint_Obsnum({'name': 'obs_num', 'sources': ['obs_num'], 'value': None})\nDMSAttrConstraint({'name': 'acq_exp', 'sources': ['exp_type'], 'value': 'mir_tacq|nis_taconfirm|nis_tacq|nrc_taconfirm|nrc_tacq|nrs_confirm|nrs_msata|nrs_taconfirm|nrs_tacq|nrs_taslit|nrs_wata'})\nDMSAttrConstraint({'name': 'acq_obsnum', 'sources': ['obs_num'], 'value': <function AsnMixin_Science.__init__.<locals>.<lambda> at 0x1197e9710>})\nDMSAttrConstraint({'name': 'asn_candidate', 'sources': ['asn_candidate'], 'value': \"\\\\('o004',\\\\ 'observation'\\\\)\"})",
    "asn_id": "o004",
    "target": "t001",
    "asn_pool": "jw00629_20190605t025157_pool",
    "products": [
        {
            "name": "jw00629-o004_t001_nircam_clear-f480m-nrcblong_{suffix}-01",
            "members": [
                {
                    "expname": "jw00629004001_02101_00002_nrcblong_cal.fits",
                    "exptype": "science",
                    "exposerr": "null",
                    "asn_candidate": "('o004', 'observation')"
                },
                {
                    "expname": "jw00629004001_02101_00001_nrcblong_cal.fits",
                    "exptype": "science",
                    "exposerr": "null",
                    "asn_candidate": "('o004', 'observation')"
                }            ]
        }
    ]
}```


