### PR TITLE
Update jwst to updated astropy.modeling api

### DIFF
--- a/docs/jwst/assign_wcs/asdf-howto.rst
+++ b/docs/jwst/assign_wcs/asdf-howto.rst
@@ -97,7 +97,7 @@ transforms the spatial coordinates to celestial coordinates and needs to pass th
 with all inputs and the operator is applied to the results, e.g. ``model = m1 + m2 * m3 – m4/m5**m6``
 
 >>> model = shift_x + shift_y
->>> model(1, 1)
+>>> model(1)
     -152.2
 
 Create the reference file
@@ -106,12 +106,13 @@ Create the reference file
 The DictortionModel in jwst.datamodels is used as an example of how to create a reference file. Similarly data models should be used to create other types of reference files as this process provides validaiton of the file structure.
 
 >>> from jwst.datamodels import DistortionModel
+>>>
 >>> dist = DistortionModel(model=model, strict_validation=True)
 >>> dist.meta.description = "New distortion model"
 >>> dist.meta.author = "INS team"
 >>> dist.meta.useafter = "2012/01/21"
 >>> dist.meta.instrument.name = "MIRI"
->>> dist .meta.instrument.detector = "MIRIMAGE"
+>>> dist.meta.instrument.detector = "MIRIMAGE"
 >>> dist.meta.pedigree = "GROUND"
 >>> dist.meta.reftype = "distortion"
 >>> dist.meta.input_units = "pixel"
@@ -128,6 +129,7 @@ Save a transform to an ASDF file
 
 >>> import asdf
 >>> from asdf import AsdfFile
+>>>
 >>> f = AsdfFile()
 >>> f.tree['model'] = model
 >>> f.write_to('reffile.asdf')
@@ -139,7 +141,7 @@ To test the file, it can be read in again using the ``asdf.open()`` function:
 
 >>> ff = asdf.open('reffile.asdf')
 >>> model = ff.tree['model']
->>> model(1, 1)
+>>> model(1)
     -152.2
 
 

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -144,7 +144,7 @@ def test_pointing_averaging(eng_db_jw703):
         3.41404261e-06,  9.99994300e-01, -3.38429548e-03
     ])
     fsmcorr_exp = np.array([-0.02558673, -0.00200601])
-    obstime_exp = Time(1559582740.4880004, format='unix')
+    obstime_exp = Time(1559582740.488000, format='unix')
 
     (q,
      j2fgs_matrix,

--- a/jwst/resample/tests/test_resample_spec.py
+++ b/jwst/resample/tests/test_resample_spec.py
@@ -60,10 +60,9 @@ def test_spatial_transform_nirspec():
         'type': 'NRS_FIXEDSLIT',
         'zero_frame': False}
 
-    im = ImageModel()
+    im = ImageModel((2048, 2048))
     im.data = np.random.rand(2048, 2048)
-    im.error = np.random.rand(2048, 2048)
-    im.dq = np.random.rand(2048, 2048)
+    im.error = np.random.rand(2048, 2048) / 100
 
     im.meta.wcsinfo._instance.update(wcsinfo)
     im.meta.instrument._instance.update(instrument)
@@ -131,10 +130,9 @@ def test_spatial_transform_miri():
         'type': 'MIR_LRS-SLITLESS',
         'zero_frame': False}
 
-    im = ImageModel()
+    im = ImageModel((416, 72))
     im.data = np.random.rand(416, 72)
-    im.error = np.random.rand(416, 72)
-    im.dq = np.random.rand(416, 72)
+    im.error = np.random.rand(416, 72) / 100
 
     im.meta.wcsinfo._instance.update(wcsinfo)
     im.meta.instrument._instance.update(instrument)

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -885,11 +885,27 @@ class V23ToSky(Rotation3D):
     
     def __init__(self, angles, axes_order, name=None):
         super(V23ToSky, self).__init__(angles, axes_order=axes_order, name=name)
-        self.inputs = ("v2", "v3")
+        self._inputs = ("v2", "v3")
         """ ("v2", "v3"): Coordinates in the (V2, V3) telescope frame."""
-        self.outputs = ("ra", "dec")
+        self._outputs = ("ra", "dec")
         """ ("ra", "dec"): RA, DEC cooridnates in ICRS."""
