### PR TITLE
JP-1451: Guidestar data models updates

### DIFF
--- a/docs/jwst/data_products/nonscience_products.rst
+++ b/docs/jwst/data_products/nonscience_products.rst
@@ -9,29 +9,29 @@ Dark exposures processed by the :ref:`calwebb_dark <calwebb_dark>` pipeline resu
 product that has the same structure and content as the :ref:`ramp <ramp>` product described above.
 The details are as follows:
 
-+-----+------------+----------+-----------+---------------------------------+
-| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                      |
-+=====+============+==========+===========+=================================+
-|  0  | N/A        | primary  | N/A       | N/A                             |
-+-----+------------+----------+-----------+---------------------------------+
-|  1  | SCI        | IMAGE    | float32   | ncols x nrows x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|  2  | PIXELDQ    | IMAGE    | uint32    | ncols x nrows                   |
-+-----+------------+----------+-----------+---------------------------------+
-|  3  | GROUPDQ    | IMAGE    | uint8     | ncols x nrows x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|  4  | ERR        | IMAGE    | float32   | ncols x nrows x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|  5  | GROUP      | BINTABLE | N/A       | variable                        |
-+-----+------------+----------+-----------+---------------------------------+
-|  6  | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols           |
-+-----+------------+----------+-----------+---------------------------------+
-|     | ZEROFRAME* | IMAGE    | float32   | ncols x nrows x nints           |
-+-----+------------+----------+-----------+---------------------------------+
-|     | REFOUT*    | IMAGE    | uint16    | ncols/4 x 256 x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|     | ASDF       | BINTABLE | N/A       | variable                        |
-+-----+------------+----------+-----------+---------------------------------+
++-----+------------+----------+-----------+-----------------------------------+
+| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                        |
++=====+============+==========+===========+===================================+
+|  0  | N/A        | primary  | N/A       | N/A                               |
++-----+------------+----------+-----------+-----------------------------------+
+|  1  | SCI        | IMAGE    | float32   | ncols x nrows x ngroups x nints   |
++-----+------------+----------+-----------+-----------------------------------+
+|  2  | PIXELDQ    | IMAGE    | uint32    | ncols x nrows                     |
++-----+------------+----------+-----------+-----------------------------------+
+|  3  | GROUPDQ    | IMAGE    | uint8     | ncols x nrows x ngroups x nints   |
++-----+------------+----------+-----------+-----------------------------------+
+|  4  | ERR        | IMAGE    | float32   | ncols x nrows x ngroups x nints   |
++-----+------------+----------+-----------+-----------------------------------+
+|  5  | GROUP      | BINTABLE | N/A       | variable                          |
++-----+------------+----------+-----------+-----------------------------------+
+|  6  | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols             |
++-----+------------+----------+-----------+-----------------------------------+
+|     | ZEROFRAME* | IMAGE    | float32   | ncols x nrows x nints             |
++-----+------------+----------+-----------+-----------------------------------+
+|     | REFOUT*    | IMAGE    | uint16    | ncols/4 x nrows x ngroups x nints |
++-----+------------+----------+-----------+-----------------------------------+
+|     | ASDF       | BINTABLE | N/A       | variable                          |
++-----+------------+----------+-----------+-----------------------------------+
 
  - SCI: 4-D data array containing the pixel values. The first two dimensions are equal to
    the size of the detector readout, with the data from multiple groups (NGROUPS) within each

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -27,23 +27,23 @@ Additional extensions can be included for certain instruments and readout types,
 below.
 The FITS file structure is as follows.
 
-+-----+------------+----------+-----------+---------------------------------+
-| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                      |
-+=====+============+==========+===========+=================================+
-|  0  | N/A        | primary  | N/A       | N/A                             |
-+-----+------------+----------+-----------+---------------------------------+
-|  1  | SCI        | IMAGE    | uint16    | ncols x nrows x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|  2  | GROUP      | BINTABLE | N/A       | variable                        |
-+-----+------------+----------+-----------+---------------------------------+
-|  3  | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols           |
-+-----+------------+----------+-----------+---------------------------------+
-|     | ZEROFRAME* | IMAGE    | uint16    | ncols x nrows x nints           |
-+-----+------------+----------+-----------+---------------------------------+
-|     | REFOUT*    | IMAGE    | uint16    | ncols/4 x 256 x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|     | ASDF       | BINTABLE | N/A       | variable                        |
-+-----+------------+----------+-----------+---------------------------------+
++-----+------------+----------+-----------+-----------------------------------+
+| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                        |
++=====+============+==========+===========+===================================+
+|  0  | N/A        | primary  | N/A       | N/A                               |
++-----+------------+----------+-----------+-----------------------------------+
+|  1  | SCI        | IMAGE    | uint16    | ncols x nrows x ngroups x nints   |
++-----+------------+----------+-----------+-----------------------------------+
+|  2  | GROUP      | BINTABLE | N/A       | variable                          |
++-----+------------+----------+-----------+-----------------------------------+
+|  3  | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols             |
++-----+------------+----------+-----------+-----------------------------------+
+|     | ZEROFRAME* | IMAGE    | uint16    | ncols x nrows x nints             |
++-----+------------+----------+-----------+-----------------------------------+
+|     | REFOUT*    | IMAGE    | uint16    | ncols/4 x nrows x ngroups x nints |
++-----+------------+----------+-----------+-----------------------------------+
+|     | ASDF       | BINTABLE | N/A       | variable                          |
++-----+------------+----------+-----------+-----------------------------------+
 
  - SCI: 4-D data array containing the raw pixel values. The first two dimensions are equal to
    the size of the detector readout, with the data from multiple groups (NGROUPS) within each
