### PR TITLE
Fix doc build warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ jobs:
       addons:
         apt:
           packages:
+            - texlive-latex-extra
+            - dvipng
             - graphviz
 
     - name: Code style check

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,15 +15,13 @@ import datetime
 import importlib
 import sys
 import os
+from distutils.version import LooseVersion
+from configparser import ConfigParser
+
 import sphinx
 import stsci_rtd_theme
 import sphinx_astropy
 
-from distutils.version import LooseVersion
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
 
 def setup(app):
     try:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,14 +19,18 @@ import sphinx
 import stsci_rtd_theme
 import sphinx_astropy
 
-def setup(app):
-    app.add_stylesheet("stsci.css")
-
 from distutils.version import LooseVersion
 try:
     from ConfigParser import ConfigParser
 except ImportError:
     from configparser import ConfigParser
+
+def setup(app):
+    try:
+        app.add_css_file("stsci.css")
+    except AttributeError:
+        app.add_stylesheet("stsci.css")
+
 conf = ConfigParser()
 
 

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -150,7 +150,7 @@ documentation on each reference file.
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`source_catalog <source_catalog_step>` | :ref:`APCORR <apcorr_reffile>`                   |
 +                                             +--------------------------------------------------+
-|                                             | :ref:`ABVEGAOFFSET <abvegaoffset_reffile>`      |
+|                                             | :ref:`ABVEGAOFFSET <abvegaoffset_reffile>`       |
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`straylight <straylight_step>`         | :ref:`REGIONS <regions_reffile>`                 |
 +---------------------------------------------+--------------------------------------------------+

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -2,11 +2,11 @@ from ..stpipe import Step
 from .. import datamodels
 from . import ami_analyze
 
+__all__ = ["AmiAnalyzeStep"]
+
 
 class AmiAnalyzeStep(Step):
-    """
-    AmiAnalyzeStep: Performs analysis of an AMI mode exposure by
-    applying the LG algorithm.
+    """Performs analysis of an AMI mode exposure by applying the LG algorithm.
     """
 
     spec = """

--- a/jwst/ami/ami_average_step.py
+++ b/jwst/ami/ami_average_step.py
@@ -2,6 +2,8 @@ from ..stpipe import Step
 
 from . import ami_average
 
+__all__ = ["AmiAverageStep"]
+
 
 class AmiAverageStep(Step):
     """

--- a/jwst/ami/ami_normalize_step.py
+++ b/jwst/ami/ami_normalize_step.py
@@ -3,6 +3,8 @@ from .. import datamodels
 
 from . import ami_normalize
 
+__all__ = ["AmiNormalizeStep"]
+
 
 class AmiNormalizeStep(Step):
     """

--- a/jwst/assign_mtwcs/assign_mtwcs_step.py
+++ b/jwst/assign_mtwcs/assign_mtwcs_step.py
@@ -17,7 +17,7 @@ class AssignMTWcsStep(Step):
 
     Parameters
     ----------
