### PR TITLE
Turn off pytest-openfiles plugin in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ results_root = jwst-pipeline-results
 doctest_plus = true
 doctest_rst = true
 text_file_format = rst
-addopts = --show-capture=no --open-files
+addopts = --show-capture=no
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
We need to turn this off for now until we can debug why our regression tests are leaving behind open files when they fail via `FITSDiff`.