### PR TITLE
Fix logging bugs formerly suppressed by pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,0 @@
-import pkg_resources
-
-entry_points = []
-for entry_point in pkg_resources.iter_entry_points('pytest11'):
-    entry_points.append(entry_point.name)
-
-if "asdf_schema_tester" not in entry_points:
-    pytest_plugins = ['asdf.tests.schema_tester']

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -91,23 +91,21 @@ class CubeBuildStep (Step):
             self.weighting = self.weighting.lower()
 
         if(self.scale1 != 0.0):
-            self.log.info('Input Scale of axis 1 %f', self.scale1)
+            self.log.info(f'Input Scale of axis 1 {self.scale1}')
         if(self.scale2 != 0.0):
-            self.log.info('Input Scale of axis 2 %f', self.scale2)
+            self.log.info(f'Input Scale of axis 2 {self.scale2}')
         if(self.scalew != 0.0):
-            self.log.info('Input wavelength scale %f  ', self.scalew)
+            self.log.info(f'Input wavelength scale {self.scalew}')
 
         if self.wavemin is not None:
-            self.log.info('Setting minimum wavelength of spectral cube to: %f',
-                          self.wavemin)
+            self.log.info(f'Setting minimum wavelength of spectral cube to: {self.wavemin}')
         if self.wavemax is not None:
-            self.log.info('Setting maximum wavelength of spectral cube to: %f',
-                          self.wavemax)
+            self.log.info(f'Setting maximum wavelength of spectral cube to: {self.wavemax}')
 
         if self.rois != 0.0:
-            self.log.info('Input Spatial ROI size %f', self.rois)
+            self.log.info(f'Input Spatial ROI size {self.rois}')
         if self.roiw != 0.0:
-            self.log.info('Input Wave ROI size %f', self.roiw)
+            self.log.info(f'Input Wave ROI size {self.roiw}')
 
 
         self.debug_file = None
@@ -150,13 +148,12 @@ class CubeBuildStep (Step):
         if self.coord_system == 'ifualign':
             self.interpolation = 'pointcloud'
 
-        self.log.info('Input interpolation: %s', self.interpolation)
-        self.log.info('Coordinate system to use: %s', self.coord_system)
+        self.log.info(f'Input interpolation: {self.interpolation}')
+        self.log.info(f'Coordinate system to use: {self.coord_system}')
         if self.interpolation == 'pointcloud':
-            self.log.info('Weighting method for point cloud: %s',
-                          self.weighting)
+            self.log.info(f'Weighting method for point cloud: {self.weighting}')
             if self.weight_power != 0:
-                self.log.info('Power weighting distance : %f', self.weight_power)
+                self.log.info(f'Power weighting distance: {self.weight_power}')
 
         if self.single:
             self.output_type = 'single'
@@ -223,7 +220,7 @@ class CubeBuildStep (Step):
         resol_filename = None
         if self.weighting == 'miripsf':
             resol_filename = self.get_reference_file(self.input_models[0], 'resol')
-            self.log.info('MIRI resol reference file %s',resol_filename)
+            self.log.info(f'MIRI resol reference file {resol_filename}')
             if resol_filename == 'N/A':
                 self.log.warning('No spectral resolution reference file found')
                 self.log.warning('Run again and turn off miripsf')

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -205,7 +205,7 @@ class IFUCubeData():
                     newname = self.output_name_base + fg_name + '_internal_s3d.fits'
 # ______________________________________________________________________________
         if self.output_type != 'single':
-            log.info('Output Name: %s', newname)
+            log.info(f'Output Name: {newname}')
         return newname
 # _______________________________________________________________________
 
@@ -507,14 +507,14 @@ class IFUCubeData():
             for i in range(number_bands):
                 this_channel = self.list_par1[i]
                 this_subchannel = self.list_par2[i]
-                log.info('Cube covers channel, subchannel: %s, %s ', this_channel, this_subchannel)
+                log.info(f'Cube covers channel, subchannel: {this_channel}, {this_subchannel}')
         elif self.instrument == 'NIRSPEC':
             # number of filters and gratings are the same
             number_bands = len(self.list_par1)
             for i in range(number_bands):
                 this_fwa = self.list_par2[i]
                 this_gwa = self.list_par1[i]
