### PR TITLE
Skip the NIRSpec IFU single exposure calspec3 regtest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,6 @@
 
 assign_wcs
 ----------
-- Remove full path from SCATFILE keyword [#4387]
 
 - A ``ValueError`` is now raised if input data is missing ``xref_sci`` or ``yref_sci`` keywords. [#4561]
 
@@ -44,9 +43,17 @@ datamodels
   an update happens from the ``extra_fits`` section of the datamodel.  Default
   is to stop doing this by default, i.e. ``False``. [#4593]
 
+- Add units to filteroffset schema.  [#4595]
+
 - Updated ``slitdata.schema.yaml`` to include ``SRCRA`` and ``SRCDEC`` for
   MOS slitlets to FITS SCI headers. These values are taken from the MOS
   metadata file. [#4613]
+
+- Many keyword updates to bring us in-sync with KWD. [#4602]
+
+- Update schemas to use transform-1.2.0. [#4604]
+
+- Allow FileNotFoundError to be raised. [#4605]
 
 extract_1d
 ----------
@@ -131,6 +138,11 @@ set_telescope_pointing
 ----------------------
 
 - Round S_REGION values in ``set_telescope_pointing`` [#4476]
+
+source_catalog
+--------------
+
+- Remove directory path when populating SCATFILE keyword. [#4597]
 
 srctype
 -------

--- a/jwst/regtest/test_nirspec_ifu.py
+++ b/jwst/regtest/test_nirspec_ifu.py
@@ -47,6 +47,7 @@ def run_spec2(jail, rtdata_module):
     return rtdata
 
 
+@pytest.mark.skip(reason="single exposure processing is redundant with calspec2")
 @pytest.fixture(scope='module')
 def run_spec3(jail, run_spec2):
     """Run the Spec3Pipeline on the results from the Spec2Pipeline run"""

--- a/jwst/regtest/test_nirspec_ifu.py
+++ b/jwst/regtest/test_nirspec_ifu.py
@@ -47,7 +47,6 @@ def run_spec2(jail, rtdata_module):
     return rtdata
 
 
-@pytest.mark.skip(reason="single exposure processing is redundant with calspec2")
 @pytest.fixture(scope='module')
 def run_spec3(jail, run_spec2):
     """Run the Spec3Pipeline on the results from the Spec2Pipeline run"""
@@ -105,6 +104,7 @@ def run_spec3_multi(jail, rtdata_module):
     return rtdata
 
 
+@pytest.mark.skip(reason="single exposure processing is redundant with calspec2")
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix',

--- a/jwst/regtest/test_nirspec_ifu.py
+++ b/jwst/regtest/test_nirspec_ifu.py
@@ -104,7 +104,6 @@ def run_spec3_multi(jail, rtdata_module):
     return rtdata
 
 
-@pytest.mark.skip(reason="single exposure processing is redundant with calspec2")
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix',
@@ -116,6 +115,7 @@ def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
                      truth_path=TRUTH_PATH)
 
 
+@pytest.mark.skip(reason="single exposure processing is redundant with calspec2")
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'output',


### PR DESCRIPTION
Update the regtest `test_nirspec_ifu` module to skip the `calwebb_spec3` test that uses a single exposure as input. It takes a long time to run and the results (only applies the `cube_build` and `extract_1d` steps) are completely redundant with the results of those steps applied in the `calwebb_spec2` test that uses the same exposure.

Also entered some missing updates to the change log.