### PR TITLE
Make stable and unstable JenkinsfileRT consistent

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -1,6 +1,17 @@
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return
 
+def PipInject(String reqs) {
+    def result = []
+    if (reqs.trim().isEmpty()) {
+        return result
+    }
+    for (req in reqs.split('\n')) {
+        result += "pip install $req"
+    }
+    return result
+}
+
 withCredentials([string(
     credentialsId: 'jwst-codecov',
     variable: 'codecov_token')]) {
@@ -51,6 +62,7 @@ bc0.build_cmds = [
     "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
+bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope",
@@ -64,6 +76,7 @@ bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-stable-deps'
 bc1.build_cmds = ["pip install -e ."]
+bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
 bc1.test_cmds = []
 bc1.test_configs = []
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -48,6 +48,7 @@ bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
     "pip install -e .[test,ephem]",
     "pip install pytest-xdist pytest-sugar",
+    "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
 bc0.test_cmds = [

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -1,6 +1,17 @@
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return
 
+def PipInject(String reqs) {
+    def result = []
+    if (reqs.trim().isEmpty()) {
+        return result
+    }
+    for (req in reqs.split('\n')) {
+        result += "pip install $req"
+    }
+    return result
+}
+
 withCredentials([string(
     credentialsId: 'jwst-codecov',
     variable: 'codecov_token')]) {
@@ -51,6 +62,7 @@ bc0.build_cmds = [
     "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
+bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope",
@@ -64,6 +76,7 @@ bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-unstable-deps'
 bc1.build_cmds = ["pip install -e ."]
+bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
 bc1.test_cmds = []
 bc1.test_configs = []
 

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -1,17 +1,6 @@
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return
 
-def PipInject(String reqs) {
-    def result = []
-    if (reqs.trim().isEmpty()) {
-	return result
-    }
-    for (req in reqs.split('\n')) {
-        result += "pip install $req"
-    }
-    return result
-}
-
 withCredentials([string(
     credentialsId: 'jwst-codecov',
     variable: 'codecov_token')]) {
@@ -19,6 +8,7 @@ withCredentials([string(
 jobconfig = new JobConfig()
 jobconfig.enable_env_publication = false
 jobconfig.publish_env_on_success_only = true
+jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
 python_version = "3.7"
@@ -32,6 +22,7 @@ env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_CONTEXT=jwst-edit",
+    "ENG_BASE_URL=http://twjwdmsemwebag.stsci.edu/JWDMSEngFqAccSide1/TlmMnemonicDataSrv.svc/",
 ]
 
 // Set pytest basetemp output directory
@@ -43,7 +34,8 @@ data_config.server_id = 'bytesalad'
 data_config.root = '${PYTEST_BASETEMP}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
-// Build and test with unreleased dependencies
+
+// Build and test with dependencies specified in requirements-dev.txt
 bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'unstable-deps'
@@ -55,13 +47,13 @@ bc0.conda_packages = [
 bc0.pip_reqs_files = ['requirements-dev.txt']
 bc0.build_cmds = [
     "pip install -e .[test,ephem]",
-    "pip install pytest-xdist",
+    "pip install pytest-xdist pytest-sugar",
+    "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
-bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest -r sxf -n 30 --bigdata --slow \
-    --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope"
+    --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope",
 ]
 bc0.test_configs = [data_config]
 
@@ -71,10 +63,7 @@ bc0.test_configs = [data_config]
 bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-unstable-deps'
-bc1.build_cmds = [
-    "pip install -e .",
-]
-bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
+bc1.build_cmds = ["pip install -e ."]
 bc1.test_cmds = []
 bc1.test_configs = []
 


### PR DESCRIPTION
The two files are the same now except for:

```
$ diff -y JenkinsfileRT JenkinsfileRT_dev --suppress-common-lines
jobconfig.enable_env_publication = true			      |	jobconfig.enable_env_publication = false
// Build and test with dependencies specified in requirements |	// Build and test with dependencies specified in requirements
bc0.name = 'stable-deps'				      |	bc0.name = 'unstable-deps'
bc0.pip_reqs_files = ['requirements-sdp.txt']		      |	bc0.pip_reqs_files = ['requirements-dev.txt']
    "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --s |	    "pytest -r sxf -n 30 --bigdata --slow \
bc1.name = 'macos-stable-deps'				      |	bc1.name = 'macos-unstable-deps'
```