### PR TITLE
Update docs for source catalog

### DIFF
--- a/docs/jwst/references_general/abvegaoffset_reffile.inc
+++ b/docs/jwst/references_general/abvegaoffset_reffile.inc
@@ -1,22 +1,22 @@
-.. _abvega_offset_reffile:
+.. _abvegaoffset_reffile:
 
-ABVEGA_OFFSET Reference File
-----------------------------
+ABVEGAOFFSET Reference File
+---------------------------
 
-:REFTYPE: ABVEGA_OFFSET
+:REFTYPE: ABVEGAOFFSET
 :Data model: `~jwst.datamodels.ABVegaOffsetModel`
 
-The ABVEGA_OFFSET reference file contains data necessary for converting
+The ABVEGAOFFSET reference file contains data necessary for converting
 from AB to Vega magnitudes.
 
-.. include:: ../references_general/abvega_offset_selection.inc
+.. include:: ../references_general/abvegaoffset_selection.inc
 
 .. include:: ../includes/standard_keywords.inc
 
-ABVEGA_OFFSET Reference File Format
-+++++++++++++++++++++++++++++++++++
+ABVEGAOFFSET Reference File Format
+++++++++++++++++++++++++++++++++++
 
-ABVEGA_OFFSET reference files are in ASDF format.  The ABVEGA_OFFSET
+ABVEGAOFFSET reference files are in ASDF format.  The ABVEGAOFFSET
 reference file contains tabular data in a key called
 ``abvega_offset``.  The content of the table varies for different
 instrument modes, as shown in the tables below.

--- a/docs/jwst/references_general/abvegaoffset_selection.inc
+++ b/docs/jwst/references_general/abvegaoffset_selection.inc
@@ -1,8 +1,8 @@
-Reference Selection Keywords for ABVEGA_OFFSET
-++++++++++++++++++++++++++++++++++++++++++++++
+Reference Selection Keywords for ABVEGAOFFSET
++++++++++++++++++++++++++++++++++++++++++++++
 
-CRDS selects appropriate ABVEGA_OFFSET references based on the
-following keywords.  ABVEGA_OFFSET is not applicable for instruments
+CRDS selects appropriate ABVEGAOFFSET references based on the
+following keywords.  ABVEGAOFFSET is not applicable for instruments
 not in the table.  All keywords used for file selection are
 *required*.
 

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -150,7 +150,7 @@ documentation on each reference file.
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`source_catalog <source_catalog_step>` | :ref:`APCORR <apcorr_reffile>`                   |
 +                                             +--------------------------------------------------+
-|                                             | :ref:`ABVEGA_OFFSET <abvega_offset_reffile>`     |
+|                                             | :ref:`ABVEGAOFFSET <abvegaoffset_reffile>`      |
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`straylight <straylight_step>`         | :ref:`REGIONS <regions_reffile>`                 |
 +---------------------------------------------+--------------------------------------------------+
@@ -162,7 +162,7 @@ documentation on each reference file.
 +--------------------------------------------------+---------------------------------------------+
 | Reference File Type (REFTYPE)                    | Pipeline Step                               |
 +==================================================+=============================================+
-| :ref:`ABVEGA_OFFSET <abvega_offset_reffile>`     | :ref:`source_catalog <source_catalog_step>` |
+| :ref:`ABVEGAOFFSET <abvegaoffset_reffile>`       | :ref:`source_catalog <source_catalog_step>` |
 +--------------------------------------------------+---------------------------------------------+
 | :ref:`APCORR <apcorr_reffile>`                   | :ref:`extract_1d <extract_1d_step>`         |
 +                                                  +---------------------------------------------+

--- a/docs/jwst/source_catalog/main.rst
+++ b/docs/jwst/source_catalog/main.rst
@@ -57,5 +57,172 @@ semimajor and semiminor axis lengths, orientation of the major axis,
 and sky coordinates at corners of the minimal bounding box enclosing
 the source.
 
+Source Catalog Table
+^^^^^^^^^^^^^^^^^^^^
+
 The output source catalog table is saved in `ECSV format
 <https://docs.astropy.org/en/stable/io/ascii/write.html#ecsv-format>`_.
