### PR TITLE
Disable regtest table comparisons of meta data [skip ci]

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -243,8 +243,10 @@ def diff_astropy_tables():
         if len(diffs) > 0:
             raise AssertionError("\n".join(diffs))
 
-        if result.meta != truth.meta:
-            diffs.append("Metadata does not match")
+        # Disable meta comparison for now, until we're able to specify
+        # individual entries for comparison
+        #if result.meta != truth.meta:
+        #    diffs.append("Metadata does not match")
 
         for col_name in truth.colnames:
             try:


### PR DESCRIPTION
Comment out the comparison of table meta data in `diff_astropy_tables`, because at least some tables (like the new _cat.ecsv table from `source_catalog`) include entries giving code versions, which change frequently and lead to unnecessary failures. Need to enhance the table meta comparison to allow for specification of which entries to compare.