### PR TITLE
Add datamodels for reference files containing AB to Vega mag offsets

### DIFF
--- a/docs/jwst/references_general/abvega_offset_reffile.inc
+++ b/docs/jwst/references_general/abvega_offset_reffile.inc
@@ -1,0 +1,68 @@
+.. _abvega_offset_reffile:
+
+ABVEGA_OFFSET Reference File
+----------------------------
+
+:REFTYPE: ABVEGA_OFFSET
+:Data model: `~jwst.datamodels.ABVegaOffsetModel`
+
+The ABVEGA_OFFSET reference file contains data necessary for converting
+from AB to Vega magnitudes.
+
+.. include:: ../references_general/abvega_offset_selection.inc
+
+.. include:: ../includes/standard_keywords.inc
+
+ABVEGA_OFFSET Reference File Format
++++++++++++++++++++++++++++++++++++
+
+ABVEGA_OFFSET reference files are in ASDF format.  The ABVEGA_OFFSET
+reference file contains tabular data in a key called
+``abvega_offset``.  The content of the table varies for different
+instrument modes, as shown in the tables below.
+
++------------+---------------+-----------+------------+----------+
+| Instrument | Column name   | Data type | Dimensions | Units    |
++============+===============+===========+============+==========+
+| FGS        | detector      | string    | 7          | N/A      |
++            +---------------+-----------+------------+----------+
+|            | abvega_offset | float     | scalar     | unitless |
++------------+---------------+-----------+------------+----------+
+
++------------+---------------+-----------+------------+----------+
+| Instrument | Column name   | Data type | Dimensions | Units    |
++============+===============+===========+============+==========+
+| MIRI       | filter        | string    | 12         | N/A      |
++            +---------------+-----------+------------+----------+
+|            | abvega_offset | float     | scalar     | unitless |
++------------+---------------+-----------+------------+----------+
+
++------------+---------------+-----------+------------+----------+
+| Instrument | Column name   | Data type | Dimensions | Units    |
++============+===============+===========+============+==========+
+| NIRCam     | filter        | string    | 12         | N/A      |
++ or         +---------------+-----------+------------+----------+
+| NIRISS     | pupil         | string    | 15         | N/A      |
++            +---------------+-----------+------------+----------+
+|            | abvega_offset | float     | scalar     | unitless |
++------------+---------------+-----------+------------+----------+
+
+
+Row Selection
+^^^^^^^^^^^^^
+
+A row of data within the reference table is selected by the pipeline
+step based on the optical elements in use for the exposure. The
+selection attributes are always contained in the first few columns of
+the table.  The last column contains the data needed to convert from
+AB to Vega magnitudes.  The row selection criteria for each
+instrument/mode are:
+
+* FGS:
+   - Detector
+* MIRI:
+   - Filter
+* NIRCam:
+   - Filter and Pupil
+* NIRISS:
+   - Filter and Pupil

--- a/docs/jwst/references_general/abvega_offset_selection.inc
+++ b/docs/jwst/references_general/abvega_offset_selection.inc
@@ -1,0 +1,16 @@
+Reference Selection Keywords for ABVEGA_OFFSET
+++++++++++++++++++++++++++++++++++++++++++++++
+
+CRDS selects appropriate ABVEGA_OFFSET references based on the
+following keywords.  ABVEGA_OFFSET is not applicable for instruments
+not in the table.  All keywords used for file selection are
+*required*.
+
+========== ======================================
+Instrument Keywords
+========== ======================================
+FGS        INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+MIRI       INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+NIRCam     INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+NIRISS     INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+========== ======================================

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -149,6 +149,8 @@ documentation on each reference file.
 | :ref:`saturation <saturation_step>`         | :ref:`SATURATION <saturation_reffile>`           |
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`source_catalog <source_catalog_step>` | :ref:`APCORR <apcorr_reffile>`                   |
++                                             +--------------------------------------------------+
+|                                             | :ref:`ABVEGA_OFFSET <abvega_offset_reffile>`     |
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`straylight <straylight_step>`         | :ref:`REGIONS <regions_reffile>`                 |
 +---------------------------------------------+--------------------------------------------------+
