### PR TITLE
Wrap first angle at 360 in forward V23ToSky and at 180 for inverse

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -184,6 +184,12 @@ stpipe
 
 - Remove further sloper references. [#4989]
 
+transforms
+----------
+
+- Wrap first spherical angle ("RA") at 360 degrees in the forward ``V23ToSky``
+  transformation and to 180 degrees for the inverse transformation ("V2"). [#5195]
+
 wavecorr
 --------
 

--- a/jwst/transforms/schemas/stsci.edu/jwst_pipeline/v23tosky-0.8.0.yaml
+++ b/jwst/transforms/schemas/stsci.edu/jwst_pipeline/v23tosky-0.8.0.yaml
@@ -1,0 +1,49 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/v23tosky-0.8.0"
+tag: "tag:stsci.edu:jwst_pipeline/v23tosky-0.8.0"
+title: >
+  A sequence of 3D rotations.
+
+description: |
+  A sequence of 3D rotations around different axes.
+  This represents JWST transform from the telescope
+  coordinate system (V2,V3) to ICRS.
+
+examples:
+  -
+    - JWST V2, V3 to sky transform.
+
+    - |
+        !<tag:stsci.edu:jwst_pipeline/v23tosky-0.8.0>
+          angles: [-0.0193, -0.1432, -0.04, -65.60, 273.089]
+          axes_order: zyxyz
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - type: object
+    properties:
+      angles:
+        description: |
+          The angles of rotation in units of deg.
+          The order of the angles is:
+          [-V2_REF, V3_REF, -ROLL_REF, -DEC_REF, RA_REF]
+        type: array
+        items:
+          type: number
+
+      axes_order:
+        description: |
+          A sequence of "x", "y" or "z" characters representing an axis of rotation.
+          The number of characters must equal the number of angles.
+          For the JWST V23 to sky transform the axes are zyxyz.
+        type: string
+
+      wrap_lon_at:
+        description: Angle at which to wrap the longitude angle.
+        type: integer
+        enum: [180, 360]
+        default: 360
+
+    required: [angles, axes_order]

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -116,13 +116,14 @@ class V23ToSkyType(JWSTTransformType):
     name = "v23tosky"
     types = [V23ToSky]
     standard = "jwst_pipeline"
-    version = "0.7.0"
+    version = "0.8.0"
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
         angles = node['angles']
         axes_order = node['axes_order']
-        return V23ToSky(angles, axes_order=axes_order)
+        wrap_lon_at = node.get('wrap_lon_at', 360)
+        return V23ToSky(angles, axes_order=axes_order, wrap_lon_at=wrap_lon_at)
 
     @classmethod
     def to_tree_transform(cls, model, ctx):


### PR DESCRIPTION
Fixes #5148 / [JP-1585](https://jira.stsci.edu/browse/JP-1585). Improves upon #5185 by restoring wrap angle for `V2` to 180 degrees so that inversion polynomials that take from detector to V2V3 frames now can work as designed.

Fundamentally, this PR implements solution `2b` in https://github.com/spacetelescope/jwst/issues/5148#issuecomment-663753458