### PR TITLE
JP-1296: Updates for NINTS=1 coron exposures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -135,6 +135,9 @@ outlier_detection
 
 - Fix outlier_detection bug when saving intermediate results. [#5108]
 
+- Update logic to correctly handle input ``CubeModel``s that have only
+  1 integration. [#5211]
+
 pathloss
 --------
 
@@ -172,6 +175,9 @@ pipeline
   ``calwebb_tso-spec2.cfg`` configuration to turn on the ``fringe`` step
   and turn off ``cube_build`` for MIRI MRS TSO. [#5202]
 
+- Update the ``Coron3Pipeline`` logic to correctly handle inputs that have
+  only 1 integration. [#5211]
+
 photom
 ------
 
@@ -184,6 +190,8 @@ ramp_fitting
 - Add multi-processing capability. [#4815]
 
 - Fix crash when DRPFRMS1 is not set [#5096]
+
+- Update to always create the rateints product, even when NINTS=1. [#5211]
 
 source_catalog
 --------------

--- a/docs/jwst/pipeline/calwebb_detector1.rst
+++ b/docs/jwst/pipeline/calwebb_detector1.rst
@@ -114,7 +114,7 @@ Outputs
 
 Result of applying all pipeline steps up through the :ref:`jump <jump_step>` step,
 to produce corrected and CR-flagged 4D ramp data, which will have the same data dimensions
-as the input raw 4D data (ncols x nints x ngroups x nints). Only created when the
+as the input raw 4D data (ncols x nrows x ngroups x nints). Only created when the
 pipeline argument ``--save_calibrated_ramp`` is set to ``True`` (default is ``False``).
 
 2D countrate product
@@ -137,8 +137,7 @@ For MIRI MRS and NIRSpec IFU exposures, the output data model will be
 :Data model: `~jwst.datamodels.CubeModel`
 :File suffix: _rateints
 
-If the input exposure contains more than one integration
-(NINTS>1), a 3D countrate product is created that contains the individual
+A 3D countrate product is created that contains the individual
 results of each integration. The 2D countrate images for each integration are
 stacked along the 3rd axis of the data cubes (ncols x nrows x nints). This
 output file will be of type "_rateints". The 3D "_rateints" product is passed along

--- a/docs/jwst/ramp_fitting/arguments.rst
+++ b/docs/jwst/ramp_fitting/arguments.rst
@@ -9,8 +9,7 @@ The ramp fitting step has three optional arguments that can be set by the user:
   for the optional output product.
 
 * ``--int_name``: A string that can be used to override the default name
-  for the per-integration product, in the case that the exposure
-  contains more than one integration.
+  for the per-integration product.
 
 * ``--maximum_cores``: The fraction of available cores that will be
   used for multi-processing in this step. The default value is 'none' which does not use

--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -5,10 +5,10 @@ This step determines the mean count rate, in units of counts per second, for
 each pixel by performing a linear fit to the data in the input file.  The fit
 is done using the "ordinary least squares" method.
 The fit is performed independently for each pixel.  There can be up to three
-output files created by the step. The primary output file ("rate"), giving the
-slope at each pixel averaged over all integrations, is always produced.
-If the input exposure contains more than one integration, slope images from each
-integration are stored as a data cube in a second output data product ("rateints").
+output files created by the step. The primary output file ("rate") contains the
+slope at each pixel averaged over all integrations.
+Slope images from each integration are stored as a data cube in a second output
+data product ("rateints").
 A third, optional output product is also available, containing detailed fit
 information for each pixel. The three types of output files are described in
 more detail below.
@@ -86,8 +86,7 @@ written as the primary output product.  In this output product, the
 The 3-D VAR_POISSON and VAR_RNOISE arrays from all integrations are averaged
 into corresponding 2-D output arrays.
 
-If the input exposure contains more than one integration, the slope
-images for each integration are stored as a data cube in a second output data
+The slope images for each integration are stored as a data cube in a second output data
 product (rateints).  Each plane of the 3-D SCI, ERR, DQ, VAR_POISSON, and VAR_RNOISE
 arrays in this product corresponds to the result for a given integration.  In this output
 product, the GROUPDQ data for a given integration is collapsed into 2-D, which

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -3,6 +3,7 @@ Various utility functions and data types
 """
 
 import sys
+import warnings
 import os
 from os.path import basename
 
@@ -181,7 +182,8 @@ def open(init=None, memmap=False, **kwargs):
     if not has_model_type:
         class_name = new_class.__name__.split('.')[-1]
         if file_name:
-            log.warning(f"model_type not found. Opening {file_name} as a {class_name}")
+            warnings.warn(f"model_type not found. Opening {file_name} as a {class_name}",
+                NoTypeWarning)
         try:
             delattr(model.meta, 'model_type')
         except AttributeError:

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -3,7 +3,6 @@ Various utility functions and data types
 """
 
 import sys
-import warnings
 import os
 from os.path import basename
 
@@ -168,9 +167,9 @@ def open(init=None, memmap=False, **kwargs):
 
     # Log a message about how the model was opened
     if file_name:
-        log.debug('Opening {0} as {1}'.format(file_name, new_class))
+        log.debug(f'Opening {file_name} as {new_class}')
     else:
-        log.debug('Opening as {0}'.format(new_class))
+        log.debug(f'Opening as {new_class}')
 
     # Actually open the model
     model = new_class(init, **kwargs)
@@ -182,8 +181,7 @@ def open(init=None, memmap=False, **kwargs):
     if not has_model_type:
         class_name = new_class.__name__.split('.')[-1]
         if file_name:
-            warnings.warn(f"model_type not found. Opening {file_name} as a {class_name}",
-                NoTypeWarning)
+            log.warning(f"model_type not found. Opening {file_name} as a {class_name}")
         try:
             delattr(model.meta, 'model_type')
         except AttributeError:

--- a/jwst/model_blender/blendmeta.py
+++ b/jwst/model_blender/blendmeta.py
@@ -233,6 +233,9 @@ def get_blended_metadata(input_models, verbose=False):
     else:
         new_table = None
 
+    for model in input_models:
+        model.close()
+
     return new_meta, new_table
 
 

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -37,7 +37,7 @@ class OutlierDetectionStep(Step):
 
     Parameters
     -----------
-    input : asn file or ModelContainer
+    user_input : asn file or ModelContainer
         Single filename association table, or a datamodels.ModelContainer.
 
     """
@@ -64,9 +64,9 @@ class OutlierDetectionStep(Step):
         search_output_file = boolean(default=False)
     """
 
-    def process(self, input):
+    def process(self, user_input):
         """Perform outlier detection processing on input data."""
-        with datamodels.open(input) as input_models:
+        with datamodels.open(user_input) as input_models:
             self.input_models = input_models
             if not isinstance(self.input_models, datamodels.ModelContainer):
                 self.input_container = False
@@ -145,21 +145,20 @@ class OutlierDetectionStep(Step):
                 detection_step = outlier_registry['ifu']
                 pars['resample_suffix'] = 's3d'
             else:
-                self.log.error("Outlier detection failed for \
-                                unknown/unsupported exposure type: {}".format(
-                                exptype))
+                self.log.error("Outlier detection failed for unknown/unsupported ",
+                               f"exposure type: {exptype}")
                 self.valid_input = False
 
             if not self.valid_input:
-                result = input_models
-                for input in result:
-                    input.meta.cal_step.outlier_detection = "SKIPPED"
-                    self.skip = True
-                return result
+                if self.input_container:
+                    for model in self.input_models:
+                        model.meta.cal_step.outlier_detection = "SKIPPED"
+                else:
+                    self.input_models.meta.cal_step.outlier_detection = "SKIPPED"
+                self.skip = True
+                return self.input_models
 
-            self.log.debug("Using {} class for outlier_detection".format(
-                           detection_step.__name__))
-
+            self.log.debug(f"Using {detection_step.__name__} class for outlier_detection")
             reffiles = {}
 
             # Set up outlier detection, then do detection
@@ -203,9 +202,9 @@ class OutlierDetectionStep(Step):
             reffiles = [self.get_reference_file(self.input_models, reftype)]
             length = 1
 
-        self.log.debug("Using {} reffile(s):".format(reftype.upper()))
+        self.log.debug("Using {reftype.upper()} reffile(s):")
         for r in set(reffiles):
-            self.log.debug("    {}".format(r))
+            self.log.debug("    {r}")
 
         # Check if all the ref files are the same.  If so build it by reading
         # the reference file just once.
@@ -227,30 +226,28 @@ class OutlierDetectionStep(Step):
         """Check to see whether input is the expected ModelContainer object."""
         ninputs = len(self.input_models)
         if not isinstance(self.input_models, datamodels.ModelContainer):
-            self.log.warning("Input is not a ModelContainer.")
-            self.log.warning("Outlier detection step will be skipped.")
+            self.log.warning("Input is not a ModelContainer")
+            self.log.warning("Outlier detection step will be skipped")
             self.valid_input = False
         elif ninputs < 2:
-            self.log.warning("Input only contains %d exposures." % (ninputs))
-            self.log.warning("Outlier detection step will be skipped.")
+            self.log.warning(f"Input only contains {ninputs} exposure")
+            self.log.warning("Outlier detection step will be skipped")
             self.valid_input = False
         else:
             self.valid_input = True
-            self.log.info("Performing outlier detection on %d inputs" %
-                          (ninputs))
+            self.log.info(f"Performing outlier detection on {ninputs} inputs")
 
     def _check_input_cube(self):
         """Check to see whether input is the expected CubeModel object."""
         ninputs = self.input_models.shape[0]
         if not isinstance(self.input_models, datamodels.CubeModel):
-            self.log.warning("Input is not the expected CubeModel.")
-            self.log.warning("Outlier detection step will be skipped.")
+            self.log.warning("Input is not the expected CubeModel")
+            self.log.warning("Outlier detection step will be skipped")
             self.valid_input = False
         elif ninputs < 2:
-            self.log.warning("Input only contains %d exposures." % (ninputs))
-            self.log.warning("Outlier detection step will be skipped.")
+            self.log.warning(f"Input only contains {ninputs} integration")
+            self.log.warning("Outlier detection step will be skipped")
             self.valid_input = False
         else:
             self.valid_input = True
-            self.log.info("Performing outlier detection with %d inputs" %
-                          (ninputs))
+            self.log.info(f"Performing outlier detection with {ninputs} inputs")

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -218,12 +218,11 @@ def ols_ramp_fit_multi(input_model, buffsize, save_opt, readnoise_2d, gain_2d,
                      input_model.meta.exposure.drop_frames1, int_times)
 
         # Populate the rateints output model
-        if number_of_integrations > 1:
-            int_model.data = int_data
-            int_model.dq = int_dq
-            int_model.var_poisson = int_var_poisson
-            int_model.var_rnoise = int_var_rnoise
-            int_model.err = int_err
+        int_model.data = int_data
+        int_model.dq = int_dq
+        int_model.var_poisson = int_var_poisson
+        int_model.var_rnoise = int_var_rnoise
+        int_model.err = int_err
 
         # Populate the optional output model
         if save_opt:
@@ -386,18 +385,17 @@ def create_output_models(input_model, number_of_integrations, save_opt, total_co
                                       err=np.zeros(imshape, dtype=np.float32))
     # ... and add all keys from input
     out_model.update(input_model)
-    # create per integrations model, if this is a multi-integration exposure
-    if number_of_integrations > 1:
-        int_model = datamodels.CubeModel(
-            data=np.zeros((number_of_integrations,) + imshape, dtype=np.float32),
-            dq=np.zeros((number_of_integrations,) + imshape, dtype=np.uint32),
-            var_poisson=np.zeros((number_of_integrations,) + imshape, dtype=np.float32),
-            var_rnoise=np.zeros((number_of_integrations,) + imshape, dtype=np.float32),
-            err=np.zeros((number_of_integrations,) + imshape, dtype=np.float32))
-        int_model.int_times = None
-        int_model.update(input_model)  # ... and add all keys from input
-    else:
-        int_model = None
+
+    # create per integrations model
+    int_model = datamodels.CubeModel(
+        data=np.zeros((number_of_integrations,) + imshape, dtype=np.float32),
+        dq=np.zeros((number_of_integrations,) + imshape, dtype=np.uint32),
+        var_poisson=np.zeros((number_of_integrations,) + imshape, dtype=np.float32),
+        var_rnoise=np.zeros((number_of_integrations,) + imshape, dtype=np.float32),
+        err=np.zeros((number_of_integrations,) + imshape, dtype=np.float32))
+    int_model.int_times = None
+    int_model.update(input_model)  # ... and add all keys from input
+
     # Create model for the optional output
     if save_opt:
         opt_model = datamodels.RampFitOutputModel(
@@ -417,12 +415,13 @@ def create_output_models(input_model, number_of_integrations, save_opt, total_co
         opt_model.update(input_model)  # ... and add all keys from input
     else:
         opt_model = None
+
     return int_model, opt_model, out_model
 
 
 def ols_ramp_fit(data, err, groupdq, inpixeldq, buffsize, save_opt, readnoise_2d, gain_2d,
-                 weighting, instrume, frame_time,
-           ngroups, group_time, groupgap, nframes, dropframes1, int_times):
+                 weighting, instrume, frame_time, ngroups, group_time, groupgap, nframes,
+                 dropframes1, int_times):
 
     """
     Fit a ramp using ordinary least squares. Calculate the count rate for each
@@ -1039,15 +1038,10 @@ def ols_ramp_fit(data, err, groupdq, inpixeldq, buffsize, save_opt, readnoise_2d
     if pixeldq is not None:
         del pixeldq
 
-    # For multiple-integration datasets, will output integration-specific
-    #    results to separate file named <basename> + '_integ.fits'
+    # Output integration-specific results to separate file
     int_times = None
-    if n_int > 1:
-        int_model = utils.output_integ(slope_int, dq_int, effintim,
-                                       var_p3, var_r3, var_both3, int_times)
-    else:
-        int_model = None
-
+    int_model = utils.output_integ(slope_int, dq_int, effintim,
+                                   var_p3, var_r3, var_both3, int_times)
     if opt_res is not None:
         del opt_res
 
@@ -1379,11 +1373,7 @@ def gls_ramp_fit(input_model, buffsize, save_opt,
     #   primary output
     final_pixeldq = dq_compress_final(dq_int, n_int)
 
-    if n_int > 1:
-        int_model = utils.gls_output_integ(input_model, slope_int, slope_err_int, dq_int)
-
-    else:
-        int_model = None
+    int_model = utils.gls_output_integ(input_model, slope_int, slope_err_int, dq_int)
 
     if save_opt: # collect optional results for output
         # Get the zero-point intercepts and the cosmic-ray amplitudes for

--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -729,8 +729,8 @@ def output_integ(slope_int, dq_int, effintim, var_p3, var_r3, var_both3,
     # Reset the warnings filter to its original state
     warnings.resetwarnings()
 
-
     return cubemod
+
 
 def gls_output_integ( model, slope_int, slope_err_int, dq_int):
     """


### PR DESCRIPTION
Several updates are contained here, in order to allow NINTS=1 exposures to be used in later stages of the pipeline for coronagraphy observations.

1) Updated the `ramp_fit` step so that it ALWAYS creates a "rateints" product, even when NINTS=1. In this case, the data is the same as the "rate" product, except for the fact that it's stored in a `CubeModel` with the 3rd dimension having length 1. This allows the "rateints" products to flow through `calwebb_image2`, producing "calints" products, which are then used as input to `calwebb_coron3`, with no changes needed to the ASN rules to use different products (e.g. "cal" instead of "calints").

2) Updated parts of the `calwebb_coron3` pipeline and the `outlier_detection` step to properly handle the `CubeModel`s that have NINTS=1. In this case, the `outlier_detection` step automatically gets skipped, due to lack of sufficient data. Various bits of logic in the pipeline and outlier step needed updating to handle all of this properly.

3) Updated the docs to indicate that the "rateints" product is no longer created only when NINTS>1.

Fixes #4566 / [JP-1296](https://jira.stsci.edu/browse/JP-1296)