### PR TITLE
Change crds dependency pin from hash to 7.4.1.2 in requirements-sdp.txt

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -7,7 +7,7 @@ chardet==3.0.4
 ci-watson==0.4
 codecov==2.0.15
 coverage==4.5.4
--e git+https://github.com/spacetelescope/crds@7.4.1.2#egg=crds
+crds==7.4.1.2
 Cython==0.29.13
 drizzle==1.13.1
 filelock==3.0.12


### PR DESCRIPTION
Now that this is installable from pypi, we can change this from pointing to the tag on Github to actually being a normal `pip install`.