### PR TITLE
JP-1679: Skip serializing None in datamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ cube_build
 - If outlier detection has flagged all the data on a input file as DO_NOT_USE, then
   skip the file in creating an ifucube [*5347]
 
+datamodels
+----------
+
+- Skip serializing `None` in datamodels to be compatible with `asdf>=2.8` [#5371]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -1,7 +1,6 @@
 import copy
 from collections import OrderedDict
 import os.path as op
-import warnings
 import re
 import logging
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -348,12 +348,6 @@ class ModelContainer(model_base.DataModel):
                                              ''.join(params[3:6]), params[6]]))
                 model.meta.group_id = group_id
             except TypeError:
-                params_dict = dict(zip(unique_exposure_parameters, params))
-                bad_params = {'meta.observation.'+k:v for k, v in params_dict.items() if not v}
-                warnings.warn(
-                    'Cannot determine grouping of exposures: '
-                    '{}'.format(bad_params)
-                    )
                 model.meta.group_id = 'exposure{0:04d}'.format(i + 1)
 
     @property

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -17,8 +17,15 @@ from astropy.wcs import WCS
 
 import asdf
 from asdf import AsdfFile
-from asdf import yamlutil
+from asdf import yamlutil, treeutil
 from asdf import schema as asdf_schema
+
+try:
+    from asdf.treeutil import RemoveNode
+except ImportError:
+    # Prior to asdf 2.8, None was used to indicate
+    # that a node should be removed.
+    RemoveNode = None
 
 from . import ndmodel
 from . import filetype
@@ -438,6 +445,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         # Enforce model_type to be the actual type of model being saved.
         self.meta.model_type = self._model_type
