### PR TITLE
JP-1666: Include per-product tracebacks for failures in calwebb_spec2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,7 +44,9 @@ pipeline
 
 - Spec3Pipeline check whether master background subtraction has already occurred. [#5308]
 
-- Implement master background subtraction in Spec2Pipeline for NIRSpec MOS data [#5302]
+- Implement master background subtraction in Spec2Pipeline for NIRSpec MOS data. [#5302]
+
+- Include the per-slit failure traceback in any RuntimeError raised in Spec2Pipeline. [#5315]
 
 
 0.17.0 (2020-08-28)

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -98,9 +98,9 @@ class Spec2Pipeline(Pipeline):
         asn = self.load_as_level2_asn(data)
 
         # Each exposure is a product in the association.
-        # Process each exposure.
+        # Process each exposure.  Delay reporting failures until the end.
         results = []
-        has_exceptions = False
+        failures = []
         for product in asn['products']:
             self.log.info('Processing product {}'.format(product['name']))
             self.output_file = product['name']
@@ -121,15 +121,13 @@ class Spec2Pipeline(Pipeline):
                 raise exception
             except Exception:
                 traceback.print_exc()
-                has_exceptions = True
+                failures.append(traceback.format_exc())
             else:
                 if result is not None:
                     results.append(result)
 
-        if has_exceptions and self.fail_on_exception:
-            raise RuntimeError(
-                'One or more products failed to process. Failing calibration.'
-            )
+        if len(failures) > 0 and self.fail_on_exception:
+            raise RuntimeError('\n'.join(failures))
 
         # We're done
         self.log.info('Ending calwebb_spec2')

--- a/jwst/pipeline/tests/test_calwebspec2.py
+++ b/jwst/pipeline/tests/test_calwebspec2.py
@@ -3,14 +3,11 @@ import pytest
 from ..calwebb_spec2 import Spec2Pipeline
 
 
-@pytest.fixture(scope='module')
-def fake_pipeline():
-    return Spec2Pipeline()
+def test_filenotfounderror_raised(capsys):
+    # Verify the failure is in the traceback message
+    with pytest.raises(RuntimeError, match="FileNotFoundError"):
+        Spec2Pipeline().run('file_does_not_exist.fits')
 
-
-def test_filenotfounderror_raised(fake_pipeline, capsys):
-    with pytest.raises(RuntimeError):
-        fake_pipeline.run('file_does_not_extis.fits')
-
+    # Verify the failure is printed to stderr
     captured = capsys.readouterr()
     assert 'FileNotFoundError' in captured.err


### PR DESCRIPTION
This includes the traceback of a per-product failure in the final `RuntimeError` message for the spec2 pipeline.

Currently on `master`:

```
E           RuntimeError: One or more products failed to process. Failing calibration.

jwst/pipeline/calwebb_spec2.py:130: RuntimeError
```

This PR:

```
E           RuntimeError: Traceback (most recent call last):
E             File "/Users/jdavies/dev/jwst/jwst/pipeline/calwebb_spec2.py", line 112, in process
E               result = self.process_exposure_product(
E             File "/Users/jdavies/dev/jwst/jwst/pipeline/calwebb_spec2.py", line 172, in process_exposure_product
E               with self.open_model(science_member) as science:
E             File "/Users/jdavies/dev/jwst/jwst/stpipe/step.py", line 1071, in open_model
E               return dm_open(self.make_input_path(obj))
E             File "/Users/jdavies/dev/jwst/jwst/datamodels/util.py", line 103, in open
E               hdulist = fits.open(init, memmap=memmap)
E             File "/Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py", line 164, in fitsopen
E               return HDUList.fromfile(name, mode, memmap, save_backup, cache,
E             File "/Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py", line 403, in fromfile
E               return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,
E             File "/Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py", line 1054, in _readfrom
E               fileobj = _File(fileobj, mode=mode, memmap=memmap, cache=cache)
E             File "/Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/astropy/utils/decorators.py", line 535, in wrapper
E               return function(*args, **kwargs)
E             File "/Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/astropy/io/fits/file.py", line 193, in __init__
E               self._open_filename(fileobj, mode, overwrite)
E             File "/Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/astropy/io/fits/file.py", line 574, in _open_filename
E               self._file = fileobj_open(self.name, IO_FITS_MODES[mode])
E             File "/Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/astropy/io/fits/util.py", line 396, in fileobj_open
E               return open(filename, mode, buffering=0)
E           FileNotFoundError: [Errno 2] No such file or directory: 'file_does_not_exist.fits'

jwst/pipeline/calwebb_spec2.py:130: RuntimeError
```

So this will make debugging nightly regression tests much easier, as we'll now see what caused the error.  This only echos the short form of the traceback into the `RuntimeError` message.

Alternatively, the first exception could be raised instead of a `RuntimeError`.

Or the `RuntimeError` could be raised from the first error (for the first failing product) at the end of the loop, which would give the whole detailed traceback (and exception type) in the traceback.

Thoughts?

Resolves #5298 / [JP-1666](https://jira.stsci.edu/browse/JP-1666)