### PR TITLE
jp-1024 Fix config_file merging bug in Step.call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -222,6 +222,9 @@ stpipe
 
 - Change properties ``Step.pars`` and ``Step.pars_model`` to methods. [#4117]
 
+- Fix bug in ``Step.call()`` where a config file referencing another config
+  file was not merged into the final spec properly. [#4161]
+
 tso_photometry
 --------------
 

--- a/jwst/stpipe/config_parser.py
+++ b/jwst/stpipe/config_parser.py
@@ -190,7 +190,7 @@ def load_spec_file(cls, preserve_comments=False):
     Returns
     -------
     spec_file: ConfigObj
-        The resulting configuration objection.
+        The resulting configuration object
     """
     # Don't use 'hasattr' here, because we don't want to inherit spec
     # from the base class.

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -531,19 +531,23 @@ class Step():
             crds_config = cls.get_config_from_reference(filename)
         else:
             log_cls.info("No filename given, cannot retrieve config from CRDS")
-            crds_config = {}
+            crds_config = config_parser.ConfigObj()
         if 'config_file' in kwargs:
             config_file = kwargs['config_file']
             del kwargs['config_file']
             config_from_file = config_parser.load_config_file(config_file)
-            crds_config.update(config_from_file)
+            config_parser.merge_config(crds_config, config_from_file)
+        else:
+            config_file = None
 
         crds_config.update(kwargs)
 
         if 'class' in crds_config:
             del crds_config['class']
 
-        instance = cls(**crds_config)
+        name = crds_config.get('name', None)
+        instance = cls.from_config_section(crds_config,
+            name=name, config_file=config_file)
 
         try:
             instance._pars_model = crds_config.pars_model
@@ -710,7 +714,6 @@ class Step():
         """
         # Create a new logger for this step
         cls.log = log.getLogger('step')
-
         cls.log.setLevel(log.logging.DEBUG)
 
         pars_model = cls.get_pars_model()

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -56,9 +56,7 @@ class MakeListStep(Step):
 
     spec = """
     par1 = float() # Control the frobulization
-
     par2 = string() # Reticulate the splines
-
     par3 = boolean(default=False) # Does it blend?
     """
 
@@ -181,7 +179,7 @@ class StepWithModel(Step):
 
 
 class ProperPipeline(Pipeline):
-    """Pipeline with proper output setupt"""
+    """Pipeline with proper output setup"""
 
     spec = """
     """
@@ -226,3 +224,17 @@ class SavePipeline(Pipeline):
         r = self.savestep(r)
 
         return r
+
+
+class FooPipeline(Pipeline):
+    """A pipeline that calls MakeListStep"""
+
+    spec = ""
+
+    step_defs = {
+        'make_list': MakeListStep,
+    }
+
+    def process(self, *args):
+
+        return self.make_list(*args)

--- a/jwst/stpipe/tests/steps/foo_pipeline.cfg
+++ b/jwst/stpipe/tests/steps/foo_pipeline.cfg
@@ -1,0 +1,6 @@
+name = "foo_pipeline"
+class = "jwst.stpipe.tests.steps.FooPipeline"
+
+[steps]
+  [[make_list]]
+  config_file = makelist.cfg

--- a/jwst/stpipe/tests/steps/makelist.cfg
+++ b/jwst/stpipe/tests/steps/makelist.cfg
@@ -1,0 +1,5 @@
+name = make_list
+class = jwst.stpipe.tests.steps.MakeListStep
+
+par1 = 43.0
+par2 = "My hovercraft is full of eels."

--- a/jwst/stpipe/tests/test_asdf_parameters.py
+++ b/jwst/stpipe/tests/test_asdf_parameters.py
@@ -5,7 +5,7 @@ import pytest
 from jwst.stpipe.config_parser import ValidationError
 from jwst.stpipe.step import Step
 
-from .steps import MakeListStep
+from .steps import MakeListStep, FooPipeline
 from .util import t_path
 
 DEFAULT_PAR1 = 42.0
@@ -86,6 +86,24 @@ def test_step_from_asdf_api_override():
     )
     results = MakeListStep.call(config_file=config_file, par1=0.)
     assert results == [0., DEFAULT_PAR2, False]
+
+
+def test_makeliststep_call_config_file():
+    """Test override step asdf with .cfg"""
+    config_file = t_path(
+        Path('steps') / 'makelist.cfg'
+    )
+    results = MakeListStep.call(config_file=config_file)
+    assert results == [43.0, 'My hovercraft is full of eels.', False]
+
+
+def test_makeliststep_call_from_within_pipeline():
+    """Test override step asdf with .cfg"""
+    config_file = t_path(
+        Path('steps') / 'foo_pipeline.cfg'
+    )
+    results = FooPipeline.call(config_file=config_file)
+    assert results == [43.0, 'My hovercraft is full of eels.', False]
 
 
 def test_step_from_asdf_noname():


### PR DESCRIPTION
`Step.call()` was using dictionaries to pass along the step configuration to the final `run()` method, but it really needed to use `ConfigObj` so that the nested merging of configs works.  I tried to pattern it after `step_from_cmdline()`.

Resolves #4079 