### PR TITLE
JP-1139: Fix photom bug for NIRSpec IFU data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,17 +1,22 @@
 0.14.2 (Unreleased)
 ===================
 
+associations
+------------
+
+- Refactor target acquistion handling [#4254]
+
 emission
 --------
 
 - Removed the emission step, documentation, and tests from the jwst package.
   [#4253]
 
-associations
-------------
+photom
+------
 
-- Refactor target acquistion handling [#4254]
-
+- Fixed a bug so that the reference table column "PHOTMJ" is used for NIRSpec IFU
+  exposures. [#4263]
 
 0.14.1 (2019-11-11)
 ===================

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -185,7 +185,7 @@ class DataSet():
                     # IFU data
                     else:
 
-                        # Get the conversion factor from the PHOTMJSR column
+                        # Get the conversion factor from the PHOTMJ column
                         conv_factor = tabdata['photmj']
 
                         # Populate the photometry keywords

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -186,7 +186,7 @@ class DataSet():
                     else:
 
                         # Get the conversion factor from the PHOTMJSR column
-                        conv_factor = tabdata['photmjsr']
+                        conv_factor = tabdata['photmj']
 
                         # Populate the photometry keywords
                         self.input.meta.photometry.conversion_megajanskys = \

--- a/jwst/tests_nightly/general/nirspec/test_nirspec_fs_spec3.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_fs_spec3.py
@@ -46,10 +46,6 @@ class TestSpec3Pipeline(BaseJWSTTest):
             assert False
 
 
-    @pytest.mark.xfail(
-        reason='Dataset fails at outlier_detection',
-        run=False
-    )
     def test_nrs_fs_spec3(self):
         """
         Regression test of calwebb_spec3 pipeline performed on

--- a/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
@@ -145,7 +145,6 @@ class TestNIRSpecWCS(BaseJWSTTest):
 
 
 @pytest.mark.bigdata
-@pytest.mark.xfail
 class TestNRSSpec2(BaseJWSTTest):
     input_loc = 'nirspec'
     ref_loc = ['test_pipelines', 'truth']

--- a/jwst/tests_nightly/general/nirspec/test_pipelines.py
+++ b/jwst/tests_nightly/general/nirspec/test_pipelines.py
@@ -38,7 +38,6 @@ class TestNIRSpecPipelines(BaseJWSTTest):
                     ['primary','sci','err','pixeldq','groupdq'])]
         self.compare_outputs(outputs)
 
-    @pytest.mark.xfail
     def test_nrs_fs_brightobj_spec2(self):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec
@@ -60,7 +59,6 @@ class TestNIRSpecPipelines(BaseJWSTTest):
                   ]
         self.compare_outputs(outputs)
 
-    @pytest.mark.xfail
     def test_nrs_msa_spec2(self):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec MSA data.
@@ -89,7 +87,6 @@ class TestNIRSpecPipelines(BaseJWSTTest):
                   ]
         self.compare_outputs(outputs)
 
-    @pytest.mark.xfail
     def test_nrs_msa_spec2b(self):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec MSA data,

--- a/jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
+++ b/jwst/tests_nightly/general/nirspec/test_spec2pipelines.py
@@ -63,7 +63,6 @@ class TestSpec2Pipeline(BaseJWSTTest):
                 ]
             }
 
-    @pytest.mark.xfail
     def test_spec2(self, input, outputs):
         """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec data.


### PR DESCRIPTION
Fix the one remaining line in the `photom` step code that was looking for a "photmjsr" entry in the NIRSpec photom reference files, so that it looks for "photmj" instead, because that's what's used in the new NIRSpec photom ref files.

Also removed the xfails for a number of NIRSpec tests that include the `photom` step. They were set to xfail a while back when the new NIRSpec photom ref files weren't working (or getting selected). Now they are, so we need to test against them again (which would've caught the above error much sooner).