### PR TITLE
JP-1444: Remove path from SCATFILE keyword for NIRISS WFSS in Spec2Pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ pipeline
   types from an input ASN. [#4937]
 
 - Updated the calwebb_spec2 pipeline to only use the basename of the source
-  catalogue file when updating the source_catalogue keyword for WFSS inputs.
+  catalog file when updating the source_catalogue keyword for WFSS inputs.
   [#4940]
 
 rscd

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ pipeline
 - Updated calwebb_image3 pipeline to only load science and background member
   types from an input ASN. [#4937]
 
+- Updated the calwebb_spec2 pipeline to only use the basename of the source
+  catalogue file when updating the source_catalogue keyword for WFSS inputs.
+  [#4940
+
 rscd
 ----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ pipeline
 
 - Updated the calwebb_spec2 pipeline to only use the basename of the source
   catalogue file when updating the source_catalogue keyword for WFSS inputs.
-  [#4940
+  [#4940]
 
 rscd
 ----

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -1,3 +1,4 @@
+import os
 from collections import defaultdict
 import os.path as op
 import traceback
@@ -164,7 +165,7 @@ class Spec2Pipeline(Pipeline):
         # name from the asn and record it to the meta
         if exp_type in WFSS_TYPES:
             try:
-                input.meta.source_catalog = members_by_type['sourcecat'][0]
+                input.meta.source_catalog = os.path.basename(members_by_type['sourcecat'][0])
                 self.log.info('Using sourcecat file {}'.format(input.meta.source_catalog))
             except IndexError:
                 if input.meta.source_catalog is None:

--- a/jwst/regtest/test_niriss_wfss.py
+++ b/jwst/regtest/test_niriss_wfss.py
@@ -40,7 +40,6 @@ def run_nis_wfss_spec2(jail, rtdata_module):
 )
 def test_nis_wfss_spec2(run_nis_wfss_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test for calwebb_spec2 applied to NIRISS WFSS data"""
-    fitsdiff_default_kwargs['ignore_keywords'].append('SCATFILE')
     rt.is_like_truth(
         run_nis_wfss_spec2, fitsdiff_default_kwargs, suffix, 'truth/test_niriss_wfss'
     )


### PR DESCRIPTION
This PR removes the path from the source catalog file before setting it as the `SCATFILE` keyword value in the `Spec2Pipeline`. 

Resolves #4923 / [JP-1444](https://jira.stsci.edu/browse/JP-1444)