### PR TITLE
JP-1668: Fix bug in extract_1d target coords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 0.17.2 (unreleased)
 ===================
 
+extract_1d
+----------
 
+- Fixed bug invovling the determination of source RA/Dec for resampled Slit
+  data. [#5353]
 
 
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ contact the [JWST Help Desk](https://jwsthelp.stsci.edu).
 
 | jwst tag | DMS build | CRDS_CONTEXT |   Date     |          Notes                                |
 | -------- | --------- | ------------ | ---------- | ----------------------------------------------|
-|  0.17.1  | B7.6rc2   | 0641         | 09/15/2020 | Second release candidate for B7.6             |
+|  0.17.1  | B7.6      | 0641         | 09/15/2020 | Final release candidate for B7.6              |
 |  0.17.0  | B7.6rc1   | 0637         | 08/28/2020 | First release candidate for B7.6              |
 |  0.16.2  | B7.5      | 0619         | 06/10/2020 | Same as 0.16.1, but with installation bug fix |
 |  0.16.1  | B7.5      | 0619         | 05/19/2020 | Final release candidate for B7.5              |

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1204,15 +1204,23 @@ class ExtractBase(abc.ABC):
         targ_dec : float or None
             The declination of the target, or None
         """
-        if slit is None:
-            targ_ra = input_model.meta.target.ra
-            targ_dec = input_model.meta.target.dec
-        else:
+        if slit is not None:
+            # If we've been passed a slit object, get the RA/Dec
+            # from the slit source attributes
             targ_ra = getattr(slit, 'source_ra', None)
             targ_dec = getattr(slit, 'source_dec', None)
             if targ_ra is None or targ_dec is None:
                 targ_ra = input_model.meta.target.ra
                 targ_dec = input_model.meta.target.dec
+        elif isinstance(input_model, datamodels.SlitModel):
+            # If the input model is a single SlitModel, again
+            # get the coords from the slit source attributes
+            targ_ra = getattr(input_model, 'source_ra', None)
+            targ_dec = getattr(input_model, 'source_dec', None)
+        else:
+            # Otherwise get it from the generic target coords
+            targ_ra = input_model.meta.target.ra
+            targ_dec = input_model.meta.target.dec
 
         if targ_ra is None or targ_dec is None:
             log.warning("Target RA and Dec could not be determined")

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1204,24 +1204,26 @@ class ExtractBase(abc.ABC):
         targ_dec : float or None
             The declination of the target, or None
         """
+        targ_ra = None
+        targ_dec = None
+
         if slit is not None:
             # If we've been passed a slit object, get the RA/Dec
             # from the slit source attributes
             targ_ra = getattr(slit, 'source_ra', None)
             targ_dec = getattr(slit, 'source_dec', None)
-            if targ_ra is None or targ_dec is None:
-                targ_ra = input_model.meta.target.ra
-                targ_dec = input_model.meta.target.dec
         elif isinstance(input_model, datamodels.SlitModel):
             # If the input model is a single SlitModel, again
             # get the coords from the slit source attributes
             targ_ra = getattr(input_model, 'source_ra', None)
             targ_dec = getattr(input_model, 'source_dec', None)
-        else:
+
+        if targ_ra is None or targ_dec is None:
             # Otherwise get it from the generic target coords
             targ_ra = input_model.meta.target.ra
             targ_dec = input_model.meta.target.dec
 
+        # Issue a warning if none of the methods succeeded
         if targ_ra is None or targ_dec is None:
             log.warning("Target RA and Dec could not be determined")
             targ_ra = targ_dec = None
@@ -2178,11 +2180,11 @@ class ImageExtractModel(ExtractBase):
         if self.subtract_background is not None:
             if not self.subtract_background:
                 if verbose and mask_bkg is not None:
-                        log.info("Background subtraction was turned off - skipping it.")
+                    log.info("Background subtraction was turned off - skipping it.")
                 mask_bkg = None
             else:
                 if verbose and mask_bkg is None:
-                        log.info("Skipping background subtraction because background regions are not defined.")
+                    log.info("Skipping background subtraction because background regions are not defined.")
 
         # Extract the background.
         if mask_bkg is not None:
@@ -3233,7 +3235,6 @@ def do_extract1d(
         or extract_ref_dict['need_to_set_to_complete']
     ):
         output_model.meta.cal_step.extract_1d = 'COMPLETE'
-
 
     return output_model
 


### PR DESCRIPTION
Updated the `get_target_coordinates` function in `extract_1d` step so that when the input model is a `SlitModel` it gets the target coords from the slit source_ra and source_dec attributes, instead of defaulting to the generic TARG_RA/TARG_DEC values (which for something like NIRSpec MOS is going to be very wrong).

Fixes #5301 / [JP-1668](https://jira.stsci.edu/browse/JP-1668)