### PR TITLE
JP-1557: Update master_background for NRS IFU pathloss

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,7 +64,7 @@ master_background
 
 - Fix open files bug [#4995]
 
-- Update to include pathloss corrections to NIRSpec IFU background [#xxxx]
+- Update to include pathloss corrections to NIRSpec IFU background [#5125]
 
 outlier_detection
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,10 +44,12 @@ datamodels
 
 extract_1d
 ----------
+
 - rechecks the input model container in run_extract1d to select the correct processing [#5076]
 
 extract_2d
 ----------
+
 - checks subwcs and new_slit variables exist before trying to delete them [#5093]
 
 coron
@@ -61,6 +63,8 @@ master_background
 -----------------
 
 - Fix open files bug [#4995]
+
+- Update to include pathloss corrections to NIRSpec IFU background [#xxxx]
 
 outlier_detection
 -----------------

--- a/jwst/datamodels/ifuimage.py
+++ b/jwst/datamodels/ifuimage.py
@@ -56,6 +56,10 @@ class IFUImageModel(DataModel):
                 self.var_rnoise = init.var_rnoise
             if init.hasattr('area'):
                 self.area = init.area
+            if init.hasattr('pathloss_point'):
+                self.pathloss_point = init.pathloss_point
+            if init.hasattr('pathloss_uniform'):
+                self.pathloss_uniform = init.pathloss_uniform
             return
 
         super(IFUImageModel, self).__init__(init=init, **kwargs)

--- a/jwst/master_background/nirspec_corrections.py
+++ b/jwst/master_background/nirspec_corrections.py
@@ -1,0 +1,26 @@
+import logging
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+def correct_nrs_ifu_bkg(input):
+    """Apply point source vs. uniform source pathloss adjustments
+    to a NIRSpec IFU 2D master background array.
+
+    Parameters
+    ----------
+    input : `~jwst.datamodels.IFUImageModel`
+        The input background data.
+
+    Returns
+    -------
+    input : `~jwst.datamodels.IFUIMAGEModel`
+        An updated (in place) version of the input with the data
+        replaced by the corrected 2D background.
+    """
+
+    log.info('Applying point source pathloss updates to IFU background')
+    input.data *= (input.pathloss_point / input.pathloss_uniform)
+
+    return input

--- a/jwst/master_background/nirspec_corrections.py
+++ b/jwst/master_background/nirspec_corrections.py
@@ -21,6 +21,23 @@ def correct_nrs_ifu_bkg(input):
     """
 
     log.info('Applying point source pathloss updates to IFU background')
-    input.data *= (input.pathloss_point / input.pathloss_uniform)
+
+    # Try to load the appropriate pathloss correction arrays
+    try:
+        pl_point = input.getarray_noinit('pathloss_point')
+    except AttributeError:
+        log.warning('Pathloss_point array not found in input')
+        log.warning('Skipping pathloss background updates')
+        return input
+
+    try:
+        pl_uniform = input.getarray_noinit('pathloss_uniform')
+    except AttributeError:
+        log.warning('Pathloss_uniform array not found in input')
+        log.warning('Skipping pathloss background updates')
+        return input
+
+    # Apply the corrections
+    input.data *= (pl_point / pl_uniform)
 
     return input

--- a/jwst/master_background/tests/test_nirspec_corrections.py
+++ b/jwst/master_background/tests/test_nirspec_corrections.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for master background NIRSpec corrections
+"""
+import numpy as np
+import pytest
+
+from jwst import datamodels
+from ..nirspec_corrections import correct_nrs_ifu_bkg
+
+
+def test_ifu_pathloss_existence():
+    """Test the case where the input is missing a pathloss array"""
+
+    input = datamodels.IFUImageModel((10, 10))
+    result = correct_nrs_ifu_bkg(input)
+
+    assert (result == input)
+
+
+def test_ifu_correction():
+    """Test application of IFU corrections"""
+
+    data = np.ones((5, 5))
+    pl_ps = 2 * data
+    pl_un = data / 2
+    input = datamodels.IFUImageModel(data=data,
+                                     pathloss_point=pl_ps,
+                                     pathloss_uniform=pl_un)
+
+    corrected = input.data * pl_ps / pl_un
+    result = correct_nrs_ifu_bkg(input)
+
+    assert np.allclose(corrected, result.data, rtol=1.e-10)

--- a/jwst/master_background/tests/test_nirspec_corrections.py
+++ b/jwst/master_background/tests/test_nirspec_corrections.py
@@ -2,7 +2,6 @@
 Unit tests for master background NIRSpec corrections
 """
 import numpy as np
-import pytest
 
 from jwst import datamodels
 from ..nirspec_corrections import correct_nrs_ifu_bkg


### PR DESCRIPTION
Updated the `expand_to_2d` module to call the new function `correct_nrs_ifu_bgk` when the science data is a point source, in order to apply the point source vs. uniform source pathloss mods to the computed 2D background, before subtracting from the science data.

Fixes #5104 / [JP-1557](https://jira.stsci.edu/browse/JP-1557)