### PR TITLE
Repin tweakwcs==0.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
         'spherical-geometry>=1.2',
         'stsci.image>=2.3.3',
         'stsci.imagestats>=1.4',
-        'tweakwcs>=0.5.3',
+        'tweakwcs==0.5.3',
     ],
     extras_require={
         'docs': DOCS_REQUIRE,


### PR DESCRIPTION
Pinning `tweakwcs==0.5.3` as it has been until yesterday.  Yesterday we unpinned it, ran the regression tests using `tweakwcs 0.6.1` and saw errors in our regression tests.  The MIRI data failed.

https://plwishmaster.stsci.edu:8081/job/RT/job/JWST/595/testReport/junit/jwst.regtest/test_miri_image/_stable_deps__test_miri_image3_i2d/

Any ideas @mcara?

The NIRCam imaging test showed differences using the new version of `tweakwcs`

https://plwishmaster.stsci.edu:8081/job/RT/job/JWST/595/testReport/junit/jwst.regtest/test_nircam_image/_stable_deps__test_nircam_image_stage3_i2d/

But this I think is just a difference noted in the accuracy of the affine transform fit in the newer version?  The combined image looks good.

We can unpin this when the issues are sorted.  Maybe when #4542 is merged.
