### PR TITLE
Add NIRSpec MOS assign_wcs regression test

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -42,8 +42,14 @@ def postmortem(request, fixturename):
     """Retrieve a fixture object if a test failed
     """
     if request.node.report_setup.passed:
-        if request.node.report_call.failed:
-            return request.node.funcargs.get(fixturename, None)
+        try:
+            if request.node.report_call.failed:
+                return request.node.funcargs.get(fixturename, None)
+        # Handle case where `report_call` hasn't been generated yet
+        # because the test hasn't finished running, as in the case of
+        # a user interrupt
+        except AttributeError:
+            return None
 
 
 @pytest.fixture(scope='function', autouse=True)

--- a/jwst/regtest/test_nirspec_wcs.py
+++ b/jwst/regtest/test_nirspec_wcs.py
@@ -41,7 +41,6 @@ def test_nirspec_mos_wcs(rtdata):
     output = input_file.replace('.fits', '_assign_wcs.fits')
     rtdata.output = output
 
-    truth = input_file.replace('.fits', '_truth_assign_wcs.fits')
     rtdata.get_truth(f"truth/test_nirspec_wcs/{output}")
 
     im = datamodels.open(rtdata.output)

--- a/jwst/regtest/test_nirspec_wcs.py
+++ b/jwst/regtest/test_nirspec_wcs.py
@@ -16,32 +16,32 @@ def run_pipeline(jail, rtdata_module):
     """Run assign_wcs"""
     def _run_pipe_with_file(input_file):
         rtdata = rtdata_module
-        
+
         if input_file == 'msa_patt_num.fits':
             rtdata.get_data('nirspec/mos/V9621500100101_short_msa.fits')
 
         rtdata.get_data('nirspec/test_wcs/' + input_file)
 
         AssignWcsStep.call(input_file, save_results=True, suffix='assign_wcs')
-        
+
         return rtdata
-    
+
     return _run_pipe_with_file
 
 @pytest.mark.bigdata
 def test_nirspec_fixedslit_wcs(run_pipeline):
-    
+
     input_file = test_data['fs_nrs1']
     rtdata = run_pipeline(input_file)
 
     output = input_file.replace('rate', 'assign_wcs')
     rtdata.output = output
-        
+
     rtdata.get_truth("truth/test_nirspec_wcs/" + output)
-    
+
     im = ImageModel(rtdata.output)
     im_ref = ImageModel(rtdata.truth)
-    
+
     print(rtdata.output)
     print(rtdata.truth)
     print(im.meta.exposure.type)
@@ -65,19 +65,19 @@ def test_nirspec_fixedslit_wcs(run_pipeline):
 
 @pytest.mark.bigdata
 def test_nirspec_mos_wcs(run_pipeline):
-    
+
     input_file = test_data['mos_nrs1']
     rtdata = run_pipeline(input_file)
 
     output = input_file.replace('.fits', '_assign_wcs.fits')
     rtdata.output = output
-    
+
     truth = input_file.replace('.fits', '_truth_assign_wcs.fits')
     rtdata.get_truth("truth/test_nirspec_wcs/" + truth)
-    
+
     im = ImageModel(rtdata.output)
     im_ref = ImageModel(rtdata.truth)
-    
+
     # Get the WCS test data
     slits = nirspec.get_open_slits(im)
     name = slits[0].name
@@ -100,18 +100,18 @@ def test_nirspec_mos_wcs(run_pipeline):
 
 @pytest.mark.bigdata
 def test_nirspec_ifu_wcs(run_pipeline):
-    
+
     input_file = test_data['ifu_nrs1']
     rtdata = run_pipeline(input_file)
 
     output = input_file.replace('rate.fits', 'assign_wcs.fits')
     rtdata.output = output
-    
+
     rtdata.get_truth("truth/test_nirspec_wcs/" + output)
-    
+
     im = ImageModel(rtdata.output)
     im_ref = ImageModel(rtdata.truth)
-    
+
     # Create WCS objects for each image
     wcs = nirspec.nrs_wcs_set_input(im, 0)
     wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)
@@ -131,18 +131,18 @@ def test_nirspec_ifu_wcs(run_pipeline):
 
 @pytest.mark.bigdata
 def test_nirspec_ifu_nrs2_wcs(run_pipeline):
