### PR TITLE
Allow CRDS to retry on CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
   global:
     - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
     - CRDS_PATH='/tmp/crds_cache'
+    - CRDS_CLIENT_RETRY_COUNT=3
+    - CRDS_CLIENT_RETRY_DELAY_SECONDS=20
     - TEST_COMMAND='pytest --cov-report=xml --cov=./'
 
 matrix:
@@ -34,7 +36,7 @@ matrix:
       env: PIP_DEPENDENCIES='.[test]'
 
     - env: PIP_DEPENDENCIES='numpy~=1.16.0 .[test]'
-      python: 3.6.8
+      python: 3.6
 
     # Test with SDP pinned dependencies
     - env: PIP_DEPENDENCIES='-r requirements-sdp.txt .'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ withCredentials([string(
 env_vars = [
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_PATH=./crds_cache",
+    "CRDS_CLIENT_RETRY_COUNT=3",
+    "CRDS_CLIENT_RETRY_DELAY_SECONDS=20",
 ]
 
 // pip related setup for local index, not used currently


### PR DESCRIPTION
Will hopefully resolve issues where a CRDS retrieval from the server fails.  The following:

```
2019-11-18 15:01:02,189 - CRDS - INFO -  Fetching  /home/jenkins/workspace/STScI_jwst_0.14.2x/crds_cache/references/jwst/nirspec/jwst_nirspec_ifuslicer_0003.asdf    2.3 K bytes  (1 / 1 files) (0 / 2.3 K bytes)
2019-11-18 15:01:02,248 - CRDS - ERROR -  Failure downloading file 'jwst_nirspec_ifuslicer_0003.asdf' : Error fetching data for 'jwst_nirspec_ifuslicer_0003.asdf' at CRDS server 'https://jwst-crds.stsci.edu' with mode 'http' : Failed downloading 'jwst_nirspec_ifuslicer_0003.asdf' from url 'https://jwst-crds.stsci.edu/unchecked_get/references/jwst/jwst_nirspec_ifuslicer_0003.asdf' : <urlopen error [Errno 104] Connection reset by peer>
```
leads to
```
_________________________ test_nirspec_ifu_against_esa _________________________

    def test_nirspec_ifu_against_esa():
        """
        Test Nirspec IFU mode using CV3 reference files.
        """
        ref = fits.open(get_file_path('Trace_IFU_Slice_00_SMOS-MOD-G1M-17-5344175105_30192_JLAB88.fits'))
    
        # Test NRS1
        pyw = astwcs.WCS(ref['SLITY1'].header)
        hdul = create_nirspec_ifu_file("OPAQUE", "G140M")
        im = datamodels.ImageModel(hdul)
        im.meta.filename = "test_ifu.fits"
>       refs = create_reference_files(im)

jwst/assign_wcs/tests/test_nirspec.py:164: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
jwst/assign_wcs/tests/test_nirspec.py:83: in create_reference_files
    refs[reftype] = step.get_reference_file(datamodel, reftype)
jwst/stpipe/step.py:683: in get_reference_file
    return crds_client.check_reference_open(reference_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

refpath = '/home/jenkins/workspace/STScI_jwst_0.14.2x/crds_cache/references/jwst/nirspec/jwst_nirspec_ifuslicer_0003.asdf'

    def check_reference_open(refpath):
        """Verify that `refpath` exists and is readable for the current user.
    
        Ignore reference path values of "N/A" or "" for checking.
        """
        if refpath != "N/A" and refpath.strip() != "":
            if s3_utils.is_s3_uri(refpath):
                if not s3_utils.object_exists(refpath):
                    raise RuntimeError("S3 object does not exist: " + refpath)
            else:
>               opened = open(refpath, "rb")
E               FileNotFoundError: [Errno 2] No such file or directory: '/home/jenkins/workspace/STScI_jwst_0.14.2x/crds_cache/references/jwst/nirspec/jwst_nirspec_ifuslicer_0003.asdf'
```
This only occurs in our CI testing where the files are retrieved in a prefetch, stored in a local cache and then accessed when the the step needs them.  The RT jobs use central store, so not an issue.