### PR TITLE
Bump crds==7.6.0 in requirements-sdp.txt

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 ci-watson==0.5
 codecov==2.1.8
 coverage==5.2.1
-crds==7.5.0.0
+crds==7.6.0
 Cython==0.29.21
 drizzle==1.13.1
 filelock==3.0.12


### PR DESCRIPTION
`crds 7.6.0` was just released, so we should run our regression tests with it and include in the Build 7.6 rc2 delivery to DMS.