### PR TITLE
JP-1250: Fix astropy overwrite warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,9 @@ pipeline
 - Don't try to save the ``cube_build`` result if the step is skipped in the
   ``calwebb_spec2`` pipeline. [#4478]
 
+- Use the `overwrite` option when saving the white-light photometry catalog in
+  the ``calwebb_tso3`` pipeline. [#xxxx]
+
 set_telescope_pointing
 ----------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,7 +51,7 @@ pipeline
   ``calwebb_spec2`` pipeline. [#4478]
 
 - Use the `overwrite` option when saving the white-light photometry catalog in
-  the ``calwebb_tso3`` pipeline. [#xxxx]
+  the ``calwebb_tso3`` pipeline. [#4493]
 
 set_telescope_pointing
 ----------------------

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -161,6 +161,6 @@ class Tso3Pipeline(Pipeline):
             phot_tab_name = self.make_output_path(suffix=phot_tab_suffix, ext='ecsv')
             self.log.info("Writing Level 3 photometry catalog {}...".format(
                       phot_tab_name))
-            phot_results.write(phot_tab_name, format='ascii.ecsv')
+            phot_results.write(phot_tab_name, format='ascii.ecsv', overwrite=True)
 
         return


### PR DESCRIPTION
Update the ``calwebb_tso3`` pipeline module to set "overwrite=True" when saving the photometric catalog results from either the ``tso_photometry`` or ``white_light`` steps. This avoids getting an ``astropy`` deprecation warning.

Fixes #4492 and [JP-1250](https://jira.stsci.edu/browse/JP-1250)