### PR TITLE
Use python 3.7 in regtest builds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 
 - Remove ``jwpsf`` module. [#3791]
 
+- Update dependencies ``python>=3.6`` and ``numpy>=1.16``. [#4134]
+
 assign_wcs
 ----------
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -10,7 +10,7 @@ jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
 
 // Define python version for conda
-python_version = '3.6'
+python_version = "3.7.2"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
@@ -38,7 +38,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'stable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '4.6.14'
+bc0.conda_ver = '4.7.12'
 bc0.conda_packages = [
     "python=${python_version}",
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -10,7 +10,7 @@ jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
 
 // Define python version for conda
-python_version = "3.7.2"
+python_version = "3.7.4"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -34,7 +34,7 @@ requests-mock==1.7.0
 scipy==1.3.1
 semantic-version==2.6.0
 six==1.12.0
-spherical-geometry==1.2.17
+spherical-geometry==1.2.18
 stsci.image==2.3.3
 stsci.imagestats==1.6.2
 stsci.stimage==0.2.4

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,6 @@ from os.path import basename
 from setuptools import setup, find_packages
 from glob import glob
 
-if sys.version_info < (3, 5):
-    error = """
-    Beginning with JWST 0.9, Python 3.5 and above is required.
-    """
-    sys.exit(error)
-
 
 def get_transforms_data():
     # Installs the schema files in jwst/transforms
@@ -85,7 +79,7 @@ setup(
         'Programming Language :: C',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     scripts=SCRIPTS,
     packages=find_packages(),
     package_data=PACKAGE_DATA,
@@ -99,7 +93,7 @@ setup(
         'drizzle>=1.13',
         'gwcs @ git+https://github.com/spacetelescope/gwcs@3e2bc108e#egg=gwcs',
         'jsonschema>=2.3,<4',
-        'numpy>=1.13',
+        'numpy>=1.16',
         'photutils>=0.7',
         'scipy>=1.0',
         'spherical-geometry>=1.2',


### PR DESCRIPTION
In addition, `setup.py` has been updated to requiring:

`python>=3.6` <- an astropy requirement
`numpy>=1.16`

Resolves #4124 