### PR TITLE
Add --job-name option to okify_regtests script

### DIFF
--- a/scripts/okify_regtests
+++ b/scripts/okify_regtests
@@ -18,7 +18,6 @@ import asdf
 
 
 ARTIFACTORY_REPO = "jwst-pipeline-results"
-BUILD_NAME = "RT :: JWST"
 SPECFILE_SUFFIX = "_okify.json"
 RTDATA_SUFFIX = "_rtdata.asdf"
 TERMINAL_WIDTH = shutil.get_terminal_size((80, 20)).columns
@@ -27,6 +26,7 @@ TERMINAL_WIDTH = shutil.get_terminal_size((80, 20)).columns
 def parse_args():
     parser = ArgumentParser(description="Okify regression test results")
     parser.add_argument("build_number", help="Jenkins build number for JWST builds", metavar="build-number")
+    parser.add_argument("--job-name", help="Jenkins job name under [RT] (default: JWST)", default="JWST", metavar="job-name")
     parser.add_argument("--dry-run", action="store_true", help="pass the --dry-run flag to JFrog CLI")
 
     return parser.parse_args()
@@ -44,7 +44,7 @@ def artifactory_copy(specfile, dry_run=False):
     subprocess.run(args, check=True)
 
 
-def artifactory_get_breadcrumbs(build_number, suffix):
+def artifactory_get_breadcrumbs(build_number, job_name, suffix):
     """Download specfiles or other breadcrump from Artifactory associated with
     a build number and return a list of their locations on the local file system
 
@@ -52,7 +52,7 @@ def artifactory_get_breadcrumbs(build_number, suffix):
 
     jfrog rt search jwst-pipeline-results/*/*_okify.json --props="build.number=540;build.name=RT :: JWST"
     """
-    build_name = BUILD_NAME
+    build_name = f"RT :: {job_name}"
 
     # Retreive all the okify specfiles for failed tests.
     args = list(["jfrog", "rt", "dl"]
@@ -64,9 +64,9 @@ def artifactory_get_breadcrumbs(build_number, suffix):
     return sorted(glob(f"*{suffix}"))
 
 
-def artifactory_get_build_artifacts(build):
-    specfiles = artifactory_get_breadcrumbs(build, SPECFILE_SUFFIX)
-    asdffiles = artifactory_get_breadcrumbs(build, RTDATA_SUFFIX)
+def artifactory_get_build_artifacts(build_number, job_name):
+    specfiles = artifactory_get_breadcrumbs(build_number, job_name, SPECFILE_SUFFIX)
+    asdffiles = artifactory_get_breadcrumbs(build_number, job_name, RTDATA_SUFFIX)
 
     if len(specfiles) != len(asdffiles):
         raise RuntimeError("Different number of _okify.json and _rtdata.asdf files")
@@ -92,13 +92,14 @@ def main():
     args = parse_args()
 
     build = args.build_number
+    name = args.job_name
 
     # Create and chdir to a temporary directory to store specfiles
     with tempfile.TemporaryDirectory() as tmpdir:
         print(f"Downloading test okify artifacts to local directory {tmpdir}")
         with pushd(tmpdir):
             # Retreive all the okify specfiles for failed tests.
-            specfiles, asdffiles = artifactory_get_build_artifacts(build)
+            specfiles, asdffiles = artifactory_get_build_artifacts(build, name)
 
             number_failed_tests = len(specfiles)
 


### PR DESCRIPTION
Allows one to do OKifying from a different job other than RT/JWST.  Mostly
useful for OKifying from a branch other than master run under a different
job, such as jdavies-dev or eisenhamer-dev.