### PR TITLE
Fix bug in guider_cds tests

### DIFF
--- a/jwst/guider_cds/tests/test_guider_cds.py
+++ b/jwst/guider_cds/tests/test_guider_cds.py
@@ -5,7 +5,7 @@ from jwst import datamodels
 from jwst.guider_cds.guider_cds import get_dataset_info, guider_cds
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def make_guider_image():
     """Generate science image"""
 
@@ -15,6 +15,7 @@ def make_guider_image():
     image.meta.exposure.frame_time = 234.3423235
     image.meta.exposure.ngroups = 4
     image.meta.exposure.group_time = 465.643643
+    image.meta.exposure.type = "FGS_FINEGUIDE"
 
     image.data = np.random.rand(4,10,10,10)
 
@@ -25,7 +26,6 @@ def test_get_dataset_info(make_guider_image):
     """Make sure information assigned to datamodel is retrieved correctly."""
 
     model = make_guider_image
-    model.meta.exposure.type = 'FGS_FINEGUIDE'
 
     imshape, n_int, grp_time, exp_type = get_dataset_info(model)
 
@@ -39,7 +39,6 @@ def test_guider_cds_fineguide_mode(make_guider_image):
     """Test the fine guiding mode"""
 
     model = make_guider_image
-    model.meta.exposure.type = 'FGS_FINEGUIDE'
 
     truth = np.zeros(model.data.shape)
 
@@ -118,7 +117,6 @@ def test_unit_assignment(make_guider_image):
     """Test that correct units are returned"""
 
     model = make_guider_image
-    model.meta.exposure.type = "FGS_FINEGUIDE"
 
     result = guider_cds(model)
 


### PR DESCRIPTION
Fixes a problem in a pytest fixture where `meta.exposure.type` is not defined, but needed by the `guider_cds` function.  The error:
```python console
$ pytest jwst/guider_cds -k test_table_extensions
============================================================= test session starts ==============================================================
platform darwin -- Python 3.7.4, pytest-5.1.3, py-1.8.0, pluggy-0.13.0
rootdir: /Users/jdavies/dev/jwst, inifile: setup.cfg
plugins: asdf-2.4.3a1.dev13+gc1373db, xdist-1.30.0, requests-mock-1.7.0, doctestplus-0.4.0, openfiles-0.4.0, cov-2.7.1, ci-watson-0.4, forked-1.1.3
collected 9 items / 8 deselected / 1 selected                                                                                                  

jwst/guider_cds/tests/test_guider_cds.py F                                                                                               [100%]

=================================================================== FAILURES ===================================================================
____________________________________________________________ test_table_extensions _____________________________________________________________

make_guider_image = <GuiderRawModel(4, 10, 10, 10)>

    def test_table_extensions(make_guider_image):
        """Test that tables are assigned to result of pipeline"""
    
        model = make_guider_image
    
        model.planned_star_table = np.arange(0, 11)
        model.flight_star_table = np.arange(0, 11)
        model.pointing_table = np.arange(0, 11)
        model.centroid_table = np.arange(0, 11)
        model.track_sub_table = np.arange(0, 11)
    
>       result = guider_cds(model)

jwst/guider_cds/tests/test_guider_cds.py:138: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

model = <GuiderRawModel(4, 10, 10, 10)>

    def guider_cds(model):
        """
        Extended Summary
        ----------------
        Calculate the count rate for each pixel in all integrations.
    
        For each integration in a given FGS guider dataset whose mode is ACQ1,
        ACQ2, or TRACK, the count rate is the last group minus the first group,
        divided by the effective integration time.  If the mode is ID, the last
        group minus the first group is calculated for both integrations; the count
        rate is then given by the minimum of these two values for each pixel,
        divided by the group time.  For the FINEGUIDE mode, the count rate is the
        average of the last 4 groups minus the average of the first 4 groups,
        divided by the group time.
    
        Parameters
        ----------
        model: data model
            input data model, assumed to be of type GuiderRawModel
        """
    
        # get needed sizes and shapes
        imshape, n_int, grp_time, exp_type = get_dataset_info(model)
    
>       if exp_type[:6] == 'FGS_ID':  # force output to have single slice
E       TypeError: 'NoneType' object is not subscriptable

jwst/guider_cds/guider_cds.py:38: TypeError
```
The reason this was not caught before is that the fixture was module-scoped, and then modified within each test.  If one ran all the tests in the module in order, it did not fail. Only when run out-of-order (parallelized) or on its own (as above) does it fail.