### PR TITLE
JP-1489: Allow calc_gwcs_pixmap to compute NaNs for drizzle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,11 @@ ramp_fitting
 
 - Update to always create the rateints product, even when NINTS=1. [#5211]
 
+resample_spec
+-------------
+
+- Fix artifacts in resampled NIRSpec slit data caused by NaNs in the WCS [#5217]
+
 source_catalog
 --------------
 

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -556,13 +556,16 @@ def gwcs_blot(median_model, blot_img, interp='poly5', sinscl=1.0):
     log.debug("Pixmap shape: {}".format(pixmap[:, :, 0].shape))
     log.debug("Sci shape: {}".format(blot_img.data.shape))
 
-    # median_model_pscale = median_model.meta.wcsinfo.cdelt1
-    # blot_pscale = blot_img.meta.wcsinfo.cdelt1
-
     pix_ratio = 1
     log.info('Blotting {} <-- {}'.format(blot_img.data.shape, median_model.data.shape))
 
     outsci = np.zeros(blot_img.shape, dtype=np.float32)
+
+    # Currently tblot cannot handle nans in the pixmap, so we need to give some
+    # other value.  -1 is not optimal and may have side effects.  But this is
+    # what we've been doing up until now, so more investigation is needed
+    # before a change is made.  Preferably, fix tblot in drizzle.
+    pixmap[np.isnan(pixmap)] = -1
     tblot(median_model.data, pixmap, outsci, scale=pix_ratio, kscale=1.0,
                    interp=interp, exptime=1.0, misval=0.0, sinscl=sinscl)
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -76,7 +76,6 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, shape=None):
 
     grid = wcstools.grid_from_bounding_box(bb)
     pixmap = np.dstack(reproject(in_wcs, out_wcs)(grid[0], grid[1]))
-    pixmap[np.isnan(pixmap)] = -1
 
     return pixmap
 


### PR DESCRIPTION
Replacing NaNs with -1 in the pixel mapping for `drizzle` was causing these artifacts.  When this was originally implemented, `drizzle` pixmap barfed when there were NaNs in the pixmap.

And of course the reason this is showing up only in NIRSpec, as that NIRSpec is the only instrument where the WCS produces NaNs for pixels in the WCS bounding box.  This is why we did not see it elsewhere.

See below for what the fix does for single-resampled `s2d` files in `calwebb_spec2` for NIRSpec MOS data:

<img width="1002" alt="Screen Shot 2020-08-05 at 11 23 08 AM" src="https://user-images.githubusercontent.com/17088869/89431582-234d3d80-d70e-11ea-8039-9c00d0a89ada.png">

Resolves #5013 / [JP-1489](https://jira.stsci.edu/browse/JP-1489)