### PR TITLE
Remove dependency on specified eng db url when using the engdb mock

### DIFF
--- a/jwst/lib/tests/engdb_mock.py
+++ b/jwst/lib/tests/engdb_mock.py
@@ -57,7 +57,6 @@ class EngDB_Mocker(requests_mock.Mocker):
 
         # Setup from meta query
         meta_query = re.compile(''.join([
-            engdb_tools.ENGDB_BASE_URL,
             engdb_tools.ENGDB_METADATA,
             '.*'
         ]))
@@ -65,7 +64,6 @@ class EngDB_Mocker(requests_mock.Mocker):
 
         # Setup to return a general data query
         data_query = re.compile(''.join([
-            engdb_tools.ENGDB_BASE_URL,
             engdb_tools.ENGDB_DATA,
             r'.+\?sTime=.+\&eTime=.+'
         ]))

--- a/jwst/regtest/test_nircam_tsgrism.py
+++ b/jwst/regtest/test_nircam_tsgrism.py
@@ -3,7 +3,6 @@ from astropy.io.fits.diff import FITSDiff
 from astropy.table import Table, setdiff
 
 from jwst.lib.set_telescope_pointing import add_wcs
-from jwst.lib import engdb_tools
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 


### PR DESCRIPTION
Removes unnecessary dependency on any specified ENG_BASE_URL when using the mocking library.

WIP #4757 
WIP [JP-1397](https://jira.stsci.edu/browse/JP-1397)