### PR TITLE
JP-1585: do not allow negative sky values

### DIFF
--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -31,7 +31,7 @@ def v23tosky(input_model):
     # In order to get only positive angles on sky we convert
     # the values to the range 0 to 360 before going to sky
     # and convert back to -180 to 180 before going from sky to V2V3.
-    # "foraward" represents np.mod(x, 360)
+    # "forward" represents np.mod(x, 360)
     forward = (Mapping((0, 0, 1)) |
                Identity(1) & Const1D(360) & Identity(1) |
                astmath.ModUfunc() & Identity(1))

--- a/jwst/assign_wcs/tests/test_niriss.py
+++ b/jwst/assign_wcs/tests/test_niriss.py
@@ -8,7 +8,7 @@ of the results is verified by the team based on the specwcs reference
 file.
 
 """
-
+import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
 from gwcs import wcs
@@ -18,6 +18,7 @@ from ...datamodels.image import ImageModel
 
 from ..assign_wcs_step import AssignWcsStep
 from .. import niriss
+from .. import pointing
 
 
 # Allowed settings for niriss
@@ -173,3 +174,14 @@ def test_imaging_distortion():
     assert_allclose(y, wcs_kw['crpix2'])
     assert_allclose(raout, ra)
     assert_allclose(decout, dec)
+
+
+def test_v23tosky():
+    hdul = create_hdul()
+    im = ImageModel(hdul)
+    transform = pointing.v23tosky(im)
+    x = np.linspace(-.5, 1050, 100)
+    y = x
+    x1, y1 = transform.inverse(*transform(x, y))
+    assert_allclose(x1, x)
+    assert_allclose(y1, y)


### PR DESCRIPTION
Fixes #5148 
Alternative to #5195

This has the same effect as #5195 but does not require a special model.
If transforms are to be removed from jwst in the future we should go with this implementation.
There's a branch `move_transforms_out_of jwst` which replaces the `V23ToSky` transform with rotations from astropy.
Worked on this with @mcara.

Most of the failing regression tests pass, some fail with small differences.