### PR TITLE
Replace RELIC with setuptools_scm

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,3 @@
-include RELIC-INFO
-exclude jwst/version.py
-recursive-include relic *.* *.py
 recursive-include jwst *.fits
 recursive-include jwst *.inc
 recursive-include jwst *.json
@@ -9,6 +6,3 @@ recursive-include jwst *.cfg
 recursive-include jwst *.csv
 recursive-include jwst *.yaml
 recursive-include jwst *.asdf
-prune relic/tests
-prune relic/relic/__pycache__
-prune relic/.git

--- a/jwst/__init__.py
+++ b/jwst/__init__.py
@@ -1,9 +1,19 @@
-try:
-    from .version import * # noqa: F403, F401
-except ImportError:  # Not available for RTD
-    __version_commit__ = 'unknown'
-    __version__ = 'dev'
+import re
 import sys
+from pkg_resources import get_distribution, DistributionNotFound
+
+__version_commit__ = ''
+_regex_git_hash = re.compile(r'.*\+g(\w+)')
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    __version__ = 'dev'
+
+if '+' in __version__:
+    commit = _regex_git_hash.match(__version__).groups()
+    if commit:
+        __version_commit__ = commit
 
 if sys.version_info < (3, 5):
     raise ImportError("JWST requires Python 3.5 and above.")

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -421,7 +421,7 @@ class Step():
             # Mark versions
             for result in results:
                 if isinstance(result, datamodels.DataModel):
-                    result.meta.calibration_software_revision = __version_commit__
+                    result.meta.calibration_software_revision = __version_commit__ or 'RELEASE'
                     result.meta.calibration_software_version = __version__
 
             # Save the output file if one was specified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
