### PR TITLE
JP-1731: Add DO_NOT_USE to pixels with all groups saturated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ ramp_fitting
 - Update to store output as an `IFUImageModel` for NIRSpec AUTOWAVE exposures
   using the IFU mode. [#5356]
 
+- Update to add 'DO_NOT_USE' DQ flag to pixels with all groups flagged as
+  saturated. [#5367]
 
 0.17.1 (2020-09-15)
 ===================

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -982,8 +982,8 @@ def ols_ramp_fit(data, err, groupdq, inpixeldq, buffsize, save_opt, readnoise_2d
 
     # Clean up ramps that are SAT on their initial groups; set ramp parameters
     #   for variances and slope so they will not contribute
-    var_p3, var_both3, slope_int = utils.fix_sat_ramps( sat_0th_group_int,
-                                           var_p3, var_both3, slope_int)
+    var_p3, var_both3, slope_int, dq_int = utils.fix_sat_ramps(
+        sat_0th_group_int, var_p3, var_both3, slope_int, dq_int)
 
     if sat_0th_group_int is not None:
         del sat_0th_group_int

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -331,8 +331,8 @@ class TestMethods:
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
         #expect SATURATED
         assert slopes[0].dq[50, 51] == 2 # is there a better way to do this test?
-        #expect SATURATED since 1st group is Saturated
-        assert slopes[0].dq[50, 52] == 2 # is there a better way to do this test?
+        #expect SATURATED and DO_NOT_USE, because 1st group is Saturated
+        assert slopes[0].dq[50, 52] == 3 # is there a better way to do this test?
 
     def test_four_groups_oneCR_orphangroupatend_fit(self, method):
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=4,gain=1,readnoise=10)

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -330,9 +330,9 @@ class TestMethods:
         cds_slope = (model1.data[0,1,50,50] - model1.data[0,0,50,50])
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
         #expect SATURATED
-        assert slopes[0].dq[50, 51] == 2 # is there a better way to do this test?
+        assert slopes[0].dq[50, 51] == dqflags.pixel['SATURATED']
         #expect SATURATED and DO_NOT_USE, because 1st group is Saturated
-        assert slopes[0].dq[50, 52] == 3 # is there a better way to do this test?
+        assert slopes[0].dq[50, 52] == dqflags.pixel['SATURATED'] + dqflags.pixel['DO_NOT_USE']
 
     def test_four_groups_oneCR_orphangroupatend_fit(self, method):
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=4,gain=1,readnoise=10)

--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -1222,7 +1222,7 @@ def remove_bad_singles( segs_beg_3 ):
     return segs_beg_3
 
 
-def fix_sat_ramps( sat_0th_group_int, var_p3, var_both3, slope_int):
+def fix_sat_ramps(sat_0th_group_int, var_p3, var_both3, slope_int, dq_int):
     """
     For ramps within an integration that are saturated on the initial group,
     reset the integration-specific variances and slope so they will have no
@@ -1245,7 +1245,10 @@ def fix_sat_ramps( sat_0th_group_int, var_p3, var_both3, slope_int):
 
     slope_int : float, 3D array
         Cube of integration-specific slopes. Some ramps may be saturated in the
-        initial group
+        initial group.
+
+    dq_int : uint32, 3D array
+        Cube of integration-specific DQ flags.
 
     Returns
     -------
@@ -1265,20 +1268,18 @@ def fix_sat_ramps( sat_0th_group_int, var_p3, var_both3, slope_int):
         Cube of integration-specific slopes; for ramps that are saturated in
         the initial group, this variance has been reset to a huge value to
         minimize the ramps contribution.
+
+    dq_int : uint32, 3D array
+        Cube of integration-specific DQ flags. For ramps that are saturated in
+        the initial group, the flag 'DO_NOT_USE' is added.
     """
-    where_all_groups_sat = np.where( sat_0th_group_int != 0)
-    num_of_sats = len(where_all_groups_sat[0])
+    var_p3[sat_0th_group_int > 0] = LARGE_VARIANCE
+    var_both3[sat_0th_group_int > 0] = LARGE_VARIANCE
+    slope_int[sat_0th_group_int > 0] = 0.
+    dq_int[sat_0th_group_int > 0] = np.bitwise_or(
+        dq_int[sat_0th_group_int > 0], dqflags.pixel['DO_NOT_USE'])
 
-    for ii_sat in range(num_of_sats):
-        ii_integ = where_all_groups_sat[0][ii_sat]
-        ii_y = where_all_groups_sat[1][ii_sat]
-        ii_x = where_all_groups_sat[2][ii_sat]
-
-        var_p3[ ii_integ, ii_y, ii_x ] = LARGE_VARIANCE
-        var_both3[ ii_integ, ii_y, ii_x ] = LARGE_VARIANCE
-        slope_int[ ii_integ, ii_y, ii_x ] = 0.
-
-    return var_p3, var_both3, slope_int
+    return var_p3, var_both3, slope_int, dq_int
 
 
 def do_all_sat( pixeldq, groupdq, imshape, n_int, save_opt):


### PR DESCRIPTION
Updated the `ramp_fitting` function `utils.fix_sat_ramps` to add the DQ flag 'DO_NOT_USE' to pixels that have all groups flagged as saturated. Also greatly simplified the whole function to get rid of looping over pixels and just use native `numpy` array indexing.

Fixes #5364 / [JP-1731](https://jira.stsci.edu/browse/JP-1731)