### PR TITLE
JP-1278: Change flag used for high persistence

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ associations
 
 barshadow
 ---------
+
 - Correct bar shadow parity bug for yslit. [#5095]
 
 combine_1d
@@ -32,11 +33,12 @@ combine_1d
 
 cube_build
 ----------
+
 - changed default weighting back to 'msm' until NIRSPEC cube pars ref file contains emsm info [#5134]
 
 - Added checks read from cube pars reference file that parameters have valid data [#5134]
  
-- change the name of  default types of cubes from ``world`` to ``skyalign`` [#4974]
+- change the name of default types of cubes from ``world`` to ``skyalign`` [#4974]
 
 - added ``ifualign`` cubes to be cubes rotated on sky to align with ifu instrument plane [#4974]
 
@@ -65,6 +67,8 @@ datamodels
 - Add TIMEUNIT keyword to schemas. [#5109]
 
 - Split ``pathloss`` object into ``pathloss_ps`` and ``pathloss_un``. [#5112]
+
+- Added "PERSISTENCE" DQ flag definition. [#5137]
 
 extract_1d
 ----------
@@ -107,6 +111,12 @@ pathloss
 
 - Update to save both point source and uniform source 2D pathloss correction
   arrays to output. [#5112]
+
+persistence
+-----------
+
+- Flag pixels with high persistence using "PERSISTENCE" DQ flag instead
+  of "DO_NOT_USE". [#5137]
 
 pipeline
 --------

--- a/docs/jwst/persistence/arguments.rst
+++ b/docs/jwst/persistence/arguments.rst
@@ -14,10 +14,10 @@ as input to the persistence step for a subsequent exposure.
 
 *  ``--flag_pers_cutoff``
 
-If this floating-point value is specified, pixels that have received a
+If this floating-point value is specified, pixels that receive a
 persistence correction greater than or equal to ``flag_pers_cutoff`` DN
-(the default is 40) will be flagged in the pixeldq extension of the
-output file.
+(the default is 40) are flagged in the PIXELDQ array of the
+output file with the DQ value "PERSISTENCE".
 
 *  ``--save_persistence``
 

--- a/docs/jwst/persistence/description.rst
+++ b/docs/jwst/persistence/description.rst
@@ -50,7 +50,9 @@ traps-filled image must be updated at the end of each group.
 
 For each pixel, the persistence in a group is the sum of the trap decays
 over all trap families.  This persistence is subtracted from the science
-data for the current group.
+data for the current group. Pixels that have large persistence values
+subtracted from them are flagged in the DQ array, as information to the
+user (see the Step Arguments section).
 
 Trap capture is more involved than is trap decay.  The computation of trap
 capture is different for an impulse (e.g. a cosmic-ray event) than for a

--- a/jwst/datamodels/dqflags.py
+++ b/jwst/datamodels/dqflags.py
@@ -26,8 +26,8 @@ pixel = {'GOOD':             0,      # No bits set, all is good
          'SATURATED':        2**1,   # Pixel saturated during exposure
          'JUMP_DET':         2**2,   # Jump detected during exposure
          'DROPOUT':          2**3,   # Data lost in transmission
-         'OUTLIER':          2**4,   # Flagged by outlier detection. Was RESERVED_1
-         'RESERVED_2':       2**5,   #
+         'OUTLIER':          2**4,   # Flagged by outlier detection (was RESERVED_1)
+         'PERSISTENCE':      2**5,   # High persistence (was RESERVED_2)
          'RESERVED_3':       2**6,   #
          'RESERVED_4':       2**7,   #
          'UNRELIABLE_ERROR': 2**8,   # Uncertainty exceeds quoted error

--- a/jwst/persistence/persistence.py
+++ b/jwst/persistence/persistence.py
@@ -368,7 +368,7 @@ class DataSet():
                         persistence.copy()
                 if persistence.max() >= self.flag_pers_cutoff:
                     mask = (persistence >= self.flag_pers_cutoff)
-                    self.output_obj.pixeldq[mask] |= dqflags.pixel['DO_NOT_USE']
+                    self.output_obj.pixeldq[mask] |= dqflags.pixel['PERSISTENCE']
 
             # Update traps_filled with the number of traps that captured
             # a charge during the current integration.


### PR DESCRIPTION
Added the new DQ flag type "PERSISTENCE" (using up another one of the leftover reserved slots) to the dqflags definitions and change the ``persistence`` step to use that flag for pixels with high persistence instead of "DO_NOT_USE". Updated ``persistence`` step docs accordingly.

Fixes #4535 / [JP-1278](https://jira.stsci.edu/browse/JP-1278)