### PR TITLE
Implement correction parameter API for FlatFieldStep

### DIFF
--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -18,7 +18,7 @@ log.setLevel(logging.DEBUG)
 
 MICRONS_100 = 1.e-4                     # 100 microns, in meters
 
-# This is for NIRSpec.  
+# This is for NIRSpec.
 FIXED_SLIT_TYPES = ["NRS_LAMP", "NRS_BRIGHTOBJ", "NRS_FIXEDSLIT"]
 NIRSPEC_SPECTRAL_EXPOSURES = ['NRS_BRIGHTOBJ', 'NRS_FIXEDSLIT', 'NRS_IFU', 'NRS_MSASPEC']
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -74,8 +74,7 @@ def do_correction(input_model,
     # NIRSpec spectrographic data are processed differently from other
     # types of data (including NIRSpec imaging).  The test on flat is
     # needed because NIRSpec imaging data are processed by do_flat_field().
-    if input_model.meta.instrument.name == 'NIRSPEC' and \
-       input_model.meta.exposure.type in NIRSPEC_SPECTRAL_EXPOSURES:
+    if input_model.meta.exposure.type in NIRSPEC_SPECTRAL_EXPOSURES:
         flat_applied = do_nirspec_flat_field(output_model, fflat, sflat, dflat,
                                              user_supplied_flat=user_supplied_flat,
                                              inverse=inverse)

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -18,8 +18,9 @@ log.setLevel(logging.DEBUG)
 
 MICRONS_100 = 1.e-4                     # 100 microns, in meters
 
-# This is for NIRSpec.  These exposure types are all fixed-slit modes.
+# This is for NIRSpec.  
 FIXED_SLIT_TYPES = ["NRS_LAMP", "NRS_BRIGHTOBJ", "NRS_FIXEDSLIT"]
+NIRSPEC_SPECTRAL_EXPOSURES = ['NRS_BRIGHTOBJ', 'NRS_FIXEDSLIT', 'NRS_IFU', 'NRS_MSASPEC']
 
 # Dispersion direction, predominantly horizontal or vertical.  These values
 # are to be compared with keyword DISPAXIS from the input header.
@@ -73,7 +74,8 @@ def do_correction(input_model,
     # NIRSpec spectrographic data are processed differently from other
     # types of data (including NIRSpec imaging).  The test on flat is
     # needed because NIRSpec imaging data are processed by do_flat_field().
-    if input_model.meta.instrument.name == 'NIRSPEC' and flat is None:
+    if input_model.meta.instrument.name == 'NIRSPEC' and \
+       input_model.meta.exposure.type in NIRSPEC_SPECTRAL_EXPOSURES:
         flat_applied = do_nirspec_flat_field(output_model, fflat, sflat, dflat,
                                              user_supplied_flat=user_supplied_flat,
                                              inverse=inverse)
@@ -288,6 +290,9 @@ def do_nirspec_flat_field(output_model, f_flat_model, s_flat_model, d_flat_model
                                    .format(type(output_model)))
             return nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis,
                                user_supplied_flat=user_supplied_flat, inverse=inverse)
+        else:
+            raise RuntimeError(f'No flat field algorithm exists for handling data {output_model}')
+
     # For datamodels with slits, MSA and Fixed slit modes:
     else:
         return nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis,

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -421,10 +421,10 @@ class Spec2Pipeline(Pipeline):
         """
         # First pass: just do the calibration to determine the correction
         # arrays.
-        pre_calibrated, ff_corrections = self.flat_field(data)
-        pre_calibrated = self.pathloss(pre_calibratedforce_extended=True_corrections=True)
-        pre_calibrated = self.barshadow(pre_calibrated, force_extended=True, return_corrections=True)
-        pre_calibrated = self.photom(pre_calibrated, force_extended=True, return_corrections=True)
+        pre_calibrated = self.flat_field(data)
+        pre_calibrated = self.pathloss(pre_calibrated)
+        pre_calibrated = self.barshadow(pre_calibrated)
+        pre_calibrated = self.photom(pre_calibrated)
 
         # At this point, assume that `pre_calibrated` is a modified `MultiSlitModel` that
         # is also carrying the science calibration information along with it.

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -421,10 +421,8 @@ class Spec2Pipeline(Pipeline):
         """
         # First pass: just do the calibration to determine the correction
         # arrays.
-        pre_calibrated, ff_corrections = self.flat_field(
-            data, force_extended=True, return_corrections=True
-        )
-        pre_calibrated = self.pathloss(pre_calibratedforce_extended=True, return_corrections=True)
+        pre_calibrated, ff_corrections = self.flat_field(data)
+        pre_calibrated = self.pathloss(pre_calibratedforce_extended=True_corrections=True)
         pre_calibrated = self.barshadow(pre_calibrated, force_extended=True, return_corrections=True)
         pre_calibrated = self.photom(pre_calibrated, force_extended=True, return_corrections=True)
 
@@ -449,10 +447,28 @@ class Spec2Pipeline(Pipeline):
         # walk backwards through the steps to uncalibrate, using the
         # calibration factors carried in `pre_calibrated`
         # Yes, using kwargs for the steps is invalid, but for design purposes only.
-        mb_multislit = self.photom(mb_multislit, inverse=True, factors=pre_calibrated)
-        mb_multislit = self.barshadow(mb_multislit, inverse=True, factors=pre_calibrated)
-        mb_multislit = self.pathloss(mb_multislit, inverse=True, factors=pre_calibrated)
-        mb_multislit = self.flat_field(mb_multislit, inverse=True, factors=pre_calibrated)
+        self.photom.use_correction_pars = True
+        self.photom.inverse = True
+        self.barshadow.use_correction_pars = True
+        self.barshadow.inverse = True
+        self.pathloss.use_correction_pars = True
+        self.pathloss.inverse = True
+        self.flat_field.use_correction_pars = True
+        self.flat_field.inverse = True
+
+        mb_multislit = self.photom(mb_multislit)
+        mb_multislit = self.barshadow(mb_multislit)
+        mb_multislit = self.pathloss(mb_multislit)
+        mb_multislit = self.flat_field(mb_multislit)
+
+        self.photom.use_correction_pars = False
+        self.photom.inverse = False
+        self.barshadow.use_correction_pars = False
+        self.barshadow.inverse = False
+        self.pathloss.use_correction_pars = False
+        self.pathloss.inverse = False
+        self.flat_field.use_correction_pars = False
+        self.flat_field.inverse = False
 
         # Now apply the de-calibrated background to the original science
         # At this point, should just be a slit-to-slit subtraction operation.

--- a/jwst/regtest/test_nirspec_image2.py
+++ b/jwst/regtest/test_nirspec_image2.py
@@ -49,3 +49,21 @@ def test_ff_inv(jail, rtdata_module, fitsdiff_default_kwargs):
     unflatted = FlatFieldStep.call(flatted, inverse=True)
 
     assert np.allclose(data.data, unflatted.data), 'Inversion failed'
+
+
+@pytest.mark.bigdata
+def test_correction_pars(jail, rtdata_module, fitsdiff_default_kwargs):
+    """Test use of correction parameters"""
+    rtdata = rtdata_module
+    data = dm.open(rtdata.get_data('nirspec/imaging/usf_assign_wcs.fits'))
+
+    # First use of FlatFieldStep will store the correction.
+    # The next use will use that correction
+    step = FlatFieldStep()
+    flatted = step.run(data)
+    assert step.correction_pars['flat'] is not None
+
+    step.use_correction_pars = True
+    reflatted = step.run(data)
+
+    assert np.allclose(flatted.data,reflatted.data), 'Re-run with correction parameters failed'

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -56,6 +56,12 @@ class Step():
     input_dir          = string(default=None)        # Input directory
     """
 
+    # Correction parameters. These store and use whatever information a Step
+    # may need to perform its operations without re-calculating, or to use
+    # from a previous run of the Step.  The structure is up to each Step.
+    self.correction_pars = None
+    self.use_correction_pars = False
+
     # Reference types for both command line override
     # definition and reference prefetch
     reference_file_types = []

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -59,8 +59,8 @@ class Step():
     # Correction parameters. These store and use whatever information a Step
     # may need to perform its operations without re-calculating, or to use
     # from a previous run of the Step.  The structure is up to each Step.
-    self.correction_pars = None
-    self.use_correction_pars = False
+    correction_pars = None
+    use_correction_pars = False
 
     # Reference types for both command line override
     # definition and reference prefetch


### PR DESCRIPTION
Implement the "easy/lazy" method of passing correction parameters around for FlatFieldStep.

Side note: The regressions discovered a dangling-if-without-else condition. See line 293 in flat_field.py. Basically, there was the possibility that NIRSPec-like model could be passed in, but have no flat field applied silently. Do not know if the condition could have happened in real life. However, because of changes where the reference files are no longer always required, the condition became possible. A runtime exception has been added just to ensure that the condition does not go unnoticed.