### PR TITLE
Fix a bug in ramp_fit multiprocessing code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,11 @@ pipeline
 - Fix open files bug in ``get_config_from_reference`` class method, and in
   ``Spec2Pipeline``, ``Spec3Pipeline`` and ``tso3``. [#4995]
 
+ramp_fitting
+------------
+
+- Add multi-processing capability. [#4815]
+
 stpipe
 ------
 
@@ -1690,10 +1695,8 @@ master_background
 model_blender
 -------------
 
-
 msaflagopen
 -----------
-
 
 outlier_detection
 -----------------


### PR DESCRIPTION
PR #4815 was a missing a line to populate the ERR array in the output rateints product for the case of single processor mode. Also added missing change log entry for the addition of multiprocessing to the step.