### PR TITLE
JP-1179: Create regression test for NIRCam image2 (plus stages 1 and 3)

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -194,6 +194,7 @@ def fitsdiff_default_kwargs():
     return dict(
         ignore_hdus=['ASDF'],
         ignore_keywords=['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+        ignore_fields=['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
         rtol=0.00001,
         atol=0.0000001,
     )

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from astropy.io.fits.diff import FITSDiff
 from astropy.table import Table, setdiff

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -1,0 +1,115 @@
+import os
+
+import pytest
+from astropy.io.fits.diff import FITSDiff
+from astropy.table import Table, setdiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipelines(jail, rtdata_module):
+    """Run stages 1-3 pipelines on NIRCam imaging data."""
+    rtdata = rtdata_module
+    rtdata.get_data("nircam/image/jw42424001001_01101_00001_nrca5_uncal.fits")
+
+    collect_pipeline_cfgs("config")
+
+    # Run detector1 pipeline only on one of the _uncal files
+    args = ["config/calwebb_detector1.cfg", rtdata.input,
+        "--steps.dq_init.save_results=True",
+        "--steps.saturation.save_results=True",
+        "--steps.superbias.save_results=True",
+        "--steps.refpix.save_results=True",
+        "--steps.linearity.save_results=True",
+        "--steps.dark_current.save_results=True",
+        "--steps.jump.save_results=True",
+        "--steps.jump.rejection_threshold=50.0",
+        ]
+    Step.from_cmdline(args)
+
+    # And run image2 pipeline on the produced _rate file
+    rtdata.input = "jw42424001001_01101_00001_nrca5_rate.fits"
+    args = ["config/calwebb_image2.cfg", rtdata.input,
+        "--steps.assign_wcs.save_results=True",
+        ]
+    Step.from_cmdline(args)
+
+    # Grab rest of _rate files for the asn and run image2 pipeline on each to
+    # produce fresh _cal files for the image3 pipeline.  We won't check these
+    # or look at intermediate products
+    rate_files = [
+    "nircam/image/jw42424001001_01101_00001_nrcb5_rate.fits",
+    "nircam/image/jw42424001001_01101_00002_nrca5_rate.fits",
+    "nircam/image/jw42424001001_01101_00002_nrcb5_rate.fits",
+    "nircam/image/jw42424001001_01101_00003_nrca5_rate.fits",
+    "nircam/image/jw42424001001_01101_00003_nrcb5_rate.fits",
+    ]
+    for rate_file in rate_files:
+        rtdata.get_data(rate_file)
+        args = ["config/calwebb_image2.cfg", rtdata.input,
+            "--steps.resample.skip=True"]
+        Step.from_cmdline(args)
+
+    # Get the level3 assocation json file (though not its members) and run
+    # image3 pipeline on all _cal files listed in association
+    rtdata.get_data("nircam/image/jw42424-o002_20191220t214154_image3_001_asn.json")
+    args = ["config/calwebb_image3.cfg", rtdata.input,
+        # Comment out following lines, as the dataset is currently broken
+        # "--steps.tweakreg.save_results=True",
+        # "--steps.skymatch.save_results=True",
+        ]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["dq_init", "saturation", "superbias",
+    "refpix", "linearity", "trapsfilled", "dark_current", "jump", "rate",
+    "assign_wcs", "cal", "i2d"])
+def test_nircam_image_stages12(run_pipelines, fitsdiff_default_kwargs, suffix):
+    """Regression test of detector1 and image2 pipelines performed on NIRCam data."""
+    rtdata = run_pipelines
+    rtdata.input = "jw42424001001_01101_00001_nrca5_uncal.fits"
+    output = "jw42424001001_01101_00001_nrca5_" + suffix + ".fits"
+    rtdata.output = output
+    assert os.path.exists(rtdata.output)
+
+    rtdata.get_truth("truth/test_nircam_image_stages/" + output)
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_nircam_image_stage3_i2d(run_pipelines, fitsdiff_default_kwargs):
+    rtdata = run_pipelines
+    rtdata.input = "jw42424-o002_20191220t214154_image3_001_asn.json"
+    rtdata.output = "jw42424-o002_t001_nircam_clear-f444w_i2d.fits"
+    rtdata.get_truth("truth/test_nircam_image_stages/jw42424-o002_t001_nircam_clear-f444w_i2d.fits")
+
+    fitsdiff_default_kwargs['ignore_fields'] = ['date', 'filename']
+    fitsdiff_default_kwargs['ignore_keywords'] += ['naxis1', 'tform*']
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_nircam_image_stage3_catalog(run_pipelines):
+    rtdata = run_pipelines
+    rtdata.input = "jw42424-o002_20191220t214154_image3_001_asn.json"
+    rtdata.output = "jw42424-o002_t001_nircam_clear-f444w_cat.ecsv"
+    rtdata.get_truth("truth/test_nircam_image_stages/jw42424-o002_t001_nircam_clear-f444w_cat.ecsv")
+
+    t = Table.read(rtdata.output)
+    tt = Table.read(rtdata.truth)
+
+    # Compare the first 3 columns only, as the RA/DEC columns cannot be sorted
+    # and thus setdiff cannot work on the whole table
+    table = Table([t[col] for col in ['id', 'xcentroid', 'ycentroid']])
+    table_truth = Table([tt[col] for col in ['id', 'xcentroid', 'ycentroid']])
+
+    # setdiff returns a table of length zero if there is no difference
+    assert len(setdiff(table, table_truth)) == 0


