### PR TITLE
Temporarily disable macos build config

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -66,5 +66,5 @@ bc1.build_cmds = ["pip install -e ."]
 bc1.test_cmds = []
 bc1.test_configs = []
 
-utils.run([jobconfig, bc0, bc1])
+utils.run([jobconfig, bc0])
 }  // withCredentials


### PR DESCRIPTION
The designated macos build node that allows the environment snapshot to be composed for that OS is offline due to a power failure. Disable that build configuration until it can be brought back online, or until a more graceful timeout behavior can be implemented.