-        
+
+    @property
+    def inputs(self):
+        return self._inputs
+
+    @inputs.setter
+    def inputs(self, val):
+        self._inputs = val
+
+    @property
+    def outputs(self):
+        return self._outputs
+
+    @outputs.setter
+    def outputs(self, val):
+        self._outputs = val
+    
     @staticmethod
     def spherical2cartesian(alpha, delta):
         """

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -163,11 +163,10 @@ class MIRI_AB2Slice(Model):
     """
     standard_broadcasting = False
     _separable = False
-
-    inputs = ("beta",)
-    """ "beta": the beta angle """
-    outputs = ("slice",)
-    """ "slice": Slice number"""
+    fittable = False
+    
+    n_inputs = 1
+    n_outputs = 1
 
     beta_zero = Parameter('beta_zero', default=0)
     """ Beta_zero parameter"""
@@ -175,6 +174,14 @@ class MIRI_AB2Slice(Model):
     """ Beta_del parameter"""
     channel = Parameter("channel", default=1)
     """ MIRI MRS channel: one of 1, 2, 3, 4"""
+
+    def __init__(self, beta_zero, beta_del, channel, **kwargs):
+        super().__init__(beta_zero=beta_zero, beta_del=beta_del,
+                         channel=channel, **kwargs)
+        self.inputs = ("beta",)
+        """ "beta": the beta angle """
+        self.outputs = ("slice",)
+        """ "slice": Slice number"""
 
     @staticmethod
     def evaluate(beta, beta_zero, beta_del, channel):
@@ -211,8 +218,8 @@ class Snell(Model):
     standard_broadcasting = False
     _separable = False
 
-    inputs = ("lam", "alpha_in", "beta_in", "zin")
-    outputs = ("alpha_out", "beta_out", "zout")
+    n_inputs = 4
+    n_outputs = 3
 
     def __init__(self, angle, kcoef, lcoef, tcoef, tref, pref,
                  temperature, pressure, name=None):
@@ -225,6 +232,8 @@ class Snell(Model):
         self.temp = temperature
         self.pressure = pref
         super(Snell, self).__init__(name=name)
+        self.inputs = ("lam", "alpha_in", "beta_in", "zin")
+        self.outputs = ("alpha_out", "beta_out", "zout")
 
     @staticmethod
     def compute_refraction_index(lam, temp, tref, pref, pressure, kcoef, lcoef, tcoef):
@@ -321,14 +330,16 @@ class RefractionIndexFromPrism(Model):
     standard_broadcasting = False
     _separable = False
 
-    inputs = ("alpha_in", "beta_in", "alpha_out",)
-    outputs = ("n")
-
+    n_inputs = 3
+    n_outputs = 1
+    
     prism_angle = Parameter(setter=np.deg2rad, getter=np.rad2deg)
 
     def __init__(self, prism_angle, name=None):
         super(RefractionIndexFromPrism, self).__init__(prism_angle=prism_angle, name=name)
-
+        self.inputs = ("alpha_in", "beta_in", "alpha_out",)
+        self.outputs = ("n",)
+        
     def evaluate(self, alpha_in, beta_in, alpha_out, prism_angle):
         sangle = (math.sin(prism_angle))
         cangle = (math.cos(prism_angle))
@@ -350,19 +361,23 @@ class AngleFromGratingEquation(Model):
     """
 
     _separable = False
-
-    inputs = ("lam", "alpha_in", "beta_in", "z")
-    """ Wavelength and 3 angle coordinates going into the grating."""
-
-    outputs = ("alpha_out", "beta_out", "zout")
-    """ Three angles coming out of the grating. """
+    n_inputs = 4
+    n_outputs = 3
 
     groove_density = Parameter()
     """ Grating ruling density."""
 
     order = Parameter(default=-1)
     """ Spectral order."""
+    
+    def __init__(self, groove_density, order, **kwargs):
+        super().__init__(groove_density=groove_density, order=order, **kwargs)
+        self.inputs = ("lam", "alpha_in", "beta_in", "z")
+        """ Wavelength and 3 angle coordinates going into the grating."""
 
+        self.outputs = ("alpha_out", "beta_out", "zout")
+        """ Three angles coming out of the grating. """
+        
     def evaluate(self, lam, alpha_in, beta_in, z, groove_density, order):
         if alpha_in.shape != beta_in.shape != z.shape:
             raise ValueError("Expected input arrays to have the same shape")
@@ -387,17 +402,21 @@ class WavelengthFromGratingEquation(Model):
     """
 
     _separable = False
