### PR TITLE
Temporarily xfail regtest that has rmap problem

### DIFF
--- a/jwst/regtest/test_nirspec_subarray.py
+++ b/jwst/regtest/test_nirspec_subarray.py
@@ -6,6 +6,8 @@ from astropy.io.fits.diff import FITSDiff
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
+from crds.exceptions import CrdsLookupError
+
 """
 nrs1_group_subarray.fits                the input (uncal) file
 nrs1_group_subarray_group_scale.fits    output from group_scale
@@ -27,7 +29,9 @@ def run_pipeline(jail, rtdata_module):
     return rtdata
 
 
-@pytest.mark.xfail(reason='known crds bestref error due to rmap')
+@pytest.mark.xfail(reason='known crds bestref error due to rmap',
+                   strict = True,
+                   raises = CrdsLookupError)
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output", [
     'nrs1_group_subarray_group_scale.fits',

--- a/jwst/regtest/test_nirspec_subarray.py
+++ b/jwst/regtest/test_nirspec_subarray.py
@@ -27,6 +27,7 @@ def run_pipeline(jail, rtdata_module):
     return rtdata
 
 
+@pytest.mark.xfail(reason='known crds bestref error due to rmap')
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output", [
     'nrs1_group_subarray_group_scale.fits',


### PR DESCRIPTION
Temporarily xfail the NIRSpec `calwebb_detector1` regtest that throws a bestref error due to an rmap problem, because it appears it's going to be a while yet till the rmap gets fixed. At least we'll get a passing regtest run this way.