### PR TITLE
Fix for JP-1008: White Light Step does not ignore NaNs in input.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1579,6 +1579,8 @@ wfs_combine
 white_light
 -----------
 
+- Fixed bug which produces NaN results when only some input has NaN [#4256]
+
 wiimatch
 --------
 

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -42,7 +42,7 @@ def white_light(input):
 
     # Compute the flux sum for each integration in the input
     for i in range(ntables):
-        fluxsums.append(np.nansum(input.spec[i].spec_table['FLUX'])) 
+        fluxsums.append(np.nansum(input.spec[i].spec_table['FLUX']))
 
     # Populate meta data for the output table
     tbl_meta = OrderedDict()

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -42,7 +42,7 @@ def white_light(input):
 
     # Compute the flux sum for each integration in the input
     for i in range(ntables):
-        fluxsums.append(input.spec[i].spec_table['FLUX'].sum())
+        fluxsums.append(np.nansum(input.spec[i].spec_table['FLUX'])) 
 
     # Populate meta data for the output table
     tbl_meta = OrderedDict()


### PR DESCRIPTION
NaNs are  now treated as 0 in the flux sum for each integration in the input.