### PR TITLE
Outlier Detection and cube blotting in Calspec3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,6 +181,9 @@ cube_build
   the wavelength "coordinates". The ``'nelem'`` field therefore is no longer
   necessary and has been removed. [#3976]
 
+- To support outlier detection the blotting from the sky back to the detector was
+  improved [#4301]
+
 datamodels
 ----------
 
@@ -515,6 +518,9 @@ outlier_detection
 - Changed default value of good_pixel from 4 to 6 [#3638]
 
 - Don't use NaNs or masked values in weight image for blotting. [#3651]
+
+- When calling cube_build for IFU data fixed selecting correct channels (MIRI) or 
+  correct grating (NIRSPEC) [#4301]
 
 pipeline
 --------

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -320,7 +320,7 @@ class CubeBlot():
         # print('blot_overlap_quick Number of elements on sky mapped to detector going to loop over',num)
         # TODO need to move this value (roi_det)  to reference file  or at least in spec ?
         roi_det = 0.5  # 1/2 a pixel
-        for ipt in range(0, num - 1):
+        for ipt in range(num):
             # search xcenter and ycenter seperately. These arrays are smallsh.
             # xcenter size = naxis1 (naxis1/2 for MIRI)
             # ycenter size = naxis2

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -4,12 +4,11 @@ import time
 import numpy as np
 import logging
 
-from jwst.transforms.models import _toindex
+#from jwst.transforms.models import _toindex
 from .. import datamodels
 from ..assign_wcs import nirspec
 from gwcs import wcstools
 from . import instrument_defaults
-from . import coord
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -75,7 +74,7 @@ class CubeBlot():
         self.crval1 = median_model.meta.wcsinfo.crval1
         self.crval2 = median_model.meta.wcsinfo.crval2
         # ________________________________________________________________
-        # set up x,y,z of Median Cube 
+        # set up x,y,z of Median Cube
         # Median cube shoud have linear wavelength
         xcube, ycube, zcube = wcstools.grid_from_bounding_box(
             self.median_skycube.meta.wcs.bounding_box,
@@ -87,7 +86,7 @@ class CubeBlot():
 
         # pull out flux from the median sky cube that matches with
         # cube_ra,dec,wave
-        self.cube_flux =  self.median_skycube.data
+        self.cube_flux = self.median_skycube.data
 
         # wavelength slices
         self.lam_centers = self.cube_wave[:, 0, 0]
@@ -95,7 +94,7 @@ class CubeBlot():
         # initialize blotted images to be original input images
         self.input_models = input_models
 
-# *******************************************************************************
+    # ***********************************************************************
 
     def blot_info(self):
         """ Prints the basic paramters of the blot image and median sky cube
@@ -127,24 +126,23 @@ class CubeBlot():
            for every pixel in a valid slice on the detector.
         2. Using WCS of input  image convert the ra and dec of input model
            to then tangent plane values: xi,eta.
-        3. For the median sky cube convert the ra and dec of each x,y in this
-           cube to xi,eta using the wcs of the input  image.
-        4. a. Loop over  every input_model valid IFU slice pixel and find the
-            median image pixels that fall within the ROI of the center of
-            pixel.The ROI parameters are the same as those used to construct
-            the median sky cube and are stored in the meta data of the median
-            cube.
-            b. After all the overlapping median pixels have been found find the
-            weighted flux using these overlapping pixels. The weighting is
-            based on the distance between the detector pixel and the median
-            flux pixel in tangent plane plane. Additional weighting parameters
-            are read in from the median cube meta data.
+        3. Loop over every input model and using the inverse (backwards) transfor
+           convert the median sky cube values ra, dec, lambda to the blotted
+           x, y detector value (x_cibe, y_cube).
+
+        4. For each input model loop over the blotted x,y values and find
+            The x, y detector values that fall within the roi region. We loop
+            over the blotted values instead of the detector x, y (the more
+            obvious method) because of speed. We can break down the x, y detector
+            pixels into a regular grid represented by an array of xcenters and
+            ycenters. Because we are really intereseted finding all those blotted
+            pixels that fall with the roi of a detector pixel we need to
+            keep track of the blot flux and blot weight as we loop.
             c. The blotted flux  = the weighted flux determined in
             step b and stored in blot.data
         """
         t0 = time.time()
         blot_models = datamodels.ModelContainer()
-        lower_limit = 0.01
         instrument_info = instrument_defaults.InstrumentInfo()
 
         for model in self.input_models:
@@ -156,8 +154,8 @@ class CubeBlot():
             indx = filename.rfind('.fits')
 
             blot_flux = np.zeros(model.shape, dtype=np.float32)
-# ________________________________________________________________________________
-# From the x,y pixel for detector. For MIRI we only work on one channel at a time
+            # ___________________________________________________________________
+            # For MIRI we only work on one channel at a time
 
             if self.instrument == 'MIRI':
                 # only one channel is blotted at a time
@@ -171,42 +169,32 @@ class CubeBlot():
                 ydet, xdet = np.mgrid[:ysize, :xsize]
                 ydet = ydet.flatten()
                 xdet = xdet.flatten()
-                print('x y det shape',xdet.shape,ydet.shape)
-                
-                valid_channel = np.logical_and(xdet >= xstart, xdet<= xend)
+
+                xsize = xend - xstart + 1
+                xcenter = np.arange(xsize) + xstart
+                ycenter = np.arange(ysize)
+                valid_channel = np.logical_and(xdet >= xstart, xdet <= xend)
                 xdet = xdet[valid_channel]
                 ydet = ydet[valid_channel]
-                print('x y det shape',xdet.shape,ydet.shape)
 
                 # cube spaxel ra,dec values --> x, y on detector
                 x_cube, y_cube = model.meta.wcs.backward_transform(self.cube_ra,
                                                                    self.cube_dec,
                                                                    self.cube_wave)
-
-                print('y_cube',y_cube.size)
-                print(self.cube_ra.shape)
-                print(self.cube_flux.shape)
-                print(y_cube.shape)
-#                for i in range(645):
-#                    yslice = y_cube[i,:,:]
-#                    xslice = x_cube[i,:,:]
-#                    valid = np.isfinite(yslice)
-#                    print(yslice[valid], xslice[valid])
-                    
                 x_cube = np.ndarray.flatten(x_cube)
                 y_cube = np.ndarray.flatten(y_cube)
                 flux_cube = np.ndarray.flatten(self.cube_flux)
-                
                 valid = ~np.isnan(y_cube)
                 x_cube = x_cube[valid]
                 y_cube = y_cube[valid]
                 flux_cube = flux_cube[valid]
-                valid_channel = np.logical_and(x_cube >= xstart, x_cube<= xend)
-                
+                valid_channel = np.logical_and(x_cube >= xstart, x_cube <= xend)
                 x_cube = x_cube[valid_channel]
                 y_cube = y_cube[valid_channel]
                 flux_cube = flux_cube[valid_channel]
 
+            # ___________________________________________________________________
+            # For NIRSPEC we need to work 1 slice at a time
             elif self.instrument == 'NIRSPEC':
                 blot.meta.filename = filename[:indx] + '_blot.fits'
                 # initialize the x_cube,y_cube, and flux_cube arrays
@@ -218,68 +206,89 @@ class CubeBlot():
                 y_cube = np.zeros((ysize, xsize))
                 flux_cube = np.zeros((ysize, xsize))
 
+                ycenter = np.arange(ysize)
+                xcenter = np.arange(xsize)
                 # for NIRSPEC each file has 30 slices
-                # wcs information access seperately for each slice
+                # wcs information accessed seperately for each slice
 
                 nslices = 30
                 log.info('Looping over 30 slices on NIRSPEC detector, this takes a little while')
                 for ii in range(nslices):
-                    slice_wcs = nirspec.nrs_wcs_set_input(model, ii)                    
-                    x_slice,y_slice = slice_wcs.invert(self.cube_ra,self.cube_dec,self.cube_wave)
-                    # many values will be nan because they do not fall on this slice. 
-                    
+                    slice_wcs = nirspec.nrs_wcs_set_input(model, ii)
+                    x_slice, y_slice = slice_wcs.invert(self.cube_ra, self.cube_dec, self.cube_wave)
+                    # there could be values that are nan because they do not fall on this slice.
                     x_slice = np.ndarray.flatten(x_slice)
                     y_slice = np.ndarray.flatten(y_slice)
                     flux_slice = np.ndarray.flatten(self.cube_flux)
-                
+                    # print('number of original cube values mapped',flux_slice.size)
                     valid = ~np.isnan(y_slice)
                     x_slice = x_slice[valid]
                     y_slice = y_slice[valid]
                     flux_slice = flux_slice[valid]
-                    if ii == 0: 
+                    # print('number of valid cube values mapped',flux_slice.size)
+                    if ii == 0:
                         x_cube = x_slice
                         y_cube = y_slice
-                        flux_cube  = flux_slice
+                        flux_cube = flux_slice
                     else:
-                        x_cube  = np.concatenate(x_cube, x_slice)
-                        y_cube  = np.concatenate(y_cube, y_slice)
-                        flux_cube  = np.concatenate(flux_cube, flux_slice)
-
+                        x_cube = np.concatenate((x_cube, x_slice), axis=0)
+                        y_cube = np.concatenate((y_cube, y_slice), axis=0)
+                        flux_cube = np.concatenate((flux_cube, flux_slice), axis=0)
 
             log.info('Blotting back %s', model.meta.filename)
-            num = x_cube.size
-            print('Number of elements on detector going to loop over',num)
+
             # ______________________________________________________________________________
             # For every detector pixel find the overlapping median cube spaxels.
             # A median spaxel that falls withing the ROI of the center of the detector
             # pixel in the tangent plane is flagged as an overlapping pixel.
-            # the Regular grid is on the x,y detector 
-            #
-            num = xdet.size 
-            roi_det = 0.5 # 1/2  a pixel
-            for ipt in range(0, num - 1):
+            # the Regular grid is on the x,y detector
 
-                # find the cube values that fall withing ROI of detector xdet, ydet
-                xdistance = (x_cube - xdet[ipt])
-                ydistance = (y_cube - ydet[ipt])
-                radius = np.sqrt(xdistance * xdistance + ydistance * ydistance)
-                # indexr holds the index of the sky median spaxels that fall
-                # within the spatial  ROI of xx,yy location
-                indexr = np.where(radius <= roi_det)
+            blotf = self.blot_overlap_quick(xcenter, ycenter, x_cube, y_cube,
+                                            flux_cube, blot_flux)
+            blot.data = blotf
+            blot_models.append(blot)
+        t1 = time.time()
+        log.info("Time Blot images = %.1f.s" % (t1 - t0,))
+        return blot_models
+    # ________________________________________________________________________________
 
+    def blot_overlap(self, xdet, ydet, x_cube, y_cube, flux_cube, blot_flux):
+        # blot_overlap finds to overlap between the blotted sky values (x_cube, y_cube)
+        # and the detector pixels.
+        # The looping is done over the x,y detector pixels (regular grid). The
+        # distance to the x_cube, y_cube array is determiend  for each pixel to to find
+        # the values in the roi of the detector pixel.
+        # It was determiend the since x_cube and y_cube are large this method takes too
+        # long. For now this routine was kept - maybe a techinque can be found to
+        # speed it up.
+
+        #t0 = time.time()
+        # looping over detector pixels finding blotted values within roi (take a long time)
+        num = xdet.size
+        # print('Number of pixels on detector going to loop over',num)
+        # print('Number of elements on sky mapped to detector going to search over',x_cube.size)
+
+        roi_det = 0.5  # 1/2  a pixel
+        for ipt in range(0, num - 1):
+
+            # find the cube values that fall withing ROI of detector xdet, ydet
+            xdistance = (x_cube - xdet[ipt])
+            ydistance = (y_cube - ydet[ipt])
+            radius = np.sqrt(xdistance * xdistance + ydistance * ydistance)
+            # indexr holds the index of the sky median spaxels that fall
+            # within the spatial  ROI of xx,yy location
+            indexr = np.where(radius <= roi_det)
+            num_roi = len(indexr[0])
+            if num_roi > 0:
                 x_found = x_cube[indexr]
                 y_found = y_cube[indexr]
-                #print('size of x found',x_found.shape)
-# ______________________________________________________________________________
                 # form the arrays to be used calculated the weighting
-                d1 = np.array(x_found - xdet[ipt]) 
-                d2 = np.array(y_found - ydet[ipt]) 
+                d1 = np.array(x_found - xdet[ipt])
+                d2 = np.array(y_found - ydet[ipt])
 
                 dxy = d1 * d1 + d2 * d2
                 dxy = np.sqrt(dxy)
                 weight_distance = np.exp(-dxy)
-                #print('weight distance',weight_distance.shape,flux_cube[indexr].shape)
-
                 blot_flux[ydet[ipt], xdet[ipt]] = np.sum(weight_distance * flux_cube[indexr])
                 blot_weight = np.sum(weight_distance)
 
@@ -289,9 +298,53 @@ class CubeBlot():
                 else:
                     blot_flux[ydet[ipt], xdet[ipt]] =  \
                         (blot_flux[ydet[ipt], xdet[ipt]] / blot_weight)
-# ________________________________________________________________________________
-            blot.data = blot_flux
-            blot_models.append(blot)
-        t1 = time.time()
-        log.info("Time Blot images = %.1f.s" % (t1 - t0,))
-        return blot_models
+
+        #  after all looping
+        # t1 = time.time()
+        # print('Time to call blot_overlap',t1 - t0)
+        return blot_flux
+    # ________________________________________________________________________________
+
+    def blot_overlap_quick(self, xcenter, ycenter, x_cube, y_cube,
+                           flux_cube, blot_flux):
+
+        # blot_overlap_quick finds to overlap between the blotted sky values (x_cube, y_cube)
+        # and the detector pixels. This is faster than blot_overlap.
+        # Looping is done over irregular arrays (x_cube, y_cube) and mapping to xcenter, ycenter
+        # is quicker than looping over detector x,y and finding overlap with large array for
+        # x_cube, y_cube
+        # t0 = time.time()
+        blot_weight = np.zeros_like(blot_flux)
+        num = x_cube.size
+
+        # print('blot_overlap_quick Number of elements on sky mapped to detector going to loop over',num)
+        # TODO need to move this value (roi_det)  to reference file  or at least in spec ?
+        roi_det = 0.5  # 1/2 a pixel
+        for ipt in range(0, num - 1):
+            # search xcenter and ycenter seperately. These arrays are smallsh.
+            # xcenter size = naxis1 (naxis1/2 for MIRI)
+            # ycenter size = naxis2
+            xdistance = np.absolute(x_cube[ipt] - xcenter)
+            ydistance = np.absolute(y_cube[ipt] - ycenter)
+            index_x = np.where(xdistance <= roi_det)
+            index_y = np.where(ydistance <= roi_det)
+
+            if len(index_x[0]) > 0 and len(index_y[0]) > 0:
+                for ix in index_x:
+                    for iy in index_y:
+                        # form the arrays to be used calculated the weighting
+                        d1 = np.array(ix - x_cube[ipt])
+                        d2 = np.array(iy - y_cube[ipt])
+                        dxy = d1 * d1 + d2 * d2
+                        dxy = np.sqrt(dxy)
+                        weight_distance = np.exp(-dxy)
+                        weighted_flux = weight_distance * flux_cube[ipt]
+                        blot_flux[iy, ix] = blot_flux[iy, ix] + weighted_flux
+                        blot_weight[iy, ix] = blot_weight[iy, ix] + weight_distance
+        # done mapping blotted x,y (x_cube, y_cube) to detector
+        good = blot_weight > 0
+        blot_flux[good] = blot_flux[good] / blot_weight[good]
+
+        # t1 = time.time()
+        # print('Time to do quick blotting',t1- t0)
+        return blot_flux

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -181,11 +181,11 @@ class CubeData():
 
             nchannels = len(valid_channel)
             nsubchannels = len(valid_subchannel)
-# _______________________________________________________________________________
-# for MIRI we can set the channel and subchannel
+            # _______________________________________________________________________________
+            # for MIRI we can set the channel and subchannel
             user_clen = len(self.channel)
             user_slen = len(self.subchannel)
-# _______________________________________________________________________________
+            # _______________________________________________________________________________
             for i in range(nchannels):
                 for j in range(nsubchannels):
                     nfiles = len(master_table.FileMap['MIRI'][valid_channel[i]][valid_subchannel[j]])
@@ -195,21 +195,17 @@ class CubeData():
                         if user_clen == 0 and user_slen == 0:
                             self.all_channel.append(valid_channel[i])
                             self.all_subchannel.append(valid_subchannel[j])
-                            # __________________________________________________
-                            # channel was set by user but not sub-channel
+                        # channel was set by user but not sub-channel
                         elif user_clen != 0 and user_slen == 0:
-                            # now check if this channel was set by user
-                            if (valid_channel[i] in self.channel):
+                            if valid_channel[i] in self.channel:
                                 self.all_channel.append(valid_channel[i])
                                 self.all_subchannel.append(valid_subchannel[j])
-# _______________________________________________________________________________
-# sub-channel was set by user but not channel
+                        # sub-channel was set by user but not channel
                         elif user_clen == 0 and user_slen != 0:
-                            if (valid_subchannel[j] in self.subchannel):
+                            if valid_subchannel[j] in self.subchannel:
                                 self.all_channel.append(valid_channel[i])
                                 self.all_subchannel.append(valid_subchannel[j])
-# _______________________________________________________________________________
-# both parameters set
+                        # both parameters set
                         else:
                             if (valid_channel[i] in self.channel and
                                 valid_subchannel[j] in self.subchannel):
@@ -230,7 +226,7 @@ class CubeData():
             if number_subchannels == 0:
                 raise ErrorNoSubchannels(
                     "The cube does not cover any subchannels, change band parameter")
-# ______________________________________________________________________
+        # _______________________________________________________________
         if self.instrument == 'NIRSPEC':
             # 1 to 1 mapping valid_gwa[i] -> valid_fwa[i]
             valid_gwa = ['g140m', 'g140h', 'g140m', 'g140h', 'g235m',
@@ -239,33 +235,30 @@ class CubeData():
                         'f170lp', 'f290lp', 'f290lp', 'clear']
 
             nbands = len(valid_fwa)
-# _____________________________________________________________________________
-        # check if input filter or grating has been set
+
             user_glen = len(self.grating)
             user_flen = len(self.filter)
-
+            # check if input filter or grating has been set
             if user_glen == 0 and user_flen != 0:
                 raise ErrorMissingParameter("Filter specified, but Grating was not")
 
-            if user_glen != 0 and user_flen == 0:
-                raise ErrorMissingParameter("Grating specified, but Filter was not")
-        # Grating and Filter not set - read in from files and create a list of
-        # all the filters and grating contained in the files
-            if user_glen == 0 and user_flen == 0:
-                for i in range(nbands):
-
-                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]])
-                    if nfiles > 0:
+            for i in range(nbands):
+                nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]])
+                if nfiles > 0:
+                    # _________________________________________________
+                    # neither parameters are set
+                    if user_glen == 0 and user_flen == 0:
                         self.all_grating.append(valid_gwa[i])
                         self.all_filter.append(valid_fwa[i])
