### PR TITLE
Make memmap=False be the default in datamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ datamodels
 
 - Deprecate MIRIRampModel [#4328]
 
+- Make memmap=False be the default in datamodels [#4445]
+
 extract_1d
 ----------
 

--- a/docs/jwst/assign_wcs/asdf-howto.rst
+++ b/docs/jwst/assign_wcs/asdf-howto.rst
@@ -137,9 +137,9 @@ catch any errors due to inconsistent inputs/outputs or invalid parameters.
 
 To test the file, it can be read in again using the ``asdf.open()`` function:
 
->>> ff = asdf.open('reffile.asdf')
->>> model = ff.tree['model']
->>> model(1)
+>>> with asdf.open('reffile.asdf') as ff:
+...     model = ff.tree['model']
+...     model(1)
     -152.2
 
 

--- a/jwst/ami/tests/test_ami_interface.py
+++ b/jwst/ami/tests/test_ami_interface.py
@@ -5,17 +5,15 @@ from jwst.ami import AmiAnalyzeStep
 import jwst
 
 
-def test_ami_analyze_calints_fail(tmpdir):
+def test_ami_analyze_calints_fail():
     """Make sure ami_analyze fails if input is CubeModel (_calints)"""
-    input_file = str(tmpdir.join("ami_analyze_input.fits"))
     model = datamodels.CubeModel((25, 19, 19))
     model.meta.instrument.name = "NIRISS"
     model.meta.instrument.filter = "F277W"
     model.meta.observation.date = "2019-01-01"
     model.meta.observation.time = "00:00:00"
-    model.save(input_file)
     with pytest.raises(RuntimeError):
-        AmiAnalyzeStep.call(input_file)
+        AmiAnalyzeStep.call(model)
 
 
 def test_ami_analyze_cube_fail():

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -39,7 +39,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     """
     schema_url = "core.schema"
 
-    def __init__(self, init=None, schema=None,
+    def __init__(self, init=None, schema=None, memmap=False,
                  pass_invalid_values=False, strict_validation=False,
                  ignore_missing_extensions=True, **kwargs):
         """
@@ -69,6 +69,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             The schema to use to understand the elements on the model.
             If not provided, the schema associated with this class
             will be used.
+
+        memmap : bool
+            Turn memmap of FITS file on or off.  (default: False).  Ignored for
+            ASDF files.
 
         pass_invalid_values : bool
             If `True`, values that do not validate the schema
@@ -163,7 +167,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                 if s3_utils.is_s3_uri(init):
                     hdulist = fits.open(s3_utils.get_object(init))
                 else:
-                    hdulist = fits.open(init)
+                    hdulist = fits.open(init, memmap=memmap)
 
                 asdffile = fits_support.from_fits(hdulist,
                                               self._schema,

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -19,7 +19,7 @@ log.addHandler(logging.NullHandler())
 class NoTypeWarning(Warning):
     pass
 
-def open(init=None, **kwargs):
+def open(init=None, memmap=False, **kwargs):
     """
     Creates a DataModel from a number of different types
 
@@ -43,6 +43,10 @@ def open(init=None, **kwargs):
           to what was passed in.
 
         - dict: The object model tree for the data model
+
+    memmap : bool
+        Turn memmap of FITS file on or off.  (default: False).  Ignored for
+        ASDF files.
 
     Returns
     -------
@@ -83,7 +87,7 @@ def open(init=None, **kwargs):
             if s3_utils.is_s3_uri(init):
                 hdulist = fits.open(s3_utils.get_object(init))
             else:
-                hdulist = fits.open(init)
+                hdulist = fits.open(init, memmap=memmap)
             file_to_close = hdulist
 
         elif file_type == "asn":
@@ -165,10 +169,8 @@ def open(init=None, **kwargs):
     if not has_model_type:
         class_name = new_class.__name__.split('.')[-1]
         if file_name:
-            errmsg = \
-                "model_type not found. Opening {} as a {}".format(file_name, class_name)
-            warnings.warn(errmsg, NoTypeWarning)
-
+            warnings.warn(f"model_type not found. Opening {file_name} as a {class_name}",
+                NoTypeWarning)
         try:
             delattr(model.meta, 'model_type')
         except AttributeError:


### PR DESCRIPTION
This turns off the memmap=True default when we open FITS files in datamodels. 

This is a potential bandaid fix for #4431/JP-1227.  It doesn't so much fix the problem as avoid the problem by not memory mapping.

Fixes #4431

Addresses some of #2887