### PR TITLE
2390 use log config

### DIFF
--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -5,9 +5,6 @@ import logging
 from .assign_wcs import load_wcs
 from .util import MSAFileError
 
-
-log = logging.getLogger(__name__)
-
 __all__ = ["AssignWcsStep"]
 
 
@@ -57,9 +54,9 @@ class AssignWcsStep(Step):
             if not (isinstance(input_model, datamodels.ImageModel) or
                     isinstance(input_model, datamodels.CubeModel) or
                     isinstance(input_model, datamodels.IFUImageModel)):
-                log.warning("Input dataset type is not supported.")
-                log.warning("assign_wcs expects ImageModel, IFUImageModel or CubeModel as input.")
-                log.warning("Skipping assign_wcs step.")
+                self.log.warning("Input dataset type is not supported.")
+                self.log.warning("assign_wcs expects ImageModel, IFUImageModel or CubeModel as input.")
+                self.log.warning("Skipping assign_wcs step.")
                 result = input_model.copy()
                 result.meta.cal_step.assign_wcs = 'SKIPPED'
                 return result
@@ -67,7 +64,7 @@ class AssignWcsStep(Step):
             for reftype in self.reference_file_types:
                 reffile = self.get_reference_file(input_model, reftype)
                 reference_file_names[reftype] = reffile if reffile else ""
-            log.debug(f'reference files used in assign_wcs: {reference_file_names}')
+            self.log.debug(f'reference files used in assign_wcs: {reference_file_names}')
 
             # Get the MSA metadata file if needed and add to reffiles
             if input_model.meta.exposure.type == "NRS_MSASPEC":
@@ -77,7 +74,7 @@ class AssignWcsStep(Step):
                     reference_file_names['msametafile'] = msa_metadata_file
                 else:
                     message = "MSA metadata file (MSAMETFL) is required for NRS_MSASPEC exposures."
-                    log.error(message)
+                    self.log.error(message)
                     raise MSAFileError(message)
             slit_y_range = [self.slit_y_low, self.slit_y_high]
             result = load_wcs(input_model, reference_file_names, slit_y_range)

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -5,8 +5,6 @@ from .. import datamodels
 from . import ramp_fit
 
 import logging
-log = logging.getLogger(__name__)
-
 
 __all__ = ["RampFitStep"]
 
@@ -43,9 +41,9 @@ class RampFitStep (Step):
                                                           'readnoise')
             gain_filename = self.get_reference_file(input_model, 'gain')
 
-            log.info('Using READNOISE reference file: %s', readnoise_filename)
+            self.log.info('Using READNOISE reference file: %s', readnoise_filename)
             readnoise_model = datamodels.ReadnoiseModel(readnoise_filename)
-            log.info('Using GAIN reference file: %s', gain_filename)
+            self.log.info('Using GAIN reference file: %s', gain_filename)
             gain_model = datamodels.GainModel(gain_filename)
 
             # Try to retrieve the gain factor from the gain reference file.
@@ -56,8 +54,8 @@ class RampFitStep (Step):
                 input_model.meta.exposure.gain_factor = \
                     gain_model.meta.exposure.gain_factor
 
-            log.info('Using algorithm = %s' % self.algorithm)
-            log.info('Using weighting = %s' % self.weighting)
+            self.log.info('Using algorithm = %s' % self.algorithm)
+            self.log.info('Using weighting = %s' % self.weighting)
 
             buffsize = ramp_fit.BUFSIZE
             if self.algorithm == "GLS":

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -9,8 +9,6 @@ from .. import datamodels
 from . import resample
 from ..assign_wcs import util
 
-log = logging.getLogger(__name__)
-
 __all__ = ["ResampleStep"]
 
 

--- a/jwst/stpipe/cmdline.py
+++ b/jwst/stpipe/cmdline.py
@@ -176,9 +176,9 @@ def just_the_step_from_cmdline(args, cls=None):
         help="The logging configuration file to load")
     parser1.add_argument(
         "--verbose", "-v", action="store_true",
-        help="Turn on all logging messages")
+        help="Set logging level to DEBUG")
     parser1.add_argument(
-        "--debug", action="store_true",
+        "--debug_run", action="store_true",
         help="When an exception occurs, invoke the Python debugger, pdb")
     parser1.add_argument(
         '--save-parameters', type=str,


### PR DESCRIPTION
This PR adds the ability to configure the logger from the `Step` API (which means also the `Pipeline` API). 

Also includes some minor refactoring of `LogConfig`, removal of module-level log definitions for step modules (the log is created during `Step.__init__()`), and a slight update to some command-line args: 
- renamed "debug" to "debug_run" to remove confusion with common usage of "--debug" as a means to configure the logging level to `DEBUG`
- Changed the "--verbose" help text to explicitly state that the argument sets the logging level to `DEBUG`