### PR TITLE
Fix failing reg tests

### DIFF
--- a/jwst/regtest/test_schema_editor.py
+++ b/jwst/regtest/test_schema_editor.py
@@ -95,7 +95,7 @@ def test_limit_datamodels(model_db):
      'multiextract1d.schema.yaml', 'multispec.schema.yaml',
      'pathloss.schema.yaml',
      'referencefile.schema.yaml',
-     'slitdata.schema.yaml',
+     'slitmeta.schema.yaml',
      'wcsinfo.schema.yaml',]
 )
 def test_full_run(jail, schema, run_editor_full, rtdata_module):

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -25,6 +25,7 @@ class SourceCatalogStep(Step):
         snr_threshold = float(default=3.0)    # SNR threshold above the bkg
         npixels = float(default=5.0)          # min number of pixels in source
         deblend = boolean(default=False)      # deblend sources?
+        output_ext = string(default='.ecsv')  # Default type of output
         suffix = string(default='cat')        # Default suffix for output files
     """
 


### PR DESCRIPTION
Replace the `source_catalog` `output_ext` param that was mistakenly removed in #4723 and causing 2 regtest to fail due to the output catalog file having the default ".fits" extension, instead of ".ecsv".

Also updated the test_schema_editor regtest code to account for the fact that #4552 replaced the meta data formerly in `slitdata.schema` with the new schema `slitmeta.schema`.