### PR TITLE
JP-1626: Fix NIRSpec IFU product names in spec3 ASN's

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ associations
 
 - Update level-3 rules to exclude IFU exposures from ``calwebb_tso3`` associations. [#5202]
 
+- Fix formatting error in Asn_IFUGrating product name construction. [#5231]
+
 barshadow
 ---------
 
@@ -42,7 +44,11 @@ combine_1d
 
 cube_build
 ----------
-- modified NIRSpec blotting to the find min and max ra and dec for each slice and only invert those values on slice that fall in range [#5144]
+
+- Fixed formatting of NIRSpec s3d output product names. [#5231]
+
+- Modified NIRSpec blotting to the find min and max ra and dec for each slice and only
+  invert those values on slice that fall in range [#5144]
 
 - Changed default weighting back to 'msm' until NIRSPEC cube pars ref file contains emsm info [#5134]
 
@@ -135,7 +141,7 @@ outlier_detection
 
 - Fix outlier_detection bug when saving intermediate results. [#5108]
 
-- Update logic to correctly handle input ``CubeModel``s that have only
+- Update logic to correctly handle input ``CubeModel`` that have only
   1 integration. [#5211]
 
 pathloss

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -587,7 +587,7 @@ class DMSBaseMixin(ACIDMixin):
             of the grating in use.
         """
         grating_id = format_list(self.constraints['grating'].found_values)
-        grating = 't{0:0>3s}'.format(str(grating_id))
+        grating = '{0:0>3s}'.format(str(grating_id))
         return grating
 
 

--- a/jwst/associations/tests/test_level3_spectrographic.py
+++ b/jwst/associations/tests/test_level3_spectrographic.py
@@ -64,7 +64,7 @@ class TestLevel3Spec(BasePoolRule):
             'o003',
             'spec3',
             r'jw99009-o003_spec3_\d{3}_asn',
-            'jw99009-o003_t002_nirspec_tg235h',
+            'jw99009-o003_t002_nirspec_g235h',
             set(('science', 'target_acquisition', 'autowave'))
         ),
     ]

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -106,7 +106,7 @@ class CubeData():
         instrument_info = instrument_defaults.InstrumentInfo()
 # -------------------------------------------------------------------------------
 # Read the cube pars reference file
-        log.info('Reading  cube parameter file %s', self.par_filename)
+        log.info('Reading cube parameter file %s', self.par_filename)
         cube_build_io_util.read_cubepars(self.par_filename,
                                          self.instrument,
                                          self.weighting,
@@ -213,9 +213,9 @@ class CubeData():
                                 self.all_channel.append(valid_channel[i])
                                 self.all_subchannel.append(valid_subchannel[j])
 
-            log.info('The desired cubes covers the MIRI Channels: %s',
+            log.info('The desired cubes cover the MIRI Channels: %s',
                      self.all_channel)
-            log.info('The desired cubes covers the MIRI subchannels: %s',
+            log.info('The desired cubes cover the MIRI subchannels: %s',
                      self.all_subchannel)
 
             number_channels = len(self.all_channel)
@@ -294,10 +294,10 @@ class CubeData():
                 if self.output_type == 'multi':
                     log.info('Output IFUcube are constructed from all the data ')
                 if self.single:
-                    log.info(' Single = true, creating a set of single exposures mapped' +
+                    log.info('Single = true, creating a set of single exposures mapped' +
                           ' to output IFUCube coordinate system')
                 if self.output_type == 'user':
-                    log.info(' The user has selected the type of IFU cube to make')
+                    log.info('The user has selected the type of IFU cube to make')
 
                 num_cubes = 1
                 cube_pars['1'] = {}
@@ -354,10 +354,10 @@ class CubeData():
                 if self.output_type == 'multi':
                     log.info('Output IFUcube are constructed from all the data ')
                 if self.single:
-                    log.info(' Single = true, creating a set of single exposures mappe' +
+                    log.info('Single = true, creating a set of single exposures' +
                           ' mapped to output IFUCube coordinate system')
                 if self.output_type == 'user':
-                    log.info(' The user has selected the type of IFU cube to make')
+                    log.info('The user has selected the type of IFU cube to make')
 
                 num_cubes = 1
                 cube_pars['1'] = {}

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -157,7 +157,7 @@ class CubeBuildStep (Step):
 
         if self.single:
             self.output_type = 'single'
-            self.log.info('Cube Type: Single cubes ')
+            self.log.info('Cube Type: Single cubes')
             self.coord_system = 'skyalign'
             self.interpolation = 'pointcloud'
 
@@ -286,10 +286,10 @@ class CubeBuildStep (Step):
 
         num_cubes, cube_pars = cubeinfo.number_cubes()
         if not self.single:
-            self.log.info(f'Number of ifucubes produced by this run  = {num_cubes}')
+            self.log.info(f'Number of IFU cubes produced by this run = {num_cubes}')
 
         if self.single:
-            self.log.info(f'Number of single ifucubes produced by a this run = {num_cubes}')
+            self.log.info(f'Number of single IFU cubes produced by a this run = {num_cubes}')
 
         # ModelContainer of ifucubes
         cube_container = datamodels.ModelContainer()

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1096,18 +1096,18 @@ class IFUCubeData():
             if np.isnan(self.weight_power):
                 self.weight_power = None
 
-        log.debug(f'spatial size {self.spatial_size:.7f}')
-        log.debug(f'spectral size {self.spectral_size:.7f}')
-        log.debug(f'spatial roi {self.rois:.7f}')
-        log.debug(f'wave min and max {self.wavemin:.7f} {self.wavemax:.7f}')
-        log.debug(f'linear wavelength {self.linear_wavelength:.7f}')
-        log.debug(f'roiw {self.roiw:.7f}')
+        log.debug(f'spatial size {self.spatial_size}')
+        log.debug(f'spectral size {self.spectral_size}')
+        log.debug(f'spatial roi {self.rois}')
+        log.debug(f'wave min and max {self.wavemin} {self.wavemax}')
+        log.debug(f'linear wavelength {self.linear_wavelength}')
+        log.debug(f'roiw {self.roiw}')
         log.debug(f'output_type {self.output_type}')
         if self.weighting == 'msm':
-            log.debug(f'weight_power {self.weight_power:.7f}')
-            log.debug(f'softrad {self.soft_rad:.7f}')
+            log.debug(f'weight_power {self.weight_power}')
+            log.debug(f'softrad {self.soft_rad}')
         if self.weighting == 'emsm':
-            log.debug(f'scalerad {self.scalerad:.7f}')
+            log.debug(f'scalerad {self.scalerad}')
 
 # ******************************************************************************
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -192,6 +192,14 @@ class IFUCubeData():
                         '_single_s3d.fits'
 # ________________________________________________________________________________
             elif self.instrument == 'NIRSPEC':
+
+                # Check to see if the output base name already has a grating/prism
+                # suffix attached. If so, strip it off, and let the following logic
+                # add all necessary grating and filter suffixes.
+                suffix = self.output_name_base[self.output_name_base.rfind('_')+1:]
+                if suffix in ['g140m', 'g235m', 'g395m', 'g140h', 'g235h', 'g395h', 'prism']:
+                    self.output_name_base = self.output_name_base[:self.output_name_base.rfind('_')]
+
                 fg_name = '_'
                 for i in range(len(self.list_par1)):
                     fg_name = fg_name + self.list_par1[i] + '-' + self.list_par2[i]
@@ -1088,18 +1096,18 @@ class IFUCubeData():
             if np.isnan(self.weight_power):
                 self.weight_power = None
 
-        log.debug(f'spatial size {self.spatial_size}')
-        log.debug(f'spectral size {self.spectral_size}')
-        log.debug(f'spatial roi {self.rois}')
-        log.debug(f'wave min and max {self.wavemin} {self.wavemax}')
-        log.debug(f'linear wavelength {self.linear_wavelength}')
-        log.debug(f'roiw {self.roiw}')
+        log.debug(f'spatial size {self.spatial_size:.7f}')
+        log.debug(f'spectral size {self.spectral_size:.7f}')
+        log.debug(f'spatial roi {self.rois:.7f}')
+        log.debug(f'wave min and max {self.wavemin:.7f} {self.wavemax:.7f}')
+        log.debug(f'linear wavelength {self.linear_wavelength:.7f}')
+        log.debug(f'roiw {self.roiw:.7f}')
         log.debug(f'output_type {self.output_type}')
         if self.weighting == 'msm':
-            log.debug(f'weight_power {self.weight_power}')
-            log.debug(f'softrad {self.soft_rad}')
+            log.debug(f'weight_power {self.weight_power:.7f}')
+            log.debug(f'softrad {self.soft_rad:.7f}')
         if self.weighting == 'emsm':
-            log.debug(f'scalerad {self.scalerad}')
+            log.debug(f'scalerad {self.scalerad:.7f}')
 
 # ******************************************************************************
 


### PR DESCRIPTION
This updates the level-3 ASN rules to remove the errant "t" prepended to the grating name for NIRSpec IFU product names that get stored in spec3 ASN files, and updates the part of the `cube_build` step that composes output file names to take into account the fact that the input product base name may already contain the grating (and hence don't add a second one). Rather than having `cube_build` decide whether or not it needs to add a grating name, the existing one is simply removed and then all the remaining logic for adding grating and filter names to the product name remains the same.

Fixes #5212 / [JP-1626](https://jira.stsci.edu/browse/JP-1626)