### PR TITLE
JP-1368:  Update source catalog step to include aperture photometry and other properties

### DIFF
--- a/docs/jwst/source_catalog/arguments.rst
+++ b/docs/jwst/source_catalog/arguments.rst
@@ -3,6 +3,8 @@ Arguments
 
 The ``source_catalog`` step uses the following user-settable arguments:
 
+* ``--bkg_boxsize``: A floating-point value giving the background mesh box size in pixels
+
 * ``--kernel_fwhm``: A floating-point value giving the Gaussian kernel
   FWHM in pixels [default=2.0]
 
@@ -20,6 +22,12 @@ The ``source_catalog`` step uses the following user-settable arguments:
 
 * ``--deblend``: A boolean indicating whether to deblend sources
   [default=False]
+
+* ``--aperture_ee1``: An integer value of the smallest aperture encircled energy value [default=30]
+
+* ``--aperture_ee2``: An integer value of the middle aperture encircled energy value [default=50]
+
+* ``--aperture_ee3``: An integer value of the largest aperture encircled energy value [default=70]
 
 * ``--suffix``: A string value giving the file name suffix to use for
   the output catalog file [default='cat']

--- a/docs/jwst/source_catalog/main.rst
+++ b/docs/jwst/source_catalog/main.rst
@@ -1,29 +1,34 @@
 Description
 ===========
+
 This step creates a catalog of source photometry and morphologies.
+Both aperture and isophotal (segment-based) photometry are calculated.
+Source morphologies are based on 2D image moments within the source
+segment.
 
 
 Source Detection
 ^^^^^^^^^^^^^^^^
+
 Sources are detected using `image segmentation
 <https://en.wikipedia.org/wiki/Image_segmentation>`_, which is a
 process of assigning a label to every pixel in an image such that
 pixels with the same label are part of the same source.  The
 segmentation procedure used is from `Photutils source extraction
-<https://photutils.readthedocs.io/en/latest/segmentation.html>`_
-and is called the threshold method, where detected sources must have a
-minimum number of connected pixels that are each greater than a
-specified threshold value in an image.  The threshold level is usually
-defined at some multiple of the background standard deviation (sigma)
-above the background.  The image can also be filtered before
-thresholding to smooth the noise and maximize the detectability of
-objects with a shape similar to the filter kernel.
+<https://photutils.readthedocs.io/en/latest/segmentation.html>`_.
+Detected sources must have a minimum number of connected pixels that
+are each greater than a specified threshold value in an image.  The
+threshold level is usually defined at some multiple of the background
+standard deviation above the background.  The image can also be
+filtered before thresholding to smooth the noise and maximize the
+detectability of objects with a shape similar to the filter kernel.
 
 Source Deblending
 ^^^^^^^^^^^^^^^^^
-Overlapping sources are detected as single sources.
-Separating those sources requires a deblending procedure, such as a
-multi-thresholding technique used by `SExtractor
+
+Overlapping sources are detected as single sources.  Separating those
+sources requires a deblending procedure, such as a multi-thresholding
+technique used by `SExtractor
 <https://www.astromatic.net/software/sextractor>`_.  Here we use the
 `Photutils deblender
 <https://photutils.readthedocs.io/en/latest/segmentation.html#source-deblending>`_,
@@ -35,12 +40,22 @@ there is a saddle between them.
 
 Source Photometry and Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 After detecting sources using image segmentation, we can measure their
-photometry, centroids, and morphological properties.  Here we use the
-functions in `Photutils
-<https://photutils.readthedocs.org/en/latest/segmentation.html>`_.  The
-properties that are currently calculated for each source include
-source centroids (both in pixel and sky coordinates), fluxes (and
-errors), AB magnitudes (and errors), area, semimajor and semiminor
-axis lengths, orientation, and sky coordinates at bounding box
-corners.
+photometry, centroids, and morphological properties.  The aperture
+photometry is measured in three apertures, based on the input
+encircled energy values.  The total aperture-corrected flux and
+magnitudes are also calculated, based on the largest aperture.  Both
+AB and Vega magnitudes are calculated.
+
+For the isophotal photometry is based on `photutils segmentation
+<https://photutils.readthedocs.org/en/latest/segmentation.html>`_.
+The properties that are currently calculated for each source include
+source centroids (both in pixel and sky coordinates), isophotal fluxes
+(and errors), AB and Vega magnitudes (and errors), isophotal area,
+semimajor and semiminor axis lengths, orientation of the major axis,
+and sky coordinates at corners of the minimal bounding box enclosing
+the source.
+
+The output source catalog table is saved in `ECSV format
+<https://docs.astropy.org/en/stable/io/ascii/write.html#ecsv-format>`_.

--- a/docs/jwst/source_catalog/main.rst
+++ b/docs/jwst/source_catalog/main.rst
@@ -48,7 +48,7 @@ encircled energy values.  The total aperture-corrected flux and
 magnitudes are also calculated, based on the largest aperture.  Both
 AB and Vega magnitudes are calculated.
 
-For the isophotal photometry is based on `photutils segmentation
+The isophotal photometry is based on `photutils segmentation
 <https://photutils.readthedocs.org/en/latest/segmentation.html>`_.
 The properties that are currently calculated for each source include
 source centroids (both in pixel and sky coordinates), isophotal fluxes

--- a/docs/jwst/source_catalog/reference_files.rst
+++ b/docs/jwst/source_catalog/reference_files.rst
@@ -1,4 +1,8 @@
 Reference File Types
 =====================
 
-The ``source_catalog`` step does not use any reference files.
+The ``source_catalog`` step uses APCORR and ABVEGA_OFFSET reference files.
+
+.. include:: ../references_general/apcorr_reffile.inc
+
+.. include:: ../references_general/abvega_offset_reffile.inc

--- a/jwst/pipeline/source_catalog.cfg
+++ b/jwst/pipeline/source_catalog.cfg
@@ -2,8 +2,9 @@ name = "source_catalog"
 class = "jwst.source_catalog.SourceCatalogStep"
 
 kernel_fwhm = 3.
-kernel_xsize = 5.
-kernel_ysize = 5.
 snr_threshold = 3.
 npixels = 50
 deblend = False
+aperture_ee1 = 30
+aperture_ee2 = 50
+aperture_ee3 = 70

--- a/jwst/pipeline/tests/data/cfgs/source_catalog.cfg
+++ b/jwst/pipeline/tests/data/cfgs/source_catalog.cfg
@@ -2,8 +2,9 @@ name = "source_catalog"
 class = "jwst.source_catalog.SourceCatalogStep"
 
 kernel_fwhm = 3.
-kernel_xsize = 5.
-kernel_ysize = 5.
 snr_threshold = 3.
 npixels = 50
 deblend = False
+aperture_ee1 = 30
+aperture_ee2 = 50
+aperture_ee3 = 70

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1,16 +1,17 @@
+from collections import OrderedDict
 import logging
 
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma, SigmaClip
-from astropy.table import join
+from astropy.table import QTable
 import astropy.units as u
+from astropy.utils import lazyproperty
 import numpy as np
 from scipy.spatial import cKDTree
 
 from photutils import Background2D, MedianBackground
 from photutils import detect_sources, deblend_sources, source_properties
 from photutils import CircularAperture, CircularAnnulus, aperture_photometry
-from photutils.utils import calc_total_error
 from photutils.utils._wcs_helpers import _pixel_scale_angle_at_skycoord
 
 from .. import datamodels
@@ -20,38 +21,26 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-class SourceCatalog:
-    def __init__(self, model, bkg_boxsize=100, kernel_fwhm=2.0,
-                 snr_threshold=3.0, npixels=5.0, deblend=False,
-                 aperture_ee=(30, 50, 70), apcorr_filename=None,
-                 abvega_offset_filename=None):
+class ReferenceData:
+    def __init__(self, model, aperture_ee=(30, 50, 70),
+                 apcorr_filename=None, abvega_offset_filename=None):
 
         if not isinstance(model, ImageModel):
             raise ValueError('The input model must be a ImageModel.')
-
         self.model = model
-        self.bkg_boxsize = np.int(bkg_boxsize)  # must be integer
-        self.kernel_fwhm = kernel_fwhm
-        self.snr_threshold = snr_threshold
-        self.npixels = npixels
-        self.deblend = deblend
+
+        self.aperture_ee = self._validate_aperture_ee(aperture_ee)
+        if apcorr_filename is None:
+            raise ValueError('apcorr_filename must be input')
         self.apcorr_filename = apcorr_filename
         self.abvega_offset_filename = abvega_offset_filename
-
-        aperture_ee = np.array(aperture_ee).astype(int)
-        if len(aperture_ee) != 3:
-            raise ValueError('aperture_ee must contain only 3 values')
-        if np.any(np.logical_or(aperture_ee <= 0, aperture_ee >= 100)):
-            raise ValueError('aperture_ee values must be between 0 and 100')
-        if np.any(aperture_ee[1:] < aperture_ee[:-1]):
-            raise ValueError('aperture_ee values must be in increasing order')
-        self.aperture_ee = aperture_ee
 
         self.instrument = self.model.meta.instrument.name
         self.detector = self.model.meta.instrument.detector
         self.filtername = self.model.meta.instrument.filter
         self.pupil = model.meta.instrument.pupil
         self.subarray = self.model.meta.subarray.name
+
         log.info(f'Instrument: {self.instrument}')
         if self.detector is not None:
             log.info(f'Detector: {self.detector}')
@@ -62,67 +51,33 @@ class SourceCatalog:
         if self.subarray is not None:
             log.info(f'Subarray: {self.subarray}')
 
-        self._ci_colname = f'CI_{self.aperture_ee[0]}_{self.aperture_ee[2]}'
-        self._flux_colnames, self._flux_coldesc = self._make_aperture_colnames('flux')
-        self._abmag_colnames, self._abmag_coldesc = self._make_aperture_colnames('abmag')
-        self._vegamag_colnames, self._vegamag_coldesc = self._make_aperture_colnames('vegamag')
-        self._bkg_colnames = ['aper_bkg_flux', 'aper_bkg_flux_err']
-        self._bkg_coldesc = ['The local background value calculated as the sigma-clipped median value in the background annulus aperture', 'The standard error of the sigma-clipped median background value']
-
-        self.coverage_mask = None
-        self._bkg = None
-        self.background = None
-        self.background_rms = None
-        self.kernel = None
-        self.threshold = None
-        self.segm = None
-        self.total_error = None
-        self.segment_catalog = None
-        self.xypos = None
-        self.null_column = None
-
-        self.is_star = None
-        self.aperture_radii = None
-        self.aperture_corrs = None
-        self.bkg_aperture_inner = None
-        self.bkg_aperture_outer = None
-        self.abvega_offset = None
-        self.aperture_catalog = None
-        self.extras_catalog = None
-        self.catalog = None
-
     @staticmethod
-    def _add_column(catalog, column, value, description=None):
-        catalog[column] = value
-        if description is not None:
-            catalog[column].info.description = description
-        return
+    def _validate_aperture_ee(aperture_ee):
+        aperture_ee = np.array(aperture_ee).astype(int)
 
-    def _make_aperture_colnames(self, name):
-        if name == 'flux':
-            ftype = 'Flux'
-            ftype2 = 'flux'
-        elif name == 'abmag':
-            ftype = ftype2 = 'AB magnitude'
-        elif name == 'vegamag':
-            ftype = ftype2 = 'Vega magnitude'
+        if not np.all(aperture_ee[1:] > aperture_ee[:-1]):
+            raise ValueError('aperture_ee values must be strictly '
+                             'increasing')
+        if len(aperture_ee) != 3:
+            raise ValueError('aperture_ee must contain only 3 values')
+        if np.any(np.logical_or(aperture_ee <= 0, aperture_ee >= 100)):
+            raise ValueError('aperture_ee values must be between 0 and 100')
+        if np.any(aperture_ee[1:] < aperture_ee[:-1]):
+            raise ValueError('aperture_ee values must be in increasing order')
 
-        colnames = []
-        descriptions = []
-        for aper_ee in self.aperture_ee:
-            basename = f'aper{aper_ee}_{name}'
-            colnames.append(basename)
-            descriptions.append(f'{ftype} within the {aper_ee}% encircled energy circular aperture')
-            colnames.append(f'{basename}_err')
-            descriptions.append(f'{ftype} error within the {aper_ee}% encircled energy circular aperture')
+        return aperture_ee
 
-        colnames.extend([f'aper_total_{name}', f'aper_total_{name}_err'])
-        descriptions.append(f'Total aperture-corrected {ftype2} based on the {self.aperture_ee[-1]}% encircled energy circular aperture - calculated only for stars')
-        descriptions.append(f'Total aperture-corrected {ftype2} error based on the {self.aperture_ee[-1]}% encircled energy circular aperture - calculated only for stars')
+    @lazyproperty
+    def _aperture_ee_table(self):
+        if self.instrument == 'NIRCAM' or self.instrument == 'NIRISS':
+            selector = {'filter': self.filtername, 'pupil': self.pupil}
+        elif self.instrument == 'MIRI':
+            selector = {'filter': self.filtername, 'subarray': self.subarray}
+        elif self.instrument == 'FGS':
+            selector = None
+        else:
+            raise RuntimeError(f'{self.instrument} is not a valid instrument')
 
-        return colnames, descriptions
-
-    def _find_aperture_params(self, selector):
         apcorr_model = datamodels.open(self.apcorr_filename)
         apcorr = apcorr_model.apcorr_table
         if selector is None:  # FGS
@@ -132,22 +87,34 @@ class SourceCatalog:
                         for key, value in selector.items()]
             ee_table = apcorr[np.logical_and.reduce(mask_idx)]
 
+        return ee_table
+
+    def _get_ee_table_row(self, aperture_ee):
+        ee_percent = np.round(self._aperture_ee_table['eefraction'] * 100)
+        row_mask = (ee_percent == aperture_ee)
+        ee_row = self._aperture_ee_table[row_mask]
+        if len(ee_row) == 0:
+            raise RuntimeError('Aperture encircled energy value of {0} '
+                               'appears to be invalid. No matching row '
+                               'was found in the apcorr reference file '
+                               '{1}'.format(aperture_ee,
+                                            self.apcorr_filename))
+        if len(ee_row) > 1:
+            raise RuntimeError('More than one matching row was found in '
+                               'the apcorr reference file {0}'
+                               .format(self.apcorr_filename))
+        return ee_row
+
+    @lazyproperty
+    def aperture_params(self):
+        params = {}
+
         radii = []
         apcorrs = []
         skyins = []
         skyouts = []
-        for ee in self.aperture_ee:
-            row = ee_table[np.round(ee_table['eefraction'] * 100) == ee]
-            if len(row) == 0:
-                raise RuntimeError('Aperture encircled energy value of {0} '
-                                   'appears to be invalid. No matching row '
-                                   'was found in the apcorr reference file '
-                                   '{1}'.format(ee, self.apcorr_filename))
-            if len(row) > 1:
-                raise RuntimeError('More than one matching row was found in '
-                                   'the apcorr reference file {0}'
-                                   .format(self.apcorr_filename))
-
+        for aper_ee in self.aperture_ee:
+            row = self._get_ee_table_row(aper_ee)
             radii.append(row['radius'][0])
             apcorrs.append(row['apcorr'][0])
             skyins.append(row['skyin'][0])
