### PR TITLE
JP-1219: Add missing NIRSpec regtests

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2879,14 +2879,13 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
         if isinstance(input_model, (datamodels.ImageModel,
                                     datamodels.DrizProductModel)):
 
-            # The following 3 lines are a temporary hack to get NIRSpec
+            # The following 2 lines are a temporary hack to get NIRSpec
             # fixed-slit exposures containing just 1 slit to make it
             # through processing. Once the DrizProductModel schema is
             # updated to carry over the necessary slit meta data, this
             # should no longer be needed. See JP-1144.
             if input_model.meta.exposure.type == 'NRS_FIXEDSLIT':
                 slitname = input_model.meta.instrument.fixed_slit
-                slit = None
 
             prev_offset = OFFSET_NOT_ASSIGNED_YET
             for sp_order in spectral_order_list:
@@ -2906,6 +2905,7 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 if subtract_background is not None:
                     extract_params['subtract_background'] = subtract_background
                 if extract_params['match'] == EXACT:
+                    slit = None
                     extract_params['dispaxis'] = \
                                 input_model.meta.wcsinfo.dispersion_direction
                     if extract_params['dispaxis'] is None:

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2878,6 +2878,16 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
 
         if isinstance(input_model, (datamodels.ImageModel,
                                     datamodels.DrizProductModel)):
+
+            # The following 3 lines are a temporary hack to get NIRSpec
+            # fixed-slit exposures containing just 1 slit to make it
+            # through processing. Once the DrizProductModel schema is
+            # updated to carry over the necessary slit meta data, this
+            # should no longer be needed. See JP-1144.
+            if input_model.meta.exposure.type == 'NRS_FIXEDSLIT':
+                slitname = input_model.meta.instrument.fixed_slit
+                slit = None
+
             prev_offset = OFFSET_NOT_ASSIGNED_YET
             for sp_order in spectral_order_list:
                 if sp_order == "not set yet":
@@ -2896,7 +2906,6 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 if subtract_background is not None:
                     extract_params['subtract_background'] = subtract_background
                 if extract_params['match'] == EXACT:
-                    slit = None
                     extract_params['dispaxis'] = \
                                 input_model.meta.wcsinfo.dispersion_direction
                     if extract_params['dispaxis'] is None:

--- a/jwst/regtest/test_nirspec_exceptions.py
+++ b/jwst/regtest/test_nirspec_exceptions.py
@@ -6,6 +6,7 @@ from jwst.stpipe import Step
 from jwst.assign_wcs.util import NoDataOnDetectorError
 from jwst.pipeline import Spec2Pipeline
 
+
 @pytest.mark.bigdata
 def test_nirspec_missing_msa_fail(_jail, rtdata, fitsdiff_default_kwargs, caplog):
     """
@@ -13,7 +14,7 @@ def test_nirspec_missing_msa_fail(_jail, rtdata, fitsdiff_default_kwargs, caplog
         that's missing an MSAMETFL. Exception should be raised.
     """
 
-    # Get the input file 
+    # Get the input file
     rtdata.get_data('nirspec/mos/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits')
 
     # Run the calwebb_spec2 pipeline
