### PR TITLE
Change RT crds context to 605

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -21,7 +21,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds-test.stsci.edu",
-    "CRDS_CONTEXT=jwst_0606.pmap",
+    "CRDS_CONTEXT=jwst_0605.pmap",
     "CRDS_PATH=/grp/crds/test_cache",
     "ENG_BASE_URL=http://twjwdmsemwebag.stsci.edu/JWDMSEngFqAccSide1/TlmMnemonicDataSrv.svc/",
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -31,7 +31,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds-test.stsci.edu",
-    "CRDS_CONTEXT=jwst_0606.pmap",
+    "CRDS_CONTEXT=jwst_0605.pmap",
     "CRDS_PATH=/grp/crds/test_cache",
 ]
 


### PR DESCRIPTION
Context 606 has empty filteroffset rmap entries for nircam and niriss, which breaks the cal code. Backing down to 605.