-
-    inputs = ("alpha_in", "beta_in", "alpha_out")
-    """ three angle - alpha_in and beta_in going into the grating and alpha_out coming out of the grating."""
-    outputs = ("lam",)
-    """ Wavelength."""
-
+    n_inputs = 3
+    n_outputs = 1
+    
     groove_density = Parameter()
     """ Grating ruling density."""
     order = Parameter(default=1)
     """ Spectral order."""
 
+    def __init__(self, groove_density, order, **kwargs):
+        super().__init__(groove_density=groove_density, order=order, **kwargs)
+        self.inputs = ("alpha_in", "beta_in", "alpha_out")
+        """ three angle - alpha_in and beta_in going into the grating and alpha_out coming out of the grating."""
+        self.outputs = ("lam",)
+        """ Wavelength."""
+        
     def evaluate(self, alpha_in, beta_in, alpha_out, groove_density, order):
         # beta_in is not used in this equation but is here because it's
         # needed for the prism computation. Currently these two computations
@@ -410,10 +429,15 @@ class Unitless2DirCos(Model):
     Transform a vector to directional cosines.
     """
     _separable = False
+    n_inputs = 2
+    n_outputs = 3
 
-    inputs = ('x', 'y')
-    outputs = ('x', 'y', 'z')
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.inputs = ('x', 'y')
+        self.outputs = ('x', 'y', 'z')
 
+    
     def evaluate(self, x, y):
         vabs = np.sqrt(1. + x**2 + y**2)
         cosa = x / vabs
@@ -430,10 +454,14 @@ class DirCos2Unitless(Model):
     Transform directional cosines to vector.
     """
     _separable = False
+    n_inputs = 3
+    n_outputs = 2
 
-    inputs = ('x', 'y', 'z')
-    outputs = ('x', 'y')
-
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.inputs = ('x', 'y', 'z')
+        self.outputs = ('x', 'y')
+        
     def evaluate(self, x, y, z):
 
         return x / z, y / z
@@ -460,8 +488,8 @@ class Rotation3DToGWA(Model):
 
     separable = False
 
-    inputs = ('x', 'y', 'z')
-    outputs = ('x', 'y', 'z')
+    n_inputs = 3
+    n_outputs = 3
 
     angles = Parameter(getter=np.rad2deg, setter=np.deg2rad)
 
@@ -483,6 +511,8 @@ class Rotation3DToGWA(Model):
                           'z': self._zrot
                           }
         super(Rotation3DToGWA, self).__init__(angles, name=name)
+        self.inputs = ('x', 'y', 'z')
+        self.outputs = ('x', 'y', 'z')
 
     @property
     def inverse(self):
@@ -543,9 +573,9 @@ class Rotation3D(Model):
     standard_broadcasting = False
     _separable = False
 
-    inputs = ('x', 'y', 'z')
-    outputs = ('x', 'y', 'z')
-
+    n_inputs = 3
+    n_outputs = 3
+    
     angles = Parameter(getter=np.rad2deg, setter=np.deg2rad)
 
     def __init__(self, angles, axes_order, name=None):
@@ -561,6 +591,9 @@ class Rotation3D(Model):
                               of axes {1}.".format(len(angles),
                                                    len(axes_order)))
         super(Rotation3D, self).__init__(angles, name=name)
+        self.inputs = ('x', 'y', 'z')
+        self.outputs = ('x', 'y', 'z')
+
 
     @property
     def inverse(self):
