### PR TITLE
JP-1426: Updates for new SRCTYAPT keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ datamodels
 
 - Added FASTGRPAVG[8,16,32,64] to the READPATT keyword allowed values. [#4818]
 
+- Added the SRCTYAPT keyword and moved SRCTYPE to the SCI extension header of
+  all applicable data model schemas. [#4885]
+
 exp_to_source
 -------------
 
@@ -160,6 +163,9 @@ srctype
 
 - Change default source type for NRS_IFU from POINT to EXTENDED. Change the source
   type for NIRSpec MOS sources with stellarity = -1 from UNKNOWN to POINT. [#4686]
+
+- Modified the step to use the SRCTYAPT keyword to get the user input value from
+  the APT and store the derived source type in the SRCTYPE keyword. [#4885]
 
 stpipe
 ------

--- a/docs/jwst/datamodels/metadata.rst
+++ b/docs/jwst/datamodels/metadata.rst
@@ -66,6 +66,8 @@ search is case-insensitive::
     <BLANKLINE>
     meta.target.source_type
     <BLANKLINE>
+    meta.target.source_type_apt
+    <BLANKLINE>
     meta.target.type
     <BLANKLINE>
     meta.visit.internal_target

--- a/docs/jwst/srctype/description.rst
+++ b/docs/jwst/srctype/description.rst
@@ -15,20 +15,23 @@ has the option of designating a source type in the APT template for the
 observation. They have the choice of declaring whether or not the source
 should be considered extended. If they don't know the character of the source,
 they can also choose a value of "UNKNOWN." The observer's choice is passed along
-to DMS processing, which sets the value of the "SRCTYPE" keyword in the
-primary header of the uncalibrated (_uncal.fits) product that's used as input
-to the calibration pipeline. If the user has selected a value in the APT, the
-"SRCTYPE" keyword will be set to "POINT", "EXTENDED", or "UNKNOWN." If the
-selection is not available for a given observing mode or a choice wasn't
-made, the "SRCTYPE" keyword will not appear in the uncalibrated product
-header.
+to DMS processing, which sets the value of the "SRCTYAPT" keyword in the
+primary header of the products used as input to the calibration pipeline.
+If the user has selected a value in the APT, the "SRCTYAPT" keyword will be set
+to "POINT", "EXTENDED", or "UNKNOWN." If the selection is not available for a
+given observing mode or a choice wasn't made, the "SRCTYAPT" keyword will not
+appear in the uncalibrated product header.
 
-The ``srctype`` calibration step checks to see if the "SRCTYPE" keyword
-is present and has already been populated. If the observer did not provide a
-source type value or chose "UNKNOWN", the ``srctype``
-step chooses a suitable value based on the observing mode and
-other characteristics of the exposure. The following choices are used, in
-order of priority:
+The ``srctype`` step sets a value for the "SRCTYPE" keyword that is stored in
+the "SCI" extension header(s) of data products. The step sets the value of
+"SRCTYPE" based on input from the user given in the "SRCTYAPT" keyword, as
+well as other rules that can override the "SRCTYAPT" values.
+
+The ``srctype`` step first checks to see if the "SRCTYAPT" keyword
+is present and has already been populated. If "SRCTYAPT" is not present or
+is set to "UNKNOWN", the step determines a suitable value based on the
+observing mode and other characteristics of the exposure.
+The following choices are used, in order of priority:
 
  - Background target exposures default to a source type of "EXTENDED."
    Background exposures are identified by the keyword "BKGDTARG" set

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -354,12 +354,18 @@ properties:
             type: number
             fits_keyword: PROP_DEC
             blend_table: True
+          source_type_apt:
+            title: Source type from APT (point/extended)
+            type: string
+            enum: [EXTENDED, POINT, UNKNOWN]
+            fits_keyword: SRCTYAPT
+            blend_table: True
           source_type:
-            title: Advised source type (point/extended)
+            title: Source type used for calibration
             type: string
             enum: [EXTENDED, POINT, UNKNOWN]
             fits_keyword: SRCTYPE
-            blend_table: True
+            fits_hdu: SCI
       instrument:
         title: Instrument configuration information
         type: object

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -68,7 +68,7 @@ allOf:
             fits_keyword: STLARITY
             fits_hdu: EXTRACT1D
           source_type:
-            title: Source type (point/extended)
+            title: Source type used for calibration
             type: string
             fits_keyword: SRCTYPE
             fits_hdu: EXTRACT1D

--- a/jwst/datamodels/schemas/slitmeta.schema.yaml
+++ b/jwst/datamodels/schemas/slitmeta.schema.yaml
@@ -57,7 +57,7 @@ properties:
     fits_keyword: STLARITY
     fits_hdu: SCI
   source_type:
-    title: Source type (point/extended)
+    title: Source type used for calibration
     type: string
     enum: [EXTENDED, POINT, UNKNOWN]
     fits_keyword: SRCTYPE

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2586,8 +2586,7 @@ def run_extract1d(input_model, refname, smoothing_length, bkg_order,
     # Remove target.source_type from the output model, so that it
     # doesn't force creation of an empty SCI extension in the output
     # x1d product just to hold this keyword.
-    if hasattr(output_model.meta.target, "source_type"):
-        del output_model.meta.target.source_type
+    output_model.meta.target.source_type = None
 
     return output_model
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2583,6 +2583,12 @@ def run_extract1d(input_model, refname, smoothing_length, bkg_order,
                                 log_increment, subtract_background,
                                 apply_nod_offset, was_source_model)
 
+    # Remove target.source_type from the output model, so that it
+    # doesn't force creation of an empty SCI extension in the output
+    # x1d product just to hold this keyword.
+    if hasattr(output_model.meta.target, "source_type"):
+        del output_model.meta.target.source_type
+
     return output_model
 
 

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -137,9 +137,7 @@ class Tso3Pipeline(Pipeline):
             # Remove source_type from the output model, if it exists,
             # to prevent the creation of an empty SCI extension just
             # for that keyword.
-            if (hasattr(x1d_result.meta.target, "source_type") and
-                x1d_result.meta.target.source_type is not None):
-                    del x1d_result.meta.target.source_type
+            x1d_result.meta.target.source_type = None
 
             # For each exposure in the TSO...
             for cube in input_models:

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -117,7 +117,7 @@ class Tso3Pipeline(Pipeline):
         # regardless of how many members there may be...
         phot_result_list = []
         if (input_exptype == 'NRC_TSIMAGE' or
-            (input_exptype == 'MIR_IMAGE'  and input_tsovisit)):
+            (input_exptype == 'MIR_IMAGE' and input_tsovisit)):
             # Create name for extracted photometry (Level 3) product
             phot_tab_suffix = 'phot'
 
@@ -132,7 +132,14 @@ class Tso3Pipeline(Pipeline):
             # define output for x1d (level 3) products
             x1d_result = datamodels.MultiSpecModel()
             # TODO: check to make sure the following line is working
-            x1d_result.update(input_models[0])
+            x1d_result.update(input_models[0], only="PRIMARY")
+
+            # Remove source_type from the output model, if it exists,
+            # to prevent the creation of an empty SCI extension just
+            # for that keyword.
+            if (hasattr(x1d_result.meta.target, "source_type") and
+                x1d_result.meta.target.source_type is not None):
+                    del x1d_result.meta.target.source_type
 
             # For each exposure in the TSO...
             for cube in input_models:

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -32,7 +32,7 @@ def set_source_type(input_model):
         log.error('EXP_TYPE value not found in input')
         raise RuntimeError('Step cannot be executed without an EXP_TYPE value')
     else:
-        log.info('Input EXP_TYPE is %s' % exptype)
+        log.info(f'Input EXP_TYPE is {exptype}')
 
     # For exposure types that have a single source specification, get the
     # user-supplied source type from the selection they provided in the APT
@@ -42,30 +42,47 @@ def set_source_type(input_model):
 
         bkg_target = input_model.meta.observation.bkgdtarg
         patttype = input_model.meta.dither.primary_type
-        user_type = input_model.meta.target.source_type
+
+        # The keyword SRCTYAPT was added in JWSTKD-354 to retain the value
+        # given by the user in the APT, while the cal code then sets a value
+        # for the SRCTYPE keyword for use in calibration. Try to preserve
+        # backwards compatibility with old datasets by first looking for the
+        # SRCTYAPT keyword and using it if available, and if not, then use
+        # SRCTYPE as both input and output (as before).
+        try:
+            user_type = input_model.meta.target.source_type_apt
+            log.info(f'Input SRCTYAPT = {user_type}')
+            if user_type is None:
+                log.warning(f'SRCTYAPT keyword not found in input; using SRCTYPE instead')
+                user_type = input_model.meta.target.source_type
+                input_model.meta.target.source_type_apt = user_type
+        except AttributeError:
+            log.warning(f'SRCTYAPT keyword not found in input; using SRCTYPE instead')
+            user_type = input_model.meta.target.source_type
+            input_model.meta.target.source_type_apt = user_type
 
         if bkg_target:
 
             # If this image is flagged as a BACKGROUND target, set the
             # source type to EXTENDED regardless of any other settings
             src_type = 'EXTENDED'
-            log.info('Exposure is a background target; setting SRCTYPE = %s' % src_type)
+            log.info(f'Exposure is a background target; setting SRCTYPE = {src_type}')
 
         elif pipe_utils.is_tso(input_model):
             src_type = 'POINT'
-            log.info('Input is a TSO exposure; setting SRCTYPE = %s' % src_type)
+            log.info(f'Input is a TSO exposure; setting SRCTYPE = {src_type}')
 
         elif (patttype is not None) and (('NOD' in patttype) or ('POINT-SOURCE' in patttype)):
 
             # Set all nodded exposures to POINT source type
             src_type = 'POINT'
-            log.info('Exposure is nodded; setting SRCTYPE = %s' % src_type)
+            log.info('Exposure is nodded; setting SRCTYPE = {src_type}')
 
         elif user_type in ['POINT', 'EXTENDED']:
 
             # Use the value supplied by the user
             src_type = user_type
-            log.info('Using input SRCTYPE = %s' % src_type)
+            log.info(f'Using input source type = {src_type}')
 
         else:
 
@@ -75,7 +92,7 @@ def set_source_type(input_model):
             else:
                 src_type = 'POINT'
 
-            log.info('Input SRCTYPE is unknown; setting default SRCTYPE = %s' % src_type)
+            log.info(f'Input source type is unknown; setting default SRCTYPE = {src_type}')
 
         # Set the source type in the global meta attribute
         input_model.meta.target.source_type = src_type
@@ -93,13 +110,13 @@ def set_source_type(input_model):
             # value, which for NRS_FIXEDSLIT is 'POINT'.
             default_type = 'POINT'
             primary_slit = input_model.meta.instrument.fixed_slit
-            log.debug(' primary_slit = {}'.format(primary_slit))
+            log.debug(f' primary_slit = {primary_slit}')
             for slit in input_model.slits:
                 if slit.name == primary_slit:
                     slit.source_type = src_type
                 else:
                     slit.source_type = default_type
-                log.debug(' slit {} = {}'.format(slit.name, slit.source_type))
+                log.debug(f' slit {slit.name} = {slit.source_type}')
 
     # For NIRSpec MSA exposures, read the stellarity value for the
     # source in each extracted slit and set the point/extended value
@@ -120,24 +137,19 @@ def set_source_type(input_model):
             else:
                 slit.source_type = 'EXTENDED'
 
-            log.info('source_id=%g, stellarity=%g, type=%s' %
-                     (slit.source_id, stellarity, slit.source_type))
-
-        # Set the source type value in the primary header to
-        # a harmless default
-        input_model.meta.target.source_type = 'UNKNOWN'
+            log.info(f'source_id={slit.source_id}, stellarity={stellarity:.4f}, type={slit.source_type}')
 
     # Set all TSO exposures to POINT
     elif pipe_utils.is_tso(input_model):
         src_type = 'POINT'
-        log.info('Input is a TSO exposure; setting default SRCTYPE = %s' % src_type)
+        log.info(f'Input is a TSO exposure; setting default SRCTYPE = {src_type}')
         input_model.meta.target.source_type = src_type
 
     # Unrecognized exposure type; set to UNKNOWN as default
     else:
-        log.warning('EXP_TYPE %s not applicable to this operation' % exptype)
+        log.warning(f'EXP_TYPE {exptype} not applicable to this operation')
         src_type = 'UNKNOWN'
-        log.warning('Setting SRCTYPE = %s' % src_type)
+        log.warning(f'Setting SRCTYPE = {src_type}')
         input_model.meta.target.source_type = src_type
 
     # We're done

--- a/jwst/srctype/srctype_step.py
+++ b/jwst/srctype/srctype_step.py
@@ -11,7 +11,7 @@ class SourceTypeStep(Step):
     """
     SourceTypeStep: Selects and sets a source type based on various inputs.
     The source type is used in later calibrations to determine the appropriate
-    methods to use. Input comes from either the SRCTYPE keyword value, which
+    methods to use. Input comes from either the SRCTYAPT keyword value, which
     is populated from user info in the APT, or the NIRSpec MSA planning tool.
     """
 


### PR DESCRIPTION
Update all necessary datamodel schemas to add the new keyword SRCTYAPT to the primary header and move the SRCTYPE keyword to the SCI and EXTRACT1D headers. Also update the `srctype` step to use SRCTYAPT as input and SRCTYPE as output, with lots of allowances for old datasets that don't have the SRCTYAPT keyword.

A couple of updates were needed in other routines, like `calwebb_tso3` and `extract_1d`, to prevent output files from having empty SCI extensions, just because of the presence of the SRCTYPE keyword defined in the SCI HDU.

This will of course create lots of regtest failures due to the new and relocated keywords, but it's necessary now, because SDP has included SRCTYAPT in their B7.5 code.

Fixes #4883 / [JP-1426](https://jira.stsci.edu/browse/JP-1426)