### PR TITLE
Update template MIRI Image2 regtest

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import os
 import copy
 import json
-import sys
 
 import getpass
 import pytest
@@ -100,7 +99,6 @@ def generate_artifactory_json(request, artifactory_repos):
         # Write the rtdata class out as an ASDF file
         path = os.path.join(cwd, "{}_rtdata.asdf".format(request.node.name))
         rtdata.to_asdf(path)
-        print(rtdata, file=sys.stderr)
 
 
 def generate_upload_schema(pattern, target, recursive=False):

--- a/jwst/regtest/test_miri_image2.py
+++ b/jwst/regtest/test_miri_image2.py
@@ -1,60 +1,50 @@
-from glob import glob
 import os
 
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
-from jwst.pipeline import Image2Pipeline
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
-
+from jwst.stpipe import Step
 
 @pytest.mark.bigdata
-def test_miri_image2_cal(request, rtdata, fitsdiff_default_kwargs, _jail):
+def test_miri_image2_cal(_jail, rtdata, fitsdiff_default_kwargs):
     rtdata.get_data("miri/image/jw00001001001_01101_00001_mirimage_rate.fits")
 
-    Image2Pipeline.call(rtdata.input, save_results=True)
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_image2.cfg", rtdata.input]
+    Step.from_cmdline(args)
     rtdata.output = "jw00001001001_01101_00001_mirimage_cal.fits"
 
     rtdata.get_truth("truth/test_miri_image2_cal/jw00001001001_01101_00001_mirimage_cal.fits")
-    assert rtdata.output != rtdata.truth
 
+    fitsdiff_default_kwargs["rtol"] = 0.0001
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report
+    assert diff.identical, diff.report()
 
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module, jail):
+def run_pipeline(jail, rtdata_module):
     """Run calwebb_image2 pipeline on MIRI imaging data."""
     rtdata = rtdata_module
     rtdata.get_data("miri/image/jw00001001001_01101_00001_mirimage_rate.fits")
 
-    collect_pipeline_cfgs('config')
-    config_file = os.path.join('config', 'calwebb_image2.cfg')
-    Image2Pipeline.call(rtdata.input, config_file=config_file,
-        save_results=True)
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_image2.cfg", rtdata.input]
+    Step.from_cmdline(args)
 
     return rtdata
 
 
 @pytest.mark.bigdata
-def test_miri_image2_completion(run_pipeline):
-    files = glob('*_cal.fits')
-    files += glob('*_i2d.fits')
-    # There should be 2 outputs
-    assert len(files) == 2
-
-
-@pytest.mark.bigdata
-@pytest.mark.parametrize("output", [
-    'jw00001001001_01101_00001_mirimage_cal.fits',
-    'jw00001001001_01101_00001_mirimage_i2d.fits',],
-    ids=['cal', 'i2d'])
-def test_miri_image2(run_pipeline, request, fitsdiff_default_kwargs, output):
-    """
-    Regression test of calwebb_image2 pipeline performed on MIRI data.
-    """
+@pytest.mark.parametrize("output",[
+    "jw00001001001_01101_00001_mirimage_cal.fits",
+    "jw00001001001_01101_00001_mirimage_i2d.fits"],
+    ids=["cal", "i2d"])
+def test_miri_image2(run_pipeline, fitsdiff_default_kwargs, output):
+    """Regression test of calwebb_image2 pipeline performed on MIRI data."""
     rtdata = run_pipeline
     rtdata.output = output
+
     rtdata.get_truth(os.path.join("truth/test_miri_image2_cal", output))
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)


### PR DESCRIPTION
- Fix bug in `diff.report()`
- Use `Step.from_cmdline()` instead of `Image2Pipeline.call()`