### PR TITLE
Fix string escape and assert_allclose deprecations

### DIFF
--- a/jwst/assign_wcs/tests/test_miri.py
+++ b/jwst/assign_wcs/tests/test_miri.py
@@ -9,7 +9,7 @@ Notes:
 import numpy as np
 from astropy.io import fits
 from gwcs import wcs
-from numpy.testing import utils
+from numpy.testing import assert_allclose
 
 from ...datamodels.image import ImageModel
 from .. import miri
@@ -87,26 +87,26 @@ def run_test(model):
         for i, s in enumerate(ref_data['s']):
             sl = int(ch) * 100 + s
             alpha, beta, lam = detector_to_alpha_beta.set_input(sl)(x[i], y[i])
-            utils.assert_allclose(alpha, ref_alpha[i], atol=0.05)
-            utils.assert_allclose(beta, ref_beta[i], atol=0.05)
-            utils.assert_allclose(lam, ref_lam[i], atol=0.05)
+            assert_allclose(alpha, ref_alpha[i], atol=0.05)
+            assert_allclose(beta, ref_beta[i], atol=0.05)
+            assert_allclose(lam, ref_lam[i], atol=0.05)
 
         v2, v3, lam = ab_to_v2v3(ref_alpha, ref_beta, ref_lam)
-        utils.assert_allclose(v2, ref_v2, atol=0.05)
-        utils.assert_allclose(v3, ref_v3, atol=0.05)
-        utils.assert_allclose(lam, ref_lam, atol=0.05)
+        assert_allclose(v2, ref_v2, atol=0.05)
+        assert_allclose(v3, ref_v3, atol=0.05)
+        assert_allclose(lam, ref_lam, atol=0.05)
 
         # Test the reverse transform
         alpha_back, beta_back, lam_back = v2v3_to_ab(v2,v3,lam)
-        utils.assert_allclose(alpha_back, ref_alpha, atol=0.05)
-        utils.assert_allclose(beta_back, ref_beta, atol=0.05)
-        utils.assert_allclose(lam_back, ref_lam, atol=0.05)
+        assert_allclose(alpha_back, ref_alpha, atol=0.05)
+        assert_allclose(beta_back, ref_beta, atol=0.05)
+        assert_allclose(lam_back, ref_lam, atol=0.05)
 
         for i, s in enumerate(ref_data['s']):
             sl = int(ch) * 100 + s
             x_back, y_back = ab_to_detector.set_input(sl)(alpha_back[i],beta_back[i],lam_back[i])
-            utils.assert_allclose(x_back, x[i], atol=0.08)
-            utils.assert_allclose(y_back, y[i], atol=0.08)
+            assert_allclose(x_back, x[i], atol=0.08)
+            assert_allclose(y_back, y[i], atol=0.08)
 
 
 def test_miri_mrs_12A():

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -8,7 +8,7 @@ of the results is verified by the team based on the specwcs reference
 file.
 
 """
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 import pytest
 
 

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -2,22 +2,24 @@
 Test functions for NIRSPEC WCS - all modes.
 """
 import os.path
+
+import pytest
 import numpy as np
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.modeling import models as astmodels
 from astropy import wcs as astwcs
 import astropy.units as u
 import astropy.coordinates as coords
 from gwcs import wcs
-from ... import datamodels
-from ...transforms.models import Slit
-from .. import nirspec
-from .. import assign_wcs_step
-from . import data
-from ..util import MSAFileError
 
-import pytest
+from jwst import datamodels
+from jwst.transforms.models import Slit
+from jwst.assign_wcs import nirspec
+from jwst.assign_wcs import assign_wcs_step
+from . import data
+from jwst.assign_wcs.util import MSAFileError
+
 
 data_path = os.path.split(os.path.abspath(data.__file__))[0]
 

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy.testing import utils
+from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy import wcs
 from astropy.tests.helper import  assert_quantity_allclose
@@ -61,7 +61,7 @@ def test_roll_angle():
     v2 = .01 # in arcsec
     v3 = .01 # in arcsec
     roll_angle = pointing.compute_roll_ref(v2_ref, v3_ref, r0, ra_ref, dec_ref, v2, v3)
-    utils.assert_allclose(roll_angle, r0, atol=1e-3)
+    assert_allclose(roll_angle, r0, atol=1e-3)
 
 
 def test_v23_to_sky():
@@ -81,7 +81,7 @@ def test_v23_to_sky():
     axes = "zyxyz"
     v2s = models.V23ToSky(angles, axes_order=axes)
     radec = v2s(v2, v3)
