### PR TITLE
JP-1726 Do not allow target acqs to be considered TSO

### DIFF
--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -358,6 +358,10 @@ class DMSBaseMixin(ACIDMixin):
         if item['pntgtype'] != 'science':
             return False
 
+        # Target acquisitions are never TSO
+        if item['exp_type'] in ACQ_EXP_TYPES:
+            return False
+
         # Setup exposure list
         all_exp_types = TSO_EXP_TYPES.copy()
         if other_exp_types:


### PR DESCRIPTION
Resolves JP-1726
Resolves #5357 

Exclude all target acquisition exposures from being processed at integrations.