### PR TITLE
jp-1690 calspec3  cube_build clean up 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ blendmeta
 cube_build
 ----------
 
+- When making SINGLE type cubes for outlier detection or mrs_imatch data not in the 
+  appropriate channel/grating is skipped [#5347]
+
+- If outlier detection has flagged all the data on a input file as DO_NOT_USE, then
+  skip the file in creating an ifucube [*5347]
+
 - If every wavelength plane of the IFU cube contains 0 data, cube_build is skipped [#5294]
 
 - Remove "clear" suffix from MIRI MRS product name templates [#5326]

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -101,7 +101,7 @@ class CubeBlot():
         """ Prints the basic paramters of the blot image and median sky cube
         """
         log.info('Information on Blotting')
-        log.info('Working with instrument %s ', self.instrument)
+        log.info('Working with instrument %s', self.instrument)
         log.info('shape of sky cube %f %f %f',
                  self.median_skycube.data.shape[2],
                  self.median_skycube.data.shape[1],

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -41,21 +41,23 @@ class CubeBlot():
         # Pull out the needed information from the Median IFUCube
         self.median_skycube = median_model
         self.instrument = median_model.meta.instrument.name
-        self.detector = median_model.meta.instrument.detector
 
         # basic information about the type of data
         self.grating = None
         self.filter = None
         self.subchannel = None
         self.channel = None
+        self.par_median = None
 
         if self.instrument == 'MIRI':
             self.channel = median_model.meta.instrument.channel
             self.subchannel = median_model.meta.instrument.band.lower()
+            self.par_median = self.channel
+
         elif self.instrument == 'NIRSPEC':
             self.grating = median_model.meta.instrument.grating
             self.filter = median_model.meta.instrument.filter
-
+            self.par_median = self.grating
         # ________________________________________________________________
         # set up x,y,z of Median Cube
         # Median cube shoud have linear wavelength
@@ -80,23 +82,31 @@ class CubeBlot():
         self.cube_wave = self.cube_wave[good_data]
         self.cube_flux = self.cube_flux[good_data]
 
-        # initialize blotted images to be original input images
-        self.input_models = input_models
+        # initialize blotted images to be original input images valid for the Median Image
+        # read channel (MIRI) or grating (NIRSpec) value that the Median Image covers
+        # only use input models in this range
+        self.input_models  = []
+        for model in input_models:
+            if self.instrument == 'MIRI':
+                par = model.meta.instrument.channel
+            if self.instrument == 'NIRSPEC':
+                par = model.meta.instrument.grating
 
+            found = par.find(self.par_median)
+            if found > -1:
+                self.input_models.append(model)
     # **********************************************************************
 
     def blot_info(self):
         """ Prints the basic paramters of the blot image and median sky cube
         """
         log.info('Information on Blotting')
-        log.info('Working with instrument %s %s', self.instrument,
-                 self.detector)
+        log.info('Working with instrument %s ', self.instrument)
         log.info('shape of sky cube %f %f %f',
                  self.median_skycube.data.shape[2],
                  self.median_skycube.data.shape[1],
                  self.median_skycube.data.shape[0])
 
-        log.info('Instrument %s ', self.instrument)
         if self.instrument == 'MIRI':
             log.info('Channel %s', self.channel)
             log.info('Sub-channel %s', self.subchannel)

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -288,9 +288,6 @@ class CubeBuildStep (Step):
         if not self.single:
             self.log.info(f'Number of IFU cubes produced by this run = {num_cubes}')
 
-        if self.single:
-            self.log.info(f'Number of single IFU cubes produced by a this run = {num_cubes}')
-
         # ModelContainer of ifucubes
         cube_container = datamodels.ModelContainer()
 
@@ -357,7 +354,7 @@ class CubeBuildStep (Step):
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)
-
+            print('file used to create singe cube',cube.meta.filename)
         if status_cube ==1:
             self.skip = True
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -354,7 +354,6 @@ class CubeBuildStep (Step):
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)
-            print('file used to create singe cube',cube.meta.filename)
         if status_cube ==1:
             self.skip = True
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -2187,7 +2187,6 @@ class IFUCubeData():
         if self.output_type == 'single':
             with datamodels.open(model_ref) as input:
                 # define the cubename for each single
-                #filename = self.input_filenames[j]
                 filename = input.meta.filename
                 indx = filename.rfind('.fits')
                 self.output_name_base = filename[:indx]
@@ -2206,7 +2205,6 @@ class IFUCubeData():
             outchannel = "".join(set(outchannel))
             outchannel = "".join(sorted(outchannel))
             ifucube_model.meta.instrument.channel = outchannel
-            #log.info(f'IFUChannel {ifucube_model.meta.instrument.channel}')
 # ______________________________________________________________________
         ifucube_model.meta.wcsinfo.crval1 = self.crval1
         ifucube_model.meta.wcsinfo.crval2 = self.crval2

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -644,10 +644,10 @@ class IFUCubeData():
                         softrad_pixel, scalerad_pixel, alpha_det, beta_det = pixelresult
                     # check that there is valid data returned
                     # If all the data is flagged as DO_NOT_USE - not common then log warning and skip data
-                    nn = wave.size
-                    no_data = False
-                    if nn == 0:
+                    if wave.size == 0:
                         no_data = True
+                    else:
+                        no_data = False
 
                     t1 = time.time()
                     log.debug("Time to transform pixels to output frame = %.1f s" % (t1 - t0,))

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -141,7 +141,7 @@ class OutlierDetectionIFU(OutlierDetection):
                 )
 
                 if save_intermediate_results:
-                    log.info("Writing out resampled IFU cubes...")
+                    log.info("Writing out (single) IFU cube {}".format(model.meta.filename))
                     model.save(model.meta.filename)
 
             # Initialize intermediate products used in the outlier detection


### PR DESCRIPTION
Clean up of making single cubes and blotted cubes.
1.   If making SINGLE type check the input file sent to cube_build and only use those of the correct channel/grating.
2.  When blotting a median IFUcube back to the detector look at the channel or grating and only blot those files that cover the same channel/grating.
3. If all the data  on the input file has been flagged as DO_NOT_USE (a by product of outlier rejection) skip the file in creating the ifucube. 
