### PR TITLE
Update MIRI LRS fixed-slit spec3 regtest

### DIFF
--- a/jwst/regtest/test_miri_lrs_slit_spec3.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec3.py
@@ -1,5 +1,5 @@
-""" Test for the spec3 pipeline using MIR data in LRS mode. This takes
-    the an association and generates the level 3 products."""
+""" Test of the spec3 pipeline using MIRI LRS fixed-slit exposures.
+    This takes an association and generates the level 3 products."""
 import os
 import pytest
 from astropy.io.fits.diff import FITSDiff
@@ -10,7 +10,7 @@ from jwst.stpipe import Step
 @pytest.fixture(scope="module")
 def run_pipeline(jail, rtdata_module):
     """Run the calwebb_spec3 pipeline on an ASN of nodded MIRI LRS
-       fixedslit exposures."""
+       fixed-slit exposures."""
 
     rtdata = rtdata_module
 
@@ -18,7 +18,7 @@ def run_pipeline(jail, rtdata_module):
     collect_pipeline_cfgs("config")
 
     # Get the spec3 ASN and its members
-    rtdata.get_asn("miri/lrs/jw00623-o044_20191106t132852_spec3_001_asn.json")
+    rtdata.get_asn("miri/lrs/jw00623-o032_20191106t132852_spec3_001_asn.json")
 
     # Run the calwebb_spec3 pipeline; save results from intermediate steps
     args = ["config/calwebb_spec3.cfg", rtdata.input]
@@ -30,18 +30,18 @@ def run_pipeline(jail, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output",["s2d", "x1d"])
-def test_miri_lrs_fs_spec3(run_pipeline, fitsdiff_default_kwargs, output):
+def test_miri_lrs_slit_spec3(run_pipeline, fitsdiff_default_kwargs, output):
     """Regression test of the calwebb_spec3 pipeline on MIRI
-       LRS fixedslit data using along-slit-nod pattern for
+       LRS fixed-slit data using along-slit-nod pattern for
        background subtraction."""
 
     # Run the pipeline and retrieve outputs
     rtdata = run_pipeline
-    rtdata.output = "jw00623-o044_t007_miri_p750l_" + output + ".fits"
+    rtdata.output = "jw00623-o032_t007_miri_p750l_" + output + ".fits"
 
     # Get the truth files
-    rtdata.get_truth(os.path.join("truth/test_miri_lrs_fs_spec3",
-                                  "jw00623-o044_t007_miri_p750l_" + output + ".fits"))
+    rtdata.get_truth(os.path.join("truth/test_miri_lrs_slit_spec3",
+                                  "jw00623-o032_t007_miri_p750l_" + output + ".fits"))
 
     # Compare the results
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)


### PR DESCRIPTION
This a modification of the existing MIRI LRS fixed-slit `calwebb_spec3` regression test. The overall structure of the test is the same (input is an ASN containing 4 nodded exposures). The old input cal files had zero-filled SCI arrays. The new inputs are from a set of simulated exposures created by the MIRI team and have had their TARG_RA/DEC and RA/DEC_REF values tweaked to match the actual locations of the (nodded) spectrum in each exposure. It also takes advantage of the recent fix (#4552) that results in spectra showing up in LRS fixed-slit resampled data products.

In summary, this is a drop-in replacement for the existing test using data files with good data in them. All inputs and truth files have been uploaded to artifactory and tested locally.