-    input : `~jwst.associations.Association.
+    input : `~jwst.associations.Association`
         A JWST association file.
     """
 

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -28,7 +28,8 @@ log.setLevel(logging.DEBUG)
 
 
 __all__ = ["reproject", "wcs_from_footprints", "velocity_correction",
-           "MSAFileError", "NoDataOnDetectorError"]
+           "MSAFileError", "NoDataOnDetectorError", "compute_scale",
+           "calc_rotation_matrix", ]
 
 
 class MSAFileError(Exception):

--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -59,15 +59,6 @@ class Association(MutableMapping):
     schema_file : str
         The name of the output schema that an association
         must adhere to.
-
-    registry : AssociationRegistry
-        The registry this association came from.
-
-    asn_name : str
-        The suggested file name of association
-
-    asn_rule : str
-        The name of the rule
     """
 
     registry = None

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -149,9 +149,6 @@ class DMSBaseMixin(ACIDMixin):
 
     Attributes
     ----------
-    from_items : [item[,...]]
-        The list of items that contributed to the association.
-
     sequence : int
         The sequence number of the current association
     """
@@ -235,7 +232,7 @@ class DMSBaseMixin(ACIDMixin):
 
     @property
     def from_items(self):
-        """List of items from which members were created"""
+        """The list of items that contributed to the association."""
         try:
             items = [
                 member.item

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -407,6 +407,7 @@ class Asn_IFU(AsnMixin_Spectrum):
 @RegistryMarker.rule
 class Asn_IFUGrating(AsnMixin_Spectrum):
     """Level 3 IFU gratings Association
+
     Note: This is here to split the associations based on the gratings
           used in the observation. In principle these observations can
           (and maybe should) be combined but to reduce processing time

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -56,10 +56,6 @@ class Main():
     associations : [`Association`, ...]
         The list of generated associations.
 
-    orphaned : `AssociationPool`
-        The pool of exposures that do not belong
-        to any association.
-
     Notes
     -----
     Refer to the :ref:`Association Generator <associations>`
@@ -286,6 +282,8 @@ class Main():
 
     @property
     def orphaned(self):
+        """The pool of exposures that do not belong to any association."""
+
         not_in_asn = np.ones((len(self.pool),), dtype=bool)
         for asn in self.associations:
             try:

--- a/jwst/associations/registry.py
+++ b/jwst/associations/registry.py
@@ -57,24 +57,6 @@ class AssociationRegistry(dict):
         If True, include base classes not considered
         rules.
 
-    Attributes
-    ----------
-    rule_set : {rule [, ...]}
-        The rules in the registry.
-
-    Methods
-    -------
-    match(item)
-        Return associations where `item` matches any of the rules.
-
-    validate(association)
-        Determine whether an association is valid, or complete,
-        according to any of the rules in the registry.
-
-    load(serialized)
-        Create an association from a serialized form.
-
-
     Notes
     -----
     The general workflow is as follows:
@@ -225,7 +207,7 @@ class AssociationRegistry(dict):
             first=True,
             **kwargs
     ):
-        """Marshall a previously serialized association
+        """Load a previously serialized association
 
         Parameters
         ----------

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -26,7 +26,7 @@ log.setLevel(logging.DEBUG)
 
 
 def match(images, skymethod='global+match', match_down=True, subtract=False):
-    r"""
+    """
     A function to compute and/or "equalize" sky background in input images.
 
     .. note::

--- a/jwst/wiimatch/lsq_optimizer.py
+++ b/jwst/wiimatch/lsq_optimizer.py
@@ -91,7 +91,7 @@ def build_lsq_eqs(images, masks, sigmas, degree, center=None,
     :py:func:`build_lsq_eqs` builds a system of linear equations
 
     .. math::
-        a \\cdot c = b
+        a \cdot c = b
 
     whose solution :math:`c` is a set of coefficients of (multivariate)
     polynomials that represent the "background" in each input image (these are
@@ -99,9 +99,7 @@ def build_lsq_eqs(images, masks, sigmas, degree, center=None,
     that the following sum is minimized:
 
     .. math::
-        L = \sum^N_{n,m=1,n \\neq m} \sum_k\
-        \\frac{\\left[I_n(k) - I_m(k) - P_n(k) + P_m(k)\\right]^2}\
-        {\sigma^2_n(k) + \sigma^2_m(k)}.
+        L = \sum^N_{n,m=1,n \neq m} \sum_k \frac{\left[I_n(k) - I_m(k) - P_n(k) + P_m(k)\right]^2}{\sigma^2_n(k) + \sigma^2_m(k)}
 
     In the above equation, index :math:`k=(k_1,k_2,...)` labels a position
     in input image's pixel grid [NOTE: all input images share a common
@@ -111,15 +109,13 @@ def build_lsq_eqs(images, masks, sigmas, degree, center=None,
     corresponding coefficients as:
 
     .. math::
-        P_n(k_1,k_2,...) = \sum_{d_1=0,d_2=0,...}^{D_1,D_2,...} \
-        c_{d_1,d_2,...}^n \\cdot k_1^{d_1} \\cdot k_2^{d_2}  \\cdot \\ldots .
+        P_n(k_1,k_2,...) = \sum_{d_1=0,d_2=0,...}^{D_1,D_2,...} c_{d_1,d_2,...}^n \cdot k_1^{d_1} \cdot k_2^{d_2}  \cdot \ldots .
 
     Coefficients :math:`c_{d_1,d_2,...}^n` are arranged in the vector :math:`c`
     in the following order:
 
     .. math::
-        (c_{0,0,\\ldots}^1,c_{1,0,\\ldots}^1,\\ldots,c_{0,0,\\ldots}^2,\
-        c_{1,0,\\ldots}^2,\\ldots).
+        (c_{0,0,\ldots}^1,c_{1,0,\ldots}^1,\ldots,c_{0,0,\ldots}^2,c_{1,0,\ldots}^2,\ldots)
 
     Examples
     --------

--- a/jwst/wiimatch/match.py
+++ b/jwst/wiimatch/match.py
@@ -21,7 +21,7 @@ SUPPORTED_SOLVERS = ['RLU', 'PINV']
 def match_lsq(images, masks=None, sigmas=None, degree=0,
               center=None, image2world=None, center_cs='image',
               ext_return=False, solver='RLU'):
-    r"""
+    """
     Compute coefficients of (multivariate) polynomials that once subtracted
     from input images would provide image intensity matching in the least
     squares sense.


### PR DESCRIPTION
We turned off checking for doc build warnings a while back (my fault), and they have accumulated.  This PR fixes them all (see [here](https://travis-ci.org/github/spacetelescope/jwst/jobs/690207622#L539-L851) for their current state).  It also returns to converting warnings to errors in both user and Travis doc builds, i.e. the equivalent of

```
sphinx-build -W docs docs/_build
```

It also fixes renderings of some equations that got munged by some `DeprecationWarning` fixes a while back (also my fault).

And it removes a number of redundant docstrings in `associations` which are now apparently a no-no since sphinx 2.1 (perhaps there's a different way - i.e. keep them and not index them?)

It's a new day.