### PR TITLE
Refactor wcs_from_footprints to use gwcs.WCS objects instead of FITS keywords

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -121,13 +121,13 @@ def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray]) -> float:
     return np.sqrt(xscale * yscale)
 
 
-def calc_rotation_matrix(angle: float, v3i_yang: float, vparity: int = 1) -> List[float]:
+def calc_rotation_matrix(roll_ref: float, v3i_yang: float, vparity: int = 1) -> List[float]:
     """Calculate the rotation matrix.
 
     Parameters
     ----------
-    angle :
-        The angle in radians to create the matrix.
+    roll_ref :
+        Telescope roll angle of V3 North over East at the ref. point in radians
 
     v3i_yang :
         The angle between ideal Y-axis and V3 in radians.
@@ -154,7 +154,7 @@ def calc_rotation_matrix(angle: float, v3i_yang: float, vparity: int = 1) -> Lis
     if vparity not in (1, -1):
         raise ValueError(f'vparity should be 1 or -1. Input was: {vparity}')
 
-    rel_angle = angle - (vparity * v3i_yang)
+    rel_angle = roll_ref - (vparity * v3i_yang)
 
     pc1_1 = vparity * np.cos(rel_angle)
     pc1_2 = np.sin(rel_angle)

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -64,7 +64,7 @@ def _domain_to_bounding_box(domain):
     return bb
 
 
-def reproject(wcs1, wcs2, origin=0):
+def reproject(wcs1, wcs2):
     """
     Given two WCSs return a function which takes pixel coordinates in
     the first WCS and computes their location in the second one.

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -95,22 +95,22 @@ def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray]) -> float:
 
     Parameters
     ----------
-    wcs :
+    wcs : `~gwcs.wcs.WCS`
         Reference WCS object from which to compute a scaling factor.
 
-    fiducial :
+    fiducial : tuple
         Input fiducial of (RA, DEC) used in calculating reference points.
 
     Returns
     -------
-    scale :
+    scale : float
         Scaling factor for x and y.
 
     """
     if len(fiducial) != 2:
         raise ValueError(f'Input fiducial must contain only (RA, DEC); Instead recieved: {fiducial}')
 
-    crpix = np.array(wcs.backward_transform(*fiducial))
+    crpix = np.array(wcs.invert(*fiducial))
     crpix_with_offsets = np.vstack((crpix, crpix + (1, 0), crpix + (0, 1))).T
     crval_with_offsets = wcs(*crpix_with_offsets)
 
@@ -126,10 +126,10 @@ def calc_rotation_matrix(roll_ref: float, v3i_yang: float, vparity: int = 1) -> 
 
     Parameters
     ----------
-    roll_ref :
+    roll_ref : float
         Telescope roll angle of V3 North over East at the ref. point in radians
 
-    v3i_yang :
+    v3i_yang : float
         The angle between ideal Y-axis and V3 in radians.
 
     vparity : int

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -229,7 +229,7 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
                 np.deg2rad(refmodel.meta.wcsinfo.v3yangle),
                 vparity=refmodel.meta.wcsinfo.vparity),
             (2, 2)
-        ).T
+        )
 
         rotation = astmodels.AffineTransformation2D(pc)
         transform.append(rotation)

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -356,7 +356,7 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
         )
         pa = default_roll_ref
 
-    pa_rad = pa * D2R
+    pa_rad = np.deg2rad(pa)
 
     # Get VIdlParity
     try:
@@ -376,10 +376,12 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
 
         v3i_yang = default_v3yangle
 
-    (model.meta.wcsinfo.pc1_1,
-     model.meta.wcsinfo.pc1_2,
-     model.meta.wcsinfo.pc2_1,
-     model.meta.wcsinfo.pc2_2) = calc_rotation_matrix(pa_rad, np.deg2rad(v3i_yang), vparity=vparity)
+    (
+        model.meta.wcsinfo.pc1_1,
+        model.meta.wcsinfo.pc1_2,
+        model.meta.wcsinfo.pc2_1,
+        model.meta.wcsinfo.pc2_2
+    ) = calc_rotation_matrix(pa_rad, np.deg2rad(v3i_yang), vparity=vparity)
 
 
 def update_wcs_from_telem(
@@ -488,12 +490,12 @@ def update_wcs_from_telem(
     if model.meta.exposure.type.lower() in TYPES_TO_UPDATE:
         model.meta.wcsinfo.crval1 = wcsinfo.ra
         model.meta.wcsinfo.crval2 = wcsinfo.dec
-        (model.meta.wcsinfo.pc1_1,
-         model.meta.wcsinfo.pc1_2,
-         model.meta.wcsinfo.pc2_1,
-         model.meta.wcsinfo.pc2_2) = calc_rotation_matrix(
-             wcsinfo.pa * D2R, np.deg2rad(model.meta.wcsinfo.v3yangle), vparity=siaf.vparity
-         )
+        (
+            model.meta.wcsinfo.pc1_1,
+            model.meta.wcsinfo.pc1_2,
+            model.meta.wcsinfo.pc2_1,
+            model.meta.wcsinfo.pc2_2
+        ) = calc_rotation_matrix(np.deg2rad(wcsinfo.pa), np.deg2rad(model.meta.wcsinfo.v3yangle), vparity=siaf.vparity)
 
     # Calculate S_REGION with the footprint
     # information

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -260,7 +260,7 @@ def update_wcs(model, default_pa_v3=0., siaf_path=None, engdb_url=None,
     model : `~jwst.datamodels.DataModel`
         The model to update.
 
-    default_pa_v3 : float
+    default_roll_ref : float
         If pointing information cannot be retrieved,
         use this as the V3 position angle.
 
@@ -315,7 +315,7 @@ def update_wcs(model, default_pa_v3=0., siaf_path=None, engdb_url=None,
         )
 
 
-def update_wcs_from_fgs_guiding(model, default_pa_v3=0.0, default_vparity=1):
+def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, default_v3yangle=0.0):
     """ Update WCS pointing from header information
 
     For Fine Guidance guiding observations, nearly everything
