### PR TITLE
JP-1680: fix tso_photometry int times computation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,11 @@ pipeline
 
 - Implement master background subtraction in Spec2Pipeline for NIRSpec MOS data [#5302]
 
+tso_photometry
+--------------
+
+- Fix a bug in the computation of integration time stamps when the INT_TIMES
+  table is not available. [#5318]
 
 0.17.0 (2020-08-28)
 ===================

--- a/jwst/tso_photometry/tests/test_tso_photometry.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry.py
@@ -56,11 +56,12 @@ def set_meta(datamodel, sub64p=False):
     """Assign some metadata"""
 
     datamodel.meta.exposure.nints = datamodel.data.shape[0]
-    datamodel.meta.exposure.ngroups = 8
-    datamodel.meta.exposure.group_time = 10.7 * datamodel.meta.exposure.ngroups
+    datamodel.meta.exposure.integration_time = 10.7
     datamodel.meta.exposure.start_time = 58704.62847
 
     datamodel.meta.exposure.integration_start = 5
+    datamodel.meta.exposure.integration_end = (
+        datamodel.meta.exposure.integration_start + datamodel.meta.exposure.nints - 1)
 
     datamodel.meta.instrument.name = 'NIRCAM'
     datamodel.meta.instrument.detector = 'NRCA2'
@@ -229,7 +230,7 @@ def test_tso_phot_4():
                                       radius + 1., radius_inner,
                                       radius_outer)
 
-    int_times = np.array([58704.63293, 58704.641845, 58704.65076,
-                          58704.65968, 58704.6686, 58704.677512,
-                          58704.686428])
+    int_times = np.array([58704.62853, 58704.628655, 58704.62878,
+                          58704.62890, 58704.6290, 58704.6291511,
+                          58704.629275])
     assert np.allclose(catalog['MJD'], int_times, rtol=1.e-8)

--- a/jwst/tso_photometry/tso_photometry_step.py
+++ b/jwst/tso_photometry/tso_photometry_step.py
@@ -60,6 +60,8 @@ class TSOPhotometryStep(Step):
             self.log.debug(f'radius = {radius}')
             self.log.debug(f'radius_inner = {radius_inner}')
             self.log.debug(f'radius_outer = {radius_outer}')
+            self.log.debug(f'xcenter = {xcenter}')
+            self.log.debug(f'ycenter = {ycenter}')
 
             # Compute the aperture photometry
             catalog = tso_aperture_photometry(model, xcenter, ycenter,


### PR DESCRIPTION
Update the `tso_photometry` step to use the number of integrations contained within a given input segment, rather than the whole exposure, when computing integration time stamps. Creating an array of time stamps based on all integrations was causing a mismatch in column lengths with the actual photometry data.

Fixes #5316 / [JP-1680](https://jira.stsci.edu/browse/JP-1680)