### PR TITLE
Fix bug in diff_astropy_tables

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -232,12 +232,12 @@ def diff_astropy_tables():
             diffs.append("Column names (or order) do not match")
 
         if len(result) != len(truth):
-            diffs.append("Row count does not match")
+            diffs.append(f"Row count does not match({len(result)} vs {len(truth)})")
 
         # If either the columns or the row count is mismatched, then don't
         # bother checking the individual column values.
         if len(diffs) > 0:
-            return diffs
+            raise AssertionError("\n".join(diffs))
 
         if result.meta != truth.meta:
             diffs.append("Metadata does not match")
@@ -269,6 +269,8 @@ def diff_astropy_tables():
         if len(diffs) != 0:
             raise AssertionError("\n".join(diffs))
 
+        # No differences
+        return True
 
     return _diff_astropy_tables
 

--- a/jwst/regtest/test_infrastructure.py
+++ b/jwst/regtest/test_infrastructure.py
@@ -2,6 +2,9 @@ from glob import glob
 import os
 
 import pytest
+from astropy.table import Table
+import astropy.units as u
+import numpy as np
 
 
 @pytest.mark.bigdata
@@ -32,3 +35,71 @@ def test_regtestdata_get_asn(rtdata):
 
 def test_fitsdiff_defaults(fitsdiff_default_kwargs):
     assert 'ASDF' in fitsdiff_default_kwargs['ignore_hdus']
+
+
+@pytest.fixture
+def two_tables(tmpdir):
+    """Return identical astropy tables written to 2 .ecsv file paths"""
+    path1 = str(tmpdir.join("catalog1.ecsv"))
+    path2 = str(tmpdir.join("catalog2.ecsv"))
+    a = np.array([1, 4, 5], dtype=np.float)
+    b = [2.0, 5.0, 8.5]
+    c = ['x', 'y', 'z']
+    d = [10, 20, 30] * u.m / u.s
+    names = ('a', 'b', 'c', 'd')
+    meta = {'name': 'first table'}
+    t = Table([a, b, c, d], names=names, meta=meta)
+    t.write(path1, format="ascii.ecsv")
+    t.write(path2, format="ascii.ecsv")
+
+    return path1, path2
+
+
+def test_diff_astropy_tables_same(diff_astropy_tables, two_tables):
+    path1, path2 = two_tables
+
+    assert diff_astropy_tables(path1, path2)
+
+
+def test_diff_astropy_tables_length(diff_astropy_tables, two_tables):
+    path1, path2 = two_tables
+
+    t1 = Table.read(path1)
+    t1.add_row([7, 5.0, 'q', 40 * u.m / u.s])
+    t1.write(path1, overwrite=True, format="ascii.ecsv")
+
+    with pytest.raises(AssertionError, match="Row count"):
+        assert diff_astropy_tables(path1, path2)
+
+
+def test_diff_astropy_tables_columns(diff_astropy_tables, two_tables):
+    path1, path2 = two_tables
+
+    t1 = Table.read(path1)
+    del t1['d']
+    t1.write(path1, overwrite=True, format="ascii.ecsv")
+
+    with pytest.raises(AssertionError, match="Column names"):
+        assert diff_astropy_tables(path1, path2)
+
+
+def test_diff_astropy_tables_meta(diff_astropy_tables, two_tables):
+    path1, path2 = two_tables
+
+    t1 = Table.read(path1)
+    t1.meta = {"name": "not the first table"}
+    t1.write(path1, overwrite=True, format="ascii.ecsv")
+
+    with pytest.raises(AssertionError, match="Metadata does not match"):
+        assert diff_astropy_tables(path1, path2)
+
+
+def test_diff_astropy_tables_allclose(diff_astropy_tables, two_tables):
+    path1, path2 = two_tables
+
+    t1 = Table.read(path1)
+    t1['a'] += 2e-5
+    t1.write(path1, overwrite=True, format="ascii.ecsv")
+
+    with pytest.raises(AssertionError, match="Not equal to tolerance"):
+        assert diff_astropy_tables(path1, path2)


### PR DESCRIPTION
A bug I introduced. Turns out `assert func()` where `func` doesn't actually return anything fails. 🙄 

Resolves issue we were seeing like the following:

```
diff_astropy_tables = <function diff_astropy_tables.<locals>._diff_astropy_tables at 0x1233048c0>

    def test_foo(diff_astropy_tables):
        table1 = "/Users/jdavies/scratch/test_nircam_image_run_detector1pipeline0/jw42424-o002_t001_nircam_clear-f444w_cat.ecsv"
        table2 = "/Users/jdavies/scratch/test_nircam_image_run_detector1pipeline0/truth/jw42424-o002_t001_nircam_clear-f444w_cat.ecsv"
    
        table1 = "/Users/jdavies/scratch/test_miri_image_rtdata_module0/det_dithered_5stars_f770w_cat.ecsv"
        table2 = "/Users/jdavies/scratch/test_miri_image_rtdata_module0/truth/det_dithered_5stars_f770w_cat.ecsv"
>       assert diff_astropy_tables(table1, table2)
E       AssertionError: assert None
E        +  where None = <function diff_astropy_tables.<locals>._diff_astropy_tables at 0x1233048c0>('/Users/jdavies/scratch/test_miri_image_rtdata_module0/det_dithered_5stars_f770w_cat.ecsv', '/Users/jdavies/scratch/test_miri_image_rtdata_module0/truth/det_dithered_5stars_f770w_cat.ecsv')
```