### PR TITLE
JP-1340 Pixel-by-pixel calls to wcs removed from extract_1d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ extract_1d
 ----------
 
 - Remove pixel-by-pixel calls to wcs; copy input keywords to output for
-  more types of input data. [#4684]
+  more types of input data. [#4685]
 
 stpipe
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.15.2 (unreleased)
 ==================
 
+extract_1d
+----------
+
+- Remove pixel-by-pixel calls to wcs; copy input keywords to output for
+  more types of input data. [#4684]
+
 stpipe
 ------
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1187,8 +1187,12 @@ class ExtractBase:
             targ_ra = input_model.meta.target.ra
             targ_dec = input_model.meta.target.dec
         else:
-            targ_ra = slit.source_ra
-            targ_dec = slit.source_dec
+            targ_ra = None
+            targ_dec = None
+            if hasattr(slit, 'source_ra'):
+                targ_ra = slit.source_ra
+            if hasattr(slit, 'source_dec'):
+                targ_dec = slit.source_dec
 
         if targ_ra is None or targ_dec is None:
             log.warning("Target RA and Dec could not be determined.")

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1155,7 +1155,7 @@ class ExtractBase:
     def assign_polynomial_limits(self, verbose):
         pass
 
-    def get_celestial_coordinates(self, input_model, slit):
+    def get_target_coordinates(self, input_model, slit):
         """Get the right ascension and declination of the target.
 
         For MultiSlitModel (or similar) data, each slit has the source
@@ -1231,7 +1231,7 @@ class ExtractBase:
             direction.
         """
 
-        targ_ra, targ_dec = self.get_celestial_coordinates(input_model, slit)
+        targ_ra, targ_dec = self.get_target_coordinates(input_model, slit)
         if targ_ra is None or targ_dec is None:
             return (0., None)
 
@@ -1923,29 +1923,22 @@ class ExtractModel(ExtractBase):
             wcs_wl = stuff[2]
             # We need one right ascension and one declination, representing
             # the direction of pointing.
-            mask = np.isnan(ra)
+            mask = np.isnan(wcs_wl)
             not_nan = np.logical_not(mask)
             if np.any(not_nan):
                 ra2 = ra[not_nan]
                 min_ra = ra2.min()
                 max_ra = ra2.max()
                 ra = (min_ra + max_ra) / 2.
-            else:
-                if verbose:
-                    log.warning("All right ascension values are NaN; "
-                                "assigning dummy value -999.")
-                ra = -999.
-            mask = np.isnan(dec)
-            not_nan = np.logical_not(mask)
-            if np.any(not_nan):
                 dec2 = dec[not_nan]
                 min_dec = dec2.min()
                 max_dec = dec2.max()
                 dec = (min_dec + max_dec) / 2.
             else:
                 if verbose:
-                    log.warning("All declination values are NaN; "
-                                "assigning dummy value -999.")
+                    log.warning("All wavelength values are NaN; assigning "
+                                "dummy value -999 to RA and Dec.")
+                ra = -999.
                 dec = -999.
 
         else:

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2369,7 +2369,7 @@ class ImageExtractModel(ExtractBase):
             wavelength = wl_array[indy, indx]
 
         if self.wcs is not None:
-            ra, dec, wcs_wl = self.wcs(x_array, y_array)
+            stuff = self.wcs(x_array, y_array)
             ra = stuff[0]
             dec = stuff[1]
             wcs_wl = stuff[2]

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -3220,9 +3220,9 @@ def populate_time_keywords(input_model, output_model):
         return
 
     int_num = input_model.int_times['integration_number']
-    start_utc = input_model.int_times['int_start_MJD_UTC']
-    mid_utc = input_model.int_times['int_mid_MJD_UTC']
-    end_utc = input_model.int_times['int_end_MJD_UTC']
+    start_time_mjd = input_model.int_times['int_start_MJD_UTC']
+    mid_time_mjd = input_model.int_times['int_mid_MJD_UTC']
+    end_time_mjd = input_model.int_times['int_end_MJD_UTC']
     start_tdb = input_model.int_times['int_start_BJD_TDB']
     mid_tdb = input_model.int_times['int_mid_BJD_TDB']
     end_tdb = input_model.int_times['int_end_BJD_TDB']
@@ -3277,9 +3277,9 @@ def populate_time_keywords(input_model, output_model):
             spec = output_model.spec[n]             # n is incremented below
             spec.int_num = int_num[row]
             spec.time_scale = "UTC"
-            spec.start_utc = start_utc[row]
-            spec.mid_utc = mid_utc[row]
-            spec.end_utc = end_utc[row]
+            spec.start_time_mjd = start_time_mjd[row]
+            spec.mid_time_mjd = mid_time_mjd[row]
+            spec.end_time_mjd = end_time_mjd[row]
             spec.start_tdb = start_tdb[row]
             spec.mid_tdb = mid_tdb[row]
             spec.end_tdb = end_tdb[row]

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1189,8 +1189,8 @@ class ExtractBase:
             targ_ra = input_model.meta.target.ra
             targ_dec = input_model.meta.target.dec
         else:
-            targ_ra = getattr(slit, 'source_ra', default=None)
-            targ_dec = getattr(slit, 'source_dec', default=None)
+            targ_ra = getattr(slit, 'source_ra', None)
+            targ_dec = getattr(slit, 'source_dec', None)
 
         if targ_ra is None or targ_dec is None:
             log.warning("Target RA and Dec could not be determined.")
@@ -2874,7 +2874,7 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             # value, if possible.
             if input_model.meta.exposure.type == 'NRS_FIXEDSLIT':
                 slitname = input_model.meta.instrument.fixed_slit
-            elif getattr(input_model, "name", default=None) is not None:
+            elif getattr(input_model, "name", None) is not None:
                 slitname = input_model.name
 
             prev_offset = OFFSET_NOT_ASSIGNED_YET
@@ -2972,7 +2972,7 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             slit = None
             # Replace the default value for slitname with a more accurate
             # value, if possible.
-            if getattr(input_model, "name", default=None) is not None:
+            if getattr(input_model, "name", None) is not None:
                 slitname = input_model.name
             if photom_has_been_run:
                 pixel_solid_angle = input_model.meta.photometry.pixelarea_steradians


### PR DESCRIPTION
The two sections in `extract_1d` where the wcs function was called in a loop over pixels have been removed, leaving just the calls to `wcs` with array arguments.

This also resolves JP-880, GitHub #3838.  Function `copy_keyword_info` is now called in two more sections, covering `ImageModel`, `DrizProductModel`, `CubeModel`, `SlitModel`.  `copy_keyword_info` also copies new slit attributes `source_ra` and `source_dec`.