### PR TITLE
JP-1204: NIRCam TSGRISM regression test

### DIFF
--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -190,13 +190,14 @@ def tsgrism(input_model, reference_files):
     # input into the forward transform is x,y,x0,y0,order
     # where x,y is the pixel location in the grism image
     # and x0,y0 is the source location in the "direct" image
-    # For this mode, the source is always at crpix1,crpis2
-    # discussion with nadia that wcsinfo might not be available
+    # For this mode, the source is always at crpix1 x crpix2, which
+    # are stored in keywords XREF_SCI, YREF_SCI.
+    # Discussion with nadia that wcsinfo might not be available
     # here but crpix info could be in wcs.source_location or similar
     # TSGRISM mode places the sources at crpix, and all subarrays
     # begin at 0,0, so no need to translate the crpix to full frame
     # because they already are in full frame coordinates.
-    xc, yc = (input_model.meta.wcsinfo.crpix1, input_model.meta.wcsinfo.crpix2)
+    xc, yc = (input_model.meta.wcsinfo.siaf_xref_sci, input_model.meta.wcsinfo.siaf_yref_sci)
     xcenter = Const1D(xc)
     xcenter.inverse = Const1D(xc)
     ycenter = Const1D(yc)

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -45,7 +45,7 @@ wcs_wfss_kw = {'wcsaxes': 2, 'ra_ref': 53.1423683802, 'dec_ref': -27.8171119969,
 
 wcs_tso_kw = {'wcsaxes': 2, 'ra_ref': 86.9875, 'dec_ref': 23.423,
               'v2_ref': 95.043034, 'v3_ref': -556.150466, 'roll_ref': 359.9521,
-              'crpix1': 887.0, 'crpix2': 35.0,
+              'xref_sci': 887.0, 'yref_sci': 35.0,
               'cdelt1': 1.76686111111111e-05, 'cdelt2': 1.78527777777777e-05,
               'ctype1': 'RA---TAN', 'ctype2': 'DEC--TAN',
               'pc1_1': -1, 'pc1_2': 0,
@@ -172,11 +172,11 @@ def test_traverse_tso_grism():
     x0, y0, lam, orderdet = grism_to_detector(xin, yin, order)
     x, y, orderdet = detector_to_grism(x0, y0, lam, order)
 
-    assert x0 == wcs_tso_kw['crpix1']
-    assert y0 == wcs_tso_kw['crpix2']
+    assert x0 == wcs_tso_kw['xref_sci']
+    assert y0 == wcs_tso_kw['yref_sci']
     assert order == orderdet
     assert_allclose(x, xin)
-    assert y == wcs_tso_kw['crpix2']
+    assert y == wcs_tso_kw['yref_sci']
 
 
 def test_imaging_frames():

--- a/jwst/regtest/test_nircam_tsgrism.py
+++ b/jwst/regtest/test_nircam_tsgrism.py
@@ -1,0 +1,71 @@
+import pytest
+from astropy.io.fits.diff import FITSDiff
+from astropy.table import Table, setdiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipelines(jail, rtdata_module):
+    """Run stage 2-3 tso pipelines on NIRCAM TSO grism data."""
+    rtdata = rtdata_module
+    collect_pipeline_cfgs("config")
+
+    # Run tso-spec2 pipeline on the _rateints file, saving intermediate products
+    rtdata.get_data("nircam/tsgrism/jw00721012001_03103_00001-seg001_nrcalong_rateints.fits")
+    args = ["config/calwebb_tso-spec2.cfg", rtdata.input,
+        "--steps.flat_field.save_results=True",
+        "--steps.extract_2d.save_results=True",
+        "--steps.srctype.save_results=True",
+        ]
+    Step.from_cmdline(args)
+
+    # Get the level3 assocation json file (though not its members) and run
+    # the tso3 pipeline on all _calints files listed in association
+    rtdata.get_data("nircam/tsgrism/jw00721-o012_20191119t043909_tso3_001_asn.json")
+    args = ["config/calwebb_tso3.cfg", rtdata.input]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["calints", "extract_2d", "flat_field",
+    "o012_crfints", "srctype", "x1dints"])
+def test_nircam_tsgrism_stage2(run_pipelines, fitsdiff_default_kwargs, suffix):
+    """Regression test of tso-spec2 pipeline performed on NIRCam TSO grism data."""
+    rtdata = run_pipelines
+    rtdata.input = "jw00721012001_03103_00001-seg001_nrcalong_rateints.fits"
+    output = "jw00721012001_03103_00001-seg001_nrcalong_" + suffix + ".fits"
+    rtdata.output = output
+
+    rtdata.get_truth("truth/test_nircam_tsgrism_stages/" + output)
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_nircam_tsgrism_stage3_x1dints(run_pipelines, fitsdiff_default_kwargs):
+    rtdata = run_pipelines
+    rtdata.input = "jw00721-o012_20191119t043909_tso3_001_asn.json"
+    rtdata.output = "jw00721-o012_t004_nircam_f444w-grismr-subgrism256_x1dints.fits"
+    rtdata.get_truth("truth/test_nircam_tsgrism_stages/jw00721-o012_t004_nircam_f444w-grismr-subgrism256_x1dints.fits")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_nircam_tsgrism_stage3_whtlt(run_pipelines):
+    rtdata = run_pipelines
+    rtdata.input = "jw00721-o012_20191119t043909_tso3_001_asn.json"
+    rtdata.output = "jw00721-o012_t004_nircam_f444w-grismr-subgrism256_whtlt.ecsv"
+    rtdata.get_truth("truth/test_nircam_tsgrism_stages/jw00721-o012_t004_nircam_f444w-grismr-subgrism256_whtlt.ecsv")
+
+    table = Table.read(rtdata.output)
+    table_truth = Table.read(rtdata.truth)
+
+    # setdiff returns a table of length zero if there is no difference
+    assert len(setdiff(table, table_truth)) == 0


### PR DESCRIPTION
New regression test that performs ``calwebb_tso-spec2`` and ``calwebb_tso3`` processing on a NIRCam TSO grism (NRC_TSGRISM) exposure. It checks intermediate products from ``calwebb_tso-spec2``, as well as all final products from both pipelines.

The data were assembled from a recent DMS dataset that uses the same instrument setup, and imbedding simulated data into the SCI array. The assembled test data start at the _uncal level.

Note that this PR also includes a critical fix to the NRC_TSGRISM portion of the ``assign_wcs`` step. It had not yet been updated to switch from using the CRPIX1/CRPIX2 keyword values to determine the source location, to using the new XREF_SCI/YREF_SCI keywords instead. This was causing the wavelength array calculations to come out incorrectly, which subsequently lead to problems downstream. This has now been fixed.

All input/truth files needed by the test have been uploaded to artifactory and a local run of the test confirms success.

Resolves #4393 and https://jira.stsci.edu/browse/JP-1204