### PR TITLE
JP-1723: Flatfield fixes for NRS lamp exposures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,17 @@ extract_1d
 - Fixed bug invovling the determination of source RA/Dec for resampled Slit
   data. [#5353]
 
+flatfield
+---------
+
+- Fixed bug in sending NIRSpec AUTOWAVE exposures to the spectroscopic
+  processing branch. [#5356]
+
+ramp_fitting
+------------
+
+- Update to store output as an `IFUImageModel` for NIRSpec AUTOWAVE exposures
+  using the IFU mode. [#5356]
 
 
 0.17.1 (2020-09-15)

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -20,7 +20,7 @@ MICRONS_100 = 1.e-4                     # 100 microns, in meters
 
 # This is for NIRSpec.
 FIXED_SLIT_TYPES = ["NRS_LAMP", "NRS_BRIGHTOBJ", "NRS_FIXEDSLIT"]
-NIRSPEC_SPECTRAL_EXPOSURES = ['NRS_BRIGHTOBJ', 'NRS_FIXEDSLIT', 'NRS_IFU', 'NRS_MSASPEC']
+NIRSPEC_SPECTRAL_EXPOSURES = ['NRS_AUTOWAVE', 'NRS_BRIGHTOBJ', 'NRS_FIXEDSLIT', 'NRS_IFU', 'NRS_MSASPEC']
 
 # Dispersion direction, predominantly horizontal or vertical.  These values
 # are to be compared with keyword DISPAXIS from the input header.
@@ -281,7 +281,8 @@ def do_nirspec_flat_field(output_model, f_flat_model, s_flat_model, d_flat_model
     # that the slices have been copied out into a MultiSlitModel, so
     # check for that case.
     if not hasattr(output_model, "slits"):
-        if exposure_type == "NRS_IFU":
+        if exposure_type == "NRS_IFU" or (
+            exposure_type == "NRS_AUTOWAVE" and output_model.meta.instrument.lamp_mode == 'IFU'):
             if not isinstance(output_model, datamodels.IFUImageModel):
                 log.error("NIRSpec IFU data is not an IFUImageModel; "
                           "don't know how to process it.")

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -44,8 +44,7 @@ class RampFitStep (Step):
 
         with datamodels.RampModel(input) as input_model:
             max_cores = self.maximum_cores
-            readnoise_filename = self.get_reference_file(input_model,
-                                                          'readnoise')
+            readnoise_filename = self.get_reference_file(input_model, 'readnoise')
             gain_filename = self.get_reference_file(input_model, 'gain')
 
             log.info('Using READNOISE reference file: %s', readnoise_filename)
@@ -89,7 +88,10 @@ class RampFitStep (Step):
 
         if out_model is not None:
             out_model.meta.cal_step.ramp_fit = 'COMPLETE'
-            if input_model.meta.exposure.type in ('NRS_IFU', 'MIR_MRS'):
+            if (input_model.meta.exposure.type in ['NRS_IFU', 'MIR_MRS']) or (
+                input_model.meta.exposure.type in ['NRS_AUTOWAVE', 'NRS_LAMP'] and
+                    input_model.meta.instrument.lamp_mode == 'IFU'):
+
                 out_model = datamodels.IFUImageModel(out_model)
 
         if int_model is not None:


### PR DESCRIPTION
Updates to the ramp_fit step to store rate product for IFU NRS_AUTOWAVE exposures as an `IFUImageModel` (as is already done for IFU science exposures) and updates to flatfield to treat NRS_AUTOWAVE as an exposure to be processed via the spectroscopic branch.

Fixes #5355 / [JP-1723](https://jira.stsci.edu/browse/JP-1723)