### PR TITLE
JP-1450: Fix mrs_imatch call to sigma_clipped_stats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ datamodels
   (remove TIME-END; add TDB-BEG, TDB-MID, TDB-END, XPOSURE, TELAPSE)
   [#4925]
 
+mrs_imatch
+----------
+
+- Fix ``mrs_imatch`` to avoid calls to ``sigma_clipped_stats`` with all-zero
+  arrays. [#4944]
+
 pipeline
 --------
 

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -338,8 +338,14 @@ def _match_models(models, channel, degree, center=None, center_cs='image'):
     for image, mask in zip(image_data, mask_data):
         # Do statistics wavelength by wavelength
         for thisimg, thismask in zip(image, mask):
-            # Sigma clipped statistics, ignoring zeros where no data
-            _, themed, clipsig = sigclip(thisimg, mask_value=0.)
+            # Avoid bug in sigma_clipped_stats (fixed in astropy 4.0.2) which
+            # fails on all-zero arrays passed when mask_value=0
+            if not np.any(thisimg):
+                themed = 0.
+                clipsig = 0.
+            else:
+                # Sigma clipped statistics, ignoring zeros where no data
+                _, themed, clipsig = sigclip(thisimg, mask_value=0.)
             # Reject beyond 3 sigma
             reject = np.where(np.abs(thisimg - themed) > 3 * clipsig)
             thismask[reject] = 0


### PR DESCRIPTION
This PR prevents calling `astropy.stats.sigma_clipped_stats` with an all-zero array while simultaneously asking that all zeros be masked.  This is a known bug in `sigma_clipped_stats` and is already fixed on `master`.  This will be fixed in the next patch release `astropy 4.0.2` which is not released yet.

Tested this on the **jw00623-o020_20200511t191459_spec3_001_asn.json** association, and `Spec3Pipeline` now does not fail at this point.

Fixes #4938 / [JP-1450](https://jira.stsci.edu/browse/JP-1450)