-requires = ["setuptools>=38.2.5", "wheel", "numpy"]
+requires = [
+    "setuptools>=38.2.5",
+    "setuptools_scm",
+    "wheel",
+    "numpy",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,14 +22,13 @@ max-line-length = 130
 exclude =
     jwst/extern,
     docs,
-    relic,
     jwst/associations,
     jwst/fits_generator,
 ignore = E203, W503, W504, W605
 
 [tool:pytest]
 minversion = 3.6
-norecursedirs = .eggs build docs/_build relic jwst/timeconversion jwst/extern scripts src
+norecursedirs = .eggs build docs/_build jwst/timeconversion jwst/extern scripts src
 asdf_schema_tests_enabled = true
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 doctest_plus = enabled

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 import os
 import sys
-import pkgutil
 from os.path import basename
-from subprocess import check_call, CalledProcessError
-from setuptools import setup, find_packages, Command
-from setuptools.command.test import test as TestCommand
+from setuptools import setup, find_packages
 from glob import glob
 
 if sys.version_info < (3, 5):
@@ -14,52 +11,20 @@ if sys.version_info < (3, 5):
     sys.exit(error)
 
 
-try:
-    from sphinx.cmd.build import build_main
-    from sphinx.setup_command import BuildDoc
-
-    class BuildSphinx(BuildDoc):
-        """Build Sphinx documentation after compiling C source files"""
-
-        description = 'Build Sphinx documentation'
-
-        user_options = BuildDoc.user_options[:]
-
-        user_options.append(
-            ('keep-going', 'k',
-             'Parses the sphinx output and sets the return code to 1 if there '
-             'are any warnings. Note that this will cause the sphinx log to '
-             'only update when it completes, rather than continuously as is '
-             'normally the case.'))
-
-
-        def initialize_options(self):
-            BuildDoc.initialize_options(self)
-
-        def finalize_options(self):
-            BuildDoc.finalize_options(self)
-
-        def run(self):
-            build_cmd = self.reinitialize_command('build_ext')
-            build_cmd.inplace = 1
-            self.run_command('build_ext')
-            retcode = build_main(['-W', '--keep-going', '-b', 'html', './docs', './docs/_build/html'])
-            if retcode != 0:
-                sys.exit(retcode)
-
-except ImportError:
-    class BuildSphinx(Command):
-        user_options = []
-
-        def initialize_options(self):
-            pass
-
-        def finalize_options(self):
-            pass
-
-        def run(self):
-            print('!\n! Sphinx is not installed!\n!', file=sys.stderr)
-            exit(1)
+def get_transforms_data():
+    # Installs the schema files in jwst/transforms
+    # Because the path to the schemas includes "stsci.edu" they
+    # can't be installed using setuptools.
+    transforms_schemas = []
+    root = os.path.join(NAME, 'transforms', 'schemas')
+    for node, dirs, files in os.walk(root):
+        for fname in files:
+            if fname.endswith('.yaml'):
+                transforms_schemas.append(
+                    os.path.relpath(os.path.join(node, fname), root))
+    # In the package directory, install to the subdirectory 'schemas'
+    transforms_schemas = [os.path.join('schemas', s) for s in transforms_schemas]
+    return transforms_schemas
 
 
 NAME = 'jwst'
@@ -94,78 +59,15 @@ TESTS_REQUIRE = [
     'pytest-cov',
     'codecov',
 ]
-
-def get_transforms_data():
-    # Installs the schema files in jwst/transforms
-    # Because the path to the schemas includes "stsci.edu" they
-    # can't be installed using setuptools.
-    transforms_schemas = []
-    root = os.path.join(NAME, 'transforms', 'schemas')
-    for node, dirs, files in os.walk(root):
-        for fname in files:
-            if fname.endswith('.yaml'):
-                transforms_schemas.append(
-                    os.path.relpath(os.path.join(node, fname), root))
-    # In the package directory, install to the subdirectory 'schemas'
-    transforms_schemas = [os.path.join('schemas', s) for s in transforms_schemas]
-    return transforms_schemas
-
+ENTRY_POINTS = dict(asdf_extensions=['jwst_pipeline = jwst.transforms.jwextension:JWSTExtension',
+                                     'jwst_datamodel = jwst.datamodels.extension:DataModelExtension'])
 
 transforms_schemas = get_transforms_data()
 PACKAGE_DATA['jwst.transforms'] = transforms_schemas
 
-
-class PyTest(TestCommand):
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = [NAME]
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        try:
-            import pytest
-        except ImportError:
-            print('Unable to run tests...')
-            print('To continue, please install "pytest":')
-            print('    pip install pytest')
-            exit(1)
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
-if not pkgutil.find_loader('relic'):
-    relic_local = os.path.exists('relic')
-    relic_submodule = (relic_local and
-                       os.path.exists('.gitmodules') and
-                       not os.listdir('relic'))
-    try:
-        if relic_submodule:
-            check_call(['git', 'submodule', 'update', '--init', '--recursive'])
-        elif not relic_local:
-            check_call(['git', 'clone', 'https://github.com/spacetelescope/relic.git'])
-
-        sys.path.insert(1, 'relic')
-    except CalledProcessError as e:
-        print(e)
-        exit(1)
-
-import relic.release # noqa: E402
-
-version = relic.release.get_info()
-relic.release.write_template(version, NAME)
-
-entry_points = dict(asdf_extensions=['jwst_pipeline = jwst.transforms.jwextension:JWSTExtension',
-                                     'jwst_datamodel = jwst.datamodels.extension:DataModelExtension'])
-
 setup(
     name=NAME,
-    version=version.pep386,
+    use_scm_version=True,
     author='JWST Pipeline developers',
     description='Python library for science observations from the James Webb Space Telescope',
     long_description=('The JWST Data Reduction Pipeline is a Python '
@@ -187,6 +89,9 @@ setup(
     scripts=SCRIPTS,
     packages=find_packages(),
     package_data=PACKAGE_DATA,
+    setup_requires=[
+        'setuptools_scm',
+    ],
     install_requires=[
         'asdf>=2.4',
         'astropy @ git+https://github.com/astropy/astropy@5f7c192#egg=astropy',
@@ -208,9 +113,5 @@ setup(
         'test': TESTS_REQUIRE,
     },
     tests_require=TESTS_REQUIRE,
-    cmdclass={
-        'test': PyTest,
-        'build_sphinx': BuildSphinx
-    },
-    entry_points=entry_points,
+    entry_points=ENTRY_POINTS,
 )


### PR DESCRIPTION
Note: 
I retained `__version_commit__` because `stpipe` stores the value as metadata. When not in development mode (i.e. no `.dev#+gHASH.dDATE` exists in `__version__`), the value is left as an empty string. If the string is empty `stpipe` will emit `RELEASE` instead of `unknown`