### PR TITLE
Remove old NIRSpec IFU masterbkg sanity check regtest

### DIFF
--- a/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
+++ b/jwst/tests_nightly/general/nirspec/test_nirspec_steps_single.py
@@ -10,9 +10,7 @@ from jwst.pipeline import Detector1Pipeline, Spec2Pipeline
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.imprint import ImprintStep
 from jwst.ramp_fitting import RampFitStep
-from jwst.extract_1d import Extract1dStep
 from jwst.master_background import MasterBackgroundStep
-from jwst.cube_build import CubeBuildStep
 from jwst import datamodels
 
 


### PR DESCRIPTION
Remove test 1 (of 3) of the regtest that runs the ``master_background`` step on NIRSpec IFU data with a user-supplied master-background spectrum. It was used as a sanity check back when we were first developing the ``master_background`` step and is no longer required. The remaining two parts of the test are sufficient for checking for regressions in the ``master_background`` step itself. It also doesn't work correctly anymore, because NIRSpec IFU data can be in units of flux (MJy) if they're point source, while the test assumes everything is in surface brightness units.