### PR TITLE
Refactor unit tests for jwst submodules

### DIFF
--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -8,169 +8,144 @@ of the results is verified by the team based on the specwcs reference
 file.
 
 """
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 import pytest
 
-
-from astropy.io import fits
-from gwcs import wcs
-
-from ...datamodels.image import ImageModel
-from ...datamodels import CubeModel
-from ..assign_wcs_step import AssignWcsStep
-from .. import nircam
-
+from ..nircam import tsgrism
 
 # Allowed settings for nircam
-tsgrism_filters = ['F277W', 'F444W', 'F322W2', 'F356W']
+TSGRISM_FILTERS = ['F277W', 'F444W', 'F322W2', 'F356W']
 
-nircam_wfss_frames = ['grism_detector', 'detector', 'v2v3', 'world']
+NIRCAM_WFSS_FRAMES = ['grism_detector', 'detector', 'v2v3', 'world']
 
-nircam_tsgrism_frames = ['grism_detector', 'full_detector', 'v2v3', 'world']
+NIRCAM_TSGRISM_FRAMES = ['grism_detector', 'full_detector', 'v2v3', 'world']
 
-nircam_imaging_frames = ['detector', 'v2v3', 'world']
+NIRCAM_IMAGING_FRAMES = ['detector', 'v2v3', 'world']
 
+# Default primary HDU information
+DEFAULT_PHDU = {
+    'telescop': 'JWST',
+    'instrume': 'NIRCAM',
+    'channel': 'LONG',
+    'detector': 'NRCALONG',
+    'FILTER': 'F444W',
+    'PUPIL': 'GRISMR',
+    'MODULE': 'A',
+    'time-obs': '8:59:37',
+    'date-obs': '2017-09-05',
+    'exp_type': 'NRC_IMAGE'
+}
 
 # Default wcs information
-wcs_wfss_kw = {'wcsaxes': 2, 'ra_ref': 53.1423683802, 'dec_ref': -27.8171119969,
-               'v2_ref': 86.103458, 'v3_ref': -493.227512, 'roll_ref': 45.04234459270135,
-               'crpix1': 1024.5, 'crpix2': 1024.5,
-               'crval1': 53.1423683802, 'crval2': -27.8171119969,
-               'cdelt1': 1.74460027777777e-05, 'cdelt2': 1.75306861111111e-05,
-               'ctype1': 'RA---TAN', 'ctype2': 'DEC--TAN',
-               'pc1_1': -1, 'pc1_2': 0,
-               'pc2_1': 0, 'pc2_2': 1,
-               'cunit1': 'deg', 'cunit2': 'deg',
-               }
+DEFAULT_WCS_WFSS = {
+    'wcsaxes': 2,
+    'ra_ref': 53.1423683802,
+    'dec_ref': -27.8171119969,
+    'v2_ref': 86.103458,
+    'v3_ref': -493.227512,
+    'roll_ref': 45.04234459270135,
+    'crpix1': 1024.5,
+    'crpix2': 1024.5,
+    'crval1': 53.1423683802,
+    'crval2': -27.8171119969,
+    'cdelt1': 1.74460027777777e-05,
+    'cdelt2': 1.75306861111111e-05,
+    'ctype1': 'RA---TAN',
+    'ctype2': 'DEC--TAN',
+    'pc1_1': -1,
+    'pc1_2': 0,
+    'pc2_1': 0,
+    'pc2_2': 1,
+    'cunit1': 'deg',
+    'cunit2': 'deg',
+}
 
-wcs_tso_kw = {'wcsaxes': 2, 'ra_ref': 86.9875, 'dec_ref': 23.423,
-              'v2_ref': 95.043034, 'v3_ref': -556.150466, 'roll_ref': 359.9521,
-              'xref_sci': 887.0, 'yref_sci': 35.0,
-              'cdelt1': 1.76686111111111e-05, 'cdelt2': 1.78527777777777e-05,
-              'ctype1': 'RA---TAN', 'ctype2': 'DEC--TAN',
-              'pc1_1': -1, 'pc1_2': 0,
-              'pc2_1': 0, 'pc2_2': 1,
-              'cunit1': 'deg', 'cunit2': 'deg',
-              }
-
-
-def create_hdul(detector='NRCALONG', channel='LONG', module='A',
-                filtername='F444W', exptype='NRC_IMAGE', pupil='GRISMR',
-                subarray='FULL', wcskeys=wcs_wfss_kw):
-    hdul = fits.HDUList()
-    phdu = fits.PrimaryHDU()
-    phdu.header['telescop'] = "JWST"
-    phdu.header['filename'] = "test+" + filtername
-    phdu.header['instrume'] = 'NIRCAM'
-    phdu.header['channel'] = channel
-    phdu.header['detector'] = detector
-    phdu.header['FILTER'] = filtername
-    phdu.header['PUPIL'] = pupil
-    phdu.header['MODULE'] = module
-    phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2017-09-05'
-    phdu.header['exp_type'] = exptype
-    scihdu = fits.ImageHDU()
-    scihdu.header['EXTNAME'] = "SCI"
-    scihdu.header['SUBARRAY'] = subarray
-    scihdu.header.update(wcskeys)
-    hdul.append(phdu)
-    hdul.append(scihdu)
-    return hdul
+DEFAULT_WCS_TSO = {
+    'wcsaxes': 2,
+    'ra_ref': 86.9875,
+    'dec_ref': 23.423,
+    'v2_ref': 95.043034,
+    'v3_ref': -556.150466,
+    'roll_ref': 359.9521,
+    'xref_sci': 887.0,
+    'yref_sci': 35.0,
+    'cdelt1': 1.76686111111111e-05,
+    'cdelt2': 1.78527777777777e-05,
+    'ctype1': 'RA---TAN',
+    'ctype2': 'DEC--TAN',
+    'pc1_1': -1,
+    'pc1_2': 0,
+    'pc2_1': 0,
+    'pc2_2': 1,
+    'cunit1': 'deg',
+    'cunit2': 'deg',
+}
 
 
-def create_wfss_wcs(pupil, filtername='F444W'):
-    """Help create WFSS GWCS object."""
-    hdul = create_hdul(exptype='NRC_WFSS', filtername=filtername, pupil=pupil)
-    im = ImageModel(hdul)
-    ref = get_reference_files(im)
-    pipeline = nircam.create_pipeline(im, ref)
-    wcsobj = wcs.WCS(pipeline)
-    return wcsobj
-
-
-def create_imaging_wcs():
-    hdul = create_hdul()
-    image = ImageModel(hdul)
-    ref = get_reference_files(image)
-    pipeline = nircam.create_pipeline(image, ref)
-    wcsobj = wcs.WCS(pipeline)
-    return wcsobj
-
-
-def create_tso_wcs(filtername=tsgrism_filters[0], subarray="SUBGRISM256"):
-    """Help create tsgrism GWCS object."""
-    hdul = create_hdul(exptype='NRC_TSGRISM', pupil='GRISMR',
-                       filtername=filtername, detector='NRCALONG',
-                       subarray=subarray, wcskeys=wcs_tso_kw)
-    im = CubeModel(hdul)
-    ref = get_reference_files(im)
-    pipeline = nircam.create_pipeline(im, ref)
-    wcsobj = wcs.WCS(pipeline)
-    return wcsobj
-
-
-def get_reference_files(datamodel):
-    """Get the reference files associated with the step."""
-    refs = {}
-    step = AssignWcsStep()
-    for reftype in AssignWcsStep.reference_file_types:
-        refs[reftype] = step.get_reference_file(datamodel, reftype)
-    return refs
-
-
-@pytest.fixture(params=tsgrism_filters)
-def tsgrism_inputs(request):
-    def _add_missing_key(missing_key=None):
-        tso_kw = wcs_tso_kw.copy()
-
-        if missing_key is not None:
-            tso_kw[missing_key] = None
-
-        hdu = create_hdul(
-            exptype='NRC_TSGRISM',
-            pupil='GRISMR',
-            filtername=request.param,
-            detector='NRCALONG',
-            subarray='SUBGRISM256',
-            wcskeys=tso_kw,
-            channel='LONG',
-            module='A',
-        )
-
-        image_model = CubeModel(hdu)
-
-        return image_model, get_reference_files(image_model)
-
-    return _add_missing_key
-
-
-def test_nircam_wfss_available_frames():
+@pytest.mark.parametrize('pupil', ('GRISMR', 'GRISMC'))
+def test_nircam_wfss_available_frames(pupil, assign_wcs_objects):
     """Make sure that the expected GWCS reference frames are created."""
-    for p in ['GRISMR', 'GRISMC']:
-        wcsobj = create_wfss_wcs(p)
-        available_frames = wcsobj.available_frames
-        assert all([a == b for a, b in zip(nircam_wfss_frames, available_frames)])
+    sci_hdu_keys = {**{'SUBARRAY': 'FULL'}, **DEFAULT_WCS_WFSS}
+
+    primary_keys = DEFAULT_PHDU.copy()
+    primary_keys.update({'PUPIL': pupil, 'exp_type': 'NRC_WFSS'})
+
+    bundle = assign_wcs_objects(
+        primary_hdu_keys=primary_keys,
+        sci_hdu_keys=sci_hdu_keys,
+        model_class_name='ImageModel'
+    )
+
+    assert all([a == b for a, b in zip(NIRCAM_WFSS_FRAMES, bundle.wcs_object.available_frames)])
 
 
-def test_nircam_tso_available_frames():
+def test_nircam_tso_available_frames(assign_wcs_objects):
     """Make sure that the expected GWCS reference frames for TSO are created."""
-    wcsobj = create_tso_wcs()
-    available_frames = wcsobj.available_frames
-    assert all([a == b for a, b in zip(nircam_tsgrism_frames, available_frames)])
+    sci_hdu_keys = {**{'SUBARRAY': 'SUBGRISM256'}, **DEFAULT_WCS_TSO}
+
+    primary_keys = DEFAULT_PHDU.copy()
+    primary_keys.update({'PUPIL': 'GRISMR', 'detector': 'NRCALONG', 'exp_type': 'NRC_TSGRISM'})
+
+    bundle = assign_wcs_objects(
+        primary_hdu_keys=primary_keys,
+        sci_hdu_keys=sci_hdu_keys,
+        model_class_name='CubeModel'
+    )
+
+    assert all([a == b for a, b in zip(NIRCAM_TSGRISM_FRAMES, bundle.wcs_object.available_frames)])
 
 
 @pytest.mark.parametrize('key', ['xref_sci', 'yref_sci'])
-def test_extract_tso_object_fails_without_xref_yref(tsgrism_inputs, key):
+def test_extract_tso_object_fails_without_xref_yref(assign_wcs_objects, key):
+    sci_hdu_keys = {**{'SUBARRAY': 'FULL'}, **DEFAULT_WCS_WFSS}
+    sci_hdu_keys.update({key: None})
+
+    bundle = assign_wcs_objects(
+        primary_hdu_keys=DEFAULT_PHDU,
+        sci_hdu_keys=sci_hdu_keys,
+        model_class_name='ImageModel'
+    )
+
     with pytest.raises(ValueError):
-        nircam.tsgrism(*tsgrism_inputs(missing_key=key))
+        tsgrism(bundle.datamodel, bundle.references)
 
 
-def traverse_wfss_trace(pupil):
+@pytest.mark.parametrize('pupil', ('GRISMR', 'GRISMC'))
+def test_traverse_wfss_grisms(pupil, assign_wcs_objects):
     """Make sure that the WFSS dispersion polynomials are reversable."""
-    wcsobj = create_wfss_wcs(pupil)
-    detector_to_grism = wcsobj.get_transform('detector', 'grism_detector')
-    grism_to_detector = wcsobj.get_transform('grism_detector', 'detector')
+    sci_hdu_keys = {**{'SUBARRAY': 'FULL'}, **DEFAULT_WCS_WFSS}
+
+    primary_keys = DEFAULT_PHDU.copy()
+    primary_keys.update({'PUPIL': pupil, 'exp_type': 'NRC_WFSS'})
+
+    bundle = assign_wcs_objects(
+        primary_hdu_keys=primary_keys,
+        sci_hdu_keys=sci_hdu_keys,
+        model_class_name='ImageModel'
+    )
+
+    detector_to_grism = bundle.wcs_object.get_transform('detector', 'grism_detector')
+    grism_to_detector = bundle.wcs_object.get_transform('grism_detector', 'detector')
 
     # check the round trip, grism pixel 100,100, source at 110,110,order 1
     xgrism, ygrism, xsource, ysource, orderin = (100, 100, 110, 110, 1)
@@ -185,17 +160,21 @@ def traverse_wfss_trace(pupil):
     assert orderdet == orderin
 
 
-def test_traverse_wfss_grisms():
-    """Check the dispersion polynomials for each grism."""
-    for pupil in ['GRISMR', 'GRISMC']:
-        traverse_wfss_trace(pupil)
-
-
-def test_traverse_tso_grism():
+def test_traverse_tso_grism(assign_wcs_objects):
     """Make sure that the TSO dispersion polynomials are reversable."""
-    wcsobj = create_tso_wcs()
-    detector_to_grism = wcsobj.get_transform('full_detector', 'grism_detector')
-    grism_to_detector = wcsobj.get_transform('grism_detector', 'full_detector')
+    sci_hdu_keys = {**{'SUBARRAY': 'SUBGRISM256'}, **DEFAULT_WCS_TSO}
+
+    primary_keys = DEFAULT_PHDU.copy()
+    primary_keys.update({'PUPIL': 'GRISMR', 'detector': 'NRCALONG', 'exp_type': 'NRC_TSGRISM'})
+
+    bundle = assign_wcs_objects(
+        primary_hdu_keys=primary_keys,
+        sci_hdu_keys=sci_hdu_keys,
+        model_class_name='CubeModel'
+    )
+
+    detector_to_grism = bundle.wcs_object.get_transform('full_detector', 'grism_detector')
+    grism_to_detector = bundle.wcs_object.get_transform('grism_detector', 'full_detector')
 
     # TSGRISM always has same source locations
     # takes x,y,order -> ra, dec, wave, order
@@ -204,35 +183,48 @@ def test_traverse_tso_grism():
     x0, y0, lam, orderdet = grism_to_detector(xin, yin, order)
     x, y, orderdet = detector_to_grism(x0, y0, lam, order)
 
-    assert x0 == wcs_tso_kw['xref_sci']
-    assert y0 == wcs_tso_kw['yref_sci']
+    assert x0 == DEFAULT_WCS_TSO['xref_sci']
+    assert y0 == DEFAULT_WCS_TSO['yref_sci']
     assert order == orderdet
     assert_allclose(x, xin)
-    assert y == wcs_tso_kw['yref_sci']
+    assert y == DEFAULT_WCS_TSO['yref_sci']
 
 
-def test_imaging_frames():
+def test_imaging_frames(assign_wcs_objects):
     """Verify the available imaging mode reference frames."""
-    wcsobj = create_imaging_wcs()
-    available_frames = wcsobj.available_frames
-    assert all([a == b for a, b in zip(nircam_imaging_frames, available_frames)])
+    sci_hdu_keys = {**{'SUBARRAY': 'FULL'}, **DEFAULT_WCS_WFSS}
+
+    bundle = assign_wcs_objects(
+        primary_hdu_keys=DEFAULT_PHDU,
+        sci_hdu_keys=sci_hdu_keys,
+        model_class_name='ImageModel'
+    )
+
+    assert all([a == b for a, b in zip(NIRCAM_IMAGING_FRAMES, bundle.wcs_object.available_frames)])
 
 
 @pytest.mark.xfail
-def test_imaging_distortion():
+def test_imaging_distortion(assign_wcs_objects):
     """Verify that the distortion correction round trips."""
-    wcsobj = create_imaging_wcs()
-    sky_to_detector = wcsobj.get_transform('world', 'detector')
-    detector_to_sky = wcsobj.get_transform('detector', 'sky')
+    sci_hdu_keys = {**{'SUBARRAY': 'FULL'}, **DEFAULT_WCS_WFSS}
+
+    bundle = assign_wcs_objects(
+        primary_hdu_keys=DEFAULT_PHDU,
+        sci_hdu_keys=sci_hdu_keys,
+        model_class_name='ImageModel'
+    )
+
+    sky_to_detector = bundle.wcs_object.get_transform('world', 'detector')
+    detector_to_sky = bundle.wcs_object.get_transform('detector', 'sky')
 
     # we'll use the crpix as the simplest reference point
-    ra = wcs_wfss_kw['crval1']
-    dec = wcs_wfss_kw['crval2']
+    ra = DEFAULT_WCS_WFSS['crval1']
+    dec = DEFAULT_WCS_WFSS['crval2']
 
     x, y = sky_to_detector(ra, dec)
     raout, decout = detector_to_sky(x, y)
 
-    assert_allclose(x, wcs_wfss_kw['crpix1'])
-    assert_allclose(y, wcs_wfss_kw['crpix2'])
+    assert_allclose(x, DEFAULT_WCS_WFSS['crpix1'])
+    assert_allclose(y, DEFAULT_WCS_WFSS['crpix2'])
     assert_allclose(raout, ra)
     assert_allclose(decout, dec)

--- a/jwst/conftest.py
+++ b/jwst/conftest.py
@@ -2,21 +2,27 @@
 import os
 import tempfile
 import pytest
+import importlib
 
-from jwst.associations import (AssociationRegistry, AssociationPool)
-from jwst.associations.tests.helpers import t_path
-from jwst.lib.tests import helpers as lib_helpers
-from jwst.lib import s3_utils
+from astropy.io import fits
+from gwcs import wcs
+
+from .associations import AssociationRegistry, AssociationPool
+from .associations.tests.helpers import t_path
+from .lib.tests import helpers as lib_helpers
+from .lib import s3_utils
+from . import datamodels
+from .assign_wcs.assign_wcs_step import AssignWcsStep
 
 
 @pytest.fixture(scope='session')
-def full_pool_rules(request):
+def full_pool_rules():
     """Setup to use the full example pool and registry"""
     pool_fname = t_path('data/mega_pool.csv')
     pool = AssociationPool.read(pool_fname)
     rules = AssociationRegistry()
 
-    return (pool, rules, pool_fname)
+    return pool, rules, pool_fname
 
 
 @pytest.fixture
@@ -27,9 +33,11 @@ def mk_tmp_dirs():
     tmp_config_path = tempfile.mkdtemp()
 
     old_path = os.getcwd()
+
     try:
         os.chdir(tmp_current_path)
-        yield (tmp_current_path, tmp_data_path, tmp_config_path)
+        yield tmp_current_path, tmp_data_path, tmp_config_path
+
     finally:
         os.chdir(old_path)
 
@@ -45,3 +53,75 @@ def slow(request):
     has been specified
     """
     return request.config.getoption('--slow')
