### PR TITLE
JP-1585: Wrap first angle at 360 in forward V2V3 to sky and at 180 for inverse.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -259,6 +259,14 @@ stpipe
 
 - Enable prefetch of pars reference files for associations. [#5249]
 
+transforms
+----------
+
+- Wrap first spherical angle ("RA") at 360 degrees in the forward ``V23ToSky``
+  transformation and to 180 degrees for the inverse transformation ("V2").
+  This is now done using models defined in ``astropy`` and ``gwcs`` packages
+  replacing ``V23ToSky`` model in JWST's WCS pipeline. [#5206]
+
 wavecorr
 --------
 

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -2,17 +2,13 @@ import numpy as np
 from astropy import units as u
 from astropy import coordinates as coords
 from astropy.modeling import models as astmodels
-from astropy.modeling.models import (
-    AffineTransformation2D, Scale, Identity, Mapping, Const1D,
-    RotationSequence3D
-)
+from astropy.modeling.models import Scale, RotationSequence3D
 from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 from gwcs import utils as gwutils
 from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
 
-from ..transforms.models import V23ToSky
 from ..datamodels import DataModel
 
 
@@ -68,10 +64,10 @@ def compute_roll_ref(v2_ref, v3_ref, roll_ref, ra_ref, dec_ref, new_v2_ref, new_
     v3_ref = v3_ref / 3600
 
     if np.isclose(v2_ref, 0, atol=1e-13) and np.isclose(v3_ref, 0, atol=1e-13):
-        angles = [-roll_ref, -dec_ref, - ra_ref]
+        angles = [roll_ref, dec_ref, ra_ref]
         axes = "xyz"
     else:
-        angles = [-v2_ref, v3_ref, -roll_ref, -dec_ref, ra_ref]
+        angles = [v2_ref, -v3_ref, roll_ref, dec_ref, -ra_ref]
         axes = "zyxyz"
 
     matrices = [rotation_matrix(a, ax) for a, ax in zip(angles, axes)]

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -2,29 +2,40 @@ import numpy as np
 from astropy import units as u
 from astropy import coordinates as coords
 from astropy.modeling import models as astmodels
-from ..datamodels import DataModel
+from astropy.modeling.models import (
+    AffineTransformation2D, Scale, Identity, Mapping, Const1D,
+    RotationSequence3D
+)
+from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 from gwcs import utils as gwutils
+from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
+
 from ..transforms.models import V23ToSky
+from ..datamodels import DataModel
 
 
 __all__ = ["compute_roll_ref", "frame_from_model", "fitswcs_transform_from_model"]
 
 
-def v23tosky(input_model):
+def v23tosky(input_model, wrap_v2_at=180, wrap_lon_at=360):
     v2_ref = input_model.meta.wcsinfo.v2_ref / 3600
     v3_ref = input_model.meta.wcsinfo.v3_ref / 3600
     roll_ref = input_model.meta.wcsinfo.roll_ref
     ra_ref = input_model.meta.wcsinfo.ra_ref
     dec_ref = input_model.meta.wcsinfo.dec_ref
 
-    angles = [-v2_ref, v3_ref, -roll_ref, -dec_ref, ra_ref]
+    angles = np.array([v2_ref, -v3_ref, roll_ref, dec_ref, -ra_ref])
     axes = "zyxyz"
-    sky_rotation = V23ToSky(angles, axes_order=axes, name="v23tosky")
+    rot = RotationSequence3D(angles, axes_order=axes)
+
     # The sky rotation expects values in deg.
     # This should be removed when models work with quantities.
-    return astmodels.Scale(1/3600) & astmodels.Scale(1/3600) | sky_rotation
+    m = ((Scale(1/3600) & Scale(1/3600)) | SphericalToCartesian(wrap_lon_at=wrap_v2_at)
+         | rot | CartesianToSpherical(wrap_lon_at=wrap_lon_at))
+    m.name = 'v23tosky'
+    return m
 
 
 def compute_roll_ref(v2_ref, v3_ref, roll_ref, ra_ref, dec_ref, new_v2_ref, new_v3_ref):
@@ -62,8 +73,10 @@ def compute_roll_ref(v2_ref, v3_ref, roll_ref, ra_ref, dec_ref, new_v2_ref, new_
     else:
         angles = [-v2_ref, v3_ref, -roll_ref, -dec_ref, ra_ref]
         axes = "zyxyz"
-    M = V23ToSky._compute_matrix(np.deg2rad(angles), axes)
-    return _roll_angle_from_matrix(M, v2, v3)
+
+    matrices = [rotation_matrix(a, ax) for a, ax in zip(angles, axes)]
+    m = matrix_product(*matrices[::-1])
+    return _roll_angle_from_matrix(m, v2, v3)
 
 
 def _roll_angle_from_matrix(matrix, v2, v3):

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -532,11 +532,6 @@ def update_s_region(model, siaf):
     )
     # Execute IdealToV2V3, followed by V23ToSky
     from ..transforms.models import IdealToV2V3
-    v2_ref_deg = model.meta.wcsinfo.v2_ref / 3600  # in deg
-    v3_ref_deg = model.meta.wcsinfo.v3_ref / 3600  # in deg
-    roll_ref = model.meta.wcsinfo.roll_ref
-    ra_ref = model.meta.wcsinfo.ra_ref
-    dec_ref = model.meta.wcsinfo.dec_ref
     vparity = model.meta.wcsinfo.vparity
     v3yangle = model.meta.wcsinfo.v3yangle
 
@@ -548,8 +543,6 @@ def update_s_region(model, siaf):
     )
     v2, v3 = idltov23(xvert, yvert)  # in arcsec
 
-    angles = [-v2_ref_deg, v3_ref_deg, -roll_ref, -dec_ref, ra_ref]
-    axes = "zyxyz"
     # hardcode wrapping angles for V2 and RA here. Could be made more
     # flexible if needed.
     v23tosky_tr = v23tosky(model, wrap_v2_at=180, wrap_lon_at=360)


### PR DESCRIPTION
Fixes #5148 / [JP-1585](https://jira.stsci.edu/browse/JP-1585). Improves upon #5185 by restoring wrap angle for `V2` to 180 degrees so that inversion polynomials that take from detector to V2V3 frames now can work as designed.

Closes #5195
Closes #5185 

This PR replaces `V23ToSky` model with "standard" models from `astropy` and `gwcs`.