### PR TITLE
fix test - should compare 0-based coordinates

### DIFF
--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -124,7 +124,7 @@ def test_create_fitwcs(tmpdir):
     hdu = fits_support.get_hdu(ff._hdulist, "SCI")
     w = wcs.WCS(hdu.header)
     wcel = w.sub(['celestial'])
-    ra, dec = wcel.all_pix2world(1, 1, 1)
+    ra, dec = wcel.all_pix2world(1, 1, 0)
     utils.assert_allclose((ra, dec), (gra, gdec))
 
     # test serialization


### PR DESCRIPTION
The 1 deg difference in the failing test is due to CDELT=1.