-    
+
     input_file = test_data['ifu_nrs2']
     rtdata = run_pipeline(input_file)
 
     output = input_file.replace('rate.fits', 'assign_wcs.fits')
     rtdata.output = output
-    
+
     rtdata.get_truth("truth/test_nirspec_wcs/" + output)
-    
+
     im = ImageModel(rtdata.output)
     im_ref = ImageModel(rtdata.truth)
-    
+
     # Create WCS objects for each image
     wcs = nirspec.nrs_wcs_set_input(im, 0)
     wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)
@@ -162,18 +162,18 @@ def test_nirspec_ifu_nrs2_wcs(run_pipeline):
 
 @pytest.mark.bigdata
 def test_nirspec_ifu_opaque_wcs(run_pipeline):
-    
+
     input_file = test_data['ifu_nrs1_opaque']
     rtdata = run_pipeline(input_file)
 
     output = input_file.replace('rate.fits', 'assign_wcs.fits')
     rtdata.output = output
-    
+
     rtdata.get_truth("truth/test_nirspec_wcs/" + output)
-    
+
     im = ImageModel(rtdata.output)
     im_ref = ImageModel(rtdata.truth)
-    
+
     # Create WCS objects for each image
     wcs = nirspec.nrs_wcs_set_input(im, 0)
     wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)

--- a/jwst/regtest/test_nirspec_wcs.py
+++ b/jwst/regtest/test_nirspec_wcs.py
@@ -6,23 +6,8 @@ from jwst.assign_wcs import AssignWcsStep, nirspec
 from jwst.datamodels import ImageModel
 
 
-@pytest.fixture
-def run_pipeline(rtdata):
-    """Run assign_wcs"""
-    def _run_pipe_with_file(input_file):
-        if input_file == 'msa_patt_num.fits':
-            rtdata.get_data('nirspec/mos/V9621500100101_short_msa.fits')
-
-        rtdata.get_data('nirspec/test_wcs/' + input_file)
-
-        AssignWcsStep.call(input_file, save_results=True, suffix='assign_wcs')
-
-    return _run_pipe_with_file
-
-
-@pytest.fixture(scope="module")
-def run_pipeline_fixed_slit(rtdata_module):
-    rtdata = rtdata_module
+@pytest.mark.bigdata
+def test_nirspec_fixedslit_wcs(rtdata):
 
     input_file = 'jw00023001001_01101_00001_nrs1_rate.fits'
     rtdata.get_data('nirspec/test_wcs/' + input_file)
@@ -33,35 +18,22 @@ def run_pipeline_fixed_slit(rtdata_module):
 
     rtdata.get_truth("truth/test_nirspec_wcs/" + output)
 
-
-@pytest.mark.parametrize("slit", ['S200A1', 'S200A2', 'S400A1', 'S1600A1'])
-@pytest.mark.bigdata
-def test_nirspec_fixedslit_wcs(slit, rtdata_module, run_pipeline_fixed_slit):
-    rtdata = rtdata_module
-
     im = ImageModel(rtdata.output)
-    im_ref = ImageModel(rtdata.truth)
+    im_truth = ImageModel(rtdata.truth)
 
-    # Create WCS objects for each image
-    wcs = nirspec.nrs_wcs_set_input(im, slit)
-    wcs_ref = nirspec.nrs_wcs_set_input(im_ref, slit)
-
-    # Compute RA, Dec, lambda values for each image array
-    grid = grid_from_bounding_box(wcs.bounding_box)
-    ra, dec, lam = wcs(*grid)
-    ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
-
-    # Compare the sky coordinates
-    assert_allclose(ra, ra_ref, equal_nan=True)
-    assert_allclose(dec, dec_ref, equal_nan=True)
-    assert_allclose(lam, lam_ref, equal_nan=True)
+    for slit in ['S200A1']:
+        wcs = nirspec.nrs_wcs_set_input(im, slit)
+        wcs_truth = nirspec.nrs_wcs_set_input(im_truth, slit)
+        assert_specwcs_grid_allclose(wcs, wcs_truth)
 
 
 @pytest.mark.bigdata
