### PR TITLE
Update Travis SDP job to use python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux
 dist: xenial
 language: python
-python: 3.8.2
+python: 3.8.5
 
 env:
   global:
@@ -26,7 +26,6 @@ jobs:
         PIP_DEPENDENCIES="-r requirements-min.txt .[test]"
 
     - name: SDP dependencies in requirements-sdp.txt, CRDS_CONTEXT=jwst-edit
-      python: 3.7.7
       env:
         PIP_DEPENDENCIES="-r requirements-sdp.txt .[test]"
         CRDS_CONTEXT=jwst-edit


### PR DESCRIPTION
We updated our nightly regression tests to use python 3.8 (see #5271) but forgot to update the Travis build for unit tests.