### PR TITLE
Remove the init file usage. Way too confusing

### DIFF
--- a/jwst/datamodels/schema_editor.py
+++ b/jwst/datamodels/schema_editor.py
@@ -510,14 +510,6 @@ class Options:
          `aaa_omitted_keywords.yaml` will be created. This file can be used as
          the input to the `--omit_file` option
 
-         It will also write the options to a file in your home directory so
-         that the next time the script is run it will not ask you about the
-         same changes twice. The name of this file is
-         `schema_editor_options.txt`. It is a text file, you can edit it or
-         delete it. You are seeing the message because no options file was
-         found in your home directory. If one is found, this message will not
-         be displayed.
-
          The first two inputs are the names of the input and output directories.
          If you leave them blank, this script will use the current directory.
          All the following input to the script should either be y (yes) or n (no).

--- a/scripts/schema_editor
+++ b/scripts/schema_editor
@@ -30,6 +30,6 @@
 # DAMAGE.
 
 from jwst.datamodels import schema_editor
-options = schema_editor.Options(filename='schema_editor_options.txt')
+options = schema_editor.Options()
 editor = schema_editor.Schema_editor()
 editor.change(options)


### PR DESCRIPTION
Removed the use of the initialization file. This was way too confusing when running the task.