### PR TITLE
Add a step generating WCS for a moving target

### DIFF
--- a/docs/jwst/assign_mtwcs/index.rst
+++ b/docs/jwst/assign_mtwcs/index.rst
@@ -1,0 +1,12 @@
+.. _assign_mtwcs_step:
+
+========================
+Assign Moving Target WCS
+========================
+
+.. toctree::
+   :maxdepth: 1
+
+   main.rst
+
+.. automodapi:: jwst.assign_mtwcs

--- a/docs/jwst/assign_mtwcs/main.rst
+++ b/docs/jwst/assign_mtwcs/main.rst
@@ -1,0 +1,30 @@
+
+Description
+===========
+
+``jwst.assign_mtwcs`` is run in the beginning of the level 3 JWST pipeline.
+It assigns a WCS to a ``Moving Target`` exposure. The table below defines the
+keywords specific to exposures with moving targets:
+
++--------------+----------------------+----------+------------------------------------------------+
+| FITS keyword | Data model attribute | Type     | Description                                    |
+|              |                      | (Value)  |                                                |
++==============+======================+==========+================================================+
+| TARGTYPE     | meta.target.type     | string   | Type of target                                 |
+|              |                      | (moving) |                                                |
++--------------+----------------------+----------+------------------------------------------------+
+| MT_RA,       | meta.wcsinfo.mt_ra,  | number,  | Average right ascension and declination        |
+| MT_DEC       | meta.wcsinfo.mt_dec  | number   | of the moving target during exposure [deg]     |
++--------------+----------------------+----------+------------------------------------------------+
+| MT_AVRA,     | meta.wcsinfo.mt_avra,| number,  | Right ascension and declination of the         |
+| MT_AVDEC     | meta.wcsinfo.mt_avdec| number   | moving target averaged between exposures [deg] |
++--------------+----------------------+----------+------------------------------------------------+
+
+The step takes the original science WCS pipeline and adds another step to it such
+that the ``output_frame`` of the final WCS is centered at the average location of
+the moving target specified by ``(MT_AVRA, MT_AVDEC)``.
+
+The transform of original WCS associated with the science aperture pointing can
+be accessed by executing::
+
+  sci_transform = model.meta.wcs.get_transform('detector', 'world')

--- a/docs/jwst/package_index.rst
+++ b/docs/jwst/package_index.rst
@@ -8,6 +8,7 @@ Package Index
    ami_analyze/index.rst
    ami_average/index.rst
    ami_normalize/index.rst
+   assign_mtwcs/index.rst
    assign_wcs/index.rst
    associations/index.rst
    background/index.rst

--- a/jwst/assign_mtwcs/__init__.py
+++ b/jwst/assign_mtwcs/__init__.py
@@ -1,0 +1,4 @@
+from .assign_mtwcs_step import AssignMTWcsStep
+
+
+__all__ = ['AssignMTWcsStep']

--- a/jwst/assign_mtwcs/assign_mtwcs_step.py
+++ b/jwst/assign_mtwcs/assign_mtwcs_step.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+from ..stpipe import Step
+from .. import datamodels
+import logging
+from .moving_target_wcs import assign_moving_target_wcs
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+__all__ = ["AssignMTWcsStep"]
+
+
+class AssignMTWcsStep(Step):
+    """
+    AssignMTWcsStep: Create a gWCS object for a moving target.
+
+    Parameters
+    ----------
+    input : `~jwst.associations.Association.
+        A JWST association file.
+    """
+
+    spec = """
+    suffix             = string(default='assign_mtwcs')        # Default suffix for output files
+    output_use_model   = boolean(default=True)      # When saving use `DataModel.meta.filename`
+    """
+    def process(self, input):
+        if isinstance(input, str):
+            input = datamodels.open(input)
+        if not isinstance(input, datamodels.ModelContainer):
+            log.warning("Input data type is not supported.")
+            # raise ValueError("Expected input to be an association file name or a ModelContainer.")
+            input.meta.cal_step.assign_mtwcs = 'SKIPPED'
+            return input
+
+        result = assign_moving_target_wcs(input)
+        return result

--- a/jwst/assign_mtwcs/moving_target_wcs.py
+++ b/jwst/assign_mtwcs/moving_target_wcs.py
@@ -1,0 +1,48 @@
+"""
+DEscription
+"""
+from copy import deepcopy
+import numpy as np
+from astropy.modeling.models import Shift, Identity
+from gwcs import WCS
+from gwcs import coordinate_frames as cf
+from jwst import datamodels
+
+
+def assign_moving_target_wcs(input_model):
+
+    if not isinstance(input_model, datamodels.ModelContainer):
+        raise ValueError("Expected a ModelContainer object")
+
+    mt_ra = np.array([model.meta.wcsinfo.mt_ra for model in input_model._models])
+    mt_dec = np.array([model.meta.wcsinfo.mt_dec for model in input_model._models])
+    mt_avra = mt_ra.mean()
+    mt_avdec = mt_dec.mean()
+
+    for model in input_model:
+        pipeline = model.meta.wcs._pipeline[:-1]
+
+        mt = deepcopy(model.meta.wcs.output_frame)
+        mt.name = 'moving_target'
+
+        mt_ra = model.meta.wcsinfo.mt_ra
+        mt_dec = model.meta.wcsinfo.mt_dec
+        model.meta.wcsinfo.mt_avra = mt_avra
+        model.meta.wcsinfo.mt_avdec = mt_avdec
+
+        rdel = mt_avra - mt_ra
+        ddel = mt_avdec - mt_dec
+
+        if isinstance(mt, cf.CelestialFrame):
+            transform_to_mt = Shift(rdel) & Shift(ddel)
+        elif isinstance(mt, cf.CompositeFrame):
+            transform_to_mt = Shift(rdel) & Shift(ddel) & Identity(1)
+        else:
+            raise ValueError("Unrecognized coordinate frame.")
+        pipeline.append((model.meta.wcs.output_frame, transform_to_mt))
+        pipeline.append((mt, None))
+        new_wcs = WCS(pipeline)
+        del model.meta.wcs
+        model.meta.wcs = new_wcs
+        model.meta.cal_step.assign_mtwcs = 'COMPLETE'
+    return input_model

