### PR TITLE
ccd-601 consolidate CRDS imports

### DIFF
--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -30,6 +30,10 @@
 """This module defines functions that connect the core CRDS package to the
 JWST CAL code and STPIPE, tailoring it to work with DATAMODELS as inputs
 and provide results in the forms required by STPIPE.
+
+WARNING:  JWST CAL and CRDS have circular dependencies.  Do not use CRDS imports
+directly in modules other than this crds_client so that dependency order and
+general integration can be managed here.
 """
 
 import re
@@ -37,6 +41,12 @@ import re
 import crds
 from crds.core import config, exceptions, heavy_client, log
 from crds.core import crds_cache_locking
+
+def get_exceptions_module():
+    """Provide external indirect access to the crds.core.exceptions module to
+    alleviate issues with circular dependencies.
+    """
+    return exceptions
 
 # This is really a testing and debug convenience function, and notably now
 # the only place in this module that a direct import of datamodels occurs

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -38,8 +38,6 @@ from . import Step
 from . import crds_client
 from . import log
 
-from crds.core import exceptions
-
 class Pipeline(Step):
     """
     A Pipeline is a way of combining a number of steps together.
@@ -180,6 +178,7 @@ class Pipeline(Step):
         #
         # Now merge any config parameters from the step cfg file
         log.log.info(f'Retrieving pipeline {cls.pars_model.meta.reftype} parameters from CRDS')
+        exceptions = crds_client.get_exceptions_module()
         try:
             ref_file = crds_client.get_reference_file(dataset,
                                                       cls.pars_model.meta.reftype,

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -36,7 +36,6 @@ from ..datamodels import open as dm_open
 from ..lib.class_property import ClassProperty
 from ..lib.suffix import remove_suffix
 
-from crds.core import exceptions
 class Step():
     """
     Step
@@ -716,6 +715,7 @@ class Step():
 
 
         cls.log.info(f'Retrieving step {cls.pars_model.meta.reftype} parameters from CRDS')
+        exceptions = crds_client.get_exceptions_module()
         try:
             ref_file = crds_client.get_reference_file(dataset,
                                                       cls.pars_model.meta.reftype,


### PR DESCRIPTION
Consolidated all direct imports of CRDS modules in the jwst.stpipe.crds_client.   Imports of the crds.core.exceptions module were deferred/delayed behind the crds_client.get_exceptions_module() getter function.
This helps manage the import order of circular CAL and CRDS imports.
The imports are circular due to the CAL dependence on CRDS for best refererences,  and the CRDS dependence on CAL for datamodels support.
