### PR TITLE
JP-1587 Implement inverse of the FlatFieldStep

### DIFF
--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -21,12 +21,12 @@ def exp_to_source(inputs):
 
     Parameters
     ----------
-    inputs: [MultiSlitModel, ...]
+    inputs : [MultiSlitModel, ...]
         List of MultiSlitModel instances to reformat.
 
     Returns
     -------
-    multiexposures: {str: MultiExposureModel[,...]}
+    multiexposures : dict
         Returns a dict of MultiExposureModel instances wherein each
         instance contains slits belonging to the same source.
         The key is the ID of each source, i.e. ``source_id``.
@@ -60,13 +60,13 @@ def multislit_to_container(inputs):
 
     Parameters
     ----------
-    inputs: [MultiSlitModel, ...]
+    inputs : [MultiSlitModel, ...]
         List of MultiSlitModel instances to reformat, or just a
         ModelContainer full of MultiSlitModels.
 
     Returns
     -------
-    containers : {str: ModelContainer[,...]}
+    containers : dict
         Returns a dict of ModelContainer instances wherein each
         instance contains ImageModels of slits belonging to the same source.
         The key is the ID of each slit, i.e. 11source_id``.
@@ -79,7 +79,7 @@ def multislit_to_container(inputs):
 
 
 class DefaultOrderedDict(OrderedDict):
-    # Source: http://stackoverflow.com/a/6190500/562769
+    # Source http://stackoverflow.com/a/6190500/562769
     def __init__(self, default_factory=None, *a, **kw):
         if (default_factory is not None and
            not isinstance(default_factory, Callable)):

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -66,7 +66,7 @@ def multislit_to_container(inputs):
 
     Returns
     -------
-    {str: ModelContainer, }
+    containers : {str: ModelContainer[,...]}
         Returns a dict of ModelContainer instances wherein each
         instance contains ImageModels of slits belonging to the same source.
         The key is the ID of each slit, i.e. 11source_id``.

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -391,8 +391,8 @@ def nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model, dispa
     return interpolated_flat
 
 
-def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model,
-                      dispaxis, user_supplied_flat=None):
+def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis,
+                      user_supplied_flat=None, inverse=False):
     """Apply flat-fielding for NIRSpec BRIGHTOBJ data, in-place
 
     Parameters
@@ -416,6 +416,9 @@ def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model,
         A pre-computed flat to use directly. If supplied,
         all other inputs are ignored
 
+    inverse : boolean
+        Invert the math operations used to apply the flat field.
+
     Returns
     -------
     ~jwst.datamodels.ImageModel
@@ -430,7 +433,10 @@ def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model,
             output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis
         )
 
-    output_model.data /= interpolated_flat.data
+    if not inverse:
+        output_model.data /= interpolated_flat.data
+    else:
+        output_model.data *= interpolated_flat.data
     output_model.dq |= interpolated_flat.dq
 
     # Update the variances and uncertainty array using BASELINE algorithm

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -453,8 +453,8 @@ def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model, di
     return interpolated_flat
 
 
-def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model,
-                dispaxis, user_supplied_flat=None):
+def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis,
+                user_supplied_flat=None, inverse=False):
     """Apply flat-fielding for NIRSpec IFU data, in-place
 
     Parameters
@@ -478,6 +478,9 @@ def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model,
         A pre-computed flat to use directly. If supplied,
         all other inputs are ignored
 
+    inverse : boolean
+        Invert the math operations used to apply the flat field.
+
     Returns
     -------
     ~jwst.datamodels.ImageModel
@@ -496,7 +499,10 @@ def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model,
         )
 
     if any_updated:
-        output_model.data /= flat
+        if not inverse:
+            output_model.data /= flat
+        else:
+            output_model.data *= flat
         output_model.dq |= flat_dq
 
         # Update the variances and uncertainty array using BASELINE algorithm

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -92,7 +92,9 @@ class FlatFieldStep(Step):
 
             # Record the user-supplied flat as the FLAT reference type for recording
             # in the result header.
