### PR TITLE
Disable pytest-openfiles in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ results_root = jwst-pipeline-results
 doctest_plus = true
 doctest_rst = true
 text_file_format = rst
-addopts = --show-capture=no --open-files
+addopts = --show-capture=no
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
Turning this on in #4740 caught some open file issues in our regression tests.  This turns off the check.  Will fix the pipeline or step open file issues and only then turn on the check in setup.cfg.