### PR TITLE
Pin requirements-sdp.txt for Build 7.6

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,4 +1,49 @@
 # To generate this file:
 #
 #     pip install -e .[test]
-#     pip freeze | grep -v jwst.git > requirements-sdp.txt
+#     pip freeze | grep -v jwst.git >> requirements-sdp.txt
+asdf==2.7.0
+astropy==4.0.1.post1
+attrs==19.3.0
+certifi==2020.6.20
+chardet==3.0.4
+ci-watson==0.5
+codecov==2.1.8
+coverage==5.2.1
+crds==7.5.0.0
+Cython==0.29.21
+drizzle==1.13.1
+filelock==3.0.12
+gwcs==0.13.0
+idna==2.10
+importlib-metadata==1.7.0
+jsonschema==3.2.0
+lxml==4.5.2
+more-itertools==8.4.0
+numpy==1.19.1
+packaging==20.4
+Parsley==1.3
+photutils==0.7.2
+pluggy==0.13.1
+psutil==5.7.2
+py==1.9.0
+pyparsing==2.4.7
+pyrsistent==0.16.0
+pytest==5.4.3
+pytest-cov==2.10.0
+pytest-doctestplus==0.8.0
+pytest-openfiles==0.5.0
+PyYAML==5.3.1
+requests==2.24.0
+requests-mock==1.8.0
+scipy==1.5.2
+semantic-version==2.8.5
+six==1.15.0
+spherical-geometry==1.2.18
+stsci.image==2.3.3
+stsci.imagestats==1.6.2
+stsci.stimage==0.2.4
+tweakwcs==0.6.4
+urllib3==1.25.10
+wcwidth==0.2.5
+zipp==3.1.0


### PR DESCRIPTION
I think there will be a release of `gwcs` soon, and that should probably be incremented here when it is released.  @nden 

Also, if `astropy 4.1` gets released soon, it can probably be updated here.

We've been testing both in our dev dependency builds, and there shouldn't be any issues.