@@ -160,6 +162,8 @@ documentation on each reference file.
 +--------------------------------------------------+---------------------------------------------+
 | Reference File Type (REFTYPE)                    | Pipeline Step                               |
 +==================================================+=============================================+
+| :ref:`ABVEGA_OFFSET <abvega_offset_reffile>`     | :ref:`source_catalog <source_catalog_step>` |
++--------------------------------------------------+---------------------------------------------+
 | :ref:`APCORR <apcorr_reffile>`                   | :ref:`extract_1d <extract_1d_step>`         |
 +                                                  +---------------------------------------------+
 |                                                  | :ref:`source_catalog <source_catalog_step>` |

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -3,6 +3,7 @@ from astropy.io import registry
 from . import ndmodel
 
 from .model_base import DataModel
+from .abvega_offset import ABVegaOffsetModel
 from .amilg import AmiLgModel
 from .apcorr import FgsImgApcorrModel, MirImgApcorrModel
 from .apcorr import NrcImgApcorrModel, NisImgApcorrModel
@@ -85,6 +86,7 @@ from .util import open
 __all__ = [
     'open',
     'DataModel',
+    'ABVegaOffsetModel',
     'AmiLgModel',
     'FgsImgApcorrModel', 'MirImgApcorrModel', 'NrcImgApcorrModel', 'NisImgApcorrModel',
     'MirLrsApcorrModel', 'MirMrsApcorrModel', 'NrcWfssApcorrModel', 'NisWfssApcorrModel',

--- a/jwst/datamodels/abvega_offset.py
+++ b/jwst/datamodels/abvega_offset.py
@@ -1,0 +1,39 @@
+from .reference import ReferenceFileModel
+
+__all__ = ['ABVegaOffsetModel']
+
+
+class ABVegaOffsetModel(ReferenceFileModel):
+    """
+    A data model containing offsets to convert from AB to Vega
+    magnitudes.
+
+    Parameters
+    ----------
+    abvega_offset : `astropy.table.Table`
+        An astropy table containing offsets to convert from AB to Vega
+        magnitudes.  The ``abvega_offset`` column represents m_AB -
+        m_Vega.
+
+        There are three types of tables, depending on the instrument, each
+        with different column selectors.  The columns names and data types
+        are:
+
+        * FGS
+
+          - detector: str
+          - abvega_offset: float32
+
+        * NIRCam and NIRISS
+
+          - filter: str
+          - pupil: str
+          - abvega_offset: float32
+
+        * MIRI
+
+          - filter: str
+          - abvega_offset: float32
+    """
+
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/abvega_offset.schema"

--- a/jwst/datamodels/abvega_offset.py
+++ b/jwst/datamodels/abvega_offset.py
@@ -1,3 +1,6 @@
+import warnings
+
+from .validate import ValidationWarning
 from .reference import ReferenceFileModel
 
 __all__ = ['ABVegaOffsetModel']
@@ -37,3 +40,30 @@ class ABVegaOffsetModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/abvega_offset.schema"
+
+    def __init__(self, init=None, **kwargs):
+        super(ABVegaOffsetModel, self).__init__(init=init, **kwargs)
+
+    def validate(self):
+        super(ABVegaOffsetModel, self).validate()
+        try:
+            assert len(self.abvega_offset) > 0
+            assert (self.meta.instrument.name in
+                    ('FGS', 'MIRI', 'NIRCAM', 'NIRISS'))
+            assert 'abvega_offset' in self.abvega_offset.colnames
+
+            if self.meta.instrument.name == 'FGS':
+                assert 'detector' in self.abvega_offset.colnames
+
+            if self.meta.instrument.name == 'MIRI':
+                assert 'filter' in self.abvega_offset.colnames
+
+            if self.meta.instrument.name in ('NIRCAM', 'NIRISS'):
+                assert 'filter' in self.abvega_offset.colnames
+                assert 'pupil' in self.abvega_offset.colnames
+
+        except AssertionError as errmsg:
+            if self._strict_validation:
+                raise AssertionError(errmsg)
+            else:
+                warnings.warn(str(errmsg), ValidationWarning)

--- a/jwst/datamodels/schemas/abvega_offset.schema.yaml
+++ b/jwst/datamodels/schemas/abvega_offset.schema.yaml
@@ -5,43 +5,23 @@ id: "http://stsci.edu/schemas/jwst_datamodel/abvegamag_offset.schema"
 title: AB to Vega magnitude offset reference file model
 allOf:
 - $ref: referencefile.schema
-- anyOf:
-  - type: object
-    properties:
-      abvega_offset_detector:
-        title: Offsets to convert AB to Vega magnitudes (FGS)
-        type: object
-        properties:
+- type: object
+  properties:
+    abvega_offset:
+      title: Offsets to convert AB to Vega magnitudes
+      type: object
+      properties:
+        abvega_offset:
+          title: AB_mag - Vega_mag
+          type: number
+        anyOf:
           detector:
             title: Detector name
             type: string
-          abvega_offset:
-            title: AB_mag - Vega_mag
-            type: number
-  - type: object
-    properties:
-      abvega_offset_filter_pupil:
-        title: Offsets to convert AB to Vega magnitudes (NIRCam and NIRISS)
-        type: object
-        properties:
           filter:
             title: Filter wheel element name
             type: string
           pupil:
             title: Pupil wheel element name
             type: string
-          abvega_offset:
-            title: AB_mag - Vega_mag
-            type: number
-  - type: object
-    properties:
-      abvega_offset_filter:
-        title: Offsets to convert AB to Vega magnitudes (MIRI)
-        type: object
-        properties:
-          filter:
-            title: Filter wheel element name
-            type: string
-          abvega_offset:
-            title: AB_mag - Vega_mag
-            type: number
+...

--- a/jwst/datamodels/schemas/abvega_offset.schema.yaml
+++ b/jwst/datamodels/schemas/abvega_offset.schema.yaml
@@ -1,0 +1,47 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/abvegamag_offset.schema"
+title: AB to Vega magnitude offset reference file model
+allOf:
+- $ref: referencefile.schema
+- anyOf:
+  - type: object
+    properties:
+      abvega_offset_detector:
+        title: Offsets to convert AB to Vega magnitudes (FGS)
+        type: object
+        properties:
+          detector:
+            title: Detector name
+            type: string
+          abvega_offset:
+            title: AB_mag - Vega_mag
+            type: number
+  - type: object
+    properties:
+      abvega_offset_filter_pupil:
+        title: Offsets to convert AB to Vega magnitudes (NIRCam and NIRISS)
+        type: object
+        properties:
+          filter:
+            title: Filter wheel element name
+            type: string
+          pupil:
+            title: Pupil wheel element name
+            type: string
+          abvega_offset:
+            title: AB_mag - Vega_mag
+            type: number
+  - type: object
+    properties:
+      abvega_offset_filter:
+        title: Offsets to convert AB to Vega magnitudes (MIRI)
+        type: object
+        properties:
+          filter:
+            title: Filter wheel element name
+            type: string
+          abvega_offset:
+            title: AB_mag - Vega_mag
+            type: number

--- a/jwst/datamodels/tests/data/nircam_abvega_offset.asdf
+++ b/jwst/datamodels/tests/data/nircam_abvega_offset.asdf
@@ -1,0 +1,61 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.4.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 2.5.2}
+history:
+  entries:
+  - !core/history_entry-1.0.0 {description: File data provided by Kevin Volk in February
+      2020. Errors are at the 3-6% level., time: ! '2020-04-17 17:40:03'}
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension.BuiltinExtension
+    software: {name: asdf, version: 2.5.2}
+  - !core/extension_metadata-1.0.0
+    extension_class: astropy.io.misc.asdf.extension.AstropyExtension
+    software: {name: astropy, version: 4.0.1.post1}
+abvega_offset: !<tag:astropy.org:astropy/table/table-1.0.0>
+  colnames: [filter, pupil, abvega_offset]
+  columns:
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      data: [F070W, F090W, F115W, F140M, F150W, F150W2, F150W2, F150W2, F182M, F187N,
+        F200W, F210M, F212N, F250M, F277W, F300M, F322W2, F322W2, F335M, F356W, F360M,
+        F410M, F430M, F444W, F444W, F444W, F444W, F460M, F480M]
+      datatype: [ucs4, 6]
+      shape: [29]
+    name: filter
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      data: [CLEAR, CLEAR, CLEAR, CLEAR, CLEAR, CLEAR, F162M, F164N, CLEAR, CLEAR,
+        CLEAR, CLEAR, CLEAR, CLEAR, CLEAR, CLEAR, CLEAR, F323N, CLEAR, CLEAR, CLEAR,
+        CLEAR, CLEAR, CLEAR, F405N, F466N, F470N, CLEAR, CLEAR]
+      datatype: [ucs4, 5]
+      shape: [29]
+    name: pupil
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      data: [0.2497600018978119, 0.5041199922561646, 0.7828400135040283, 1.1191799640655518,
+        1.2431399822235107, 1.2230199575424194, 1.3764400482177734, 1.4193600416183472,
+        1.5876799821853638, 1.6553699970245361, 1.705970048904419, 1.8102200031280518,
+        1.8312100172042847, 2.1488699913024902, 2.315419912338257, 2.490180015563965,
+        2.570039987564087, 2.6431798934936523, 2.71697998046875, 2.823899984359741,
+        2.870759963989258, 3.107640027999878, 3.212130069732666, 3.2418100833892822,
+        3.1260299682617188, 3.422950029373169, 3.4076600074768066, 3.3788299560546875,
+        3.4422800540924072]
+      datatype: float32
+      shape: [29]
+    name: abvega_offset
+meta:
+  author: Space Telescope Science Institute
+  description: Offset from AB to Vega magnitudes
+  instrument: {name: NIRCAM}
+  model_type: ABVegaOffsetModel
+  pedigree: GROUND
+  reftype: abvega_offset
+  telescope: JWST
+  title: AB to Vega magnitude offset reference file
+  useafter: '2015-01-01T00:00:00'
+...

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -6,6 +6,7 @@ import warnings
 import jsonschema
 
 import pytest
