### PR TITLE
Echo CRDS context in regression test build logs

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -47,6 +47,7 @@ bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
     "pip install -e .[test,ephem]",
     "pip install pytest-xdist",
+    'echo "CRDS_CONTEXT = $(crds list --contexts jwst-edit --mappings | grep pmap)"',
 ]
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -56,6 +56,7 @@ bc0.pip_reqs_files = ['requirements-dev.txt']
 bc0.build_cmds = [
     "pip install -e .[test,ephem]",
     "pip install pytest-xdist",
+    'echo "CRDS_CONTEXT = $(crds list --contexts jwst-edit --mappings | grep pmap)"',
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [


### PR DESCRIPTION
This will print to the build log the pmap that `jwst-edit` points to.

```
$ echo "CRDS_CONTEXT = $(crds list --contexts jwst-edit --mappings | grep pmap)"
CRDS_CONTEXT = jwst_0587.pmap
```