### PR TITLE
Fix NIRSPEC IFU slices problem in JP-932

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,12 @@ master_background
 
 - Fix open files bug [#4995]
 
+pathloss
+--------
+- fix bug in NIRSpec IFU data that causes valid pixel dq flags to set to 
+  NON-SCIENCE in the region of an overlapping bounding box slice [#5047]
+  
+
 pipeline
 --------
 
@@ -57,6 +63,11 @@ pipeline
 
 - Fix open files bug in ``get_config_from_reference`` class method, and in
   ``Spec2Pipeline``, ``Spec3Pipeline`` and ``tso3``. [#4995]
+
+photom
+------
+- fix bug in NIRSpec IFU data that causes valid pixel dq flags to set to 
+  NON-SCIENCE in the region of an overlapping bounding box slice [#5047]
 
 ramp_fitting
 ------------

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -333,12 +333,11 @@ def do_correction(input_model, pathloss_model):
         for slice in NIRSPEC_IFU_SLICES:
             slice_wcs = nirspec.nrs_wcs_set_input(input_model, slice)
             x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
-            xmin = int(x.min())
-            xmax = int(x.max())
-            ymin = int(y.min())
-            ymax = int(y.max())
             ra, dec, wavelength = slice_wcs(x, y)
-            wavelength_array[ymin:ymax+1, xmin:xmax+1] = wavelength
+            valid = ~np.isnan(wavelength)
+            x = x[valid]
+            y = y[valid]
+            wavelength_array[y.astype(int), x.astype(int)] = wavelength[valid]
 
         # Compute the pathloss 2D correction
         if is_pointsource(input_model.meta.target.source_type):


### PR DESCRIPTION
This PR fixes the NIRSPEC slices not mapping properly.
A fix was required in pathloss and photom to remove wavelengths with NANs

Resolves #3910 / [JP-932](https://jira.stsci.edu/browse/JP-932)