@@ -159,8 +126,9 @@ class SourceCatalog:
         # the user changes the output pixel scale in the resample step,
         # then these radii need to be scaled.  Changing the output pixel
         # scale is not yet a pipeline option (as of Apr 2020).
-        self.aperture_radii = np.array(radii)
-        self.aperture_corrs = np.array(apcorrs)
+        params['aperture_ee'] = self.aperture_ee
+        params['aperture_radii'] = np.array(radii)
+        params['aperture_corrs'] = np.array(apcorrs)
 
         skyins = np.unique(skyins)
         skyouts = np.unique(skyouts)
@@ -168,26 +136,13 @@ class SourceCatalog:
             raise RuntimeError('Expected to find only one value for skyin '
                                'and skyout in the apcorr reference file for '
                                'a given selector.')
-        self.bkg_aperture_inner = skyins[0]
-        self.bkg_aperture_outer = skyouts[0]
+        params['bkg_aperture_inner'] = skyins[0]
+        params['bkg_aperture_outer'] = skyouts[0]
 
-        return
+        return params
 
-    def set_aperture_params(self):
-        if self.instrument == 'NIRCAM' or self.instrument == 'NIRISS':
-            selector = {'filter': self.filtername, 'pupil': self.pupil}
-        elif self.instrument == 'MIRI':
-            selector = {'filter': self.filtername, 'subarray': self.subarray}
-        elif self.instrument == 'FGS':
-            selector = None
-        else:
-            raise RuntimeError(f'{self.instrument} is not a valid instrument')
-
-        self._find_aperture_params(selector)
-
-        return
-
-    def set_abvega_offset(self):
+    @lazyproperty
+    def abvega_offset(self):
         if self.instrument == 'NIRCAM' or self.instrument == 'NIRISS':
             selector = {'filter': self.filtername, 'pupil': self.pupil}
         elif self.instrument == 'MIRI':
@@ -198,10 +153,9 @@ class SourceCatalog:
             raise RuntimeError(f'{self.instrument} is not a valid instrument')
 
         if self.abvega_offset_filename is None:
-            self.abvega_offset = 0.0
             log.info('ABVegaOffsetModel reference file was not input -- '
                      'catalog Vega magnitudes are not correct.')
-            return
+            return 0.0
 
         abvega_offset_model = ABVegaOffsetModel(self.abvega_offset_filename)
         offsets_table = abvega_offset_model.abvega_offset
@@ -225,31 +179,20 @@ class SourceCatalog:
                                'ABVegaOffsetModel reference file {0}'
                                .format(self.abvega_offset_filename))
 
-        self.abvega_offset = row['abvega_offset'][0]
-        log.info('AB to Vega magnitude offset {:.5f}'
-                 .format(self.abvega_offset))
+        abvega_offset = row['abvega_offset'][0]
+        log.info('AB to Vega magnitude offset {:.5f}'.format(abvega_offset))
 
-        return
+        return abvega_offset
 
-    def convert_to_jy(self):
-        """ convert from MJy/sr to Jy"""
 
-        if self.model.meta.bunit_data != 'MJy/sr':
-            raise ValueError('data is expected to be in units of MJy/sr')
-        self.model.data *= (1.e6 *
-                            self.model.meta.photometry.pixelarea_steradians)
-        self.model.meta.bunit_data = 'Jy'
+class Background:
+    def __init__(self, data, bkg_boxsize=100, mask=None):
+        self.data = data
+        self.bkg_boxsize = np.int(bkg_boxsize)  # must be integer
+        self.mask = mask
 
-        return
-
-    def make_coverage_mask(self):
-        # NOTE: currently the wht output from the resample step is
-        # always an exposure-time map
-        self.coverage_mask = (self.model.wht == 0)
-
-        return self.coverage_mask
-
-    def estimate_background(self):
+    @lazyproperty
+    def _background2d(self):
         """
         Estimate the 2D background and background RMS noise in an image.
 
@@ -272,165 +215,161 @@ class SourceCatalog:
         sigma_clip = SigmaClip(sigma=3.)
         bkg_estimator = MedianBackground()
         filter_size = (3, 3)
-        bkg = Background2D(self.model.data, self.bkg_boxsize,
-                           filter_size=filter_size, mask=self.coverage_mask,
+        bkg = Background2D(self.data, self.bkg_boxsize,
+                           filter_size=filter_size, mask=self.mask,
                            sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
 
         # apply the coverage mask
-        bkg.background *= np.logical_not(self.coverage_mask)
-        bkg.background_rms *= np.logical_not(self.coverage_mask)
+        bkg.background *= np.logical_not(self.mask)
+        bkg.background_rms *= np.logical_not(self.mask)
 
-        self._bkg = bkg
-        self.background = bkg.background
-        self.background_rms = bkg.background_rms
+        return bkg
 
-        return self.background, self.background_rms
+    @lazyproperty
+    def background(self):
+        return self._background2d.background
 
-    def subtract_background(self):
-        self.model.data -= self.background
-        return
+    @lazyproperty
+    def background_rms(self):
+        return self._background2d.background_rms
 
-    def make_kernel(self):
-        """
-        Make a 2D Gaussian smoothing kernel that is used to filter the image
-        before thresholding.
 
-        Filtering the image will smooth the noise and maximize detectability
-        of objects with a shape similar to the kernel.
+def make_kernel(kernel_fwhm):
+    """
+    Make a 2D Gaussian smoothing kernel that is used to filter the image
+    before thresholding.
 
-        Parameters
-        ----------
-        kernel_fwhm : float
-            The full-width at half-maximum (FWHM) of the 2D Gaussian kernel.
+    Filtering the image will smooth the noise and maximize detectability
+    of objects with a shape similar to the kernel.
 
-        Returns
-        -------
-        kernel : `astropy.convolution.Kernel2D`
-            The output smoothing kernel, normalized such that it sums to 1.
-        """
+    Parameters
+    ----------
+    kernel_fwhm : float
+        The full-width at half-maximum (FWHM) of the 2D Gaussian kernel.
 
-        sigma = self.kernel_fwhm * gaussian_fwhm_to_sigma
-        kernel = Gaussian2DKernel(sigma)
-        kernel.normalize(mode='integral')
+    Returns
+    -------
+    kernel : `astropy.convolution.Kernel2D`
+        The output smoothing kernel, normalized such that it sums to 1.
+    """
 
+    sigma = kernel_fwhm * gaussian_fwhm_to_sigma
+    kernel = Gaussian2DKernel(sigma)
+    kernel.normalize(mode='integral')
+
+    return kernel
+
+
+def make_segment_img(data, threshold, npixels=5.0, kernel=None, mask=None,
+                     deblend=False):
+    """
+    Detect sources in an image, including deblending.
+
+    Parameters
+    ----------
+    data : `ImageModel`
+        The input `ImageModel` of a single drizzled image.  The
+        input image is assumed to be background subtracted.
+
+    threshold : float
+        The data value or pixel-wise data values to be used for the
+        detection threshold. A 2D threshold must have the same shape as
+        ``model.data``.
+
+    npixels : int
+        The number of connected pixels, each greater than the threshold
+        that an object must have to be detected.  ``npixels`` must be a
+        positive integer.
+
+    kernel : `astropy.convolution.Kernel2D`
+        The filtering kernel.
+
+    mask : bool ndarray
+
+    deblend : bool, optional
+        Whether to deblend overlapping sources.  Source deblending
+        requires scikit-image.
+
+    Returns
+    -------
+    segment_image : `~photutils.segmentation.SegmentationImage` or `None`
+        A 2D segmentation image, with the same shape as the input data
+        where sources are marked by different positive integer values.
+        A value of zero is reserved for the background.  If no sources
+        are found then `None` is returned.
+    """
+
+    connectivity = 8
+    segm = detect_sources(data, threshold, npixels, filter_kernel=kernel,
+                          mask=mask, connectivity=connectivity)
+
+    # segm=None for photutils >= 0.7
+    # segm.nlabels=0 for photutils < 0.7
+    if segm is None or segm.nlabels == 0:
+        return None
+
+    # source deblending requires scikit-image
+    if deblend:
+        nlevels = 32
+        contrast = 0.001
+        mode = 'exponential'
+        segm = deblend_sources(data, segm, npixels=npixels,
+                               filter_kernel=kernel, nlevels=nlevels,
+                               contrast=contrast, mode=mode,
+                               connectivity=connectivity, relabel=True)
+
+    return segm
+
+
+def calc_total_error(model):
+    """
+    Calculate the total error (background plus source Poisson error).
+    """
+
+    # TODO: Until errors are produced for the level 3 drizzle
+    # products, the JPWG has decided that the errors should not be
+    # populated.
+    return np.zeros_like(model.data)
+
+
+class SourceCatalog:
+    def __init__(self, model, segment_img, error=None, kernel=None,
+                 aperture_params=None, abvega_offset=0.0):
+
+        if not isinstance(model, ImageModel):
+            raise ValueError('The input model must be a ImageModel.')
+        self.model = model  # background was subtracted in SourceDetection
+
+        self.segment_img = segment_img
+        self.error = error  # total error array
         self.kernel = kernel
+        self.aperture_params = aperture_params
+        self.abvega_offset = abvega_offset
 
-        return self.kernel
+        self.aperture_ee = aperture_params['aperture_ee']
+        self.n_aper = len(self.aperture_ee)
+        self.column_desc = {}
 
-    def calc_threshold(self):
-        self.threshold = self.snr_threshold * self.background_rms
-        return self.threshold
+        # self.wcs = self.model.meta.wcs  # gWCS
+        self.wcs = self.model.get_fits_wcs()  # FITS WCS
 
-    def detect_sources(self):
-        """
-        Detect sources in an image, including deblending.
+    def convert_to_jy(self):
+        """ convert from MJy/sr to Jy"""
 
-        Parameters
-        ----------
-        model : `ImageModel`
-            The input `ImageModel` of a single drizzled image.  The
-            input image is assumed to be background subtracted.
+        if self.model.meta.bunit_data != 'MJy/sr':
+            raise ValueError('data is expected to be in units of MJy/sr')
+        self.model.data *= (1.e6 *
+                            self.model.meta.photometry.pixelarea_steradians)
+        self.model.meta.bunit_data = 'Jy'
 
-        threshold : float
-            The data value or pixel-wise data values to be used for the
-            detection threshold. A 2D threshold must have the same shape as
-            ``model.data``.
-
-        npixels : int
-            The number of connected pixels, each greater than the threshold
-            that an object must have to be detected.  ``npixels`` must be a
-            positive integer.
-
-        kernel : `astropy.convolution.Kernel2D`
-            The filtering kernel.
-
-        mask : bool ndarray
-
-        deblend : bool, optional
-            Whether to deblend overlapping sources.  Source deblending
-            requires scikit-image.
-
-        Returns
-        -------
-        segment_image : `~photutils.segmentation.SegmentationImage` or `None`
-            A 2D segmentation image, with the same shape as the input data
-            where sources are marked by different positive integer values.
-            A value of zero is reserved for the background.  If no sources
-            are found then `None` is returned.
-        """
-
-        connectivity = 8
-        segm = detect_sources(self.model.data, self.threshold,
-                              npixels=self.npixels, filter_kernel=self.kernel,
-                              mask=self.coverage_mask,
-                              connectivity=connectivity)
-
-        # segm=None for photutils >= 0.7
-        # segm.nlabels=0 for photutils < 0.7
-        if segm is None or segm.nlabels == 0:
-            return None
-
-        # source deblending requires scikit-image
-        if self.deblend:
-            nlevels = 32
-            contrast = 0.001
-            mode = 'exponential'
-            segm = deblend_sources(self.model.data, segm,
-                                   npixels=self.npixels,
-                                   filter_kernel=self.kernel, nlevels=nlevels,
-                                   contrast=contrast, mode=mode,
-                                   connectivity=connectivity, relabel=True)
-        self.segm = segm
-
-        return segm
-
-    def _calc_total_error(self):
-        """
-        Calculate total error (background plus source Poisson error).
-        """
-
-        # The resample step still does not allow for background-only
-        # inverse-variance maps.  Here we estimate the background-only rms
-        # directly from the data, but note this is dependent on the
-        # ``box_size`` parameter in ``estimate_background``.
-        bkg_error = self.background_rms  # Jy
-
-        # The source Poisson noise contribution to the total error requires
-        # converting the image into electrons.  The input images are in
-        # units of MJy/sr.  They can be converted to units of counts (DN)
-        # per second via the PHOTMJSR keyword, and then to counts (DN) using
-        # the exposure-time weight map.  However, the final conversion from
-        # DN to electrons requires knowing the gain, which is not available
-        # in the level-3 products.  Here we assume the gain is 1.
-
-        # the effective gain is the multiplicative factor to convert the
-        # input image from Jy to e-
-        gain = 1.0  # e-/DN; this is a rough approximation
-        dn_s_factor = (1.e6 *
-                       self.model.meta.photometry.pixelarea_steradians *
-                       self.model.meta.photometry.conversion_megajanskys)
-        effective_gain = gain / dn_s_factor * self.model.wht  # Jy -> e-
-
-        self.total_error = calc_total_error(self.model.data, bkg_error,
-                                            effective_gain)
-
-        return self.total_error
-
-    def calc_total_error(self):
-        #self.total_error = self._calc_total_error()
-        self.total_error = np.zeros_like(self.model.data)
-        return self.total_error
-
-    def apply_units(self):
         unit = u.Jy
         self.model.data <<= unit
-        self.total_error <<= unit
-        self.background <<= unit
-        self.background_rms <<= unit
+        self.error <<= unit
+
         return
 
     @staticmethod
-    def flux_to_abmag(flux, flux_err):
+    def convert_flux_to_abmag(flux, flux_err):
         """
         Parameters
         ----------
@@ -449,60 +388,10 @@ class SourceCatalog:
 
         return abmag, abmag_err
 
