### PR TITLE
JP-1359 Two recent changes to extract_1d were backed out

### DIFF
--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -84,6 +84,16 @@ allOf:
             default: 0.0
             fits_keyword: SRCYPOS
             fits_hdu: EXTRACT1D
+          source_ra:
+            title: Right Ascension of the source
+            type: number
+            fits_keyword: SRCRA
+            fits_hdu: EXTRACT1D
+          source_dec:
+            title: Declination of the source
+            type: number
+            fits_keyword: SRCDEC
+            fits_hdu: EXTRACT1D
           shutter_state:
             title: All (open and close) shutters in a slit
             type: string

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1237,7 +1237,10 @@ class ExtractBase:
         # of the spectrum, so the extraction region should be centered here.
         locn_info = self.locn_from_wcs(input_model, slit, targ_ra, targ_dec,
                                        verbose)
-        middle, middle_wl, locn = locn_info
+        if locn_info is None:
+            middle = middle_wl = locn = None
+        else:
+            middle, middle_wl, locn = locn_info
         if middle is not None and verbose:
             log.debug("Spectrum location from WCS used column (or row) %d",
                       middle)
@@ -1292,7 +1295,8 @@ class ExtractBase:
 
         Returns
         -------
-        middle : int or None
+        tuple (middle, middle_wl, locn) or None
+        middle : int
             Pixel coordinate in the dispersion direction within the 2-D
             cutout (or the entire input image) at the middle of the WCS
             bounding box.  This is the point at which to determine the
@@ -1300,17 +1304,18 @@ class ExtractBase:
             spectrum.  The offset will then be the difference between
             `locn` (below) and the nominal location.
 
-        middle_wl : float or None
+        middle_wl : float
             The wavelength at pixel `middle`.
 
-        locn : float or None
+        locn : float
             Pixel coordinate in the cross-dispersion direction within the
             2-D cutout (or the entire input image) that has right ascension
             and declination coordinates corresponding to the target location.
             The spectral extraction region should be centered here.
-            None will be returned for `middle`, `middle_wl`, and `locn`
-            if there was not sufficient information available, e.g. if the
-            wavelength attribute or wcs function is not defined.
+
+        None will be returned if there was not sufficient information
+        available, e.g. if the wavelength attribute or wcs function is not
+        defined.
         """
 
         # WFSS data are not currently supported.
@@ -1318,7 +1323,7 @@ class ExtractBase:
             log.warning("For exposure type %s, we currently can't use "
                         "target coordinates to get location of spectrum.",
                         input_model.meta.exposure.type)
-            return None, None, None
+            return None
 
         bb = self.wcs.bounding_box          # ((x0, x1), (y0, y1))
 
@@ -1362,7 +1367,7 @@ class ExtractBase:
         except NotImplementedError:
             log.warning("Inverse wcs is not implemented, so can't use "
                         "target coordinates to get location of spectrum.")
-            return None, None, None
+            return None
 
         # locn is the XD location of the spectrum:
         if self.dispaxis == HORIZONTAL:
@@ -2882,7 +2887,7 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 slitname = input_model.meta.instrument.fixed_slit
             elif getattr(input_model, "name", None) is not None:
                 slitname = input_model.name
-            log.debug('slitname=%s', slitname)
+            log.debug(f'slitname={slitname}')
 
             prev_offset = OFFSET_NOT_ASSIGNED_YET
             for sp_order in spectral_order_list:
@@ -2981,7 +2986,7 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             # value, if possible.
             # xxx if getattr(input_model, "name", None) is not None:
             # xxx     slitname = input_model.name
-            log.debug('slitname=%s', slitname)
+            log.debug(f'slitname={slitname}')
             if photom_has_been_run:
                 pixel_solid_angle = input_model.meta.photometry.pixelarea_steradians
                 if pixel_solid_angle is None:

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1313,6 +1313,13 @@ class ExtractBase:
             wavelength attribute or wcs function is not defined.
         """
 
+        # WFSS data are not currently supported.
+        if input_model.meta.exposure.type in WFSS_EXPTYPES:
+            log.warning("For exposure type %s, we currently can't use "
+                        "target coordinates to get location of spectrum.",
+                        input_model.meta.exposure.type)
+            return None, None, None
+
         bb = self.wcs.bounding_box          # ((x0, x1), (y0, y1))
 
         if bb is None:
@@ -2823,14 +2830,13 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             output_model.spec.append(spec)
     else:
         # These default values for slitname are not really slit names, and
-        # slitname may be assigned a better value below.  See the sections
+        # slitname may be assigned a better value below, in the sections
         # for input_model being an ImageModel or a SlitModel.
         slitname = input_model.meta.exposure.type
         if slitname is None:
             slitname = ANY
         if slitname == 'NIS_SOSS':
             slitname = input_model.meta.subarray.name
-        log.debug('slitname=%s', slitname)
 
         # Loop over these spectral order numbers.
         if input_model.meta.exposure.type == "NIS_SOSS":
@@ -2876,6 +2882,7 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
                 slitname = input_model.meta.instrument.fixed_slit
             elif getattr(input_model, "name", None) is not None:
                 slitname = input_model.name
+            log.debug('slitname=%s', slitname)
 
             prev_offset = OFFSET_NOT_ASSIGNED_YET
             for sp_order in spectral_order_list:
@@ -2972,8 +2979,9 @@ def do_extract1d(input_model, ref_dict, smoothing_length=None,
             slit = None
             # Replace the default value for slitname with a more accurate
             # value, if possible.
-            if getattr(input_model, "name", None) is not None:
-                slitname = input_model.name
+            # xxx if getattr(input_model, "name", None) is not None:
+            # xxx     slitname = input_model.name
+            log.debug('slitname=%s', slitname)
             if photom_has_been_run:
                 pixel_solid_angle = input_model.meta.photometry.pixelarea_steradians
                 if pixel_solid_angle is None:


### PR DESCRIPTION
For WFSS and NRC_TSGRISM data, don't try to determine the pixel location of the target spectrum from the wcs.  Also, for NRS_BRIGHTOBJ data, leave `slitname` set to 'NRS_BRIGHTOBJ', rather than changing it to the actual slit name, 'S1600A1'.