### PR TITLE
JP-1032: Update spectroscopic photom data models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,6 +109,7 @@ datamodels
   'astropy.io.misc.asdf.extension.AstropyAsdfExtension' from package astropy-4.0.dev24515,
   but older version astropy-3.2.1 is installed``. [#4070]
 
+- Added new spectroscopic mode photom reference file data models. [#4096]
 
 exp_to_source
 -------------

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -41,9 +41,13 @@ from .nirspec_flat import NirspecFlatModel, NirspecQuadFlatModel
 from .outlierpars import OutlierParsModel
 from .pathloss import PathlossModel
 from .persat import PersistenceSatModel
-from .photom import PhotomModel, FgsPhotomModel, FgsImgPhotomModel, NircamPhotomModel, NrcImgPhotomModel
-from .photom import NirissPhotomModel, NisImgPhotomModel, NirspecPhotomModel, NirspecFSPhotomModel
-from .photom import MiriImgPhotomModel, MirImgPhotomModel, MiriMrsPhotomModel
+from .photom import PhotomModel, FgsPhotomModel, FgsImgPhotomModel
+from .photom import MiriImgPhotomModel, MirImgPhotomModel, MirLrsPhotomModel
+from .photom import MiriMrsPhotomModel, MirMrsPhotomModel
+from .photom import NircamPhotomModel, NrcImgPhotomModel, NrcWfssPhotomModel
+from .photom import NirissPhotomModel, NisImgPhotomModel, NisSossPhotomModel, NisWfssPhotomModel
+from .photom import NirspecPhotomModel, NirspecFSPhotomModel
+from .photom import NrsFsPhotomModel, NrsMosPhotomModel
 from .pixelarea import PixelAreaModel, NirspecSlitAreaModel, NirspecMosAreaModel, NirspecIfuAreaModel
 from .psfmask import PsfMaskModel
 from .quad import QuadModel
@@ -103,9 +107,13 @@ __all__ = [
     'PathlossModel',
     'PersistenceSatModel',
     'PixelAreaModel', 'NirspecSlitAreaModel', 'NirspecMosAreaModel', 'NirspecIfuAreaModel',
-    'PhotomModel', 'FgsPhotomModel', 'FgsImgPhotomModel', 'MiriImgPhotomModel', 'MirImgPhotomModel', 'MiriMrsPhotomModel',
-    'NircamPhotomModel', 'NrcImgPhotomModel', 'NirissPhotomModel', 'NisImgPhotomModel',
+    'PhotomModel', 'FgsPhotomModel', 'FgsImgPhotomModel',
+    'MiriImgPhotomModel', 'MirImgPhotomModel', 'MirLrsPhotomModel',
+    'MiriMrsPhotomModel', 'MirMrsPhotomModel',
+    'NircamPhotomModel', 'NrcImgPhotomModel', 'NrcWfssPhotomModel',
+    'NirissPhotomModel', 'NisImgPhotomModel', 'NisSossPhotomModel', 'NisWfssPhotomModel',
     'NirspecPhotomModel', 'NirspecFSPhotomModel',
+    'NrsFsPhotomModel', 'NrsMosPhotomModel',
     'PsfMaskModel',
     'QuadModel', 'RampModel', 'MIRIRampModel',
     'RampFitOutputModel', 'ReadnoiseModel',

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -62,6 +62,32 @@ class NrcImgPhotomModel(ReferenceFileModel):
     schema_url = "nrcimg_photom.schema"
 
 
+class NrcWfssPhotomModel(ReferenceFileModel):
+    """
+    A data model for NIRCam WFSS photom reference files.
+
+    Parameters
+    __________
+    phot_table : numpy table
+        Photometric flux conversion factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and photometric conversion
+        factors associated with those modes.
+
+        - filter: str[12]
+        - pupil: str[15]
+        - order: int16
+        - photmjsr: float32
+        - uncertainty: float32
+        - nelem: int16
+        - wavelength: float32[*]
+        - relresponse: float32[*]
+        - reluncertainty: float32[*]
+
+    """
+    schema_url = "nrcwfss_photom.schema"
+
+
 class NirissPhotomModel(PhotomModel):
     """
     A data model for NIRISS photom reference files.
@@ -108,6 +134,59 @@ class NisImgPhotomModel(ReferenceFileModel):
     schema_url = "nisimg_photom.schema"
 
 
+class NisWfssPhotomModel(ReferenceFileModel):
+    """
+    A data model for NIRISS WFSS photom reference files.
+
+    Parameters
+    __________
+    phot_table : numpy table
+        Photometric flux conversion factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and photometric conversion
+        factors associated with those modes.
+
+        - filter: str[12]
+        - pupil: str[15]
+        - order: int16
+        - photmjsr: float32
+        - uncertainty: float32
+        - nelem: int16
+        - wavelength: float32[*]
+        - relresponse: float32[*]
+        - reluncertainty: float32[*]
+
+    """
+    schema_url = "niswfss_photom.schema"
+
+
+class NisSossPhotomModel(ReferenceFileModel):
+    """
+    A data model for NIRISS SOSS photom reference files.
+
+    Parameters
+    __________
+    phot_table : numpy table
+        Photometric flux conversion factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and photometric conversion
+        factors associated with those modes.
+
+        - filter: str[12]
+        - pupil: str[15]
+        - order: int16
+        - srctype: str[15]
+        - photcorr: float32
+        - uncertainty: float32
+        - nelem: int16
+        - wavelength: float32[*]
+        - relresponse: float32[*]
+        - reluncertainty: float32[*]
+
+    """
+    schema_url = "nissoss_photom.schema"
+
+
 class NirspecPhotomModel(PhotomModel):
     """
     A data model for NIRSpec imaging, IFU, and MOS photom reference files.
@@ -131,6 +210,32 @@ class NirspecPhotomModel(PhotomModel):
 
     """
     schema_url = "nirspec_photom.schema"
+
+
+class NrsMosPhotomModel(ReferenceFileModel):
+    """
+    A data model for NIRSpec MOS and IFU photom reference files.
+
+    Parameters
+    __________
+    phot_table : numpy table
+        Photometric flux conversion factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and photometric conversion
+        factors associated with those modes.
+
+        - filter: str[12]
+        - grating: str[15]
+        - srctype: str[15]
+        - photcorr: float32
+        - uncertainty: float32
+        - nelem: int16
+        - wavelength: float32[*]
+        - relresponse: float32[*]
+        - reluncertainty: float32[*]
+
+    """
+    schema_url = "nrsmos_photom.schema"
 
 
 class NirspecFSPhotomModel(PhotomModel):
@@ -160,6 +265,33 @@ class NirspecFSPhotomModel(PhotomModel):
 
     def __init__(self, init=None, **kwargs):
         super(NirspecFSPhotomModel, self).__init__(init=init, **kwargs)
+
+
+class NrsFsPhotomModel(ReferenceFileModel):
+    """
+    A data model for NIRSpec Fixed-Slit photom reference files.
+
+    Parameters
+    __________
+    phot_table : numpy table
+        Photometric flux conversion factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and photometric conversion
+        factors associated with those modes.
+
+        - filter: str[12]
+        - grating: str[15]
+        - slit: str[15]
+        - srctype: str[15]
+        - photcorr: float32
+        - uncertainty: float32
+        - nelem: int16
+        - wavelength: float32[*]
+        - relresponse: float32[*]
+        - reluncertainty: float32[*]
+
+    """
+    schema_url = "nrsfs_photom.schema"
 
 
 class MiriImgPhotomModel(PhotomModel):
@@ -208,7 +340,68 @@ class MirImgPhotomModel(ReferenceFileModel):
     schema_url = "mirimg_photom.schema"
 
 
+class MirLrsPhotomModel(ReferenceFileModel):
+    """
+    A data model for MIRI LRS photom reference files.
+
+    Parameters
+    __________
+    phot_table : numpy table
+        Photometric flux conversion factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and photometric conversion
+        factors associated with those modes.
+
+       - filter: str[12]
+       - subarray: str[15]
+       - photmjsr: float32
+       - uncertainty: float32
+       - nelem: int16
+       - wavelength: float32[*]
+       - relresponse: float32[*]
+       - reluncertainty: float32[*]
+
+    """
+    schema_url = "mirlrs_photom.schema"
+
+
 class MiriMrsPhotomModel(PhotomModel):
+    """
+    A data model for MIRI MRS photom reference files.
+
+    Parameters
+    ----------
+    init : any
+        Any of the initializers supported by `~jwst.datamodels.DataModel`.
+
+    data : numpy array
+        An array-like object containing the pixel-by-pixel conversion values
+        in units of DN / sec / mJy / pixel.
+
+    err : numpy array
+        An array-like object containing the uncertainties in the conversion
+        values, in the same units as the data array.
+
+    dq : numpy array
+        An array-like object containing bit-encoded data quality flags,
+        indicating problem conditions for values in the data array.
+
+    dq_def : numpy array
+        A table-like object containing the data quality definitions table.
+
+    pixsiz : numpy array
+        An array-like object containing pixel-by-pixel size values, in units of
+        square arcseconds (arcsec^2).
+    """
+    schema_url = "mirimrs_photom.schema"
+
+    def __init__(self, init=None, **kwargs):
+        super(MiriMrsPhotomModel, self).__init__(init=init, **kwargs)
+
+        self.dq = dynamic_mask(self)
+
+
+class MirMrsPhotomModel(ReferenceFileModel):
     """
     A data model for MIRI MRS photom reference files.
 
@@ -239,7 +432,7 @@ class MiriMrsPhotomModel(PhotomModel):
     schema_url = "mirmrs_photom.schema"
 
     def __init__(self, init=None, **kwargs):
-        super(MiriMrsPhotomModel, self).__init__(init=init, **kwargs)
+        super(MirMrsPhotomModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self)
 

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -175,8 +175,7 @@ class NisSossPhotomModel(ReferenceFileModel):
         - filter: str[12]
         - pupil: str[15]
         - order: int16
-        - srctype: str[15]
-        - photcorr: float32
+        - photmj: float32
         - uncertainty: float32
         - nelem: int16
         - wavelength: float32[*]
@@ -226,8 +225,7 @@ class NrsMosPhotomModel(ReferenceFileModel):
 
         - filter: str[12]
         - grating: str[15]
-        - srctype: str[15]
-        - photcorr: float32
+        - photmj: float32
         - uncertainty: float32
         - nelem: int16
         - wavelength: float32[*]
@@ -282,8 +280,7 @@ class NrsFsPhotomModel(ReferenceFileModel):
         - filter: str[12]
         - grating: str[15]
         - slit: str[15]
-        - srctype: str[15]
-        - photcorr: float32
+        - photmj: float32
         - uncertainty: float32
         - nelem: int16
         - wavelength: float32[*]

--- a/jwst/datamodels/schemas/mirimrs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirimrs_photom.schema.yaml
@@ -1,11 +1,8 @@
 title: MIRI MRS photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: photom.schema.yaml
 - $ref: keyword_band.schema.yaml
 - $ref: keyword_photmjsr.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
@@ -1,0 +1,32 @@
+title: MIRI LRS photometric flux conversion data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
+- type: object
+  properties:
+    phot_table:
+      title: Photometric flux conversion factors table
+      fits_hdu: PHOTOM
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: subarray
+        datatype: [ascii, 15]
+      - name: photmjsr
+        datatype: float32
+      - name: uncertainty
+        datatype: float32
+      - name: nelem
+        datatype: int16
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: relresponse
+        datatype: float32
+        ndim: 1
+      - name: reluncertainty
+        datatype: float32
+        ndim: 1
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nissoss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nissoss_photom.schema.yaml
@@ -16,9 +16,7 @@ allOf:
         datatype: [ascii, 15]
       - name: order
         datatype: int16
-      - name: srctype
-        datatype: [ascii, 15]
-      - name: photcorr
+      - name: photmj
         datatype: float32
       - name: uncertainty
         datatype: float32

--- a/jwst/datamodels/schemas/nissoss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nissoss_photom.schema.yaml
@@ -1,0 +1,36 @@
+title: NIRISS SOSS photometric flux conversion data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
+- type: object
+  properties:
+    phot_table:
+      title: Photometric flux conversion factors table
+      fits_hdu: PHOTOM
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: pupil
+        datatype: [ascii, 15]
+      - name: order
+        datatype: int16
+      - name: srctype
+        datatype: [ascii, 15]
+      - name: photcorr
+        datatype: float32
+      - name: uncertainty
+        datatype: float32
+      - name: nelem
+        datatype: int16
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: relresponse
+        datatype: float32
+        ndim: 1
+      - name: reluncertainty
+        datatype: float32
+        ndim: 1
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/niswfss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/niswfss_photom.schema.yaml
@@ -1,0 +1,34 @@
+title: NIRISS WFSS photometric flux conversion data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
+- type: object
+  properties:
+    phot_table:
+      title: Photometric flux conversion factors table
+      fits_hdu: PHOTOM
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: pupil
+        datatype: [ascii, 15]
+      - name: order
+        datatype: int16
+      - name: photmjsr
+        datatype: float32
+      - name: uncertainty
+        datatype: float32
+      - name: nelem
+        datatype: int16
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: relresponse
+        datatype: float32
+        ndim: 1
+      - name: reluncertainty
+        datatype: float32
+        ndim: 1
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrcwfss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrcwfss_photom.schema.yaml
@@ -1,0 +1,34 @@
+title: NIRCam WFSS photometric flux conversion data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
+- type: object
+  properties:
+    phot_table:
+      title: Photometric flux conversion factors table
+      fits_hdu: PHOTOM
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: pupil
+        datatype: [ascii, 15]
+      - name: order
+        datatype: int16
+      - name: photmjsr
+        datatype: float32
+      - name: uncertainty
+        datatype: float32
+      - name: nelem
+        datatype: int16
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: relresponse
+        datatype: float32
+        ndim: 1
+      - name: reluncertainty
+        datatype: float32
+        ndim: 1
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrsfs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrsfs_photom.schema.yaml
@@ -16,9 +16,7 @@ allOf:
         datatype: [ascii, 15]
       - name: slit
         datatype: [ascii, 15]
-      - name: srctype
-        datatype: [ascii, 15]
-      - name: photcorr
+      - name: photmj
         datatype: float32
       - name: uncertainty
         datatype: float32

--- a/jwst/datamodels/schemas/nrsfs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrsfs_photom.schema.yaml
@@ -1,0 +1,36 @@
+title: NIRSpec Fixed-Slit photometric flux conversion data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
+- type: object
+  properties:
+    phot_table:
+      title: Photometric flux conversion factors table
+      fits_hdu: PHOTOM
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: grating
+        datatype: [ascii, 15]
+      - name: slit
+        datatype: [ascii, 15]
+      - name: srctype
+        datatype: [ascii, 15]
+      - name: photcorr
+        datatype: float32
+      - name: uncertainty
+        datatype: float32
+      - name: nelem
+        datatype: int16
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: relresponse
+        datatype: float32
+        ndim: 1
+      - name: reluncertainty
+        datatype: float32
+        ndim: 1
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrsmos_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrsmos_photom.schema.yaml
@@ -1,0 +1,34 @@
+title: NIRSpec MOS and IFU photometric flux conversion data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
+- type: object
+  properties:
+    phot_table:
+      title: Photometric flux conversion factors table
+      fits_hdu: PHOTOM
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: grating
+        datatype: [ascii, 15]
+      - name: srctype
+        datatype: [ascii, 15]
+      - name: photcorr
+        datatype: float32
+      - name: uncertainty
+        datatype: float32
+      - name: nelem
+        datatype: int16
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: relresponse
+        datatype: float32
+        ndim: 1
+      - name: reluncertainty
+        datatype: float32
+        ndim: 1
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrsmos_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrsmos_photom.schema.yaml
@@ -14,9 +14,7 @@ allOf:
         datatype: [ascii, 12]
       - name: grating
         datatype: [ascii, 15]
-      - name: srctype
-        datatype: [ascii, 15]
-      - name: photcorr
+      - name: photmj
         datatype: float32
       - name: uncertainty
         datatype: float32


### PR DESCRIPTION
Baseline version of updated/new spectroscopic mode photom reference file data models, per the specs outlined in JP-1018. The discussion of the specs is not quite finalized, so there may be some further updates before merging.

As with the imaging mode photom data models, a little rearranging of MIRI model class names was necessary to maintain backwards compatibility with the models and reffiles currently in use. The old MIRI MRS model is `MiriMrsPhotomModel`, which uses schema ``mirimrs_photom.schema.yaml``, while the new one is `MirMrsPhotomModel` and uses schema ``mirmrs_photom.schema.yaml`` (note that the only difference in the names is the extra "i" after "Mir" in the old model).

Fixes #4088 