### PR TITLE
JP-1252: Fix formatting error calwebb_coron3 docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,9 @@ pipeline
 - Use the `overwrite` option when saving the white-light photometry catalog in
   the ``calwebb_tso3`` pipeline. [#4493]
 
+- Fixed error in formatting of example ASN file contents in the documents for
+  the ``calwebb_coron3`` and ``calwebb_ami3`` pipelines. [#4496]
+
 set_telescope_pointing
 ----------------------
 

--- a/docs/jwst/pipeline/calwebb_ami3.rst
+++ b/docs/jwst/pipeline/calwebb_ami3.rst
@@ -76,16 +76,16 @@ as indicated by the "exptype" values for each.
       {"name": "jw10005-a3001_t001_niriss_f277w-nrm",
        "members": [
            {"expname": "jw10005007001_02102_00001_nis_cal.fits",
-            "exptype": "psf",
+            "exptype": "psf"
            },
            {"expname": "jw10005027001_02102_00001_nis_cal.fits",
-            "exptype": "psf",
+            "exptype": "psf"
            },
            {"expname": "jw10005004001_02102_00001_nis_cal.fits",
-            "exptype": "science",
+            "exptype": "science"
            },
            {"expname": "jw10005001001_02102_00001_nis_cal.fits",
-            "exptype": "science",
+            "exptype": "science"
            }
        ]
       }

--- a/docs/jwst/pipeline/calwebb_coron3.rst
+++ b/docs/jwst/pipeline/calwebb_coron3.rst
@@ -75,13 +75,13 @@ indicated by the "exptype" values for each::
       {"name": "jw10005-c1001_t001_nircam_f430m-maskrnd-sub320a430r",
        "members": [
            {"expname": "jw10005009001_02102_00001_nrcalong_calints.fits",
-            "exptype": "psf",
+            "exptype": "psf"
            },
            {"expname": "jw10005006001_02102_00001_nrcalong_calints.fits",
-            "exptype": "science",
+            "exptype": "science"
            },
            {"expname": "jw10005003001_02102_00001_nrcalong_calints.fits",
-            "exptype": "science",
+            "exptype": "science"
            }
        ]
       }


### PR DESCRIPTION
Removed the offending commas at the ends of some lines in the example ASN files included in the docs for the ``calwebb_coron3`` and ``calwebb_ami3`` pipelines. The presence of the trailing commas was causing an error when using the examples to run the pipeline.

Fixes #4495 and [JP-1252](https://jira.stsci.edu/browse/JP-1252)