### PR TITLE
Update tsophot.schema.yaml

### DIFF
--- a/jwst/datamodels/schemas/tsophot.schema.yaml
+++ b/jwst/datamodels/schemas/tsophot.schema.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
 id: "http://stsci.edu/schemas/jwst_datamodel/tsophot.schema"
 title: TSO image photometry reference file model (tso_photometry step)
 allOf:


### PR DESCRIPTION
`TsoPhotModel` can only get serialized to an ASDF file, so it only needs to be validated against `asdf-schema-1.0.0`.  It does not use the `fits_keyword` and `fits_hdu` attributes.