### PR TITLE
Make text_diff an assertion helper

### DIFF
--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -403,7 +403,7 @@ def is_like_truth(rtdata, fitsdiff_default_kwargs, output, truth_path, is_suffix
 
 
 def text_diff(from_path, to_path):
-    """Generate a list of differences between files
+    """Assertion helper for diffing two text files
 
     Parameters
     ----------
@@ -411,7 +411,7 @@ def text_diff(from_path, to_path):
         File to diff from.
 
     to_path: str
-        File to diff to.
+        File to diff to.  The truth.
 
     Returns
     -------
@@ -419,16 +419,20 @@ def text_diff(from_path, to_path):
         A generator of a list of strings that are the differences.
         The output from `difflib.unified_diff`
     """
+    __tracebackhide__ = True
     with open(from_path) as fh:
         from_lines = fh.readlines()
     with open(to_path) as fh:
         to_lines = fh.readlines()
 
-    diffs = unified_diff(
-        from_lines, to_lines, from_path, to_path
-    )
+    diffs = unified_diff(from_lines, to_lines, from_path, to_path)
 
-    return diffs
+    diff = list(diffs)
+    if len(diff) > 0:
+        diff.insert(0, "\n")
+        raise AssertionError("".join(diff))
+    else:
+        return True
 
 
 def _data_glob_local(*glob_parts):

--- a/jwst/regtest/test_infrastructure.py
+++ b/jwst/regtest/test_infrastructure.py
@@ -5,6 +5,7 @@ import pytest
 from astropy.table import Table
 import astropy.units as u
 import numpy as np
+from .regtestdata import text_diff
 
 
 @pytest.mark.bigdata
@@ -103,3 +104,20 @@ def test_diff_astropy_tables_allclose(diff_astropy_tables, two_tables):
 
     with pytest.raises(AssertionError, match="Not equal to tolerance"):
         assert diff_astropy_tables(path1, path2)
+
+
+def test_text_diff(tmpdir):
+    path1 = str(tmpdir.join("test1.txt"))
+    path2 = str(tmpdir.join("test2.txt"))
+    with open(path1, "w") as text_file:
+        print("foo", file=text_file)
+    with open(path2, "w") as text_file:
+        print("foo", file=text_file)
+
+    assert text_diff(path1, path2)
+
+    with open(path2, "w") as text_file:
+        print("bar", file=text_file)
+
+    with pytest.raises(AssertionError):
+        assert text_diff(path1, path2)

--- a/jwst/regtest/test_schema_editor.py
+++ b/jwst/regtest/test_schema_editor.py
@@ -7,7 +7,6 @@ The tests here are for later modifications.
 """
 import os
 from pathlib import Path
-import sys
 import yaml
 
 import pytest
@@ -105,8 +104,7 @@ def test_full_run(jail, schema, run_editor_full, rtdata_module):
     rt.output = os.path.join(run_editor_full, schema)
     rt.get_truth(SCHEMA_TRUTH + '/' + schema)
 
-    diff = list(text_diff(rt.output, rt.truth))
-    assert not diff, sys.stderr.writelines(diff)
+    assert text_diff(rt.output, rt.truth)
 
 
 @pytest.mark.bigdata


### PR DESCRIPTION
This makes `text_diff` an assertion helper for `pytest`.  The benefit here is that the diff output is now encapsulated in the `AssertionError` which means it will get formatted and stored properly for output. Also, it will be available for `okify_regtests`.

Previously the diff was redirected to stdout.

An example of what it now produces

```
>       assert text_diff(rt.output, rt.truth)
E       AssertionError: 
E       --- /private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-476/test_schema_editor0/fixed/schemas_2020_03_03_00/core.schema.yaml
E       +++ /private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-476/test_schema_editor0/truth/core.schema.yaml
E       @@ -620,11 +622,11 @@
E                  readpatt:
E                    title: Readout pattern
E                    type: string
E       -            enum: [SLOW, FAST, FASTGRPAVG, DEEP8, DEEP2, MEDIUM8, MEDIUM2, 
E       -              SHALLOW4, SHALLOW2, BRIGHT2, BRIGHT1, RAPID, NRSRAPID, NRS, 
E       -              NRSSLOW, NRSN8R2, NRSN16R4, NRSN32R8, ID, ACQ1, ACQ2, TRACK, 
E       -              FINEGUIDE, FGS60, FGS840, FGS8370, FGSRAPID, FGS, NISRAPID, NIS, 
E       -              NRSIRS2, N/A, ANY, NRSIRS2RAPID]
E       +            enum: [ACQ1, ACQ2, BRIGHT1, BRIGHT2, DEEP2, DEEP8, FAST, FASTGRPAVG, 
E       +              FGS, FGS60, FGS8370, FGS840, FGSRAPID, FINEGUIDE, ID, MEDIUM2, 
E       +              MEDIUM8, NIS, NISRAPID, NRS, NRSIRS2, NRSN16R4, NRSN32R8, NRSN8R2, 
E       +              NRSRAPID, NRSIRS2RAPID, NRSRAPIDD1, NRSRAPIDD2, NRSRAPIDD6, 
E       +              NRSSLOW, RAPID, SHALLOW2, SHALLOW4, SLOW, TRACK, ANY, N/A]
E                    fits_keyword: READPATT
E                    blend_table: True
E                  segment_number:
E       @@ -2116,6 +2128,14 @@
E                    type: string
E                    fits_keyword: S_WHTLIT
E                    blend_table: True
E       +      tweakreg_catalog:
E       +        title: Tweakreg catalog filename
E       +        type: string
E       +        fits_keyword: TCATFILE
E       +      source_catalog:
E       +        title: Source catalog filename
E       +        type: string
E       +        fits_keyword: SCATFILE
E              background:
E                title: Background information
E                type: object

/Users/jdavies/dev/jwst/jwst/regtest/test_schema_editor.py:108: AssertionError
```