### PR TITLE
Round S_REGION values in set_telescope_pointing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,9 @@ datamodels
 
 - Force data model type setting on save [#4318]
 
-- Deprecate MIRIRampModel [#4328]
+- Deprecate ``MIRIRampModel`` [#4328]
 
-- Make memmap=False be the default in datamodels [#4445]
+- Make ``memmap=False`` be the default in ``datamodels`` [#4445]
 
 - Update schemas to add the ``id`` field and switch relative references
   from filesystem paths to URIs.  Make ``schema_url`` absolute to facilitate
@@ -44,6 +44,11 @@ pipeline
 
 - Make the naming and writing out of the resampled results to an `i2d` file
   in `Image2Pipeline` consistent between config and class invocations [#4333]
+
+set_telescope_pointing
+----------------------
+
+- Round S_REGION values in ``set_telescope_pointing`` [#4476]
 
 tweakreg
 --------

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from astropy.time import Time
 import numpy as np
 
+from ..assign_wcs.util import update_s_region_keyword
 from ..datamodels import Level1bModel
 from ..lib.engdb_tools import ENGDB_Service
 from .exposure_types import IMAGING_TYPES, FGS_GUIDE_EXP_TYPES
@@ -502,13 +503,7 @@ def update_s_region(model, siaf):
     ra_vert[negative_ind] = ra_vert[negative_ind] + 360
     # Do not do any sorting, use the vertices in the SIAF order.
     footprint = np.array([ra_vert, dec_vert]).T
-    s_region = (
-        "POLYGON ICRS "
-        " {0} {1}"
-        " {2} {3}"
-        " {4} {5}"
-        " {6} {7}".format(*footprint.flatten()))
-    model.meta.wcsinfo.s_region = s_region
+    update_s_region_keyword(model, footprint)
 
 
 def calc_wcs(pointing, siaf, **transform_kwargs):

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -32,9 +32,13 @@ def run_spec2_pipeline(jail, rtdata_module):
 def generate_tso3_asn():
     """Generate an association file that references the output of run_spec2_pipeline."""
     asn = asn_from_list([f"{DATASET_ID}_calints.fits"], product_name=PRODUCT_NAME)
-    asn["program"] = "80600"
+    asn.data["program"] = "80600"
+    asn.data["asn_id"] = "o012"
+    asn.data["asn_type"] = "tso-spec3"
+    asn.sequence = 1
 
     name, serialized = asn.dump(format="json")
+    name = "jw80600-o012_tso-spec3_001_asn.json"
     with open(name, "w") as f:
         f.write(serialized)
 


### PR DESCRIPTION
This should fix some regression test failures in the new system:

 - Round S_REGION RA/Dec values in `set_telescope_pointing`
 - Make `asn.sequence` repeatable in MIRI LRS slitless TSO regtest (it is a `Counter` class)