-            self._reference_files_used.append(('flat', Path(self.user_supplied_flat).name))
+            self._reference_files_used.append(
+                ('flat', reference_file_models['user_supplied_flat'].meta.filename)
+            )
 
         # Do the flat-field correction
         output_model, flat_applied = flat_field.do_correction(

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -43,6 +43,7 @@ class FlatFieldStep(Step):
     spec = """
         save_interpolated_flat = boolean(default=False) # Save interpolated NRS flat
         user_supplied_flat = string(default=None)  # User-supplied flat
+        inverse = boolean(default=False)  # Invert the operation
     """
 
     reference_file_types = ["flat", "fflat", "sflat", "dflat"]
@@ -91,6 +92,7 @@ class FlatFieldStep(Step):
         output_model, flat_applied = flat_field.do_correction(
             input_model,
             **reference_file_models,
+            inverse=self.inverse
         )
 
         # Close the input and reference files
@@ -161,6 +163,7 @@ class FlatFieldStep(Step):
                 reference_file_models[reftype] = model_type[reftype](reffile)
                 self.log.debug('Using %s reference file: %s', reftype.upper(), reffile)
             else:
+                self.log.debug('No reference found for type %s', reftype.upper())
                 reference_file_models[reftype] = None
 
         return reference_file_models

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ..stpipe import Step
 from .. import datamodels
 from . import flat_field
@@ -87,6 +89,10 @@ class FlatFieldStep(Step):
             reference_file_models = {
                 'user_supplied_flat': datamodels.open(self.user_supplied_flat)
             }
+
+            # Record the user-supplied flat as the FLAT reference type for recording
+            # in the result header.
+            self._reference_files_used.append(('flat', Path(self.user_supplied_flat).name))
 
         # Do the flat-field correction
         output_model, flat_applied = flat_field.do_correction(

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from ..stpipe import Step
 from .. import datamodels
 from . import flat_field

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -84,7 +84,7 @@ def test_nirspec_ifu_user_supplied_flat(jail, rtdata_module, fitsdiff_default_kw
 def test_flat_field_step_user_supplied_flat(jail, rtdata_module, fitsdiff_default_kwargs):
     """Test providing a user-supplied flat field to the FlatFieldStep"""
     rtdata = rtdata_module
-    data = dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits'))
+    data = rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits')
     user_supplied_flat = rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_interpolated_flat.fits')
 
     data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat)

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -4,6 +4,7 @@ import pytest
 from . import regtestdata as rt
 
 from astropy.io.fits.diff import FITSDiff
+import numpy as np
 
 import jwst.datamodels as dm
 from jwst.flatfield import FlatFieldStep
@@ -93,3 +94,16 @@ def test_flat_field_step_user_supplied_flat(jail, rtdata_module, fitsdiff_defaul
     rtdata.get_truth(TRUTH_PATH + '/' + 'flat_fielded_step_user_supplied.fits')
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+def test_ff_inv(jail, rtdata_module, fitsdiff_default_kwargs):
+    """Test flat field inversion"""
+    rtdata = rtdata_module
+    data = dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits'))
+
+    flatted = FlatFieldStep.call(data)
+    unflatted = FlatFieldStep.call(flatted, inverse=True)
+
+    assert np.allclose(data.data, unflatted.data), 'Inversion failed'

--- a/jwst/regtest/test_nirspec_image2.py
+++ b/jwst/regtest/test_nirspec_image2.py
@@ -1,6 +1,10 @@
 import pytest
-from astropy.io.fits.diff import FITSDiff
 
+from astropy.io.fits.diff import FITSDiff
+import numpy as np
+
+import jwst.datamodels as dm
+from jwst.flatfield import FlatFieldStep
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
@@ -17,3 +21,31 @@ def test_nirspec_image2(_jail, rtdata, fitsdiff_default_kwargs):
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_flat_field_step_user_supplied_flat(jail, rtdata_module, fitsdiff_default_kwargs):
+    """Test providing a user-supplied flat field to the FlatFieldStep"""
+    rtdata = rtdata_module
+    data = rtdata.get_data('nirspec/imaging/usf_assign_wcs.fits')
+    user_supplied_flat = rtdata.get_data('nirspec/imaging/usf_flat.fits')
+
+    data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat)
+    rtdata.output = 'flat_fielded_step_user_supplied.fits'
+    data_flat_fielded.write(rtdata.output)
+
+    rtdata.get_truth('truth/test_nirspec_image2/flat_fielded_step_user_supplied.fits')
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_ff_inv(jail, rtdata_module, fitsdiff_default_kwargs):
+    """Test flat field inversion"""
+    rtdata = rtdata_module
+    data = dm.open(rtdata.get_data('nirspec/imaging/usf_assign_wcs.fits'))
+
+    flatted = FlatFieldStep.call(data)
+    unflatted = FlatFieldStep.call(flatted, inverse=True)
+
+    assert np.allclose(data.data, unflatted.data), 'Inversion failed'

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -1,7 +1,10 @@
 import os
 import pytest
-from astropy.io.fits.diff import FITSDiff
 
+from astropy.io.fits.diff import FITSDiff
+import numpy as np
+
+import jwst.datamodels as dm
 from jwst.flatfield import FlatFieldStep
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
@@ -71,3 +74,20 @@ def test_flat_field_step_user_supplied_flat(jail, rtdata_module, fitsdiff_defaul
     rtdata.get_truth('truth/test_nirspec_mos_spec2/flat_fielded_step_user_supplied.fits')
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_ff_inv(jail, rtdata_module, fitsdiff_default_kwargs):
+    """Test flat field inversion with MOS"""
+    rtdata = rtdata_module
+    data = dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits'))
+
+    flatted = FlatFieldStep.call(data)
+    unflatted = FlatFieldStep.call(flatted, inverse=True)
+
+    bad_slits = []
+    for idx, slits in enumerate(zip(data.slits, unflatted.slits)):
+        data_slit, unflatted_slit = slits
+        if not np.allclose(data_slit.data, unflatted_slit.data):
+            bad_slits.append(idx)
+    assert not bad_slits, f'Inversion failed for slits {bad_slits}'

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -78,7 +78,7 @@ def test_flat_field_step_user_supplied_flat(jail, rtdata_module, fitsdiff_defaul
 
 @pytest.mark.bigdata
 def test_ff_inv(jail, rtdata_module, fitsdiff_default_kwargs):
-    """Test flat field inversion with MOS"""
+    """Test flat field inversion"""
     rtdata = rtdata_module
     data = dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits'))
 


### PR DESCRIPTION
After many red-herrings and other issues, the inversion of `FlatFieldStep` is (near) ready.

Issues/conditions:

~1. Inversion is not done for any other instrument except NIRSpec. A `NotImplementedError` is currently produced. Just haven't looked that far.~ Done.
2. Question: For the override of the flat field, how should that be recorded in the headers. Reference files are populated, but not sure if the user-supplied file should go into the `FLAT` reference or as something else. Storing in `FLAT` may be misleading, especially for NIRSpec, since that reference file type is not used at all.