### PR TITLE
Fix a calspec3 bug introduced in PR4865 [skip ci]

### DIFF
--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -182,7 +182,7 @@ class Spec3Pipeline(Pipeline):
                 # the downstream products have the correct table name since
                 # the _cal files are not saved they will not be updated
                 for cal_array in result:
-                    cal_array.meta.asn.table_name = op.basename(result.meta.table_name)
+                    cal_array.meta.asn.table_name = op.basename(input_models.meta.table_name)
                 result = self.outlier_detection(result)
 
                 # Resample time. Dependent on whether the data is IFU or not.


### PR DESCRIPTION
#4865 introduced a bug, which this fixes. Variable `result` has no meta data anymore once it's gone through the branch for inputs that get resampled, so we have to use the table_name from the original input.