### PR TITLE
Fix ami bug in analyticnrm2.psf() call

### DIFF
--- a/jwst/ami/lg_model.py
+++ b/jwst/ami/lg_model.py
@@ -230,7 +230,7 @@ class NrmModel:
         # accumulate polychromatic oversampled psf in the object
 
         for w, l in bandpass:  # w: wavelength's weight, l: lambda (wavelength)
-            self.psf_over += w * analyticnrm2.PSF(self.pixel,  # det pixel, rad
+            self.psf_over += w * analyticnrm2.psf(self.pixel,  # det pixel, rad
                                                   fov,   # in detpix number
                                                   over,
                                                   self.ctrs,


### PR DESCRIPTION
Follow on to #5390 fixing a bug:

```
/Users/jdavies/dev/jwst/jwst/ami/ami_analyze_step.py:60: in process
    result = ami_analyze.apply_LG_plus(input_model, throughput_model,
/Users/jdavies/dev/jwst/jwst/ami/ami_analyze.py:68: in apply_LG_plus
    affine2d = find_rotation(data[:,:], psf_offset_find_rotation, rotsearch_d,
/Users/jdavies/dev/jwst/jwst/ami/find_affine2d_parameters.py:108: in find_rotation
    jw.simulate(fov=npix, bandpass=bandpass, over=over, psf_offset=psf_offset)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <jwst.ami.lg_model.NrmModel object at 0x7fcbd73176a0>, fov = 80, bandpass = array([[1.0e+00, 4.3e-06]]), over = 11
psf_offset = (0.0, 0.0)

    def simulate(self, fov=None, bandpass=None, over=None, psf_offset=(0, 0)):
        '''
        Short Summary
        -------------
        Simulate a detector-scale psf using parameters input from the call and
        already stored in the object,and generate a simulation fits header
        storing all of the  parameters used to generate that psf.  If the input
        bandpass is one number it will calculate a monochromatic psf.
    
        Parameters
        ----------
        fov: integer, default=None
            number of detector pixels on a side
    
        bandpass: 2D float array, default=None
            array of the form: [(weight1, wavl1), (weight2, wavl2), ...]
    
        over: integer
            Oversampling factor
    
        psf_offset: detector pixels
            Center offset from center of array
    
        Returns
        -------
        Object's 'psf': float 2D array
            simulated psf
        '''
        self.simhdr = fits.PrimaryHDU().header
        # First set up conditions for choosing various parameters
        self.bandpass = bandpass
    
        if over is None:
            over = 1  # ?  Always comes in as integer.
    
        self.simhdr['OVER'] = (over, 'sim pix = det pix/over')
        self.simhdr['PIX_OV'] = (self.pixel/float(over),
                                 'Sim pixel scale in radians')
    
        self.psf_over = np.zeros((over*fov, over*fov))
        nspec = 0
        # accumulate polychromatic oversampled psf in the object
    
        for w, l in bandpass:  # w: wavelength's weight, l: lambda (wavelength)
>           self.psf_over += w * analyticnrm2.PSF(self.pixel,  # det pixel, rad
                                                  fov,   # in detpix number
                                                  over,
                                                  self.ctrs,
                                                  self.d, l,
                                                  self.phi,
                                                  psf_offset,  # det pixels
                                                  self.affine2d,
                                                  shape=self.holeshape)
E           AttributeError: module 'jwst.ami.analyticnrm2' has no attribute 'PSF'

/Users/jdavies/dev/jwst/jwst/ami/lg_model.py:233: AttributeError
```