### PR TITLE
Add BAND keyword to MirLrsPhotomModel

### DIFF
--- a/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
@@ -3,6 +3,7 @@ allOf:
 - $ref: referencefile.schema.yaml
 - $ref: keyword_exptype.schema.yaml
 - $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_band.schema.yaml
 - $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:


### PR DESCRIPTION
Initial version of the new `MirLrsPhotomModel` data model schema was missing the ``BAND`` keyword, which is needed as a CRDS selector for all MIRI photom reference files. Added it to ``mirlrs_photom.schema``.