### PR TITLE
Populate meta.asn.table_name when association opened in ModelContainer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ datamodels
   (remove TIME-END; add TDB-BEG, TDB-MID, TDB-END, XPOSURE, TELAPSE)
   [#4925]
 
+- Populate meta.asn.table_name when an association is loaded into a
+  ``ModelContainer``. [#4873]
+
 lib
 ---
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -236,6 +236,8 @@ class ModelContainer(model_base.DataModel):
             self.meta.table_name = 'not specified'
         else:
             self.meta.table_name = op.basename(asn_file_path)
+            for model in self:
+                model.meta.asn.table_name = op.basename(asn_file_path)
         self.meta.pool_name = asn_data['asn_pool']
 
     def save(self,

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -237,7 +237,11 @@ class ModelContainer(model_base.DataModel):
         else:
             self.meta.table_name = op.basename(asn_file_path)
             for model in self:
-                model.meta.asn.table_name = op.basename(asn_file_path)
+                try:
+                    model.meta.asn.table_name = op.basename(asn_file_path)
+                    model.meta.asn.pool_name = asn_data['asn_pool']
+                except AttributeError:
+                    pass
         self.meta.pool_name = asn_data['asn_pool']
 
     def save(self,

--- a/jwst/datamodels/tests/data/association_w_cat.json
+++ b/jwst/datamodels/tests/data/association_w_cat.json
@@ -1,0 +1,31 @@
+{
+    "asn_rule": "Asn_Image",
+    "degraded_status": "No known degraded exposures in association.",
+    "target": "1",
+    "code_version": "0.7.0",
+    "version_id": null,
+    "asn_pool": "pool",
+    "asn_id": "a3001",
+    "program": "80600",
+    "products": [
+        {
+            "name": "jw80600-a3001_t001_miri_p750l",
+            "members": [
+                {
+                    "exptype": "SCIENCE",
+                    "expname": "test.fits",
+                },
+                {
+                    "exptype": "SCIENCE",
+                    "expname": "test.fits",
+                },
+                {
+                    "exptype": "sourcecat",
+                    "expname": "test_cat.ecsv",
+                },
+            ]
+        }
+    ],
+    "asn_type": "image",
+    "constraints": "Constraints:\n    target: 1\n    opt_elem: P750L\n    exp_type: MIR_LRS-SLITLESS|MIR_TACQ\n    instrument: MIRI\n    program: 80600\n    subarray: SUBPRISM"
+}

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -57,6 +57,14 @@ def test_open_association():
             assert isinstance(c, ModelContainer)
             for model in c:
                 assert model.meta.asn.table_name == "association.json"
+                assert model.meta.asn.pool_name == "pool"
+
+
+def test_container_open_asn_with_sourcecat():
+    path = t_path("association_w_cat.json")
+    with datamodels.open(path, asn_exptypes="science") as c:
+        for model in c:
+            assert model.meta.asn.table_name == "association_w_cat.json"
 
 
 def test_open_shape():

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -55,6 +55,8 @@ def test_open_association():
         warnings.filterwarnings("ignore", "model_type not found")
         with datamodels.open(asn_file) as c:
             assert isinstance(c, ModelContainer)
+            for model in c:
+                assert model.meta.asn.table_name == "association.json"
 
 
 def test_open_shape():


### PR DESCRIPTION
Populate `meta.asn.table_name` in each member of the association that is loaded into a `ModelContainer`.

Related to #4871 #4865 and #4870.