### PR TITLE
JP-954 Swap alpha and beta arrays; add support for a DQ extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,11 @@ photom
 - Added ``spectral_order`` to the fields matching the ``photom`` reference files
   for NIRCAM WFSS and TSGRISM modes. [#4538, 4558]
 
+refpix
+------
+
+- Interchanged alpha and beta reference arrays; use the DQ extension [#4575]
+
 set_telescope_pointing
 ----------------------
 

--- a/docs/jwst/references_general/refpix_reffile.inc
+++ b/docs/jwst/references_general/refpix_reffile.inc
@@ -29,9 +29,9 @@ READPATT   model.meta.exposure.readpatt
 
 Reference File Format
 +++++++++++++++++++++
-REFPIX reference files are FITS format, with 1 BINTABLE extension.
+REFPIX reference files are FITS format, with two BINTABLE extensions.
 The FITS primary HDU does not contain a data array.
-The BINTABLE extension is labeled with EXTNAME = "IRS2" and has the
+The first BINTABLE extension is labeled with EXTNAME = "IRS2" and has the
 following column characteristics:
 
 =======  =========
@@ -47,12 +47,52 @@ beta_2   float32
 beta_3   float32
 =======  =========
 
-The "alpha" arrays contain correction multipliers to the data,
-and the "beta" arrays contain correction multipliers to the reference
-output. Both arrays have 4 components; one for each sector.
+The "alpha" arrays contain correction multipliers to the reference output,
+and the "beta" arrays contain correction multipliers to the interleaved
+reference pixels. Both arrays have 4 components, one for each sector
+(amplifier output).  These are applied to (i.e. multiplied by) the Fourier
+transform of the interleaved reference pixel data.
 The coefficients are intrinsically complex values, but have their
 real and imaginary parts stored in alternating table rows, i.e. row 1
 contains the real components of all coefficients and row 2 contains
 the corresponding imaginary components for each.
 This storage scheme results in a total of 2916352 (2048 * 712 * 2)
 rows in the table.
+
+The second BINTABLE extension is labeled with EXTNAME = "DQ" and has the
+following column characteristics:
+
+=======   =========
+Column    Data type
+=======   =========
+output    int16
+odd_even  int16
+mask      uint32
+=======   =========
+
+This table has eight rows.  The "output" column contains the amplifier output
+numbers:  1, 1, 2, 2, 3, 3, 4, 4.  The "odd_even" column contains values
+1 or 2, indicating that either the first or second pair of reference pixel
+reads respectively should be regarded as bad.  The "mask" column contains
+32-bit unsigned integer values.  The interpretation of these values was
+described in the ESA CDP3 document as follows:
+
+"There is also a DQ extension that holds a binary table with three
+columns (OUTPUT, ODD_EVEN, and MASK) and eight rows. In the current
+IRS2 implementation, one jumps 32 times to odd and 32 times to even
+reference pixels, which are then read twice consecutively. Therefore,
+the masks are 32 bit unsigned integers that encode bad interleaved
+reference pixels/columns from left to right (increasing column index)
+in the native detector frame. When a bit is set, the corresponding
+reference data should not be used for the correction."
+
+I assumed that "native detector frame" in the above description referred to
+the order that the data and interleaved reference pixels were read out from
+the detector, not the physical locations of the pixels on the detector.  The
+difference is that the readout direction changes when going from one
+amplifier output to the next; that is, the pixels are read out from left to
+right for the first and third outputs, and they are read out from right to
+left for the second and fourth outputs.  Furthermore, I assumed that for the
+first amplifier output, it is the least significant bit in the value from the
+MASK column that corresponds to the first set of four reads of interleaved
+reference pixel values (reading pixels from left to right).

--- a/docs/jwst/references_general/refpix_reffile.inc
+++ b/docs/jwst/references_general/refpix_reffile.inc
@@ -86,13 +86,13 @@ reference pixels/columns from left to right (increasing column index)
 in the native detector frame. When a bit is set, the corresponding
 reference data should not be used for the correction."
 
-I assumed that "native detector frame" in the above description referred to
+We assume that "native detector frame" in the above description referred to
 the order that the data and interleaved reference pixels were read out from
 the detector, not the physical locations of the pixels on the detector.  The
 difference is that the readout direction changes when going from one
 amplifier output to the next; that is, the pixels are read out from left to
 right for the first and third outputs, and they are read out from right to
-left for the second and fourth outputs.  Furthermore, I assumed that for the
+left for the second and fourth outputs.  Furthermore, we assume that for the
 first amplifier output, it is the least significant bit in the value from the
 MASK column that corresponds to the first set of four reads of interleaved
 reference pixel values (reading pixels from left to right).

--- a/docs/jwst/refpix/description.rst
+++ b/docs/jwst/refpix/description.rst
@@ -88,7 +88,7 @@ MIR Detector Data
        it has been found that there is a significant odd-even row effect.
        Bad pixels (those whose DQ flag has the "DO_NOT_USE" bit set) are not
        included in the calculation of the mean. The mean is calculated as a
-       clipped mean with a 3-sigma rejection threshold using the 
+       clipped mean with a 3-sigma rejection threshold using the
        ``scipy.stats.sigmaclip`` method.
     #. Average the left and right reference pixel mean values.
     #. Subtract each mean from all pixels that the mean is representative of,
@@ -153,7 +153,10 @@ CRDS reference file factors are applied.  IRS2 readout is only used for
 full-frame data, never for subarrays.  The full detector is read out
 by four separate amplifiers simultaneously, and the reference output is
 read at the same time.  Each of these five readouts is the same size,
-640 by 2048 pixels (for IRS2).  The first step in this processing is to
+640 by 2048 pixels (for IRS2).  If the CRDS reference file includes a
+DQ (data quality) BINTABLE extension, interleaved reference pixel values
+will be set to zero if they are flagged as bad in the DQ extension.
+The next step in this processing is to
 copy the science data and the reference pixel data separately to temporary
 1-D arrays (both of length 712 * 2048); this is done separately for each
 amp output.  The reference output is also copied to such an array, but
@@ -179,7 +182,7 @@ output amplifiers.  ``alpha`` is read from columns 'ALPHA_0', 'ALPHA_1',
 'ALPHA_2', and 'ALPHA_3'.  ``beta`` is read from columns 'BETA_0',
 'BETA_1', 'BETA_2', and 'BETA_3'.
 
-The following is done in a loop over groups.
+For each integration, the following is done in a loop over groups.
 
 Let ``k`` be the output number, i.e. an index for sectors 0 through 3.
 Let ``ft_refpix`` be an array of shape (4, 712 * 2048); for each output
@@ -188,7 +191,7 @@ number ``k``, ``ft_refpix[k]`` is the Fourier transform of the temporary
 transform of the temporary 1-D array of reference output data.  Then: ::
 
     for k in range(4):
-        ft_refpix_corr[k] = ft_refpix[k] * alpha[k] + ft_refout * beta[k]
+        ft_refpix_corr[k] = ft_refpix[k] * beta[k] + ft_refout * alpha[k]
 
 For each ``k``, the inverse Fourier transform of ``ft_refpix_corr[k]`` is
 the processed array of reference pixel data, which is then subtracted from

--- a/jwst/datamodels/irs2.py
+++ b/jwst/datamodels/irs2.py
@@ -11,10 +11,14 @@ class IRS2Model(DataModel):
     Parameters
     __________
     irs2_table : numpy table
-         Reference file for IRS2 refpix correction
-         A table with 8 columns and 2916352 (2048 * 712 * 2) rows.  All
-         values are float, but these are interpreted as alternating real
-         and imaginary parts (real, imag, real, imag, ...) of complex
-         values.  There are four columns for ALPHA and four for BETA.
+        Reference file for IRS2 refpix correction
+        A table with 8 columns and 2916352 (2048 * 712 * 2) rows.  All
+        values are float, but these are interpreted as alternating real
+        and imaginary parts (real, imag, real, imag, ...) of complex
+        values.  There are four columns for ALPHA and four for BETA.
+
+    dq_table : data quality info table
+        A table with three columns (OUTPUT, ODD_EVEN, and MASK) and
+        eight rows.
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/irs2.schema"

--- a/jwst/datamodels/irs2.py
+++ b/jwst/datamodels/irs2.py
@@ -11,13 +11,14 @@ class IRS2Model(DataModel):
     Parameters
     __________
     irs2_table : numpy table
-        Reference file for IRS2 refpix correction
+        Table for IRS2 refpix correction.
         A table with 8 columns and 2916352 (2048 * 712 * 2) rows.  All
         values are float, but these are interpreted as alternating real
         and imaginary parts (real, imag, real, imag, ...) of complex
         values.  There are four columns for ALPHA and four for BETA.
 
     dq_table : data quality info table
+        Table for identifying bad reference pixels.
         A table with three columns (OUTPUT, ODD_EVEN, and MASK) and
         eight rows.
     """

--- a/jwst/datamodels/schemas/irs2.schema.yaml
+++ b/jwst/datamodels/schemas/irs2.schema.yaml
@@ -10,7 +10,7 @@ allOf:
 - type: object
   properties:
     irs2_table:
-      title: Reference file for IRS2 refpix correction
+      title: Table for IRS2 refpix correction
       fits_hdu: IRS2
       datatype:
       - name: alpha_0

--- a/jwst/datamodels/schemas/irs2.schema.yaml
+++ b/jwst/datamodels/schemas/irs2.schema.yaml
@@ -30,7 +30,7 @@ allOf:
       - name: beta_3
         datatype: float32
     dq_table:
-      title: Reference file for IRS2 refpix correction
+      title: Table of Data Quality information
       fits_hdu: DQ
       datatype:
       - name: OUTPUT

--- a/jwst/datamodels/schemas/irs2.schema.yaml
+++ b/jwst/datamodels/schemas/irs2.schema.yaml
@@ -29,3 +29,13 @@ allOf:
         datatype: float32
       - name: beta_3
         datatype: float32
+    dq_table:
+      title: Reference file for IRS2 refpix correction
+      fits_hdu: DQ
+      datatype:
+      - name: OUTPUT
+        datatype: int16
+      - name: ODD_EVEN
+        datatype: int16
+      - name: MASK
+        datatype: uint32

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -290,7 +290,7 @@ def exclude_ref(output_model, irs2_mask):
 def decode_mask(output, mask, row):
     """Interpret the MASK column of the DQ table.
 
-    As per the ESA CD{3 document:
+    As per the ESA CDP3 document:
     "There is also a DQ extension that holds a binary table with three
     columns (OUTPUT, ODD_EVEN, and MASK) and eight rows. In the current
     IRS2 implementation, one jumps 32 times to odd and 32 times to even


### PR DESCRIPTION
The `alpha` and `beta` arrays from the `IRS2Model` reference file were used incorrectly.  The `alpha` arrays are now used for the reference output, and the `beta` arrays are now used for the interleaved reference pixels.

If there is a DQ array in the reference file, this will now be used to set some of the reference pixel values to zero.