### PR TITLE
JP-1255: Fix calwebb_tso3 merge conflict warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,10 @@ pipeline
 - Fixed error in formatting of example ASN file contents in the documents for
   the ``calwebb_coron3`` and ``calwebb_ami3`` pipelines. [#4496]
 
+- Fixed the ``calwebb_tso3`` calculation of the number_of_integrations recorded
+  in the photometric table product to avoid ``astropy.table`` merge conflicts.
+  [#4502]
+
 set_telescope_pointing
 ----------------------
 

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -158,6 +158,7 @@ class Tso3Pipeline(Pipeline):
             self.log.info("Could not create a photometric catalog for data")
         else:
             phot_results = vstack(phot_result_list)
+            phot_results.meta['number_of_integrations'] = len(phot_results)
             phot_tab_name = self.make_output_path(suffix=phot_tab_suffix, ext='ecsv')
             self.log.info("Writing Level 3 photometry catalog {}...".format(
                       phot_tab_name))

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -8,6 +8,7 @@ from astropy.time import Time, TimeDelta
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+
 def white_light(input):
 
     ntables = len(input.spec)
@@ -36,7 +37,6 @@ def white_light(input):
         else:
             ntables_order[norders - 1] += 1
 
-    nints = max(ntables_order)
     log.debug("norders = %d, sporders = %s, ntables_order = %s",
               norders, str(sporders), str(ntables_order))
 

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -53,7 +53,6 @@ def white_light(input):
     tbl_meta['filter'] = input.meta.instrument.filter
     tbl_meta['pupil'] = input.meta.instrument.pupil
     tbl_meta['target_name'] = input.meta.target.catalog_name
-    tbl_meta['number_of_integrations'] = nints
 
     # Create the output table
     tbl = QTable(meta=tbl_meta)


### PR DESCRIPTION
The ``astropy.table.vstack`` function used in ``calwebb_tso3`` to merge multiple results from the ``white_light`` step was issuing a MergeConflict warning regarding the table meta attribute "number_of_integrations". The number of integrations was being set in the ``white_light`` step as it processed each exposure segment, but the value can vary from one segment to another. So when ``calwebb_tso3`` tried to merge all the results into a single output table, it had multiple values for that meta attribute - hence the warning.

This change moves the population of "number_of_integrations" out of the ``white_light`` step and puts it into ``calwebb_tso3`` after the final merged table has been created. The value is simply based on the total number of rows of data in the final table, which should presumably be equal to the total number of integrations.

@philhodge What about cases where there's data for multiple spectra orders? This change will set "number_of_integrations" to the total number of rows in the photometry table, summing over entries for all orders. Do you think that's OK? Was your original intention (when writing the looping code in the ``white_light`` step) to have "number_of_integration" be the value **per order**, as opposed to the **sum** over all orders?

Fixes #4500 and [JP-1255](https://jira.stsci.edu/browse/JP-1255)