### PR TITLE
Add blendheaders keyword to drizpars; remove err array

### DIFF
--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -46,6 +46,7 @@ class ResampleSpecStep(ResampleStep):
             # Deal with NIRSpec which currently has no default drizpars reffile
             self.log.info("No NIRSpec DIRZPARS reffile")
             kwargs = self._set_spec_defaults()
+            kwargs['blendheaders'] = self.blendheaders
 
         self.drizpars = kwargs
         if isinstance(input_models[0], MultiSlitModel):
@@ -84,6 +85,8 @@ class ResampleSpecStep(ResampleStep):
                 model.meta.cal_step.resample = "COMPLETE"
                 model.meta.asn.pool_name = input_models.meta.pool_name
                 model.meta.asn.table_name = input_models.meta.table_name
+                if hasattr(model.meta, "bunit_err") and model.meta.bunit_err is not None:
+                    del model.meta.bunit_err
                 update_s_region_spectral(model)
             # Everything resampled to single output model
             if len(drizzled_models) == 1:
@@ -130,6 +133,8 @@ class ResampleSpecStep(ResampleStep):
         result.meta.cal_step.resample = "COMPLETE"
         result.meta.asn.pool_name = input_models.meta.pool_name
         result.meta.asn.table_name = input_models.meta.table_name
+        if hasattr(result.meta, "bunit_err") and result.meta.bunit_err is not None:
+            del result.meta.bunit_err
         update_s_region_spectral(result)
         result.meta.bunit_data = drizzled_models[0].meta.bunit_data
         return result


### PR DESCRIPTION
This PR fixes a bug where for input NIRSpec data to `ResampleSpecStep`, the `blendheaders` parameter was not being updated correctly, resulting in blending occurring for all NIRSpec inputs.

In addition, empty ERR extensions created during blending are explicitly removed at the end of `ResampleSpecStep`

Resolves  #4773 / [JP-1402](https://jira.stsci.edu/browse/JP-1402)