### PR TITLE
Add "stpipe" as root log for all modules

### DIFF
--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -11,7 +11,7 @@ from .nrm_model import NrmModel
 from . import webb_psf
 from . import leastsqnrm
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def apply_LG(input_model, filter_model, oversample, rotation):

--- a/jwst/ami/ami_average.py
+++ b/jwst/ami/ami_average.py
@@ -4,7 +4,7 @@
 import logging
 from .. import datamodels
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def average_LG(lg_products):

--- a/jwst/ami/ami_normalize.py
+++ b/jwst/ami/ami_normalize.py
@@ -5,7 +5,7 @@
 
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def normalize_LG(target_model, reference_model):

--- a/jwst/ami/analyticnrm2.py
+++ b/jwst/ami/analyticnrm2.py
@@ -10,7 +10,7 @@ import numpy as np
 import scipy.special
 from . import leastsqnrm
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def Jinc(x, y):
     """

--- a/jwst/ami/hexee.py
+++ b/jwst/ami/hexee.py
@@ -14,7 +14,7 @@
 import logging
 import numpy as np
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def g_eeAG(xi, eta, **kwargs):

--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -5,7 +5,7 @@ import numpy.linalg as linalg
 from scipy.special import comb, jv
 from . import hexee
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def flip(holearray):
     """

