### PR TITLE
Fix pytest --ignore= bugs in JenkinsfileRT

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -50,7 +50,7 @@ bc0.build_cmds = [
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml \
-    --ignore=jwst/regtest jwst",
+    -k 'not regtest' jwst",
     "codecov --token=${codecov_token} -F nightly"
 ]
 bc0.test_configs = [data_config]

--- a/JenkinsfileRT_new
+++ b/JenkinsfileRT_new
@@ -50,7 +50,7 @@ bc0.build_cmds = [
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml \
-    --ignore=jwst/tests_nightly jwst",
+    -k 'not tests_nightly' --env=newdev jwst",
     "codecov --token=${codecov_token} -F newnightly"
 ]
 bc0.test_configs = [data_config]


### PR DESCRIPTION
For some reason, the preferred syntax
```
pytest --ignore=jwst/regtest
```
is not working as a drop-in replacement for
```
ptyest -k "not regtest"
```
on Jenkins.  Not sure why, as it works fine running locally.  So I'm changing it back.  Also, specifying `--env=newdev` for the new test, which I'd overlooked before.

Both these bugs prevent our nightly regression tests from running properly.