### PR TITLE
JP-1101: Add python3.8 build to TravisCI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ matrix:
 
     - env: PIP_DEPENDENCIES='.[test]'
 
+    - python: 3.8
+      env: PIP_DEPENDENCIES='.[test]'
+
     - env: NUMPY_VERSION=1.16.0
            PIP_DEPENDENCIES='.[test]'
       python: 3.6.8
@@ -53,6 +56,9 @@ matrix:
            PIP_DEPENDENCIES='flake8'
 
   allow_failures:
+    - python: 3.8
+      env: PIP_DEPENDENCIES='.[test]'
+
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
 
     - env: CRDS_CONTEXT="jwst-edit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: python
-python: 3.7.4
+python: 3.7.5
 
 sudo: false
 #os: linux
@@ -12,12 +12,12 @@ addons:
       - texlive-latex-extra
       - dvipng
       - graphviz
+      - liblapack-dev
 
 env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - NUMPY_VERSION=1.17.3
     - TEST_COMMAND='pytest --cov=./'
 
 matrix:
@@ -33,12 +33,12 @@ matrix:
     - python: 3.8
       env: PIP_DEPENDENCIES='.[test]'
 
-    - env: NUMPY_VERSION=1.16.0
-           PIP_DEPENDENCIES='.[test]'
+    - env: PIP_DEPENDENCIES='numpy~=1.16.0 .[test]'
       python: 3.6.8
 
     # Test with SDP pinned dependencies
     - env: PIP_DEPENDENCIES='-r requirements-sdp.txt .'
+      python: 3.7.4
 
     # Test with dev dependencies
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
@@ -65,7 +65,6 @@ matrix:
            PIP_DEPENDENCIES=".[test]"
 
 install:
-  - pip install numpy~=$NUMPY_VERSION
   - pip install $PIP_DEPENDENCIES
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - NUMPY_VERSION=1.17.2
+    - NUMPY_VERSION=1.17.3
     - TEST_COMMAND='pytest --cov=./'
 
 matrix:


### PR DESCRIPTION
This will be testing `python 3.8` as installed via `venv`.  Right now it is set as an allowed failure.

Resolves #4197