### PR TITLE
Modify test to create and compare ramp_fit optional product.

### DIFF
--- a/jwst/regtest/test_miri_image_detector1.py
+++ b/jwst/regtest/test_miri_image_detector1.py
@@ -23,7 +23,8 @@ def run_pipeline(jail, rtdata_module):
             "--steps.dark_current.save_results=True",
             "--steps.refpix.save_results=True",
             "--steps.jump.rejection_threshold=25",
-            "--steps.jump.save_results=True"]
+            "--steps.jump.save_results=True",
+            "--steps.ramp_fit.save_results=True"]
 
     Step.from_cmdline(args)
     return rtdata
@@ -33,7 +34,7 @@ def run_pipeline(jail, rtdata_module):
 @pytest.mark.parametrize("output", ['rate', 'rateints', 'linearity', 'rscd',
                                     'dq_init', 'firstframe', 'lastframe',
                                     'saturation', 'dark_current', 'refpix',
-                                    'jump'])
+                                    'jump', 'fitopt'])
 def test_miri_image_detector1(run_pipeline, request, fitsdiff_default_kwargs, output):
     """
     Regression test of calwebb_detector1 pipeline performed on MIRI data.

--- a/jwst/regtest/test_miri_image_detector1.py
+++ b/jwst/regtest/test_miri_image_detector1.py
@@ -24,6 +24,7 @@ def run_pipeline(jail, rtdata_module):
             "--steps.refpix.save_results=True",
             "--steps.jump.rejection_threshold=25",
             "--steps.jump.save_results=True",
+            "--steps.ramp_fit.save_opt=True",
             "--steps.ramp_fit.save_results=True"]
 
     Step.from_cmdline(args)


### PR DESCRIPTION
There is no existing test that creates and compares the ramp_fit optional output product, so modify an existing test to do so. Addresses JP-1236.