### PR TITLE
Ignore src dir for git and pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ pip-wheel-metadata/
 .pydevproject
 .vscode
 *code-workspace
-src/launch.json
+src/
 scripts/launch.json
 *.orig
 .ipynb_checkpoints

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - NUMPY_VERSION=1.16
+    - NUMPY_VERSION=1.17
     - TEST_COMMAND='pytest --cov=./'
 
 matrix:
@@ -31,6 +31,12 @@ matrix:
     # Test with python 3.7
     - python: 3.7
       env: PIP_DEPENDENCIES='.[test]'
+
+    # Test with numpy 1.16
+    - env: NUMPY_VERSION=1.16
+
+    # Test with SDP pinned dependencies
+    - env: PIP_DEPENDENCIES='-r requirements-sdp.txt .'
 
     # Test with dev dependencies
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
 
     # Test with numpy 1.16
     - env: NUMPY_VERSION=1.16
+           PIP_DEPENDENCIES='.[test]'
 
     # Test with SDP pinned dependencies
     - env: PIP_DEPENDENCIES='-r requirements-sdp.txt .'

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ ignore = E203, W503, W504, W605
 
 [tool:pytest]
 minversion = 3.6
-norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern scripts
+norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern scripts src
 asdf_schema_tests_enabled = true
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 doctest_plus = enabled


### PR DESCRIPTION
If our `requirements-sdp.txt` file contains editable installs of dependencies, `pip` installs those into a local `src` dir within the `jwst` package.  This can mess up pytest's test discovery.  So we should ignore this directory.

Closes #4073 