-    def make_segment_catalog(self):
-        """
-        Create a catalog of source photometry and morphologies based on
-        segmentation.
-        """
-
-        # wcs = self.model.meta.wcs  # gWCS
-        wcs = self.model.get_fits_wcs()  # FITS WCS
-
-        source_props = source_properties(self.model.data.astype(float),
-                                         self.segm, error=self.total_error,
-                                         background=self.background,
-                                         filter_kernel=self.kernel, wcs=wcs)
-
-        columns = ['id', 'xcentroid', 'ycentroid', 'sky_centroid',
-                   'source_sum', 'source_sum_err', 'area',
-                   'semimajor_axis_sigma', 'semiminor_axis_sigma',
-                   'ellipticity', 'orientation', 'sky_bbox_ll', 'sky_bbox_ul',
-                   'sky_bbox_lr', 'sky_bbox_ur']
-        catalog = source_props.to_table(columns=columns)
-
-        # save the source positions for aperture photometry
-        self.xypos = np.transpose((catalog['xcentroid'],
-                                   catalog['ycentroid']))
-
-        flux_col = 'isophotal_flux'
-        flux_err_col = 'isophotal_flux_err'
-        catalog.rename_column('source_sum', flux_col)
-        catalog.rename_column('source_sum_err', flux_err_col)
-        catalog.rename_column('area', 'isophotal_area')
-        catalog.rename_column('semimajor_axis_sigma', 'semimajor_sigma')
-        catalog.rename_column('semiminor_axis_sigma', 'semiminor_sigma')
-
-        # Define the orientation position angle (E of N)
-        # NOTE: crpix1 and crpix2 are 1-based values
-        skycoord = wcs.pixel_to_world(self.model.meta.wcsinfo.crpix1 - 1,
-                                      self.model.meta.wcsinfo.crpix2 - 1)
-        _, angle = _pixel_scale_angle_at_skycoord(skycoord, wcs)
-        sky_orientation = (180.0 * u.deg) - angle + catalog['orientation']
-        catalog.add_column(sky_orientation, name='sky_orientation', index=11)
-
-        # Add ABmag and Vegamag columns
-        flux = catalog[flux_col]
-        flux_err = catalog[flux_err_col]
-        abmag, abmag_err = self.flux_to_abmag(flux, flux_err)
-        vegamag = abmag - self.abvega_offset
-        vegamag_err = abmag_err
-        catalog.add_column(abmag, name='isophotal_abmag', index=6)
-        catalog.add_column(abmag_err, name='isophotal_abmag_err', index=7)
-        catalog.add_column(vegamag, name='isophotal_vegamag', index=8)
-        catalog.add_column(vegamag_err, name='isophotal_vegamag_err', index=9)
-
-        # add column descriptions
-        desc = {}
+    @lazyproperty
+    def segment_colnames(self):
+        # define segment column names and descriptions
+        desc = OrderedDict()
         desc['id'] = 'Unique source identification number'
         desc['xcentroid'] = 'X pixel value of the source centroid'
         desc['ycentroid'] = 'Y pixel value of the source centroid'
@@ -538,54 +427,180 @@ class SourceCatalog:
         desc['sky_bbox_ur'] = ('Sky coordinate of the upper-right vertex of '
                                'the minimal bounding box of the source')
 
-        for key, val in desc.items():
-            catalog[key].info.description = val
+        self.column_desc.update(desc)
 
+        return list(desc.keys())
 
-        #catalog['id'].info.description = 'Unique source identification number'
-        #catalog['xcentroid'].info.description = 'X pixel value of the source centroid'
-        #catalog['ycentroid'].info.description = 'Y pixel value of the source centroid'
-        #catalog['sky_centroid'].info.description = 'Sky coordinate of the source centroid'
-        #catalog['isophotal_flux'].info.description = 'Isophotal flux'
-        #catalog['isophotal_flux_err'].info.description = 'Isophotal flux error'
-        #catalog['isophotal_abmag'].info.description = 'Isophotal AB magnitude'
-        #catalog['isophotal_abmag_err'].info.description = 'Isophotal AB magnitude error'
-        #catalog['isophotal_vegamag'].info.description = 'Isophotal Vega magnitude'
-        #catalog['isophotal_vegamag_err'].info.description = 'Isophotal Vega magnitude error'
-        #catalog['isophotal_area'].info.description = 'Isophotal area'
-        #catalog['semimajor_sigma'].info.description = '1-sigma standard deviation along the semimajor axis of the 2D Gaussian function that has the same second-order central moments as the source'
-        #catalog['semiminor_sigma'].info.description = '1-sigma standard deviation along the semiminor axis of the 2D Gaussian function that has the same second-order central moments as the source'
-        #catalog['ellipticity'].info.description = '1 minus the ratio of the 1-sigma lengths of the semimajor and semiminor axes'
-        #catalog['orientation'].info.description = 'The angle (degrees) between the positive X axis and the major axis (increases counter-clockwise)'
-        #catalog['sky_orientation'].info.description = 'The position angle (degrees) from North of the major axis'
-        #catalog['sky_bbox_ll'].info.description = 'Sky coordinate of the lower-left vertex of the minimal bounding box of the source'
-        #catalog['sky_bbox_ul'].info.description = 'Sky coordinate of the upper-left vertex of the minimal bounding box of the source'
-        #catalog['sky_bbox_lr'].info.description = 'Sky coordinate of the lower-right vertex of the minimal bounding box of the source'
-        #catalog['sky_bbox_ur'].info.description = 'Sky coordinate of the upper-right vertex of the minimal bounding box of the source'
+    def set_segment_properties(self):
+        """
+        Create a catalog of source photometry and morphologies based on
+        segmentation.
+        """
 
-        self.segment_catalog = catalog
+        source_props = source_properties(self.model.data.astype(float),
+                                         self.segment_img,
+                                         error=self.error,
+                                         filter_kernel=self.kernel,
+                                         wcs=self.wcs)
 
-        return self.segment_catalog
+        # rename some columns in the output catalog
+        prop_names = {}
+        prop_names['isophotal_flux'] = 'source_sum'
+        prop_names['isophotal_flux_err'] = 'source_sum_err'
+        prop_names['isophotal_area'] = 'area'
+        prop_names['semimajor_sigma'] = 'semimajor_axis_sigma'
+        prop_names['semiminor_sigma'] = 'semiminor_axis_sigma'
 
-    def make_null_column(self):
-        values = np.empty(len(self.segment_catalog))
+        for column in self.segment_colnames:
+            # define the property name
+            prop_name = prop_names.get(column, column)
+
+            try:
+                value = getattr(source_props, prop_name)
+            except AttributeError:
+                value = getattr(self, prop_name)
+
+            setattr(self, column, value)
+
+        return
+
+    @lazyproperty
+    def null_column(self):
+        values = np.empty(len(self.id))
         values.fill(np.nan)
-        self.null_column = values
+        return values
 
-        return self.null_column
+    @lazyproperty
+    def xypos(self):
+        # source positions
+        return np.transpose((self.xcentroid, self.ycentroid))
 
-    def calc_aper_local_background(self, bkg_aper):
+    @lazyproperty
+    def _isophotal_abmag(self):
+        return self.convert_flux_to_abmag(self.isophotal_flux,
+                                          self.isophotal_flux_err)
+
+    @lazyproperty
+    def isophotal_abmag(self):
+        return self._isophotal_abmag[0]
+
+    @lazyproperty
+    def isophotal_abmag_err(self):
+        return self._isophotal_abmag[1]
+
+    @lazyproperty
+    def isophotal_vegamag(self):
+        return self.isophotal_abmag - self.abvega_offset
+
+    @lazyproperty
+    def isophotal_vegamag_err(self):
+        return self.isophotal_abmag_err
+
+    @lazyproperty
+    def sky_orientation(self):
+        # Define the orientation position angle (E of N)
+        # NOTE: crpix1 and crpix2 are 1-based values
+        skycoord = self.wcs.pixel_to_world(self.model.meta.wcsinfo.crpix1 - 1,
+                                           self.model.meta.wcsinfo.crpix2 - 1)
+        _, angle = _pixel_scale_angle_at_skycoord(skycoord, self.wcs)
+
+        return (180.0 * u.deg) - angle + self.orientation
+
+    def _make_aperture_colnames(self, name):
+        colnames = []
+        for aper_ee in self.aperture_ee:
+            basename = f'aper{aper_ee}_{name}'
+            colnames.append(basename)
+            colnames.append(f'{basename}_err')
+        colnames.extend([f'aper_total_{name}', f'aper_total_{name}_err'])
+
+        return colnames
+
+    def _make_aperture_descriptions(self, name):
+        if name == 'flux':
+            ftype = 'Flux'
+            ftype2 = 'flux'
+        elif name == 'abmag':
+            ftype = ftype2 = 'AB magnitude'
+        elif name == 'vegamag':
+            ftype = ftype2 = 'Vega magnitude'
+
+        desc = []
+        for aper_ee in self.aperture_ee:
+            desc.append(f'{ftype} within the {aper_ee}% encircled energy '
+                        'circular aperture')
+            desc.append(f'{ftype} error within the {aper_ee}% encircled '
+                        'energy circular aperture')
+
+        desc.append(f'Total aperture-corrected {ftype2} based on the '
+                    f'{self.aperture_ee[-1]}% encircled energy circular '
+                    'aperture - calculated only for stars')
+        desc.append(f'Total aperture-corrected {ftype2} error based on the '
+                    f'{self.aperture_ee[-1]}% encircled energy circular '
+                    'aperture - calculated only for stars')
+
+        return desc
+
+    @lazyproperty
+    def aperture_flux_colnames(self):
+        return self._make_aperture_colnames('flux')
+
+    @lazyproperty
+    def aperture_flux_descriptions(self):
+        return self._make_aperture_descriptions('flux')
+
+    @lazyproperty
+    def aperture_abmag_colnames(self):
+        return self._make_aperture_colnames('abmag')
+
+    @lazyproperty
+    def aperture_abmag_descriptions(self):
+        return self._make_aperture_descriptions('abmag')
+
+    @lazyproperty
+    def aperture_vegamag_colnames(self):
+        return self._make_aperture_colnames('vegamag')
+
+    @lazyproperty
+    def aperture_vegamag_descriptions(self):
+        return self._make_aperture_descriptions('vegamag')
+
+    @lazyproperty
+    def aperture_colnames(self):
+        desc = OrderedDict()
+        desc['aper_bkg_flux'] = ('The local background value calculated as '
+                                 'the sigma-clipped median value in the '
+                                 'background annulus aperture')
+        desc['aper_bkg_flux_err'] = ('The standard error of the '
+                                     'sigma-clipped median background value')
+
+        for idx, colname in enumerate(self.aperture_flux_colnames):
+            desc[colname] = self.aperture_flux_descriptions[idx]
+        for idx, colname in enumerate(self.aperture_abmag_colnames):
+            desc[colname] = self.aperture_abmag_descriptions[idx]
+        for idx, colname in enumerate(self.aperture_vegamag_colnames):
+            desc[colname] = self.aperture_vegamag_descriptions[idx]
+
+        self.column_desc.update(desc)
+
+        return list(desc.keys())
+
+    @lazyproperty
+    def _aper_local_background(self):
         """
         Estimate the local background as the sigma-clipped median value
         in the input aperture.
         """
 
+        bkg_aper = CircularAnnulus(self.xypos,
+                                   self.aperture_params['bkg_aperture_inner'],
+                                   self.aperture_params['bkg_aperture_outer'])
         bkg_aper_masks = bkg_aper.to_mask(method='center')
         sigclip = SigmaClip(sigma=3)
 
+        nvalues = []
         bkg_median = []
         bkg_std = []
-        nvalues = []
         for mask in bkg_aper_masks:
             bkg_data = mask.multiply(self.model.data.value)
             bkg_data_1d = bkg_data[mask.data > 0]
@@ -604,13 +619,73 @@ class SourceCatalog:
 
         return bkg_median, bkg_median_err
 
-    def calc_concentration_index(self):
-        col1 = self._abmag_colnames[0]  # ee_fraction[0]
-        col2 = self._abmag_colnames[4]  # ee_fraction[2]
+    @lazyproperty
+    def aper_bkg_flux(self):
+        return self._aper_local_background[0]
 
-        return self.aperture_catalog[col1] - self.aperture_catalog[col2]
+    @lazyproperty
+    def aper_bkg_flux_err(self):
+        return self._aper_local_background[1]
 
-    def calc_is_star(self):
+    def set_aperture_properties(self):
+        apertures = [CircularAperture(self.xypos, radius) for radius in
+                     self.aperture_params['aperture_radii']]
+        aper_phot = aperture_photometry(self.model.data, apertures,
+                                        error=self.error)
+
+        for i, aperture in enumerate(apertures):
+            flux_col = f'aperture_sum_{i}'
+            flux_err_col = f'aperture_sum_err_{i}'
+
+            # subtract the local background measured in the annulus
+            aper_phot[flux_col] -= (self.aper_bkg_flux * aperture.area)
+
+            flux = aper_phot[flux_col]
+            flux_err = aper_phot[flux_err_col]
+            abmag, abmag_err = self.convert_flux_to_abmag(flux, flux_err)
+            vegamag = abmag - self.abvega_offset
+            vegamag_err = abmag_err
+
+            idx0 = 2 * i
+            idx1 = (2 * i) + 1
+            setattr(self, self.aperture_flux_colnames[idx0], flux)
+            setattr(self, self.aperture_flux_colnames[idx1], flux_err)
+            setattr(self, self.aperture_abmag_colnames[idx0], abmag)
+            setattr(self, self.aperture_abmag_colnames[idx1], abmag_err)
+            setattr(self, self.aperture_vegamag_colnames[idx0], vegamag)
+            setattr(self, self.aperture_vegamag_colnames[idx1], vegamag_err)
+
+    @lazyproperty
+    def extras_colnames(self):
+        desc = OrderedDict()
+
+        ci_desc = ('Concentration index calculated as '
+                   f'{self.aperture_abmag_colnames[0]} - '
+                   f'{self.aperture_abmag_colnames[4]}')
+        desc['concentration_index'] = ci_desc
+
+        desc['is_star'] = 'Flag indicating whether the source is a star'
+        desc['sharpness'] = 'The DAOFind source sharpness statistic'
+        desc['roundness'] = 'The DAOFind source roundness statistic'
+        desc['nn_dist'] = 'The distance in pixels to the nearest neighbor'
+        desc['nn_abmag'] = 'The AB magnitude of the nearest neighbor'
+
+        self.column_desc.update(desc)
+
+        return list(desc.keys())
+
+    @lazyproperty
+    def ci_colname(self):
+        return f'CI_{self.aperture_ee[0]}_{self.aperture_ee[2]}'
+
+    @lazyproperty
+    def concentration_index(self):
+        abmag1 = self.aperture_abmag_colnames[0]  # ee_fraction[0]
+        abmag2 = self.aperture_abmag_colnames[4]  # ee_fraction[2]
+        return getattr(self, abmag1) - getattr(self, abmag2)
+
+    @lazyproperty
+    def is_star(self):
         """
         Calculate a flag based on whether the source is a star.
 
@@ -619,132 +694,20 @@ class SourceCatalog:
         """
 
         # TODO: need algorithm for this flag
-        #is_star = np.random.randint(2, size=len(self.aperture_catalog))
+        #is_star = np.random.randint(2, size=len(self.id))
         #return is_star.astype(bool)
-
         return self.null_column
 
