### PR TITLE
JP-1379: Update READPATT keyword allowed values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ datamodels
 
 - Added ``pupil`` to the ``FilteroffsetModel`` to support NIRCAM and NIRISS WCS. [#4750]
 
+- Added FASTGRPAVG[8,16,32,64] to the READPATT keyword allowed values. [#4818]
+
 exp_to_source
 -------------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -384,7 +384,7 @@ properties:
             fits_keyword: MODULE
             blend_table: True
           channel:
-            title: 'NIRCam channel: long or short'
+            title: Instrument channel
             type: string
             # Values grouped by instrument:
             anyOf:
@@ -650,8 +650,8 @@ properties:
           readpatt:
             title: Readout pattern
             type: string
-            enum: [ACQ1, ACQ2, BRIGHT1, BRIGHT2,
-              DEEP2, DEEP8, FAST, FASTGRPAVG,
+            enum: [ACQ1, ACQ2, BRIGHT1, BRIGHT2, DEEP2, DEEP8, FAST,
+              FASTGRPAVG, FASTGRPAVG8, FASTGRPAVG16, FASTGRPAVG32, FASTGRPAVG64,
               FGS, FGS60, FGS8370, FGS840, FGSRAPID, FINEGUIDE,
               ID, MEDIUM2, MEDIUM8, NIS, NISRAPID,
               NRS, NRSIRS2, NRSN16R4, NRSN32R8, NRSN8R2,

--- a/jwst/datamodels/schemas/keyword_readpatt.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_readpatt.schema.yaml
@@ -13,8 +13,8 @@ properties:
           readpatt:
             title: Readout pattern
             type: string
-            enum: [ACQ1, ACQ2, BRIGHT1, BRIGHT2,
-              DEEP2, DEEP8, FAST, FASTGRPAVG,
+            enum: [ACQ1, ACQ2, BRIGHT1, BRIGHT2, DEEP2, DEEP8, FAST,
+              FASTGRPAVG, FASTGRPAVG8, FASTGRPAVG16, FASTGRPAVG32, FASTGRPAVG64,
               FGS, FGS60, FGS8370, FGS840, FGSRAPID, FINEGUIDE,
               ID, MEDIUM2, MEDIUM8, NIS, NISRAPID,
               NRS, NRSIRS2, NRSN16R4, NRSN32R8, NRSN8R2,


### PR DESCRIPTION
Add new entries to the READPATT enum list for the new MIRI patterns FASTGRPAVG[8,16,32,64] as outlined in [JSOCINT-367](https://jira.stsci.edu/browse/JSOCINT-367).

Also finally updated the comment for the CHANNEL keyword, which was hardwired to refer to NIRCam, even though it's also used for MIRI. This change has been requested for a while. Unfortunately this is going to cause many, many regtest failures. Thank goodness for `okify_regtests`.

Fixes #4718 / [JP-1379](https://jira.stsci.edu/browse/JP-1379)