### PR TITLE
Streamline environment specification

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -42,8 +42,9 @@ bc0.conda_ver = '4.7.12'
 bc0.conda_packages = [
     "python=${python_version}",
 ]
+bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
-    "pip install -r requirements-sdp.txt --src=../src -e .[ephem]",
+    "pip install -e .[ephem]",
     "pip install pytest-xdist",
 ]
 bc0.test_cmds = [
@@ -60,7 +61,7 @@ bc0.test_configs = [data_config]
 bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-stable-deps'
-bc1.build_cmds = ["pip install -r requirements-sdp.txt -e ."]
+bc1.build_cmds = ["pip install -e ."]
 bc1.test_cmds = []
 bc1.test_configs = []
 

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,5 +1,5 @@
--e git+https://github.com/spacetelescope/asdf@1b41c6d04f65794#egg=asdf
--e git+https://github.com/astropy/astropy@a1c65299b78d402#egg=astropy
+asdf @ git+https://github.com/spacetelescope/asdf@1b41c6d04f65794
+astropy @ git+https://github.com/astropy/astropy@a1c65299b78d402
 atomicwrites==1.3.0
 attrs==19.1.0
 certifi==2019.9.11
@@ -11,7 +11,7 @@ crds==7.4.1.2
 Cython==0.29.13
 drizzle==1.13.1
 filelock==3.0.12
--e git+https://github.com/spacetelescope/gwcs@ace1c2c30a658264a15339b2edbea1af32f6adff#egg=gwcs
+gwcs @ git+https://github.com/spacetelescope/gwcs@ace1c2c30a65826
 idna==2.8
 importlib-metadata==0.23
 jsonschema==3.0.2


### PR DESCRIPTION
* Specify requirements files in `BuildConfigs`.
* Use non-editable installs in requirements file used to populate build environment.

In addition to simplifying the build environment setup, these changes facilitate an improved environment snapshot process provided by https://github.com/spacetelescope/jenkins_shared_ci_utils/pull/69, namely making the snapshot artifacts produced compatible with the environment creation procedures used by DMS when accepting release deliveries.
