### PR TITLE
JP-1556: Store both versions of pathloss correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ datamodels
 
 - Add TIMEUNIT keyword to schemas. [#5109]
 
+- Split ``pathloss`` object into ``pathloss_ps`` and ``pathloss_un``. [#5112]
+
 extract_1d
 ----------
 - rechecks the input model container in run_extract1d to select the correct processing [#5076]
@@ -60,9 +62,11 @@ master_background
 
 pathloss
 --------
-- fix bug in NIRSpec IFU data that causes valid pixel dq flags to set to 
+- Fix bug in NIRSpec IFU data that causes valid pixel dq flags to set to 
   NON-SCIENCE in the region of an overlapping bounding box slice [#5047]
   
+- Update to save both point source and uniform source 2D pathloss correction
+  arrays to output. [#5112]
 
 pipeline
 --------

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -259,9 +259,9 @@ The FITS file structure for a ``calints`` product is as follows:
 +-----+-------------+----------+-----------+-----------------------+
 |     | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows x nints |
 +-----+-------------+----------+-----------+-----------------------+
-|     | AREA*       | IMAGE    |           | ncols x nrows         |
+|     | VAR_FLAT    | IMAGE    | float32   | ncols x nrows x nints |
 +-----+-------------+----------+-----------+-----------------------+
-|     | RELSENS*    | BINTABLE | N/A       | variable              |
+|     | AREA*       | IMAGE    |           | ncols x nrows         |
 +-----+-------------+----------+-----------+-----------------------+
 |     | WAVELENGTH* | IMAGE    | float32   | ncols x nrows         |
 +-----+-------------+----------+-----------+-----------------------+
@@ -280,10 +280,10 @@ The FITS file structure for a ``calints`` product is as follows:
    based on Poisson noise only, for each integration.
  - VAR_RNOISE: 3-D data array containing the variance estimate for each pixel,
    based on read noise only, for each integration.
+ - VAR_FLAT: 2-D data array containing the variance estimate for each pixel,
+   based on uncertainty in the flat-field.
  - AREA: 2-D data array containing pixel area values, added by the :ref:`photom <photom_step>`
    step, for imaging modes.
- - RELSENS: A table of sensitivity values as a function of wavelength, added by the
-   :ref:`photom <photom_step>` step, for some spectroscopic modes.
  - WAVELENGTH: 2-D data array of wavelength values for each pixel, for some spectroscopic modes.
  - ADSF: The data model meta data.
 
@@ -300,27 +300,21 @@ The FITS file structure for a ``cal`` product is as follows:
 +-----+---------------------------+----------+-----------+---------------+
 |  3  | DQ                        | IMAGE    | uint32    | ncols x nrows |
 +-----+---------------------------+----------+-----------+---------------+
-|     | VAR_POISSON               | IMAGE    | float32   | ncols x nrows |
+|  4  | VAR_POISSON               | IMAGE    | float32   | ncols x nrows |
 +-----+---------------------------+----------+-----------+---------------+
-|     | VAR_RNOISE                | IMAGE    | float32   | ncols x nrows |
+|  5  | VAR_RNOISE                | IMAGE    | float32   | ncols x nrows |
++-----+---------------------------+----------+-----------+---------------+
+|  6  | VAR_FLAT                  | IMAGE    | float32   | ncols x nrows |
 +-----+---------------------------+----------+-----------+---------------+
 |     | AREA*                     | IMAGE    | float32   | ncols x nrows |
 +-----+---------------------------+----------+-----------+---------------+
-|     | RELSENS*                  | BINTABLE | N/A       | variable      |
+|     | WAVELENGTH*               | IMAGE    | float32   | ncols x nrows |
 +-----+---------------------------+----------+-----------+---------------+
-|     | RELSENS2D*                | BINTABLE | N/A       | ncols x nrows |
+|     | PATHLOSS_PS*              | IMAGE    | float32   | ncols x nrows |
 +-----+---------------------------+----------+-----------+---------------+
-|     | PATHLOSS_POINTSOURCE*     | IMAGE    | float32   | ncols         |
-+-----+---------------------------+----------+-----------+---------------+
-|     | WAVELENGTH_POINTSOURCE*   | IMAGE    | float32   | ncols         |
-+-----+---------------------------+----------+-----------+---------------+
-|     | PATHLOSS_UNIFORMSOURCE*   | IMAGE    | float32   | ncols         |
-+-----+---------------------------+----------+-----------+---------------+
-|     | WAVELENGTH_UNIFORMSOURCE* | IMAGE    | float32   | ncols         |
+|     | PATHLOSS_UN*              | IMAGE    | float32   | ncols x nrows |
 +-----+---------------------------+----------+-----------+---------------+
 |     | BARSHADOW*                | IMAGE    | float32   | ncols x nrows |
-+-----+---------------------------+----------+-----------+---------------+
-|     | WAVELENGTH*               | IMAGE    | float32   | ncols x nrows |
 +-----+---------------------------+----------+-----------+---------------+
 |     | ASDF                      | BINTABLE | N/A       | variable      |
 +-----+---------------------------+----------+-----------+---------------+
@@ -334,30 +328,22 @@ The FITS file structure for a ``cal`` product is as follows:
    based on Poisson noise only.
  - VAR_RNOISE: 2-D data array containing the variance estimate for each pixel,
    based on read noise only.
+ - VAR_FLAT: 2-D data array containing the variance estimate for each pixel,
+   based on uncertainty in the flat-field.
  - AREA: 2-D data array containing pixel area values, added by the :ref:`photom <photom_step>`
    step, for imaging modes.
- - RELSENS: A table of sensitivity values as a function of wavelength, added by the
-   :ref:`photom <photom_step>` step, for some spectroscopic modes.
- - RELSENS2D: 2-D data array of sensitivity values per pixel, added by the
-   :ref:`photom <photom_step>` step, for IFU spectroscopic modes.
- - PATHLOSS_POINTSOURCE: 1-D data array of point-source pathloss correction factors, added by
-   the :ref:`pathloss <pathloss_step>` step, for some spectroscopic modes.
- - WAVELENGTH_POINTSOURCE: 1-D data array of wavelength values associated with the
-   PATHLOSS_POINTSOURCE correction factors, added by the :ref:`pathloss <pathloss_step>` step,
-   for some spectroscopic modes.
- - PATHLOSS_UNIFORMSOURCE: 1-D data array of uniform-source pathloss correction factors, added by
-   the :ref:`pathloss <pathloss_step>` step, for some spectroscopic modes.
- - WAVELENGTH_UNIFORMSOURCE: 1-D data array of wavelength values associated with the
-   PATHLOSS_UNIFORMSOURCE correction factors, added by the :ref:`pathloss <pathloss_step>` step,
-   for some spectroscopic modes.
- - BARSHADOW: 2-D data array of NIRSpec MSA bar shadow correction factors, added by the
-   :ref:`barshadow <barshadow_step>` step, for NIRSpec MSA exposures only.
  - WAVELENGTH: 2-D data array of wavelength values for each pixel, for some spectroscopic modes.
+ - PATHLOSS_PS: 2-D data array of point-source pathloss correction factors, added by
+   the :ref:`pathloss <pathloss_step>` step, for some spectroscopic modes.
+ - PATHLOSS_UN: 1-D data array of uniform-source pathloss correction factors, added by
+   the :ref:`pathloss <pathloss_step>` step, for some spectroscopic modes.
+ - BARSHADOW: 2-D data array of NIRSpec MSA bar shadow correction factors, added by the
+   :ref:`barshadow <barshadow_step>` step, for NIRSpec MOS exposures only.
  - ADSF: The data model meta data.
 
 For spectroscopic modes that contain data for multiple sources, such as NIRSpec MOS,
 NIRCam WFSS, and NIRISS WFSS, there will be multiple tuples of the SCI, ERR, DQ, VAR_POISSON,
-VAR_RNOISE, RELSENS, etc. extensions, where each tuple contains the data for a given source or
+VAR_RNOISE, etc. extensions, where each tuple contains the data for a given source or
 slit, as created by the :ref:`extract_2d <extract_2d_step>` step. FITS "EXTVER" keywords are
 used in each extension header to segregate the multiple instances of each extension type by
 source.
@@ -425,8 +411,6 @@ The FITS file structure for ``s2d`` products is as follows:
 +-----+-------------+----------+-----------+---------------+
 |  3  | WHT         | IMAGE    | float32   | ncols x nrows |
 +-----+-------------+----------+-----------+---------------+
-|  4  | RELSENS     | BINTABLE | N/A       | variable      |
-+-----+-------------+----------+-----------+---------------+
 |     | HDRTAB*     | BINTABLE | N/A       | variable      |
 +-----+-------------+----------+-----------+---------------+
 |     | ASDF        | BINTABLE | N/A       | variable      |
@@ -437,14 +421,12 @@ The FITS file structure for ``s2d`` products is as follows:
    to a specific output pixel.
  - WHT: 2-D weight image giving the relative weight of the output pixels (effectively a
    relative exposure time map).
- - RELSENS: A table of sensitivity values as a function of wavelength, carried along from the
-   input calibrated product.
  - HDRTAB: A table containing meta data (FITS keyword values) for all of the input images
    that were combined to produce the output image. Only appears when multiple inputs are used.
  - ADSF: The data model meta data.
 
 For exposure-based products that contain spectra for more than one source or slit
-(e.g. NIRSpec MOS) there will be multiple tuples of the SCI, CON, WHT, and RELSENS
+(e.g. NIRSpec MOS) there will be multiple tuples of the SCI, CON, and WHT
 extensions, one set for each source or slit. FITS "EXTVER" keywords are used in each
 extension header to segregate the multiple instances of each extension type by
 source.

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -37,12 +37,13 @@ for both point source and uniform source data types.
 For the uniform source pathloss calculation, there is no dependence on position
 in the aperture/slit.
 
-Once the 1-D correction arrays have been computed, the appropriate form of the
-correction (point or uniform) is interpolated, as a function of wavelength, into
-the 2-D space of the slit or IFU data and divided into the SCI and ERR arrays of the
-science data.
-The 2-D correction array is also attached to the datamodel (extension "PATHLOSS")
-as a record of what was applied.
+Once the 1-D correction arrays have been computed, both forms of the correction
+(point and uniform) are interpolated, as a function of wavelength, into
+the 2-D space of the slit or IFU data and attached to the output data model
+(extensions "PATHLOSS_PS" and "PATHLOSS_UN") as a record of what was computed.
+The form of the 2-D correction (point or uniform) that's appropriate for the
+data is divided into the SCI and ERR arrays and propagated into the variance
+arrays of the science data.
 
 NIRISS
 ++++++
@@ -57,8 +58,8 @@ The algorithm calculates the correction for each column by simply interpolating
 along the Pupil Wheel position dimension of the reference file using linear
 interpolation.  The 1-D vector of correction vs. column number is interpolated,
 as a function of wavelength, into the 2-D space of the science image and divided
-into the SCI and ERR arrays.
-The 2-D correction array is also attached to the datamodel (extension "PATHLOSS")
+into the SCI and ERR arrays and propagated into the variance arrays.
+The 2-D correction array is also attached to the datamodel (extension "PATHLOSS_PS")
 as a record of what was applied.
 
 Error Propagation

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -171,7 +171,7 @@ the output type will consist of either a single slit model or a mutli-slit model
 The multi-slit model is simply an array of multiple slit models, each one
 containing the data and relevant meta data for a particular extracted slit or
 source. A `~jwst.datamodels.MultiSlitModel` product will contain multiple
-tuples of SCI, ERR, DQ, WAVELENGTH, RELSENS, etc. arrays; one for each of the
+tuples of SCI, ERR, DQ, WAVELENGTH, etc. arrays; one for each of the
 extracted slits/sources.
 
 2D resampled data

--- a/jwst/datamodels/ifuimage.py
+++ b/jwst/datamodels/ifuimage.py
@@ -23,9 +23,6 @@ class IFUImageModel(DataModel):
     zeroframe : numpy float32 array
          Zeroframe array
 
-    area : numpy float32 array
-         Pixel area map array
-
     var_poisson : numpy float32 array
          variance due to poisson noise
 
@@ -35,8 +32,14 @@ class IFUImageModel(DataModel):
     wavelength : numpy float32 array
          wavelength
 
-    pathloss : numpy float32 array
-         pathloss correction
+    pathloss_ps : numpy float32 array
+         pathloss correction for point source
+
+    pathloss_un : numpy float32 array
+         pathloss correction for uniform source
+
+    area : numpy float32 array
+         Pixel area map array
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifuimage.schema"
 
@@ -47,12 +50,12 @@ class IFUImageModel(DataModel):
             self.data = init.data
             self.dq = init.dq
             self.err = init.err
-            if init.hasattr('area'):
-                self.area = init.area
             if init.hasattr('var_poisson'):
                 self.var_poisson = init.var_poisson
             if init.hasattr('var_rnoise'):
                 self.var_rnoise = init.var_rnoise
+            if init.hasattr('area'):
+                self.area = init.area
             return
 
         super(IFUImageModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/ifuimage.py
+++ b/jwst/datamodels/ifuimage.py
@@ -32,10 +32,10 @@ class IFUImageModel(DataModel):
     wavelength : numpy float32 array
          wavelength
 
-    pathloss_ps : numpy float32 array
+    pathloss_point : numpy float32 array
          pathloss correction for point source
 
-    pathloss_un : numpy float32 array
+    pathloss_uniform : numpy float32 array
          pathloss correction for uniform source
 
     area : numpy float32 array

--- a/jwst/datamodels/image.py
+++ b/jwst/datamodels/image.py
@@ -22,17 +22,20 @@ class ImageModel(DataModel):
     zeroframe : numpy float32 array
          Zeroframe array
 
-    area : numpy float32 array
-         Pixel area map array
-
-    pathloss : numpy float32 array
-         Pathloss correction
-
     var_poisson : numpy float32 array
          variance due to poisson noise
 
     var_rnoise : numpy float32 array
          variance due to read noise
+
+    area : numpy float32 array
+         Pixel area map array
+
+    pathloss_ps : numpy float32 array
+         Pathloss correction for point source
+
+    pathloss_un : numpy float32 array
+         Pathloss correction for uniform source
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/image.schema"
 

--- a/jwst/datamodels/image.py
+++ b/jwst/datamodels/image.py
@@ -31,10 +31,10 @@ class ImageModel(DataModel):
     area : numpy float32 array
          Pixel area map array
 
-    pathloss_ps : numpy float32 array
+    pathloss_point : numpy float32 array
          Pathloss correction for point source
 
-    pathloss_un : numpy float32 array
+    pathloss_uniform : numpy float32 array
          Pathloss correction for uniform source
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/image.schema"

--- a/jwst/datamodels/multiexposure.py
+++ b/jwst/datamodels/multiexposure.py
@@ -67,8 +67,8 @@ class MultiExposureModel(DataModel):
             self.exposures[0].var_flat = init.var_flat
             self.exposures[0].wavelength = init.wavelength
             self.exposures[0].barshadow = init.barshadow
-            self.exposures[0].pathloss_ps = init.pathloss_ps
-            self.exposures[0].pathloss_un = init.pathloss_un
+            self.exposures[0].pathloss_point = init.pathloss_point
+            self.exposures[0].pathloss_uniform = init.pathloss_uniform
             self.exposures[0].area = init.area
             return
 

--- a/jwst/datamodels/multiexposure.py
+++ b/jwst/datamodels/multiexposure.py
@@ -62,13 +62,14 @@ class MultiExposureModel(DataModel):
             self.exposures[0].data = init.data
             self.exposures[0].dq = init.dq
             self.exposures[0].err = init.err
-            self.exposures[0].wavelength = init.wavelength
-            self.exposures[0].barshadow = init.barshadow
-            self.exposures[0].area = init.area
             self.exposures[0].var_poisson = init.var_poisson
             self.exposures[0].var_rnoise = init.var_rnoise
             self.exposures[0].var_flat = init.var_flat
-            self.exposures[0].pathloss = init.pathloss
+            self.exposures[0].wavelength = init.wavelength
+            self.exposures[0].barshadow = init.barshadow
+            self.exposures[0].pathloss_ps = init.pathloss_ps
+            self.exposures[0].pathloss_un = init.pathloss_un
+            self.exposures[0].area = init.area
             return
 
         super(MultiExposureModel, self).__init__(

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -37,23 +37,26 @@ class MultiSlitModel(model_base.DataModel):
     slits.items.err : numpy float32 array
          Error array
 
-    slits.items.wavelength : numpy float32 array
-         Wavelength array, corrected for zero-point
-
-    slits.items.barshadow : numpy float32 array
-         Bar shadow correction
-
-    slits.items.area : numpy float32 array
-         Pixel area map array
-
     slits.items.var_poisson : numpy float32 array
          variance due to poisson noise
 
     slits.items.var_rnoise : numpy float32 array
          variance due to read noise
 
-    slits.items.pathloss : numpy float32 array
-         pathloss array
+    slits.items.wavelength : numpy float32 array
+         Wavelength array, corrected for zero-point
+
+    slits.items.barshadow : numpy float32 array
+         Bar shadow correction
+
+    slits.items.pathloss_ps : numpy float32 array
+         pathloss array for point source
+
+    slits.items.pathloss_un : numpy float32 array
+         pathloss array for uniform source
+
+    slits.items.area : numpy float32 array
+         Pixel area map array
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/multislit.schema"
 

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -49,10 +49,10 @@ class MultiSlitModel(model_base.DataModel):
     slits.items.barshadow : numpy float32 array
          Bar shadow correction
 
-    slits.items.pathloss_ps : numpy float32 array
+    slits.items.pathloss_point : numpy float32 array
          pathloss array for point source
 
-    slits.items.pathloss_un : numpy float32 array
+    slits.items.pathloss_uniform : numpy float32 array
          pathloss array for uniform source
 
     slits.items.area : numpy float32 array

--- a/jwst/datamodels/schemas/pathlosscorr.schema.yaml
+++ b/jwst/datamodels/schemas/pathlosscorr.schema.yaml
@@ -4,12 +4,12 @@ $schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
 id: "http://stsci.edu/schemas/jwst_datamodel/pathlosscorr.schema"
 type: object
 properties:
-  pathloss_ps:
+  pathloss_point:
     title: Pathloss point source correction
     fits_hdu: PATHLOSS_PS
     ndim: 2
     datatype: float32
-  pathloss_un:
+  pathloss_uniform:
     title: Pathloss uniformsource correction
     fits_hdu: PATHLOSS_UN
     ndim: 2

--- a/jwst/datamodels/schemas/pathlosscorr.schema.yaml
+++ b/jwst/datamodels/schemas/pathlosscorr.schema.yaml
@@ -4,8 +4,13 @@ $schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
 id: "http://stsci.edu/schemas/jwst_datamodel/pathlosscorr.schema"
 type: object
 properties:
-  pathloss:
-    title: Path loss correction
-    fits_hdu: PATHLOSS
+  pathloss_ps:
+    title: Pathloss point source correction
+    fits_hdu: PATHLOSS_PS
+    ndim: 2
+    datatype: float32
+  pathloss_un:
+    title: Pathloss uniformsource correction
+    fits_hdu: PATHLOSS_UN
     ndim: 2
     datatype: float32

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -31,7 +31,6 @@ allOf:
       title: Bar shadow correction
       fits_hdu: BARSHADOW
       ndim: 2
-      default: 1.0
       datatype: float32
     area:
       title: Pixel area map array
@@ -48,9 +47,9 @@ allOf:
       fits_hdu: CON
       default: 0
       datatype: int32
-- $ref: slitmeta.schema
 - $ref: variance.schema
 - $ref: pathlosscorr.schema
+- $ref: slitmeta.schema
 - $ref: bunit.schema
 - $ref: photometry.schema
 - $ref: wcsinfo.schema

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -20,24 +20,26 @@ class SlitDataModel(DataModel):
     err : numpy float32 array
          Error array
 
-    wavelength : numpy float32 array
-         Wavelength array, corrected for zero-point
-
-    barshadow : numpy float32 array
-         Bar shadow correction
-
-    area : numpy float32 array
-         Pixel area map array
-
     var_poisson : numpy float32 array
          variance due to poisson noise
 
     var_rnoise : numpy float32 array
          variance due to read noise
 
-    pathloss : numpy float32 array
-         pathloss array
+    wavelength : numpy float32 array
+         Wavelength array, corrected for zero-point
 
+    barshadow : numpy float32 array
+         Bar shadow correction
+
+    pathloss_ps : numpy float32 array
+         pathloss array for point source
+
+    pathloss_un : numpy float32 array
+         pathloss array for uniform source
+
+    area : numpy float32 array
+         Pixel area map array
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/slitdata.schema"
@@ -49,12 +51,12 @@ class SlitDataModel(DataModel):
             self.dq = init.dq
             self.err = init.err
             self.area = init.area
-            if init.hasattr('wavelength'):
-                self.wavelength = init.wavelength
             if init.hasattr('var_poisson'):
                 self.var_poisson = init.var_poisson
             if init.hasattr('var_rnoise'):
                 self.var_rnoise = init.var_rnoise
+            if init.hasattr('wavelength'):
+                self.wavelength = init.wavelength
             for key in kwargs:
                 setattr(self, key, kwargs[key])
 
@@ -84,27 +86,29 @@ class SlitModel(DataModel):
     err : numpy float32 array
          Error array
 
-    wavelength : numpy float32 array
-         Wavelength array, corrected for zero-point
-
-    barshadow : numpy float32 array
-         Bar shadow correction
-
-    area : numpy float32 array
-         Pixel area map array
-
     var_poisson : numpy float32 array
          variance due to poisson noise
 
     var_rnoise : numpy float32 array
          variance due to read noise
 
-    pathloss : numpy float32 array
-         pathloss array
+    wavelength : numpy float32 array
+         Wavelength array, corrected for zero-point
+
+    barshadow : numpy float32 array
+         Bar shadow correction
+
+    pathloss_ps : numpy float32 array
+         pathloss array for point source
+
+    pathloss_un : numpy float32 array
+         pathloss array for uniform source
+
+    area : numpy float32 array
+         Pixel area map array
 
     int_times : numpy table
          table of times for each integration
-
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/slit.schema"
 
@@ -116,12 +120,12 @@ class SlitModel(DataModel):
             self.dq = init.dq
             self.err = init.err
             self.area = init.area
-            if init.hasattr('wavelength'):
-                self.wavelength = init.wavelength
             if init.hasattr('var_poisson'):
                 self.var_poisson = init.var_poisson
             if init.hasattr('var_rnoise'):
                 self.var_rnoise = init.var_rnoise
+            if init.hasattr('wavelength'):
+                self.wavelength = init.wavelength
             if init.hasattr('int_times'):
                 self.int_times = init.int_times
             if init.meta.hasattr('wcs'):

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -32,10 +32,10 @@ class SlitDataModel(DataModel):
     barshadow : numpy float32 array
          Bar shadow correction
 
-    pathloss_ps : numpy float32 array
+    pathloss_point : numpy float32 array
          pathloss array for point source
 
-    pathloss_un : numpy float32 array
+    pathloss_uniform : numpy float32 array
          pathloss array for uniform source
 
     area : numpy float32 array
@@ -98,10 +98,10 @@ class SlitModel(DataModel):
     barshadow : numpy float32 array
          Bar shadow correction
 
-    pathloss_ps : numpy float32 array
+    pathloss_point : numpy float32 array
          pathloss array for point source
 
-    pathloss_un : numpy float32 array
+    pathloss_uniform : numpy float32 array
          pathloss array for uniform source
 
     area : numpy float32 array

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -261,7 +261,7 @@ def test_imagemodel():
     dims = (10,10)
     with ImageModel(dims) as dm:
         assert dm.data.shape == dims
-        assert dm.err.shape == dims 
+        assert dm.err.shape == dims
         assert dm.dq.shape == dims
         assert dm.data.mean() == 0.0
         assert dm.err.mean() == 0.0
@@ -270,7 +270,7 @@ def test_imagemodel():
         assert dm.area.shape == dims
         assert dm.pathloss_point.shape == dims
         assert dm.pathloss_uniform.shape == dims
-        
+
 
 def test_multislit():
     with MultiSlitModel() as dm:

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -141,7 +141,6 @@ def test_open():
             assert isinstance(dm, QuadModel)
 
 
-
 def test_open_warning():
     with warnings.catch_warnings(record=True) as warners:
         # Cause all warnings to always be triggered.
@@ -258,6 +257,21 @@ def test_default_value_anyof_schema():
         assert val.instance == {}
 
 
+def test_imagemodel():
+    dims = (10,10)
+    with ImageModel(dims) as dm:
+        assert dm.data.shape == dims
+        assert dm.err.shape == dims 
+        assert dm.dq.shape == dims
+        assert dm.data.mean() == 0.0
+        assert dm.err.mean() == 0.0
+        assert dm.dq.mean() == 0.0
+        assert dm.zeroframe.shape == dims
+        assert dm.area.shape == dims
+        assert dm.pathloss_point.shape == dims
+        assert dm.pathloss_uniform.shape == dims
+        
+
 def test_multislit():
     with MultiSlitModel() as dm:
         dm.slits.append(dm.slits.item())
@@ -265,6 +279,10 @@ def test_multislit():
         slit.data = np.random.rand(5, 5)
         slit.dm = np.random.rand(5, 5)
         slit.err = np.random.rand(5, 5)
+        assert slit.wavelength.shape == (0,0)
+        assert slit.pathloss_point.shape == (0,0)
+        assert slit.pathloss_uniform.shape == (0,0)
+        assert slit.barshadow.shape == (0,0)
 
 
 def test_secondary_shapes():

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -254,11 +254,11 @@ def do_correction(input_model, pathloss_model):
                         slit.pathloss_ps = pathloss_2d_ps
                         slit.pathloss_un = pathloss_2d_un
                     else:
-                        log.warning(f"Source is outside slit. Skipping "
-                                    "pathloss correction for slit {slit_number}")
+                        log.warning("Source is outside slit. Skipping "
+                                    f"pathloss correction for slit {slit_number}")
                 else:
-                    log.warning(f"Cannot find matching pathloss model for slit with"
-                                "{nshutters} shutters")
+                    log.warning("Cannot find matching pathloss model for slit with"
+                                f"{nshutters} shutters")
                     log.warning("Skipping pathloss correction for this slit")
                     continue
             else:
@@ -334,8 +334,8 @@ def do_correction(input_model, pathloss_model):
                     slit.pathloss_un = pathloss_2d_un
 
                 else:
-                    log.warning(f'Source is outside slit. Skipping '
-                                'pathloss correction for slit {slit.name}')
+                    log.warning('Source is outside slit. Skipping '
+                                f'pathloss correction for slit {slit.name}')
             else:
                 log.warning(f'Cannot find matching pathloss model for {slit.name}')
                 log.warning('Skipping pathloss correction for this slit')
@@ -431,8 +431,8 @@ def do_correction(input_model, pathloss_model):
         # Get the pupil wheel position
         pupil_wheel_position = input_model.meta.instrument.pupil_position
         if pupil_wheel_position is None:
-            log.warning(f'Unable to get pupil wheel position from PWCPOS keyword '
-                        'for {input_model.meta.filename}')
+            log.warning('Unable to get pupil wheel position from PWCPOS keyword '
+                        f'for {input_model.meta.filename}')
             log.warning("Pathloss correction skipped")
             output_model.meta.cal_step.pathloss = 'SKIPPED'
             return output_model
@@ -441,8 +441,8 @@ def do_correction(input_model, pathloss_model):
         subarray = input_model.meta.subarray.name
         aperture = get_aperture_from_model(pathloss_model, subarray)
         if aperture is None:
-            log.warning(f'Unable to get Aperture from reference file '
-                        'for subarray {subarray}')
+            log.warning('Unable to get Aperture from reference file '
+                        f'for subarray {subarray}')
             log.warning("Pathloss correction skipped")
             output_model.meta.cal_step.pathloss = 'SKIPPED'
             return output_model

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -251,8 +251,8 @@ def do_correction(input_model, pathloss_model):
                         slit.var_rnoise /= pathloss_2d**2
                         if slit.var_flat is not None and np.size(slit.var_flat) > 0:
                             slit.var_flat /= pathloss_2d**2
-                        slit.pathloss_ps = pathloss_2d_ps
-                        slit.pathloss_un = pathloss_2d_un
+                        slit.pathloss_point = pathloss_2d_ps
+                        slit.pathloss_uniform = pathloss_2d_un
                     else:
                         log.warning("Source is outside slit. Skipping "
                                     f"pathloss correction for slit {slit_number}")
@@ -330,8 +330,8 @@ def do_correction(input_model, pathloss_model):
                     slit.var_rnoise /= pathloss_2d**2
                     if slit.var_flat is not None and np.size(slit.var_flat) > 0:
                         slit.var_flat /= pathloss_2d**2
-                    slit.pathloss_ps = pathloss_2d_ps
-                    slit.pathloss_un = pathloss_2d_un
+                    slit.pathloss_point = pathloss_2d_ps
+                    slit.pathloss_uniform = pathloss_2d_un
 
                 else:
                     log.warning('Source is outside slit. Skipping '
@@ -403,8 +403,8 @@ def do_correction(input_model, pathloss_model):
         output_model.var_rnoise /= pathloss_2d**2
         if output_model.var_flat is not None and np.size(output_model.var_flat) > 0:
             output_model.var_flat /= pathloss_2d**2
-        output_model.pathloss_ps = pathloss_2d_ps
-        output_model.pathloss_un = pathloss_2d_un
+        output_model.pathloss_point = pathloss_2d_ps
+        output_model.pathloss_uniform = pathloss_2d_un
 
         # This might be useful to other steps
         output_model.wavelength = wavelength_array
@@ -486,7 +486,7 @@ def do_correction(input_model, pathloss_model):
         output_model.var_rnoise /= pathloss_2d**2
         if output_model.var_flat is not None and np.size(output_model.var_flat) > 0:
             output_model.var_flat /= pathloss_2d**2
-        output_model.pathloss_ps = pathloss_2d
+        output_model.pathloss_point = pathloss_2d
 
         # Set step status to complete
         output_model.meta.cal_step.pathloss = 'COMPLETE'

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -10,8 +10,9 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-# There are 30 slices in the NIRSPEC IFU, numbered from 0 to 29
+# There are 30 slices in the NIRSpec IFU, numbered from 0 to 29
 NIRSPEC_IFU_SLICES = np.arange(30)
+
 
 def get_center(exp_type, input):
     """Get the center of the target in the aperture.
@@ -22,9 +23,10 @@ def get_center(exp_type, input):
 
         # Currently assume IFU sources are centered
         return (0.0, 0.0)
+
     elif exp_type in ["NRS_MSASPEC", "NRS_FIXEDSLIT", "NRS_BRIGHTOBJ"]:
-        #
-        # MSA centering specified in the MiltiSlit model
+
+        # MSA centering is specified in the MiltiSlit model
         # "input" treated as a slit object
         try:
             xcenter = input.source_xpos
@@ -35,10 +37,12 @@ def get_center(exp_type, input):
             xcenter = 0.0
             ycenter = 0.0
         return (xcenter, ycenter)
+
     else:
-        log.warning("No method to get centering for exp_type {}".format(exp_type))
+        log.warning(f'No method to get centering for exp_type {exp_type}')
         log.warning("Using (0.0, 0.0)")
         return (0.0, 0.0)
+
 
 def get_aperture_from_model(input_model, match):
     """Figure out the correct aperture based on the value of the 'match'
@@ -56,11 +60,11 @@ def get_aperture_from_model(input_model, match):
             if aperture.name == match:
                 return aperture
     else:
-        log.warning("Unable to get aperture from "
-            "model type {0}".format(input_model.meta.exposure.type))
+        log.warning(f'Unable to get aperture from exp_type {input_model.meta.exposure.type}')
 
     # If nothing matches, return None
     return None
+
 
 def calculate_pathloss_vector(pathloss_refdata,
                               pathloss_wcs,
@@ -105,15 +109,15 @@ def calculate_pathloss_vector(pathloss_refdata,
     wavelength = np.zeros(wavesize, dtype=np.float32)
     pathloss_vector = np.zeros(wavesize, dtype=np.float32)
 
-    # uniformsource.data is 1-d, we just return it, along with
-    # a vector of wavelengths calculated using the WCS
+    # uniformsource.data is 1-d. We just return it, along with
+    # a vector of wavelengths calculated using the WCS.
     # Uniform source is always inside the slitlet
     if len(pathloss_refdata.shape) == 1:
         crpix1 = pathloss_wcs.crpix1
         crval1 = pathloss_wcs.crval1
         cdelt1 = pathloss_wcs.cdelt1
         for i in np.arange(wavesize):
-            wavelength[i] = crval1 +(float(i+1) - crpix1)*cdelt1
+            wavelength[i] = crval1 + (float(i+1) - crpix1)*cdelt1
         return wavelength, pathloss_refdata, True
 
     # pointsource.data is 3-d, so we have to extract a wavelength vector
@@ -123,7 +127,8 @@ def calculate_pathloss_vector(pathloss_refdata,
         crval3 = pathloss_wcs.crval3
         cdelt3 = pathloss_wcs.cdelt3
         for i in np.arange(wavesize):
-            wavelength[i] = crval3 +(float(i+1) - crpix3)*cdelt3
+            wavelength[i] = crval3 +(float(i+1) - crpix3) * cdelt3
+
         # Calculate python index of object center
         crpix1 = pathloss_wcs.crpix1
         crval1 = pathloss_wcs.crval1
@@ -153,7 +158,9 @@ def calculate_pathloss_vector(pathloss_refdata,
                                + a12*pathloss_refdata[:, i+1, j]
                                + a21*pathloss_refdata[:, i, j+1]
                                + a11*pathloss_refdata[:, i+1, j+1])
+
         return wavelength, pathloss_vector, is_inside_slitlet
+
 
 def do_correction(input_model, pathloss_model):
     """
@@ -172,20 +179,26 @@ def do_correction(input_model, pathloss_model):
     Returns
     -------
     output_model : data model object
-        Science data with pathloss extensions added
+        Corrected science data with pathloss extensions added
 
     """
     exp_type = input_model.meta.exposure.type
-    log.info('Input exposure type is {}'.format(exp_type))
+    log.info(f'Input exposure type is {exp_type}')
     output_model = input_model.copy()
+
+    # NIRSpec MOS data
     if exp_type == 'NRS_MSASPEC':
         slit_number = 0
+
+        # Loop over all MOS slitlets
         for slit in output_model.slits:
             slit_number = slit_number + 1
-            log.info('Working on slit {}'.format(slit_number))
+            log.info(f'Working on slit {slit_number}')
             size = slit.data.size
-            # That has data.size > 0
+
+            # Only work on slits with data.size > 0
             if size > 0:
+
                 # Get centering
                 xcenter, ycenter = get_center(exp_type, slit)
                 # Calculate the 1-d wavelength and pathloss vectors
@@ -207,23 +220,30 @@ def do_correction(input_model, pathloss_model):
                     if is_inside_slitlet:
 
                         # Wavelengths in the reference file are in meters,
-                        #need them to be in microns
+                        # need them to be in microns
                         wavelength_pointsource *= 1.0e6
                         wavelength_uniformsource *= 1.0e6
 
                         wavelength_array = slit.wavelength
 
-                        # Compute the pathloss 2D correction
+                        # Compute the point source pathloss 2D correction
+                        pathloss_2d_ps = interpolate_onto_grid(
+                            wavelength_array,
+                            wavelength_pointsource,
+                            pathloss_pointsource_vector)
+
+                        # Compute the uniform source pathloss 2D correction
+                        pathloss_2d_un = interpolate_onto_grid(
+                            wavelength_array,
+                            wavelength_uniformsource,
+                            pathloss_uniform_vector)
+
+                        # Use the appropriate correction for this slit
                         if is_pointsource(slit.source_type):
-                            pathloss_2d = interpolate_onto_grid(
-                                wavelength_array,
-                                wavelength_pointsource,
-                                pathloss_pointsource_vector)
+                            pathloss_2d = pathloss_2d_ps
                         else:
-                            pathloss_2d = interpolate_onto_grid(
-                                wavelength_array,
-                                wavelength_uniformsource,
-                                pathloss_uniform_vector)
+                            pathloss_2d = pathloss_2d_un
+
                         # Apply the pathloss 2D correction and attach to datamodel
                         slit.data /= pathloss_2d
                         slit.err /= pathloss_2d
@@ -231,34 +251,41 @@ def do_correction(input_model, pathloss_model):
                         slit.var_rnoise /= pathloss_2d**2
                         if slit.var_flat is not None and np.size(slit.var_flat) > 0:
                             slit.var_flat /= pathloss_2d**2
-                        slit.pathloss = pathloss_2d
+                        slit.pathloss_ps = pathloss_2d_ps
+                        slit.pathloss_un = pathloss_2d_un
                     else:
-                        log.warning("Source is outside slit.  Skipping "
-                        "pathloss correction for slit {}".format(slit_number))
+                        log.warning(f"Source is outside slit. Skipping "
+                                    "pathloss correction for slit {slit_number}")
                 else:
-                    log.warning("Cannot find matching pathloss model for slit "
-                        "with {} shutters, skipping pathloss correction for this "
-                        "slit".format(nshutters))
+                    log.warning(f"Cannot find matching pathloss model for slit with"
+                                "{nshutters} shutters")
+                    log.warning("Skipping pathloss correction for this slit")
                     continue
             else:
-                log.warning("Slit has data size = {}, skipping "
-                    "pathloss correction for this slitlet".format(size))
+                log.warning(f"Slit has data size = {size}")
+                log.warning("Skipping pathloss correction for this slitlet")
+
+        # Set step status to complete
         output_model.meta.cal_step.pathloss = 'COMPLETE'
+
+    # NIRSpec fixed-slit data
     elif exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
         slit_number = 0
         is_inside_slit = True
-        # For each slit
+
+        # Loop over all slits contained in the input
         for slit in output_model.slits:
-            log.info('Working on slit {}'.format(slit.name))
+            log.info(f'Working on slit {slit.name}')
             slit_number = slit_number + 1
+
             # Get centering
             xcenter, ycenter = get_center(exp_type, slit)
-            # Calculate the 1-d wavelength and pathloss vectors
-            # for the source position
+            # Calculate the 1-d wavelength and pathloss vectors for the source position
             # Get the aperture from the reference file that matches the slit
             aperture = get_aperture_from_model(pathloss_model, slit.name)
+
             if aperture is not None:
-                log.info("Using aperture {}".format(aperture.name))
+                log.info(f'Using aperture {aperture.name}')
                 (wavelength_pointsource,
                  pathloss_pointsource_vector,
                  is_inside_slit) = calculate_pathloss_vector(aperture.pointsource_data,
@@ -271,24 +298,31 @@ def do_correction(input_model, pathloss_model):
                                                     xcenter, ycenter)
                 if is_inside_slit:
 
-                    # Wavelengths in the reference file are in meters, need them to be
-                    # in microns
+                    # Wavelengths in the reference file are in meters,
+                    # need them to be in microns
                     wavelength_pointsource *= 1.0e6
                     wavelength_uniformsource *= 1.0e6
 
                     wavelength_array = slit.wavelength
 
-                    # Compute the pathloss 2D correction
+                    # Compute the point source pathloss 2D correction
+                    pathloss_2d_ps = interpolate_onto_grid(
+                        wavelength_array,
+                        wavelength_pointsource,
+                        pathloss_pointsource_vector)
+
+                    # Compute the uniform source pathloss 2D correction
+                    pathloss_2d_un = interpolate_onto_grid(
+                        wavelength_array,
+                        wavelength_uniformsource,
+                        pathloss_uniform_vector)
+
+                    # Use the appropriate correction for this slit
                     if is_pointsource(slit.source_type):
-                        pathloss_2d = interpolate_onto_grid(
-                            wavelength_array,
-                            wavelength_pointsource,
-                            pathloss_pointsource_vector)
+                        pathloss_2d = pathloss_2d_ps
                     else:
-                        pathloss_2d = interpolate_onto_grid(
-                            wavelength_array,
-                            wavelength_uniformsource,
-                            pathloss_uniform_vector)
+                        pathloss_2d = pathloss_2d_un
+
                     # Apply the pathloss 2D correction and attach to datamodel
                     slit.data /= pathloss_2d
                     slit.err /= pathloss_2d
@@ -296,21 +330,26 @@ def do_correction(input_model, pathloss_model):
                     slit.var_rnoise /= pathloss_2d**2
                     if slit.var_flat is not None and np.size(slit.var_flat) > 0:
                         slit.var_flat /= pathloss_2d**2
-                    slit.pathloss = pathloss_2d
+                    slit.pathloss_ps = pathloss_2d_ps
+                    slit.pathloss_un = pathloss_2d_un
+
                 else:
-                    log.warning("Source is outside slit.  Skipping "
-                        "pathloss correction for slit {}".format(slit.name))
+                    log.warning(f'Source is outside slit. Skipping '
+                                'pathloss correction for slit {slit.name}')
             else:
-                log.warning("Cannot find matching pathloss model for aperture {} "
-                    "skipping pathloss correction for this slit".format(slit.name))
+                log.warning(f'Cannot find matching pathloss model for {slit.name}')
+                log.warning('Skipping pathloss correction for this slit')
                 continue
+
+        # Set step status to complete
         output_model.meta.cal_step.pathloss = 'COMPLETE'
+
+    # NIRSpec IFU
     elif exp_type == 'NRS_IFU':
         # IFU targets are always inside slit
         # Get centering
         xcenter, ycenter = get_center(exp_type, None)
-        # Calculate the 1-d wavelength and pathloss vectors
-        # for the source position
+        # Calculate the 1-d wavelength and pathloss vectors for the source position
         aperture = pathloss_model.apertures[0]
         (wavelength_pointsource,
          pathloss_pointsource_vector,
@@ -322,12 +361,12 @@ def do_correction(input_model, pathloss_model):
          dummy) = calculate_pathloss_vector(aperture.uniform_data,
                                             aperture.uniform_wcs,
                                             xcenter, ycenter)
-        # Wavelengths in the reference file are in meters, need them to be
-        # in microns
+        # Wavelengths in the reference file are in meters;
+        # need them to be in microns
         wavelength_pointsource *= 1.0e6
         wavelength_uniformsource *= 1.0e6
 
-        # Create the 2-d pathloss arrays, initialize with NaNs
+        # Create the 2-d wavelength arrays, initialize with NaNs
         wavelength_array = np.zeros(input_model.shape, dtype=np.float32)
         wavelength_array.fill(np.nan)
         for slice in NIRSPEC_IFU_SLICES:
@@ -339,17 +378,24 @@ def do_correction(input_model, pathloss_model):
             y = y[valid]
             wavelength_array[y.astype(int), x.astype(int)] = wavelength[valid]
 
-        # Compute the pathloss 2D correction
+        # Compute the point source pathloss 2D correction
+        pathloss_2d_ps = interpolate_onto_grid(
+            wavelength_array,
+            wavelength_pointsource,
+            pathloss_pointsource_vector)
+
+        # Compute the uniform source pathloss 2D correction
+        pathloss_2d_un = interpolate_onto_grid(
+            wavelength_array,
+            wavelength_uniformsource,
+            pathloss_uniform_vector)
+
+        # Use the appropriate correction for the source type
         if is_pointsource(input_model.meta.target.source_type):
-            pathloss_2d = interpolate_onto_grid(
-                wavelength_array,
-                wavelength_pointsource,
-                pathloss_pointsource_vector)
+            pathloss_2d = pathloss_2d_ps
         else:
-            pathloss_2d = interpolate_onto_grid(
-                wavelength_array,
-                wavelength_uniformsource,
-                pathloss_uniform_vector)
+            pathloss_2d = pathloss_2d_un
+
         # Apply the pathloss 2D correction and attach to datamodel
         output_model.data /= pathloss_2d
         output_model.err /= pathloss_2d
@@ -357,21 +403,24 @@ def do_correction(input_model, pathloss_model):
         output_model.var_rnoise /= pathloss_2d**2
         if output_model.var_flat is not None and np.size(output_model.var_flat) > 0:
             output_model.var_flat /= pathloss_2d**2
-        output_model.pathloss = pathloss_2d
+        output_model.pathloss_ps = pathloss_2d_ps
+        output_model.pathloss_un = pathloss_2d_un
 
         # This might be useful to other steps
         output_model.wavelength = wavelength_array
 
+        # Set the step status to complete
         output_model.meta.cal_step.pathloss = 'COMPLETE'
 
+    # NIRISS SOSS
     elif exp_type == 'NIS_SOSS':
         """NIRISS SOSS pathloss correction is basically a correction for the
         flux from the 2nd and 3rd order dispersion that falls outside the
-        subarray aperture.  The correction depends
-        on the pupil wheel position and column number (or wavelength).  The
-        simple option is to do the correction by column number, then the only
-        interpolation needed is a 1-d interpolation into the pupil wheel position
-        dimension."""
+        subarray aperture.  The correction depends on the pupil wheel position
+        and column number (or wavelength).  The simple option is to do the
+        correction by column number, then the only interpolation needed is a
+        1-d interpolation into the pupil wheel position dimension.
+        """
 
         # Omit correction if this is a TSO observation
         if input_model.meta.visit.tsovisit:
@@ -379,26 +428,29 @@ def do_correction(input_model, pathloss_model):
             output_model.meta.cal_step.pathloss = 'SKIPPED'
             return output_model
 
+        # Get the pupil wheel position
         pupil_wheel_position = input_model.meta.instrument.pupil_position
         if pupil_wheel_position is None:
-            log.warning("Unable to get pupil wheel position from PWCPOS keyword "
-                "for {}".format(input_model.meta.filename))
+            log.warning(f'Unable to get pupil wheel position from PWCPOS keyword '
+                        'for {input_model.meta.filename}')
             log.warning("Pathloss correction skipped")
             output_model.meta.cal_step.pathloss = 'SKIPPED'
             return output_model
 
-        subarray = input_model.meta.subarray.name
         # Get the aperture from the reference file that matches the subarray
+        subarray = input_model.meta.subarray.name
         aperture = get_aperture_from_model(pathloss_model, subarray)
         if aperture is None:
-            log.warning("Unable to get Aperture from reference file "
-                "for subarray {}".format(subarray))
+            log.warning(f'Unable to get Aperture from reference file '
+                        'for subarray {subarray}')
             log.warning("Pathloss correction skipped")
             output_model.meta.cal_step.pathloss = 'SKIPPED'
             return output_model
 
         else:
-            log.info("Aperture {} selected from reference file".format(aperture.name))
+            log.info(f'Aperture {aperture.name} selected from reference file')
+
+        # Set up pathloss correction array
         pathloss_array = aperture.pointsource_data[0]
         nrows, ncols = pathloss_array.shape
         _, data_ncols = input_model.data.shape
@@ -409,8 +461,8 @@ def do_correction(input_model, pathloss_model):
         pupil_wheel_index = crpix1 + (pupil_wheel_position - crval1) / cdelt1 - 1
 
         if pupil_wheel_index < 0 or pupil_wheel_index > (ncols - 2):
-            log.info("Pupil Wheel position outside reference file coverage")
-            log.info("Setting pathloss correction to 1.0")
+            log.warning("Pupil Wheel position outside reference file coverage")
+            log.warning("Setting pathloss correction to 1.0")
         else:
             ix = int(pupil_wheel_index)
             dx = pupil_wheel_index - ix
@@ -426,6 +478,7 @@ def do_correction(input_model, pathloss_model):
                     correction[row] = (1.0 - dx) * pathloss_array[refrow_index, ix] + \
                                       dx * pathloss_array[refrow_index, ix + 1]
 
+        # Create and apply the 2D correction
         pathloss_2d = np.broadcast_to(correction, input_model.data.shape)
         output_model.data /= pathloss_2d
         output_model.err /= pathloss_2d
@@ -433,11 +486,13 @@ def do_correction(input_model, pathloss_model):
         output_model.var_rnoise /= pathloss_2d**2
         if output_model.var_flat is not None and np.size(output_model.var_flat) > 0:
             output_model.var_flat /= pathloss_2d**2
-        output_model.pathloss = pathloss_2d
+        output_model.pathloss_ps = pathloss_2d
 
+        # Set step status to complete
         output_model.meta.cal_step.pathloss = 'COMPLETE'
 
     return output_model
+
 
 def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
     """
@@ -510,6 +565,7 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
                                  - extended_pathloss_vector[lower_indices]))
 
     return pathloss_grid
+
 
 def is_pointsource(srctype):
     """Returns True if srctype is POINT"""

--- a/jwst/pathloss/pathloss_step.py
+++ b/jwst/pathloss/pathloss_step.py
@@ -7,8 +7,7 @@ __all__ = ["PathLossStep"]
 
 class PathLossStep(Step):
     """
-    PathLossStep: Inserts the pathloss and wavelength arrays
-    into the data.
+    PathLossStep: Apply the path loss correction to a science exposure.
 
     Pathloss depends on the centering of the source in the aperture if the
     source is a point source.
@@ -24,16 +23,14 @@ class PathLossStep(Step):
         # Open the input data model
         with datamodels.open(input) as input_model:
 
-            # Get the name of the path loss reference file to use
-            self.pathloss_name = self.get_reference_file(input_model,
-                                                         'pathloss')
-            self.log.info('Using PATHLOSS reference file %s',
-                          self.pathloss_name)
+            # Get the name of the pathloss reference file to use
+            self.pathloss_name = self.get_reference_file(input_model, 'pathloss')
+            self.log.info(f'Using PATHLOSS reference file {self.pathloss_name}')
 
             # Check for a valid reference file
             if self.pathloss_name == 'N/A':
                 self.log.warning('No PATHLOSS reference file found')
-                self.log.warning('Path loss step will be skipped')
+                self.log.warning('Pathloss step will be skipped')
                 result = input_model.copy()
                 result.meta.cal_step.pathloss = 'SKIPPED'
                 return result


### PR DESCRIPTION
Update all of the `datamodels` schemas that contain a "pathloss" array to now contain both a "pathloss_ps" and "pathloss_un" (point source and uniform, respectively). Update the `pathloss` step to always compute both 2D versions, apply the appropriate one, and store both versions in the output. For NIRISS SOSS, which only has one version of the pathloss correction, store as "pathloss_ps", because it's assumed that only point sources will be observed with that mode.

Fixes #5103 / [JP-1556](https://jira.stsci.edu/browse/JP-1556)