-def test_nirspec_mos_wcs(rtdata, run_pipeline):
+def test_nirspec_mos_wcs(rtdata):
 
     input_file = 'msa_patt_num.fits'
-    run_pipeline(input_file)
+    rtdata.get_data('nirspec/mos/V9621500100101_short_msa.fits')
+    rtdata.get_data('nirspec/test_wcs/' + input_file)
+    AssignWcsStep.call(input_file, save_results=True, suffix='assign_wcs')
 
     output = input_file.replace('.fits', '_assign_wcs.fits')
     rtdata.output = output
@@ -70,43 +42,29 @@ def test_nirspec_mos_wcs(rtdata, run_pipeline):
     rtdata.get_truth("truth/test_nirspec_wcs/" + truth)
 
     im = ImageModel(rtdata.output)
-    im_ref = ImageModel(rtdata.truth)
+    im_truth = ImageModel(rtdata.truth)
 
-    # Get the WCS test data
     slits = nirspec.get_open_slits(im)
-    name = slits[0].name
-    wcs = nirspec.nrs_wcs_set_input(im, name)
-
-    # Get the WCS for truth data
-    slits_ref = nirspec.get_open_slits(im)
-    name_ref = slits_ref[0].name
-    wcs_ref = nirspec.nrs_wcs_set_input(im_ref, name_ref)
-
-    # Compute RA, Dec, lambda values for each image array
-    grid = grid_from_bounding_box(wcs.bounding_box)
-    ra, dec, lam = wcs(*grid)
-    ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
-
-    # Compare the sky coordinates
-    assert_allclose(ra, ra_ref, equal_nan=True)
-    assert_allclose(dec, dec_ref, equal_nan=True)
-    assert_allclose(lam, lam_ref, equal_nan=True)
+    names = [slit.name for slit in slits]
+    for name in names:
+        wcs = nirspec.nrs_wcs_set_input(im, name)
+        wcs_truth = nirspec.nrs_wcs_set_input(im_truth, name)
+        assert_specwcs_grid_allclose(wcs, wcs_truth)
 
 
-test_data = {
-    'ifu_nrs1':'jw00011001001_01120_00001_nrs1_rate.fits',
-    'ifu_nrs1_opaque':'jw00011001001_01120_00002_nrs1_rate.fits',
-    'ifu_nrs2': 'jw00011001001_01120_00003_nrs2_rate.fits',
-}
+params = [
+    'jw00011001001_01120_00001_nrs1_rate.fits',
+    'jw00011001001_01120_00002_nrs1_rate.fits',
+    'jw00011001001_01120_00003_nrs2_rate.fits',
+]
+ids = ['ifu_nrs1', 'ifu_nrs1_opaque', 'ifu_nrs2']
 
-params = [item[1] for item in test_data.items()]
-ids = [item[0] for item in test_data.items()]
-@pytest.mark.parametrize("input", params, ids=ids)
+@pytest.mark.parametrize("input_file", params, ids=ids)
 @pytest.mark.bigdata
-def test_nirspec_ifu_wcs(input, rtdata, run_pipeline):
+def test_nirspec_ifu_wcs(input_file, rtdata):
 
-    input_file = test_data['ifu_nrs1']
-    run_pipeline(input_file)
+    rtdata.get_data('nirspec/test_wcs/' + input_file)
+    AssignWcsStep.call(input_file, save_results=True, suffix='assign_wcs')
 
     output = input_file.replace('rate.fits', 'assign_wcs.fits')
     rtdata.output = output
@@ -114,21 +72,27 @@ def test_nirspec_ifu_wcs(input, rtdata, run_pipeline):
     rtdata.get_truth("truth/test_nirspec_wcs/" + output)
 
     im = ImageModel(rtdata.output)
-    im_ref = ImageModel(rtdata.truth)
+    im_truth = ImageModel(rtdata.truth)
 
