### PR TITLE
Limit looping over FITS HDU's for schema arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ associations
 datamodels
 ----------
 
+- Limit looping over HDU's while resolving arrays in schema [#4951]
+
 - Relax asdf requirement and use validator flag when asdf 2.6.x is installed [#4905]
 
 - Updated core schema to include recent Keyword Dictionary changes

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -457,7 +457,7 @@ def _load_from_schema(hdulist, schema, tree, context):
 
     # Determine maximum EXTVER that could be used in finding named HDU's.
     # This is needed to constrain the loop over HDU's when resolving arrays.
-    max_extver = calculate_max_extver(hdulist)
+    max_extver = max(hdu.ver for hdu in hdulist) if len(hdulist) else 0
 
     def callback(schema, path, combiner, ctx, recurse):
         result = None
@@ -597,23 +597,3 @@ def from_fits_hdu(hdu, schema):
         data._coldefs._listeners = listeners
 
     return data
-
-
-def calculate_max_extver(hdulist):
-    """Return the maxiumum EXTVER possible
-
-    Parameters
-    ----------
-    hdulist: FITS hdulist
-        The HDUlist.
-
-    Returns
-    -------
-    max_extver: int
-        The maximum EXTVER for any named HDU.
-    """
-    if not len(hdulist):
-        return 0
-    hdu_counts = Counter(hdu.name for hdu in hdulist)
-    max_extver = max(hdu_counts.values())
-    return max_extver

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -1,4 +1,3 @@
-from collections import Counter
 import datetime
 import os
 import re
@@ -358,7 +357,7 @@ def _save_extra_fits(hdulist, tree):
         hdu_name = fits_hdu_name(hdu_name)
         if 'data' in parts:
             hdu_type = _get_hdu_type(hdu_name, value=parts['data'])
-            hdu = _get_or_make_hdu(hdulist, hdu_name, hdu_type = hdu_type,
+            hdu = _get_or_make_hdu(hdulist, hdu_name, hdu_type=hdu_type,
                                    value=parts['data'])
         if 'header' in parts:
             hdu = _get_or_make_hdu(hdulist, hdu_name)
@@ -390,6 +389,7 @@ def _save_history(hdulist, tree):
             else:
                 history[i] = HistoryEntry({'description': str(history[i])})
         hdulist[0].header['HISTORY'] = history[i]['description']
+
 
 def to_fits(tree, schema):
     hdulist = fits.HDUList()
@@ -563,10 +563,11 @@ def from_fits(hdulist, schema, context, **kwargs):
 
     return ff
 
+
 def from_fits_asdf(hdulist,
-                  ignore_version_mismatch=True,
-                  ignore_unrecognized_tag=False,
-                  **kwargs):
+                   ignore_version_mismatch=True,
+                   ignore_unrecognized_tag=False,
+                   **kwargs):
     """
     Wrap asdf call to extract optional argumentscommet
     """


### PR DESCRIPTION
WIP [JP-1343](https://jira.stsci.edu/browse/JP-1343) / #4663 

Looping was being performed over all available HDU's
to resolve arrays. However, only the maximum EXTVER for
any named HDU need be considered; anything after that will
guarantee no data.