### PR TITLE
Modifications to extract_2d for grism data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,7 @@ extract_2d
 
 - For GRISM data, the variance arrays and INT_TIMES table are copied to output,
   and keywords SLTSTRT1 and SLTSTRT2 are set to the pixel location of the
-  cutout in the input file. [#4503]
+  cutout in the input file. [#4504]
 
 master_background
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,15 +16,9 @@ datamodels
 
 - Force data model type setting on save [#4318]
 
-- Deprecate ``MIRIRampModel`` [#4328]
+- Deprecate MIRIRampModel [#4328]
 
-- Make ``memmap=False`` be the default in ``datamodels`` [#4445]
-
-- Update schemas to add the ``id`` field and switch relative references
-  from filesystem paths to URIs.  Make ``schema_url`` absolute to facilitate
-  subclassing DataModel with schemas from other asdf extensions. [#4435]
-
-- Update core.schema.yaml to include new NIRCam entries for PATTTYPE [#4475]
+- Make memmap=False be the default in datamodels [#4445]
 
 extract_1d
 ----------
@@ -33,6 +27,13 @@ extract_1d
 
 - Fixed bug regarding background for NIRSpec or NIRISS (SOSS) point source
   spectra. [#4459]
+
+extract_2d
+----------
+
+- For GRISM data, the variance arrays and INT_TIMES table are copied to output,
+  and keywords SLTSTRT1 and SLTSTRT2 are set to the pixel location of the
+  cutout in the input file. [#4503]
 
 master_background
 -----------------
@@ -46,29 +47,6 @@ pipeline
 
 - Make the naming and writing out of the resampled results to an `i2d` file
   in `Image2Pipeline` consistent between config and class invocations [#4333]
-
-- Don't try to save the ``cube_build`` result if the step is skipped in the
-  ``calwebb_spec2`` pipeline. [#4478]
-
-- Use the `overwrite` option when saving the white-light photometry catalog in
-  the ``calwebb_tso3`` pipeline. [#4493]
-
-- Fixed error in formatting of example ASN file contents in the documents for
-  the ``calwebb_coron3`` and ``calwebb_ami3`` pipelines. [#4496]
-
-- Fixed the ``calwebb_tso3`` calculation of the number_of_integrations recorded
-  in the photometric table product to avoid ``astropy.table`` merge conflicts.
-  [#4502]
-
-set_telescope_pointing
-----------------------
-
-- Round S_REGION values in ``set_telescope_pointing`` [#4476]
-
-stpipe
-------
-
-- Fix sub-step nesting in parameter reference files [#4488]
 
 tweakreg
 --------
@@ -601,7 +579,7 @@ outlier_detection
 
 - Don't use NaNs or masked values in weight image for blotting. [#3651]
 
-- When calling cube_build for IFU data fixed selecting correct channels (MIRI) or
+- When calling cube_build for IFU data fixed selecting correct channels (MIRI) or 
   correct grating (NIRSPEC) [#4301]
 
 pipeline

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,15 @@ datamodels
 
 - Force data model type setting on save [#4318]
 
-- Deprecate MIRIRampModel [#4328]
+- Deprecate ``MIRIRampModel`` [#4328]
 
-- Make memmap=False be the default in datamodels [#4445]
+- Make ``memmap=False`` be the default in ``datamodels`` [#4445]
+
+- Update schemas to add the ``id`` field and switch relative references
+  from filesystem paths to URIs.  Make ``schema_url`` absolute to facilitate
+  subclassing DataModel with schemas from other asdf extensions. [#4435]
+
+- Update core.schema.yaml to include new NIRCam entries for PATTTYPE [#4475]
 
 extract_1d
 ----------
@@ -47,6 +53,29 @@ pipeline
 
 - Make the naming and writing out of the resampled results to an `i2d` file
   in `Image2Pipeline` consistent between config and class invocations [#4333]
+
+- Don't try to save the ``cube_build`` result if the step is skipped in the
+  ``calwebb_spec2`` pipeline. [#4478]
+
+- Use the `overwrite` option when saving the white-light photometry catalog in
+  the ``calwebb_tso3`` pipeline. [#4493]
+
+- Fixed error in formatting of example ASN file contents in the documents for
+  the ``calwebb_coron3`` and ``calwebb_ami3`` pipelines. [#4496]
+
+- Fixed the ``calwebb_tso3`` calculation of the number_of_integrations recorded
+  in the photometric table product to avoid ``astropy.table`` merge conflicts.
+  [#4502]
+
+set_telescope_pointing
+----------------------
+
+- Round S_REGION values in ``set_telescope_pointing`` [#4476]
+
+stpipe
+------
+
+- Fix sub-step nesting in parameter reference files [#4488]
 
 tweakreg
 --------
@@ -579,7 +608,7 @@ outlier_detection
 
 - Don't use NaNs or masked values in weight image for blotting. [#3651]
 
-- When calling cube_build for IFU data fixed selecting correct channels (MIRI) or 
+- When calling cube_build for IFU data fixed selecting correct channels (MIRI) or
   correct grating (NIRSPEC) [#4301]
 
 pipeline

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -193,10 +193,27 @@ def extract_tso_object(input_model,
         log.info("WCS made explicit for order: {}".format(order))
         log.info("Trace extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
 
+        # Note that for variances we copy the entire row, as with ext_data, etc.
+        if input_model.var_poisson is not None and np.size(input_model.var_poisson) > 0:
+            var_poisson = input_model.var_poisson[..., ymin:ymax+1, :].copy()
+        else:
+            var_poisson = None
+        if input_model.var_rnoise is not None and np.size(input_model.var_rnoise) > 0:
+            var_rnoise = input_model.var_rnoise[..., ymin:ymax+1, :].copy()
+        else:
+            var_rnoise = None
+        if input_model.var_flat is not None and np.size(input_model.var_flat) > 0:
+            var_flat = input_model.var_flat[..., ymin:ymax+1, :].copy()
+        else:
+            var_flat = None
+
         if output_model.meta.model_type == "SlitModel":
             output_model.data = ext_data
             output_model.err = ext_err
             output_model.dq = ext_dq
+            output_model.var_poisson = var_poisson
+            output_model.var_rnoise = var_rnoise
+            output_model.var_flat = var_flat
             output_model.meta.wcs = subwcs
             output_model.meta.wcs.bounding_box = util.wcs_bbox_from_shape(ext_data.shape)
             output_model.meta.wcsinfo.siaf_yref_sci = 34  # update for the move, vals are the same
@@ -206,16 +223,21 @@ def extract_tso_object(input_model,
                         input_model.meta.wcsinfo.dispersion_direction
             if compute_wavelength:
                 output_model.wavelength = compute_wavelength_array(output_model)
-            output_model.name = 'TSO object'
+            output_model.name = '1'
+            output_model.source_type = input_model.meta.target.source_type
+            output_model.source_name = input_model.meta.target.catalog_name
+            output_model.source_alias = input_model.meta.target.proposer_name
             output_model.xstart = 1  # fits pixels
             output_model.xsize = ext_data.shape[-1]
-            output_model.ystart = 1  # fits pixels
+            output_model.ystart = ymin + 1  # fits pixels
             output_model.ysize = ext_data.shape[-2]
             output_model.source_xpos = source_xpos
             output_model.source_ypos = 34
             output_model.source_id = 1
             output_model.bunit_data = input_model.meta.bunit_data
             output_model.bunit_err = input_model.meta.bunit_err
+            if hasattr(input_model, 'int_times'):
+                output_model.int_times = input_model.int_times.copy()
 
     del subwcs
     log.info("Finished extractions")
@@ -431,9 +453,10 @@ def extract_grism_objects(input_model,
                 # The overall subarray offset is recorded in model.meta.subarray.
                 # nslit = obj.sid - 1  # catalog id starts at zero
                 new_slit.name = "{0}".format(obj.sid)
-                new_slit.xstart = 1  # fits pixels
+                new_slit.source_type = 'UNKNOWN'
+                new_slit.xstart = xmin + 1  # fits pixels
                 new_slit.xsize = ext_data.shape[1]
-                new_slit.ystart = 1  # fits pixels
+                new_slit.ystart = ymin + 1  # fits pixels
                 new_slit.ysize = ext_data.shape[0]
                 new_slit.source_xpos = float(obj.xcentroid)
                 new_slit.source_ypos = float(obj.ycentroid)


### PR DESCRIPTION
For NIRCam TSO GRISM data, the variance arrays and the INT_TIMES table are now copied from input to output.  This was overlooked in previous updates.  The related issues are [JP-845](https://jira.stsci.edu/browse/JP-845) (GitHub #3784) to copy the variance arrays, and [JP-1249](https://jira.stsci.edu/browse/JP-1249) (GitHub #4489) to copy the INT_TIMES table.

For NIS_WFSS, NRC_WFSS, or NRC_TSGRISM data, the SLTSTRT1 and SLTSTRT2 keywords now give the start location of the 2-D cutout in the input image.  Previously, these keywords were 1.  The related issue is [JP-903](https://jira.stsci.edu/browse/JP-903) (GitHub #3872).