### PR TITLE
regtest: fix override abvegaoffset name

### DIFF
--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -70,7 +70,7 @@ def run_image3(run_image2, rtdata_module):
         "--steps.tweakreg.use2dhist=False",
         "--steps.tweakreg.minobj=4",
         "--steps.source_catalog.snr_threshold=20",
-        "--steps.source_catalog.override_abvega_offset=jwst_miri_abvega_offset_0001.asdf",
+        "--steps.source_catalog.override_abvegaoffset=jwst_miri_abvega_offset_0001.asdf",
         ]
     Step.from_cmdline(args)
 

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -69,7 +69,7 @@ def run_image3pipeline(run_image2pipeline, rtdata_module, jail):
         # "--steps.tweakreg.save_results=True",
         # "--steps.skymatch.save_results=True",
         "--steps.source_catalog.snr_threshold=20",
-        "--steps.source_catalog.override_abvega_offset='jwst_nircam_abvega_offset_0001.asdf'",
+        "--steps.source_catalog.override_abvegaoffset='jwst_nircam_abvega_offset_0001.asdf'",
         ]
     Step.from_cmdline(args)
 

--- a/jwst/regtest/test_nircam_mtimage.py
+++ b/jwst/regtest/test_nircam_mtimage.py
@@ -16,7 +16,7 @@ def test_nircam_image_moving_target(rtdata, fitsdiff_default_kwargs):
     rtdata.get_asn("nircam/image/mt_asn.json")
     rtdata.output = "mt_assoc_i2d.fits"
     args = ["config/calwebb_image3.cfg", rtdata.input,
-            "--steps.source_catalog.override_abvega_offset='jwst_nircam_abvega_offset_0001.asdf'"]
+            "--steps.source_catalog.override_abvegaoffset='jwst_nircam_abvega_offset_0001.asdf'"]
     Step.from_cmdline(args)
     rtdata.get_truth("truth/test_nircam_mtimage/mt_assoc_i2d.fits")
 


### PR DESCRIPTION
Fix the name of the override param in calimage3  regression tests from abvega_offset to abvegaoffset, now that the ref file name has changed.