-        # Both filter and grating input parameter have been set
-        # Find the files that have these parameters set
-
-            else:
-                for i in range(nbands):
-                    nfiles = len(master_table.FileMap['NIRSPEC'][valid_gwa[i]][valid_fwa[i]])
-                    if nfiles > 0:
-                        # now check if THESE Filter and Grating input parameters were set
+                    # __________________________________________________
+                    # grating was set by user but not filter
+                    elif user_glen != 0 and user_flen == 0:
+                        if valid_gwa[i] in self.grating:
+                            self.all_grating.append(valid_gwa[i])
+                            self.all_filter.append(valid_fwa[i])
+                    # __________________________________________________
+                    # both parameters set
+                    else:
                         if (valid_fwa[i] in self.filter and
                             valid_gwa[i] in self.grating):
                             self.all_grating.append(valid_gwa[i])

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -206,7 +206,7 @@ class CubeBuildStep (Step):
         self.pipeline = 3
         if self.output_type == 'multi' and len(self.input_filenames) == 1:
             self.pipeline = 2
-
+        print('in cube build the self.pipeline',self.pipeline)
 # ________________________________________________________________________________
 # Read in Cube Parameter Reference file
 # identify what reference file has been associated with these input

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -206,7 +206,7 @@ class CubeBuildStep (Step):
         self.pipeline = 3
         if self.output_type == 'multi' and len(self.input_filenames) == 1:
             self.pipeline = 2
