### PR TITLE
JP-1212: NIRSpec MOS spec3 regtest

### DIFF
--- a/jwst/regtest/test_nirspec_mos_spec3.py
+++ b/jwst/regtest/test_nirspec_mos_spec3.py
@@ -1,0 +1,37 @@
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+    """Run calwebb_spec3 on NIRSpec MOS data."""
+    rtdata = rtdata_module
+    rtdata.get_asn("nirspec/mos/jw00626-o030_20191210t193826_spec3_001_asn.json")
+
+    # Run the calwebb_spec3 pipeline on the association
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_spec3.cfg", rtdata.input]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d"])
+@pytest.mark.parametrize("source_id", ["s00000", "s00227", "s00279", "s00443",
+                                       "s00482", "s02315"])
+def test_nirspec_mos_spec3(run_pipeline, suffix, source_id, fitsdiff_default_kwargs):
+    """Check results of calwebb_spec3"""
+    rtdata = run_pipeline
+
+    output = "jw00626-o030_" + source_id + "_nirspec_f170lp-g235m_" + suffix + ".fits"
+    rtdata.output = output
+    rtdata.get_truth("truth/test_nirspec_mos_spec3/" + output)
+
+    fitsdiff_default_kwargs['rtol'] = 0.00001
+    fitsdiff_default_kwargs['atol'] = 0.00001
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
Resolves #4403  and https://jira.stsci.edu/browse/JP-1212

``calwebb_spec3`` test on NIRSpec MOS data. Used 3-point dither pattern of simulated MOS images (for both detectors) and embedded the images in SDP files from jw00626 obs30. The MSA metadata file is chopped down to contain only 6 sources, 3 of which result in data on the NRS2 detector (all 6 have data on NRS1), with a mixture of point vs extended source designations and one dedicated background shutter (slitlet #8) thrown in for good measure. The 6 input _cal products result in 6 source-based results, each of which has a cal, crf, s2d, and x1d product. All 24 resulting products are tested.

Inputs and truth files have been uploaded to artifactory.