### PR TITLE
JP-1681: Fix empty int_times table in rateints products

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,10 @@ pipeline
 
 - Include the per-slit failure traceback in any RuntimeError raised in Spec2Pipeline. [#5315]
 
+ramp_fitting
+------------
+
+- Reinstate copying of INT_TIMES table to output rateints product for TSO exposures. [#5321]
 
 tso_photometry
 --------------

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -223,6 +223,7 @@ def ols_ramp_fit_multi(input_model, buffsize, save_opt, readnoise_2d, gain_2d,
         int_model.var_poisson = int_var_poisson
         int_model.var_rnoise = int_var_rnoise
         int_model.err = int_err
+        int_model.int_times = int_times
 
         # Populate the optional output model
         if save_opt:
@@ -292,6 +293,7 @@ def ols_ramp_fit_multi(input_model, buffsize, save_opt, readnoise_2d, gain_2d,
         int_model, opt_model, out_model = create_output_models(input_model,
                             number_of_integrations, save_opt, total_cols, total_rows,
                                                                actual_segments, actual_CRs)
+        int_model.int_times = int_times
 
         # iterate over the number of slices and place the results into the output models
         for resultslice in real_results:
@@ -1039,7 +1041,6 @@ def ols_ramp_fit(data, err, groupdq, inpixeldq, buffsize, save_opt, readnoise_2d
         del pixeldq
 
     # Output integration-specific results to separate file
-    int_times = None
     int_model = utils.output_integ(slope_int, dq_int, effintim,
                                    var_p3, var_r3, var_both3, int_times)
     if opt_res is not None:

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -26,7 +26,7 @@ def test_int_times():
     model1.meta.visit.tsovisit = True
     slopes, int_model, dum1, dum2 = ramp_fit(model1, 512, False, rnModel, gain, 'OLS', 'optimal', 'none')
     assert(len(int_model.int_times) == nints)
-    
+
 
 def test_one_group_small_buffer_fit_ols():
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=1,gain=1,readnoise=10)
@@ -677,7 +677,6 @@ def setup_small_cube(ngroups=10, nints=1, nrows=2, ncols=2, deltatime=10.,
 def setup_inputs(ngroups=10, readnoise=10, nints=1,
                  nrows=103, ncols=102, nframes=1, grouptime=1.0,gain=1, deltatime=1):
 
-    times = np.array(list(range(ngroups)),dtype=np.float64) * deltatime
     gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
     err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint32)

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -12,6 +12,22 @@ from jwst.datamodels import GainModel, ReadnoiseModel
 # expected to fail.  Needs fixing, but the fix is not clear
 # to me. [KDG - 19 Dec 2018]
 
+def test_int_times():
+    # Test whether int_times table gets copied to output when it should
+    nints = 5
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=3, nints=nints, nrows=2, ncols=2)
+
+    # Set TSOVISIT false, in which case the int_times table should come back with zero length
+    model1.meta.visit.tsovisit = False
+    slopes, int_model, dum1, dum2 = ramp_fit(model1, 512, False, rnModel, gain, 'OLS', 'optimal', 'none')
+    assert(len(int_model.int_times) == 0)
+
+    # Set TSOVISIT true, in which case the int_times table should come back with length nints
+    model1.meta.visit.tsovisit = True
+    slopes, int_model, dum1, dum2 = ramp_fit(model1, 512, False, rnModel, gain, 'OLS', 'optimal', 'none')
+    assert(len(int_model.int_times) == nints)
+    
+
 def test_one_group_small_buffer_fit_ols():
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=1,gain=1,readnoise=10)
     model1.data[0, 0, 50, 50] = 10.0
@@ -668,7 +684,8 @@ def setup_inputs(ngroups=10, readnoise=10, nints=1,
     pixdq = np.zeros(shape=(nrows, ncols), dtype= np.float64)
     read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
-    model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
+    int_times = np.zeros((nints,7))
+    model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, int_times=int_times)
     model1.meta.instrument.name='MIRI'
     model1.meta.instrument.detector='MIRIMAGE'
     model1.meta.instrument.filter='F480M'


### PR DESCRIPTION
Fix `ramp_fit` to populate the `int_times` attribute in the `rateints` products. I think it got removed during the rework to add multi-processing.

Fixes #5320 / [JP-1681](https://jira.stsci.edu/browse/JP-1681)