+
+The table contains a row for each source, with the following columns:
+
++------------------------+----------------------------------------------------+
+| Column                 | Description                                        |
++========================+====================================================+
+| id                     | Unique source identification number                |
++------------------------+----------------------------------------------------+
+| xcentroid              | X pixel value of the source centroid               |
++------------------------+----------------------------------------------------+
+| ycentroid              | Y pixel value of the source centroid               |
++------------------------+----------------------------------------------------+
+| sky_centroid           | Sky coordinate of the source centroid              |
++------------------------+----------------------------------------------------+
+| aper_bkg_flux          | The local background value calculated as the       |
+|                        | sigma-clipped median value in the background       |
+|                        | annulus aperture                                   |
++------------------------+----------------------------------------------------+
+| aper_bkg_flux_err      | The standard error of the sigma-clipped median     |
+|                        | background value                                   |
++------------------------+----------------------------------------------------+
+| aper30_flux            | Flux within the 30% encircled energy circular      |
+|                        | aperture                                           |
++------------------------+----------------------------------------------------+
+| aper30_flux_err        | Flux error within the 30% encircled energy         |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper50_flux            | Flux within the 50% encircled energy circular      |
+|                        | aperture                                           |
++------------------------+----------------------------------------------------+
+| aper50_flux_err        | Flux error within the 50% encircled energy         |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper70_flux            | Flux within the 70% encircled energy circular      |
+|                        | aperture                                           |
++------------------------+----------------------------------------------------+
+| aper70_flux_err        | Flux error within the 70% encircled energy         |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper_total_flux        | Total aperture-corrected flux based on the 70%     |
+|                        | encircled energy circular aperture; calculated     |
+|                        | only for stars                                     |
++------------------------+----------------------------------------------------+
+| aper_total_flux_err    | Total aperture-corrected flux error based on the   |
+|                        | 70% encircled energy circular aperture; calculated |
+|                        | only for stars                                     |
++------------------------+----------------------------------------------------+
+| aper30_abmag           | AB magnitude within the 30% encircled energy       |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper30_abmag_err       | AB magnitude error within the 30% encircled energy |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper50_abmag           | AB magnitude within the 50% encircled energy       |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper50_abmag_err       | AB magnitude error within the 50% encircled energy |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper70_abmag           | AB magnitude within the 70% encircled energy       |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper70_abmag_err       | AB magnitude error within the 70% encircled energy |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper_total_abmag       | Total aperture-corrected AB magnitude based on the |
+|                        | 70% encircled energy circular aperture; calculated |
+|                        | only for stars                                     |
++------------------------+----------------------------------------------------+
+| aper_total_abmag_err   | Total aperture-corrected AB magnitude error based  |
+|                        | on the 70% encircled energy circular aperture;     |
+|                        | calculated only for stars                          |
++------------------------+----------------------------------------------------+
+| aper30_vegamag         | Vega magnitude within the 30% encircled energy     |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper30_vegamag_err     | Vega magnitude error within the 30% encircled      |
+|                        | energy circular aperture                           |
++------------------------+----------------------------------------------------+
+| aper50_vegamag         | Vega magnitude within the 50% encircled energy     |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper50_vegamag_err     | Vega magnitude error within the 50% encircled      |
+|                        | energy circular aperture                           |
++------------------------+----------------------------------------------------+
+| aper70_vegamag         | Vega magnitude within the 70% encircled energy     |
+|                        | circular aperture                                  |
++------------------------+----------------------------------------------------+
+| aper70_vegamag_err     | Vega magnitude error within the 70% encircled      |
+|                        | energy circular aperture                           |
++------------------------+----------------------------------------------------+
+| aper_total_vegamag     | Total aperture-corrected Vega magnitude based on   |
+|                        | the 70% encircled energy circular aperture;        |
+|                        | calculated only for stars                          |
++------------------------+----------------------------------------------------+
+| aper_total_vegamag_err | Total aperture-corrected Vega magnitude error      |
+|                        | based on the 70% encircled energy circular         |
+|                        | aperture; calculated only for stars                |
++------------------------+----------------------------------------------------+
+| CI_30_50               | Concentration index calculated as aper30_abmag -   |
+|                        | aper50_abmag                                       |
++------------------------+----------------------------------------------------+
+| CI_50_70               | Concentration index calculated as aper50_abmag -   |
+|                        | aper70_abmag                                       |
++------------------------+----------------------------------------------------+
+| CI_30_70               | Concentration index calculated as aper30_abmag -   |
+|                        | aper70_abmag                                       |
++------------------------+----------------------------------------------------+
+| is_star                | Flag indicating whether the source is a star       |
++------------------------+----------------------------------------------------+
+| sharpness              | The DAOFind source sharpness statistic             |
++------------------------+----------------------------------------------------+
+| roundness              | The DAOFind source roundness statistic             |
++------------------------+----------------------------------------------------+
+| nn_dist                | The distance in pixels to the nearest neighbor     |
++------------------------+----------------------------------------------------+
+| nn_abmag               | The AB magnitude of the nearest neighbor.  If the  |
+|                        | object is a star it is the total aperture-         |
+|                        | corrected AB magnitude, otherwise it is the        |
+|                        | isophotal AB magnitude.                            |
++------------------------+----------------------------------------------------+
+| isophotal_flux         | Isophotal flux                                     |
++------------------------+----------------------------------------------------+
+| isophotal_flux_err     | Isophotal flux error                               |
++------------------------+----------------------------------------------------+
+| isophotal_abmag        | Isophotal AB magnitude                             |
++------------------------+----------------------------------------------------+
+| isophotal_abmag_err    | Isophotal AB magnitude error                       |
++------------------------+----------------------------------------------------+
+| isophotal_vegamag      | Isophotal Vega magnitude                           |
++------------------------+----------------------------------------------------+
+| isophotal_vegamag_err  | Isophotal Vega magnitude error                     |
++------------------------+----------------------------------------------------+
+| isophotal_area         | Isophotal area                                     |
++------------------------+----------------------------------------------------+
+| semimajor_sigma        | 1-sigma standard deviation along the semimajor     |
+|                        | axis of the 2D Gaussian function that has the same |
+|                        | second-order central moments as the source         |
++------------------------+----------------------------------------------------+
+| semiminor_sigma        | 1-sigma standard deviation along the semiminor     |
+|                        | axis of the 2D Gaussian function that has the same |
+|                        | second-order central moments as the source         |
++------------------------+----------------------------------------------------+
+| ellipticity            | 1 minus the ratio of the 1-sigma lengths of the    |
+|                        | semimajor and semiminor axes                       |
++------------------------+----------------------------------------------------+
+| orientation            | The angle (degrees) between the positive X axis    |
+|                        | and the major axis (increases counter-clockwise)   |
++------------------------+----------------------------------------------------+
+| sky_orientation        | The position angle (degrees) from North of the     |
+|                        | major axis                                         |
++------------------------+----------------------------------------------------+
+| sky_bbox_ll            | Sky coordinate of the lower-left vertex of the     |
+|                        | minimal bounding box of the source                 |
++------------------------+----------------------------------------------------+
+| sky_bbox_ul            | Sky coordinate of the upper-left vertex of the     |
+|                        | minimal bounding box of the source                 |
++------------------------+----------------------------------------------------+
+| sky_bbox_lr            | Sky coordinate of the lower-right vertex of the    |
+|                        | minimal bounding box of the source                 |
++------------------------+----------------------------------------------------+
+| sky_bbox_ur            | Sky coordinate of the upper-right vertex of the    |
+|                        | minimal bounding box of the source                 |
++------------------------+----------------------------------------------------+

