### PR TITLE
Jp 1413 Updates to split grating observations into separate asns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ ami
 associations
 ------------
 
+- Restrict NIRSpec IFU data to include one grating per level 3 association [#4854]
+
 - Update asn_from_list to have default values in the asn header [#4720]
 
 - Update rules so exclude dark files from associations [#4668]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 0.16.1 (unreleased)
 ===================
 
-
+associations
+------------
+- Modify NIRSpec IFU level-3 ASN rules to include only one grating per association [#4845]
 
 0.16.0 (2020-05-04)
 ===================

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -581,15 +581,6 @@ class DMSBaseMixin(ACIDMixin):
         return target
 
     def _get_grating(self):
-<<<<<<< HEAD
-        """Get string representation of the grating
-
-        Returns
-        -------
-        target : str
-            The Level3 Product name representation
-            of the grating or source ID.
-=======
         """Get string representation of the grating in use
 
         Returns
@@ -597,7 +588,6 @@ class DMSBaseMixin(ACIDMixin):
         grating : str
             The Level3 Product name representation
             of the grating in use.
->>>>>>> JP-1413 Updates to split grating observations into separate asns
         """
         grating_id = format_list(self.constraints['grating'].found_values)
         grating = 't{0:0>3s}'.format(str(grating_id))

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -581,6 +581,7 @@ class DMSBaseMixin(ACIDMixin):
         return target
 
     def _get_grating(self):
+<<<<<<< HEAD
         """Get string representation of the grating
 
         Returns
@@ -588,6 +589,15 @@ class DMSBaseMixin(ACIDMixin):
         target : str
             The Level3 Product name representation
             of the grating or source ID.
+=======
+        """Get string representation of the grating in use
+
+        Returns
+        -------
+        grating : str
+            The Level3 Product name representation
+            of the grating in use.
+>>>>>>> JP-1413 Updates to split grating observations into separate asns
         """
         grating_id = format_list(self.constraints['grating'].found_values)
         grating = 't{0:0>3s}'.format(str(grating_id))

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -580,6 +580,19 @@ class DMSBaseMixin(ACIDMixin):
         target = 't{0:0>3s}'.format(str(target_id))
         return target
 
+    def _get_grating(self):
+        """Get string representation of the grating
+
+        Returns
+        -------
+        target : str
+            The Level3 Product name representation
+            of the grating or source ID.
+        """
+        grating_id = format_list(self.constraints['grating'].found_values)
+        grating = 't{0:0>3s}'.format(str(grating_id))
+        return grating
+
 
 # -----------------
 # Basic constraints

--- a/jwst/associations/lib/product_utils.py
+++ b/jwst/associations/lib/product_utils.py
@@ -1,0 +1,96 @@
+""" Utilities for product manipulation."""
+
+from collections import defaultdict, Counter
+import copy
+import logging
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+def sort_by_candidate(asns):
+    """Sort associations by candidate
+
+    Parameters
+    ----------
+    asns: [Association[,...]]
+        List of associations
+
+    Returns
+    -------
+    sorted_by_candidate: [Associations[,...]]
+        New list of the associations sorted.
+
+    Notes
+    -----
+    The current definition of candidates allows strictly lexigraphical
+    sorting:
+    aXXXX > cXXXX > oXXX
+
+    If this changes, a comparision function will need be implemented
+    """
+    return sorted(asns, key=lambda asn: asn['asn_id'])
+
+def get_product_names(asns):
+    """Return product names from associations and flag duplicates
+
+    Parameters
+    ----------
+    asns: [`Association`[, ...]]
+
+    Returns
+    -------
+    product_names, duplicates: set(str[, ...]), [str[,...]]
+        2-tuple consisting of the set of product names and the list of duplicates.
+    """
+    product_names = [
+        asn['products'][0]['name']
+        for asn in asns
+    ]
+
+    dups = [
+        name
+        for name, count in Counter(product_names).items()
+        if count > 1
+    ]
+    if dups:
+        logger.debug(
+            'Duplicate product names: %s', dups
+        )
+
+    return set(product_names), dups
+
+def prune_duplicate_products(asns):
+    """Remove duplicate products in favor of higher level versions
+
+    For Level 2 associations, since the products are always just the input
+    exposures, different candidates can be created for each exposure. Remove
+    those associations of lesser candidates.
+
+    The assumption is that there is only one product per association, before merging
+
+    Parameters
+    ----------
+    asns: [Association[,...]]
+        Associations to prune
+
+    Returns
+    pruned: [Association[,...]]
+        Pruned list of associations
+    """
+    product_names, dups = get_product_names(asns)
+    if not dups:
+        return asns
+
+    pruned = copy.copy(asns)
+    to_prune = defaultdict(list)
+    for asn in asns:
+        product_name = asn['products'][0]['name']
+        if product_name in dups:
+            to_prune[product_name].append(asn)
+
+    for product_name, asns_to_prune in to_prune.items():
+        asns_to_prune = sort_by_candidate(asns_to_prune)
+        for asn in asns_to_prune[1:]:
+            pruned.remove(asn)
+
+    return pruned

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -34,6 +34,7 @@ from jwst.associations.lib.rules_level3_base import _EMPTY
 from jwst.associations.lib.rules_level3_base import Utility as Utility_Level3
 from jwst.lib.suffix import remove_suffix
 from jwst.associations.lib.product_utils import prune_duplicate_products
+
 # Configure logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -511,22 +511,6 @@ class Asn_IFUGratingBkg(AsnMixin_AuxData, AsnMixin_BkgScience):
         # Check and continue initialization.
         super(Asn_IFUGratingBkg, self).__init__(*args, **kwargs)
 
-    @property
-    def dms_product_name(self):
-        """Define product name."""
-        target = self._get_target()
-
-        instrument = self._get_instrument()
-
-        product_name = 'jw{}-{}_{}_{}_{}'.format(
-            self.data['program'],
-            self.acid.id,
-            target,
-            instrument,
-            self._get_grating()
-        )
-        return product_name.lower()
-
 @RegistryMarker.rule
 class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
 

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -334,7 +334,14 @@ class Asn_SpectralSource(AsnMixin_Spectrum):
                     Constraint_MSA()
                 ],
                 reduce=Constraint.any
-            )
+            ),
+            Constraint([
+                DMSAttrConstraint(
+                    name='grating',
+                    sources=['grating'],
+                    force_unique=True),
+
+            ])
         ])
 
         # Check and continue initialization.
