### PR TITLE
Official add master background but disable by default

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -375,11 +375,11 @@ class Spec2Pipeline(Pipeline):
         calibrated = self.srctype(calibrated)
 
         # Master background requires a different order of processing.
-        if False or not self.master_background.skip:
+        if not self.master_background.skip:
             calibrated = self_process_nirspec_masterbackground(calibrated)
 
         # Now continue calibration of the science.
-        calibrated = self.wavecore(calibrated)
+        calibrated = self.wavecorr(calibrated)
         calibrated = self.flat_field(calibrated)
         calibrated = self.pathloss(calibrated)
         calibrated = self.barshadow(calibrated)

--- a/jwst/pipeline/calwebb_tso-spec2.cfg
+++ b/jwst/pipeline/calwebb_tso-spec2.cfg
@@ -12,6 +12,8 @@ save_results = True
       [[msa_flagging]]
         skip = true
       [[extract_2d]]
+      [[master_background]]
+        skip = true
       [[flat_field]]
       [[srctype]]
       [[straylight]]

--- a/jwst/regtest/test_miri_mrs.py
+++ b/jwst/regtest/test_miri_mrs.py
@@ -102,6 +102,7 @@ def run_spec3_multi(jail, rtdata_module):
     return rt.run_step_from_dict(rtdata_module, **step_params)
 
 
+@pytest.mark.slow
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix',
@@ -114,6 +115,7 @@ def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
                      truth_path=TRUTH_PATH)
 
 
+@pytest.mark.slow
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'output',
@@ -135,6 +137,7 @@ def test_spec3(run_spec3, fitsdiff_default_kwargs, output):
     )
 
 
+@pytest.mark.slow
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'output',
@@ -160,6 +163,7 @@ def test_spec3_multi(run_spec3_multi, fitsdiff_default_kwargs, output):
     )
 
 
+@pytest.mark.slow
 @pytest.mark.bigdata
 def test_miri_mrs_wcs(run_spec2, fitsdiff_default_kwargs):
     rtdata, asn_path = run_spec2

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -44,6 +44,7 @@ def run_spec2(jail, rtdata_module):
     return rtdata
 
 
+@pytest.mark.slow
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix',


### PR DESCRIPTION
Disable master background by default.

Also mark some Spec2Pipeline tests as slow, so that regtests can be run without always waiting forever.