@@ -33,7 +34,7 @@ def test_nirspec_missing_msa_nofail(_jail, rtdata, fitsdiff_default_kwargs, capl
         that's missing an MSAMETFL. Exception should NOT be raised.
     """
 
-    # Get the input file 
+    # Get the input file
     rtdata.get_data('nirspec/mos/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits')
 
     # Run the calwebb_spec2 pipeline
@@ -54,7 +55,7 @@ def test_nirspec_assignwcs_skip(_jail, rtdata, fitsdiff_default_kwargs, caplog):
         with the AssignWcs step skipped. The pipeline should abort.
     """
 
-    # Get the input file 
+    # Get the input file
     rtdata.get_data('nirspec/mos/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits')
 
     # Run the calwebb_spec2 pipeline
@@ -76,7 +77,7 @@ def test_nirspec_nrs2_nodata_api(_jail, rtdata, fitsdiff_default_kwargs):
         the NRS2 detector. Pipeline should raise an exception.
     """
 
-    # Get the input file 
+    # Get the input file
     rtdata.get_data('nirspec/ifu/jw84700006001_02101_00001_nrs2_rate.fits')
 
     # Call the Spec2Pipeline
@@ -95,7 +96,7 @@ def test_nirspec_nrs2_nodata_strun(_jail, rtdata, fitsdiff_default_kwargs, caplo
         the NRS2 detector. Pipeline should return with non-zero exit status.
     """
 
-    # Get the input file 
+    # Get the input file
     rtdata.get_data('nirspec/ifu/jw84700006001_02101_00001_nrs2_rate.fits')
 
     # Call the Spec2Pipeline

--- a/jwst/regtest/test_nirspec_exceptions.py
+++ b/jwst/regtest/test_nirspec_exceptions.py
@@ -1,0 +1,109 @@
+import pytest
+import subprocess
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+from jwst.assign_wcs.util import NoDataOnDetectorError
+from jwst.pipeline import Spec2Pipeline
+
+@pytest.mark.bigdata
+def test_nirspec_missing_msa_fail(_jail, rtdata, fitsdiff_default_kwargs, caplog):
+    """
+        Test of calwebb_spec2 pipeline performed on NIRSpec MSA exposure
+        that's missing an MSAMETFL. Exception should be raised.
+    """
+
+    # Get the input file 
+    rtdata.get_data('nirspec/mos/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits')
+
+    # Run the calwebb_spec2 pipeline
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_spec2.cfg", rtdata.input]
+
+    with pytest.raises(Exception):
+        Step.from_cmdline(args)
+
+    assert 'Missing MSA meta (MSAMETFL) file' in caplog.text
+
+
+@pytest.mark.bigdata
+def test_nirspec_missing_msa_nofail(_jail, rtdata, fitsdiff_default_kwargs, caplog):
+    """
+        Test of calwebb_spec2 pipeline performed on NIRSpec MSA exposure
+        that's missing an MSAMETFL. Exception should NOT be raised.
+    """
+
+    # Get the input file 
+    rtdata.get_data('nirspec/mos/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits')
+
+    # Run the calwebb_spec2 pipeline
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_spec2.cfg",
+            rtdata.input,
+            '--fail_on_exception=False']
+
+    Step.from_cmdline(args)
+
+    assert 'Missing MSA meta (MSAMETFL) file' in caplog.text
+
+
+@pytest.mark.bigdata
+def test_nirspec_assignwcs_skip(_jail, rtdata, fitsdiff_default_kwargs, caplog):
+    """
+        Test of calwebb_spec2 pipeline performed on NIRSpec MSA exposure
+        with the AssignWcs step skipped. The pipeline should abort.
+    """
+
+    # Get the input file 
+    rtdata.get_data('nirspec/mos/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits')
+
+    # Run the calwebb_spec2 pipeline
+    collect_pipeline_cfgs("config")
+    args = ["config/calwebb_spec2.cfg",
+            rtdata.input,
+            '--steps.assign_wcs.skip=True']
+
+    Step.from_cmdline(args)
+
+    assert 'Aborting remaining processing for this exposure.' in caplog.text
+
+
+@pytest.mark.bigdata
+def test_nirspec_nrs2_nodata_api(_jail, rtdata, fitsdiff_default_kwargs):
+    """
+        Test of calwebb_spec2 pipeline performed on NIRSpec IFU exposure
+        that has a filter/grating combination that produces no data on
+        the NRS2 detector. Pipeline should raise an exception.
+    """
+
+    # Get the input file 
+    rtdata.get_data('nirspec/ifu/jw84700006001_02101_00001_nrs2_rate.fits')
+
+    # Call the Spec2Pipeline
+    step = Spec2Pipeline()
+    step.assign_wcs.skip = False
+
+    with pytest.raises(NoDataOnDetectorError):
+        step.run(rtdata.input)
+
+
+@pytest.mark.bigdata
+def test_nirspec_nrs2_nodata_strun(_jail, rtdata, fitsdiff_default_kwargs, caplog):
+    """
+        Test of calwebb_spec2 pipeline performed on NIRSpec IFU exposure
+        that has a filter/grating combination that produces no data on
+        the NRS2 detector. Pipeline should return with non-zero exit status.
+    """
+
+    # Get the input file 
+    rtdata.get_data('nirspec/ifu/jw84700006001_02101_00001_nrs2_rate.fits')
+
+    # Call the Spec2Pipeline
+    cmd = [
+        'strun',
+        'jwst.pipeline.Spec2Pipeline',
+        rtdata.input]
+
+    status = subprocess.run(cmd)
+
+    assert status.returncode == 64

--- a/jwst/regtest/test_nirspec_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_fs_spec2.py
@@ -22,7 +22,7 @@ def run_pipeline(jail, rtdata_module, request):
     collect_pipeline_cfgs("config")
 
     # Get the input exposure