@@ -343,14 +343,14 @@ def update_wcs_from_fgs_guiding(model, default_pa_v3=0.0, default_vparity=1):
 
     # Get position angle
     try:
-        pa = model.meta.wcsinfo.pa_v3
+        pa = model.meta.wcsinfo.roll_ref
     except AttributeError:
         logger.warning(
-            'Keyword `PA_V3` not found. Using {} as default value'.format(
-                default_pa_v3
+            'Keyword `ROLL_REF` not found. Using {} as default value'.format(
+                default_roll_ref
             )
         )
-        pa = default_pa_v3
+        pa = default_roll_ref
     pa_rad = pa * D2R
 
     # Get VIdlParity
@@ -364,10 +364,17 @@ def update_wcs_from_fgs_guiding(model, default_pa_v3=0.0, default_vparity=1):
         )
         vparity = default_vparity
 
+    try:
+        v3i_yang = model.meta.wcsinfo.v3yangle
+    except AttributeError:
+        logger.warning(f'Keyword "V3I_YANG" not found. Using {default_v3yangle} as default value.')
+
+        v3i_yang = default_v3yangle
+
     (model.meta.wcsinfo.pc1_1,
      model.meta.wcsinfo.pc1_2,
      model.meta.wcsinfo.pc2_1,
-     model.meta.wcsinfo.pc2_2) = calc_rotation_matrix(pa_rad, vparity=vparity)
+     model.meta.wcsinfo.pc2_2) = calc_rotation_matrix(pa_rad, v3i_yang, vparity=vparity)
 
 
 def update_wcs_from_telem(

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -244,7 +244,7 @@ def update_mt_kwds(model):
     return model
 
 
-def update_wcs(model, default_pa_v3=0., siaf_path=None, engdb_url=None,
+def update_wcs(model, default_pa_v3=0., default_roll_ref=0., siaf_path=None, engdb_url=None,
                tolerance=60, allow_default=False,
                reduce_func=None, **transform_kwargs):
     """Update WCS pointing information
@@ -263,6 +263,10 @@ def update_wcs(model, default_pa_v3=0., siaf_path=None, engdb_url=None,
     default_roll_ref : float
         If pointing information cannot be retrieved,
         use this as the V3 position angle.
+
+    default_roll_ref : float
+        If pointing information cannot be retrieved,
+        use this as the roll ref angle.
 
     siaf_path : str
         The path to the SIAF file, i.e. ``XML_DATA`` env variable.
@@ -305,7 +309,7 @@ def update_wcs(model, default_pa_v3=0., siaf_path=None, engdb_url=None,
 
     if exp_type in FGS_GUIDE_EXP_TYPES:
         update_wcs_from_fgs_guiding(
-            model, default_pa_v3=default_pa_v3
+            model, default_roll_ref=default_roll_ref
         )
     else:
         update_wcs_from_telem(

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -495,7 +495,11 @@ def update_wcs_from_telem(
             model.meta.wcsinfo.pc1_2,
             model.meta.wcsinfo.pc2_1,
             model.meta.wcsinfo.pc2_2
-        ) = calc_rotation_matrix(np.deg2rad(wcsinfo.pa), np.deg2rad(model.meta.wcsinfo.v3yangle), vparity=siaf.vparity)
+        ) = calc_rotation_matrix(
+            np.deg2rad(model.meta.wcsinfo.roll_ref),
+            np.deg2rad(model.meta.wcsinfo.v3yangle),
+            vparity=siaf.vparity
+        )
 
     # Calculate S_REGION with the footprint
     # information

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -347,7 +347,7 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
 
     # Get position angle
     try:
-        pa = model.meta.wcsinfo.roll_ref
+        pa = model.meta.wcsinfo.roll_ref if model.meta.wcsinfo.roll_ref is not None else default_roll_ref
     except AttributeError:
         logger.warning(
             'Keyword `ROLL_REF` not found. Using {} as default value'.format(
@@ -355,6 +355,7 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
             )
         )
         pa = default_roll_ref
+
     pa_rad = pa * D2R
 
     # Get VIdlParity
@@ -491,7 +492,7 @@ def update_wcs_from_telem(
          model.meta.wcsinfo.pc1_2,
          model.meta.wcsinfo.pc2_1,
          model.meta.wcsinfo.pc2_2) = calc_rotation_matrix(
-             wcsinfo.pa * D2R, vparity=siaf.vparity
+             wcsinfo.pa * D2R, model.meta.wcsinfo.v3yangle, vparity=siaf.vparity
          )
 
     # Calculate S_REGION with the footprint

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -379,7 +379,7 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
     (model.meta.wcsinfo.pc1_1,
      model.meta.wcsinfo.pc1_2,
      model.meta.wcsinfo.pc2_1,
-     model.meta.wcsinfo.pc2_2) = calc_rotation_matrix(pa_rad, v3i_yang, vparity=vparity)
+     model.meta.wcsinfo.pc2_2) = calc_rotation_matrix(pa_rad, np.deg2rad(v3i_yang), vparity=vparity)
 
 
 def update_wcs_from_telem(
@@ -492,7 +492,7 @@ def update_wcs_from_telem(
          model.meta.wcsinfo.pc1_2,
          model.meta.wcsinfo.pc2_1,
          model.meta.wcsinfo.pc2_2) = calc_rotation_matrix(
-             wcsinfo.pa * D2R, model.meta.wcsinfo.v3yangle, vparity=siaf.vparity
+             wcsinfo.pa * D2R, np.deg2rad(model.meta.wcsinfo.v3yangle), vparity=siaf.vparity
          )
 
     # Calculate S_REGION with the footprint

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -347,16 +347,16 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
 
     # Get position angle
     try:
-        pa = model.meta.wcsinfo.roll_ref if model.meta.wcsinfo.roll_ref is not None else default_roll_ref
+        roll_ref = model.meta.wcsinfo.roll_ref if model.meta.wcsinfo.roll_ref is not None else default_roll_ref
     except AttributeError:
         logger.warning(
             'Keyword `ROLL_REF` not found. Using {} as default value'.format(
                 default_roll_ref
             )
         )
-        pa = default_roll_ref
+        roll_ref = default_roll_ref
 
-    pa_rad = np.deg2rad(pa)
+    roll_ref = np.deg2rad(roll_ref)
 
     # Get VIdlParity
     try:
@@ -381,7 +381,7 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
         model.meta.wcsinfo.pc1_2,
         model.meta.wcsinfo.pc2_1,
         model.meta.wcsinfo.pc2_2
-    ) = calc_rotation_matrix(pa_rad, np.deg2rad(v3i_yang), vparity=vparity)
+    ) = calc_rotation_matrix(roll_ref, np.deg2rad(v3i_yang), vparity=vparity)
 
 
 def update_wcs_from_telem(

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -9,7 +9,7 @@ from astropy.time import Time
 from scipy.interpolate import interp1d
 import numpy as np
 
-from ..assign_wcs.util import update_s_region_keyword
+from ..assign_wcs.util import update_s_region_keyword, calc_rotation_matrix
 from ..datamodels import Level1bModel
 from ..lib.engdb_tools import ENGDB_Service
 from .exposure_types import IMAGING_TYPES, FGS_GUIDE_EXP_TYPES
@@ -1238,48 +1238,6 @@ def _get_wcs_values_from_siaf(aperture_name, useafter, prd_db_filepath=None):
         return siaf
     else:
         return default_siaf
-
-
-def calc_rotation_matrix(angle, vparity=1):
-    """ Calculate the rotation matrix.
-
-    Parameters
-    ----------
-    angle : float in radians
-        The angle to create the matrix.
-
-    vparity : int
-        The x-axis parity, usually taken from
-        the JWST SIAF parameter VIdlParity.
-        Value should be "1" or "-1".
-
-    Returns
-    -------
-    matrix: [pc1_1, pc1_2, pc2_1, pc2_2]
-        The rotation matrix
-
-    Notes
-    -----
-    The rotation is
-
-       ----------------
-       | pc1_1  pc2_1 |
-       | pc1_2  pc2_2 |
-       ----------------
-
-    where:
-        pc1_1 = vparity * cos(angle)
-        pc1_2 = sin(angle)
-        pc2_1 = -1 * vparity * sin(angle)
-        pc2_2 = cos(angle)
-    """
-
-    pc1_1 = vparity * cos(angle)
-    pc1_2 = sin(angle)
-    pc2_1 = vparity * -sin(angle)
-    pc2_2 = cos(angle)
-
-    return [pc1_1, pc1_2, pc2_1, pc2_2]
 
 
 def get_mnemonics(obsstart, obsend, tolerance, engdb_url=None):

--- a/jwst/lib/tests/test_fgs_pointing.py
+++ b/jwst/lib/tests/test_fgs_pointing.py
@@ -36,10 +36,10 @@ def test_fgs_pointing():
     model = make_level1b()
     stp.update_wcs(model, siaf_path=siaf_db)
 
-    assert model.meta.wcsinfo.pc1_1 == -0.31456307387761373
-    assert model.meta.wcsinfo.pc1_2 == -0.9492365735435329
-    assert model.meta.wcsinfo.pc2_1 == -0.9492365735435329
-    assert model.meta.wcsinfo.pc2_2 == 0.31456307387761373
+    assert model.meta.wcsinfo.pc1_1 == -0.9997617223891989
+    assert model.meta.wcsinfo.pc1_2 == -0.02182884434372137
+    assert model.meta.wcsinfo.pc2_1 == -0.02182884434372137
+    assert model.meta.wcsinfo.pc2_2 == 0.9997617223891989
 
 
 # ---------

--- a/jwst/lib/tests/test_fgs_pointing.py
+++ b/jwst/lib/tests/test_fgs_pointing.py
@@ -36,10 +36,10 @@ def test_fgs_pointing():
     model = make_level1b()
     stp.update_wcs(model, siaf_path=siaf_db)
 
-    assert model.meta.wcsinfo.pc1_1 == -1.0
-    assert model.meta.wcsinfo.pc1_2 == 0.0
-    assert model.meta.wcsinfo.pc2_1 == 0.0
-    assert model.meta.wcsinfo.pc2_2 == 1.0
+    assert model.meta.wcsinfo.pc1_1 == -0.31456307387761373
+    assert model.meta.wcsinfo.pc1_2 == -0.9492365735435329
+    assert model.meta.wcsinfo.pc2_1 == -0.9492365735435329
+    assert model.meta.wcsinfo.pc2_2 == 0.31456307387761373
 
 
 # ---------

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -243,10 +243,10 @@ def test_add_wcs_default(data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -1.0)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 1.0)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.3999853149883513)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, -0.9165215479156338)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, -0.9165215479156338)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.3999853149883513)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -305,10 +305,10 @@ def test_add_wcs_fsmcorr_v1(data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -1.0)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.0)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 1.0)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.3999853149883513)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, -0.9165215479156338)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, -0.9165215479156338)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.3999853149883513)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -349,10 +349,10 @@ def test_add_wcs_with_db(eng_db_ngas, data_file, siaf_file=siaf_db):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.0385309)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992574)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992574)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.0385309)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.9312527700727293)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, -0.3643738166112768)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, -0.3643738166112768)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.9312527700727293)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -393,10 +393,10 @@ def test_add_wcs_with_db_fsmcorr_v1(eng_db_ngas, data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.0385309)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992574)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992574)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.0385309)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.9312527700727293)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, -0.3643738166112768)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, -0.3643738166112768)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.9312527700727293)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -243,10 +243,10 @@ def test_add_wcs_default(data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.3999853149883513)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, -0.9165215479156338)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, -0.9165215479156338)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.3999853149883513)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7431448254773942)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.6691306063588582)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.6691306063588582)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7431448254773942)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -305,10 +305,10 @@ def test_add_wcs_fsmcorr_v1(data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.3999853149883513)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, -0.9165215479156338)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, -0.9165215479156338)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.3999853149883513)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7431448254773942)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.6691306063588582)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.6691306063588582)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7431448254773942)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -349,10 +349,10 @@ def test_add_wcs_with_db(eng_db_ngas, data_file, siaf_file=siaf_db):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.9312527700727293)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, -0.3643738166112768)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, -0.3643738166112768)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.9312527700727293)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.6972678111114343)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.7168107139181649)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.7168107139181649)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.6972678111114343)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -393,10 +393,10 @@ def test_add_wcs_with_db_fsmcorr_v1(eng_db_ngas, data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.9312527700727293)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, -0.3643738166112768)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, -0.3643738166112768)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.9312527700727293)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.6972678111114343)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.7168107139181649)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.7168107139181649)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.6972678111114343)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -243,10 +243,10 @@ def test_add_wcs_default(data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7431448254773942)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.6691306063588582)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.6691306063588582)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7431448254773942)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7558009243361943)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.654801468211972)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.654801468211972)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7558009243361943)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -305,10 +305,10 @@ def test_add_wcs_fsmcorr_v1(data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7431448254773942)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.6691306063588582)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.6691306063588582)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7431448254773942)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7558009243361943)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.654801468211972)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.654801468211972)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7558009243361943)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -349,10 +349,10 @@ def test_add_wcs_with_db(eng_db_ngas, data_file, siaf_file=siaf_db):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.6972678111114343)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.7168107139181649)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.7168107139181649)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.6972678111114343)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.03853303979862607)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992573266400789)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992573266400789)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.03853303979862607)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1
@@ -393,10 +393,10 @@ def test_add_wcs_with_db_fsmcorr_v1(eng_db_ngas, data_file):
     assert model.meta.wcsinfo.cunit2 == 'deg'
     assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
     assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.6972678111114343)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.7168107139181649)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.7168107139181649)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.6972678111114343)
+    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.03853303979862607)
+    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992573266400789)
+    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992573266400789)
+    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.03853303979862607)
     assert model.meta.wcsinfo.v2_ref == 200.0
     assert model.meta.wcsinfo.v3_ref == -350.0
     assert model.meta.wcsinfo.vparity == -1

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -56,36 +56,6 @@ def make_output_wcs(input_models):
     return output_wcs
 
 
-def compute_output_transform(refwcs, filename, fiducial):
-    """Compute a simple FITS-type WCS transform
-    """
-    x0, y0 = refwcs.backward_transform(*fiducial)
-    x1 = x0 + 1
-    y1 = y0 + 1
-    ra0, dec0 = refwcs(x0, y0)
-    ra_xdir, dec_xdir = refwcs(x1, y0)
-    ra_ydir, dec_ydir = refwcs(x0, y1)
-
-    position0 = SkyCoord(ra=ra0, dec=dec0, unit='deg')
-    position_xdir = SkyCoord(ra=ra_xdir, dec=dec_xdir, unit='deg')
-    position_ydir = SkyCoord(ra=ra_ydir, dec=dec_ydir, unit='deg')
-    offset_xdir = position0.spherical_offsets_to(position_xdir)
-    offset_ydir = position0.spherical_offsets_to(position_ydir)
-
-    xscale = np.abs(position0.separation(position_xdir).value)
-    yscale = np.abs(position0.separation(position_ydir).value)
-    scale = np.sqrt(xscale * yscale)
-
-    c00 = offset_xdir[0].value / scale
-    c01 = offset_xdir[1].value / scale
-    c10 = offset_ydir[0].value / scale
-    c11 = offset_ydir[1].value / scale
-    pc_matrix = AffineTransformation2D(matrix=[[c00, c01], [c10, c11]])
-    cdelt = Scale(scale) & Scale(scale)
-
-    return pc_matrix | cdelt
-
-
 def shape_from_bounding_box(bounding_box):
     """ Return a numpy shape based on the provided bounding_box
     """

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -3,8 +3,6 @@ import warnings
 
 import numpy as np
 from astropy import wcs as fitswcs
-from astropy.coordinates import SkyCoord
-from astropy.modeling.models import Scale, AffineTransformation2D
 from astropy.modeling import Model
 from gwcs import WCS, wcstools
 


### PR DESCRIPTION
This PR refactors `wcs_from_footprints` and some functions that it depends on to utilize the `wcs` object from `refmodel` rather than using FITS-dependent keywords. 

Resolves #3250
Resolves #3900 / [JP-921](https://jira.stsci.edu/browse/JP-921)
Resolves #4784 