### PR TITLE
Add build-backend to pyproject.toml so that pep517.build works

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,15 +19,14 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Generate distributions build
 bc0 = new BuildConfig()
 bc0.nodetype = 'linux'
-bc0.name = 'wheel-sdist'
+bc0.name = 'build-dists'
 bc0.conda_ver = '4.8.2'
 bc0.conda_packages = [
-    "python=3.6",
+    "python",
 ]
 bc0.build_cmds = [
-    "pip install numpy",
-    "pip wheel .",
-    "python setup.py sdist",
+    "pip install pep517",
+    "python -m pep517.build .",
 ]
 
 // Generate pip build/test with released upstream dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = [
     "setuptools>=38.2.5",
     "setuptools_scm",
     "wheel",
-    "numpy",
 ]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This will allow building the sdist and wheel via

```
python -m pep517.build .
```
replacing

```
python setup.py sdist
python setup.py bdist_wheel
```