### PR TITLE
Update NIRCam and MIRI image regtests to override abvega

### DIFF
--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -6,6 +6,7 @@ from gwcs.wcstools import grid_from_bounding_box
 from jwst.stpipe import Step
 from jwst import datamodels
 
+
 @pytest.fixture(scope="module")
 def run_detector1(rtdata_module):
     """Run detector1 pipeline on MIRI imaging data."""
@@ -61,6 +62,7 @@ def run_image3(run_image2, rtdata_module):
     """Get the level3 assocation json file (though not its members) and run
     image3 pipeline on all _cal files listed in association"""
     rtdata = rtdata_module
+    rtdata.get_data("miri/image/jwst_miri_abvega_offset_0001.asdf")
     rtdata.get_data("miri/image/det_dithered_5stars_image3_asn.json")
     args = ["config/calwebb_image3.cfg", rtdata.input,
         # Set some unique param values needed for these data
@@ -68,6 +70,7 @@ def run_image3(run_image2, rtdata_module):
         "--steps.tweakreg.use2dhist=False",
         "--steps.tweakreg.minobj=4",
         "--steps.source_catalog.snr_threshold=20",
+        "--steps.source_catalog.override_abvega_offset=jwst_miri_abvega_offset_0001.asdf",
         ]
     Step.from_cmdline(args)
 

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -62,12 +62,14 @@ def run_image3pipeline(run_image2pipeline, rtdata_module, jail):
 
     # Get the level3 assocation json file (though not its members) and run
     # image3 pipeline on all _cal files listed in association
+    rtdata.get_data("nircam/image/jwst_nircam_abvega_offset_0001.asdf")
     rtdata.get_data("nircam/image/jw42424-o002_20191220t214154_image3_001_asn.json")
     args = ["config/calwebb_image3.cfg", rtdata.input,
         # Comment out following lines, as the dataset is currently broken
         # "--steps.tweakreg.save_results=True",
         # "--steps.skymatch.save_results=True",
         "--steps.source_catalog.snr_threshold=20",
+        "--steps.source_catalog.override_abvega_offset='jwst_nircam_abvega_offset_0001.asdf'",
         ]
     Step.from_cmdline(args)
 

--- a/jwst/regtest/test_nircam_mtimage.py
+++ b/jwst/regtest/test_nircam_mtimage.py
@@ -9,9 +9,11 @@ from jwst.stpipe import Step
 def test_nircam_image_moving_target(rtdata, fitsdiff_default_kwargs):
     """Test resampled i2d of moving target exposures for NIRCam imaging"""
     collect_pipeline_cfgs("config")
+    rtdata.get_data("nircam/image/jwst_nircam_abvega_offset_0001.asdf")
     rtdata.get_asn("nircam/image/mt_asn.json")
     rtdata.output = "mt_assoc_i2d.fits"
-    args = ["config/calwebb_image3.cfg", rtdata.input]
+    args = ["config/calwebb_image3.cfg", rtdata.input,
+            "--steps.source_catalog.override_abvega_offset='jwst_nircam_abvega_offset_0001.asdf'"]
     Step.from_cmdline(args)
     rtdata.get_truth("truth/test_nircam_mtimage/mt_assoc_i2d.fits")
 


### PR DESCRIPTION
Temporarily modify the NIRCam and MIRI image regtests to override the abvega_offset ref file used by source_catalog until they're available in CRDS. Copies of the ref files have been added to the appropriate artifactory directories.

Will revert once the ref files are in CRDS.