### PR TITLE
JP-1462: Fix bug that results in obscure linear algebra error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 0.16.2 (unreleased)
 ===================
 
+extract_1d
+----------
 
+- Fix bug in creating a polynomial fit used in background extraction. [#4970]
 
 0.16.1 (2020-05-19)
 ===================

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -20,7 +20,9 @@ The extract_1d step has five step-specific arguments.
   subtracted from the target data.  ``bkg_order`` = 0 (the minimum allowed
   value) means to fit a constant.  The user-supplied value (if any)
   overrides the value in the reference file.  If neither is specified, a
-  value of 0 will be used.
+  value of 0 will be used. If a sufficient number of valid data points is
+  unavailable to construct the polynomial fit, the fit will be forced to
+  0 for that particular column (or row).
 
 ``--log_increment``
   Most log messages are suppressed while looping over integrations, i.e. when

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -390,7 +390,8 @@ def _extract_src_flux(image, x, j, lam, srclim,
 
 
 def _fit_background_model(image, x, j, bkglim, bkg_order):
-    """Extract background pixels and fit a polynomial.
+    """Extract background pixels and fit a polynomial. If the number of good data points is <= 1, the fit model will be
+    forced to 0 to avoid divergent
 
     Parameters:
     -----------

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -434,8 +434,8 @@ def _fit_background_model(image, x, j, bkglim, bkg_order):
     good = np.isfinite(val)
     npts = good.sum()
 
-    if npts == 0 or not np.any(good):
-        return (models.Polynomial1D(0), 0)
+    if npts <= 1 or not np.any(good):
+        return models.Polynomial1D(0), 0
 
     # filter-out bad values:
     val = val[good]
@@ -446,7 +446,7 @@ def _fit_background_model(image, x, j, bkglim, bkg_order):
     bkg_model = lsqfitter(models.Polynomial1D(min(bkg_order, npts - 1)),
                           y, val, weights=wht)
 
-    return (bkg_model, npts)
+    return bkg_model, npts
 
 
 def _extract_colpix(image_data, x, j, limits):

--- a/jwst/extract_1d/tests/test_fit_background_model.py
+++ b/jwst/extract_1d/tests/test_fit_background_model.py
@@ -2,13 +2,14 @@
 Test for extract_1d._fit_background_model
 """
 import math
-
 import numpy as np
+import pytest
 
 from jwst.extract_1d import extract1d
 
-def test_fit_background_model():
 
+@pytest.fixture
+def inputs_constant():
     shape = (9, 5)
     image = np.arange(shape[0] * shape[1], dtype=np.float32).reshape(shape)
     x = 2
@@ -19,18 +20,37 @@ def test_fit_background_model():
     bkglim = [[b_lower, b_upper]]
     bkg_order = 0
 
-    (bkg_model, npts) = extract1d._fit_background_model(
-                        image, x, j, bkglim, bkg_order)
+    return image, x, j, bkglim, bkg_order
+
+
+def test_fit_background_model(inputs_constant):
+
+    (bkg_model, npts) = extract1d._fit_background_model(*inputs_constant)
 
     assert math.isclose(bkg_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
     assert math.isclose(bkg_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
 
     assert npts == 2
 
+
+def test_handles_nan(inputs_constant):
+    image, x, j, bkglim, bkg_order = inputs_constant
     image[:, 2] = np.nan
 
-    (bkg_model, npts) = extract1d._fit_background_model(
-                        image, x, j, bkglim, bkg_order)
+    (bkg_model, npts) = extract1d._fit_background_model(image, x, j, bkglim, bkg_order)
+
+    assert math.isclose(bkg_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(bkg_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert npts == 0
+
+
+def test_handles_one_value(inputs_constant):
+    image, x, j, bkglim, bkg_order = inputs_constant
+    image[np.where(image == 22)] = np.nan   # During extraction, only two pixels are returned "normally"; set one to Nan
+
+    # If only one data point is available, the polynomial fit is forced to 0
+    bkg_model, npts = extract1d._fit_background_model(image, x, j, bkglim, bkg_order)
 
     assert math.isclose(bkg_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
     assert math.isclose(bkg_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)


### PR DESCRIPTION
This PR resolves [JP-1462](https://jira.stsci.edu/browse/JP-1462) in which an error was being raised when attempting to construct a polynomial fit with `LinearLSQFittter` and `Polynomial1D` with inputs of length 1. The minimum number of "good points" is now 2.