### PR TITLE
JP-1324 Change data type of OUTPUT and ODD_EVEN columns to uint8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,8 @@ refpix
 
 - Fixed bugs in PR #4575; added unit tests [#4596]
 
+- Changed the data type of columns OUTPUT and ODD_EVEN in DQ [#4618]
+
 set_telescope_pointing
 ----------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,7 +124,8 @@ refpix
 
 - Fixed bugs in PR #4575; added unit tests [#4596]
 
-- Changed the data type of columns OUTPUT and ODD_EVEN in DQ [#4618]
+- Changed the data type of columns OUTPUT and ODD_EVEN in the section of the
+  schema for the DQ table in the NIRSpec IRS2 refpix reference file [#4618]
 
 set_telescope_pointing
 ----------------------

--- a/jwst/datamodels/schemas/irs2.schema.yaml
+++ b/jwst/datamodels/schemas/irs2.schema.yaml
@@ -34,8 +34,8 @@ allOf:
       fits_hdu: DQ
       datatype:
       - name: OUTPUT
-        datatype: int16
+        datatype: uint8
       - name: ODD_EVEN
-        datatype: int16
+        datatype: uint8
       - name: MASK
         datatype: uint32


### PR DESCRIPTION
In the schema for the data model `IRS2Model`, the DQ bintable extension has three columns.  Two of these columns had data type int16, but the reference files that were recently installed in CRDS have data type uint8.  The schema has been changed to agree with the reference files.