### PR TITLE
Performance improvement in GAIA alignment and bug fix wcs name

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -39,7 +39,7 @@ spherical-geometry==1.2.18
 stsci.image==2.3.3
 stsci.imagestats==1.6.2
 stsci.stimage==0.2.4
-tweakwcs==0.6.3
+tweakwcs==0.6.4
 urllib3==1.25.9
 wcwidth==0.1.9
 zipp==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         'spherical-geometry>=1.2',
         'stsci.image>=2.3.3',
         'stsci.imagestats>=1.4',
-        'tweakwcs>=0.6.3',
+        'tweakwcs>=0.6.4',
     ],
     extras_require={
         'docs': DOCS_REQUIRE,


### PR DESCRIPTION
This PR turns off optimization of the order in which catalogs are aligned to GAIA since there is only one "group catalog" and this turns off computation of image footprints on the sky.

Bug fix: the way previous code was written, it would have resulted in `wcs.name` being overwritten (actually lost) in the next loop. This PR fixes that.

If this PR is merged before next release - no changelog entry should be required.
