### PR TITLE
Be explicit in .travis.yml about Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ matrix:
   fast_finish: true
 
   include:
-    - python: 3.6
-    - python: 3.7
-    - python: 3.8
+    - python: 3.6.9
+    - python: 3.7.5
+    - python: 3.8.0
 
     - env: PIP_DEPENDENCIES='numpy~=1.16.0 .[test]'
-      python: 3.6
+      python: 3.6.9
 
     # Test with SDP pinned dependencies
     - env: PIP_DEPENDENCIES='-r requirements-sdp.txt .'


### PR DESCRIPTION
If we set the TravisCI versions like
```yaml
   include:
    - python: 3.6
    - python: 3.7
```
Then we get maybe old, maybe very old versions:

- python 3.6.7 https://travis-ci.org/spacetelescope/jwst/jobs/615155895#L567
- python 3.7.1 https://travis-ci.org/spacetelescope/jwst/jobs/615155896#L567

So let's be explicit that we want all the latest bugfix releases as well.
```yaml
   include:
    - python: 3.6.9
    - python: 3.7.5
```

Fixup from changes made in #3957