### PR TITLE
Add .codecov.yml to specify coverage flags unit, nightly, newnightly

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default: off
+      unit:
+        flags: unit
+      nightly:
+        flags: nightly
+      newnightly:
+        flags: newnightly
+
+flags:
+  unit:
+    joined: true
+  nightly:
+    joined: false
+  newnightly:
+    joined: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,4 @@ script:
   - $TEST_COMMAND
 
 after_success:
-  - if [[ ${TEST_COMMAND} =~ ^pytest ]]; then codecov -F unittests; fi
+  - if [[ ${TEST_COMMAND} =~ ^pytest ]]; then codecov -F unit; fi


### PR DESCRIPTION
Hopefully this will give us a better per-PR codecov report.