### PR TITLE
Disable validation of schema default values

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ ignore = E203, W503, W504, W605
 minversion = 3.6
 norecursedirs = docs/_build jwst/timeconversion jwst/extern scripts jwst/tests_nightly
 asdf_schema_tests_enabled = true
+asdf_schema_validate_default = false
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 junit_family = xunit2
 inputs_root = jwst-pipeline


### PR DESCRIPTION
The next version of asdf includes a bug fix that makes validation of the schema `default` property more strict.  This breaks several tests in jwst due to property definitions like this example from jwst/datamodels/schemas/amilg.schema.yaml:

```
    fit_image:
      title: Fitted image
      fits_hdu: FIT
      default: 0.0
      ndim: 2
      datatype: float32
```

Since `0.0` is not an ndarray of 2 dimensions, the stricter validation fails.  If we wanted a default that would pass validation, we'd have to do something like this:

```
    fit_image:
      title: Fitted image
      fits_hdu: FIT
      default: !<tag:stsci.edu:asdf/core/ndarray-1.0.0>
        data:
          - [0.0, 0.0, 0.0, 0.0, 0.0]
          - [0.0, 0.0, 0.0, 0.0, 0.0]
          - [0.0, 0.0, 0.0, 0.0, 0.0]
          - [0.0, 0.0, 0.0, 0.0, 0.0]
          - [0.0, 0.0, 0.0, 0.0, 0.0]
        datatype: float32
        shape: [5, 5]
      ndim: 2
      datatype: float32
```

but that's not feasible, because the shape of the ndarray isn't constant.

This PR disables validation of the `default` property in the schema tester, so that jwst can use whatever value is most helpful, even something like this:

```
    fit_image:
      title: Fitted image
      fits_hdu: FIT
      default: An ndarray of zeros
      ndim: 2
      datatype: float32
```

The feature in asdf that enables this hasn't been merged yet: https://github.com/asdf-format/asdf/pull/831

The other option is to keep default validation and remove `default` from array definitions.  Let me know if you'd prefer that approach.