### PR TITLE
Fix nonsensical premature closing of FITS file of a DataModel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ datamodels
 
 - Added "PERSISTENCE" DQ flag definition. [#5137]
 
+- Fix nonsensical premature closing of FITS file of a ``DataModel``. [#4930]
+
 extract_1d
 ----------
 

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -13,7 +13,6 @@ def read_cubepars(par_filename,
                   all_grating,
                   all_filter,
                   instrument_info):
-
     """ Read in cube parameter reference file
 
     Based on the instrument and channel/subchannels (MIRI) or
@@ -49,183 +48,183 @@ def read_cubepars(par_filename,
 
     """
     if instrument == 'MIRI':
-        ptab = datamodels.MiriIFUCubeParsModel(par_filename)
-        number_bands = len(all_channel)
-        # pull out the channels and subchannels that cover the cube
-        for i in range(number_bands):
-            this_channel = all_channel[i]
-            # compare_channel = 'CH'+this_channel
-            this_sub = all_subchannel[i]
-            # find the table entries for this combination
-            for tabdata in ptab.ifucubepars_table:
-                table_channel = tabdata['channel']
-                table_band = tabdata['band'].lower()
-                table_spaxelsize = tabdata['SPAXELSIZE']
-                table_spectralstep = tabdata['SPECTRALSTEP']
-                table_wavemin = tabdata['WAVEMIN']
-                table_wavemax = tabdata['WAVEMAX']
-                # match on this_channel and this_sub
-                if(this_channel == table_channel and this_sub == table_band):
-                    instrument_info.SetSpatialSize(table_spaxelsize, this_channel, this_sub)
-                    instrument_info.SetSpectralStep(table_spectralstep, this_channel, this_sub)
-                    instrument_info.SetWaveMin(table_wavemin, this_channel, this_sub)
-                    instrument_info.SetWaveMax(table_wavemax, this_channel, this_sub)
-            #  modified shepard method 1/r weighting
-            if weighting == 'msm':
-                for tabdata in ptab.ifucubepars_msm_table:
+        with datamodels.MiriIFUCubeParsModel(par_filename) as ptab:
+            number_bands = len(all_channel)
+            # pull out the channels and subchannels that cover the cube
+            for i in range(number_bands):
+                this_channel = all_channel[i]
+                # compare_channel = 'CH'+this_channel
+                this_sub = all_subchannel[i]
+                # find the table entries for this combination
+                for tabdata in ptab.ifucubepars_table:
                     table_channel = tabdata['channel']
                     table_band = tabdata['band'].lower()
+                    table_spaxelsize = tabdata['SPAXELSIZE']
+                    table_spectralstep = tabdata['SPECTRALSTEP']
+                    table_wavemin = tabdata['WAVEMIN']
+                    table_wavemax = tabdata['WAVEMAX']
+                    # match on this_channel and this_sub
+                    if(this_channel == table_channel and this_sub == table_band):
+                        instrument_info.SetSpatialSize(table_spaxelsize, this_channel, this_sub)
+                        instrument_info.SetSpectralStep(table_spectralstep, this_channel, this_sub)
+                        instrument_info.SetWaveMin(table_wavemin, this_channel, this_sub)
+                        instrument_info.SetWaveMax(table_wavemax, this_channel, this_sub)
+                #  modified shepard method 1/r weighting
+                if weighting == 'msm':
+                    for tabdata in ptab.ifucubepars_msm_table:
+                        table_channel = tabdata['channel']
+                        table_band = tabdata['band'].lower()
+                        table_sroi = tabdata['ROISPATIAL']
+                        table_wroi = tabdata['ROISPECTRAL']
+                        table_power = tabdata['POWER']
+                        table_softrad = tabdata['SOFTRAD']
+                    # match on this_channel and this_sub
+                        if(this_channel == table_channel and this_sub == table_band):
+                            instrument_info.SetMSM(this_channel, this_sub,
+                                                   table_sroi, table_wroi,
+                                                   table_power, table_softrad)
+
+                #  modified shepard method e^-r weighting
+                elif weighting == 'emsm':
+                    for tabdata in ptab.ifucubepars_emsm_table:
+                        table_channel = tabdata['channel']
+                        table_band = tabdata['band'].lower()
+                        table_sroi = tabdata['ROISPATIAL']
+                        table_wroi = tabdata['ROISPECTRAL']
+                        table_scalerad = tabdata['SCALERAD']
+                    # match on this_channel and this_sub
+                        if(this_channel == table_channel and this_sub == table_band):
+                            instrument_info.SetEMSM(this_channel, this_sub,
+                                                    table_sroi, table_wroi,
+                                                    table_scalerad)
+
+            #  read in wavelength table for modified shepard method 1/r weighting
+            if weighting == 'msm':
+                for tabdata in ptab.ifucubepars_multichannel_msm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
                     table_sroi = tabdata['ROISPATIAL']
                     table_wroi = tabdata['ROISPECTRAL']
                     table_power = tabdata['POWER']
                     table_softrad = tabdata['SOFTRAD']
-                # match on this_channel and this_sub
-                    if(this_channel == table_channel and this_sub == table_band):
-                        instrument_info.SetMSM(this_channel, this_sub,
-                                               table_sroi, table_wroi,
-                                               table_power, table_softrad)
-
-            #  modified shepard method e^-r weighting
+                    instrument_info.SetMultiChannelTable(table_wave, table_sroi,
+                                                         table_wroi, table_power,
+                                                         table_softrad)
+            #  read in wavelength table for modified shepard method 1/r weighting
             elif weighting == 'emsm' or weighting == 'miripsf':
-                for tabdata in ptab.ifucubepars_emsm_table:
-                    table_channel = tabdata['channel']
-                    table_band = tabdata['band'].lower()
+                for tabdata in ptab.ifucubepars_multichannel_emsm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
                     table_sroi = tabdata['ROISPATIAL']
                     table_wroi = tabdata['ROISPECTRAL']
                     table_scalerad = tabdata['SCALERAD']
-                # match on this_channel and this_sub
-                    if(this_channel == table_channel and this_sub == table_band):
-                        instrument_info.SetEMSM(this_channel, this_sub,
-                                               table_sroi, table_wroi,
-                                               table_scalerad)
-
-        #  read in wavelength table for modified shepard method 1/r weighting
-        if weighting == 'msm':
-            for tabdata in ptab.ifucubepars_multichannel_msm_wavetable:
-                table_wave = tabdata['WAVELENGTH']
-                table_sroi = tabdata['ROISPATIAL']
-                table_wroi = tabdata['ROISPECTRAL']
-                table_power = tabdata['POWER']
-                table_softrad = tabdata['SOFTRAD']
-                instrument_info.SetMultiChannelTable(table_wave, table_sroi,
-                                                     table_wroi, table_power,
-                                                     table_softrad)
-        #  read in wavelength table for modified shepard method 1/r weighting
-        elif weighting == 'emsm' or weighting == 'miripsf':
-            for tabdata in ptab.ifucubepars_multichannel_emsm_wavetable:
-                table_wave = tabdata['WAVELENGTH']
-                table_sroi = tabdata['ROISPATIAL']
-                table_wroi = tabdata['ROISPECTRAL']
-                table_scalerad = tabdata['SCALERAD']
-                instrument_info.SetMultiChannelEMSMTable(table_wave, table_sroi,
-                                                     table_wroi, table_scalerad)
+                    instrument_info.SetMultiChannelEMSMTable(table_wave, table_sroi,
+                                                             table_wroi, table_scalerad)
 
     # Read in NIRSPEC Values
     elif instrument == 'NIRSPEC':
-        ptab = datamodels.NirspecIFUCubeParsModel(par_filename)
-        number_gratings = len(all_grating)
+        with datamodels.NirspecIFUCubeParsModel(par_filename) as ptab:
+            number_gratings = len(all_grating)
 
-        for i in range(number_gratings):
-            this_gwa = all_grating[i]
-            this_filter = all_filter[i]
-            for tabdata in ptab.ifucubepars_table:
-                table_grating = tabdata['DISPERSER'].lower()
-                table_filter = tabdata['FILTER'].lower()
-                table_spaxelsize = tabdata['SPAXELSIZE']
-                table_spectralstep = tabdata['SPECTRALSTEP']
-                table_wavemin = tabdata['WAVEMIN']
-                table_wavemax = tabdata['WAVEMAX']
-
-                if(this_gwa == table_grating and this_filter == table_filter):
-                    instrument_info.SetSpatialSize(table_spaxelsize, this_gwa, this_filter)
-                    instrument_info.SetSpectralStep(table_spectralstep, this_gwa, this_filter)
-                    instrument_info.SetWaveMin(table_wavemin, this_gwa, this_filter)
-                    instrument_info.SetWaveMax(table_wavemax, this_gwa, this_filter)
-
-            #  modified shepard method 1/r weighting
-            if weighting == 'msm':
-                for tabdata in ptab.ifucubepars_msm_table:
+            for i in range(number_gratings):
+                this_gwa = all_grating[i]
+                this_filter = all_filter[i]
+                for tabdata in ptab.ifucubepars_table:
                     table_grating = tabdata['DISPERSER'].lower()
                     table_filter = tabdata['FILTER'].lower()
+                    table_spaxelsize = tabdata['SPAXELSIZE']
+                    table_spectralstep = tabdata['SPECTRALSTEP']
+                    table_wavemin = tabdata['WAVEMIN']
+                    table_wavemax = tabdata['WAVEMAX']
+
+                    if(this_gwa == table_grating and this_filter == table_filter):
+                        instrument_info.SetSpatialSize(table_spaxelsize, this_gwa, this_filter)
+                        instrument_info.SetSpectralStep(table_spectralstep, this_gwa, this_filter)
+                        instrument_info.SetWaveMin(table_wavemin, this_gwa, this_filter)
+                        instrument_info.SetWaveMax(table_wavemax, this_gwa, this_filter)
+
+                #  modified shepard method 1/r weighting
+                if weighting == 'msm':
+                    for tabdata in ptab.ifucubepars_msm_table:
+                        table_grating = tabdata['DISPERSER'].lower()
+                        table_filter = tabdata['FILTER'].lower()
+                        table_sroi = tabdata['ROISPATIAL']
+                        table_wroi = tabdata['ROISPECTRAL']
+                        table_power = tabdata['POWER']
+                        table_softrad = tabdata['SOFTRAD']
+
+                        if(this_gwa == table_grating and this_filter == table_filter):
+                            instrument_info.SetMSM(this_gwa, this_filter,
+                                                   table_sroi, table_wroi,
+                                                   table_power, table_softrad)
+                #  modified shepard method e^-r weighting
+                elif weighting == 'emsm':
+                    for tabdata in ptab.ifucubepars_emsm_table:
+                        table_grating = tabdata['DISPERSER'].lower()
+                        table_filter = tabdata['FILTER'].lower()
+                        table_sroi = tabdata['ROISPATIAL']
+                        table_wroi = tabdata['ROISPECTRAL']
+                        table_scalerad = tabdata['SCALERAD']
+
+                        if(this_gwa == table_grating and this_filter == table_filter):
+                            instrument_info.SetEMSM(this_gwa, this_filter,
+                                                    table_sroi, table_wroi,
+                                                    table_scalerad)
+
+            # read in wavelength tables
+            if weighting == 'msm':
+                for tabdata in ptab.ifucubepars_prism_msm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
                     table_sroi = tabdata['ROISPATIAL']
                     table_wroi = tabdata['ROISPECTRAL']
                     table_power = tabdata['POWER']
                     table_softrad = tabdata['SOFTRAD']
+                    instrument_info.SetPrismTable(table_wave, table_sroi,
+                                                  table_wroi, table_power,
+                                                  table_softrad)
 
-                    if(this_gwa == table_grating and this_filter == table_filter):
-                        instrument_info.SetMSM(this_gwa, this_filter,
-                                               table_sroi, table_wroi,
-                                               table_power, table_softrad)
-            #  modified shepard method e^-r weighting
+                for tabdata in ptab.ifucubepars_med_msm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
+                    table_sroi = tabdata['ROISPATIAL']
+                    table_wroi = tabdata['ROISPECTRAL']
+                    table_power = tabdata['POWER']
+                    table_softrad = tabdata['SOFTRAD']
+                    instrument_info.SetMedTable(table_wave, table_sroi,
+                                                table_wroi, table_power,
+                                                table_softrad)
+
+                for tabdata in ptab.ifucubepars_high_msm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
+                    table_sroi = tabdata['ROISPATIAL']
+                    table_wroi = tabdata['ROISPECTRAL']
+                    table_power = tabdata['POWER']
+                    table_softrad = tabdata['SOFTRAD']
+                    instrument_info.SetHighTable(table_wave, table_sroi,
+                                                 table_wroi, table_power,
+                                                 table_softrad)
+
             elif weighting == 'emsm':
-                for tabdata in ptab.ifucubepars_emsm_table:
-                    table_grating = tabdata['DISPERSER'].lower()
-                    table_filter = tabdata['FILTER'].lower()
+                for tabdata in ptab.ifucubepars_prism_emsm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
                     table_sroi = tabdata['ROISPATIAL']
                     table_wroi = tabdata['ROISPECTRAL']
                     table_scalerad = tabdata['SCALERAD']
+                    instrument_info.SetPrismEMSMTable(table_wave, table_sroi,
+                                                      table_wroi, table_scalerad)
 
-                    if(this_gwa == table_grating and this_filter == table_filter):
-                        instrument_info.SetEMSM(this_gwa, this_filter,
-                                               table_sroi, table_wroi,
-                                               table_scalerad)
+                for tabdata in ptab.ifucubepars_med_emsm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
+                    table_sroi = tabdata['ROISPATIAL']
+                    table_wroi = tabdata['ROISPECTRAL']
+                    table_scalerad = tabdata['SCALERAD']
+                    instrument_info.SetMedEMSMTable(table_wave, table_sroi,
+                                                    table_wroi, table_scalerad)
 
-        # read in wavelength tables
-        if weighting == 'msm':
-            for tabdata in ptab.ifucubepars_prism_msm_wavetable:
-                table_wave = tabdata['WAVELENGTH']
-                table_sroi = tabdata['ROISPATIAL']
-                table_wroi = tabdata['ROISPECTRAL']
-                table_power = tabdata['POWER']
-                table_softrad = tabdata['SOFTRAD']
-                instrument_info.SetPrismTable(table_wave, table_sroi,
-                                              table_wroi, table_power,
-                                              table_softrad)
-
-            for tabdata in ptab.ifucubepars_med_msm_wavetable:
-                table_wave = tabdata['WAVELENGTH']
-                table_sroi = tabdata['ROISPATIAL']
-                table_wroi = tabdata['ROISPECTRAL']
-                table_power = tabdata['POWER']
-                table_softrad = tabdata['SOFTRAD']
-                instrument_info.SetMedTable(table_wave, table_sroi,
-                                            table_wroi, table_power,
-                                            table_softrad)
-
-            for tabdata in ptab.ifucubepars_high_msm_wavetable:
-                table_wave = tabdata['WAVELENGTH']
-                table_sroi = tabdata['ROISPATIAL']
-                table_wroi = tabdata['ROISPECTRAL']
-                table_power = tabdata['POWER']
-                table_softrad = tabdata['SOFTRAD']
-                instrument_info.SetHighTable(table_wave, table_sroi,
-                                             table_wroi, table_power,
-                                             table_softrad)
-
-        elif weighting == 'emsm':
-            for tabdata in ptab.ifucubepars_prism_emsm_wavetable:
-                table_wave = tabdata['WAVELENGTH']
-                table_sroi = tabdata['ROISPATIAL']
-                table_wroi = tabdata['ROISPECTRAL']
-                table_scalerad = tabdata['SCALERAD']
-                instrument_info.SetPrismEMSMTable(table_wave, table_sroi,
-                                              table_wroi, table_scalerad)
-
-            for tabdata in ptab.ifucubepars_med_emsm_wavetable:
-                table_wave = tabdata['WAVELENGTH']
-                table_sroi = tabdata['ROISPATIAL']
-                table_wroi = tabdata['ROISPECTRAL']
-                table_scalerad = tabdata['SCALERAD']
-                instrument_info.SetMedEMSMTable(table_wave, table_sroi,
-                                            table_wroi, table_scalerad)
-
-            for tabdata in ptab.ifucubepars_high_emsm_wavetable:
-                table_wave = tabdata['WAVELENGTH']
-                table_sroi = tabdata['ROISPATIAL']
-                table_wroi = tabdata['ROISPECTRAL']
-                table_scalerad = tabdata['SCALERAD']
-                instrument_info.SetHighEMSMTable(table_wave, table_sroi,
-                                             table_wroi, table_scalerad)
+                for tabdata in ptab.ifucubepars_high_emsm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
+                    table_sroi = tabdata['ROISPATIAL']
+                    table_wroi = tabdata['ROISPECTRAL']
+                    table_scalerad = tabdata['SCALERAD']
+                    instrument_info.SetHighEMSMTable(table_wave, table_sroi,
+                                                     table_wroi, table_scalerad)
 # _____________________________________________________________________________
 
 
@@ -233,7 +232,6 @@ def read_resolution_file(resol_filename,
                          all_channel,
                          all_subchannel,
                          instrument_info):
-
     """ Read in the MIRI Resolution reference file
 
     If this is MIRI data and the weighting is miripsf then read in the
@@ -273,10 +271,10 @@ def read_resolution_file(resol_filename,
     table_beta_b_long = ptab.psf_fwhm_beta_table['B_B_LONG']
 
     instrument_info.Set_psf_alpha_parameters(table_alpha_cutoff,
-                                            table_alpha_a_short,
-                                            table_alpha_b_short,
-                                            table_alpha_a_long,
-                                            table_alpha_b_long)
+                                             table_alpha_a_short,
+                                             table_alpha_b_short,
+                                             table_alpha_a_long,
+                                             table_alpha_b_long)
 
     instrument_info.Set_psf_beta_parameters(table_beta_cutoff,
                                             table_beta_a_short,
@@ -305,19 +303,19 @@ def read_resolution_file(resol_filename,
             # match on this_channel and this_sub
             if compare_band == table_sub_band:
                 instrument_info.Set_RP_Wave_Cutoff(table_wave_center,
-                                                  this_channel, this_sub)
+                                                   this_channel, this_sub)
 
                 instrument_info.Set_RP_low(table_res_a_low,
-                                          table_res_b_low,
-                                          table_res_c_low,
-                                          this_channel, this_sub)
+                                           table_res_b_low,
+                                           table_res_c_low,
+                                           this_channel, this_sub)
 
                 instrument_info.Set_RP_high(table_res_a_high,
-                                          table_res_b_high,
-                                          table_res_c_high,
-                                          this_channel, this_sub)
+                                            table_res_b_high,
+                                            table_res_c_high,
+                                            this_channel, this_sub)
 
                 instrument_info.Set_RP_ave(table_res_a_ave,
-                                          table_res_b_ave,
-                                          table_res_c_ave,
-                                          this_channel, this_sub)
+                                           table_res_b_ave,
+                                           table_res_c_ave,
+                                           this_channel, this_sub)

--- a/jwst/cube_build/tests/test_miri_cubepars.py
+++ b/jwst/cube_build/tests/test_miri_cubepars.py
@@ -19,72 +19,74 @@ def miri_cube_pars(tmpdir_factory):
     filename = str(filename.join('miri_cube_pars.fits'))
     hdu0 = fits.PrimaryHDU()
     hdu0.header['REFTYPE'] = 'CUBEPAR'
-    hdu0.header['INSTRUME']='MIRI'
-    hdu0.header['MODELNAM']='FM'
-    hdu0.header['DETECTOR']='N/A'
-    hdu0.header['EXP_TYPE']='MIR_MRS'
+    hdu0.header['INSTRUME'] = 'MIRI'
+    hdu0.header['MODELNAM'] = 'FM'
+    hdu0.header['DETECTOR'] = 'N/A'
+    hdu0.header['EXP_TYPE'] = 'MIR_MRS'
 
     # make the first extension
-    channel=np.array(['1','1','1','2','2','2','3','3','3','4','4','4'])
-    subchannel=np.array(['SHORT','MEDIUM','LONG','SHORT','MEDIUM','LONG',
-                         'SHORT','MEDIUM','LONG','SHORT','MEDIUM','LONG'])
+    channel = np.array(['1', '1', '1', '2', '2', '2', '3', '3', '3', '4', '4', '4'])
+    subchannel = np.array(['SHORT', 'MEDIUM', 'LONG', 'SHORT', 'MEDIUM', 'LONG',
+                           'SHORT', 'MEDIUM', 'LONG', 'SHORT', 'MEDIUM', 'LONG'])
 
-    spsize=np.array([0.13,0.13,0.13,0.17,0.17,0.17,0.2,0.2,0.2,0.35,0.35,0.35])
-    wsamp=np.array([0.001,0.001,0.001,0.002,0.002,0.002,0.003,0.003,0.003,0.006,0.006,0.006])
+    spsize = np.array([0.13, 0.13, 0.13, 0.17, 0.17, 0.17, 0.2, 0.2, 0.2, 0.35, 0.35, 0.35])
+    wsamp = np.array([0.001, 0.001, 0.001, 0.002, 0.002, 0.002, 0.003, 0.003, 0.003, 0.006, 0.006, 0.006])
 
-    wmin=np.array([4.89,5.65,6.52,7.49,8.65,10.00,11.53,13.37,15.44,17.66,20.54,23.95])
-    wmax=np.array([5.75,6.64,7.66,8.78,10.14,11.7,13.48,15.63,18.05,20.92,24.40,28.45])
+    wmin = np.array([4.89, 5.65, 6.52, 7.49, 8.65, 10.00, 11.53, 13.37, 15.44, 17.66, 20.54, 23.95])
+    wmax = np.array([5.75, 6.64, 7.66, 8.78, 10.14, 11.7, 13.48, 15.63, 18.05, 20.92, 24.40, 28.45])
 
-    col1=fits.Column(name='CHANNEL',format='1A',array=channel)
-    col2=fits.Column(name='BAND',format='6A',array=subchannel)
-    col3=fits.Column(name='WAVEMIN',format='E',array=wmin, unit='micron')
-    col4=fits.Column(name='WAVEMAX',format='E',array=wmax, unit='micron')
-    col5=fits.Column(name='SPAXELSIZE',format='E',array=spsize, unit='arcsec')
-    col6=fits.Column(name='SPECTRALSTEP',format='D',array=wsamp, unit='micron')
+    col1 = fits.Column(name='CHANNEL', format='1A', array=channel)
+    col2 = fits.Column(name='BAND', format='6A', array=subchannel)
+    col3 = fits.Column(name='WAVEMIN', format='E', array=wmin, unit='micron')
+    col4 = fits.Column(name='WAVEMAX', format='E', array=wmax, unit='micron')
+    col5 = fits.Column(name='SPAXELSIZE', format='E', array=spsize, unit='arcsec')
+    col6 = fits.Column(name='SPECTRALSTEP', format='D', array=wsamp, unit='micron')
 
-    hdu1=fits.BinTableHDU.from_columns([col1,col2,col3,col4,col5,col6])
-    hdu1.header['EXTNAME']='CUBEPAR'
+    hdu1 = fits.BinTableHDU.from_columns([col1, col2, col3, col4, col5, col6])
+    hdu1.header['EXTNAME'] = 'CUBEPAR'
 
     # make the second extension
 
-    roispat=np.array([0.1,0.1,0.1,0.15,0.15,0.15,0.20,0.20,0.20,0.40,0.40,0.40])
-    roispec=np.array([0.001,0.001,0.001,0.002,0.002,0.002,0.003,0.003,0.003,0.006,0.006,0.006])
+    roispat = np.array([0.1, 0.1, 0.1, 0.15, 0.15, 0.15, 0.20, 0.20, 0.20, 0.40, 0.40, 0.40])
+    roispec = np.array([0.001, 0.001, 0.001, 0.002, 0.002, 0.002, 0.003, 0.003, 0.003, 0.006, 0.006, 0.006])
 
-    power=np.array([2,2,2,2,2,2,2,2,2,2,2,2])
-    softrad=np.array([0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01])
+    power = np.array([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])
+    softrad = np.array([0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01])
 
-    col1=fits.Column(name='CHANNEL',format='1A',array=channel)
-    col2=fits.Column(name='BAND',format='6A',array=subchannel)
-    col3=fits.Column(name='ROISPATIAL',format='E',array=roispat, unit='arcsec')
-    col4=fits.Column(name='ROISPECTRAL',format='E',array=roispec, unit='micron')
-    col5=fits.Column(name='POWER',format='I',array=power)
-    col6=fits.Column(name='SOFTRAD',format='E',array=softrad, unit='arcsec')
+    col1 = fits.Column(name='CHANNEL', format='1A', array=channel)
+    col2 = fits.Column(name='BAND', format='6A', array=subchannel)
+    col3 = fits.Column(name='ROISPATIAL', format='E', array=roispat, unit='arcsec')
+    col4 = fits.Column(name='ROISPECTRAL', format='E', array=roispec, unit='micron')
+    col5 = fits.Column(name='POWER', format='I', array=power)
+    col6 = fits.Column(name='SOFTRAD', format='E', array=softrad, unit='arcsec')
 
-    hdu2=fits.BinTableHDU.from_columns([col1,col2,col3,col4,col5,col6])
-    hdu2.header['EXTNAME']='CUBEPAR_MSM'
+    hdu2 = fits.BinTableHDU.from_columns([col1, col2, col3, col4, col5, col6])
+    hdu2.header['EXTNAME'] = 'CUBEPAR_MSM'
 
     # make the third extension
     # Define the multiextension wavelength solution - only use a few number for testing
-    finalwave = np.array([5,10,15,20,25])
-    roispat = np.array([0.1,0.2,0.3,0.4,0.5])
-    roispec = np.array([0.001,0.002,0.003,0.004,0.005])
-    power = np.array([1,2,3,4,5])
-    softrad = np.array([0.01,0.02,0.03,0.04,0.05])
+    finalwave = np.array([5, 10, 15, 20, 25])
+    roispat = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    roispec = np.array([0.001, 0.002, 0.003, 0.004, 0.005])
+    power = np.array([1, 2, 3, 4, 5])
+    softrad = np.array([0.01, 0.02, 0.03, 0.04, 0.05])
 
-    col1=fits.Column(name='WAVELENGTH',format='D',array=finalwave, unit='micron')
-    col2=fits.Column(name='ROISPATIAL',format='E',array=roispat, unit='arcsec')
-    col3=fits.Column(name='ROISPECTRAL',format='E',array=roispec, unit='micron')
-    col4=fits.Column(name='POWER',format='I',array=power)
-    col5=fits.Column(name='SOFTRAD',format='E',array=softrad, unit='arcsec')
-    hdu3=fits.BinTableHDU.from_columns([col1,col2,col3,col4,col5])
-    hdu3.header['EXTNAME']='MULTICHANNEL_MSM'
+    col1 = fits.Column(name='WAVELENGTH', format='D',  array=finalwave, unit='micron')
+    col2 = fits.Column(name='ROISPATIAL', format='E', array=roispat, unit='arcsec')
+    col3 = fits.Column(name='ROISPECTRAL', format='E', array=roispec, unit='micron')
+    col4 = fits.Column(name='POWER', format='I', array=power)
+    col5 = fits.Column(name='SOFTRAD', format='E', array=softrad, unit='arcsec')
+    hdu3 = fits.BinTableHDU.from_columns([col1, col2, col3, col4, col5])
+    hdu3.header['EXTNAME'] = 'MULTICHANNEL_MSM'
 
-    hdu = fits.HDUList([hdu0,hdu1,hdu2,hdu3])
-    hdu.writeto(filename,overwrite=True)
+    hdu = fits.HDUList([hdu0, hdu1, hdu2, hdu3])
+    hdu.writeto(filename, overwrite=True)
+    hdu.close()
 
     return filename
 
-def test_miri_use_cubepars(_jail, miri_cube_pars):
+
+def test_miri_use_cubepars(_jail,  miri_cube_pars):
     """ Test reading in the miri cube pars file """
 
     instrument_info = instrument_defaults.InstrumentInfo()
@@ -107,18 +109,18 @@ def test_miri_use_cubepars(_jail, miri_cube_pars):
     par1 = '1'
     par2 = 'medium'
 
-    ascale,bscale,wscale = instrument_info.GetScale(par1,par2)
+    ascale, bscale, wscale = instrument_info.GetScale(par1, par2)
 
     # check that the values are read in correctly
     assert math.isclose(ascale, 0.13, abs_tol=0.00001)
     assert math.isclose(bscale, 0.13, abs_tol=0.00001)
     assert math.isclose(wscale, 0.001, abs_tol=0.00001)
 
-    roiw = instrument_info.GetWaveRoi(par1,par2)
-    rois = instrument_info.GetSpatialRoi(par1,par2)
-    power = instrument_info.GetMSMPower(par1,par2)
-    wavemin = instrument_info.GetWaveMin(par1,par2)
-    wavemax = instrument_info.GetWaveMax(par1,par2)
+    roiw = instrument_info.GetWaveRoi(par1, par2)
+    rois = instrument_info.GetSpatialRoi(par1, par2)
+    power = instrument_info.GetMSMPower(par1, par2)
+    wavemin = instrument_info.GetWaveMin(par1, par2)
+    wavemax = instrument_info.GetWaveMax(par1, par2)
 
     assert math.isclose(roiw, 0.001, abs_tol=0.00001)
     assert math.isclose(rois, 0.1, abs_tol=0.00001)
@@ -126,7 +128,7 @@ def test_miri_use_cubepars(_jail, miri_cube_pars):
     assert math.isclose(wavemin, 5.65, abs_tol=0.00001)
     assert math.isclose(wavemax, 6.64, abs_tol=0.00001)
 
-    #set up the ifucube class
+    # set up the ifucube class
     pars_cube = {
         'scale1': 0.0,
         'scale2': 0.0,
@@ -151,7 +153,7 @@ def test_miri_use_cubepars(_jail, miri_cube_pars):
     input_model = None
     output_name_base = None
     output_type = 'band'
-    instrument  = 'MIRI'
+    instrument = 'MIRI'
     list_par1 = all_channel
     list_par2 = all_subchannel
     master_table = None
@@ -169,19 +171,19 @@ def test_miri_use_cubepars(_jail, miri_cube_pars):
         master_table,
         **pars_cube)
 
-    this_cube.num_files = 1 # set in ifu cube
+    this_cube.num_files = 1  # set in ifu cube
     # test that the correct values read from the table are filled
     # in in the this_cube class. Also check that for this configuration
     # linear_wavelength = True
     this_cube.determine_cube_parameters()
 
-    assert math.isclose(this_cube.wavemin,wavemin, abs_tol=0.00001)
-    assert math.isclose(this_cube.wavemax,wavemax, abs_tol=0.00001)
-    assert this_cube.linear_wavelength == True
+    assert math.isclose(this_cube.wavemin, wavemin, abs_tol=0.00001)
+    assert math.isclose(this_cube.wavemax, wavemax, abs_tol=0.00001)
+    assert this_cube.linear_wavelength
 
     assert math.isclose(this_cube.weight_power, 2, abs_tol=0.00001)
     assert math.isclose(this_cube.roiw, 0.001, abs_tol=0.00001)
-    rois = 0.1 * 1.5 # increase for single file
+    rois = 0.1 * 1.5  # increase for single file
     assert math.isclose(this_cube.rois, rois, abs_tol=0.00001)
     assert math.isclose(this_cube.spatial_size, 0.13, abs_tol=0.00001)
 
@@ -212,17 +214,17 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
 
     # first check that it reads in correct values for this band
     # from the reference file
-    ascale,bscale,wscale = instrument_info.GetScale(par1,par2)
+    ascale, bscale, wscale = instrument_info.GetScale(par1, par2)
 
     assert math.isclose(ascale, 0.35, abs_tol=0.00001)
     assert math.isclose(bscale, 0.35, abs_tol=0.00001)
     assert math.isclose(wscale, 0.006, abs_tol=0.00001)
 
-    roiw = instrument_info.GetWaveRoi(par1,par2)
-    rois = instrument_info.GetSpatialRoi(par1,par2)
-    power = instrument_info.GetMSMPower(par1,par2)
-    wavemin = instrument_info.GetWaveMin(par1,par2)
-    wavemax = instrument_info.GetWaveMax(par1,par2)
+    roiw = instrument_info.GetWaveRoi(par1, par2)
+    rois = instrument_info.GetSpatialRoi(par1, par2)
+    power = instrument_info.GetMSMPower(par1, par2)
+    wavemin = instrument_info.GetWaveMin(par1, par2)
+    wavemax = instrument_info.GetWaveMax(par1, par2)
 
     assert math.isclose(roiw, 0.006, abs_tol=0.00001)
     assert math.isclose(rois, 0.4, abs_tol=0.00001)
@@ -230,7 +232,7 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
     assert math.isclose(wavemin, 23.95, abs_tol=0.00001)
     assert math.isclose(wavemax, 28.45, abs_tol=0.00001)
 
-    #set up the ifucube class
+    # set up the ifucube class
     pars_cube = {
         'scale1': 0.0,
         'scale2': 0.0,
@@ -255,7 +257,7 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
     input_model = None
     output_name_base = None
     output_type = 'band'
-    instrument  = 'MIRI'
+    instrument = 'MIRI'
     list_par1 = all_channel
     list_par2 = all_subchannel
     master_table = None
@@ -273,24 +275,24 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
         master_table,
         **pars_cube)
 
-    this_cube.num_files = 1 # set in ifu cube
+    this_cube.num_files = 1  # set in ifu cube
     # test that the correct values read from the table are filled
     # in in the this_cube class. Also check that for this configuration
     # linear_wavelength = True
     this_cube.determine_cube_parameters()
     # now test if the user has provided input to build cube
 
-    assert math.isclose(this_cube.wavemin,wavemin, abs_tol=0.00001)
-    assert math.isclose(this_cube.wavemax,wavemax, abs_tol=0.00001)
-    assert this_cube.linear_wavelength == True
+    assert math.isclose(this_cube.wavemin, wavemin, abs_tol=0.00001)
+    assert math.isclose(this_cube.wavemax, wavemax, abs_tol=0.00001)
+    assert this_cube.linear_wavelength
 
     assert math.isclose(this_cube.weight_power, 2, abs_tol=0.00001)
     assert math.isclose(this_cube.roiw, roiw, abs_tol=0.00001)
-    rois = rois * 1.5 # increase for single file
+    rois = rois * 1.5  # increase for single file
     assert math.isclose(this_cube.rois, rois, abs_tol=0.00001)
     assert math.isclose(this_cube.spatial_size, 0.35, abs_tol=0.00001)
 
-    user_ascale  = 0.2
+    user_ascale = 0.2
     user_wscale = 0.05
     user_power = 1
     user_wave_min = 24.5
@@ -329,17 +331,18 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
         master_table,
         **pars_cube)
 
-    this_cube.num_files = 1 # set in check_ifucube
+    this_cube.num_files = 1  # set in check_ifucube
     this_cube.determine_cube_parameters()
     # do they match the user provided ones
-    assert math.isclose(this_cube.wavemin,user_wave_min, abs_tol=0.00001)
-    assert math.isclose(this_cube.wavemax,user_wave_max, abs_tol=0.00001)
-    assert this_cube.linear_wavelength == True
+    assert math.isclose(this_cube.wavemin, user_wave_min, abs_tol=0.00001)
+    assert math.isclose(this_cube.wavemax, user_wave_max, abs_tol=0.00001)
+    assert this_cube.linear_wavelength
     assert math.isclose(this_cube.spatial_size, user_ascale, abs_tol=0.00001)
     assert math.isclose(this_cube.spectral_size, user_wscale, abs_tol=0.00001)
     assert math.isclose(this_cube.weight_power, user_power, abs_tol=0.00001)
     assert math.isclose(this_cube.roiw, user_roiw, abs_tol=0.00001)
     assert math.isclose(this_cube.rois, user_rois, abs_tol=0.00001)
+
 
 def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
     """ Read in the miri cube pars file. Test cube has correct values when multiple bands are used """
@@ -385,17 +388,17 @@ def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
 
     # first check that it reads in correct values for this band
     # from the reference file
-    ascale,bscale,wscale = instrument_info.GetScale(par1,par2)
+    ascale, bscale, wscale = instrument_info.GetScale(par1, par2)
 
     assert math.isclose(ascale, 0.2, abs_tol=0.00001)
     assert math.isclose(bscale, 0.2, abs_tol=0.00001)
     assert math.isclose(wscale, 0.003, abs_tol=0.00001)
 
-    roiw = instrument_info.GetWaveRoi(par1,par2)
-    rois = instrument_info.GetSpatialRoi(par1,par2)
-    power = instrument_info.GetMSMPower(par1,par2)
-    wavemin = instrument_info.GetWaveMin(par1,par2)
-    wavemax = instrument_info.GetWaveMax(par1,par2)
+    roiw = instrument_info.GetWaveRoi(par1, par2)
+    rois = instrument_info.GetSpatialRoi(par1, par2)
+    power = instrument_info.GetMSMPower(par1, par2)
+    wavemin = instrument_info.GetWaveMin(par1, par2)
+    wavemax = instrument_info.GetWaveMax(par1, par2)
 
     assert math.isclose(roiw, 0.003, abs_tol=0.00001)
     assert math.isclose(rois, 0.2, abs_tol=0.00001)
@@ -403,7 +406,7 @@ def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
     assert math.isclose(wavemin, 13.37, abs_tol=0.00001)
     assert math.isclose(wavemax, 15.63, abs_tol=0.00001)
 
-    #set up the ifucube class
+    # set up the ifucube class
     pars_cube = {
         'scale1': 0.0,
         'scale2': 0.0,
@@ -428,7 +431,7 @@ def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
     input_model = None
     output_name_base = None
     output_type = 'multi'
-    instrument  = 'MIRI'
+    instrument = 'MIRI'
     list_par1 = all_channel
     list_par2 = all_subchannel
     master_table = None
@@ -446,7 +449,7 @@ def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
         master_table,
         **pars_cube)
 
-    this_cube.num_files = 12 # set in ifu cube
+    this_cube.num_files = 12  # set in ifu cube
     # test that the correct values read from the table are filled
     # in in the this_cube class when multiple bands and output_type = multi
     # are set. Also check that for this configuration linear_wavelength = False
@@ -454,17 +457,17 @@ def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
 
     # for multiple bands the smallest spatial scale is chosen
     assert math.isclose(this_cube.spatial_size, 0.13, abs_tol=0.00001)
-    assert this_cube.linear_wavelength == False
+    assert not this_cube.linear_wavelength
 
     # wavemin - min for channels 1-3 (min of channel 1 short)
-    assert math.isclose(this_cube.wavemin,4.89, abs_tol=0.00001)
+    assert math.isclose(this_cube.wavemin, 4.89, abs_tol=0.00001)
     # wavemas = max for channels 1-3 (max of channel 3 long)
-    assert math.isclose(this_cube.wavemax,18.05, abs_tol=0.00001)
+    assert math.isclose(this_cube.wavemax, 18.05, abs_tol=0.00001)
 
-    weight_test = np.array([1,2,3,4])
-    roiw_test = np.array([0.001,0.002,0.003,0.004])
-    rois_test = np.array([0.1,0.2,0.3,0.4])
-    wave_test = np.array([5,10,15,20])
+    weight_test = np.array([1, 2, 3, 4])
+    roiw_test = np.array([0.001, 0.002, 0.003, 0.004])
+    rois_test = np.array([0.1, 0.2, 0.3, 0.4])
+    wave_test = np.array([5, 10, 15, 20])
     assert np.allclose(this_cube.weight_power_table, weight_test, rtol=0.00001)
     assert np.allclose(this_cube.roiw_table, roiw_test, rtol=0.00001)
     assert np.allclose(this_cube.rois_table, rois_test, rtol=0.00001)

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -79,6 +79,7 @@ class ModelContainer(model_base.DataModel):
         super().__init__(init=None, asn_exptypes=None, **kwargs)
 
         self._models = []
+        self._iscopy = False
         self.asn_exptypes = asn_exptypes
         self.asn_n_members = asn_n_members
         self._memmap = kwargs.get("memmap", False)
@@ -108,6 +109,7 @@ class ModelContainer(model_base.DataModel):
             self._ctx = self
             self.__class__ = init.__class__
             self._models = init._models
+            self._iscopy = True
         elif is_association(init):
             self.from_asn(init)
         elif isinstance(init, str):
@@ -377,8 +379,9 @@ class ModelContainer(model_base.DataModel):
 
     def close(self):
         """Close all datamodels."""
-        for model in self._models:
-            model.close()
+        if not self._iscopy:
+            for model in self._models:
+                model.close()
 
 
 def make_file_with_index(file_path, idx):

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -307,7 +307,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         _drop_array(self._instance)
 
     def close(self):
-        if not self._iscopy and getattr(self, '_asdf', None) is not None:
+        if not self._iscopy and self._asdf is not None:
             self._asdf.close()
             self._drop_arrays()
 

--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -406,42 +406,42 @@ def test_table_with_unsigned_int():
         }
     }
 
-    dm = DataModel(schema=schema)
+    with DataModel(schema=schema) as dm:
 
-    float64_info = np.finfo(np.float64)
-    float64_arr = np.random.uniform(size=(10,))
-    float64_arr[0] = float64_info.min
-    float64_arr[-1] = float64_info.max
+        float64_info = np.finfo(np.float64)
+        float64_arr = np.random.uniform(size=(10,))
+        float64_arr[0] = float64_info.min
+        float64_arr[-1] = float64_info.max
 
-    uint32_info = np.iinfo(np.uint32)
-    uint32_arr = np.random.randint(uint32_info.min, uint32_info.max + 1, size=(10,), dtype=np.uint32)
-    uint32_arr[0] = uint32_info.min
-    uint32_arr[-1] = uint32_info.max
+        uint32_info = np.iinfo(np.uint32)
+        uint32_arr = np.random.randint(uint32_info.min, uint32_info.max + 1, size=(10,), dtype=np.uint32)
+        uint32_arr[0] = uint32_info.min
+        uint32_arr[-1] = uint32_info.max
 
-    test_table = np.array(list(zip(float64_arr, uint32_arr)), dtype=dm.test_table.dtype)
+        test_table = np.array(list(zip(float64_arr, uint32_arr)), dtype=dm.test_table.dtype)
 
-    def assert_table_correct(model):
-        for idx, (col_name, col_data) in enumerate([('float64_col', float64_arr), ('uint32_col', uint32_arr)]):
-            # The table dtype and field dtype are stored separately, and may not
-            # necessarily agree.
-            assert np.can_cast(model.test_table.dtype[idx], col_data.dtype, 'equiv')
-            assert np.can_cast(model.test_table.field(col_name).dtype, col_data.dtype, 'equiv')
-            assert np.array_equal(model.test_table.field(col_name), col_data)
+        def assert_table_correct(model):
+            for idx, (col_name, col_data) in enumerate([('float64_col', float64_arr), ('uint32_col', uint32_arr)]):
+                # The table dtype and field dtype are stored separately, and may not
+                # necessarily agree.
+                assert np.can_cast(model.test_table.dtype[idx], col_data.dtype, 'equiv')
+                assert np.can_cast(model.test_table.field(col_name).dtype, col_data.dtype, 'equiv')
+                assert np.array_equal(model.test_table.field(col_name), col_data)
 
-    # The datamodel casts our array to FITS_rec on assignment, so here we're
-    # checking that the data survived the casting.
-    dm.test_table = test_table
-    assert_table_correct(dm)
+        # The datamodel casts our array to FITS_rec on assignment, so here we're
+        # checking that the data survived the casting.
+        dm.test_table = test_table
+        assert_table_correct(dm)
 
-    # Confirm that saving the table (and converting the uint32 values to signed int w/TZEROn)
-    # doesn't mangle the data.
-    dm.save(TMP_FITS)
-    assert_table_correct(dm)
+        # Confirm that saving the table (and converting the uint32 values to signed int w/TZEROn)
+        # doesn't mangle the data.
+        dm.save(TMP_FITS)
+        assert_table_correct(dm)
 
     # Confirm that the data loads from the file intact (converting the signed ints back to
     # the appropriate uint32 values).
-    dm2 = DataModel(TMP_FITS, schema=schema)
-    assert_table_correct(dm2)
+    with DataModel(TMP_FITS, schema=schema) as dm2:
+        assert_table_correct(dm2)
 
 
 def test_metadata_from_fits():

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -617,12 +617,18 @@ def test_hasattr():
 
 
 def test_validate_on_read():
+    """ Test for proper validation error
+
+    Note: The FITS file is opened separately in order to properly close
+    the file.
+    """
     schema = ImageModel((10, 10))._schema.copy()
     schema['properties']['meta']['properties']['calibration_software_version']['fits_required'] = True
+    hduls = fits.open(FITS_FILE)
 
     with pytest.raises(jsonschema.ValidationError):
-        with ImageModel(FITS_FILE, schema=schema, strict_validation=True):
-            pass
+        ImageModel(hduls, schema=schema, strict_validation=True)
+    hduls.close()
 
 
 def test_validate_required_field():

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -624,11 +624,10 @@ def test_validate_on_read():
     """
     schema = ImageModel((10, 10))._schema.copy()
     schema['properties']['meta']['properties']['calibration_software_version']['fits_required'] = True
-    hduls = fits.open(FITS_FILE)
 
-    with pytest.raises(jsonschema.ValidationError):
-        ImageModel(hduls, schema=schema, strict_validation=True)
-    hduls.close()
+    with fits.open(FITS_FILE) as hduls:
+        with pytest.raises(jsonschema.ValidationError):
+            ImageModel(hduls, schema=schema, strict_validation=True)
 
 
 def test_validate_required_field():

--- a/jwst/exp_to_source/tests/test_exp_to_source.py
+++ b/jwst/exp_to_source/tests/test_exp_to_source.py
@@ -14,7 +14,9 @@ def run_exp_to_source():
         for f in helpers.INPUT_FILES
     ]
     outputs = exp_to_source(inputs)
-    return inputs, outputs
+    yield inputs, outputs
+    for model in inputs:
+        model.close()
 
 
 @pytest.fixture(scope='module')
@@ -46,13 +48,13 @@ def test_model_roundtrip(tmpdir, run_exp_to_source):
         outputs[output].save(file_path)
         files.append(file_path)
     for file_path in files:
-        multiexposure_model = MultiExposureModel(file_path)
-        assert len(multiexposure_model.exposures) == 3
-        exp_files = set()
-        for exposure in multiexposure_model.exposures:
-            exp_files.add(exposure.meta.filename)
-        assert len(exp_files) == len(multiexposure_model.exposures)
-        assert multiexposure_model.meta.filename not in exp_files
+        with MultiExposureModel(file_path) as multiexposure_model:
+            assert len(multiexposure_model.exposures) == 3
+            exp_files = set()
+            for exposure in multiexposure_model.exposures:
+                exp_files.add(exposure.meta.filename)
+            assert len(exp_files) == len(multiexposure_model.exposures)
+            assert multiexposure_model.meta.filename not in exp_files
 
 
 def test_container_structure(run_multislit_to_container):

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -184,32 +184,30 @@ def add_wcs(filename, default_pa_v3=0., siaf_path=None, engdb_url=None,
     in the header other than what is required by the standard.
     """
     logger.info('Updating WCS info for file {}'.format(filename))
-    model = Level1bModel(filename)
-    update_wcs(
-        model,
-        default_pa_v3=default_pa_v3,
-        siaf_path=siaf_path,
-        engdb_url=engdb_url,
-        tolerance=tolerance,
-        allow_default=allow_default,
-        reduce_func=reduce_func,
-        **transform_kwargs
-    )
+    with Level1bModel(filename) as model:
+        update_wcs(
+            model,
+            default_pa_v3=default_pa_v3,
+            siaf_path=siaf_path,
+            engdb_url=engdb_url,
+            tolerance=tolerance,
+            allow_default=allow_default,
+            reduce_func=reduce_func,
+            **transform_kwargs
+        )
 
-    try:
-        if model.meta.target.type.lower() == 'moving':
-            update_mt_kwds(model)
-    except AttributeError:
-        pass
+        try:
+            if model.meta.target.type.lower() == 'moving':
+                update_mt_kwds(model)
+        except AttributeError:
+            pass
 
-    model.meta.model_type = None
+        model.meta.model_type = None
 
-    if dry_run:
-        logger.info('Dry run requested; results are not saved.')
-    else:
-        model.save(filename)
-
-    model.close()
+        if dry_run:
+            logger.info('Dry run requested; results are not saved.')
+        else:
+            model.save(filename)
     logger.info('...update completed')
 
 def update_mt_kwds(model):

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -228,42 +228,42 @@ def test_add_wcs_default(data_file):
             '\nException={}'.format(e)
         )
 
-    model = datamodels.Level1bModel(data_file)
-    assert model.meta.pointing.ra_v1 == TARG_RA
-    assert model.meta.pointing.dec_v1 == TARG_DEC
-    assert model.meta.pointing.pa_v3 == 0.
-    assert model.meta.wcsinfo.wcsaxes == 2
-    assert model.meta.wcsinfo.crpix1 == 693.5
-    assert model.meta.wcsinfo.crpix2 == 512.5
-    assert model.meta.wcsinfo.crval1 == TARG_RA
-    assert model.meta.wcsinfo.crval2 == TARG_DEC
-    assert model.meta.wcsinfo.ctype1 == "RA---TAN"
-    assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
-    assert model.meta.wcsinfo.cunit1 == 'deg'
-    assert model.meta.wcsinfo.cunit2 == 'deg'
-    assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7558009243361943)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.654801468211972)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.654801468211972)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7558009243361943)
-    assert model.meta.wcsinfo.v2_ref == 200.0
-    assert model.meta.wcsinfo.v3_ref == -350.0
-    assert model.meta.wcsinfo.vparity == -1
-    assert model.meta.wcsinfo.v3yangle == 42.0
-    assert model.meta.wcsinfo.ra_ref == TARG_RA
-    assert model.meta.wcsinfo.dec_ref == TARG_DEC
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 358.9045979379)
-    assert word_precision_check(
-        model.meta.wcsinfo.s_region,
-        (
-            'POLYGON ICRS'
-            ' 345.11054995209815 -87.02586884935684'
-            ' 344.6537904121288 -87.00498014679253'
-            ' 345.04569816117015 -86.98138111042982'
-            ' 345.50498899320183 -87.00187988107017'
+    with datamodels.Level1bModel(data_file) as model:
+        assert model.meta.pointing.ra_v1 == TARG_RA
+        assert model.meta.pointing.dec_v1 == TARG_DEC
+        assert model.meta.pointing.pa_v3 == 0.
+        assert model.meta.wcsinfo.wcsaxes == 2
+        assert model.meta.wcsinfo.crpix1 == 693.5
+        assert model.meta.wcsinfo.crpix2 == 512.5
+        assert model.meta.wcsinfo.crval1 == TARG_RA
+        assert model.meta.wcsinfo.crval2 == TARG_DEC
+        assert model.meta.wcsinfo.ctype1 == "RA---TAN"
+        assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
+        assert model.meta.wcsinfo.cunit1 == 'deg'
+        assert model.meta.wcsinfo.cunit2 == 'deg'
+        assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
+        assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
+        assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7558009243361943)
+        assert np.isclose(model.meta.wcsinfo.pc1_2, 0.654801468211972)
+        assert np.isclose(model.meta.wcsinfo.pc2_1, 0.654801468211972)
+        assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7558009243361943)
+        assert model.meta.wcsinfo.v2_ref == 200.0
+        assert model.meta.wcsinfo.v3_ref == -350.0
+        assert model.meta.wcsinfo.vparity == -1
+        assert model.meta.wcsinfo.v3yangle == 42.0
+        assert model.meta.wcsinfo.ra_ref == TARG_RA
+        assert model.meta.wcsinfo.dec_ref == TARG_DEC
+        assert np.isclose(model.meta.wcsinfo.roll_ref, 358.9045979379)
+        assert word_precision_check(
+            model.meta.wcsinfo.s_region,
+            (
+                'POLYGON ICRS'
+                ' 345.11054995209815 -87.02586884935684'
+                ' 344.6537904121288 -87.00498014679253'
+                ' 345.04569816117015 -86.98138111042982'
+                ' 345.50498899320183 -87.00187988107017'
+            )
         )
-    )
 
 
 def test_add_wcs_default_nosiaf(data_file_nosiaf, caplog):
@@ -290,42 +290,42 @@ def test_add_wcs_fsmcorr_v1(data_file):
             '\nException={}'.format(e)
         )
 
-    model = datamodels.Level1bModel(data_file)
-    assert model.meta.pointing.ra_v1 == TARG_RA
-    assert model.meta.pointing.dec_v1 == TARG_DEC
-    assert model.meta.pointing.pa_v3 == 0.
-    assert model.meta.wcsinfo.wcsaxes == 2
-    assert model.meta.wcsinfo.crpix1 == 693.5
-    assert model.meta.wcsinfo.crpix2 == 512.5
-    assert model.meta.wcsinfo.crval1 == TARG_RA
-    assert model.meta.wcsinfo.crval2 == TARG_DEC
-    assert model.meta.wcsinfo.ctype1 == "RA---TAN"
-    assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
-    assert model.meta.wcsinfo.cunit1 == 'deg'
-    assert model.meta.wcsinfo.cunit2 == 'deg'
-    assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7558009243361943)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.654801468211972)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.654801468211972)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7558009243361943)
-    assert model.meta.wcsinfo.v2_ref == 200.0
-    assert model.meta.wcsinfo.v3_ref == -350.0
-    assert model.meta.wcsinfo.vparity == -1
-    assert model.meta.wcsinfo.v3yangle == 42.0
-    assert model.meta.wcsinfo.ra_ref == TARG_RA
-    assert model.meta.wcsinfo.dec_ref == TARG_DEC
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 358.9045979379)
-    assert word_precision_check(
-        model.meta.wcsinfo.s_region,
-        (
-            'POLYGON ICRS'
-            ' 345.11054995209815 -87.02586884935684'
-            ' 344.6537904121288 -87.00498014679253'
-            ' 345.04569816117015 -86.98138111042982'
-            ' 345.50498899320183 -87.00187988107017'
+    with  datamodels.Level1bModel(data_file) as model:
+        assert model.meta.pointing.ra_v1 == TARG_RA
+        assert model.meta.pointing.dec_v1 == TARG_DEC
+        assert model.meta.pointing.pa_v3 == 0.
+        assert model.meta.wcsinfo.wcsaxes == 2
+        assert model.meta.wcsinfo.crpix1 == 693.5
+        assert model.meta.wcsinfo.crpix2 == 512.5
+        assert model.meta.wcsinfo.crval1 == TARG_RA
+        assert model.meta.wcsinfo.crval2 == TARG_DEC
+        assert model.meta.wcsinfo.ctype1 == "RA---TAN"
+        assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
+        assert model.meta.wcsinfo.cunit1 == 'deg'
+        assert model.meta.wcsinfo.cunit2 == 'deg'
+        assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
+        assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
+        assert np.isclose(model.meta.wcsinfo.pc1_1, -0.7558009243361943)
+        assert np.isclose(model.meta.wcsinfo.pc1_2, 0.654801468211972)
+        assert np.isclose(model.meta.wcsinfo.pc2_1, 0.654801468211972)
+        assert np.isclose(model.meta.wcsinfo.pc2_2, 0.7558009243361943)
+        assert model.meta.wcsinfo.v2_ref == 200.0
+        assert model.meta.wcsinfo.v3_ref == -350.0
+        assert model.meta.wcsinfo.vparity == -1
+        assert model.meta.wcsinfo.v3yangle == 42.0
+        assert model.meta.wcsinfo.ra_ref == TARG_RA
+        assert model.meta.wcsinfo.dec_ref == TARG_DEC
+        assert np.isclose(model.meta.wcsinfo.roll_ref, 358.9045979379)
+        assert word_precision_check(
+            model.meta.wcsinfo.s_region,
+            (
+                'POLYGON ICRS'
+                ' 345.11054995209815 -87.02586884935684'
+                ' 344.6537904121288 -87.00498014679253'
+                ' 345.04569816117015 -86.98138111042982'
+                ' 345.50498899320183 -87.00187988107017'
+            )
         )
-    )
 
 
 @pytest.mark.skipif(sys.version_info.major<3,
@@ -334,42 +334,42 @@ def test_add_wcs_with_db(eng_db_ngas, data_file, siaf_file=siaf_db):
     """Test using the database"""
     stp.add_wcs(data_file, siaf_path=siaf_db, j2fgs_transpose=False)
 
-    model = datamodels.Level1bModel(data_file)
-    assert np.isclose(model.meta.pointing.ra_v1, 348.9278669)
-    assert np.isclose(model.meta.pointing.dec_v1, -38.749239)
-    assert np.isclose(model.meta.pointing.pa_v3, 50.1767077)
-    assert model.meta.wcsinfo.wcsaxes == 2
-    assert model.meta.wcsinfo.crpix1 == 693.5
-    assert model.meta.wcsinfo.crpix2 == 512.5
-    assert np.isclose(model.meta.wcsinfo.crval1, 348.8776709)
-    assert np.isclose(model.meta.wcsinfo.crval2, -38.854159)
-    assert model.meta.wcsinfo.ctype1 == "RA---TAN"
-    assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
-    assert model.meta.wcsinfo.cunit1 == 'deg'
-    assert model.meta.wcsinfo.cunit2 == 'deg'
-    assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.03853303979862607)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992573266400789)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992573266400789)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.03853303979862607)
-    assert model.meta.wcsinfo.v2_ref == 200.0
-    assert model.meta.wcsinfo.v3_ref == -350.0
-    assert model.meta.wcsinfo.vparity == -1
-    assert model.meta.wcsinfo.v3yangle == 42.0
-    assert np.isclose(model.meta.wcsinfo.ra_ref, 348.8776709)
-    assert np.isclose(model.meta.wcsinfo.dec_ref, -38.854159)
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 50.20832726650)
-    assert word_precision_check(
-        model.meta.wcsinfo.s_region,
-        (
-            'POLYGON ICRS'
-            ' 348.8563379013152 -38.874810886750495'
-            ' 348.85810582665334 -38.84318773861823'
-            ' 348.8982592685148 -38.84439628911871'
-            ' 348.89688051688233 -38.876020020321164'
+    with datamodels.Level1bModel(data_file) as model:
+        assert np.isclose(model.meta.pointing.ra_v1, 348.9278669)
+        assert np.isclose(model.meta.pointing.dec_v1, -38.749239)
+        assert np.isclose(model.meta.pointing.pa_v3, 50.1767077)
+        assert model.meta.wcsinfo.wcsaxes == 2
+        assert model.meta.wcsinfo.crpix1 == 693.5
+        assert model.meta.wcsinfo.crpix2 == 512.5
+        assert np.isclose(model.meta.wcsinfo.crval1, 348.8776709)
+        assert np.isclose(model.meta.wcsinfo.crval2, -38.854159)
+        assert model.meta.wcsinfo.ctype1 == "RA---TAN"
+        assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
+        assert model.meta.wcsinfo.cunit1 == 'deg'
+        assert model.meta.wcsinfo.cunit2 == 'deg'
+        assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
+        assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
+        assert np.isclose(model.meta.wcsinfo.pc1_1, 0.03853303979862607)
+        assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992573266400789)
+        assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992573266400789)
+        assert np.isclose(model.meta.wcsinfo.pc2_2, -0.03853303979862607)
+        assert model.meta.wcsinfo.v2_ref == 200.0
+        assert model.meta.wcsinfo.v3_ref == -350.0
+        assert model.meta.wcsinfo.vparity == -1
+        assert model.meta.wcsinfo.v3yangle == 42.0
+        assert np.isclose(model.meta.wcsinfo.ra_ref, 348.8776709)
+        assert np.isclose(model.meta.wcsinfo.dec_ref, -38.854159)
+        assert np.isclose(model.meta.wcsinfo.roll_ref, 50.20832726650)
+        assert word_precision_check(
+            model.meta.wcsinfo.s_region,
+            (
+                'POLYGON ICRS'
+                ' 348.8563379013152 -38.874810886750495'
+                ' 348.85810582665334 -38.84318773861823'
+                ' 348.8982592685148 -38.84439628911871'
+                ' 348.89688051688233 -38.876020020321164'
+            )
         )
-    )
 
 
 @pytest.mark.skipif(sys.version_info.major<3,
@@ -378,75 +378,73 @@ def test_add_wcs_with_db_fsmcorr_v1(eng_db_ngas, data_file):
     """Test using the database with original FSM correction"""
     stp.add_wcs(data_file, fsmcorr_version='v1', siaf_path=siaf_db, j2fgs_transpose=False)
 
-    model = datamodels.Level1bModel(data_file)
-    assert np.isclose(model.meta.pointing.ra_v1, 348.9278669)
-    assert np.isclose(model.meta.pointing.dec_v1, -38.749239)
-    assert np.isclose(model.meta.pointing.pa_v3, 50.1767077)
-    assert model.meta.wcsinfo.wcsaxes == 2
-    assert model.meta.wcsinfo.crpix1 == 693.5
-    assert model.meta.wcsinfo.crpix2 == 512.5
-    assert np.isclose(model.meta.wcsinfo.crval1, 348.8776709)
-    assert np.isclose(model.meta.wcsinfo.crval2, -38.854159)
-    assert model.meta.wcsinfo.ctype1 == "RA---TAN"
-    assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
-    assert model.meta.wcsinfo.cunit1 == 'deg'
-    assert model.meta.wcsinfo.cunit2 == 'deg'
-    assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
-    assert np.isclose(model.meta.wcsinfo.pc1_1, 0.03853303979862607)
-    assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992573266400789)
-    assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992573266400789)
-    assert np.isclose(model.meta.wcsinfo.pc2_2, -0.03853303979862607)
-    assert model.meta.wcsinfo.v2_ref == 200.0
-    assert model.meta.wcsinfo.v3_ref == -350.0
-    assert model.meta.wcsinfo.vparity == -1
-    assert model.meta.wcsinfo.v3yangle == 42.0
-    assert np.isclose(model.meta.wcsinfo.ra_ref, 348.8776709)
-    assert np.isclose(model.meta.wcsinfo.dec_ref, -38.854159)
-    assert np.isclose(model.meta.wcsinfo.roll_ref, 50.20832726650)
-    assert word_precision_check(
-        model.meta.wcsinfo.s_region,
-        (
-            'POLYGON ICRS'
-            ' 348.8563379013152 -38.874810886750495'
-            ' 348.85810582665334 -38.84318773861823'
-            ' 348.8982592685148 -38.84439628911871'
-            ' 348.89688051688233 -38.876020020321164'
+    with datamodels.Level1bModel(data_file) as model:
+        assert np.isclose(model.meta.pointing.ra_v1, 348.9278669)
+        assert np.isclose(model.meta.pointing.dec_v1, -38.749239)
+        assert np.isclose(model.meta.pointing.pa_v3, 50.1767077)
+        assert model.meta.wcsinfo.wcsaxes == 2
+        assert model.meta.wcsinfo.crpix1 == 693.5
+        assert model.meta.wcsinfo.crpix2 == 512.5
+        assert np.isclose(model.meta.wcsinfo.crval1, 348.8776709)
+        assert np.isclose(model.meta.wcsinfo.crval2, -38.854159)
+        assert model.meta.wcsinfo.ctype1 == "RA---TAN"
+        assert model.meta.wcsinfo.ctype2 == "DEC--TAN"
+        assert model.meta.wcsinfo.cunit1 == 'deg'
+        assert model.meta.wcsinfo.cunit2 == 'deg'
+        assert np.isclose(model.meta.wcsinfo.cdelt1, 3.0555555e-5)
+        assert np.isclose(model.meta.wcsinfo.cdelt2, 3.0555555e-5)
+        assert np.isclose(model.meta.wcsinfo.pc1_1, 0.03853303979862607)
+        assert np.isclose(model.meta.wcsinfo.pc1_2, 0.9992573266400789)
+        assert np.isclose(model.meta.wcsinfo.pc2_1, 0.9992573266400789)
+        assert np.isclose(model.meta.wcsinfo.pc2_2, -0.03853303979862607)
+        assert model.meta.wcsinfo.v2_ref == 200.0
+        assert model.meta.wcsinfo.v3_ref == -350.0
+        assert model.meta.wcsinfo.vparity == -1
+        assert model.meta.wcsinfo.v3yangle == 42.0
+        assert np.isclose(model.meta.wcsinfo.ra_ref, 348.8776709)
+        assert np.isclose(model.meta.wcsinfo.dec_ref, -38.854159)
+        assert np.isclose(model.meta.wcsinfo.roll_ref, 50.20832726650)
+        assert word_precision_check(
+            model.meta.wcsinfo.s_region,
+            (
+                'POLYGON ICRS'
+                ' 348.8563379013152 -38.874810886750495'
+                ' 348.85810582665334 -38.84318773861823'
+                ' 348.8982592685148 -38.84439628911871'
+                ' 348.89688051688233 -38.876020020321164'
+            )
         )
-    )
 
 
 def test_default_siaf_values(eng_db_ngas, data_file_nosiaf):
     """
     Test that FITS WCS default values were set.
     """
-    model = datamodels.Level1bModel(data_file_nosiaf)
-    model.meta.exposure.start_time = STARTTIME.mjd
-    model.meta.exposure.end_time = ENDTIME.mjd
-    model.meta.target.ra = TARG_RA
-    model.meta.target.dec = TARG_DEC
-    model.meta.aperture.name = "MIRIM_TAFULL"
-    model.meta.observation.date = '1/1/2017'
-    model.meta.exposure.type = "MIR_IMAGE"
-    stp.update_wcs(model, siaf_path=siaf_db, allow_default=False)
-    assert model.meta.wcsinfo.crpix1 == 0
-    assert model.meta.wcsinfo.crpix2 == 0
-    assert model.meta.wcsinfo.cdelt1 == 1
-    assert model.meta.wcsinfo.cdelt2 == 1
+    with datamodels.Level1bModel(data_file_nosiaf) as model:
+        model.meta.exposure.start_time = STARTTIME.mjd
+        model.meta.exposure.end_time = ENDTIME.mjd
+        model.meta.target.ra = TARG_RA
+        model.meta.target.dec = TARG_DEC
+        model.meta.aperture.name = "MIRIM_TAFULL"
+        model.meta.observation.date = '1/1/2017'
+        model.meta.exposure.type = "MIR_IMAGE"
+        stp.update_wcs(model, siaf_path=siaf_db, allow_default=False)
+        assert model.meta.wcsinfo.crpix1 == 0
+        assert model.meta.wcsinfo.crpix2 == 0
+        assert model.meta.wcsinfo.cdelt1 == 1
+        assert model.meta.wcsinfo.cdelt2 == 1
 
 
 def test_tsgrism_siaf_values(eng_db_ngas, data_file_nosiaf):
     """
     Test that FITS WCS default values were set.
     """
-    model = datamodels.Level1bModel(data_file_nosiaf)
-    model.meta.exposure.start_time = STARTTIME.mjd
-    model.meta.exposure.end_time = ENDTIME.mjd
-    #model.meta.target.ra = TARG_RA
-    #model.meta.target.dec = TARG_DEC
-    model.meta.aperture.name = "NRCA5_GRISM256_F444W"
-    model.meta.observation.date = '1/1/2017'
-    model.meta.exposure.type = "NRC_TSGRISM"
-    stp.update_wcs(model, siaf_path=siaf_db)
-    assert model.meta.wcsinfo.siaf_xref_sci == 887
-    assert model.meta.wcsinfo.siaf_yref_sci == 35
+    with datamodels.Level1bModel(data_file_nosiaf) as model:
+        model.meta.exposure.start_time = STARTTIME.mjd
+        model.meta.exposure.end_time = ENDTIME.mjd
+        model.meta.aperture.name = "NRCA5_GRISM256_F444W"
+        model.meta.observation.date = '1/1/2017'
+        model.meta.exposure.type = "NRC_TSGRISM"
+        stp.update_wcs(model, siaf_path=siaf_db)
+        assert model.meta.wcsinfo.siaf_xref_sci == 887
+        assert model.meta.wcsinfo.siaf_yref_sci == 35

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -468,8 +468,6 @@ class Step():
         finally:
             log.delegator.log = orig_log
 
-        self.closeout(to_close=args)
-
         return step_result
 
     __call__ = run

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -139,12 +139,12 @@ class SaveStep(Step):
     """
 
     def process(self, *args):
-        with ImageModel(args[0]) as model:
+        model = ImageModel(args[0])
 
-            self.log.info('Saving model as "processed"')
-            self.save_model(model, 'processed')
+        self.log.info('Saving model as "processed"')
+        self.save_model(model, 'processed')
 
-            return model
+        return model
 
 
 class StepWithContainer(Step):
@@ -172,9 +172,9 @@ class StepWithModel(Step):
     """
 
     def process(self, *args):
-        with self.open_model(args[0]) as input_path:
-            with ImageModel(input_path) as model:
-                return model
+        model = self.open_model(args[0])
+        model = ImageModel(model)
+        return model
 
 
 class EmptyPipeline(Pipeline):

--- a/jwst/stpipe/tests/test_pipeline.py
+++ b/jwst/stpipe/tests/test_pipeline.py
@@ -60,9 +60,9 @@ class MultiplyBy2(Step):
 
     def process(self, image):
         with datamodels.ImageModel(image) as dm:
-            with datamodels.ImageModel() as dm2:
-                dm2.data = dm.data * 2
-                return dm2
+            dm2 = datamodels.ImageModel()
+            dm2.data = dm.data * 2
+            return dm2
 
 
 class MyPipeline(Pipeline):

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,11 @@ DOCS_REQUIRE = [
 ]
 TESTS_REQUIRE = [
     'ci-watson>=0.3.0',
-    'pytest>=3.9.1',
+    'pytest>=4.6.0',
     'pytest-doctestplus',
     'requests_mock>=1.0',
-    'pytest-openfiles',
-    'pytest-cov>=2.0.0',
+    'pytest-openfiles>=0.5.0',
+    'pytest-cov>=2.9.0',
     'codecov>=1.6.0',
 ]
 AWS_REQUIRE = [


### PR DESCRIPTION
Or, well methinks its nonsensical anyways, but the PR review will indicate otherwise.

In general, when a `DataModel` is opened from a FITS file, the filehandle for the FITS file is held internally until the `DataModel` is `close`ed garbage-collected (maybe). However, ran across this bit of code in which the FITS file is opened in a context manager and the file handled is stored for later closing. This would be the nonsensical point: either a context manager should not be used OR the filehandle should not be stored for later re-closing.

Though having the FITS file open is an integral part of `DataModel` operation, this appears to have not had any operational effect. But, current work on `DataModel` reading efficiency has actually caused the expected "I/O operation on closed file" error.

Because of the confusing nature of the current code, and with an eye to possible future issues, this PR, which removes the context manager bit and leaving closing to the intended (?) closing of the DataModel itself, is being filed.

The set of file changes are as follows
    - The fix is in `model_base.py`
    - Many tests and a couple cube-related modules have been modified to use contexts as needed.
    - Finally, and my apologies, a number of tests are changed only for PEP8 issues.