### PR TITLE
JP-1181: NIRSpec calwebb_image2 regression test

### DIFF
--- a/jwst/regtest/test_nirspec_image2.py
+++ b/jwst/regtest/test_nirspec_image2.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+@pytest.mark.bigdata
+def test_nirspec_image2_cal(_jail, rtdata, fitsdiff_default_kwargs):
+    rtdata.get_data("nirspec/imaging/jw84600010001_02102_00001_nrs2_rate.fits")
+
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_image2.cfg", rtdata.input]
+    Step.from_cmdline(args)
+    rtdata.output = "jw84600010001_02102_00001_nrs2_cal.fits"
+
+    rtdata.get_truth("truth/test_nirspec_image2_cal/jw84600010001_02102_00001_nrs2_cal.fits")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_nirspec_image2.py
+++ b/jwst/regtest/test_nirspec_image2.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
@@ -7,7 +5,7 @@ from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
 @pytest.mark.bigdata
-def test_nirspec_image2_cal(_jail, rtdata, fitsdiff_default_kwargs):
+def test_nirspec_image2(_jail, rtdata, fitsdiff_default_kwargs):
     rtdata.get_data("nirspec/imaging/jw84600010001_02102_00001_nrs2_rate.fits")
 
     collect_pipeline_cfgs("config")
@@ -15,7 +13,7 @@ def test_nirspec_image2_cal(_jail, rtdata, fitsdiff_default_kwargs):
     Step.from_cmdline(args)
     rtdata.output = "jw84600010001_02102_00001_nrs2_cal.fits"
 
-    rtdata.get_truth("truth/test_nirspec_image2_cal/jw84600010001_02102_00001_nrs2_cal.fits")
+    rtdata.get_truth("truth/test_nirspec_image2/jw84600010001_02102_00001_nrs2_cal.fits")
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()


### PR DESCRIPTION
calwebb_image2 test using a NIRSpec imaging-mode exposure as input (in particular, EXP_TYPE='NRS_CONFIRM'). These kinds of exposures don't get resampled, so the only output is a _cal product, which is compared by the test.

Input and truth files have been uploaded to artifactory, at the locations specified in the test.