### PR TITLE
Pin pytest<=5.3.5 because --basetemp is broken

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ DOCS_REQUIRE = [
 ]
 TESTS_REQUIRE = [
     'ci-watson>=0.3.0',
-    'pytest',
+    'pytest<=5.3.5',
     'pytest-doctestplus',
     'requests_mock',
     'pytest-openfiles',


### PR DESCRIPTION
The newest version of Pytest `5.4.1` broke `--basetemp` when used in conjunction with `pytest-xdist`.

See https://github.com/pytest-dev/pytest/issues/6987

This PR pins it for now.  This will fix the issue of failed test artifacts not being pushed to Artifactory (and thus tests not being able to be OKified).