### PR TITLE
Use float64 data arrays in convolve for wfs_combine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,12 @@ tweakreg
   Now the code will gracefully skip the ``tweakreg`` step altogether in such
   situations. [#4299]
 
+wfs_combine
+-----------
+
+- Use float64 data types internally in ``wfs_combine`` so as not to cause an
+  error in ``scipy.signal.convolve``. [#4432]
+
 
 0.14.2 (2019-11-18)
 ===================

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -6,8 +6,9 @@ import numpy as np
 import logging
 from .. import datamodels
 from ..datamodels import dqflags
-import scipy
 from scipy.interpolate import griddata
+from scipy.signal import convolve
+from scipy import mgrid
 
 
 log = logging.getLogger(__name__)
@@ -145,7 +146,7 @@ class DataSet():
 
             # 1b. Create smoothed image by smoothing this 'repaired' image
             g = gauss_kern(BLUR_SIZE, sizey=None)
-            s_data_1 = scipy.signal.convolve(data_1, g, mode='valid')
+            s_data_1 = convolve(data_1, g, mode='valid')
 
 
 
@@ -411,7 +412,7 @@ def gauss_kern(size, sizey=None):
     else:
         sizey = int(sizey)
 
-    x, y = scipy.mgrid[-size:size + 1, -sizey:sizey + 1]
+    x, y = mgrid[-size:size + 1, -sizey:sizey + 1]
     g = np.exp(-(x**2 / float(size) + y**2 / float(sizey)))
 
     return g / g.sum()


### PR DESCRIPTION
Fixes 2 identical regression test failures when using `scipy 1.4.1`.  The problem is that `scipy.signal.convolve` does not like convolving a `float32` with a `float64`.  The solution is to use `float64` for the internal computations.  Probably a good idea outside of the error from Scipy.

Also, the `smooth_image` function was a 2-liner and obscured more than it helped.  So I removed it.

Resolves #4430 / JP-1228