### PR TITLE
Add unit tests for new jump step algorithm

### DIFF
--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -201,7 +201,7 @@ def test_twoints_onecr_10_groups_neighbors_flagged_multi(setup_inputs):
     """"
     A multiprocessing test that has two CRs on the boundary between two slices
     in different integrations. This makes sure that we are correctly flagging
-    neighbors in different slices and the we are parsing the integrations correctly.
+    neighbors in different slices and that we are parsing the integrations correctly.
     """
     grouptime = 3.0
     ingain = 200
@@ -452,7 +452,7 @@ def test_single_CR_neighbor_flag( setup_inputs):
     """"
     A single CR in a 10 group exposure. Tests that:
     - if neighbor-flagging is set, the 4 neighboring pixels *ARE* flagged, and
-    - if neighbor-flagging is *NOT* set, the 4 neighboring pixels are *NOT flagged
+    - if neighbor-flagging is *NOT* set, the 4 neighboring pixels are *NOT* flagged
     """
     grouptime = 3.0
     ingain = 5

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -9,7 +9,7 @@ from jwst.datamodels import dqflags
 
 def test_nocrs_noflux(setup_inputs):
     """"
-    all pixel values are zero. So slope should be zero
+    All pixel values are zero. So slope should be zero
     """
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
     out_model = detect_jumps(model1, gain, rnModel, 4.0,  1, 200, 4, True)
@@ -32,7 +32,7 @@ def test_nocrs_noflux_badgain_pixel(setup_inputs):
 
 def test_nocrs_noflux_subarray(setup_inputs):
     """"
-    all pixel values are zero. This shows that the subarray reference files get extracted from the full frame
+    All pixel values are zero. This shows that the subarray reference files get extracted from the full frame
     versions.
     """
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5, subarray=True)
@@ -98,8 +98,8 @@ def test_nocr_100_groups_nframes1(setup_inputs):
 
 def test_twoints_onecr_each_10_groups_neighbors_flagged(setup_inputs):
     """"
-        Two integrations with CRs in different locations. This makes sure we are correctly
-        dealing with integrations.
+    Two integrations with CRs in different locations. This makes sure we are correctly
+    dealing with integrations.
     """
     grouptime = 3.0
     ingain = 200
@@ -142,9 +142,8 @@ def test_twoints_onecr_each_10_groups_neighbors_flagged(setup_inputs):
 
 def test_flagging_of_CRs_across_slice_boundaries(setup_inputs):
     """"
-            A multiprocessing test that has two CRs on the boundary between two
-            slices. This makes sure that we are correctly flagging neighbors in different
-            slices.
+    A multiprocessing test that has two CRs on the boundary between two slices.
+    This makes sure that we are correctly flagging neighbors in different  slices.
     """
     grouptime = 3.0
     ingain = 200
@@ -200,10 +199,9 @@ def test_flagging_of_CRs_across_slice_boundaries(setup_inputs):
 
 def test_twoints_onecr_10_groups_neighbors_flagged_multi(setup_inputs):
     """"
-               A multiprocessing test that has two CRs on the boundary between two
-               slices in different integrations. This makes sure that we are correctly
-               flagging neighbors in different slices and the we are parsing the integrations
-               correctly.
+    A multiprocessing test that has two CRs on the boundary between two slices
+    in different integrations. This makes sure that we are correctly flagging
+    neighbors in different slices and the we are parsing the integrations correctly.
     """
     grouptime = 3.0
     ingain = 200
@@ -247,8 +245,8 @@ def test_twoints_onecr_10_groups_neighbors_flagged_multi(setup_inputs):
 @pytest.mark.skip(reason="Test is only used to test performance issue. No need to run every time.")
 def test_every_pixel_CR_neighbors_flagged(setup_inputs):
     """"
-                   A multiprocessing test that has a jump in every pixel. This is used
-                   to test the performance gain from multiprocessing.
+    A multiprocessing test that has a jump in every pixel. This is used
+    to test the performance gain from multiprocessing.
     """
     grouptime = 3.0
     ingain = 200