@@ -648,10 +681,8 @@ class Gwa2Slit(Model):
     """
     _separable = False
 
-    inputs = ('name', 'angle1', 'angle2', 'angle3')
-    """ Name of the slit and the three angle coordinates at the GWA going from detector to sky."""
-    outputs = ('name', 'x_slit', 'y_slit', 'lam')
-    """ Name of the slit, x and y coordinates within the virtual slit and wavelength."""
+    n_inputs = 4
+    n_outputs = 4
 
     def __init__(self, slits, models):
         if isiterable(slits[0]):
@@ -663,6 +694,10 @@ class Gwa2Slit(Model):
 
         self.models = models
         super(Gwa2Slit, self).__init__()
+        self.inputs = ('name', 'angle1', 'angle2', 'angle3')
+        """ Name of the slit and the three angle coordinates at the GWA going from detector to sky."""
+        self.outputs = ('name', 'x_slit', 'y_slit', 'lam')
+        """ Name of the slit, x and y coordinates within the virtual slit and wavelength."""
 
     @property
     def slits(self):
@@ -698,13 +733,15 @@ class Slit2Msa(Model):
     """
     _separable = False
 
-    inputs = ('name', 'x_slit', 'y_slit')
-    """ Name of the slit, x and y coordinates within the virtual slit."""
-    outputs = ('x_msa', 'y_msa')
-    """ x and y coordinates in the MSA frame."""
+    n_inputs = 3
+    n_outputs = 2
 
     def __init__(self, slits, models):
         super(Slit2Msa, self).__init__()
+        self.inputs = ('name', 'x_slit', 'y_slit')
+        """ Name of the slit, x and y coordinates within the virtual slit."""
+        self.outputs = ('x_msa', 'y_msa')
+        """ x and y coordinates in the MSA frame."""
         if isiterable(slits[0]):
             self._slits = [tuple(s) for s in slits]
             self.slit_ids = [s[0] for s in self._slits]
@@ -745,13 +782,16 @@ class NirissSOSSModel(Model):
 
     _separable = False
 
-    inputs = ('x', 'y', 'spectral_order')
-    """ x and y pixel coordinates and spectral order"""
-    outputs = ('ra', 'dec', 'lam')
-    """ RA and DEC coordinates and wavelength"""
+    n_inputs = 3
+    n_outputs = 3
 
     def __init__(self, spectral_orders, models):
         super(NirissSOSSModel, self).__init__()
+        self.inputs = ('x', 'y', 'spectral_order')
+        """ x and y pixel coordinates and spectral order"""
+        self.outputs = ('ra', 'dec', 'lam')
+        """ RA and DEC coordinates and wavelength"""
+        
         self.spectral_orders = spectral_orders
         self.models = dict(zip(spectral_orders, models))
 
@@ -787,9 +827,8 @@ class Logical(Model):
     value : float, ndarray
         Value to substitute where condition is True.
     """
-    inputs = ('x', )
-    outputs = ('x', )
-
+    n_inputs = 1
+    n_outputs = 1
     _separable = False
 
     conditions = {'GT': np.greater,
@@ -803,6 +842,8 @@ class Logical(Model):
         self.compareto = compareto
         self.value = value
         super(Logical, self).__init__(**kwargs)
+        self.inputs = ('x', )
+        self.outputs = ('x', )
 
     def evaluate(self, x):
         x = x.copy()
@@ -839,14 +880,16 @@ class V23ToSky(Rotation3D):
 
     _separable = False
 
-    inputs = ("v2", "v3")
-    """ ("v2", "v3"): Coordinates in the (V2, V3) telescope frame."""
-    outputs = ("ra", "dec")
-    """ ("ra", "dec"): RA, DEC cooridnates in ICRS."""
-
+    n_inputs = 2
+    n_outputs = 2
+    
     def __init__(self, angles, axes_order, name=None):
         super(V23ToSky, self).__init__(angles, axes_order=axes_order, name=name)
-
+        self.inputs = ("v2", "v3")
+        """ ("v2", "v3"): Coordinates in the (V2, V3) telescope frame."""
+        self.outputs = ("ra", "dec")
+        """ ("ra", "dec"): RA, DEC cooridnates in ICRS."""
+        
     @staticmethod
     def spherical2cartesian(alpha, delta):
         """
