### PR TITLE
Allow pytest 6.0 and up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ DOCS_REQUIRE = [
 ]
 TESTS_REQUIRE = [
     'ci-watson>=0.3.0',
-    'pytest>=4.6.0,<6.0 # doctestplus fails with 6+',
+    'pytest>=4.6.0',
     'pytest-doctestplus',
     'requests_mock>=1.0',
     'pytest-openfiles>=0.5.0',


### PR DESCRIPTION
`pytest-doctestplus 0.8` has been released, so we can now use `pytest 6`.