### PR TITLE
JP-1129: Add guard for xref/yref; add unit tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.14.3 (Unreleased)
 ===================
 
+assign_wcs
+----------
+
+- A ``ValueError`` is now raised if input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
+
 associations
 ------------
 
@@ -44,6 +49,8 @@ extract_2d
 - For GRISM data, the variance arrays and INT_TIMES table are copied to output,
   and keywords SLTSTRT1 and SLTSTRT2 are set to the pixel location of the
   cutout in the input file. [#4504]
+
+- A ``ValueError`` is now raised if the input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
 
 master_background
 -----------------
@@ -118,6 +125,10 @@ wfs_combine
 - Use float64 data types internally in ``wfs_combine`` so as not to cause an
   error in ``scipy.signal.convolve``. [#4432]
 
+tso_photometry
+--------------
+
+- A ``ValueError`` is now raised if the input data for ``call`` is missing ``crpix1`` or ``crpix2`` keywords. [#4561]
 
 0.14.2 (2019-11-18)
 ===================
@@ -2076,8 +2087,6 @@ assign_wcs
 
 - fix input units to meters when filter=OPAQUE [#2134]
 
-- A ``ValueError`` is now raised if input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
-
 
 associations
 ------------
@@ -2141,8 +2150,6 @@ extract_1d
 
 extract_2d
 ----------
-
-- A ``ValueError`` is now raised if the input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
 
 firstframe
 ----------
@@ -2294,9 +2301,6 @@ tso_photometry
 - Added a new model for setting parameters for TSO photometry [#2239]
 
 - Add a  reference file for use with tso_photometry [#2254, #2264]
-
-- - A ``ValueError`` is now raised if the input data for ``call`` is missing ``crpix1`` or ``crpix2`` keywords. [#4561]
-
 
 tweakreg
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2076,6 +2076,9 @@ assign_wcs
 
 - fix input units to meters when filter=OPAQUE [#2134]
 
+- A ``ValueError`` is now raised if input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
+
+
 associations
 ------------
 
@@ -2139,6 +2142,7 @@ extract_1d
 extract_2d
 ----------
 
+- A ``ValueError`` is now raised if the input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
 
 firstframe
 ----------
@@ -2290,6 +2294,9 @@ tso_photometry
 - Added a new model for setting parameters for TSO photometry [#2239]
 
 - Add a  reference file for use with tso_photometry [#2254, #2264]
+
+- - A ``ValueError`` is now raised if the input data for ``call`` is missing ``crpix1`` or ``crpix2`` keywords. [#4561]
+
 
 tweakreg
 --------

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -198,6 +198,13 @@ def tsgrism(input_model, reference_files):
     # begin at 0,0, so no need to translate the crpix to full frame
     # because they already are in full frame coordinates.
     xc, yc = (input_model.meta.wcsinfo.siaf_xref_sci, input_model.meta.wcsinfo.siaf_yref_sci)
+
+    if xc is None:
+        raise ValueError('XREF_SCI is missing.')
+
+    if yc is None:
+        raise ValueError('YREF_SCI is missing.')
+
     xcenter = Const1D(xc)
     xcenter.inverse = Const1D(xc)
     ycenter = Const1D(yc)

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -119,6 +119,32 @@ def get_reference_files(datamodel):
     return refs
 
 
+@pytest.fixture(params=tsgrism_filters)
+def tsgrism_inputs(request):
+    def _add_missing_key(missing_key=None):
+        tso_kw = wcs_tso_kw.copy()
+
+        if missing_key is not None:
+            tso_kw[missing_key] = None
+
+        hdu = create_hdul(
+            exptype='NRC_TSGRISM',
+            pupil='GRISMR',
+            filtername=request.param,
+            detector='NRCALONG',
+            subarray='SUBGRISM256',
+            wcskeys=tso_kw,
+            channel='LONG',
+            module='A',
+        )
+
+        image_model = CubeModel(hdu)
+
+        return image_model, get_reference_files(image_model)
+
+    return _add_missing_key
+
+
 def test_nircam_wfss_available_frames():
     """Make sure that the expected GWCS reference frames are created."""
     for p in ['GRISMR', 'GRISMC']:
@@ -132,6 +158,12 @@ def test_nircam_tso_available_frames():
     wcsobj = create_tso_wcs()
     available_frames = wcsobj.available_frames
     assert all([a == b for a, b in zip(nircam_tsgrism_frames, available_frames)])
+
+
+@pytest.mark.parametrize('key', ['xref_sci', 'yref_sci'])
+def test_extract_tso_object_fails_without_xref_yref(tsgrism_inputs, key):
+    with pytest.raises(ValueError):
+        nircam.tsgrism(*tsgrism_inputs(missing_key=key))
 
 
 def traverse_wfss_trace(pupil):

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -111,6 +111,12 @@ def extract_tso_object(input_model,
     if len(available_orders) > 1:
         raise NotImplementedError("Multiple order extraction for TSO not currently implemented")
 
+    if input_model.meta.wcsinfo.siaf_xref_sci is None:
+        raise ValueError('XREF_SCI is missing.')
+
+    if input_model.meta.wcsinfo.siaf_yref_sci is None:
+        raise  ValueError('YREF_SCI is missing.')
+
     log.info("Extracting order: {}".format(available_orders))
     output_model = datamodels.SlitModel()
     output_model.update(input_model)

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -115,7 +115,7 @@ def extract_tso_object(input_model,
         raise ValueError('XREF_SCI is missing.')
 
     if input_model.meta.wcsinfo.siaf_yref_sci is None:
-        raise  ValueError('YREF_SCI is missing.')
+        raise ValueError('YREF_SCI is missing.')
 
     log.info("Extracting order: {}".format(available_orders))
     output_model = datamodels.SlitModel()

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -160,6 +160,40 @@ def get_reference_files(datamodel):
     return refs
 
 
+@pytest.fixture(params=tsgrism_filters)
+def tsgrism_inputs(request):
+    def _add_missing_key(missing_key=None):
+        tso_kw = wcs_tso_kw.copy()
+        tso_kw.update({'xref_sci': 887.0, 'yref_sci': 35.0})
+
+        if missing_key is not None:
+            tso_kw[missing_key] = None
+
+        hdu = create_hdul(
+            exptype='NRC_TSGRISM',
+            pupil='GRISMR',
+            filtername=request.param,
+            detector='NRCALONG',
+            subarray='SUBGRISM256',
+            wcskeys=tso_kw,
+            channel='LONG',
+            module='A',
+        )
+
+        image_model = CubeModel(hdu)
+
+        return image_model, get_reference_files(image_model)
+
+    return _add_missing_key
+
+
+@pytest.mark.parametrize('key', ['xref_sci', 'yref_sci'])
+def test_extract_tso_object_fails_without_xref_yref(tsgrism_inputs, key):
+    with pytest.raises(ValueError):
+        image_model, refs = tsgrism_inputs(missing_key=key)
+        extract_grism_objects(image_model, reference_files=refs)
+
+
 @pytest.mark.filterwarnings("ignore: Card is too long")
 def test_create_box_fits():
     """Make sure that a box is created around a source catalog object.

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -191,7 +191,7 @@ def tsgrism_inputs(request):
 def test_extract_tso_object_fails_without_xref_yref(tsgrism_inputs, key):
     with pytest.raises(ValueError):
         image_model, refs = tsgrism_inputs(missing_key=key)
-        extract_grism_objects(image_model, reference_files=refs)
+        extract_tso_object(image_model, reference_files=refs)
 
 
 @pytest.mark.filterwarnings("ignore: Card is too long")

--- a/jwst/tso_photometry/tests/test_tso_photometry_step.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry_step.py
@@ -1,0 +1,25 @@
+import pytest
+
+from astropy.io import fits
+
+from jwst.tso_photometry.tso_photometry_step import TSOPhotometryStep
+
+
+@pytest.fixture
+def test_hdu():
+    hdu = fits.HDUList()
+    phdu = fits.PrimaryHDU()
+    phdu.header['telescop'] = "JWST"
+    phdu.header['time-obs'] = '8:59:37'
+    phdu.header['date-obs'] = '2017-09-05'
+
+    scihdu = fits.ImageHDU()
+    scihdu.header['EXTNAME'] = "SCI"
+    hdu.append(phdu)
+    hdu.append(scihdu)
+    return hdu
+
+
+def test_tsophotometry_process_fails_with_missing_crpix(test_hdu):
+    with pytest.raises(ValueError):
+        TSOPhotometryStep().process(test_hdu)

--- a/jwst/tso_photometry/tests/test_tso_photometry_step.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry_step.py
@@ -2,7 +2,7 @@ import pytest
 
 from astropy.io import fits
 
-from jwst.tso_photometry.tso_photometry_step import TSOPhotometryStep
+from ..tso_photometry_step import TSOPhotometryStep
 
 
 @pytest.fixture

--- a/jwst/tso_photometry/tso_photometry_step.py
+++ b/jwst/tso_photometry/tso_photometry_step.py
@@ -27,8 +27,14 @@ class TSOPhotometryStep(Step):
 
     reference_file_types = ['tsophot']
 
-    def process(self, input):
-        with CubeModel(input) as model:
+    def process(self, input_data):
+        with CubeModel(input_data) as model:
+
+            if model.meta.wcsinfo.crpix1 is None:
+                raise ValueError('CRPIX1 is missing.')
+
+            if model.meta.wcsinfo.crpix2 is None:
+                raise ValueError('CRPIX2 is missing.')
 
             xcenter = model.meta.wcsinfo.crpix1 - 1    # 1-based origin
             ycenter = model.meta.wcsinfo.crpix2 - 1    # 1-based origin


### PR DESCRIPTION
This PR adds exceptions in cases where `xref_xci` or `yref_sci` are missing in `assign_wcs.nircam.tsgrism`, `extract_2d.extract_tso_object`, and `tso_photomoetry.TSOPhotometryStep`.

Additionally, unit tests were added to test for cases where the exception should be raised.

Resolves #4239 / [JP-1129](https://jira.stsci.edu/browse/JP-1129)