### PR TITLE
Update flatfield and linearity docs

### DIFF
--- a/docs/jwst/flatfield/arguments.rst
+++ b/docs/jwst/flatfield/arguments.rst
@@ -4,10 +4,7 @@ Step Arguments
 The ``flat_field`` step has one step-specific argument, and it is only
 relevant for NIRSpec data.
 
-``--flat_suffix``
-  is a string and specifies the file name suffix to use when constructing the
-  name of the optional output file for on-the-fly flat fields.  If
-  ``flat_suffix`` is specified (and if the input data are NIRSpec),
-  the extracted and interpolated flat fields will be saved to a file with
-  this suffix.  The default (if ``flat_suffix`` is not specified) is to
-  not write this optional output file.
+``--save_interpolated_flat``
+  is a boolean that indicates whether to save to a file the NIRSpec
+  flat field that was constructed on-the-fly by the step.
+  The default is False (do not save).

--- a/docs/jwst/flatfield/main.rst
+++ b/docs/jwst/flatfield/main.rst
@@ -7,10 +7,21 @@ science data set, and the flat-field DQ array is combined with the science DQ
 array using a bitwise OR operation. Details for particular modes are given
 in the sections below.
 
+Upon completion of the step, the step status keyword "S_FLAT" gets set
+to "COMPLETE" in the output science data.
+
 Imaging and Non-NIRSpec Spectroscopic Data
 ------------------------------------------
-Simple imaging data, usually in the form of an ImageModel, is handled as
-follows:
+Simple imaging data, usually in the form of an ImageModel, and many
+spectroscopic modes, use a straight-forward approach that involves applying
+a single flat-field reference file to the science image. The spectroscopic
+modes included in this category are NIRCam WFSS and Time-Series Grism,
+NIRISS WFSS and SOSS, MIRI MRS and LRS. All of these modes are processed
+as follows:
+
+- If the science data have been taken using a subarray and the flat-field
+  reference file is a full-frame image, extract the corresponding subarray
+  region from the flat-field data.
 
 - Find pixels that have a value of NaN or zero in the FLAT reference file
   SCI array and set their DQ values to "NO_FLAT_FIELD."
@@ -23,68 +34,47 @@ follows:
 - Propagate the FLAT reference file DQ values into the science exposure
   DQ array using a bitwise OR operation.
 
-Spectroscopic data in the form of MultiSlit data models are handled as follows:
-
-- If the flat-field reference file supplied to the step is also in the form of a
-  MultiSlit model, search the reference file for slits with names that
-  match the slits in the science exposure (e.g. 'S1600A1' or 'S200B1').
-
-- When a match is found, use the flat-field data for that slit to correct the
-  particular slit data in the science exposure, using the same procedures as
-  outlined above for imaging data.
-
-If, on the other hand, the flat-field consists of a single image model, the
-region corresponding to each slit in the science data is extracted on-the-fly
-from the flat-field data and applied to the corresponding slit in the science data.
-
-Multi-integration datasets ("_rateints.fits" products) are handled by applying
-the above flat-field procedures to each integration.
-
-If any part of the input data model gets flat-fielded (e.g. at least one
-slit of a MultiSlit model), the status keyword "S_FLAT" gets set to
-"COMPLETE" in the output science data.
+Multi-integration datasets ("_rateints.fits" products), which are common
+for modes like NIRCam Time-Series Grism, NIRISS SOSS, and MIRI LRS Slitless,
+are handled by applying the above flat-field procedures to each integration.
 
 NIRSpec Spectroscopic Data
 --------------------------
 Flat-fielding of NIRSpec spectrographic data differs from other modes
 in that the flat-field array that will be applied to the science data
 is not read directly from CRDS.  This is because the flat-field varies with
-wavelength, and the wavelength of light that falls on any given pixel
-depends on mode and on which slit or slits are open.  The flat-field array
+wavelength and the wavelength of light that falls on any given pixel
+depends on the mode and which slits are open.  The flat-field array
 that is divided into the SCI and ERR arrays is constructed on-the-fly
 by extracting the relevant section from the reference files, and then --
 for each pixel -- interpolating to the appropriate wavelength for that
 pixel.  This interpolation requires knowledge of the dispersion direction,
-which is gotten from keyword "DISPAXIS."  See the Reference File section for
-further details.  There is an option to save the on-the-fly flat field to
-a file.
+which is read from keyword "DISPAXIS."  See the Reference File section for
+further details.
 
