### PR TITLE
Setup regtests to use crds-test and 0595 context

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -20,8 +20,8 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environement variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
-    "CRDS_CONTEXT=jwst-edit",
+    "CRDS_SERVER_URL=https://jwst-crds-test.stsci.edu",
+    "CRDS_CONTEXT=jwst_0595.pmap",
     "ENG_BASE_URL=http://twjwdmsemwebag.stsci.edu/JWDMSEngFqAccSide1/TlmMnemonicDataSrv.svc/",
 ]
 

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -30,8 +30,8 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environement variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
-    "CRDS_CONTEXT=jwst-edit",
+    "CRDS_SERVER_URL=https://jwst-crds-test.stsci.edu",
+    "CRDS_CONTEXT=jwst_0595.pmap",
 ]
 
 // Set pytest basetemp output directory


### PR DESCRIPTION
PR #4819 requires the use of new apcorr ref files that are currently only available on the CRDS test server, in context 595, so I'm temporarily updating the regtest environment to use those. Will revert once these are available on the regular crds ops server.