--- a/jwst/assign_mtwcs/moving_target_wcs.py
+++ b/jwst/assign_mtwcs/moving_target_wcs.py
@@ -1,5 +1,11 @@
 """
-DEscription
+Adjust the WCS of a moving target exposure.
+
+Computes the average RA and DEC of a moving
+target in all exposures in an association and adds a step to
+each of the WCS pipelines to allow aligning the exposures to the average
+location of the target.
+
 """
 from copy import deepcopy
 import numpy as np

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -2,7 +2,6 @@
 Utility function for assign_wcs.
 
 """
-import warnings
 import logging
 import functools
 import numpy as np
@@ -121,12 +120,7 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
         Bounding_box of the new WCS.
         If not supplied it is computed from the bounding_box of all inputs.
     """
-    if domain is not None:
-        warnings.warning("'domain' was deprecated in 0.8 and will be removed from next"
-                         "version. Use 'bounding_box' instead.")
-        bb = _domain_to_bounding_box(domain)
-    else:
-        bb = bounding_box
+    bb = bounding_box
     wcslist = [im.meta.wcs for im in dmodels]
     if not isiterable(wcslist):
         raise ValueError("Expected 'wcslist' to be an iterable of WCS objects.")
@@ -187,9 +181,7 @@ def compute_fiducial(wcslist, bounding_box=None, domain=None):
 
     This function assumes all WCSs have the same output coordinate frame.
     """
-    if domain is not None:
-        warnings.warning("'domain' was deprecated in 0.8 and will be removed from next"
-                         "version. Use 'bounding_box' instead.")
+
     axes_types = wcslist[0].output_frame.axes_type
     spatial_axes = np.array(axes_types) == 'SPATIAL'
     spectral_axes = np.array(axes_types) == 'SPECTRAL'

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1971,6 +1971,11 @@ properties:
             type: string
             fits_keyword: S_WCS
             blend_table: True
+          assign_mtwcs:
+            title: Assign Moving Target World Coordinate System 
+            type: string
+            fits_keyword: S_MTWCS
+            blend_table: True
           back_sub:
             title: Background subtraction
             type: string

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -318,3 +318,23 @@ properties:
             type: number
             fits_keyword: YREF_SCI
             fits_hdu: SCI
+          mt_ra:
+            title: "[deg] Average right ascension of the moving target during exposure"
+            type: number
+            fits_keyword: MT_RA
+            fits_hdu: SCI
+          mt_dec:
+            title: "[deg] Average declination of the moving target during exposure"
+            type: number
+            fits_keyword: MT_DEC
+            fits_hdu: SCI
+          mt_avra:
+            title: "[deg] Right ascension of the moving target averaged between exposures"
+            type: number
+            fits_keyword: MT_AVRA
+            fits_hdu: SCI
+          mt_avdec:
+            title: "[deg] Declination of the moving target averaged between exposures"
+            type: number
+            fits_keyword: MT_AVDEC
+            fits_hdu: SCI

--- a/jwst/lib/exposure_types.py
+++ b/jwst/lib/exposure_types.py
@@ -20,3 +20,11 @@ FGS_GUIDE_EXP_TYPES = [
     'fgs_id-stack',
     'fgs_track',
 ]
+
+
+def is_moving_target(input_models):
+    """ Determine if a moving target exposure."""
+    model = input_models[0]
+    if model.meta.target.type == 'moving':
+        return True
+    return False

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -188,6 +188,8 @@ _calculated_suffixes = set([
     'jump',
     'extract1dstep',
     'tweakregstep',
+    'assignmtwcsstep',
+    'assign_mtwcs',
 ])
 
 

--- a/jwst/pipeline/assign_mtwcs.cfg
+++ b/jwst/pipeline/assign_mtwcs.cfg
@@ -1,0 +1,3 @@
+name = "assign_mtwcs"
+class = "jwst.assign_mtwcs.AssignMTWcsStep"
+


### PR DESCRIPTION
Resolves #4649

This is a working skeleton of the step - to provide context for questions.

The input is an association and the output is a `ModelContainer`. Is this OK?
The association is read into a `ModelContainer` and each model in the container is modified in place.


*Questions:* 

- The step iterates over `ModelContainer._models`. Is there a better way to do this, i.e. not using private variables?
- When I run the step on the command line it creates 4 new files on disk named `mt_asn_0_assign_mtwcs.fits`. What am I doing wrong or is this expected?

- What keywords define an exposure as a moving target (other than `MT_RA` and `MT_DEC`)?
    (EDIT: I found `model.meta.target.type` with a possible value of `moving`)