-    # Create WCS objects for each image
-    wcs = nirspec.nrs_wcs_set_input(im, 0)
-    wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)
+    for slice_ in range(29):
+        wcs = nirspec.nrs_wcs_set_input(im, slice_)
+        wcs_truth = nirspec.nrs_wcs_set_input(im_truth, slice_)
+        assert_specwcs_grid_allclose(wcs, wcs_truth)
+
+
+def assert_specwcs_grid_allclose(wcs, wcs_truth):
+    __traceback__ = False
 
     # Compute RA, Dec, lambda values for each image array
     grid = grid_from_bounding_box(wcs.bounding_box)
     ra, dec, lam = wcs(*grid)
-    ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
+    grid_truth = grid_from_bounding_box(wcs_truth.bounding_box)
+    ra_truth, dec_truth, lam_truth = wcs_truth(*grid_truth)
 
     # Compare the sky coordinates
     # equal_nan is used, because many of the entries are NaN,
     # due to the bounding_box being rectilinear while the
     # defined spectral traces are curved
-    assert_allclose(ra, ra_ref, equal_nan=True)
-    assert_allclose(dec, dec_ref, equal_nan=True)
-    assert_allclose(lam, lam_ref, equal_nan=True)
+    assert_allclose(ra, ra_truth, equal_nan=True)
+    assert_allclose(dec, dec_truth, equal_nan=True)
+    assert_allclose(lam, lam_truth, equal_nan=True)

--- a/jwst/regtest/test_nirspec_wcs.py
+++ b/jwst/regtest/test_nirspec_wcs.py
@@ -5,60 +5,53 @@ from gwcs.wcstools import grid_from_bounding_box
 from jwst.assign_wcs import AssignWcsStep, nirspec
 from jwst.datamodels import ImageModel
 
-test_data = [
-    ('ifu_nrs1', 'jw00011001001_01120_00001_nrs1_rate.fits', 'jw00011001001_01120_00001_nrs1_assign_wcs.fits'),
-    ('ifu_nrs1_opaque', 'jw00011001001_01120_00002_nrs1_rate.fits', 'jw00011001001_01120_00002_nrs1_assign_wcs.fits'),
-    ('ifu_nrs2', 'jw00011001001_01120_00003_nrs2_rate.fits', 'jw00011001001_01120_00003_nrs2_assign_wcs.fits'),
-    ('fs_nrs1', 'jw00023001001_01101_00001_nrs1_rate.fits', 'jw00023001001_01101_00001_nrs1_assign_wcs.fits')]
+test_data = {'ifu_nrs1':'jw00011001001_01120_00001_nrs1_rate.fits',
+             'ifu_nrs1_opaque':'jw00011001001_01120_00002_nrs1_rate.fits',
+             'ifu_nrs2': 'jw00011001001_01120_00003_nrs2_rate.fits',
+             'fs_nrs1': 'jw00023001001_01101_00001_nrs1_rate.fits',
+             'mos_nrs1':'msa_patt_num.fits'}
 
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+    """Run assign_wcs"""
+    def _run_pipe_with_file(input_file):
+        rtdata = rtdata_module
+        
+        if input_file == 'msa_patt_num.fits':
+            rtdata.get_data('nirspec/mos/V9621500100101_short_msa.fits')
+
+        rtdata.get_data('nirspec/test_wcs/' + input_file)
+
+        AssignWcsStep.call(input_file, save_results=True, suffix='assign_wcs')
+        
+        return rtdata
+    
+    return _run_pipe_with_file
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("test_id, input_file, truth_file", test_data)
-def test_nirspec_wcs(_jail, rtdata, test_id, input_file, truth_file):
-    """
-        Test of the AssignWcs step on 4 different NIRSpec exposures:
-        1) IFU NRS1 exposure,
-        2) IFU NRS1 exposure with FILTER=OPAQUE,
-        3) IFU NRS2 exposure, and
-        4) FS NRS1 exposure with 4 slits.
-    """
+def test_nirspec_fixedslit_wcs(run_pipeline):
+    
+    input_file = test_data['fs_nrs1']
+    rtdata = run_pipeline(input_file)
 
-    # Get the input and truth files
-    rtdata.get_data('nirspec/test_wcs/' + input_file)
-    rtdata.get_truth('truth/test_nirspec_wcs/' + truth_file)
+    output = input_file.replace('rate', 'assign_wcs')
+    rtdata.output = output
+        
+    rtdata.get_truth("truth/test_nirspec_wcs/" + output)
+    
+    im = ImageModel(rtdata.output)
+    im_ref = ImageModel(rtdata.truth)
+    
+    print(rtdata.output)
+    print(rtdata.truth)
+    print(im.meta.exposure.type)
 
