### PR TITLE
JP-1234: Add MIRI image2 pipeline wcs regression test

### DIFF
--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from gwcs.wcstools import grid_from_bounding_box
 from jwst.stpipe import Step
-from jwst  import datamodels
+from jwst import datamodels
 
 @pytest.fixture(scope="module")
 def run_pipelines(jail, rtdata_module):

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -116,10 +116,11 @@ def test_miri_image_wcs(run_pipelines, fitsdiff_default_kwargs):
     rtdata = run_pipelines
 
     # get input assign_wcs and truth file
-    rtdata.output = "det_image_1_MIRIMAGE_F770Wexp1_5stars_assign_wcs.fits"
-    rtdata.get_truth("truth/test_miri_image_stages/" + rtdata.output)
+    output = "det_image_1_MIRIMAGE_F770Wexp1_5stars_assign_wcs.fits"
+    rtdata.output = output
+    rtdata.get_truth("truth/test_miri_image_stages/" + output)
     # Open the output and truth file
-    im = datamodels.open(rtdata.output)
+    im = datamodels.open(output)
     im_truth = datamodels.open(rtdata.truth)
 
     x, y = grid_from_bounding_box(im.meta.wcs.bounding_box)

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -24,6 +24,7 @@ def run_pipeline(jail, rtdata_module):
     args = ["config/calwebb_spec2.cfg", rtdata.input,
             "--steps.resample_spec.skip=true",       # remove when bug fixed
             "--save_bsub=true",
+            "--steps.assign_wcs.save_results=true",
             "--steps.flat_field.save_results=true",
             "--steps.srctype.save_results=true"]
     Step.from_cmdline(args)

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -5,7 +5,7 @@ from astropy.io.fits.diff import FITSDiff
 from numpy.testing import assert_allclose
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
-from jwst  import datamodels
+from jwst import datamodels
 from gwcs.wcstools import grid_from_bounding_box
 
 @pytest.fixture(scope="module")

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -37,7 +37,7 @@ def run_pipeline(jail, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output",[
-    "bsub", "flat_field", "assign_wcs","srctype", "cal", "x1d"])
+    "bsub", "flat_field", "assign_wcs", "srctype", "cal", "x1d"])
 def test_miri_lrs_slit_spec2(run_pipeline, fitsdiff_default_kwargs, output):
     """Regression test of the calwebb_spec2 pipeline on MIRI
        LRS fixedslit data using along-slit-nod pattern for

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -6,7 +6,7 @@ from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 from gwcs.wcstools import grid_from_bounding_box
 from jwst.associations.asn_from_list import asn_from_list
-from jwst  import datamodels
+from jwst import datamodels
 
 DATASET_ID = "jw00623026001_03106_00005_mirimage"
 PRODUCT_NAME = "jw00623-a3001_t001_miri_p750l-slitlessprism"

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -45,6 +45,7 @@ def run_tso_spec2_pipeline(run_tso1_pipeline, jail, rtdata_module):
         "config/calwebb_tso-spec2.cfg",
         rtdata.input,
         "--steps.flat_field.save_results=true",
+        "--steps.assign_wcs.save_results=true",
         "--steps.srctype.save_results=true",
     ]
     Step.from_cmdline(args)
@@ -96,7 +97,7 @@ def test_miri_lrs_slitless_tso1(run_tso1_pipeline, rtdata_module, fitsdiff_defau
 
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("step_suffix", ["flat_field", "srctype", "calints", "x1dints"])
+@pytest.mark.parametrize("step_suffix", ["flat_field", "srctype", "calints", "assign_wcs", "x1dints"])
 def test_miri_lrs_slitless_tso_spec2(run_tso_spec2_pipeline, rtdata_module, fitsdiff_default_kwargs,
     step_suffix):
     """Compare the output of a MIRI LRS slitless calwebb_tso-spec2 pipeline."""
@@ -153,3 +154,25 @@ def test_miri_lrs_slitless_tso3_whtlt(run_tso3_pipeline, generate_tso3_asn,
 
     diff = diff_astropy_tables(rtdata.output, rtdata.truth)
     assert len(diff) == 0, "\n".join(diff)
+
+
+@pytest.mark.bigdata
+def test_miri_lrsslitless_wcs(run_tso_spec2_pipeline, fitsdiff_default_kwargs):
+    rtdata = run_tso_spec2_pipeline
+
+    output_filename = f"{PRODUCT_NAME}_assign_wcs.fits"
+    # get input assign_wcs and truth file
+    rtdata.output = output_filename
+    rtdata.truth("truth/test_miri_lrs_slitless_tso2/"+rtdata.output)
+
+    # Open the output and truth file
+    im = datamodels.open(rtdata.output)
+    im_truth = datamodels.open(rtdata.truth_file)
+
+    x, y = grid_from_bounding_box(im.meta.wcs.bounding_box)
+    ra, dec, lam = im.meta.wcs(x, y)
+    ratruth, dectruth, lamtruth = im_truth.meta.wcs(x, y)
+    assert_allclose(ra, ratruth)
+    assert_allclose(dec, dectruth)
+    assert_allclose(lam, lamtruth)
+

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -1,9 +1,12 @@
 import pytest
 from astropy.io.fits.diff import FITSDiff
+from numpy.testing import assert_allclose
 
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
+from gwcs.wcstools import grid_from_bounding_box
 from jwst.associations.asn_from_list import asn_from_list
+from jwst  import datamodels
 
 DATASET_ID = "jw00623026001_03106_00005_mirimage"
 PRODUCT_NAME = "jw00623-a3001_t001_miri_p750l-slitlessprism"
@@ -157,17 +160,18 @@ def test_miri_lrs_slitless_tso3_whtlt(run_tso3_pipeline, generate_tso3_asn,
 
 
 @pytest.mark.bigdata
-def test_miri_lrsslitless_wcs(run_tso_spec2_pipeline, fitsdiff_default_kwargs):
-    rtdata = run_tso_spec2_pipeline
+def test_miri_lrs_slitless_wcs(run_tso_spec2_pipeline, fitsdiff_default_kwargs,
+                               rtdata_module):
 
-    output_filename = f"{PRODUCT_NAME}_assign_wcs.fits"
+    rtdata = rtdata_module
+    output = f"{DATASET_ID}_assign_wcs.fits"
     # get input assign_wcs and truth file
-    rtdata.output = output_filename
-    rtdata.truth("truth/test_miri_lrs_slitless_tso2/"+rtdata.output)
+    rtdata.output = output
+    rtdata.get_truth("truth/test_miri_lrs_slitless_tso_spec2/"+output)
 
     # Open the output and truth file
     im = datamodels.open(rtdata.output)
-    im_truth = datamodels.open(rtdata.truth_file)
+    im_truth = datamodels.open(rtdata.truth)
 
     x, y = grid_from_bounding_box(im.meta.wcs.bounding_box)
     ra, dec, lam = im.meta.wcs(x, y)
@@ -175,4 +179,3 @@ def test_miri_lrsslitless_wcs(run_tso_spec2_pipeline, fitsdiff_default_kwargs):
     assert_allclose(ra, ratruth)
     assert_allclose(dec, dectruth)
     assert_allclose(lam, lamtruth)
-

--- a/jwst/regtest/test_miri_mrs.py
+++ b/jwst/regtest/test_miri_mrs.py
@@ -5,7 +5,7 @@ import pytest
 from numpy.testing import assert_allclose
 from jwst.associations import load_asn
 from jwst.lib.suffix import replace_suffix
-from jwst  import datamodels
+from jwst import datamodels
 from gwcs.wcstools import grid_from_bounding_box
 from . import regtestdata as rt
 

--- a/jwst/regtest/test_miri_mrs.py
+++ b/jwst/regtest/test_miri_mrs.py
@@ -2,9 +2,11 @@
 from pathlib import Path
 import pytest
 
+from numpy.testing import assert_allclose
 from jwst.associations import load_asn
 from jwst.lib.suffix import replace_suffix
-
+from jwst  import datamodels
+from gwcs.wcstools import grid_from_bounding_box
 from . import regtestdata as rt
 
 # Define artifactory source and truth
@@ -156,16 +158,16 @@ def test_spec3_multi(run_spec3_multi, fitsdiff_default_kwargs, output):
 
 
 @pytest.mark.bigdata
-def test_miri_mrs_wcs(run_spec2, fitsdiff_default_kwargs, suffix):
-    rtdata = run_specs
-
+def test_miri_mrs_wcs(run_spec2, fitsdiff_default_kwargs):
+    rtdata, asn_path = run_spec2
     # get input assign_wcs and truth file
-    rtdata.output = "ifushort_ch12_assign_wcs.fits"
-    rtdata.truth("truth/test_miri_mrs/"+rtdata.output)
+    output = "ifushort_ch12_assign_wcs.fits"
+    rtdata.output = output
+    rtdata.get_truth("truth/test_miri_mrs/"+output)
 
     # Open the output and truth file
     im = datamodels.open(rtdata.output)
-    im_truth = datamodels.open(rtdata.truth_file)
+    im_truth = datamodels.open(rtdata.truth)
 
     x, y = grid_from_bounding_box(im.meta.wcs.bounding_box)
     ra, dec, lam = im.meta.wcs(x, y)

--- a/jwst/regtest/test_miri_mrs.py
+++ b/jwst/regtest/test_miri_mrs.py
@@ -153,3 +153,29 @@ def test_spec3_multi(run_spec3_multi, fitsdiff_default_kwargs, output):
         truth_path=TRUTH_PATH,
         is_suffix=False
     )
+
+
+@pytest.mark.bigdata
+def test_miri_mrs_wcs(run_spec2, fitsdiff_default_kwargs, suffix):
+    rtdata = run_specs
+
+    # get input assign_wcs and truth file
+    rtdata.output = "ifushort_ch12_assign_wcs.fits"
+    rtdata.truth("truth/test_miri_mrs/"+rtdata.output)
+
+    # Open the output and truth file
+    im = datamodels.open(rtdata.output)
+    im_truth = datamodels.open(rtdata.truth_file)
+
+    x, y = grid_from_bounding_box(im.meta.wcs.bounding_box)
+    ra, dec, lam = im.meta.wcs(x, y)
+    ratruth, dectruth, lamtruth = im_truth.meta.wcs(x, y)
+    assert_allclose(ra, ratruth)
+    assert_allclose(dec, dectruth)
+    assert_allclose(lam, lamtruth)
+
+    # Test the inverse transform
+    xtest, ytest = im.meta.wcs.backward_transform(ra, dec, lam)
+    xtruth, ytruth = im_truth.meta.wcs.backward_transform (ratruth, dectruth, lamtruth)
+    assert_allclose(xtest, xtruth)
+    assert_allclose(ytest, ytruth)


### PR DESCRIPTION
I updated the first test for the WCS - imager.
I am still working on the other modes and will add those to this PR soon. 
I just wanted to make sure this is all that was needed for WCS testing. 
@hbushouse @jdavies-st 