### PR TITLE
Lock down asdf version to < 2.6

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,1 +1,1 @@
-# Nothing here right now
+asdf==2.5.2

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,1 +1,1 @@
-asdf==2.5.2
+# Nothing here right now

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         # https://github.com/spacetelescope/asdf/pull/777
         # We can remove the upper limit here once asdf 2.6 is released
         # and jwst starts using the _visit_repeat_nodes flag.
-        'asdf>=2.5,<2.6',
+        'asdf~=2.5.0',
         'astropy>=4.0',
         'crds>=7.2.7',
         'drizzle>=1.13',

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,12 @@ setup(
         'setuptools_scm',
     ],
     install_requires=[
-        'asdf>=2.5',
+        # asdf 2.6 will change a validator implementation detail whose
+        # behavior jwst currently relies upon.  See
+        # https://github.com/spacetelescope/asdf/pull/777
+        # We can remove the upper limit here once asdf 2.6 is released
+        # and jwst starts using the _visit_repeat_nodes flag.
+        'asdf>=2.5,<2.6',
         'astropy>=4.0',
         'crds>=7.2.7',
         'drizzle>=1.13',


### PR DESCRIPTION
This PR prevents jwst from pulling in the as-yet-unreleased asdf 2.6.  That release will include a change to validator behavior that will require a small update to jwst/datamodels/fits_support.py.

@jdavies-st did I do the right thing in requirements-sdp.txt?