### PR TITLE
Refactor photom to also update multislit models' bunit keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,11 @@ mrs_imatch
 - Fix ``mrs_imatch`` to avoid calls to ``sigma_clipped_stats`` with all-zero
   arrays. [#4944]
 
+photom
+------
+
+- Fix flux units in photom for MultiSlit cases. [#4958]
+
 pipeline
 --------
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -738,12 +738,12 @@ class DataSet():
             if no_cal is not None:
                 self.input.dq[..., no_cal] = np.bitwise_or(self.input.dq[..., no_cal],
                                                            dqflags.pixel['DO_NOT_USE'])
-            if unit_is_surface_brightness:
-                self.input.meta.bunit_data = 'MJy/sr'
-                self.input.meta.bunit_err = 'MJy/sr'
-            else:
-                self.input.meta.bunit_data = 'MJy'
-                self.input.meta.bunit_err = 'MJy'
+        if unit_is_surface_brightness:
+            self.input.meta.bunit_data = 'MJy/sr'
+            self.input.meta.bunit_err = 'MJy/sr'
+        else:
+            self.input.meta.bunit_data = 'MJy'
+            self.input.meta.bunit_err = 'MJy'
 
         return
 


### PR DESCRIPTION
This PR resolves [JP-1434](https://jira.stsci.edu/browse/JP-1434). 

Fixes a bug where input `MultiSlitModel` `bunit` keys were not being updated with new flux units which resulted in incorrect units in the headers of the individual slit products due to header blending down the line