### PR TITLE
JP-1225 MIRI master_background tests copied to new regtest

### DIFF
--- a/jwst/regtest/test_miri_lrs_dedicated_mbkg.py
+++ b/jwst/regtest/test_miri_lrs_dedicated_mbkg.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+
+    rtdata = rtdata_module
+
+    collect_pipeline_cfgs("config")
+
+    rtdata.get_asn("miri/lrs/miri_lrs_mbkg_dedicated_spec3_asn.json")
+
+    args = ["config/master_background.cfg", rtdata.input,
+            "--save_results=True"]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+def test_miri_lrs_dedicated_mbkg(run_pipeline, fitsdiff_default_kwargs):
+    """Run a test for MIRI LRS data with dedicated background exposures."""
+
+    # Run the step and retrieve the output
+    rtdata = run_pipeline
+    rtdata.output = "miri_lrs_seq2_exp2_master_background.fits"
+
+    # Get the truth file
+    rtdata.get_truth(os.path.join(
+                "truth/test_miri_lrs_dedicated_mbkg",
+                "miri_lrs_seq2_exp2_master_background.fits"))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_lrs_dedicated_mbkg.py
+++ b/jwst/regtest/test_miri_lrs_dedicated_mbkg.py
@@ -26,7 +26,6 @@ def run_pipeline(jail, rtdata_module):
 def test_miri_lrs_dedicated_mbkg(run_pipeline, fitsdiff_default_kwargs):
     """Run a test for MIRI LRS data with dedicated background exposures."""
 
-    # Run the step and retrieve the output
     rtdata = run_pipeline
     rtdata.output = "miri_lrs_seq2_exp2_master_background.fits"
 

--- a/jwst/regtest/test_miri_lrs_masterbg_user.py
+++ b/jwst/regtest/test_miri_lrs_masterbg_user.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+
+    rtdata = rtdata_module
+
+    collect_pipeline_cfgs("config")
+
+    # This is the user-supplied background file.
+    rtdata.get_data("miri/lrs/miri_lrs_bkg_x1d.fits")
+    user_bkg = rtdata.input
+
+    # This is the input file for the master_background step.
+    rtdata.get_data("miri/lrs/miri_lrs_sci+bkg_cal.fits")
+
+    args = ["config/master_background.cfg", rtdata.input,
+            "--user_background=" + user_bkg,
+            "--save_results=True"]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+def test_miri_lrs_masterbg_user(run_pipeline, fitsdiff_default_kwargs):
+    """Run a test for MIRI LRS data with a user-supplied background file."""
+
+    # Run the step and retrieve the output
+    rtdata = run_pipeline
+    rtdata.output = "miri_lrs_sci+bkg_master_background.fits"
+
+    # Get the truth file
+    rtdata.get_truth(os.path.join("truth/test_miri_lrs_masterbg_user",
+                                  "miri_lrs_sci+bkg_master_background.fits"))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_lrs_masterbg_user.py
+++ b/jwst/regtest/test_miri_lrs_masterbg_user.py
@@ -32,7 +32,6 @@ def run_pipeline(jail, rtdata_module):
 def test_miri_lrs_masterbg_user(run_pipeline, fitsdiff_default_kwargs):
     """Run a test for MIRI LRS data with a user-supplied background file."""
 
-    # Run the step and retrieve the output
     rtdata = run_pipeline
     rtdata.output = "miri_lrs_sci+bkg_master_background.fits"
 

--- a/jwst/regtest/test_miri_lrs_nod_masterbg.py
+++ b/jwst/regtest/test_miri_lrs_nod_masterbg.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+
+    rtdata = rtdata_module
+
+    collect_pipeline_cfgs("config")
+
+    rtdata.get_asn("miri/lrs/miri_lrs_mbkg_nodded_spec3_asn.json")
+
+    args = ["config/master_background.cfg", rtdata.input,
+            "--save_results=True"]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("nod_seq", ["seq1", "seq2"])
+def test_miri_lrs_nod_masterbg(run_pipeline, fitsdiff_default_kwargs, nod_seq):
+    """Run a regression test for nodded MIRI LRS data."""
+
+    # Run the step and retrieve the output
+    rtdata = run_pipeline
+    rtdata.output = "miri_lrs_nod_" + nod_seq + "_exp1_master_background.fits"
+
+    # Get the truth file
+    rtdata.get_truth(os.path.join(
+                "truth/test_miri_lrs_nod_masterbg",
+                "miri_lrs_nod_" + nod_seq + "_exp1_master_background.fits"))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_lrs_nod_masterbg.py
+++ b/jwst/regtest/test_miri_lrs_nod_masterbg.py
@@ -27,7 +27,6 @@ def run_pipeline(jail, rtdata_module):
 def test_miri_lrs_nod_masterbg(run_pipeline, fitsdiff_default_kwargs, nod_seq):
     """Run a regression test for nodded MIRI LRS data."""
 
