### PR TITLE
JP-1541 Implement memory check in resample to prevent huge arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ outlier_detection
 
 - Fix bug where background was being subtracted on the input data [#4858]
 
+- Implement memory check in resample to prevent huge arrays [#5354]
+
 pathloss
 --------
 
@@ -96,6 +98,11 @@ ramp_fitting
 ------------
 
 - Reinstate copying of INT_TIMES table to output rateints product for TSO exposures. [#5321]
+
+resample
+--------
+
+- Implement memory check in resample to prevent huge arrays [#5354]
 
 tso_photometry
 --------------

--- a/docs/jwst/datamodels/models.rst
+++ b/docs/jwst/datamodels/models.rst
@@ -312,3 +312,49 @@ returns a dictionary of of the instance at the model._extra_fits node.
 
 `_instance` can be used at any node in the tree to return a dictionary
 of rest of the tree structure at that node.
+
+Environmental Variables
+-----------------------
+
+There are a number of environmental variables that affect how models are read.
+
+PASS_INVALID_VALUES
+  Used by `~jwst.datamodels.DataModel` when instantiating
+  a model from a file. If ``True``, values that do not validate the schema will
+  still be added to the metadata. If ``False``, they will be set to ``None``.
+  Default is ``False``.
+
+STRICT_VALIDATION
+  Used by `~jwst.datamodels.DataModel` when instantiating a model from a file.
+  If ``True``, schema validation errors will generate an exception.
+  If ``False``, they will generate a warning.
+  Default is ``False``.
+
+SKIP_FITS_UPDATE
+  Used by `~jwst.datamodels.DataModel` when instantiating a
+  model from a FITS file. When ``False``, models opened from FITS files will
+  proceed and load the FITS header values into the model. When ``True`` and the
+  FITS file has an ASDF extension, the loading/validation of the FITS header
+  will be skipped, loading the model only from the ASDF extension. If not
+  defined, the instantiation routines will determine whether the loading/validation
+  of the FITS header can be skipped or not.
+
+DMODEL_ALLOWED_MEMORY
+  Implemented by the utility function
+  `jwst.datamodels.util.check_memory_allocation` and used by
+  `~jwst.outlier_detection.OutlierDetectionStep` and
+  `~jwst.resample.ResampleStep`. When defined, determines how much of currently
+  available memory should be used to instantiated an output resampled image. If
+  not defined, no check is made.
+
+  Examples would be: ``1.0`` would allow all available memory to be used. ``0.5``
+  would allow only half the available memory to be used.
+
+For flag or boolean variables, any value in ``('true', 't', 'yes', 'y')`` or a
+non-zero number, will evaluate as ``True``. Any value in ``('false', 'f', 'no',
+'n', '0')`` will evaluate as ``False``. The values are case-insensitive.
+
+All of the environmental variables have equivalent function arguments in the API
+for the relevant code. The environment variables are used only if explicit
+values had not been used in a script. In other words, values in code override
+environmental variables.

--- a/docs/jwst/outlier_detection/arguments.rst
+++ b/docs/jwst/outlier_detection/arguments.rst
@@ -66,3 +66,13 @@ that control the behavior of the processing:
 ``--scale_detection`` (bool, default=False)
   Specifies whether or not to rescale the individual input images
   to match total signal when doing comparisons.
+
+``--allowed_memory`` (float, default=None)
+  Specifies the fractional amount of
+  free memory to allow when creating the resampled image. If ``None``, the
+  environmental variable ``DMODEL_ALLOWED_MEMORY`` is used. If not defined, no
+  check is made. If the resampled image would be larger than specified, an
+  ``OutputTooLargeError`` exception will be generated.
+
+  For example, if set to ``0.5``, only resampled images that use less than half
+  the available memory can be created.

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -29,3 +29,13 @@ image.
 ``--blendheaders`` (bool, default=True)
   Apply `blendmodels` on all of the input images to combine ('blend')
   their meta data into the output resampled image.
+
+``--allowed_memory`` (float, default=None)
+  Specifies the fractional amount of
+  free memory to allow when creating the resampled image. If ``None``, the
+  environmental variable ``DMODEL_ALLOWED_MEMORY`` is used. If not defined, no
+  check is made. If the resampled image would be larger than specified, an
+  ``OutputTooLargeError`` exception will be generated.
+
+  For example, if set to ``0.5``, only resampled images that use less than half
+  the available memory can be created.

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -45,9 +45,9 @@ def test_check_memory_allocation_env(monkeypatch, mock_get_available_memory,
                                      allowed_env, allowed_explicit, result):
     """Check environmental control over memory check"""
     if allowed_env is None:
-        monkeypatch.delenv('ALLOWED_MEMORY', raising=False)
+        monkeypatch.delenv('DMODEL_ALLOWED_MEMORY', raising=False)
     else:
-        monkeypatch.setenv('ALLOWED_MEMORY', allowed_env)
+        monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', allowed_env)
 
     # Allocate amount that would fit at 100% + swap.
     can_allocate, required = util.check_memory_allocation(

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -35,10 +35,10 @@ def mock_get_available_memory(monkeypatch):
     'allowed_env, allowed_explicit, result',
     [
         (None, None, True),  # Perform no check.
-        (10, None, False),   # Force too little memory.
-        (10, 100, True),     # Explicit overrides environment.
-        (100, 10, False),    # Explicit overrides environment.
-        (None, 10, False),   # Explicit overrides environment.
+        (0.1, None, False),  # Force too little memory.
+        (0.1, 1.0, True),    # Explicit overrides environment.
+        (1.0, 0.1, False),   # Explicit overrides environment.
+        (None, 0.1, False),  # Explicit overrides environment.
     ]
 )
 def test_check_memory_allocation_env(monkeypatch, mock_get_available_memory,
@@ -59,11 +59,11 @@ def test_check_memory_allocation_env(monkeypatch, mock_get_available_memory,
 @pytest.mark.parametrize(
     'dim, allowed, include_swap, result',
     [
-        (MEMORY // 2, 100, True, True),    # Fit within memory and swap
-        (MEMORY // 2, 100, False, False),  # Does not fit without swap
-        (MEMORY, 100, True, False),        # Does not fit at all
+        (MEMORY // 2, 1.0, True, True),    # Fit within memory and swap
+        (MEMORY // 2, 1.0, False, False),  # Does not fit without swap
+        (MEMORY, 1.0, True, False),        # Does not fit at all
         (MEMORY, None, True, True),        # Check disabled
-        (MEMORY // 2, 10, True, False),    # Does not fit in restricted memory
+        (MEMORY // 2, 0.1, True, False),   # Does not fit in restricted memory
     ]
 )
 def test_check_memory_allocation(mock_get_available_memory, dim, allowed, include_swap, result):

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -518,29 +518,6 @@ def check_memory_allocation(shape, allowed=100, model_type=None, include_swap=Tr
     -------
     can_instantiate, required_memory : bool, number
         True if the model can be instantiated and the predicted memory footprint.
-
-    Examples
-    --------
-    >>> check_memory_allocation((1, 1))
-        (True...
-
-    >>> check_memory_allocation((1e10, 1e10))
-        (False...
-
-    >>> check_memory_allocation((1e10, 1e10), allowed=None)
-        (True...
-
-    >>> with_swap = get_available_memory(True)
-    >>> without_swap = get_available_memory(False)
-    >>> dim_size = int((with_swap / 4)**0.5) - 100
-    >>> check_memory_allocation((dim_size, dim_size), allowed=100)
-        (True,...
-
-    >>> check_memory_allocation((dim_size, dim_size), allowed=1)
-        (False,...
-
-    >>> check_memory_allocation((dim_size, dim_size), allowed=100, include_swap=False)
-        (False,...
     """
     # Create the unit shape
     unit_shape = (1,) * len(shape)

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -522,7 +522,7 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
     """
     # Determine desired allowed amount.
     if allowed is None:
-        allowed = os.environ.get('ALLOWED_MEMORY', None)
+        allowed = os.environ.get('DMODEL_ALLOWED_MEMORY', None)
         if allowed is not None:
             allowed = int(allowed)
 

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -495,7 +495,7 @@ def get_envar_as_boolean(name, default=False):
     return default
 
 
-def check_memory_allocation(shape, allowed=100, model_type=None, include_swap=True):
+def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=True):
     """Check if a DataModel can be instantiated
 
     Parameters
@@ -505,7 +505,8 @@ def check_memory_allocation(shape, allowed=100, model_type=None, include_swap=Tr
 
     allowed : number or None
         Percentage of memory allowed to be allocated.
-        If None, no check is made and will always return True.
+        If None, the environmental variable `ALLOWED_MEMORY`
+        is retrieved. If undefined, then no check is performed.
 
     model_type : DataModel or None
         The desired model to instantiate.
@@ -519,6 +520,12 @@ def check_memory_allocation(shape, allowed=100, model_type=None, include_swap=Tr
     can_instantiate, required_memory : bool, number
         True if the model can be instantiated and the predicted memory footprint.
     """
+    # Determine desired allowed amount.
+    if allowed is None:
+        allowed = os.environ.get('ALLOWED_MEMORY', None)
+        if allowed is not None:
+            allowed = int(allowed)
+            
     # Create the unit shape
     unit_shape = (1,) * len(shape)
 

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -525,7 +525,7 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
         allowed = os.environ.get('ALLOWED_MEMORY', None)
         if allowed is not None:
             allowed = int(allowed)
-            
+
     # Create the unit shape
     unit_shape = (1,) * len(shape)
 

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -522,10 +522,13 @@ def check_memory_allocation(shape, allowed=100, model_type=None, include_swap=Tr
     Examples
     --------
     >>> check_memory_allocation((1, 1))
-        (True, 4)
+        (True...
 
     >>> check_memory_allocation((1e10, 1e10))
-        (False, 4e+20)
+        (False...
+
+    >>> check_memory_allocation((1e10, 1e10), allowed=None)
+        (True...
 
     >>> with_swap = get_available_memory(True)
     >>> without_swap = get_available_memory(False)

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -504,9 +504,10 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
         The desired shape of the model.
 
     allowed : number or None
-        Percentage of memory allowed to be allocated.
-        If None, the environmental variable `ALLOWED_MEMORY`
+        Fraction of memory allowed to be allocated.
+        If None, the environmental variable `DMODEL_ALLOWED_MEMORY`
         is retrieved. If undefined, then no check is performed.
+        `1.0` would be all available memory. `0.5` would be half available memory.
 
     model_type : DataModel or None
         The desired model to instantiate.
@@ -524,7 +525,7 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
     if allowed is None:
         allowed = os.environ.get('DMODEL_ALLOWED_MEMORY', None)
         if allowed is not None:
-            allowed = int(allowed)
+            allowed = float(allowed)
 
     # Create the unit shape
     unit_shape = (1,) * len(shape)
@@ -552,9 +553,9 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
             f' system available {bytes2human(available)}'
         )
 
-    if allowed and size > (allowed / 100.0 * available):
+    if allowed and size > (allowed * available):
         log.debug(
-            f'Model size greater than allowed memory {bytes2human(allowed / 100.0 * available)}'
+            f'Model size greater than allowed memory {bytes2human(allowed * available)}'
         )
         return False, size
 

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -518,6 +518,26 @@ def check_memory_allocation(shape, allowed=100, model_type=None, include_swap=Tr
     -------
     can_instantiate, required_memory : bool, number
         True if the model can be instantiated and the predicted memory footprint.
+
+    Examples
+    --------
+    >>> check_memory_allocation((1, 1))
+        (True, 4)
+
+    >>> check_memory_allocation((1e10, 1e10))
+        (False, 4e+20)
+
+    >>> with_swap = get_available_memory(True)
+    >>> without_swap = get_available_memory(False)
+    >>> dim_size = int((with_swap / 4)**0.5) - 100
+    >>> check_memory_allocation((dim_size, dim_size), allowed=100)
+        (True,...
+
+    >>> check_memory_allocation((dim_size, dim_size), allowed=1)
+        (False,...
+
+    >>> check_memory_allocation((dim_size, dim_size), allowed=100, include_swap=False)
+        (False,...
     """
     # Create the unit shape
     unit_shape = (1,) * len(shape)

--- a/jwst/lib/basic_utils.py
+++ b/jwst/lib/basic_utils.py
@@ -2,6 +2,41 @@
 import re
 
 
+def bytes2human(n):
+    """Convert bytes to human-readable format
+
+    Taken from the `psutil` library which references
+    http://code.activestate.com/recipes/578019
+
+    Parameters
+    ----------
+    n : int
+        Number to convert
+
+    Returns
+    -------
+    readable : str
+        A string with units attached.
+
+    Examples
+    --------
+    >>> bytes2human(10000)
+        '9.8K'
+
+    >>> bytes2human(100001221)
+        '95.4M'
+    """
+    symbols = ('K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+    prefix = {}
+    for i, s in enumerate(symbols):
+        prefix[s] = 1 << (i + 1) * 10
+    for s in reversed(symbols):
+        if n >= prefix[s]:
+            value = float(n) / prefix[s]
+            return '%.1f%s' % (value, s)
+    return "%sB" % n
+
+
 def multiple_replace(string, rep_dict):
     """Single-pass replacement of multiple substrings
 

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -62,7 +62,7 @@ class OutlierDetectionStep(Step):
         good_bits = string(default="~DO_NOT_USE")  # DQ flags to allow
         scale_detection = boolean(default=False)
         search_output_file = boolean(default=False)
-        allowed_memory = integer(default=None)  # Percentage of memory to use for the combined image.
+        allowed_memory = float(default=None)  # Fraction of memory to use for the combined image.
     """
 
     def process(self, input_data):

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -8,6 +8,7 @@ from . import outlier_detection
 from . import outlier_detection_scaled
 from . import outlier_detection_ifu
 from . import outlier_detection_spec
+from ..resample.resample import OutputTooLargeError
 
 # Categorize all supported versions of outlier_detection
 outlier_registry = {'imaging': outlier_detection.OutlierDetection,
@@ -167,7 +168,7 @@ class OutlierDetectionStep(Step):
             step = detection_step(self.input_models, reffiles=reffiles, **pars)
             try:
                 step.do_detection()
-            except RuntimeError as exception:
+            except OutputTooLargeError as exception:
                 self.log.error(f'{exception}')
                 state = 'SKIP'
                 self.skip = True

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -62,7 +62,6 @@ class OutlierDetectionStep(Step):
         good_bits = string(default="~DO_NOT_USE")  # DQ flags to allow
         scale_detection = boolean(default=False)
         search_output_file = boolean(default=False)
-        max_pixels = integer(default=10000000000)  # Maximum number of pixels in combined image. 0 for no restriction.
         allowed_memory = integer(default=100)  # Percentage of memory to use for the combined image.
     """
 
@@ -106,7 +105,6 @@ class OutlierDetectionStep(Step):
                 'snr': self.snr,
                 'scale': self.scale,
                 'backg': self.backg,
-                'max_pixels' : int(self.max_pixels),
                 'allowed_memory' : self.allowed_memory,
                 'save_intermediate_results': self.save_intermediate_results,
                 'resample_data': self.resample_data,

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -167,13 +167,20 @@ class OutlierDetectionStep(Step):
 
             # Set up outlier detection, then do detection
             step = detection_step(self.input_models, reffiles=reffiles, **pars)
-            step.do_detection()
+            try:
+                step.do_detection()
+            except RuntimeError as exception:
+                self.log.error(f'{exception}')
+                state = 'SKIP'
+                self.skip = True
+            else:
+                state = 'COMPLETE'
 
             if self.input_container:
                 for model in self.input_models:
-                    model.meta.cal_step.outlier_detection = 'COMPLETE'
+                    model.meta.cal_step.outlier_detection = state
             else:
-                self.input_models.meta.cal_step.outlier_detection = 'COMPLETE'
+                self.input_models.meta.cal_step.outlier_detection = state
 
             return self.input_models
 

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -8,7 +8,6 @@ from . import outlier_detection
 from . import outlier_detection_scaled
 from . import outlier_detection_ifu
 from . import outlier_detection_spec
-from ..resample.resample import OutputTooLargeError
 
 # Categorize all supported versions of outlier_detection
 outlier_registry = {'imaging': outlier_detection.OutlierDetection,

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -62,6 +62,7 @@ class OutlierDetectionStep(Step):
         good_bits = string(default="~DO_NOT_USE")  # DQ flags to allow
         scale_detection = boolean(default=False)
         search_output_file = boolean(default=False)
+        max_pixels = integer(default=10000000000)  # Maximum number of pixels in combined image. 0 for no restriction.
     """
 
     def process(self, input_data):
@@ -104,6 +105,7 @@ class OutlierDetectionStep(Step):
                 'snr': self.snr,
                 'scale': self.scale,
                 'backg': self.backg,
+                'max_pixels' : int(self.max_pixels),
                 'save_intermediate_results': self.save_intermediate_results,
                 'resample_data': self.resample_data,
                 'good_bits': self.good_bits,

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -166,15 +166,9 @@ class OutlierDetectionStep(Step):
 
             # Set up outlier detection, then do detection
             step = detection_step(self.input_models, reffiles=reffiles, **pars)
-            try:
-                step.do_detection()
-            except OutputTooLargeError as exception:
-                self.log.error(f'{exception}')
-                state = 'SKIP'
-                self.skip = True
-            else:
-                state = 'COMPLETE'
+            step.do_detection()
 
+            state = 'COMPLETE'
             if self.input_container:
                 for model in self.input_models:
                     model.meta.cal_step.outlier_detection = state

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -63,6 +63,7 @@ class OutlierDetectionStep(Step):
         scale_detection = boolean(default=False)
         search_output_file = boolean(default=False)
         max_pixels = integer(default=10000000000)  # Maximum number of pixels in combined image. 0 for no restriction.
+        allowed_memory = integer(default=100)  # Percentage of memory to use for the combined image.
     """
 
     def process(self, input_data):
@@ -106,6 +107,7 @@ class OutlierDetectionStep(Step):
                 'scale': self.scale,
                 'backg': self.backg,
                 'max_pixels' : int(self.max_pixels),
+                'allowed_memory' : self.allowed_memory,
                 'save_intermediate_results': self.save_intermediate_results,
                 'resample_data': self.resample_data,
                 'good_bits': self.good_bits,

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -62,7 +62,7 @@ class OutlierDetectionStep(Step):
         good_bits = string(default="~DO_NOT_USE")  # DQ flags to allow
         scale_detection = boolean(default=False)
         search_output_file = boolean(default=False)
-        allowed_memory = integer(default=100)  # Percentage of memory to use for the combined image.
+        allowed_memory = integer(default=None)  # Percentage of memory to use for the combined image.
     """
 
     def process(self, input_data):

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -86,4 +86,5 @@ class Image3Pipeline(Pipeline):
                 input_models = self.outlier_detection(input_models)
 
             result = self.resample(input_models)
-            self.source_catalog(result)
+            if isinstance(result, datamodels.ImageModel) and result.meta.cal_step.resample == 'COMPLETE':
+                self.source_catalog(result)

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -1,10 +1,6 @@
 """Regression tests for FGS Guidestar in ID and FINEGUIDE modes"""
-import os
-
 import pytest
-from astropy.io.fits.diff import FITSDiff
 
-from jwst.lib.suffix import replace_suffix
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.resample.resample import OutputTooLargeError
 from jwst.stpipe import Step

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -42,8 +42,8 @@ def test_fgs_guider(run_guider_pipelines, fitsdiff_default_kwargs, suffix):
 def test_fgs_toobig(rtdata, fitsdiff_default_kwargs, caplog, monkeypatch):
     """Test for the situation where the combined mosaic is too large"""
 
-    # Set the environment ALLOWED_MEMORY to not allow the resultant too-large image.
-    monkeypatch.setenv('ALLOWED_MEMORY', 100)
+    # Set the environment to not allow the resultant too-large image.
+    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', 100)
 
     rtdata.get_asn('fgs/image3/image3_asn.json')
 

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -39,8 +39,12 @@ def test_fgs_guider(run_guider_pipelines, fitsdiff_default_kwargs, suffix):
 
 
 @pytest.mark.bigdata
-def test_fgs_toobig(rtdata, fitsdiff_default_kwargs, caplog):
+def test_fgs_toobig(rtdata, fitsdiff_default_kwargs, caplog, monkeypatch):
     """Test for the situation where the combined mosaic is too large"""
+
+    # Set the environment ALLOWED_MEMORY to not allow the resultant too-large image.
+    monkeypatch.setenv('ALLOWED_MEMORY', 100)
+
     rtdata.get_asn('fgs/image3/image3_asn.json')
 
     collect_pipeline_cfgs('config')

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -6,6 +6,7 @@ from astropy.io.fits.diff import FITSDiff
 
 from jwst.lib.suffix import replace_suffix
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.resample.resample import OutputTooLargeError
 from jwst.stpipe import Step
 
 from . import regtestdata as rt
@@ -43,11 +44,11 @@ def test_fgs_toobig(rtdata, fitsdiff_default_kwargs, caplog, monkeypatch):
     """Test for the situation where the combined mosaic is too large"""
 
     # Set the environment to not allow the resultant too-large image.
-    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', 1.0)
+    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', "0.9")
 
     rtdata.get_asn('fgs/image3/image3_asn.json')
 
     collect_pipeline_cfgs('config')
     args = ['config/calwebb_image3.cfg', rtdata.input]
-    Step.from_cmdline(args)
-    assert 'model cannot be instantiated' in caplog.text
+    with pytest.raises(OutputTooLargeError):
+        Step.from_cmdline(args)

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -8,18 +8,7 @@ from jwst.lib.suffix import replace_suffix
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
-
-def is_like_truth(rtdata, fitsdiff_default_kwargs, suffix, truth_path='truth/fgs/test_fgs_guider'):
-    """Compare step outputs with truth"""
-    output = replace_suffix(
-        os.path.splitext(os.path.basename(rtdata.input))[0], suffix
-    ) + '.fits'
-    rtdata.output = output
-
-    rtdata.get_truth(os.path.join(truth_path, output))
-
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()
+from . import regtestdata as rt
 
 
 file_roots = ['exptype_fgs_acq1', 'exptype_fgs_fineguide', 'exptype_fgs_id_image', 'exptype_fgs_id_stack']
@@ -45,4 +34,5 @@ guider_suffixes = ['cal', 'dq_init', 'guider_cds']
 @pytest.mark.parametrize('suffix', guider_suffixes, ids=guider_suffixes)
 def test_fgs_guider(run_guider_pipelines, fitsdiff_default_kwargs, suffix):
     """Regression for FGS Guider data"""
-    is_like_truth(run_guider_pipelines, fitsdiff_default_kwargs, suffix)
+    rt.is_like_truth(run_guider_pipelines, fitsdiff_default_kwargs, suffix,
+                     'truth/fgs/test_fgs_guider', is_suffix=True)

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -36,3 +36,14 @@ def test_fgs_guider(run_guider_pipelines, fitsdiff_default_kwargs, suffix):
     """Regression for FGS Guider data"""
     rt.is_like_truth(run_guider_pipelines, fitsdiff_default_kwargs, suffix,
                      'truth/fgs/test_fgs_guider', is_suffix=True)
+
+
+@pytest.mark.bigdata
+def test_fgs_toobig(rtdata, fitsdiff_default_kwargs, caplog):
+    """Test for the situation where the combined mosaic is too large"""
+    rtdata.get_asn('fgs/image3/image3_asn.json')
+
+    collect_pipeline_cfgs('config')
+    args = ['config/calwebb_image3.cfg', rtdata.input]
+    Step.from_cmdline(args)
+    assert 'model cannot be instantiated' in caplog.text

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -43,7 +43,7 @@ def test_fgs_toobig(rtdata, fitsdiff_default_kwargs, caplog, monkeypatch):
     """Test for the situation where the combined mosaic is too large"""
 
     # Set the environment to not allow the resultant too-large image.
-    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', 100)
+    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', 1.0)
 
     rtdata.get_asn('fgs/image3/image3_asn.json')
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -12,7 +12,11 @@ from ..model_blender import blendmeta
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-__all__ = ["ResampleData"]
+__all__ = ["OutputTooLargeError", "ResampleData"]
+
+
+class OutputTooLargeError(RuntimeError):
+    """Raised when the output is too large for in-memory instanitation"""
 
 
 class ResampleData:
@@ -62,9 +66,9 @@ class ResampleData:
             self.output_wcs.data_size, pars['allowed_memory'], datamodels.ImageModel
         )
         if not can_allocate:
-            raise RuntimeError(
+            raise OutputTooLargeError(
                 f'Combined ImageModel size {self.output_wcs.data_size} requires {bytes2human(required_memory)}'
-                f'\nUsing {pars["allowed_memory"]}% of free memory, the model cannot be instantiated.'
+                f'\nModel cannot be instantiated.'
             )
         self.blank_output = datamodels.ImageModel(self.output_wcs.data_size)
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -58,13 +58,13 @@ class ResampleData:
         # Define output WCS based on all inputs, including a reference WCS
         self.output_wcs = resample_utils.make_output_wcs(self.input_models)
         log.debug('Output mosaic size: {}'.format(self.output_wcs.data_size))
-        can_allocate, required_memory = datamodels.check_memory_allocation(
+        can_allocate, required_memory = datamodels.util.check_memory_allocation(
             self.output_wcs.data_size, pars['allowed_memory'], datamodels.ImageModel
         )
         if not can_allocate:
             raise RuntimeError(
-                f'Combined ImageModel size {size} requires {bytes2human(required_memory)}'
-                f'\nUsing {pars["allowed_memory"]}% cannot allocate the model.'
+                f'Combined ImageModel size {self.output_wcs.data_size} requires {bytes2human(required_memory)}'
+                f'\nUsing {pars["allowed_memory"]}% of free memory, the model cannot be instantiated.'
             )
         self.blank_output = datamodels.ImageModel(self.output_wcs.data_size)
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -1,12 +1,11 @@
 import logging
 from collections import OrderedDict
 import numpy as np
-from psutil._common import bytes2human
-
-from .. import datamodels
 
 from . import gwcs_drizzle
 from . import resample_utils
+from .. import datamodels
+from ..lib.basic_utils import bytes2human
 from ..model_blender import blendmeta
 
 log = logging.getLogger(__name__)
@@ -16,7 +15,7 @@ __all__ = ["OutputTooLargeError", "ResampleData"]
 
 
 class OutputTooLargeError(RuntimeError):
-    """Raised when the output is too large for in-memory instanitation"""
+    """Raised when the output is too large for in-memory instantiation"""
 
 
 class ResampleData:

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -44,6 +44,9 @@ class ResampleData:
 
         output : str
             filename for output
+
+        pars : dict
+            `drizpars` parameters
         """
         self.input_models = input_models
         self.drizpars = pars
@@ -54,6 +57,14 @@ class ResampleData:
         # Define output WCS based on all inputs, including a reference WCS
         self.output_wcs = resample_utils.make_output_wcs(self.input_models)
         log.debug('Output mosaic size: {}'.format(self.output_wcs.data_size))
+        if pars['max_pixels']:
+            size = self.output_wcs.data_size[0]
+            for x in self.output_wcs.data_size[1:]:
+                size *= x
+            if size > pars['max_pixels']:
+                raise RuntimeError(
+                    f'Combined image size {size} greater than allowed max_pixels {pars["max_pixels"]}'
+                )
         self.blank_output = datamodels.ImageModel(self.output_wcs.data_size)
 
         # update meta data and wcs

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -2,11 +2,11 @@ import logging
 
 import numpy as np
 
+from . import resample
 from ..stpipe import Step
 from ..extern.configobj.validate import Validator
 from ..extern.configobj.configobj import ConfigObj
 from .. import datamodels
-from . import resample
 from ..assign_wcs import util
 
 log = logging.getLogger(__name__)
@@ -74,7 +74,7 @@ class ResampleStep(Step):
         kwargs['allowed_memory'] = self.allowed_memory
         try:
             resamp = resample.ResampleData(input_models, **kwargs)
-        except RuntimeError as exception:
+        except resample.OutputTooLargeError as exception:
             self.log.error(f'{exception}')
             self.skip = True
             return input_models

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -36,7 +36,7 @@ class ResampleStep(Step):
         weight_type = option('exptime', default='exptime')
         single = boolean(default=False)
         blendheaders = boolean(default=True)
-        allowed_memory = integer(default=None)  # Percentage of memory to use for the combined image.
+        allowed_memory = float(default=None)  # Fraction of memory to use for the combined image.
     """
 
     reference_file_types = ['drizpars']

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -72,12 +72,7 @@ class ResampleStep(Step):
 
         # Call the resampling routine
         kwargs['allowed_memory'] = self.allowed_memory
-        try:
-            resamp = resample.ResampleData(input_models, **kwargs)
-        except resample.OutputTooLargeError as exception:
-            self.log.error(f'{exception}')
-            self.skip = True
-            return input_models
+        resamp = resample.ResampleData(input_models, **kwargs)
         resamp.do_drizzle()
 
         for model in resamp.output_models:

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -36,7 +36,7 @@ class ResampleStep(Step):
         weight_type = option('exptime', default='exptime')
         single = boolean(default=False)
         blendheaders = boolean(default=True)
-        allowed_memory = integer(default=100)  # Percentage of memory to use for the combined image.
+        allowed_memory = integer(default=None)  # Percentage of memory to use for the combined image.
     """
 
     reference_file_types = ['drizpars']

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     jsonschema>=3.0.2
     numpy>=1.16
     photutils>=0.7
+    psutil>=5.7.2
     pyparsing>=2.2
     requests>=2.22
     scipy>=1.1.0


### PR DESCRIPTION
Resolves [JP-1541](https://jira.stsci.edu/browse/JP-1541)
Resolves #5081 

A predictive memory check is implemented in the `resample` module. The steps `OutlierDetectionStep` and `ResampleStep`, both of which have the potential of building very large images, make use of this check through the parameter `allowed_memory`. The value represents the fraction of available memory to use in instantiating the output data model. `None` means do not check.

If the output is too large, steps will raise `OutputTooLargeError` exception. This exception is subclassed from `RuntimeError`.

There is also an environmental defined, DMODEL_ALLOWED_MEMORY, that is queried if the step parameter is `None`.