### PR TITLE
Turn on tweakreg in MIRI imaging regtest

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -39,7 +39,7 @@ def pytest_runtest_makereport(item, call):
 
 
 def postmortem(request, fixturename):
-    """Retrieve a fixture object if a test failed
+    """Retrieve a fixture object if a test failed, else return None
     """
     if request.node.report_setup.passed:
         try:
@@ -222,6 +222,7 @@ def diff_astropy_tables():
     """Compare astropy tables with tolerances for float columns."""
 
     def _diff_astropy_tables(result_path, truth_path, rtol=1e-5, atol=1e-7):
+        __tracebackhide__ = True
         result = Table.read(result_path)
         truth = Table.read(truth_path)
 
@@ -253,8 +254,9 @@ def diff_astropy_tables():
                         assert_allclose(result[col_name], truth[col_name],
                             rtol=rtol, atol=atol)
                     except AssertionError as err:
-                        diffs.append(
-                            f"Column '{col_name}' values do not match (within tolerances) \n{str(err)}"
+                        diffs.append("\n----------------------------------\n"
+                            + f"Column '{col_name}' values do not "
+                            + f"match (within tolerances) \n{str(err)}"
                         )
                 else:
                     if not (result[col_name] == truth[col_name]).all():
@@ -264,7 +266,9 @@ def diff_astropy_tables():
                 # of SkyCoord objects
                 pass
 
-        return diffs
+        if len(diffs) != 0:
+            raise AssertionError("\n".join(diffs))
+
 
     return _diff_astropy_tables
 

--- a/jwst/regtest/test_infrastructure.py
+++ b/jwst/regtest/test_infrastructure.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.mark.bigdata
-def test_regtestdata_get_data(rtdata, _jail):
+def test_regtestdata_get_data(rtdata):
     rtdata.get_data("infrastructure/test_regtestdata/file1_rate.fits")
     rtdata.output = "file1_cal.fits"
 
@@ -13,7 +13,7 @@ def test_regtestdata_get_data(rtdata, _jail):
 
 
 @pytest.mark.bigdata
-def test_regtestdata_get_truth(rtdata, _jail):
+def test_regtestdata_get_truth(rtdata):
     rtdata.get_truth("infrastructure/test_regtestdata/file1_rate.fits")
     rtdata.output = "file1_rate.fits"
 
@@ -21,7 +21,7 @@ def test_regtestdata_get_truth(rtdata, _jail):
 
 
 @pytest.mark.bigdata
-def test_regtestdata_get_asn(_jail, rtdata):
+def test_regtestdata_get_asn(rtdata):
     rtdata.get_asn("infrastructure/test_regtestdata/my_asn.json")
     files = glob("*.fits")
     rtdata.output = "file1_rate.fits"

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -58,11 +58,10 @@ def run_pipelines(jail, rtdata_module):
         # Set some unique param values needed for these data
         "--steps.tweakreg.snr_threshold=200",
         "--steps.tweakreg.use2dhist=False",
+        "--steps.tweakreg.minobj=4",
         "--steps.source_catalog.snr_threshold=20",
         ]
     Step.from_cmdline(args)
-
-    return rtdata
 
 
 @pytest.mark.bigdata
@@ -71,14 +70,14 @@ def run_pipelines(jail, rtdata_module):
     "rateints",
     "assign_wcs", "flat_field", "cal", "i2d",
     "a3001_crf"])
-def test_miri_image_stages123(run_pipelines, fitsdiff_default_kwargs, suffix):
+def test_miri_image(run_pipelines, rtdata_module, fitsdiff_default_kwargs, suffix):
     """Regression test of detector1 and image2 pipelines performed on MIRI data."""
-    rtdata = run_pipelines
+    rtdata = rtdata_module
     rtdata.input = "det_image_1_MIRIMAGE_F770Wexp1_5stars_uncal.fits"
-    output = "det_image_1_MIRIMAGE_F770Wexp1_5stars_" + suffix + ".fits"
+    output = f"det_image_1_MIRIMAGE_F770Wexp1_5stars_{suffix}.fits"
     rtdata.output = output
 
-    rtdata.get_truth("truth/test_miri_image_stages/" + output)
+    rtdata.get_truth(f"truth/test_miri_image_stages/{output}")
 
     # Set tolerances so the crf, rscd and rateints file comparisons work across
     # architectures
@@ -89,8 +88,8 @@ def test_miri_image_stages123(run_pipelines, fitsdiff_default_kwargs, suffix):
 
 
 @pytest.mark.bigdata
-def test_miri_image_stage3_i2d(run_pipelines, fitsdiff_default_kwargs):
-    rtdata = run_pipelines
+def test_miri_image3_i2d(run_pipelines, rtdata_module, fitsdiff_default_kwargs):
+    rtdata = rtdata_module
     rtdata.input = "det_dithered_5stars_image3_asn.json"
     rtdata.output = "det_dithered_5stars_f770w_i2d.fits"
     rtdata.get_truth("truth/test_miri_image_stages/det_dithered_5stars_f770w_i2d.fits")
@@ -101,8 +100,8 @@ def test_miri_image_stage3_i2d(run_pipelines, fitsdiff_default_kwargs):
 
 
 @pytest.mark.bigdata
-def test_miri_image_stage3_catalog(run_pipelines, diff_astropy_tables):
-    rtdata = run_pipelines
+def test_miri_image3_catalog(run_pipelines, rtdata_module, diff_astropy_tables):
+    rtdata = rtdata_module
     rtdata.input = "det_dithered_5stars_image3_asn.json"
     rtdata.output = "det_dithered_5stars_f770w_cat.ecsv"
     rtdata.get_truth("truth/test_miri_image_stages/det_dithered_5stars_f770w_cat.ecsv")

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -60,6 +60,7 @@ def run_image2(run_detector1, rtdata_module):
 def run_image3(run_image2, rtdata_module):
     """Get the level3 assocation json file (though not its members) and run
     image3 pipeline on all _cal files listed in association"""
+    rtdata = rtdata_module
     rtdata.get_data("miri/image/det_dithered_5stars_image3_asn.json")
     args = ["config/calwebb_image3.cfg", rtdata.input,
         # Set some unique param values needed for these data
@@ -113,8 +114,7 @@ def test_miri_image3_catalog(run_image3, rtdata_module, diff_astropy_tables):
     rtdata.output = "det_dithered_5stars_f770w_cat.ecsv"
     rtdata.get_truth("truth/test_miri_image_stages/det_dithered_5stars_f770w_cat.ecsv")
 
-    diff = diff_astropy_tables(rtdata.output, rtdata.truth, rtol=1e-4)
-    assert len(diff) == 0, "\n".join(diff)
+    assert diff_astropy_tables(rtdata.output, rtdata.truth, rtol=1e-4)
 
 
 @pytest.mark.bigdata

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -8,7 +8,7 @@ from jwst import datamodels
 
 @pytest.fixture(scope="module")
 def run_detector1(rtdata_module):
-    """Run stage 1-3 pipelines on MIRI imaging data."""
+    """Run detector1 pipeline on MIRI imaging data."""
     rtdata = rtdata_module
     rtdata.get_data("miri/image/det_image_1_MIRIMAGE_F770Wexp1_5stars_uncal.fits")
 

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -155,8 +155,7 @@ def test_miri_lrs_slitless_tso3_whtlt(run_tso3_pipeline, generate_tso3_asn,
     rtdata.output = output_filename
     rtdata.get_truth(f"truth/test_miri_lrs_slitless_tso3/{output_filename}")
 
-    diff = diff_astropy_tables(rtdata.output, rtdata.truth)
-    assert len(diff) == 0, "\n".join(diff)
+    assert diff_astropy_tables(rtdata.output, rtdata.truth)
 
 
 @pytest.mark.bigdata

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -128,5 +128,4 @@ def test_nircam_image_stage3_catalog(run_image3pipeline, rtdata_module, diff_ast
     rtdata.output = "jw42424-o002_t001_nircam_clear-f444w_cat.ecsv"
     rtdata.get_truth("truth/test_nircam_image_stages/jw42424-o002_t001_nircam_clear-f444w_cat.ecsv")
 
-    diff = diff_astropy_tables(rtdata.output, rtdata.truth, atol=1e-5)
-    assert len(diff) == 0, "\n".join(diff)
+    assert diff_astropy_tables(rtdata.output, rtdata.truth, rtol=1e-4, atol=1e-5)

--- a/jwst/regtest/test_nirspec_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_fs_spec2.py
@@ -7,8 +7,14 @@ from jwst.lib.suffix import replace_suffix
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
-file_roots = ['jw00023001001_01101_00001_nrs1_', 'jw93045010001_02101_00001_nrs2_', 'jwtest1013001_01101_00001_nrs1_']
-@pytest.fixture(scope="module", params=file_roots, ids=file_roots)
+file_roots = [
+    'jw00023001001_01101_00001_nrs1_',
+    'jw93045010001_02101_00001_nrs2_',
+    'jwtest1013001_01101_00001_nrs1_'
+]
+ids = ["fullframe", "ALLSLITS-subarray", "S400A1-subarray"]
+
+@pytest.fixture(scope="module", params=file_roots, ids=ids)
 def run_pipeline(jail, rtdata_module, request):
     """Run the calwebb_spec2 pipeline on NIRSpec Fixed-Slit exposures.
        We currently test the following types of inputs:


### PR DESCRIPTION
This allows the MIRI imaging test data with only 5 stars to be run through `tweakreg`.  Also:

- Set `rejection_threshold=200` in `JumpStep` for this dataset.  It was detecting lots of noise.
- break up the pipeline-running fixtures in the MIRI Imaging regtests to be a single fixture for each pipeline stage, so if I only want to run the ramp test, I don't have to run the stage 2 and 3 pipelines.  Makes everything more modular.
- Update the the `diff_astropy_tables` assertion helper to be more assertion-like.
- Clean up parametrization of `test_nirspec_fs_spec2`