### PR TITLE
JP-1738 Implement full class deprecator decorator and use for MIRIRampModel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ datamodels
 
 - Skip serializing `None` in datamodels to be compatible with `asdf>=2.8` [#5371]
 
+- Implement full class deprecator decorator and use for MIRIRampModel [#5382]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -45,7 +45,6 @@ class RampModel(DataModel):
         self.err = self.err
 
 
-
 @deprecate_class(RampModel)
 class MIRIRampModel:
     pass

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -45,4 +45,7 @@ class RampModel(DataModel):
 
 @deprecate_class(RampModel)
 class MIRIRampModel:
-    pass
+    """A data model for 4D MIRI ramps.
+
+    This model has been deprecated. Please use `RampModel` instead.
+    """

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -1,5 +1,3 @@
-import warnings
-
 from .model_base import DataModel
 from ..lib.basic_utils import deprecate_class
 

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -1,7 +1,7 @@
 import warnings
 
 from .model_base import DataModel
-
+from ..lib.basic_utils import deprecation_helper
 
 __all__ = ['RampModel']
 
@@ -45,8 +45,7 @@ class RampModel(DataModel):
         self.err = self.err
 
 
-def MIRIRampModel(*args, **kwargs):
-    warnings.simplefilter('default')
-    warnings.warn(message="MIRIRampModel is deprecated and will be removed.  "
-        "Use RampModel.", category=DeprecationWarning)
-    return RampModel(*args, **kwargs)
+
+@deprecation_helper(RampModel)
+class MIRIRampModel:
+    pass

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -1,7 +1,7 @@
 import warnings
 
 from .model_base import DataModel
-from ..lib.basic_utils import deprecation_helper
+from ..lib.basic_utils import deprecate_class
 
 __all__ = ['RampModel']
 
@@ -46,6 +46,6 @@ class RampModel(DataModel):
 
 
 
-@deprecation_helper(RampModel)
+@deprecate_class(RampModel)
 class MIRIRampModel:
     pass

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -21,6 +21,21 @@ from jwst.datamodels import util
 MEMORY = 100  # 100 bytes
 
 
+def test_mirirampmodel_deprecation(_jail):
+    """Test that a deprecated MIRIRampModel can be opened"""
+
+    # Create a MIRIRampModel, working around the deprecation.
+    model = datamodels.RampModel((1, 1, 10, 10))
+    model.save('ramp.fits')
+    hduls = fits.open('ramp.fits', mode='update')
+    hduls[0].header['datamodl'] = 'MIRIRampModel'
+    hduls.close()
+
+    # Test it.
+    miri_ramp = datamodels.open('ramp.fits')
+    assert isinstance(miri_ramp, datamodels.RampModel)
+
+
 @pytest.fixture
 def mock_get_available_memory(monkeypatch):
     def mock(include_swap=True):

--- a/jwst/lib/basic_utils.py
+++ b/jwst/lib/basic_utils.py
@@ -2,6 +2,43 @@
 import re
 
 
+def deprecation_helper(new_class,
+                       message='"{old_class}" is deprecated and will be removed. Use {new_class}'):
+    """Deprecate a class in favor of another class
+
+    Parameters
+    ----------
+    new_class : class
+        The class/object that should be used instead
+
+    message : str
+        The deprecation warning message
+    """
+
+    # Implement the inner decorator
+    def inner(old_class):
+
+        def init(self, *args, **kwargs):
+
+            """New init for the new class to print the message"""
+            import warnings
+            warnings.simplefilter('default')
+            warnings.warn(message.format(old_class=old_class.__name__, new_class=new_class.__name__),
+                          category=DeprecationWarning)
+            new_class.__init__(self, *args, **kwargs)
+
+        # Create the class
+        deprecated = type(
+            old_class.__name__,
+            (new_class,),
+            {'__init__': init}
+        )
+
+        return deprecated
+
+    return inner
+
+
 def bytes2human(n):
     """Convert bytes to human-readable format
 

--- a/jwst/lib/basic_utils.py
+++ b/jwst/lib/basic_utils.py
@@ -2,8 +2,8 @@
 import re
 
 
-def deprecation_helper(new_class,
-                       message='"{old_class}" is deprecated and will be removed. Use {new_class}'):
+def deprecate_class(new_class,
+                    message='"{old_class}" is deprecated and will be removed. Use {new_class}'):
     """Deprecate a class in favor of another class
 
     Parameters

--- a/jwst/lib/basic_utils.py
+++ b/jwst/lib/basic_utils.py
@@ -16,11 +16,9 @@ def deprecate_class(new_class,
     """
 
     # Implement the inner decorator
-    def inner(old_class):
+    def _decorator(old_class):
 
         def init(self, *args, **kwargs):
-
-            """New init for the new class to print the message"""
             import warnings
             warnings.simplefilter('default')
             warnings.warn(message.format(old_class=old_class.__name__, new_class=new_class.__name__),
@@ -31,12 +29,15 @@ def deprecate_class(new_class,
         deprecated = type(
             old_class.__name__,
             (new_class,),
-            {'__init__': init}
+            {'__doc__': old_class.__doc__,
+             '__init__': init,
+             '__module__': old_class.__module__,
+             '__name__': old_class.__name__}
         )
 
         return deprecated
 
-    return inner
+    return _decorator
 
 
 def bytes2human(n):


### PR DESCRIPTION
Resolves [JP-1738](https://jira.stsci.edu/browse/JP-1738)
Resolves #5379 

Original deprecation implementation for `MIRIRampModel` used a function. However, this breaks tests that look for class comparisons. A class decorator, `deprecate_class` has been implement to enable full class deprecation.