--- a/docs/jwst/source_catalog/reference_files.rst
+++ b/docs/jwst/source_catalog/reference_files.rst
@@ -1,8 +1,9 @@
 Reference File Types
 =====================
 
-The ``source_catalog`` step uses APCORR and ABVEGA_OFFSET reference files.
+The ``source_catalog`` step uses APCORR and ABVEGAOFFSET reference
+files.
 
 .. include:: ../references_general/apcorr_reffile.inc
 
-.. include:: ../references_general/abvega_offset_reffile.inc
+.. include:: ../references_general/abvegaoffset_reffile.inc

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -165,8 +165,8 @@ class ReferenceData:
         """
 
         if self.apcorr_filename is None:
-            log.warning('APCorrModel reference file was not input -- '
-                        'using fallback aperture sizes without any aperture '
+            log.warning('APCorrModel reference file was not input. '
+                        'Using fallback aperture sizes without any aperture '
                         'corrections.')
             params = {'aperture_radii': np.array((1.0, 2.0, 3.0)),
                       'aperture_corrections': np.array((1.0, 1.0, 1.0)),
@@ -217,8 +217,8 @@ class ReferenceData:
         """
 
         if self.abvegaoffset_filename is None:
-            log.warning('ABVEGAOFFSET reference file was not input -- '
-                        'catalog Vega magnitudes are not correct.')
+            log.warning('ABVEGAOFFSET reference file was not input. '
+                        'Catalog Vega magnitudes are not correct.')
             return 0.0
 
         if self.instrument == 'NIRCAM' or self.instrument == 'NIRISS':
@@ -777,10 +777,10 @@ class SourceCatalog:
 
         desc.append(f'Total aperture-corrected {ftype2} based on the '
                     f'{self.aperture_ee[-1]}% encircled energy circular '
-                    'aperture - calculated only for stars')
+                    'aperture; calculated only for stars')
         desc.append(f'Total aperture-corrected {ftype2} error based on the '
                     f'{self.aperture_ee[-1]}% encircled energy circular '
-                    'aperture - calculated only for stars')
+                    'aperture; calculated only for stars')
 
         return desc
 
@@ -953,7 +953,10 @@ class SourceCatalog:
         desc['sharpness'] = 'The DAOFind source sharpness statistic'
         desc['roundness'] = 'The DAOFind source roundness statistic'
         desc['nn_dist'] = 'The distance in pixels to the nearest neighbor'
-        desc['nn_abmag'] = 'The AB magnitude of the nearest neighbor'
+        desc['nn_abmag'] = ('The AB magnitude of the nearest neighbor.  If '
+                            'the object is a star it is the total '
+                            'aperture-corrected AB magnitude, otherwise it '
+                            'is the isophotal AB magnitude.')
 
         self.column_desc.update(desc)
 


### PR DESCRIPTION
This PR updates the docs for the source catalog step to include the table columns and descriptions.  It also fixes the name of the ABVEGAOFFSET model in the docs.

Followup to https://github.com/spacetelescope/jwst/pull/4906