-    def append_aper_total(self, catalog):
-        """
-        Calculate the aperture-corrected total flux for sources that are
-        stars.
-
-        The aperture fluxes in the largest aperture (i.e., the largest
-        encircled energy) are corrected to total flux.
-        """
-
-        idx = 2  # apcorr for the largest EE (largest radius)
-        apcorr = self.aperture_corrs[idx]
-        total_flux = (apcorr *
-                      self.aperture_catalog[self._flux_colnames[idx*2]])
-        total_flux_err = (apcorr *
-                          self.aperture_catalog[self._flux_colnames[idx*2 + 1]])
-
-        if np.isnan(self.is_star[0]):
-            # TODO: remove this when ``is_star`` values are available
-            # this array is all False
-            is_star = np.zeros(len(self.aperture_catalog), dtype=bool)
-        else:
-            is_star = self.is_star
-
-        not_star = np.logical_not(is_star)
-        total_flux[not_star] = np.nan
-        total_flux_err[not_star] = np.nan
-        catalog[self._flux_colnames[-2]] = total_flux
-        catalog[self._flux_colnames[-1]] = total_flux_err
-
-        abmag, abmag_err = self.flux_to_abmag(total_flux, total_flux_err)
-        vegamag = abmag - self.abvega_offset
-        vegamag_err = abmag_err
-        #catalog[self._abmag_colnames[-2]] = abmag
-        #catalog[self._abmag_colnames[-1]] = abmag_err
-        #catalog[self._vegamag_colnames[-2]] = vegamag
-        #catalog[self._vegamag_colnames[-1]] = vegamag_err
-
-        for idx in (-2, -1):
-            self._add_column(catalog, self._flux_colnames[idx], total_flux,
-                             self._flux_coldesc[idx])
-            self._add_column(catalog, self._abmag_colnames[idx], total_flux,
-                             self._abmag_coldesc[idx])
-            self._add_column(catalog, self._vegamag_colnames[idx], total_flux,
-                             self._vegamag_coldesc[idx])
-
-
-        #catalog[self._flux_colnames[-2]].info.description = self._flux_coldesc[-2]
-        #catalog[self._flux_colnames[-1]].info.description = self._flux_coldesc[-1]
-        #catalog[self._abmag_colnames[-2]].info.description = self._abmag_coldesc[-2]
-        #catalog[self._abmag_colnames[-1]].info.description = self._abmag_coldesc[-1]
-        #catalog[self._vegamag_colnames[-2]].info.description = self._vegamag_coldesc[-2]
-        #catalog[self._vegamag_colnames[-1]].info.description = self._vegamag_coldesc[-2]
-
-        return catalog
-
-    def make_aperture_catalog(self):
-        bkg_aperture = CircularAnnulus(self.xypos, self.bkg_aperture_inner,
-                                       self.bkg_aperture_outer)
-        bkg_median, bkg_median_err = self.calc_aper_local_background(
-            bkg_aperture)
-
-        apertures = [CircularAperture(self.xypos, radius) for radius in
-                     self.aperture_radii]
-        aper_phot = aperture_photometry(self.model.data, apertures,
-                                        error=self.total_error)
-
-        for i, aperture in enumerate(apertures):
-            flux_col = f'aperture_sum_{i}'
-            flux_err_col = f'aperture_sum_err_{i}'
-
-            # subtract the local background measured in the annulus
-            aper_phot[flux_col] -= (bkg_median * aperture.area)
-
-            flux = aper_phot[flux_col]
-            flux_err = aper_phot[flux_err_col]
-            abmag, abmag_err = self.flux_to_abmag(flux, flux_err)
-            vegamag = abmag - self.abvega_offset
-            vegamag_err = abmag_err
-
-            idx0 = 2 * i
-            idx1 = (2 * i) + 1
-            new_flux_col = self._flux_colnames[idx0]
-            new_flux_err_col = self._flux_colnames[idx1]
-            abmag_col = self._abmag_colnames[idx0]
-            abmag_err_col = self._abmag_colnames[idx1]
-            vegamag_col = self._vegamag_colnames[idx0]
-            vegamag_err_col = self._vegamag_colnames[idx1]
-
-            aper_phot.rename_column(flux_col, new_flux_col)
-            aper_phot.rename_column(flux_err_col, new_flux_err_col)
-            aper_phot[new_flux_col].info.description = self._flux_coldesc[idx0]
-            aper_phot[new_flux_err_col].info.description = self._flux_coldesc[idx1]
-
-            #print(abmag_col, abmag, self._abmag_coldesc[idx0])
-
-            self._add_column(aper_phot, abmag_col, abmag,
-                             self._abmag_coldesc[idx0])
-            self._add_column(aper_phot, abmag_err_col, abmag_err,
-                             self._abmag_coldesc[idx1])
-            self._add_column(aper_phot, vegamag_col, vegamag,
-                             self._vegamag_coldesc[idx0])
-            self._add_column(aper_phot, vegamag_err_col, vegamag_err,
-                             self._vegamag_coldesc[idx1])
-
-        aper_phot.add_column(bkg_median, name=self._bkg_colnames[0], index=3)
-        aper_phot.add_column(bkg_median_err, name=self._bkg_colnames[1],
-                             index=4)
-        aper_phot[self._bkg_colnames[0]].info.description = self._bkg_coldesc[0]
-        aper_phot[self._bkg_colnames[1]].info.description = self._bkg_coldesc[1]
-
-        self.aperture_catalog = aper_phot
-
-        return self.aperture_catalog
-
-    def calc_sharpness(self, catalog):
+    @lazyproperty
+    def sharpness(self):
         return self.null_column
 
-    def calc_roundness(self, catalog):
+    @lazyproperty
+    def roundness(self):
         return self.null_column
 
-    def calc_nearest_neighbors(self, catalog):
+    @lazyproperty
+    def _ckdtree_query(self):
         """
         Calculate the distance in pixels to the nearest neighbor and
         its AB magnitude.
@@ -754,54 +717,119 @@ class SourceCatalog:
         magnitude is used.
         """
 
-        xypos = np.transpose((self.segment_catalog['xcentroid'],
-                              self.segment_catalog['ycentroid']))
-        tree = cKDTree(xypos)
-        qdist, qidx = tree.query(xypos, k=2)
-        dist = np.transpose(qdist)[1]
-        idx = np.transpose(qidx)[1]
+        tree = cKDTree(self.xypos)
+        qdist, qidx = tree.query(self.xypos, k=2)
+        return np.transpose(qdist)[1], np.transpose(qidx)[1]
 
-        nn_abmag = catalog['aper_total_abmag'][idx]
-        nn_isomag = self.segment_catalog['isophotal_abmag'][idx]
+    @lazyproperty
+    def nn_dist(self):
+        return self._ckdtree_query[0] * u.pixel
 
-        return dist, np.where(np.isnan(nn_abmag), nn_isomag, nn_abmag)
+    @lazyproperty
+    def nn_abmag(self):
+        nn_abmag = self.aper_total_abmag[self._ckdtree_query[1]]
+        nn_isomag = self.isophotal_abmag[self._ckdtree_query[1]]
+        return np.where(np.isnan(nn_abmag), nn_isomag, nn_abmag)
 
-    def make_extras_catalog(self):
-        catalog = self.segment_catalog[['id']]  # new table
+    @lazyproperty
+    def _not_star(self):
+        if np.isnan(self.is_star[0]):
+            # TODO: remove this when ``is_star`` values are available.
+            # this array is all False:
+            is_star = np.zeros(len(self.id), dtype=bool)
+        else:
+            is_star = self.is_star
 
-        self.is_star = self.calc_is_star()
-        catalog = self.append_aper_total(catalog)
+        return np.logical_not(is_star)
 
-        ci_desc = ('Concentration index calculated as '
-                   f'{self._abmag_colnames[0]} - {self._abmag_colnames[4]}')
-        self._add_column(catalog, self._ci_colname,
-                         self.calc_concentration_index(), ci_desc)
+    @lazyproperty
+    def aper_total_flux(self):
+        """
+        Calculate the aperture-corrected total flux for sources that are
+        stars.
 
-        is_star_desc = 'Flag indicating whether the source is a star'
-        self._add_column(catalog, 'is_star', self.is_star, is_star_desc)
+        The aperture fluxes in the largest aperture (i.e., the largest
+        encircled energy) are corrected to total flux.
+        """
 
-        sharpness_desc = 'The DAOFind source sharpness statistic'
-        self._add_column(catalog, 'sharpness', self.calc_sharpness(catalog),
-                         sharpness_desc)
+        idx = self.n_aper - 1  # apcorr for the largest EE (largest radius)
+        flux = (self.aperture_params['aperture_corrs'][idx] *
+                getattr(self, self.aperture_flux_colnames[idx*2]))
+        flux[self._not_star] = np.nan
 
-        roundness_desc = 'The DAOFind source roundness statistic'
-        self._add_column(catalog, 'roundness', self.calc_roundness(catalog),
-                         roundness_desc)
+        return flux
 
-        nn_dist, nn_abmag = self.calc_nearest_neighbors(catalog)
-        nn_dist_desc = 'The distance in pixels to the nearest neighbor'
-        self._add_column(catalog, 'nn_dist', nn_dist * u.pixel, nn_dist_desc)
+    @lazyproperty
+    def aper_total_flux_err(self):
+        idx = self.n_aper - 1  # apcorr for the largest EE (largest radius)
+        flux_err = (self.aperture_params['aperture_corrs'][idx] *
+                    getattr(self, self.aperture_flux_colnames[idx*2 + 1]))
+        flux_err[self._not_star] = np.nan
 
-        nn_abmag_desc = 'The AB magnitude of the nearest neighbor'
-        self._add_column(catalog, 'nn_abmag', nn_abmag, nn_abmag_desc)
+        return flux_err
 
-        self.extras_catalog = catalog
+    @lazyproperty
+    def _abmag_total(self):
+        return self.convert_flux_to_abmag(self.aper_total_flux,
+                                          self.aper_total_flux_err)
 
-        return self.extras_catalog
+    @lazyproperty
+    def aper_total_abmag(self):
+        return self._abmag_total[0]
 
-    def make_source_catalog(self):
-        catalog = join(self.segment_catalog, self.aperture_catalog)
-        catalog = join(catalog, self.extras_catalog)
+    @lazyproperty
+    def aper_total_abmag_err(self):
+        return self._abmag_total[1]
+
+    @lazyproperty
+    def aper_total_vegamag(self):
+        return self.aper_total_abmag - self.abvega_offset
+
+    @lazyproperty
+    def aper_total_vegamag_err(self):
+        return self.aper_total_abmag_err
+
+    @lazyproperty
+    def colnames(self):
+        # Define the column name order for the final source catalog
+        colnames = self.segment_colnames[0:4]
+        colnames.extend(self.aperture_colnames)
+        colnames.extend(self.extras_colnames)
+        colnames.extend(self.segment_colnames[4:])
+
+        return colnames
+
+    @staticmethod
+    def format_columns(catalog):
+        # output formatting requested by the JPWG (2020.02.05)
+        for colname in catalog.colnames:
+            if colname in ('xcentroid', 'ycentroid') or 'CI_' in colname:
+                catalog[colname].info.format = '.4f'
+            if 'flux' in colname:
+                catalog[colname].info.format = '.6e'
+            if 'abmag' in colname or 'vegamag' in colname or 'nn_' in colname:
+                catalog[colname].info.format = '.6f'
+            if colname in ('semimajor_sigma', 'semiminor_sigma',
+                           'ellipticity', 'orientation', 'sky_orientation'):
+                catalog[colname].info.format = '.6f'
+
+        return catalog
+
+    @lazyproperty
+    def catalog(self):
+        #self.subtract_background()
+        self.convert_to_jy()
+        self.set_segment_properties()
+        self.set_aperture_properties()
+
+        renamed = {}
+        renamed['concentration_index'] = self.ci_colname
+
+        catalog = QTable()
+        for column in self.colnames:
+            colname = renamed.get(column, column)
+            catalog[colname] = getattr(self, column)
+            catalog[colname].info.description = self.column_desc[column]
 
         # TODO: Until errors are produced for the level 3 drizzle
         # products, the JPWG has decided that the errors should not be
@@ -810,55 +838,6 @@ class SourceCatalog:
             if colname.endswith('_err'):
                 catalog[colname][:] = self.null_column
 
-        # Define the column name order for the final source catalog
-        colnames = self.segment_catalog.colnames[0:4]
-        colnames.extend(self._bkg_colnames)
-        colnames.extend(self._flux_colnames)
-        colnames.extend(self._abmag_colnames)
-        colnames.extend(self._vegamag_colnames)
-        colnames.extend(self.extras_catalog.colnames[7:])
-        colnames.extend(self.segment_catalog.colnames[4:])
-        self.catalog = catalog[colnames]
+        catalog = self.format_columns(catalog)
 
-        return self.catalog
-
-    def run(self):
-        self.convert_to_jy()
-        self.make_coverage_mask()
-        self.estimate_background()
-        self.subtract_background()
-        self.make_kernel()
-        self.calc_threshold()
-
-        segm = self.detect_sources()
-        if segm is None:
-            log.info('No sources were found. Source catalog will not be '
-                     'created.')
-            return None
-        log.info(f'Detected {segm.nlabels} sources')
-
-        self.calc_total_error()
-        self.apply_units()
-        self.set_abvega_offset()
-
-        self.make_segment_catalog()
-        self.make_null_column()
-
-        self.set_aperture_params()
-        self.make_aperture_catalog()
-        self.make_extras_catalog()
-        self.make_source_catalog()
-
-        # output formatting requested by the JPWG (2020.02.05)
-        for colname in self.catalog.colnames:
-            if colname in ('xcentroid', 'ycentroid') or 'CI_' in colname:
-                self.catalog[colname].info.format = '.4f'
-            if 'flux' in colname:
-                self.catalog[colname].info.format = '.6e'
-            if 'abmag' in colname or 'vegamag' in colname or 'nn_' in colname:
-                self.catalog[colname].info.format = '.6f'
-            if colname in ('semimajor_sigma', 'semiminor_sigma',
-                           'ellipticity', 'orientation', 'sky_orientation'):
-                self.catalog[colname].info.format = '.6f'
-
-        return self.catalog
+        return catalog

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -109,9 +109,6 @@ class ReferenceData:
             raise ValueError('aperture_ee must contain only 3 values')
         if np.any(np.logical_or(aperture_ee <= 0, aperture_ee >= 100)):
             raise ValueError('aperture_ee values must be between 0 and 100')
-        if np.any(aperture_ee[1:] < aperture_ee[:-1]):
-            raise ValueError('aperture_ee values must be in increasing order')
-
         return aperture_ee
 
     @lazyproperty
@@ -169,9 +166,9 @@ class ReferenceData:
         """
 
         if self.apcorr_filename is None:
-            log.info('APCorrModel reference file was not input -- '
-                     'using fallback aperture sizes without any aperture '
-                     'corrections.')
+            log.warning('APCorrModel reference file was not input -- '
+                        'using fallback aperture sizes without any aperture '
+                        'corrections.')
             params = {'aperture_radii': np.array((1.0, 2.0, 3.0)),
                       'aperture_corrections': np.array((1.0, 1.0, 1.0)),
                       'aperture_ee': np.array((1, 2, 3)),
@@ -221,8 +218,8 @@ class ReferenceData:
         """
 
         if self.abvega_offset_filename is None:
-            log.info('ABVegaOffsetModel reference file was not input -- '
-                     'catalog Vega magnitudes are not correct.')
+            log.warning('ABVegaOffsetModel reference file was not input -- '
+                        'catalog Vega magnitudes are not correct.')
             return 0.0
 
         if self.instrument == 'NIRCAM' or self.instrument == 'NIRISS':
