### PR TITLE
Jp 1100 Implement MultiExposureModel throughout calibration

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -471,6 +471,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         current_date.format = 'isot'
         self.meta.date = current_date.value
 
+        # Force the model_type to be what this model actually is.
+        self.meta.model_type = self.__class__.__name__
+
     def save(self, path, dir_path=None, *args, **kwargs):
         """
         Save to either a FITS or ASDF file, depending on the path.

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -35,13 +35,20 @@ def exp_to_source(inputs):
     result = DefaultOrderedDict(MultiExposureModel)
     for exposure in inputs:
         log.info('Reorganizing data from exposure {}'.format(exposure.meta.filename))
+        initial = True
         for slit in exposure.slits:
             log.debug('Copying source {}'.format(slit.source_id))
-            result[str(slit.source_id)].exposures.append(slit)
+            result_slit = result[str(slit.source_id)]
+            result_slit.exposures.append(slit)
             merge_tree(
-                result[str(slit.source_id)].exposures[-1].meta.instance,
+                result_slit.exposures[-1].meta.instance,
                 exposure.meta.instance
             )
+            if result_slit.meta.instrument.name is None:
+                merge_tree(
+                    result_slit.meta.instance,
+                    exposure.meta.instance
+                )
         exposure.close()
 
     # Turn off the default factory

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 
 from ..datamodels import (
+    DataModel,
     MultiExposureModel,
     SourceModelContainer
 )
@@ -45,10 +46,10 @@ def exp_to_source(inputs):
                 exposure.meta.instance
             )
             if result_slit.meta.instrument.name is None:
-                merge_tree(
-                    result_slit.meta.instance,
-                    exposure.meta.instance
-                )
+                if isinstance(inputs, DataModel):
+                    result_slit.update(inputs)
+                result_slit.update(exposure)
+
         exposure.close()
 
     # Turn off the default factory

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -27,7 +27,7 @@ def exp_to_source(inputs):
 
     Returns
     -------
-    {str: MultiExposureModel, }
+    multiexposures: {str: MultiExposureModel[,...]}
         Returns a dict of MultiExposureModel instances wherein each
         instance contains slits belonging to the same source.
         The key is the ID of each source, i.e. ``source_id``.

--- a/jwst/exp_to_source/tests/test_exp_to_source.py
+++ b/jwst/exp_to_source/tests/test_exp_to_source.py
@@ -34,7 +34,6 @@ def test_model_structure(run_exp_to_source):
             assert (exposure.data == slit.data).all()
             assert len(exposure.meta._instance) >= len(in_model.meta._instance)
             assert exposure.meta.filename == in_model.meta.filename
-            assert outputs[str(slit.source_id)].meta.filename != in_model.meta.filename
 
 
 def test_model_roundtrip(tmpdir, run_exp_to_source):

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2716,12 +2716,15 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
 
     if (was_source_model or
         isinstance(input_model, datamodels.MultiSlitModel) or
+        isinstance(input_model, datamodels.MultiExposureModel) or
         isinstance(input_model, datamodels.MultiProductModel)):
 
         if was_source_model:            # from a SourceModelContainer?
             slits = [input_model]
         elif isinstance(input_model, datamodels.MultiSlitModel):
             slits = input_model.slits
+        elif isinstance(input_model, datamodels.MultiExposureModel):
+            slits = input_model.exposures
         else:                           # MultiProductModel
             slits = input_model.products
 

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -107,8 +107,8 @@ class Extract1dStep(Step):
         elif isinstance(input_model, datamodels.MultiSlitModel):
             self.log.debug('Input is a MultiSlitModel')
         elif isinstance(input_model, datamodels.MultiExposureModel):
-            self.log.warning('Input is a MultiExposureModel, '
-                             'which is not currently supported')
+            self.log.debug('Input is a MultiExposureModel, '
+                           'which is only supported for multi-object modes')
         elif isinstance(input_model, datamodels.MultiProductModel):
             self.log.debug('Input is a MultiProductModel')
         elif isinstance(input_model, datamodels.IFUCubeModel):
@@ -195,5 +195,8 @@ class Extract1dStep(Step):
             result.meta.cal_step.extract_1d = 'COMPLETE'
 
         input_model.close()
+
+        if len(result) and result[0].meta.exposure.type == 'NIS_SOSS':
+            result = datamodels.MultiExposureModel(result)
 
         return result

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -98,6 +98,9 @@ class OutlierDetection:
         if isinstance(self.inputs, datamodels.ModelContainer):
             self.input_models = self.inputs
             self.converted = False
+        elif isinstance(self.inputs, datamodels.MultiExposureModel):
+            self.input_models = datamodels.SourceModelContainer(self.inputs)
+            self.converted = True
         else:
             self.input_models = datamodels.ModelContainer()
             num_inputs = self.inputs.data.shape[0]

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -153,7 +153,11 @@ class OutlierDetectionStep(Step):
 
             if not self.valid_input:
                 result = input_models
-                for input in result:
+                if isinstance(result, datamodels.ModelContainer):
+                    result_iter = result
+                else:
+                    result_iter = [result]
+                for input in result_iter:
                     input.meta.cal_step.outlier_detection = "SKIPPED"
                     self.skip = True
                 return result

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -68,6 +68,8 @@ class OutlierDetectionStep(Step):
         """Perform outlier detection processing on input data."""
         with datamodels.open(input) as input_models:
             self.input_models = input_models
+            if isinstance(self.input_models, datamodels.MultiExposureModel):
+                self.input_models = datamodels.SourceModelContainer(self.input_models)
             if not isinstance(self.input_models, datamodels.ModelContainer):
                 self.input_container = False
             else:
@@ -169,6 +171,9 @@ class OutlierDetectionStep(Step):
                 for model in self.input_models:
                     model.meta.cal_step.outlier_detection = 'COMPLETE'
             else:
+                self.input_models.meta.cal_step.outlier_detection = 'COMPLETE'
+            if isinstance(self.input_models, datamodels.SourceModelContainer):
+                self.input_models = self.input_models._multiexposure
                 self.input_models.meta.cal_step.outlier_detection = 'COMPLETE'
 
             return self.input_models

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -154,7 +154,7 @@ class Spec3Pipeline(Pipeline):
             # The MultiExposureModel is a required output.
             if isinstance(result, datamodels.MultiExposureModel):
                 self.save_model(result, 'cal')
-            breakpoint()
+
             # Call the skymatch step for MIRI MRS data
             if exptype in ['MIR_MRS']:
                 result = self.mrs_imatch(result)
@@ -164,7 +164,10 @@ class Spec3Pipeline(Pipeline):
                 # Update the asn table name to the level 3 instance so that
                 # the downstream products have the correct table name since
                 # the _cal files are not saved they will not be updated
-                for cal_array in result:
+                result_iterator = result
+                if isinstance(result, datamodels.MultiExposureModel):
+                    result_iterator = result.exposures
+                for cal_array in result_iterator:
                     cal_array.meta.asn.table_name = result.meta.table_name
                 result = self.outlier_detection(result)
 

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from .. import datamodels
 from ..associations.lib.rules_level3_base import format_product
-from ..exp_to_source import multislit_to_container
+from ..exp_to_source import exp_to_source
 from ..master_background.master_background_step import split_container
 from ..stpipe import Pipeline
 
@@ -135,7 +135,7 @@ class Spec3Pipeline(Pipeline):
             self.log.info('Convert from exposure-based to source-based data.')
             sources = [
                 (name, model)
-                    for name, model in multislit_to_container(source_models).items()
+                    for name, model in exp_to_source(source_models).items()
                 ]
         else:
             # Single-source. The source ID is simply the target name.
@@ -152,9 +152,9 @@ class Spec3Pipeline(Pipeline):
                 )
 
             # The MultiExposureModel is a required output.
-            if isinstance(result, datamodels.SourceModelContainer):
+            if isinstance(result, datamodels.MultiExposureModel):
                 self.save_model(result, 'cal')
-
+            breakpoint()
             # Call the skymatch step for MIRI MRS data
             if exptype in ['MIR_MRS']:
                 result = self.mrs_imatch(result)

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -190,12 +190,6 @@ class Spec3Pipeline(Pipeline):
             if exptype in SLITLESS_TYPES:
 
                 # For slitless data, extract 1D spectra and then combine them
-
-                if exptype in ['NIS_SOSS']:
-                    # For NIRISS SOSS, don't save the extract_1d results,
-                    # they're identical to the calwebb_spec2 x1d products
-                    self.extract_1d.save_results = False
-
                 result = self.extract_1d(result)
                 result = self.combine_1d(result)
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -22,7 +22,9 @@ class ResampleSpecStep(ResampleStep):
         input = datamodels.open(input)
 
         # If single DataModel input, wrap in a ModelContainer
-        if not isinstance(input, ModelContainer):
+        if isinstance(input, datamodels.MultiExposureModel):
+            input_models = datamodels.SourceModelContainer(input)
+        elif not isinstance(input, ModelContainer):
             input_models = datamodels.ModelContainer([input])
             input_models.meta.resample.output = input.meta.filename
             self.blendheaders = False

--- a/jwst/tests_nightly/general/nirspec/test_nirspec_fs_spec3.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_fs_spec3.py
@@ -46,7 +46,6 @@ class TestSpec3Pipeline(BaseJWSTTest):
             assert False
 
 
-    @pytest.mark.xfail(reason='Dataset fails at outlier_detection', run=False)
     def test_nrs_fs_spec3(self):
         """
         Regression test of calwebb_spec3 pipeline performed on


### PR DESCRIPTION
Resolves #4195 and JP-1100.

For multi-object modes, `SourceModelContainer` was used as a blanket wrapper around `MultiExposureModel`. However, this masked some necessary information resulting in mistreatment of data. The blanket use of `SourceModelContainer` is removed, and applied only in specific cases in specific steps. Otherwise, the native `MultiExposureModel` is implemented.

As a side effect, the desire of JP-1100, to have non-TSO NIS_SOSS save the intermediate extract_1d results in a single file, is implemented.