### PR TITLE
JP-1063: Initial version of imaging APCORR ref file models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,10 @@ datamodels
 
 - Added new spectroscopic mode photom reference file data models. [#4096]
 
+- Added new imaging mode aperture correction (apcorr) reference file data
+  models ``FgsImgApcorrModel``, ``MirImgApcorrModel``, ``NrcImgApcorrModel``,
+  and ``NisImgApcorrModel``. [#4168]
+
 exp_to_source
 -------------
 

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -4,6 +4,8 @@ from . import ndmodel
 
 from .model_base import DataModel
 from .amilg import AmiLgModel
+from .apcorr import FgsImgApcorrModel, MirImgApcorrModel
+from .apcorr import NrcImgApcorrModel, NisImgApcorrModel
 from .asn import AsnModel
 from .barshadow import BarshadowModel
 from .combinedspec import CombinedSpecModel
@@ -83,7 +85,9 @@ from .util import open
 __all__ = [
     'open',
     'DataModel',
-    'AmiLgModel', 'AsnModel',
+    'AmiLgModel',
+    'FgsImgApcorrModel', 'MirImgApcorrModel', 'NrcImgApcorrModel', 'NisImgApcorrModel',
+    'AsnModel',
     'BarshadowModel', 'CameraModel', 'CollimatorModel',
     'CombinedSpecModel', 'ContrastModel', 'CubeModel',
     'DarkModel', 'DarkMIRIModel',

--- a/jwst/datamodels/apcorr.py
+++ b/jwst/datamodels/apcorr.py
@@ -1,0 +1,98 @@
+from .reference import ReferenceFileModel
+
+__all__ = ['FgsImgApcorrModel', 'MirImgApcorrModel',
+           'NrcImgApcorrModel', 'NisImgApcorrModel']
+
+
+class FgsImgApcorrModel(ReferenceFileModel):
+    """
+    A data model for FGS imaging apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - eefraction: float32
+        - radius: float32
+        - apcorr: float32
+        - skyin: float32
+        - skyout: float32
+
+    """
+    schema_url = "fgsimg_apcorr.schema"
+
+
+class MirImgApcorrModel(ReferenceFileModel):
+    """
+    A data model for MIRI imaging apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - filter: str[12]
+        - subarray: str[15]
+        - eefraction: float32
+        - radius: float32
+        - apcorr: float32
+        - skyin: float32
+        - skyout: float32
+
+    """
+    schema_url = "mirimg_apcorr.schema"
+
+
+class NrcImgApcorrModel(ReferenceFileModel):
+    """
+    A data model for NIRCam imaging apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - filter: str[12]
+        - pupil: str[15]
+        - eefraction: float32
+        - radius: float32
+        - apcorr: float32
+        - skyin: float32
+        - skyout: float32
+
+    """
+    schema_url = "nrcimg_apcorr.schema"
+
+
+class NisImgApcorrModel(ReferenceFileModel):
+    """
+    A data model for NIRISS imaging apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - filter: str[12]
+        - pupil: str[15]
+        - eefraction: float32
+        - radius: float32
+        - apcorr: float32
+        - skyin: float32
+        - skyout: float32
+
+    """
+    schema_url = "nisimg_apcorr.schema"

--- a/jwst/datamodels/schemas/fgsimg_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/fgsimg_apcorr.schema.yaml
@@ -1,0 +1,22 @@
+title: FGS aperture correction data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: eefraction
+        datatype: float32
+      - name: radius
+        datatype: float32
+      - name: apcorr
+        datatype: float32
+      - name: skyin
+        datatype: float32
+      - name: skyout
+        datatype: float32
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/mirimg_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_apcorr.schema.yaml
@@ -1,0 +1,26 @@
+title: MIRI imaging aperture correction data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: subarray
+        datatype: [ascii, 15]
+      - name: eefraction
+        datatype: float32
+      - name: radius
+        datatype: float32
+      - name: apcorr
+        datatype: float32
+      - name: skyin
+        datatype: float32
+      - name: skyout
+        datatype: float32
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nisimg_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/nisimg_apcorr.schema.yaml
@@ -1,0 +1,26 @@
+title: NIRISS imaging aperture correction data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: pupil
+        datatype: [ascii, 15]
+      - name: eefraction
+        datatype: float32
+      - name: radius
+        datatype: float32
+      - name: apcorr
+        datatype: float32
+      - name: skyin
+        datatype: float32
+      - name: skyout
+        datatype: float32
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrcimg_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/nrcimg_apcorr.schema.yaml
@@ -1,0 +1,26 @@
+title: NIRCam imaging aperture correction data model
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: pupil
+        datatype: [ascii, 15]
+      - name: eefraction
+        datatype: float32
+      - name: radius
+        datatype: float32
+      - name: apcorr
+        datatype: float32
+      - name: skyin
+        datatype: float32
+      - name: skyout
+        datatype: float32
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
New data models for the imaging mode aperture correction reference files, according to the specs provided in JP-1022.

Fixes #4145 