### PR TITLE
Jenkinsfile*: set conda_ver to 4.8.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 bc0 = new BuildConfig()
 bc0.nodetype = 'linux'
 bc0.name = 'wheel-sdist'
-bc0.conda_ver = '4.6.14'
+bc0.conda_ver = '4.8.2'
 bc0.conda_packages = [
     "python=3.6",
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -39,7 +39,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'stable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '4.8.1'
+bc0.conda_ver = '4.8.2'
 bc0.conda_packages = [
     "python=${python_version}",
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -48,7 +48,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'unstable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '4.7.12'
+bc0.conda_ver = '4.8.2'
 bc0.conda_packages = [
     "python=${python_version}",
 ]


### PR DESCRIPTION
Updates `conda` version used by Jenkins jobs from 4.[6,7] to 4.8.2. 

Reason:

The `python` package installed by `conda-4.6.x` errors out claiming `libffi.so` is missing.