-                log.info('Cube covers grating, filter: %s, %s ', this_gwa, this_fwa)
+                log.info(f'Cube covers grating, filter: {this_gwa}, {this_fwa}')
 # ________________________________________________________________________________
 
     def build_ifucube(self):
@@ -606,7 +606,7 @@ class IFUCubeData():
             for k in range(nfiles):
                 ifile = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
 
-                log.debug("Working on Band defined by: %s %s ", this_par1, this_par2)
+                log.debug(f"Working on Band defined by: {this_par1} {this_par2}")
                 # --------------------------------------------------------------------------------
                 # POINTCLOUD used for skyalign and IFUalign
                 # --------------------------------------------------------------------------------
@@ -1019,8 +1019,8 @@ class IFUCubeData():
                 # We don't need to increase it if using 'emsm' weighting
                 if self.weighting.lower() != 'emsm':
                     self.rois = self.rois * 1.5
-                    log.info('Increasing spatial region of interest ' +
-                             'default value set for 4 dithers %f', self.rois)
+                    log.info('Increasing spatial region of interest '
+                             f'default value set for 4 dithers {self.rois}')
 
         if self.scale1 != 0:
             self.spatial_size = self.scale1
@@ -1087,26 +1087,19 @@ class IFUCubeData():
         if self.weight_power is not None:
             if np.isnan(self.weight_power):
                 self.weight_power = None
-        #if self.soft_rad is not None:
-        #    if np.isnan(self.soft_rad):
-        #        self.soft_rad = None
-        #if self.scalerad is not None:
-        #    if np.isnan(self.scalerad):
-        #        self.scalerad = None
 
-
-        log.debug('spatial size %f', self.spatial_size)
-        log.debug('spectral size %f', self.spectral_size)
-        log.debug('spatial roi %f', self.rois)
-        log.debug('wave min and max %f %f', self.wavemin, self.wavemax)
-        log.debug('linear wavelength %d', self.linear_wavelength)
-        log.debug('roiw %f ', self.roiw)
-        log.debug('output_type %s ',self.output_type)
+        log.debug(f'spatial size {self.spatial_size}')
+        log.debug(f'spectral size {self.spectral_size}')
+        log.debug(f'spatial roi {self.rois}')
+        log.debug(f'wave min and max {self.wavemin} {self.wavemax}')
+        log.debug(f'linear wavelength {self.linear_wavelength}')
+        log.debug(f'roiw {self.roiw}')
+        log.debug(f'output_type {self.output_type}')
         if self.weighting == 'msm':
-            log.debug('weight_power %f ',self.weight_power)
-            log.debug('softrad %f ',self.soft_rad)
+            log.debug(f'weight_power {self.weight_power}')
+            log.debug(f'softrad {self.soft_rad}')
         if self.weighting == 'emsm':
-            log.debug('scalerad %f ',self.scalerad)
+            log.debug(f'scalerad {self.scalerad}')
 
 # ******************************************************************************
 
@@ -1152,8 +1145,7 @@ class IFUCubeData():
         if self.coord_system == 'ifualign':
             this_a = parameter1[0] # 0 is first band - this_a is channel
             this_b = parameter2[0] # 0 is first band - this_b is sub-channel
-            log.info('Defining rotation between ra-dec and IFU plane using %s, %s'
-                     , this_a, this_b)
+            log.info(f'Defining rotation between ra-dec and IFU plane using {this_a}, {this_b}')
             # first file for this band
             ifile = self.master_table.FileMap[self.instrument][this_a][this_b][0]
             with datamodels.IFUImageModel(ifile) as input_model:
@@ -1193,7 +1185,7 @@ class IFUCubeData():
                 # temp_dec1 is in degrees
                 dra, ddec = (temp_ra2 - temp_ra1) * np.cos(temp_dec1 * np.pi/180.0), (temp_dec2 - temp_dec1)
                 self.rot_angle = np.arctan2(dra, ddec) * 180./np.pi
