### PR TITLE
JP-1485: fix level-2b FGS WFSC ASN generation

### DIFF
--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -10,7 +10,7 @@ from jwst.associations.lib.constraint import (Constraint, AttrConstraint, Simple
 from jwst.associations.lib.utilities import getattr_from_list
 
 
-__all__ = ['Constraint_TargetAcq', 'Constraint_TSO', 'DMSBaseMixin']
+__all__ = ['Constraint_TargetAcq', 'Constraint_TSO', 'Constraint_WFSC', 'DMSBaseMixin']
 
 # Default product name
 PRODUCT_NAME_DEFAULT = 'undefined'
@@ -653,6 +653,25 @@ class Constraint_TSO(Constraint):
                 )
             ],
             name='is_tso'
+        )
+
+
+class Constraint_WFSC(Constraint):
+    """Match on Wave Front Sensing and Control Observations"""
+    def __init__(self, *args, **kwargs):
+        super(Constraint_WFSC, self).__init__(
+            [
+                Constraint(
+                    [
+                        DMSAttrConstraint(
+                            name='wfsc',
+                            sources=['visitype'],
+                            value='.+wfsc.+',
+                            force_unique=True
+                        )
+                    ]
+                )
+            ]
         )
 
 

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -8,6 +8,7 @@ from jwst.associations.registry import RegistryMarker
 from jwst.associations.lib.constraint import (Constraint, SimpleConstraint)
 from jwst.associations.lib.dms_base import (
     Constraint_TSO,
+    Constraint_WFSC,
     format_list
 )
 from jwst.associations.lib.member import Member
@@ -196,6 +197,10 @@ class Asn_Lv2FGS(
                     'fgs_image'
                     '|fgs_focus'
                 ),
+            ),
+            Constraint(
+                [Constraint_WFSC()],
+                reduce=Constraint.notany
             )
         ])
 
@@ -883,16 +888,7 @@ class Asn_Lv2WFSC(
             Constraint_Image_Science(),
             Constraint_Single_Science(self.has_science),
             Constraint_ExtCal(),
-            Constraint(
-                [
-                    DMSAttrConstraint(
-                        name='wfsc',
-                        sources=['visitype'],
-                        value='.+wfsc.+',
-                        force_unique=True
-                    )
-                ]
-            )
+            Constraint_WFSC(),
         ])
 
         # Now check and continue initialization.


### PR DESCRIPTION
Update the level-2b FGS ASN constraint that builds normal science `image2` ASN's to exclude any WFSC exposures, so that FGS WFSC exposures result in a `wfsc-image2` ASN, instead of a regular `image2` ASN.

Fixes #5009 / [JP-1485](https://jira.stsci.edu/browse/JP-1485)