### PR TITLE
Make Image2Pipeline consistent across different instantiation methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,12 @@ master_background
 
 - Updated to fill the asn table and asn pool names. [#4240]
 
-=======
+pipeline
+--------
+
+- Make the naming and writing out of the resampled results to an `i2d` file
+  in `Image2Pipeline` consistent between config and class invocations [#4333]
+
 tweakreg
 --------
 

--- a/jwst/pipeline/calwebb_image2.cfg
+++ b/jwst/pipeline/calwebb_image2.cfg
@@ -1,15 +1,9 @@
 name = "Image2Pipeline"
 class = "jwst.pipeline.Image2Pipeline"
-save_results = True
 
     [steps]
       [[bkg_subtract]]
       [[assign_wcs]]
-        config_file = assign_wcs.cfg
       [[flat_field]]
-        config_file = flat_field.cfg
       [[photom]]
-        config_file = photom.cfg
       [[resample]]
-        config_file = resample.cfg
-        save_results = true

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -153,9 +153,9 @@ class Image2Pipeline(Pipeline):
         # regular 2D science image types
         if input.meta.exposure.type.upper() in self.image_exptypes and \
         len(input.data.shape) == 2:
-            i2d = self.resample(input)
-            if self.save_results:
-                self.save_model(i2d, suffix="i2d")
+            self.resample.save_results = self.save_results
+            self.resample.suffix = 'i2d'
+            self.resample(input)
 
         # That's all folks
         self.log.info(

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -153,7 +153,9 @@ class Image2Pipeline(Pipeline):
         # regular 2D science image types
         if input.meta.exposure.type.upper() in self.image_exptypes and \
         len(input.data.shape) == 2:
-            self.resample(input)
+            i2d = self.resample(input)
+            if self.save_results:
+                self.save_model(i2d, suffix="i2d")
 
         # That's all folks
         self.log.info(


### PR DESCRIPTION
We discovered this in the Hack Day today:
```
strun calwebb_image2.cfg input_rate.fits
```
produces a `_cal` and `_i2d` file for MIRI Imaging mode.  As expected, as this is the way SDP runs the pipeline.

But the following:
```
strun jwst.pipeline.Image2Pipeline input_rate.fits
```
produces only the `_cal` file.  And if we try to explicitly force writing out the resampled file:
```
strun jwst.pipeline.Image2Pipeline input_rate.fits --steps.resample.save_results=True
```
produces the `_cal` file and a `_resample` file, not the `_i2d` file.

From within python:
```
result = Image2Pipeline.call("input_rate.fits")
```
no files were written out, as expected, with the `_cal` product returned to `result` in memory.  But
```
result = Image2Pipeline.call("input_rate.fits", save_results=True)
```
writes out the `_cal` but not the `_i2d`.  And
```
result = Image2Pipeline.call("input_rate.fits", config_file="calwebb_image2.cfg")
```
writes out the `_cal` file and the `i2d`, with no way to control whether it is or not.

So big inconsistencies in how the pipeline works depending on how it is run.

This PR fixes those for `Image2Pipeline`.  So now using a config file or the class name from the command line always writes out the `_cal` and `_i2d` files.  This banks on the fact that `strun` always switches on `self.save_results` for the pipeline it is running.  Writing out the resampled produced can piggyback on that.

And the consistency is now from within python as well.  No files are written out unless specifically requested:
```
Image2Pipeline.call("input_rate.fits", save_results=True)
```
outputs `_cal` and `_i2d` files as one would expect, but without `save_results` writes out nothing.