### PR TITLE
Define DataModel.model_type and force that when saving

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ associations
 
 - Update act_id format to allow base 36 values in product name [#4282]
 
+datamodels
+----------
+
+- Force data model type setting on save [#4318]
+
 master_background
 -----------------
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -239,15 +239,12 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                     setattr(self, attr, value)
 
     @property
-    def model_type(self):
-        match = re.search(r"(\w+)'", str(type(self)))
-        if match:
-            return match.group(1)
-        return "DataModel"
-        
+    def _model_type(self):
+        return self.__class__.__name__
+
     def __repr__(self):
         buf = ['<']
-        buf.append(self.model_type)
+        buf.append(self._model_type)
 
         if self.shape:
             buf.append(str(self.shape))
@@ -473,7 +470,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         self.meta.date = current_date.value
 
         # Enforce model_type to be the actual type of model being saved.
-        self.meta.model_type = self.model_type
+        self.meta.model_type = self._model_type
 
     def save(self, path, dir_path=None, *args, **kwargs):
         """

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -5,6 +5,7 @@ Data model class heirarchy
 import copy
 import datetime
 import os
+import re
 import sys
 import warnings
 
@@ -237,16 +238,16 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                 if 'datatype' in subschema:
                     setattr(self, attr, value)
 
-
-    def __repr__(self):
-        import re
-
-        buf = ['<']
+    @property
+    def model_type(self):
         match = re.search(r"(\w+)'", str(type(self)))
         if match:
-            buf.append(match.group(1))
-        else:
-            buf.append("DataModel")
+            return match.group(1)
+        return "DataModel"
+        
+    def __repr__(self):
+        buf = ['<']
+        buf.append(self.model_type)
 
         if self.shape:
             buf.append(str(self.shape))
@@ -470,6 +471,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         current_date = Time(datetime.datetime.now())
         current_date.format = 'isot'
         self.meta.date = current_date.value
+
+        # Enforce model_type to be the actual type of model being saved.
+        self.meta.model_type = self.model_type
 
     def save(self, path, dir_path=None, *args, **kwargs):
         """

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -5,7 +5,6 @@ Data model class heirarchy
 import copy
 import datetime
 import os
-import re
 import sys
 import warnings
 


### PR DESCRIPTION
When saving `DataModel`s to FITS, there is a core header keyword that is set, `DATAMODL` with the name of the model. This is used as a very strong hint as to what model to create when the file is read back in. However, being part of the model's schema, `meta.model_type`, it is easy to change this value, potentially creating a file of one model type but `DATAMODL` indicates another.

This change simply forces `DATAMODL` to be the current model type on saving.

Note: This is a partial fix for issue [JP-1162](https://jira.stsci.edu/browse/JP-1162) / #4317 