@@ -471,7 +468,7 @@ class SourceCatalog:
     ----------
     model : `ImageModel`
         The input `ImageModel`.  The data is assumed to be
-        background-subtracted.
+        background subtracted.
 
     segment_image : `~photutils.segmentation.SegmentationImage`
         A 2D segmentation image, with the same shape as the input data,
@@ -521,6 +518,8 @@ class SourceCatalog:
         self.n_aper = len(self.aperture_ee)
         self.column_desc = {}
 
+        # cannot use gwcs until this issue is resolved (both in jwst and
+        # gwcs):  https://github.com/spacetelescope/gwcs/issues/294
         # self.wcs = self.model.meta.wcs  # gWCS
         self.wcs = self.model.get_fits_wcs()  # FITS WCS
 
@@ -983,7 +982,7 @@ class SourceCatalog:
     @lazyproperty
     def is_star(self):
         """
-        Flag indicationg whether the source is a star.
+        Flag indicating whether the source is a star.
 
         2020.03.02: The JWST Photometry Working Group has not determined
         the criteria for this flag.

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -498,7 +498,6 @@ class SourceCatalog:
         bkg_median, bkg_median_err = self.calc_aper_local_background(
             bkg_aperture)
 
-        log.info('{}'.format(self.aperture_radii))
         apertures = [CircularAperture(self.xypos, radius) for radius in
                      self.aperture_radii]
         aper_phot = aperture_photometry(self.model.data, apertures,
@@ -615,5 +614,17 @@ class SourceCatalog:
         self.make_aperture_catalog()
         self.make_extras_catalog()
         self.make_source_catalog()
+
+        # output formatting requested by the JPWG (2020.02.05)
+        for colname in self.catalog.colnames:
+            if colname in ('xcentroid', 'ycentroid') or 'CI_' in colname:
+                self.catalog[colname].info.format = '.4f'
+            if 'flux' in colname:
+                self.catalog[colname].info.format = '.6e'
+            if 'abmag' in colname or 'vegamag' in colname:
+                self.catalog[colname].info.format = '.6f'
+            if colname in ('semimajor_sigma', 'semiminor_sigma',
+                           'ellipticity', 'orientation', 'sky_orientation'):
+                self.catalog[colname].info.format = '.6f'
 
         return self.catalog

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1,3 +1,7 @@
+"""
+Module to calculate the source catalog.
+"""
+
 from collections import OrderedDict
 import logging
 
@@ -22,6 +26,39 @@ log.setLevel(logging.DEBUG)
 
 
 class ReferenceData:
+    """
+    Class for apcorr and abvega_offset reference file data needed by
+    `SourceCatalogStep`.
+
+    Parameters
+    ----------
+    model : `ImageModel`
+        An `ImageModel` of drizzled image.
+
+    aperture_ee : tuple of 3 int
+        The aperture encircled energies to be used for aperture
+        photometry.  The values must be 3 strictly-increasing integers.
+        Valid values are defined in the ``apcorr`` reference files (20,
+        30, 40, 50, 60, 70, or 80).
+
+    apcorr_filename : str
+        The full path and filenames of the ``apcorr`` reference file.
+
+    abvega_offset_filename : str
+        The full path and filenames of the ``abvega_offset`` reference
+        file.
+
+    Attributes
+    ----------
+    aperture_params : `dict`
+        A dictionary containing the aperture parameters (radii, aperture
+        corrections, and background annulus inner and outer radii).
+
+    abvega_offset : float
+        Offset to convert from AB to Vega magnitudes.  The value
+        reprents m_AB - m_Vega.
+    """
+
     def __init__(self, model, aperture_ee=(30, 50, 70),
                  apcorr_filename=None, abvega_offset_filename=None):
 
@@ -53,6 +90,10 @@ class ReferenceData:
 
     @staticmethod
     def _validate_aperture_ee(aperture_ee):
+        """
+        Validate the input ``aperture_ee``.
+        """
+
         aperture_ee = np.array(aperture_ee).astype(int)
 
         if not np.all(aperture_ee[1:] > aperture_ee[:-1]):
@@ -69,6 +110,11 @@ class ReferenceData:
 
     @lazyproperty
     def _aperture_ee_table(self):
+        """
+        Get the encircled energy table for the given instrument
+        configuration.
+        """
+
         if self.instrument == 'NIRCAM' or self.instrument == 'NIRISS':
             selector = {'filter': self.filtername, 'pupil': self.pupil}
         elif self.instrument == 'MIRI':
@@ -90,6 +136,10 @@ class ReferenceData:
         return ee_table
 
     def _get_ee_table_row(self, aperture_ee):
+        """
+        Get the encircled energy row for the input ``aperture_ee``.
+        """
+
         ee_percent = np.round(self._aperture_ee_table['eefraction'] * 100)
         row_mask = (ee_percent == aperture_ee)
         ee_row = self._aperture_ee_table[row_mask]
@@ -107,6 +157,11 @@ class ReferenceData:
 
     @lazyproperty
     def aperture_params(self):
+        """
+        A dictionary containing the aperture parameters (radii, aperture
+        corrections, and background annulus inner and outer radii).
+        """
+
         params = {}
 
         radii = []
@@ -143,6 +198,12 @@ class ReferenceData:
 
     @lazyproperty
     def abvega_offset(self):
+        """
+        Offset to convert from AB to Vega magnitudes.
+
+        The value reprents m_AB - m_Vega.
+        """
+
         if self.instrument == 'NIRCAM' or self.instrument == 'NIRISS':
             selector = {'filter': self.filtername, 'pupil': self.pupil}
         elif self.instrument == 'MIRI':
@@ -186,9 +247,37 @@ class ReferenceData:
 
 
 class Background:
-    def __init__(self, data, bkg_boxsize=100, mask=None):
+    """
+    Class to estimate a 2D background and background RMS noise in an
+    image.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The input 2D array.
+
+    box_size : int or array_like (int)
+        The box size along each axis.  If ``box_size`` is a scalar then
+        a square box of size ``box_size`` will be used.  If ``box_size``
+        has two elements, they should be in ``(ny, nx)`` order.
+
+    mask : array_like (bool), optional
+        A boolean mask, with the same shape as ``data``, where a `True`
+        value indicates the corresponding element of ``data`` is masked.
+        Masked data are excluded from calculations.
+
+    Attributes
+    ----------
+    background : 2D `~numpy.ndimage`
+        The estimated 2D background image.
+
+    background_rms : 2D `~numpy.ndimage`
+        The estimated 2D background RMS image.
+    """
+
+    def __init__(self, data, box_size=100, mask=None):
         self.data = data
-        self.bkg_boxsize = np.int(bkg_boxsize)  # must be integer
+        self.box_size = np.int(box_size)  # must be integer
         self.mask = mask
 
     @lazyproperty
@@ -215,7 +304,7 @@ class Background:
         sigma_clip = SigmaClip(sigma=3.)
         bkg_estimator = MedianBackground()
         filter_size = (3, 3)
-        bkg = Background2D(self.data, self.bkg_boxsize,
+        bkg = Background2D(self.data, self.box_size,
                            filter_size=filter_size, mask=self.mask,
                            sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
 
@@ -227,10 +316,16 @@ class Background:
 
     @lazyproperty
     def background(self):
+        """
+        The 2D background image.
+        """
         return self._background2d.background
 
     @lazyproperty
     def background_rms(self):
+        """
+        The 2D background RMS image.
+        """
         return self._background2d.background_rms
 
 
@@ -267,24 +362,28 @@ def make_segment_img(data, threshold, npixels=5.0, kernel=None, mask=None,
 
     Parameters
     ----------
-    data : `ImageModel`
-        The input `ImageModel` of a single drizzled image.  The
-        input image is assumed to be background subtracted.
+    data : 2D `~numpy.ndarray`
+        The input 2D array.
 
     threshold : float
         The data value or pixel-wise data values to be used for the
         detection threshold. A 2D threshold must have the same shape as
-        ``model.data``.
+        ``data``.
 
     npixels : int
-        The number of connected pixels, each greater than the threshold
+        The number of connected pixels, each greater than ``threshold``
         that an object must have to be detected.  ``npixels`` must be a
         positive integer.
 
     kernel : `astropy.convolution.Kernel2D`
-        The filtering kernel.
+        The filtering kernel.  Filtering the image will smooth the noise
+        and maximize detectability of objects with a shape similar to
+        the kernel.
 
-    mask : bool ndarray
+    mask : array_like of bool, optional
+        A boolean mask, with the same shape as the input ``data``, where
+        `True` values indicate masked pixels.  Masked pixels will not be
+        included in any source.
 
     deblend : bool, optional
         Whether to deblend overlapping sources.  Source deblending
@@ -293,7 +392,7 @@ def make_segment_img(data, threshold, npixels=5.0, kernel=None, mask=None,
     Returns
     -------
     segment_image : `~photutils.segmentation.SegmentationImage` or `None`
-        A 2D segmentation image, with the same shape as the input data
+        A 2D segmentation image, with the same shape as the input data,
         where sources are marked by different positive integer values.
         A value of zero is reserved for the background.  If no sources
         are found then `None` is returned.
@@ -323,7 +422,20 @@ def make_segment_img(data, threshold, npixels=5.0, kernel=None, mask=None,
 
 def calc_total_error(model):
     """
-    Calculate the total error (background plus source Poisson error).
+    Calculate the total error array.
+
+    The total error includes both background-only error and the source
+    Poisson noise.
+
+    Parameters
+    ----------
+    model : `ImageModel`
+        The input `ImageModel`.
+
+    Returns
+    -------
+    total_error : `~numpy.ndarray`
+        The total error array.
     """
 
     # TODO: Until errors are produced for the level 3 drizzle
@@ -333,6 +445,42 @@ def calc_total_error(model):
 
 
 class SourceCatalog:
+    """
+    Class for the source catalog.
+
+    Parameters
+    ----------
+    model : `ImageModel`
+        The input `ImageModel`.  The data is assumed to be
+        background-subtracted.
+
+    segment_image : `~photutils.segmentation.SegmentationImage`
+        A 2D segmentation image, with the same shape as the input data,
+        where sources are marked by different positive integer values.
+        A value of zero is reserved for the background.
+
+    error : array_like or `~astropy.units.Quantity`, optional
+        The total error array corresponding to the input ``data`` array.
+        ``error`` is assumed to include *all* sources of error,
+        including the Poisson error of the sources (see
+        `~photutils.utils.calc_total_error`) .  ``error`` must have the
+        same shape as the input ``data``.
+
+    kernel : array-like (2D) or `~astropy.convolution.Kernel2D`, optional
+        The 2D array of the kernel used to filter the data prior to
+        calculating the source centroid and morphological parameters.
+        The kernel should be the same one used in defining the source
+        segments.
+
+    aperture_params : `dict`
+        A dictionary containing the aperture parameters (radii, aperture
+        corrections, and background annulus inner and outer radii).
+
+    abvega_offset : float
+        Offset to convert from AB to Vega magnitudes.  The value
+        reprents m_AB - m_Vega.
+    """
+
     def __init__(self, model, segment_img, error=None, kernel=None,
                  aperture_params=None, abvega_offset=0.0):
 
@@ -354,7 +502,10 @@ class SourceCatalog:
         self.wcs = self.model.get_fits_wcs()  # FITS WCS
 
     def convert_to_jy(self):
-        """ convert from MJy/sr to Jy"""
+        """
+        Convert the data and errors from MJy/sr to Jy and convert to
+        `~astropy.unit.Quantity` objects.
+        """
 
         if self.model.meta.bunit_data != 'MJy/sr':
             raise ValueError('data is expected to be in units of MJy/sr')
@@ -371,10 +522,17 @@ class SourceCatalog:
     @staticmethod
     def convert_flux_to_abmag(flux, flux_err):
         """
+        Convert flux (and error) to AB magnitude (and error).
+
         Parameters
         ----------
-        flux : float, ndarray
-            In units of Jy
+        flux, flux_err : `~astropy.unit.Quantity`
+            The input flux and error arrays in units of Jy.
+
+        Returns
+        -------
+        abmag, abmag_err : `~astropy.ndarray`
+            The output AB magnitude and error arrays.
         """
 
         abmag = -2.5 * np.log10(flux.value) + 8.9
@@ -390,7 +548,11 @@ class SourceCatalog:
 
     @lazyproperty
     def segment_colnames(self):
-        # define segment column names and descriptions
+        """
+        A dictionary of the output table column names and descriptions
+        for the segment catalog.
+        """
+
         desc = OrderedDict()
         desc['id'] = 'Unique source identification number'
         desc['xcentroid'] = 'X pixel value of the source centroid'
@@ -433,8 +595,9 @@ class SourceCatalog:
 
     def set_segment_properties(self):
         """
