### PR TITLE
Store pip `-e` source directory outside of tree

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ bc1 = utils.copy(bc0)
 bc1.name = "stable-deps"
 bc1.env_vars = env_vars
 bc1.build_cmds = [
-    "pip install -e .[test]",
+    "pip install --src=../src -e .[test]",
 ]
 bc1.test_cmds = [
     "pytest --cov=./ -r sx --junitxml=results.xml",
@@ -46,7 +46,7 @@ bc2.nodetype = 'python3.7'
 bc2.name = 'conda-free'
 bc2.env_vars = env_vars
 bc2.build_cmds = [
-    "pip install -e .[test]",
+    "pip install --src=../src -e .[test]",
 ]
 bc2.test_cmds = [
     "pytest --cov=./ -r sx --junitxml=results.xml",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -43,7 +43,7 @@ bc0.conda_packages = [
     "python=${python_version}",
 ]
 bc0.build_cmds = [
-    "pip install -r requirements-sdp.txt -e .[ephem]",
+    "pip install -r requirements-sdp.txt --src=../src -e .[ephem]",
     "pip install pytest-xdist",
 ]
 bc0.test_cmds = [


### PR DESCRIPTION
With any luck this will prevent `coverage` from scanning the source directories created by `pip` under `./src` (by default).