-    utils.assert_allclose(radec, expected_ra_dec, atol=1e-10)
+    assert_allclose(radec, expected_ra_dec, atol=1e-10)
 
 
 def test_frame_from_model(tmpdir):
@@ -90,8 +90,8 @@ def test_frame_from_model(tmpdir):
     im = _create_model_3d()
     frame = pointing.frame_from_model(im)
     radec, lam = frame.coordinates(1, 2, 3)
-    utils.assert_allclose(radec.spherical.lon.value, 1)
-    utils.assert_allclose(radec.spherical.lat.value, 2)
+    assert_allclose(radec.spherical.lon.value, 1)
+    assert_allclose(radec.spherical.lat.value, 2)
     assert_quantity_allclose(lam, 3 * u.um)
 
     # Test CompositeFrame initialization with custom frames
@@ -114,7 +114,7 @@ def test_frame_from_model(tmpdir):
 
 
 @pytest.mark.filterwarnings("ignore: The WCS transformation has more axes")
-def test_create_fitwcs(tmpdir):
+def test_create_fits_wcs(tmpdir):
     """ Test GWCS vs FITS WCS results. """
     im = _create_model_3d()
     w3d = pointing.create_fitswcs(im)
@@ -125,7 +125,7 @@ def test_create_fitwcs(tmpdir):
     w = wcs.WCS(hdu.header)
     wcel = w.sub(['celestial'])
     ra, dec = wcel.all_pix2world(1, 1, 0)
-    utils.assert_allclose((ra, dec), (gra, gdec))
+    assert_allclose((ra, dec), (gra, gdec))
 
     # test serialization
     tree = {'wcs': w3d}

--- a/jwst/associations/tests/data/rules_level3_set1.py
+++ b/jwst/associations/tests/data/rules_level3_set1.py
@@ -10,7 +10,7 @@ from jwst.associations.registry import RegistryMarker
 
 # The schema that these associations must adhere to.
 _ASN_SCHEMA_LEVEL3 = 'asn_schema_jw_level3.json'
-_DMS_POOLNAME_REGEX = 'jw(\d{5})_(\d{8}[Tt]\d{6})_pool'
+_DMS_POOLNAME_REGEX = r'jw(\d{5})_(\d{8}[Tt]\d{6})_pool'
 
 
 class DMS_Level3_Base_Set1(Association):

--- a/jwst/associations/tests/data/rules_level3_set2.py
+++ b/jwst/associations/tests/data/rules_level3_set2.py
@@ -10,7 +10,7 @@ from jwst.associations.registry import RegistryMarker
 
 # The schema that these associations must adhere to.
 _ASN_SCHEMA_LEVEL3 = 'asn_schema_jw_level3.json'
-_DMS_POOLNAME_REGEX = 'jw(\d{5})_(\d{8}[Tt]\d{6})_pool'
+_DMS_POOLNAME_REGEX = r'jw(\d{5})_(\d{8}[Tt]\d{6})_pool'
 
 
 class DMS_Level3_Base_Set2(Association):

--- a/jwst/associations/tests/test_asn_names.py
+++ b/jwst/associations/tests/test_asn_names.py
@@ -7,30 +7,30 @@ from .. import generate
 from ..main import constrain_on_candidates
 
 LEVEL3_ASN_ACID_NAME_REGEX = (
-    'jw'
-    '(?P<program>\d{5})'
-    '-(?P<acid>(o|c)\d{3,4})'
-    '_(?P<asn_type>\w+)'
-    '_(?P<sequence>\d{3})'
-    '_asn'
+    r'jw'
+    r'(?P<program>\d{5})'
+    r'-(?P<acid>(o|c)\d{3,4})'
+    r'_(?P<asn_type>\w+)'
+    r'_(?P<sequence>\d{3})'
+    r'_asn'
 )
 LEVEL3_ASN_DISCOVERED_NAME_REGEX = (
-    'jw'
-    '(?P<program>\d{5})'
-    '-(?P<acid>a\d{4})'
-    '_(?P<asn_type>\w+)'
-    '_(?P<sequence>\d{3})'
-    '_asn'
+    r'jw'
+    r'(?P<program>\d{5})'
+    r'-(?P<acid>a\d{4})'
+    r'_(?P<asn_type>\w+)'
+    r'_(?P<sequence>\d{3})'
+    r'_asn'
 )
 
 LEVEL3_ASN_WITH_VERSION = (
-    'jw'
-    '(?P<program>\d{5})'
-    '-(?P<acid>[a-z]\d{3,4})'
-    '_(?P<stamp>.+)'
-    '_(?P<asn_type>.+)'
-    '_(?P<sequence>\d{3})'
-    '_asn'
+    r'jw'
+    r'(?P<program>\d{5})'
+    r'-(?P<acid>[a-z]\d{3,4})'
+    r'_(?P<stamp>.+)'
+    r'_(?P<asn_type>.+)'
+    r'_(?P<sequence>\d{3})'
+    r'_asn'
 )
 
 all_candidates = constrain_on_candidates(None)

