### PR TITLE
Add test to ensure substep configs are read during Step.call

### DIFF
--- a/jwst/stpipe/tests/data/proper_pipeline.asdf
+++ b/jwst/stpipe/tests/data/proper_pipeline.asdf
@@ -1,0 +1,14 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.5.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 2.6.0}
+parameters:
+  class: jwst.stpipe.tests.steps.ProperPipeline
+  name: ProperPipeline
+  steps:
+    withdefaultsstep:
+      par1: newpar1
+...

--- a/jwst/stpipe/tests/data/proper_pipeline.asdf
+++ b/jwst/stpipe/tests/data/proper_pipeline.asdf
@@ -1,10 +1,8 @@
 #ASDF 1.0.0
-#ASDF_STANDARD 1.5.0
+#ASDF_STANDARD 1.4.0
 %YAML 1.1
 %TAG ! tag:stsci.edu:asdf/
 --- !core/asdf-1.1.0
-asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
-  name: asdf, version: 2.6.0}
 parameters:
   class: jwst.stpipe.tests.steps.ProperPipeline
   name: ProperPipeline

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -199,6 +199,7 @@ class ProperPipeline(Pipeline):
         'stepwithmodel': StepWithModel,
         'another_stepwithmodel': StepWithModel,
         'stepwithcontainer': StepWithContainer,
+        'withdefaultsstep': WithDefaultsStep
     }
 
     def process(self, *args):
@@ -213,6 +214,8 @@ class ProperPipeline(Pipeline):
         r = self.another_stepwithmodel(r)
         self.stepwithcontainer.suffix = 'swc'
         r = self.stepwithcontainer(r)
+        self.withdefaultsstep.suffix = 'wds'
+        r = self.withdefaultsstep(r)
 
         return r
 

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -14,7 +14,7 @@ from jwst.stpipe import Step, crds_client
 from jwst.stpipe import cmdline
 from jwst.stpipe.config_parser import ValidationError
 
-from .steps import EmptyPipeline, MakeListPipeline, MakeListStep
+from .steps import EmptyPipeline, MakeListPipeline, MakeListStep, ProperPipeline
 from .util import t_path
 
 from crds.core.exceptions import CrdsLookupError
@@ -716,3 +716,17 @@ def test_search_attr():
 def test_print_configspec():
     step = Step()
     step.print_configspec()
+
+
+def test_call_with_config(caplog, _jail):
+    """Test call using a config file with substeps
+
+    In particular, from JP-1482, there was a case where a substep parameter
+    was not being overridden. Test for that case.
+    """
+    cfg = t_path(join('data', 'proper_pipeline.asdf'))
+    model = t_path(join('data', 'flat.fits'))
+
+    ProperPipeline.call(model, config_file=cfg)
+
+    assert "'par1': 'newpar1'" in caplog.text


### PR DESCRIPTION
Resolves JP-1482
Resolves #5005 

The issue itself was not reproducible. This PR adds the specific test for the condition described.