### PR TITLE
JP-1342 Fix unclosed file warnings

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -365,6 +365,11 @@ class ModelContainer(model_base.DataModel):
             result.append(group[0].meta.group_id)
         return result
 
+    def close(self):
+        """Close all datamodels."""
+        for model in self._models:
+            model.close()
+
 
 def make_file_with_index(file_path, idx):
     """Append an index to a filename

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -468,7 +468,7 @@ class Step():
         finally:
             log.delegator.log = orig_log
 
-        self.closeout(args)
+        self.closeout(to_close=args)
 
         return step_result
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -468,6 +468,8 @@ class Step():
         finally:
             log.delegator.log = orig_log
 
+        self.closeout(args)
+
         return step_result
 
     __call__ = run
@@ -1032,7 +1034,8 @@ class Step():
         to_del += to_close
         for item in to_close:
             try:
-                item.close()
+                if hasattr(item, 'close'):
+                    item.close()
             except Exception as exception:
                 self.log.debug(
                     'Could not close "{}"'

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -172,9 +172,8 @@ class StepWithModel(Step):
     """
 
     def process(self, *args):
-        input_path = self.open_model(args[0])
-        model = ImageModel(input_path)
-
+        with self.open_model(args[0]) as input_path:
+            model = ImageModel(input_path)
         return model
 
 

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -94,6 +94,7 @@ def test_use_input_dir(mk_tmp_dirs):
 
     step.closeout()
 
+
 def test_fail_input_dir(mk_tmp_dirs):
     """Fail with a bad file path"""
     input_file = 'flat.fits'
@@ -107,8 +108,8 @@ def test_fail_input_dir(mk_tmp_dirs):
 
 def test_input_dir_with_model(mk_tmp_dirs):
     """Use with an already opened DataModel"""
-    model = dm_open(t_path('data/flat.fits'))
-    step = StepWithModel()
-    step.run(model)
+    with dm_open(t_path('data/flat.fits')) as model:
+        step = StepWithModel()
+        step.run(model)
 
     assert step.input_dir == ''

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -59,6 +59,8 @@ def test_default_input_dir(mk_tmp_dirs):
     input_path = path.split(input_file)[0]
     assert step.input_dir == input_path
 
+    step.closeout()
+
 
 def test_set_input_dir(mk_tmp_dirs):
     """Simply set the path"""
@@ -72,6 +74,8 @@ def test_set_input_dir(mk_tmp_dirs):
 
     # Check that `input_dir` is set.
     assert step.input_dir == 'junkdir'
+
+    step.closeout()
 
 
 def test_use_input_dir(mk_tmp_dirs):
@@ -88,6 +92,7 @@ def test_use_input_dir(mk_tmp_dirs):
     # Check that `input_dir` is set.
     assert step.input_dir == input_dir
 
+    step.closeout()
 
 def test_fail_input_dir(mk_tmp_dirs):
     """Fail with a bad file path"""

--- a/jwst/stpipe/tests/test_logger.py
+++ b/jwst/stpipe/tests/test_logger.py
@@ -5,6 +5,7 @@ import pytest
 from .. import log as stpipe_log
 
 
+@pytest.mark.openfiles_ignore
 def test_configuration(tmpdir):
     logfilename = tmpdir.join('output.log')
 
@@ -20,6 +21,7 @@ format = '%(message)s'
     fd.write(configuration)
     fd.seek(0)
     stpipe_log.load_configuration(fd)
+    fd.close()
 
     log = stpipe_log.getLogger(stpipe_log.STPIPE_ROOT_LOGGER)
 

--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -43,12 +43,10 @@ def test_save_step_default(mk_tmp_dirs):
         data_fn_path
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     fname = 'flat_stepwithmodel.fits'
     assert path.isfile(fname)
-
-    step.closeout()
 
 
 def test_save_step_withoutput(mk_tmp_dirs):
@@ -63,12 +61,10 @@ def test_save_step_withoutput(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_file)
     assert path.isfile(output_path + '_stepwithmodel' + output_ext)
