### PR TITLE
Fix __version_commit__ regression

### DIFF
--- a/jwst/__init__.py
+++ b/jwst/__init__.py
@@ -13,7 +13,7 @@ except DistributionNotFound:
 if '+' in __version__:
     commit = _regex_git_hash.match(__version__).groups()
     if commit:
-        __version_commit__ = commit
+        __version_commit__ = commit[0]
 
 if sys.version_info < (3, 5):
     raise ImportError("JWST requires Python 3.5 and above.")

--- a/jwst/tests/test_version.py
+++ b/jwst/tests/test_version.py
@@ -1,0 +1,8 @@
+def test_version_is_string():
+    from jwst import __version__
+    assert isinstance(__version__, str)
+
+
+def test_version_commit_is_string():
+    from jwst import __version_commit__
+    assert isinstance(__version_commit__, str)


### PR DESCRIPTION
Fixes the following bug introduced by #4104 :

```
[...]/validate.py:35: ValidationWarning: While validating calibration_software_revision the following error occurred:
  ('5a2e91e3',) is not of type 'string'
  
  Failed validating 'type' in schema:
      {'$schema': 'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema',
       'blend_table': True,
       'fits_keyword': 'CAL_VCS',
       'title': 'Calibration software version control sys number',
       'type': 'string'}
  
  On instance:
      ('5a2e91e3',)
    warnings.warn(errmsg, ValidationWarning)
```
Resolves #4106