-        print('in cube build the self.pipeline',self.pipeline)
+        #print('in cube build the self.pipeline',self.pipeline)
 # ________________________________________________________________________________
 # Read in Cube Parameter Reference file
 # identify what reference file has been associated with these input

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -79,17 +79,17 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
 
     nplane = naxis1 * naxis2
 
-# now loop over the pixel values for this region and find the spaxels that fall
-# withing the region of interest.
+    # now loop over the pixel values for this region and find the spaxels that fall
+    # withing the region of interest.
     nn = coord1.size
-# Left this commented code in to check when we get new cube par reference files
-# The roi size was too small at long wavelength that may pixels did not match
-# to a spaxel.
-#    ilow = 0
-#    ihigh = 0
-#    imatch  = 0
-#    print('looping over n points mapping to cloud',nn)
-# ________________________________________________________________________________
+    # Left this commented code in to check when we get new cube par reference files
+    # The roi size was too small at long wavelength that may pixels did not match
+    # to a spaxel.
+    #    ilow = 0
+    #    ihigh = 0
+    #    imatch  = 0
+    #    print('looping over n points mapping to cloud',nn)
+    # ________________________________________________________________________________
     for ipt in range(0, nn - 1):
         # xcenters, ycenters is a flattened 1-D array of the 2 X 2 xy plane
         # cube coordinates.
