### PR TITLE
jp-1066 Add Step.skip=True for Step.record_step_status()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -225,6 +225,9 @@ stpipe
 - Fix bug in ``Step.call()`` where a config file referencing another config
   file was not merged into the final spec properly. [#4161]
 
+- Set ``Step.skip = True`` in ``Step.record_step_status()`` if
+  ``success == False``. [#4165]
+
 tso_photometry
 --------------
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -1139,8 +1139,7 @@ class Step():
                 # Not a file-checkable object. Ignore.
                 pass
 
-    @staticmethod
-    def record_step_status(datamodel, cal_step, success=True):
+    def record_step_status(self, datamodel, cal_step, success=True):
         """Record whether or not a step completed in meta.cal_step
 
         Parameters
@@ -1158,6 +1157,7 @@ class Step():
             status = 'COMPLETE'
         else:
             status = 'SKIPPED'
+            self.skip = True
 
         if isinstance(datamodel, ModelContainer):
             for model in datamodel:


### PR DESCRIPTION
If `Step.record_step_status()` is called with `success=False`, then also set `Step.skip = True`.

Resolves #4150.