### PR TITLE
JP-1127: Update allowed values for CORONMSK keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.14.1 (Unreleased)
 ===================
 
+datamodels
+----------
+
+- Updated the list of allowed NIRCam CORONMSK values in model schemas. [#4234]
+
 lib
 ---
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -461,10 +461,20 @@ properties:
           coronagraph:
             title: coronagraph mask used
             type: string
-            enum: [4QPM, 4QPM_1065, 4QPM_1140, 4QPM_1550,
-                   LYOT, LYOT_2300,
-                   MASK210R, MASKSWB, MASK335R, MASK430R, MASKLWB,
-                   NONE]
+            anyOf:
+              # MIRI
+              - enum:
+                  [4QPM, 4QPM_1065, 4QPM_1140, 4QPM_1550,
+                   LYOT, LYOT_2300]
+              # NIRCam
+              - enum:
+                  [MASKA210R, MASKA335R, MASKA430R, MASKALWB, MASKASWB]
+              # All
+              - enum:
+                  [NONE]
+              # Obsolete NIRCam
+              - enum:
+                  [MASK210R, MASK335R, MASK430R, MASKLWB, MASKSWB]
             fits_keyword: CORONMSK
             blend_table: True
           msa_state:

--- a/jwst/datamodels/schemas/keyword_coronmsk.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_coronmsk.schema.yaml
@@ -9,9 +9,18 @@ properties:
           coronagraph:
             title: coronagraph mask used
             type: string
-            enum: [4QPM, 4QPM_1065, 4QPM_1140, 4QPM_1550,
-                   LYOT, LYOT_2300,
-                   MASK210R, MASKSWB, MASK335R, MASK430R, MASKLWB,
-                   NONE]
+            anyOf:
+              # MIRI
+              - enum:
+                  [4QPM, 4QPM_1065, 4QPM_1140, 4QPM_1550,
+                   LYOT, LYOT_2300]
+              # NIRCam
+              - enum:
+                  [MASKA210R, MASKA335R, MASKA430R, MASKALWB, MASKASWB]
+              # All
+              - enum:
+                  [NONE]
+              # Obsolete NIRCam
+              - enum:
+                  [MASK210R, MASK335R, MASK430R, MASKLWB, MASKSWB]
             fits_keyword: CORONMSK
-


### PR DESCRIPTION
Added new/modified NIRCam values for the CORONMSK keyword.

Fixes #4233  / JP-1127