### PR TITLE
JP-1440: Make source catalog background estimation more robust

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,16 @@ associations
 ------------
 - Modify NIRSpec IFU level-3 ASN rules to include only one grating per association [#4845]
 
+source_catalog
+--------------
+
+- Added fallback background estimation method to make background
+  estimation moare robust. [#4929]
+
+- Fixed the nearest-neighbor code to handle the case of exactly one
+  detected source. [#4929]
+
+
 0.16.0 (2020-05-04)
 ===================
 
@@ -39,7 +49,7 @@ datamodels
 
 - Update schemas to add moving_target_position and cheby tables to the level1b
   schema [#4760]
-  
+
 - Deprecate ``DrizProductModel`` and ``MultiProductModel`` and replace with
   updated versions of ``ImageModel`` and ``SlitModel`` that include "CON" and
   "WHT" arrays for resampled data. [#4552]

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1187,9 +1187,12 @@ class SourceCatalog:
         """
         The distance in pixels to the nearest neighbor and its index.
         """
-        tree = cKDTree(self.xypos)
-        qdist, qidx = tree.query(self.xypos, k=2)
-        return np.transpose(qdist)[1], np.transpose(qidx)[1]
+        if self.xypos.shape[0] == 1:  # only one detected source
+            return [np.nan], [np.nan]
+        else:
+            tree = cKDTree(self.xypos)
+            qdist, qidx = tree.query(self.xypos, k=2)
+            return np.transpose(qdist)[1], np.transpose(qidx)[1]
 
     @lazyproperty
     def nn_dist(self):
@@ -1207,6 +1210,10 @@ class SourceCatalog:
         total AB magnitude is used.  Otherwise, its isophotal AB
         magnitude is used.
         """
+
+        if len(self._ckdtree_query[1]) == 1:  # only one detected source
+            return np.nan
+
         nn_abmag = self.aper_total_abmag[self._ckdtree_query[1]]
         nn_isomag = self.isophotal_abmag[self._ckdtree_query[1]]
         return np.where(np.isnan(nn_abmag), nn_isomag, nn_abmag)

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -4,6 +4,7 @@ Module to calculate the source catalog.
 
 from collections import OrderedDict
 import logging
+import warnings
 
 from astropy import __version__ as astropy_version
 from astropy.convolution import Gaussian2DKernel
@@ -569,14 +570,18 @@ class SourceCatalog:
             The output AB magnitude and error arrays.
         """
 
-        abmag = -2.5 * np.log10(flux.value) + 8.9
-        # assuming SNR >> 1 (otherwise abmag_err is asymmetric)
-        abmag_err = 2.5 * np.log10(np.e) * (flux_err.value / flux.value)
+        # ignore RunTimeWarning if flux or flux_err contains NaNs
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
 
-        # handle negative fluxes
-        idx = flux.value < 0
-        abmag[idx] = np.nan
-        abmag_err[idx] = np.nan
+            abmag = -2.5 * np.log10(flux.value) + 8.9
+            # assuming SNR >> 1 (otherwise abmag_err is asymmetric)
+            abmag_err = 2.5 * np.log10(np.e) * (flux_err.value / flux.value)
+
+            # handle negative fluxes
+            idx = flux.value < 0
+            abmag[idx] = np.nan
+            abmag_err[idx] = np.nan
 
         return abmag, abmag_err
 

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -71,6 +71,11 @@ class SourceCatalogStep(Step):
                                     abvegaoffset_filename=abvegaoffset_fn)
 
             coverage_mask = (model.wht == 0)
+            if coverage_mask.all():
+                self.log.warn('There are no pixels with non-zero weight. '
+                              'Source catalog will not be created.')
+                return
+
             bkg = Background(model.data, box_size=self.bkg_boxsize,
                              mask=coverage_mask)
             model.data -= bkg.background
@@ -83,7 +88,7 @@ class SourceCatalogStep(Step):
                                            mask=coverage_mask,
                                            deblend=self.deblend)
             if segment_img is None:
-                self.log.info('No sources were found. Source catalog will '
+                self.log.warn('No sources were found. Source catalog will '
                               'not be created.')
                 return
             self.log.info(f'Detected {segment_img.nlabels} sources')


### PR DESCRIPTION
This PR adds a fallback background estimation if the background cannot be determined in meshes.  This PR also adds some checks for completely-masked data.

Fixes #4913 / [JP-1440](https://jira.stsci.edu/browse/JP-1440)