### PR TITLE
Do not attempt prefetch on pipelines that are set to not allow prefetch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,11 @@ scripts
 
 - Add pointing analysis commands v1_calculate and pointing_summary. [#5311]
 
+stpipe
+------
+
+- Do not attempt prefetch on pipelines that are set to not allow prefetch. [#5363]
+
 ramp_fitting
 ------------
 

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -85,9 +85,12 @@ class Pipeline(Step):
 
     @property
     def _unskipped_steps(self):
-        """Return a list of the unskipped Step objects launched by `self`."""
+        """Return a list of the unskipped Step objects launched by `self`.
+
+        Steps are also excluded if `Step.prefetch_references` is False.
+        """
         return [getattr(self, name) for name in self.step_defs
-                if not getattr(self, name).skip]
+                if (not getattr(self, name).skip and getattr(self, name).prefetch_references)]
 
     def get_ref_override(self, reference_file_type):
         """Return any override for `reference_file_type` for any of the steps in

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -5,6 +5,28 @@ from jwst.datamodels import (
     ModelContainer,
 )
 
+class StepWithReference(Step):
+    """Step that refers to a reference file"""
+
+    reference_file_types = ['flat']
+
+    def process(self, data):
+        return data
+
+
+class PipeWithReference(Pipeline):
+    """Pipeline calling step with reference"""
+
+    spec = """
+    """
+
+    step_defs = {'step_with_reference': StepWithReference}
+
+    def process(self, data):
+        result = self.step_with_reference(data)
+
+        return result
+
 
 class AnotherDummyStep(Step):
     """


### PR DESCRIPTION
Resolves [JP-1712](https://jira.stsci.edu/browse/JP-1712)
Resolves #5350 

If a `Pipeline` has `prefetch_references == False`, do not attempt to prefetch any reference files for the Pipeline, or its steps.

Reviewers: The fix is the one-liner at pipeline.py:93