### PR TITLE
trivial docs typo fix: mJy/steradian should be MJy/steradian in cube_build/main.rst

### DIFF
--- a/docs/jwst/cube_build/main.rst
+++ b/docs/jwst/cube_build/main.rst
@@ -146,7 +146,7 @@ DQ       3      2 spatial and 1 spectral  integer
 WMAP     3      2 spatial and 1 spectral  integer
 =======  =====  ========================  =========
 
-The SCI image contains the surface brightness of cube spaxels in units of mJy/steradian. The wavelength dimension of the IFU cube
+The SCI image contains the surface brightness of cube spaxels in units of MJy/steradian. The wavelength dimension of the IFU cube
 can either be linear or non-linear. If the wavelength is non-linear then the IFU cube contain data from more than one band.  A
 table containing the wavelength of each plane is provided and conforms to the  'WAVE_TAB' fits convention. The wavelengths in the table are read in from the cubepar reference file.  The ERR image contains the
 uncertainty on the SCI values, the DQ image contains the data quality flags for each spaxel, and the WMAP image


### PR DESCRIPTION
One-character fix for a typo I noticed while reading the docs for cube_build: Currently it says the output units are in "milliJy"/steradian but in fact they are in megaJy/steradian.
