### PR TITLE
Update MT_RA/DEC keyword comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,15 +6,17 @@ associations
 
 - Update diagrams to change sloper to detector1. [#4986]
 
-extract_1d
-----------
-
-- Fix bug in creating a polynomial fit used in background extraction. [#4970]
-
 datamodels
 ----------
 
 - Added methods ``Model.info`` and ``Model.search``. [#4660]
+
+- Trimmed MT_RA, MT_DEC keyword comments to fit within FITS record. [#4994]
+
+extract_1d
+----------
+
+- Fix bug in creating a polynomial fit used in background extraction. [#4970]
 
 0.16.1 (2020-05-19)
 ===================

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -319,22 +319,22 @@ properties:
             fits_keyword: YREF_SCI
             fits_hdu: SCI
           mt_ra:
-            title: "[deg] Moving target right ascension at mid-point of exposure"
+            title: "[deg] Moving target RA at exposure mid-point"
             type: number
             fits_keyword: MT_RA
             fits_hdu: SCI
           mt_dec:
-            title: "[deg] Moving target declination at mid-point of exposure"
+            title: "[deg] Moving target Dec at exposure mid-point"
             type: number
             fits_keyword: MT_DEC
             fits_hdu: SCI
           mt_avra:
-            title: "[deg] Right ascension of the moving target averaged between exposures"
+            title: "[deg] Moving target average RA over exposures"
             type: number
             fits_keyword: MT_AVRA
             fits_hdu: SCI
           mt_avdec:
-            title: "[deg] Declination of the moving target averaged between exposures"
+            title: "[deg] Moving target average Dec over exposures"
             type: number
             fits_keyword: MT_AVDEC
             fits_hdu: SCI


### PR DESCRIPTION
Updated the comment strings for the MT_RA, MT_DEC, MT_AVRA, and MT_AVDEC keywords in `wcsinfo.schema.yaml` to match what was recently implemented for these keywords in the Keyword Dictionary (JWSTKD-358, JWSTKD-359). The original comment strings were shortened so that they won't get truncated when appearing in actual FITS header records.

Should only affect regtest datasets that actually use moving target data (which is a very small number).