### PR TITLE
Skip grism test if engineering database is unavailable

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -33,7 +33,6 @@ env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_CONTEXT=jwst-edit",
-    "ENG_BASE_URL=http://twjwdmsemwebag.stsci.edu/JWDMSEngFqAccSide1/TlmMnemonicDataSrv.svc/",
 ]
 
 // Set pytest basetemp output directory

--- a/jwst/regtest/test_nircam_tsgrism.py
+++ b/jwst/regtest/test_nircam_tsgrism.py
@@ -84,7 +84,10 @@ def test_nircam_setpointing(_jail, rtdata, fitsdiff_default_kwargs):
     rtdata.output = rtdata.input
 
     # Call the WCS routine, using the ENGDB_Service
-    add_wcs(rtdata.input, siaf_path=siaf_path)
+    try:
+        add_wcs(rtdata.input, siaf_path=siaf_path)
+    except ValueError:
+        pytest.skip('Engineering Database not available.')
 
     rtdata.get_truth("truth/test_nircam_setpointing/jw00721012001_03103_00001-seg001_nrcalong_uncal.fits")
 


### PR DESCRIPTION
Made the grism test resilient against database availability. If not available, test is skipped.

Also, reverted the switch to the D1 string DB, since that is under build at the moment. D2 is the side to for the moment.