--- a/jwst/associations/tests/test_level2_basics.py
+++ b/jwst/associations/tests/test_level2_basics.py
@@ -14,7 +14,7 @@ from .. import (
 from ..main import Main
 
 NONSSCIENCE = ['background']
-REGEX_LEVEL2A = '(?P<path>.+)(?P<type>_rate(ints)?)(?P<extension>\..+)'
+REGEX_LEVEL2A = r'(?P<path>.+)(?P<type>_rate(ints)?)(?P<extension>\..+)'
 
 
 def from_level2_schema():

--- a/jwst/associations/tests/test_level3_spectrographic.py
+++ b/jwst/associations/tests/test_level3_spectrographic.py
@@ -49,21 +49,21 @@ class TestLevel3Spec(BasePoolRule):
         (
             'o001',
             'spec3',
-            'jw99009-o001_spec3_\d{3}_asn',
+            r'jw99009-o001_spec3_\d{3}_asn',
             'jw99009-o001_{source_id}_nirspec_f100lp-g140m-s200a2-s200a2',
             set(('science', 'target_acquisition', 'autowave'))
         ),
         (
             'o002',
             'spec3',
-            'jw99009-o002_spec3_\d{3}_asn',
+            r'jw99009-o002_spec3_\d{3}_asn',
             'jw99009-o002_{source_id}_nirspec_f100lp-g140h',
             set(('science', 'target_acquisition', 'autoflat', 'autowave'))
         ),
         (
             'o003',
             'spec3',
-            'jw99009-o003_spec3_\d{3}_asn',
+            r'jw99009-o003_spec3_\d{3}_asn',
             'jw99009-o003_t002_nirspec',
             set(('science', 'target_acquisition', 'autowave'))
         ),
@@ -100,13 +100,13 @@ def test_nirspec_modes(nirspec_params):
         (
             'o007',
             'spec3',
-            'jw99009-o007_spec3_\d{3}_asn',
+            r'jw99009-o007_spec3_\d{3}_asn',
             'jw99009-o007_t001_miri',
         ),
         (
             'o008',
             'spec3',
-            'jw99009-o008_spec3_\d{3}_asn',
+            r'jw99009-o008_spec3_\d{3}_asn',
             'jw99009-o008_t001_miri',
         ),
     ]

--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -1,11 +1,12 @@
 """
 Unit tests for background subtraction
 """
+import os
+
 from astropy.stats import sigma_clipped_stats
 import pytest
 import numpy as np
-import os
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 
 from jwst import datamodels
 from jwst.assign_wcs import AssignWcsStep
@@ -15,11 +16,14 @@ from jwst.stpipe.step import Step
 from jwst.background.background_sub import robust_mean, mask_from_source_cat, no_NaN
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 
+
 data_path = os.path.split(os.path.abspath(data_directory.__file__))[0]
+
 
 def get_file_path(filename):
     """Construct an absolute path."""
     return os.path.join(data_path, filename)
+
 
 @pytest.fixture(scope='module')
 def background(tmpdir_factory):

--- a/jwst/cube_skymatch/skycube.py
+++ b/jwst/cube_skymatch/skycube.py
@@ -44,7 +44,7 @@ class SkyCube():
                  weights=None, cube_weight=1.0,
                  bkg_deg=0, bkg_center=None,
                  id=None, meta=None):
-        """ Initializes the SkyCube object.
+        r""" Initializes the SkyCube object.
 
         Parameters
         ----------

--- a/jwst/cube_skymatch/skycube.py
+++ b/jwst/cube_skymatch/skycube.py
@@ -14,7 +14,7 @@ __all__ = ['SkyCube']
 
 
 class SkyCube():
-    """
+    r"""
     Container that holds information about properties of a *single*
     image such as:
 
@@ -39,7 +39,6 @@ class SkyCube():
     be computed as a function of world coordinates
     (:math:`\alpha`, :math:`\delta`, :math:`\lambda`) instead of the
     image/cube coordinates (x, y, z).
