### PR TITLE
JP-1283 Fix bug in outlier_detection to save intermediate results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,7 +59,7 @@ master_background
 outlier_detection
 -----------------
 
-- Fis but in saving intermediate resuls. [#]
+- Fix outlier_detection bug when saving intermediate resuls. [#5108]
 
   pathloss
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,7 +59,7 @@ master_background
 outlier_detection
 -----------------
 
-- Fix outlier_detection bug when saving intermediate resuls. [#5108]
+- Fix outlier_detection bug when saving intermediate results. [#5108]
 
   pathloss
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,7 +56,12 @@ master_background
 
 - Fix open files bug [#4995]
 
-pathloss
+outlier_detection
+-----------------
+
+- Fis but in saving intermediate resuls. [#]
+
+  pathloss
 --------
 - fix bug in NIRSpec IFU data that causes valid pixel dq flags to set to 
   NON-SCIENCE in the region of an overlapping bounding box slice [#5047]

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -194,11 +194,16 @@ class OutlierDetection:
             for model in drizzled_models:
                 if save_intermediate_results:
                     log.info("Writing out resampled exposures...")
-                    self.save_model(
-                        model,
-                        output_file=model.meta.filename,
-                        suffix=self.resample_suffix
+                    self.save_results = True
+                    self.output_use_model = model.meta.filename
+                    self.log = log
+                    Step.save_model(
+                        self,
+                        model=model,
+                        output_file=model.meta.filename.lstrip("_"),
+                        suffix=self.resample_suffix.lstrip("_").replace('.fits','')
                     )
+                    self.save_resutls = False
         else:
             drizzled_models = self.input_models
             for i in range(len(self.input_models)):

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -194,16 +194,10 @@ class OutlierDetection:
             for model in drizzled_models:
                 if save_intermediate_results:
                     log.info("Writing out resampled exposures...")
-                    self.save_results = True
-                    self.output_use_model = model.meta.filename
-                    self.log = log
-                    Step.save_model(
-                        self,
-                        model=model,
-                        output_file=model.meta.filename.lstrip("_"),
-                        suffix=self.resample_suffix.lstrip("_").replace('.fits','')
-                    )
-                    self.save_resutls = False
+                    model_output_path = self.make_output_path(
+                        basepath=model.meta.filename,
+                        suffix='outlier_i2d')
+                    model.save(model_output_path)
         else:
             drizzled_models = self.input_models
             for i in range(len(self.input_models)):


### PR DESCRIPTION
Updated the outlier detection code to save intermediate results when save_intermediate_results = True.
Fixes [JP-1283](https://jira.stsci.edu/browse/JP-1283) , #4540