### PR TITLE
Make DataModel.update no longer update from extra_fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,9 @@ datamodels
 - Update core.schema.yaml to include new allowed values for PATTTYPE
   [#4475, 4517, 4564]
 
-- DataModel.update() no longer updates from ``extra_fits`` [#4593]
+- DataModel.update() now has ``extra_fits=False`` kwarg that controls whether
+  an update happens from the ``extra_fits`` section of the datamodel.  Default
+  is to stop doing this by default, i.e. ``False``. [#4593]
 
 extract_1d
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ datamodels
 - Update core.schema.yaml to include new allowed values for PATTTYPE
   [#4475, 4517, 4564]
 
+- DataModel.update() no longer updates from ``extra_fits`` [#4593]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -948,12 +948,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             if not protected_keyword(path):
                 set_hdu_keyword(self._instance, d, path)
 
-        # Perform updates to extra_fits area of a model
-
-        for hdu_name in hdu_names:
-            path = ['extra_fits', hdu_name, 'header']
-            set_hdu_keyword(self._instance, d, path)
-
         self.validate()
 
     def to_flat_dict(self, include_arrays=True):

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -951,9 +951,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         # Update from extra_fits as well, if indicated
         if extra_fits:
-            for hdu_name in hdu_names:		
-                 path = ['extra_fits', hdu_name, 'header']		
-                 set_hdu_keyword(self._instance, d, path)		
+            for hdu_name in hdu_names:
+                 path = ['extra_fits', hdu_name, 'header']
+                 set_hdu_keyword(self._instance, d, path)
 
         self.validate()
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -837,7 +837,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
     values = itervalues
 
-    def update(self, d, only='', extra_fits=False):
+    def update(self, d, only=None, extra_fits=False):
         """
         Updates this model with the metadata elements from another model.
 
@@ -848,10 +848,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         d : `~jwst.datamodels.DataModel` or dictionary-like object
             The model to copy the metadata elements from. Can also be a
             dictionary or dictionary of dictionaries or lists.
-        only: str
-            Only update the named hdu from ``extra_fits``, e.g.
-            ``only='PRIMARY'``. Can either be a list of hdu names
-            or a single string. If left blank, update all the hdus.
+        only: str, None
+            Update only the named hdu, e.g. ``only='PRIMARY'``. Can either be
+            a string or list of hdu names. Default is to update all the hdus.
         extra_fits : boolean
             Update from ``extra_fits``.  Default is False.
         """
@@ -924,7 +923,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         # Get the list of hdu names from the model so that updates
         # are limited to those hdus
 
-        if only:
+        if only is not None:
             if isinstance(only, str):
                 hdu_names = set([only])
             else:

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -837,7 +837,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
     values = itervalues
 
-    def update(self, d, only=''):
+    def update(self, d, only='', extra_fits=False):
         """
         Updates this model with the metadata elements from another model.
 
@@ -852,6 +852,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             Only update the named hdu from ``extra_fits``, e.g.
             ``only='PRIMARY'``. Can either be a list of hdu names
             or a single string. If left blank, update all the hdus.
+        extra_fits : boolean
+            Update from ``extra_fits``.  Default is False.
         """
         def hdu_keywords_from_data(d, path, hdu_keywords):
             # Walk tree and add paths to keywords to hdu keywords
@@ -943,10 +945,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             hdu_keywords_from_data(d, path, hdu_keywords)
 
         # Perform the updates to the keywords mentioned in the schema
-
         for path in hdu_keywords:
             if not protected_keyword(path):
                 set_hdu_keyword(self._instance, d, path)
+
+        # Update from extra_fits as well, if indicated
+        if extra_fits:
+            for hdu_name in hdu_names:		
+                 path = ['extra_fits', hdu_name, 'header']		
+                 set_hdu_keyword(self._instance, d, path)		
 
         self.validate()
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -952,8 +952,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         # Update from extra_fits as well, if indicated
         if extra_fits:
             for hdu_name in hdu_names:
-                 path = ['extra_fits', hdu_name, 'header']
-                 set_hdu_keyword(self._instance, d, path)
+                path = ['extra_fits', hdu_name, 'header']
+                set_hdu_keyword(self._instance, d, path)
 
         self.validate()
 

--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -184,16 +184,6 @@ def test_extra_fits():
         assert _header_to_dict(dm.extra_fits.PRIMARY.header)['SCIYSTRT'] == 705
 
 
-def test_extra_fits_update():
-    path = os.path.join(ROOT_DIR, "headers.fits")
-
-    with DataModel(path) as dm:
-        with DataModel() as dm2:
-            dm2.update(dm)
-            assert 'BITPIX' not in _header_to_dict(dm.extra_fits.PRIMARY.header)
-            assert _header_to_dict(dm.extra_fits.PRIMARY.header)['SCIYSTRT'] == 705
-
-
 def test_hdu_order():
     from astropy.io import fits
 

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -451,7 +451,7 @@ def datamodel_for_update(tmpdir):
 
 @pytest.mark.parametrize("extra_fits", [True, False])
 @pytest.mark.parametrize("only", [None, "PRIMARY", "SCI"])
-def test_update(tmpdir, datamodel_for_update, only, extra_fits):
+def test_update_from_datamodel(tmpdir, datamodel_for_update, only, extra_fits):
     """Test update method does not update from extra_fits unless asked"""
     tmpfile = datamodel_for_update
 
@@ -499,6 +499,19 @@ def test_update(tmpdir, datamodel_for_update, only, extra_fits):
             else:
                 assert "TELESCOP" in hdulist["PRIMARY"].header
                 assert "CRVAL1" in hdulist["SCI"].header
+
+
+def test_update_from_dict(tmpdir):
+    """Test update method from a dictionary"""
+    tmpfile = str(tmpdir.join("update.fits"))
+    with ImageModel((5, 5)) as im:
+        update_dict = dict(meta=dict(telescope="JWST", wcsinfo=dict(crval1=5)))
+        im.update(update_dict)
+        im.save(tmpfile)
+
+    with fits.open(tmpfile) as hdulist:
+        assert "TELESCOP" in hdulist[0].header
+        assert "CRVAL1" in hdulist[1].header
 
 
 @pytest.fixture(scope="module")

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -429,8 +429,9 @@ def test_image_with_extra_keyword_to_multislit():
             assert slit.data.shape == (4, 4)
 
 
-def test_update_extra_fits(tmpdir):
-    """Test that the update method does not update from extra_fits"""
+@pytest.mark.parametrize("extra_fits", [True, False])
+def test_update_extra_fits(tmpdir, extra_fits):
+    """Test update method does not update from extra_fits unless asked"""
     tmpfile = str(tmpdir.join("old.fits"))
     with DataModel() as im:
         im.save(tmpfile)
@@ -443,13 +444,14 @@ def test_update_extra_fits(tmpdir):
     with DataModel() as newim:
         with DataModel(tmpfile) as oldim:
             assert oldim.extra_fits.PRIMARY.header == [['FOO', 'BAR', '']]
-            newim.update(oldim)
+            newim.update(oldim, extra_fits=extra_fits)
         newim.save(newtmpfile)
 
     with fits.open(newtmpfile) as hdulist:
-        assert "FOO" not in hdulist[0].header
-
-
+        if extra_fits:
+            assert "FOO" in hdulist[0].header
+        else:
+            assert "FOO" not in hdulist[0].header
 
 
 @pytest.fixture(scope="module")

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -9,6 +9,7 @@ import pytest
 from astropy.time import Time
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy.io import fits
 
 from .. import (DataModel, ImageModel, MaskModel, QuadModel,
                 MultiSlitModel, ModelContainer, SlitModel,
@@ -407,7 +408,7 @@ def test_open_fits_model_s3():
     assert isinstance(model, DataModel)
 
 def test_image_with_extra_keyword_to_multislit():
-    with ImageModel(data=np.empty((32, 32))) as im:
+    with ImageModel((32, 32)) as im:
         im.save(TMP_FITS, overwrite=True)
 
     from astropy.io import fits
@@ -418,7 +419,7 @@ def test_image_with_extra_keyword_to_multislit():
         with MultiSlitModel() as ms:
             ms.update(im)
             for i in range(3):
-                ms.slits.append(ImageModel(data=np.empty((4, 4))))
+                ms.slits.append(ImageModel((4, 4)))
             assert len(ms.slits) == 3
 
             ms.save(TMP_FITS2, overwrite=True)
@@ -429,29 +430,75 @@ def test_image_with_extra_keyword_to_multislit():
             assert slit.data.shape == (4, 4)
 
 
-@pytest.mark.parametrize("extra_fits", [True, False])
-def test_update_extra_fits(tmpdir, extra_fits):
-    """Test update method does not update from extra_fits unless asked"""
+@pytest.fixture
+def datamodel_for_update(tmpdir):
+    """Provide ImageModel with one keyword each defined in PRIMARY and SCI
+    extensions from the schema, and one each not in the schema"""
     tmpfile = str(tmpdir.join("old.fits"))
-    with DataModel() as im:
-        im.save(tmpfile)
+    with ImageModel((5, 5)) as im:
+        # Add schema keywords, one to each extension
+        im.meta.telescope = "JWST"
+        im.meta.wcsinfo.crval1 = 5
 
-    from astropy.io import fits
+        im.save(tmpfile)
+    # Add non-schema keywords that will get dumped in the extra_fits attribute
     with fits.open(tmpfile, mode="update") as hdulist:
-        hdulist[0].header['FOO'] = 'BAR'
+        hdulist["PRIMARY"].header["FOO"] = "BAR"
+        hdulist["SCI"].header["BAZ"] = "BUZ"
+
+    return tmpfile
+
+
+@pytest.mark.parametrize("extra_fits", [True, False])
+@pytest.mark.parametrize("only", [None, "PRIMARY", "SCI"])
+def test_update(tmpdir, datamodel_for_update, only, extra_fits):
+    """Test update method does not update from extra_fits unless asked"""
+    tmpfile = datamodel_for_update
 
     newtmpfile = str(tmpdir.join("new.fits"))
-    with DataModel() as newim:
-        with DataModel(tmpfile) as oldim:
+    with ImageModel((5, 5)) as newim:
+        with ImageModel(tmpfile) as oldim:
+
+            # Verify the fixture returns keywords we expect
+            assert oldim.meta.telescope == "JWST"
+            assert oldim.meta.wcsinfo.crval1 == 5
             assert oldim.extra_fits.PRIMARY.header == [['FOO', 'BAR', '']]
-            newim.update(oldim, extra_fits=extra_fits)
+            assert oldim.extra_fits.SCI.header == [['BAZ', 'BUZ', '']]
+
+            newim.update(oldim, only=only, extra_fits=extra_fits)
         newim.save(newtmpfile)
 
     with fits.open(newtmpfile) as hdulist:
         if extra_fits:
-            assert "FOO" in hdulist[0].header
+            if only == "PRIMARY":
+                assert "TELESCOP" in hdulist["PRIMARY"].header
+                assert "CRVAL1" not in hdulist["SCI"].header
+                assert "FOO" in hdulist["PRIMARY"].header
+                assert "BAZ" not in hdulist["SCI"].header
+            elif only == "SCI":
+                assert "TELESCOP" not in hdulist["PRIMARY"].header
+                assert "CRVAL1" in hdulist["SCI"].header
+                assert "FOO" not in hdulist["PRIMARY"].header
+                assert "BAZ" in hdulist["SCI"].header
+            else:
+                assert "TELESCOP" in hdulist["PRIMARY"].header
+                assert "CRVAL1" in hdulist["SCI"].header
+                assert "FOO" in hdulist["PRIMARY"].header
+                assert "BAZ" in hdulist["SCI"].header
+
         else:
-            assert "FOO" not in hdulist[0].header
+            assert "FOO" not in hdulist["PRIMARY"].header
+            assert "BAZ" not in hdulist["SCI"].header
+
+            if only == "PRIMARY":
+                assert "TELESCOP" in hdulist["PRIMARY"].header
+                assert "CRVAL1" not in hdulist["SCI"].header
+            elif only == "SCI":
+                assert "TELESCOP" not in hdulist["PRIMARY"].header
+                assert "CRVAL1" in hdulist["SCI"].header
+            else:
+                assert "TELESCOP" in hdulist["PRIMARY"].header
+                assert "CRVAL1" in hdulist["SCI"].header
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
DataModel.update() method will now ignore `extra_fits` in the model that is providing the updated metadata, unless requested via keyword arg `extra_fits=True`.

Resolves #4591