### PR TITLE
JP-1344 Exclude dark files from associations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 associations
 ------------
 
+- Update rules so exclude dark files from associations [#4668]
+
 - Update association rules so that nodded observations procduce level 3 asn's [#4675]
 
 extract_1d

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -434,6 +434,11 @@ class Asn_Lv2NRSLAMPSpectral(
                         name='opt_elem2',
                         sources=['grating'],
                         value='mirror'
+                    ),
+                    DMSAttrConstraint(
+                        name='exp_type',
+                        sources=['exp_type'],
+                        value='.*_dark$'
                     )
                 ],
                 reduce=Constraint.notany


### PR DESCRIPTION
Updated level 2 asn rules to exclude dark files. 
All the association tests pass. 
............s                                                            [100%]

==== 56 passed, 12 skipped, 303 deselected, 2 xfailed in 1310.24s (0:21:50) ====


closes #4668