### PR TITLE
JP-1447: Fix set difference bug in get_object_info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@
 assign_wcs
 ----------
 
-- Update get_object_info to check for and replace legacy keys for WFSS inputs [#4943]
+- Update keyword and attribute usage around SkyObject to reflect updated keywords. [#4943]
+
 associations
 ------------
 
@@ -18,6 +19,11 @@ datamodels
 - Updated core schema to include recent Keyword Dictionary changes
   (remove TIME-END; add TDB-BEG, TDB-MID, TDB-END, XPOSURE, TELAPSE)
   [#4925]
+
+lib
+---
+
+- Update SkyObject keys. [#4943]
 
 pipeline
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 0.16.1 (unreleased)
 ===================
 
+assign_wcs
+----------
+
+- Update get_object_info to check for and replace legacy keys for WFSS inputs [#4943]
 associations
 ------------
 

--- a/jwst/assign_wcs/tests/data/step_SourceCatalogStep_cat.ecsv
+++ b/jwst/assign_wcs/tests/data/step_SourceCatalogStep_cat.ecsv
@@ -21,8 +21,8 @@
 # - {name: sky_bbox_ur.ra, unit: deg, datatype: float64}
 # - {name: sky_bbox_ur.dec, unit: deg, datatype: float64}
 # - {name: orientation_sky, unit: deg, datatype: float64}
-# - {name: abmag, datatype: float64}
-# - {name: abmag_error, datatype: float32}
+# - {name: isophotal_abmag, datatype: float64}
+# - {name: isophotal_abmag_err, datatype: float32}
 # meta: !!omap
 # - __serialized_columns__:
 #     area:
@@ -39,11 +39,11 @@
 #       value: !astropy.table.SerializedColumn {name: orientation_sky}
 #     semimajor_axis_sigma:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: !astropy.units.Unit {unit: pix}
+#       unit: &id002 !astropy.units.Unit {unit: pix}
 #       value: !astropy.table.SerializedColumn {name: semimajor_axis_sigma}
 #     semiminor_axis_sigma:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: !astropy.units.Unit {unit: pix}
+#       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: semiminor_axis_sigma}
 #     sky_bbox_ll:
 #       __class__: astropy.coordinates.sky_coordinate.SkyCoord
@@ -122,13 +122,13 @@
 #       representation_type: spherical
 #     xcentroid:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: &id002 !astropy.units.Unit {unit: pix}
+#       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: xcentroid}
 #     ycentroid:
 #       __class__: astropy.units.quantity.Quantity
 #       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: ycentroid}
 # schema: astropy-2.0
-id xcentroid ycentroid sky_centroid.ra sky_centroid.dec area source_sum source_sum_err semimajor_axis_sigma semiminor_axis_sigma orientation sky_bbox_ll.ra sky_bbox_ll.dec sky_bbox_ul.ra sky_bbox_ul.dec sky_bbox_lr.ra sky_bbox_lr.dec sky_bbox_ur.ra sky_bbox_ur.dec orientation_sky abmag abmag_error
+id xcentroid ycentroid sky_centroid.ra sky_centroid.dec area source_sum source_sum_err semimajor_axis_sigma semiminor_axis_sigma orientation sky_bbox_ll.ra sky_bbox_ll.dec sky_bbox_ul.ra sky_bbox_ul.dec sky_bbox_lr.ra sky_bbox_lr.dec sky_bbox_ur.ra sky_bbox_ur.dec orientation_sky isophotal_abmag isophotal_abmag_err
 9 1762.8446187443838 953.654293812466 53.13773660029234 -27.80858320887945 6237.0 80273.42 12.255219 10.80902011255591 5.8717035878587875 -10.621426243149482 53.137991428096846 -27.80995279519762 53.13918998548874 -27.808885946466223 53.13613513665963 -27.808305315924617 53.137333694092675 -27.807238483225525 304.33141392502716 nan nan
 19 805.2922935370586 1438.978856541085 53.15786614730031 -27.814422430047713 3950.0 47461.207 9.424652 10.240579756141942 4.998599189576314 -26.265879769088762 53.158024922014874 -27.81539255850512 53.15890283709383 -27.81461090409957 53.15668475033097 -27.814203596345116 53.15756266544928 -27.81342195041563 288.68696039908787 nan nan

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -448,8 +448,12 @@ def get_object_info(catalog_name=None):
     # validate that the expected columns are there
     # id is just a bad name for a param, but it's used in the catalog
     required_fields = list(SkyObject()._fields)
-    if "sid" in required_fields:
-        required_fields[required_fields.index("sid")] = "id"
+
+    legacy_keys = {'sid': 'id', 'abmag': 'isophotal_abmag', 'abmag_error': 'isophotal_abmag_err'}
+
+    for legacy, updated in legacy_keys.items():
+        if legacy in required_fields:
+            required_fields[required_fields.index(legacy)] = updated
 
     try:
         if not set(required_fields).issubset(set(catalog.colnames)):
@@ -473,8 +477,8 @@ def get_object_info(catalog_name=None):
                                  xcentroid=row['xcentroid'],
                                  ycentroid=row['ycentroid'],
                                  sky_centroid=row['sky_centroid'],
-                                 abmag=row['abmag'],
-                                 abmag_error=row['abmag_error'],
+                                 abmag=row['isophotal_abmag'],
+                                 abmag_error=row['isophotal_abmag_err'],
                                  sky_bbox_ll=row['sky_bbox_ll'],
                                  sky_bbox_lr=row['sky_bbox_lr'],
                                  sky_bbox_ul=row['sky_bbox_ul'],

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -446,14 +446,7 @@ def get_object_info(catalog_name=None):
     objects = []
 
     # validate that the expected columns are there
-    # id is just a bad name for a param, but it's used in the catalog
-    required_fields = list(SkyObject()._fields)
-
-    legacy_keys = {'sid': 'id', 'abmag': 'isophotal_abmag', 'abmag_error': 'isophotal_abmag_err'}
-
-    for legacy, updated in legacy_keys.items():
-        if legacy in required_fields:
-            required_fields[required_fields.index(legacy)] = updated
+    required_fields = set(SkyObject()._fields)
 
     try:
         if not set(required_fields).issubset(set(catalog.colnames)):
@@ -473,12 +466,12 @@ def get_object_info(catalog_name=None):
     # (hence, the four separate columns).
 
     for row in catalog:
-        objects.append(SkyObject(sid=row['id'],
+        objects.append(SkyObject(id=row['id'],
                                  xcentroid=row['xcentroid'],
                                  ycentroid=row['ycentroid'],
                                  sky_centroid=row['sky_centroid'],
-                                 abmag=row['isophotal_abmag'],
-                                 abmag_error=row['isophotal_abmag_err'],
+                                 isophotal_abmag=row['isophotal_abmag'],
+                                 isophotal_abmag_err=row['isophotal_abmag_err'],
                                  sky_bbox_ll=row['sky_bbox_ll'],
                                  sky_bbox_lr=row['sky_bbox_lr'],
                                  sky_bbox_ul=row['sky_bbox_ul'],
@@ -597,8 +590,8 @@ def create_grism_bbox(input_model,
 
     grism_objects = []  # the return list of GrismObjects
     for obj in skyobject_list:
-        if obj.abmag is not None:
-            if obj.abmag < mmag_extract:
+        if obj.isophotal_abmag is not None:
+            if obj.isophotal_abmag < mmag_extract:
                 # could add logic to ignore object if too far off image,
 
                 # save the image frame center of the object
@@ -658,12 +651,12 @@ def create_grism_bbox(input_model,
 
                     if contained == 0:
                         exclude = True
-                        log.info("Excluding off-image object: {}, order {}".format(obj.sid, order))
+                        log.info("Excluding off-image object: {}, order {}".format(obj.id, order))
                     elif contained >= 1:
                         outbox = pts[np.logical_not(inidx)]
                         if len(outbox) > 0:
                             ispartial = True
-                            log.info("Partial order on detector for obj: {} order: {}".format(obj.sid, order))
+                            log.info("Partial order on detector for obj: {} order: {}".format(obj.id, order))
 
                     if not exclude:
                         order_bounding[order] = ((round(ymin), round(ymax)), (round(xmin), round(xmax)))
@@ -671,7 +664,7 @@ def create_grism_bbox(input_model,
                         partial_order[order] = ispartial
 
                 if len(order_bounding) > 0:
-                    grism_objects.append(GrismObject(sid=obj.sid,
+                    grism_objects.append(GrismObject(sid=obj.id,
                                                      order_bounding=order_bounding,
                                                      sky_centroid=obj.sky_centroid,
                                                      partial_order=partial_order,

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -453,7 +453,7 @@ def get_object_info(catalog_name=None):
 
     try:
         if not set(required_fields).issubset(set(catalog.colnames)):
-            difference = set(catalog.colnames).difference(required_fields)
+            difference = set(required_fields).difference(set(catalog.colnames))
             err_text = "Missing required columns in source catalog: {0}".format(difference)
             log.error(err_text)
             raise KeyError(err_text)

--- a/jwst/background/tests/data/test_cat.ecsv
+++ b/jwst/background/tests/data/test_cat.ecsv
@@ -21,8 +21,8 @@
 # - {name: sky_bbox_ur.ra, unit: deg, datatype: float64}
 # - {name: sky_bbox_ur.dec, unit: deg, datatype: float64}
 # - {name: orientation_sky, unit: deg, datatype: float64}
-# - {name: abmag, datatype: float64}
-# - {name: abmag_error, datatype: float32}
+# - {name: isophotal_abmag, datatype: float64}
+# - {name: isophotal_abmag_err, datatype: float32}
 # meta: !!omap
 # - __serialized_columns__:
 #     area:
@@ -39,11 +39,11 @@
 #       value: !astropy.table.SerializedColumn {name: orientation_sky}
 #     semimajor_axis_sigma:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: !astropy.units.Unit {unit: pix}
+#       unit: &id002 !astropy.units.Unit {unit: pix}
 #       value: !astropy.table.SerializedColumn {name: semimajor_axis_sigma}
 #     semiminor_axis_sigma:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: !astropy.units.Unit {unit: pix}
+#       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: semiminor_axis_sigma}
 #     sky_bbox_ll:
 #       __class__: astropy.coordinates.sky_coordinate.SkyCoord
@@ -56,7 +56,7 @@
 #         __class__: astropy.coordinates.angles.Longitude
 #         unit: *id001
 #         value: !astropy.table.SerializedColumn {name: sky_bbox_ll.ra}
-#         wrap_angle: &id002 !astropy.coordinates.Angle
+#         wrap_angle: &id003 !astropy.coordinates.Angle
 #           unit: *id001
 #           value: 360.0
 #       representation_type: spherical
@@ -71,7 +71,7 @@
 #         __class__: astropy.coordinates.angles.Longitude
 #         unit: *id001
 #         value: !astropy.table.SerializedColumn {name: sky_bbox_lr.ra}
-#         wrap_angle: *id002
+#         wrap_angle: *id003
 #       representation_type: spherical
 #     sky_bbox_ul:
 #       __class__: astropy.coordinates.sky_coordinate.SkyCoord
@@ -84,7 +84,7 @@
 #         __class__: astropy.coordinates.angles.Longitude
 #         unit: *id001
 #         value: !astropy.table.SerializedColumn {name: sky_bbox_ul.ra}
-#         wrap_angle: *id002
+#         wrap_angle: *id003
 #       representation_type: spherical
 #     sky_bbox_ur:
 #       __class__: astropy.coordinates.sky_coordinate.SkyCoord
@@ -97,7 +97,7 @@
 #         __class__: astropy.coordinates.angles.Longitude
 #         unit: *id001
 #         value: !astropy.table.SerializedColumn {name: sky_bbox_ur.ra}
-#         wrap_angle: *id002
+#         wrap_angle: *id003
 #       representation_type: spherical
 #     sky_centroid:
 #       __class__: astropy.coordinates.sky_coordinate.SkyCoord
@@ -110,18 +110,18 @@
 #         __class__: astropy.coordinates.angles.Longitude
 #         unit: *id001
 #         value: !astropy.table.SerializedColumn {name: sky_centroid.ra}
-#         wrap_angle: *id002
+#         wrap_angle: *id003
 #       representation_type: spherical
 #     xcentroid:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: &id003 !astropy.units.Unit {unit: pix}
+#       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: xcentroid}
 #     ycentroid:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: *id003
+#       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: ycentroid}
 # schema: astropy-2.0
-id xcentroid ycentroid sky_centroid.ra sky_centroid.dec area source_sum source_sum_err semimajor_axis_sigma semiminor_axis_sigma orientation sky_bbox_ll.ra sky_bbox_ll.dec sky_bbox_ul.ra sky_bbox_ul.dec sky_bbox_lr.ra sky_bbox_lr.dec sky_bbox_ur.ra sky_bbox_ur.dec orientation_sky abmag abmag_error
+id xcentroid ycentroid sky_centroid.ra sky_centroid.dec area source_sum source_sum_err semimajor_axis_sigma semiminor_axis_sigma orientation sky_bbox_ll.ra sky_bbox_ll.dec sky_bbox_ul.ra sky_bbox_ul.dec sky_bbox_lr.ra sky_bbox_lr.dec sky_bbox_ur.ra sky_bbox_ur.dec orientation_sky isophotal_abmag isophotal_abmag_err
 2 1777.652238481037 170.01540474826263 53.14666557034219 -27.80713677752155 75.0 728.18805 2.9282207 1.5637714124328412 1.4929967724271964 5.940707967484156 53.14677076477291 -27.80722012009914 53.14677277145135 -27.80705602898487 53.14654402563116 -27.80721795051216 53.14654603265186 -27.807053859401304 276.553125629852 20.394437789916992 0.004366008
 3 252.0518174088754 276.8019135457481 53.17813554840662 -27.805487142968335 117.0 1621.8623 4.3626847 1.6801889279565265 1.6497992805681438 19.14707952799964 53.17826922515514 -27.805603303521906 53.17827183728369 -27.805384514766672 53.178001263967154 -27.805600800209078 53.178003876634996 -27.805382011458658 289.7594971903675 19.525012969970703 0.0029205466
 4 643.0723319287848 417.31178148916507 53.17010646964325 -27.8028497833051 280.0 4258.8887 7.0671167 2.461319256973988 2.152392199285991 35.88685081396852 53.17030184339177 -27.803012297634876 53.17030578554253 -27.8026841147135 53.16991021740034 -27.803008616299795 53.16991416073337 -27.80268043338929 306.49926847633634 18.476806640625 0.0018016493

--- a/jwst/extract_2d/tests/data/step_SourceCatalogStep_cat.ecsv
+++ b/jwst/extract_2d/tests/data/step_SourceCatalogStep_cat.ecsv
@@ -21,8 +21,8 @@
 # - {name: sky_bbox_ur.ra, unit: deg, datatype: float64}
 # - {name: sky_bbox_ur.dec, unit: deg, datatype: float64}
 # - {name: orientation_sky, unit: deg, datatype: float64}
-# - {name: abmag, datatype: float64}
-# - {name: abmag_error, datatype: float32}
+# - {name: isophotal_abmag, datatype: float64}
+# - {name: isophotal_abmag_err, datatype: float32}
 # meta: !!omap
 # - __serialized_columns__:
 #     area:
@@ -39,11 +39,11 @@
 #       value: !astropy.table.SerializedColumn {name: orientation_sky}
 #     semimajor_axis_sigma:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: !astropy.units.Unit {unit: pix}
+#       unit: &id002 !astropy.units.Unit {unit: pix}
 #       value: !astropy.table.SerializedColumn {name: semimajor_axis_sigma}
 #     semiminor_axis_sigma:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: !astropy.units.Unit {unit: pix}
+#       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: semiminor_axis_sigma}
 #     sky_bbox_ll:
 #       __class__: astropy.coordinates.sky_coordinate.SkyCoord
@@ -122,14 +122,14 @@
 #       representation_type: spherical
 #     xcentroid:
 #       __class__: astropy.units.quantity.Quantity
-#       unit: &id002 !astropy.units.Unit {unit: pix}
+#       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: xcentroid}
 #     ycentroid:
 #       __class__: astropy.units.quantity.Quantity
 #       unit: *id002
 #       value: !astropy.table.SerializedColumn {name: ycentroid}
 # schema: astropy-2.0
-id xcentroid ycentroid sky_centroid.ra sky_centroid.dec area source_sum source_sum_err semimajor_axis_sigma semiminor_axis_sigma orientation sky_bbox_ll.ra sky_bbox_ll.dec sky_bbox_ul.ra sky_bbox_ul.dec sky_bbox_lr.ra sky_bbox_lr.dec sky_bbox_ur.ra sky_bbox_ur.dec orientation_sky abmag abmag_error
+id xcentroid ycentroid sky_centroid.ra sky_centroid.dec area source_sum source_sum_err semimajor_axis_sigma semiminor_axis_sigma orientation sky_bbox_ll.ra sky_bbox_ll.dec sky_bbox_ul.ra sky_bbox_ul.dec sky_bbox_lr.ra sky_bbox_lr.dec sky_bbox_ur.ra sky_bbox_ur.dec orientation_sky isophotal_abmag isophotal_abmag_err
 9 1762.8446187443838 953.654293812466 53.13773660029234 -27.80858320887945 6237.0 80273.42 12.255219 10.80902011255591 5.8717035878587875 -10.621426243149482 53.137991428096846 -27.80995279519762 53.13918998548874 -27.808885946466223 53.13613513665963 -27.808305315924617 53.137333694092675 -27.807238483225525 304.33141392502716 27.0 nan
 19 805.2922935370586 1438.978856541085 53.15786614730031 -27.814422430047713 3950.0 47461.207 9.424652 10.240579756141942 4.998599189576314 -26.265879769088762 53.158024922014874 -27.81539255850512 53.15890283709383 -27.81461090409957 53.15668475033097 -27.814203596345116 53.15756266544928 -27.81342195041563 288.68696039908787 27.0 nan
 25 286.2709905740931 1840.4092996608497 53.17070591865739 -27.815869291238855 2188.0 5187.832 3.1489005 10.203277818018973 6.966775517614506 -18.07273859029408 53.17081637779171 -27.816584202206837 53.17149913753544 -27.815976186373682 53.16990886197875 -27.81577926081113 53.17059162174916 -27.815171249441473 296.88010157788256 18.0 nan

--- a/jwst/lib/catalog_utils.py
+++ b/jwst/lib/catalog_utils.py
@@ -75,12 +75,12 @@ def replace_suffix_ext(filename, old_suffix_list, new_suffix,
     return output_path
 
 
-class SkyObject(namedtuple('SkyObject', ("sid",
+class SkyObject(namedtuple('SkyObject', ("id",
                                          "xcentroid",
                                          "ycentroid",
                                          "sky_centroid",
-                                         "abmag",
-                                         "abmag_error",
+                                         "isophotal_abmag",
+                                         "isophotal_abmag_err",
                                          "sky_bbox_ll",
                                          "sky_bbox_lr",
                                          "sky_bbox_ul",
@@ -98,7 +98,7 @@ class SkyObject(namedtuple('SkyObject', ("sid",
 
     Parameters
     ----------
-    sid : int
+    id : int
         source identifed
     xcentroid : float
         x center of object in pixels
@@ -106,9 +106,9 @@ class SkyObject(namedtuple('SkyObject', ("sid",
         y center of object in pixels
     sky_centroid: `~astropy.coordinates.SkyCoord`
         ra and dec of the center of the object
-    abmag : float
+    isophotal_abmag : float
         AB Magnitude of object
-    abmag_error : float
+    isophotal_abmag_err : float
         Error on the AB magnitude
     sky_bbox_ll : `~astropy.coordinates.SkyCoord`
         Lower left corner of the minimum bounding box
@@ -122,24 +122,24 @@ class SkyObject(namedtuple('SkyObject', ("sid",
 
     __slots__ = ()  # prevent instance dictionary creation for lower mem
 
-    def __new__(cls, sid=None,
+    def __new__(cls, id=None,
                      xcentroid=None,
                      ycentroid=None,
                      sky_centroid=None,
-                     abmag=None,
-                     abmag_error=None,
+                     isophotal_abmag=None,
+                     isophotal_abmag_err=None,
                      sky_bbox_ll=None,
                      sky_bbox_lr=None,
                      sky_bbox_ul=None,
                      sky_bbox_ur=None):
 
         return super(SkyObject, cls).__new__(cls,
-                                             sid=sid,
+                                             id=id,
                                              xcentroid=xcentroid,
                                              ycentroid=ycentroid,
                                              sky_centroid=sky_centroid,
-                                             abmag=abmag,
-                                             abmag_error=abmag_error,
+                                             isophotal_abmag=isophotal_abmag,
+                                             isophotal_abmag_err=isophotal_abmag_err,
                                              sky_bbox_ll=sky_bbox_ll,
                                              sky_bbox_lr=sky_bbox_lr,
                                              sky_bbox_ul=sky_bbox_ul,
@@ -151,18 +151,18 @@ class SkyObject(namedtuple('SkyObject', ("sid",
                 "xcentroid: {1}\n"
                 "ycentroid: {2}\n"
                 "sky_centroid: {3}\n"
-                "abmag: {4}\n"
-                "abmag_error: {5}\n"
+                "isophotal_abmag: {4}\n"
+                "isophotal_abmag_err: {5}\n"
                 "sky_bbox_ll: {6}\n"
                 "sky_bbox_lr: {7}\n"
                 "sky_bbox_ul: {8}\n"
                 "sky_bbox_ur: {9}\n"
-                .format(self.sid,
+                .format(self.id,
                         self.xcentroid,
                         self.ycentroid,
                         str(self.sky_centroid),
-                        self.abmag,
-                        self.abmag_error,
+                        self.isophotal_abmag,
+                        self.isophotal_abmag_err,
                         str(self.sky_bbox_ll),
                         str(self.sky_bbox_lr),
                         str(self.sky_bbox_ul),


### PR DESCRIPTION
`assign_wcs.util.get_object_info` was resulting in the incorrect reporting of missing columns in an input catalogue due to a set difference being in the wrong order. This has been fixed, and now the correct list of missing columns will be used in the error message

Resolves #4932 / [JP-1447](https://jira.stsci.edu/browse/JP-1447)