### PR TITLE
Changes to datamodels to add default value for meta.instrument.lamp_mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ datamodels
 
 - Trimmed MT_RA, MT_DEC keyword comments to fit within FITS record. [#4994]
 
+- Add enum list and default value of 'NONE' for ``meta.instrument.lamp_mode`` [#5022]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -515,6 +515,8 @@ properties:
           lamp_mode:
             title: Lamp operating mode
             type: string
+            default: 'NONE'
+            enum: [BRIGHTOBJ, FIXEDSLIT, GRATING-ONLY, IFU, MSASPEC, 'NONE']
             fits_keyword: OPMODE
             blend_table: True
           gwa_xtilt:


### PR DESCRIPTION
As it will be used as a parkey in CRDS ref file selection and we want there to be a default value even if the OPMODE keyword is missing from the science data headers.  Also added enum list.