### PR DESCRIPTION
This implements stages 1, 2 and 3 pipelines for Mirage-simulated NIRCam imaging dataset `jw42424001001`.

One `_uncal` file is processed through to the end of calwebb_image3.  The other 5 members of the association are processed from the `_rate` file through stage 2 and 3 pipelines.

Currently the dataset has the wrong pointing info, so the final `_i2d` mosaic doesn't look great.  Will resolve this with fixed input and truth data in the near future.

Also cleaned up the postmortem path handling, which should have no effect on functionality.

Test results:
```
$ pytest --bigdata --env=newdev test_nircam_image.py -v
============================ test session starts ============================
platform darwin -- Python 3.7.5, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /Users/jdavies/miniconda3/envs/jwst/bin/python
cachedir: .pytest_cache
rootdir: /Users/jdavies/dev/jwst, inifile: setup.cfg
plugins: asdf-2.4.3a1.dev13+gc1373db, xdist-1.30.0, requests-mock-1.7.0, openfiles-0.4.0, ci-watson-0.4, forked-1.1.3, doctestplus-0.5.0, cov-2.8.1
collected 15 items                                                                                                                                    

test_nircam_image.py::test_nircam_image_stages12[dq_init] PASSE        [  6%]
test_nircam_image.py::test_nircam_image_stages12[saturation] PASSED    [ 13%]
test_nircam_image.py::test_nircam_image_stages12[superbias] PASSED     [ 20%]
test_nircam_image.py::test_nircam_image_stages12[refpix] PASSED        [ 26%]
test_nircam_image.py::test_nircam_image_stages12[linearity] PASSED     [ 33%]
test_nircam_image.py::test_nircam_image_stages12[trapsfilled] PASSED   [ 40%]
test_nircam_image.py::test_nircam_image_stages12[dark_current] PASSED  [ 46%]
test_nircam_image.py::test_nircam_image_stages12[jump] PASSED          [ 53%]
test_nircam_image.py::test_nircam_image_stages12[rate] PASSED          [ 60%]
test_nircam_image.py::test_nircam_image_stages12[flat_field] PASSED    [ 66%]
test_nircam_image.py::test_nircam_image_stages12[cal] PASSED           [ 73%]
test_nircam_image.py::test_nircam_image_stages12[i2d] PASSED           [ 80%]
test_nircam_image.py::test_nircam_image_stage2_wcs PASSED              [ 86%]
test_nircam_image.py::test_nircam_image_stage3_i2d PASSED              [ 93%]
test_nircam_image.py::test_nircam_image_stage3_catalog PASSED          [100%]
```

Resolves #4349