### PR TITLE
JP-1322: Use only a single member of an association for CRDS STEPPARS checking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ stpipe
 
 - Add command line and environmental options to not retrieve steppars references [#4676]
 
+- Use only a single member of an association for CRDS STEPPARS checking [#4684]
+
 
 0.15.1 (2020-03-10)
 ===================

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -192,8 +192,14 @@ To start the Python debugger if the step itself raises an exception,
 pass the `--debug` option to the commandline.
 
 
-Disabling CRDS Retrieval of Step Parameters
-```````````````````````````````````````````
+CRDS Retrieval of Step Parameters
+`````````````````````````````````
+
+In general, CRDS uses the input to a ``Step`` to determine which reference files
+to use. Nearly all JWST-related steps take only a single input file. However,
+often times that input file is an association. Since step parameters are
+configured only once per execution of a step or pipeline, only the first
+qualifying member, usually of type ``science`` is used.
 
 Retrieval of ``Step`` parameters from CRDS can be completely disabled by
 using the ``--disable-crds-steppars`` command-line switch, or setting the

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -80,7 +80,7 @@ class ModelContainer(model_base.DataModel):
 
         self._models = []
         self.asn_exptypes = asn_exptypes
-        self.asn_n_members = asn_n_members 
+        self.asn_n_members = asn_n_members
 
         if init is None:
             # Don't populate the container with models

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -48,6 +48,8 @@ class ModelContainer(model_base.DataModel):
        - asn_exptypes: list of exposure types from the asn file to read
          into the pipeline, if None read all the given files.
 
+       - asn_n_members: Open only the first N qualifying members.
+
     Examples
     --------
     >>> container = ModelContainer('example_asn.json')
@@ -72,12 +74,13 @@ class ModelContainer(model_base.DataModel):
     # does not describe the data contents of the container.
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/container.schema"
 
-    def __init__(self, init=None, asn_exptypes=None, **kwargs):
+    def __init__(self, init=None, asn_exptypes=None, asn_n_members=None, **kwargs):
 
         super().__init__(init=None, asn_exptypes=None, **kwargs)
 
         self._models = []
         self.asn_exptypes = asn_exptypes
+        self.asn_n_members = asn_n_members 
 
         if init is None:
             # Don't populate the container with models
@@ -209,8 +212,14 @@ class ModelContainer(model_base.DataModel):
         if asn_file_path:
             asn_dir = op.dirname(asn_file_path)
             infiles = [op.join(asn_dir, f) for f in infiles]
+
+        # Only handle the specified number of members.
+        if self.asn_n_members:
+            sublist = infiles[:self.asn_n_members]
+        else:
+            sublist = infiles
         try:
-            self._models = [datamodel_open(infile) for infile in infiles]
+            self._models = [datamodel_open(infile) for infile in sublist]
         except IOError:
             raise IOError('Cannot open {}'.format(infiles))
 

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -186,7 +186,7 @@ class Pipeline(Step):
         log.log.debug('Retrieving all substep parameters from CRDS')
         #
         # Iterate over the steps in the pipeline
-        model = dm_open(dataset)
+        model = dm_open(dataset, asn_n_members=1)
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]
             refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -38,6 +38,7 @@ from . import Step
 from . import crds_client
 from . import log
 from .step import get_disable_crds_steppars
+from ..datamodels import open as dm_open
 from ..lib.class_property import ClassInstanceMethod
 
 
@@ -185,17 +186,18 @@ class Pipeline(Step):
         log.log.debug('Retrieving all substep parameters from CRDS')
         #
         # Iterate over the steps in the pipeline
+        model = dm_open(dataset)
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]
             refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(
-                dataset, observatory=observatory
+                model, observatory=observatory
             )
         #
         # Now merge any config parameters from the step cfg file
         log.log.debug(f'Retrieving pipeline {pars_model.meta.reftype.upper()} parameters from CRDS')
         exceptions = crds_client.get_exceptions_module()
         try:
-            ref_file = crds_client.get_reference_file(dataset,
+            ref_file = crds_client.get_reference_file(model,
                                                       pars_model.meta.reftype,
                                                       observatory=observatory,
                                                       asn_exptypes=['science'])

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -705,6 +705,7 @@ class Step():
             The parameters as retrieved from CRDS. If there is an issue, log as such
             and return an empty config obj.
         """
+
         # Get the root logger, since the following operations
         # are happening in the surrounding architecture.
         logger = log.delegator.log


### PR DESCRIPTION
Resolves #4607/JP-1322

Changes include:

- Using only the first science member of an association for CRDS STEPPARS determination
- For pipelines, only open the `DataModel` once and pass it to each step for STEPPARS determination.