### PR TITLE
Set source_catalog.snr_threshold=20 for MIRI/NIRCam image3 regtests

### DIFF
--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -55,9 +55,10 @@ def run_pipelines(jail, rtdata_module):
     # image3 pipeline on all _cal files listed in association
     rtdata.get_data("miri/image/det_dithered_5stars_image3_asn.json")
     args = ["config/calwebb_image3.cfg", rtdata.input,
-        # Set some unique tweakreg param values needed for these data
+        # Set some unique param values needed for this data
         "--steps.tweakreg.snr_threshold=200",
-        "--steps.tweakreg.use2dhist=False"
+        "--steps.tweakreg.use2dhist=False",
+        "--steps.source_catalog.snr_threshold=20",
         ]
     Step.from_cmdline(args)
 

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -55,7 +55,7 @@ def run_pipelines(jail, rtdata_module):
     # image3 pipeline on all _cal files listed in association
     rtdata.get_data("miri/image/det_dithered_5stars_image3_asn.json")
     args = ["config/calwebb_image3.cfg", rtdata.input,
-        # Set some unique param values needed for this data
+        # Set some unique param values needed for these data
         "--steps.tweakreg.snr_threshold=200",
         "--steps.tweakreg.use2dhist=False",
         "--steps.source_catalog.snr_threshold=20",

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -61,6 +61,7 @@ def run_pipelines(jail, rtdata_module):
         # Comment out following lines, as the dataset is currently broken
         # "--steps.tweakreg.save_results=True",
         # "--steps.skymatch.save_results=True",
+        "--steps.source_catalog.snr_threshold=20",
         ]
     Step.from_cmdline(args)
 
@@ -113,6 +114,8 @@ def test_nircam_image_stage3_i2d(run_pipelines, fitsdiff_default_kwargs):
 
     fitsdiff_default_kwargs['ignore_fields'] += ['filename']
     fitsdiff_default_kwargs['ignore_keywords'] += ['naxis1', 'tform*']
+    fitsdiff_default_kwargs['rtol'] = 0.00001
+    fitsdiff_default_kwargs['atol'] = 0.00001
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 


### PR DESCRIPTION
This fixes the `test_miri_image_stage3_catalog` test that is currently failing

https://plwishmaster.stsci.edu:8081/job/RT/job/JWST_RT_REFACTOR/93/testReport/junit/jwst.regtest/test_miri_image/_stable_deps__test_miri_image_stage3_catalog/

 in the new regression test system because it is digging down into the noise of the maskbar to find sources and coming up with `NaN` for x and y centroids.  And of course `nan != nan` so the comparison fails.

The solution is to set the source catalog detection threshold higher to only detect the 5 simulated stars in the field.  It still detects a 6th non-star, but at least this blob has a centroid.

The truth file has already been updated on Artifactory.

```
$ pytest --bigdata --env=newdev jwst/regtest/ -k test_miri_image_stage3_catalog
============================= test session starts =============================
platform darwin -- Python 3.7.5, pytest-5.3.1, py-1.8.0, pluggy-0.13.1
rootdir: /Users/jdavies/dev/jwst, inifile: setup.cfg
plugins: asdf-2.4.3a1.dev13+gc1373db, xdist-1.30.0, requests-mock-1.7.0, openfiles-0.4.0, ci-watson-0.4, forked-1.1.3, doctestplus-0.5.0, cov-2.8.1
collected 140 items / 139 deselected / 1 selected                                                                                      

jwst/regtest/test_miri_image.py .                                         [100%]
========== 1 passed, 139 deselected, 38 warnings in 115.50s (0:01:55) ==========
```