--- a/jwst/ami/nrm_model.py
+++ b/jwst/ami/nrm_model.py
@@ -27,7 +27,7 @@ from . import utils
 from . import hexee
 from . import nrm_consts
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class NrmModel:

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 import numpy.fft as fft
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def quadratic(p, x):
     """

--- a/jwst/ami/webb_psf.py
+++ b/jwst/ami/webb_psf.py
@@ -5,7 +5,7 @@ import numpy as np
 from . import utils
 from . import nrm_consts
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def get_webbpsf_filter(filter_model, specbin=None, trim=False):

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -6,7 +6,7 @@ from .util import (update_s_region_spectral, update_s_region_imaging,
 from ..lib.exposure_types import IMAGING_TYPES, SPEC_TYPES
 from ..lib.dispaxis import get_dispersion_direction
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 __all__ = ["load_wcs"]
 

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -1,12 +1,8 @@
 #! /usr/bin/env python
 from ..stpipe import Step
 from .. import datamodels
-import logging
 from .assign_wcs import load_wcs
 from .util import MSAFileError
-
-
-log = logging.getLogger(__name__)
 
 __all__ = ["AssignWcsStep"]
 
@@ -57,9 +53,9 @@ class AssignWcsStep(Step):
             if not (isinstance(input_model, datamodels.ImageModel) or
                     isinstance(input_model, datamodels.CubeModel) or
                     isinstance(input_model, datamodels.IFUImageModel)):
-                log.warning("Input dataset type is not supported.")
-                log.warning("assign_wcs expects ImageModel, IFUImageModel or CubeModel as input.")
-                log.warning("Skipping assign_wcs step.")
+                self.log.warning("Input dataset type is not supported.")
+                self.log.warning("assign_wcs expects ImageModel, IFUImageModel or CubeModel as input.")
+                self.log.warning("Skipping assign_wcs step.")
                 result = input_model.copy()
                 result.meta.cal_step.assign_wcs = 'SKIPPED'
                 return result
@@ -67,7 +63,7 @@ class AssignWcsStep(Step):
             for reftype in self.reference_file_types:
                 reffile = self.get_reference_file(input_model, reftype)
                 reference_file_names[reftype] = reffile if reffile else ""
-            log.debug(f'reference files used in assign_wcs: {reference_file_names}')
+            self.log.debug(f'reference files used in assign_wcs: {reference_file_names}')
 
             # Get the MSA metadata file if needed and add to reffiles
             if input_model.meta.exposure.type == "NRS_MSASPEC":
@@ -77,7 +73,7 @@ class AssignWcsStep(Step):
                     reference_file_names['msametafile'] = msa_metadata_file
                 else:
                     message = "MSA metadata file (MSAMETFL) is required for NRS_MSASPEC exposures."
-                    log.error(message)
+                    self.log.error(message)
                     raise MSAFileError(message)
             slit_y_range = [self.slit_y_low, self.slit_y_high]
             result = load_wcs(input_model, reference_file_names, slit_y_range)

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -12,7 +12,7 @@ from .util import (not_implemented_mode, subarray_transform,
 from . import pointing
 from ..datamodels import DistortionModel
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 __all__ = ["create_pipeline", "imaging"]

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -19,7 +19,7 @@ from ..datamodels import (DistortionModel, FilteroffsetModel,
 from ..lib import s3_utils
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 __all__ = ["create_pipeline", "imaging", "lrs", "ifu"]

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -13,7 +13,7 @@ from ..transforms.models import (NIRCAMForwardRowGrismDispersion,
                                  NIRCAMForwardColumnGrismDispersion,
                                  NIRCAMBackwardGrismDispersion)
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 __all__ = ["create_pipeline", "imaging", "tsgrism", "wfss"]

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -17,7 +17,7 @@ from ..transforms.models import (NirissSOSSModel,
 from ..datamodels import ImageModel, NIRISSGrismModel, DistortionModel
 from ..lib import s3_utils
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 __all__ = ["create_pipeline", "imaging", "niriss_soss", "niriss_soss_set_input", "wfss"]
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -30,7 +30,7 @@ from ..datamodels import (CollimatorModel, CameraModel, DisperserModel, FOREMode
                           IFUFOREModel, MSAModel, OTEModel, IFUPostModel, IFUSlicerModel,
                           WavelengthrangeModel, FPAModel)
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 __all__ = ["create_pipeline", "imaging", "ifu", "slits_wcs", "get_open_slits", "nrs_wcs_set_input",

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -23,7 +23,7 @@ from ..lib.catalog_utils import SkyObject
 from ..transforms.models import GrismObject
 from ..datamodels import WavelengthrangeModel, DataModel
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 __all__ = ["reproject", "wcs_from_footprints", "velocity_correction",

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -7,7 +7,7 @@ from ..assign_wcs.util import create_grism_bbox
 from astropy.stats import sigma_clip
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def background_sub(input_model, bkg_list, sigma, maxiters):

--- a/jwst/background/subtract_images.py
+++ b/jwst/background/subtract_images.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def subtract(model1, model2):

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -6,7 +6,7 @@ import numpy as np
 import logging
 from gwcs import wcstools
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 SLITRATIO = 1.15     # Ratio of slit spacing to slit height
 

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -9,7 +9,7 @@ import numpy as np
 from .. import datamodels
 from ..extract_1d.spec_wcs import create_spectral_wcs
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class InputSpectrumModel:

--- a/jwst/coron/hlsp.py
+++ b/jwst/coron/hlsp.py
@@ -12,7 +12,7 @@ import math
 from .. import datamodels
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def snr_image(target_model):
     """

--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -6,7 +6,7 @@ from scipy.ndimage import fourier_shift
 from ..datamodels import QuadModel
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def align_fourierLSQ(reference, target, mask=None):

--- a/jwst/coron/klip.py
+++ b/jwst/coron/klip.py
@@ -9,7 +9,7 @@
 import numpy as np
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def klip(target_model, refs_model, truncate):
 

--- a/jwst/coron/stack_refs.py
+++ b/jwst/coron/stack_refs.py
@@ -9,7 +9,7 @@ import numpy as np
 from .. import datamodels
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def make_cube(input_models):

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -8,7 +8,7 @@ from ..assign_wcs import nirspec
 from gwcs import wcstools
 from . import instrument_defaults
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class CubeBlot():

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -5,7 +5,7 @@ from . import cube_build_io_util
 from . import file_table
 from . import instrument_defaults
 
