### PR TITLE
Enumerate tests in okify_regtests script

### DIFF
--- a/scripts/okify_regtests
+++ b/scripts/okify_regtests
@@ -100,9 +100,11 @@ def main():
             # Retreive all the okify specfiles for failed tests.
             specfiles, asdffiles = artifactory_get_build_artifacts(build)
 
-            print(f"{len(specfiles)} failed tests to okify")
+            number_failed_tests = len(specfiles)
 
-            for specfile, asdffile in zip(specfiles, asdffiles):
+            print(f"{number_failed_tests} failed tests to okify")
+
+            for i, (specfile, asdffile) in enumerate(zip(specfiles, asdffiles)):
 
                 # Print traceback and OKify info for this test failure
                 with asdf.open(asdffile) as af:
@@ -118,12 +120,14 @@ def main():
                 remote_results = os.path.join(remote_results_path,
                     os.path.basename(output))
 
-                print(f" {test_name} ".center(TERMINAL_WIDTH, "-"))
+                test_number = i + 1
+
+                print(f" {test_name} ".center(TERMINAL_WIDTH, "—"))
                 print(traceback)
-                print("-" * TERMINAL_WIDTH)
+                print("—" * TERMINAL_WIDTH)
                 print(f"OK: {remote_results}")
                 print(f"--> {truth_remote}")
-                print("-" * TERMINAL_WIDTH)
+                print(f"[ test {test_number} of {number_failed_tests} ]".center(TERMINAL_WIDTH, "—"))
 
                 # Ask if user wants to okify this test
                 while True:


### PR DESCRIPTION
Updates the `okify_regtests` script to keep track of how many tests one needs to okify.  The new interface now shows `test n of m`:

```
———————————————————————————————————————————————————— test_full_run[multispec.schema.yaml] ———————————————————————————————————————————————————
jail = local('/data1/jenkins/workspace/RT/JWST/clone/test_outputs/popen-gw27/test_schema_editor0')
schema = 'multispec.schema.yaml'
run_editor_full = 'fixed/schemas_2020_02_29_00'
rtdata_module = {'input': '/data1/jenkins/workspace/RT/JWST/clone/test_outputs/popen-gw27/test_schema_editor0/keyword_db/nirspec.ifu.d...tor0/truth/multispec.schema.yaml',
 'truth_remote': 'jwst-pipeline/dev/truth/test_schema_editor/multispec.schema.yaml'}

    @pytest.mark.bigdata
    @pytest.mark.parametrize(
        'schema',
        ['container.schema.yaml', 'core.schema.yaml',
         'extract1dimage.schema.yaml',
         'guider_cal.schema.yaml', 'guider_raw.schema.yaml',
         'ifucube.schema.yaml',
         'keyword_exptype.schema.yaml', 'keyword_pband.schema.yaml', 'keyword_readpatt.schema.yaml',
         'lev3_prod.schema.yaml',
         'multiextract1d.schema.yaml', 'multispec.schema.yaml',
         'pathloss.schema.yaml',
         'referencefile.schema.yaml',
         'wcsinfo.schema.yaml',]
    )
    def test_full_run(jail, schema, run_editor_full, rtdata_module):
        """Check fixed schema files"""
        rt = rtdata_module
        rt.output = os.path.join(run_editor_full, schema)
        rt.get_truth(SCHEMA_TRUTH + '/' + schema)
    
        diff = list(text_diff(rt.output, rt.truth))
>       assert not diff, sys.stderr.writelines(diff)
E       AssertionError: None
E       assert not ['--- /data1/jenkins/workspace/RT/JWST/clone/test_outputs/popen-gw27/test_schema_editor0/fixed/schemas_2020_02_29_00/m...\n', '             fits_keyword: TIMESYS\n', '             fits_hdu: EXTRACT1D\n', '           start_time_mjd:\n', ...]

../../../jwst/regtest/test_schema_editor.py:109: AssertionError
—————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
OK: jwst-pipeline-results/2020-02-29_jenkins-RT-JWST-565_0/test_full_run/multispec.schema.yaml
--> jwst-pipeline/dev/truth/test_schema_editor/multispec.schema.yaml
———————————————————————————————————————————————————————————————[ test 2 of 6 ]———————————————————————————————————————————————————————————————
Enter 'o' to okify, 's' to skip:
```