### PR TITLE
Add Codecov flags unittests, nightly, newnightly

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,6 @@ omit =
     docs/*
     jwst/conftest.py
     jwst/tests*
-    jwst/*/tests/*
+    jwst/regtest
+    jwst/**/tests
     jwst/extern/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
-    - TEST_COMMAND='pytest --cov=./'
+    - TEST_COMMAND='pytest --cov-report=xml --cov=./'
 
 matrix:
   # Don't wait for allowed failures
@@ -70,5 +70,5 @@ install:
 script:
   - $TEST_COMMAND
 
-after_script:
-  - if [ "${TEST_COMMAND:0:6}" = "pytest" ]; then codecov -F unittests; fi
+after_success:
+  - codecov -F unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ script:
   - $TEST_COMMAND
 
 after_script:
-  - if [ "${TEST_COMMAND:0:6}" = "pytest" ]; then codecov; fi
+  - if [ "${TEST_COMMAND:0:6}" = "pytest" ]; then codecov -F unittests; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ script:
   - $TEST_COMMAND
 
 after_success:
-  - codecov -F unittests
+  - if [[ ${TEST_COMMAND} =~ ^pytest ]]; then codecov -F unittests; fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,8 +49,7 @@ bc2.build_cmds = [
     "pip install --src=../src -e .[test]",
 ]
 bc2.test_cmds = [
-    "pytest --cov=./ -r sx --junitxml=results.xml",
-    "codecov --token=${codecov_token}"
+    "pytest --cov=./ -r sx --junitxml=results.xml"
 ]
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,11 +33,10 @@ bc1 = utils.copy(bc0)
 bc1.name = "stable-deps"
 bc1.env_vars = env_vars
 bc1.build_cmds = [
-    "pip install --src=../src -e .[test]",
+    "pip install -e .[test]",
 ]
 bc1.test_cmds = [
-    "pytest --cov=./ -r sx --junitxml=results.xml",
-    "codecov --token=${codecov_token}"
+    "pytest -r sxf --junitxml=results.xml",
 ]
 
 // Generate conda-free build with python 3.7
@@ -46,10 +45,10 @@ bc2.nodetype = 'python3.7'
 bc2.name = 'conda-free'
 bc2.env_vars = env_vars
 bc2.build_cmds = [
-    "pip install --src=../src -e .[test]",
+    "pip install -e .[test]",
 ]
 bc2.test_cmds = [
-    "pytest --cov=./ -r sx --junitxml=results.xml"
+    "pytest -r sxf --junitxml=results.xml"
 ]
 
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -50,7 +50,7 @@ bc0.build_cmds = [
 bc0.test_cmds = [
     "pytest --cov=./ -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp}  --junit-xml=results.xml jwst",
-    "codecov --token=${codecov_token}"
+    "codecov --token=${codecov_token} -F nightly"
 ]
 bc0.test_configs = [data_config]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -48,8 +48,8 @@ bc0.build_cmds = [
     "pip install pytest-xdist",
 ]
 bc0.test_cmds = [
-    "pytest --cov=./ -r sxf -n 30 --bigdata --slow \
-    --basetemp=${pytest_basetemp}  --junit-xml=results.xml jwst",
+    "pytest --cov-report=xml --cov=./ -r sxf -n 30 --bigdata --slow \
+    --basetemp=${pytest_basetemp} --junit-xml=results.xml jwst",
     "codecov --token=${codecov_token} -F nightly"
 ]
 bc0.test_configs = [data_config]

--- a/JenkinsfileRT_Unstable
+++ b/JenkinsfileRT_Unstable
@@ -60,8 +60,8 @@ bc0.build_cmds = [
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
-    "pytest --cov=./ -r sx -n 30 --bigdata --slow \
-    --basetemp=${pytest_basetemp}  --junit-xml=results.xml jwst"
+    "pytest -r sxf -n 30 --bigdata --slow \
+    --basetemp=${pytest_basetemp} --junit-xml=results.xml jwst"
 ]
 bc0.test_configs = [data_config]
 

--- a/JenkinsfileRT_Unstable
+++ b/JenkinsfileRT_Unstable
@@ -60,11 +60,8 @@ bc0.build_cmds = [
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
-    "pytest --cov=./ -r sx -v -n 30 --bigdata --slow \
-    --basetemp=${pytest_basetemp}  --junit-xml=results.xml \
-    --log-level=INFO \
-    jwst",
-    "codecov --token=${codecov_token}"
+    "pytest --cov=./ -r sx -n 30 --bigdata --slow \
+    --basetemp=${pytest_basetemp}  --junit-xml=results.xml jwst"
 ]
 bc0.test_configs = [data_config]
 


### PR DESCRIPTION
Sets up Codecov flags

- `unittests`
- `nightly`
- `newnightly`

So that our daily coverage testing is being tracked in parallel, and that there are apples-to-apples comparisons.

And only do coverage on the TravisCI builds and the nightly Jenkins RT builds.

Resolves #4264