+
+        # Remove None nodes from the tree:
+        def _remove_none(node):
+            if node is None:
+                return RemoveNode
+            else:
+                return node
+
+        self._instance = treeutil.walk_and_modify(self._instance, _remove_none)
 
     def save(self, path, dir_path=None, *args, **kwargs):
         """

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -891,3 +891,17 @@ def test_getarray_noinit_noinit():
     except AttributeError:
         pass
     assert 'area' not in model.instance
+
+
+@pytest.mark.parametrize("filename", ["null.fits", "null.asdf"])
+def test_skip_serializing_null(tmpdir, filename):
+    """Make sure that None is not written out to the ASDF tree"""
+    path = str(tmpdir.join(filename))
+    with DataModel() as model:
+        model.meta.telescope = None
+        model.save(path)
+
+    with DataModel(path) as model:
+        # Make sure that 'telescope' is not in the tree
+        with pytest.raises(KeyError):
+            assert model.meta["telescope"] is None

--- a/jwst/dq_init/tests/test_dq_init.py
+++ b/jwst/dq_init/tests/test_dq_init.py
@@ -194,9 +194,11 @@ def test_dq_subarray():
     ref_data.meta.subarray.xsize = fullxsize
     ref_data.meta.subarray.ystart = 1
     ref_data.meta.subarray.ysize = fullysize
-
-    # Filter out validation warnings from ref_data
-    warnings.filterwarnings("ignore", category=ValidationWarning)
+    ref_data.meta.description = "foo"
+    ref_data.meta.reftype = "mask"
+    ref_data.meta.author = "pytest"
+    ref_data.meta.pedigree = "foo"
+    ref_data.meta.useafter = "2000-01-01T00:00:00"
 
     # run correction step
     outfile = do_dqinit(im, ref_data)

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -213,7 +213,8 @@ class ResampleSpecData:
             wavelength_array = np.flip(wavelength_array,axis=None)
 
         pix_to_wavelength = Tabular1D(lookup_table=wavelength_array,
-                                      bounds_error=False, name='pix2wavelength')
+                                      bounds_error=False, fill_value=None,
+                                      name='pix2wavelength')
 
         # Tabular models need an inverse explicitly defined.
         # If the wavelength array is decending instead of ascending, both
@@ -227,7 +228,8 @@ class ResampleSpecData:
             lookup_table = lookup_table[::-1]
         pix_to_wavelength.inverse = Tabular1D(points=points,
                                               lookup_table=lookup_table,
-                                              bounds_error=False, name='wavelength2pix')
+                                              bounds_error=False, fill_value=None,
+                                              name='wavelength2pix')
 
         # For the input mapping, duplicate the spatial coordinate
         mapping = Mapping((spatial_axis, spatial_axis, spectral_axis))

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -390,7 +390,7 @@ class ResampleSpecData:
             output_model.meta.resample.weight_type = self.drizpars['weight_type']
             output_model.meta.resample.pointings = pointings
 
-            # Update mutlislit slit info on the output_model. This is needed
+            # Update slit info on the output_model. This is needed
             # because model.slit attributes are not in model.meta, so the
             # normal update() method doesn't work with them.
             for attr in ['name', 'xstart', 'xsize', 'ystart', 'ysize',

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -213,7 +213,7 @@ class ResampleSpecData:
             wavelength_array = np.flip(wavelength_array,axis=None)
 
         pix_to_wavelength = Tabular1D(lookup_table=wavelength_array,
-                                      bounds_error=False, fill_value=None, name='pix2wavelength')
+                                      bounds_error=False, name='pix2wavelength')
 
         # Tabular models need an inverse explicitly defined.
         # If the wavelength array is decending instead of ascending, both
@@ -227,7 +227,7 @@ class ResampleSpecData:
             lookup_table = lookup_table[::-1]
         pix_to_wavelength.inverse = Tabular1D(points=points,
                                               lookup_table=lookup_table,
-                                              bounds_error=False, fill_value=None, name='wavelength2pix')
+                                              bounds_error=False, name='wavelength2pix')
 
         # For the input mapping, duplicate the spatial coordinate
         mapping = Mapping((spatial_axis, spatial_axis, spectral_axis))
@@ -390,7 +390,9 @@ class ResampleSpecData:
             output_model.meta.resample.weight_type = self.drizpars['weight_type']
             output_model.meta.resample.pointings = pointings
 
-            # Update mutlislit slit info on the output_model
+            # Update mutlislit slit info on the output_model. This is needed
+            # because model.slit attributes are not in model.meta, so the
+            # normal update() method doesn't work with them.
             for attr in ['name', 'xstart', 'xsize', 'ystart', 'ysize',
                          'slitlet_id', 'source_id', 'source_name', 'source_alias',
                          'stellarity', 'source_type', 'source_xpos', 'source_ypos',
@@ -400,7 +402,8 @@ class ResampleSpecData:
                 except AttributeError:
                     pass
                 else:
-                    setattr(output_model, attr, val)
+                    if val is not None:
+                        setattr(output_model, attr, val)
 
             self.output_models.append(output_model)
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -110,7 +110,8 @@ class ResampleSpecStep(ResampleStep):
             # Everything resampled to single output model
             if len(drizzled_models) == 1:
                 result.slits.append(drizzled_models[0])
-                result.slits[-1].meta.bunit_data = container[0].meta.bunit_data
+                if container[0].meta.bunit_data is not None:
+                    result.slits[0].meta.bunit_data = container[0].meta.bunit_data
             else:
                 # When each input is resampled to its own output
                 for model in drizzled_models:

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -111,7 +111,7 @@ class ResampleSpecStep(ResampleStep):
             if len(drizzled_models) == 1:
                 result.slits.append(drizzled_models[0])
                 if container[0].meta.bunit_data is not None:
-                    result.slits[0].meta.bunit_data = container[0].meta.bunit_data
+                    result.slits[-1].meta.bunit_data = container[0].meta.bunit_data
             else:
                 # When each input is resampled to its own output
                 for model in drizzled_models:


### PR DESCRIPTION
From `asdf 2.8` onwards, `None` will not be stripped from the ASDF tree before serialization.  But `jwst.datamodels` currently depends on this behavior for a variety of reasons.

Lots of pipeline steps populate things in `meta` with `None`.  If we don't strip `None`, it causes a validation error for many of the items in our schemas, because `None` is not an allowed type.  The schema is expecting a string or number, not `None`.

So the solution is to strip any `None` values before save, and avoid populating attributes with `None` internally.

Other clean up:
 - warnings were being emitted by `ModelContainer` for instruments that were not NIRCam.  A useless warning that I put in several years ago to detect malformed NIRCam simulated data.  No longer needed.

HT: @eslavich for way forward and the first commit.  🚀 

Resolves #5314 / [JP-1679](https://jira.stsci.edu/browse/JP-1679)