-                log.info('Rotation angle between ifu and sky: %f', self.rot_angle)
+                log.info(f'Rotation angle between ifu and sky: {self.rot_angle}')
 
 # ________________________________________________________________________________
 # now loop over data and find min and max ranges data covers
@@ -1209,7 +1201,7 @@ class IFUCubeData():
         for i in range(self.num_bands):
             this_a = parameter1[i]
             this_b = parameter2[i]
-            log.debug('Working on data from %s, %s', this_a, this_b)
+            log.debug(f'Working on data from {this_a}, {this_b}')
             n = len(self.master_table.FileMap[self.instrument][this_a][this_b])
             log.debug('number of files %d', n)
             for k in range(n):
@@ -1273,22 +1265,22 @@ class IFUCubeData():
         if self.instrument == 'MIRI' and self.coord_system == 'internal_cal':
             #  we have a 1 to 1 mapping in y across slice  dimension
             nslice = self.instrument_info.GetNSlice(parameter1[0])
-            log.info('Across slice scale %f ', self.cdelt2)
+            log.info(f'Across slice scale {self.cdelt2}')
             self.cdelt2 = (final_b_max - final_b_min) / nslice
 
             final_b_max = final_b_min + (nslice) * self.cdelt2
             log.info('Changed the across slice scale dimension so we have 1-1 mapping between b and slice #')
-            log.info('New across slice scale %f ', self.cdelt2)
+            log.info(f'New across slice scale {self.cdelt2}')
 
         # ______________________________________________________________________
         if self.instrument == 'NIRSPEC' and self.coord_system == 'internal_cal':
             #  we have a 1 to 1 mapping in x - across slice  dimension.
             nslice = 30
-            log.info('Across slice scale %f ', self.cdelt1)
+            log.info(f'Across slice scale {self.cdelt1}')
             self.cdelt1 = (final_b_max - final_b_min) / nslice
             final_b_max = final_b_min + (nslice) * self.cdelt1
             log.info('Changed the across slice scale dimension so we have 1-1 mapping between b and slice #')
-            log.info('New across slice Scale %f ', self.cdelt1)
+            log.info(f'New across slice Scale {self.cdelt1}')
             self.cdelt2 = self.cdelt1/2.0
 
 # ________________________________________________________________________________
@@ -1297,7 +1289,7 @@ class IFUCubeData():
         test_b = final_b_max - final_b_min
         tolerance1 = 0.00001
         if(test_a < tolerance1 or test_b < tolerance1):
-            log.info('No Valid IFU slice data found %f %f ', test_a, test_b)
+            log.info(f'No Valid IFU slice data found {test_a} {test_b}')
 # ________________________________________________________________________________
     # Based on Scaling and Min and Max values determine naxis1, naxis2, naxis3
     # set cube CRVALs, CRPIXs
@@ -1506,12 +1498,12 @@ class IFUCubeData():
             valid_max = np.where(wave <= max_wave_tolerance)
             not_mapped_high = wave.size - len(valid_max[0])
             if not_mapped_low > 0:
-                log.info('# of detector pixels not mapped to output plane: %i with wavelength below %f',
-                         not_mapped_low, min_wave_tolerance)
+                log.info('# of detector pixels not mapped to output plane: '
+                    f'{not_mapped_low} with wavelength below {min_wave_tolerance}')
 
             if not_mapped_high > 0:
-                log.info('# of detector pixels not mapped to output plane: %i with wavelength above  %f',
-                         not_mapped_high, max_wave_tolerance)
+                log.info('# of detector pixels not mapped to output plane: '
+                    f'{not_mapped_high} with wavelength above {max_wave_tolerance}')
 
 # ______________________________________________________________________________
 # using the DQFlags from the input_image find pixels that should be excluded
@@ -2167,7 +2159,7 @@ class IFUCubeData():
             outchannel = "".join(set(outchannel))
             outchannel = "".join(sorted(outchannel))
             ifucube_model.meta.instrument.channel = outchannel