-        Create a catalog of source photometry and morphologies based on
-        segmentation.
+        Calculate the segment-based source photometry and morphologies.
+
+        The values are set as dynamic attributes.
         """
 
         source_props = source_properties(self.model.data.astype(float),
@@ -466,39 +629,64 @@ class SourceCatalog:
 
     @lazyproperty
     def null_column(self):
+        """
+        An array containing only NaNs.
+        """
         values = np.empty(len(self.id))
         values.fill(np.nan)
         return values
 
     @lazyproperty
     def xypos(self):
-        # source positions
+        """
+        The (x, y) source positions, defined from the segmentation
+        image.
+        """
         return np.transpose((self.xcentroid, self.ycentroid))
 
     @lazyproperty
     def _isophotal_abmag(self):
+        """
+        The isophotal AB magnitude and error.
+        """
         return self.convert_flux_to_abmag(self.isophotal_flux,
                                           self.isophotal_flux_err)
 
     @lazyproperty
     def isophotal_abmag(self):
+        """
+        The isophotal AB magnitude.
+        """
         return self._isophotal_abmag[0]
 
     @lazyproperty
     def isophotal_abmag_err(self):
+        """
+        The isophotal AB magnitude error.
+        """
         return self._isophotal_abmag[1]
 
     @lazyproperty
     def isophotal_vegamag(self):
+        """
+        The isophotal Vega magnitude.
+        """
         return self.isophotal_abmag - self.abvega_offset
 
     @lazyproperty
     def isophotal_vegamag_err(self):
+        """
+        The isophotal Vega magnitude error.
+        """
         return self.isophotal_abmag_err
 
     @lazyproperty
     def sky_orientation(self):
-        # Define the orientation position angle (E of N)
+        """
+        The orientation of the source major axis as the position angle
+        in degrees measured East of North.
+        """
+
         # NOTE: crpix1 and crpix2 are 1-based values
         skycoord = self.wcs.pixel_to_world(self.model.meta.wcsinfo.crpix1 - 1,
                                            self.model.meta.wcsinfo.crpix2 - 1)
@@ -507,6 +695,23 @@ class SourceCatalog:
         return (180.0 * u.deg) - angle + self.orientation
 
     def _make_aperture_colnames(self, name):
+        """
+        Make the aperture column names.
+
+        There are separate columns for the flux/magnitude for each of
+        the encircled energies and the total flux/magnitude.
+
+        Parameters
+        ----------
+        name : {'flux', 'abmag', 'vegamag'}
+            The name type of the column.
+
+        Returns
+        -------
+        colnames : list of str
+            A list of the output column names.
+        """
+
         colnames = []
         for aper_ee in self.aperture_ee:
             basename = f'aper{aper_ee}_{name}'
@@ -517,6 +722,20 @@ class SourceCatalog:
         return colnames
 
     def _make_aperture_descriptions(self, name):
+        """
+        Make aperture column descriptions.
+
+        Parameters
+        ----------
+        name : {'flux', 'abmag', 'vegamag'}
+            The name type of the column.
+
+        Returns
+        -------
+        descriptions : list of str
+            A list of the output column descriptions.
+        """
+
         if name == 'flux':
             ftype = 'Flux'
             ftype2 = 'flux'
@@ -543,30 +762,53 @@ class SourceCatalog:
 
     @lazyproperty
     def aperture_flux_colnames(self):
+        """
+        The aperture flux column names.
+        """
         return self._make_aperture_colnames('flux')
 
     @lazyproperty
     def aperture_flux_descriptions(self):
+        """
+        The aperture flux column descriptions.
+        """
         return self._make_aperture_descriptions('flux')
 
     @lazyproperty
     def aperture_abmag_colnames(self):
+        """
+        The aperture AB magnitude column names.
+        """
         return self._make_aperture_colnames('abmag')
 
     @lazyproperty
     def aperture_abmag_descriptions(self):
+        """
+        The aperture AB magnitude column descriptions.
+        """
         return self._make_aperture_descriptions('abmag')
 
     @lazyproperty
     def aperture_vegamag_colnames(self):
+        """
+        The aperture Vega magnitude column names.
+        """
         return self._make_aperture_colnames('vegamag')
 
     @lazyproperty
     def aperture_vegamag_descriptions(self):
+        """
+        The aperture Vega magnitude column descriptions.
+        """
         return self._make_aperture_descriptions('vegamag')
 
     @lazyproperty
     def aperture_colnames(self):
+        """
+        A dictionary of the output table column names and descriptions
+        for the aperture catalog.
+        """
+
         desc = OrderedDict()
         desc['aper_bkg_flux'] = ('The local background value calculated as '
                                  'the sigma-clipped median value in the '
@@ -588,8 +830,12 @@ class SourceCatalog:
     @lazyproperty
     def _aper_local_background(self):
         """
-        Estimate the local background as the sigma-clipped median value
-        in the input aperture.
+        Estimate the local background and error using a circular annulus
+        aperture.
+
+        The local backround is the sigma-clipped median value in the
+        annulus.  The background error is the standard error of the
+        median, sqrt(pi / 2N) * std.
         """
 
         bkg_aper = CircularAnnulus(self.xypos,
@@ -621,13 +867,25 @@ class SourceCatalog:
 
     @lazyproperty
     def aper_bkg_flux(self):
+        """
+        The aperture local background flux (per pixel).
+        """
         return self._aper_local_background[0]
 
     @lazyproperty
     def aper_bkg_flux_err(self):
+        """
+        The aperture local background flux error (per pixel).
+        """
         return self._aper_local_background[1]
 
     def set_aperture_properties(self):
+        """
+        Calculate the aperture photometry.
+
+        The values are set as dynamic attributes.
+        """
+
         apertures = [CircularAperture(self.xypos, radius) for radius in
                      self.aperture_params['aperture_radii']]
         aper_phot = aperture_photometry(self.model.data, apertures,
@@ -657,6 +915,11 @@ class SourceCatalog:
 
     @lazyproperty
     def extras_colnames(self):
+        """
+        A dictionary of the output table column names and descriptions
+        for the additional catalog values.
+        """
+
         desc = OrderedDict()
 
         ci_desc = ('Concentration index calculated as '
@@ -676,10 +939,17 @@ class SourceCatalog:
 
     @lazyproperty
     def ci_colname(self):
+        """
+        The concentration index column name.
+        """
         return f'CI_{self.aperture_ee[0]}_{self.aperture_ee[2]}'
 
     @lazyproperty
     def concentration_index(self):
+        """
+        The concentration index calculated as the difference of AB
+        magnitudes between the smallest and largest aperture radii.
+        """
         abmag1 = self.aperture_abmag_colnames[0]  # ee_fraction[0]
         abmag2 = self.aperture_abmag_colnames[4]  # ee_fraction[2]
         return getattr(self, abmag1) - getattr(self, abmag2)
@@ -687,7 +957,7 @@ class SourceCatalog:
     @lazyproperty
     def is_star(self):
         """
-        Calculate a flag based on whether the source is a star.
+        Flag indicationg whether the source is a star.
 
         2020.03.02: The JWST Photometry Working Group has not determined
         the criteria for this flag.
@@ -700,39 +970,66 @@ class SourceCatalog:
 
     @lazyproperty
     def sharpness(self):
+        """
+        The DAOFind source sharpness statistic.
+
+        The sharpness statistic measures the ratio of the difference
+        between the height of the central pixel and the mean of the
+        surrounding non-bad pixels to the height of the best fitting
+        Gaussian function at that point.
+
+        Stars generally have a ``sharpness`` between 0.2 and 1.0.
+        """
         return self.null_column
 
     @lazyproperty
     def roundness(self):
+        """
+        The DAOFind source roundness statistic based on symmetry.
+
+        The roundness characteristic computes the ratio of a measure of
+        the bilateral symmetry of the object to a measure of the
+        four-fold symmetry of the object.
+
+        "Round" objects have a ``roundness`` close to 0, generally
+        between -1 and 1.
+        """
         return self.null_column
 
     @lazyproperty
     def _ckdtree_query(self):
         """
-        Calculate the distance in pixels to the nearest neighbor and
-        its AB magnitude.
-
-        If the nearest-neighbor is a star, then its aperture-corrected
-        total AB magnitude is used.  Otherwise, its isophotal AB
-        magnitude is used.
+        The distance in pixels to the nearest neighbor and its index.
         """
-
         tree = cKDTree(self.xypos)
         qdist, qidx = tree.query(self.xypos, k=2)
         return np.transpose(qdist)[1], np.transpose(qidx)[1]
 
     @lazyproperty
     def nn_dist(self):
+        """
+        The distance in pixels to the nearest neighbor.
+        """
         return self._ckdtree_query[0] * u.pixel
 
     @lazyproperty
     def nn_abmag(self):
+        """
+        The AB magnitude of the nearest neighbor.
+
+        If the nearest-neighbor is a star, then its aperture-corrected
+        total AB magnitude is used.  Otherwise, its isophotal AB
+        magnitude is used.
+        """
         nn_abmag = self.aper_total_abmag[self._ckdtree_query[1]]
         nn_isomag = self.isophotal_abmag[self._ckdtree_query[1]]
         return np.where(np.isnan(nn_abmag), nn_isomag, nn_abmag)
 
     @lazyproperty
     def _not_star(self):
+        """
+        Whether the source is not a star.
+        """
         if np.isnan(self.is_star[0]):
             # TODO: remove this when ``is_star`` values are available.
             # this array is all False:
@@ -745,13 +1042,9 @@ class SourceCatalog:
     @lazyproperty
     def aper_total_flux(self):
         """
-        Calculate the aperture-corrected total flux for sources that are
-        stars.
-
-        The aperture fluxes in the largest aperture (i.e., the largest
-        encircled energy) are corrected to total flux.
+        The aperture-corrected total flux for sources that are stars,
+        based on the flux in largest aperture.
         """
-
         idx = self.n_aper - 1  # apcorr for the largest EE (largest radius)
         flux = (self.aperture_params['aperture_corrs'][idx] *
                 getattr(self, self.aperture_flux_colnames[idx*2]))
@@ -761,6 +1054,10 @@ class SourceCatalog:
 
     @lazyproperty
     def aper_total_flux_err(self):
+        """
+        The aperture-corrected total flux error for sources that are
+        stars, based on the flux in largest aperture.
+        """
         idx = self.n_aper - 1  # apcorr for the largest EE (largest radius)
         flux_err = (self.aperture_params['aperture_corrs'][idx] *
                     getattr(self, self.aperture_flux_colnames[idx*2 + 1]))
@@ -770,37 +1067,67 @@ class SourceCatalog:
 
     @lazyproperty
     def _abmag_total(self):
+        """
+        The total AB magnitude and error.
+        """
         return self.convert_flux_to_abmag(self.aper_total_flux,
                                           self.aper_total_flux_err)
 
     @lazyproperty
     def aper_total_abmag(self):
+        """
+        The total AB magnitude.
+        """
         return self._abmag_total[0]
 
     @lazyproperty
     def aper_total_abmag_err(self):
+        """
+        The total AB magnitude error.
+        """
         return self._abmag_total[1]
 
     @lazyproperty
     def aper_total_vegamag(self):
+        """
+        The total Vega magnitude.
+        """
         return self.aper_total_abmag - self.abvega_offset
 
     @lazyproperty
     def aper_total_vegamag_err(self):
+        """
+        The total Vega magnitude error.
+        """
         return self.aper_total_abmag_err
 
     @lazyproperty
     def colnames(self):
-        # Define the column name order for the final source catalog
+        """
+        The column name order for the final source catalog.
+        """
         colnames = self.segment_colnames[0:4]
         colnames.extend(self.aperture_colnames)
         colnames.extend(self.extras_colnames)
         colnames.extend(self.segment_colnames[4:])
-
         return colnames
 
     @staticmethod
     def format_columns(catalog):
+        """
+        Format the values in the output catalog.
+
+        Parameters
+        ----------
+        catalog : `~astropy.table.Table`
+            The catalog to format.
+
+        Returns
+        -------
+        result : `~astropy.table.Table`
+            The formated catalog.
+        """
+
         # output formatting requested by the JPWG (2020.02.05)
         for colname in catalog.colnames:
             if colname in ('xcentroid', 'ycentroid') or 'CI_' in colname:
@@ -817,7 +1144,10 @@ class SourceCatalog:
 
     @lazyproperty
     def catalog(self):
-        #self.subtract_background()
+        """
+        The final source catalog.
+        """
+
         self.convert_to_jy()
         self.set_segment_properties()
         self.set_aperture_properties()

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1,282 +1,440 @@
+import logging
+
 import numpy as np
+
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma, SigmaClip
+from astropy.table import join, QTable
 import astropy.units as u
-import photutils
+
 from photutils import Background2D, MedianBackground
+from photutils import detect_sources, deblend_sources, source_properties
+from photutils import CircularAperture, CircularAnnulus, aperture_photometry
+from photutils.utils import calc_total_error
+from photutils.utils._wcs_helpers import _pixel_scale_angle_at_skycoord
 
 from ..datamodels import ImageModel
 
-
-def make_kernel(kernel_fwhm, kernel_xsize, kernel_ysize):
-    """
-    Make a 2D Gaussian smoothing kernel that is used to filter the image
-    before thresholding.
-
-    Filtering the image will smooth the noise and maximize detectability
-    of objects with a shape similar to the kernel.
-
-    Parameters
-    ----------
-    kernel_fwhm : float
-        The full-width at half-maximum (FWHM) of the 2D Gaussian kernel.
-
-    kernel_xsize : odd int
-        The size in the x dimension (columns) of the kernel array.
-
-    kernel_ysize : odd int
-        The size in the y dimension (row) of the kernel array.
-
-    Returns
-    -------
-    kernel : `astropy.convolution.Kernel2D`
-        The output smoothing kernel, normalized such that it sums to 1.
-    """
-
-    sigma = kernel_fwhm * gaussian_fwhm_to_sigma
-    kernel = Gaussian2DKernel(sigma, x_size=kernel_xsize, y_size=kernel_ysize)
-    kernel.normalize(mode='integral')
-
-    return kernel
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 
-def estimate_background(model, box_size=(50, 50)):
-    """
-    Estimate the 2D background and background RMS noise in an image.
+class SourceCatalog:
+    def __init__(self, model, bkg_boxsize=100, kernel_fwhm=2.0,
+                 snr_threshold=3.0, npixels=5.0, deblend=False,
+                 aperture_ee=(30, 50, 70)):
 
-    Parameters
-    ----------
-    box_size : int or array_like (int)
-        The box size along each axis.  If ``box_size`` is a scalar then
-        a square box of size ``box_size`` will be used.  If ``box_size``
-        has two elements, they should be in ``(ny, nx)`` order.
+        if not isinstance(model, ImageModel):
+            raise ValueError('The input model must be a ImageModel.')
 
-    Returns
-    -------
-    background : `photutils.background.Background2D`
-        A Background2D object containing the 2D background and
-        background RMS noise estimates.
-    """
+        self.model = model
+        self.bkg_boxsize = np.int(bkg_boxsize)  # must be integer
+        self.kernel_fwhm = kernel_fwhm
+        self.snr_threshold = snr_threshold
+        self.npixels = npixels
+        self.deblend = deblend
+        self.aperture_ee = aperture_ee
 
-    sigma_clip = SigmaClip(sigma=3.)
-    bkg_estimator = MedianBackground()
+        self.coverage_mask = None
+        self._bkg = None
+        self.background = None
+        self.background_rms = None
+        self.kernel = None
+        self.threshold = None
+        self.segm = None
+        self.total_error = None
+        self.segment_catalog = None
 
