### PR TITLE
JP-1554: Add TIMEUNIT keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ datamodels
 
 - Add enum list and default value of 'NONE' for ``meta.instrument.lamp_mode`` [#5022]
 
+- Add TIMEUNIT keyword to schemas. [#5109]
+
 extract_1d
 ----------
 - rechecks the input model container in run_extract1d to select the correct processing [#5076]

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -22,6 +22,11 @@ properties:
         type: string
         fits_keyword: TIMESYS
         blend_table: True
+      time_unit:
+        title: Default unit applicable to all time values
+        type: string
+        default: 's'
+        fits_keyword: TIMEUNIT
       filename:
         title: Name of the file
         type: string

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -134,6 +134,12 @@ allOf:
             default: "UTC"
             fits_keyword: TIMESYS
             fits_hdu: EXTRACT1D
+          time_unit:
+            title: Default unit applicable to all time values
+            type: string
+            default: 's'
+            fits_keyword: TIMEUNIT
+            fits_hdu: EXTRACT1D
           start_time_mjd:
             title: "[d] integration start time in MJD"
             type: number

--- a/jwst/datamodels/schemas/referencefile.schema.yaml
+++ b/jwst/datamodels/schemas/referencefile.schema.yaml
@@ -19,6 +19,11 @@ properties:
         title: principal time system for time-related keywords
         type: string
         fits_keyword: TIMESYS
+      time_unit:
+        title: Default unit applicable to all time values
+        type: string
+        default: 's'
+        fits_keyword: TIMEUNIT
       filename:
         title: Name of the file
         type: string

--- a/jwst/datamodels/schemas/steppars.schema.yaml
+++ b/jwst/datamodels/schemas/steppars.schema.yaml
@@ -16,6 +16,10 @@ properties:
       time_sys:
         title: principal time system for time-related keywords
         type: string
+      time_unit:
+        title: Default unit applicable to all time values
+        type: string
+        default: 's'
       filename:
         title: Name of the file
         type: string


### PR DESCRIPTION
Update all existing schemas that contain the TIMESYS keyword to also include TIMEUNIT, with specs as outlined in JP-1554 and requested in JWSTKD-97.

Should cause lots of regression test failures, due to extra keyword showing up in all outputs. Warming up okify_regtests now ...

Fixes #5101 / [JP-1554](https://jira.stsci.edu/browse/JP-1554)