### PR TITLE
Add ``source_ra`` and ``source_dec`` to Slit MOS attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,9 +37,14 @@ datamodels
 - Update core.schema.yaml to include new allowed values for PATTTYPE
   [#4475, 4517, 4564]
 
+
 - DataModel.update() now has ``extra_fits=False`` kwarg that controls whether
   an update happens from the ``extra_fits`` section of the datamodel.  Default
   is to stop doing this by default, i.e. ``False``. [#4593]
+
+- Updated ``slitdata.schema.yaml`` to include ``SRCRA`` and ``SRCDEC`` for
+  MOS slitlets to FITS SCI headers. These values are taken from the MOS
+  metadata file. [#4613]
 
 extract_1d
 ----------
@@ -59,6 +64,9 @@ extract_2d
 - A ``ValueError`` is now raised if the input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
 
 - Fix the WCS subarray offsets for NIRCam TSGRISM cutouts [#4573]
+
+- Added ``source_ra`` and ``source_dec`` to MSA ``Slit`` with values
+  from the MSA metadata file. [#4613]
 
 master_background
 -----------------
@@ -130,6 +138,15 @@ stpipe
 
 - Fix sub-step nesting in parameter reference files [#4488]
 
+transforms
+----------
+
+ - Refactored the WFSS transforms to improve performance. [#4603]
+
+ - Added ``source_ra`` and ``source_dec`` to the ``Slit`` namedtuple
+   with default values of 0.0. These are populated from the MSA metadata file. [#4613]
+
+  
 tweakreg
 --------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -510,7 +510,8 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
     slitlets : list
         A list of `~jwst.transforms.models.Slit` objects. Each slitlet is a tuple with
         ("name", "shutter_id", "xcen", "ycen", "ymin", "ymax",
-        "quadrant", "source_id", "shutter_state")
+        "quadrant", "source_id", "shutter_state", "source_name", "source_alias", "stellarity",
+        "source_xpos", "source_ypos", "source_ra", "source_dec")
 
     """
     slitlets = []
@@ -580,7 +581,6 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
         open_shutters = [x['shutter_column'] for x in slitlets_sid]
 
         n_main_shutter = len([s for s in slitlets_sid if s['primary_source'] == 'Y'])
-
         # In the next part we need to calculate, find, determine 5 things:
         #    quadrant,  xcen, ycen,  ymin, ymax
 
@@ -628,8 +628,8 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
         # subtract 1 because shutter numbers in the MSA reference file are 1-based.
         shutter_id = xcen + (ycen - 1) * 365
         try:
-            source_name, source_alias, stellarity = [
-                (s['source_name'], s['alias'], s['stellarity']) \
+            source_name, source_alias, stellarity, source_ra, source_dec = [
+                (s['source_name'], s['alias'], s['stellarity'], s['ra'], s['dec']) \
                 for s in msa_source if s['source_id'] == source_id][0]
         except IndexError:
             # all background shutters
@@ -637,6 +637,8 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
             source_name = "background_{}".format(slitlet_id)
             source_alias = "bkg_{}".format(slitlet_id)
             stellarity = 0.0
+            source_ra = 0.0
+            source_dec = 0.0
 
         # Create the output list of tuples that contain the required
         # data for further computations
@@ -656,7 +658,7 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
 
         slitlets.append(Slit(slitlet_id, shutter_id, dither_position, xcen, ycen, ymin, ymax,
                              quadrant, source_id, all_shutters, source_name, source_alias,
-                             stellarity, source_xpos, source_ypos))
+                             stellarity, source_xpos, source_ypos, source_ra, source_dec))
     msa_file.close()
     return slitlets
 

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -95,7 +95,7 @@ allOf:
       title: Center of shutter in MSA coordinates (Y dir)
       type: integer
     source_ra:
-      title: Right Ascention of the source
+      title: Right Ascension of the source
       type: number
       fits_keyword: SRCRA
       fits_hdu: SCI

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -94,6 +94,16 @@ allOf:
     ycen:
       title: Center of shutter in MSA coordinates (Y dir)
       type: integer
+    source_ra:
+      title: Right Ascention of the source
+      type: number
+      fits_keyword: SRCRA
+      fits_hdu: SCI
+    source_dec:
+      title: Declination of the source
+      type: number
+      fits_keyword: SRCDEC
+      fits_hdu: SCI
     data:
       title: The science data
       fits_hdu: SCI

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -181,6 +181,8 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
         output_model.xcen = int(slit.xcen)
         output_model.ycen = int(slit.ycen)
         output_model.dither_position = int(slit.dither_position)
+        output_model.source_ra = float(slit.source_ra)
+        output_model.source_dec = float(slit.source_dec)
         # for pathloss correction
         output_model.shutter_state = slit.shutter_state
     log.info('set slit_attributes completed')

--- a/jwst/msaflagopen/tests/test_msa_open.py
+++ b/jwst/msaflagopen/tests/test_msa_open.py
@@ -89,7 +89,8 @@ def test_create_slitlets():
     slit_fields = ('name','shutter_id','dither_position','xcen',
                    'ycen','ymin','ymax','quadrant','source_id',
                    'shutter_state','source_name','source_alias',
-                   'stellarity','source_xpos','source_ypos')
+                   'stellarity','source_xpos','source_ypos',
+                   'source_ra', 'source_dec')
 
     for slit in result:
         # Test the returned data type and fields.

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -673,7 +673,8 @@ class Gwa2Slit(Model):
         A slit is a namedtupe of type `~jwst.transforms.models.Slit`
         Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
         "quadrant", "source_id", "shutter_state", "source_name",
-        "source_alias", "stellarity", "source_xpos", "source_ypos"])
+        "source_alias", "stellarity", "source_xpos", "source_ypos",
+        "source_ra", "source_dec"])
     models : list
         List of models (`~astropy.modeling.core.Model`) corresponding to the
         list of slits.
@@ -725,7 +726,8 @@ class Slit2Msa(Model):
         A slit is a namedtupe, `~jwst.transforms.models.Slit`
         Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
         "quadrant", "source_id", "shutter_state", "source_name",
-        "source_alias", "stellarity", "source_xpos", "source_ypos")
+        "source_alias", "stellarity", "source_xpos", "source_ypos",
+        "source_ra", "source_dec")
     models : list
         List of models (`~astropy.modeling.core.Model`) corresponding to the
         list of slits.

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -36,12 +36,12 @@ N_SHUTTERS_QUADRANT = 62415
 Slit = namedtuple('Slit', ["name", "shutter_id", "dither_position", "xcen", "ycen",
                            "ymin", "ymax", "quadrant", "source_id", "shutter_state",
                            "source_name", "source_alias", "stellarity",
-                           "source_xpos", "source_ypos", ])
+                           "source_xpos", "source_ypos", "source_ra", "source_dec"])
 """ Nirspec Slit structure definition"""
 
 
-Slit.__new__.__defaults__ = ("", 0, 0, 0.0, 0.0, 0.0, 0.0, 0, 0, "", "", "", "",
-                             0.0, 0.0, 0.0)
+Slit.__new__.__defaults__ = ("", 0, 0, 0.0, 0.0, 0.0, 0.0, 0, 0, "", "", "",
+                             0.0, 0.0, 0.0, 0.0, 0.0)
 
 
 class GrismObject(namedtuple('GrismObject', ("sid",
@@ -194,10 +194,9 @@ class Snell(Model):
     """
     Apply transforms, including Snell law, through the NIRSpec prism.
 
-
     Parameters
     ----------
-    angle : flaot
+    angle : float
         Prism angle in deg.
     kcoef : list
         K coefficients in Sellmeir equation.
@@ -717,7 +716,7 @@ class Gwa2Slit(Model):
 
 class Slit2Msa(Model):
     """
-    NIRSpec slit to MSA transform.
+    Transform from Nirspec ``slit_frame`` to ``msa_frame``.
 
     Parameters
     ----------
@@ -768,7 +767,7 @@ class Slit2Msa(Model):
 
 class NirissSOSSModel(Model):
     """
-    NIRISS SOSS wavelength solution implemented as a Model.
+    NIRISS SOSS wavelength solution model.
 
     Parameters
     ----------


### PR DESCRIPTION
Adds `Slit.source_ra` and `Slit.source_dec` for MOS data with values from the MSA metadata file.
These are saved to the headers of FITS SCI extensions as keywords `SRCRA` and `SRCDEC`.