-    return Background2D(model.data, box_size, filter_size=(3, 3),
-                        sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
+        self.bkg_aper_in = None
+        self.bkg_aper_out = None
+        self.aper_radii = None
+        self.abmag_offset = None
+        self.aperture_catalog = None
 
+    def convert_to_jy(self):
+        """ convert from MJy/sr to Jy"""
 
-def detect_sources(model, threshold, npixels, kernel, deblend_nlevels=32,
-                   deblend_contrast=0.001, deblend_mode='exponential',
-                   connectivity=8, deblend=False):
-    """
-    Detect sources in an image.
+        if self.model.meta.bunit_data != 'MJy/sr':
+            raise ValueError('data is expected to be in units of MJy/sr')
+        self.model.data *= (1.e6 *
+                            self.model.meta.photometry.pixelarea_steradians)
+        self.model.meta.bunit_data = 'Jy'
 
-    Parameters
-    ----------
-    model : `ImageModel`
-        The input `ImageModel` of a single drizzled image.  The
-        input image is assumed to be background subtracted.
+        return
 
-    threshold : float
-        The data value or pixel-wise data values to be used for the
-        detection threshold. A 2D threshold must have the same shape as
-        ``model.data``.
+    def make_coverage_mask(self):
+        # NOTE: currently the wht output from the resample step is
+        # always an exposure-time map
+        self.coverage_mask = (self.model.wht == 0)
 
-    npixels : int
-        The number of connected pixels, each greater than the threshold
-        that an object must have to be detected.  ``npixels`` must be a
-        positive integer.
+        return
 
-    kernel : `astropy.convolution.Kernel2D`
-        The filtering kernel.
+    def estimate_background(self):
+        """
+        Estimate the 2D background and background RMS noise in an image.
 
-    deblend_nlevels : int, optional
-        The number of multi-thresholding levels to use for deblending
-        sources.  Each source will be re-thresholded at
-        ``deblend_nlevels``, spaced exponentially or linearly (see the
-        ``deblend_mode`` keyword), between its minimum and maximum
-        values within the source segment.
+        Parameters
+        ----------
+        box_size : int or array_like (int)
+            The box size along each axis.  If ``box_size`` is a scalar then
+            a square box of size ``box_size`` will be used.  If ``box_size``
+            has two elements, they should be in ``(ny, nx)`` order.
 
-    deblend_contrast : float, optional
-        The fraction of the total (blended) source flux that a local
-        peak must have to be considered as a separate object.
-        ``deblend_contrast`` must be between 0 and 1, inclusive.  If
-        ``deblend_contrast = 0`` then every local peak will be made a
-        separate object (maximum deblending).  If ``deblend_contrast =
-        1`` then no deblending will occur.  The default is 0.001, which
-        will deblend sources with a magnitude differences of about 7.5.
+        coverage_mask : bool ndarray
 
-    deblend_mode : {'exponential', 'linear'}, optional
-        The mode used in defining the spacing between the
-        multi-thresholding levels (see the ``deblend_nlevels`` keyword)
-        when deblending sources.
+        Returns
+        -------
+        background : `photutils.background.Background2D`
+            A Background2D object containing the 2D background and
+            background RMS noise estimates.
+        """
 
-    connectivity : {4, 8}, optional
-        The type of pixel connectivity used in determining how pixels
-        are grouped into a detected source.  The options are 4 or 8
-        (default).  4-connected pixels touch along their edges.
-        8-connected pixels touch along their edges or corners.  For
-        reference, SExtractor uses 8-connected pixels.
+        sigma_clip = SigmaClip(sigma=3.)
+        bkg_estimator = MedianBackground()
+        filter_size = (3, 3)
+        bkg = Background2D(self.model.data, self.bkg_boxsize,
+                           filter_size=filter_size, mask=self.coverage_mask,
+                           sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
 
-    deblend : bool, optional
-        Whether to deblend overlapping sources.  Source deblending
-        requires scikit-image.
+        # apply the coverage mask
+        bkg.background *= ~self.coverage_mask
+        bkg.background_rms *= ~self.coverage_mask
 
-    Returns
-    -------
-    segment_image : `~photutils.segmentation.SegmentationImage` or `None`
-        A 2D segmentation image, with the same shape as the input data
-        where sources are marked by different positive integer values.
-        A value of zero is reserved for the background.  If no sources
-        are found then `None` is returned.
-    """
+        self._bkg = bkg
+        self.background = bkg.background
+        self.background_rms = bkg.background_rms
 
-    if not isinstance(model, ImageModel):
-        raise ValueError('The input model must be a ImageModel.')
+        return
 
-    segm = photutils.detect_sources(model.data, threshold, npixels=npixels,
-                                    filter_kernel=kernel,
-                                    connectivity=connectivity)
+    def subtract_background(self):
+        self.model.data -= self.background
+        return
 
-    # segm=None for photutils >= 0.7; segm.nlabels == 0 for photutils < 0.7
-    if segm is None or segm.nlabels == 0:
-        return None
+    def make_kernel(self):
+        """
+        Make a 2D Gaussian smoothing kernel that is used to filter the image
+        before thresholding.
 
-    # source deblending requires scikit-image
-    if deblend:
-        segm = photutils.deblend_sources(model.data, segm, npixels=npixels,
-                                         filter_kernel=kernel,
-                                         nlevels=deblend_nlevels,
-                                         contrast=deblend_contrast,
-                                         mode=deblend_mode,
-                                         connectivity=connectivity,
-                                         relabel=True)
+        Filtering the image will smooth the noise and maximize detectability
+        of objects with a shape similar to the kernel.
 
-    return segm
+        Parameters
+        ----------
+        kernel_fwhm : float
+            The full-width at half-maximum (FWHM) of the 2D Gaussian kernel.
 
+        Returns
+        -------
+        kernel : `astropy.convolution.Kernel2D`
+            The output smoothing kernel, normalized such that it sums to 1.
+        """
 
-def make_source_catalog(model, segm, kernel=None):
-    """
-    Create a final catalog of source photometry and morphologies.
+        sigma = self.kernel_fwhm * gaussian_fwhm_to_sigma
+        #kernel = Gaussian2DKernel(sigma)
+        kernel = Gaussian2DKernel(sigma, x_size=5, y_size=5)
+        kernel.normalize(mode='integral')
 
-    Parameters
-    ----------
-    model : `ImageModel`
-        The input `ImageModel` of a single drizzled image.  The
-        input image is assumed to be background subtracted.
+        self.kernel = kernel
 
-    segment_image : `~photutils.segmentation.SegmentationImage` or `None`
-        A 2D segmentation image, with the same shape as the input data
-        where sources are marked by different positive integer values.
-        A value of zero is reserved for the background.
+        return
 
-    kernel : `astropy.convolution.Kernel2D`
-        The smoothing kernel, normalized such that it sums to 1.
+    def calc_threshold(self):
+        self.threshold = self.snr_threshold * self.background_rms
+        return
 
-    Returns
-    -------
-    catalog : `~astropy.Table` or `None`
-        An astropy Table containing the source photometry and
-        morphologies.  If no sources are detected then `None` is
-        returned.
-    """
+    def detect_sources(self):
+        """
+        Detect sources in an image, including deblending.
 
-    if not isinstance(model, ImageModel):
-        raise ValueError('The input model must be a ImageModel.')
+        Parameters
+        ----------
+        model : `ImageModel`
+            The input `ImageModel` of a single drizzled image.  The
+            input image is assumed to be background subtracted.
 
-    # The resample step still does not allow for background-only
-    # inverse-variance maps.  Set the errors to zero until there is a
-    # way to get background-only errors for the resampled image.
-    total_error = np.zeros_like(model.data)
+        threshold : float
+            The data value or pixel-wise data values to be used for the
+            detection threshold. A 2D threshold must have the same shape as
+            ``model.data``.
 
-    wcs = model.get_fits_wcs()
-    source_props = photutils.source_properties(
-        model.data, segm, error=total_error, filter_kernel=kernel, wcs=wcs)
+        npixels : int
+            The number of connected pixels, each greater than the threshold
+            that an object must have to be detected.  ``npixels`` must be a
+            positive integer.
 
-    columns = ['id', 'xcentroid', 'ycentroid', 'sky_centroid', 'area',
-               'source_sum', 'source_sum_err', 'semimajor_axis_sigma',
-               'semiminor_axis_sigma', 'orientation',
-               'sky_bbox_ll', 'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
-    catalog = source_props.to_table(columns=columns)
+        kernel : `astropy.convolution.Kernel2D`
+            The filtering kernel.
 
-    # convert orientation to degrees
-    orient_deg = catalog['orientation'].to(u.deg)
-    catalog.replace_column('orientation', orient_deg)
+        mask : bool ndarray
 
-    # define orientation position angle
-    rot = _get_rotation(wcs)
-    catalog['orientation_sky'] = ((270. - rot +
-                                   catalog['orientation'].value) * u.deg)
+        deblend : bool, optional
+            Whether to deblend overlapping sources.  Source deblending
+            requires scikit-image.
 
-    # define flux in microJanskys
-    nsources = len(catalog)
-    pixelarea = model.meta.photometry.pixelarea_arcsecsq
-    if pixelarea is None:
-        micro_Jy = np.full(nsources, np.nan)
-    else:
-        micro_Jy = (catalog['source_sum'] *
-                    model.meta.photometry.conversion_microjanskys *
-                    model.meta.photometry.pixelarea_arcsecsq)
+        Returns
+        -------
+        segment_image : `~photutils.segmentation.SegmentationImage` or `None`
+            A 2D segmentation image, with the same shape as the input data
+            where sources are marked by different positive integer values.
+            A value of zero is reserved for the background.  If no sources
+            are found then `None` is returned.
+        """
 
-    # define AB mag
-    abmag = np.full(nsources, np.nan)
-    mask = np.isfinite(micro_Jy)
-    abmag[mask] = -2.5 * np.log10(micro_Jy[mask]) + 23.9
-    catalog['abmag'] = abmag
+        connectivity = 8
+        segm = detect_sources(self.model.data, self.threshold,
+                              npixels=self.npixels, filter_kernel=self.kernel,
+                              mask=self.coverage_mask,
+                              connectivity=connectivity)
 
-    # define AB mag error
-    # assuming SNR >> 1 (otherwise abmag_error is asymmetric)
-    abmag_error = (2.5 * np.log10(np.e) * catalog['source_sum_err'] /
-                   catalog['source_sum'])
-    abmag_error[~mask] = np.nan
-    catalog['abmag_error'] = abmag_error
+        # segm=None for photutils >= 0.7
+        # segm.nlabels=0 for photutils < 0.7
+        if segm is None or segm.nlabels == 0:
+            return None
 
-    return catalog
+        # source deblending requires scikit-image
+        if self.deblend:
+            nlevels = 32
+            contrast = 0.001
+            mode = 'exponential'
+            segm = deblend_sources(self.model.data, segm,
+                                   npixels=self.npixels,
+                                   filter_kernel=self.kernel, nlevels=nlevels,
+                                   contrast=contrast, mode=mode,
+                                   connectivity=connectivity, relabel=True)
+        self.segm = segm
 
+        return segm
 
-def _get_rotation(wcs, skew_tolerance=0.01):
-    """
-    Get the rotation of an image from its WCS.
+    def _calc_total_error(self):
+        """
+        Calculate total error (background plus source Poisson error).
+        """
 
-    Parameters
-    ----------
-    wcs : `~astropy.wcs.WCS` instance
-        The image WCS.
+        # The resample step still does not allow for background-only
+        # inverse-variance maps.  Here we estimate the background-only rms
+        # directly from the data, but note this is dependent on the
+        # ``box_size`` parameter in ``estimate_background``.
+        bkg_error = self.background_rms  # Jy
 
-    skew_tolerance : float, optional
-        The absolute allowable difference between the x and y axis
-        rotations.
+        # The source Poisson noise contribution to the total error requires
+        # converting the image into electrons.  The input images are in
+        # units of MJy/sr.  They can be converted to units of counts (DN)
+        # per second via the PHOTMJSR keyword, and then to counts (DN) using
+        # the exposure-time weight map.  However, the final conversion from
+        # DN to electrons requires knowing the gain, which is not available
+        # in the level-3 products.  Here we assume the gain is 1.
 
-    Returns
-    -------
-    rot : float
-        The counterclockwise rotation angle of the image.
-    """
+        # the effective gain is the multiplicative factor to convert the
+        # input image from Jy to e-
+        gain = 1.0  # e-/DN; this is a rough approximation
+        dn_s_factor = (1.e6 *
+                       self.model.meta.photometry.pixelarea_steradians *
+                       self.model.meta.photometry.conversion_megajanskys)
+        effective_gain = gain / dn_s_factor * self.model.wht  # Jy -> e-
 
-    if hasattr(wcs.wcs, 'pc'):
-        rot_matrix = wcs.wcs.pc
-    elif hasattr(wcs.wcs, 'cd'):
-        rot_matrix = wcs.wcs.cd
-    else:
-        raise ValueError("wcs must have a PC or CD matrix.")
+        self.total_error = calc_total_error(self.model.data, bkg_error,
+                                            effective_gain)
 
-    if rot_matrix[1, 0] == 0 and rot_matrix[0, 1] == 0:    # no rotation
-        return 0.
+        return
 
-    if np.linalg.det(rot_matrix) < 0:
-        sgn = -1
-    else:
-        sgn = 1
+    def calc_total_error(self):
+        self.total_error = np.zeros_like(self.model.data)
+        return
 
-    xrot = np.arctan2(sgn * rot_matrix[1, 0],
-                      sgn * rot_matrix[0, 0]) * 180. / np.pi
-    yrot = np.arctan2(-rot_matrix[0, 1], rot_matrix[1, 1]) * 180. / np.pi
+    def apply_units(self):
+        unit = u.Jy
+        self.model.data <<= unit
+        self.total_error <<= unit
+        self.background <<= unit
+        self.background_rms <<= unit
+        return
 
-    if np.abs(xrot - yrot) > skew_tolerance:
-        raise ValueError('x and y axes are skewed: x_rot={0:.2f} deg, '
-                         'y_rot={1:.2f} deg'.format(xrot, yrot))
+    @staticmethod
+    def flux_to_abmag(flux, flux_err):
+        """
+        Parameters
+        ----------
+        flux : float, ndarray
+            In units of Jy
+        """
 
-    if wcs.wcs.lonpole != 180:
-        xrot += (180.0 - wcs.wcs.lonpole)
+        abmag = -2.5 * np.log10(flux.value) + 8.9
+        # assuming SNR >> 1 (otherwise abmag_err is asymmetric)
+        abmag_err = 2.5 * np.log10(np.e) * (flux_err.value / flux.value)
 
-    return xrot
+        return abmag, abmag_err
+
+    def make_segment_catalog(self):
+        """
+        Create a catalog of source photometry and morphologies based on
+        segmentation.
+        """
+
+        # wcs = self.model.meta.wcs  # gWCS
+        wcs = self.model.get_fits_wcs()  # FITS WCS
+
+        source_props = source_properties(self.model.data.astype(float),
+                                         self.segm, error=self.total_error,
+                                         background=self.background,
+                                         filter_kernel=self.kernel, wcs=wcs)
+
+        columns = ['id', 'xcentroid', 'ycentroid', 'sky_centroid',
+                   'source_sum', 'source_sum_err', 'area',
+                   'semimajor_axis_sigma', 'semiminor_axis_sigma',
+                   'ellipticity', 'orientation', 'sky_bbox_ll', 'sky_bbox_ul',
+                   'sky_bbox_lr', 'sky_bbox_ur']
+        catalog = source_props.to_table(columns=columns)
+
+        catalog.rename_column('source_sum', 'isophotal_flux')
+        catalog.rename_column('source_sum_err', 'isophotal_fluxerr')
+        catalog.rename_column('area', 'isophotal_area')
+        catalog.rename_column('semimajor_axis_sigma', 'semimajor_sigma')
+        catalog.rename_column('semiminor_axis_sigma', 'semiminor_sigma')
+
+        # define the orientation position angle (E of N)
+        # NOTE: crpix1 and crpix2 are 1-based values
+        skycoord = wcs.pixel_to_world(self.model.meta.wcsinfo.crpix1 - 1,
+                                      self.model.meta.wcsinfo.crpix2 - 1)
+        _, angle = _pixel_scale_angle_at_skycoord(skycoord, wcs)
+        sky_orientation = (180.0 * u.deg) - angle + catalog['orientation']
+
+        #TODO
+        #catalog.add_column(sky_orientation, name='sky_orientation', index=11)
+        catalog.add_column(sky_orientation, name='sky_orientation')
+
+        #TODO
+        # add magnitude columns
+
+        self.segment_catalog = catalog
+        self.xypos = np.transpose((catalog['xcentroid'],
+                                   catalog['ycentroid']))
+
+        return
+
+    def aper_local_background(self, bkg_aper):
+        """
+        Estimate the local background as the sigma-clipped median value
+        in the input aperture.
+        """
+
+        bkg_aper_masks = bkg_aper.to_mask(method='center')
+        sigclip = SigmaClip(sigma=3)
+
+        bkg_median = []
+        bkg_std = []
+        nvalues = []
+        for mask in bkg_aper_masks:
+            bkg_data = mask.multiply(self.model.data.value)
+            bkg_data_1d = bkg_data[mask.data > 0]
+            values = sigclip(bkg_data_1d, masked=False)
+            nvalues.append(values.size)
+            bkg_median.append(np.median(values))
+            bkg_std.append(np.std(values))
+
+        nvalues = np.array(nvalues)
+        bkg_median = np.array(bkg_median)
+        # standard error of the median
+        bkg_median_err = np.sqrt(np.pi / (2. * nvalues)) * np.array(bkg_std)
+
+        bkg_median <<= self.model.data.unit
+        bkg_median_err <<= self.model.data.unit
+
+        return bkg_median, bkg_median_err
+
+    def get_aperture_radii(self):
+        self.bkg_aper_in = 10
+        self.bkg_aper_out = 15
+        self.aper_radii = (3, 5, 7)
+        return
+
+    def get_abmag_offset(self):
+        filepath = 'abmag_to_vega.ecsv'
+        tbl = QTable.read(filepath)
+        self.abmag_offset = 0.
+        return
+
+    def make_aperture_catalog(self):
+        self.get_aperture_radii()
+        bkg_aperture = CircularAnnulus(self.xypos, self.bkg_aper_in,
+                                       self.bkg_aper_out)
+        bkg_median, bkg_median_err = self.aper_local_background(bkg_aperture)
+
+        apertures = [CircularAperture(self.xypos, radius) for radius in
+                     self.aper_radii]
+        aper_phot = aperture_photometry(self.model.data, apertures,
+                                        error=self.total_error)
+
+        for i, aperture in enumerate(apertures):
+            flux_col = f'aperture_sum_{i}'
+            flux_err_col = f'aperture_sum_err_{i}'
+
+            eefraction = self.aperture_ee[i]
+            name = f'aper{eefraction}'
+            new_flux_col = name + '_flux'
+            new_flux_err_col = name + '_flux_err'
+            abmag_col = name + '_abmag'
+            abmag_err_col = name + '_abmag_err'
+            vegamag_col = name + '_vegamag'
+            vegamag_err_col = name + '_vegamag_err'
+
+            #new_flux_col = f'aper_flux_{eefraction}'
+            #new_flux_err_col = f'aper_flux_err_{eefraction}'
+            #abmag_col = f'aper_abmag_{eefraction}'
+            #abmag_err_col = f'aper_abmag_err_{eefraction}'
+            #vegamag_col = f'aper_vegamag_{eefraction}'
+            #vegamag_err_col = f'aper_vegamag_err_{eefraction}'
+
+            flux = aper_phot[flux_col]
+            flux_err = aper_phot[flux_err_col]
+            abmag, abmag_err = self.flux_to_abmag(flux, flux_err)
+            vegamag = abmag - self.abmag_offset
+            vegamag_err = abmag_err
+
+            aper_phot[flux_col] -= (bkg_median * aperture.area)
+            aper_phot.rename_column(flux_col, new_flux_col)
+            aper_phot.rename_column(flux_err_col, new_flux_err_col)
+
+            aper_phot[abmag_col] = abmag
+            aper_phot[abmag_err_col] = abmag_err
+            aper_phot[vegamag_col] = vegamag
+            aper_phot[vegamag_err_col] = vegamag_err
+
+        aper_phot['aper_bkg_flux'] = bkg_median
+        aper_phot['aper_bkg_fluxerr'] = bkg_median_err
+
+        self.aperture_catalog = aper_phot
+
+        return
+
+    def make_source_catalog(self):
+        self.catalog = join(self.segment_catalog, self.aperture_catalog)
+        return
+
+    def run(self):
+        self.convert_to_jy()
+        self.make_coverage_mask()
+        self.estimate_background()
+        self.subtract_background()
+        self.make_kernel()
+        self.calc_threshold()
+
+        segm = self.detect_sources()
+        if segm is None:
+            log.info('No sources were found. Source catalog will not be '
+                     'created.')
+            return None
+        log.info(f'Detected {segm.nlabels} sources')
+
+        # TODO
+        from astropy.io import fits
+        fits.writeto('segm_new.fits', segm.data, overwrite=True)
+
+        self._calc_total_error()
+        self.apply_units()
+        self.get_abmag_offset()
+
+        self.make_segment_catalog()
+        self.make_aperture_catalog()
+        self.make_source_catalog()
+
+        return self.catalog

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -35,12 +35,19 @@ class SourceCatalogStep(Step):
         suffix = string(default='cat')        # Default suffix for output files
     """
 
-    reference_file_types = ['apcorr']
+    reference_file_types = ['apcorr', 'abvega_offset']
 
     def process(self, input_model):
-        with datamodels.open(input)  as model:
+        with datamodels.open(input_model) as model:
             apcorr_filename = self.get_reference_file(input_model, 'apcorr')
             self.log.info(f'Using apcorr reference file {apcorr_filename}')
+
+            # TODO: fix after reference file is in CRDS
+            #abvega_offset_filename = self.get_reference_file(
+            #    input_model, 'abvega_offset')
+            abvega_offset_filename = None
+            self.log.info('Using abvega_offset reference file ' +
+                          f'{abvega_offset_filename}')
 
             if self.aperture_ee2 < self.aperture_ee1:
                 raise ValueError('aperture_ee2 value must be less than '
@@ -48,15 +55,16 @@ class SourceCatalogStep(Step):
             if self.aperture_ee3 < self.aperture_ee2:
                 raise ValueError('aperture_ee3 value must be less than '
                                  'aperture_ee2')
-            aperture_ee = (self.aperture_ee1, self.aperture_ee2,
-                           self.aperture_ee3)
+            aperture_ee = (int(self.aperture_ee1), int(self.aperture_ee2),
+                           int(self.aperture_ee3))
 
             catobj = SourceCatalog(model, bkg_boxsize=self.bkg_boxsize,
                                    kernel_fwhm=self.kernel_fwhm,
                                    snr_threshold=self.snr_threshold,
                                    npixels=self.npixels, deblend=self.deblend,
                                    aperture_ee=aperture_ee,
-                                   apcorr_filename=apcorr_filename)
+                                   apcorr_filename=apcorr_filename,
+                                   abvega_offset_filename=abvega_offset_filename)
             catalog = catobj.run()
 
             if self.save_results:

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -3,6 +3,7 @@ Module for the source catalog step.
 """
 
 import os
+import warnings
 
 from crds.core.exceptions import CrdsLookupError
 
@@ -28,8 +29,8 @@ class SourceCatalogStep(Step):
     spec = """
         bkg_boxsize = float(default=100)      # background mesh box size in pixels
         kernel_fwhm = float(default=2.0)      # Gaussian kernel FWHM in pixels
-        kernel_xsize = float(default=5)       # Kernel x size in pixels
-        kernel_ysize = float(default=5)       # Kernel y size in pixels
+        kernel_xsize = float(default=None)    # Kernel x size in pixels
+        kernel_ysize = float(default=None)    # Kernel y size in pixels
         snr_threshold = float(default=3.0)    # SNR threshold above the bkg
         npixels = float(default=5.0)          # min number of pixels in source
         deblend = boolean(default=False)      # deblend sources?
@@ -42,6 +43,11 @@ class SourceCatalogStep(Step):
     reference_file_types = ['apcorr', 'abvega_offset']
 
     def process(self, input_model):
+        if self.kernel_xsize is not None or self.kernel_ysize is not None:
+            warnings.simplefilter('default')
+            warnings.warn('kernel_xsize and kernel_ysize are deprecated and '
+                          'no longer used', DeprecationWarning)
+
         with datamodels.open(input_model) as model:
             try:
                 apcorr_fn = self.get_reference_file(input_model, 'apcorr')

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -38,10 +38,16 @@ class SourceCatalogStep(Step):
         deblend = self.deblend
 
         with datamodels.open(input)  as model:
+            bkg = source_catalog.estimate_background(model, box_size=128)
+            model.data -= bkg.background
+
+            threshold = snr_threshold * bkg.background_rms
+
             kernel = source_catalog.make_kernel(kernel_fwhm, kernel_xsize,
                                                 kernel_ysize)
+
             segm = source_catalog.detect_sources(
-                model, kernel, snr_threshold, npixels, deblend=deblend)
+                model, threshold, npixels, kernel, deblend=deblend)
             catalog = source_catalog.make_source_catalog(model, segm, kernel)
 
             if catalog is None:

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -4,6 +4,8 @@ Module for the source catalog step.
 
 import os
 
+from crds.core.exceptions import CrdsLookupError
+
 from .source_catalog import (ReferenceData, Background, make_kernel,
                              make_segment_img, calc_total_error,
                              SourceCatalog)
@@ -42,13 +44,17 @@ class SourceCatalogStep(Step):
 
     def process(self, input_model):
         with datamodels.open(input_model) as model:
-            apcorr_fn = self.get_reference_file(input_model, 'apcorr')
+            try:
+                apcorr_fn = self.get_reference_file(input_model, 'apcorr')
+            except CrdsLookupError:
+                apcorr_fn = None
             self.log.info(f'Using apcorr reference file {apcorr_fn}')
 
-            # TODO: fix after reference file is in CRDS
-            #abvega_offset_fn = self.get_reference_file(
-            #    input_model, 'abvega_offset')
-            abvega_offset_fn = None
+            try:
+                abvega_offset_fn = self.get_reference_file(
+                    input_model, 'abvega_offset')
+            except CrdsLookupError:
+                abvega_offset_fn = None
             self.log.info('Using abvega_offset reference file ' +
                           f'{abvega_offset_fn}')
 

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+"""
+Module for the source catalog step.
+"""
 
 import os
 
@@ -18,8 +20,7 @@ class SourceCatalogStep(Step):
     Parameters
     -----------
     input : str or `ImageModel`
-        A FITS filename or a `ImageModel` of a single drizzled
-        image.  The input image is assumed to be background subtracted.
+        A FITS filename or an `ImageModel` of a drizzled image.
     """
 
     spec = """
@@ -58,7 +59,7 @@ class SourceCatalogStep(Step):
                                     abvega_offset_filename=abvega_offset_fn)
 
             coverage_mask = (model.wht == 0)
-            bkg = Background(model.data, bkg_boxsize=self.bkg_boxsize,
+            bkg = Background(model.data, box_size=self.bkg_boxsize,
                              mask=coverage_mask)
             model.data -= bkg.background
 

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -81,6 +81,7 @@ class SourceCatalogStep(Step):
 
             catobj = SourceCatalog(model, segment_img, error=total_error,
                                    kernel=kernel,
+                                   kernel_fwhm=self.kernel_fwhm,
                                    aperture_params=refdata.aperture_params,
                                    abvega_offset=refdata.abvega_offset)
             catalog = catobj.catalog

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -38,9 +38,10 @@ class SourceCatalogStep(Step):
         deblend = self.deblend
 
         with datamodels.open(input)  as model:
+            kernel = source_catalog.make_kernel(kernel_fwhm, kernel_xsize,
+                                                kernel_ysize)
             catalog = source_catalog.make_source_catalog(
-                model, kernel_fwhm, kernel_xsize, kernel_ysize, snr_threshold,
-                npixels, deblend=deblend)
+                model, kernel, snr_threshold, npixels, deblend=deblend)
 
             if catalog is None:
                 self.log.info('No sources were found.  Source catalog will '

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -40,8 +40,9 @@ class SourceCatalogStep(Step):
         with datamodels.open(input)  as model:
             kernel = source_catalog.make_kernel(kernel_fwhm, kernel_xsize,
                                                 kernel_ysize)
-            catalog = source_catalog.make_source_catalog(
+            segm = source_catalog.detect_sources(
                 model, kernel, snr_threshold, npixels, deblend=deblend)
+            catalog = source_catalog.make_source_catalog(model, segm, kernel)
 
             if catalog is None:
                 self.log.info('No sources were found.  Source catalog will '

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -36,7 +36,6 @@ class SourceCatalogStep(Step):
         aperture_ee1 = float(default=30)      # aperture encircled energy 1
         aperture_ee2 = float(default=50)      # aperture encircled energy 2
         aperture_ee3 = float(default=70)      # aperture encircled energy 3
-        output_ext = string(default='.ecsv')  # Default file extension
         suffix = string(default='cat')        # Default suffix for output files
     """
 
@@ -93,7 +92,7 @@ class SourceCatalogStep(Step):
             catalog = catobj.catalog
 
             if self.save_results:
-                cat_filepath = self.make_output_path()
+                cat_filepath = self.make_output_path(ext='.ecsv')
                 catalog.write(cat_filepath, format='ascii.ecsv',
                               overwrite=True)
                 model.meta.source_catalog = os.path.basename(cat_filepath)


### PR DESCRIPTION
This PR represents a complete rewrite of the source catalog step to incorporate aperture photometry (including aperture corrections) and other source properties as requested by the JWST Photometry Working Group (JPWG) in https://jira.stsci.edu/browse/JP-645.  This PR also closes https://jira.stsci.edu/browse/JP-1368.  The source catalog now contains 52 properties for each source.

The JPWG has not yet determined an algorithm for the `is_star` property, and thus that column contains NaN values.  As a result of this, the aperture-corrected "total" flux and magnitude columns are also set to NaN values because aperture-corrected photometry is only appropriate for stars. 

Also, after discussion with the CALWG, it was decided to set all photometric errors to NaN because the resampled `i2d` data do not contain any error information (better to report no errors than incorrect errors).

Also, based on an email from Brad Whitmore I changed the "isolation_metric" column to two columns, `nn_dist` and `nn_abmag` representing the distance (in pixels) and AB mag of the nearest-neighbor source, respectively.

The source catalog step now uses `APCORR` and `ABVEGA_OFFSET` (see #4680) reference files.  This PR ~will run without~ depends on #4680 (but `abvega_offset` defaults to 0.0 if no reference file is found).  There is also an outstanding issue with the delivered `APCORR` reference files using `detector` as a selector (see discussion in https://jira.stsci.edu/browse/JP-1022), given that `i2d` NIRCam data will typically represent the combination of several detectors (`detector = None`) .  However, there is currently a bug (https://github.com/spacetelescope/jwst/issues/4681) where `meta.instrument.detector` is set incorrectly for combined NIRCam `i2d` products (thus the `APCORR` reference files currently in `CRDS-test` work, but they shouldn't).

Finally, I also removed the `output_ext` spec, which closes https://jira.stsci.edu/browse/JP-997.

Note that all of the output source catalogs used as "truth" files in the regression test suite will need to be updated.  I don't know what the procedure is for that.

Closes https://github.com/spacetelescope/jwst/issues/4708