@@ -367,10 +374,16 @@ class Asn_IFU(AsnMixin_Spectrum):
                         name='patttype',
                         sources=['patttype'],
                         value=['none'],
-                    )
+                    ),
                 ],
-                reduce=Constraint.notany
-            )        ])
+                reduce=Constraint.notany),
+            Constraint([
+                DMSAttrConstraint(
+                    name='grating',
+                    sources=['grating'],
+                    force_unique=True)
+                        ]),
+            ])
         # Check and continue initialization.
         super(Asn_IFU, self).__init__(*args, **kwargs)
 
@@ -428,6 +441,13 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
                 ],
                 reduce=Constraint.any
                 ),
+            Constraint(
+                [
+                    DMSAttrConstraint(
+                        name='grating',
+                        sources=['grating'],
+                        force_unique=True)
+                ])
                 ])
 
         # Check and continue initialization.

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -4,6 +4,7 @@ import logging
 
 from jwst.associations.registry import RegistryMarker
 from jwst.associations.lib.dms_base import (Constraint_TargetAcq, Constraint_TSO)
+from jwst.associations.lib.process_list import ProcessList
 from jwst.associations.lib.rules_level3_base import *
 from jwst.associations.lib.rules_level3_base import (
     dms_product_name_sources,
@@ -14,6 +15,7 @@ __all__ = [
     'Asn_AMI',
     'Asn_ACQ_Reprocess',
     'Asn_Coron',
+    'Asn_IFUGrating',
     'Asn_IFU',
     'Asn_Lv3SpecAux',
     'Asn_Image',
@@ -334,14 +336,7 @@ class Asn_SpectralSource(AsnMixin_Spectrum):
                     Constraint_MSA()
                 ],
                 reduce=Constraint.any
-            ),
-            Constraint([
-                DMSAttrConstraint(
-                    name='grating',
-                    sources=['grating'],
-                    force_unique=True),
-
-            ])
+            )
         ])
 
         # Check and continue initialization.
@@ -374,15 +369,22 @@ class Asn_IFU(AsnMixin_Spectrum):
                         name='patttype',
                         sources=['patttype'],
                         value=['none'],
-                    ),
+                    )
                 ],
