### PR TITLE
JP-1546: Updates for MIRI MRS TSO processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ associations
 
 - Update diagrams in documentation to change sloper to detector1. [#4986]
 
+- Update level-3 rules to exclude IFU exposures from ``calwebb_tso3`` associations. [#5202]
+
 barshadow
 ---------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,11 @@ extract_2d
   which allows a user to specify the extraction height in the
   cross-dispersion direction for WFSS mode. [#5140]
 
+fringe
+------
+
+- Update the fringe step to handle 3D inputs for MIRI MRS TSO mode. [#5202]
+
 master_background
 -----------------
 
@@ -159,6 +164,11 @@ pipeline
 
 - Update the ``Spec2Pipeline`` to include the new ``wavecorr`` step and put
   ``srctype`` before ``wavecorr``. [#5133]
+
+- Update the ``Spec2Pipeline`` to skip ``extract_1d`` for IFU data that
+  have not had a cube built (e.g. MIRI MRS TSO), and update the
+  ``calwebb_tso-spec2.cfg`` configuration to turn on the ``fringe`` step
+  and turn off ``cube_build`` for MIRI MRS TSO. [#5202]
 
 photom
 ------

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -735,6 +735,13 @@ class Asn_TSO(AsnMixin_Science):
                 name='exp_type',
                 sources=['exp_type'],
             ),
+            # Don't allow IFU exposures in tso3
+            Constraint(
+                [
+                    Constraint_IFU(),
+                ],
+                reduce=Constraint.notany
+            ),
         ])
 
         super(Asn_TSO, self).__init__(*args, **kwargs)

--- a/jwst/fringe/fringe.py
+++ b/jwst/fringe/fringe.py
@@ -61,14 +61,12 @@ def apply_fringe(input_model, fringe):
     # Initialize the output model as a copy of the input
     output_model = input_model.copy()
 
-    fringe_data = fringe.data
-    # fringe_dq = fringe.dq
-
     # Fringe-correct data and error arrays, applying correction only
-    #    to pixels having good reference values
-    good_pix = np.isfinite(fringe_data)
-    output_model.data[good_pix] /= fringe_data[good_pix]
-    output_model.err[good_pix] /= fringe_data[good_pix]
+    # to pixels having good calibration values
+    fringe_data = fringe.data
+    fringe_data[np.isnan(fringe_data)] = 1.0
+    output_model.data /= fringe_data
+    output_model.err /= fringe_data
 
 ### 05/22/14: For now, commenting out the following updating of the output
 ###    DQ based on the DQ of the reference file. This is done now because the
@@ -77,12 +75,11 @@ def apply_fringe(input_model, fringe):
 ###    will be logged for now. This behavior may be changed later.
 ###
     # set DQ flag for bad pixels in the fringe
-#       dq_mask = fringe_dq * 0
-#       dq_mask[np.where(fringe_dq != 0)] = dqflags.pixel['DEAD']
+#   dq_mask = fringe.dq * 0
+#   dq_mask[np.where(fringe.dq != 0)] = dqflags.pixel['DEAD']
 
     # update DQ array based on fringe's DQ values
-#       output_model.dq = np.bitwise_or(output_model.dq, dq_mask)
-    log.info('The DQ values in the reference file will NOT be used to update the\
-    DQ values in the output DQ array.')
+#   output_model.dq = np.bitwise_or(output_model.dq, dq_mask)
+    log.info('DQ values in the reference file NOT used to update the output DQ.')
 
     return output_model

--- a/jwst/fringe/fringe_step.py
+++ b/jwst/fringe/fringe_step.py
@@ -16,7 +16,7 @@ class FringeStep(Step):
     reference_file_types = ['fringe']
 
     def process(self, input):
-        with datamodels.IFUImageModel(input) as input_model:
+        with datamodels.open(input) as input_model:
 
             # Open the reference file
             self.fringe_filename = self.get_reference_file(input_model,

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -316,6 +316,10 @@ class Spec2Pipeline(Pipeline):
             result_extra = result
 
         # Extract a 1D spectrum from the 2D/3D data
+        if exp_type in ['MIR_MRS', 'NRS_IFU'] and self.cube_build.skip:
+            # Skip extract_1d for IFU modes where no cube was built
+            self.extract_1d.skip = True
+
         self.extract_1d.save_results = self.save_results
         if multi_int:
             self.extract_1d.suffix = 'x1dints'

--- a/jwst/pipeline/calwebb_tso-spec2.cfg
+++ b/jwst/pipeline/calwebb_tso-spec2.cfg
@@ -17,7 +17,6 @@ save_results = True
       [[straylight]]
         skip = true
       [[fringe]]
-        skip = true
       [[pathloss]]
         skip = true
       [[barshadow]]
@@ -26,4 +25,5 @@ save_results = True
       [[resample_spec]]
         skip = true
       [[cube_build]]
+        skip = true
       [[extract_1d]]

--- a/jwst/regtest/test_miri_mrs_tso.py
+++ b/jwst/regtest/test_miri_mrs_tso.py
@@ -19,7 +19,6 @@ def run_spec2(jail, rtdata_module):
     # Setup the inputs
     file_name = 'jw80600018001_02101_00003_mirifushort_rateints.fits'
     rtdata.get_data(INPUT_PATH + '/' + file_name)
-    file_path = rtdata.input
 
     # Run the pipeline
     args = ["config/calwebb_tso-spec2.cfg", rtdata.input,

--- a/jwst/regtest/test_miri_mrs_tso.py
+++ b/jwst/regtest/test_miri_mrs_tso.py
@@ -1,0 +1,48 @@
+"""Regression test for MIRI MRS TSO mode"""
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+# Define artifactory source and truth
+INPUT_PATH = 'miri/mrs'
+TRUTH_PATH = 'truth/test_miri_mrs_tso'
+
+
+@pytest.fixture(scope='module')
+def run_spec2(jail, rtdata_module):
+    """Run the Spec2Pipeline on a single exposure"""
+    rtdata = rtdata_module
+    collect_pipeline_cfgs("config")
+
+    # Setup the inputs
+    file_name = 'jw80600018001_02101_00003_mirifushort_rateints.fits'
+    rtdata.get_data(INPUT_PATH + '/' + file_name)
+    file_path = rtdata.input
+
+    # Run the pipeline
+    args = ["config/calwebb_tso-spec2.cfg", rtdata.input,
+        '--steps.assign_wcs.save_results=true',
+        '--steps.flat_field.save_results=true',
+        '--steps.srctype.save_results=true',
+        '--steps.fringe.save_results=true',
+        '--steps.photom.save_results=true',
+        ]
+
+    Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize(
+    'suffix', ['assign_wcs', 'calints', 'flat_field', 'fringe', 'photom', 'srctype'])
+def test_spec2(rtdata_module, run_spec2, fitsdiff_default_kwargs, suffix):
+    """Test ensuring the calwebb_tso-spec2 is operating appropriately for MIRI MRS TSO data"""
+    rtdata = rtdata_module
+    output = f"jw80600018001_02101_00003_mirifushort_{suffix}.fits"
+    rtdata.output = output
+
+    rtdata.get_truth(f"{TRUTH_PATH}/{output}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
As part of the minimal processing support for MIRI MRS exposures taken in TSO mode, the calspec2 fringe step has been requested to be applied, as it is for non-TSO MRS data. This updates the fringe step code to allow for both 2D and 3D inputs. In the case of 3D input, the 2D fringe correction is simply broadcast to all planes of the 3D cube.

Fixes #5087 / [JP-1546](https://jira.stsci.edu/browse/JP-1546)