### PR TITLE
Update datamodels schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ datamodels
 
 - Make memmap=False be the default in datamodels [#4445]
 
+- Update schemas to add the ``id`` field and switch relative references
+  from filesystem paths to URIs.  Make ``schema_url`` absolute to facilitate
+  subclassing DataModel with schemas from other asdf extensions. [#4435]
+
 extract_1d
 ----------
 
@@ -569,7 +573,7 @@ outlier_detection
 
 - Don't use NaNs or masked values in weight image for blotting. [#3651]
 
-- When calling cube_build for IFU data fixed selecting correct channels (MIRI) or 
+- When calling cube_build for IFU data fixed selecting correct channels (MIRI) or
   correct grating (NIRSPEC) [#4301]
 
 pipeline

--- a/jwst/datamodels/amilg.py
+++ b/jwst/datamodels/amilg.py
@@ -34,7 +34,7 @@ class AmiLgModel(DataModel):
     solns_table : numpy table
          Solutions table
     """
-    schema_url = "amilg.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/amilg.schema"
 
     def get_primary_array_name(self):
         """

--- a/jwst/datamodels/apcorr.py
+++ b/jwst/datamodels/apcorr.py
@@ -23,7 +23,7 @@ class FgsImgApcorrModel(ReferenceFileModel):
         - skyout: float32
 
     """
-    schema_url = "fgsimg_apcorr.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/fgsimg_apcorr.schema"
 
 
 class MirImgApcorrModel(ReferenceFileModel):
@@ -47,7 +47,7 @@ class MirImgApcorrModel(ReferenceFileModel):
         - skyout: float32
 
     """
-    schema_url = "mirimg_apcorr.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirimg_apcorr.schema"
 
 
 class NrcImgApcorrModel(ReferenceFileModel):
@@ -71,7 +71,7 @@ class NrcImgApcorrModel(ReferenceFileModel):
         - skyout: float32
 
     """
-    schema_url = "nrcimg_apcorr.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcimg_apcorr.schema"
 
 
 class NisImgApcorrModel(ReferenceFileModel):
@@ -95,4 +95,4 @@ class NisImgApcorrModel(ReferenceFileModel):
         - skyout: float32
 
     """
-    schema_url = "nisimg_apcorr.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nisimg_apcorr.schema"

--- a/jwst/datamodels/asn.py
+++ b/jwst/datamodels/asn.py
@@ -8,7 +8,7 @@ class AsnModel(DataModel):
     """
     A data model for association tables.
     """
-    schema_url = "asn.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/asn.schema"
     supported_formats = ['yaml', 'json', 'fits']
 
     def __init__(self, init=None, **kwargs):

--- a/jwst/datamodels/barshadow.py
+++ b/jwst/datamodels/barshadow.py
@@ -21,4 +21,4 @@ class BarshadowModel(ReferenceFileModel):
     var1x3 : numpy float32 array
          Bar Shadow 1x3 correction variance
     """
-    schema_url = "barshadow.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/barshadow.schema"

--- a/jwst/datamodels/combinedspec.py
+++ b/jwst/datamodels/combinedspec.py
@@ -12,4 +12,4 @@ class CombinedSpecModel(DataModel):
     spec_table : numpy table
          Combined, extracted spectral data table
     """
-    schema_url = "combinedspec.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/combinedspec.schema"

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -70,7 +70,7 @@ class ModelContainer(model_base.DataModel):
 
     # This schema merely extends the 'meta' part of the datamodel, and
     # does not describe the data contents of the container.
-    schema_url = "container.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/container.schema"
 
     def __init__(self, init=None, asn_exptypes=None, **kwargs):
 

--- a/jwst/datamodels/contrast.py
+++ b/jwst/datamodels/contrast.py
@@ -12,4 +12,4 @@ class ContrastModel(DataModel):
     contrast_table : numpy table
          Contrast curve table
     """
-    schema_url = "contrast.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/contrast.schema"

--- a/jwst/datamodels/cube.py
+++ b/jwst/datamodels/cube.py
@@ -37,7 +37,7 @@ class CubeModel(DataModel):
     var_rnoise : numpy float32 array
          Integration-specific variances of slope due to read noise
     """
-    schema_url = "cube.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/cube.schema"
 
     def __init__(self, init=None, **kwargs):
 

--- a/jwst/datamodels/dark.py
+++ b/jwst/datamodels/dark.py
@@ -22,7 +22,7 @@ class DarkModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "dark.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/dark.schema"
 
     def __init__(self, init=None, **kwargs):
         super(DarkModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/darkMIRI.py
+++ b/jwst/datamodels/darkMIRI.py
@@ -22,7 +22,7 @@ class DarkMIRIModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "darkMIRI.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/darkMIRI.schema"
 
     def __init__(self, init=None, **kwargs):
         super(DarkMIRIModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/drizpars.py
+++ b/jwst/datamodels/drizpars.py
@@ -7,4 +7,4 @@ class DrizParsModel(ReferenceFileModel):
     """
     A data model for drizzle parameters reference tables.
     """
-    schema_url = "drizpars.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/drizpars.schema"

--- a/jwst/datamodels/drizproduct.py
+++ b/jwst/datamodels/drizproduct.py
@@ -19,7 +19,7 @@ class DrizProductModel(DataModel):
     wht : numpy float32 array
          Drizzle Weight array
     """
-    schema_url = "drizproduct.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/drizproduct.schema"
 
     @property
     def hdrtab(self):

--- a/jwst/datamodels/extract1dimage.py
+++ b/jwst/datamodels/extract1dimage.py
@@ -11,4 +11,4 @@ class Extract1dImageModel(DataModel):
     data : numpy float32 array
          1-D extraction regions array
     """
-    schema_url = "extract1dimage.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/extract1dimage.schema"

--- a/jwst/datamodels/flat.py
+++ b/jwst/datamodels/flat.py
@@ -23,7 +23,7 @@ class FlatModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "flat.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/flat.schema"
 
     def __init__(self, init=None, **kwargs):
         super(FlatModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/fringe.py
+++ b/jwst/datamodels/fringe.py
@@ -23,7 +23,7 @@ class FringeModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "fringe.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/fringe.schema"
 
     def __init__(self, init=None, **kwargs):
         super(FringeModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/gain.py
+++ b/jwst/datamodels/gain.py
@@ -13,4 +13,4 @@ class GainModel(ReferenceFileModel):
     data : numpy float32 array
          The gain
     """
-    schema_url = "gain.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/gain.schema"

--- a/jwst/datamodels/gls_rampfit.py
+++ b/jwst/datamodels/gls_rampfit.py
@@ -25,4 +25,4 @@ class GLS_RampFitModel(DataModel):
     sigcrmag : numpy float32 array
          Sigma for CR magnitudes
     """
-    schema_url = "gls_rampfit.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/gls_rampfit.schema"

--- a/jwst/datamodels/guidercal.py
+++ b/jwst/datamodels/guidercal.py
@@ -34,7 +34,7 @@ class GuiderCalModel(DataModel):
          Track subarray data table
     """
 
-    schema_url = "guider_cal.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/guider_cal.schema"
 
     def __init__(self, init=None, **kwargs):
 

--- a/jwst/datamodels/guiderraw.py
+++ b/jwst/datamodels/guiderraw.py
@@ -34,7 +34,7 @@ class GuiderRawModel(DataModel):
          Track subarray data table
     """
 
-    schema_url = "guider_raw.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/guider_raw.schema"
 
     def __init__(self, init=None, **kwargs):
 

--- a/jwst/datamodels/ifucube.py
+++ b/jwst/datamodels/ifucube.py
@@ -25,7 +25,7 @@ class IFUCubeModel(DataModel):
     wavetable : numpy table
          Wavelength value for slices
     """
-    schema_url = "ifucube.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifucube.schema"
 
     def __init__(self, init=None, **kwargs):
         super(IFUCubeModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/ifucubepars.py
+++ b/jwst/datamodels/ifucubepars.py
@@ -35,7 +35,7 @@ class NirspecIFUCubeParsModel(ReferenceFileModel):
     ifucubepars_high_emsm_wavetable : numpy table
          default IFU cube high resolution emsm  wavetable
     """
-    schema_url = "nirspec_ifucubepars.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_ifucubepars.schema"
 
 
 class MiriIFUCubeParsModel(ReferenceFileModel):
@@ -60,4 +60,4 @@ class MiriIFUCubeParsModel(ReferenceFileModel):
          default IFU cube emsm wavetable
 
     """
-    schema_url = "miri_ifucubepars.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/miri_ifucubepars.schema"

--- a/jwst/datamodels/ifuimage.py
+++ b/jwst/datamodels/ifuimage.py
@@ -38,7 +38,7 @@ class IFUImageModel(DataModel):
     pathloss : numpy float32 array
          pathloss correction
     """
-    schema_url = "ifuimage.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifuimage.schema"
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, ImageModel):

--- a/jwst/datamodels/image.py
+++ b/jwst/datamodels/image.py
@@ -34,7 +34,7 @@ class ImageModel(DataModel):
     var_rnoise : numpy float32 array
          variance due to read noise
     """
-    schema_url = "image.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/image.schema"
 
     def __init__(self, init=None, **kwargs):
 

--- a/jwst/datamodels/ipc.py
+++ b/jwst/datamodels/ipc.py
@@ -11,4 +11,4 @@ class IPCModel(ReferenceFileModel):
     data : numpy float32 array
          IPC deconvolution kernel
     """
-    schema_url = "ipc.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/ipc.schema"

--- a/jwst/datamodels/irs2.py
+++ b/jwst/datamodels/irs2.py
@@ -17,4 +17,4 @@ class IRS2Model(DataModel):
          and imaginary parts (real, imag, real, imag, ...) of complex
          values.  There are four columns for ALPHA and four for BETA.
     """
-    schema_url = "irs2.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/irs2.schema"

--- a/jwst/datamodels/lastframe.py
+++ b/jwst/datamodels/lastframe.py
@@ -23,7 +23,7 @@ class LastFrameModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "lastframe.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/lastframe.schema"
 
     def __init__(self, init=None, **kwargs):
         super(LastFrameModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/level1b.py
+++ b/jwst/datamodels/level1b.py
@@ -25,7 +25,7 @@ class Level1bModel(DataModel):
          table of times for each integration
 
     """
-    schema_url = "level1b.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/level1b.schema"
 
     def __init__(self, init=None, **kwargs):
         super(Level1bModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/linearity.py
+++ b/jwst/datamodels/linearity.py
@@ -20,7 +20,7 @@ class LinearityModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "linearity.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/linearity.schema"
 
     def __init__(self, init=None, **kwargs):
         super(LinearityModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/mask.py
+++ b/jwst/datamodels/mask.py
@@ -16,7 +16,7 @@ class MaskModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "mask.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mask.schema"
 
     def __init__(self, init=None, **kwargs):
         super(MaskModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/metaschema/fits-schema.yaml
+++ b/jwst/datamodels/metaschema/fits-schema.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+$schema: "http://json-schema.org/draft-04/schema"
 id: "http://stsci.edu/schemas/fits-schema/fits-schema"
 description: |
   A metaschema extending ASDF's YAML schema to support things specific
@@ -17,4 +17,3 @@ allOf:
         anyOf:
           - type: string
           - type: integer
-...

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -30,14 +30,12 @@ from ..lib import s3_utils
 
 from .history import HistoryList
 
-from .extension import URL_PREFIX
-
 
 class DataModel(properties.ObjectNode, ndmodel.NDModel):
     """
     Base class of all of the data models.
     """
-    schema_url = "core.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/core.schema"
 
     def __init__(self, init=None, schema=None, memmap=False,
                  pass_invalid_values=False, strict_validation=False,
@@ -103,10 +101,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         # Load the schema files
         if schema is None:
-            schema_path = os.path.join(URL_PREFIX, self.schema_url)
             # Create an AsdfFile so we can use its resolver for loading schemas
             asdf_file = AsdfFile()
-            schema = asdf_schema.load_schema(schema_path,
+            schema = asdf_schema.load_schema(self.schema_url,
                                              resolver=asdf_file.resolver,
                                              resolve_references=True)
 

--- a/jwst/datamodels/multiextract1d.py
+++ b/jwst/datamodels/multiextract1d.py
@@ -27,7 +27,7 @@ class MultiExtract1dImageModel(ReferenceFileModel):
     __________
     images.items.data : numpy float32 array
     """
-    schema_url = "multiextract1d.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/multiextract1d.schema"
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, Extract1dImageModel):

--- a/jwst/datamodels/multiprod.py
+++ b/jwst/datamodels/multiprod.py
@@ -34,7 +34,7 @@ class MultiProductModel(model_base.DataModel):
     products.items.con : numpy int32 array
          drizzle algorithm context array
     """
-    schema_url = "multiproduct.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/multiproduct.schema"
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, DrizProductModel):

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -55,7 +55,7 @@ class MultiSlitModel(model_base.DataModel):
     slits.items.pathloss : numpy float32 array
          pathloss array
     """
-    schema_url = "multislit.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/multislit.schema"
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, (SlitModel, ImageModel)):

--- a/jwst/datamodels/multispec.py
+++ b/jwst/datamodels/multispec.py
@@ -46,7 +46,7 @@ class MultiSpecModel(model_base.DataModel):
     ...     spec = datamodels.SpecModel(spec_table=otab)
     ...     output_model.spec.append(spec)
     """
-    schema_url = "multispec.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/multispec.schema"
 
     def __init__(self, init=None, **kwargs):
 

--- a/jwst/datamodels/nirspec_flat.py
+++ b/jwst/datamodels/nirspec_flat.py
@@ -28,7 +28,7 @@ class NirspecFlatModel(ReferenceFileModel):
          DQ flag definitions
     """
 
-    schema_url = "nirspec_flat.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_flat.schema"
 
     def __init__(self, init=None, **kwargs):
         super(NirspecFlatModel, self).__init__(init=init, **kwargs)
@@ -65,7 +65,7 @@ class NirspecQuadFlatModel(ReferenceFileModel):
          DQ flag definitions
     """
 
-    schema_url = "nirspec_quad_flat.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_quad_flat.schema"
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, NirspecFlatModel):

--- a/jwst/datamodels/outlierpars.py
+++ b/jwst/datamodels/outlierpars.py
@@ -7,4 +7,4 @@ class OutlierParsModel(ReferenceFileModel):
     """
     A data model for outlier detection parameters reference tables.
     """
-    schema_url = "outlierpars.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/outlierpars.schema"

--- a/jwst/datamodels/pathloss.py
+++ b/jwst/datamodels/pathloss.py
@@ -22,4 +22,4 @@ class PathlossModel(ReferenceFileModel):
     apertures.items.uniform_err : numpy float32 array
          Uniform source pathloss variance
     """
-    schema_url = "pathloss.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/pathloss.schema"

--- a/jwst/datamodels/persat.py
+++ b/jwst/datamodels/persat.py
@@ -18,7 +18,7 @@ class PersistenceSatModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "persat.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/persat.schema"
 
     def __init__(self, init=None, **kwargs):
         super(PersistenceSatModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -23,7 +23,7 @@ class FgsImgPhotomModel(ReferenceFileModel):
         - uncertainty: float32
 
     """
-    schema_url = "fgsimg_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/fgsimg_photom.schema"
 
 
 class MirImgPhotomModel(ReferenceFileModel):
@@ -44,7 +44,7 @@ class MirImgPhotomModel(ReferenceFileModel):
        - uncertainty: float32
 
     """
-    schema_url = "mirimg_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirimg_photom.schema"
 
 
 class MirLrsPhotomModel(ReferenceFileModel):
@@ -69,7 +69,7 @@ class MirLrsPhotomModel(ReferenceFileModel):
        - reluncertainty: float32[*]
 
     """
-    schema_url = "mirlrs_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_photom.schema"
 
 
 class MirMrsPhotomModel(ReferenceFileModel):
@@ -100,7 +100,7 @@ class MirMrsPhotomModel(ReferenceFileModel):
         An array-like object containing pixel-by-pixel size values, in units of
         square arcseconds (arcsec^2).
     """
-    schema_url = "mirmrs_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirmrs_photom.schema"
 
     def __init__(self, init=None, **kwargs):
         super(MirMrsPhotomModel, self).__init__(init=init, **kwargs)
@@ -126,7 +126,7 @@ class NrcImgPhotomModel(ReferenceFileModel):
         - uncertainty: float32
 
     """
-    schema_url = "nrcimg_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcimg_photom.schema"
 
 
 class NrcWfssPhotomModel(ReferenceFileModel):
@@ -152,7 +152,7 @@ class NrcWfssPhotomModel(ReferenceFileModel):
         - reluncertainty: float32[*]
 
     """
-    schema_url = "nrcwfss_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcwfss_photom.schema"
 
 
 class NisImgPhotomModel(ReferenceFileModel):
@@ -173,7 +173,7 @@ class NisImgPhotomModel(ReferenceFileModel):
         - uncertainty: float32
 
     """
-    schema_url = "nisimg_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nisimg_photom.schema"
 
 
 class NisWfssPhotomModel(ReferenceFileModel):
@@ -199,7 +199,7 @@ class NisWfssPhotomModel(ReferenceFileModel):
         - reluncertainty: float32[*]
 
     """
-    schema_url = "niswfss_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/niswfss_photom.schema"
 
 
 class NisSossPhotomModel(ReferenceFileModel):
@@ -225,7 +225,7 @@ class NisSossPhotomModel(ReferenceFileModel):
         - reluncertainty: float32[*]
 
     """
-    schema_url = "nissoss_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nissoss_photom.schema"
 
 
 class NrsFsPhotomModel(ReferenceFileModel):
@@ -251,7 +251,7 @@ class NrsFsPhotomModel(ReferenceFileModel):
         - reluncertainty: float32[*]
 
     """
-    schema_url = "nrsfs_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsfs_photom.schema"
 
 
 class NrsMosPhotomModel(ReferenceFileModel):
@@ -276,4 +276,4 @@ class NrsMosPhotomModel(ReferenceFileModel):
         - reluncertainty: float32[*]
 
     """
-    schema_url = "nrsmos_photom.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsmos_photom.schema"

--- a/jwst/datamodels/pixelarea.py
+++ b/jwst/datamodels/pixelarea.py
@@ -14,7 +14,7 @@ class PixelAreaModel(ReferenceFileModel):
     data : numpy float32 array
          The pixel area array
     """
-    schema_url = "pixelarea.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/pixelarea.schema"
 
 
 
@@ -33,7 +33,7 @@ class NirspecSlitAreaModel(ReferenceFileModel):
          - slit_id: str[15]
          - pixarea: float32
     """
-    schema_url = "nirspec_area_slit.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_area_slit.schema"
 
 
 class NirspecMosAreaModel(ReferenceFileModel):
@@ -53,7 +53,7 @@ class NirspecMosAreaModel(ReferenceFileModel):
          - shutter_y: int16
          - pixarea: float32
     """
-    schema_url = "nirspec_area_mos.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_area_mos.schema"
 
 
 class NirspecIfuAreaModel(ReferenceFileModel):
@@ -71,4 +71,4 @@ class NirspecIfuAreaModel(ReferenceFileModel):
          - slice_id: int16
          - pixarea: float32
     """
-    schema_url = "nirspec_area_ifu.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_area_ifu.schema"

--- a/jwst/datamodels/psfmask.py
+++ b/jwst/datamodels/psfmask.py
@@ -13,4 +13,4 @@ class PsfMaskModel(ReferenceFileModel):
     data : numpy float32 array
          The PSF mask
     """
-    schema_url = "psfmask.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/psfmask.schema"

--- a/jwst/datamodels/quad.py
+++ b/jwst/datamodels/quad.py
@@ -18,7 +18,7 @@ class QuadModel(DataModel):
     err : numpy float32 array
          Error array
     """
-    schema_url = "quad.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/quad.schema"
 
     def __init__(self, init=None, **kwargs):
         super(QuadModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -34,7 +34,7 @@ class RampModel(DataModel):
          table of times for each integration
 
     """
-    schema_url = "ramp.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/ramp.schema"
 
     def __init__(self, init=None, **kwargs):
         super(RampModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/rampfitoutput.py
+++ b/jwst/datamodels/rampfitoutput.py
@@ -43,4 +43,4 @@ class RampFitOutputModel(DataModel):
     crmag : numpy float32 array (n_int, max_seg, ny, nx)
         Approximate CR magnitudes
     """
-    schema_url = "rampfitoutput.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/rampfitoutput.schema"

--- a/jwst/datamodels/readnoise.py
+++ b/jwst/datamodels/readnoise.py
@@ -13,4 +13,4 @@ class ReadnoiseModel(ReferenceFileModel):
     data : numpy float32 array
          Read noise
     """
-    schema_url = "readnoise.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/readnoise.schema"

--- a/jwst/datamodels/reference.py
+++ b/jwst/datamodels/reference.py
@@ -14,7 +14,7 @@ class ReferenceFileModel(DataModel):
     A data model for reference tables
 
     """
-    schema_url = "referencefile.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencefile.schema"
 
     def __init__(self, init=None, **kwargs):
         super(ReferenceFileModel, self).__init__(init=init, **kwargs)
@@ -63,7 +63,7 @@ class ReferenceImageModel(ReferenceFileModel):
     err : numpy float32 array
          Error array
     """
-    schema_url = "referenceimage.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/referenceimage.schema"
 
     def __init__(self, init=None, **kwargs):
         super(ReferenceImageModel, self).__init__(init=init, **kwargs)
@@ -91,7 +91,7 @@ class ReferenceCubeModel(ReferenceFileModel):
     err : numpy float32 array
          Error array
     """
-    schema_url = "referencecube.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencecube.schema"
 
     def __init__(self, init=None, **kwargs):
         super(ReferenceCubeModel, self).__init__(init=init, **kwargs)
@@ -115,7 +115,7 @@ class ReferenceQuadModel(ReferenceFileModel):
     err : numpy float32 array
          Error array
     """
-    schema_url = "referencequad.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencequad.schema"
 
     def __init__(self, init=None, **kwargs):
         super(ReferenceQuadModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/reset.py
+++ b/jwst/datamodels/reset.py
@@ -22,7 +22,7 @@ class ResetModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "reset.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/reset.schema"
 
     def __init__(self, init=None, **kwargs):
         super(ResetModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/resolution.py
+++ b/jwst/datamodels/resolution.py
@@ -12,7 +12,7 @@ class ResolutionModel(ReferenceFileModel):
     data : numpy float32 array
         Resolving Power table
     """
-    schema_url = "resolution.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/resolution.schema"
 
 
 class MiriResolutionModel(ResolutionModel):
@@ -45,4 +45,4 @@ class MiriResolutionModel(ResolutionModel):
         than cuttoff. Columns 4 and 5 give the polynomial coefficients (a,b)
         describing beta FWHM for wavelengths longer than the cutoff.
     """
-    schema_url = "miri_resolution.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/miri_resolution.schema"

--- a/jwst/datamodels/rscd.py
+++ b/jwst/datamodels/rscd.py
@@ -15,4 +15,4 @@ class RSCDModel(ReferenceFileModel):
         A table with seven columns, three string-valued that identify which
         row to select, and four float columns containing coefficients.
     """
-    schema_url = "rscd.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/rscd.schema"

--- a/jwst/datamodels/saturation.py
+++ b/jwst/datamodels/saturation.py
@@ -18,7 +18,7 @@ class SaturationModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "saturation.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/saturation.schema"
 
     def __init__(self, init=None, **kwargs):
         super(SaturationModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/schemas/amilg.schema.yaml
+++ b/jwst/datamodels/schemas/amilg.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/amilg.schema"
 title: AMI LG analysis data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     fit_image:
@@ -50,4 +54,3 @@ allOf:
       datatype:
       - name: coeffs
         datatype: float64
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/asn.schema.yaml
+++ b/jwst/datamodels/schemas/asn.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/asn.schema"
 title: Association table data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     asn_table:
@@ -11,4 +15,3 @@ allOf:
         datatype: [ascii, 80]
       - name: exptype
         datatype: [ascii, 15]
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/barshadow.schema.yaml
+++ b/jwst/datamodels/schemas/barshadow.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/barshadow.schema"
 title: Bar shadow correction data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     data1x1:
@@ -45,4 +49,3 @@ allOf:
       type: number
       fits_keyword: CDELT2
       fits_hdu: data1x1
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/bunit.schema.yaml
+++ b/jwst/datamodels/schemas/bunit.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/bunit.schema"
 allOf:
 - type: object
   properties:
@@ -15,4 +19,3 @@ allOf:
           type: string
           fits_hdu: ERR
           fits_keyword: BUNIT
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/camera.schema.yaml
+++ b/jwst/datamodels/schemas/camera.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/camera.schema"
 title: NirSpec CAMERA reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_pdetector.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_pdetector.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     model:

--- a/jwst/datamodels/schemas/collimator.schema.yaml
+++ b/jwst/datamodels/schemas/collimator.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/collimator.schema"
 title: NirSpec COLLIMATOR reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     model:

--- a/jwst/datamodels/schemas/combinedspec.schema.yaml
+++ b/jwst/datamodels/schemas/combinedspec.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/combinedspec.schema"
 title: Combined spectrum data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     spec_table:
@@ -23,4 +27,3 @@ allOf:
         datatype: float64
       - name: N_INPUT
         datatype: float64
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/container.schema.yaml
+++ b/jwst/datamodels/schemas/container.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/container.schema"
 type: object
 properties:
   meta:
@@ -21,4 +25,3 @@ properties:
           pointings:
             title: Number of pointings
             type: integer
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/contrast.schema.yaml
+++ b/jwst/datamodels/schemas/contrast.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/contrast.schema"
 title: Coronagraphic contrast curve data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     contrast_table:
@@ -11,4 +15,3 @@ allOf:
         datatype: float32
       - name: sigma
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/core.schema"
 type: object
 properties:
   meta:
@@ -2196,4 +2200,3 @@ properties:
             title: Master background file used
             type: string
             fits_keyword: MASTERBG
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/cube.schema.yaml
+++ b/jwst/datamodels/schemas/cube.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/cube.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     data:
@@ -38,7 +42,6 @@ allOf:
       ndim: 2
       default: 0.0
       datatype: float32
-- $ref: int_times.schema.yaml
-- $ref: variance.schema.yaml
+- $ref: int_times.schema
+- $ref: variance.schema
 
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/dark.schema.yaml
+++ b/jwst/datamodels/schemas/dark.schema.yaml
@@ -1,14 +1,18 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/dark.schema"
 title: Dark current data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_readpatt.schema.yaml
-- $ref: keyword_preadpatt.schema.yaml
-- $ref: keyword_nframes.schema.yaml
-- $ref: keyword_ngroups.schema.yaml
-- $ref: keyword_groupgap.schema.yaml
-- $ref: keyword_gainfact.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_preadpatt.schema
+- $ref: keyword_nframes.schema
+- $ref: keyword_ngroups.schema
+- $ref: keyword_groupgap.schema
+- $ref: keyword_gainfact.schema
+- $ref: subarray.schema
 - type: object
   properties:
     data:
@@ -29,5 +33,4 @@ allOf:
       default: 0.0
       ndim: 3
       datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/darkMIRI.schema.yaml
+++ b/jwst/datamodels/schemas/darkMIRI.schema.yaml
@@ -1,13 +1,17 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/darkMIRI.schema"
 title: MIRI Dark current data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_readpatt.schema.yaml
-- $ref: keyword_preadpatt.schema.yaml
-- $ref: keyword_nframes.schema.yaml
-- $ref: keyword_ngroups.schema.yaml
-- $ref: keyword_groupgap.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_preadpatt.schema
+- $ref: keyword_nframes.schema
+- $ref: keyword_ngroups.schema
+- $ref: keyword_groupgap.schema
+- $ref: subarray.schema
 - type: object
   properties:
     data:
@@ -28,5 +32,4 @@ allOf:
       default: 0.0
       ndim: 4
       datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/disperser.schema.yaml
+++ b/jwst/datamodels/schemas/disperser.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/disperser.schema"
 title: NirSpec Disperser reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_grating.schema.yaml
-- $ref: keyword_pgrating.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_grating.schema
+- $ref: keyword_pgrating.schema
 - type: object
   properties:
     groovedensity:

--- a/jwst/datamodels/schemas/distortion.schema.yaml
+++ b/jwst/datamodels/schemas/distortion.schema.yaml
@@ -1,15 +1,19 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/distortion.schema"
 title: Distortion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_pfilter.schema.yaml
-- $ref: keyword_pupil.schema.yaml
-- $ref: keyword_ppupil.schema.yaml
-- $ref: keyword_module.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: keyword_psubarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_pfilter.schema
+- $ref: keyword_pupil.schema
+- $ref: keyword_ppupil.schema
+- $ref: keyword_module.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: subarray.schema
+- $ref: keyword_psubarray.schema
 - type: object
   properties:
     model:

--- a/jwst/datamodels/schemas/distortion_mrs.schema.yaml
+++ b/jwst/datamodels/schemas/distortion_mrs.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/distortion_mrs.schema"
 title: Distortion data model for MIRI MRS reference data
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_band.schema.yaml
-- $ref: keyword_channel.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_band.schema
+- $ref: keyword_channel.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     slices:

--- a/jwst/datamodels/schemas/dq_def.schema.yaml
+++ b/jwst/datamodels/schemas/dq_def.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/dq_def.schema"
 type: object
 properties:
   dq_def:
@@ -12,4 +16,3 @@ properties:
       datatype: [ascii, 40]
     - name: DESCRIPTION
       datatype: [ascii, 80]
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/drizpars.schema.yaml
+++ b/jwst/datamodels/schemas/drizpars.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/drizpars.schema"
 title: Default Drizzle parameters data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     data:
@@ -21,4 +25,3 @@ allOf:
         datatype: [ascii, 10]
       - name: stepsize
         datatype: int32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/drizproduct.schema.yaml
+++ b/jwst/datamodels/schemas/drizproduct.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/drizproduct.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: lev3_prod.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: lev3_prod.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     meta:
@@ -31,4 +35,3 @@ allOf:
       fits_hdu: WHT
       default: 0.0
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/extract1dimage.schema.yaml
+++ b/jwst/datamodels/schemas/extract1dimage.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/extract1dimage.schema"
 title: 1-D extraction regions array
 allOf:
-- $ref: subarray.schema.yaml
+- $ref: subarray.schema
 - type: object
   properties:
     data:
@@ -28,4 +32,3 @@ allOf:
       type: integer
       fits_keyword: SMOOTH_L
       fits_hdu: SCI
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/fgsimg_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/fgsimg_apcorr.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/fgsimg_apcorr.schema"
 title: FGS aperture correction data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     apcorr_table:
@@ -19,4 +23,3 @@ allOf:
         datatype: float32
       - name: skyout
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/fgsimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/fgsimg_photom.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/fgsimg_photom.schema"
 title: FGS photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -14,4 +18,3 @@ allOf:
         datatype: float32
       - name: uncertainty
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/filteroffset.schema.yaml
+++ b/jwst/datamodels/schemas/filteroffset.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/filteroffset.schema"
 title: MIRI Imager Filteroffset reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_pfilter.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_pfilter.schema
 - type: object
   properties:
     filters:

--- a/jwst/datamodels/schemas/flat.schema.yaml
+++ b/jwst/datamodels/schemas/flat.schema.yaml
@@ -1,11 +1,15 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/flat.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_pfilter.schema.yaml
-- $ref: keyword_pupil.schema.yaml
-- $ref: keyword_ppupil.schema.yaml
-- $ref: keyword_channel.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_pfilter.schema
+- $ref: keyword_pupil.schema
+- $ref: keyword_ppupil.schema
+- $ref: keyword_channel.schema
 - type: object
   properties:
     data:
@@ -24,5 +28,4 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/fore.schema.yaml
+++ b/jwst/datamodels/schemas/fore.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/fore.schema"
 title: NirSpec filter dependent FORE reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     model:

--- a/jwst/datamodels/schemas/fpa.schema.yaml
+++ b/jwst/datamodels/schemas/fpa.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/fpa.schema"
 title: NirSpec FPA reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_pdetector.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_pdetector.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     nrs1_model:

--- a/jwst/datamodels/schemas/fringe.schema.yaml
+++ b/jwst/datamodels/schemas/fringe.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/fringe.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_band.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_band.schema
 - type: object
   properties:
     data:
@@ -19,5 +23,4 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/gain.schema.yaml
+++ b/jwst/datamodels/schemas/gain.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/gain.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: keyword_gainfact.schema.yaml
-- $ref: bunit.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
+- $ref: keyword_gainfact.schema
+- $ref: bunit.schema
 - type: object
   properties:
     data:
@@ -11,4 +15,3 @@ allOf:
       default: 0.0
       ndim: 2
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/gls_rampfit.schema.yaml
+++ b/jwst/datamodels/schemas/gls_rampfit.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/gls_rampfit.schema"
 title: Optional output for GLS ramp fitting
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     yint:
@@ -33,4 +37,3 @@ allOf:
       default: 0.0
       ndim: 4
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/group.schema.yaml
+++ b/jwst/datamodels/schemas/group.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/group.schema"
 type: object
 properties:
   group:
@@ -30,4 +34,3 @@ properties:
       datatype: float64
     - name: helio_end_time
       datatype: float64
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/guider_cal.schema.yaml
+++ b/jwst/datamodels/schemas/guider_cal.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/guider_cal.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     meta:
@@ -222,4 +226,3 @@ allOf:
         datatype: int32
       - name: y_size
         datatype: int32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/guider_raw.schema.yaml
+++ b/jwst/datamodels/schemas/guider_raw.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/guider_raw.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     meta:
@@ -222,4 +226,3 @@ allOf:
         datatype: int32
       - name: y_size
         datatype: int32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/ifucube.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     meta:
@@ -84,4 +88,3 @@ allOf:
       type: string
       fits_keyword: TDIM2
       fits_hdu: WCS-TABLE
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifucubepars.schema.yaml
+++ b/jwst/datamodels/schemas/ifucubepars.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/ifucubepars.schema"
 title: Default IFU CUBE parameters data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     ifucubepars_table:
@@ -19,4 +23,3 @@ allOf:
         datatype: float32
       - name: wave_roi
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ifufore.schema.yaml
+++ b/jwst/datamodels/schemas/ifufore.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/ifufore.schema"
 title: NirSpec IFUFORE reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     model:

--- a/jwst/datamodels/schemas/ifuimage.schema.yaml
+++ b/jwst/datamodels/schemas/ifuimage.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/ifuimage.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     data:
@@ -29,7 +33,7 @@ allOf:
       title: Pixel area map array
       fits_hdu: AREA
       datatype: float32
-- $ref: variance.schema.yaml
+- $ref: variance.schema
 - type: object
   properties:
     wavelength:
@@ -37,5 +41,4 @@ allOf:
       fits_hdu: WAVELENGTH
       datatype: float32
       default: 0.0
-- $ref: pathlosscorr.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: pathlosscorr.schema

--- a/jwst/datamodels/schemas/ifupost.schema.yaml
+++ b/jwst/datamodels/schemas/ifupost.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/ifupost.schema"
 title: Nirspec IFUPOST reference file model
 definitions:
   slice_transforms:
@@ -31,8 +35,8 @@ definitions:
           The wavelength dependent distortion polynomial in X.
           The backward polynomial is assigned as inverse.
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     slice_0:

--- a/jwst/datamodels/schemas/ifuslicer.schema.yaml
+++ b/jwst/datamodels/schemas/ifuslicer.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/ifuslicer.schema"
 title: NirSpec IFUSlicer reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     model:

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/image.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     data:
@@ -31,8 +35,8 @@ allOf:
       fits_hdu: AREA
       default: 0.0
       datatype: float32
-- $ref: variance.schema.yaml
-- $ref: pathlosscorr.schema.yaml
+- $ref: variance.schema
+- $ref: pathlosscorr.schema
 - type: object
   properties:
     meta:
@@ -52,4 +56,3 @@ allOf:
                 title: Output source catalog filename
                 type: string
                 fits_keyword: SCATFILE
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/int_times.schema.yaml
+++ b/jwst/datamodels/schemas/int_times.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/int_times.schema"
 type: object
 properties:
   int_times:
@@ -18,4 +22,3 @@ properties:
       datatype: float64
     - name: int_end_BJD_TDB
       datatype: float64
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ipc.schema.yaml
+++ b/jwst/datamodels/schemas/ipc.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/ipc.schema"
 title: IPC kernel model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     data:
@@ -8,4 +12,3 @@ allOf:
       fits_hdu: SCI
       default: 1.0
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/irs2.schema.yaml
+++ b/jwst/datamodels/schemas/irs2.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/irs2.schema"
 title: IRS2 refpix reference file data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_readpatt.schema.yaml
-- $ref: keyword_preadpatt.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_preadpatt.schema
 - type: object
   properties:
     irs2_table:
@@ -25,4 +29,3 @@ allOf:
         datatype: float32
       - name: beta_3
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/keyword_band.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_band.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_band.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_channel.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_channel.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_channel.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_coronmsk.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_coronmsk.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_coronmsk.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_exptype.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_exptype.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_exptype.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_filter.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_filter.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_filter.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_gainfact.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_gainfact.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_gainfact.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_grating.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_grating.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_grating.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_groupgap.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_groupgap.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_groupgap.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_module.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_module.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_module.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_nframes.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_nframes.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_nframes.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_ngroups.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_ngroups.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_ngroups.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_pband.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pband.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_pband.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_pchannel.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pchannel.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_pchannel.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_pdetector.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pdetector.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_pdetector.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_pexptype.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pexptype.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_pexptype.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_pfilter.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pfilter.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_pfilter.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_pgrating.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pgrating.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_pgrating.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_photmjsr.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_photmjsr.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_photmjsr.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_pixelarea.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pixelarea.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_pixelarea.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_ppupil.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_ppupil.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_ppupil.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_preadpatt.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_preadpatt.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_preadpatt.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_psubarray.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_psubarray.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_psubarray.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_pupil.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pupil.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_pupil.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/keyword_readpatt.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_readpatt.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_readpatt.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/lastframe.schema.yaml
+++ b/jwst/datamodels/schemas/lastframe.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/lastframe.schema"
 title: Last Frame Correction data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     data:
@@ -21,5 +25,4 @@ allOf:
       default: 0.0
       ndim: 2
       datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/lev3_prod.schema.yaml
+++ b/jwst/datamodels/schemas/lev3_prod.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/lev3_prod.schema"
 type: object
 properties:
   meta:
@@ -71,4 +75,3 @@ properties:
             title: Output source catalog filename
             type: string
             fits_keyword: SCATFILE
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/level1b.schema.yaml
+++ b/jwst/datamodels/schemas/level1b.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/level1b.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     data:
@@ -23,6 +27,5 @@ allOf:
       default: 0.0
       ndim: 4
       datatype: uint16
-- $ref: group.schema.yaml
-- $ref: int_times.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: group.schema
+- $ref: int_times.schema

--- a/jwst/datamodels/schemas/linearity.schema.yaml
+++ b/jwst/datamodels/schemas/linearity.schema.yaml
@@ -1,10 +1,14 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/linearity.schema"
 title: Linearity correction data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: keyword_band.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_gainfact.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
+- $ref: keyword_band.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_gainfact.schema
 - type: object
   properties:
     coeffs:
@@ -18,5 +22,4 @@ allOf:
       fits_hdu: DQ
       default: 0
       datatype: uint32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/mask.schema.yaml
+++ b/jwst/datamodels/schemas/mask.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mask.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: keyword_preadpatt.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
+- $ref: keyword_preadpatt.schema
 - type: object
   properties:
     dq:
@@ -10,5 +14,4 @@ allOf:
       default: 0
       ndim: 2
       datatype: uint32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/miri_ifucubepars.schema.yaml
+++ b/jwst/datamodels/schemas/miri_ifucubepars.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/miri_ifucubepars.schema"
 title: Default MIRI IFU cube parameters data model
 allOf:
-- $ref: ifucubepars.schema.yaml
+- $ref: ifucubepars.schema
 - type: object
   properties:
     ifucubepars_table:
@@ -75,4 +79,3 @@ allOf:
         datatype: float32
       - name: scalerad
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/miri_resolution.schema.yaml
+++ b/jwst/datamodels/schemas/miri_resolution.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/miri_resolution.schema"
 title: Miri Resolution Reference file
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     resolving_power_table:
@@ -57,4 +61,3 @@ allOf:
          datatype: float32
        - name: B_B_LONG
          datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/mirimg_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_apcorr.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mirimg_apcorr.schema"
 title: MIRI imaging aperture correction data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     apcorr_table:
@@ -23,4 +27,3 @@ allOf:
         datatype: float32
       - name: skyout
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -1,10 +1,14 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mirimg_photom.schema"
 title: MIRI imaging photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_band.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_band.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -19,4 +23,3 @@ allOf:
         datatype: float32
       - name: uncertainty
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
@@ -1,10 +1,14 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mirlrs_photom.schema"
 title: MIRI LRS photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_band.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_band.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -30,4 +34,3 @@ allOf:
       - name: reluncertainty
         datatype: float32
         ndim: 1
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/mirmrs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirmrs_photom.schema.yaml
@@ -1,11 +1,15 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mirmrs_photom.schema"
 title: MIRI MRS photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_band.schema.yaml
-- $ref: keyword_photmjsr.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_band.schema
+- $ref: keyword_photmjsr.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     data:
@@ -26,7 +30,7 @@ allOf:
       default: 0
       ndim: 2
       datatype: uint32
-- $ref: dq_def.schema.yaml
+- $ref: dq_def.schema
 - type: object
   properties:
     pixsiz:
@@ -35,4 +39,3 @@ allOf:
       default: 1.0
       ndim: 2
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/msa.schema.yaml
+++ b/jwst/datamodels/schemas/msa.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/msa.schema"
 title: NirSpec MSA reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pdetector.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pdetector.schema
 - type: object
   properties:
     Q1:

--- a/jwst/datamodels/schemas/multiexposure.schema.yaml
+++ b/jwst/datamodels/schemas/multiexposure.schema.yaml
@@ -1,5 +1,9 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/multiexposure.schema"
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     exposures:
@@ -7,9 +11,8 @@ allOf:
       title: An array of slits
       items:
         allOf:
-        - $ref: slitdata.schema.yaml
+        - $ref: slitdata.schema
         - type: object
           properties:
             meta:
               title: META info from the exposure source file
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/multiextract1d.schema.yaml
+++ b/jwst/datamodels/schemas/multiextract1d.schema.yaml
@@ -1,5 +1,9 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/multiextract1d.schema"
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     images:
@@ -32,4 +36,3 @@ allOf:
             type: integer
             fits_keyword: SMOOTH_L
             fits_hdu: SCI
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/multiproduct.schema.yaml
+++ b/jwst/datamodels/schemas/multiproduct.schema.yaml
@@ -1,5 +1,9 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/multiproduct.schema"
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     products:
@@ -7,8 +11,8 @@ allOf:
       title: An array of DrizProducts
       items:
         allOf:
-        - $ref: photometry.schema.yaml
-        - $ref: wcsinfo.schema.yaml
+        - $ref: photometry.schema
+        - $ref: wcsinfo.schema
         - type: object
           properties:
             data:
@@ -111,4 +115,3 @@ allOf:
               default: ""
               fits_keyword: SHUTSTA
               fits_hdu: SCI
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/multislit.schema.yaml
+++ b/jwst/datamodels/schemas/multislit.schema.yaml
@@ -1,5 +1,9 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/multislit.schema"
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     slits:
@@ -8,5 +12,4 @@ allOf:
       description: |
         An array of SlitModel instances. All slits come from the same exposure.
       items:
-        $ref: slitdata.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+        $ref: slitdata.schema

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/multispec.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: int_times.schema.yaml
+- $ref: core.schema
+- $ref: int_times.schema
 - type: object
   properties:
     spec:
@@ -150,4 +154,3 @@ allOf:
             type: number
             fits_keyword: TDB-END
             fits_hdu: EXTRACT1D
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nirspec_area_ifu.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_area_ifu.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nirspec_area_ifu.schema"
 title: NIRSpec IFU pixel area data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_grating.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_grating.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     area_table:
@@ -14,4 +18,3 @@ allOf:
         datatype: int16
       - name: pixarea
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nirspec_area_mos.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_area_mos.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nirspec_area_mos.schema"
 title: NIRSpec MOS pixel area data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_grating.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_grating.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     area_table:
@@ -18,4 +22,3 @@ allOf:
         datatype: int16
       - name: pixarea
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nirspec_area_slit.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_area_slit.schema.yaml
@@ -1,10 +1,14 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nirspec_area_slit.schema"
 title: NIRSpec fixed-slit pixel area data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_grating.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_grating.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     area_table:
@@ -15,4 +19,3 @@ allOf:
         datatype: [ascii, 15]
       - name: pixarea
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nirspec_flat.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_flat.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nirspec_flat.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_grating.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_grating.schema
+- $ref: keyword_pexptype.schema
+- $ref: subarray.schema
 - type: object
   properties:
     data:
@@ -44,5 +48,4 @@ allOf:
       - name: data
         shape: [130000]
         datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nirspec_ifucubepars.schema"
 title: Default NIRSPEC IFU cube parameters data model
 allOf:
-- $ref: ifucubepars.schema.yaml
+- $ref: ifucubepars.schema
 - type: object
   properties:
     ifucubepars_table:
@@ -127,4 +131,3 @@ allOf:
         datatype: float32
       - name: scalerad
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nirspec_quad_flat.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_quad_flat.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nirspec_quad_flat.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
 - type: object
   properties:
     quadrants:
@@ -44,5 +48,4 @@ allOf:
             - name: data
               shape: [130000]
               datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/nisimg_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/nisimg_apcorr.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nisimg_apcorr.schema"
 title: NIRISS imaging aperture correction data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     apcorr_table:
@@ -23,4 +27,3 @@ allOf:
         datatype: float32
       - name: skyout
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nisimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nisimg_photom.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nisimg_photom.schema"
 title: NIRISS imaging photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -18,4 +22,3 @@ allOf:
         datatype: float32
       - name: uncertainty
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nissoss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nissoss_photom.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nissoss_photom.schema"
 title: NIRISS SOSS photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -31,4 +35,3 @@ allOf:
       - name: reluncertainty
         datatype: float32
         ndim: 1
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/niswfss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/niswfss_photom.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/niswfss_photom.schema"
 title: NIRISS WFSS photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -31,4 +35,3 @@ allOf:
       - name: reluncertainty
         datatype: float32
         ndim: 1
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrcimg_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/nrcimg_apcorr.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrcimg_apcorr.schema"
 title: NIRCam imaging aperture correction data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     apcorr_table:
@@ -23,4 +27,3 @@ allOf:
         datatype: float32
       - name: skyout
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrcimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrcimg_photom.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrcimg_photom.schema"
 title: NIRCam imaging photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -18,4 +22,3 @@ allOf:
         datatype: float32
       - name: uncertainty
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrcwfss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrcwfss_photom.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrcwfss_photom.schema"
 title: NIRCam WFSS photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -31,4 +35,3 @@ allOf:
       - name: reluncertainty
         datatype: float32
         ndim: 1
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrsfs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrsfs_photom.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrsfs_photom.schema"
 title: NIRSpec Fixed-Slit photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -31,4 +35,3 @@ allOf:
       - name: reluncertainty
         datatype: float32
         ndim: 1
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/nrsmos_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nrsmos_photom.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrsmos_photom.schema"
 title: NIRSpec MOS and IFU photometric flux conversion data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_pixelarea.schema
 - type: object
   properties:
     phot_table:
@@ -29,4 +33,3 @@ allOf:
       - name: reluncertainty
         datatype: float32
         ndim: 1
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ote.schema.yaml
+++ b/jwst/datamodels/schemas/ote.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/ote.schema"
 title: NirSpec OTE reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
 - type: object
   properties:
     model:

--- a/jwst/datamodels/schemas/outlierpars.schema.yaml
+++ b/jwst/datamodels/schemas/outlierpars.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/outlierpars.schema"
 title: Default Oulier Detection parameters data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     outlierpars_table:
@@ -54,4 +58,3 @@ allOf:
       - name: backg
         datatype: float32
 
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/pathloss.schema.yaml
+++ b/jwst/datamodels/schemas/pathloss.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/pathloss.schema"
 title: Pathloss correction data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_pexptype.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     apertures:
@@ -97,4 +101,3 @@ allOf:
                 title: cdelt1
                 fits_keyword: cdelt1
                 fits_hdu: uni
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/pathlosscorr.schema.yaml
+++ b/jwst/datamodels/schemas/pathlosscorr.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/pathlosscorr.schema"
 type: object
 properties:
   pathloss:
@@ -5,4 +9,3 @@ properties:
     fits_hdu: PATHLOSS
     ndim: 2
     datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/persat.schema.yaml
+++ b/jwst/datamodels/schemas/persat.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/persat.schema"
 title: Persistence saturation threshold
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
 - type: object
   properties:
     data:
@@ -15,5 +19,4 @@ allOf:
       fits_hdu: DQ
       default: 0
       datatype: uint32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/photometry.schema.yaml
+++ b/jwst/datamodels/schemas/photometry.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/photometry.schema"
 type: object
 properties:
   meta:
@@ -31,4 +35,3 @@ properties:
             fits_keyword: PIXAR_A2
             fits_hdu: SCI
             blend_table: True
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/pixelarea.schema.yaml
+++ b/jwst/datamodels/schemas/pixelarea.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/pixelarea.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_pixelarea.schema.yaml
-- $ref: keyword_pupil.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_pixelarea.schema
+- $ref: keyword_pupil.schema
 
 - type: object
   properties:
@@ -13,4 +17,3 @@ allOf:
       default: 1.0
       ndim: 2
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/psfmask.schema.yaml
+++ b/jwst/datamodels/schemas/psfmask.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/psfmask.schema"
 title: Coronagraphic PSF mask data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_coronmsk.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_coronmsk.schema
+- $ref: subarray.schema
 - type: object
   properties:
     data:
@@ -12,4 +16,3 @@ allOf:
       default: 1.0
       ndim: 2
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/quad.schema.yaml
+++ b/jwst/datamodels/schemas/quad.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/quad.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     data:
@@ -21,4 +25,3 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/ramp.schema.yaml
+++ b/jwst/datamodels/schemas/ramp.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/ramp.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
+- $ref: core.schema
+- $ref: bunit.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema
 - type: object
   properties:
     data:
@@ -40,6 +44,5 @@ allOf:
       default: 0.0
       ndim: 4
       datatype: float32
-- $ref: group.schema.yaml
-- $ref: int_times.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: group.schema
+- $ref: int_times.schema

--- a/jwst/datamodels/schemas/rampfitoutput.schema.yaml
+++ b/jwst/datamodels/schemas/rampfitoutput.schema.yaml
@@ -1,5 +1,9 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/rampfitoutput.schema"
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     slope:
@@ -56,4 +60,3 @@ allOf:
       default: 0.0
       ndim: 4
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/readnoise.schema.yaml
+++ b/jwst/datamodels/schemas/readnoise.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/readnoise.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: keyword_readpatt.schema.yaml
-- $ref: keyword_gainfact.schema.yaml
-- $ref: bunit.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_gainfact.schema
+- $ref: bunit.schema
 - type: object
   properties:
     data:
@@ -12,4 +16,3 @@ allOf:
       default: 0.0
       ndim: 2
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/referencecube.schema.yaml
+++ b/jwst/datamodels/schemas/referencecube.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/referencecube.schema"
 title: Reference cube data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     data:
@@ -19,4 +23,3 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/referencefile.schema.yaml
+++ b/jwst/datamodels/schemas/referencefile.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/referencefile.schema"
 type: object
 properties:
   meta:
@@ -70,4 +74,3 @@ properties:
             description: Detector name.
             fits_keyword: DETECTOR
 
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/referenceimage.schema.yaml
+++ b/jwst/datamodels/schemas/referenceimage.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/referenceimage.schema"
 title: Reference image data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     data:
@@ -19,4 +23,3 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/referencequad.schema.yaml
+++ b/jwst/datamodels/schemas/referencequad.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/referencequad.schema"
 title: Reference quad data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     data:
@@ -19,4 +23,3 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/regions.schema.yaml
+++ b/jwst/datamodels/schemas/regions.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/regions.schema"
 title: MIRI MRS REGIONS reference file model (assign_wcs step)
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_band.schema.yaml
-- $ref: keyword_channel.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_band.schema
+- $ref: keyword_channel.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     regions:

--- a/jwst/datamodels/schemas/reset.schema.yaml
+++ b/jwst/datamodels/schemas/reset.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/reset.schema"
 title: Reset Correction data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     data:
@@ -21,5 +25,4 @@ allOf:
       default: 0.0
       ndim: 4
       datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/resolution.schema.yaml
+++ b/jwst/datamodels/schemas/resolution.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/resolution.schema"
 title: Default Resolution Reference file
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     data:
@@ -8,4 +12,3 @@ allOf:
       fits_hdu: SCI
       default: 1.0
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/rscd.schema.yaml
+++ b/jwst/datamodels/schemas/rscd.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/rscd.schema"
 title: RSCD reference file model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     rscd_table:
@@ -41,4 +45,3 @@ allOf:
         datatype: float32
       - name:  sat_scale
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/saturation.schema.yaml
+++ b/jwst/datamodels/schemas/saturation.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/saturation.schema"
 title: Saturation checking data
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: keyword_gainfact.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
+- $ref: keyword_gainfact.schema
 - type: object
   properties:
     data:
@@ -16,5 +20,4 @@ allOf:
       fits_hdu: DQ
       default: 0
       datatype: uint32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/slit.schema.yaml
+++ b/jwst/datamodels/schemas/slit.schema.yaml
@@ -1,5 +1,8 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/slit.schema"
 allOf:
-- $ref: core.schema.yaml
-- $ref: slitdata.schema.yaml
-- $ref: int_times.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: core.schema
+- $ref: slitdata.schema
+- $ref: int_times.schema

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/slitdata.schema"
 allOf:
 - type: object
   properties:
@@ -122,9 +126,8 @@ allOf:
       fits_hdu: AREA
       default: 0.0
       datatype: float32
-- $ref: variance.schema.yaml
-- $ref: pathlosscorr.schema.yaml
-- $ref: bunit.schema.yaml
-- $ref: photometry.schema.yaml
-- $ref: wcsinfo.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: variance.schema
+- $ref: pathlosscorr.schema
+- $ref: bunit.schema
+- $ref: photometry.schema
+- $ref: wcsinfo.schema

--- a/jwst/datamodels/schemas/spec.schema.yaml
+++ b/jwst/datamodels/schemas/spec.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/spec.schema"
 title: Spectrum data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: core.schema
 - type: object
   properties:
     spec_table:
@@ -25,4 +29,3 @@ allOf:
         datatype: float64
       - name: NPIXELS
         datatype: float64
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/specwcs.schema.yaml
+++ b/jwst/datamodels/schemas/specwcs.schema.yaml
@@ -1,10 +1,14 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/specwcs.schema"
 title: SPECWCS reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_band.schema.yaml
-- $ref: keyword_channel.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_band.schema
+- $ref: keyword_channel.schema
+- $ref: keyword_exptype.schema
+- $ref: subarray.schema
 - type: object
   properties:
     slices:

--- a/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
+++ b/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/specwcs_nircam_grism.schema"
 title: SPECWCS_NIRCAM_GRISM reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_module.schema.yaml
-- $ref: keyword_pupil.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_module.schema
+- $ref: keyword_pupil.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     displ:

--- a/jwst/datamodels/schemas/specwcs_niriss_grism.schema.yaml
+++ b/jwst/datamodels/schemas/specwcs_niriss_grism.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/specwcs_niriss_grism.schema"
 title: SPECWCS_NIRISS_GRISM reference file model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_pupil.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_pupil.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     displ:

--- a/jwst/datamodels/schemas/steppars.schema.yaml
+++ b/jwst/datamodels/schemas/steppars.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/steppars.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/straylight.schema.yaml
+++ b/jwst/datamodels/schemas/straylight.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/straylight.schema"
 title: Straylight MRS correction data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_band.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_band.schema
 - type: object
   properties:
     data:
@@ -10,4 +14,3 @@ allOf:
       default: 0.0
       ndim: 2
       datatype: uint8
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/subarray.schema.yaml
+++ b/jwst/datamodels/schemas/subarray.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/subarray.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/superbias.schema.yaml
+++ b/jwst/datamodels/schemas/superbias.schema.yaml
@@ -1,9 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/superbias.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: keyword_readpatt.schema.yaml
-- $ref: keyword_preadpatt.schema.yaml
-- $ref: keyword_gainfact.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_preadpatt.schema
+- $ref: keyword_gainfact.schema
 - type: object
   properties:
     data:
@@ -22,5 +26,4 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/throughput.schema.yaml
+++ b/jwst/datamodels/schemas/throughput.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/throughput.schema"
 title: Filter throughput data model
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_filter.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_filter.schema
 - type: object
   properties:
     filter_table:
@@ -12,4 +16,3 @@ allOf:
         datatype: float32
       - name: throughput
         datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/trapdensity.schema.yaml
+++ b/jwst/datamodels/schemas/trapdensity.schema.yaml
@@ -1,7 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/trapdensity.schema"
 title: Trap density map
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: referencefile.schema
+- $ref: subarray.schema
 - type: object
   properties:
     data:
@@ -15,5 +19,4 @@ allOf:
       fits_hdu: DQ
       default: 0
       datatype: uint32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/schemas/trappars.schema.yaml
+++ b/jwst/datamodels/schemas/trappars.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/trappars.schema"
 title: TrapPars data model
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     trappars_table:
@@ -15,4 +19,3 @@ allOf:
         datatype: float64
       - name: decay_param
         datatype: float64
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/trapsfilled.schema.yaml
+++ b/jwst/datamodels/schemas/trapsfilled.schema.yaml
@@ -1,8 +1,12 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/trapsfilled.schema"
 title: Traps-filled map
 allOf:
-- $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: core.schema
+- $ref: wcsinfo.schema
+- $ref: subarray.schema
 - type: object
   properties:
     data:
@@ -11,4 +15,3 @@ allOf:
       default: 0.0
       ndim: 3
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/tsophot.schema.yaml
+++ b/jwst/datamodels/schemas/tsophot.schema.yaml
@@ -1,6 +1,10 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/tsophot.schema"
 title: TSO image photometry reference file model (tso_photometry step)
 allOf:
-- $ref: referencefile.schema.yaml
+- $ref: referencefile.schema
 - type: object
   properties:
     radii:

--- a/jwst/datamodels/schemas/variance.schema.yaml
+++ b/jwst/datamodels/schemas/variance.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/variance.schema"
 type: object
 properties:
     var_poisson:
@@ -18,4 +22,3 @@ properties:
       max_ndim: 3
       default: 0.0
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/wavecorr.schema.yaml
+++ b/jwst/datamodels/schemas/wavecorr.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/wavecorr.schema"
 title: NirSpec WAVECORR (wavelength zero-point correction) reference file model
 definitions:
   zero_point_correction:
@@ -26,8 +30,8 @@ definitions:
         type: number
         title: Aperture or pitch width [in m]
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
 - type: object
   properties:
     apertures:

--- a/jwst/datamodels/schemas/wavelengthrange.schema.yaml
+++ b/jwst/datamodels/schemas/wavelengthrange.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/wavelengthrange.schema"
 title: WAVELENGTHRANGE reference file model
 definitions:
   wfss-wavelengthrange:
@@ -13,10 +17,10 @@ definitions:
       - type: number
       - type: number
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_band.schema.yaml
-- $ref: keyword_channel.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_band.schema
+- $ref: keyword_channel.schema
 - type: object
   properties:
     waverange_selector:

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -1,3 +1,7 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/wcsinfo.schema"
 type: object
 properties:
   meta:

--- a/jwst/datamodels/schemas/wfssbkg.schema.yaml
+++ b/jwst/datamodels/schemas/wfssbkg.schema.yaml
@@ -1,10 +1,14 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/wfssbkg.schema"
 allOf:
-- $ref: referencefile.schema.yaml
-- $ref: keyword_exptype.schema.yaml
-- $ref: keyword_filter.schema.yaml
-- $ref: keyword_pupil.schema.yaml
-- $ref: subarray.schema.yaml
-- $ref: bunit.schema.yaml
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_pupil.schema
+- $ref: subarray.schema
+- $ref: bunit.schema
 - type: object
   properties:
     data:
@@ -23,5 +27,4 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-- $ref: dq_def.schema.yaml
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema
+- $ref: dq_def.schema

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -40,7 +40,7 @@ class SlitDataModel(DataModel):
 
     """
 
-    schema_url = "slitdata.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/slitdata.schema"
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, (SlitModel, ImageModel)):
@@ -106,7 +106,7 @@ class SlitModel(DataModel):
          table of times for each integration
 
     """
-    schema_url = "slit.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/slit.schema"
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, (SlitModel, ImageModel)):

--- a/jwst/datamodels/spec.py
+++ b/jwst/datamodels/spec.py
@@ -15,4 +15,4 @@ class SpecModel(DataModel):
         A table with at least four columns:  wavelength, flux, an error
         estimate for the flux, and data quality flags.
     """
-    schema_url = "spec.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/spec.schema"

--- a/jwst/datamodels/steppars.py
+++ b/jwst/datamodels/steppars.py
@@ -24,7 +24,7 @@ class StepParsModel(DataModel):
     """
     A data model for `Step` parameters.
     """
-    schema_url = "steppars.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/steppars.schema"
 
     def __init__(self, init=None, **kwargs):
         super().__init__(init=init, **kwargs)

--- a/jwst/datamodels/straylight.py
+++ b/jwst/datamodels/straylight.py
@@ -13,4 +13,4 @@ class StrayLightModel(ReferenceFileModel):
     data : numpy uint8 array
          Straylight mask
     """
-    schema_url = "straylight.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/straylight.schema"

--- a/jwst/datamodels/superbias.py
+++ b/jwst/datamodels/superbias.py
@@ -23,7 +23,7 @@ class SuperBiasModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "superbias.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/superbias.schema"
 
     def __init__(self, init=None, **kwargs):
         super(SuperBiasModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/tests/data/nonstandard_primary_array.schema.yaml
+++ b/jwst/datamodels/tests/data/nonstandard_primary_array.schema.yaml
@@ -1,5 +1,8 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
 allOf:
-- $ref: ../../schemas/core.schema.yaml
+- $ref: http://stsci.edu/schemas/jwst_datamodel/core.schema
 - type: object
   title: Test schema - demonstrate infinite recursion loop
   properties:
@@ -17,4 +20,3 @@ allOf:
       ndim: 2
       units: arcsec
       datatype: float32
-$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/throughput.py
+++ b/jwst/datamodels/throughput.py
@@ -13,4 +13,4 @@ class ThroughputModel(ReferenceFileModel):
     filter_table : numpy table
          Filter throughput table
     """
-    schema_url = "throughput.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/throughput.schema"

--- a/jwst/datamodels/trapdensity.py
+++ b/jwst/datamodels/trapdensity.py
@@ -18,7 +18,7 @@ class TrapDensityModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "trapdensity.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/trapdensity.schema"
 
     def __init__(self, init=None, **kwargs):
         super(TrapDensityModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/trappars.py
+++ b/jwst/datamodels/trappars.py
@@ -16,4 +16,4 @@ class TrapParsModel(ReferenceFileModel):
          column for the trap-decay parameter.  Each row of the table is
          for a different trap family.
     """
-    schema_url = "trappars.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/trappars.schema"

--- a/jwst/datamodels/trapsfilled.py
+++ b/jwst/datamodels/trapsfilled.py
@@ -14,4 +14,4 @@ class TrapsFilledModel(DataModel):
         The map of the number of traps filled over the detector, with
         one plane for each "trap family."
     """
-    schema_url = "trapsfilled.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/trapsfilled.schema"

--- a/jwst/datamodels/tsophot.py
+++ b/jwst/datamodels/tsophot.py
@@ -11,7 +11,7 @@ class TsoPhotModel(ReferenceFileModel):
     """
     A model for a reference file of type "tsophot".
     """
-    schema_url = "tsophot.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/tsophot.schema"
     reftype = "tsophot"
 
     def __init__(self, init=None, radii=None, **kwargs):

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -62,7 +62,7 @@ class DistortionModel(_SimpleModel):
     """
     A model for a reference file of type "distortion".
     """
-    schema_url = "distortion.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/distortion.schema"
     reftype = "distortion"
 
     def validate(self):
@@ -84,7 +84,7 @@ class DistortionMRSModel(ReferenceFileModel):
     """
     A model for a reference file of type "distortion" for the MIRI MRS.
     """
-    schema_url = "distortion_mrs.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/distortion_mrs.schema"
     reftype = "distortion"
 
     def __init__(self, init=None, x_model=None, y_model=None, alpha_model=None, beta_model=None,
@@ -158,7 +158,7 @@ class SpecwcsModel(_SimpleModel):
     used during extract_2D. See NIRCAMGrismModel and
     NIRISSGrismModel.
     """
-    schema_url = "specwcs.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs.schema"
     reftype = "specwcs"
 
     def validate(self):
@@ -204,7 +204,7 @@ class NIRCAMGrismModel(ReferenceFileModel):
           dispersion models
 
     """
-    schema_url = "specwcs_nircam_grism.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_nircam_grism.schema"
     reftype = "specwcs"
 
     def __init__(self, init=None,
@@ -282,7 +282,7 @@ class NIRISSGrismModel(ReferenceFileModel):
     fwcpos_ref : float
         The reference value for the filter wheel position
     """
-    schema_url = "specwcs_niriss_grism.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_niriss_grism.schema"
     reftype = "specwcs"
 
     def __init__(self, init=None,
@@ -339,7 +339,7 @@ class RegionsModel(ReferenceFileModel):
     """
     A model for a reference file of type "regions".
     """
-    schema_url = "regions.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/regions.schema"
     reftype = "regions"
 
     def __init__(self, init=None, regions=None, **kwargs):
@@ -394,7 +394,7 @@ class WavelengthrangeModel(ReferenceFileModel):
         The units for the wavelength data
 
     """
-    schema_url = "wavelengthrange.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/wavelengthrange.schema"
     reftype = "wavelengthrange"
 
     def __init__(self, init=None, wrange_selector=None, wrange=None,
@@ -433,7 +433,7 @@ class FPAModel(ReferenceFileModel):
     """
     A model for a NIRSPEC reference file of type "fpa".
     """
-    schema_url = "fpa.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/fpa.schema"
     reftype = "fpa"
 
     def __init__(self, init=None, nrs1_model=None, nrs2_model=None, **kwargs):
@@ -491,7 +491,7 @@ class IFUPostModel(ReferenceFileModel):
 
     """
 
-    schema_url = "ifupost.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifupost.schema"
     reftype = "ifupost"
 
     def __init__(self, init=None, slice_models=None, **kwargs):
@@ -526,7 +526,7 @@ class IFUSlicerModel(ReferenceFileModel):
     """
     A model for a NIRSPEC reference file of type "ifuslicer".
     """
-    schema_url = "ifuslicer.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifuslicer.schema"
     reftype = "ifuslicer"
 
     def __init__(self, init=None, model=None, data=None, **kwargs):
@@ -559,7 +559,7 @@ class MSAModel(ReferenceFileModel):
     """
     A model for a NIRSPEC reference file of type "msa".
     """
-    schema_url = "msa.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/msa.schema"
     reftype = "msa"
 
     def __init__(self, init=None, models=None, data=None, **kwargs):
@@ -595,7 +595,7 @@ class DisperserModel(ReferenceFileModel):
     """
     A model for a NIRSPEC reference file of type "disperser".
     """
-    schema_url = "disperser.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/disperser.schema"
     reftype = "disperser"
 
     def __init__(self, init=None, angle=None, gwa_tiltx=None, gwa_tilty=None,
@@ -664,7 +664,7 @@ class FilteroffsetModel(ReferenceFileModel):
     """
     A model for a NIRSPEC reference file of type "disperser".
     """
-    schema_url = "filteroffset.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/filteroffset.schema"
     reftype = "filteroffset"
 
     def __init__(self, init=None, filters=None, **kwargs):
@@ -697,7 +697,7 @@ class IFUFOREModel(_SimpleModel):
     """
     A model for a NIRSPEC reference file of type "ifufore".
     """
-    schema_url = "ifufore.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifufore.schema"
     reftype = "ifufore"
 
     def populate_meta(self):
@@ -711,7 +711,7 @@ class CameraModel(_SimpleModel):
     """
     A model for a reference file of type "camera".
     """
-    schema_url = "camera.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/camera.schema"
     reftype = 'camera'
 
     def populate_meta(self):
@@ -727,7 +727,7 @@ class CollimatorModel(_SimpleModel):
     """
     A model for a reference file of type "collimator".
     """
-    schema_url = "collimator.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/collimator.schema"
     reftype = 'collimator'
 
     def populate_meta(self):
@@ -743,7 +743,7 @@ class OTEModel(_SimpleModel):
     """
     A model for a reference file of type "ote".
     """
-    schema_url = "ote.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/ote.schema"
     reftype = 'ote'
 
     def populate_meta(self):
@@ -759,7 +759,7 @@ class FOREModel(_SimpleModel):
     """
     A model for a reference file of type "fore".
     """
-    schema_url = "fore.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/fore.schema"
     reftype = 'fore'
 
     def populate_meta(self):
@@ -788,7 +788,7 @@ class FOREModel(_SimpleModel):
 class WaveCorrModel(ReferenceFileModel):
 
     reftype = "wavecorr"
-    schema_url = "wavecorr.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/wavecorr.schema"
 
     def __init__(self, init=None, apertures=None, **kwargs):
         super(WaveCorrModel, self).__init__(init, **kwargs)

--- a/jwst/datamodels/wfssbkg.py
+++ b/jwst/datamodels/wfssbkg.py
@@ -23,7 +23,7 @@ class WfssBkgModel(ReferenceFileModel):
     dq_def : numpy table
          DQ flag definitions
     """
-    schema_url = "wfssbkg.schema"
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/wfssbkg.schema"
 
     def __init__(self, init=None, **kwargs):
         super(WfssBkgModel, self).__init__(init=init, **kwargs)


### PR DESCRIPTION
This PR will make datamodels schemas more friendly to users who want to subclass DataModel (e.g., https://github.com/spacetelescope/jwst/issues/4246), and also lay the groundwork for a fix in asdf for https://github.com/spacetelescope/asdf/issues/683.  It's a large diff, but the changes were mostly automated.  Here's a summary:

- Change schema_url values in model classes to be absolute URIs, so that DataModel can be subclassed with schemas from other asdf extensions.
- Add an `id` field to each model schema so that relative references are unambiguous.
- Since I was in there anyway, add the missing `%YAML` directive and move the `$schema` declaration to the top to match the schemas in asdf-standard.
- Drop the `.yaml` extension from references in model schemas so that they can be treated as relative URIs instead of relative filesystem paths.

These changes are compatible with existing releases of asdf.