@@ -236,17 +236,17 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
     """
 
     nplane = naxis1 * naxis2
-# now loop over the pixel values for this region and find the spaxels that fall
-# withing the region of interest.
+    # now loop over the pixel values for this region and find the spaxels
+    # that fall withing the region of interest.
     nn = coord1.size
-#    print('looping over n points mapping to cloud',nn)
-# ______________________________________________________________________________
+    #    print('looping over n points mapping to cloud',nn)
+    # _______________________________________________________________________
     for ipt in range(0, nn - 1):
         lower_limit = softrad_pixel[ipt]
-# ______________________________________________________________________________
+        # ___________________________________________________________________
         # xcenters, ycenters is a flattened 1-D array of the 2 X 2 xy plane
         # cube coordinates.
-        # find the spaxels that fall withing ROI of point cloud defined  by
+        # find the spaxels that fall withing ROI of point cloud defined by
         # coord1,coord2,wave
 
         xdistance = (xcenters - coord1[ipt])
@@ -256,13 +256,14 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
         indexr = np.where(radius <= rois_pixel[ipt])
         indexz = np.where(abs(zcoord - wave[ipt]) <= roiw_pixel[ipt])
 
-# ______________________________________________________________________________
-# loop over the points in the ROI
+        # _______________________________________________________________
+        # loop over the points in the ROI
         for iz, zz in enumerate(indexz[0]):
             istart = zz * nplane
             for ir, rr in enumerate(indexr[0]):
-# ______________________________________________________________________________
-# if weight is miripsf -distances determined in alpha-beta coordinate system
+                # ________________________________________________________
+                # if weight is miripsf -distances determined in alpha-beta
+                # coordinate system
 
                 weights = FindNormalizationWeights(wave[ipt],
                                                    wave_resol,
@@ -296,9 +297,9 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
 
 
 def FindNormalizationWeights(wavelength,
-                              wave_resol,
-                              alpha_resol,
-                              beta_resol):
+                             wave_resol,
+                             alpha_resol,
+                             beta_resol):
     """ Routine used in MIRI PSF weighting to normalize data
 
 

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -80,7 +80,7 @@ def match_det2cube_msm(naxis1, naxis2, naxis3,
     nplane = naxis1 * naxis2
 
     # now loop over the pixel values for this region and find the spaxels that fall
-    # withing the region of interest.
+    # within the region of interest.
     nn = coord1.size
     # Left this commented code in to check when we get new cube par reference files
     # The roi size was too small at long wavelength that may pixels did not match
@@ -237,7 +237,7 @@ def match_det2cube_miripsf(alpha_resol, beta_resol, wave_resol,
 
     nplane = naxis1 * naxis2
     # now loop over the pixel values for this region and find the spaxels
-    # that fall withing the region of interest.
+    # that fall within the region of interest.
     nn = coord1.size
     #    print('looping over n points mapping to cloud',nn)
     # _______________________________________________________________________

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -92,9 +92,7 @@ class FileTable():
 
             with datamodels.IFUImageModel(input) as input_model:
 
-                #detector = input_model.meta.instrument.detector
                 instrument = input_model.meta.instrument.name.upper()
-
                 assign_wcs = input_model.meta.cal_step.assign_wcs
 
                 if(assign_wcs != 'COMPLETE'):

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -206,7 +206,7 @@ class IFUCubeData():
                 fg_name = fg_name.lower()
                 newname = self.output_name_base + fg_name + '_s3d.fits'
                 if self.output_type == 'single':
-                    newname = self.output_name_base + fg_name + 'single_s3d.fits'
+                    newname = self.output_name_base + fg_name + '_single_s3d.fits'
 # ______________________________________________________________________________
         if self.output_type != 'single':
             log.info('Output Name: %s', newname)

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -122,12 +122,12 @@ class OutlierDetectionIFU(OutlierDetection):
             if self.instrument == 'MIRI':
                 cubestep = CubeBuildStep(config_file=cube_build_config,
                                          channel=band,
-                                         single='true')
+                                         single=True)
 
             if self.instrument == 'NIRSPEC':
                 cubestep = CubeBuildStep(config_file=cube_build_config,
                                          grating=band,
-                                         single='true')
+                                         single=True)
 
             single_IFUCube_result = cubestep.process(self.input_models)
 

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -67,15 +67,6 @@ class OutlierDetectionIFU(OutlierDetection):
         """
         OutlierDetection.__init__(self, input_models,
                                   reffiles=reffiles, **pars)
-        # NOTE:  Need to confirm that this attribute accurately reports the
-        #        channel 'names' for both types of IFU data; MIRI and NRS
-
-#        try:
-#            self.channels = input_models[0].meta.instrument.channel
-#            if self.channels is None:  # account for NIRSpec IFU data
-#                self.channels = '1'
-#        except AttributeError:
-#            self.channels = '1'
 
     def _find_ifu_coverage(self):
         self.channels = []
@@ -96,11 +87,11 @@ class OutlierDetectionIFU(OutlierDetection):
         self.channels = list(set(self.channels))
         self.gratings = list(set(self.gratings))
         self.ifu_band = []
-        if self.instrument == 'MIRI': 
+        if self.instrument == 'MIRI':
             self.ifu_band = self.channels
         elif self.instrument == 'NIRSPEC':
             self.ifu_band = self.gratings
-        
+
     def _convert_inputs(self):
         self.input_models = self.inputs
         self.converted = False
@@ -133,11 +124,11 @@ class OutlierDetectionIFU(OutlierDetection):
                                          channel=band,
                                          single='true')
 
-            if self.instrument == 'NIRSPEC' :
+            if self.instrument == 'NIRSPEC':
                 cubestep = CubeBuildStep(config_file=cube_build_config,
                                          grating=band,
                                          single='true')
-    
+
             single_IFUCube_result = cubestep.process(self.input_models)
 
             for model in single_IFUCube_result:
@@ -171,8 +162,9 @@ class OutlierDetectionIFU(OutlierDetection):
             # in the original input list/ASN/ModelContainer
             #
             # need to override with IFU-specific version of blot for
-            # each channel/grating this will need to combine the multiple channels
-            # of data into a single frame to match the original input...
+            # each channel/grating this will need to combine the multiple
+            # channels (MIRI) of data into a single frame to match the
+            # original input...
             self.blot_median(median_model)
             if save_intermediate_results:
                 log.info("Writing out BLOT images...")
@@ -227,3 +219,9 @@ class OutlierDetectionIFU(OutlierDetection):
         for j in range(len(blot_models)):
             self.blot_models[j].data += blot_models[j].data
             self.blot_models[j].meta = blot_models[j].meta
+
+
+class ErrorWrongInstrument(Exception):
+    """ Raises an exception if the instrument is not MIRI or NIRSPEC
+    """
+    pass


### PR DESCRIPTION
Fixed outlier detection to correctly call cube_build with the correct channels (MIRI) or gratings (NIRSPEC)
Fixed blot_cube_build.py to correctly blot the median sky cube back to the detector.

In blot_cube_build.py my first attempt was blot_overlap - this took way too long. So I modified the method and created blot_overlap_quick. I can probably delete blot_overlap but I left it in for now.
I think reviewing blot_overlap_quick is sufficient. 

David look at the weighting function in blot_overlap_quick and make sure that is what you want. Also when finding the overlap between the blotting sky and detector I did not search a radius but a distance in x and distance in y. We can change this if you prefer and change it to a radius between the centers (like in cube_build). I was just trying to find all the blotting values that fall on a pixel. 
