### PR TITLE
JP-1393 Re-enable exeption tracebacks from strun for issues outside step processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ associations
 
 - Update association rules so that nodded observations procduce level 3 asn's [#4675]
 
+cmdline
+-------
+
+- Re-enable exeption tracebacks from strun for issues outside step processing [#4761]
+
 coron
 -----
 
@@ -102,6 +107,11 @@ stpipe
 - Add command line and environmental options to not retrieve steppars references [#4676]
 
 - Use only a single member of an association for CRDS STEPPARS checking [#4684]
+
+strun
+-----
+
+- Re-enable exeption tracebacks from strun for issues outside step processing [#4761]
 
 tweakreg
 --------

--- a/jwst/stpipe/cmdline.py
+++ b/jwst/stpipe/cmdline.py
@@ -345,11 +345,9 @@ def step_from_cmdline(args, cls=None):
         else:
             step.run(*positional)
     except Exception as e:
-        import traceback
-        lines = traceback.format_exc()
         _print_important_message(
-            "ERROR RUNNING STEP {0!r}:".format(step_class.__name__),
-            str(e), lines)
+            "ERROR RUNNING STEP {0!r}:".format(step_class.__name__), str(e)
+        )
 
         if debug_on_exception:
             import pdb

--- a/scripts/strun
+++ b/scripts/strun
@@ -25,6 +25,10 @@ if __name__ == '__main__':
     try:
         step = Step.from_cmdline(sys.argv[1:])
     except NoDataOnDetectorError:
+        import traceback
+        traceback.print_exc()
         sys.exit(64)
     except Exception:
+        import traceback
+        traceback.print_exc()
         sys.exit(1)

--- a/scripts/strun
+++ b/scripts/strun
@@ -24,10 +24,20 @@ if __name__ == '__main__':
 
     try:
         step = Step.from_cmdline(sys.argv[1:])
+
     except NoDataOnDetectorError:
+        #  No science data is present on a detector. This can happen
+        #  with NIRSpec and the NRS2 detector: Situations occur when no spectra
+        #  disperse across both detectors.
+        #
+        #  Special exit status is provided so that automatic processing can detect
+        #  this situation and act accordingly.
+        #
+        #  Full discussion: https://github.com/spacetelescope/jwst/issues/2336
         import traceback
         traceback.print_exc()
         sys.exit(64)
+
     except Exception:
         import traceback
         traceback.print_exc()


### PR DESCRIPTION
PR #4468 removed exception traceback printing from `strun` to avoid double tracebacks on failure. However, the side effect is that any error happening outside of step processing now went unreported, causing silent failures. In particular, config file errors would cease processing without reason.

This refactor restores `strun` but removes the traceback from `cmdline.step_from_cmdline`, ensuring that all errors get reported and avoiding the double traceback.