### PR TITLE
Support asdf 2.6.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ associations
 ------------
 - Modify NIRSpec IFU level-3 ASN rules to include only one grating per association [#4845]
 
+datamodels
+----------
+
+- Relax asdf requirement and use validator flag when asdf 2.6.x is installed [#4905]
+
 0.16.0 (2020-05-04)
 ===================
 
@@ -39,7 +44,7 @@ datamodels
 
 - Update schemas to add moving_target_position and cheby tables to the level1b
   schema [#4760]
-  
+
 - Deprecate ``DrizProductModel`` and ``MultiProductModel`` and replace with
   updated versions of ``ImageModel`` and ``SlitModel`` that include "CON" and
   "WHT" arrays for resampled data. [#4552]

--- a/setup.py
+++ b/setup.py
@@ -89,12 +89,7 @@ setup(
         'setuptools_scm',
     ],
     install_requires=[
-        # asdf 2.6 will change a validator implementation detail whose
-        # behavior jwst currently relies upon.  See
-        # https://github.com/spacetelescope/asdf/pull/777
-        # We can remove the upper limit here once asdf 2.6 is released
-        # and jwst starts using the _visit_repeat_nodes flag.
-        'asdf~=2.5.0',
+        'asdf>=2.5',
         'astropy>=4.0',
         'crds>=7.2.7',
         'drizzle>=1.13',


### PR DESCRIPTION
The asdf 2.6.0 release includes a validator performance improvement that skips nodes that have already been visited during the current validation pass.  This package relies on the old behavior to ensure that fits headers have been fully populated, so here I'm setting a flag that will cause asdf to continue to revisit nodes.  This flag is not available in earlier versions of asdf so we need to inspect the asdf version before attempting to use it.

Resolves #4864 