### PR TITLE
JP-1264: Fix TSGRISM WCS subarray offset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ extract_2d
 
 - A ``ValueError`` is now raised if the input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
 
+- Fix the WCS subarray offsets for NIRCam TSGRISM cutouts [#4573]
+
 master_background
 -----------------
 

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -5,9 +5,10 @@ Overview
 --------
 The ``extract_2d`` step extracts 2D arrays from spectral images. The extractions
 are performed within all of the SCI, ERR, and DQ arrays of the input image
-model. It also computes an array of wavelengths. The SCI, ERR, DQ and WAVELENGTH
-arrays are stored as one or more ``slit`` objects in an output MultiSlitModel
-and saved as separate extensions in the output FITS file.
+model, as well as any variance arrays that may be present. It also computes an
+array of wavelengths to attach to the extracted data. The extracted arrays
+are stored as one or more ``slit`` objects in an output MultiSlitModel
+and saved as separate tuples of extensions in the output FITS file.
 
 Assumptions
 -----------
@@ -15,28 +16,33 @@ This step uses the ``bounding_box`` attribute of the WCS stored in the data mode
 which is populated by the ``assign_wcs`` step. Hence the ``assign_wcs`` step
 must be applied to the science exposure before running this step.
 
-For WFSS modes in NIRCam and NIRSS, no ``bounding_box`` has been attached
-to the datamodel. This is to keep the WCS flexible enough to be used with any
+For NIRCam and NIRISS WFSS modes, no ``bounding_box`` has been attached
+to the data model. This is to keep the WCS flexible enough to be used with any
 source catalog that may be associated with the dispersed image. Instead, there
 is a helper method that is used to calculate the bounding boxes that contain
-the dispersed spectra for each object. One box is made for each order. ``extract2d``
-uses the source catalog referenced in the input models meta information to create
-the list of objects and their corresponding bounding box. This list is used to make
-the 2D cutouts from the dispersed image.
+the dispersed spectra for each object. One box is made for each spectral order of
+each object. The ``extract2d`` step uses the source catalog referenced in the input
+model's meta information to create the list of objects and their corresponding
+bounding box. This list is used to make the 2D cutouts from the dispersed image.
+
+NIRCam TSGRISM exposures do not use a source catalog, so instead it relies on the
+assumption that the source of interest is located at the aperture reference point.
+More details are given below.
 
 Algorithm
 ---------
-The step is currently applied only to NIRSpec Fixed Slit, NIRSpec MSA, NIRSpec TSO,
-NIRCam and NIRISS WFSS, and NIRCam TSGRISM observations.
+This step is currently applied only to NIRSpec Fixed-Slit, NIRSpec MOS, NIRSpec TSO
+(BrightObj), NIRCam and NIRISS WFSS, and NIRCam TSGRISM observations.
 
 NIRSpec
 +++++++
 
 If the step parameter ``slit_name`` is left unspecified, the default behavior is
-to extract all slits which project on the detector. Only one slit may be extracted by
-specifying the slit name with the ``slit_name`` argument, using one of the following
-accepted names: "S1600A1", "S200A1", "S200A2", "S200B1" or "S400A1"
-in the case of a NIRSpec FS exposure or any of the slitlet names in the case of the MSA.
+to extract all slits that project onto the detector. A single slit may be extracted by
+specifying the slit name with the ``slit_name`` argument. In the case of a NIRSpec
+fixed-slit exposure the allowed slit names are: "S1600A1", "S200A1", "S200A2", "S200B1"
+and "S400A1". For NIRSpec MOS exposures, the slit name is the slitlet number from the
+MSA metadata file, corresponding to the value of the "SLTNAME" keyword in FITS products.
 
 To find out what slits are available for extraction:
 
@@ -76,22 +82,32 @@ The dispersion direction will be documented by copying keyword "DISPAXIS"
 NIRCam TSGRISM
 ++++++++++++++
 
-There is no source catalog created for TSO observations, because the source is always
-placed on the same pixel; the user can only vary the size of the subarray. All of the
-subarrays have their "bottom" edge located at the physical bottom edge of the detector
-and grow in size vertically. The source spectrum trace will always be centered
-somewhere near row 34 in the vertical direction (dispersion running parallel to rows).
-So the larger subarrays will just result in larger amount of sky above the spectrum.
+There is no source catalog created for TSO grism observations, because no associated
+direct images are obtained from which to derive such a catalog. So the ``extract_2d``
+step relies on the fact that the source of interest is placed at the aperture reference
+point to determine the source location. The aperture reference location, in units of
+image x and y pixels, is read from the keywords "XREF_SCI" and "YREF_SCI" in the SCI
+extension header of the input image. These values are used to set the source location
+for all computations involving the extent of the spectral trace and pixel wavelength
+assignments.
 
-``extract_2d`` will always produce a cutout that is 64 pixels in height
-(cross-dispersion direction) for all subarrays and full frame exposures,
-which is equal to the height of the smallest available subarray (2048 x 64).
+NIRCam subarrays used for TSGRISM observations always have their "bottom" edge located
+at the physical bottom edge of the detector and vary in size vertically.
+The source spectrum trace will always be centered somewhere near row 34 in the vertical
+direction (dispersion running parallel to rows) of the dispersed image.
+So the larger subarrays just result in a larger region of sky above the spectrum.
+
+For TSGRISM, ``extract_2d`` always produces a cutout that is 64 pixels in height
+(cross-dispersion direction), regardless of whether the original image is full-frame
+or subarray.
+This cutout height is equal to the height of the smallest available subarray (2048 x 64).
 This is to allow area within the cutout for sampling the background in later steps,
 such as ``extract_1d``. The slit height is a parameter that a user can set
-(during reprocessing) to tailor their results. 
+(during reprocessing) to tailor their results, but the entire extent of the image in
+the dispersion direction (along the image x-axis) is always included in the cutout.
 
 The dispersion direction is horizontal for this mode, and it will be
-documented by copying keyword "DISPAXIS" (with value 1) from the input file
+documented by copying the keyword "DISPAXIS" (with value 1) from the input file
 to the output cutout.
 
 
@@ -101,10 +117,8 @@ The ``extract_2d`` step has various optional arguments that apply to certain obs
 modes. For NIRSpec observations there are two arguments:
 
 ``--slit_name``
-  name [string value] of a specific slit region to
-  extract. The default value of None will cause all known slits for the
-  instrument mode to be extracted. Currently only used for NIRSpec fixed slit
-  exposures.
+  name [string value] of a specific slit region to extract. The default value of None
+  will cause all known slits for the instrument mode to be extracted.
 
 ``--apply_wavecorr``
   bool (default is True). Flag indicating whether to apply the NIRSpec wavelength
@@ -126,8 +140,8 @@ For NIRCam and NIRISS WFSS, the ``extract_2d`` step has three optional arguments
 For NIRCam TSGRISM, the ``extract_2d`` step has two optional arguments:
 
 ``--extract_orders``
-  list. The list of orders to extract. The default is taken from the ``wavelengthrange`` reference file.
+  list. The list of orders to extract. The default is taken from the ``wavelengthrange``
+  reference file.
 
 ``--extract_height``
-  int. The cross-dispersion size to extract.
-
+  int. The cross-dispersion size (in units of pixels) to extract.

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -195,7 +195,7 @@ def extract_tso_object(input_model,
         # subarray WCS transform. If the team ever decides to change the extraction limits,
         # the following two constants must be modified accordingly.
         xmin_ext = 0  # hardwire min x for extraction to zero
-        xmax_ext = input_model.data.shape[-1]  # hardwire max x for extraction to size of data
+        xmax_ext = input_model.data.shape[-1] - 1  # hardwire max x for extraction to size of data
 
         order_model = Const1D(order)
         order_model.inverse = Const1D(order)
@@ -210,22 +210,22 @@ def extract_tso_object(input_model,
 
         log.info("WCS made explicit for order: {}".format(order))
         log.info("Spectral trace extents: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
-        log.info("Extraction limits: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin_ext, ymin, xmax_ext-1, ymax))
+        log.info("Extraction limits: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin_ext, ymin, xmax_ext, ymax))
 
         # Cut out the subarray from the input data arrays
-        ext_data = input_model.data[..., ymin: ymax + 1, xmin_ext:xmax_ext].copy()
-        ext_err = input_model.err[..., ymin: ymax + 1, xmin_ext:xmax_ext].copy()
-        ext_dq = input_model.dq[..., ymin: ymax + 1, xmin_ext:xmax_ext].copy()
+        ext_data = input_model.data[..., ymin: ymax + 1, xmin_ext:xmax_ext + 1].copy()
+        ext_err = input_model.err[..., ymin: ymax + 1, xmin_ext:xmax_ext + 1].copy()
+        ext_dq = input_model.dq[..., ymin: ymax + 1, xmin_ext:xmax_ext + 1].copy()
         if input_model.var_poisson is not None and np.size(input_model.var_poisson) > 0:
-            var_poisson = input_model.var_poisson[..., ymin:ymax+1, xmin_ext:xmax_ext].copy()
+            var_poisson = input_model.var_poisson[..., ymin:ymax+1, xmin_ext:xmax_ext + 1].copy()
         else:
             var_poisson = None
         if input_model.var_rnoise is not None and np.size(input_model.var_rnoise) > 0:
-            var_rnoise = input_model.var_rnoise[..., ymin:ymax+1, xmin_ext:xmax_ext].copy()
+            var_rnoise = input_model.var_rnoise[..., ymin:ymax+1, xmin_ext:xmax_ext + 1].copy()
         else:
             var_rnoise = None
         if input_model.var_flat is not None and np.size(input_model.var_flat) > 0:
-            var_flat = input_model.var_flat[..., ymin:ymax+1, xmin_ext:xmax_ext].copy()
+            var_flat = input_model.var_flat[..., ymin:ymax+1, xmin_ext:xmax_ext + 1].copy()
         else:
             var_flat = None
 

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -24,22 +24,22 @@ def extract_tso_object(input_model,
                        extract_orders=None,
                        compute_wavelength=True):
     """
-    Extract the spectrum for a NIRCAM TSO observation.
+    Extract the spectrum for a NIRCam TSO grism observation.
 
     Parameters
     ----------
     input_model : `~jwst.datamodels.CubeModel` or `~jwst.datamodels.ImageModel`
-        The input TSO image as an instance of a CubeModel (3D) or ImageModel (2D)
+        The input TSO data is an instance of a CubeModel (3D) or ImageModel (2D)
 
     reference_files : dict
         Needs to include the name of the wavelengthrange reference file
 
     extract_height : int
-        The extraction height, in total, for the spectra in the
+        The extraction height, in total, for the spectrum in the
         cross-dispersion direction. If this is other than None,
         it will override the team default of 64 pixels. The team
         wants the source centered near row 34, so the extraction
-        height is not the same on either size of the central pixel.
+        height is not the same on either size of the central row.
 
     extract_orders : list[ints]
         This is an optional parameter that will override the
@@ -57,35 +57,37 @@ def extract_tso_object(input_model,
 
     Notes
     -----
-    This method supports NRC_TSGRISM only, where only one
-    bright object is considered in the field, so there's
-    no catalog of sources and the object is assumed to
-    have been observed at the aperture location crpix1/2.
-    CRPIX1/2 are read from the SIAF and saved as
-    "meta.wcsinfo.siaf_xref_sci" and "meta.wcsinfo.siaf_yref_sci".
+    This method supports NRC_TSGRISM only, where only one bright object is
+    considered in the field, so there's no catalog of sources and the object
+    is assumed to have been observed at the aperture reference position.
+    The aperture reference location is read during level-1b (uncal) product
+    creation by the "set_telescope_pointing" script from the SIAF entries
+    XSciRef and YSciRef (reference location in the science frame) and saved as
+    "meta.wcsinfo.siaf_xref_sci" and "meta.wcsinfo.siaf_yref_sci" (FITS header
+    keywords XREF_SCI and YREF_SCI).
 
-    GrismObject is a named tuple which contains distilled
-    information about each catalog object and the bounding
-    boxes that will be used to define the 2d extraction area.
+    Because this mode has a single known source location, the utilities used
+    in the WFSS modes are overkill. Instead, similar structures are created
+    during the extract2d process and then directly used.
 
-    Since this mode has a single known source location the utilities
-    used in the WFSS modes are overkill, instead, similar structures
-    are created during the extrac 2d process and then directly used.
-
-    https://jwst-docs.stsci.edu/display/JTI/NIRCam+Grism+Time+Series
+    https://jwst-docs.stsci.edu/near-infrared-camera/nircam-observing-modes/nircam-time-series-observations/nircam-grism-time-series
     """
 
+    # Check for reference files
     if not isinstance(reference_files, dict):
         raise TypeError("Expected a dictionary for reference_files")
 
+    # Check for wavelengthrange reference file
     if 'wavelengthrange' not in reference_files.keys():
         raise KeyError("No wavelengthrange reference file specified")
 
+    # If an extraction height is not supplied, default to entire
+    # cross-dispersion size of the data array
     if extract_height is None:
         extract_height = input_model.meta.subarray.ysize
     log.info("Setting extraction height to {}".format(extract_height))
 
-    # Get the disperser parameters which have the wave limits
+    # Get the disperser parameters that have the wave limits
     with WavelengthrangeModel(reference_files['wavelengthrange']) as f:
         if (f.meta.instrument.name != 'NIRCAM'):
             raise ValueError("Wavelengthrange reference file not for NIRCAM!")
@@ -94,8 +96,8 @@ def extract_tso_object(input_model,
         wavelengthrange = f.wavelengthrange
         ref_extract_orders = f.extract_orders
 
-    # this supports the user override and overriding the WFSS order extraction
-    # when called from the pipeline only the first order is extracted
+    # If user-supplied spectral orders are not provided,
+    # default to extracting only the 1st order
     if extract_orders is None:
         log.info("Using default order extraction from reference file")
         extract_orders = ref_extract_orders
@@ -111,26 +113,29 @@ def extract_tso_object(input_model,
     if len(available_orders) > 1:
         raise NotImplementedError("Multiple order extraction for TSO not currently implemented")
 
+    # Check for the existence of the aperture reference location meta data
     if input_model.meta.wcsinfo.siaf_xref_sci is None:
         raise ValueError('XREF_SCI is missing.')
 
     if input_model.meta.wcsinfo.siaf_yref_sci is None:
         raise ValueError('YREF_SCI is missing.')
 
+    # Create the extracted output as a SlitModel
     log.info("Extracting order: {}".format(available_orders))
     output_model = datamodels.SlitModel()
     output_model.update(input_model)
     subwcs = copy.deepcopy(input_model.meta.wcs)
 
+    # Loop over spectral orders
     for order in available_orders:
         range_select = [(x[2], x[3]) for x in wavelengthrange if (x[0] == order and x[1] == input_model.meta.instrument.filter)]
-        # All objects in the catalog will use the same filter for translation
-        # that filter is the one that was used in front of the grism
+
+        # Use the filter that was in front of the grism for translation
         lmin, lmax = range_select.pop()
 
-        # create the order bounding box
-        source_xpos = input_model.meta.wcsinfo.siaf_xref_sci - 1  # remove fits
-        source_ypos = input_model.meta.wcsinfo.siaf_yref_sci - 1  # remove fits
+        # Create the order bounding box
+        source_xpos = input_model.meta.wcsinfo.siaf_xref_sci - 1  # remove FITS 1-indexed offset
+        source_ypos = input_model.meta.wcsinfo.siaf_yref_sci - 1  # remove FITS 1-indexed offset
         transform = input_model.meta.wcs.get_transform('full_detector', 'grism_detector')
         xmin, ymin, _ = transform(source_xpos,
                                   source_ypos,
@@ -141,20 +146,18 @@ def extract_tso_object(input_model,
                                   lmax,
                                   order)
 
-        # Add the shift to the lower corner to each subarray WCS object
-        # The shift should just be the lower bounding box corner
-        # also replace the object center location inputs to the GrismDispersion
+        # Add the shift to the lower corner to the subarray WCS object.
+        # The shift should just be the lower bounding box corner.
+        # Also replace the object center location inputs to the GrismDispersion
         # model with the known object center and order information (in pixels of direct image)
-        # This is changes the user input to the model from (x,y,x0,y0,order) -> (x,y)
+        # This changes the user input to the model from (x,y,x0,y0,order) -> (x,y)
         #
-        # The bounding boxes here are also limited to the size of the detector in the
-        # dispersion direction and 64 pixels in the cross-dispersion
-        # The check for boxes entirely off the detector is done in create_grism_bbox right now
-
-        # The team wants the object to fall near  row 34 for all cutouts,
-        # but the default cutout height is 64pixel (32 on either side)
-        # so use crpix2 when it equals 34, but  bump the ycenter by 2 pixel
-        # in the case that it's 32 so that the height is 30 above and 34 below (in full frame)
+        # The bounding box is limited to the size of the detector in the dispersion direction
+        # and 64 pixels in the cross-dispersion direction (at request of instrument team).
+        #
+        # The team wants the object to fall near row 34 for all cutouts, but the default cutout
+        # height is 64 pixels (32 on either side). So bump the extraction ycenter, when necessary,
+        # so that the height is 30 above and 34 below (in full frame) the object center.
         bump = source_ypos - 34
         extract_y_center = source_ypos - bump
 
@@ -167,23 +170,37 @@ def extract_tso_object(input_model,
             extract_y_min = 0
             extract_y_max = extract_height - 1
         else:
-            extract_y_min = extract_y_center - 34  # always return source at pixel 34 in cutout.
+            extract_y_min = extract_y_center - 34  # always return source at row 34 in cutout
             extract_y_max = extract_y_center + extract_height - 34 - 1
 
+        # Check for bad results
         if (extract_y_min > extract_y_max):
             raise ValueError("Something bad happened calculating extraction y-size")
 
-        # limit the bounding box to the detector
+        # Limit the bounding box to the detector edges
         ymin, ymax = (max(extract_y_min, 0), min(extract_y_max, input_model.meta.subarray.ysize))
         xmin, xmax = (max(xmin, 0), min(xmax, input_model.meta.subarray.xsize))
-        log.info("xmin, xmax: {} {}  ymin, ymax: {} {}".format(xmin, xmax, ymin, ymax))
 
-        # the order and source position are put directly into
-        # the new wcs for the subarray for the forward transform
+        # The order and source position are put directly into the new WCS of the subarray
+        # for the forward transform.
+        #
+        # NOTE NOTE NOTE  2020-02-14
+        # We would normally use x-axis (along dispersion) extraction limits calculated
+        # above based on the min/max wavelength range and the source position to do the
+        # subarray extraction and set the subarray WCS accordingly. HOWEVER, the NIRCam
+        # team has asked for all data along the dispersion direction to be included in
+        # subarray cutout, so here we override the xmin/xmax values calculated above and
+        # instead hardwire the extraction limits for the x (dispersion) direction to
+        # cover the entire range of the data and use this new minimum x value in the
+        # subarray WCS transform. If the team ever decides to change the extraction limits,
+        # the following two constants must be modified accordingly.
+        xmin_ext = 0  # hardwire min x for extraction to zero
+        xmax_ext = input_model.data.shape[-1]  # hardwire max x for extraction to size of data
+
         order_model = Const1D(order)
         order_model.inverse = Const1D(order)
         tr = input_model.meta.wcs.get_transform('grism_detector', 'full_detector')
-        tr = Mapping((0, 1, 0)) | Shift(xmin) & Shift(ymin) & order_model | tr
+        tr = Mapping((0, 1, 0)) | Shift(xmin_ext) & Shift(ymin) & order_model | tr
         subwcs.set_transform('grism_detector', 'full_detector', tr)
 
         xmin = int(xmin)
@@ -191,28 +208,28 @@ def extract_tso_object(input_model,
         ymin = int(ymin)
         ymax = int(ymax)
 
-        # cut it out, keep the entire row though
-        ext_data = input_model.data[..., ymin: ymax + 1, :].copy()
-        ext_err = input_model.err[..., ymin: ymax + 1, :].copy()
-        ext_dq = input_model.dq[..., ymin: ymax + 1, :].copy()
-
         log.info("WCS made explicit for order: {}".format(order))
-        log.info("Trace extents are: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
+        log.info("Spectral trace extents: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin, ymin, xmax, ymax))
+        log.info("Extraction limits: (xmin:{}, ymin:{}), (xmax:{}, ymax:{})".format(xmin_ext, ymin, xmax_ext-1, ymax))
 
-        # Note that for variances we copy the entire row, as with ext_data, etc.
+        # Cut out the subarray from the input data arrays
+        ext_data = input_model.data[..., ymin: ymax + 1, xmin_ext:xmax_ext].copy()
+        ext_err = input_model.err[..., ymin: ymax + 1, xmin_ext:xmax_ext].copy()
+        ext_dq = input_model.dq[..., ymin: ymax + 1, xmin_ext:xmax_ext].copy()
         if input_model.var_poisson is not None and np.size(input_model.var_poisson) > 0:
-            var_poisson = input_model.var_poisson[..., ymin:ymax+1, :].copy()
+            var_poisson = input_model.var_poisson[..., ymin:ymax+1, xmin_ext:xmax_ext].copy()
         else:
             var_poisson = None
         if input_model.var_rnoise is not None and np.size(input_model.var_rnoise) > 0:
-            var_rnoise = input_model.var_rnoise[..., ymin:ymax+1, :].copy()
+            var_rnoise = input_model.var_rnoise[..., ymin:ymax+1, xmin_ext:xmax_ext].copy()
         else:
             var_rnoise = None
         if input_model.var_flat is not None and np.size(input_model.var_flat) > 0:
-            var_flat = input_model.var_flat[..., ymin:ymax+1, :].copy()
+            var_flat = input_model.var_flat[..., ymin:ymax+1, xmin_ext:xmax_ext].copy()
         else:
             var_flat = None
 
+        # Finish populating the output model and meta data
         if output_model.meta.model_type == "SlitModel":
             output_model.data = ext_data
             output_model.err = ext_err
@@ -226,16 +243,17 @@ def extract_tso_object(input_model,
             output_model.meta.wcsinfo.siaf_xref_sci = input_model.meta.wcsinfo.siaf_xref_sci
             output_model.meta.wcsinfo.spectral_order = order
             output_model.meta.wcsinfo.dispersion_direction = \
-                        input_model.meta.wcsinfo.dispersion_direction
+                input_model.meta.wcsinfo.dispersion_direction
             if compute_wavelength:
+                log.debug("Computing wavelengths (this takes a while ...)")
                 output_model.wavelength = compute_wavelength_array(output_model)
             output_model.name = '1'
             output_model.source_type = input_model.meta.target.source_type
             output_model.source_name = input_model.meta.target.catalog_name
             output_model.source_alias = input_model.meta.target.proposer_name
-            output_model.xstart = 1  # fits pixels
+            output_model.xstart = 1  # FITS pixels are 1-indexed
             output_model.xsize = ext_data.shape[-1]
-            output_model.ystart = ymin + 1  # fits pixels
+            output_model.ystart = ymin + 1  # FITS pixels are 1-indexed
             output_model.ysize = ext_data.shape[-2]
             output_model.source_xpos = source_xpos
             output_model.source_ypos = 34
@@ -246,7 +264,7 @@ def extract_tso_object(input_model,
                 output_model.int_times = input_model.int_times.copy()
 
     del subwcs
-    log.info("Finished extractions")
+    log.info("Finished extraction")
     return output_model
 
 
@@ -350,7 +368,7 @@ def extract_grism_objects(input_model,
                      .format(input_model.meta.source_catalog.filename))
 
     if not isinstance(grism_objects, list):
-            raise TypeError("Expected input grism objects to be a list")
+        raise TypeError("Expected input grism objects to be a list")
     if len(grism_objects) == 0:
         raise ValueError("No grism objects created from source catalog")
 
@@ -450,9 +468,10 @@ def extract_grism_objects(input_model,
                                                 var_flat=var_flat)
                 new_slit.meta.wcsinfo.spectral_order = order
                 new_slit.meta.wcsinfo.dispersion_direction = \
-                        input_model.meta.wcsinfo.dispersion_direction
+                    input_model.meta.wcsinfo.dispersion_direction
                 new_slit.meta.wcs = subwcs
                 if compute_wavelength:
+                    log.debug("Computing wavelengths (this takes a while ...)")
                     new_slit.wavelength = compute_wavelength_array(new_slit)
 
                 # set x/ystart values relative to the image (screen) frame.


### PR DESCRIPTION
This implements the fix that was determined for the wavelength scale of NIRCam TSGRISM exposures, as discussed extensively in [JP-1264](https://jira.stsci.edu/browse/JP-1264). The fix is to set the x-shift added to the subarray WCS transform to zero, which corresponds to the fact that the entire x-axis worth of data is included in the subarray extraction. Detailed notes have been included in the code, for future maintenance.

Also cleaned up some of the existing code comments that were originally copied from the `extract_grism_objects` routine, but did not apply (at least not directly) to the `extract_tso_object` routine.

Minor updates to the `extract_2d` docs are forthcoming.

Fixes #4513 