### PR TITLE
Update RT context and remove abvega overrides

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -21,7 +21,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds-test.stsci.edu",
-    "CRDS_CONTEXT=jwst_0605.pmap",
+    "CRDS_CONTEXT=jwst_0615.pmap",
     "CRDS_PATH=/grp/crds/test_cache",
     "ENG_BASE_URL=http://twjwdmsemwebag.stsci.edu/JWDMSEngFqAccSide1/TlmMnemonicDataSrv.svc/",
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -31,7 +31,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds-test.stsci.edu",
-    "CRDS_CONTEXT=jwst_0605.pmap",
+    "CRDS_CONTEXT=jwst_0615.pmap",
     "CRDS_PATH=/grp/crds/test_cache",
 ]
 

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -62,7 +62,6 @@ def run_image3(run_image2, rtdata_module):
     """Get the level3 assocation json file (though not its members) and run
     image3 pipeline on all _cal files listed in association"""
     rtdata = rtdata_module
-    rtdata.get_data("miri/image/jwst_miri_abvega_offset_0001.asdf")
     rtdata.get_data("miri/image/det_dithered_5stars_image3_asn.json")
     args = ["config/calwebb_image3.cfg", rtdata.input,
         # Set some unique param values needed for these data
@@ -70,7 +69,6 @@ def run_image3(run_image2, rtdata_module):
         "--steps.tweakreg.use2dhist=False",
         "--steps.tweakreg.minobj=4",
         "--steps.source_catalog.snr_threshold=20",
-        "--steps.source_catalog.override_abvegaoffset=jwst_miri_abvega_offset_0001.asdf",
         ]
     Step.from_cmdline(args)
 

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -62,14 +62,12 @@ def run_image3pipeline(run_image2pipeline, rtdata_module, jail):
 
     # Get the level3 assocation json file (though not its members) and run
     # image3 pipeline on all _cal files listed in association
-    rtdata.get_data("nircam/image/jwst_nircam_abvega_offset_0001.asdf")
     rtdata.get_data("nircam/image/jw42424-o002_20191220t214154_image3_001_asn.json")
     args = ["config/calwebb_image3.cfg", rtdata.input,
         # Comment out following lines, as the dataset is currently broken
         # "--steps.tweakreg.save_results=True",
         # "--steps.skymatch.save_results=True",
         "--steps.source_catalog.snr_threshold=20",
-        "--steps.source_catalog.override_abvegaoffset='jwst_nircam_abvega_offset_0001.asdf'",
         ]
     Step.from_cmdline(args)
 

--- a/jwst/regtest/test_nircam_mtimage.py
+++ b/jwst/regtest/test_nircam_mtimage.py
@@ -12,11 +12,9 @@ from jwst.stpipe import Step
 def test_nircam_image_moving_target(rtdata, fitsdiff_default_kwargs):
     """Test resampled i2d of moving target exposures for NIRCam imaging"""
     collect_pipeline_cfgs("config")
-    rtdata.get_data("nircam/image/jwst_nircam_abvega_offset_0001.asdf")
     rtdata.get_asn("nircam/image/mt_asn.json")
     rtdata.output = "mt_assoc_i2d.fits"
-    args = ["config/calwebb_image3.cfg", rtdata.input,
-            "--steps.source_catalog.override_abvegaoffset='jwst_nircam_abvega_offset_0001.asdf'"]
+    args = ["config/calwebb_image3.cfg", rtdata.input]
     Step.from_cmdline(args)
     rtdata.get_truth("truth/test_nircam_mtimage/mt_assoc_i2d.fits")
 


### PR DESCRIPTION
Update regression test CRDS context to 615, which includes the new abvegaoffset reference files, and remove the overrides for those ref files from the 3 imaging tests that use them.