### PR TITLE
Jp 918 Correct bar shadow parity bug for yslit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ associations
 
 - Update diagrams to change sloper to detector1. [#4986]
 
+  barshadow
+---------
+- Correct bar shadow parity bug for yslit. [#5095]
+
 combine_1d
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ associations
 
 - Update diagrams to change sloper to detector1. [#4986]
 
-  barshadow
+barshadow
 ---------
 - Correct bar shadow parity bug for yslit. [#5095]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -763,6 +763,8 @@ associations
 barshadow
 ---------
 
+- Update barshadow position [#3897]
+
 - Unit tests were added. [#3930]
 
 combine_1d

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -39,7 +38,6 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
-        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+import pdb
 
 from .. import (Association, AssociationRegistry, load_asn)
 from ..asn_from_list import (Main, asn_from_list)
@@ -38,6 +39,7 @@ def test_level2_tuple():
     products = asn['products']
     assert len(products) == len(items)
     for product in products:
+        #pdb.set_trace()
         assert product['name'] in ','.join(','.join(map(str, row)) for row in items)
         members = product['members']
         assert len(members) == 1

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -89,7 +89,7 @@ def do_correction(input_model, barshadow_model):
                 # shutter_status has an index of shadow.shape[0] - shutter_height.  Each subsequent
                 # shutter center has an index shutter_height greater.
                 index_of_fiducial_in_array = shadow.shape[0] - shutter_height * (1 + index_of_fiducial)
-                yrow = index_of_fiducial_in_array - yslit * shutter_height
+                yrow = index_of_fiducial_in_array + yslit * shutter_height
                 wcol = (wavelength - w0)/wave_increment
 
                 # Interpolate the bar shadow correction for non-Nan pixels


### PR DESCRIPTION
This is a correction for the fact that the yslit values in a 2D science spectrum _decrease_ from bottom to top but in the reference file they _increase_ from bottom to top. 

Fixes #3897 / [JP-918](https://jira.stsci.edu/browse/JP-918)