### PR TITLE
JP-1053 Fix bugs in photom

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -200,6 +200,11 @@ photom
 
 - The code was modified to work with the new photom reference files. [#4118]
 
+- Two bugs were fixed.  For NIRSpec IFU data the code was trying to access
+  an attribute of a "slit", but there were no slits for this type of data.
+  For NIRISS extended-source data, the code tried to divide by the pixel
+  area, but the pixel area was undefined.  [#4174]
+
 refpix
 ------
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -665,17 +665,25 @@ class DataSet():
                 else:
                     srctype = self.input.meta.target.source_type
                 if srctype is None or srctype.upper() != 'POINT':
-                    log.debug('Converting conversion factor from flux '
-                              'to surface brightness')
-                    conversion /= slit.meta.photometry.pixelarea_steradians
+                    if slit.meta.photometry.pixelarea_steradians is None:
+                        log.warning("Pixel area is None, so can't convert "
+                                    "flux to surface brightness!")
+                    else:
+                        log.debug("Converting conversion factor from flux "
+                                  "to surface brightness")
+                        conversion /= slit.meta.photometry.pixelarea_steradians
                 else:
                     unit_is_surface_brightness = False
             else:
                 srctype = self.input.meta.target.source_type
                 if srctype is None or srctype.upper() != 'POINT':
-                    log.debug('Converting conversion factor from flux '
-                              'to surface brightness')
-                    conversion /= self.input.meta.photometry.pixelarea_steradians
+                    if self.input.meta.photometry.pixelarea_steradians is None:
+                        log.warning("Pixel area is None, so can't convert "
+                                    "flux to surface brightness!")
+                    else:
+                        log.debug("Converting conversion factor from flux "
+                                  "to surface brightness")
+                        conversion /= self.input.meta.photometry.pixelarea_steradians
                 else:
                     unit_is_surface_brightness = False
 
@@ -846,9 +854,13 @@ class DataSet():
 
             # Copy the pixel area values to the output
             log.debug('PIXAR_SR = %s, PIXAR_A2 = %s', str(area_ster), str(area_a2))
-            if area_a2 is not None:
+            if area_a2 is None:
+                self.input.meta.photometry.pixelarea_arcsecsq = None
+            else:
                 self.input.meta.photometry.pixelarea_arcsecsq = float(area_a2)
-            if area_ster is not None:
+            if area_ster is None:
+                self.input.meta.photometry.pixelarea_steradians = None
+            else:
                 self.input.meta.photometry.pixelarea_steradians = float(area_ster)
 
         pix_area.close()
@@ -912,9 +924,9 @@ class DataSet():
             # There is a slice_id column for selecting a matching slice, but
             # we're just going to average the pixel area for all slices.
             pixel_area = np.nanmean(pixarea)
-            slit.meta.photometry.pixelarea_arcsecsq = pixel_area
-            slit.meta.photometry.pixelarea_steradians = \
-                slit.meta.photometry.pixelarea_arcsecsq * A2_TO_SR
+            self.input.meta.photometry.pixelarea_arcsecsq = pixel_area
+            self.input.meta.photometry.pixelarea_steradians = \
+                self.input.meta.photometry.pixelarea_arcsecsq * A2_TO_SR
 
         else:
             log.warning('EXP_TYPE of NIRSpec data is %s, which is not an '


### PR DESCRIPTION
Function save_area_nirspec failed for NIRSpec IFU data because it was trying to assign a value to slit.meta.photometry.pixelarea_arcsecsq, but when running photom the input is a single 2048x2048 array, i.e. there are no slits.

Function photom_io failed for NIRISS extended-source data.  The conversion factor should be divided by the pixel area, but that value was None.