### PR TITLE
JP-1645 Supress CRDS unknown reftype errors while retrieving step parameter reference files.

### DIFF
--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -11,6 +11,7 @@ class StepWithReference(Step):
     reference_file_types = ['flat']
 
     def process(self, data):
+        self.log.debug(f'Finding flat for {data}')
         return data
 
 

--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -38,8 +38,8 @@ class CrdsStep(Step):
 
 def test_steppars_error_supression(_jail, caplog):
     """Test supression of CRDS errors while retrieving step parameters"""
-    model = datamodels.ImageModel((10, 10))
-    model.save('image.fits')
+    with datamodels.ImageModel((10, 10)) as model:
+        model.save('image.fits')
 
     args = ['jwst.stpipe.tests.steps.WithDefaultsStep', 'image.fits']
     Step.from_cmdline(args)

--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -6,9 +6,11 @@ import pytest
 
 from astropy.io import fits
 
+import crds
+from jwst import datamodels
+
 from .. import Step
 from ..import crds_client
-import crds
 
 TMP_DIR = None
 TMP_FITS = None
@@ -32,6 +34,17 @@ class CrdsStep(Step):
         with datamodels.open(input_file) as dm:
             self.ref_filename = self.get_reference_file(dm, 'flat')
         return datamodels.DataModel()
+
+
+def test_steppars_error_supression(_jail, caplog):
+    """Test supression of CRDS errors while retrieving step parameters"""
+    model = datamodels.ImageModel((10, 10))
+    model.save('image.fits')
+
+    args = ['jwst.stpipe.tests.steps.WithDefaultsStep', 'image.fits']
+    Step.from_cmdline(args)
+
+    assert 'pars-withdefaultsstep' not in caplog.text
 
 
 def test_crds_step():


### PR DESCRIPTION
Resolves [JP-1645](https://jira.stsci.edu/browse/JP-1645)
Resolves #5251 

Currently, the CRDS database is sparsely populated with respect to all the possible step parameter reftypes. As such, under normal usage, it is expected to not find a requested reftype. As such, suppress CRDS errors unless debugging is in effect.