### PR TITLE
JP-1507 checks subwcs and new_slit variables exist before trying to delete them

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,10 @@ extract_1d
 ----------
 - rechecks the input model container in run_extract1d to select the correct processing [#5076]
 
+extract_2d
+----------
+- checks subwcs and new_slit variables exist before trying to delete them [#]
+
 coron
 -----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,7 @@ extract_1d
 
 extract_2d
 ----------
-- checks subwcs and new_slit variables exist before trying to delete them [#]
+- checks subwcs and new_slit variables exist before trying to delete them [#5093]
 
 coron
 -----

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -485,8 +485,18 @@ def extract_grism_objects(input_model,
                 new_slit.bunit_err = input_model.meta.bunit_err
                 slits.append(new_slit)
     output_model.slits.extend(slits)
-    del subwcs
-    del new_slit
+    # In the case that there are no spectra to extract deleting the variables
+    # will fail so add the try block.
+    try:
+        del subwcs
+    except UnboundLocalError:
+        pass
+    try:
+        del new_slit
+    except UnboundLocalError:
+        pass
+    #del subwcs
+    #del new_slit
     log.info("Finished extractions")
     return output_model
 


### PR DESCRIPTION
extract_2d fails when trying to delete the variables subwcs and new_slit in the case that there are no grism spectra extracted. The unit tests pass, 
pytest test_grisms.py
...
= 13 passed, 1 xpassed, 6 warnings in 8.35s=
Some of the regression tests fail due to known precision issues between OS X and unix. 

Fixes #5039 / [JP-1507](https://jira.stsci.edu/browse/JP-1507)