### PR TITLE
Ignore doctestplus import errors in ramp_fit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ results_root = jwst-pipeline-results
 doctest_plus = true
 doctest_rst = true
 text_file_format = rst
-addopts = --show-capture=no --open-files
+addopts = --show-capture=no --open-files --doctest-ignore-import-errors
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
This fix ignores pytest collection errors we've seen with the recently released `pytest-doctestplus 0.6` which now raises a collection error if modules in the repo are not importable.  This is probably good behavior, but we have several modules in the repo that are not importable currently:

```
================================================================= ERRORS =================================================================
__________________________________________________ ERROR collecting docs/exts/numfig.py __________________________________________________
docs/exts/numfig.py:1: in <module>
    from docutils.nodes import figure, caption, Text, reference, raw, SkipNode, Element
E   ModuleNotFoundError: No module named 'docutils'
______________________________________________ ERROR collecting jwst/ramp_fitting/mc_2d.py _______________________________________________
jwst/ramp_fitting/mc_2d.py:43: in <module>
    import energy_dists
E   ModuleNotFoundError: No module named 'energy_dists'
__________________________________________ ERROR collecting jwst/ramp_fitting/rotate_dataset.py __________________________________________
jwst/ramp_fitting/rotate_dataset.py:11: in <module>
    from . import rotate_utils
jwst/ramp_fitting/rotate_utils.py:8: in <module>
    import Rotatefitscube
E   ModuleNotFoundError: No module named 'Rotatefitscube'
___________________________________________ ERROR collecting jwst/ramp_fitting/rotate_utils.py ___________________________________________
jwst/ramp_fitting/rotate_utils.py:8: in <module>
    import Rotatefitscube
E   ModuleNotFoundError: No module named 'Rotatefitscube'
```
