### PR TITLE
JP-1405 Investigate Cube build speed

### DIFF
--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -101,10 +101,17 @@ class CubeBlot():
 
         log.info('Number of input models %i ', len(self.input_models))
 
-    # ************************************************************************
-    def blot_images(self):
-        """ Core blotting routine
 
+    def blot_images(self):
+        if self.instrument == 'MIRI':
+            blotmodels = self.blot_images_miri()
+        elif self.instrument == 'NIRSPEC':
+            blotmodels = self.blot_images_nirspec()
+        return blotmodels
+    # ************************************************************************
+    def blot_images_miri(self):
+        """ Core blotting routine for MIRI
+        
         This is the main routine for blotting the median sky image back to
         the detector space and creating a blotting image for each input model
         1. Loop over every data model to be blotted and find ra,dec,wavelength
@@ -137,110 +144,44 @@ class CubeBlot():
             # ___________________________________________________________________
             # For MIRI we only work on one channel at a time
 
-            if self.instrument == 'MIRI':
-                # only one channel is blotted at a time
-                this_par1 = self.channel
+            # only one channel is blotted at a time
+            this_par1 = self.channel
 
-                # get the detector values for this model
-                xstart, xend = instrument_info.GetMIRISliceEndPts(this_par1)
-
-                ysize, xsize = model.data.shape
-                ydet, xdet = np.mgrid[:ysize, :xsize]
-                ydet = ydet.flatten()
-                xdet = xdet.flatten()
-                self.ycenter_grid, self.xcenter_grid = np.mgrid[0:ysize,
+            # get the detector values for this model
+            xstart, xend = instrument_info.GetMIRISliceEndPts(this_par1)
+                
+            ysize, xsize = model.data.shape
+            ydet, xdet = np.mgrid[:ysize, :xsize]
+            ydet = ydet.flatten()
+            xdet = xdet.flatten()
+            self.ycenter_grid, self.xcenter_grid = np.mgrid[0:ysize,
                                                                 0:xsize]
 
-                xsize = xend - xstart + 1
-                xcenter = np.arange(xsize) + xstart
-                ycenter = np.arange(ysize)
+            xsize = xend - xstart + 1
+            xcenter = np.arange(xsize) + xstart
+            ycenter = np.arange(ysize)
+            
+            valid_channel = np.logical_and(xdet >= xstart, xdet <= xend)
 
-                valid_channel = np.logical_and(xdet >= xstart, xdet <= xend)
-
-                xdet = xdet[valid_channel]
-                ydet = ydet[valid_channel]
-                # cube spaxel ra,dec values --> x, y on detector
-                x_cube, y_cube = model.meta.wcs.backward_transform(self.cube_ra,
-                                                                   self.cube_dec,
-                                                                   self.cube_wave)
-                x_cube = np.ndarray.flatten(x_cube)
-                y_cube = np.ndarray.flatten(y_cube)
-                flux_cube = np.ndarray.flatten(self.cube_flux)
-                valid = ~np.isnan(y_cube)
-                x_cube = x_cube[valid]
-                y_cube = y_cube[valid]
-                flux_cube = flux_cube[valid]
-                valid_channel = np.logical_and(x_cube >= xstart, x_cube <= xend)
-                x_cube = x_cube[valid_channel]
-                y_cube = y_cube[valid_channel]
-                flux_cube = flux_cube[valid_channel]
+            xdet = xdet[valid_channel]
+            ydet = ydet[valid_channel]
+            # cube spaxel ra,dec values --> x, y on detector
+            x_cube, y_cube = model.meta.wcs.backward_transform(self.cube_ra,
+                                                               self.cube_dec,
+                                                               self.cube_wave)
+            x_cube = np.ndarray.flatten(x_cube)
+            y_cube = np.ndarray.flatten(y_cube)
+            flux_cube = np.ndarray.flatten(self.cube_flux)
+            valid = ~np.isnan(y_cube)
+            x_cube = x_cube[valid]
+            y_cube = y_cube[valid]
+            flux_cube = flux_cube[valid]
+            valid_channel = np.logical_and(x_cube >= xstart, x_cube <= xend)
+            x_cube = x_cube[valid_channel]
+            y_cube = y_cube[valid_channel]
+            flux_cube = flux_cube[valid_channel]
             # ___________________________________________________________________
-            # For NIRSPEC we need to work 1 slice at a time
-            elif self.instrument == 'NIRSPEC':
-                # initialize the x_cube,y_cube, and flux_cube arrays
-                # we will loop over slices and fill in values
-                # the flag_det will be set when a slice pixel is filled in
-                #   at the end we will use this flag to pull out valid data
-                ysize, xsize = model.data.shape
-                x_cube = np.zeros((ysize, xsize))
-                y_cube = np.zeros((ysize, xsize))
-                flux_cube = np.zeros((ysize, xsize))
 
-                ycenter = np.arange(ysize)
-                xcenter = np.arange(xsize)
-                self.ycenter_grid, self.xcenter_grid = np.mgrid[0:ysize,
-                                                               0:xsize]
-
-                # for NIRSPEC each file has 30 slices
-                # wcs information accessed seperately for each slice
-
-                nslices = 30
-                log.info('Looping over 30 slices on NIRSPEC detector, this takes a little while')
-                t0 = time.time()
-                for ii in range(nslices):
-                    # for each slice pull out the blotted values that actually fall on the slice region
-                    # used the bounding box of each slice to determine the slice limits
-                    slice_wcs = nirspec.nrs_wcs_set_input(model, ii)
-                    print('size of median cube inverting back',self.cube_ra.size)
-                    ta = time.time()
-                    x_slice, y_slice = slice_wcs.invert(self.cube_ra, self.cube_dec, self.cube_wave)
-                    tb = time.time()
-                    log.info("Time to invert median cube to slice = %.1f s" % (tb-ta,))
-                    
-                    x_slice = np.ndarray.flatten(x_slice)
-                    y_slice = np.ndarray.flatten(y_slice)
-                    flux_slice = np.ndarray.flatten(self.cube_flux)
-                    xlimit, ylimit = slice_wcs.bounding_box
-
-                    xuse = np.logical_and(x_slice >= xlimit[0], x_slice <= xlimit[1])
-                    yuse = np.logical_and(y_slice >= ylimit[0], y_slice <= ylimit[1])
-
-                    print('for slice x y range',ii+1,xlimit[0],xlimit[1],ylimit[0],ylimit[1])
-
-                    fuse = np.logical_and(xuse, yuse)
-                    x_slice = x_slice[fuse]
-                    y_slice = y_slice[fuse]
-                    
-                    # For now keeping these print statements in case we need to revise
-                    # how blotting is done for NIRSPEC. It is very slow. After the NIRSPEC team
-                    # confirms the blotting routine is working these can be take out.
-                    # print('number of original values', flux_slice.size)
-                    # print('on slice ', ii, xlimit[0], xlimit[1], ylimit[0], ylimit[1])
-                    # print('min max of xslice', np.amin(x_slice), np.amax(x_slice))
-                    # print('min max of yslice', np.amin(y_slice), np.amax(y_slice))
-                    flux_slice = flux_slice[fuse]
-                    print('number for slice', flux_slice.size)
-                    if ii == 0:
-                        x_cube = x_slice
-                        y_cube = y_slice
-                        flux_cube = flux_slice
-                    else:
-                        x_cube = np.concatenate((x_cube, x_slice), axis=0)
-                        y_cube = np.concatenate((y_cube, y_slice), axis=0)
-                        flux_cube = np.concatenate((flux_cube, flux_slice), axis=0)
-                        print('cube pixels on detector',flux_cube.size)
-                t1 = time.time()
-                log.info("Time to invert all slices = %.1f s" % (t1-t0,))
             log.info('Blotting back to %s', model.meta.filename)
             # ______________________________________________________________________________
             # For every detector pixel find the overlapping median cube spaxels.
@@ -257,6 +198,7 @@ class CubeBlot():
         return blot_models
     # ________________________________________________________________________________
 
+    # ________________________________________________________________________________
     def blot_overlap_quick(self, model, xcenter, ycenter, xstart,
                            x_cube, y_cube, flux_cube):
 
@@ -272,15 +214,13 @@ class CubeBlot():
         blot_ysize, blot_xsize = blot_flux.shape
         blot_flux = np.ndarray.flatten(blot_flux)
         blot_weight = np.ndarray.flatten(blot_weight)
-        self.xcenter_grid = np.ndarray.flatten(self.xcenter_grid)
-        self.ycenter_grid = np.ndarray.flatten(self.ycenter_grid)
-        # num = x_cube.size
+
         # loop over valid points in cube (not empty edge pixels)
-        # TODO need to move this value (roi_det)  to reference file  or at least in spec ?
         roi_det = 1.0  # Just large enough that we don't get holes
         ivalid = np.nonzero(np.absolute(flux_cube))
         
         t0 = time.time()
+        print('number of points looping over',len(ivalid[0]))
         for ipt in ivalid[0]:
             # if(flux_cube[ipt] > 0):
             # search xcenter and ycenter seperately. These arrays are smallsh.
@@ -297,13 +237,187 @@ class CubeBlot():
                 d2pix = np.array(y_cube[ipt] - ycenter[index_y])
 
                 dxy = [ (dx*dx + dy*dy)  for dy in d2pix for dx in d1pix]
-                print('new dxy',dxy)
-                dxy=[]
-                for dy in d2pix:
-                    for dx in d1pix:
-                        dxy.append((dx * dx) + (dy * dy))
+                dxy = np.sqrt(dxy)
+                weight_distance = np.exp(-dxy)
+                weighted_flux = weight_distance * flux_cube[ipt]
+                index2d = [iy * blot_xsize + ix for iy in index_y[0] for ix in (index_x[0]+xstart)]
+                blot_flux[index2d] = blot_flux[index2d] + weighted_flux
+                blot_weight[index2d] = blot_weight[index2d] + weight_distance
+
+        t1 = time.time()
+        log.info("Time to blot median image to input model = %.1f s" % (t1-t0,))
+        # done mapping blotted x,y (x_cube, y_cube) to detector
+        igood = np.where(blot_weight > 0)
+        blot_flux[igood] = blot_flux[igood] / blot_weight[igood]
+        blot_flux = blot_flux.reshape((blot_ysize, blot_xsize))
+        return blot_flux
+
+    # ************************************************************************
+    def blot_images_nirspec(self):
+        """ Core blotting routine for NIRSPEC
+
+        This is the main routine for blotting the median sky image back to
+        the detector space and creating a blotting image for each input model
+        1. Loop over every data model to be blotted and find ra,dec,wavelength
+           for every pixel in a valid slice on the detector.
+        2. Using WCS of input  image convert the ra and dec of input model
+           to then tangent plane values: xi,eta.
+        3. Loop over every input model and using the inverse (backwards) transform
+           convert the median sky cube values ra, dec, lambda to the blotted
+           x, y detector value (x_cube, y_cube).
+
+        4. For each input model loop over the blotted x,y values and find
+            The x, y detector values that fall within the roi region. We loop
+            over the blotted values instead of the detector x, y (the more
+            obvious method) because of speed. We can break down the x, y detector
+            pixels into a regular grid represented by an array of xcenters and
+            ycenters. Because we are really intereseted finding all those blotted
+            pixels that fall with the roi of a detector pixel we need to
+            keep track of the blot flux and blot weight as we loop.
+            c. The blotted flux  = the weighted flux determined in
+            step b and stored in blot.data
+        """
+        blot_models = datamodels.ModelContainer()
+        instrument_info = instrument_defaults.InstrumentInfo()
+        
+        for model in self.input_models:
+            blot_flux = np.zeros(model.shape, dtype=np.float32)
+            blot_weight = np.zeros(model.shape, dtype=np.float32)
+            blot_ysize, blot_xsize = blot_flux.shape
+            blot_flux = np.ndarray.flatten(blot_flux)
+            blot_weight = np.ndarray.flatten(blot_weight)
+            t0 = time.time()
+            blot = model.copy()
+            blot.err = None
+            blot.dq = None
+            # ___________________________________________________________________
+            ysize, xsize = model.data.shape
+            ycenter = np.arange(ysize)
+            xcenter = np.arange(xsize)
+            #self.ycenter_grid, self.xcenter_grid = np.mgrid[0:ysize,0:xsize]
+
+            # for NIRSPEC wcs information accessed seperately for each slice 
+            nslices = 30
+            log.info('Looping over 30 slices on NIRSPEC detector, this takes a little while')
+            t0 = time.time()
+            roi_det = 1.0  # Just large enough that we don't get holes
+            for ii in range(nslices):
+                ts0 = time.time()
+                # for each slice pull out the blotted values that actually fall on the slice region
+                # used the bounding box of each slice to determine the slice limits
+                slice_wcs = nirspec.nrs_wcs_set_input(model, ii)
+                print('size of median cube inverting back',ii+1,self.cube_ra.size)
+                x_slice, y_slice = slice_wcs.invert(self.cube_ra, self.cube_dec, self.cube_wave)
+                print('number of x_slice values',x_slice.size)
+
+                    # median cube ra,dec,wave -> x_slice, y_slice
+                x_slice = np.ndarray.flatten(x_slice)
+                y_slice = np.ndarray.flatten(y_slice)
+                flux_slice = np.ndarray.flatten(self.cube_flux)
+
+                valid1 = ~np.isnan(x_slice)
+                valid2 = ~np.isnan(y_slice)
+                good_data = np.where(valid1 & valid2)
+
+                x_slice = x_slice[good_data]
+                y_slice = y_slice[good_data]
+                flux_slice = flux_slice[good_data]
+
+                print('xslice min max',np.amin(x_slice), np.amax(x_slice))
+                print('yslice min max',np.amin(y_slice), np.amax(y_slice))
+
+                xlimit, ylimit = slice_wcs.bounding_box
+                xuse = np.logical_and(x_slice >= xlimit[0], x_slice <= xlimit[1])
+                yuse = np.logical_and(y_slice >= ylimit[0], y_slice <= ylimit[1])
+                print('for slice x y range',ii+1,xlimit[0],xlimit[1],ylimit[0],ylimit[1])
+
+                fuse = np.logical_and(xuse, yuse)
+                x_slice = x_slice[fuse]
+                y_slice = y_slice[fuse]
+                flux_slice = flux_slice[fuse]
+
+                print('second pass xslice min max',np.amin(x_slice), np.amax(x_slice))
+                print('second pass yslice min max',np.amin(y_slice), np.amax(y_slice))
                 
-                print('old dxy',dxy)
+                valid3 = np.nonzero(np.absolute(flux_slice))
+
+                nn = flux_slice.size
+                print('number of points looping over', nn)
+                for ipt in range(nn):
+                    # search xcenter and ycenter seperately. These arrays are smallsh.
+                    # xcenter size = naxis1 on detector 
+                    # ycenter size = naxis2 on detector
+                    xdistance = np.absolute(x_slice[ipt] - xcenter)
+                    ydistance = np.absolute(y_slice[ipt] - ycenter)
+
+                    index_x = np.where(xdistance <= roi_det)
+                    index_y = np.where(ydistance <= roi_det)
+                      
+                    if len(index_x[0]) > 0 and len(index_y[0]) > 0:
+                          d1pix = np.array(x_slice[ipt] - xcenter[index_x])
+                          d2pix = np.array(y_slice[ipt] - ycenter[index_y])
+
+                          dxy = [ (dx*dx + dy*dy)  for dy in d2pix for dx in d1pix]
+                          dxy = np.sqrt(dxy)
+                          weight_distance = np.exp(-dxy)
+                          weighted_flux = weight_distance * flux_slice[ipt]
+                          index2d = [iy * blot_xsize + ix for iy in index_y[0] for ix in (index_x[0])]
+                          blot_flux[index2d] = blot_flux[index2d] + weighted_flux
+                          blot_weight[index2d] = blot_weight[index2d] + weight_distance
+                ts1 = time.time()
+                log.info("Time to map 1 slice  = %.1f s" % (ts1-ts0,))
+            # done mapping median cube  to this input model
+            t1 = time.time()
+            log.info("Time to blot median image to input model = %.1f s" % (t1-t0,))
+            igood = np.where(blot_weight > 0)
+            blot_flux[igood] = blot_flux[igood] / blot_weight[igood]
+            blot_flux = blot_flux.reshape((blot_ysize, blot_xsize))
+            blot.data = blot_flux
+            blot_models.append(blot)
+        return blot_models
+        
+
+
+    def blot_overlap_kdtree(self, model, xcenter, ycenter, xstart,
+                            x_cube, y_cube, flux_cube):
+
+        # blot_overlap_quick finds to overlap between the blotted sky values
+        # (x_cube, y_cube) and the detector pixels.
+        # Looping is done over irregular arrays (x_cube, y_cube) and mapping
+        # to xcenter ycenter is quicker than looping over detector x,y and
+        # finding overlap with large array for x_cube, y_cube
+
+        print('in blot overlap kdtree')
+        blot_flux = np.zeros(model.shape, dtype=np.float32)
+        blot_weight = np.zeros(model.shape, dtype=np.float32)
+        blot_ysize, blot_xsize = blot_flux.shape
+        blot_flux = np.ndarray.flatten(blot_flux)
+        blot_weight = np.ndarray.flatten(blot_weight)
+        points = zip(self.xcenter_grid.ravel(), self,ycenter_grid.ravel())
+        tree = spatial.KDTree(points)
+        
+        # num = x_cube.size
+        # loop over valid points in cube (not empty edge pixels)
+        # TODO need to move this value (roi_det)  to reference file  or at least in spec ?
+        roi_det = 1.0  # Just large enough that we don't get holes
+        ivalid = np.nonzero(np.absolute(flux_cube))
+        
+        t0 = time.time()
+        print('number of points looping over',len(ivalid[0]))
+        for ipt in ivalid[0]:
+            match = tree.query_ball_point([xcube[ipt], y_cube[ipt]], 1.4)
+
+            xdistance = np.absolute(x_cube[ipt] - xcenter)
+            ydistance = np.absolute(y_cube[ipt] - ycenter)
+
+            index_x = np.where(xdistance <= roi_det)
+            index_y = np.where(ydistance <= roi_det)
+
+            if len(index_x[0]) > 0 and len(index_y[0]) > 0:
+                d1pix = np.array(x_cube[ipt] - xcenter[index_x])
+                d2pix = np.array(y_cube[ipt] - ycenter[index_y])
+
+                dxy = [ (dx*dx + dy*dy)  for dy in d2pix for dx in d1pix]
                 dxy = np.sqrt(dxy)
                 weight_distance = np.exp(-dxy)
                 weighted_flux = weight_distance * flux_cube[ipt]

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -1,6 +1,7 @@
 """ This is the main ifu spectral cube building routine.
 """
 from ..stpipe import Step
+import time
 from .. import datamodels
 from . import cube_build
 from . import ifu_cube
@@ -327,7 +328,10 @@ class CubeBuildStep (Step):
 
             thiscube.determine_cube_parameters()
 
+            t0 = time.time()
             thiscube.setup_ifucube_wcs()
+            t1 = time.time()
+            self.log.info("Time to set up complete WCS = %.1f s" % (t1 - t0,))
 # _______________________________________________________________________________
 # build the IFU Cube
 
@@ -336,14 +340,20 @@ class CubeBuildStep (Step):
 # This option is used for background matching and outlier rejection
             if self.single:
                 self.output_file = None
+                t0 = time.time()
                 cube_container = thiscube.build_ifucube_single()
+                t1 = time.time()
+                self.log.info("Time to build set of single IFU cubes = %.1f s" % (t1 - t0,))
                 self.log.info("Number of Single IFUCube models returned %i ",
                               len(cube_container))
 
 # Else standard IFU cube building
             else:
+                t0 = time.time()
                 result = thiscube.build_ifucube()
                 cube_container.append(result)
+                t1 = time.time()
+                self.log.info("Time to build IFU cube = %.1f s" % (t1 - t0,))
             if self.debug_pixel == 1:
                 self.spaxel_debug.close()
         for cube in cube_container:

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -1,5 +1,6 @@
 """ Routines related to WCS procedures of cube_build
 """
+import time
 import numpy as np
 from ..assign_wcs import nirspec
 from gwcs import wcstools
@@ -36,6 +37,7 @@ def find_footprint_MIRI(input, this_channel, instrument_info, coord_system):
     # x,y values for channel - convert to output coordinate system
     # return the min & max of spatial coords and wavelength
 
+    t0 = time.time()
     xstart, xend = instrument_info.GetMIRISliceEndPts(this_channel)
     ysize = input.data.shape[0]
 
@@ -62,6 +64,8 @@ def find_footprint_MIRI(input, this_channel, instrument_info, coord_system):
     lambda_min = np.nanmin(lam)
     lambda_max = np.nanmax(lam)
 
+    t1 = time.time()
+    log.info("Time to determine output WCS  = %.1f s" % (t1 - t0,))
     return a_min, a_max, b_min, b_max, lambda_min, lambda_max
 # ********************************************************************************
 
@@ -95,6 +99,7 @@ def find_footprint_NIRSPEC(input, coord_system):
     # x,y values for slice. Then convert the x,y values to  v2,v3,lambda
     # return the min & max of spatial coords and wavelength  - these are of the pixel centers
 
+    t0 = time.time()
     nslices = 30
     a_slice = np.zeros(nslices * 2)
     b_slice = np.zeros(nslices * 2)
@@ -144,6 +149,8 @@ def find_footprint_NIRSPEC(input, coord_system):
     if (a_min == 0.0 and a_max == 0.0 and b_min == 0.0 and b_max == 0.0):
         log.info('This NIRSPEC exposure has no IFU data on it - skipping file')
 
+    t1 = time.time()
+    log.info("Time to determine output WCS input model  = %.1f s" % (t1 - t0,))
     return a_min, a_max, b_min, b_max, lambda_min, lambda_max
 # _______________________________________________________________________________
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -534,6 +534,7 @@ class IFUCubeData():
 
         number_bands = len(self.list_par1)
 
+        ta = time.time()
         for i in range(number_bands):
             this_par1 = self.list_par1[i]
             this_par2 = self.list_par2[i]
@@ -554,7 +555,7 @@ class IFUCubeData():
                     coord1, coord2, wave, flux, err, slice_no, rois_pixel, roiw_pixel, weight_pixel,\
                         softrad_pixel, scalerad_pixel, alpha_det, beta_det = pixelresult
                     t1 = time.time()
-                    log.info("Time to transform pixels to output frame = %.1f s" % (t1 - t0,))
+                    log.info("Time to transform 1 input model pixels to output frame = %.1f s" % (t1 - t0,))
 
                     # If setting the DQ plane of the IFU
                     if self.skip_dqflagging:
@@ -662,6 +663,8 @@ class IFUCubeData():
 # _______________________________________________________________________
 # Mapped all data to cube or Point Cloud
 # now determine Cube Spaxel flux
+        tb = time.time()
+        log.info("Time build all IFU cubes for this run  = %.1f s" % (tb - ta,))
 
         t0 = time.time()
         self.find_spaxel_flux()


### PR DESCRIPTION
This is not to be merged. I pulled out the general blotting and made a routine that blots for MIRI and one the blots for NIRSPEC so I could investigate why NIRSPEC takes so long to do blotting that is used in outlier detection. This PR is just what I have done because I do have question on the results of blotting the median sky cube to each slice on the detector.

For the example I am using I have a NRS1 and NRS2 exposure. The median cube that is created  in outlier detection has 4, 389,760 values.
When I blot this median cube back to the first NIRSPEC slice there are 2,048, 273 mapped back values that fall in the slice. 
For slice 2: 2,003,114
For slice 3: 2,051,264 
around 2 million for each slice
I do not think that is possible. We only have 4 million values in the median cube. The slices on NIRPSPEC do not overlap - so I am not sure what is going on in the invert mapping:
In detail:
for each slice grab the wcs of input model:
slice_wcs = nirspec.nrs_wcs_set_input(model, ii)
x_slice, y_slice = slice_wcs.invert(self.cube_ra, self.cube_dec, self.cube_wave)
then check the bb of the slice and only use x_slice, y_slice in the bb.
those are the number reported above. 
Not sure what is going on here  - maybe @jdavies-st or @nden  can comment 