-    # Run the step and retrieve the output
     rtdata = run_pipeline
     rtdata.output = "miri_lrs_nod_" + nod_seq + "_exp1_master_background.fits"
 

--- a/jwst/regtest/test_miri_mrs_dedicated_mbkg.py
+++ b/jwst/regtest/test_miri_mrs_dedicated_mbkg.py
@@ -1,0 +1,43 @@
+import os
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+
+    rtdata = rtdata_module
+
+    collect_pipeline_cfgs("config")
+
+    rtdata.get_asn("miri/mrs/miri_mrs_mbkg_0304_spec3_asn.json")
+
+    args = ["config/master_background.cfg", rtdata.input,
+            "--save_results=True"]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("exp_seq", ["exp1", "exp2", "exp3"])
+def test_miri_mrs_dedicated_mbkg(run_pipeline, fitsdiff_default_kwargs,
+                                 exp_seq):
+    """Run a test for MIRI MRS data with dedicated background exposures."""
+
+    # Run the step and retrieve the output
+    rtdata = run_pipeline
+    rtdata.output = "miri_mrs_seq1_long_34_" + exp_seq + \
+                    "_master_background.fits"
+
+    # Get the truth file
+    rtdata.get_truth(os.path.join(
+            "truth/test_miri_mrs_dedicated_mbkg",
+            "miri_mrs_seq1_long_34_" + exp_seq + "_master_background.fits"))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_mrs_dedicated_mbkg.py
+++ b/jwst/regtest/test_miri_mrs_dedicated_mbkg.py
@@ -28,7 +28,6 @@ def test_miri_mrs_dedicated_mbkg(run_pipeline, fitsdiff_default_kwargs,
                                  exp_seq):
     """Run a test for MIRI MRS data with dedicated background exposures."""
 
-    # Run the step and retrieve the output
     rtdata = run_pipeline
     rtdata.output = "miri_mrs_seq1_long_34_" + exp_seq + \
                     "_master_background.fits"

--- a/jwst/regtest/test_miri_mrs_nod_masterbg.py
+++ b/jwst/regtest/test_miri_mrs_nod_masterbg.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+
+    rtdata = rtdata_module
+
+    collect_pipeline_cfgs("config")
+
+    rtdata.get_asn("miri/mrs/miri_mrs_mbkg_nodded_spec3_asn.json")
+
+    args = ["config/master_background.cfg", rtdata.input,
+            "--save_results=True"]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("nod_seq", ["seq1", "seq2"])
+def test_miri_mrs_nod_masterbg(run_pipeline, fitsdiff_default_kwargs, nod_seq):
+    """Run a test for MIRI MRS data with nodded background exposures."""
+
+    # Run the step and retrieve the output
+    rtdata = run_pipeline
+    rtdata.output = "miri_mrs_nod_" + nod_seq + \
+                    "_short12_exp1_master_background.fits"
+
+    # Get the truth file
+    rtdata.get_truth(os.path.join(
+        "truth/test_miri_mrs_nod_masterbg",
+        "miri_mrs_nod_" + nod_seq + "_short12_exp1_master_background.fits"))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_mrs_nod_masterbg.py
+++ b/jwst/regtest/test_miri_mrs_nod_masterbg.py
@@ -27,7 +27,6 @@ def run_pipeline(jail, rtdata_module):
 def test_miri_mrs_nod_masterbg(run_pipeline, fitsdiff_default_kwargs, nod_seq):
     """Run a test for MIRI MRS data with nodded background exposures."""
 
-    # Run the step and retrieve the output
     rtdata = run_pipeline
     rtdata.output = "miri_mrs_nod_" + nod_seq + \
                     "_short12_exp1_master_background.fits"


### PR DESCRIPTION
Tests of the `master_background` step for MIRI data have been created in the new regression test system, using input data copied from the old regtests.  There is a test with a user-supplied background file, a test with each of LRS and MRS data for the case of nodded exposures, and a similar pair of tests for the case of dedicated background exposures.