### PR TITLE
Add crds to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 git+https://github.com/astropy/astropy#egg=astropy
 git+https://github.com/spacetelescope/asdf#egg=asdf
+git+https://github.com/spacetelescope/crds#egg=crds
 git+https://github.com/spacetelescope/gwcs#egg=gwcs
 git+https://github.com/astropy/photutils#egg=photutils


### PR DESCRIPTION
It would be good to be testing against `crds` master in our dev builds on TravisCI (allowed failure) and Jenkins RT.