-log = logging.getLogger(__name__)
+log = llogging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class CubeData():

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -5,7 +5,7 @@ from . import cube_build_io_util
 from . import file_table
 from . import instrument_defaults
 
-log = llogging.getLogger('.'.join(['stpipe', __name__]))
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class CubeData():

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -2,7 +2,7 @@
 """
 from .. import datamodels
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def read_cubepars(par_filename,

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -4,7 +4,7 @@ import numpy as np
 from ..assign_wcs import nirspec
 from gwcs import wcstools
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def find_footprint_MIRI(input, this_channel, instrument_info, coord_system):

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -3,7 +3,7 @@
 import numpy as np
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def match_det2cube_msm(naxis1, naxis2, naxis3,

--- a/jwst/cube_build/cube_cloud_quick.py
+++ b/jwst/cube_build/cube_cloud_quick.py
@@ -3,7 +3,7 @@ import numpy as np
 import math
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 #________________________________________________________________________________
 def match_det2cube_msm(naxis1, naxis2, naxis3,
                        cdelt1, cdelt2, cdelt3,

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -5,7 +5,7 @@ single datamodel or several data models stored in a ModelContainer.
 import os
 from .. import datamodels
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 # ******************************************************************************

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -2,7 +2,7 @@
 """
 from .. import datamodels
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class FileTable():

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -19,7 +19,7 @@ from . import cube_overlap
 from . import cube_cloud
 from . import coord
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class IFUCubeData():

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -2,7 +2,7 @@
 """
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class InstrumentInfo():

--- a/jwst/cube_skymatch/skymatch.py
+++ b/jwst/cube_skymatch/skymatch.py
@@ -16,7 +16,7 @@ __all__ = ['match']
 __author__ = 'Mihai Cara'
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def match(skycubes, subtract=False):

--- a/jwst/dark_current/dark_sub.py
+++ b/jwst/dark_current/dark_sub.py
@@ -6,7 +6,7 @@ import numpy as np
 import logging
 from .. import datamodels
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model, dark_model, dark_output=None):

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -21,7 +21,7 @@ __doctest_skip__ = ['ModelContainer']
 __all__ = ['ModelContainer']
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('.'.join(['stpipe', __name__]))
 logger.addHandler(logging.NullHandler())
 
 class ModelContainer(model_base.DataModel):

--- a/jwst/datamodels/dynamicdq.py
+++ b/jwst/datamodels/dynamicdq.py
@@ -2,7 +2,7 @@ import numpy as np
 from . import dqflags
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 log.addHandler(logging.NullHandler())
 
 def dynamic_mask(input_model):

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -23,7 +23,7 @@ from . import util
 from . import validate
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 log.addHandler(logging.NullHandler())
 
 

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -15,7 +15,7 @@ from . import validate
 from . import schema as mschema
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 log.addHandler(logging.NullHandler())
 
 __all__ = ['ObjectNode', 'ListNode']

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 from ..lib import s3_utils
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 log.addHandler(logging.NullHandler())
 
 class NoTypeWarning(Warning):

--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -5,7 +5,7 @@ import numpy as np
 from .. import datamodels
 from ..lib import reffile_utils
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 # FGS guide star mode exposure types

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -13,7 +13,7 @@ from ..datamodels.properties import merge_tree
 
 __all__ = ['exp_to_source', 'multislit_to_container']
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def exp_to_source(inputs):

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -16,7 +16,7 @@ from . import extract1d
 from . import ifu
 from . import spec_wcs
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
 """Exposure types to be regarded as wide-field slitless spectroscopy."""

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -18,7 +18,7 @@ __all__ = ['extract1d']
 __taskname__ = 'extract1d'
 __author__ = 'Mihai Cara'
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def extract1d(image, lambdas, disp_range,
               p_src, p_bkg=None, independent_var="wavelength",

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -11,7 +11,7 @@ from .. import datamodels
 from ..datamodels import dqflags
 from . import spec_wcs
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 # These values are used to indicate whether the input reference file
 # (if any) is JSON or IMAGE.

--- a/jwst/extract_1d/spec_wcs.py
+++ b/jwst/extract_1d/spec_wcs.py
@@ -8,7 +8,7 @@ from astropy import coordinates as coord
 from gwcs.wcs import WCS
 from gwcs import coordinate_frames as cf
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def create_spectral_wcs(ra, dec, wavelength):
     """Assign a WCS for sky coordinates and a table of wavelengths

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -7,7 +7,7 @@ import logging
 from .nirspec import nrs_extract2d
 from .grisms import extract_grism_objects, extract_tso_object
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def extract2d(input_model,

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -14,7 +14,7 @@ from .. import datamodels
 from ..assign_wcs import util
 from ..datamodels import WavelengthrangeModel
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def extract_tso_object(input_model,

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -14,7 +14,7 @@ from ..assign_wcs import nirspec
 from ..assign_wcs import util
 from ..lib import pipe_utils
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_files={}):

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -6,7 +6,7 @@ import numpy as np
 import logging
 from ..datamodels import dqflags
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model):

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -13,7 +13,7 @@ from .. datamodels import dqflags
 from .. lib import reffile_utils
 from .. assign_wcs import nirspec
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 MICRONS_100 = 1.e-4                     # 100 microns, in meters
 

