### PR TITLE
JP-1152 Check whether the output pixel number is NaN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ associations
 
 - Update act_id format to allow base 36 values in product name [#4282]
 
+combine_1d
+----------
+
+- Check output pixel numbers for NaN [#4409]
+
 datamodels
 ----------
 

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -196,12 +196,13 @@ class OutputSpectrumModel:
                                         in_spec.wavelength)
             # i is a pixel number in the current input spectrum, and
             # k is the corresponding pixel number in the output spectrum.
+            nan_flag = np.isnan(out_pixel)
+            n_nan += nan_flag.sum()
             for i in range(len(out_pixel)):
                 if in_spec.dq[i] & datamodels.dqflags.pixel['DO_NOT_USE'] > 0:
                     continue
                 # Round to the nearest pixel.
-                if np.isnan(out_pixel[i]):
-                    n_nan += 1
+                if nan_flag[i]:         # skip if the pixel number is NaN
                     continue
                 k = round(float(out_pixel[i]))
                 if k < 0 or k >= nelem:


### PR DESCRIPTION
For each input spectrum, the array of corresponding pixel numbers in the output, combined spectrum is computed by using the inverse WCS function.  It is possible for some of these pixel numbers (probably only at an endpoint of the input spectrum) to be NaN due to the finite bounding box for the WCS.  A check for NaN was added.

While testing this change, another bug was uncovered.  In the section that tests for the possibility that there was no input data for some output pixel, the error estimate for flux was being assigned to the error estimate for surface brightness.  This has been fixed.