@@ -896,12 +939,9 @@ class IdealToV2V3(Model):
     Note: This model has no schema implemented - add schema if needed.
     """
     _separable = False
-
-    inputs = ('xidl', 'yidl')
-    """ x and y coordinates in the telescope Ideal frame."""
-    outputs = ('v2', 'v3')
-    """ coorinates in the telescope (V2,V3) frame."""
-
+    n_inputs = 2
+    n_outputs = 2
+    
     v3idlyangle = Parameter() # in deg
     v2ref = Parameter() # in arcsec
     v3ref = Parameter() # in arcsec
@@ -912,6 +952,10 @@ class IdealToV2V3(Model):
         super(IdealToV2V3, self).__init__(v3idlyangle=v3idlyangle, v2ref=v2ref,
                                           v3ref=v3ref, vparity=vparity, name=name,
                                           **kwargs)
+        self.inputs = ('xidl', 'yidl')
+        """ x and y coordinates in the telescope Ideal frame."""
+        self.outputs = ('v2', 'v3')
+        """ coorinates in the telescope (V2,V3) frame."""
 
     @staticmethod
     def evaluate(xidl, yidl, v3idlyangle, v2ref, v3ref, vparity):
@@ -952,10 +996,8 @@ class V2V3ToIdeal(Model):
     """
     _separable = False
 
-    inputs = ('v2', 'v3')
-    """ ('v2', 'v3'): coorinates in the telescope (V2,V3) frame."""
-    outputs = ('xidl', 'yidl')
-    """ ('xidl', 'yidl'): x and y coordinates in the telescope Ideal frame."""
+    n_inputs = 2
+    n_outputs =2
 
     v3idlyangle = Parameter() # in deg
     v2ref = Parameter() # in arcsec
@@ -966,6 +1008,10 @@ class V2V3ToIdeal(Model):
         super(V2V3ToIdeal, self).__init__(v3idlyangle=v3idlyangle, v2ref=v2ref,
                                           v3ref=v3ref, vparity=vparity, name=name,
                                           **kwargs)
+        self.inputs = ('v2', 'v3')
+        """ ('v2', 'v3'): coorinates in the telescope (V2,V3) frame."""
+        self.outputs = ('xidl', 'yidl')
+        """ ('xidl', 'yidl'): x and y coordinates in the telescope Ideal frame."""
 
     @staticmethod
     def evaluate(v2, v3, v3idlyangle, v2ref, v3ref, vparity):
@@ -1055,9 +1101,9 @@ class NIRCAMForwardRowGrismDispersion(Model):
     fittable = False
     linear = False
 
-    inputs = ("x", "y", "x0", "y0", "order")
-    outputs = ("x", "y", "wavelength", "order")
-
+    n_inputs = 5
+    n_outputs = 4
+    
     def __init__(self, orders, lmodels=None, xmodels=None,
                  ymodels=None, name=None, meta=None):
         self.orders = orders
@@ -1070,6 +1116,8 @@ class NIRCAMForwardRowGrismDispersion(Model):
             name = 'nircam_forward_row_grism_dispersion'
         super(NIRCAMForwardRowGrismDispersion, self).__init__(name=name,
                                                               meta=meta)
+        self.inputs = ("x", "y", "x0", "y0", "order")
+        self.outputs = ("x", "y", "wavelength", "order")
 
     def evaluate(self, x, y, x0, y0, order):
         """Return the transform from grism to image for the given spectral order.
@@ -1133,8 +1181,8 @@ class NIRCAMForwardColumnGrismDispersion(Model):
     fittable = False
     linear = False
 
-    inputs = ("x", "y", "x0", "y0", "order")
-    outputs = ("x", "y", "wavelength", "order")
+    n_inputs = 5
+    n_outputs = 4
 
     def __init__(self, orders, lmodels=None, xmodels=None,
                  ymodels=None, name=None, meta=None):
@@ -1148,6 +1196,8 @@ class NIRCAMForwardColumnGrismDispersion(Model):
             name = 'nircam_forward_column_grism_dispersion'
         super(NIRCAMForwardColumnGrismDispersion, self).__init__(name=name,
                                                                  meta=meta)
+        self.inputs = ("x", "y", "x0", "y0", "order")
+        self.outputs = ("x", "y", "wavelength", "order")
 
     def evaluate(self, x, y, x0, y0, order):
         """Return the transform from grism to image for the given spectral order.
@@ -1210,9 +1260,9 @@ class NIRCAMBackwardGrismDispersion(Model):
     fittable = False
     linear = False
 
