### PR TITLE
Try python 3.8 again in the nightly regression tests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -22,7 +22,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
-python_version = "3.7"
+python_version = "3.8"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -22,7 +22,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
-python_version = "3.7"
+python_version = "3.8"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     ],
     extras_require={
         'docs': DOCS_REQUIRE,
-        'ephem': ['pymssql-linux=2.1.6', 'jplephem==2.9'], # for timeconversion
+        'ephem': ['pymssql-linux==2.1.6', 'jplephem==2.9'], # for timeconversion
         'test': TESTS_REQUIRE,
         'aws': AWS_REQUIRE,
     },

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     ],
     extras_require={
         'docs': DOCS_REQUIRE,
-        'ephem': ['pymssql==2.1.4', 'jplephem==2.9'], # for timeconversion
+        'ephem': ['pymssql-linux=2.1.6', 'jplephem==2.9'], # for timeconversion
         'test': TESTS_REQUIRE,
         'aws': AWS_REQUIRE,
     },


### PR DESCRIPTION
Another attempt to update the regtests to use python 3.8, this time with `pymssql-linux` used in place of the generic `pymssql` pkg.