### PR TITLE
use input_frame when creating a gWCS object

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -244,8 +244,13 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
 
     out_frame = refmodel.meta.wcs.output_frame
     input_frame = dmodels[0].meta.wcs.input_frame
-    wnew = wcs_from_fiducial(fiducial, coordinate_frame=out_frame, projection=prj,
-                             transform=transform, input_frame=input_frame)
+    wnew = wcs_from_fiducial(fiducial, coordinate_frame=out_frame, projection=prj, transform=transform)
+    # temporary fix before gwcs 0.14 is released
+    # wnew = wcs_from_fiducial(fiducial, coordinate_frame=out_frame, projection=prj,
+    #                          transform=transform, input_frame=input_frame)
+    pipe = wnew.pipeline[:]
+    pipe[0] = (input_frame, pipe[0][1])
+    wnew = WCS(pipe)
 
     footprints = [w.footprint().T for w in wcslist]
     domain_bounds = np.hstack([wnew.backward_transform(*f) for f in footprints])


### PR DESCRIPTION
temporary fix for #5120 until gwcs 0.14 is released - #5120 works now with older versions of gwcs.