@@ -276,9 +274,9 @@ def test_every_pixel_CR_neighbors_flagged(setup_inputs):
 
 def test_crs_on_edge_with_neighbor_flagging(setup_inputs):
     """"
-                   A test to make sure that the neighbors of CRs on the edges of the
-                   array are flagged correctly.
-        """
+    A test to make sure that the neighbors of CRs on the edges of the
+    array are flagged correctly.
+    """
     grouptime = 3.0
     ingain = 200
     inreadnoise = np.float64(7)
@@ -287,7 +285,7 @@ def test_crs_on_edge_with_neighbor_flagging(setup_inputs):
                                                           gain=ingain, readnoise=inreadnoise,
                                                           deltatime=grouptime)
     # two segments perfect fit, second segment has twice the slope
-    #CR on 1st row
+    # CR on 1st row
     model1.data[0, 0, 0, 15] = 15.0
     model1.data[0, 1, 0, 15] = 20.0
     model1.data[0, 2, 0, 15] = 25.0
@@ -298,7 +296,7 @@ def test_crs_on_edge_with_neighbor_flagging(setup_inputs):
     model1.data[0, 7, 0, 15] = 160.0
     model1.data[0, 8, 0, 15] = 170.0
     model1.data[0, 9, 0, 15] = 180.0
-    #CR on last row
+    # CR on last row
     model1.data[0, 0, 1023, 5] = 15.0
     model1.data[0, 1, 1023, 5] = 20.0
     model1.data[0, 2, 1023, 5] = 25.0
@@ -309,7 +307,7 @@ def test_crs_on_edge_with_neighbor_flagging(setup_inputs):
     model1.data[0, 7, 1023, 5] = 160.0
     model1.data[0, 8, 1023, 5] = 170.0
     model1.data[0, 9, 1023, 5] = 180.0
-    #CR on 1st column
+    # CR on 1st column
     model1.data[0, 0, 5, 0] = 15.0
     model1.data[0, 1, 5, 0] = 20.0
     model1.data[0, 2, 5, 0] = 25.0
@@ -320,7 +318,7 @@ def test_crs_on_edge_with_neighbor_flagging(setup_inputs):
     model1.data[0, 7, 5, 0] = 160.0
     model1.data[0, 8, 5, 0] = 170.0
     model1.data[0, 9, 5, 0] = 180.0
-    #CR on last column
+    # CR on last column
     model1.data[0, 0, 15, 1027] = 15.0
     model1.data[0, 1, 15, 1027] = 20.0
     model1.data[0, 2, 15, 1027] = 25.0
@@ -332,7 +330,7 @@ def test_crs_on_edge_with_neighbor_flagging(setup_inputs):
     model1.data[0, 8, 15, 1027] = 170.0
     model1.data[0, 9, 15, 1027] = 180.0
     out_model = detect_jumps(model1, gain, rnModel, 4.0,  1, 200, 10, True)
-    #flag CR and three neighbors of first row CR
+    # flag CR and three neighbors of first row CR
     assert (4 == out_model.groupdq[0, 5, 0, 15])
     assert (4 == out_model.groupdq[0, 5, 1, 15])
     assert (4 == out_model.groupdq[0, 5, 0, 14])
@@ -386,8 +384,8 @@ def test_onecr_10_groups(setup_inputs):
 
 def test_onecr_10_groups_fullarray(setup_inputs):
     """"
-      A test that has a cosmic ray in the 5th group for all pixels except column 10. In column
-      10 the jump is in the 7th group.
+    A test that has a cosmic ray in the 5th group for all pixels except column 10. In column
+    10 the jump is in the 7th group.
     """
     grouptime = 3.0
     ingain = 5
@@ -422,8 +420,8 @@ def test_onecr_10_groups_fullarray(setup_inputs):
 
 def test_onecr_50_groups(setup_inputs):
     """"
