### PR TITLE
Use bitwise operator to check for presence of flag

### DIFF
--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -543,7 +543,7 @@ def calc_slope_vars(rn_sect, gain_sect, gdq_sect, group_time, max_seg):
         del wh_good
 
         # Locate any CRs that appear before the first SAT group...
-        wh_cr = np.where( gdq_2d_nan[i_read, :] == dqflags.group['JUMP_DET'])
+        wh_cr = np.where( gdq_2d_nan[i_read, :] & dqflags.group['JUMP_DET'] > 0 )
 
         # ... but not on final read:
         if (len(wh_cr[0]) > 0 and (i_read < nreads-1) ):

--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -543,7 +543,7 @@ def calc_slope_vars(rn_sect, gain_sect, gdq_sect, group_time, max_seg):
         del wh_good
 
         # Locate any CRs that appear before the first SAT group...
-        wh_cr = np.where( gdq_2d_nan[i_read, :] & dqflags.group['JUMP_DET'] > 0 )
+        wh_cr = np.where( gdq_2d_nan[i_read, :].astype(np.int32) & dqflags.group['JUMP_DET'] > 0 )
 
         # ... but not on final read:
         if (len(wh_cr[0]) > 0 and (i_read < nreads-1) ):


### PR DESCRIPTION
In the midst of a conversation with @jdavies-st about DQ flags, I made a search through this codebase for cases where we check for flag presence with `==` instead of `&`.  This is the one example that turned up.