### PR TITLE
Jp 1146 Update act_id format to allow base 36 values in product name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 0.14.3 (Unreleased)
 ===================
 
+associations
+------------
 
+- Update act_id format to allow base 36 values in product name [#4282]
 
 
 

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -614,7 +614,7 @@ class Utility():
 format_product = FormatTemplate(
     key_formats={
         'source_id': ['s{:05d}', 's{:s}'],
-        'expspcin': ['{:2.2s}']
+        'expspcin': ['{:0>2s}']
 
     }
 )

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -614,7 +614,8 @@ class Utility():
 format_product = FormatTemplate(
     key_formats={
         'source_id': ['s{:05d}', 's{:s}'],
-        'expspcin': ['{:02d}']
+        'expspcin': ['{:2.2s}']
+
     }
 )
 

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -39,7 +38,6 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
-        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -38,6 +39,7 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
+        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1


### PR DESCRIPTION
Update the format of the output product name to allow a two digit activity number (base 36).
Testing:
```
pytest  ~/src/JWST/scsb/jwst/jwst/associations/tests
...
==== 133 passed, 2 xfailed, 25 warnings in 274.35s (0:04:34) ====
```
```
pytest -n 3 -ra --bigdata --basetemp=/Users/ddavis/src/JWST/develop/JP-1136/test_Nov19a ~/src/JWST/scsb/jwst/jwst/tests_nightly/general/associations/  --junit-xml=results.xml | tee assoc_tests_JP-1136a.log
============================= test session starts ==============================
platform darwin -- Python 3.7.4, pytest-5.2.2, py-1.8.0, pluggy-0.13.0
rootdir: /Users/ddavis/src/JWST/scsb/jwst, inifile: setup.cfg
plugins: xdist-1.30.0, requests-mock-1.7.0, doctestplus-0.4.0
...
============ 56 passed, 23 skipped, 2 xfailed in 485.14s (0:08:05) =============

```