+
+
+# assign_wcs
+class DataBundle:
+    """Class that creates and contains several objects required for assign_wcs tests. Builds the requested datamodel \
+    instance from a fits HDUList that contains given keywords for the primary HDU and SCI HDU. Collects references and
+    from the datamodel instance and references, creates a WCS object.
+    """
+
+    # noinspection PyTypeChecker
+    def __init__(self, primary_hdu_keys: dict, sci_hdu_keys: dict, model_class_name: str,
+                 hdu_class_name: str = 'ImageHDU'):
+        self.hdu_list = fits.HDUList()
+        self.datamodel = None
+        self.references = None
+        self.wcs_object = None
+
+        if 'instrume' not in primary_hdu_keys:
+            raise KeyError('INSTRUME keyword is required in the primary_hdu_keys to build the correct WCS object.')
+
+        self.create_hdu_list(primary_hdu_keys, sci_hdu_keys, hdu_class_name)
+        self.create_datamodel(self.hdu_list, model_class_name)
+        self.get_references(self.datamodel)
+        self.create_wcs(self.hdu_list[0].header['instrume'], self.datamodel, self.references)
+
+    def create_hdu_list(self, primary_hdu_keys: dict, sci_hdu_keys: dict, hdu_class_name: str) -> fits.HDUList:
+        """Create a basic HDUList for use in generating a DataModel instance for testing."""
+        primary_hdu = fits.PrimaryHDU()
+        primary_hdu.header.update(primary_hdu_keys)
+
+        sci_hdu_class = getattr(fits, hdu_class_name)
+        sci_hdu = sci_hdu_class()
+        sci_hdu.header['EXTNAME'] = 'SCI'
+        sci_hdu.header.update(sci_hdu_keys)
+
+        self.hdu_list.extend([primary_hdu, sci_hdu])
+
+        return self.hdu_list
+
+    def create_datamodel(self, hdu_list: fits.HDUList, model_class_name: str) -> datamodels.DataModel:
+        """Create a DataModel instance from an HDUList for testing."""
+        model_class = getattr(datamodels, model_class_name)
+        self.datamodel = model_class(hdu_list)
+
+        return self.datamodel
+
+    def get_references(self, datamodel: datamodels.DataModel) -> dict:
+        """Get references required for AssignWcsStep for the given DataModel."""
+        step = AssignWcsStep()
+        self.references = {
+            reftype: step.get_reference_file(datamodel, reftype) for reftype in AssignWcsStep.reference_file_types
+        }
+
+        return self.references
+
+    def create_wcs(self, instrument: str, datamodel: datamodels.DataModel, references: dict) -> wcs.WCS:
+        """Create a WCS instance for use in testing."""
+        module = importlib.import_module(f'.assign_wcs.{instrument.lower()}', package='jwst')
+        create_pipeline = getattr(module, 'create_pipeline')
+
+        pipeline = create_pipeline(datamodel, references)
+        self.wcs_object = wcs.WCS(pipeline)
+
+        return self.wcs_object
+
+
+@pytest.fixture
+def assign_wcs_objects():
+    def _create_data_bundle(*args, **kwargs):
+        return DataBundle(*args, **kwargs)
+
+    return _create_data_bundle


### PR DESCRIPTION
This PR adds the class `DataBundle` for creating DataModels and corresponding WCS instances for testing. Unit tests in the `assign_wcs` submodule have been refactored to use a fixture-factory for producing these bundles. 