-
     """
     def __init__(self, data, wcs=None, wcsinfo=None,
                  weights=None, cube_weight=1.0,

--- a/jwst/datamodels/schema_editor.py
+++ b/jwst/datamodels/schema_editor.py
@@ -54,10 +54,10 @@ from urllib.parse import urlparse
 import yaml
 
 from asdf import schema as aschema
-from asdf import resolver as aresolver
 from asdf import generic_io
 from asdf import reference
 from asdf import treeutil
+from asdf.extension import get_default_resolver
 
 from . import model_base
 
@@ -386,7 +386,7 @@ class Keyword_db:
         """
         Resolve urls in the schema
         """
-        resolver = aresolver.default_url_mapping
+        resolver = get_default_resolver()
 
         def resolve_refs(node, json_id):
             if json_id is None:

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -327,7 +327,7 @@ def load_local_pkg(fpath):
     sys.path.insert(0, package_fpath)
     try:
         for module_fpath in folder_traverse(
-            fpath, basename_regex='[^_].+\.py$', path_exclude_regex='tests'
+            fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='tests'
         ):
             folder_path, fname = path.split(module_fpath[package_fpath_len:])
             module_path = folder_path.split('/')

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -26,7 +26,7 @@ log.setLevel(logging.DEBUG)
 
 
 def match(images, skymethod='global+match', match_down=True, subtract=False):
-    """
+    r"""
     A function to compute and/or "equalize" sky background in input images.
 
     .. note::
@@ -108,8 +108,7 @@ stsci_python_sphinxdocs_2.13/drizzlepac/astrodrizzle.html>`_ because it
 
     :py:func:`match` provides new algorithms for sky value computations
     and enhances previously available algorithms used by, e.g.,
-    `astrodrizzle <http://stsdas.stsci.edu/\
-stsci_python_sphinxdocs_2.13/drizzlepac/astrodrizzle.html>`_\ .
+    `astrodrizzle <http://stsdas.stsci.edu/stsci_python_sphinxdocs_2.13/drizzlepac/astrodrizzle.html>`_ .
 
     Two new methods of sky subtraction have been introduced (compared to the
     standard ``'local'``): ``'global'`` and ``'match'``, as well as a

--- a/jwst/transforms/tests/tests.py
+++ b/jwst/transforms/tests/tests.py
@@ -3,8 +3,9 @@
 Test jwst.transforms
 """
 import pytest
-from numpy.testing.utils import assert_allclose
-from ..import models
+from numpy.testing import assert_allclose
+
+from jwst.transforms import models
 
 
 #_RANDOM_SEED = 0x1337

--- a/jwst/wiimatch/lsq_optimizer.py
+++ b/jwst/wiimatch/lsq_optimizer.py
@@ -16,7 +16,7 @@ __all__ = ['build_lsq_eqs', 'pinv_solve', 'rlu_solve']
 
 def build_lsq_eqs(images, masks, sigmas, degree, center=None,
                   image2world=None, center_cs='image'):
-    """
+    r"""
     Build system of linear equations whose solution would provide image
     intensity matching in the least squares sense.
 

--- a/jwst/wiimatch/match.py
+++ b/jwst/wiimatch/match.py
@@ -21,7 +21,7 @@ SUPPORTED_SOLVERS = ['RLU', 'PINV']
 def match_lsq(images, masks=None, sigmas=None, degree=0,
               center=None, image2world=None, center_cs='image',
               ext_return=False, solver='RLU'):
-    """
+    r"""
     Compute coefficients of (multivariate) polynomials that once subtracted
     from input images would provide image intensity matching in the least
     squares sense.


### PR DESCRIPTION
This fixes `DeprecationWarnings` produced by `numpy` and `python` that we've been seeing.

```
/data1/jenkins/workspace/RT/JWST/clone/jwst/skymatch/skymatch.py:235: DeprecationWarning: invalid escape sequence \ 
  """

/data1/jenkins/workspace/RT/JWST/clone/jwst/wiimatch/match.py:173: DeprecationWarning: invalid escape sequence \s
  """

/data1/jenkins/workspace/RT/JWST/clone/jwst/wiimatch/lsq_optimizer.py:171: DeprecationWarning: invalid escape sequence \s
  """
```

```
jwst/lib/suffix.py:330
  /data1/jenkins/workspace/RT/JWST/clone/jwst/lib/suffix.py:330: DeprecationWarning: invalid escape sequence \.
    fpath, basename_regex='[^_].+\.py$', path_exclude_regex='tests'
```

```
jwst/regtest/test_schema_editor.py::test_limit_datamodels_from_file
jwst/regtest/test_schema_editor.py::test_full_run[core.schema.yaml]
  /Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/asdf/resolver.py:164: AsdfDeprecationWarning: 'default_url_mapping' is deprecated.
    warnings.warn("'default_url_mapping' is deprecated.", AsdfDeprecationWarning)
```

etc.