-      A test with a fifty group integration. There are two jumps in pixel 5,5. One in group 5 and
-      one in group 30.
+    A test with a fifty group integration. There are two jumps in pixel 5,5. One in group 5 and
+    one in group 30.
     """
     grouptime = 3.0
     ingain = 5
@@ -447,8 +445,158 @@ def test_onecr_50_groups(setup_inputs):
     out_model = detect_jumps(model1, gain, rnModel, 4.0,  1, 200, 10, False)
     assert (out_model.groupdq[0, 5, 5, 5] == 4) # CR in group 5
     assert (out_model.groupdq[0, 30, 5, 5] == 4) # CR in group 30
-    assert (np.all(out_model.groupdq[0, 6:30, 5, 5] == 0)) # groups inbetween are not flagged
+    assert (np.all(out_model.groupdq[0, 6:30, 5, 5] == 0)) # groups in between are not flagged
 
+
+def test_single_CR_neighbor_flag( setup_inputs):
+    """"
+    A single CR in a 10 group exposure. Tests that:
+    - if neighbor-flagging is set, the 4 neighboring pixels *ARE* flagged, and
+    - if neighbor-flagging is *NOT* set, the 4 neighboring pixels are *NOT flagged
+    """
+    grouptime = 3.0
+    ingain = 5
+    inreadnoise = np.float64(7)
+    ngroups = 10
+
+    model1, gdq, rnModel, pixdq, err, gain = \
+        setup_inputs( ngroups=ngroups, nrows=5, ncols=6, gain=ingain, readnoise=inreadnoise,
+                      deltatime=grouptime )
+
+    # two segments perfect fit, second segment has twice the slope
+    model1.data[0, 0, 3, 3] = 15.0
+    model1.data[0, 1, 3, 3] = 20.0
+    model1.data[0, 2, 3, 3] = 25.0
+    model1.data[0, 3, 3, 3] = 30.0
+    model1.data[0, 4, 3, 3] = 35.0
+    model1.data[0, 5, 3, 3] = 140.0
+    model1.data[0, 6, 3, 3] = 150.0
+    model1.data[0, 7, 3, 3] = 160.0
+    model1.data[0, 8, 3, 3] = 170.0
+    model1.data[0, 9, 3, 3] = 180.0
+
+    # Flag neighbors
+    out_model = detect_jumps( model1, gain, rnModel, 4.0,  1, 200, 4, True )
+
+    assert (4 == np.max(out_model.groupdq[0, 5, 3, 3]))
+    assert (4 == out_model.groupdq[0, 5, 3, 4])
+    assert (4 == out_model.groupdq[0, 5, 3, 2])
+    assert (4 == out_model.groupdq[0, 5, 2, 3])
+    assert (4 == out_model.groupdq[0, 5, 4, 3])
+
+    # Do not flag neighbors
+    out_model = detect_jumps( model1, gain, rnModel, 4.0,  1, 200, 4, False )
+
+    assert (4 == np.max(out_model.groupdq[0, 5, 3, 3]))
+    assert (0 == out_model.groupdq[0, 5, 3, 4])
+    assert (0 == out_model.groupdq[0, 5, 3, 2])
+    assert (0 == out_model.groupdq[0, 5, 2, 3])
+    assert (0 == out_model.groupdq[0, 5, 4, 3])
+
+
+def test_proc(setup_inputs):
+    """"
+    A single CR in a 10 group exposure. Verify that the pixels flagged using
+    multiprocessing are identical to the pixels flagged when no
+    multiprocessing is done.
+    """
+    grouptime = 3.0
+    ingain = 5
+    inreadnoise = np.float64(7)
+    ngroups = 10
+
+    model1, gdq, rnModel, pixdq, err, gain = \
+        setup_inputs( ngroups=ngroups, nrows=5, ncols=6, nints=2, gain=ingain, readnoise=inreadnoise,
+                      deltatime=grouptime )
+
+    model1.data[0, 0, 2, 3] = 15.0
+    model1.data[0, 1, 2, 3] = 21.0
+    model1.data[0, 2, 2, 3] = 25.0
+    model1.data[0, 3, 2, 3] = 30.2
+    model1.data[0, 4, 2, 3] = 35.0
+    model1.data[0, 5, 2, 3] = 140.0
+    model1.data[0, 6, 2, 3] = 151.0
+    model1.data[0, 7, 2, 3] = 160.0
+    model1.data[0, 8, 2, 3] = 170.0
+    model1.data[0, 9, 2, 3] = 180.0
+
+    out_model_a = detect_jumps( model1, gain, rnModel, 4.0, 'half', 200, 4, True )
+    out_model_b = detect_jumps( model1, gain, rnModel, 4.0, None, 200, 4, True )
+    assert( out_model_a.groupdq == out_model_b.groupdq ).all()
+
+    out_model_c = detect_jumps( model1, gain, rnModel, 4.0, 'All', 200, 4, True )
+    assert( out_model_a.groupdq == out_model_c.groupdq ).all()
+
+
+def test_adjacent_CRs( setup_inputs ):
+    """
+    Three CRs in a 10 group exposure; the CRs have overlapping neighboring
+    pixels. This test makes sure that the correct pixels are flagged.
+    """
+    grouptime = 3.0
+    ingain = 5
+    inreadnoise = np.float64(7)
+    ngroups = 10
+    model1, gdq, rnModel, pixdq, err, gain = \
+        setup_inputs( ngroups=ngroups, nrows=5, ncols=6, gain=ingain,
+                      readnoise=inreadnoise, deltatime=grouptime )
+
+    # Populate arrays for 1st CR, centered at (x=2, y=3)
+    x=2; y=3
+    model1.data[0, 0, y, x] = 15.0
+    model1.data[0, 1, y, x] = 20.0
+    model1.data[0, 2, y, x] = 26.0
+    model1.data[0, 3, y, x] = 30.0
+    model1.data[0, 4, y, x] = 35.0
+    model1.data[0, 5, y, x] = 140.0
+    model1.data[0, 6, y, x] = 150.0
+    model1.data[0, 7, y, x] = 161.0
+    model1.data[0, 8, y, x] = 170.0
+    model1.data[0, 9, y, x] = 180.0
+
+    # Populate arrays for 2nd CR, centered at (x=2, y=2)
+    x=2; y=2
+    model1.data[0, 0, y, x] = 20.0
+    model1.data[0, 1, y, x] = 30.0
+    model1.data[0, 2, y, x] = 41.0
+    model1.data[0, 3, y, x] = 51.0
+    model1.data[0, 4, y, x] = 62.0
+    model1.data[0, 5, y, x] = 170.0
+    model1.data[0, 6, y, x] = 200.0
+    model1.data[0, 7, y, x] = 231.0
+    model1.data[0, 8, y, x] = 260.0
+    model1.data[0, 9, y, x] = 290.0
+
+    # Populate arrays for 3rd CR, centered at (x=3, y=2)
+    x=3; y=2
+    model1.data[0, 0, y, x] = 120.0
+    model1.data[0, 1, y, x] = 140.0
+    model1.data[0, 2, y, x] = 161.0
+    model1.data[0, 3, y, x] = 181.0
+    model1.data[0, 4, y, x] = 202.0
+    model1.data[0, 5, y, x] = 70.0
+    model1.data[0, 6, y, x] = 100.0
+    model1.data[0, 7, y, x] = 131.0
+    model1.data[0, 8, y, x] = 160.0
+    model1.data[0, 9, y, x] = 190.0
+
+    out_model = detect_jumps(model1, gain, rnModel, 4.0, 'half', 200, 4, True)
+
+    # 1st CR (centered at x=2, y=3)
+    assert (4 == out_model.groupdq[ 0,5,2,2 ])
+    assert (4 == out_model.groupdq[ 0,5,3,1 ])
+    assert (4 == out_model.groupdq[ 0,5,3,2 ])
+    assert (4 == out_model.groupdq[ 0,5,3,3 ])
+    assert (4 == out_model.groupdq[ 0,5,4,2 ])
+
+    # 2nd CR (centered at x=2, y=2)
+    assert (4 == out_model.groupdq[ 0,5,1,2 ])
+    assert (4 == out_model.groupdq[ 0,5,2,1 ])
+    assert (4 == out_model.groupdq[ 0,5,2,3 ])
+
+    # 3rd CR (centered at x=3, y=2)
+    assert (4 == out_model.groupdq[ 0,5,1,3 ])
+    assert (4 == out_model.groupdq[ 0,5,2,4 ])
 
 # Need test for multi-ints near zero with positive and negative slopes
 


### PR DESCRIPTION
For new jump step algorithm that flags neighboring pixels, added unit tests for multiprocessing, and adjacent cosmic rays. Minor whitespace changes. See JP-1298, GH issues #4481 and #4569, and GH PR #4297.