-            log.info('IFUChannel %s', ifucube_model.meta.instrument.channel)
+            log.info(f'IFUChannel {ifucube_model.meta.instrument.channel}')
 # ______________________________________________________________________
         ifucube_model.meta.wcsinfo.crval1 = self.crval1
         ifucube_model.meta.wcsinfo.crval2 = self.crval2

--- a/jwst/cube_build/tests/test_miri_cubepars.py
+++ b/jwst/cube_build/tests/test_miri_cubepars.py
@@ -345,7 +345,9 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
 
 
 def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
-    """ Read in the miri cube pars file. Test cube has correct values when multiple bands are used """
+    """Read in the miri cube pars file. Test cube has correct values when
+    multiple bands are used
+    """
 
     instrument_info = instrument_defaults.InstrumentInfo()
     all_channel = []

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ DOCS_REQUIRE = [
 ]
 TESTS_REQUIRE = [
     'ci-watson>=0.3.0',
-    'pytest>=4.6.0',
+    'pytest>=4.6.0,<6.0 # doctestplus fails with 6+',
     'pytest-doctestplus',
     'requests_mock>=1.0',
     'pytest-openfiles>=0.5.0',


### PR DESCRIPTION
Pin `pytest<6` because of `pytest-doctestplus` imcompatibility (for now).

This fixes some logging bugs in `cube_build` where `None` objects were getting passed through an `%f` formatter in log messages.

```
$ pytest jwst/cube_build/tests/test_miri_cubepars.py::test_miri_cubepars_multiple_bands
========================================= test session starts =========================================
platform darwin -- Python 3.7.7, pytest-6.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /Users/jdavies/dev/jwst, configfile: setup.cfg
plugins: doctestplus-0.7.0, requests-mock-1.8.0, asdf-2.7.0, ci-watson-0.5, cov-2.10.0, xdist-1.34.0, openfiles-0.5.0, forked-1.3.0
collected 1 item                                                                                      

jwst/cube_build/tests/test_miri_cubepars.py F                                                   [100%]

============================================== FAILURES ===============================================
__________________________________ test_miri_cubepars_multiple_bands __________________________________

_jail = '/private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-20/test_miri_cubepars_multiple_ba0'
miri_cube_pars = '/private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-20/cube_pars0/miri_cube_pars.fits'

<snip>

>       this_cube.determine_cube_parameters()

/Users/jdavies/dev/jwst/jwst/cube_build/tests/test_miri_cubepars.py:456: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/Users/jdavies/dev/jwst/jwst/cube_build/ifu_cube.py:1099: in determine_cube_parameters
    log.debug('spectral size %f', self.spectral_size)

<snip>

/Users/jdavies/miniconda3/envs/test/lib/python3.7/logging/__init__.py:608: in format
    record.message = record.getMessage()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <LogRecord: stpipe, 10, /Users/jdavies/dev/jwst/jwst/cube_build/ifu_cube.py, 1099, "spectral size %f">

    def getMessage(self):
        """
        Return the message for this LogRecord.
    
        Return the message for this LogRecord after merging any user-supplied
        arguments with the message.
        """
        msg = str(self.msg)
        if self.args:
>           msg = msg % self.args
E           TypeError: must be real number, not NoneType

/Users/jdavies/miniconda3/envs/test/lib/python3.7/logging/__init__.py:369: TypeError
======================================= short test summary info =======================================
FAILED jwst/cube_build/tests/test_miri_cubepars.py::test_miri_cubepars_multiple_bands - TypeError: m...
========================================== 1 failed in 1.18s ==========================================
```

These were not showing up in our unit tests before because `pytest` used to suppress them.  That is no longer the case in `pytest 6.0`.  See https://docs.pytest.org/en/stable/changelog.html#id37 (pytest-dev/pytest#6433)

I went ahead and changed all the log messages in these 2 modules to use f-strings for consistency.

Also, I removed some legacy code for handling the pytest schema checker outside of entry points when using old versions of `asdf` which can no longer be used with this package.