### PR TITLE
Mark some tests with xfail

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -241,6 +241,12 @@ stpipe
 - Set ``Step.skip = True`` in ``Step.record_step_status()`` if
   ``success == False``. [#4165]
 
+tests_nightly
+-------------
+
+- Some tests in general/nirspec/ were marked as "expected to fail" because
+  the new reference files are not being selected. [#4180]
+
 tso_photometry
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -207,7 +207,7 @@ photom
 
 - NRS_BRIGHTOBJ data were incorrectly treated the same as fixed-slit, but
   the data models are actually not the same.  Also, the logic for pixel area
-  for fixed-slit data was incorrect. [#4178]
+  for fixed-slit data was incorrect. [#4179]
 
 refpix
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,6 +205,10 @@ photom
   For NIRISS extended-source data, the code tried to divide by the pixel
   area, but the pixel area was undefined.  [#4174]
 
+- NRS_BRIGHTOBJ data were incorrectly treated the same as fixed-slit, but
+  the data models are actually not the same.  Also, the logic for pixel area
+  for fixed-slit data was incorrect. [#4178]
+
 refpix
 ------
 

--- a/jwst/tests_nightly/general/nirspec/test_pipelines.py
+++ b/jwst/tests_nightly/general/nirspec/test_pipelines.py
@@ -38,6 +38,7 @@ class TestNIRSpecPipelines(BaseJWSTTest):
                     ['primary','sci','err','pixeldq','groupdq'])]
         self.compare_outputs(outputs)
 
+    @pytest.mark.xfail
     def test_nrs_fs_brightobj_spec2(self):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec
@@ -59,6 +60,7 @@ class TestNIRSpecPipelines(BaseJWSTTest):
                   ]
         self.compare_outputs(outputs)
 
+    @pytest.mark.xfail
     def test_nrs_msa_spec2(self):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec MSA data.
@@ -87,6 +89,7 @@ class TestNIRSpecPipelines(BaseJWSTTest):
                   ]
         self.compare_outputs(outputs)
 
+    @pytest.mark.xfail
     def test_nrs_msa_spec2b(self):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec MSA data,

--- a/jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
+++ b/jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
@@ -63,6 +63,7 @@ class TestSpec2Pipeline(BaseJWSTTest):
                 ]
             }
 
+    @pytest.mark.xfail
     def test_spec2(self, input, outputs):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec data.


### PR DESCRIPTION
Some NIRSpec regression tests are not passing because the photom reference file is not being found by CRDS, due (in some cases, at least) to a value of USEAFTER that is more recent than the date of observation.