### PR TITLE
Jp 1036 Update number of associations in test_generate to match number after NRS_MIMF fix (JP1000)

### DIFF
--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -39,7 +38,6 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
-        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -38,6 +39,7 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
+        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1

--- a/jwst/tests_nightly/general/associations/test_generate.py
+++ b/jwst/tests_nightly/general/associations/test_generate.py
@@ -12,7 +12,7 @@ def test_generate(full_pool_rules):
     """Run a full sized pool using all rules"""
     pool, rules, pool_fname = full_pool_rules
     asns = generate(pool, rules)
-    assert len(asns) == 98
+    assert len(asns) == 99
     for asn in asns:
         asn_name, asn_store = asn.dump()
         asn_table = load_asn(asn_store)


### PR DESCRIPTION
Update the number of expected associations in nightly tests test_generate from the current 98
to the 99 being created. 