### PR TITLE
Revert "Pin pytest<=5.3.5 because --basetemp is broken"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ DOCS_REQUIRE = [
 ]
 TESTS_REQUIRE = [
     'ci-watson>=0.3.0',
-    'pytest<=5.3.5',
+    'pytest',
     'pytest-doctestplus',
     'requests_mock',
     'pytest-openfiles',


### PR DESCRIPTION
This reverts commit a1ae375a2a441236af071016013784d78d9866c1.

Pytest has now released a fix for this:

https://github.com/pytest-dev/pytest/releases/tag/5.4.2

And running our regression tests locally indicates that it works.  They basically reverted the introduced bug.