### PR TITLE
JP-1639: Update PATTTYPE allowed values for new MIRI LRS patterns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ datamodels
 
 - Update underlying MultiExposureModel from the SourceModelContainer models. [#5154]
 
+- Add new MIRI LRS dither patterns to PATTTYPE enum list. [#5254]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1003,8 +1003,10 @@ properties:
              [5-POINT-SMALL-GRID, 9-POINT-SMALL-GRID,
               # MIRI imaging
               4-POINT-SETS, CYCLING, GAUSSIAN, REULEAUX, WFSC,
-              # MIRI LRS
-              2PIXEL-SLITLESS-SCAN-SHORT, ALONG-SLIT-NOD, MAPPING,
+              # MIRI LRS slit
+              7PIX-5PIX-SLIT-SCAN, ALONG-SLIT-NOD, MAPPING,
+              # MIRI LRS sliteless
+              2PIXEL-SLITLESS-SCAN-SHORT, EXTENDED-FLAT-SLITLESS,
               # MIRI MRS
               2-POINT, 4-POINT, EXTENDED-SOURCE, POINT-SOURCE,
               # NIRCam


### PR DESCRIPTION
Update `core.schema.yaml` to add new MIRI LRS pattern names to `PATTTYPE` enum list.

Fixes #5238 / [JP-1639](https://jira.stsci.edu/browse/JP-1639)