-    # Run the AssignWcs step
-    result = AssignWcsStep.call(input_file, save_results=True, suffix='assign_wcs')
-    result.close()
-
-    # Open the output and truth files
-    im = ImageModel(result.meta.filename)
-    im_ref = ImageModel(truth_file)
-
-    if result.meta.exposure.type == 'NRS_FIXEDSLIT':
-
-        # Loop over the 4 slit instances
-        for slit in ['S200A1', 'S200A2', 'S400A1', 'S1600A1']:
-
-            # Create WCS objects for each image
-            wcs = nirspec.nrs_wcs_set_input(im, slit)
-            wcs_ref = nirspec.nrs_wcs_set_input(im_ref, slit)
-
-            # Compute RA, Dec, lambda values for each image array
-            grid = grid_from_bounding_box(wcs.bounding_box)
-            ra, dec, lam = wcs(*grid)
-            ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
-
-            # Compare the sky coordinates
-            assert_allclose(ra, ra_ref, equal_nan=True)
-            assert_allclose(dec, dec_ref, equal_nan=True)
-            assert_allclose(lam, lam_ref, equal_nan=True)
-
-    else:
+    # Loop over the 4 slit instances
+    for slit in ['S200A1', 'S200A2', 'S400A1', 'S1600A1']:
 
         # Create WCS objects for each image
-        wcs = nirspec.nrs_wcs_set_input(im, 0)
-        wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)
+        wcs = nirspec.nrs_wcs_set_input(im, slit)
+        wcs_ref = nirspec.nrs_wcs_set_input(im_ref, slit)
 
         # Compute RA, Dec, lambda values for each image array
         grid = grid_from_bounding_box(wcs.bounding_box)
@@ -66,9 +59,134 @@ def test_nirspec_wcs(_jail, rtdata, test_id, input_file, truth_file):
         ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
 
         # Compare the sky coordinates
-        # equal_nan is used, because many of the entries are NaN,
-        # due to the bounding_box being rectilinear while the
-        # defined spectral traces are curved
         assert_allclose(ra, ra_ref, equal_nan=True)
         assert_allclose(dec, dec_ref, equal_nan=True)
         assert_allclose(lam, lam_ref, equal_nan=True)
