### PR TITLE
use order to match photom information in tsgrism mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,7 +86,7 @@ photom
 ------
 
 - Added ``spectral_order`` to the fields matching the ``photom`` reference files
-  for NIRCAM WFSS mode. [#4538]
+  for NIRCAM WFSS and TSGRISM modes. [#4538, 4558]
 
 set_telescope_pointing
 ----------------------

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -452,6 +452,13 @@ class DataSet():
                 if row is None:
                     continue
                 self.photom_io(ftab.phot_table[row])
+        elif self.exptype == 'NRC_TSGRISM':
+            order = self.input.meta.wcsinfo.spectral_order
+            fields_to_match = {'filter': self.filter, 'pupil': self.pupil, 'order': order}
+            row = find_row(ftab.phot_table, fields_to_match)
+            if row is None:
+                return
+            self.photom_io(ftab.phot_table[row])
         else:
             fields_to_match = {'filter': self.filter, 'pupil': self.pupil}
             row = find_row(ftab.phot_table, fields_to_match)


### PR DESCRIPTION
Modified photom step to use also `spectral_order` when searching the reference table.