### PR TITLE
Reactivate failing NIRSpec regtest

### DIFF
--- a/jwst/regtest/test_nirspec_subarray.py
+++ b/jwst/regtest/test_nirspec_subarray.py
@@ -6,8 +6,6 @@ from astropy.io.fits.diff import FITSDiff
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
-from crds.exceptions import CrdsLookupError
-
 """
 nrs1_group_subarray.fits                the input (uncal) file
 nrs1_group_subarray_group_scale.fits    output from group_scale

--- a/jwst/regtest/test_nirspec_subarray.py
+++ b/jwst/regtest/test_nirspec_subarray.py
@@ -29,9 +29,6 @@ def run_pipeline(jail, rtdata_module):
     return rtdata
 
 
-@pytest.mark.xfail(reason='known crds bestref error due to rmap',
-                   strict = True,
-                   raises = CrdsLookupError)
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output", [
     'nrs1_group_subarray_group_scale.fits',


### PR DESCRIPTION
Now that the NIRSpec readnoise rmap has been fixed in the latest CRDS context, the NIRSpec regtest that had been xfail-ed a couple weeks ago can be reinstated, because ref file retrieval is successful again.