### PR TITLE
use transform-1.2.0 in schemas

### DIFF
--- a/jwst/datamodels/schemas/camera.schema.yaml
+++ b/jwst/datamodels/schemas/camera.schema.yaml
@@ -11,7 +11,7 @@ allOf:
 - type: object
   properties:
     model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
       description: |
         NirSpec Camera model.
     meta:

--- a/jwst/datamodels/schemas/collimator.schema.yaml
+++ b/jwst/datamodels/schemas/collimator.schema.yaml
@@ -10,7 +10,7 @@ allOf:
 - type: object
   properties:
     model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
       description: |
         NirSpec Collimator model, an instance of astropy.modeling.Model.
     meta:

--- a/jwst/datamodels/schemas/disperser.schema.yaml
+++ b/jwst/datamodels/schemas/disperser.schema.yaml
@@ -30,7 +30,7 @@ allOf:
           items:
             type: number
         tilt_model:
-          $ref: http://stsci.edu/schemas/asdf/transform/polynomial-1.2.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
           description: |
             Relation THETA_Y vs GWA_X reading.
         unit:
@@ -56,7 +56,7 @@ allOf:
           items:
             type: number
         tilt_model:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
           description: |
             Relation THETA_Y vs GWA_X reading.
         unit:

--- a/jwst/datamodels/schemas/disperser.schema.yaml
+++ b/jwst/datamodels/schemas/disperser.schema.yaml
@@ -30,7 +30,7 @@ allOf:
           items:
             type: number
         tilt_model:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/polynomial-1.2.0
           description: |
             Relation THETA_Y vs GWA_X reading.
         unit:

--- a/jwst/datamodels/schemas/distortion.schema.yaml
+++ b/jwst/datamodels/schemas/distortion.schema.yaml
@@ -17,7 +17,7 @@ allOf:
 - type: object
   properties:
     model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     meta:
       type: object
       properties:

--- a/jwst/datamodels/schemas/distortion_mrs.schema.yaml
+++ b/jwst/datamodels/schemas/distortion_mrs.schema.yaml
@@ -19,7 +19,7 @@ allOf:
     x_model:
       type: array
       items:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
       description: |
         Transform from (alpha, beta) to detector x coordinate.
         The transform is a Polynomial as a function of alpha and lambda.
@@ -28,7 +28,7 @@ allOf:
     y_model:
       type: array
       items:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
       description: |
         Transform from (alpha, beta) to detector y coordinate.
         The transform is a Polynomial as a function of alpha and lambda.
@@ -37,7 +37,7 @@ allOf:
     alpha_model:
       type: array
       items:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
       description: |
         Transform from detector (x, y) coordinates to alpha coordinate
         in a subchannel cube. The transform is a Polynomial as a function of x and y.
@@ -45,7 +45,7 @@ allOf:
     beta_model:
       type: array
       items:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
       description: |
         Transform from detector (x, y) coordinates to a beta coordinate
         in a subchannel cube.
@@ -91,7 +91,7 @@ allOf:
         model:
           type: array
           items:
-            $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+            $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     meta:
       type: object
       properties:

--- a/jwst/datamodels/schemas/fore.schema.yaml
+++ b/jwst/datamodels/schemas/fore.schema.yaml
@@ -11,7 +11,7 @@ allOf:
 - type: object
   properties:
     model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     meta:
       type: object
       properties:

--- a/jwst/datamodels/schemas/fpa.schema.yaml
+++ b/jwst/datamodels/schemas/fpa.schema.yaml
@@ -11,9 +11,9 @@ allOf:
 - type: object
   properties:
     nrs1_model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     nrs2_model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     meta:
       type: object
       properties:

--- a/jwst/datamodels/schemas/ifufore.schema.yaml
+++ b/jwst/datamodels/schemas/ifufore.schema.yaml
@@ -9,7 +9,7 @@ allOf:
 - type: object
   properties:
     model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     meta:
       type: object
       properties:

