### PR TITLE
JP-1732: NRS MOS updates for lamp exposures with no sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 0.17.2 (unreleased)
 ===================
 
+cube_build
+----------
+
+- When making SINGLE type cubes for outlier detection or mrs_imatch data not in the 
+  appropriate channel/grating is skipped [#5347]
+
+- If outlier detection has flagged all the data on a input file as DO_NOT_USE, then
+  skip the file in creating an ifucube [*5347]
+
 extract_1d
 ----------
 
@@ -13,6 +22,20 @@ flatfield
 - Fixed bug in sending NIRSpec AUTOWAVE exposures to the spectroscopic
   processing branch. [#5356]
 
+- Updated branch logic to handle NRS_LAMP exposures as spectroscopic. [#5370]
+
+master_background
+-----------------
+
+- Update the NIRSpec MOS master background logic to only proceed with processing
+  after verifying that there are both background and source slits available in
+  the input dataset. [#5370]
+
+outlier_detection
+-----------------
+
+- Implement memory check in resample to prevent huge arrays [#5354]
+
 ramp_fitting
 ------------
 
@@ -21,6 +44,11 @@ ramp_fitting
 
 - Update to add 'DO_NOT_USE' DQ flag to pixels with all groups flagged as
   saturated. [#5367]
+
+resample
+--------
+
+- Implement memory check in resample to prevent huge arrays [#5354]
 
 0.17.1 (2020-09-15)
 ===================
@@ -46,12 +74,6 @@ blendmeta
 cube_build
 ----------
 
-- When making SINGLE type cubes for outlier detection or mrs_imatch data not in the 
-  appropriate channel/grating is skipped [#5347]
-
-- If outlier detection has flagged all the data on a input file as DO_NOT_USE, then
-  skip the file in creating an ifucube [*5347]
-
 - If every wavelength plane of the IFU cube contains 0 data, cube_build is skipped [#5294]
 
 - Remove "clear" suffix from MIRI MRS product name templates [#5326]
@@ -76,8 +98,6 @@ outlier_detection
 -----------------
 
 - Fix bug where background was being subtracted on the input data [#4858]
-
-- Implement memory check in resample to prevent huge arrays [#5354]
 
 pathloss
 --------
@@ -116,11 +136,6 @@ ramp_fitting
 ------------
 
 - Reinstate copying of INT_TIMES table to output rateints product for TSO exposures. [#5321]
-
-resample
---------
-
-- Implement memory check in resample to prevent huge arrays [#5354]
 
 tso_photometry
 --------------

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -20,7 +20,7 @@ MICRONS_100 = 1.e-4                     # 100 microns, in meters
 
 # This is for NIRSpec.
 FIXED_SLIT_TYPES = ["NRS_LAMP", "NRS_BRIGHTOBJ", "NRS_FIXEDSLIT"]
-NIRSPEC_SPECTRAL_EXPOSURES = ['NRS_AUTOWAVE', 'NRS_BRIGHTOBJ', 'NRS_FIXEDSLIT', 'NRS_IFU', 'NRS_MSASPEC']
+NIRSPEC_SPECTRAL_EXPOSURES = ['NRS_AUTOWAVE', 'NRS_BRIGHTOBJ', 'NRS_FIXEDSLIT', 'NRS_IFU', 'NRS_LAMP', 'NRS_MSASPEC']
 
 # Dispersion direction, predominantly horizontal or vertical.  These values
 # are to be compared with keyword DISPAXIS from the input header.


### PR DESCRIPTION
Updates to a couple of steps to properly handle NRS_LAMP exposures in MSASPEC mode, which don't have any sources defined in their MSA metadata files. The `assign_wcs` step was already setup to handle this properly, in that any slitlet without a source assigned to it is classified as a background slitlet, so all lamp exposure slitlets get processed as background type. Added some checks to the new NIRSpec master_background step so that it does not compute or apply the master bkg spectrum when there are no background slits available or no source slits to apply it to (as is the case for lamp exposures). Also a fix to `flat_field` to properly classify NRS_LAMP exposures as spectroscopic type, rather than imaging.

Fixes #5365 / [JP-1732](https://jira.stsci.edu/browse/JP-1732)