### PR TITLE
Improve AssertionError reporting in diff_astropy_tables

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -7,7 +7,7 @@ import getpass
 import pytest
 from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
 from astropy.table import Table
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 from astropy.io.fits import conf
 
 from .regtestdata import RegtestData
@@ -232,11 +232,15 @@ def diff_astropy_tables():
 
         diffs = []
 
-        if result.colnames != truth.colnames:
-            diffs.append("Column names (or order) do not match")
+        try:
+            assert result.colnames == truth.colnames
+        except AssertionError as err:
+            diffs.append(f"Column names (or order) do not match\n{err}")
 
-        if len(result) != len(truth):
-            diffs.append(f"Row count does not match({len(result)} vs {len(truth)})")
+        try:
+            assert len(result) == len(truth)
+        except AssertionError as err:
+            diffs.append(f"Row count does not match\n{err}")
 
         # If either the columns or the row count is mismatched, then don't
         # bother checking the individual column values.
@@ -250,23 +254,26 @@ def diff_astropy_tables():
 
         for col_name in truth.colnames:
             try:
-                if result[col_name].dtype != truth[col_name].dtype:
-                    diffs.append(f"Column '{col_name}' dtype does not match")
+                try:
+                    assert result[col_name].dtype == truth[col_name].dtype
+                except AssertionError as err:
+                    diffs.append(f"Column '{col_name}' dtype does not match\n{err}")
                     continue
 
-                dtype = truth[col_name].dtype
-                if dtype.kind == "f":
+                if truth[col_name].dtype.kind == "f":
                     try:
                         assert_allclose(result[col_name], truth[col_name],
                             rtol=rtol, atol=atol)
                     except AssertionError as err:
                         diffs.append("\n----------------------------------\n"
                             + f"Column '{col_name}' values do not "
-                            + f"match (within tolerances) \n{str(err)}"
+                            + f"match (within tolerances) \n{err}"
                         )
                 else:
-                    if not (result[col_name] == truth[col_name]).all():
-                        diffs.append(f"Column '{col_name}' values do not match")
+                    try:
+                        assert_equal(result[col_name], truth[col_name])
+                    except AssertionError as err:
+                        diffs.append(f"Column '{col_name}' values do not match\n{err}")
             except AttributeError:
                 # Ignore case where a column does not have a dtype, as in the case
                 # of SkyCoord objects

--- a/jwst/regtest/test_infrastructure.py
+++ b/jwst/regtest/test_infrastructure.py
@@ -107,6 +107,32 @@ def test_diff_astropy_tables_allclose(diff_astropy_tables, two_tables):
         assert diff_astropy_tables(path1, path2)
 
 
+def test_diff_astropy_tables_dtype(diff_astropy_tables, two_tables):
+    path1, path2 = two_tables
+
+    t1 = Table.read(path1)
+    t1['a'] = np.array([1, 4, 6], dtype=np.int)
+    t1.write(path1, overwrite=True, format="ascii.ecsv")
+
+    with pytest.raises(AssertionError, match="dtype does not match"):
+        assert diff_astropy_tables(path1, path2)
+
+
+def test_diff_astropy_tables_all_equal(diff_astropy_tables, two_tables):
+    path1, path2 = two_tables
+
+    t1 = Table.read(path1)
+    t1['a'] = np.array([1, 4, 6], dtype=np.int)
+    t1.write(path1, overwrite=True, format="ascii.ecsv")
+
+    t2 = Table.read(path2)
+    t2['a'] = np.array([1, 4, 7], dtype=np.int)
+    t2.write(path2, overwrite=True, format="ascii.ecsv")
+
+    with pytest.raises(AssertionError, match="values do not match"):
+        assert diff_astropy_tables(path1, path2)
+
+
 def test_text_diff(tmpdir):
     path1 = str(tmpdir.join("test1.txt"))
     path2 = str(tmpdir.join("test2.txt"))


### PR DESCRIPTION
Now instead of getting a test failure message like this:

```
>       assert diff_astropy_tables(path1, path2)
E       AssertionError: Column names (or order) do not match
```

we get something like

```
>       assert diff_astropy_tables(path1, path2)
E       AssertionError: Column names (or order) do not match
E       assert ['a', 'b', 'c'] == ['a', 'b', 'c', 'd']
E         Right contains one more item: 'd'
E         Use -v to get the full diff
```

and similar improvements for other diffs.  Should be more useful in evaluating on whether to OKify a test or not.