### PR TITLE
Remove SCATFILE/TCATFILE from lev3 product schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ datamodels
   MOS slitlets to FITS SCI headers. These values are taken from the MOS
   metadata file. [#4613]
 
-- Many keyword updates to bring us in-sync with KWD. [#4602]
+- Many keyword updates to bring us in-sync with KWD. [#4602, #4627]
 
 - Update schemas to use transform-1.2.0. [#4604]
 

--- a/jwst/datamodels/schemas/lev3_prod.schema.yaml
+++ b/jwst/datamodels/schemas/lev3_prod.schema.yaml
@@ -61,17 +61,3 @@ properties:
             title: Extname of the WHT extension
             type: string
             fits_keyword: WHTEXT
-      tweakreg_catalog:
-        type: object
-        properties:
-          filename:
-            title: Output tweakreg catalog filename
-            type: string
-            fits_keyword: TCATFILE
-      source_catalog:
-        type: object
-        properties:
-          filename:
-            title: Output source catalog filename
-            type: string
-            fits_keyword: SCATFILE


### PR DESCRIPTION
#4602 added definitions for the SCATFILE and TCATFILE keywords to core.schema, but failed to remove them from the lev3_prod.schema. This removes them.

Note that the entire lev3_prod.schema will be going away completely when when #4552 gets merged (eventually).