### PR TITLE
Remove/replace SUBPRISM in unit tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,30 @@ lib
 
 - Updated the EngDB web service url in ``engdb_tools``. [#4187]
 
+photom
+------
+
+- Updated unit tests to use proper names for the MIRI LRS fixedslit
+  subarray. [#4205]
+
 pipeline
 --------
 
 - Updated ``calwebb_spec3`` to allow for processing of non-TSO
   NIRISS SOSS exposures. [#4194]
+
+resample_spec
+-------------
+
+- Updated unit tests for new name of MIRI LRS slitless subarray
+  ('SUBPRISM' -> 'SLITLESSPRISM'). [#4205]
+
+rscd
+----
+
+- Updated to handle science data and reference files that use the old
+  'SUBPRISM' name for the MIRI LRS slitless subarray and update the values
+  to 'SLITLESSPRISM'. [#4205]
 
 tests_nightly
 -------------

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -290,7 +290,7 @@ def create_input(instrument, detector, exptype,
             input_model.var_poisson = np.ones(shape, dtype=np.float32)
             input_model.var_rnoise = np.ones(shape, dtype=np.float32)
             input_model.var_flat = np.ones(shape, dtype=np.float32)
-            input_model.meta.subarray.name = 'SUBPRISM'     # matches 'GENERIC'
+            input_model.meta.subarray.name = 'FULL'
             input_model.meta.target.source_type = 'POINT'
             input_model.meta.photometry.pixelarea_arcsecsq = 0.0025
             input_model.meta.photometry.pixelarea_steradians = 0.0025 * A2_TO_SR
@@ -681,7 +681,7 @@ def create_photom_miri_lrs(min_wl=5.0, max_wl=10.0, min_r=8.0, max_r=9.0):
     """
 
     filter = ["F560W", "P750L", "F1000W"]
-    subarray = ["GENERIC", "GENERIC", "GENERIC"]
+    subarray = ["GENERIC", "FULL", "GENERIC"]
 
     nrows = len(filter)
     nx = 3

--- a/jwst/resample/tests/test_resample_spec.py
+++ b/jwst/resample/tests/test_resample_spec.py
@@ -105,7 +105,7 @@ def test_spatial_transform_miri():
 
     subarray = {
         'fastaxis': 1,
-        'name': 'SUBPRISM',
+        'name': 'SLITLESSPRISM',
         'slowaxis': 2,
         'xsize': 72,
         'xstart': 1,

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -196,7 +196,10 @@ def get_rscd_parameters(input_model, rscd_model):
     readpatt = input_model.meta.exposure.readpatt
     subarray = input_model.meta.subarray.name
 
-#    if subarray == 'SUBPRISM': subarray = 'SLITLESSPRISM'
+    # Check for old values of the MIRI LRS slitless subarray name
+    # in the science data and change to the new
+    if subarray.upper() == 'SUBPRISM': subarray = 'SLITLESSPRISM'
+
     # Load the reference table columns of parameters
     readpatt_table = rscd_model.rscd_table['READPATT']
     subarray_table = rscd_model.rscd_table['SUBARRAY']
@@ -215,6 +218,12 @@ def get_rscd_parameters(input_model, rscd_model):
     sat_mzp_table = rscd_model.rscd_table['SAT_MZP']
     sat_rowterm_table = rscd_model.rscd_table['SAT_ROWTERM']
     sat_scale_table = rscd_model.rscd_table['SAT_SCALE']
+
+    # Check for old values of the MIRI LRS slitless subarray name
+    # in the reference file and change to the new
+    for i in range(len(subarray_table)):
+        if subarray_table[i].upper() == 'SUBPRISM':
+            subarray_table[i] = 'SLITLESSPRISM'
 
     # Find the matching table row index for even row parameters:
     # the match is based on READPATT, SUBARRAY, and row type (even/odd)


### PR DESCRIPTION
MIRI LRS slitless exposures are now coming out of DMS with SUBARRAY='SLITLESSPRISM' instead of the old 'SUBPRISM' value. Most MIRI reference files now use SLITLESSPRISM too. So this excises the use of 'SUBPRISM' from our code base.