-
-    step.closeout()
 
 
 def test_save_step_withoutputsuffix(mk_tmp_dirs):
@@ -84,11 +80,9 @@ def test_save_step_withoutputsuffix(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     assert path.isfile(actual_output_file)
-
-    step.closeout()
 
 
 def test_save_step_withdir(mk_tmp_dirs):
@@ -101,15 +95,13 @@ def test_save_step_withdir(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_fn_path = path.join(
         tmp_data_path,
         data_name + '_stepwithmodel' + data_ext,
     )
     assert path.isfile(output_fn_path)
-
-    step.closeout()
 
 
 def test_save_step_withdir_environment(mk_tmp_dirs):
@@ -124,15 +116,13 @@ def test_save_step_withdir_environment(mk_tmp_dirs):
         '--output_dir=$TSSWE_OUTPATH'
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_fn_path = path.join(
         tmp_data_path,
         data_name + '_stepwithmodel' + data_ext,
     )
     assert path.isfile(output_fn_path)
-
-    step.closeout()
 
 
 def test_save_step_withdir_withoutput(mk_tmp_dirs):
@@ -148,7 +138,7 @@ def test_save_step_withdir_withoutput(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_file)
     output_fn_path = path.join(
@@ -156,8 +146,6 @@ def test_save_step_withdir_withoutput(mk_tmp_dirs):
         output_path + '_stepwithmodel' + output_ext
     )
     assert path.isfile(output_fn_path)
-
-    step.closeout()
 
 
 def test_save_container(mk_tmp_dirs):
@@ -169,12 +157,10 @@ def test_save_container(mk_tmp_dirs):
         data_fn_path,
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     assert path.isfile('flat_0_stepwithcontainer.fits')
     assert path.isfile('flat_1_stepwithcontainer.fits')
-
-    step.closeout()
 
 
 def test_save_container_usemodel(mk_tmp_dirs):
@@ -187,12 +173,10 @@ def test_save_container_usemodel(mk_tmp_dirs):
         '--output_use_model=true'
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     assert path.isfile('swc_model1_stepwithcontainer.fits')
     assert path.isfile('swc_model2_stepwithcontainer.fits')
-
-    step.closeout()
 
 
 def test_save_container_withfile(mk_tmp_dirs):
@@ -231,7 +215,7 @@ def test_save_pipeline_default(mk_tmp_dirs):
         '--steps.savestep.skip=False'
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     # Output from the explicit `SaveStep.save_model`
     desired = data_name + '_processed' + data_ext
@@ -244,8 +228,6 @@ def test_save_pipeline_default(mk_tmp_dirs):
     # Output from the Steps' default saving of `SavePipeline`
     desired = data_name + '_savepipeline' + data_ext
     assert path.isfile(desired)
-
-    step.closeout()
 
 
 def test_save_pipeline_withdir(mk_tmp_dirs):
@@ -263,15 +245,13 @@ def test_save_pipeline_withdir(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path,
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_pipeline_fn_path = path.join(
         tmp_data_path,
         data_name + '_savepipeline' + data_ext
     )
     assert path.isfile(output_pipeline_fn_path)
-
-    step.closeout()
 
 
 def test_save_substep_withdir(mk_tmp_dirs):
@@ -290,7 +270,7 @@ def test_save_substep_withdir(mk_tmp_dirs):
         '--steps.savestep.output_dir=' + tmp_data_path
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     # Output from the explicit `SaveStep.save_model`
     desired = path.join(
@@ -310,8 +290,6 @@ def test_save_substep_withdir(mk_tmp_dirs):
     desired = data_name + '_savepipeline' + data_ext
     assert path.isfile(desired)
 
-    step.closeout()
-
 
 def test_save_proper_pipeline(mk_tmp_dirs):
     """Test how pipeline saving should work"""
@@ -321,11 +299,9 @@ def test_save_proper_pipeline(mk_tmp_dirs):
         '--steps.stepwithcontainer.skip=true',
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     assert path.isfile('flat_pp.fits')
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_withdir(mk_tmp_dirs):
@@ -338,11 +314,10 @@ def test_save_proper_pipeline_withdir(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path,
         '--steps.stepwithcontainer.skip=true',
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     assert path.isfile(path.join(tmp_data_path, 'flat_pp.fits'))
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_withdir_withoutput(mk_tmp_dirs):
@@ -358,14 +333,13 @@ def test_save_proper_pipeline_withdir_withoutput(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path,
         '--steps.stepwithcontainer.skip=true',
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_name)
     assert path.isfile(path.join(
         tmp_data_path, output_path + '_pp' + output_ext
     ))
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_substeps(mk_tmp_dirs):
@@ -377,13 +351,12 @@ def test_save_proper_pipeline_substeps(mk_tmp_dirs):
         '--steps.another_stepwithmodel.save_results=true',
         '--steps.stepwithcontainer.skip=true',
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     assert path.isfile('flat_pp.fits')
     assert path.isfile('flat_swm.fits')
     assert path.isfile('flat_aswm.fits')
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_substeps_skip(mk_tmp_dirs):
@@ -396,13 +369,12 @@ def test_save_proper_pipeline_substeps_skip(mk_tmp_dirs):
         '--steps.another_stepwithmodel.skip=true',
         '--steps.stepwithcontainer.skip=true',
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     assert path.isfile('flat_pp.fits')
     assert path.isfile('flat_swm.fits')
     assert not path.isfile('flat_aswm.fits')
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_substeps_withdir(mk_tmp_dirs):
@@ -418,13 +390,12 @@ def test_save_proper_pipeline_substeps_withdir(mk_tmp_dirs):
         '--steps.another_stepwithmodel.output_dir=' + tmp_config_path,
         '--steps.stepwithcontainer.skip=true',
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     assert path.isfile(path.join(tmp_data_path, 'flat_pp.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_swm.fits'))
     assert path.isfile(path.join(tmp_config_path, 'flat_aswm.fits'))
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_container(mk_tmp_dirs):
@@ -434,12 +405,10 @@ def test_save_proper_pipeline_container(mk_tmp_dirs):
         data_fn_path,
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     assert path.isfile('flat_0_pp.fits')
     assert path.isfile('flat_1_pp.fits')
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_container_withdir(mk_tmp_dirs):
@@ -451,12 +420,11 @@ def test_save_proper_pipeline_container_withdir(mk_tmp_dirs):
         data_fn_path,
         '--output_dir=' + tmp_data_path,
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     assert path.isfile(path.join(tmp_data_path, 'flat_0_pp.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_1_pp.fits'))
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_container_withdir_withoutput(mk_tmp_dirs):
@@ -471,7 +439,8 @@ def test_save_proper_pipeline_container_withdir_withoutput(mk_tmp_dirs):
         '--output_file=' + output_name,
         '--output_dir=' + tmp_data_path,
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_name)
     assert path.isfile(path.join(
@@ -480,8 +449,6 @@ def test_save_proper_pipeline_container_withdir_withoutput(mk_tmp_dirs):
     assert path.isfile(path.join(
         tmp_data_path, output_path + '_1_pp' + output_ext
     ))
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_container_substeps(mk_tmp_dirs):
@@ -493,7 +460,8 @@ def test_save_proper_pipeline_container_substeps(mk_tmp_dirs):
         '--steps.another_stepwithmodel.save_results=true',
         '--steps.stepwithcontainer.save_results=true',
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     assert path.isfile('flat_0_pp.fits')
     assert path.isfile('flat_1_pp.fits')
@@ -501,8 +469,6 @@ def test_save_proper_pipeline_container_substeps(mk_tmp_dirs):
     assert path.isfile('flat_aswm.fits')
     assert path.isfile('flat_0_swc.fits')
     assert path.isfile('flat_1_swc.fits')
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_container_substeps_skip(mk_tmp_dirs):
@@ -515,7 +481,8 @@ def test_save_proper_pipeline_container_substeps_skip(mk_tmp_dirs):
         '--steps.another_stepwithmodel.skip=true',
         '--steps.stepwithcontainer.save_results=true',
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     assert path.isfile('flat_0_pp.fits')
     assert path.isfile('flat_1_pp.fits')
@@ -523,8 +490,6 @@ def test_save_proper_pipeline_container_substeps_skip(mk_tmp_dirs):
     assert not path.isfile('flat_aswm.fits')
     assert path.isfile('flat_0_swc.fits')
     assert path.isfile('flat_1_swc.fits')
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_container_substeps_withdir(mk_tmp_dirs):
@@ -540,7 +505,8 @@ def test_save_proper_pipeline_container_substeps_withdir(mk_tmp_dirs):
         '--steps.another_stepwithmodel.output_dir=' + tmp_config_path,
         '--steps.stepwithcontainer.save_results=true',
     ]
-    step = Step.from_cmdline(args)
+
+    Step.from_cmdline(args)
 
     assert path.isfile(path.join(tmp_data_path, 'flat_0_pp.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_1_pp.fits'))
@@ -548,8 +514,6 @@ def test_save_proper_pipeline_container_substeps_withdir(mk_tmp_dirs):
     assert path.isfile(path.join(tmp_config_path, 'flat_aswm.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_0_swc.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_1_swc.fits'))
-
-    step.closeout()
 
 
 def test_save_proper_pipeline_container_usemodel(mk_tmp_dirs):
@@ -561,7 +525,7 @@ def test_save_proper_pipeline_container_usemodel(mk_tmp_dirs):
         '--steps.stepwithcontainer.output_use_model=true',
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_files = [
         path.split(result_path)[1]
@@ -580,8 +544,6 @@ def test_save_proper_pipeline_container_usemodel(mk_tmp_dirs):
 
     assert len(output_files) == 0
 
-    step.closeout()
-
 
 def test_save_proper_pipeline_container_nosearch(mk_tmp_dirs):
     """Test how pipeline saving should work"""
@@ -592,7 +554,7 @@ def test_save_proper_pipeline_container_nosearch(mk_tmp_dirs):
         '--steps.stepwithcontainer.search_output_file=false',
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_files = [
         path.split(result_path)[1]
@@ -612,5 +574,3 @@ def test_save_proper_pipeline_container_nosearch(mk_tmp_dirs):
         output_files.remove(valid_file)
 
     assert len(output_files) == 0
-
-    step.closeout()

--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -43,10 +43,12 @@ def test_save_step_default(mk_tmp_dirs):
         data_fn_path
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     fname = 'flat_stepwithmodel.fits'
     assert path.isfile(fname)
+
+    step.closeout()
 
 
 def test_save_step_withoutput(mk_tmp_dirs):
@@ -61,10 +63,12 @@ def test_save_step_withoutput(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_file)
     assert path.isfile(output_path + '_stepwithmodel' + output_ext)
+
+    step.closeout()
 
 
 def test_save_step_withoutputsuffix(mk_tmp_dirs):
@@ -80,9 +84,11 @@ def test_save_step_withoutputsuffix(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile(actual_output_file)
+
+    step.closeout()
 
 
 def test_save_step_withdir(mk_tmp_dirs):
@@ -95,13 +101,15 @@ def test_save_step_withdir(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_fn_path = path.join(
         tmp_data_path,
         data_name + '_stepwithmodel' + data_ext,
     )
     assert path.isfile(output_fn_path)
+
+    step.closeout()
 
 
 def test_save_step_withdir_environment(mk_tmp_dirs):
@@ -116,13 +124,15 @@ def test_save_step_withdir_environment(mk_tmp_dirs):
         '--output_dir=$TSSWE_OUTPATH'
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_fn_path = path.join(
         tmp_data_path,
         data_name + '_stepwithmodel' + data_ext,
     )
     assert path.isfile(output_fn_path)
+
+    step.closeout()
 
 
 def test_save_step_withdir_withoutput(mk_tmp_dirs):
@@ -138,7 +148,7 @@ def test_save_step_withdir_withoutput(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_file)
     output_fn_path = path.join(
@@ -146,6 +156,8 @@ def test_save_step_withdir_withoutput(mk_tmp_dirs):
         output_path + '_stepwithmodel' + output_ext
     )
     assert path.isfile(output_fn_path)
+
+    step.closeout()
 
 
 def test_save_container(mk_tmp_dirs):
@@ -157,10 +169,12 @@ def test_save_container(mk_tmp_dirs):
         data_fn_path,
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('flat_0_stepwithcontainer.fits')
     assert path.isfile('flat_1_stepwithcontainer.fits')
+
+    step.closeout()
 
 
 def test_save_container_usemodel(mk_tmp_dirs):
@@ -173,10 +187,12 @@ def test_save_container_usemodel(mk_tmp_dirs):
         '--output_use_model=true'
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('swc_model1_stepwithcontainer.fits')
     assert path.isfile('swc_model2_stepwithcontainer.fits')
+
+    step.closeout()
 
 
 def test_save_container_withfile(mk_tmp_dirs):
@@ -189,10 +205,12 @@ def test_save_container_withfile(mk_tmp_dirs):
         '--output_file=tscwf.fits',
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('tscwf_0_stepwithcontainer.fits')
     assert path.isfile('tscwf_1_stepwithcontainer.fits')
+
+    step.closeout()
 
 
 def test_save_pipeline_default(mk_tmp_dirs):
@@ -213,7 +231,7 @@ def test_save_pipeline_default(mk_tmp_dirs):
         '--steps.savestep.skip=False'
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     # Output from the explicit `SaveStep.save_model`
     desired = data_name + '_processed' + data_ext
@@ -226,6 +244,8 @@ def test_save_pipeline_default(mk_tmp_dirs):
     # Output from the Steps' default saving of `SavePipeline`
     desired = data_name + '_savepipeline' + data_ext
     assert path.isfile(desired)
+
+    step.closeout()
 
 
 def test_save_pipeline_withdir(mk_tmp_dirs):
@@ -243,13 +263,15 @@ def test_save_pipeline_withdir(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path,
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_pipeline_fn_path = path.join(
         tmp_data_path,
         data_name + '_savepipeline' + data_ext
     )
     assert path.isfile(output_pipeline_fn_path)
+
+    step.closeout()
 
 
 def test_save_substep_withdir(mk_tmp_dirs):
@@ -268,7 +290,7 @@ def test_save_substep_withdir(mk_tmp_dirs):
         '--steps.savestep.output_dir=' + tmp_data_path
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     # Output from the explicit `SaveStep.save_model`
     desired = path.join(
@@ -288,6 +310,8 @@ def test_save_substep_withdir(mk_tmp_dirs):
     desired = data_name + '_savepipeline' + data_ext
     assert path.isfile(desired)
 
+    step.closeout()
+
 
 def test_save_proper_pipeline(mk_tmp_dirs):
     """Test how pipeline saving should work"""
@@ -297,9 +321,11 @@ def test_save_proper_pipeline(mk_tmp_dirs):
         '--steps.stepwithcontainer.skip=true',
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('flat_pp.fits')
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_withdir(mk_tmp_dirs):
@@ -312,9 +338,11 @@ def test_save_proper_pipeline_withdir(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path,
         '--steps.stepwithcontainer.skip=true',
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile(path.join(tmp_data_path, 'flat_pp.fits'))
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_withdir_withoutput(mk_tmp_dirs):
@@ -330,12 +358,14 @@ def test_save_proper_pipeline_withdir_withoutput(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path,
         '--steps.stepwithcontainer.skip=true',
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_name)
     assert path.isfile(path.join(
         tmp_data_path, output_path + '_pp' + output_ext
     ))
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_substeps(mk_tmp_dirs):
@@ -347,11 +377,13 @@ def test_save_proper_pipeline_substeps(mk_tmp_dirs):
         '--steps.another_stepwithmodel.save_results=true',
         '--steps.stepwithcontainer.skip=true',
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('flat_pp.fits')
     assert path.isfile('flat_swm.fits')
     assert path.isfile('flat_aswm.fits')
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_substeps_skip(mk_tmp_dirs):
@@ -364,11 +396,13 @@ def test_save_proper_pipeline_substeps_skip(mk_tmp_dirs):
         '--steps.another_stepwithmodel.skip=true',
         '--steps.stepwithcontainer.skip=true',
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('flat_pp.fits')
     assert path.isfile('flat_swm.fits')
     assert not path.isfile('flat_aswm.fits')
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_substeps_withdir(mk_tmp_dirs):
@@ -384,11 +418,13 @@ def test_save_proper_pipeline_substeps_withdir(mk_tmp_dirs):
         '--steps.another_stepwithmodel.output_dir=' + tmp_config_path,
         '--steps.stepwithcontainer.skip=true',
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile(path.join(tmp_data_path, 'flat_pp.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_swm.fits'))
     assert path.isfile(path.join(tmp_config_path, 'flat_aswm.fits'))
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_container(mk_tmp_dirs):
@@ -398,10 +434,12 @@ def test_save_proper_pipeline_container(mk_tmp_dirs):
         data_fn_path,
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('flat_0_pp.fits')
     assert path.isfile('flat_1_pp.fits')
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_container_withdir(mk_tmp_dirs):
@@ -413,10 +451,12 @@ def test_save_proper_pipeline_container_withdir(mk_tmp_dirs):
         data_fn_path,
         '--output_dir=' + tmp_data_path,
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile(path.join(tmp_data_path, 'flat_0_pp.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_1_pp.fits'))
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_container_withdir_withoutput(mk_tmp_dirs):
@@ -431,7 +471,7 @@ def test_save_proper_pipeline_container_withdir_withoutput(mk_tmp_dirs):
         '--output_file=' + output_name,
         '--output_dir=' + tmp_data_path,
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_name)
     assert path.isfile(path.join(
@@ -440,6 +480,8 @@ def test_save_proper_pipeline_container_withdir_withoutput(mk_tmp_dirs):
     assert path.isfile(path.join(
         tmp_data_path, output_path + '_1_pp' + output_ext
     ))
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_container_substeps(mk_tmp_dirs):
@@ -451,7 +493,7 @@ def test_save_proper_pipeline_container_substeps(mk_tmp_dirs):
         '--steps.another_stepwithmodel.save_results=true',
         '--steps.stepwithcontainer.save_results=true',
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('flat_0_pp.fits')
     assert path.isfile('flat_1_pp.fits')
@@ -459,6 +501,8 @@ def test_save_proper_pipeline_container_substeps(mk_tmp_dirs):
     assert path.isfile('flat_aswm.fits')
     assert path.isfile('flat_0_swc.fits')
     assert path.isfile('flat_1_swc.fits')
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_container_substeps_skip(mk_tmp_dirs):
@@ -471,7 +515,7 @@ def test_save_proper_pipeline_container_substeps_skip(mk_tmp_dirs):
         '--steps.another_stepwithmodel.skip=true',
         '--steps.stepwithcontainer.save_results=true',
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile('flat_0_pp.fits')
     assert path.isfile('flat_1_pp.fits')
@@ -479,6 +523,8 @@ def test_save_proper_pipeline_container_substeps_skip(mk_tmp_dirs):
     assert not path.isfile('flat_aswm.fits')
     assert path.isfile('flat_0_swc.fits')
     assert path.isfile('flat_1_swc.fits')
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_container_substeps_withdir(mk_tmp_dirs):
@@ -494,7 +540,7 @@ def test_save_proper_pipeline_container_substeps_withdir(mk_tmp_dirs):
         '--steps.another_stepwithmodel.output_dir=' + tmp_config_path,
         '--steps.stepwithcontainer.save_results=true',
     ]
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     assert path.isfile(path.join(tmp_data_path, 'flat_0_pp.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_1_pp.fits'))
@@ -502,6 +548,8 @@ def test_save_proper_pipeline_container_substeps_withdir(mk_tmp_dirs):
     assert path.isfile(path.join(tmp_config_path, 'flat_aswm.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_0_swc.fits'))
     assert path.isfile(path.join(tmp_data_path, 'flat_1_swc.fits'))
+
+    step.closeout()
 
 
 def test_save_proper_pipeline_container_usemodel(mk_tmp_dirs):
@@ -513,7 +561,7 @@ def test_save_proper_pipeline_container_usemodel(mk_tmp_dirs):
         '--steps.stepwithcontainer.output_use_model=true',
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_files = [
         path.split(result_path)[1]
@@ -532,6 +580,8 @@ def test_save_proper_pipeline_container_usemodel(mk_tmp_dirs):
 
     assert len(output_files) == 0
 
+    step.closeout()
+
 
 def test_save_proper_pipeline_container_nosearch(mk_tmp_dirs):
     """Test how pipeline saving should work"""
@@ -542,7 +592,7 @@ def test_save_proper_pipeline_container_nosearch(mk_tmp_dirs):
         '--steps.stepwithcontainer.search_output_file=false',
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
 
     output_files = [
         path.split(result_path)[1]
@@ -562,3 +612,5 @@ def test_save_proper_pipeline_container_nosearch(mk_tmp_dirs):
         output_files.remove(valid_file)
 
     assert len(output_files) == 0
+
+    step.closeout()

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -86,6 +86,8 @@ def test_parameters_from_crds_fail():
     pars = RefPixStep.get_config_from_reference(data)
     assert not len(pars)
 
+    data.close()
+
 
 @pytest.mark.parametrize(
     'cfg_file, expected',
@@ -110,7 +112,7 @@ def test_saving_pars(tmpdir):
     """Save the step parameters from the commandline"""
     cfg_path = t_path(join('steps', 'jwst_generic_pars-makeliststep_0002.asdf'))
     saved_path = tmpdir.join('savepars.asdf')
-    Step.from_cmdline([
+    step = Step.from_cmdline([
         cfg_path,
         '--save-parameters',
         str(saved_path)
@@ -118,6 +120,9 @@ def test_saving_pars(tmpdir):
     assert saved_path.check()
     saved = datamodels.StepParsModel(str(saved_path))
     assert saved.parameters == ParsModelWithPar3.parameters
+
+    step.closeout()
+    saved.close()
 
 
 @pytest.mark.parametrize(

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -118,11 +118,11 @@ def test_saving_pars(tmpdir):
         str(saved_path)
     ])
     assert saved_path.check()
-    saved = datamodels.StepParsModel(str(saved_path))
-    assert saved.parameters == ParsModelWithPar3.parameters
+
+    with datamodels.StepParsModel(str(saved_path)) as saved:
+        assert saved.parameters == ParsModelWithPar3.parameters
 
     step.closeout()
-    saved.close()
 
 
 @pytest.mark.parametrize(

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ results_root = jwst-pipeline-results
 doctest_plus = true
 doctest_rst = true
 text_file_format = rst
-addopts = --no-print-logs
+addopts = --no-print-logs --open-files
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ results_root = jwst-pipeline-results
 doctest_plus = true
 doctest_rst = true
 text_file_format = rst
-addopts = --no-print-logs --open-files
+addopts = --no-print-logs
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
This PR resolves `ResourceWarning`s triggered by unclosed files over the course of some pipeline runs. A call to `closeout` was added to the end of `Step.run` to ensure that inputs were properly closed. In addition, a simple `close` method was added to `ModelContainer` in order to close models in the container. 

Resolves #4662 / [JP-1342](https://jira.stsci.edu/browse/JP-1342)