-NIRSpec NRS_BRIGHTOBJ data are processed much like other NIRSpec
-spectrographic data, except that NRS_BRIGHTOBJ data are in a CubeModel,
-rather than a MultiSlitModel or ImageModel (used for IFU data).  A 2-D
-flat field image is constructed on-the-fly as usual, but this image
-is divided into each plane of the 3-D science data and error arrays,
-resulting in an output CubeModel.
+For NIRSpec Fixed-Slit and MOS exposures, an on-the-fly flat-field is
+constructed to match each of the slits/slitlets contained in the science
+exposure. For NIRSpec IFU exposures, a single full-frame flat-field is
+constructed, which is applied to the entire science image.
 
-Subarrays
----------
-This step handles input science exposures that were taken in subarray modes in
-a flexible way. If the reference data arrays are the same size as the science
-data, they will be applied directly. If there is a mismatch, the routine will
-extract a matching subarray from the reference file data arrays and apply them
-to the science data. Hence full-frame reference files can be
-used for both full-frame and subarray science exposures, or subarray-dependent
-reference files can be provided if desired.
+NIRSpec NRS_BRIGHTOBJ data are processed just like NIRSpec Fixed-Slit
+data, except that NRS_BRIGHTOBJ data are stored in a CubeModel,
+rather than a MultiSlitModel.  A 2-D flat-field image is constructed
+on-the-fly as usual, but this image is then divided into each plane of
+the 3-D SCI and ERR arrays.
+
+In all cases, there is a step option that allows for saving the
+on-the-fly flat field to a file, if desired.
 
 Error Propagation
 -----------------
-The VAR_POISSON and VAR_RNOISE variance arrays are divided by the square
-of the flat-field value for each pixel. A flat-field variance array,
-VAR_FLAT, is created from the science exposure and flat-field reference
-file data using the following formula:
+The VAR_POISSON and VAR_RNOISE variance arrays of the science exposure
+are divided by the square of the flat-field value for each pixel.
+A flat-field variance array, VAR_FLAT, is created from the science exposure
+and flat-field reference file data using the following formula:
 
 .. math::
    VAR\_FLAT = ( SCI_{science}^{2} / SCI_{flat}^{2} ) * ERR_{flat}^{2}
 
-The total ERR array is updated as the square root of the quadratic sum of
-VAR_POISSON, VAR_RNOISE, and VAR_FLAT.
+The total ERR array in the science exposure is updated as the square root
+of the quadratic sum of VAR_POISSON, VAR_RNOISE, and VAR_FLAT.

--- a/docs/jwst/linearity/description.rst
+++ b/docs/jwst/linearity/description.rst
@@ -4,12 +4,16 @@ Description
 Assumptions
 -----------
 It is assumed that the input science exposure data for near-IR instruments
-have had the superbias subtraction applied, therefore the correction
-coefficients stored in the linearity reference files for those instruments
-must have been derived from data that also had the zero group subtracted.
+have had the :ref:`superbias <superbias_step>` subtraction step applied,
+therefore the correction coefficients stored in the linearity reference files
+for those instruments must have been derived from data that has also been
+bias subtracted.
+MIRI data, on the other hand, do not receive bias subtraction
+(see :ref:`calwebb_detector1 <calwebb_detector1>`) and hence the linearity
+correction is derived and applied in the raw data space.
 
 It is also assumed that the saturation step has already been applied to
-the science data, so that saturation flags are set in the GROUPDQ array of
+the input data, so that saturation flags are set in the GROUPDQ array of
 the input science data.
 
 Algorithm

--- a/docs/jwst/linearity/description.rst
+++ b/docs/jwst/linearity/description.rst
@@ -10,7 +10,7 @@ for those instruments must have been derived from data that has also been
 bias subtracted.
 MIRI data, on the other hand, do not receive bias subtraction
 (see :ref:`calwebb_detector1 <calwebb_detector1>`) and hence the linearity
-correction is derived and applied in the raw data space.
+correction is derived from data that has not been bias subtracted.
 
 It is also assumed that the saturation step has already been applied to
 the input data, so that saturation flags are set in the GROUPDQ array of


### PR DESCRIPTION
Update the flat-field docs to move/remove old NIRSpec info from the non-NIRSpec section of the docs. Also updated the name of the argument used to save the on-the-fly flat as used in the code. Update the linearity docs to make it explicit that MIRI data do not get bias subtracted before doing linearity correction (or ever).

Fixes #4524 / [JP-1268](https://jira.stsci.edu/browse/JP-1268)
Fixes #4526 / [JP-1271](https://jira.stsci.edu/browse/JP-1271)