### PR TITLE
improve slit footprint computation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,6 +143,8 @@ extract_2d
 - For NIRCam TSO data, wavelengths are computed and assigned to the
   wavelength attribute. [#3863]
 
+- Improved the computation of ``S_REGION`` of a slit. [#4111]
+
 flat_field
 ----------
 

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -433,8 +433,8 @@ def test_shutter_size_on_sky():
     virtual_corners_x = [-.5, -.5, .5, .5, -.5]
     virtual_corners_y = [-.5, .5, .5, -.5, -.5]
     input_lam = [2e-6] * 5
-    
-    slit2world = wslit.get_transform('slit_frame', 'world')    
+
+    slit2world = wslit.get_transform('slit_frame', 'world')
     ra, dec, lam = slit2world(virtual_corners_x,
                               virtual_corners_y,
                               input_lam)
@@ -446,4 +446,3 @@ def test_shutter_size_on_sky():
     assert sep_x.value < 0.194
     assert sep_y.value > 0.45
     assert sep_y.value < 0.46
-    

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -7,6 +7,8 @@ from numpy.testing.utils import assert_allclose
 from astropy.io import fits
 from astropy.modeling import models as astmodels
 from astropy import wcs as astwcs
+import astropy.units as u
+import astropy.coordinates as coords
 from gwcs import wcs
 from ... import datamodels
 from ...transforms.models import Slit
@@ -408,3 +410,40 @@ def test_open_slits():
 
     slits = nirspec.get_open_slits(model)
     assert len(slits) == 1
+
+
+def test_shutter_size_on_sky():
+    """
+    Test the size of a MOS shutter on sky is ~ .2 x .4 arcsec.
+    """
+    image = create_nirspec_mos_file()
+    model = datamodels.ImageModel(image)
+    msaconfl = get_file_path('msa_configuration.fits')
+
+    model.meta.instrument.msa_metadata_file = msaconfl
+    model.meta.instrument.msa_metadata_id = 12
+
+    refs = create_reference_files(model)
+
+    pipe = nirspec.create_pipeline(model, refs, slit_y_range=(-.5, .5))
+    w = wcs.WCS(pipe)
+    model.meta.wcs = w
+    slit = w.get_transform('slit_frame', 'msa_frame').slits[0]
+    wslit = nirspec.nrs_wcs_set_input(model, slit.name)
+    virtual_corners_x = [-.5, -.5, .5, .5, -.5]
+    virtual_corners_y = [-.5, .5, .5, -.5, -.5]
+    input_lam = [2e-6] * 5
+    
+    slit2world = wslit.get_transform('slit_frame', 'world')    
+    ra, dec, lam = slit2world(virtual_corners_x,
+                              virtual_corners_y,
+                              input_lam)
+    sky = coords.SkyCoord(ra*u.deg, dec*u.deg)
+    sep_x = sky[0].separation(sky[3]).to(u.arcsec)
+    sep_y = sky[0].separation(sky[1]).to(u.arcsec)
+
+    assert sep_x.value > 0.193
+    assert sep_x.value < 0.194
+    assert sep_y.value > 0.45
+    assert sep_y.value < 0.46
+    

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -798,8 +798,10 @@ def compute_footprint_nrs_slit(slit):
     slit : `~jwst.datamodels.SlitModel`
     """
     slit2world = slit.meta.wcs.get_transform("slit_frame", "world")
+    # Define the corners of a virtual slit. The center of the slit is (0, 0).
     virtual_corners_x = [-.5, -.5, .5, .5]
     virtual_corners_y = [slit.slit_ymin, slit.slit_ymax, slit.slit_ymax, slit.slit_ymin]
+    # Use a default wavelength or 2 microns as input to the transform.
     input_lam = [2e-6] * 4
     ra, dec, lam = slit2world(virtual_corners_x,
                               virtual_corners_y,

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -790,6 +790,28 @@ def update_s_region_spectral(model):
     update_s_region_keyword(model, footprint)
 
 
+def compute_footprint_nrs_slit(slit):
+    """ Compute the footprint of a Nirspec slit using the instrument model.
+    
+    Parameters
+    ----------
+    slit : `~jwst.datamodels.SlitModel`
+    """
+    slit2world = slit.meta.wcs.get_transform("slit_frame", "world")
+    virtual_corners_x = [-.5, -.5, .5, .5]
+    virtual_corners_y = [slit.slit_ymin, slit.slit_ymax, slit.slit_ymax, slit.slit_ymin]
+    input_lam = [2e-6] * 4
+    ra, dec, lam = slit2world(virtual_corners_x,
+                              virtual_corners_y,
+                              input_lam)
+    return np.array([ra, dec]).T
+
+
+def update_s_region_nrs_slit(slit):
+    footprint = compute_footprint_nrs_slit(slit)
+    update_s_region_keyword(slit, footprint)
+    
+
 def update_s_region_keyword(model, footprint):
     """ Update the S_REGION keyword.
     """

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -792,7 +792,7 @@ def update_s_region_spectral(model):
 
 def compute_footprint_nrs_slit(slit):
     """ Compute the footprint of a Nirspec slit using the instrument model.
-    
+
     Parameters
     ----------
     slit : `~jwst.datamodels.SlitModel`
@@ -810,7 +810,7 @@ def compute_footprint_nrs_slit(slit):
 def update_s_region_nrs_slit(slit):
     footprint = compute_footprint_nrs_slit(slit)
     update_s_region_keyword(slit, footprint)
-    
+
 
 def update_s_region_keyword(model, footprint):
     """ Update the S_REGION keyword.

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -73,7 +73,7 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
                                                         exp_type, apply_wavecorr, reffile)
         set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi)
         orig_s_region = output_model.meta.wcsinfo.s_region.strip()
-        util.update_s_region_spectral(output_model)
+        util.update_s_region_nrs_slit(output_model)
         if orig_s_region != output_model.meta.wcsinfo.s_region.strip():
             log.info('extract_2d updated S_REGION to '
                      '{0}'.format(output_model.meta.wcsinfo.s_region))
@@ -87,13 +87,14 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
 
             slits.append(new_model)
             orig_s_region = new_model.meta.wcsinfo.s_region.strip()
-            util.update_s_region_spectral(new_model)
-            if orig_s_region != new_model.meta.wcsinfo.s_region.strip():
-                log.info('extract_2d updated S_REGION to {0}'.format(new_model.meta.wcsinfo.s_region))
             # set x/ystart values relative to the image (screen) frame.
             # The overall subarray offset is recorded in model.meta.subarray.
             set_slit_attributes(new_model, slit, xlo, xhi, ylo, yhi)
 
+            util.update_s_region_nrs_slit(new_model)
+            if orig_s_region != new_model.meta.wcsinfo.s_region.strip():
+                log.info('extract_2d updated S_REGION to {0}'.format(new_model.meta.wcsinfo.s_region))
+            
             # Copy BUNIT values to output slit
             new_model.meta.bunit_data = input_model.meta.bunit_data
             new_model.meta.bunit_err = input_model.meta.bunit_err
@@ -164,6 +165,9 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
     output_model.ystart = ylo + 1 # FITS 1-indexed
     output_model.ysize = (yhi - ylo)
     output_model.source_id = int(slit.source_id)
+    output_model.slit_ymin = slit.ymin
+    output_model.slit_ymax = slit.ymax
+    log.info('slit.ymin {}'.format(slit.ymin))
     if output_model.meta.exposure.type.lower() in ['nrs_msaspec', 'nrs_autoflat']:
         #output_model.source_id = int(slit.source_id)
         output_model.source_name = slit.source_name

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -94,7 +94,7 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
             util.update_s_region_nrs_slit(new_model)
             if orig_s_region != new_model.meta.wcsinfo.s_region.strip():
                 log.info('extract_2d updated S_REGION to {0}'.format(new_model.meta.wcsinfo.s_region))
-            
+
             # Copy BUNIT values to output slit
             new_model.meta.bunit_data = input_model.meta.bunit_data
             new_model.meta.bunit_err = input_model.meta.bunit_err


### PR DESCRIPTION
Resolves #3929 

The footprint is computed using the transform from "slit_frame" to "world" .

TODO: 
[x] Verify the order of corners in `S_REGION`
   It looks like th eorder here is correct - clockwise - which means the rest of the footprints are incorrect. I'll open an issue about it.
[ X] Find out what is the best order of corner coordinates for mosviz
   ~After some off-line discussion it's still unclear what mosviz needs. Best if a new ticket is filed for that work.~ Got a confirmation that this is good for mosviz.

This will produce failures in some regression tests.