### PR TITLE
JP-1382: Add updates to source models to include header info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ datamodels
 - Remove lev3_prod schema and move resample-related keywords to
   core schema. [#4552]
 
+exp_to_source
+-------------
+
+- Resulting MultiExposureModels are now updated with header information from the inputs
+
 extract_1d
 ----------
 

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -36,13 +36,11 @@ def exp_to_source(inputs):
 
     for exposure in inputs:
         log.info(f'Reorganizing data from exposure {exposure.meta.filename}')
-        initial = True
 
         for slit in exposure.slits:
             log.debug(f'Copying source {slit.source_id}')
             result_slit = result[str(slit.source_id)]
             result_slit.exposures.append(slit)
-            result[str(slit.source_id)].exposures.append(slit)
             merge_tree(result_slit.exposures[-1].meta.instance, exposure.meta.instance)
 
             if result_slit.meta.instrument.name is None:

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -7,8 +7,7 @@ from collections.abc import Callable
 
 from ..datamodels import (
     MultiExposureModel,
-    SourceModelContainer,
-    DataModel)
+    SourceModelContainer)
 from ..datamodels.properties import merge_tree
 
 __all__ = ['exp_to_source', 'multislit_to_container']

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -49,6 +49,8 @@ def exp_to_source(inputs):
 
                 result_slit.update(exposure)
 
+            result_slit.meta.filename = None  # Resulting merged data doesn't come from one file
+
         exposure.close()
 
     # Turn off the default factory

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -44,9 +44,6 @@ def exp_to_source(inputs):
             merge_tree(result_slit.exposures[-1].meta.instance, exposure.meta.instance)
 
             if result_slit.meta.instrument.name is None:
-                if isinstance(inputs, DataModel):
-                    result_slit.update(inputs)
-
                 result_slit.update(exposure)
 
             result_slit.meta.filename = None  # Resulting merged data doesn't come from one file


### PR DESCRIPTION
This PR resolves #4725 / [JP-1382](https://jira.stsci.edu/browse/JP-1382) where results from `exp_to_source` did not include any header information from the original exposures. Now, each new `MultiExposureModel` will contain header information from the input `MultiSlitModels`