### PR TITLE
JP-952 Skip reading and validating non-datamodel members

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ combine_1d
 datamodels
 ----------
 
+- Skip reading and validating non-datamodel members [#3946]
+
 - Force data model type setting on save [#4318]
 
 - Deprecate ``MIRIRampModel`` [#4328]

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -8,6 +8,14 @@ import logging
 from asdf import AsdfFile
 from astropy.io import fits
 
+from jwst.associations.lib.dms_base import (
+    CORON_EXP_TYPES,
+    IMAGE2_NONSCIENCE_EXP_TYPES,
+    IMAGE2_SCIENCE_EXP_TYPES,
+    SPEC2_SCIENCE_EXP_TYPES,
+    ACQ_EXP_TYPES
+)
+
 from ..associations import (
     AssociationNotValidError,
     load_asn)
@@ -106,6 +114,12 @@ class ModelContainer(model_base.DataModel):
         elif is_association(init):
             self.from_asn(init)
         elif isinstance(init, str):
+            self.asn_exptypes = (CORON_EXP_TYPES +
+                                 IMAGE2_NONSCIENCE_EXP_TYPES +
+                                 IMAGE2_SCIENCE_EXP_TYPES +
+                                 SPEC2_SCIENCE_EXP_TYPES +
+                                 list(ACQ_EXP_TYPES))
+
             init_from_asn = self.read_asn(init)
             self.from_asn(init_from_asn, asn_file_path=init)
         else:


### PR DESCRIPTION
Restricted the import and verification of association exptypes to those known about in dms_base to prevent the code from reading and trying to verify files that have no datamodel associated with them. 

local pytest results:
```
pytest --bigdata --basetemp=/Users/ddavis/src/JWST/develop/JP-952/Feb10/ ~/src/JWST/scsb/jwst/jwst/regtest/ -k test_associations 2>&1 | tee test_Feb10ab.log
============================= test session starts ==============================
platform darwin -- Python 3.7.4, pytest-5.3.5, py-1.8.1, pluggy-0.13.0
rootdir: /Users/ddavis/src/JWST/scsb/jwst, inifile: setup.cfg
plugins: xdist-1.30.0, requests-mock-1.7.0, doctestplus-0.4.0, openfiles-0.4.0, ci-watson-0.4, asdf-2.5.1, forked-1.1.3, cov-2.8.1
collected 363 items / 282 deselected / 81 selected

../../scsb/jwst/jwst/regtest/test_associations_generate.py ss            [  2%]
../../scsb/jwst/jwst/regtest/test_associations_io.py ssss                [  7%]
../../scsb/jwst/jwst/regtest/test_associations_level3_product_names.py s [  8%]
                                                                         [  8%]
../../scsb/jwst/jwst/regtest/test_associations_main.py ssss              [ 13%]
../../scsb/jwst/jwst/regtest/test_associations_sdp_pools.py ......s...s. [ 28%]
s..ss....s.s.......xx..s...s...ss                                        [ 69%]
../../scsb/jwst/jwst/regtest/test_associations_standards.py ............ [ 83%]
............s                                                            [100%]

==== 56 passed, 23 skipped, 282 deselected, 2 xfailed in 1354.67s (0:22:34) ====
```

should also point out that the test case now works,
```
>>> from jwst import datamodels
>>> a = datamodels.open('test_asn.json')
>>>

```

