### PR TITLE
use gwcs 0.14.0 for sdp delivery

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1526,19 +1526,19 @@ def nrs_wcs_set_input(input_model, slit_name, wavelength_range=None):
     else:
         wrange = wavelength_range
     slit_wcs = copy.deepcopy(wcsobj)
-    slit_wcs.set_transform('sca', 'gwa', wcsobj.pipeline[1][1][1:])
+    slit_wcs.set_transform('sca', 'gwa', wcsobj.pipeline[1].transform[1:])
     # get the open slits from the model
     # Need them to get the slit ymin,ymax
-    g2s = wcsobj.pipeline[2][1]
+    g2s = wcsobj.pipeline[2].transform
     open_slits = g2s.slits
 
     slit_wcs.set_transform('gwa', 'slit_frame', g2s.get_model(slit_name))
     if input_model.meta.exposure.type.lower() == 'nrs_ifu':
         slit_wcs.set_transform('slit_frame', 'slicer',
-                           wcsobj.pipeline[3][1].get_model(slit_name) & Identity(1))
+                           wcsobj.pipeline[3].transform.get_model(slit_name) & Identity(1))
     else:
         slit_wcs.set_transform('slit_frame', 'msa_frame',
-                           wcsobj.pipeline[3][1].get_model(slit_name) & Identity(1))
+                           wcsobj.pipeline[3].transform.get_model(slit_name) & Identity(1))
     slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
 
     if input_model.meta.exposure.type.lower() != 'nrs_ifu':

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -15,7 +15,7 @@ crds==7.5.0.0
 Cython==0.29.21
 drizzle==1.13.1
 filelock==3.0.12
-gwcs==0.13.0
+gwcs==0.14.0
 idna==2.10
 importlib-metadata==1.7.0
 jsonschema==3.2.0

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -3,7 +3,7 @@
 #     pip install -e .[test]
 #     pip install pytest-xdist
 #     pip freeze | grep -v jwst.git >> requirements-sdp.txt
-asdf==2.7.0
+asdf==2.7.1
 astropy==4.0.1.post1
 attrs==19.3.0
 certifi==2020.6.20

--- a/setup.py
+++ b/setup.py
@@ -89,11 +89,11 @@ setup(
         'setuptools_scm',
     ],
     install_requires=[
-        'asdf>=2.5',
+        'asdf>=2.7.1',
         'astropy>=4.0',
         'crds>=7.4.1.3',
         'drizzle>=1.13',
-        'gwcs>=0.13.0',
+        'gwcs>=0.14.0',
         'jsonschema>=3.0.1',
         'numpy>=1.16',
         'photutils>=0.7',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         'crds>=7.4.1.3',
         'drizzle>=1.13',
         'gwcs>=0.14.0',
-        'jsonschema>=3.0.1',
+        'jsonschema>=3.0.2',
         'numpy>=1.16',
         'photutils>=0.7',
         'pyparsing>=2.2',


### PR DESCRIPTION
This PR sets the version of gwcs in SDP to 0.14.0 and the version of asdf to 2.7.1
It includes some minor changes to the Nirspec pipeline to take advantage of the fact that the WCS pipeline is not a list of `wcs.Step` instances instead of a list of (frame, transform) tuples and the `transform` and `frame` of a step should be accessed as attributes. Indexing the step still works but raises a `DeprecationWarning`.

Update: Bumped the version numbers of gwcs and asdf in setup.py