### PR TITLE
Resolve open file issues in unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ scripts/launch.json
 *.orig
 .ipynb_checkpoints
 */.ipynb_checkpoints/*.ipynb
+.coverage
+htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ scripts/launch.json
 *.orig
 .ipynb_checkpoints
 */.ipynb_checkpoints/*.ipynb
-.coverage
 htmlcov

--- a/jwst/assign_wcs/tests/test_schemas.py
+++ b/jwst/assign_wcs/tests/test_schemas.py
@@ -7,6 +7,7 @@ def test_distortion_schema(tmpdir):
     """Make sure DistortionModel roundtrips"""
     m = models.Shift(1) & models.Shift(2)
     dist = DistortionModel(model=m, input_units=u.pixel, output_units=u.arcsec)
+
     dist.meta.instrument.name = "NIRCAM"
     dist.meta.instrument.detector = "NRCA1"
     dist.meta.instrument.p_pupil = "F162M|F164N|CLEAR|"

--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -263,21 +263,23 @@ def test_nis_wfss_background(filters, pupils, make_wfss_datamodel):
 
     # Get References
     wavelenrange = Step().get_reference_file(wcs_corrected, "wavelengthrange")
+    bkg_file = Step().get_reference_file(wcs_corrected, 'wfssbkg')
+
     mask = mask_from_source_cat(wcs_corrected, wavelenrange)
 
-    bkg_file = Step().get_reference_file(wcs_corrected, 'wfssbkg')
-    bkg_ref = datamodels.open(bkg_file)
-    bkg_ref = no_NaN(bkg_ref)
+    with datamodels.open(bkg_file) as bkg_ref:
+        bkg_ref = no_NaN(bkg_ref)
 
-    # calculate backgrounds
-    pipeline_data_mean = robust_mean(wcs_corrected.data[mask])
-    test_data_mean,_,_ = sigma_clipped_stats(wcs_corrected.data, sigma=2)
+        # calculate backgrounds
+        pipeline_data_mean = robust_mean(wcs_corrected.data[mask])
+        test_data_mean,_,_ = sigma_clipped_stats(wcs_corrected.data, sigma=2)
 
-    pipeline_reference_mean = robust_mean(bkg_ref.data[mask])
-    test_reference_mean,_,_ = sigma_clipped_stats(bkg_ref.data, sigma=2)
+        pipeline_reference_mean = robust_mean(bkg_ref.data[mask])
+        test_reference_mean,_,_ = sigma_clipped_stats(bkg_ref.data, sigma=2)
 
-    assert np.isclose([pipeline_data_mean], [test_data_mean], rtol=1e-3)
-    assert np.isclose([pipeline_reference_mean], [test_reference_mean], rtol=1e-1)
+        assert np.isclose([pipeline_data_mean], [test_data_mean], rtol=1e-3)
+        assert np.isclose([pipeline_reference_mean], [test_reference_mean], rtol=1e-1)
+
 
 def test_robust_mean():
     """Test robust mean calculation"""

--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -31,25 +31,26 @@ def background(tmpdir_factory):
 
     filename = tmpdir_factory.mktemp('background_input')
     filename = str(filename.join('background.fits'))
-    image = datamodels.IFUImageModel((10, 10))
-    image.data[:,:] = 10
-    image.meta.instrument.name = 'NIRSPEC'
-    image.meta.instrument.detector = 'NRS1'
-    image.meta.instrument.filter = 'CLEAR'
-    image.meta.instrument.grating = 'PRISM'
-    image.meta.exposure.type = 'NRS_IFU'
-    image.meta.observation.date = '2019-02-27'
-    image.meta.observation.time = '13:37:18.548'
-    image.meta.date = '2019-02-27T13:37:18.548'
+    with datamodels.IFUImageModel((10, 10)) as image:
+        image.data[:,:] = 10
+        image.meta.instrument.name = 'NIRSPEC'
+        image.meta.instrument.detector = 'NRS1'
+        image.meta.instrument.filter = 'CLEAR'
+        image.meta.instrument.grating = 'PRISM'
+        image.meta.exposure.type = 'NRS_IFU'
+        image.meta.observation.date = '2019-02-27'
+        image.meta.observation.time = '13:37:18.548'
+        image.meta.date = '2019-02-27T13:37:18.548'
 
-    image.meta.subarray.xstart = 1
-    image.meta.subarray.ystart = 1
+        image.meta.subarray.xstart = 1
+        image.meta.subarray.ystart = 1
 
-    image.meta.instrument.gwa_xtilt = 0.0001
-    image.meta.instrument.gwa_ytilt = 0.0001
-    image.meta.instrument.gwa_tilt = 37.0610
+        image.meta.instrument.gwa_xtilt = 0.0001
+        image.meta.instrument.gwa_ytilt = 0.0001
+        image.meta.instrument.gwa_tilt = 37.0610
 
-    image.save(filename)
+        image.save(filename)
+
     return filename
 
 
@@ -230,21 +231,22 @@ def test_nrc_wfss_background(filters, pupils, detectors, make_wfss_datamodel):
 
     # Get References
     wavelenrange = Step().get_reference_file(wcs_corrected, "wavelengthrange")
+    bkg_file = Step().get_reference_file(wcs_corrected, 'wfssbkg')
+
     mask = mask_from_source_cat(wcs_corrected, wavelenrange)
 
-    bkg_file = Step().get_reference_file(wcs_corrected, 'wfssbkg')
-    bkg_ref = datamodels.open(bkg_file)
-    bkg_ref = no_NaN(bkg_ref)
+    with datamodels.open(bkg_file) as bkg_ref:
+        bkg_ref = no_NaN(bkg_ref)
 
-    # calculate backgrounds
-    pipeline_data_mean = robust_mean(wcs_corrected.data[mask])
-    test_data_mean,_,_ = sigma_clipped_stats(wcs_corrected.data, sigma=2)
+        # calculate backgrounds
+        pipeline_data_mean = robust_mean(wcs_corrected.data[mask])
+        test_data_mean,_,_ = sigma_clipped_stats(wcs_corrected.data, sigma=2)
 
-    pipeline_reference_mean = robust_mean(bkg_ref.data[mask])
-    test_reference_mean,_,_ = sigma_clipped_stats(bkg_ref.data, sigma=2)
+        pipeline_reference_mean = robust_mean(bkg_ref.data[mask])
+        test_reference_mean,_,_ = sigma_clipped_stats(bkg_ref.data, sigma=2)
 
-    assert np.isclose([pipeline_data_mean], [test_data_mean], rtol=1e-3)
-    assert np.isclose([pipeline_reference_mean], [test_reference_mean], rtol=1e-1)
+        assert np.isclose([pipeline_data_mean], [test_data_mean], rtol=1e-3)
+        assert np.isclose([pipeline_reference_mean], [test_reference_mean], rtol=1e-1)
 
 
 @pytest.mark.parametrize("filters", ['GR150C', 'GR150R'])

--- a/jwst/cube_skymatch/cube_skymatch_step.py
+++ b/jwst/cube_skymatch/cube_skymatch_step.py
@@ -50,8 +50,8 @@ class CubeSkyMatchStep(Step):
     reference_file_types = []
 
     def process(self, input1, input2):
-        cube_models = datamodels.ModelContainer(input1, persist=False)
-        models2d = datamodels.ModelContainer(input2, persist=False)
+        cube_models = datamodels.ModelContainer(input1)
+        models2d = datamodels.ModelContainer(input2)
         dqbits = interpret_bit_flags(self.dqbits)
 
         # set sky stattistics:

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -299,11 +299,6 @@ class ModelContainer(model_base.DataModel):
 
         return output_paths
 
-    def close(self):
-        for model in self._models:
-            model.close()
-
-
     def _assign_group_ids(self):
         """
         Assign an ID grouping by exposure.

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -81,22 +81,23 @@ class ModelContainer(model_base.DataModel):
         self._models = []
         self.asn_exptypes = asn_exptypes
         self.asn_n_members = asn_n_members
+        self._memmap = kwargs.get("memmap", False)
 
         if init is None:
             # Don't populate the container with models
             pass
         elif isinstance(init, fits.HDUList):
-            self._models.append([datamodel_open(init)])
+            self._models.append([datamodel_open(init, memmap=self._memmap)])
         elif isinstance(init, list):
             if all(isinstance(x, (str, fits.HDUList, model_base.DataModel)) for x in init):
                 # Try opening the list as datamodels
                 try:
-                    init = [datamodel_open(m) for m in init]
+                    init = [datamodel_open(m, memmap=self._memmap) for m in init]
                 except (FileNotFoundError, ValueError):
                     raise
             else:
-                raise TypeError("list must contain items that can be opened"
-                                "DataModels.open()")
+                raise TypeError("list must contain items that can be opened "
+                                "with jwst.datamodels.open()")
             self._models = init
         elif isinstance(init, self.__class__):
             instance = copy.deepcopy(init._instance)
@@ -220,7 +221,7 @@ class ModelContainer(model_base.DataModel):
         else:
             sublist = infiles
         try:
-            self._models = [datamodel_open(infile) for infile in sublist]
+            self._models = [datamodel_open(infile, memmap=self._memmap) for infile in sublist]
         except IOError:
             raise IOError('Cannot open {}'.format(infiles))
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -88,14 +88,15 @@ class ModelContainer(model_base.DataModel):
         elif isinstance(init, fits.HDUList):
             self._models.append([datamodel_open(init)])
         elif isinstance(init, list):
-            if all(isinstance(x, (str, fits.HDUList)) for x in init):
-                # Try opening the list of files as datamodels
+            if all(isinstance(x, (str, fits.HDUList, model_base.DataModel)) for x in init):
+                # Try opening the list as datamodels
                 try:
                     init = [datamodel_open(m) for m in init]
                 except (FileNotFoundError, ValueError):
                     raise
-            elif not all(isinstance(x, model_base.DataModel) for x in init):
-                raise TypeError('list must contain DataModels')
+            else:
+                raise TypeError("list must contain items that can be opened"
+                                "DataModels.open()")
             self._models = init
         elif isinstance(init, self.__class__):
             instance = copy.deepcopy(init._instance)
@@ -296,6 +297,11 @@ class ModelContainer(model_base.DataModel):
                 output_paths.append(save_model_func(model, idx=idx))
 
         return output_paths
+
+    def close(self):
+        for model in self._models:
+            model.close()
+
 
     def _assign_group_ids(self):
         """

--- a/jwst/datamodels/dynamicdq.py
+++ b/jwst/datamodels/dynamicdq.py
@@ -4,20 +4,19 @@ from . import dqflags
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-log.addHandler(logging.NullHandler())
+
 
 def dynamic_mask(input_model):
-    #
-    # Return a mask model given a mask with dynamic DQ flags
-    # Dynamic flags define what each plane refers to using the DQ_DEF extension
+    """Return a mask model given a mask with dynamic DQ flags
 
+    Dynamic flags define what each plane refers to using the DQ_DEF extension
+    """
     dq_table = input_model.dq_def
+
     # Get the DQ array and the flag definitions
-    if (dq_table is not None and
-        not np.isscalar(dq_table) and
-        len(dq_table.shape) and
-        len(dq_table)):
-        #
+    if (dq_table is not None and not np.isscalar(dq_table) and
+        len(dq_table.shape) and len(dq_table)):
+
         # Make an empty mask
         dqmask = np.zeros(input_model.dq.shape, dtype=input_model.dq.dtype)
         for record in dq_table:
@@ -26,7 +25,8 @@ def dynamic_mask(input_model):
             try:
                 standard_bitvalue = dqflags.pixel[dqname]
             except KeyError:
-                log.warning('Keyword %s does not correspond to an existing DQ mnemonic, so will be ignored' % (dqname))
+                log.warning('Keyword %s does not correspond to an existing '
+                    'DQ mnemonic, so will be ignored' % (dqname))
                 continue
             just_this_bit = np.bitwise_and(input_model.dq, bitplane)
             pixels = np.where(just_this_bit != 0)

--- a/jwst/datamodels/dynamicdq.py
+++ b/jwst/datamodels/dynamicdq.py
@@ -4,19 +4,20 @@ from . import dqflags
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-
+log.addHandler(logging.NullHandler())
 
 def dynamic_mask(input_model):
-    """Return a mask model given a mask with dynamic DQ flags
+    #
+    # Return a mask model given a mask with dynamic DQ flags
+    # Dynamic flags define what each plane refers to using the DQ_DEF extension
 
-    Dynamic flags define what each plane refers to using the DQ_DEF extension
-    """
     dq_table = input_model.dq_def
-
     # Get the DQ array and the flag definitions
-    if (dq_table is not None and not np.isscalar(dq_table) and
-        len(dq_table.shape) and len(dq_table)):
-
+    if (dq_table is not None and
+        not np.isscalar(dq_table) and
+        len(dq_table.shape) and
+        len(dq_table)):
+        #
         # Make an empty mask
         dqmask = np.zeros(input_model.dq.shape, dtype=input_model.dq.dtype)
         for record in dq_table:
@@ -25,8 +26,7 @@ def dynamic_mask(input_model):
             try:
                 standard_bitvalue = dqflags.pixel[dqname]
             except KeyError:
-                log.warning('Keyword %s does not correspond to an existing '
-                    'DQ mnemonic, so will be ignored' % (dqname))
+                log.warning('Keyword %s does not correspond to an existing DQ mnemonic, so will be ignored' % (dqname))
                 continue
             just_this_bit = np.bitwise_and(input_model.dq, bitplane)
             pixels = np.where(just_this_bit != 0)

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -162,15 +162,17 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             if file_type == "fits":
                 if s3_utils.is_s3_uri(init):
-                    hdulist = fits.open(s3_utils.get_object(init))
+                    init_fitsopen = s3_utils.get_object(init)
+                    memmap = None
                 else:
-                    hdulist = fits.open(init, memmap=memmap)
+                    init_fitsopen = init
 
-                asdffile = fits_support.from_fits(hdulist,
-                                              self._schema,
-                                              self._ctx,
-                                              **kwargs)
-                self._files_to_close.append(hdulist)
+                with fits.open(init_fitsopen, memmap=memmap) as hdulist:
+                    asdffile = fits_support.from_fits(hdulist,
+                                                  self._schema,
+                                                  self._ctx,
+                                                  **kwargs)
+                    self._files_to_close.append(hdulist)
 
             elif file_type == "asdf":
                 asdffile = self.open_asdf(init=init, **kwargs)

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -17,7 +17,6 @@ from . import schema as mschema
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-log.addHandler(logging.NullHandler())
 
 __all__ = ['ObjectNode', 'ListNode']
 
@@ -255,7 +254,7 @@ class Node():
         self._name = attr
         self._instance = instance
         self._schema = schema
-        self._schema['$schema'] = 'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'
+        self._schema['$schema'] = 'http://stsci.edu/schemas/asdf/asdf-schema-1.0.0'
         self._ctx = ctx
 
     def _validate(self):

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -17,6 +17,8 @@ from . import schema as mschema
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+log.addHandler(logging.NullHandler())
+
 
 __all__ = ['ObjectNode', 'ListNode']
 
@@ -254,7 +256,6 @@ class Node():
         self._name = attr
         self._instance = instance
         self._schema = schema
-        self._schema['$schema'] = 'http://stsci.edu/schemas/asdf/asdf-schema-1.0.0'
         self._ctx = ctx
 
     def _validate(self):

--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import tempfile
-import gc
 
 import pytest
 
@@ -238,10 +237,9 @@ def test_metadata_doesnt_override():
     from astropy.io import fits
     with fits.open(TMP_FITS, mode='update', memmap=False) as hdulist:
         hdulist[0].header['FILTER'] = 'F150W2'
-        hdulist.close()
 
-        with ImageModel(TMP_FITS) as dm:
-            assert dm.meta.instrument.filter == 'F150W2'
+    with ImageModel(TMP_FITS) as dm:
+        assert dm.meta.instrument.filter == 'F150W2'
 
 
 def test_table_with_metadata():

--- a/jwst/datamodels/tests/test_history.py
+++ b/jwst/datamodels/tests/test_history.py
@@ -72,23 +72,23 @@ def test_history_from_model_to_fits():
     }))
     m.save(TMP_FITS)
 
-    hdulist = fits.open(TMP_FITS)
-    assert list(hdulist[0].header['HISTORY']) == ["First entry", "Second entry"]
-    hdulist.close()
+    with fits.open(TMP_FITS, memmap=False) as hdulist:
+        assert list(hdulist[0].header['HISTORY']) == ["First entry", 
+                                                      "Second entry"]
 
-    m = DataModel(TMP_FITS)
-    m2 = DataModel()
-    m2.update(m)
-    m2.history = m.history
+    with DataModel(TMP_FITS) as m2:
+        m2 = DataModel()
+        m2.update(m)
+        m2.history = m.history
 
-    assert m2.history == [{'description': "First entry"},
-                          {'description': "Second entry"}]
+        assert m2.history == [{'description': "First entry"},
+                              {'description': "Second entry"}]
 
-    m2.save(TMP_FITS)
+        m2.save(TMP_FITS)
 
-    hdulist = fits.open(TMP_FITS)
-    assert list(hdulist[0].header['HISTORY']) == ["First entry", "Second entry"]
-    hdulist.close()
+    with fits.open(TMP_FITS, memmap=False) as hdulist:
+        assert list(hdulist[0].header['HISTORY']) == ["First entry",
+                                                      "Second entry"]
 
 
 def test_history_from_fits():
@@ -97,17 +97,16 @@ def test_history_from_fits():
     header['HISTORY'] = "Second entry"
     fits.writeto(TMP_FITS, np.array([]), header, overwrite=True)
 
-    m = DataModel(TMP_FITS)
-    assert m.history == [{'description': 'First entry'},
-                         {'description': 'Second entry'}]
+    with DataModel(TMP_FITS) as m:
+        assert m.history == [{'description': 'First entry'},
+                             {'description': 'Second entry'}]
 
-    del m.history[0]
-    m.history.append(HistoryEntry({'description': "Third entry"}))
-    assert m.history == [{'description': "Second entry"},
-                         {'description': "Third entry"}]
+        del m.history[0]
+        m.history.append(HistoryEntry({'description': "Third entry"}))
+        assert m.history == [{'description': "Second entry"},
+                             {'description': "Third entry"}]
+        m.save(TMP_FITS)
 
-    m.save(TMP_FITS)
-
-    m = DataModel(TMP_FITS)
-    assert m.history == [{'description': "Second entry"},
-                         {'description': "Third entry"}]
+    with DataModel(TMP_FITS) as m:
+        assert m.history == [{'description': "Second entry"},
+                             {'description': "Third entry"}]

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -522,7 +522,7 @@ def test_update_from_dict(tmpdir):
         assert "CRVAL1" in hdulist[1].header
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def container():
     warnings.simplefilter("ignore")
     asn_file_path, asn_file_name = op.split(ASN_FILE)

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -522,7 +522,7 @@ def test_update_from_dict(tmpdir):
         assert "CRVAL1" in hdulist[1].header
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def container():
     warnings.simplefilter("ignore")
     asn_file_path, asn_file_name = op.split(ASN_FILE)
@@ -544,37 +544,38 @@ def container():
 def test_modelcontainer_iteration(container):
     for model in container:
         assert model.meta.telescope == 'JWST'
+    container.close()
 
 
 def test_modelcontainer_indexing(container):
     assert isinstance(container[0], DataModel)
+    container.close()
 
 
 def test_modelcontainer_group1(container):
-    reset_group_id(container)
     for group in container.models_grouped:
         assert len(group) == 2
         for model in group:
             pass
+    container.close()
 
 
 def test_modelcontainer_group2(container):
-    reset_group_id(container)
     container[0].meta.observation.exposure_number = '2'
     for group in container.models_grouped:
         assert len(group) == 1
         for model in group:
             pass
     container[0].meta.observation.exposure_number = '1'
+    container.close()
 
 
 def test_modelcontainer_group_names(container):
-    reset_group_id(container)
     assert len(container.group_names) == 1
     reset_group_id(container)
     container[0].meta.observation.exposure_number = '2'
     assert len(container.group_names) == 2
-    container[0].meta.observation.exposure_number = '1'
+    container.close()
 
 
 def test_object_node_iterator():

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -20,10 +20,11 @@ from jwst import datamodels
 def test_open_fits():
     """Test opening a model from a FITS file"""
 
-    warnings.simplefilter("ignore")
-    fits_file = t_path('test.fits')
-    with datamodels.open(fits_file) as model:
-        assert isinstance(model, DataModel)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "model_type not found")
+        fits_file = t_path('test.fits')
+        with datamodels.open(fits_file) as model:
+            assert isinstance(model, DataModel)
 
 
 def test_open_fits_s3(s3_root_dir):
@@ -81,10 +82,11 @@ def test_open_hdulist():
 
 
 def test_open_image():
-    warnings.simplefilter("ignore")
-    image_name = t_path('jwst_image.fits')
-    with datamodels.open(image_name) as model:
-        assert type(model) == ImageModel
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "model_type not found")
+        image_name = t_path('jwst_image.fits')
+        with datamodels.open(image_name) as model:
+            assert type(model) == ImageModel
 
 
 def test_open_reference_files():
@@ -94,32 +96,33 @@ def test_open_reference_files():
              'nircam_gain.fits' : GainModel,
              'nircam_readnoise.fits' : ReadnoiseModel}
 
-    warnings.simplefilter("ignore")
-    for base_name, klass in files.items():
-        file = t_path(base_name)
-        model = datamodels.open(file)
-        if model.shape:
-            ndim = len(model.shape)
-        else:
-            ndim = 0
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "model_type not found")
+        for base_name, klass in files.items():
+            file = t_path(base_name)
+            model = datamodels.open(file)
+            if model.shape:
+                ndim = len(model.shape)
+            else:
+                ndim = 0
 
-        if ndim == 0:
-            my_klass = ReferenceFileModel
-        elif ndim == 2:
-            my_klass = ReferenceImageModel
-        elif ndim == 3:
-            my_klass = ReferenceCubeModel
-        elif ndim == 4:
-            my_klass = ReferenceQuadModel
-        else:
-            my_klass = None
+            if ndim == 0:
+                my_klass = ReferenceFileModel
+            elif ndim == 2:
+                my_klass = ReferenceImageModel
+            elif ndim == 3:
+                my_klass = ReferenceCubeModel
+            elif ndim == 4:
+                my_klass = ReferenceQuadModel
+            else:
+                my_klass = None
 
-        assert isinstance(model, my_klass)
-        model.close()
+            assert isinstance(model, my_klass)
+            model.close()
 
-        model = klass(file)
-        assert isinstance(model, klass)
-        model.close()
+            model = klass(file)
+            assert isinstance(model, klass)
+            model.close()
 
 
 def test_open_fits_readonly(tmpdir):

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -10,11 +10,10 @@ import pytest
 import numpy as np
 from astropy.io import fits
 
-from ..util import open
-from .. import (DataModel, ModelContainer, ImageModel, ReferenceFileModel,
-                ReferenceImageModel, ReferenceCubeModel, ReferenceQuadModel,
-                FlatModel, MaskModel, NrcImgPhotomModel, GainModel,
-                ReadnoiseModel, DistortionModel)
+from jwst.datamodels import (DataModel, ModelContainer, ImageModel,
+    ReferenceFileModel, ReferenceImageModel, ReferenceCubeModel,
+    ReferenceQuadModel, FlatModel, MaskModel, NircamPhotomModel, GainModel,
+    ReadnoiseModel, DistortionModel)
 from jwst import datamodels
 
 
@@ -23,8 +22,9 @@ def test_open_fits():
 
     warnings.simplefilter("ignore")
     fits_file = t_path('test.fits')
-    with open(fits_file) as model:
+    with datamodels.open(fits_file) as model:
         assert isinstance(model, DataModel)
+
 
 def test_open_fits_s3(s3_root_dir):
     """Test opening a model from a FITS file on S3"""
@@ -32,8 +32,9 @@ def test_open_fits_s3(s3_root_dir):
     with DataModel() as dm:
         dm.save(path)
 
-    m = open("s3://test-s3-data/test.fits")
-    assert isinstance(m, DataModel)
+    with datamodels.open("s3://test-s3-data/test.fits") as m:
+        assert isinstance(m, DataModel)
+
 
 def test_open_asdf_s3(s3_root_dir):
     """Test opening a model from an ASDF file on S3"""
@@ -41,8 +42,9 @@ def test_open_asdf_s3(s3_root_dir):
     with DataModel() as dm:
         dm.save(path)
 
-    m = open("s3://test-s3-data/test.asdf")
-    assert isinstance(m, DataModel)
+    with datamodels.open("s3://test-s3-data/test.asdf") as m:
+        assert isinstance(m, DataModel)
+
 
 def test_open_association():
     """Test for opening an association"""
@@ -50,18 +52,21 @@ def test_open_association():
     asn_file = t_path('association.json')
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "model_type not found")
-        with open(asn_file) as c:
+        with datamodels.open(asn_file) as c:
             assert isinstance(c, ModelContainer)
+
 
 def test_open_shape():
     init = (200, 200)
-    with open(init) as model:
+    with datamodels.open(init) as model:
         assert type(model) == ImageModel
+
 
 def test_open_illegal():
     with pytest.raises(ValueError):
         init = 5
-        open(init)
+        datamodels.open(init)
+
 
 def test_open_hdulist():
     hdulist = fits.HDUList()
@@ -71,13 +76,14 @@ def test_open_hdulist():
     science = fits.ImageHDU(data=data, name='SCI')
     hdulist.append(science)
 
-    with open(hdulist) as model:
+    with datamodels.open(hdulist) as model:
         assert type(model) == ImageModel
+
 
 def test_open_image():
     warnings.simplefilter("ignore")
     image_name = t_path('jwst_image.fits')
-    with open(image_name) as model:
+    with datamodels.open(image_name) as model:
         assert type(model) == ImageModel
 
 
@@ -91,7 +97,7 @@ def test_open_reference_files():
     warnings.simplefilter("ignore")
     for base_name, klass in files.items():
         file = t_path(base_name)
-        model = open(file)
+        model = datamodels.open(file)
         if model.shape:
             ndim = len(model.shape)
         else:
@@ -115,6 +121,7 @@ def test_open_reference_files():
         assert isinstance(model, klass)
         model.close()
 
+
 def test_open_fits_readonly(tmpdir):
     """Test opening a FITS-format datamodel that is read-only on disk"""
     tmpfile = str(tmpdir.join('readonly.fits'))
@@ -132,6 +139,7 @@ def test_open_fits_readonly(tmpdir):
 
     with datamodels.open(tmpfile) as model:
         assert model.meta.telescope == 'JWST'
+
 
 def test_open_asdf_readonly(tmpdir):
     tmpfile = str(tmpdir.join('readonly.asdf'))

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 
 from jwst.datamodels import (DataModel, ModelContainer, ImageModel,
     ReferenceFileModel, ReferenceImageModel, ReferenceCubeModel,
-    ReferenceQuadModel, FlatModel, MaskModel, NircamPhotomModel, GainModel,
+    ReferenceQuadModel, FlatModel, MaskModel, NrcImgPhotomModel, GainModel,
     ReadnoiseModel, DistortionModel)
 from jwst import datamodels
 

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -23,8 +23,8 @@ def test_open_fits():
 
     warnings.simplefilter("ignore")
     fits_file = t_path('test.fits')
-    m = open(fits_file)
-    assert isinstance(m, DataModel)
+    with open(fits_file) as model:
+        assert isinstance(model, DataModel)
 
 def test_open_fits_s3(s3_root_dir):
     """Test opening a model from a FITS file on S3"""
@@ -50,14 +50,13 @@ def test_open_association():
     asn_file = t_path('association.json')
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "model_type not found")
-        m = open(asn_file)
-    assert isinstance(m, ModelContainer)
+        with open(asn_file) as c:
+            assert isinstance(c, ModelContainer)
 
 def test_open_shape():
     init = (200, 200)
-    model = open(init)
-    assert type(model) == ImageModel
-    model.close()
+    with open(init) as model:
+        assert type(model) == ImageModel
 
 def test_open_illegal():
     with pytest.raises(ValueError):
@@ -72,16 +71,14 @@ def test_open_hdulist():
     science = fits.ImageHDU(data=data, name='SCI')
     hdulist.append(science)
 
-    model = open(hdulist)
-    assert type(model) == ImageModel
-    model.close()
+    with open(hdulist) as model:
+        assert type(model) == ImageModel
 
 def test_open_image():
     warnings.simplefilter("ignore")
     image_name = t_path('jwst_image.fits')
-    model = open(image_name)
-    assert type(model) == ImageModel
-    model.close()
+    with open(image_name) as model:
+        assert type(model) == ImageModel
 
 
 def test_open_reference_files():

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -614,8 +614,8 @@ def test_validate_transform_from_file():
     Tests that custom types, like transform, can be validated.
     """
     fname = os.path.join(os.path.dirname(__file__), 'data', 'collimator_fake.asdf')
-    m = CollimatorModel(fname, strict_validation=True)
-    m.validate()
+    with CollimatorModel(fname, strict_validation=True) as m:
+        m.validate()
 
 
 def test_multislit_append_string():

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -14,7 +14,6 @@ from ..lib import s3_utils
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-log.addHandler(logging.NullHandler())
 
 class NoTypeWarning(Warning):
     pass
@@ -431,7 +430,7 @@ def create_history_entry(description, software=None):
     import datetime
 
     if isinstance(software, list):
-            software = [Software(x) for x in software]
+        software = [Software(x) for x in software]
     elif software is not None:
         software = Software(software)
 

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -14,6 +14,8 @@ from ..lib import s3_utils
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+log.addHandler(logging.NullHandler())
+
 
 class NoTypeWarning(Warning):
     pass

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -1,6 +1,6 @@
-from ... import (Pipeline, Step)
-from .... import datamodels
-from ....datamodels import (
+from jwst.stpipe import (Pipeline, Step)
+from jwst import datamodels
+from jwst.datamodels import (
     ImageModel,
     ModelContainer,
 )
@@ -139,12 +139,12 @@ class SaveStep(Step):
     """
 
     def process(self, *args):
-        model = ImageModel(args[0])
+        with ImageModel(args[0]) as model:
 
-        self.log.info('Saving model as "processed"')
-        self.save_model(model, 'processed')
+            self.log.info('Saving model as "processed"')
+            self.save_model(model, 'processed')
 
-        return model
+            return model
 
 
 class StepWithContainer(Step):

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -173,8 +173,8 @@ class StepWithModel(Step):
 
     def process(self, *args):
         with self.open_model(args[0]) as input_path:
-            model = ImageModel(input_path)
-        return model
+            with ImageModel(input_path) as model:
+                return model
 
 
 class EmptyPipeline(Pipeline):

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -55,6 +55,7 @@ def test_default_input_dir(mk_tmp_dirs):
     # Check that `input_dir` is set.
     input_path = path.split(input_file)[0]
     assert step.input_dir == input_path
+    step.closeout()
 
     step.closeout()
 

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -6,9 +6,9 @@ import pytest
 from .steps import StepWithModel
 from .util import t_path
 
-from ..step import Step
-from ...datamodels import (DataModel, ModelContainer)
-from ...datamodels import open as dm_open
+from jwst.stpipe import Step
+from jwst.datamodels import (DataModel, ModelContainer)
+from jwst import datamodels
 
 
 def test_default_input_with_container(mk_tmp_dirs):
@@ -25,7 +25,7 @@ def test_default_input_with_container(mk_tmp_dirs):
 def test_default_input_with_full_model():
     """Test default input name retrieval with actual model"""
     model_path = t_path('data/flat.fits')
-    with dm_open(model_path) as model:
+    with datamodels.open(model_path) as model:
         step = StepWithModel()
         step.run(model)
 
@@ -55,9 +55,6 @@ def test_default_input_dir(mk_tmp_dirs):
     # Check that `input_dir` is set.
     input_path = path.split(input_file)[0]
     assert step.input_dir == input_path
-    step.closeout()
-
-    step.closeout()
 
 
 def test_set_input_dir(mk_tmp_dirs):
@@ -72,8 +69,6 @@ def test_set_input_dir(mk_tmp_dirs):
 
     # Check that `input_dir` is set.
     assert step.input_dir == 'junkdir'
-
-    step.closeout()
 
 
 def test_use_input_dir(mk_tmp_dirs):
@@ -90,8 +85,6 @@ def test_use_input_dir(mk_tmp_dirs):
     # Check that `input_dir` is set.
     assert step.input_dir == input_dir
 
-    step.closeout()
-
 
 def test_fail_input_dir(mk_tmp_dirs):
     """Fail with a bad file path"""
@@ -106,7 +99,7 @@ def test_fail_input_dir(mk_tmp_dirs):
 
 def test_input_dir_with_model(mk_tmp_dirs):
     """Use with an already opened DataModel"""
-    with dm_open(t_path('data/flat.fits')) as model:
+    with datamodels.open(t_path('data/flat.fits')) as model:
         step = StepWithModel()
         step.run(model)
 

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -15,24 +15,21 @@ def test_default_input_with_container(mk_tmp_dirs):
     """Test default input name from a ModelContainer"""
 
     model_path = t_path('data/flat.fits')
-    model = dm_open(model_path)
-    container = ModelContainer([model])
+    with ModelContainer([model_path]) as container:
+        step = StepWithModel()
+        step.run(container)
 
-    step = StepWithModel()
-    step.run(container)
-
-    assert step._input_filename is None
+        assert step._input_filename is None
 
 
 def test_default_input_with_full_model():
     """Test default input name retrieval with actual model"""
     model_path = t_path('data/flat.fits')
-    model = dm_open(model_path)
+    with dm_open(model_path) as model:
+        step = StepWithModel()
+        step.run(model)
 
-    step = StepWithModel()
-    step.run(model)
-
-    assert step._input_filename == model.meta.filename
+        assert step._input_filename == model.meta.filename
 
 
 def test_default_input_with_new_model():
@@ -112,4 +109,4 @@ def test_input_dir_with_model(mk_tmp_dirs):
         step = StepWithModel()
         step.run(model)
 
-    assert step.input_dir == ''
+        assert step.input_dir == ''

--- a/jwst/stpipe/tests/test_logger.py
+++ b/jwst/stpipe/tests/test_logger.py
@@ -1,4 +1,5 @@
 import io
+import logging
 
 import pytest
 
@@ -30,6 +31,8 @@ format = '%(message)s'
 
     with pytest.raises(stpipe_log.LoggedException):
         log.critical("Breaking")
+
+    logging.shutdown()
 
     with open(logfilename, 'r') as fd:
         lines = [x.strip() for x in fd.readlines()]

--- a/jwst/stpipe/tests/test_pipeline.py
+++ b/jwst/stpipe/tests/test_pipeline.py
@@ -101,13 +101,15 @@ class MyPipeline(Pipeline):
         self.display(combined)
         dm = datamodels.ImageModel(combined)
         dm.save(self.output_filename)
+        science.close()
+        flat.close()
         return dm
 
 
-def test_pipeline():
+def test_pipeline(tmpdir):
     pipeline_fn = join(dirname(__file__), 'steps', 'python_pipeline.cfg')
     pipe = Step.from_config_file(pipeline_fn)
-    pipe.output_filename = "output.fits"
+    pipe.output_filename = tmpdir.join("output.fits")
 
     assert pipe.flat_field.threshold == 42.0
     assert pipe.flat_field.multiplier == 2.0

--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -43,7 +43,8 @@ def test_save_step_default(mk_tmp_dirs):
         data_fn_path
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
+    step.closeout()
 
     fname = 'flat_stepwithmodel.fits'
     assert path.isfile(fname)

--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -62,7 +62,8 @@ def test_save_step_withoutput(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
+    step.closeout()
 
     output_path, output_ext = path.splitext(output_file)
     assert path.isfile(output_path + '_stepwithmodel' + output_ext)
@@ -81,7 +82,8 @@ def test_save_step_withoutputsuffix(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
+    step.closeout()
 
     assert path.isfile(actual_output_file)
 
@@ -96,7 +98,8 @@ def test_save_step_withdir(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
+    step.closeout()
 
     output_fn_path = path.join(
         tmp_data_path,
@@ -117,7 +120,8 @@ def test_save_step_withdir_environment(mk_tmp_dirs):
         '--output_dir=$TSSWE_OUTPATH'
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
+    step.closeout()
 
     output_fn_path = path.join(
         tmp_data_path,
@@ -139,7 +143,8 @@ def test_save_step_withdir_withoutput(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    Step.from_cmdline(args)
+    step = Step.from_cmdline(args)
+    step.closeout()
 
     output_path, output_ext = path.splitext(output_file)
     output_fn_path = path.join(

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -81,12 +81,10 @@ def test_parameters_from_crds():
 
 def test_parameters_from_crds_fail():
     """Test retrieval of parameters from CRDS"""
-    data = datamodels.open(t_path(join('data', 'miri_data.fits')))
-    data.meta.instrument.name = 'NIRSPEC'
-    pars = RefPixStep.get_config_from_reference(data)
-    assert not len(pars)
-
-    data.close()
+    with datamodels.open(t_path(join('data', 'miri_data.fits'))) as data:
+        data.meta.instrument.name = 'NIRSPEC'
+        pars = RefPixStep.get_config_from_reference(data)
+        assert not len(pars)
 
 
 @pytest.mark.parametrize(

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ results_root = jwst-pipeline-results
 doctest_plus = true
 doctest_rst = true
 text_file_format = rst
-addopts = --no-print-logs
+addopts = --show-capture=no --open-files
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
This PR is for a branch started a year ago.  I've rebased it and added a few fixes to it, so it is complimentary to #4731 I think.  @jwhite3 have a look.  I don't think it solves the regression test pipeline issues, but it does resolve the unit test issues and allows turning on the `pytest-openfiles` plugin.

Resolves #4737 