### PR TITLE
Don't count tests in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,5 @@ omit =
     docs/*
     jwst/conftest.py
     jwst/tests*
-    jwst/regtest
-    jwst/**/tests
+    jwst/**/test*
     jwst/extern/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
            PIP_DEPENDENCIES='.[docs]'
 
     # PEP8 check
-    - env: TEST_COMMAND='flake8 jwst'
+    - env: TEST_COMMAND='flake8'
            PIP_DEPENDENCIES='flake8'
 
   allow_failures:

--- a/scripts/okify_regression_tests.py
+++ b/scripts/okify_regression_tests.py
@@ -9,10 +9,8 @@ Requires JFrog CLI (https://jfrog.com/getcli/) configured with credentials
 that have write access to the jwst-pipeline repository.
 """
 
-import sys
 import re
 import subprocess
-import os
 from argparse import ArgumentParser
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from os.path import basename
 from setuptools import setup, find_packages
 from glob import glob


### PR DESCRIPTION
Currently, we are inadvertently counting `test_*.py` files in our coverage, which of course, since they get run top to bottom in our test suite, get counted at 100%.  This excludes them from our coverage, so we are only covering production code.

**note: this will cause our coverge to drop from ~62% to ~52% for unit tests, as we are changing the denominator.**  😞 

Also some PEP8 cleanup and adjustment to our `flake8` script to keep it clean.