### PR TITLE
Jp 1380 Update asn_from_list to have default values in the level 2 asn header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ ami
 associations
 ------------
 
+- Update asn_from_list to have default values in the asn header [#4720]
+
 - Update rules so exclude dark files from associations [#4668]
 
 - Update association rules so that nodded observations procduce level 3 asn's [#4675]

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -100,6 +100,15 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
                 'check': self.validate_candidates
             }
         })
+        # Other presumptions on the association
+        if 'constraints' not in self.data:
+            self.data['constraints'] = 'No constraints'
+        if 'asn_type' not in self.data:
+            self.data['asn_type'] = 'user_built'
+        if 'asn_id' not in self.data:
+            self.data['asn_id'] = 'a3001'
+        if 'asn_pool' not in self.data:
+            self.data['asn_pool'] = 'none'
 
     def check_and_set_constraints(self, item):
         """Override of Association method


### PR DESCRIPTION
Add default values for the asn header file when using --rule DMSLevel2bBase. This matches what is done when constructing associations using the default DMS_Level3_Base rules.

All the regression tests pass, 
==== 56 passed, 12 skipped, 303 deselected, 2 xfailed in 1352.97s (0:22:32) ====


This closes #4720