### PR TITLE
Update .travis.yml for syntax and python version for SDP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
+os: linux
 dist: xenial
 language: python
 python: 3.7.7
-
-sudo: false
 
 # The apt packages below are needed for sphinx builds
 addons:
@@ -22,7 +21,7 @@ env:
     - TEST_COMMAND="pytest --cov-report=xml --cov=./"
     - PIP_DEPENDENCIES=".[test]"
 
-matrix:
+jobs:
   # Don't wait for allowed failures
   fast_finish: true
 
@@ -38,7 +37,7 @@ matrix:
 
     # Test with SDP pinned dependencies
     - env: PIP_DEPENDENCIES="-r requirements-sdp.txt .[test]"
-      python: 3.7.6
+      python: 3.7.7
 
     # Test with dev dependencies
     - env: PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"


### PR DESCRIPTION
This is to resolve the following syntax warnings:

<img width="480" alt="Screen Shot 2020-05-05 at 3 42 47 PM" src="https://user-images.githubusercontent.com/17088869/81109818-b21ca500-8ee8-11ea-8659-d2f0f826ce2c.png">

And also update the python version used with `requirements-sdp.txt` to match what is being used in our delivery and regression tests.