### PR TITLE
Fix dangling file handle when ModelContainer.from_asn() fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@ pipeline
 stpipe
 ------
 
+- Limit reference file prefetch to the first "science" exptype
+  when a pipeline has an association as input. [#5031]
+
 - Remove further sloper references. [#4989]
 
 0.16.1 (2020-05-19)

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -221,9 +221,11 @@ class ModelContainer(model_base.DataModel):
         else:
             sublist = infiles
         try:
-            self._models = [datamodel_open(infile, memmap=self._memmap) for infile in sublist]
+            for filepath in sublist:
+                self._models.append(datamodel_open(filepath, memmap=self._memmap))
         except IOError:
-            raise IOError('Cannot open {}'.format(infiles))
+            self.close()
+            raise
 
         # Pull the whole association table into meta.asn_table
         self.meta.asn_table = {}

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -568,6 +568,20 @@ def test_modelcontainer_group_names(container):
     assert len(container.group_names) == 2
 
 
+def test_modelcontainer_error_from_asn(tmpdir):
+    from jwst.associations.asn_from_list import asn_from_list
+
+    asn = asn_from_list(["foo.fits"], product_name="foo_out")
+    name, serialized = asn.dump(format="json")
+    path = str(tmpdir.join(name))
+    with open(path, "w") as f:
+        f.write(serialized)
+
+    # The foo.fits file doesn't exist
+    with pytest.raises(FileNotFoundError):
+        datamodels.open(path)
+
+
 def test_object_node_iterator():
     im = ImageModel()
     items = []

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -51,8 +51,8 @@ def test_niriss_soss_stage2(rtdata_module, run_tso_spec2, fitsdiff_default_kwarg
 
 
 @pytest.mark.bigdata
-def test_niriss_soss_stage2_crfints(rtdata_module, run_tso_spec3, fitsdiff_default_kwargs):
-    """Regression test of tso-spec2 pipeline performed on NIRISS SOSS data."""
+def test_niriss_soss_stage3_crfints(rtdata_module, run_tso_spec3, fitsdiff_default_kwargs):
+    """Regression test of tso-spec3 pipeline outlier_detection results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
     output = "jw00625023001_03101_00001-seg001_nis_o023_crfints.fits"
     rtdata.output = output
@@ -65,6 +65,7 @@ def test_niriss_soss_stage2_crfints(rtdata_module, run_tso_spec3, fitsdiff_defau
 
 @pytest.mark.bigdata
 def test_niriss_soss_stage3_x1dints(run_tso_spec3, rtdata_module, fitsdiff_default_kwargs):
+    """Regression test of tso-spec3 pipeline extract_1d results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
 
     output = "jw00625-o023_t001_niriss_clear-gr700xd-substrip256_x1dints.fits"
@@ -77,6 +78,7 @@ def test_niriss_soss_stage3_x1dints(run_tso_spec3, rtdata_module, fitsdiff_defau
 
 @pytest.mark.bigdata
 def test_niriss_soss_stage3_whtlt(run_tso_spec3, rtdata_module, diff_astropy_tables):
+    """Regression test of tso-spec3 pipeline white_light results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
 
     output = "jw00625-o023_t001_niriss_clear-gr700xd-substrip256_whtlt.ecsv"

--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -131,8 +131,8 @@ def check_reference_open(refpath):
             if not s3_utils.object_exists(refpath):
                 raise RuntimeError("S3 object does not exist: " + refpath)
         else:
-            opened = open(refpath, "rb")
-            opened.close()
+            with open(refpath, "rb"):
+                pass
     return refpath
 
 

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -265,7 +265,8 @@ class Pipeline(Step):
         """
         from .. import datamodels
         try:
-            with datamodels.open(input_file) as model:
+            with datamodels.open(input_file, asn_n_members=1,
+                                asn_exptypes=["science"]) as model:
                 self._precache_references_opened(model)
         except (ValueError, TypeError, IOError):
             self.log.info(
@@ -319,7 +320,7 @@ class Pipeline(Step):
 
         for (reftype, refpath) in sorted(ref_path_map.items()):
             how = "Override" if reftype in ovr_refs else "Prefetch"
-            self.log.info("{0} for {1} reference file is '{2}'.".format(how, reftype.upper(), refpath))
+            self.log.info(f"{how} for {reftype.upper()} reference file is '{refpath}'.")
             crds_client.check_reference_open(refpath)
 
     @classmethod


### PR DESCRIPTION
In our dev nightly regression tests which use the latest dev `astropy` (also happens with `astropy 4.1rc1`), we see open files left behind in `jwst.regtest.test_niriss_soss.py`:

https://plwishmaster.stsci.edu:8081/job/RT/job/JWST_UNSTABLE/272/testReport/jwst.regtest/test_niriss_soss/_unstable_deps__test_niriss_soss_stage2_calints_/

```
E           AssertionError: File(s) not closed:
E             /data1/jenkins/workspace/RT/JWST_UNSTABLE/clone/test_outputs/popen-gw24/test_niriss_soss_run_pipelines0/jw00625023001_03101_00001-seg002_nis_calints.fits
E             /data1/jenkins/workspace/RT/JWST_UNSTABLE/clone/test_outputs/popen-gw24/test_niriss_soss_run_pipelines0/jw00625023001_03101_00001-seg001_nis_calints.fits

/data1/jenkins/workspace/RT/JWST_UNSTABLE/miniconda/envs/tmp_env0/lib/python3.7/site-packages/pytest_openfiles/plugin.py:137: AssertionError
```

This happens due to a CRDS reffile prefetch failure.  It is because the association for TSO3 processing in this test contains a 3rd target acquisition file listed that doesn't get downloaded for the test.  When `ModelContainer.from_asn()` tries to load the 3 files in order to do reffile prefetch, it only finds 2 of them and fails.  We catch the error and continue processing, but these files remain open, even though the test passes.

So the following are solutions in this PR:

- If one file in an association doesn't load and `from_asn()` raises an error, clean up the file handles on exit.
- reffile prefetch should probably not be trying to prefetch for non-science data anyway, and maybe only for the first science file.  **So limit the prefetch to the first science exptype only.**
- Refactor the `test_niriss_soss.py` regression test so that only the tso2 pipeline need be run if a test doesn't require a tso3 product.  This was to aid debugging, but is good practice anyway.

We had seen similar behavior in `calwebb_coron3` and had turned off reffile_prefetch at the class level.  These modifications mean that perhaps we could consider turning it back on.  Something to consider.

Resolves #4978 / [JP-1468](https://jira.stsci.edu/browse/JP-1468)