### PR TITLE
Remove codecov reporting on nightly flagged builds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,13 +6,9 @@ coverage:
         flags: unit
       nightly:
         flags: nightly
-      newnightly:
-        flags: newnightly
 
 flags:
   unit:
     joined: true
   nightly:
-    joined: false
-  newnightly:
     joined: false

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -51,7 +51,6 @@ bc0.build_cmds = [
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope",
-    "codecov --token=${codecov_token} -F nightly"
 ]
 bc0.test_configs = [data_config]
 


### PR DESCRIPTION
Flags don't work properly right now in codecov (and haven't since we started using it).

https://docs.codecov.io/docs/flags#section-flags-in-the-codecov-ui

And it is making our coverage check not very useful, as it is comparing unit test coverage for a PR to the coverage from the unit tests plus regression tests (which is 20% higher).  Since the nightly tests run nightly, the first PR to be merged every day is being compared to the nightly coverage, not the previous unit test coverage, which always gives a big ❌ .

So this turns off reporting to codecov for nightly tests.  We should try to see if there's a different way to do this, because it would be handy to have this via a link.

Coverage of the regression tests can be found within the runs on `jwcalibdev` for now by running
```
$ coverage html
$ ls htmlcov/index.html
```