### PR TITLE
JP-1373: Documentation updates for step arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,27 @@ extract_2d
 - Change the source type for NIRSpec MOS sources with stellarity = -1 from
   UNKOWN to POINT. [#4686]
 
+master_background
+-----------------
+
+- Updated step arguments in the documentation. [#4723]
+
+outlier_detection
+-----------------
+
+- Updated step arguments in the documentation. [#4723]
+
+resample
+--------
+
+- Updated documentation to include step arguments and reference file
+  description. [#4723]
+
+source_catalog
+--------------
+
+- Updated step arguments in the documentation. [#4723]
+
 srctype
 -------
 
@@ -45,6 +66,10 @@ stpipe
 
 - Use only a single member of an association for CRDS STEPPARS checking [#4684]
 
+tweakreg
+--------
+
+- Updated step arguments in the documentation. [#4723]
 
 0.15.1 (2020-03-10)
 ===================

--- a/docs/jwst/master_background/arguments.rst
+++ b/docs/jwst/master_background/arguments.rst
@@ -24,3 +24,7 @@ The master background subtraction step uses the following optional arguments.
   :ref:`calwebb_spec2 <calwebb_spec2>` :ref:`background <background_step>` step has
   already been applied. If ``--force_subtract = True``, the master background will be
   applied.
+
+``--output_use_model``
+  A boolean indicating whether to use the "filename" meta attribute in the data model to
+  determine the name of the output file created by the step. Defaults to ``True``.

--- a/docs/jwst/outlier_detection/arguments.rst
+++ b/docs/jwst/outlier_detection/arguments.rst
@@ -22,6 +22,7 @@ that control the behavior of the processing:
   The value to assign to resampled image pixels that have zero weight or
   do not receive any flux from any input pixels during drizzling.
   Any floating-point value, given as a string, is valid.
+  A value of 'INDEF' will use the last zero weight flux.
 
 ``--nlow`` (integer, default=0)
   The number of low values in each pixel stack to ignore

--- a/docs/jwst/outlier_detection/arguments.rst
+++ b/docs/jwst/outlier_detection/arguments.rst
@@ -1,0 +1,66 @@
+.. _outlier_detection_step_args:
+
+Step Arguments
+==============
+The `outlier_detection` step has the following optional arguments
+that control the behavior of the processing:
+
+``--weight_type`` (string, default='exptime')
+  The type of data weighting to use during resampling;
+  options are 'exptime', 'error', and 'None'.
+
+``--pixfrac`` (float, default=1.0)
+  The pixel fraction used during resampling;
+  valid values go from 0.0 to 1.0.
+
+``--kernel`` (string, default='square')
+  The form of the kernel function used to distribute flux onto a
+  resampled image. Options are 'square', 'turbo', 'point',
+  'lanczos', and 'tophat'.
+
+``--fillval`` (string, default='INDEF')
+  The value to assign to resampled image pixels that have zero weight or
+  do not receive any flux from any input pixels during drizzling.
+  Any floating-point value, given as a string, is valid.
+
+``--nlow`` (integer, default=0)
+  The number of low values in each pixel stack to ignore
+  when computing the median value.
+
+``--nhigh`` (integer, default=0)
+  The number of high values in each pixel stack to ignore
+  when computing the median value.
+
+``--maskpt`` (float, default=0.7)
+  The percent of maximum weight to use as lower-limit for valid data;
+  valid values go from 0.0 to 1.0.
+
+``--grow`` (integer, default=1)
+  The radius, in pixels, from a bad pixel for neighbor rejection.
+
+``--snr`` (string, default='4.0 3.0')
+  The signal-to-noise values to use for bad pixel identification. Valid
+  values are a pair of floating-point values in a single string.
+
+``--scale`` (string, default='0.5 0.4')
+  The scaling factor applied to derivative used to identify bad pixels.
+  Valid values are a pair of floating-point values in a single string.
+
+``--backg`` (float, default=0.0)
+  User-specified background value to apply to the median image.
+
+``--save_intermediate_results`` (boolean, default=False)
+  Specifies whether or not to save any intermediate products created
+  during step processing.
+
+``--resample_data`` (boolean, default=True)
+  Specifies whether or not to resample the input images when
+  performing outlier detection.
+
+``--good_bits`` (int, default=6)
+  The integer sum of all bit values from the input image DQ arrays
+  that should be considered 'good' when building the weight mask.
+
+``--scale_detection`` (bool, default=False)
+  Specifies whether or not to rescale the individual input images
+  to match total signal when doing comparisons.

--- a/docs/jwst/outlier_detection/index.rst
+++ b/docs/jwst/outlier_detection/index.rst
@@ -8,6 +8,7 @@ Outlier Detection
    :maxdepth: 2
 
    main.rst
+   arguments.rst
    outlier_detection_step.rst
    outlier_detection.rst
    outlier_detection_ifu.rst

--- a/docs/jwst/outlier_detection/outlier_detection.rst
+++ b/docs/jwst/outlier_detection/outlier_detection.rst
@@ -10,38 +10,8 @@ basic outlier detection algorithm used with HST data, as adapted to JWST.
 Specifically, this routine performs the following operations:
 
 * Extract parameter settings from input model and merge them with any user-provided values.
-  The full set of user parameters includes::
-
-    weight_type: type of data weighting to use during resampling;
-                 options are 'exptime', 'error', 'None' [default='exptime']
-    pixfrac: pixel fraction used during resampling;
-             valid values go from 0.0-1.0 [default=1.0]
-    kernel: name of resampling kernel; options are 'square', 'turbo', 'point',
-            'lanczos', 'tophat' [default='square']
-    fillval: value to use to replace missing data when resampling;
-              any floating point value (as a string) is valid (default='INDEF')
-    nlow: Number (as an integer) of low values in each pixel stack to ignore
-          when computing median value [default=0]
-    nhigh:  Number (as an integer) of high values in each pixel stack to ignore
-          when computing median value [default=0]
-    maskpt: Percent of maximum weight to use as lower-limit for valid data;
-            valid values go from 0.0-1.0 [default=0.7]
-    grow: Radius (in pixels) from bad-pixel for neighbor rejection [default=1]
-    snr: Signal-to-noise values to use for bad-pixel identification; valid
-         values are a pair of floating-point values in a single string
-         [default='4.0 3.0']
-    scale: Scaling factor applied to derivative used to identify bad-pixels;
-           valid value is a string with 2 floating point values [default='0.5 0.4')]
-    backg: user-specified background value to apply to median image;
-           [default=0.0]
-    save_intermediate_results: specifies whether or not to save any products
-                               created during outlier_detection [default=False]
-    resample_data: specifies whether or not to resample the input data [default=True]
-    good_bits: Sum of DQ integer values which should be considered good when
-               creating weight and median images [default=6]
-    scale_detection: Boolean indicating whether to rescale the individual input
-                     images/integrations to match total signal when doing
-                     comparisons [default=False]
+  See :ref:`outlier detection arguments <outlier_detection_step_args>` for the full list
+  of parameters.
 
 * Convert input data, as needed, to make sure it is in a format that can be processed
 
@@ -56,7 +26,7 @@ Specifically, this routine performs the following operations:
 * By default, resample all input images into grouped observation mosaics; for example,
   combining all NIRCam multiple detector images from `a single exposure or
   from a dithered set of exposures.
-  <https://jwst-docs.stsci.edu/display/JTI/NIRCam+Dithers+and+Mosaics>`_
+  <https://jwst-docs.stsci.edu/near-infrared-camera/nircam-operations/nircam-dithers-and-mosaics>`_
 
   - Resampled images will be written out to disk if the
     ``save_intermediate_results`` parameter is set to `True`

--- a/docs/jwst/references_general/drizpars_reffile.inc
+++ b/docs/jwst/references_general/drizpars_reffile.inc
@@ -1,0 +1,51 @@
+.. _drizpars_reffile:
+
+DRIZPARS Reference File
+-----------------------
+
+:REFTYPE: DRIZPARS
+:Data model: `~jwst.datamodels.DrizParsModel`
+
+The DRIZPARS reference file contains various drizzle parameter values that
+control the characteristics of a drizzled image and how it is built.
+
+.. include:: ../references_general/drizpars_selection.inc
+
+.. include:: ../includes/standard_keywords.inc
+
+Type Specific Keywords for DRIZPARS
++++++++++++++++++++++++++++++++++++++
+No additional specific keywords are required in DRIZPARS reference
+files, because CRDS selection is based only on the instrument name
+(see :ref:`drizpars_selectors`).
+
+Reference File Format
++++++++++++++++++++++
+DRIZPARS reference files are FITS format, with 1 BINTABLE extension.
+The FITS primary HDU does not contain a data array.
+The format and content of the file is as follows:
+
+========  ========  =====  =======================  =========
+EXTNAME   XTENSION  NAXIS  Dimensions               Data type
+========  ========  =====  =======================  =========
+DRIZPARS  BINTABLE    2    TFIELDS = 7              N/A
+========  ========  =====  =======================  =========
+
+The DRIZPARS extension contains various step parameter values to be
+used when processing certain types of image collections. The first
+two columns (numimages and filter) are used as row selectors within
+the table. Image collections that match those selectors then use the
+parameter values specified in the remainder of that table row.
+The table contains the following 7 columns:
+
+===========  =======  ===========================================
+TTYPE        TFORM    Description
+===========  =======  ===========================================
+numimages    integer  The number of images to be combined
+filter       integer  The filter used to obtain the images
+pixfrac      float    The pixel "shrinkage" fraction
+kernel       string   The kernel function used to distribute flux
+fillval      float    Value assigned to pixels with no input flux
+wht_type     sting    The input image weighting type
+stepsize     integer  Output WCS grid interpolation step size
+===========  =======  ===========================================

--- a/docs/jwst/references_general/drizpars_selection.inc
+++ b/docs/jwst/references_general/drizpars_selection.inc
@@ -1,0 +1,16 @@
+.. _drizpars_selectors:
+
+Reference Selection Keywords for DRIZPARS
++++++++++++++++++++++++++++++++++++++++++
+CRDS selects appropriate DRIZPARS references based on the following keywords.
+DRIZPARS is not applicable for instruments not in the table.
+All keywords used for file selection are *required*.
+
+========== ========
+Instrument Keywords
+========== ========
+MIRI       INSTRUME
+NIRCam     INSTRUME
+NIRISS     INSTRUME
+========== ========
+

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -1,0 +1,35 @@
+.. _resample_step_args:
+
+Step Arguments
+==============
+The `resample` step has the following optional arguments that control
+the behavior of the processing and the characteristics of the resampled
+image.
+
+``--pixfrac`` (float, default=1.0)
+  The fraction by which input pixels are "shrunk" before being drizzled
+  onto the output image grid, given as a real number between 0 and 1.
+
+``--kernel`` (str, default='square')
+  The form of the kernel function used to distribute flux onto the output
+  image.
+
+``--fillval`` (str, default='INDEF')
+  The value to assign to output pixels that have zero weight or do not
+  receive any flux from any input pixels during drizzling.
+
+``--weight_type`` (str, default='exptime')
+  The weighting factor for each input image. If `weight_type=exptime`,
+  the scaling value will be set equal to the exposure time found in
+  the image header.
+
+``--good_bits`` (int, default=6)
+  The integer sum of all bit values from the input image DQ arrays
+  that should be considered 'good' when building the weight mask.
+
+``--single`` (bool, default=False)
+  Resample each input image into a separate output.
+
+``--blendheaders`` (bool, default=True)
+  Apply `blendmodels` on all of the input images to combine ('blend')
+  their meta data into the output resampled image.

--- a/docs/jwst/resample/index.rst
+++ b/docs/jwst/resample/index.rst
@@ -8,6 +8,8 @@ Resampling
    :maxdepth: 2
 
    main.rst
+   arguments.rst
+   reference_files.rst
    resample_step.rst
    resample.rst
 

--- a/docs/jwst/resample/reference_files.rst
+++ b/docs/jwst/resample/reference_files.rst
@@ -1,0 +1,5 @@
+Reference File
+==============
+The ``resample`` step uses the DRIZPARS reference file.
+
+.. include:: ../references_general/drizpars_reffile.inc

--- a/docs/jwst/source_catalog/arguments.rst
+++ b/docs/jwst/source_catalog/arguments.rst
@@ -20,3 +20,6 @@ The ``source_catalog`` step uses the following user-settable arguments:
 
 * ``--deblend``: A boolean indicating whether to deblend sources
   [default=False]
+
+* ``--suffix``: A string value giving the file name suffix to use for
+  the output catalog file [default='cat']

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -56,6 +56,12 @@ The ``tweakreg`` step has the following optional arguments:
 * ``snr_threshold``: A `float` value indicating SNR threshold above the
   background. (Default=5.0)
 
+* ``brightest``: A positive `int` value indicating the number of brightest
+  objects to keep. (Default=100)
+
+* ``peakmax``: A `float` value used to filter out objects with pixel values
+  >= ``peakmax``. (Default=None)
+
 **Optimize alignment order:**
 
 * ``enforce_user_order``: a boolean value indicating whether or not take the

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -26,7 +26,6 @@ class SourceCatalogStep(Step):
         snr_threshold = float(default=3.0)    # SNR threshold above the bkg
         npixels = float(default=5.0)          # min number of pixels in source
         deblend = boolean(default=False)      # deblend sources?
-        output_ext = string(default='.ecsv')  # Default type of output
         suffix = string(default='cat')        # Default suffix for output files
     """
 


### PR DESCRIPTION
Update the documentation for several steps, due to missing info about step arguments.

Fixes #4714 / [JP-1373](https://jira.stsci.edu/browse/JP-1373)  - resample arguments
Fixes #4713 / [JP-1374](https://jira.stsci.edu/browse/JP-1374)  - outlier_detection arguments
Fixes #4712 / [JP-1375](https://jira.stsci.edu/browse/JP-1375)  - tweakreg arguments
Fixes #4716 / [JP-1376](https://jira.stsci.edu/browse/JP-1376)  - source_catalog arguments
Fixes #4715 / [JP-1377](https://jira.stsci.edu/browse/JP-1377)  - master_background arguments

In addition to updating the argument list for `resample`, docs describing the `drizpars` reference file were also added.

One unused argument ("output_ext") was removed from the spec list in the `source_catalog` step.