### PR TITLE
JP-1490: skip assign_mtwcs if target coords missing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.16.2 (unreleased)
 ===================
 
+assign_mtwcs
+------------
+
+- Skip the step if any input MT_RA/DEC keyword values are missing. [#5015]
+
 associations
 ------------
 

--- a/jwst/assign_mtwcs/assign_mtwcs_step.py
+++ b/jwst/assign_mtwcs/assign_mtwcs_step.py
@@ -40,10 +40,4 @@ class AssignMTWcsStep(Step):
         # Apply the step
         result = assign_moving_target_wcs(input)
 
-        # Check for a null result
-        if result is None:
-            for model in input:
-                model.meta.cal_step.assign_mtwcs = 'SKIPPED'
-            return input
-
         return result

--- a/jwst/assign_mtwcs/assign_mtwcs_step.py
+++ b/jwst/assign_mtwcs/assign_mtwcs_step.py
@@ -1,9 +1,8 @@
 #! /usr/bin/env python
+import logging
 from ..stpipe import Step
 from .. import datamodels
-import logging
 from .moving_target_wcs import assign_moving_target_wcs
-
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -22,17 +21,29 @@ class AssignMTWcsStep(Step):
     """
 
     spec = """
-    suffix             = string(default='assign_mtwcs')        # Default suffix for output files
-    output_use_model   = boolean(default=True)      # When saving use `DataModel.meta.filename`
+        suffix = string(default='assign_mtwcs')    # Default suffix for output files
+        output_use_model = boolean(default=True)   # When saving use `DataModel.meta.filename`
     """
+
     def process(self, input):
+
         if isinstance(input, str):
             input = datamodels.open(input)
+
+        # Can't apply the step if we aren't given a ModelContainer as input
         if not isinstance(input, datamodels.ModelContainer):
             log.warning("Input data type is not supported.")
             # raise ValueError("Expected input to be an association file name or a ModelContainer.")
             input.meta.cal_step.assign_mtwcs = 'SKIPPED'
             return input
 
+        # Apply the step
         result = assign_moving_target_wcs(input)
+
+        # Check for a null result
+        if result is None:
+            for model in input:
+                model.meta.cal_step.assign_mtwcs = 'SKIPPED'
+            return input
+
         return result

--- a/jwst/assign_mtwcs/moving_target_wcs.py
+++ b/jwst/assign_mtwcs/moving_target_wcs.py
@@ -7,6 +7,7 @@ each of the WCS pipelines to allow aligning the exposures to the average
 location of the target.
 
 """
+import logging
 from copy import deepcopy
 import numpy as np
 from astropy.modeling.models import Shift, Identity
@@ -14,16 +15,29 @@ from gwcs import WCS
 from gwcs import coordinate_frames as cf
 from jwst import datamodels
 
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+__all__ = ["assign_moving_target_wcs"]
+
 
 def assign_moving_target_wcs(input_model):
 
     if not isinstance(input_model, datamodels.ModelContainer):
         raise ValueError("Expected a ModelContainer object")
 
+    # Get the MT RA/Dec values from all the input exposures
     mt_ra = np.array([model.meta.wcsinfo.mt_ra for model in input_model._models])
     mt_dec = np.array([model.meta.wcsinfo.mt_dec for model in input_model._models])
-    mt_avra = mt_ra.mean()
-    mt_avdec = mt_dec.mean()
+
+    # Compute the mean MT RA/Dec over all exposures
+    if (None in mt_ra) or (None in mt_dec):
+        log.warning("One or more MT RA/Dec values missing in input images")
+        log.warning("Step will be skipped, resulting in target misalignment")
+        return None
+    else:
+        mt_avra = mt_ra.mean()
+        mt_avdec = mt_dec.mean()
 
     for model in input_model:
         pipeline = model.meta.wcs._pipeline[:-1]
@@ -45,10 +59,12 @@ def assign_moving_target_wcs(input_model):
             transform_to_mt = Shift(rdel) & Shift(ddel) & Identity(1)
         else:
             raise ValueError("Unrecognized coordinate frame.")
+
         pipeline.append((model.meta.wcs.output_frame, transform_to_mt))
         pipeline.append((mt, None))
         new_wcs = WCS(pipeline)
         del model.meta.wcs
         model.meta.wcs = new_wcs
         model.meta.cal_step.assign_mtwcs = 'COMPLETE'
+
     return input_model

--- a/jwst/assign_mtwcs/moving_target_wcs.py
+++ b/jwst/assign_mtwcs/moving_target_wcs.py
@@ -34,7 +34,9 @@ def assign_moving_target_wcs(input_model):
     if (None in mt_ra) or (None in mt_dec):
         log.warning("One or more MT RA/Dec values missing in input images")
         log.warning("Step will be skipped, resulting in target misalignment")
-        return None
+        for model in input_model:
+            model.meta.cal_step.assign_mtwcs = 'SKIPPED'
+        return input_model
     else:
         mt_avra = mt_ra.mean()
         mt_avdec = mt_dec.mean()


### PR DESCRIPTION
If any of the input images to the `assign_mtwcs` step are missing the MT_RA or MT_DEC keyword values, issue a warning and skip the step.

Fixes #5014 / [JP-1490](https://jira.stsci.edu/browse/JP-1490)