### PR TITLE
src_catalog_error_note

### DIFF
--- a/docs/jwst/source_catalog/main.rst
+++ b/docs/jwst/source_catalog/main.rst
@@ -57,6 +57,12 @@ semimajor and semiminor axis lengths, orientation of the major axis,
 and sky coordinates at corners of the minimal bounding box enclosing
 the source.
 
+.. Note::
+
+   Errors are only created when an image has an error extension.  Products
+   created from the resampling step currently do not have an error extension 
+   and the error columns are currently filled with a value of nan. 
+
 Source Catalog Table
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This adds a note to the Source catalog documentation indicating that the error array is filled with `nan` in the case for resampled data.   This documents the issue highlighted in #5182 

Relates to [JP-1611](https://jira.stsci.edu/browse/JP-1611)