### PR TITLE
Incorrect model for NRS_BRIGHTOBJ data.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -207,7 +207,7 @@ photom
 
 - NRS_BRIGHTOBJ data were incorrectly treated the same as fixed-slit, but
   the data models are actually not the same.  Also, the logic for pixel area
-  for fixed-slit data was incorrect. [#4178]
+  for fixed-slit data was incorrect. [#4179]
 
 refpix
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,6 +205,10 @@ photom
   For NIRISS extended-source data, the code tried to divide by the pixel
   area, but the pixel area was undefined.  [#4174]
 
+- NRS_BRIGHTOBJ data were incorrectly treated the same as fixed-slit, but
+  the data models are actually not the same.  Also, the logic for pixel area
+  for fixed-slit data was incorrect. [#4178]
+
 refpix
 ------
 


### PR DESCRIPTION
NRS_BRIGHTOBJ data were incorrectly treated the same as fixed-slit, but the data models are actually not the same.  Also, the logic in the function for getting the pixel area for fixed-slit data was incorrect.