### PR TITLE
JP-1401: Spectroscopic APCORR data models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ datamodels
 - Remove lev3_prod schema and move resample-related keywords to
   core schema. [#4552]
 
+- Add data models for spectroscopic mode APCORR reference files. [#4770]
+
 extract_1d
 ----------
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Software vs DMS build version map
 
 | jwst tag | DMS build | CRDS_CONTEXT |   Date     |          Notes                           |
 | -------- | --------- | ------------ | ---------- | -----------------------------------------|
-|  0.15.1  | B7.4.2rc2 | 0586         | 03/10/2020 | Second release candidate for B7.4.2      |
+|  0.15.1  | B7.4.2    | 0586         | 03/10/2020 | Final release candidate for B7.4.2       |
 |  0.15.0  | B7.4.2rc1 | 0585         | 02/28/2020 | First release candidate for B7.4.2       |
 |  0.14.2  | B7.4      | 0570         | 11/18/2019 | Final release candidate for B7.4         |
 |  0.14.1  | B7.4rc2   | 0568         | 11/11/2019 | Second release candidate for B7.4        |

--- a/docs/jwst/references_general/apcorr_reffile.inc
+++ b/docs/jwst/references_general/apcorr_reffile.inc
@@ -1,0 +1,280 @@
+APCORR Reference File
+---------------------
+
+:REFTYPE: APCORR
+
+The APCORR reference file contains data necessary for correcting
+extracted imaging and spectroscopic photometry to the equivalent
+of an infinite aperture. It is used within the
+:ref:`source_catalog <source_catalog_step>` step for imaging and
+within the :ref:`extract_1d <extract_1d_step>` step for
+spectroscopic data.
+
+.. include:: ../references_general/apcorr_selection.inc
+
+.. include:: ../includes/standard_keywords.inc
+
+Type Specific Keywords for APCORR
++++++++++++++++++++++++++++++++++
+In addition to the standard reference file keywords listed above,
+the following keywords are *required* in APCORR reference files,
+because they are used as CRDS selectors
+(see :ref:`apcorr_selectors`):
+
+=========  ========================  ===========
+Keyword    Data Model Name           Instruments
+=========  ========================  ===========
+EXP_TYPE   model.meta.exposure.type  All
+=========  ========================  ===========
+
+APCORR Reference File Format
+++++++++++++++++++++++++++++
+APCORR reference files are FITS format.
+The APCORR reference file contains tabular data
+in a BINTABLE extension with EXTNAME = 'APCORR'.
+The FITS primary HDU does not contain a data array.
+The contents of the table extension varies for different
+instrument modes, as shown in the tables below.
+
+:Data model: `~jwst.datamodels.FgsImgApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| FGS        | Image | eefraction  | float     | scalar     | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | radius      | float     | scalar     | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | scalar     | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | skyin       | float     | scalar     | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | skyout      | float     | scalar     | pixels   |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.MirImgApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| MIRI       | Image | filter      | string    | 12         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | subarray    | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | eefraction  | float     | scalar     | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | radius      | float     | scalar     | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | scalar     | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | skyin       | float     | scalar     | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | skyout      | float     | scalar     | pixels   |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.MirLrsApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| MIRI       | LRS   | subarray    | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | wavelength  | float     | 1D array   | micron   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_wl    | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | size        | integer   | 1D array   | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_size  | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | 2D array   | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr_err  | float     | 2D array   | unitless |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.MirMrsApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| MIRI       | MRS   | wavelength  | float     | 1D array   | micron   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_wl    | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | radius      | float     | 1D array   | arcsec   |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | 1D array   | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr_err  | float     | 1D array   | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | inner_bkg   | float     | 1D array   | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | outer_bkg   | float     | 1D array   | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | axis_ratio  | float     | 1D array   | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | axis_pa     | float     | 1D array   | N/A      |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.NrcImgApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| NIRCam     | Image | filter      | string    | 12         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | pupil       | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | eefraction  | float     | scalar     | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | radius      | float     | scalar     | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | scalar     | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | skyin       | float     | scalar     | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | skyout      | float     | scalar     | pixels   |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.NrcWfssApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| NIRCam     | WFSS  | filter      | string    | 12         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | pupil       | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | wavelength  | float     | 1D array   | micron   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_wl    | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | size        | integer   | 1D array   | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_size  | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | 2D array   | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr_err  | float     | 2D array   | unitless |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.NisImgApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| NIRISS     | Image | filter      | string    | 12         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | pupil       | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | eefraction  | float     | scalar     | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | radius      | float     | scalar     | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | scalar     | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | skyin       | float     | scalar     | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | skyout      | float     | scalar     | pixels   |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.NisWfssApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| NIRISS     | WFSS  | filter      | string    | 12         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | pupil       | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | wavelength  | float     | 1D array   | micron   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_wl    | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | size        | integer   | 1D array   | pixels   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_size  | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | 2D array   | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr_err  | float     | 2D array   | unitless |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.NrsFsApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| NIRSpec    |  FS   | filter      | string    | 12         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | grating     | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | slit        | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | wavelength  | float     | 1D array   | micron   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_wl    | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | size        | integer   | 2D array   | arcsec   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_size  | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | pixphase    | float     | 1D array   | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | 3D array   | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr_err  | float     | 3D array   | unitless |
++------------+-------+-------------+-----------+------------+----------+
+
+:Data model: `~jwst.datamodels.NrsMosApcorrModel`
+
++------------+-------+-------------+-----------+------------+----------+
+| Instrument | Mode  | Column name | Data type | Dimensions | Units    |
++============+=======+=============+===========+============+==========+
+| NIRSpec    | MOS   | filter      | string    | 12         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            | and   | grating     | string    | 15         | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            | IFU   | wavelength  | float     | 1D array   | micron   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_wl    | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | size        | integer   | 2D array   | arcsec   |
++            +       +-------------+-----------+------------+----------+
+|            |       | nelem_size  | integer   | scalar     | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | pixphase    | float     | 1D array   | N/A      |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr      | float     | 3D array   | unitless |
++            +       +-------------+-----------+------------+----------+
+|            |       | apcorr_err  | float     | 3D array   | unitless |
++------------+-------+-------------+-----------+------------+----------+
+
+Row Selection
+^^^^^^^^^^^^^
+A row of data within the reference table is selected by the pipeline step
+based on the optical elements in use for the exposure. The selection
+attributes are always contained in the first few columns of the table.
+The remaining columns contain the data needed for the aperture correction.
+The row selection criteria for each instrument+mode are:
+
+* FGS Image:
+   - None (table contains a single row)
+* MIRI:
+   - Image: Filter and Subarray
+   - LRS: Subarray
+   - MRS: None (table contains a single row)
+* NIRCam:
+   - Image: Filter and Pupil
+   - WFSS: Filter and Pupil
+* NIRISS:
+   - Image: Filter and Pupil
+   - WFSS: Filter and Pupil
+* NIRSpec:
+   - IFU and MOS: Filter and Grating
+   - Fixed Slits: Filter, Grating, and Slit name
+
+Note: Spectroscopic mode reference files contain the "nelem_wl" and "nelem_size"
+entries, which indicate to the pipeline step how many valid elements are contained
+in the "wavelength" and "size" arrays, respectively. Only the first "nelem_wl"
+and "nelem_size" entries are read from each array.

--- a/docs/jwst/references_general/apcorr_reffile.rst
+++ b/docs/jwst/references_general/apcorr_reffile.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+.. _apcorr_reffile:
+
+.. include:: apcorr_reffile.inc

--- a/docs/jwst/references_general/apcorr_selection.inc
+++ b/docs/jwst/references_general/apcorr_selection.inc
@@ -1,0 +1,15 @@
+Reference Selection Keywords for APCORR
++++++++++++++++++++++++++++++++++++++++
+CRDS selects appropriate APCORR references based on the following keywords.
+APCORR is not applicable for instruments not in the table.
+All keywords used for file selection are *required*.
+
+========== ======================================
+Instrument Keywords
+========== ======================================
+FGS        INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+MIRI       INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+NIRCam     INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+NIRISS     INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+NIRSpec    INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+========== ======================================

--- a/docs/jwst/references_general/apcorr_selection.rst
+++ b/docs/jwst/references_general/apcorr_selection.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+.. _apcorr_selectors:
+
+.. include:: ../references_general/apcorr_selection.inc

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -35,7 +35,6 @@ undergone by the files before being ingested in CRDS.
 Reference File Types
 ====================
 
-
 Most reference files have a one-to-one relationship with calibration steps, e.g.
 there is one step that uses one type of reference file. Some steps, however, use
 several types of reference files and some reference file types are used by more
@@ -96,6 +95,8 @@ documentation on each reference file.
 | :ref:`dq_init <dq_init_step>`               | :ref:`MASK <mask_reffile>`                       |
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`extract_1d <extract_1d_step>`         | :ref:`EXTRACT1D <extract1d_reffile>`             |
++                                             +--------------------------------------------------+
+|                                             | :ref:`APCORR <apcorr_reffile>`                   |
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`extract_2d <extract_2d_step>`         | :ref:`WAVECORR <wavecorr_reffile>`               |
 +                                             +--------------------------------------------------+
@@ -147,6 +148,8 @@ documentation on each reference file.
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`saturation <saturation_step>`         | :ref:`SATURATION <saturation_reffile>`           |
 +---------------------------------------------+--------------------------------------------------+
+| :ref:`source_catalog <source_catalog_step>` | :ref:`APCORR <apcorr_reffile>`                   |
++---------------------------------------------+--------------------------------------------------+
 | :ref:`straylight <straylight_step>`         | :ref:`REGIONS <regions_reffile>`                 |
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`superbias <superbias_step>`           | :ref:`SUPERBIAS <superbias_reffile>`             |
@@ -157,6 +160,10 @@ documentation on each reference file.
 +--------------------------------------------------+---------------------------------------------+
 | Reference File Type (REFTYPE)                    | Pipeline Step                               |
 +==================================================+=============================================+
+| :ref:`APCORR <apcorr_reffile>`                   | :ref:`extract_1d <extract_1d_step>`         |
++                                                  +---------------------------------------------+
+|                                                  | :ref:`source_catalog <source_catalog_step>` |
++--------------------------------------------------+---------------------------------------------+
 | :ref:`AREA <area_reffile>`                       | :ref:`photom <photom_step>`                 |
 +--------------------------------------------------+---------------------------------------------+
 | :ref:`BARSHADOW <barshadow_reffile>`             | :ref:`barshadow <barshadow_step>`           |

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -6,6 +6,9 @@ from .model_base import DataModel
 from .amilg import AmiLgModel
 from .apcorr import FgsImgApcorrModel, MirImgApcorrModel
 from .apcorr import NrcImgApcorrModel, NisImgApcorrModel
+from .apcorr import MirLrsApcorrModel, MirMrsApcorrModel
+from .apcorr import NrcWfssApcorrModel, NisWfssApcorrModel
+from .apcorr import NrsMosApcorrModel, NrsFsApcorrModel
 from .asn import AsnModel
 from .barshadow import BarshadowModel
 from .combinedspec import CombinedSpecModel
@@ -35,9 +38,9 @@ from .mask import MaskModel
 from .ramp import MIRIRampModel
 from .multiexposure import MultiExposureModel
 from .multiextract1d import MultiExtract1dImageModel
+from .multiprod import MultiProductModel
 from .multislit import MultiSlitModel
 from .multispec import MultiSpecModel
-from .multiprod import MultiProductModel
 from .nirspec_flat import NirspecFlatModel, NirspecQuadFlatModel
 from .outlierpars import OutlierParsModel
 from .pathloss import PathlossModel
@@ -84,6 +87,8 @@ __all__ = [
     'DataModel',
     'AmiLgModel',
     'FgsImgApcorrModel', 'MirImgApcorrModel', 'NrcImgApcorrModel', 'NisImgApcorrModel',
+    'MirLrsApcorrModel', 'MirMrsApcorrModel', 'NrcWfssApcorrModel', 'NisWfssApcorrModel',
+    'NrsMosApcorrModel', 'NrsFsApcorrModel',
     'AsnModel',
     'BarshadowModel', 'CameraModel', 'CollimatorModel',
     'CombinedSpecModel', 'ContrastModel', 'CubeModel',
@@ -103,6 +108,7 @@ __all__ = [
     'ImageModel', 'IPCModel', 'IRS2Model', 'LastFrameModel', 'Level1bModel',
     'LinearityModel', 'MaskModel', 'ModelContainer', 'MSAModel',
     'MultiExposureModel', 'MultiExtract1dImageModel', 'MultiSlitModel',
+    'MultiProductModel',
     'MultiSpecModel', 'OTEModel',
     'NIRCAMGrismModel','NIRISSGrismModel',
     'OutlierParsModel',
@@ -111,7 +117,6 @@ __all__ = [
     'PixelAreaModel', 'NirspecSlitAreaModel', 'NirspecMosAreaModel', 'NirspecIfuAreaModel',
     'FgsImgPhotomModel',
     'MirImgPhotomModel', 'MirLrsPhotomModel', 'MirMrsPhotomModel',
-    'MultiProductModel',
     'NrcImgPhotomModel', 'NrcWfssPhotomModel',
     'NisImgPhotomModel', 'NisSossPhotomModel', 'NisWfssPhotomModel',
     'NrsFsPhotomModel', 'NrsMosPhotomModel',

--- a/jwst/datamodels/apcorr.py
+++ b/jwst/datamodels/apcorr.py
@@ -66,12 +66,12 @@ class MirLrsApcorrModel(ReferenceFileModel):
         factors associated with those modes.
 
         - subarray: str[15]
-        - wavelength: float32
+        - wavelength: float32 1D array
         - nelem_wl: int16
-        - size: float32
+        - size: uint8 1D array
         - nelem_size: int16
-        - apcorr: float32
-        - apcorr_err: float32
+        - apcorr: float32 2D array
+        - apcorr_err: float32 2D array
 
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_apcorr.schema"
@@ -89,15 +89,15 @@ class MirMrsApcorrModel(ReferenceFileModel):
         of instrument mode parameters and aperture correction
         factors associated with those modes.
 
-        - wavelength: float32
+        - wavelength: float32 1D array
         - nelem_wl: int16
-        - radius: float32
-        - apcorr: float32
-        - apcorr_err: float32
-        - inner_bkg: float32
-        - outer_bkg: float32
-        - axis_ratio: float32
-        - axis_pa: float32
+        - radius: float32 1D array
+        - apcorr: float32 1D array
+        - apcorr_err: float32 1D array
+        - inner_bkg: float32 1D array
+        - outer_bkg: float32 1D array
+        - axis_ratio: float32 1D array
+        - axis_pa: float32 1D array
 
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirmrs_apcorr.schema"
@@ -141,12 +141,12 @@ class NrcWfssApcorrModel(ReferenceFileModel):
 
         - filter: str[12]
         - pupil: str[15]
-        - wavelength: float32
+        - wavelength: float32 1D array
         - nelem_wl: int16
-        - size: float32
+        - size: uint8 1D array
         - nelem_size: int16
-        - apcorr: float32
-        - apcorr_err: float32
+        - apcorr: float32 2D array
+        - apcorr_err: float32 2D array
 
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcwfss_apcorr.schema"
@@ -190,12 +190,12 @@ class NisWfssApcorrModel(ReferenceFileModel):
 
         - filter: str[12]
         - pupil: str[15]
-        - wavelength: float32
+        - wavelength: float32 1D array
         - nelem_wl: int16
-        - size: float32
+        - size: uint8 1D array
         - nelem_size: int16
-        - apcorr: float32
-        - apcorr_err: float32
+        - apcorr: float32 2D array
+        - apcorr_err: float32 2D array
 
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/niswfss_apcorr.schema"
@@ -215,13 +215,13 @@ class NrsMosApcorrModel(ReferenceFileModel):
 
         - filter: str[12]
         - grating: str[15]
-        - wavelength: float32
+        - wavelength: float32 1D array
         - nelem_wl: int16
-        - size: float32
+        - size: float32 2D array
         - nelem_size: int16
-        - pixphase: float32
-        - apcorr: float32
-        - apcorr_err: float32
+        - pixphase: float32 1D array
+        - apcorr: float32 3D array
+        - apcorr_err: float32 3D array
 
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsmos_apcorr.schema"
@@ -242,13 +242,13 @@ class NrsFsApcorrModel(ReferenceFileModel):
         - filter: str[12]
         - grating: str[15]
         - slit: str[15]
-        - wavelength: float32
+        - wavelength: float32 1D array
         - nelem_wl: int16
-        - size: float32
+        - size: float32 2D array
         - nelem_size: int16
-        - pixphase: float32
-        - apcorr: float32
-        - apcorr_err: float32
+        - pixphase: float32 1D array
+        - apcorr: float32 3D array
+        - apcorr_err: float32 3D array
 
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsfs_apcorr.schema"

--- a/jwst/datamodels/apcorr.py
+++ b/jwst/datamodels/apcorr.py
@@ -1,7 +1,10 @@
 from .reference import ReferenceFileModel
 
 __all__ = ['FgsImgApcorrModel', 'MirImgApcorrModel',
-           'NrcImgApcorrModel', 'NisImgApcorrModel']
+           'NrcImgApcorrModel', 'NisImgApcorrModel',
+           'MirLrsApcorrModel', 'MirMrsApcorrModel',
+           'NrcWfssApcorrModel', 'NisWfssApcorrModel',
+           'NrsMosApcorrModel', 'NrsFsApcorrModel']
 
 
 class FgsImgApcorrModel(ReferenceFileModel):
@@ -50,6 +53,56 @@ class MirImgApcorrModel(ReferenceFileModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirimg_apcorr.schema"
 
 
+class MirLrsApcorrModel(ReferenceFileModel):
+    """
+    A data model for MIRI LRS apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - subarray: str[15]
+        - wavelength: float32
+        - nelem_wl: int16
+        - size: float32
+        - nelem_size: int16
+        - apcorr: float32
+        - apcorr_err: float32
+
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_apcorr.schema"
+
+
+class MirMrsApcorrModel(ReferenceFileModel):
+    """
+    A data model for MIRI MRS apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - wavelength: float32
+        - nelem_wl: int16
+        - radius: float32
+        - apcorr: float32
+        - apcorr_err: float32
+        - inner_bkg: float32
+        - outer_bkg: float32
+        - axis_ratio: float32
+        - axis_pa: float32
+
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirmrs_apcorr.schema"
+
+
 class NrcImgApcorrModel(ReferenceFileModel):
     """
     A data model for NIRCam imaging apcorr reference files.
@@ -74,6 +127,31 @@ class NrcImgApcorrModel(ReferenceFileModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcimg_apcorr.schema"
 
 
+class NrcWfssApcorrModel(ReferenceFileModel):
+    """
+    A data model for NIRCam WFSS apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - filter: str[12]
+        - pupil: str[15]
+        - wavelength: float32
+        - nelem_wl: int16
+        - size: float32
+        - nelem_size: int16
+        - apcorr: float32
+        - apcorr_err: float32
+
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcwfss_apcorr.schema"
+
+
 class NisImgApcorrModel(ReferenceFileModel):
     """
     A data model for NIRISS imaging apcorr reference files.
@@ -96,3 +174,81 @@ class NisImgApcorrModel(ReferenceFileModel):
 
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nisimg_apcorr.schema"
+
+
+class NisWfssApcorrModel(ReferenceFileModel):
+    """
+    A data model for NIRISS WFSS apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - filter: str[12]
+        - pupil: str[15]
+        - wavelength: float32
+        - nelem_wl: int16
+        - size: float32
+        - nelem_size: int16
+        - apcorr: float32
+        - apcorr_err: float32
+
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/niswfss_apcorr.schema"
+
+
+class NrsMosApcorrModel(ReferenceFileModel):
+    """
+    A data model for NIRSpec MOS and IFU apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - filter: str[12]
+        - grating: str[15]
+        - wavelength: float32
+        - nelem_wl: int16
+        - size: float32
+        - nelem_size: int16
+        - pixphase: float32
+        - apcorr: float32
+        - apcorr_err: float32
+
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsmos_apcorr.schema"
+
+
+class NrsFsApcorrModel(ReferenceFileModel):
+    """
+    A data model for NIRSpec Fixed-Slit apcorr reference files.
+
+    Parameters
+    __________
+    apcorr_table : numpy table
+        Aperture correction factors table
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and aperture correction
+        factors associated with those modes.
+
+        - filter: str[12]
+        - grating: str[15]
+        - slit: str[15]
+        - wavelength: float32
+        - nelem_wl: int16
+        - size: float32
+        - nelem_size: int16
+        - pixphase: float32
+        - apcorr: float32
+        - apcorr_err: float32
+
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsfs_apcorr.schema"

--- a/jwst/datamodels/schemas/mirlrs_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/mirlrs_apcorr.schema.yaml
@@ -1,0 +1,33 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mirlrs_apcorr.schema"
+title: MIRI LRS aperture correction data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: subarray
+        datatype: [ascii, 15]
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: nelem_wl
+        datatype: int16
+      - name: size
+        datatype: uint8
+        ndim: 1
+      - name: nelem_size
+        datatype: int16
+      - name: apcorr
+        datatype: float32
+        ndim: 2
+      - name: apcorr_err
+        datatype: float32
+        ndim: 2

--- a/jwst/datamodels/schemas/mirmrs_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/mirmrs_apcorr.schema.yaml
@@ -1,0 +1,41 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mirmrs_apcorr.schema"
+title: MIRI MRS aperture correction data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: nelem_wl
+        datatype: int16
+      - name: radius
+        datatype: float32
+        ndim: 1
+      - name: apcorr
+        datatype: float32
+        ndim: 1
+      - name: apcorr_err
+        datatype: float32
+        ndim: 1
+      - name: inner_bkg
+        datatype: float32
+        ndim: 1
+      - name: outer_bkg
+        datatype: float32
+        ndim: 1
+      - name: axis_ratio
+        datatype: float32
+        ndim: 1
+      - name: axis_pa
+        datatype: float32
+        ndim: 1

--- a/jwst/datamodels/schemas/niswfss_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/niswfss_apcorr.schema.yaml
@@ -1,0 +1,35 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/niswfss_apcorr.schema"
+title: NIRISS Wide Field Slitless Spectroscopy aperture correction data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: pupil
+        datatype: [ascii, 15]
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: nelem_wl
+        datatype: int16
+      - name: size
+        datatype: uint8
+        ndim: 1
+      - name: nelem_size
+        datatype: int16
+      - name: apcorr
+        datatype: float32
+        ndim: 2
+      - name: apcorr_err
+        datatype: float32
+        ndim: 2

--- a/jwst/datamodels/schemas/nrcwfss_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/nrcwfss_apcorr.schema.yaml
@@ -1,0 +1,35 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrcwfss_apcorr.schema"
+title: NIRCam Wide Field Slitless Spectroscopy aperture correction data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: pupil
+        datatype: [ascii, 15]
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: nelem_wl
+        datatype: int16
+      - name: size
+        datatype: uint8
+        ndim: 1
+      - name: nelem_size
+        datatype: int16
+      - name: apcorr
+        datatype: float32
+        ndim: 2
+      - name: apcorr_err
+        datatype: float32
+        ndim: 2

--- a/jwst/datamodels/schemas/nrsfs_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/nrsfs_apcorr.schema.yaml
@@ -1,0 +1,40 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrsmos_apcorr.schema"
+title: NIRSpec Fixed Slit aperture correction data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: grating
+        datatype: [ascii, 15]
+      - name: slit
+        datatype: [ascii, 15]
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: nelem_wl
+        datatype: int16
+      - name: size
+        datatype: float32
+        ndim: 2
+      - name: nelem_size
+        datatype: int16
+      - name: pixphase
+        datatype: float32
+        ndim: 1
+      - name: apcorr
+        datatype: float32
+        ndim: 3
+      - name: apcorr_err
+        datatype: float32
+        ndim: 3

--- a/jwst/datamodels/schemas/nrsmos_apcorr.schema.yaml
+++ b/jwst/datamodels/schemas/nrsmos_apcorr.schema.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrsmos_apcorr.schema"
+title: NIRSpec MOS and IFU aperture correction data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_pexptype.schema
+- type: object
+  properties:
+    apcorr_table:
+      title: Aperture correction factors table
+      fits_hdu: APCORR
+      datatype:
+      - name: filter
+        datatype: [ascii, 12]
+      - name: grating
+        datatype: [ascii, 15]
+      - name: wavelength
+        datatype: float32
+        ndim: 1
+      - name: nelem_wl
+        datatype: int16
+      - name: size
+        datatype: float32
+        ndim: 2
+      - name: nelem_size
+        datatype: int16
+      - name: pixphase
+        datatype: float32
+        ndim: 1
+      - name: apcorr
+        datatype: float32
+        ndim: 3
+      - name: apcorr_err
+        datatype: float32
+        ndim: 3

--- a/jwst/regtest/test_nirspec_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_fs_spec2.py
@@ -12,7 +12,7 @@ file_roots = [
     'jw93045010001_02101_00001_nrs2_',
     'jwtest1013001_01101_00001_nrs1_'
 ]
-ids = ["fullframe", "ALLSLITS-subarray", "S400A1-subarray"]
+ids = ["fullframe", "S400A1-subarray", "ALLSLITS-subarray"]
 
 @pytest.fixture(scope="module", params=file_roots, ids=ids)
 def run_pipeline(jail, rtdata_module, request):


### PR DESCRIPTION
New datamodels schemas for spectroscopic aperture correction reference files, as specified in [JP-1049](https://jira.stsci.edu/browse/JP-1049). Still need to add the new models to the reference file docs.

Fixes #4768 / [JP-1401](https://jira.stsci.edu/browse/JP-1401)