### PR TITLE
Turn off memmap for FITSDiff in regtests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: python
-python: 3.7.6
+python: 3.7.7
 
 sudo: false
 
@@ -27,12 +27,12 @@ matrix:
   fast_finish: true
 
   include:
-    - python: 3.6.9
-    - python: 3.7.6
-    - python: 3.8.1
+    - python: 3.6.10
+    - python: 3.7.7
+    - python: 3.8.2
 
     - env: PIP_DEPENDENCIES="numpy~=1.16.0 .[test]"
-      python: 3.6.9
+      python: 3.6.10
 
     - env: PIP_DEPENDENCIES="numpy~=1.17.0 .[test]"
 
@@ -42,7 +42,7 @@ matrix:
 
     # Test with dev dependencies
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
-      python: 3.8.1
+      python: 3.8.2
 
     # Test with latest delivered CRDS_CONTEXT, as in regressions tests
     - env: CRDS_CONTEXT="jwst-edit"
@@ -58,7 +58,7 @@ matrix:
 
   allow_failures:
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
-      python: 3.8.1
+      python: 3.8.2
 
     - env: CRDS_CONTEXT="jwst-edit"
            PIP_DEPENDENCIES=".[test]"

--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -8,12 +8,16 @@ import pytest
 from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
 from astropy.table import Table
 from numpy.testing import assert_allclose
+from astropy.io.fits import conf
 
 from .regtestdata import RegtestData
 from jwst.regtest.sdp_pools_source import SDPPoolsSource
 
 
 TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
+
+# Turn of FITS memmap for all regtests (affects FITSDiff)
+conf.use_memmap = False
 
 
 @pytest.fixture(scope="session")

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ results_root = jwst-pipeline-results
 doctest_plus = true
 doctest_rst = true
 text_file_format = rst
-addopts = --show-capture=no
+addopts = --show-capture=no --open-files
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
This should solve our issues with FITSDiff leaving behind open files when a difference is found.

Also, this updates the patch versions of python used in TravisCI.