### PR TITLE
JP-1216 Remove the temporary cast to float64

### DIFF
--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -47,10 +47,7 @@ class InputSpectrumModel:
             to use weight = 1.
         """
 
-        # We're casting this from dtype('>f8') to dtype('float64') because our version
-        # of gwcs has a bug that prevents it from recognizing big-endian dtypes as
-        # numeric.  Once we upgrade to gwcs 0.11 we can remove the cast.
-        self.wavelength = spec.spec_table.field("wavelength").copy().astype(np.float64)
+        self.wavelength = spec.spec_table.field("wavelength").copy()
 
         self.flux = spec.spec_table.field("flux").copy()
         self.error = spec.spec_table.field("error").copy()


### PR DESCRIPTION
Remove cast to float 64 needed for early version of gwcs version < 0.11.
Unit tests pass, 
== 3 passed in 0.83s ==

Some minor issues in reg tests, all precision related e.g.
E              10 different pixels found (0.00% different).
e.g. 
E                 a> 20801.225
E                 b> 20801.504

HDU 10
E                 a> 1862.8383761319246
E                 b> 1862.8663302334871
E              1 different table data element(s) found (0.03% different).
