### PR TITLE
JP-1201 Remove full path from SCATFILE keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 assign_wcs
 ----------
+- Remove full path from SCATFILE keyword [#4387]
 
 - A ``ValueError`` is now raised if input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
 

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 from ..stpipe import Step
 from ..datamodels import DrizProductModel
 from . import source_catalog
@@ -56,7 +57,8 @@ class SourceCatalogStep(Step):
                 )
                 self.log.info('Wrote source catalog: {0}'
                               .format(cat_filepath))
-                model.meta.source_catalog.filename = cat_filepath
+                model.meta.source_catalog.filename = os.path.basename(
+                    cat_filepath)
 
         # nothing is returned because this is the last step
         return


### PR DESCRIPTION
Update assign_wcs so that only the filename is saved in the keyword SCATFILE.

This is tested in test_niriss_wfss.py and the resulting keyword is listed as 
```
# EXTENSION:    0
SCATFILE= 'nir_wfss_cat.ecsv'  / Output source catalog filename

```
Fixes JP-1201
Fixes #4387