### PR TITLE
Fix flake8 F523 and F541 bugs dealing with .format() and f-strings

### DIFF
--- a/jwst/engdblog/tests/test_engdblog.py
+++ b/jwst/engdblog/tests/test_engdblog.py
@@ -32,7 +32,7 @@ def test_barestring(caplog, engdb):
     assert mnemonic in result
     assert 'EngDBLogStep instance created' in caplog.text
     assert mnemonic in caplog.text
-    assert "Step EngDBLogStep running with args ('INRSI_GWA_Y_TILT_AVGED',).".format(mnemonic) in caplog.text
+    assert f"Step EngDBLogStep running with args ('{mnemonic}')." in caplog.text
     assert '{}[2016-01-01:2016-01-31] = '.format(mnemonic) in caplog.text
     assert 'Step EngDBLogStep done' in caplog.text
 

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -53,11 +53,11 @@ def set_source_type(input_model):
             user_type = input_model.meta.target.source_type_apt
             log.info(f'Input SRCTYAPT = {user_type}')
             if user_type is None:
-                log.warning(f'SRCTYAPT keyword not found in input; using SRCTYPE instead')
+                log.warning('SRCTYAPT keyword not found in input; using SRCTYPE instead')
                 user_type = input_model.meta.target.source_type
                 input_model.meta.target.source_type_apt = user_type
         except AttributeError:
-            log.warning(f'SRCTYAPT keyword not found in input; using SRCTYPE instead')
+            log.warning('SRCTYAPT keyword not found in input; using SRCTYPE instead')
             user_type = input_model.meta.target.source_type
             input_model.meta.target.source_type_apt = user_type
 

--- a/jwst/stpipe/subproc.py
+++ b/jwst/stpipe/subproc.py
@@ -61,7 +61,7 @@ class SystemCall(Step):
         newargs = []
         for i, arg in enumerate(args):
             if isinstance(arg, datamodels.DataModel):
-                filename = "{0}.{1:04d}.{1}".format(
+                filename = "{0}.{1:04d}.{2}".format(
                     self.qualified_name, i, arg.get_fileext())
                 arg.save(filename)
                 newargs.append(filename)


### PR DESCRIPTION
The new version of `flake8` has uncovered some long-existing string formatting bugs in our code.  And some new-ish ones.  Seen here

https://travis-ci.org/github/spacetelescope/jwst/jobs/685867988#L216-L220

```
./jwst/stpipe/subproc.py:64:28: F523 '...'.format(...) has unused arguments at position(s): 2
./jwst/srctype/srctype.py:56:29: F541 f-string is missing placeholders
./jwst/srctype/srctype.py:60:25: F541 f-string is missing placeholders
./jwst/engdblog/tests/test_engdblog.py:35:12: F523 '...'.format(...) has unused arguments at position(s): 0
```

And of course these are failing on `master` in our PEP8 check.  This PR fixes them.