### PR TITLE
JP-1339: Update default SRCTYPE for NRS_IFU to EXTENDED

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.15.2 (unreleased)
 ==================
 
+extract_1d
+----------
+
+- Remove pixel-by-pixel calls to wcs; copy input keywords to output for
+  more types of input data. [#4685]
+
 extract_2d
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 0.15.2 (unreleased)
 ==================
 
+extract_2d
+----------
+
+- Change the source type for NIRSpec MOS sources with stellarity = -1 from
+  UNKOWN to POINT. [#4686]
+
+srctype
+-------
+
+- Change default source type for NRS_IFU from POINT to EXTENDED. Change the source
+  type for NIRSpec MOS sources with stellarity = -1 from UNKNOWN to POINT. [#4686]
+
 stpipe
 ------
 

--- a/docs/jwst/srctype/description.rst
+++ b/docs/jwst/srctype/description.rst
@@ -100,9 +100,9 @@ evaluated by the ``srctype`` step to determine whether each source
 should be treated as point or extended.
 
 If the stellarity value for a given source in the MSA metadata is less
-than zero, the source type is set to "UNKNOWN." If the stellarity value is
+than zero, the source type defaults to "POINT." If the stellarity value is
 between zero and 0.75, it is set to "EXTENDED", and if the stellarity value
-is greater than 0.75, it is set to "POINT." The resulting choice as stored in
+is greater than 0.75, it is set to "POINT." The resulting choice is stored in
 the "SRCTYPE" keyword located in the header of the SCI extension associated with
 each slitlet.
 

--- a/docs/jwst/srctype/description.rst
+++ b/docs/jwst/srctype/description.rst
@@ -25,7 +25,7 @@ header.
 
 The ``srctype`` calibration step checks to see if the "SRCTYPE" keyword
 is present and has already been populated. If the observer did not provide a
-source type value or it is set to "UNKNOWN", the ``srctype``
+source type value or chose "UNKNOWN", the ``srctype``
 step chooses a suitable value based on the observing mode and
 other characteristics of the exposure. The following choices are used, in
 order of priority:
@@ -63,11 +63,11 @@ order of priority:
 +-------------------+------------------------+----------+
 | NRS_BRIGHTOBJ     | NIRSpec bright object  | POINT    |
 +-------------------+------------------------+----------+
-| NRS_IFU           | NIRSpec IFU            | POINT    |
+| NRS_IFU           | NIRSpec IFU            | EXTENDED |
 +-------------------+------------------------+----------+
 
 If the EXP_TYPE value of the input image is not in the above list,
-the default choice will be SRCTYPE="EXTENDED."
+SRCTYPE will be set to "UNKNOWN".
 
 NOTE: NIRSpec fixed-slit (EXP_TYPE="NRS_FIXEDSLIT") exposures are
 unique in that a single target is specified in the APT, yet data for

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -398,12 +398,12 @@ def _is_point_source(slit, exp_type, user_type):
     """
     result = False
     if exp_type == 'NRS_MSASPEC':
-        if slit.stellarity > 0.75:
+        if slit.stellarity > 0.75 or slit.stellarity < 0.0:
             result = True
-            log.info("Detected a point source in slit {0}, stelarity is {1}".format(slit.name, slit.stellarity))
+            log.info("Detected a point source in slit {0}, stellarity is {1}".format(slit.name, slit.stellarity))
         else:
             result = False
-            log.info("Detected an extended source in slit {0}, stelarity is {1}".format(slit.name, slit.stellarity))
+            log.info("Detected an extended source in slit {0}, stellarity is {1}".format(slit.name, slit.stellarity))
     else:
         # Get the value the user specified (if any)
         if (user_type is not None) and (user_type.upper() in ['POINT', 'EXTENDED']):

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -114,7 +114,7 @@ def set_source_type(input_model):
             # a threshold value from a reference file. For now, the
             # threshold is hardwired.
             if stellarity < 0.0:
-                slit.source_type = 'UNKNOWN'
+                slit.source_type = 'POINT'
             elif stellarity > 0.75:
                 slit.source_type = 'POINT'
             else:

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -70,7 +70,7 @@ def set_source_type(input_model):
         else:
 
             # Set a default value based on the exposure type
-            if exptype == 'MIR_MRS':
+            if exptype in ['MIR_MRS', 'NRS_IFU']:
                 src_type = 'EXTENDED'
             else:
                 src_type = 'POINT'

--- a/jwst/srctype/tests/test_srctype.py
+++ b/jwst/srctype/tests/test_srctype.py
@@ -154,7 +154,7 @@ def test_nrs_msaspec():
     result = srctype.set_source_type(input)
 
     assert(result.slits[0].source_type == 'POINT')
-    assert(result.slits[1].source_type == 'UNKNOWN')
+    assert(result.slits[1].source_type == 'POINT')
     assert(result.slits[2].source_type == 'EXTENDED')
 
 def test_nrs_fixedslit():

--- a/jwst/srctype/tests/test_srctype.py
+++ b/jwst/srctype/tests/test_srctype.py
@@ -80,7 +80,7 @@ def test_user_input():
     # Result should be POINT regardless of other input settings
     assert output.meta.target.source_type == 'POINT'
 
-def test_unknown():
+def test_mrs_unknown():
 
     # An exposure with upstream input UNKNOWN
     input = datamodels.ImageModel((10,10))
@@ -88,6 +88,21 @@ def test_unknown():
     input.meta.exposure.type = 'MIR_MRS'
     input.meta.observation.bkgdtarg = False
     input.meta.dither.primary_type = 'CYCLING'
+    input.meta.target.source_type = 'UNKNOWN'
+
+    output = srctype.set_source_type(input)
+
+    # Result should be EXTENDED regardless of other input settings
+    assert output.meta.target.source_type == 'EXTENDED'
+
+def test_ifu_unknown():
+
+    # An exposure with upstream input UNKNOWN
+    input = datamodels.ImageModel((10,10))
+
+    input.meta.exposure.type = 'NRS_IFU'
+    input.meta.observation.bkgdtarg = False
+    input.meta.dither.primary_type = '4-POINT'
     input.meta.target.source_type = 'UNKNOWN'
 
     output = srctype.set_source_type(input)


### PR DESCRIPTION
Update the `srctype` step to use a default value of EXTENDED for NIRSpec IFU exposures, same as MIRI MRS. Added a unit test and updated docs.

Fixes #4652 / [JP-1339](https://jira.stsci.edu/browse/JP-1339) 

Fixes #4623 / [JP-1330](https://jira.stsci.edu/browse/JP-1330)