### PR TITLE
Fix open file issues in master background, tso and spec pipelines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,12 +20,21 @@ extract_1d
 
 - Fix bug in creating a polynomial fit used in background extraction. [#4970]
 
+master_background
+-----------------
+
+- Fix open files bug [#4995]
+
 pipeline
 --------
 
 - Refactor the ``Image3Pipeline`` to use ``stpipe`` infrastructure. [#4990]
 
-- Fix ``Coron3Pipeline`` to blend headers just from each input science model, not every integration. [#5007]
+- Fix ``Coron3Pipeline`` to blend headers just from each input science model,
+  not every integration. [#5007]
+
+- Fix open files bug in ``get_config_from_reference`` class method, and in
+  ``Spec2Pipeline``, ``Spec3Pipeline`` and ``tso3``. [#4995]
 
 stpipe
 ------

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -46,7 +46,7 @@ class ModelContainer(model_base.DataModel):
           DataModels can be added via the ``append()`` method.
 
        - asn_exptypes: list of exposure types from the asn file to read
-         into the pipeline, if None read all the given files.
+         into the ModelContainer, if None read all the given files.
 
        - asn_n_members: Open only the first N qualifying members.
 

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -123,8 +123,11 @@ class MasterBackgroundStep(Step):
                         background_2d = expand_to_2d(model, master_background)
                         result.append(subtract_2d_background(model, background_2d))
 
+                    input_data.close()
+
                 else:
                     result = input_data.copy()
+                    input_data.close()
                     self.log.warning(
                         "Input %s of type %s cannot be handled without user-supplied background.  Step skipped.",
                         input, type(input)

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -268,6 +268,10 @@ class Spec2Pipeline(Pipeline):
         # Apply flux calibration
         result = self.photom(input)
 
+        # Close the input file.  We should really be doing this further up
+        # passing along result all the way down.
+        input.close()
+
         # Record ASN pool and table names in output
         result.meta.asn.pool_name = pool_name
         result.meta.asn.table_name = op.basename(asn_file)

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -227,7 +227,7 @@ class Spec3Pipeline(Pipeline):
                     'Resampling was not completed. Skipping extract_1d.'
                 )
 
-        source_models.close()
+        input_models.close()
 
         self.log.info('Ending calwebb_spec3')
         return

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -126,7 +126,9 @@ class Spec3Pipeline(Pipeline):
             # would've been done in master_background
             if self.master_background.skip:
                 source_models, bkg_models = split_container(input_models)
-                del bkg_models  # we don't need the background members
+                # we don't need the background members
+                bkg_models.close()
+                del bkg_models
         else:
             # The input didn't contain any background members,
             # so we use all the inputs in subsequent steps
@@ -225,6 +227,7 @@ class Spec3Pipeline(Pipeline):
                     'Resampling was not completed. Skipping extract_1d.'
                 )
 
-        # We're done
+        source_models.close()
+
         self.log.info('Ending calwebb_spec3')
         return

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -152,12 +152,13 @@ class Tso3Pipeline(Pipeline):
                 phot_result_list.append(self.white_light(result))
 
             # Update some metadata from the association
-            x1d_result.meta.asn.pool_name = \
-                input_models.meta.asn_table.asn_pool
+            x1d_result.meta.asn.pool_name = input_models.meta.asn_table.asn_pool
             x1d_result.meta.asn.table_name = op.basename(input)
 
             # Save the final x1d Multispec model
             self.save_model(x1d_result, suffix='x1dints')
+
+        input_models.close()
 
         if len(phot_result_list) == 1 and phot_result_list[0] is None:
             self.log.info("Could not create a photometric catalog for data")

--- a/jwst/regtest/test_nirspec_fs_spec3.py
+++ b/jwst/regtest/test_nirspec_fs_spec3.py
@@ -1,7 +1,5 @@
-import os
-
-import pytest
 from astropy.io.fits.diff import FITSDiff
+import pytest
 
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
@@ -12,7 +10,6 @@ def run_pipeline(jail, rtdata_module):
     """
     Run the calwebb_spec3 pipeline on NIRSpec Fixed-Slit exposures.
     """
-
     rtdata = rtdata_module
 
     # Get the cfg files
@@ -28,22 +25,22 @@ def run_pipeline(jail, rtdata_module):
             "--steps.extract_1d.save_results=true"]
     Step.from_cmdline(args)
 
-    return rtdata
-
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d"])
-def test_nirspec_fs_spec3(run_pipeline, fitsdiff_default_kwargs, suffix):
-    """Regression test of the calwebb_spec3 pipeline on a set
-       of NIRSpec FS exposures."""
+def test_nirspec_fs_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix):
+    """Test spec3 pipeline on a set of NIRSpec FS exposures."""
+    rtdata = rtdata_module
 
-    # Run the pipeline and retrieve outputs
-    rtdata = run_pipeline
-    output = 'jw93045-o010_s00003_nirspec_f290lp-g395h-subs400a1_' + suffix + '.fits'
+    output = f"jw93045-o010_s00003_nirspec_f290lp-g395h-subs400a1_{suffix}.fits"
     rtdata.output = output
 
     # Get the truth files
-    rtdata.get_truth(os.path.join("truth/test_nirspec_fs_spec3", output))
+    rtdata.get_truth(f"truth/test_nirspec_fs_spec3/{output}")
+
+    # Set looser tolerance for resampled s2d comparison
+    if suffix == "s2d":
+        fitsdiff_default_kwargs["atol"] = 1e-5
 
     # Compare the results
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -191,12 +191,12 @@ class Pipeline(Step):
         log.log.debug('Retrieving all substep parameters from CRDS')
         #
         # Iterate over the steps in the pipeline
-        model = dm_open(dataset, asn_n_members=1)
-        for cal_step in cls.step_defs.keys():
-            cal_step_class = cls.step_defs[cal_step]
-            refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(
-                model, observatory=observatory
-            )
+        with dm_open(dataset, asn_n_members=1) as model:
+            for cal_step in cls.step_defs.keys():
+                cal_step_class = cls.step_defs[cal_step]
+                refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(
+                    model, observatory=observatory
+                )
         #
         # Now merge any config parameters from the step cfg file
         log.log.debug(f'Retrieving pipeline {pars_model.meta.reftype.upper()} parameters from CRDS')


### PR DESCRIPTION
We still have some open file issues, which appeared when running the updated version of `pytest-openfiles` and the latest `astropy` release candidate.

This should now get our nightly regression test builds that use dev dependencies passing (and will make sure that our regular nightly tests pass under `astropy 4.1` when it is released).

Thanks to @eslavich for some help debugging this.

Resolves #4978 / [JP-1468](https://jira.stsci.edu/browse/JP-1468)