### PR TITLE
Mark a bad NIRSpec reg test as xfail

### DIFF
--- a/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
@@ -145,6 +145,7 @@ class TestNIRSpecWCS(BaseJWSTTest):
 
 
 @pytest.mark.bigdata
+@pytest.mark.xfail
 class TestNIRISSSpec2(BaseJWSTTest):
     input_loc = 'nirspec'
     ref_loc = ['test_pipelines', 'truth']


### PR DESCRIPTION
One more NIRSpec reg test that's failing with differences, because the new NIRSpec photom ref files have a bad USEAFTER date, which is causing the old ref files to get used with the new photom code. Mark as xfail for now, until ref files get fixed.