### PR TITLE
Use bespoke data for data_glob testing from Artifactory

### DIFF
--- a/jwst/tests/test_infrastructure.py
+++ b/jwst/tests/test_infrastructure.py
@@ -64,7 +64,7 @@ def test_data_glob_local(glob_filter, nfiles, _jail):
         ('*', 1),
         ('*.txt', 0),
         ('*.fits', 1)
-    ], ids=['all', 'txt', 'fits']
+    ]
 )
 def test_data_glob_url(glob_filter, nfiles, pytestconfig, request):
     """Test globbing over a URL
@@ -80,7 +80,6 @@ def test_data_glob_url(glob_filter, nfiles, pytestconfig, request):
     inputs_root = pytestconfig.getini('inputs_root')[0]
     env = request.config.getoption('env')
     path = os.path.join(inputs_root, env, 'infrastructure/test_data_glob')
-    print(path)
 
     files = _data_glob_url(path, glob_filter, root=get_bigdata_root())
     assert len(files) == nfiles
@@ -95,9 +94,9 @@ class TestBaseJWSTTest(BaseJWSTTest):
     @pytest.mark.parametrize(
         'glob_filter, nfiles',
         [
-            ('*', [1, 2]),
-            ('*.txt', [0]),
-            ('*.fits', [1])
+            ('*', 1),
+            ('*.txt', 0),
+            ('*.fits', 1)
         ], ids=['all', 'txt', 'fits']
     )
     def test_data_glob_from_class(self, glob_filter, nfiles):
@@ -116,7 +115,7 @@ class TestBaseJWSTTest(BaseJWSTTest):
             url-based artifactory location or local.
         """
         files = self.data_glob('test_data_glob', glob=glob_filter)
-        assert len(files) in nfiles
+        assert len(files) == nfiles
 
 
 def test_submodules_can_be_imported():


### PR DESCRIPTION
Fixes current issue in regression tests caused by merging of #3957 

These tests should now work with `--env=dev` and `--env=newdev`.

To reproduce the failure currently in master:
```
$ pytest jwst/tests/test_infrastructure.py --bigdata --env=newdev
============================================================= test session starts ==============================================================
platform darwin -- Python 3.7.4, pytest-5.1.3, py-1.8.0, pluggy-0.13.0
rootdir: /Users/jdavies/dev/jwst, inifile: setup.cfg
plugins: asdf-2.4.3a1.dev13+gc1373db, xdist-1.30.0, requests-mock-1.7.0, doctestplus-0.4.0, openfiles-0.4.0, cov-2.7.1, ci-watson-0.4, forked-1.1.3
collected 11 items                                                                                                                             

jwst/tests/test_infrastructure.py .......F.F.                                                                                            [100%]

=================================================================== FAILURES ===================================================================
____________________________________________________ TestBaseJWSTTest.test_glob[*-nfiles0] _____________________________________________________

self = <jwst.tests.test_infrastructure.TestBaseJWSTTest object at 0x11763bdd0>, glob_filter = '*', nfiles = [1, 2]

    @pytest.mark.parametrize(
        'glob_filter, nfiles',
        [
            ('*', [1, 2]),
            ('*.txt', [0]),
            ('*.fits', [1])
        ]
    )
    def test_glob(self, glob_filter, nfiles):
        """Test data globbing
    
        Ensure glob gets the right files.
    
        Parameters
        ----------
        glob_filter: str
            The `glob`-like filter to use.
    
        nfiles: [int[,...]]
            Number of files expected to be returned.
            List because the number can change depending on whether
            url-based artifactory location or local.
        """
        files = self.data_glob('test_bias_drift', glob=glob_filter)
>       assert len(files) in nfiles
E       assert 0 in [1, 2]
E        +  where 0 = len([])

/Users/jdavies/dev/jwst/jwst/tests/test_infrastructure.py:114: AssertionError
__________________________________________________ TestBaseJWSTTest.test_glob[*.fits-nfiles2] __________________________________________________

self = <jwst.tests.test_infrastructure.TestBaseJWSTTest object at 0x117644c90>, glob_filter = '*.fits', nfiles = [1]

    @pytest.mark.parametrize(
        'glob_filter, nfiles',
        [
            ('*', [1, 2]),
            ('*.txt', [0]),
            ('*.fits', [1])
        ]
    )
    def test_glob(self, glob_filter, nfiles):
        """Test data globbing
    
        Ensure glob gets the right files.
    
        Parameters
        ----------
        glob_filter: str
            The `glob`-like filter to use.
    
        nfiles: [int[,...]]
            Number of files expected to be returned.
            List because the number can change depending on whether
            url-based artifactory location or local.
        """
        files = self.data_glob('test_bias_drift', glob=glob_filter)
>       assert len(files) in nfiles
E       assert 0 in [1]
E        +  where 0 = len([])

/Users/jdavies/dev/jwst/jwst/tests/test_infrastructure.py:114: AssertionError
========================================================= 2 failed, 9 passed in 1.74s ==========================================================
```