--- a/jwst/fringe/fringe.py
+++ b/jwst/fringe/fringe.py
@@ -5,7 +5,7 @@
 import numpy as np
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model, fringe_model):

--- a/jwst/gain_scale/gain_scale.py
+++ b/jwst/gain_scale/gain_scale.py
@@ -1,7 +1,7 @@
 import numpy as np
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model, gain_factor):

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -5,7 +5,7 @@
 
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model):

--- a/jwst/guider_cds/guider_cds.py
+++ b/jwst/guider_cds/guider_cds.py
@@ -7,7 +7,7 @@ import logging
 
 from .. import datamodels
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def guider_cds(model):

--- a/jwst/guider_cds/guider_cds_step.py
+++ b/jwst/guider_cds/guider_cds_step.py
@@ -4,9 +4,6 @@ from ..stpipe import Step
 from .. import datamodels
 from . import guider_cds
 
-import logging
-log = logging.getLogger(__name__)
-
 __all__ = ["GuiderCdsStep"]
 
 

--- a/jwst/ipc/ipc_corr.py
+++ b/jwst/ipc/ipc_corr.py
@@ -9,7 +9,7 @@ import numpy as np
 from ..lib import pipe_utils
 from . import x_irs2
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 NumRefPixels = namedtuple("NumRefPixels",
                           ["bottom_rows", "top_rows",

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -7,7 +7,7 @@ from ..lib import reffile_utils
 from . import twopoint_difference as twopt
 import multiprocessing
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def detect_jumps (input_model, gain_model, readnoise_model,
                   rejection_threshold, max_cores,

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -13,7 +13,7 @@ import logging
 import numpy as np
 from ..datamodels import dqflags
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 HUGE_NUM = np.finfo(np.float32).max
 

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -5,7 +5,7 @@ import numpy as np
 import logging
 from ..datamodels import dqflags
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model):

--- a/jwst/lib/dispaxis.py
+++ b/jwst/lib/dispaxis.py
@@ -1,6 +1,6 @@
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def get_dispersion_direction(exposure_type, grating="ANY", filter_wh="ANY",
                              pupil="ANY"):

--- a/jwst/lib/engdb_tools.py
+++ b/jwst/lib/engdb_tools.py
@@ -11,7 +11,7 @@ import re
 import requests
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('.'.join(['stpipe', __name__]))
 logger.addHandler(logging.NullHandler())
 
 # #############################################

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -1,7 +1,7 @@
 from jwst import datamodels
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def is_subarray(input_model):

--- a/jwst/lib/signal_slot.py
+++ b/jwst/lib/signal_slot.py
@@ -10,7 +10,7 @@ __all__ = ['Signal',
            'SignalsNotAClass']
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('.'.join(['stpipe', __name__]))
 logger.addHandler(logging.NullHandler())
 
 """Slot data structure

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -32,7 +32,7 @@ import sys
 __all__ = ['remove_suffix']
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('.'.join(['stpipe', __name__]))
 logger.addHandler(logging.NullHandler())
 
 # Suffixes that are hard-coded or otherwise

--- a/jwst/lib/utc_to_tdb.py
+++ b/jwst/lib/utc_to_tdb.py
@@ -18,7 +18,7 @@ except Exception:
     import astropy.constants
     USE_TIMECONVERSION = False
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 # This is an interface to call
 #    timeconversion.compute_bary_helio_time(targetcoord, times)

--- a/jwst/linearity/linearity.py
+++ b/jwst/linearity/linearity.py
@@ -5,7 +5,7 @@ from .linearity_func import apply_linearity_func
 import numpy as np
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model, lin_model):

--- a/jwst/linearity/linearity_func.py
+++ b/jwst/linearity/linearity_func.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def apply_linearity_func(ramparr, dqarr, coeffarr, dq_flag):

--- a/jwst/master_background/create_master_bkg.py
+++ b/jwst/master_background/create_master_bkg.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .. import datamodels
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 def create_background(wavelength, surf_bright):
     """Create a 1-D spectrum table as a MultiSpecModel.

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -8,7 +8,7 @@ from .. assign_wcs import nirspec   # For NIRSpec IFU data
 from .. datamodels import dqflags
 from ..lib.wcs_utils import get_wavelengths
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
 

--- a/jwst/msaflagopen/msaflag_open.py
+++ b/jwst/msaflagopen/msaflag_open.py
@@ -10,7 +10,7 @@ from ..assign_wcs.nirspec import slitlets_wcs, nrs_wcs_set_input
 from ..transforms.models import Slit
 from gwcs.wcs import WCS
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 FAILEDOPENFLAG = datamodels.dqflags.pixel['MSA_FAILED_OPEN']

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -14,7 +14,7 @@ from ..resample.resample_utils import build_driz_weight, calc_gwcs_pixmap
 from ..stpipe.step import Step
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 CRBIT = np.uint32(datamodels.dqflags.pixel['JUMP_DET'])
 

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -13,7 +13,7 @@ from .. import datamodels
 
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 __all__ = ["OutlierDetectionIFU"]
 

--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -14,7 +14,7 @@ from ..tso_photometry.tso_photometry import tso_aperture_photometry
 from .outlier_detection import OutlierDetection
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class OutlierDetectionScaled(OutlierDetection):

--- a/jwst/outlier_detection/outlier_detection_spec.py
+++ b/jwst/outlier_detection/outlier_detection_spec.py
@@ -6,7 +6,7 @@ from ..resample import resample_spec, resample_utils
 from .outlier_detection import OutlierDetection
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 __all__ = ["OutlierDetectionSpec"]

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -6,7 +6,7 @@ import logging
 from jwst.assign_wcs import nirspec, util
 from gwcs import wcstools
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 # There are 30 slices in the NIRSPEC IFU, numbered from 0 to 29

--- a/jwst/persistence/persistence.py
+++ b/jwst/persistence/persistence.py
@@ -7,7 +7,7 @@ import logging
 from .. import datamodels
 from .. datamodels import dqflags
 
-log = logging.getLogger()
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 SCALEFACTOR = 2.
 """This factor is to account for the difference in gain for charges freed

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -9,7 +9,7 @@ from .. import datamodels
 from .. datamodels import dqflags
 from .. lib.wcs_utils import get_wavelengths
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 PHOT_TOL = 0.001  # relative tolerance between PIXAR_* keys
 

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -13,9 +13,6 @@ from ..model_blender import blendmeta
 
 __all__ = ['Ami3Pipeline']
 
-# Define logging
-log = logging.getLogger()
-
 
 class Ami3Pipeline(Pipeline):
     """
@@ -38,7 +35,7 @@ class Ami3Pipeline(Pipeline):
 
     def process(self, input):
 
-        log.info('Starting calwebb_ami3')
+        self.log.info('Starting calwebb_ami3')
 
         # Load the input association table
         asn = self.load_as_level3_asn(input)
@@ -64,14 +61,14 @@ class Ami3Pipeline(Pipeline):
 
         # Make sure we found some science target members
         if len(targ_files) == 0:
-            log.error('No science target members found in association table')
-            log.error('Calwebb_ami3 processing will be aborted')
+            self.log.error('No science target members found in association table')
+            self.log.error('Calwebb_ami3 processing will be aborted')
             return
 
         # If there aren't any PSF images, we can't do the normalize step
         if len(psf_files) == 0:
-            log.info('No PSF reference members found in association table')
-            log.info('ami_normalize step will be skipped')
+            self.log.info('No PSF reference members found in association table')
+            self.log.info('ami_normalize step will be skipped')
 
         # Loop over all the images in the assocation
         psf_files = []
@@ -80,7 +77,7 @@ class Ami3Pipeline(Pipeline):
             input_file = member['expname']
 
             # Do the LG analysis for this image
-            log.debug('Do LG processing for member %s', input_file)
+            self.log.debug('Do LG processing for member %s', input_file)
             result = self.ami_analyze(input_file)
 
             # Save the LG analysis results to a file
@@ -167,6 +164,6 @@ class Ami3Pipeline(Pipeline):
             result.close()
 
         # We're done
-        log.info('... ending calwebb_ami3')
+        self.log.info('... ending calwebb_ami3')
 
         return

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -18,9 +18,6 @@ from ..linearity import linearity_step
 
 __all__ = ['DarkPipeline']
 
-# Define logging
-log = logging.getLogger()
-
 
 class DarkPipeline(Pipeline):
     """
@@ -48,7 +45,7 @@ class DarkPipeline(Pipeline):
     # start the actual processing
     def process(self, input):
 
-        log.info('Starting calwebb_dark ...')
+        self.log.info('Starting calwebb_dark ...')
 
         # open the input
         input = datamodels.RampModel(input)
@@ -57,7 +54,7 @@ class DarkPipeline(Pipeline):
 
             # process MIRI exposures;
             # the steps are in a different order than NIR
-            log.debug('Processing a MIRI exposure')
+            self.log.debug('Processing a MIRI exposure')
 
             input = self.group_scale(input)
             input = self.dq_init(input)
@@ -71,7 +68,7 @@ class DarkPipeline(Pipeline):
         else:
 
             # process Near-IR exposures
-            log.debug('Processing a Near-IR exposure')
+            self.log.debug('Processing a Near-IR exposure')
 
             input = self.group_scale(input)
             input = self.dq_init(input)
@@ -81,6 +78,6 @@ class DarkPipeline(Pipeline):
             input = self.refpix(input)
             input = self.linearity(input)
 
-        log.info('... ending calwebb_dark')
+        self.log.info('... ending calwebb_dark')
 
         return input

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -22,9 +22,6 @@ from ..gain_scale import gain_scale_step
 
 __all__ = ['Detector1Pipeline']
 
-# Define logging
-log = logging.getLogger()
-
 
 class Detector1Pipeline(Pipeline):
     """
@@ -60,7 +57,7 @@ class Detector1Pipeline(Pipeline):
     # start the actual processing
     def process(self, input):
 
-        log.info('Starting calwebb_detector1 ...')
+        self.log.info('Starting calwebb_detector1 ...')
 
         # open the input as a RampModel
         input = datamodels.RampModel(input)
@@ -73,7 +70,7 @@ class Detector1Pipeline(Pipeline):
 
             # process MIRI exposures;
             # the steps are in a different order than NIR
-            log.debug('Processing a MIRI exposure')
+            self.log.debug('Processing a MIRI exposure')
 
             input = self.group_scale(input)
             input = self.dq_init(input)
@@ -92,7 +89,7 @@ class Detector1Pipeline(Pipeline):
         else:
 
             # process Near-IR exposures
-            log.debug('Processing a Near-IR exposure')
+            self.log.debug('Processing a Near-IR exposure')
 
             input = self.group_scale(input)
             input = self.dq_init(input)
@@ -140,7 +137,7 @@ class Detector1Pipeline(Pipeline):
         # setup output_file for saving
         self.setup_output(input)
 
-        log.info('... ending calwebb_detector1')
+        self.log.info('... ending calwebb_detector1')
 
         return input
 

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -10,9 +10,6 @@ from ..guider_cds import guider_cds_step
 
 __all__ = ['GuiderPipeline']
 
-# Define logging
-log = logging.getLogger()
-
 
 class GuiderPipeline(Pipeline):
     """
@@ -33,14 +30,14 @@ class GuiderPipeline(Pipeline):
         # Set the output product type
         self.suffix = 'cal'
 
-        log.info('Starting calwebb_guider ...')
+        self.log.info('Starting calwebb_guider ...')
 
         # Open the input:
         # If the first two steps are set to be skipped, assume
         # they've been run before and open the input as a Cal
         # model, appropriate for input to flat_field
         if (self.dq_init.skip and self.guider_cds.skip):
-            log.info("dq_init and guider_cds are set to skip; assume they"
+            self.log.info("dq_init and guider_cds are set to skip; assume they"
                      " were run before and load data as GuiderCalModel")
             input = datamodels.GuiderCalModel(input)
         else:
@@ -51,6 +48,6 @@ class GuiderPipeline(Pipeline):
         input = self.guider_cds(input)
         input = self.flat_field(input)
 
-        log.info('... ending calwebb_guider')
+        self.log.info('... ending calwebb_guider')
 
         return input

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -26,7 +26,7 @@ from . import gls_fit           # used only if algorithm is "GLS"
 from . import utils
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 BUFSIZE = 1024 * 30000  # 30Mb cache size for data section
 

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -5,7 +5,7 @@ from .. import datamodels
 from . import ramp_fit
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 __all__ = ["RampFitStep"]

--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -9,7 +9,7 @@ from .. import datamodels
 from ..datamodels import dqflags
 from ..lib import reffile_utils
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 # Replace zero or negative variances with this:
 LARGE_VARIANCE = 1.e8

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -3,7 +3,8 @@ import logging
 import numpy as np
 from scipy.ndimage.filters import convolve1d
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
+
 
 def correct_model(input_model, irs2_model,
                   scipix_n_default=16, refpix_r_default=4, pad=8):

--- a/jwst/refpix/reference_pixels.py
+++ b/jwst/refpix/reference_pixels.py
@@ -43,7 +43,7 @@ import logging
 from ..datamodels import dqflags
 from ..lib import reffile_utils
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 #
 # NIR Reference section dictionaries are zero indexed and specify the values

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -6,7 +6,7 @@ from drizzle import cdrizzle
 from . import resample_utils
 
 import logging
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class GWCSDrizzle:

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -8,7 +8,7 @@ from . import gwcs_drizzle
 from . import resample_utils
 from ..model_blender import blendmeta
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 __all__ = ["ResampleData"]
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -19,7 +19,7 @@ from . import resample_utils
 
 CRBIT = np.uint32(datamodels.dqflags.pixel['JUMP_DET'])
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 class ResampleSpecData:

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -9,7 +9,7 @@ from .. import datamodels
 from . import resample
 from ..assign_wcs import util
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 __all__ = ["ResampleStep"]
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -11,7 +11,7 @@ from astropy.nddata.bitmask import interpret_bit_flags
 
 from ..assign_wcs.util import wcs_from_footprints, wcs_bbox_from_shape
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def make_output_wcs(input_models):

--- a/jwst/reset/reset_sub.py
+++ b/jwst/reset/reset_sub.py
@@ -4,7 +4,7 @@
 import numpy as np
 import logging
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model, reset_model):

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -6,7 +6,7 @@ import numpy as np
 import logging
 from .. import datamodels
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model, rscd_model):

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -10,7 +10,7 @@ from . import x_irs2
 
 import numpy as np
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 HUGE_NUM = 100000.
 

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -21,7 +21,7 @@ __author__ = 'Mihai Cara'
 #DEBUG
 __local_debug__ = True
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def match(images, skymethod='global+match', match_down=True, subtract=False):

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -3,7 +3,7 @@ from ..lib import pipe_utils
 
 from .. import datamodels
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def set_source_type(input_model):

--- a/jwst/stpipe/log.py
+++ b/jwst/stpipe/log.py
@@ -156,6 +156,14 @@ class LogConfig():
         # Set a handler
         for handler_str in self.handler:
             handler = self.get_handler(handler_str)
+
+            # Adding additional stream handlers will result in duplicate messages if a stream handler is in the root
+            if (
+                    isinstance(handler, logging.StreamHandler)
+                    and logging.StreamHandler in [type(item) for item in log.root.handlers]
+            ):
+                continue
+
             handler._from_config = True
             handler.setLevel(self.level)
             log.addHandler(handler)

--- a/jwst/stpipe/log.py
+++ b/jwst/stpipe/log.py
@@ -157,10 +157,11 @@ class LogConfig():
         for handler_str in self.handler:
             handler = self.get_handler(handler_str)
 
-            # Adding additional stream handlers will result in duplicate messages if a stream handler is in the root
+            # Adding additional stream handlers will result in duplicate messages if a stream handler is in the
+            # top-level ancestor.
             if (
                     isinstance(handler, logging.StreamHandler)
-                    and logging.StreamHandler in [type(item) for item in log.root.handlers]
+                    and logging.StreamHandler in [type(item) for item in getLogger(log.name.split('.')[0]).handlers]
             ):
                 continue
 

--- a/jwst/straylight/straylight.py
+++ b/jwst/straylight/straylight.py
@@ -15,7 +15,7 @@ import logging
 from ..datamodels import dqflags
 from astropy.convolution import convolve, Box2DKernel
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def correct_mrs(input_model, slice_map):

--- a/jwst/superbias/bias_sub.py
+++ b/jwst/superbias/bias_sub.py
@@ -6,7 +6,7 @@ import numpy as np
 import logging
 from ..lib import reffile_utils
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def do_correction(input_model, bias_model):

--- a/jwst/timeconversion/time_conversion.py
+++ b/jwst/timeconversion/time_conversion.py
@@ -44,7 +44,7 @@ import scipy.interpolate as sciint
 import logging
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('.'.join(['stpipe', __name__]))
 
 JDOFFSET = 2400000.5
 

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -11,7 +11,7 @@ from photutils import CircularAperture, CircularAnnulus
 
 from ..datamodels import CubeModel
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -11,7 +11,7 @@ from scipy.signal import convolve
 from scipy import mgrid
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 # The following should probably be in a ref file instead
 OFF_DELTA = 2  # for searching +/-2 around nominal offsets

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from astropy.table import QTable
 from astropy.time import Time, TimeDelta
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('.'.join(['stpipe', __name__]))
 
 
 def white_light(input):


### PR DESCRIPTION
This PR fixes the bug where "jwst" loggers are assigned with default settings as opposed to settings that match "stpipe" loggers. 

`stpipe` is now the root logger for (most) jwst modules. 