-                reduce=Constraint.notany),
+                reduce=Constraint.notany
+            ),
+            # The instrument constraint was addded to force nirspec observations
+            # to be processed in the IFUGrating class and should be removed if
+            # that class is deleted.
             Constraint([
                 DMSAttrConstraint(
-                    name='grating',
-                    sources=['grating'],
-                    force_unique=True)
-                        ]),
+                    name='instrument',
+                    sources=['instrume'],
+                    value=['nirspec'],
+                    )
+                ],
+                       reduce=Constraint.notany
+                      ),
             ])
         # Check and continue initialization.
         super(Asn_IFU, self).__init__(*args, **kwargs)
@@ -399,6 +401,64 @@ class Asn_IFU(AsnMixin_Spectrum):
             self.acid.id,
             target,
             instrument
+        )
+        return product_name.lower()
+
+@RegistryMarker.rule
+class Asn_IFUGrating(AsnMixin_Spectrum):
+    """Level 3 IFU gratings Association
+    Note: This is here to split the associations based on the gratings
+          used in the observation. In principle these observations can
+          (and maybe should) be combined but to reduce processing time
+          they are separated. To return to the original behavior just
+          remove this class and the different gratings will appear in
+          the same association.
+
+    Characteristics:
+        - Association type: ``spec3``
+        - Pipeline: ``calwebb_spec3``
+        - optical path determined by calibration
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Setup for checking.
+        self.constraints = Constraint([
+            Constraint_Target(association=self),
+            Constraint_IFU(),
+            Constraint(
+                [
+                    Constraint_TSO(),
+                    #DMSAttrConstraint(
+                    #    name='patttype',
+                    #    sources=['patttype'],
+                    #    value=['none'],
+                    #)
+                ],
+                reduce=Constraint.notany
+            ),
+            Constraint([
+                DMSAttrConstraint(
+                    name='grating',
+                    sources=['grating'],
+                    force_unique=True,)
+                        ]),
+            ])
+        # Check and continue initialization.
+        super(Asn_IFUGrating, self).__init__(*args, **kwargs)
+
+    @property
+    def dms_product_name(self):
+        """Define product name."""
+        target = self._get_target()
+
+        instrument = self._get_instrument()
+
+        product_name = 'jw{}-{}_{}_{}_{}'.format(
+            self.data['program'],
+            self.acid.id,
+            target,
+            instrument,
+            self._get_grating()
         )
         return product_name.lower()
 
@@ -441,13 +501,6 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
                 ],
                 reduce=Constraint.any
                 ),
-            Constraint(
-                [
-                    DMSAttrConstraint(
-                        name='grating',
-                        sources=['grating'],
-                        force_unique=True)
-                ])
                 ])
 
         # Check and continue initialization.

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -385,11 +385,7 @@ class Asn_IFU(AsnMixin_Spectrum):
                 ],
                        reduce=Constraint.notany
                       ),
-<<<<<<< HEAD
-            ])
-=======
                 ])
->>>>>>> JP-1413 Updates to split grating observations into separate asns
         # Check and continue initialization.
         super(Asn_IFU, self).__init__(*args, **kwargs)
 

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -428,11 +428,11 @@ class Asn_IFUGrating(AsnMixin_Spectrum):
             Constraint(
                 [
                     Constraint_TSO(),
-                    #DMSAttrConstraint(
-                    #    name='patttype',
-                    #    sources=['patttype'],
-                    #    value=['none'],
-                    #)
+                    DMSAttrConstraint(
+                        name='patttype',
+                        sources=['patttype'],
+                        value=['none'],
+                    )
                 ],
                 reduce=Constraint.notany
             ),
@@ -445,6 +445,71 @@ class Asn_IFUGrating(AsnMixin_Spectrum):
             ])
         # Check and continue initialization.
         super(Asn_IFUGrating, self).__init__(*args, **kwargs)
+
+    @property
+    def dms_product_name(self):
+        """Define product name."""
+        target = self._get_target()
+
+        instrument = self._get_instrument()
+
+        product_name = 'jw{}-{}_{}_{}_{}'.format(
+            self.data['program'],
+            self.acid.id,
+            target,
+            instrument,
+            self._get_grating()
+        )
+        return product_name.lower()
+
+@RegistryMarker.rule
+class Asn_IFUGratingBkg(AsnMixin_AuxData, AsnMixin_BkgScience):
+
+    """Level 3 Spectral Association
+
+    Characteristics:
+        - Association type: ``spec3``
+        - Pipeline: ``calwebb_spec3``
+    """
+    def __init__(self, *args, **kwargs):
+
+        # Setup for checking.
+        self.constraints = Constraint([
+            Constraint_Target(association=self),
+            Constraint(
+                [
+                    Constraint_TSO(),
+                ],
+                reduce=Constraint.notany
+            ),
+            Constraint(
+                [
+                    DMSAttrConstraint(
+                        name='bkgdtarg',
+                        sources=['bkgdtarg'],
+                        value=['T'],)
+                ],
+                reduce=Constraint.any
+                ),
+            Constraint(
+                [
+                    DMSAttrConstraint(
+                        name='allowed_bkgdtarg',
+                        sources=['exp_type'],
+                        value=['nrs_ifu'],)
+                ],
+                reduce=Constraint.any
+                ),
+            Constraint([
+                DMSAttrConstraint(
+                    name='grating',
+                    sources=['grating'],
+                    force_unique=True,)
+                        ]),
+                ])
+
+        # Check and continue initialization.
+        super(Asn_IFUGratingBkg, self).__init__(*args, **kwargs)
 
     @property
     def dms_product_name(self):
@@ -496,7 +561,7 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
                     DMSAttrConstraint(
                         name='allowed_bkgdtarg',
                         sources=['exp_type'],
-                        value=['mir_mrs','nrs_ifu','mir_lrs-fixedslit',
+                        value=['mir_mrs','mir_lrs-fixedslit',
                                'nrs_fixedslit'],)
                 ],
                 reduce=Constraint.any

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -385,7 +385,11 @@ class Asn_IFU(AsnMixin_Spectrum):
                 ],
                        reduce=Constraint.notany
                       ),
+<<<<<<< HEAD
             ])
+=======
+                ])
+>>>>>>> JP-1413 Updates to split grating observations into separate asns
         # Check and continue initialization.
         super(Asn_IFU, self).__init__(*args, **kwargs)
 

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -1,6 +1,5 @@
 """Base classes which define the Level3 Associations"""
 from collections import defaultdict
-#import copy
 import logging
 from os.path import (
     basename,
@@ -600,6 +599,7 @@ class Utility():
             else:
                 finalized_asns.append(asn)
 
+        #lv3_asns = prune_duplicate_products(lv3_asns)
         # Ensure sequencing is correct.
         Utility.resequence(lv3_asns)
 

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -41,6 +41,7 @@ from jwst.associations.lib.dms_base import (
 )
 from jwst.associations.lib.format_template import FormatTemplate
 from jwst.associations.lib.member import Member
+from jwst.associations.lib.product_utils import prune_duplicate_products
 
 __all__ = [
     'ASN_SCHEMA',
@@ -599,7 +600,7 @@ class Utility():
             else:
                 finalized_asns.append(asn)
 
-        #lv3_asns = prune_duplicate_products(lv3_asns)
+        lv3_asns = prune_duplicate_products(lv3_asns)
         # Ensure sequencing is correct.
         Utility.resequence(lv3_asns)
 

--- a/jwst/associations/tests/test_level3_basics.py
+++ b/jwst/associations/tests/test_level3_basics.py
@@ -48,7 +48,7 @@ def test_targacq(pool_file):
     assert len(asns) > 0
     for asn in asns:
         # Ignore reprocessed asn's with only science
-        if asn['asn_rule'] != "Asn_Lv3SpecAux":
+        if not asn['asn_rule'] in ["Asn_Lv3SpecAux", "Asn_IFUGratingBkg"]:
             for product in asn['products']:
                 exptypes = [
                     member['exptype'].lower()

--- a/jwst/associations/tests/test_level3_spectrographic.py
+++ b/jwst/associations/tests/test_level3_spectrographic.py
@@ -64,7 +64,7 @@ class TestLevel3Spec(BasePoolRule):
             'o003',
             'spec3',
             r'jw99009-o003_spec3_\d{3}_asn',
-            'jw99009-o003_t002_nirspec',
+            'jw99009-o003_t002_nirspec_tg235h',
             set(('science', 'target_acquisition', 'autowave'))
         ),
     ]


### PR DESCRIPTION
Updated the asn rules to segregate observations based on the grating in use. This touched many more modules than I expected. 

closes JP-1413, #4845