### PR TITLE
JP-1641: Update calami3 to exclude targ_acqs from processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -188,6 +188,9 @@ pipeline
 
 - Refactor Spec2Pipeline for execution logic and step flow isolation [#5214] 
 
+- Update ``Ami3Pipeline`` to only process psf and science members from the
+  input ASN. [#5243]
+
 photom
 ------
 

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -60,16 +60,16 @@ def multislit_to_container(inputs):
 
     Parameters
     ----------
-    inputs: [MultiSlitModel, ...]
+    inputs : [MultiSlitModel, ...]
         List of MultiSlitModel instances to reformat, or just a
         ModelContainer full of MultiSlitModels.
 
     Returns
     -------
-    {str: ModelContainer, }
+    containers : dict
         Returns a dict of ModelContainer instances wherein each
         instance contains ImageModels of slits belonging to the same source.
-        The key is the ID of each slit, i.e. 11source_id``.
+        The key is the ID of each slit, i.e. ``source_id``.
     """
     containers = exp_to_source(inputs)
     for id in containers:

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -2,7 +2,6 @@
 import logging
 import os.path as op
 
-from .. import datamodels
 from ..stpipe import Pipeline
 
 # step imports

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -44,8 +44,7 @@ class Ami3Pipeline(Pipeline):
         # Load the input association table
         asn = self.load_as_level3_asn(input)
 
-        # We assume there's one final product defined by the
-        # association
+        # We assume there's one final product defined by the association
         asn_id = asn['asn_id']
         prod = asn['products'][0]
         self.output_file = prod.get('name', self.output_file)
@@ -74,11 +73,9 @@ class Ami3Pipeline(Pipeline):
             log.info('No PSF reference members found in association table')
             log.info('ami_normalize step will be skipped')
 
-        # Loop over all the images in the assocation
-        psf_files = []
-        targ_files = []
-        for member in prod['members']:
-            input_file = member['expname']
+        # Run ami_analyze on all the target members
+        targ_lg = []
+        for input_file in targ_files:
 
             # Do the LG analysis for this image
             log.debug('Do LG processing for member %s', input_file)
@@ -89,19 +86,30 @@ class Ami3Pipeline(Pipeline):
             result.meta.asn.table_name = op.basename(asn.filename)
             self.save_model(result, output_file=input_file, suffix='ami', asn_id=asn_id)
 
-            # Save the result file name for input to ami_average
-            if member['exptype'].upper() == 'PSF':
-                psf_files.append(result)
-            if member['exptype'].upper() == 'SCIENCE':
-                targ_files.append(result)
+            # Save the result for use as input to ami_average
+            targ_lg.append(result)
+
+        # Run ami_analyze on all the psf members
+        psf_lg = []
+        for input_file in psf_files:
+
+            # Do the LG analysis for this image
+            log.debug('Do LG processing for member %s', input_file)
+            result = self.ami_analyze(input_file)
+
+            # Save the LG analysis results to a file
+            result.meta.asn.pool_name = asn['asn_pool']
+            result.meta.asn.table_name = op.basename(asn.filename)
+            self.save_model(result, output_file=input_file, suffix='ami', asn_id=asn_id)
+
+            # Save the result for use as input to ami_average
+            psf_lg.append(result)
 
         # Average the reference PSF image results
         psf_avg = None
         if len(psf_files) > 0:
             self.log.debug('Calling ami_average for PSF results ...')
-            psf_avg = self.ami_average(psf_files)
-            for f in psf_files:
-                f.close()
+            psf_avg = self.ami_average(psf_lg)
 
             # Save the results to a file, if requested
             if self.save_averages:
@@ -110,29 +118,15 @@ class Ami3Pipeline(Pipeline):
 
                 # Perform blending of metadata for all inputs to this
                 # output file
-                self.log.info(
-                    'Blending metadata for averaged psf...'
-                )
-                self.log.info(
-                    "INPUT WCS: {}".format(
-                        hasattr(datamodels.open(psf_files[0]), 'meta.wcs')
-                    )
-                )
-                self.log.info("PSF_AVG type: {}".format(psf_avg.meta.model_type))
-                self.log.info(
-                    "PSF_AVG WCS: {}".format(
-                        hasattr(psf_avg, 'meta.wcs')
-                    )
-                )
-                blendmeta.blendmodels(psf_avg, inputs=psf_files)
+                self.log.info('Blending metadata for averaged psf')
+                blendmeta.blendmodels(psf_avg, inputs=psf_lg)
                 self.save_model(psf_avg, suffix='psf-amiavg')
+                del psf_lg
 
         # Average the science target image results
         if len(targ_files) > 0:
             self.log.debug('Calling ami_average for target results ...')
-            targ_avg = self.ami_average(targ_files)
-            for f in targ_files:
-                f.close()
+            targ_avg = self.ami_average(targ_lg)
 
             # Save the results to a file, if requested
             if self.save_averages:
@@ -141,12 +135,10 @@ class Ami3Pipeline(Pipeline):
 
                 # Perform blending of metadata for all inputs to this
                 # output file
-                self.log.info(
-                    'Blending metadata for averaged target'
-                )
-                blendmeta.blendmodels(targ_avg, inputs=targ_files)
-
+                self.log.info('Blending metadata for averaged target')
+                blendmeta.blendmodels(targ_avg, inputs=targ_lg)
                 self.save_model(targ_avg, suffix='amiavg')
+                del targ_lg
 
         # Now that all LGAVG products have been produced, do
         # normalization of the target results by the reference
@@ -160,12 +152,12 @@ class Ami3Pipeline(Pipeline):
             result.meta.asn.table_name = op.basename(asn.filename)
 
             # Perform blending of metadata for all inputs to this output file
-            self.log.info(
-                'Blending metadata for PSF normalized target...'
-            )
+            self.log.info('Blending metadata for PSF normalized target')
             blendmeta.blendmodels(result, inputs=[targ_avg, psf_avg])
             self.save_model(result, suffix='aminorm')
             result.close()
+            del psf_avg
+            del targ_avg
 
         # We're done
         log.info('... ending calwebb_ami3')


### PR DESCRIPTION
Updated the `calwebb_ami3.py` module to only send PSF and science target members from the input ASN through the processing steps, so as to exclude any other member types, such as target_acquisition. Comparison with previous results shows that "ami" products are no longer created for target_acq members and the results of all other processing are identical.

Fixes #5240 / [JP-1641](https://jira.stsci.edu/browse/JP-1641)