### PR TITLE
Disable FITS Hash checking by default

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -663,7 +663,7 @@ def _verify_skip_fits_update(skip_fits_update, hdulist, asdf_struct, context):
         All conditions are satisfied for skipping FITS updating.
     """
     if skip_fits_update is None:
-        skip_fits_update = util.get_envar_as_boolean('SKIP_FITS_UPDATE', None)
+        skip_fits_update = util.get_envar_as_boolean('SKIP_FITS_UPDATE', False)
 
     # If skipping has been explicitly disallowed, indicate as such.
     if skip_fits_update is False:

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -476,5 +476,5 @@ def get_envar_as_boolean(name, default=False):
             return value_lowcase in truths
         return value
 
-    log.debug('Environmental "{name}" cannot be found. Using default value of "{default}".')
+    log.debug(f'Environmental "{name}" cannot be found. Using default value of "{default}".')
     return default


### PR DESCRIPTION
Necessary because ASDF needs to update to at least 2.6.1. When done so, the default can be reset.