+
+@pytest.mark.bigdata
+def test_nirspec_mos_wcs(run_pipeline):
+    
+    input_file = test_data['mos_nrs1']
+    rtdata = run_pipeline(input_file)
+
+    output = input_file.replace('.fits', '_assign_wcs.fits')
+    rtdata.output = output
+    
+    truth = input_file.replace('.fits', '_truth_assign_wcs.fits')
+    rtdata.get_truth("truth/test_nirspec_wcs/" + truth)
+    
+    im = ImageModel(rtdata.output)
+    im_ref = ImageModel(rtdata.truth)
+    
+    # Get the WCS test data
+    slits = nirspec.get_open_slits(im)
+    name = slits[0].name
+    wcs = nirspec.nrs_wcs_set_input(im, name)
+
+    # Get the WCS for truth data
+    slits_ref = nirspec.get_open_slits(im)
+    name_ref = slits_ref[0].name
+    wcs_ref = nirspec.nrs_wcs_set_input(im_ref, name_ref)
+
+    # Compute RA, Dec, lambda values for each image array
+    grid = grid_from_bounding_box(wcs.bounding_box)
+    ra, dec, lam = wcs(*grid)
+    ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
+
+    # Compare the sky coordinates
+    assert_allclose(ra, ra_ref, equal_nan=True)
+    assert_allclose(dec, dec_ref, equal_nan=True)
+    assert_allclose(lam, lam_ref, equal_nan=True)
+
+@pytest.mark.bigdata
+def test_nirspec_ifu_wcs(run_pipeline):
+    
+    input_file = test_data['ifu_nrs1']
+    rtdata = run_pipeline(input_file)
+
+    output = input_file.replace('rate.fits', 'assign_wcs.fits')
+    rtdata.output = output
+    
+    rtdata.get_truth("truth/test_nirspec_wcs/" + output)
+    
+    im = ImageModel(rtdata.output)
+    im_ref = ImageModel(rtdata.truth)
+    
+    # Create WCS objects for each image
+    wcs = nirspec.nrs_wcs_set_input(im, 0)
+    wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)
+
+    # Compute RA, Dec, lambda values for each image array
+    grid = grid_from_bounding_box(wcs.bounding_box)
+    ra, dec, lam = wcs(*grid)
+    ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
+
+    # Compare the sky coordinates
+    # equal_nan is used, because many of the entries are NaN,
+    # due to the bounding_box being rectilinear while the
+    # defined spectral traces are curved
+    assert_allclose(ra, ra_ref, equal_nan=True)
+    assert_allclose(dec, dec_ref, equal_nan=True)
+    assert_allclose(lam, lam_ref, equal_nan=True)
+
+@pytest.mark.bigdata
+def test_nirspec_ifu_nrs2_wcs(run_pipeline):
+    
+    input_file = test_data['ifu_nrs2']
+    rtdata = run_pipeline(input_file)
+
+    output = input_file.replace('rate.fits', 'assign_wcs.fits')
+    rtdata.output = output
+    
+    rtdata.get_truth("truth/test_nirspec_wcs/" + output)
+    
+    im = ImageModel(rtdata.output)
+    im_ref = ImageModel(rtdata.truth)
+    
+    # Create WCS objects for each image
+    wcs = nirspec.nrs_wcs_set_input(im, 0)
+    wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)
+
+    # Compute RA, Dec, lambda values for each image array
+    grid = grid_from_bounding_box(wcs.bounding_box)
+    ra, dec, lam = wcs(*grid)
+    ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
+
+    # Compare the sky coordinates
+    # equal_nan is used, because many of the entries are NaN,
+    # due to the bounding_box being rectilinear while the
+    # defined spectral traces are curved
+    assert_allclose(ra, ra_ref, equal_nan=True)
+    assert_allclose(dec, dec_ref, equal_nan=True)
+    assert_allclose(lam, lam_ref, equal_nan=True)
+
+@pytest.mark.bigdata
+def test_nirspec_ifu_opaque_wcs(run_pipeline):
+    
+    input_file = test_data['ifu_nrs1_opaque']
+    rtdata = run_pipeline(input_file)
+
+    output = input_file.replace('rate.fits', 'assign_wcs.fits')
+    rtdata.output = output
+    
+    rtdata.get_truth("truth/test_nirspec_wcs/" + output)
+    
+    im = ImageModel(rtdata.output)
+    im_ref = ImageModel(rtdata.truth)
+    
+    # Create WCS objects for each image
+    wcs = nirspec.nrs_wcs_set_input(im, 0)
+    wcs_ref = nirspec.nrs_wcs_set_input(im_ref, 0)
+
+    # Compute RA, Dec, lambda values for each image array
+    grid = grid_from_bounding_box(wcs.bounding_box)
+    ra, dec, lam = wcs(*grid)
+    ra_ref, dec_ref, lam_ref = wcs_ref(*grid)
+
+    # Compare the sky coordinates
+    # equal_nan is used, because many of the entries are NaN,
+    # due to the bounding_box being rectilinear while the
+    # defined spectral traces are curved
+    assert_allclose(ra, ra_ref, equal_nan=True)
+    assert_allclose(dec, dec_ref, equal_nan=True)
+    assert_allclose(lam, lam_ref, equal_nan=True)


### PR DESCRIPTION
This PR continues #4586 and adds some more commits that clean up the already existing NIRSpec IFU and FS tests:

- restructure the inputs on Artifactory to go by instrument/mode instead of `nirspec/test_wcs`
- use `rtdata.output` and `rtdata.truth` in the fixed-slit test so that it is testing something.  Before it was comparing truth to truth, which of course always passes.  It's been like this since Oct 2018.
- add an assertion helper for comparing grids mapped through `wcs` objects.
- make the breadcrumb postmortem more robust to the test run being aborted via Cntrl-C

Closes #4586
Resolves #3479