### PR TITLE
Fix MIRI Image2Pipeline regtest to save results

### DIFF
--- a/jwst/tests_nightly/general/miri/test_image2pipeline_1.py
+++ b/jwst/tests_nightly/general/miri/test_image2pipeline_1.py
@@ -18,7 +18,8 @@ class TestImage2Pipeline(BaseJWSTTest):
                                    'jw00001001001_01101_00001_mirimage_rate.fits')
         collect_pipeline_cfgs('cfgs')
         Image2Pipeline.call(input_file,
-                            config_file='cfgs/calwebb_image2.cfg'
+                            config_file='cfgs/calwebb_image2.cfg',
+                            save_results=True
                            )
 
         outputs = [('jw00001001001_01101_00001_mirimage_cal.fits',


### PR DESCRIPTION
Since we are using `call`, explicitly save the outputs.  Failed due to changes in #4333