### PR TITLE
JP-1195: calspec2 regtest for NIRSpec MOS

### DIFF
--- a/jwst/regtest/test_lrs_slit_spec2.py
+++ b/jwst/regtest/test_lrs_slit_spec2.py
@@ -44,7 +44,8 @@ def test_miri_lrs_slit_spec2(run_pipeline, fitsdiff_default_kwargs, output):
     rtdata.output = "jw00623032001_03102_00001_mirimage_" + output + ".fits"
 
     # Get the truth files
-    rtdata.get_truth(os.path.join("truth", "test_miri_lrs_slit_spec2", rtdata.output))
+    rtdata.get_truth(os.path.join("truth/test_miri_lrs_slit_spec2",
+                                  "jw00623032001_03102_00001_mirimage_" + output + ".fits"))
 
     # Compare the results
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+    """Run the calwebb_spec2 pipeline on a single NIRSpec MOS exposure."""
+
+    rtdata = rtdata_module
+
+    # Get the cfg files
+    collect_pipeline_cfgs("config")
+
+    # Get the MSA metadata file referenced in the input exposure
+    rtdata.get_data("nirspec/spectroscopic/jw95065006001_0_short_msa.fits")
+
+    # Get the input exposure
+    rtdata.get_data("nirspec/spectroscopic/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits")
+
+    # Run the calwebb_spec2 pipeline; save results from intermediate steps
+    args = ["config/calwebb_spec2.cfg", rtdata.input,
+            "--steps.assign_wcs.save_results=true",
+            "--steps.msa_flagging.save_results=true",
+            "--steps.extract_2d.save_results=true",
+            "--steps.flat_field.save_results=true",
+            "--steps.srctype.save_results=true",
+            "--steps.pathloss.save_results=true",
+            "--steps.barshadow.save_results=true"]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("output",[
+    "assign_wcs", "msa_flagging", "extract_2d", "flat_field", "srctype",
+    "pathloss", "barshadow", "cal", "s2d", "x1d"])
+def test_nirspec_mos_spec2(run_pipeline, fitsdiff_default_kwargs, output):
+    """Regression test of the calwebb_spec2 pipeline on a
+       NIRSpec MOS exposure."""
+
+    # Run the pipeline and retrieve outputs
+    rtdata = run_pipeline
+    rtdata.output = "f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_" + output + ".fits"
+
+    # Get the truth files
+    rtdata.get_truth(os.path.join("truth", "test_nirspec_mos_spec2", rtdata.output))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -47,7 +47,8 @@ def test_nirspec_mos_spec2(run_pipeline, fitsdiff_default_kwargs, output):
     rtdata.output = "f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_" + output + ".fits"
 
     # Get the truth files
-    rtdata.get_truth(os.path.join("truth", "test_nirspec_mos_spec2", rtdata.output))
+    rtdata.get_truth(os.path.join("truth/test_nirspec_mos_spec2",
+                                  "f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_" + output + ".fits"))
 
     # Compare the results
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)


### PR DESCRIPTION
New calspec2 regression test of a NIRSpec MOS exposure. Just copied data from an existing test in the old system. Reduced the number of source in the MSA metadata file to only 5, and also edited the stellarity values for 2-3 sources in the MSA metadata file so that they get treated as extended source (thus triggering the barshadow correction and different handling in photom and extract_1d). So it exercises a pretty good chunk of parameter space.

It save results from all intermediate steps and includes them in the comparisons.

Input and truth files have been uploaded to artifactory and I've confirmed that it runs fine locally.