### PR TITLE
JP-1448: Only load science/bkg members in calimage3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ associations
 ------------
 - Modify NIRSpec IFU level-3 ASN rules to include only one grating per association [#4845]
 
+pipeline
+--------
+
+- Updated calwebb_image3 pipeline to only load science and background member
+  types from an input ASN. [#4937]
+
 source_catalog
 --------------
 

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -53,10 +53,11 @@ class Image3Pipeline(Pipeline):
 
         self.log.info('Starting calwebb_image3 ...')
 
-        input_models = datamodels.open(input)
+        # Only load science and background members from input ASN
+        asn_exptypes = ['science', 'background']
+        input_models = datamodels.open(input, asn_exptypes=asn_exptypes)
 
-        # If input is an association, set the output to the product
-        # name.
+        # If input is an association, set the output to the product name.
         try:
             self.output_file = input_models.meta.asn_table.products[0].name
         except AttributeError:


### PR DESCRIPTION
Updated the `calwebb_image3` pipeline module to only load `science` and `background` member types from the input ASN (just like `calwebb_spec3`). Verified that this still works properly when the input is a single cal file and not an ASN.

Fixes #4933 / [JP-1448](jw00623020001_06101_00003_mirimage_cal.fits)