-    inputs = ("x", "y", "wavelength", "order")
-    outputs = ("x", "y", "x0", "y0", "order")
-
+    n_inputs = 4
+    n_outputs = 5
+    
     def __init__(self, orders, lmodels=None, xmodels=None,
                  ymodels=None, name=None, meta=None):
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
@@ -1225,6 +1275,8 @@ class NIRCAMBackwardGrismDispersion(Model):
             name = "nircam_backward_grism_dispersion"
         super(NIRCAMBackwardGrismDispersion, self).__init__(name=name,
                                                             meta=meta)
+        self.inputs = ("x", "y", "wavelength", "order")
+        self.outputs = ("x", "y", "x0", "y0", "order")
 
     def evaluate(self, x, y, wavelength, order):
         """Return the tranfrom from image to grism for the given spectral order.
@@ -1290,9 +1342,9 @@ class NIRISSBackwardGrismDispersion(Model):
     fittable = False
     linear = False
 
-    inputs = ("x", "y", "wavelength", "order")
-    outputs = ("x", "y", "x0", "y0", "order")
-
+    n_inputs = 4
+    n_outputs = 5
+    
     def __init__(self, orders, lmodels=None, xmodels=None,
                  ymodels=None, theta=None, name=None, meta=None):
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
@@ -1306,6 +1358,8 @@ class NIRISSBackwardGrismDispersion(Model):
             name = 'niriss_backward_grism_dispersion'
         super(NIRISSBackwardGrismDispersion, self).__init__(name=name,
                                                             meta=meta)
+        self.inputs = ("x", "y", "wavelength", "order")
+        self.outputs = ("x", "y", "x0", "y0", "order")
 
     def evaluate(self, x, y, wavelength, order):
         """Return the valid pixel(s) and wavelengths given center x,y and lam
@@ -1388,10 +1442,9 @@ class NIRISSForwardRowGrismDispersion(Model):
     fittable = False
     linear = False
 
-    # starts with the backwards pixel and calculates the forward pixel
-    inputs = ("x", "y", "x0", "y0", "order")
-    outputs = ("x", "y", "wavelength", "order")
-
+    n_inputs = 5
+    n_outputs = 4
+    
     def __init__(self, orders, lmodels=None, xmodels=None,
                  ymodels=None, theta=0., name=None, meta=None):
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
@@ -1405,6 +1458,9 @@ class NIRISSForwardRowGrismDispersion(Model):
             name = 'niriss_forward_row_grism_dispersion'
         super(NIRISSForwardRowGrismDispersion, self).__init__(name=name,
                                                               meta=meta)
+        # starts with the backwards pixel and calculates the forward pixel
+        self.inputs = ("x", "y", "x0", "y0", "order")
+        self.outputs = ("x", "y", "wavelength", "order")
 
     def evaluate(self, x, y, x0, y0, order):
         """Return the valid pixel(s) and wavelengths given center x,y and lam
@@ -1489,9 +1545,8 @@ class NIRISSForwardColumnGrismDispersion(Model):
     fittable = False
     linear = False
 
-    # starts with the backwards pixel and calculates the forward pixel
-    inputs = ("x", "y", "x0", "y0", "order")
-    outputs = ("x", "y", "wavelength", "order")
+    n_inputs = 5
+    n_outputs = 4
 
     def __init__(self, orders, lmodels=None, xmodels=None,
                  ymodels=None, theta=None, name=None, meta=None):
@@ -1506,6 +1561,9 @@ class NIRISSForwardColumnGrismDispersion(Model):
             name = 'niriss_forward_column_grism_dispersion'
         super(NIRISSForwardColumnGrismDispersion, self).__init__(name=name,
                                                                  meta=meta)
+         # starts with the backwards pixel and calculates the forward pixel
+        self.inputs = ("x", "y", "x0", "y0", "order")
+        self.outputs = ("x", "y", "wavelength", "order")
 
     def evaluate(self, x, y, x0, y0, order):
         """Return the valid pixel(s) and wavelengths given center x,y and lam

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-# git+https://github.com/numpy/numpy#egg=numpy
 git+https://github.com/astropy/astropy#egg=astropy
 git+https://github.com/spacetelescope/asdf#egg=asdf
 git+https://github.com/spacetelescope/gwcs#egg=gwcs

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,4 +1,4 @@
-asdf==2.4.2
+-e git+https://github.com/spacetelescope/asdf@1b41c6d04f657940c3fc02443dd3bdfd78619ba8#egg=asdf
 -e git+https://github.com/nden/astropy@11386e2df7af8cd934a6e0483b0ef8657fdd5721#egg=astropy
 atomicwrites==1.3.0
 attrs==19.1.0

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,5 +1,5 @@
 asdf==2.4.2
