### PR TITLE
JP-1151: Fix NIRSpec MOS PPS reference point bug.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ assign_wcs
 
 - Update keyword and attribute usage around SkyObject to reflect updated keywords. [#4943]
 
-- Refactor PPS origin to bottom left rather than top left.
+- Refactor PPS origin of NIRSpec MOS shutters from top left to bottom left. [#4959]
 
 associations
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ assign_wcs
 
 - Update keyword and attribute usage around SkyObject to reflect updated keywords. [#4943]
 
+- Refactor PPS origin to bottom left rather than top left.
+
 associations
 ------------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -648,7 +648,7 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
         columns "estimated_source_in_shutter_x" and "estimated_source_in_shutter_y".
         The source position is in a coordinate system associated with each shutter whose
         origin is the lower left corner of the shutter, positive x is to the right
-        and positive y is downwards.
+        and positive y is upwards.
         """
         source_xpos -= 0.5
         source_ypos -= 0.5

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -650,8 +650,8 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
         origin is the lower left corner of the shutter, positive x is to the right
         and positive y is downwards.
         """
-        source_xpos = source_xpos - 0.5
-        source_ypos = source_ypos - 0.5
+        source_xpos -= 0.5
+        source_ypos -= 0.5
 
         # Create the shutter_state string
         all_shutters = _shutter_id_to_str(open_shutters, ycen)

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -647,11 +647,11 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
         The source x,y position in the shutter is given in the msa configuration file,
         columns "estimated_source_in_shutter_x" and "estimated_source_in_shutter_y".
         The source position is in a coordinate system associated with each shutter whose
-        origin is the upper left corner of the shutter, positive x is to the right
+        origin is the lower left corner of the shutter, positive x is to the right
         and positive y is downwards.
         """
         source_xpos = source_xpos - 0.5
-        source_ypos = -source_ypos + 0.5
+        source_ypos = source_ypos - 0.5
 
         # Create the shutter_state string
         all_shutters = _shutter_id_to_str(open_shutters, ycen)

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -278,7 +278,7 @@ def test_msa_configuration_normal():
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
     ref_slit = Slit(55, 9376, 1, 251, 26, -5.15, 0.55, 4, 1, '1111x', '95065_1', '2122',
-                    0.13, -0.31716078999999997, 0.18092266)
+                    0.13, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -307,7 +307,7 @@ def test_msa_configuration_all_background():
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
     ref_slit = Slit(57, 8646, 1, 251, 24, -2.85, .55, 4, 0, '11x', 'background_57', 'bkg_57',
-                    0, -0.5, 0.5)
+                    0, -0.5, -0.5)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -324,7 +324,7 @@ def test_msa_configuration_row_skipped():
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
     ref_slit = Slit(58, 8646, 1, 251, 24, -2.85, 5.15, 4, 1, '11x1011', '95065_1', '2122',
-                    0.130, -0.31716078999999997, 0.18092266)
+                    0.130, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -339,9 +339,9 @@ def test_msa_configuration_multiple_returns():
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
     ref_slit1 = Slit(59, 8651, 1, 256, 24, -2.85, 5.15, 4, 1, '11x1011', '95065_1', '2122',
-                     0.13000000000000003, -0.31716078999999997, 0.18092266)
+                     0.13000000000000003, -0.31716078999999997, -0.18092266)
     ref_slit2 = Slit(60, 11573, 1, 258, 32, -2.85, 4, 4, 2, '11x111', '95065_2', '172',
-                     0.70000000000000007, -0.31716078999999997, 0.18092266)
+                     0.70000000000000007, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit1)
     _compare_slits(slitlet_info[1], ref_slit2)
 


### PR DESCRIPTION
This PR resolves #4291 / [JP-1151](https://jira.stsci.edu/browse/JP-1151) and includes a fix in the conversion from the PPS coordinate frame to the Model frame. 