-    rtdata.get_data('nirspec/spectroscopic/' + request.param + 'rate.fits')
+    rtdata.get_data('nirspec/fs/' + request.param + 'rate.fits')
 
     # Run the calwebb_spec2 pipeline; save results from intermediate steps
     args = ["config/calwebb_spec2.cfg", rtdata.input,

--- a/jwst/regtest/test_nirspec_fs_spec3.py
+++ b/jwst/regtest/test_nirspec_fs_spec3.py
@@ -1,0 +1,50 @@
+import os
+
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+    """
+    Run the calwebb_spec3 pipeline on NIRSpec Fixed-Slit exposures.
+    """
+
+    rtdata = rtdata_module
+
+    # Get the cfg files
+    collect_pipeline_cfgs("config")
+
+    # Get the ASN file and input exposures
+    rtdata.get_asn('nirspec/fs/jw93045-o010_20180725t035735_spec3_001_asn.json')
+
+    # Run the calwebb_spec3 pipeline; save results from intermediate steps
+    args = ["config/calwebb_spec3.cfg", rtdata.input,
+            "--steps.outlier_detection.save_results=true",
+            "--steps.resample_spec.save_results=true",
+            "--steps.extract_1d.save_results=true"]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d"])
+def test_nirspec_fs_spec3(run_pipeline, fitsdiff_default_kwargs, suffix):
+    """Regression test of the calwebb_spec3 pipeline on a set
+       of NIRSpec FS exposures."""
+
+    # Run the pipeline and retrieve outputs
+    rtdata = run_pipeline
+    output = 'jw93045-o010_s00003_nirspec_f290lp-g395h-subs400a1_' + suffix + '.fits'
+    rtdata.output = output
+
+    # Get the truth files
+    rtdata.get_truth(os.path.join("truth/test_nirspec_fs_spec3", output))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_nirspec_ifu.py
+++ b/jwst/regtest/test_nirspec_ifu.py
@@ -8,7 +8,7 @@ from . import regtestdata as rt
 def run_spec2(jail, rtdata_module):
     """Run the pipelines"""
     step_params = {
-        'input_path': 'nirspec/ifu/nrs_ifu_nrs1_rate.fits',
+        'input_path': 'nirspec/ifu/nrs_ifu_spec2_asn.json',
         'step': 'calwebb_spec2.cfg',
         'args': [
             '--steps.bkg_subtract.save_results=true',
@@ -55,7 +55,7 @@ def run_spec3(jail, rtdata_module):
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix',
-    ['assign_wcs', 'cal', 'flat_field', 'msa_flagging', 'pathloss', 'photom', 's3d', 'srctype', 'x1d']
+    ['assign_wcs', 'cal', 'flat_field', 'imprint_subtract', 'msa_flagging', 'pathloss', 'photom', 's3d', 'srctype', 'x1d']
 )
 def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test matching output files"""

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -15,10 +15,10 @@ def run_pipeline(jail, rtdata_module):
     collect_pipeline_cfgs("config")
 
     # Get the MSA metadata file referenced in the input exposure
-    rtdata.get_data("nirspec/spectroscopic/jw95065006001_0_short_msa.fits")
+    rtdata.get_data("nirspec/mos/jw95065006001_0_short_msa.fits")
 
     # Get the input exposure
-    rtdata.get_data("nirspec/spectroscopic/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits")
+    rtdata.get_data("nirspec/mos/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits")
 
     # Run the calwebb_spec2 pipeline; save results from intermediate steps
     args = ["config/calwebb_spec2.cfg", rtdata.input,

--- a/jwst/regtest/test_nirspec_subarray.py
+++ b/jwst/regtest/test_nirspec_subarray.py
@@ -17,7 +17,7 @@ nrs1_group_subarray_rate.fits           output
 def run_pipeline(jail, rtdata_module):
     """Run calwebb_detector1 pipeline on NIRSpec subarray data."""
     rtdata = rtdata_module
-    rtdata.get_data("nirspec/spectroscopic/nrs1_group_subarray.fits")
+    rtdata.get_data("nirspec/fs/nrs1_group_subarray.fits")
 
     collect_pipeline_cfgs('config')
     args = ["config/calwebb_detector1.cfg", rtdata.input,

--- a/jwst/regtest/test_nirspec_wcs.py
+++ b/jwst/regtest/test_nirspec_wcs.py
@@ -1,0 +1,73 @@
+import pytest
+from numpy.testing import assert_allclose
+from gwcs.wcstools import grid_from_bounding_box
+
+from jwst.assign_wcs import AssignWcsStep, nirspec
+from jwst.datamodels import ImageModel
+
+test_data = [
+    ('ifu_nrs1', 'jw00011001001_01120_00001_nrs1_rate.fits', 'jw00011001001_01120_00001_nrs1_assign_wcs.fits'),
+    ('ifu_nrs1_opaque', 'jw00011001001_01120_00002_nrs1_rate.fits', 'jw00011001001_01120_00002_nrs1_assign_wcs.fits'),
+    ('ifu_nrs2', 'jw00011001001_01120_00003_nrs2_rate.fits', 'jw00011001001_01120_00003_nrs2_assign_wcs.fits'),
+    ('fs_nrs1', 'jw00023001001_01101_00001_nrs1_rate.fits', 'jw00023001001_01101_00001_nrs1_assign_wcs.fits')]
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("test_id, input_file, truth_file", test_data)
+def test_nirspec_wcs(_jail, rtdata, test_id, input_file, truth_file):
+    """
+        Test of the AssignWcs step on 4 different NIRSpec exposures:
+        1) IFU NRS1 exposure,
+        2) IFU NRS1 exposure with FILTER=OPAQUE,
+        3) IFU NRS2 exposure, and
+        4) FS NRS1 exposure with 4 slits.
+    """
+
+    # Get the input and truth files
+    rtdata.get_data('nirspec/test_wcs/' + input_file)
+    rtdata.get_truth('truth/test_nirspec_wcs/' + truth_file)
+
+    # Run the AssignWcs step
+    result = AssignWcsStep.call(input_file, save_results=True, suffix='assign_wcs')
+    result.close()
+
+    # Open the output and truth files
+    im = ImageModel(result.meta.filename)
+    im_ref = ImageModel(truth_file)
+
+    if result.meta.exposure.type == 'NRS_FIXEDSLIT':
+
+        # Loop over the 4 slit instances
+        for slit in ['S200A1', 'S200A2', 'S400A1', 'S1600A1']:
+
+            # Create WCS objects for each image
+            wcs = nirspec.nrs_wcs_set_input(im, slit)
+            wcs_ref = nirspec.nrs_wcs_set_input(im_ref, slit)
+
+            # Compute RA, Dec, lambda values for each image array
+            grid = grid_from_bounding_box(wcs.bounding_box)
+            ra, dec, lam = wcs(*grid)
+            ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
+
+            # Compare the sky coordinates
+            assert_allclose(ra, ra_ref, equal_nan=True)
+            assert_allclose(dec, dec_ref, equal_nan=True)
+            assert_allclose(lam, lam_ref, equal_nan=True)
+
+    else:
+
+        # Create WCS objects for each image
+        wcs = nirspec.nrs_wcs_set_input(im, 0)
+        wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)
+
+        # Compute RA, Dec, lambda values for each image array
+        grid = grid_from_bounding_box(wcs.bounding_box)
+        ra, dec, lam = wcs(*grid)
+        ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
+
+        # Compare the sky coordinates
+        # equal_nan is used, because many of the entries are NaN,
+        # due to the bounding_box being rectilinear while the
+        # defined spectral traces are curved
+        assert_allclose(ra, ra_ref, equal_nan=True)
+        assert_allclose(dec, dec_ref, equal_nan=True)
+        assert_allclose(lam, lam_ref, equal_nan=True)

--- a/jwst/regtest/test_nirspec_wcs.py
+++ b/jwst/regtest/test_nirspec_wcs.py
@@ -11,6 +11,7 @@ test_data = [
     ('ifu_nrs2', 'jw00011001001_01120_00003_nrs2_rate.fits', 'jw00011001001_01120_00003_nrs2_assign_wcs.fits'),
     ('fs_nrs1', 'jw00023001001_01101_00001_nrs1_rate.fits', 'jw00023001001_01101_00001_nrs1_assign_wcs.fits')]
 
+
 @pytest.mark.bigdata
 @pytest.mark.parametrize("test_id, input_file, truth_file", test_data)
 def test_nirspec_wcs(_jail, rtdata, test_id, input_file, truth_file):


### PR DESCRIPTION
Add new NIRSpec regression tests to fill holes in coverage from the old set. In particular, this adds tests for FS and IFU WCS computations, as well as exceptions that are often encountered due to no data falling on the NRS2 detector (for some filter+grating combinations) and missing MSA meta data files.

A few existing test modules have been updated to change the directory paths of their input and/or truth files, just to better and more consistently organize the data on artifactory. All necessary changes to artifactory have been made.

A few more holes still need to be filled, including a test of the ``imprint`` step in ``calwebb_spec2``.