### PR TITLE
Move to RTD version 2 YAML

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - htmlzip
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,9 +1,0 @@
-name: jwst
-dependencies:
-  - "python>=3"
-  - "pip>=10.0"
-  - "nomkl"
-  - numpy
-  - setuptools
-  - pip:
-    - ".[docs]"


### PR DESCRIPTION
Our readthedocs documentation builds have been failing for a while. This fixes it by removing `conda` from the builds.

Resolves #4262 

Thanks for the pointer @pllim. 

Successful build of this branch here

https://readthedocs.org/projects/jwsttest/builds/9982204/