### PR TITLE
Make calwebb_tso3 more robust

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,9 @@ pipeline
 - Fix open files bug in ``get_config_from_reference`` class method, and in
   ``Spec2Pipeline``, ``Spec3Pipeline`` and ``tso3``. [#4995]
 
+- Update ``calwebb_tso3`` to do more robust checking of input data type.
+  [#5107]
+
 photom
 ------
 - fix bug in NIRSpec IFU data that causes valid pixel dq flags to set to 

--- a/docs/jwst/pipeline/calwebb_tso3.rst
+++ b/docs/jwst/pipeline/calwebb_tso3.rst
@@ -29,6 +29,15 @@ exposures are shown below:
 | :ref:`white_light <white_light_step>`             |         | |check|      |
 +---------------------------------------------------+---------+--------------+
 
+The logic that decides whether to apply the imaging or spectroscopy steps is based
+on the EXP_TYPE and TSOVISIT keyword values of the input data. Imaging steps are
+applied if either of the following is true:
+
+ - EXP_TYPE = 'NRC_TSIMAGE'
+ - EXP_TYPE = 'MIR_IMAGE' and TSOVISIT = True
+
+The spectroscopy steps will be applied in all other cases.
+
 Inputs
 ------
 

--- a/jwst/lib/pipe_utils.py
+++ b/jwst/lib/pipe_utils.py
@@ -3,10 +3,6 @@
 import numpy as np
 
 from ..associations.lib.dms_base import TSO_EXP_TYPES
-from ..datamodels import CubeModel
-
-# Model types that typically represent TSO's
-TSO_MODEL_TYPES = (CubeModel,)
 
 
 def is_tso(model):
@@ -42,9 +38,6 @@ def is_tso(model):
             is_tso = False
     except AttributeError:
         pass
-
-    # Check on model type
-    is_tso = is_tso or isinstance(model, TSO_MODEL_TYPES)
 
     # We've checked everything.
     return is_tso

--- a/jwst/lib/tests/test_pipe_utils.py
+++ b/jwst/lib/tests/test_pipe_utils.py
@@ -8,22 +8,6 @@ from .. import pipe_utils
 from ... import datamodels
 from ...associations.lib import dms_base
 
-all_datamodels = [
-    model
-    for name, model in inspect.getmembers(datamodels, inspect.isclass)
-    if issubclass(model, datamodels.DataModel)
-    and model not in pipe_utils.TSO_MODEL_TYPES
-]
-
-model_list = [
-    (model, True)
-    for model in pipe_utils.TSO_MODEL_TYPES
-]
-model_list.extend([
-    (model, False)
-    for model in all_datamodels
-])
-
 all_exp_types = dms_base.IMAGE2_NONSCIENCE_EXP_TYPES + \
             dms_base.IMAGE2_SCIENCE_EXP_TYPES + \
             dms_base.SPEC2_SCIENCE_EXP_TYPES
@@ -37,24 +21,6 @@ exp_types.extend([
     (exp_type, True)
     for exp_type in dms_base.TSO_EXP_TYPES
 ])
-
-
-@pytest.mark.parametrize(
-    'model_class, expected',
-    model_list
-)
-def test_is_tso_from_datamodel(model_class, expected):
-    """Test integrity of is_tso based on datamodels"""
-    try:
-        model = model_class()
-    except Exception:
-        # Can't generate a model. Mark as skipped
-        pytest.skip(
-            'Unable to generate a model from class'
-            '{}'.format(model_class)
-        )
-    else:
-        assert pipe_utils.is_tso(model) is expected
 
 
 @pytest.mark.parametrize(

--- a/jwst/lib/tests/test_pipe_utils.py
+++ b/jwst/lib/tests/test_pipe_utils.py
@@ -1,5 +1,4 @@
 """Test utilities"""
-import inspect
 import pytest
 
 import numpy as np

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -1,5 +1,6 @@
 import os.path as op
 
+import numpy as np
 from astropy.table import vstack
 
 from ..stpipe import Pipeline
@@ -9,6 +10,8 @@ from ..outlier_detection import outlier_detection_step
 from ..tso_photometry import tso_photometry_step
 from ..extract_1d import extract_1d_step
 from ..white_light import white_light_step
+
+from ..lib.pipe_utils import is_tso
 
 __all__ = ['Tso3Pipeline']
 
@@ -54,56 +57,62 @@ class Tso3Pipeline(Pipeline):
 
         input_models = datamodels.open(input, asn_exptypes=asn_exptypes)
 
+        # Sanity check the input data
+        input_tsovisit = is_tso(input_models[0])
+        if not input_tsovisit:
+            self.log.error('INPUT DATA ARE NOT TSO MODE. ABORTING PROCESSING.')
+            return
+
         if self.output_file is None:
             self.output_file = input_models.meta.asn_table.products[0].name
         self.asn_id = input_models.meta.asn_table.asn_id
 
-        input_exptype = None
-        input_tsovisit = None
         # Input may consist of multiple exposures, so loop over each of them
+        input_exptype = None
         for cube in input_models:
             if input_exptype is None:
                 input_exptype = cube.meta.exposure.type
-
-            if input_tsovisit is None:
-                input_tsovisit = cube.meta.visit.tsovisit
 
             # Can't do outlier detection if there isn't a stack of images
             if len(cube.data.shape) < 3:
                 self.log.warning('Input data are 2D; skipping outlier_detection')
                 break
 
-            # Convert CubeModel into ModelContainer of 2-D DataModels
-            input_2dmodels = datamodels.ModelContainer()
-            for i in range(cube.data.shape[0]):
-                # convert each plane of data cube into it own array
-                # for outlier detection...
-                image = datamodels.ImageModel(data=cube.data[i],
-                                              err=cube.err[i], dq=cube.dq[i])
-                image.update(cube)
-                image.meta.wcs = cube.meta.wcs
-                input_2dmodels.append(image)
-
+            # Perform regular outlier detection
             if not self.scale_detection:
-                msg = "Performing outlier detection on input images..."
-                self.log.info(msg)
+
+                # Convert CubeModel into ModelContainer of 2-D DataModels to
+                # use as input to outlier detection step
+                input_2dmodels = datamodels.ModelContainer()
+                for i in range(cube.data.shape[0]):
+                    # convert each plane of data cube into its own array
+                    image = datamodels.ImageModel(data=cube.data[i],
+                                                  err=cube.err[i], dq=cube.dq[i])
+                    image.update(cube)
+                    image.meta.wcs = cube.meta.wcs
+                    input_2dmodels.append(image)
+
+                self.log.info("Performing outlier detection on input images ...")
                 input_2dmodels = self.outlier_detection(input_2dmodels)
 
                 # Transfer updated DQ values to original input observation
                 for i in range(cube.data.shape[0]):
                     # Update DQ arrays with those from outlier_detection step
-                    cube.dq[i] = input_2dmodels[i].dq
+                    cube.dq[i] = np.bitwise_or(cube.dq[i], input_2dmodels[i].dq)
+
                 cube.meta.cal_step.outlier_detection = \
                     input_2dmodels[0].meta.cal_step.outlier_detection
 
+                del input_2dmodels
+
             else:
-                msg = "Performing scaled outlier detection on input images..."
-                self.log.info(msg)
+                self.log.info("Performing scaled outlier detection on input images ...")
                 self.outlier_detection.scale_detection = True
                 cube = self.outlier_detection(cube)
 
+        # Save crfints products
         if input_models[0].meta.cal_step.outlier_detection == 'COMPLETE':
-            self.log.info("Writing Level 2c cubes with updated DQ arrays...")
+            self.log.info("Saving crfints products with updated DQ arrays ...")
             for cube in input_models:
                 # preserve output filename
                 original_filename = cube.meta.filename
@@ -114,41 +123,44 @@ class Tso3Pipeline(Pipeline):
                 cube.meta.filename = original_filename
 
         # Create final photometry results as a single output
-        # regardless of how many members there may be...
+        # regardless of how many input members there may be
         phot_result_list = []
+
+        # Imaging
         if (input_exptype == 'NRC_TSIMAGE' or
             (input_exptype == 'MIR_IMAGE' and input_tsovisit)):
+
             # Create name for extracted photometry (Level 3) product
             phot_tab_suffix = 'phot'
 
             for cube in input_models:
                 # Extract Photometry from imaging data
                 phot_result_list.append(self.tso_photometry(cube))
+
+        # Spectroscopy
         else:
             # Create name for extracted white-light (Level 3) product
             phot_tab_suffix = 'whtlt'
 
-            # Working with spectroscopic TSO data...
+            # Working with spectroscopic TSO data;
             # define output for x1d (level 3) products
             x1d_result = datamodels.MultiSpecModel()
-            # TODO: check to make sure the following line is working
             x1d_result.update(input_models[0], only="PRIMARY")
 
-            # Remove source_type from the output model, if it exists,
-            # to prevent the creation of an empty SCI extension just
-            # for that keyword.
+            # Remove source_type from the output model, if it exists, to prevent
+            # the creation of an empty SCI extension just for that keyword.
             x1d_result.meta.target.source_type = None
 
             # For each exposure in the TSO...
             for cube in input_models:
                 # Process spectroscopic TSO data
                 # extract 1D
-                self.log.info("Extracting 1-D spectra...")
+                self.log.info("Extracting 1-D spectra ...")
                 result = self.extract_1d(cube)
                 x1d_result.spec.extend(result.spec)
 
                 # perform white-light photometry on 1d extracted data
-                self.log.info("Performing white-light photometry...")
+                self.log.info("Performing white-light photometry ...")
                 phot_result_list.append(self.white_light(result))
 
             # Update some metadata from the association
@@ -166,8 +178,9 @@ class Tso3Pipeline(Pipeline):
             phot_results = vstack(phot_result_list)
             phot_results.meta['number_of_integrations'] = len(phot_results)
             phot_tab_name = self.make_output_path(suffix=phot_tab_suffix, ext='ecsv')
-            self.log.info("Writing Level 3 photometry catalog {}...".format(
-                      phot_tab_name))
+            self.log.info(f"Writing Level 3 photometry catalog {phot_tab_name}")
             phot_results.write(phot_tab_name, format='ascii.ecsv', overwrite=True)
 
+        # All done. Nothing to return, because all products have
+        # been created here.
         return

--- a/jwst/tso_photometry/tso_photometry_step.py
+++ b/jwst/tso_photometry/tso_photometry_step.py
@@ -17,8 +17,7 @@ class TSOPhotometryStep(Step):
     Parameters
     -----------
     input : str or `CubeModel`
-        A filename for either a FITS image or and association table or a
-        `CubeModel`.
+        Filename for a FITS image or association table, or a `CubeModel`.
     """
 
     spec = """
@@ -28,39 +27,46 @@ class TSOPhotometryStep(Step):
     reference_file_types = ['tsophot']
 
     def process(self, input_data):
+
+        # Open the input as a CubeModel
         with CubeModel(input_data) as model:
 
+            # Need the FITS WCS CRPIX1/2 values for setting the
+            # photometry aperture location
             if model.meta.wcsinfo.crpix1 is None:
                 raise ValueError('CRPIX1 is missing.')
-
             if model.meta.wcsinfo.crpix2 is None:
                 raise ValueError('CRPIX2 is missing.')
 
             xcenter = model.meta.wcsinfo.crpix1 - 1    # 1-based origin
             ycenter = model.meta.wcsinfo.crpix2 - 1    # 1-based origin
 
+            # Get the tsophot reference file
             tsophot_filename = self.get_reference_file(model, 'tsophot')
-            self.log.debug('Reference file name = {}'.format(tsophot_filename))
+            self.log.debug(f'Reference file name = {tsophot_filename}')
             if tsophot_filename == 'N/A':
                 self.log.warning('No TSOPHOT reference file found;')
                 self.log.warning('the tso_photometry step will be skipped.')
                 return None
 
+            # Retrieve aperture info from the reference file
             pupil_name = 'ANY'
             if model.meta.instrument.pupil is not None:
                 pupil_name = model.meta.instrument.pupil
 
             (radius, radius_inner, radius_outer) = get_ref_data(
                         tsophot_filename, pupil=pupil_name)
-            self.log.debug('Using reference file {}'.format(tsophot_filename))
-            self.log.debug('radius = {}'.format(radius))
-            self.log.debug('radius_inner = {}'.format(radius_inner))
-            self.log.debug('radius_outer = {}'.format(radius_outer))
 
+            self.log.debug(f'radius = {radius}')
+            self.log.debug(f'radius_inner = {radius_inner}')
+            self.log.debug(f'radius_outer = {radius_outer}')
+
+            # Compute the aperture photometry
             catalog = tso_aperture_photometry(model, xcenter, ycenter,
                                               radius, radius_inner,
                                               radius_outer)
 
+            # Save the photometry in an output catalog
             if self.save_catalog:
                 old_suffixes = ['calints', 'crfints']
                 output_dir = self.search_attr('output_dir')
@@ -70,8 +76,7 @@ class TSOPhotometryStep(Step):
                                                   output_dir=output_dir)
                 catalog.write(cat_filepath, format='ascii.ecsv',
                               overwrite=True)
-                self.log.info('Wrote TSO photometry catalog: {0}'.
-                              format(cat_filepath))
+                self.log.info(f'Wrote TSO photometry catalog: {cat_filepath}')
 
         return catalog
 


### PR DESCRIPTION
A user recently reported that MIRI imaging TSO data were going through the spectroscopic branch of the ``calwebb_tso3`` pipeline, which turned out to be due to the fact that the TSOVISIT keyword was missing. These updates make the ``calwebb_tso3`` pipeline more robust to that kind of obvious problem with the input data and causes it to issue an error message and abort. Also needed to update the ``is_tso`` helper function, because it was assuming that any ``CubeModel`` data were TSO, which is not correct: coronagraphy data is also ``CubeModel``. Also just did a little general clean-up and addition of comments, etc. to the modules involved, as well as adding a description of the keyword logic to the docs.

At some point we should probably also try to figure out how to update the ``extract_1d`` and ``white_light`` steps to have them figure out if they've actually been given spectroscopic data as input and if not, then abort. Before the updates here, MIRI imaging data actually somehow made it through both of those steps, which is crazy.