### PR TITLE
Jp 1130 Update to add level 3 asn table names to the products. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ associations
 
 - Update act_id format to allow base 36 values in product name [#4282]
 
+master_background
+-----------------
+
+- Updated to fill the asn table and asn pool names. [#4240]
 
 
 0.14.2 (2019-11-18)

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -39,7 +38,6 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
-        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -38,6 +39,7 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
+        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -216,6 +216,8 @@ def split_container(container):
 
     # Pass along the association table to the output science container
     science.meta.asn_table = {}
+    science.meta.pool_name = container.meta.pool_name
+    science.meta.table_name = container.meta.table_name
     datamodels.model_base.properties.merge_tree(
         science.meta.asn_table._instance, asn
     )

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -150,6 +150,11 @@ class Spec3Pipeline(Pipeline):
 
             # Call outlier detection
             if exptype not in SLITLESS_TYPES:
+                # Update the asn table name to the level 3 instance so that
+                # the downstream products have the correct table name since
+                # the _cal files are not saved they will not be updated
+                for cal_array in result:
+                    cal_array.meta.asn.table_name = result.meta.table_name
                 result = self.outlier_detection(result)
 
                 # Resample time. Dependent on whether the data is IFU or not.


### PR DESCRIPTION
The level-3 output s2d and x1d files as well as the crf files now have the asn table and asn pool names added to the header. 

```
fkeyprint jw00623-o044_t007_miri_p750l_s2d.fits"[0]" ASN

# FILE: jw00623-o044_t007_miri_p750l_s2d.fits[0]
# KEYNAME: ASN

# EXTENSION:    0
ASNPOOL = 'jw00623_20191106t132852_pool' / Name of the ASN pool
ASNTABLE= 'jw00623-o044_20191106t132852_spec3_001_asn.json' / Name of the ASN ta
(jwst_dev) bash>fkeyprint jw00623-o044_t007_miri_p750l_x1d.fits"[0]" ASN

# FILE: jw00623-o044_t007_miri_p750l_x1d.fits[0]
# KEYNAME: ASN

# EXTENSION:    0
ASNPOOL = 'jw00623_20191106t132852_pool' / Name of the ASN pool
ASNTABLE= 'jw00623-o044_20191106t132852_spec3_001_asn.json' / Name of the ASN ta
(jwst_dev) bash>fkeyprint jw00623044001_02103_00002_mirimage_o044_crf.fits"[0]" ASN

# FILE: jw00623044001_02103_00002_mirimage_o044_cr
# KEYNAME: ASN

# EXTENSION:    0
ASNPOOL = 'jw00623_20191106t132852_pool' / Name of the ASN pool
ASNTABLE= 'jw00623-o044_20191106t132852_spec3_001_asn.json' / Name of the ASN ta
(jwst_dev) bash>fkeyprint jw00623044001_02101_00001_mirimage_o044_crf.fits"[0]" ASN

# FILE: jw00623044001_02101_00001_mirimage_o044_cr
# KEYNAME: ASN

# EXTENSION:    0
ASNPOOL = 'jw00623_20191106t132852_pool' / Name of the ASN pool
ASNTABLE= 'jw00623-o044_20191106t132852_spec3_001_asn.json' / Name of the ASN ta
```
and the cal files still have, 
```
fkeyprint jw00623044001_02101_00001_mirimage_cal.fits"[0]" ASN

# FILE: jw00623044001_02101_00001_mirimage_cal.fit
# KEYNAME: ASN

# EXTENSION:    0
ASNPOOL = 'jw00623_20191106t132852_pool' / Name of the ASN pool
ASNTABLE= 'jw00623-o044_20191106t132852_spec2_001_asn.json' / Name of the ASN ta
```