### PR TITLE
JP-1631: implement master bkg mapping to MOS slits

### DIFF
--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -7,7 +7,6 @@ from .. import datamodels
 from .. assign_wcs import nirspec   # For NIRSpec IFU data
 from .. datamodels import dqflags
 from ..lib.wcs_utils import get_wavelengths
-from .nirspec_utils import correct_nrs_ifu_bkg
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -157,6 +156,7 @@ def bkg_for_multislit(input, tab_wavelength, tab_background):
     max_wave = np.amax(tab_wavelength)
 
     for (k, slit) in enumerate(input.slits):
+        log.info(f'Expanding background for slit {slit.name}')
         wl_array = get_wavelengths(slit, input.meta.exposure.type)
         if wl_array is None:
             raise RuntimeError("Can't determine wavelengths for {}"
@@ -248,6 +248,7 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
         wavelength table.
 
     """
+    from .nirspec_utils import correct_nrs_ifu_bkg
 
     background = input.copy()
     background.data[:, :] = 0.

--- a/jwst/master_background/nirspec_utils.py
+++ b/jwst/master_background/nirspec_utils.py
@@ -1,12 +1,37 @@
 import logging
 
 from jwst import datamodels
-from ..resample import resample_spec_step
-from ..extract_1d import extract_1d_step
-from ..combine_1d.combine1d import combine_1d_spectra
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+
+
+def map_to_science_slits(input_model, master_bkg):
+    """Interpolate 1D master background spectrum to the 2D space
+    of each source slitlet in the input MultiSlitModel.
+
+    Parameters
+    ----------
+    input_model : `~jwst.datamodels.MultiSlitModel`
+        The input data model containing all slit instances.
+
+    master_bkg : `~jwst.datamodels.CombinedSpecModel`
+        The 1D master background spectrum.
+
+    Returns
+    -------
+    output_model: `~jwst.datamodels.MultiSlitModel`
+        The output data model containing background signal.
+    """
+    from .expand_to_2d import expand_to_2d
+
+    log.info('Interpolating 1D master background to 2D slitlets')
+
+    # Loop over all input slits, creating 2D master background to
+    # match each 2D slitlet cutout
+    output_model = expand_to_2d(input_model, master_bkg)
+
+    return output_model
 
 
 def create_background_from_multislit(input_model):
@@ -24,6 +49,9 @@ def create_background_from_multislit(input_model):
     master_bkg: `~jwst.datamodels.CombinedSpecModel`
         The 1D master background spectrum created from the inputs.
     """
+    from ..resample import resample_spec_step
+    from ..extract_1d import extract_1d_step
+    from ..combine_1d.combine1d import combine_1d_spectra
 
     log.info('Creating master background from background slitlets')
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -444,7 +444,7 @@ class Spec2Pipeline(Pipeline):
         # First step is to map the master background into a MultiSlitModel
         # where the science slits are replaced by the master background
         # Here the broadcasting from 1D to 2D need also occur.
-        mb_multislit = map_to_science_slits(pre_calibrated, master_background)
+        mb_multislit = nirspec_utils.map_to_science_slits(pre_calibrated, master_background)
 
         # Now that the master background is pretending to be science,
         # walk backwards through the steps to uncalibrate, using the

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -444,7 +444,7 @@ class Spec2Pipeline(Pipeline):
         # First step is to map the master background into a MultiSlitModel
         # where the science slits are replaced by the master background
         # Here the broadcasting from 1D to 2D need also occur.
-        mb_multislit = map_to_science_slits(master_background, pre_calibrated)
+        mb_multislit = map_to_science_slits(pre_calibrated, master_background)
 
         # Now that the master background is pretending to be science,
         # walk backwards through the steps to uncalibrate, using the


### PR DESCRIPTION
Add the `map_to_science_slits` function to `nirspec_utils` for use in `calwebb_spec2` processing of NIRSpec MOS master bkg. Note that right now the function is a simple 1-line call to the existing `expand_to_2d` function, because `expand_to_2d` is already setup to correctly recognize a `MultiSlitModel` as input and process all slits in it. This means we're expanding the master bkg to ALL slits, including those with extended sources, as well as the background slits themselves (neither of which may be strictly necessary). Hence this may change in a future version, if we want to restrict which slits get the expanded background.

Fixes #5219 / [JP-1631](https://jira.stsci.edu/browse/JP-1631)