### PR TITLE
JP-1352 Update asn rules to include nodded observations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 0.15.2 (unreleased)
 ==================
 
-stpipe
+associations
+------------
+
+- Update association rules so that nodded observations procduce level 3 asn's [#4675]
+
+  stpipe
 ------
 
 - Add command line and environmental options to not retrieve steppars references [#4676]

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -366,7 +366,7 @@ class Asn_IFU(AsnMixin_Spectrum):
                     DMSAttrConstraint(
                         name='patttype',
                         sources=['patttype'],
-                        value=['2-point-nod|4-point-nod|along-slit-nod'],
+                        value=['none'],
                     )
                 ],
                 reduce=Constraint.notany


### PR DESCRIPTION
Update the logic for the Asn_IFU so that entries with the PATTTYPE keyword with values of 2-point-nod, 4-point-nod, or along-slit-nod are included in the level 3 associations. 

Closes #4676