### PR TITLE
Re-enable FITS-hash by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,8 @@ cube_build
 datamodels
 ----------
 
+- Re-enable FITS-hash by default. [#5191]
+
 - Add blend rule for keywords DETECTOR and MODULE. [#4998]
 
 - Add methods ``Model.info`` and ``Model.search``. [#4660]
@@ -76,9 +78,9 @@ datamodels
 
 - Add "PERSISTENCE" DQ flag definition. [#5137]
 
-- Fixed nonsensical premature closing of FITS file of a ``DataModel``. [#4930]
+- Fix nonsensical premature closing of FITS file of a ``DataModel``. [#4930]
 
-- Added a hash set/check to DataModel I/O to check whether schema traversal is necessary. [#5110]
+- Add a hash set/check to DataModel I/O to check whether schema traversal is necessary. [#5110]
 
 - Update underlying MultiExposureModel from the SourceModelContainer models. [#5154]
 

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -32,6 +32,7 @@ env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_CONTEXT=jwst-edit",
+    "ENG_BASE_URL=http://twjwdmsemwebag.stsci.edu/JWDMSEngFqAccSide1/TlmMnemonicDataSrv.svc/",
 ]
 
 // Set pytest basetemp output directory

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -663,7 +663,7 @@ def _verify_skip_fits_update(skip_fits_update, hdulist, asdf_struct, context):
         All conditions are satisfied for skipping FITS updating.
     """
     if skip_fits_update is None:
-        skip_fits_update = util.get_envar_as_boolean('SKIP_FITS_UPDATE', False)
+        skip_fits_update = util.get_envar_as_boolean('SKIP_FITS_UPDATE', None)
 
     # If skipping has been explicitly disallowed, indicate as such.
     if skip_fits_update is False:

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -90,7 +90,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             Defaults to `True`.
 
         kwargs : dict
-            Additional arguments passed to lower level functions.
+            Additional keyword arguments passed to lower level functions. These arguments
+            are generally file format-specific. Arguments of note are:
+
+            - FITS
+
+              skip_fits_update - bool or None
+                  `True` to skip updating the ASDF tree from the FITS headers, if possible.
+                  If `None`, value will be taken from the environmental SKIP_FITS_UPDATE.
+                  Otherwise, the default value is `True`.
         """
 
         # Override value of validation parameters if not explicitly set.

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -50,6 +50,17 @@ def open(init=None, memmap=False, **kwargs):
         Turn memmap of FITS file on or off.  (default: False).  Ignored for
         ASDF files.
 
+    kwargs : dict
+        Additional keyword arguments passed to lower level functions. These arguments
+        are generally file format-specific. Arguments of note are:
+
+        - FITS
+
+           skip_fits_update - bool or None
+              `True` to skip updating the ASDF tree from the FITS headers, if possible.
+              If `None`, value will be taken from the environmental SKIP_FITS_UPDATE.
+              Otherwise, the default value is `True`.
+
     Returns
     -------
     model : DataModel instance


### PR DESCRIPTION
After ASDF > 2.6.1 is available, re-enable FITS-Hash.