### PR TITLE
Update abmag error calculation

### DIFF
--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -575,8 +575,7 @@ class SourceCatalog:
             warnings.simplefilter("ignore", category=RuntimeWarning)
 
             abmag = -2.5 * np.log10(flux.value) + 8.9
-            # assuming SNR >> 1 (otherwise abmag_err is asymmetric)
-            abmag_err = 2.5 * np.log10(np.e) * (flux_err.value / flux.value)
+            abmag_err = 2.5 * np.log10(1.0 + (flux_err.value / flux.value))
 
             # handle negative fluxes
             idx = flux.value < 0


### PR DESCRIPTION
Minor change to abmag error calculation to be valid for all S/N.  Note that all errors in the source catalog are still reported as NaN (because we don't have errors for the drizzled images yet), so I don't think this needs a changelog entry.