### PR TITLE
JP-1419: Update ASNTABLE in all calspec3 products

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,9 @@ pipeline
 - Update ``calwebb_spec3`` to use suffix ``c1d`` for ``combine_1d`` products.
   [#4846]
 
+- Update ``calwebb_spec3`` to update the ASNTABLE keyword in all output
+  products, to reflect the name of the spec3 ASN used as input. [#4865]
+
 resample
 --------
 

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -89,6 +89,11 @@ class Spec3Pipeline(Pipeline):
         # do a direct open of all members in ASN file, e.g.
         input_models = datamodels.open(input, asn_exptypes=asn_exptypes)
 
+        # Immediately update the ASNTABLE keyword value in all inputs,
+        # so that all outputs get the new value
+        for model in input_models:
+            model.meta.asn.table_name = input_models.meta.table_name
+
         # For the first round of development we will assume that the input
         # is ALWAYS an ASN. There's no use case for anyone ever running a
         # single exposure through.

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from collections import defaultdict
+import os.path as op
 
 from .. import datamodels
 from ..associations.lib.rules_level3_base import format_product
@@ -92,7 +93,7 @@ class Spec3Pipeline(Pipeline):
         # Immediately update the ASNTABLE keyword value in all inputs,
         # so that all outputs get the new value
         for model in input_models:
-            model.meta.asn.table_name = input_models.meta.table_name
+            model.meta.asn.table_name = op.basename(input_models.meta.table_name)
 
         # For the first round of development we will assume that the input
         # is ALWAYS an ASN. There's no use case for anyone ever running a
@@ -181,7 +182,7 @@ class Spec3Pipeline(Pipeline):
                 # the downstream products have the correct table name since
                 # the _cal files are not saved they will not be updated
                 for cal_array in result:
-                    cal_array.meta.asn.table_name = result.meta.table_name
+                    cal_array.meta.asn.table_name = op.basename(result.meta.table_name)
                 result = self.outlier_detection(result)
 
                 # Resample time. Dependent on whether the data is IFU or not.


### PR DESCRIPTION
Updated the `calwebb_spec3` pipeline module to update the ASNTABLE keyword value in all input models, so that the updated value gets propagated to all output products.

Fixes #4863 / [JP-1419](https://jira.stsci.edu/browse/JP-1419)