### PR TITLE
Fix doctest jail dir behavoir for pytest-doctestplus>=0.5

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -5,7 +5,7 @@ def _docdir(request):
 
     # Trigger ONLY for doctestplus.
     doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
-    if isinstance(request.node, doctest_plugin._doctest_textfile_item_cls):
+    if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
         tmpdir = request.getfixturevalue('tmpdir')
         with tmpdir.as_cwd():
             yield


### PR DESCRIPTION
This will make sure our doctests don't leave behind files in the working dir.