### PR TITLE
Revert RT setup back to using CRDS ops

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -20,9 +20,8 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environement variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_SERVER_URL=https://jwst-crds-test.stsci.edu",
-    "CRDS_CONTEXT=jwst_0615.pmap",
-    "CRDS_PATH=/grp/crds/test_cache",
+    "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
+    "CRDS_CONTEXT=jwst-edit",
     "ENG_BASE_URL=http://twjwdmsemwebag.stsci.edu/JWDMSEngFqAccSide1/TlmMnemonicDataSrv.svc/",
 ]
 

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -30,9 +30,8 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environement variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_SERVER_URL=https://jwst-crds-test.stsci.edu",
-    "CRDS_CONTEXT=jwst_0615.pmap",
-    "CRDS_PATH=/grp/crds/test_cache",
+    "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
+    "CRDS_CONTEXT=jwst-edit",
 ]
 
 // Set pytest basetemp output directory


### PR DESCRIPTION
Revert JenkinsRT setup back to using crds ops server and latest context, now that all updates have been migrated from test.