### PR TITLE
JP-1636: Fix slit wcs issue in extract_1d apcorr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,8 @@ extract_1d
 
 - Fixed the conversion of flux to surface brightness for IFU extended source case [#5201]
 
+- Fixed bugs in aperture correction for NIRSpec multi-slit modes. [#5260]
+
 extract_2d
 ----------
 

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -15,8 +15,6 @@ class ApCorrBase(abc.ABC):
     ----------
     input_model : `~/jwst.datamodels.DataModel`
         Input data model used to determine matching parameters.
-    slit_name : str
-        For MultiSlitModels, the name of the slit being processed.
     apcorr_table : `~/astropy.io.fits.FITS_rec`
         Aperture correction table data from APCORR reference file.
     location : tuple, Optional
@@ -26,6 +24,8 @@ class ApCorrBase(abc.ABC):
     apcorr_row_units : str, Optional
         Units for the aperture correction data "row" values (assuming the aperture correction is a 2D array).
         If not given, units will be determined from the input apcorr_table ColDefs if possible.
+    slit_name : str, Optional
+        For MultiSlitModels, the name of the slit being processed.
 
     Raises
     ------
@@ -57,15 +57,15 @@ class ApCorrBase(abc.ABC):
 
     size_key = None
 
-    def __init__(self, input_model: DataModel, slit_name: str, apcorr_table: fits.FITS_rec, sizeunit: str,
-                 location: Tuple[float, float, float] = None, **match_kwargs):
+    def __init__(self, input_model: DataModel, apcorr_table: fits.FITS_rec, sizeunit: str,
+                 location: Tuple[float, float, float] = None, slit_name: str = None, **match_kwargs):
         self.correction = None
 
         self.model = input_model
-        self.slit_name = slit_name
         self._reference_table = apcorr_table
         self.location = location
         self.apcorr_sizeunits = sizeunit
+        self.slit_name = slit_name
 
         self.match_keys = self._get_match_keys()
         self.match_pars = self._get_match_pars()

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -15,6 +15,8 @@ class ApCorrBase(abc.ABC):
     ----------
     input_model : `~/jwst.datamodels.DataModel`
         Input data model used to determine matching parameters.
+    slit_name : str
+        For MultiSlitModels, the name of the slit being processed.
     apcorr_table : `~/astropy.io.fits.FITS_rec`
         Aperture correction table data from APCORR reference file.
     location : tuple, Optional
@@ -55,11 +57,12 @@ class ApCorrBase(abc.ABC):
 
     size_key = None
 
-    def __init__(self, input_model: DataModel, apcorr_table: fits.FITS_rec, sizeunit: str,
+    def __init__(self, input_model: DataModel, slit_name: str, apcorr_table: fits.FITS_rec, sizeunit: str,
                  location: Tuple[float, float, float] = None, **match_kwargs):
         self.correction = None
 
         self.model = input_model
+        self.slit_name = slit_name
         self._reference_table = apcorr_table
         self.location = location
         self.apcorr_sizeunits = sizeunit
@@ -77,10 +80,11 @@ class ApCorrBase(abc.ABC):
         if self.apcorr_sizeunits.startswith('arcsec'):
             if self.location is not None:
                 if isinstance(self.model, MultiSlitModel):
+                    idx = [slit.name for slit in self.model.slits].index(self.slit_name)
                     self.reference[self.size_key] /= compute_scale(
-                        self.model.slits[0].meta.wcs,
+                        self.model.slits[idx].meta.wcs,
                         self.location,
-                        disp_axis=self.model.slits[0].meta.wcsinfo.dispersion_direction
+                        disp_axis=self.model.slits[idx].meta.wcsinfo.dispersion_direction
                     )
                 else:
                     self.reference[self.size_key] /= compute_scale(

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2831,7 +2831,8 @@ def do_extract1d(
                     match_kwargs['slit'] = slitname
 
                 apcorr = select_apcorr(input_model)(
-                    input_model, slit.name, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit, **match_kwargs
+                    input_model, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit,
+                    slit_name = slitname, **match_kwargs
                 )
                 apcorr.apply(spec.spec_table)
 
@@ -2997,7 +2998,6 @@ def do_extract1d(
 
                     apcorr = select_apcorr(input_model)(
                         input_model,
-                        slitname,
                         apcorr_ref_model.apcorr_table,
                         apcorr_ref_model.sizeunit,
                         location=(ra, dec, wl)
@@ -3156,7 +3156,8 @@ def do_extract1d(
                             match_kwargs['slit'] = slitname
 
                         apcorr = select_apcorr(input_model)(
-                            input_model, slitname, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit, **match_kwargs
+                            input_model, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit,
+                            slit_name = slitname, **match_kwargs
                         )
                         apcorr.apply(spec.spec_table)
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2831,7 +2831,7 @@ def do_extract1d(
                     match_kwargs['slit'] = slitname
 
                 apcorr = select_apcorr(input_model)(
-                    input_model, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit, **match_kwargs
+                    input_model, slit.name, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit, **match_kwargs
                 )
                 apcorr.apply(spec.spec_table)
 
@@ -2987,7 +2987,7 @@ def do_extract1d(
                 # ImageModel now has the attributes we will look for in this function.
                 copy_keyword_info(input_model, slitname, spec)
 
-                if source_type.upper() == 'POINT' and apcorr_ref_model is not None:
+                if source_type is not None and source_type.upper() == 'POINT' and apcorr_ref_model is not None:
                     log.info('Applying Aperture correction.')
 
                     if instrument == 'NIRSPEC':
@@ -2997,6 +2997,7 @@ def do_extract1d(
 
                     apcorr = select_apcorr(input_model)(
                         input_model,
+                        slitname,
                         apcorr_ref_model.apcorr_table,
                         apcorr_ref_model.sizeunit,
                         location=(ra, dec, wl)
@@ -3142,7 +3143,7 @@ def do_extract1d(
                     spec.dispersion_direction = extract_params['dispaxis']
                     copy_keyword_info(input_model, slitname, spec)
 
-                    if source_type.upper() == 'POINT' and apcorr_ref_model is not None:
+                    if source_type is not None and source_type.upper() == 'POINT' and apcorr_ref_model is not None:
                         log.info('Applying Aperture correction.')
 
                         if instrument == 'NIRSPEC':
@@ -3155,7 +3156,7 @@ def do_extract1d(
                             match_kwargs['slit'] = slitname
 
                         apcorr = select_apcorr(input_model)(
-                            input_model, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit, **match_kwargs
+                            input_model, slitname, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit, **match_kwargs
                         )
                         apcorr.apply(spec.spec_table)
 


### PR DESCRIPTION
`extract_1d` was failing when trying to process NIRSpec FS or MOS data in a `MultiSlitModel` when trying to compute the pixel scale (converting arcsec from ref file to pixels), because it was trying to use the WCS from the first slit instance in the model for all slits. This was giving null/NaN results for all slits other than the first. So this updates the routine to use the WCS object for the particular slit being processed. Required adding the slit name to the `ApCorr` base class, so that it's available for use.

Fixes #5229 / [JP-1636](https://jira.stsci.edu/browse/JP-1636)