--- a/jwst/datamodels/schemas/ifupost.schema.yaml
+++ b/jwst/datamodels/schemas/ifupost.schema.yaml
@@ -10,27 +10,27 @@ definitions:
       The Nirspec IFUPOST transform for one slice.
     properties:
       linear:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         description: |
           The linear part of the transform per slice.
           It has an analytical inverse.
       xpoly:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         description: |
           The forward polynomial in X.
           The backward polynomial should be assigned when creating the model.
       xpoly_distortion:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         description: |
           The wavelength dependent distortion polynomial in X.
           The backward polynomial is assigned as inverse.
       ypoly:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         description: |
           The forward polynomial in Y.
           The backward polynomial should be assigned when creating the model.
       ypoly_distortion:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         description: |
           The wavelength dependent distortion polynomial in X.
           The backward polynomial is assigned as inverse.

--- a/jwst/datamodels/schemas/ifuslicer.schema.yaml
+++ b/jwst/datamodels/schemas/ifuslicer.schema.yaml
@@ -9,7 +9,7 @@ allOf:
 - type: object
   properties:
     model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     data:
       $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
     meta:

--- a/jwst/datamodels/schemas/msa.schema.yaml
+++ b/jwst/datamodels/schemas/msa.schema.yaml
@@ -14,35 +14,35 @@ allOf:
       type: object
       properties:
         model:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         data:
           $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
     Q2:
       type: object
       properties:
         model:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         data:
           $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
     Q3:
       type: object
       properties:
         model:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         data:
           $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
     Q4:
       type: object
       properties:
         model:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         data:
           $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
     Q5:
       type: object
       properties:
         model:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         data:
           $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
     meta:

--- a/jwst/datamodels/schemas/ote.schema.yaml
+++ b/jwst/datamodels/schemas/ote.schema.yaml
@@ -10,7 +10,7 @@ allOf:
 - type: object
   properties:
     model:
-      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+      $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     meta:
       type: object
       properties:
@@ -26,3 +26,4 @@ allOf:
           anyOf:
             - type: string
             - $ref: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+...

--- a/jwst/datamodels/schemas/specwcs.schema.yaml
+++ b/jwst/datamodels/schemas/specwcs.schema.yaml
@@ -20,7 +20,7 @@ allOf:
     model:
       type: array
       items:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
       description: |
         Transform from detector (x, y) coordinate to lambda.
         The transform is a Polynomial as a function of x and y.

--- a/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
+++ b/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
@@ -15,37 +15,37 @@ allOf:
           Nircam Grism wavelength dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     dispx:
         description: |
           Nircam Grism row dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     dispy:
         description: |
           Nircam Grism column dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     invdispl:
         description: |
           Nircam Grism inverse wavelength dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     invdispx:
         description: |
           Nircam Grism inverse row dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     invdispy:
         description: |
           Nircam Grism inverse column dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     orders:
         description: |
           NIRCAM Grism orders, matched to the array locations of the dispersion models

--- a/jwst/datamodels/schemas/specwcs_niriss_grism.schema.yaml
+++ b/jwst/datamodels/schemas/specwcs_niriss_grism.schema.yaml
@@ -14,7 +14,7 @@ allOf:
           NIRISS Grism wavelength dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     dispx:
         description: |
           NIRISS Grism row dispersion model, instance of astropy.modeling.Model
@@ -22,7 +22,7 @@ allOf:
         items:
           type: array
           items:
-            $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+            $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     dispy:
         description: |
           NIRISS Grism column dispersion model, instance of astropy.modeling.Model
@@ -30,13 +30,13 @@ allOf:
         items:
           type: array
           items:
-            $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+            $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     invdispl:
         description: |
           NIRISS Grism inverse wavelength dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
     orders:
         description: |
           NIRISS Grism orders, matched to the array locations of the dispersion models

--- a/jwst/datamodels/schemas/wavecorr.schema.yaml
+++ b/jwst/datamodels/schemas/wavecorr.schema.yaml
@@ -11,7 +11,7 @@ definitions:
         type: string
         enum: [S200A1, S200A2, S400A1, S1600A1, S200B1, MOS]
       zero_point_offset:
-        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+        $ref: http://stsci.edu/schemas/asdf/transform/transform-1.2.0
         title: Zero-point offset
         description: |
           Zero-point offset (in units of detector pixel) as a function of wavelength (in m)


### PR DESCRIPTION
The schemas in datamodels were updated to use transform version 1.2.0. This fixes the problem with reading the Nirspec disperser reference file [seen here](https://travis-ci.org/spacetelescope/jwst/jobs/653521852#L1455) in our CI testing that uses dev versions of `asdf` and `astropy`.

The schemas in jwst/transforms will be dealt with separately.