### PR TITLE
Fix bug in new WFSS extraction code

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -681,11 +681,11 @@ def _create_grism_bbox(input_model, mmag_extract=99.0,
                     ymax = int(np.max(ystack))
 
                     if wfss_extract_half_height is not None and obj.is_star:
-                        if input_model.meta.wcsinfo.dispaxis == 2:
+                        if input_model.meta.wcsinfo.dispersion_direction == 2:
                             center = (xmax + xmin) / 2
                             xmin = center - wfss_extract_half_height
                             xmax = center + wfss_extract_half_height
-                        elif input_model.meta.wcsinfo.dispaxis == 1:
+                        elif input_model.meta.wcsinfo.dispersion_direction == 1:
                             center = (ymax + ymin) / 2
                             ymin = center - wfss_extract_half_height
                             ymax = center + wfss_extract_half_height

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -393,7 +393,7 @@ def test_wfss_extract_custom_height():
      object 26 should have order 2 excluded at order 1 partial
     """
     imwcs, refs = setup_image_cat()
-    imwcs.meta.wcsinfo._instance['dispaxis'] = 1
+    imwcs.meta.wcsinfo._instance['dispersion_direction'] = 1
     extract_orders = [1]  # just extract the first order
     test_boxes = create_grism_bbox(imwcs, refs,
                                    mmag_extract=99.,


### PR DESCRIPTION
Fix a bug in the new WFSS extraction region code in assign_wcs functions, which is referring to `model.meta.wcsinfo.dispaxis` instead of the correct `model.meta.wcsinfo.dispersion_direction`. Regression tests caught this error, causing all WFSS level-2b processing to fail.