### PR TITLE
JP-1054: Fix mistake in calwebb_spec2 docs

### DIFF
--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -77,7 +77,7 @@ The instrument mode abbreviations used in the table are as follows:
 :sup:`1`\ Note that for NIRISS and NIRCam WFSS, as well as NIRCam TSO grism exposures,
 the order of the :ref:`extract_2d <extract_2d_step>` and :ref:`flat_field <flatfield_step>`
 steps is reversed: :ref:`flat_field <flatfield_step>` is performed first, then
-:ref:`background <background_step>`.
+:ref:`extract_2d <extract_2d_step>`.
 
 The :ref:`resample_spec <resample_step>` step produces a resampled/rectified product for
 non-IFU modes of some spectroscopic exposures. If the :ref:`resample_spec <resample_step>` step


### PR DESCRIPTION
Changed the comment about the order of the `extract_2d` and `flat-field` steps to remove the mistaken reference to the `background` step.