@@ -75,29 +75,29 @@ from integer to floating-point data type. The same is true for the ZEROFRAME and
 data extensions, if they are present. An ERR array and two types of data quality arrays are
 also added to the product. The FITS file layout is as follows:
 
-+-----+------------+----------+-----------+---------------------------------+
-| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                      |
-+=====+============+==========+===========+=================================+
-|  0  | N/A        | primary  | N/A       | N/A                             |
-+-----+------------+----------+-----------+---------------------------------+
-|  1  | SCI        | IMAGE    | float32   | ncols x nrows x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|  2  | PIXELDQ    | IMAGE    | uint32    | ncols x nrows                   |
-+-----+------------+----------+-----------+---------------------------------+
-|  3  | GROUPDQ    | IMAGE    | uint8     | ncols x nrows x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|  4  | ERR        | IMAGE    | float32   | ncols x nrows x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|     | ZEROFRAME* | IMAGE    | float32   | ncols x nrows x nints           |
-+-----+------------+----------+-----------+---------------------------------+
-|     | GROUP      | BINTABLE | N/A       | variable                        |
-+-----+------------+----------+-----------+---------------------------------+
-|     | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols           |
-+-----+------------+----------+-----------+---------------------------------+
-|     | REFOUT*    | IMAGE    | uint16    | ncols/4 x 256 x ngroups x nints |
-+-----+------------+----------+-----------+---------------------------------+
-|     | ASDF       | BINTABLE | N/A       | variable                        |
-+-----+------------+----------+-----------+---------------------------------+
++-----+------------+----------+-----------+-----------------------------------+
+| HDU | EXTNAME    | HDU Type | Data Type | Dimensions                        |
++=====+============+==========+===========+===================================+
+|  0  | N/A        | primary  | N/A       | N/A                               |
++-----+------------+----------+-----------+-----------------------------------+
+|  1  | SCI        | IMAGE    | float32   | ncols x nrows x ngroups x nints   |
++-----+------------+----------+-----------+-----------------------------------+
+|  2  | PIXELDQ    | IMAGE    | uint32    | ncols x nrows                     |
++-----+------------+----------+-----------+-----------------------------------+
+|  3  | GROUPDQ    | IMAGE    | uint8     | ncols x nrows x ngroups x nints   |
++-----+------------+----------+-----------+-----------------------------------+
+|  4  | ERR        | IMAGE    | float32   | ncols x nrows x ngroups x nints   |
++-----+------------+----------+-----------+-----------------------------------+
+|     | ZEROFRAME* | IMAGE    | float32   | ncols x nrows x nints             |
++-----+------------+----------+-----------+-----------------------------------+
+|     | GROUP      | BINTABLE | N/A       | variable                          |
++-----+------------+----------+-----------+-----------------------------------+
+|     | INT_TIMES  | BINTABLE | N/A       | nints (rows) x 7 cols             |
++-----+------------+----------+-----------+-----------------------------------+
+|     | REFOUT*    | IMAGE    | uint16    | ncols/4 x nrows x ngroups x nints |
++-----+------------+----------+-----------+-----------------------------------+
+|     | ASDF       | BINTABLE | N/A       | variable                          |
++-----+------------+----------+-----------+-----------------------------------+
 
  - SCI: 4-D data array containing the pixel values. The first two dimensions are equal to
    the size of the detector readout, with the data from multiple groups (NGROUPS) within each

--- a/jwst/datamodels/schemas/guider_cal.schema.yaml
+++ b/jwst/datamodels/schemas/guider_cal.schema.yaml
@@ -89,7 +89,7 @@ allOf:
       - name: delta_j3_pa
         datatype: float64
       - name: HGA_motion
-        datatype: int16
+        datatype: [ascii, 16]
     centroid_table:
       title: Centroid packet table
       fits_hdu: FGS Centroid Packet

--- a/jwst/datamodels/schemas/guider_meta.schema.yaml
+++ b/jwst/datamodels/schemas/guider_meta.schema.yaml
@@ -17,6 +17,11 @@ properties:
         type: string
         fits_keyword: GUIDESTA
         fits_hdu: FGS Centroid Packet
+      numrefst:
+        title: Number of reference stars
+        type: integer
+        fits_keyword: NUMREFST
+        fits_hdu: Flight Reference Stars
       ddc_field_point:
         title: Differential Distortion Compensation field point
         type: string

--- a/jwst/datamodels/schemas/guider_raw.schema.yaml
+++ b/jwst/datamodels/schemas/guider_raw.schema.yaml
@@ -89,7 +89,7 @@ allOf:
       - name: delta_j3_pa
         datatype: float64
       - name: HGA_motion
-        datatype: int16
+        datatype: [ascii, 16]
     centroid_table:
       title: Centroid packet table
       fits_hdu: FGS Centroid Packet


### PR DESCRIPTION
Updated the guidestar datamodels schemas to include the missing keyword NUMREFST and change the HGA_motion table column data type from integer to string.

Also made a couple additional changes to unrelated docs to fix descriptions of the MIRI REFOUT extension ([JP-987](https://jira.stsci.edu/browse/JP-987))

Fixes #4939 / [JP-1451](https://jira.stsci.edu/browse/JP-1451)