### PR TITLE
Add ability to change artifactory environment

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -65,7 +65,7 @@ bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
-    --env=${env.ARTIFACTORY_ENV} jwst/regtest/test_infrastructure.py",
+    --env=${env.ARTIFACTORY_ENV} ",
 ]
 bc0.test_configs = [data_config]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -22,7 +22,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
-python_version = "3.7"
+python_version = "3.8"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"
@@ -64,7 +64,8 @@ bc0.build_cmds = [
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
-    --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope",
+    --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
+    jwst/regtest/test_infrastructure.py",
 ]
 bc0.test_configs = [data_config]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -65,7 +65,7 @@ bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
-    jwst/regtest/test_infrastructure.py",
+    --env=${env.ARTIFACTORY_ENV} jwst/regtest/test_infrastructure.py",
 ]
 bc0.test_configs = [data_config]
 

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -1,8 +1,9 @@
 # To generate this file:
 #
 #     pip install -e .[test]
+#     pip install pytest-xdist
 #     pip freeze | grep -v jwst.git >> requirements-sdp.txt
-asdf==2.7.0
+asdf==2.7.1
 astropy==4.0.1.post1
 attrs==19.3.0
 certifi==2020.6.20
@@ -14,7 +15,7 @@ crds==7.5.0.0
 Cython==0.29.21
 drizzle==1.13.1
 filelock==3.0.12
-gwcs==0.13.0
+gwcs==0.14.0
 idna==2.10
 importlib-metadata==1.7.0
 jsonschema==3.2.0
@@ -33,6 +34,7 @@ pytest==5.4.3
 pytest-cov==2.10.0
 pytest-doctestplus==0.8.0
 pytest-openfiles==0.5.0
+pytest-xdist==1.34.0
 PyYAML==5.3.1
 requests==2.24.0
 requests-mock==1.8.0

--- a/setup.py
+++ b/setup.py
@@ -89,12 +89,12 @@ setup(
         'setuptools_scm',
     ],
     install_requires=[
-        'asdf>=2.5',
+        'asdf>=2.7.1',
         'astropy>=4.0',
         'crds>=7.4.1.3',
         'drizzle>=1.13',
-        'gwcs>=0.13.0',
-        'jsonschema>=3.0.1',
+        'gwcs>=0.14.0',
+        'jsonschema>=3.0.2',
         'numpy>=1.16',
         'photutils>=0.7',
         'pyparsing>=2.2',
@@ -106,7 +106,7 @@ setup(
     ],
     extras_require={
         'docs': DOCS_REQUIRE,
-        'ephem': ['pymssql==2.1.4', 'jplephem==2.9'], # for timeconversion
+        'ephem': ['pymssql-linux==2.1.6', 'jplephem==2.9'], # for timeconversion
         'test': TESTS_REQUIRE,
         'aws': AWS_REQUIRE,
     },


### PR DESCRIPTION
Add a new Jenkins build string parameter "ARTIFACTORY_ENV" so that the regressions can use a different artifactory environment instead of just "dev".

To setup Jenkins builds, in "Configure", add a new string parameter called "ARTIFACTORY_ENV". Make the default "dev", and set the description to "Set which environment to use from the jwst-pipeline artifactory to test against."