### PR TITLE
JP-1454:  Exit gracefully if APCORR data is missing

### DIFF
--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -136,6 +136,11 @@ class ReferenceData:
                         for key, value in selector.items()]
             ee_table = apcorr[np.logical_and.reduce(mask_idx)]
 
+        if len(ee_table) == 0:
+            raise RuntimeError('APCORR reference file data is missing for '
+                               f'{selector}.')
+            return
+
         return ee_table
 
     def _get_ee_table_row(self, aperture_ee):

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -67,9 +67,16 @@ class SourceCatalogStep(Step):
 
             aperture_ee = (self.aperture_ee1, self.aperture_ee2,
                            self.aperture_ee3)
-            refdata = ReferenceData(model, aperture_ee=aperture_ee,
-                                    apcorr_filename=apcorr_fn,
-                                    abvegaoffset_filename=abvegaoffset_fn)
+            try:
+                refdata = ReferenceData(model, aperture_ee=aperture_ee,
+                                        apcorr_filename=apcorr_fn,
+                                        abvegaoffset_filename=abvegaoffset_fn)
+                aperture_params = refdata.aperture_params
+                abvega_offset = refdata.abvega_offset
+            except RuntimeError as err:
+                msg = f'{err} Source catalog will not be created.'
+                self.log.warn(msg)
+                return
 
             coverage_mask = (model.wht == 0)
             if coverage_mask.all():
@@ -104,8 +111,8 @@ class SourceCatalogStep(Step):
             catobj = SourceCatalog(model, segment_img, error=total_error,
                                    kernel=kernel,
                                    kernel_fwhm=self.kernel_fwhm,
-                                   aperture_params=refdata.aperture_params,
-                                   abvega_offset=refdata.abvega_offset)
+                                   aperture_params=aperture_params,
+                                   abvega_offset=abvega_offset)
             catalog = catobj.catalog
 
             if self.save_results:


### PR DESCRIPTION
JP-1454 is caused by an invalid "BRIGHT" subarray in the MIRI APCORR reference file.  It should be called "BRIGHTSKY".

This PR raises an error if APCORR reference file data is missing.  It also now catches `RuntimeError` to print a warning message and exit gracefully for reference file errors.

Fixes #4947 / [JP-1454](https://jira.stsci.edu/browse/JP-1454)