### PR TITLE
Add python 3.7.4 to SDP TravisCI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: python
-python: 3.6.8
+python: 3.7.4
 
 sudo: false
 #os: linux
@@ -17,7 +17,7 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - NUMPY_VERSION=1.17
+    - NUMPY_VERSION=1.17.2
     - TEST_COMMAND='pytest --cov=./'
 
 matrix:
@@ -25,26 +25,20 @@ matrix:
   fast_finish: true
 
   include:
-    # Run tests
-    - env: PIP_DEPENDENCIES='.[test]'
-
-    # Test with python 3.7
-    - python: 3.7
+    - python: 3.6.8
       env: PIP_DEPENDENCIES='.[test]'
 
-    # Test with numpy 1.16
-    - env: NUMPY_VERSION=1.16
+    - env: PIP_DEPENDENCIES='.[test]'
+
+    - env: NUMPY_VERSION=1.16.0
            PIP_DEPENDENCIES='.[test]'
+      python: 3.6.8
 
     # Test with SDP pinned dependencies
     - env: PIP_DEPENDENCIES='-r requirements-sdp.txt .'
 
     # Test with dev dependencies
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
-
-    # Test with python 3.7 and dev dependencies
-    - python: 3.7
-      env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
 
     # Test with latest delivered CRDS_CONTEXT, as in regressions tests
     - env: CRDS_CONTEXT="jwst-edit"
@@ -60,9 +54,6 @@ matrix:
 
   allow_failures:
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
-
-    - python: 3.7
-      env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
 
     - env: CRDS_CONTEXT="jwst-edit"
            PIP_DEPENDENCIES=".[test]"


### PR DESCRIPTION
- Make `python 3.7.4` our default testing env
- Fix bug that was resulting in wrong version of `numpy` to be used.

For future reference (to my future self) the full semantic version needs to be used with `~=` operator, or else one gets unexpected results:

`pip install numpy~=1.16` will install `numpy==1.17.2`
`pip install numpy~=1.16.0` will install `numpy==1.16.5`