### PR TITLE
Add NIRCam calwebb_coron3 regression test

### DIFF
--- a/JenkinsfileRT_new
+++ b/JenkinsfileRT_new
@@ -50,7 +50,7 @@ bc0.build_cmds = [
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml \
-    -k 'not tests_nightly' --env=newdev jwst",
+    -k 'not tests_nightly' --env=newdev --dist=loadscope jwst",
     "codecov --token=${codecov_token} -F newnightly"
 ]
 bc0.test_configs = [data_config]

--- a/jwst/regtest/test_nircam_coron3.py
+++ b/jwst/regtest/test_nircam_coron3.py
@@ -1,0 +1,54 @@
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+    """Run calwebb_coron3 on coronographic data."""
+    rtdata = rtdata_module
+    psfmask = rtdata.get_data("nircam/coron/jwst_nircam_psfmask_somb.fits")
+    rtdata.get_asn("nircam/coron/jw99999-a3001_20170327t121212_coron3_001_asn.json")
+
+
+    # Run the calwebb_coron3 pipeline on the association
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_coron3.cfg", rtdata.input,
+        f"--steps.align_refs.override_psfmask={psfmask}",
+    ]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["psfalign", "psfsub", "crfints"])
+@pytest.mark.parametrize("exposure", ["00001", "00002"])
+def test_nircam_coron3_exp(run_pipeline, suffix, exposure, fitsdiff_default_kwargs):
+    """Check intermediate results of calwebb_coron3"""
+    rtdata = run_pipeline
+
+    output = "jw9999947001_02102_" + exposure + "_nrcb3_a3001_" + suffix + ".fits"
+    rtdata.output = output
+    rtdata.get_truth("truth/test_nircam_coron3/" + output)
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["psfstack", "i2d"])
+def test_nircam_coron3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
+    """Check final products of calwebb_coron3"""
+    rtdata = run_pipeline
+
+    output = "jw99999-a3001_t1_nircam_f140m-maskbar_" + suffix + ".fits"
+    rtdata.output = output
+    rtdata.get_truth("truth/test_nircam_coron3/" + output)
+
+    fitsdiff_default_kwargs['rtol'] = 0.00001
+    fitsdiff_default_kwargs['atol'] = 0.00001
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
This ports over the existing coron3 pipeline regression test to the new system with some data cleanup done - correct file names, `assign_wcs` run on the `_calints` files to get the new NIRCam distortion, clean out `extra_fits`, etc.

This dataset uses the no-longer-existing SUB320 subarray, but the actual data size is
```
  1  SCI           1 ImageHDU        49   (158, 158, 33)   float32   
```

Because of this, it needs its own `psfmask` reference file override.

It would be nice to replace this data with something that is less cobbled-together and that uses a standard subarray.

Resolves #4399 / JP-1207

```
$ pytest --bigdata --basetemp=/Users/jdavies/scratch/ --env=newdev jwst/regtest/test_nircam_coron3.py -v
=================================== test session starts ====================================
platform darwin -- Python 3.7.5, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /Users/jdavies/miniconda3/envs/jwst/bin/python
cachedir: .pytest_cache
rootdir: /Users/jdavies/dev/jwst, inifile: setup.cfg
plugins: asdf-2.4.3a1.dev13+gc1373db, xdist-1.30.0, requests-mock-1.7.0, openfiles-0.4.0, ci-watson-0.4, forked-1.1.3, doctestplus-0.5.0, cov-2.8.1
collected 8 items                                                                          

jwst/regtest/test_nircam_coron3.py::test_nircam_coron3_exp[00001-psfalign] PASSED    [ 12%]
jwst/regtest/test_nircam_coron3.py::test_nircam_coron3_exp[00001-psfsub] PASSED      [ 25%]
jwst/regtest/test_nircam_coron3.py::test_nircam_coron3_exp[00001-crfints] PASSED     [ 37%]
jwst/regtest/test_nircam_coron3.py::test_nircam_coron3_exp[00002-psfalign] PASSED    [ 50%]
jwst/regtest/test_nircam_coron3.py::test_nircam_coron3_exp[00002-psfsub] PASSED      [ 62%]
jwst/regtest/test_nircam_coron3.py::test_nircam_coron3_exp[00002-crfints] PASSED     [ 75%]
jwst/regtest/test_nircam_coron3.py::test_nircam_coron3_product[psfstack] PASSED      [ 87%]
jwst/regtest/test_nircam_coron3.py::test_nircam_coron3_product[i2d] PASSED           [100%]

============================== 8 passed in 108.45s (0:01:48) ===============================
```