### PR TITLE
JP-1561: Update srctype to use DITHOPFR for MIRI MRS

### DIFF
--- a/docs/jwst/srctype/description.rst
+++ b/docs/jwst/srctype/description.rst
@@ -43,9 +43,12 @@ The following choices are used, in order of priority:
 
  - Exposures that are part of a nodded dither pattern, which are assumed
    to only be used with point-like targets, default to a source type
-   of "POINT." Nodded exposures are identified by the "PATTTYPE" keyword
-   either being set to a value of "POINT-SOURCE" (MIRI MRS) or containing
-   the sub-string "NOD" (NIRSpec IFU and Fixed Slit).
+   of "POINT." Nodded exposures are usually identified by the "PATTTYPE"
+   keyword either being set to a value of "POINT-SOURCE" or containing the
+   sub-string "NOD" (NIRSpec IFU and Fixed Slit). For MIRI MRS exposures
+   the keyword "DITHOPFR" (DITHer pattern OPtimized FoR) is used instead of
+   "PATTTYPE". If it has a value of "POINT-SOURCE", the source type is set
+   to "POINT".
 
  - If none of the above conditions apply, and the user did not choose a
    value in the APT, the following table of defaults is used, based on

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -40,8 +40,13 @@ def set_source_type(input_model):
                    'NRC_TSGRISM', 'NIS_SOSS', 'NRS_FIXEDSLIT',
                    'NRS_BRIGHTOBJ', 'NRS_IFU']:
 
+        # Get info about the exposure, including whether it's a background
+        # target and the dither pattern type
         bkg_target = input_model.meta.observation.bkgdtarg
-        patttype = input_model.meta.dither.primary_type
+        if exptype == 'MIR_MRS':
+            patttype = input_model.meta.dither.optimized_for
+        else:
+            patttype = input_model.meta.dither.primary_type
 
         # The keyword SRCTYAPT was added in JWSTKD-354 to retain the value
         # given by the user in the APT, while the cal code then sets a value
@@ -69,6 +74,8 @@ def set_source_type(input_model):
             log.info(f'Exposure is a background target; setting SRCTYPE = {src_type}')
 
         elif pipe_utils.is_tso(input_model):
+
+            # Treat all TSO exposures as a point source
             src_type = 'POINT'
             log.info(f'Input is a TSO exposure; setting SRCTYPE = {src_type}')
 

--- a/jwst/srctype/tests/test_srctype.py
+++ b/jwst/srctype/tests/test_srctype.py
@@ -57,7 +57,8 @@ def test_mirmrs_nodded():
 
     input.meta.exposure.type = 'MIR_MRS'
     input.meta.observation.bkgdtarg = False
-    input.meta.dither.primary_type = 'POINT-SOURCE'
+    input.meta.dither.primary_type = '2-POINT'
+    input.meta.dither.optimized_for = 'POINT-SOURCE'
     input.meta.target.source_type = 'EXTENDED'
 
     output = srctype.set_source_type(input)


### PR DESCRIPTION
Update the srctype step to look at the "DITHOPFR" keyword, instead of "PATTTYPE", when using the dither pattern to decide if a source should be considered point-like.

Fixes #5116 / [JP-1561](https://jira.stsci.edu/browse/JP-1561)