### PR TITLE
JP-840: Handle cube_build skip in calwebb_spec2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ pipeline
 - Make the naming and writing out of the resampled results to an `i2d` file
   in `Image2Pipeline` consistent between config and class invocations [#4333]
 
+- Don't try to save the ``cube_build`` result if the step is skipped in the
+  ``calwebb_spec2`` pipeline. [#4478]
+
 set_telescope_pointing
 ----------------------
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -292,10 +292,9 @@ class Spec2Pipeline(Pipeline):
             # always create a single cube containing multiple
             # wavelength bands
             self.cube_build.output_type = 'multi'
-            self.cube_build.suffix = 's3d'
             self.cube_build.save_results = False
             result_extra = self.cube_build(result)
-            if self.cube_build.skip == False:
+            if not self.cube_build.skip:
                 self.save_model(result_extra[0], 's3d')
         else:
             result_extra = result

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -295,7 +295,8 @@ class Spec2Pipeline(Pipeline):
             self.cube_build.suffix = 's3d'
             self.cube_build.save_results = False
             result_extra = self.cube_build(result)
-            self.save_model(result_extra[0], 's3d')
+            if self.cube_build.skip == False:
+                self.save_model(result_extra[0], 's3d')
         else:
             result_extra = result
 


### PR DESCRIPTION
Updated the ``calwebb_spec2`` pipeline module to NOT save the ``cube_build`` result if the step is skipped. The ``extract_1d`` step is already fairly robust at handling situations where it doesn't get the right input (i.e. if ``cube_build`` has been skipped).

Fixes #3771 and [JP-840](https://jira.stsci.edu/browse/JP-840)