### PR TITLE
JP-1653 changed default weighting to emsm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ combine_1d
 cube_build
 ----------
 
+- Changed default weighting to 'emsm'. [#5277]
+
 - Fixed formatting of NIRSpec s3d output product names. [#5231]
 
 - Modified NIRSpec blotting to the find min and max ra and dec for each slice and only

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -41,7 +41,7 @@ class CubeBuildStep (Step):
          scale1 = float(default=0.0) # cube sample size to use for axis 1, arc seconds
          scale2 = float(default=0.0) # cube sample size to use for axis 2, arc seconds
          scalew = float(default=0.0) # cube sample size to use for axis 3, microns
-         weighting = option('emsm','msm','miripsf',default = 'msm') # Type of weighting function
+         weighting = option('emsm','msm','miripsf',default = 'emsm') # Type of weighting function
          coord_system = option('skyalign','world','internal_cal','ifualign',default='skyalign') # Output Coordinate system.
          rois = float(default=0.0) # region of interest spatial size, arc seconds
          roiw = float(default=0.0) # region of interest wavelength size, microns


### PR DESCRIPTION
@drlaw1558 
This should do it. I am checking on what the nightly regression test use for the CRDS context. Once we confirm it includes the new NIRSpec Cube pars reference file we will be able to merge this PR