### PR TITLE
JP-1415: Update resample to reject NON_SCIENCE pixels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,6 +117,9 @@ resample
   The parameter ``good_bits`` has been removed in favor of allowing all
   DQ flags except for ``DO_NOT_USE``
 
+- Updated to reject pixels with DQ flag NON_SCIENCE, in addition to
+  DO_NOT_USE. [#4851]
+
 resample_spec
 -------------
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -15,8 +15,8 @@ log.setLevel(logging.DEBUG)
 __all__ = ["ResampleStep"]
 
 
-# Force use of all DQ flagged data except for DO_NOT_USE
-GOOD_BITS = '~DO_NOT_USE'
+# Force use of all DQ flagged data except for DO_NOT_USE and NON_SCIENCE
+GOOD_BITS = '~DO_NOT_USE+NON_SCIENCE'
 
 
 class ResampleStep(Step):


### PR DESCRIPTION
Updated the resample step module to by default reject all pixels with DQ flags of NON_SCIENCE, in addition to DO_NOT_USE. This is especially necessary for MIRI Imaging exposures, where the portion of the detector not covered by direct images (e.g. the LRS and 4QPM areas) is flagged as NON_SCIENCE.

Fixes #4850 / [JP-1415](https://jira.stsci.edu/browse/JP-1415)