### PR TITLE
Revert "Use python 3.8 in nightly regression tests"

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -22,7 +22,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
-python_version = "3.8"
+python_version = "3.7"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -22,7 +22,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
-python_version = "3.8"
+python_version = "3.7"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"


### PR DESCRIPTION
Reverts spacetelescope/jwst#5259 until we get 3.8 problems with installing `pymssql` figured out.