### PR TITLE
JP-1689: Fix level-3 IFU product names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.17.1 (unreleased)
 ===================
 
+associations
+------------
+
+- Add product name override to the `IFUGratingBkg` class, to prevent the default
+  "clear" suffix showing up in NIRSpec IFU product names. [#5326]
+
 barshadow
 ---------
 
@@ -17,6 +23,8 @@ cube_build
 ----------
 
 - If every wavelength plane of the IFU cube contains 0 data, cube_build is skipped [#5294]
+
+- Remove "clear" suffix from MIRI MRS product name templates [#5326]
 
 flat_field
 ----------

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -512,6 +512,22 @@ class Asn_IFUGratingBkg(AsnMixin_AuxData, AsnMixin_BkgScience):
         # Check and continue initialization.
         super(Asn_IFUGratingBkg, self).__init__(*args, **kwargs)
 
+    @property
+    def dms_product_name(self):
+        """Define product name."""
+        target = self._get_target()
+
+        instrument = self._get_instrument()
+
+        product_name = 'jw{}-{}_{}_{}_{}'.format(
+            self.data['program'],
+            self.acid.id,
+            target,
+            instrument,
+            self._get_grating()
+        )
+        return product_name.lower()
+
 @RegistryMarker.rule
 class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -163,6 +163,18 @@ class IFUCubeData():
             newname = self.output_name_base + '_s3d.fits'
         else:
             if self.instrument == 'MIRI':
+
+                # Check to see if the output base name already contains the
+                # field "clear", which sometimes shows up in IFU product
+                # names created by the ASN rules. If so, strip it off, so
+                # that the remaining suffixes created below form the entire
+                # list of optical elements in the final output name.
+                suffix = self.output_name_base[self.output_name_base.rfind('_')+1:]
+                if suffix in ['clear']:
+                    self.output_name_base = self.output_name_base[:self.output_name_base.rfind('_')]
+
+                # Now compose the appropriate list of optical element suffix names
+                # based on MRS channel and sub-channel
                 channels = []
                 for ch in self.list_par1:
                     if ch not in channels:


### PR DESCRIPTION
A few different types of MIRI MRS and NIRSpec IFU associations (mostly involving dedicated bkg exposures) are leading to product name templates in the ASN files with the suffix "_clear" attached. The NIRSpec IFU case is fixed here by adding the same product name override to the `IFUGratingBkg` class that's already in the `IFUGrating` class, which overrides the base class product name (which contains "clear" for the optical element). A similar fix in the ASN rules for the MRS bkg case (rule class `Lv3SpecAux`) was not as straightforward, because that same class is also used for NIRSpec dedicated backgrounds and hence a change could cause collateral damage to those. So instead, an update is being made to the `cube_build` function that builds level-3 MRS product names so that it looks for the suffix "_clear" in the product template name and strips it off, before then adding legit suffixes for channel and sub-channel.

Fixes #5324 / [JP-1689](https://jira.stsci.edu/browse/JP-1689)