### PR TITLE
Get the pixel area from the photom reference file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ photom
 - Fixed a bug so that the reference table column "PHOTMJ" is used for NIRSpec IFU
   exposures. [#4263]
 
+- The pixel area is now gotten from the photom reference file. [#4270]
+
 0.14.1 (2019-11-11)
 ===================
 

--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -83,12 +83,10 @@ The process of attaching the pixel
 area data also populates the keywords PIXAR_SR and PIXAR_A2 in the primary
 header of the science product, which give the average pixel area in units of
 steradians and square arcseconds, respectively.
-The photom step copies the values from the pixel area reference file to
-populate the PIXAR_SR and PIXAR_A2 keywords in the science data.  The values
-are taken either from the primary header or, for NIRSpec data, from a binary
-table extension.
-Note that while both the photom and pixel area reference files contain these
-keywords, the values are taken only from the pixel area reference file.
+For NIRSpec, the photom step obtains the values from a binary table extension
+of the pixel area reference file.
+For all other instruments, the photom step copies the values from the primary
+header of the photom reference file.
 
 NIRSpec IFU
 -----------

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -800,7 +800,7 @@ class DataSet():
 
         return
 
-    def save_area_info(self, area_fname):
+    def save_area_info(self, ftab, area_fname):
         """
         Short Summary
         -------------
@@ -815,6 +815,9 @@ class DataSet():
 
         Parameters
         ----------
+        ftab : `~jwst.datamodels.DataModel`
+            A photom reference file data model
+
         area_fname : str
             Pixel area reference file name
         """
@@ -838,19 +841,19 @@ class DataSet():
         if instrument == 'NIRSPEC':
             self.save_area_nirspec(pix_area)
         else:
-            # Load the average pixel area values from the pixel area reference
+            # Load the average pixel area values from the photom reference file
             try:
-                area_ster = pix_area.meta.photometry.pixelarea_steradians
+                area_ster = ftab.meta.photometry.pixelarea_steradians
             except AttributeError:
                 area_ster = None
                 log.warning('The PIXAR_SR keyword is missing from %s',
-                            area_fname)
+                            ftab.meta.filename)
             try:
-                area_a2 = pix_area.meta.photometry.pixelarea_arcsecsq
+                area_a2 = ftab.meta.photometry.pixelarea_arcsecsq
             except AttributeError:
                 area_a2 = None
                 log.warning('The PIXAR_A2 keyword is missing from %s',
-                            area_fname)
+                            ftab.meta.filename)
 
             # Copy the pixel area values to the output
             log.debug('PIXAR_SR = %s, PIXAR_A2 = %s', str(area_ster), str(area_a2))
@@ -988,7 +991,7 @@ class DataSet():
         # Load the pixel area reference file, if it exists, and attach the
         # reference data to the science model
         if area_fname != 'N/A':
-            self.save_area_info(area_fname)
+            self.save_area_info(ftab, area_fname)
 
         if self.instrument == 'NIRISS':
             self.calc_niriss(ftab)


### PR DESCRIPTION
For all instruments other than NIRSpec, the pixel area (solid angle) is not gotten from the photom reference file instead of from the area reference file.