--e git+https://github.com/astropy/astropy@5f7c192#egg=astropy
+-e git+https://github.com/nden/astropy@11386e2df7af8cd934a6e0483b0ef8657fdd5721#egg=astropy
 atomicwrites==1.3.0
 attrs==19.1.0
 certifi==2019.9.11

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/spacetelescope/asdf@1b41c6d04f657940c3fc02443dd3bdfd78619ba8#egg=asdf
--e git+https://github.com/nden/astropy@11386e2df7af8cd934a6e0483b0ef8657fdd5721#egg=astropy
+-e git+https://github.com/nden/astropy@3d18bde5dc64d1a1c2d1ec7cc3253401b9c32ba6#egg=astropy
 atomicwrites==1.3.0
 attrs==19.1.0
 certifi==2019.9.11

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -11,7 +11,7 @@ crds==7.4.1.2
 Cython==0.29.13
 drizzle==1.13.1
 filelock==3.0.12
--e git+https://github.com/spacetelescope/gwcs@3e2bc108e#egg=gwcs
+-e git+https://github.com/spacetelescope/gwcs@ace1c2c30a658264a15339b2edbea1af32f6adff#egg=gwcs
 idna==2.8
 importlib-metadata==0.23
 jsonschema==3.0.2

--- a/setup.py
+++ b/setup.py
@@ -91,10 +91,10 @@ setup(
     ],
     install_requires=[
         'asdf>=2.4',
-        'astropy @ git+https://github.com/astropy/astropy@5f7c192#egg=astropy',
+        'astropy @ git+https://github.com/nden/astropy@11386e2df7af8',
         'crds>=7.2.7',
         'drizzle>=1.13',
-        'gwcs @ git+https://github.com/spacetelescope/gwcs@3e2bc108e#egg=gwcs',
+        'gwcs @ git+https://github.com/spacetelescope/gwcs@3e2bc108e',
         'jsonschema>=2.3,<4',
         'numpy>=1.16',
         'photutils>=0.7',

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     ],
     install_requires=[
         'asdf @ git+https://github.com/spacetelescope/asdf@1b41c6d04f657',
-        'astropy @ git+https://github.com/nden/astropy@11386e2df7af8',
+        'astropy @ git+https://github.com/nden/astropy@3d18bde5dc64d1a',
         'crds>=7.2.7',
         'drizzle>=1.13',
         'gwcs @ git+https://github.com/spacetelescope/gwcs@ace1c2c30a658',

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         'setuptools_scm',
     ],
     install_requires=[
-        'asdf>=2.4',
+        'asdf @ git+https://github.com/spacetelescope/asdf@1b41c6d04f657',
         'astropy @ git+https://github.com/nden/astropy@11386e2df7af8',
         'crds>=7.2.7',
         'drizzle>=1.13',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         'astropy @ git+https://github.com/nden/astropy@11386e2df7af8',
         'crds>=7.2.7',
         'drizzle>=1.13',
-        'gwcs @ git+https://github.com/spacetelescope/gwcs@3e2bc108e',
+        'gwcs @ git+https://github.com/spacetelescope/gwcs@ace1c2c30a658',
         'jsonschema>=2.3,<4',
         'numpy>=1.16',
         'photutils>=0.7',


### PR DESCRIPTION
This is a fork of 

https://github.com/spacetelescope/jwst/tree/inputs-outputs-transforms

with a couple tests fixed and the dependency hashes in `requirements-sdp.txt` and `setup.py` updated.  Using to see what fails in unit and regression tests.

The astropy URL will need to be changed from `nden/astropy` to `astropy/astropy` with the approriate hash once that bugfix PR is merged into master.

Standard regression test being run on this branch here

https://plwishmaster.stsci.edu:8081/job/RT/job/jdavies-dev/148/