### PR TITLE
Update source_catalog argument list in step docs

### DIFF
--- a/docs/jwst/source_catalog/arguments.rst
+++ b/docs/jwst/source_catalog/arguments.rst
@@ -8,16 +8,10 @@ The ``source_catalog`` step uses the following user-settable arguments:
 * ``--kernel_fwhm``: A floating-point value giving the Gaussian kernel
   FWHM in pixels [default=2.0]
 
-* ``--kernel_xsize``: A floating-point value giving the kernel x size
-  in pixels [default=5]
-
-* ``--kernel_ysize``: A floating-point value giving the kernel y size
-  in pixels [default=5]
-
 * ``--snr_threshold``: A floating-point value that sets the SNR
   threshold (above background) for source detection [default=3.0]
 
-* ``--npixels``: A integer value that sets the minimum number of
+* ``--npixels``: An integer value that sets the minimum number of
   pixels in a source [default=5]
 
 * ``--deblend``: A boolean indicating whether to deblend sources
@@ -29,9 +23,15 @@ The ``source_catalog`` step uses the following user-settable arguments:
 
 * ``--aperture_ee3``: An integer value of the largest aperture encircled energy value [default=70]
 
-* ``--ci1_star_threshold``: A floating-float value of the threshold compared to the concentration index calculated from aperture_ee1 and aperture_ee2 that is used to determine whether a source is a star. Sources must meet the criteria of both ci1_star_threshold and ci2_star_threshold to be considered a star.
+* ``--ci1_star_threshold``: A floating-float value of the threshold compared to the concentration
+  index calculated from aperture_ee1 and aperture_ee2 that is used to determine whether a source
+  is a star. Sources must meet the criteria of both ci1_star_threshold and ci2_star_threshold to be
+  considered a star.
 
-* ``--ci2_star_threshold``: A floating-float value of the threshold compared to the concentration index calculated from aperture_ee2 and aperture_ee3 that is used to determine whether a source is a star. Sources must meet the criteria of both ci1_star_threshold and ci2_star_threshold to be considered a star.
+* ``--ci2_star_threshold``: A floating-float value of the threshold compared to the concentration
+  index calculated from aperture_ee2 and aperture_ee3 that is used to determine whether a source
+  is a star. Sources must meet the criteria of both ci1_star_threshold and ci2_star_threshold to be
+  considered a star.
 
 * ``--suffix``: A string value giving the file name suffix to use for
   the output catalog file [default='cat']


### PR DESCRIPTION
Remove `kernel_xsize` and `kernel_ysize` arguments from `source_catalog` step docs, because those params were removed from the step in a recent update.