### PR TITLE
JP-1200: REGTEST for NIRSpec brightobj

### DIFF
--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -18,7 +18,7 @@ def run_tso_spec2_pipeline(jail, rtdata_module, request):
     # Get the input exposure
     rtdata.get_data('nirspec/tso/jw84600042001_02101_00001_nrs2_rateints.fits')
 
-    # Run the calwebb_spec2 pipeline; 
+    # Run the calwebb_spec2 pipeline;
     collect_pipeline_cfgs("config")
     args = ["config/calwebb_tso-spec2.cfg", rtdata.input]
     Step.from_cmdline(args)

--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.lib.suffix import replace_suffix
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+@pytest.fixture(scope="module")
+def run_tso_spec2_pipeline(jail, rtdata_module, request):
+    """Run the calwebb_spec2 pipeline performed on NIRSpec
+        fixed-slit data that uses the NRS_BRIGHTOBJ mode (S1600A1 slit)
+    """
+
+    rtdata = rtdata_module
+
+    # Get the input exposure
+    rtdata.get_data('nirspec/tso/jw84600042001_02101_00001_nrs2_rateints.fits')
+
+    # Run the calwebb_spec2 pipeline; 
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_tso-spec2.cfg", rtdata.input]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix",['calints', 'x1dints'])
+def test_nirspec_brightobj_spec2(run_tso_spec2_pipeline, fitsdiff_default_kwargs, suffix):
+    """
+        Regression test of calwebb_spec2 pipeline performed on NIRSpec
+        fixed-slit data that uses the NRS_BRIGHTOBJ mode (S1600A1 slit).
+    """
+    rtdata = run_tso_spec2_pipeline
+    output = replace_suffix(
+            os.path.splitext(os.path.basename(rtdata.input))[0], suffix) + '.fits'
+    rtdata.output = output
+
+    # Get the truth files
+    rtdata.get_truth(os.path.join("truth/test_nirspec_brightobj_spec2", output))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -20,14 +20,18 @@ def run_tso_spec2_pipeline(jail, rtdata_module, request):
 
     # Run the calwebb_spec2 pipeline;
     collect_pipeline_cfgs("config")
-    args = ["config/calwebb_tso-spec2.cfg", rtdata.input]
+    args = ["config/calwebb_tso-spec2.cfg", rtdata.input,
+            "--steps.assign_wcs.save_results=True",
+            "--steps.flat_field.save_results=True",
+            "--steps.extract_2d.save_results=True",
+            "--steps.photom.save_results=True"]
     Step.from_cmdline(args)
 
     return rtdata
 
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("suffix",['calints', 'x1dints'])
+@pytest.mark.parametrize("suffix",['assign_wcs', 'extract_2d', 'flat_field', 'photom', 'calints', 'x1dints'])
 def test_nirspec_brightobj_spec2(run_tso_spec2_pipeline, fitsdiff_default_kwargs, suffix):
     """
         Regression test of calwebb_spec2 pipeline performed on NIRSpec


### PR DESCRIPTION
Added a test for nirspec bright obj:
 Regression test of calwebb_spec2 pipeline performed on NIRSpec fixed-slit data that uses the NRS_BRIGHTOBJ mode (S1600A1 slit).

Closes #4383  