+from astropy.table import Table
 from astropy.time import Time
 import numpy as np
 from numpy.testing import assert_allclose
@@ -13,7 +14,7 @@ from astropy.io import fits
 
 from jwst.datamodels import (DataModel, ImageModel, MaskModel, QuadModel,
                 MultiSlitModel, ModelContainer, SlitModel,
-                SlitDataModel, IFUImageModel)
+                SlitDataModel, IFUImageModel, ABVegaOffsetModel)
 from jwst import datamodels
 from jwst.lib.file_utils import pushdir
 
@@ -691,3 +692,13 @@ def test_ifuimage():
 def test_datamodel_raises_filenotfound():
     with pytest.raises(FileNotFoundError):
         DataModel(init='file_does_not_exist.fits')
+
+def test_abvega_offset_model():
+    filepath = os.path.join(ROOT_DIR, 'nircam_abvega_offset.asdf')
+    model = ABVegaOffsetModel(filepath)
+    assert isinstance(model, ABVegaOffsetModel)
+    assert hasattr(model, 'abvega_offset')
+    assert isinstance(model.abvega_offset, Table)
+    assert model.abvega_offset.colnames == ['filter', 'pupil', 'abvega_offset']
+    model.validate()
+    model.close()


### PR DESCRIPTION
This PR adds new imaging-mode Vega magnitude offsets (from AB magnitudes) reference file data models: `FgsImgVegaMagOffsetModel`, `MirImgVegaMagOffsetModel`, `NrcImgVegaMagOffsetModel`, and `NisImgVegaMagOffsetModel`.

The JWST Photometry Working Group (JPWG) has requested both AB and Vega magnitudes in the source catalog.  These new reference files contain a table of the offsets to convert from AB mag to Vega mag for each filter.

There should be only one reference file of this type for each instrument.  Because the level-3 resampled/combined `i2d` image may represents the combination of several detectors, there does not need to be a separate reference file for each detector.  The selectors for each instrument are:
 * FGS:  None (it's a single number)
 * NIRCam, NIRISS:  `filter`, `pupil`
 * MIRI:  `filter` (I don't think `subarray` is needed here because different `subarrays` could be combined?)

I also made the Vega mag offset reference files for each instrument.  I do not yet have the Vega mag offset for FGS, so I set it to zero for now.