### PR TITLE
Populate the background column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ extract_1d
 
 - Updated to work with the current output from photom [#4369]
 
+- Fixed bug regarding background for NIRSpec or NIRISS (SOSS) point source
+  spectra. [#4459]
+
 master_background
 -----------------
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2878,6 +2878,15 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
 
         if isinstance(input_model, (datamodels.ImageModel,
                                     datamodels.DrizProductModel)):
+
+            # The following 2 lines are a temporary hack to get NIRSpec
+            # fixed-slit exposures containing just 1 slit to make it
+            # through processing. Once the DrizProductModel schema is
+            # updated to carry over the necessary slit meta data, this
+            # should no longer be needed. See JP-1144.
+            if input_model.meta.exposure.type == 'NRS_FIXEDSLIT':
+                slitname = input_model.meta.instrument.fixed_slit
+
             prev_offset = OFFSET_NOT_ASSIGNED_YET
             for sp_order in spectral_order_list:
                 if sp_order == "not set yet":

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2805,10 +2805,9 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             if photom_has_been_run:
                 # for NIRSpec data and NIRISS SOSS, point source
                 if input_units_are_megajanskys:
-                    # MJy --> Jy
-                    flux = temp_flux * 1.e6
+                    flux = temp_flux * 1.e6             # MJy --> Jy
                     surf_bright[:] = 0.
-                    background[:] = 0.
+                    background[:] /= pixel_solid_angle  # MJy / sr
                 else:
                     # MJy / steradian --> Jy
                     flux = temp_flux * pixel_solid_angle * 1.e6
@@ -2938,10 +2937,9 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 if photom_has_been_run:
                     # for NIRSpec data and NIRISS SOSS, point source
                     if input_units_are_megajanskys:
-                        # MJy --> Jy
-                        flux = temp_flux * 1.e6
+                        flux = temp_flux * 1.e6             # MJy --> Jy
                         surf_bright[:] = 0.
-                        background[:] = 0.
+                        background[:] /= pixel_solid_angle  # MJy / sr
                     else:
                         # MJy / steradian --> Jy
                         flux = temp_flux * pixel_solid_angle * 1.e6
@@ -3049,10 +3047,9 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                     if photom_has_been_run:
                         # for NIRSpec data and NIRISS SOSS, point source
                         if input_units_are_megajanskys:
-                            # MJy --> Jy
-                            flux = temp_flux * 1.e6
+                            flux = temp_flux * 1.e6             # MJy --> Jy
                             surf_bright[:] = 0.
-                            background[:] = 0.
+                            background[:] /= pixel_solid_angle  # MJy / sr
                         else:
                             # MJy / steradian --> Jy
                             flux = temp_flux * pixel_solid_angle * 1.e6

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -109,17 +109,17 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background):
     background /= npixels_temp
     del npixels_temp
 
+    pixel_solid_angle = input_model.meta.photometry.pixelarea_steradians
+    if pixel_solid_angle is None:
+        log.warning("Pixel area (solid angle) is not populated; "
+                    "the flux will not be correct.")
+        pixel_solid_angle = 1.
     if input_units_are_megajanskys:
-        # Convert flux from MJy to Jy.
+        # Convert flux from MJy to Jy, and convert background to MJy / sr.
         flux = temp_flux * 1.e6
         surf_bright[:] = 0.
-        background[:] = 0.
+        background[:] /= pixel_solid_angle
     else:
-        pixel_solid_angle = input_model.meta.photometry.pixelarea_steradians
-        if pixel_solid_angle is None:
-            log.warning("Pixel area (solid angle) is not populated; "
-                        "the flux will not be correct.")
-            pixel_solid_angle = 1.
         # Convert flux from MJy / steradian to Jy.
         flux = temp_flux * pixel_solid_angle * 1.e6
         # surf_bright and background were computed above


### PR DESCRIPTION
For the case that the target is a point source and the instrument is NIRSpec or NIRISS (SOSS), the input units are megajanskys, and the background was being set to zero.  The extracted background is now divided by the pixel area (solid angle) to convert to units of surface brightness.