### PR TITLE
Rework handling of NO_SAT_CHECK pixels in saturation step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,13 @@ resample
 
 - Implement memory check in resample to prevent huge arrays [#5354]
 
+saturation
+----------
+
+- Set saturation threshold to A-to-D limit of 65535 for pixels flagged with
+  NO_SAT_CHECK in the saturation reference file, instead of skipping any
+  test of those pixels. [#5394]
+
 0.17.1 (2020-09-15)
 ===================
 

--- a/docs/jwst/saturation/description.rst
+++ b/docs/jwst/saturation/description.rst
@@ -3,13 +3,21 @@ Description
 
 The ``saturation`` step flags saturated pixel values. It loops over all
 integrations within an exposure, examining each one group-by-group, comparing the
-pixel values in the SCI array with defined saturation thresholds for each pixel.
+pixel values in the SCI array against pixel-by-pixel thresholds stored in a
+saturation reference file.
 When it finds a pixel value in a given group that is above the threshold, it
 sets the "SATURATED" flag in the corresponding location of the "GROUPDQ"
 array in the science exposure. It also flags all subsequent groups for that
 pixel as saturated. For example, if there are 10 groups in an integration and
 group 7 is the first one to cross the saturation threshold for a given pixel,
 then groups 7 through 10 will all be flagged for that pixel.
+
+Pixels with thresholds set to NaN or flagged as "NO_SAT_CHECK" in the saturation
+reference file have their thresholds set to the 16-bit A-to-D converter limit
+of 65535 and hence will only be flagged as saturated if the pixel reaches that
+hard limit in at least one group. The "NO_SAT_CHECK" flag is propagated to the
+PIXELDQ array in the output science data to indicate which pixels fall into
+this category.
 
 NIRSpec data acquired using the "IRS2" readout pattern require special
 handling in this step, due to the extra reference pixel values that are interleaved
@@ -36,10 +44,6 @@ extra entries for these pixels. The step-by-step process is as follows:
 - For each group in the input science data, set the "SATURATION" flag in the
   "GROUPDQ" array if the pixel value is greater than or equal to the saturation
   threshold from the reference file
-
-Note that pixels set to NaN or flagged as "NO_SAT_CHECK" in the saturation
-reference file do not receive any saturation checking by this step. They are
-simply flagged as "NO_SAT_CHECK" in the output science data.
 
 Subarrays
 =========

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -99,7 +99,7 @@ def do_correction(input_model, ref_model):
     # Save the saturation flags in the output GROUPDQ array
     output_model.groupdq = groupdq
 
-    n_sat = len(np.where(np.any(np.any(groupdq, axis=0), axis=0))[0])
+    n_sat = np.any(np.any(np.bitwise_and(groupdq, sat_flag), axis=0), axis=0).sum()
     log.info(f'Detected {n_sat} saturated pixels')
 
     # Save the NO_SAT_CHECK flags in the output PIXELDQ array

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -1,4 +1,4 @@
-#
+
 #  Module for 2d saturation
 #
 import logging
@@ -13,6 +13,8 @@ import numpy as np
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+SATURATED = dqflags.pixel['SATURATED']
+NO_SAT_CHECK = dqflags.pixel['NO_SAT_CHECK']
 ATOD_LIMIT = 65535.  # Hard DN limit of 16-bit A-to-D converter
 
 
@@ -40,7 +42,6 @@ def do_correction(input_model, ref_model):
     ramp_array = input_model.data
     nints = ramp_array.shape[0]
     ngroups = ramp_array.shape[1]
-    sat_flag = dqflags.group['SATURATED']
     detector = input_model.meta.instrument.detector
 
     # If NIRSpec IRS2 readout mode was used, create a mask
@@ -65,15 +66,13 @@ def do_correction(input_model, ref_model):
         ref_sub_model.close()
 
     # For pixels flagged in reference file as NO_SAT_CHECK,
-    # set the output dq mask to NO_SAT_CHECK and set the
-    # saturation check threshold to the A-to-D converter limit.
-    wh_sat = np.bitwise_and(sat_dq, dqflags.pixel['NO_SAT_CHECK'])
-    sat_dq[wh_sat == dqflags.pixel['NO_SAT_CHECK']] = dqflags.pixel['NO_SAT_CHECK']
-    sat_thresh[wh_sat == dqflags.pixel['NO_SAT_CHECK']] = ATOD_LIMIT
-    del wh_sat
+    # set the saturation check threshold to the A-to-D converter limit.
+    sat_thresh[np.bitwise_and(sat_dq, NO_SAT_CHECK) == NO_SAT_CHECK] = ATOD_LIMIT
 
-    # Reset NaN values in the saturation threshold array
-    correct_for_NaN(sat_thresh, sat_dq)
+    # Also reset NaN values in the saturation threshold array to the
+    # A-to-D limit and flag them with NO_SAT_CHECK
+    sat_dq[np.isnan(sat_thresh)] |= NO_SAT_CHECK
+    sat_thresh[np.isnan(sat_thresh)] = ATOD_LIMIT
 
     # Loop over integrations and groups, checking for pixel values
     # that are above the saturation threshold
@@ -86,20 +85,20 @@ def do_correction(input_model, ref_model):
                 sci_temp = x_irs2.from_irs2(ramp_array[ints, group, :, :],
                                             irs2_mask,
                                             detector)
-                flag_temp = np.where(sci_temp >= sat_thresh, sat_flag, 0)
+                flag_temp = np.where(sci_temp >= sat_thresh, SATURATED, 0)
                 # Copy flag_temp into flagarray.
                 x_irs2.to_irs2(flagarray, flag_temp, irs2_mask, detector)
 
             else:
                 flagarray[:, :] = np.where(ramp_array[ints, group, :, :] >= sat_thresh,
-                                           sat_flag, 0)
+                                           SATURATED, 0)
             np.bitwise_or(groupdq[ints, group:, :, :], flagarray,
                           groupdq[ints, group:, :, :])
 
     # Save the saturation flags in the output GROUPDQ array
     output_model.groupdq = groupdq
 
-    n_sat = np.any(np.any(np.bitwise_and(groupdq, sat_flag), axis=0), axis=0).sum()
+    n_sat = np.any(np.any(np.bitwise_and(groupdq, SATURATED), axis=0), axis=0).sum()
     log.info(f'Detected {n_sat} saturated pixels')
 
     # Save the NO_SAT_CHECK flags in the output PIXELDQ array
@@ -112,36 +111,3 @@ def do_correction(input_model, ref_model):
         output_model.pixeldq = np.bitwise_or(output_model.pixeldq, sat_dq)
 
     return output_model
-
-
-def correct_for_NaN(satmask, dqmask):
-    """
-    Short Summary
-    -------------
-    If there are NaNs in the saturation values in the reference file, reset
-    them to a very high value such that the comparison never results in a
-    positive (saturated) result for the associated pixels in the science data.
-    Also reset the associated dqmask values to indicate that, effectively,
-    no saturation check will be done for those pixels.
-
-    Parameters
-    ----------
-    satmask : 2-d array
-        Subarray of saturation thresholds, from the saturation reference
-        file.  This may be modified in-place.
-
-    dqmask : ndarray, same shape as `satmask`
-        The DQ array from the saturation reference file, used to update
-        the PIXELDQ array in the output.  This may be modified in-place.
-    """
-    # If there are NaNs as the saturation values, update those values
-    # to the A-to-D converter limit.
-    wh_nan = np.isnan(satmask)
-
-    if np.any(wh_nan):
-        satmask[wh_nan] = ATOD_LIMIT
-        dqmask[wh_nan] |= dqflags.pixel['NO_SAT_CHECK']
-
-        log.info("Unflagged pixels having saturation values set to NaN were"
-                 " detected in the ref file; for those affected pixels no"
-                 " saturation check will be made.")

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -13,89 +13,103 @@ import numpy as np
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-HUGE_NUM = 100000.
+ATOD_LIMIT = 65535.  # Hard DN limit of 16-bit A-to-D converter
+
 
 def do_correction(input_model, ref_model):
     """
     Short Summary
     -------------
-    Execute all tasks for saturation, including using a saturation reference
-    file.
+    Apply saturation flagging based on threshold values stored in the
+    saturation reference file.
 
     Parameters
     ----------
-    input_model: data model object
+    input_model : `~jwst.datamodels.RampModel`
         The input science data to be corrected
 
-    ref_model: data model object
-        Saturation reference file mode object
+    ref_model : `~jwst.datamodels.SaturationModel`
+        Saturation reference file data model
 
     Returns
     -------
-    output_model: data model object
-        object having GROUPDQ array saturation flags set
+    output_model : `~jwst.datamodels.RampModel`
+        Data model with saturation flags set in GROUPDQ array
     """
 
-    ramparr = input_model.data
-    # Was IRS2 readout used?
+    ramp_array = input_model.data
+    nints = ramp_array.shape[0]
+    ngroups = ramp_array.shape[1]
+    sat_flag = dqflags.group['SATURATED']
+    detector = input_model.meta.instrument.detector
+
+    # If NIRSpec IRS2 readout mode was used, create a mask
+    # of the appropriate size
     is_irs2_format = pipe_utils.is_irs2(input_model)
     if is_irs2_format:
         irs2_mask = x_irs2.make_mask(input_model)
 
-   # Create the output model as a copy of the input
+    # Create the output model as a copy of the input
     output_model = input_model.copy()
     groupdq = output_model.groupdq
 
-    # Extract subarray from reference file, if necessary
+    # Extract subarray from saturation reference file, if necessary
     if reffile_utils.ref_matches_sci(input_model, ref_model):
-        satmask = ref_model.data
-        dqmask = ref_model.dq
+        sat_thresh = ref_model.data
+        sat_dq = ref_model.dq
     else:
         log.info('Extracting reference file subarray to match science data')
         ref_sub_model = reffile_utils.get_subarray_model(input_model, ref_model)
-        satmask = ref_sub_model.data.copy()
-        dqmask = ref_sub_model.dq.copy()
+        sat_thresh = ref_sub_model.data.copy()
+        sat_dq = ref_sub_model.dq.copy()
         ref_sub_model.close()
 
-    # For pixels flagged in reference file as NO_SAT_CHECK, set the dq mask
-    #   and saturation mask
-    wh_sat = np.bitwise_and(dqmask, dqflags.pixel['NO_SAT_CHECK'])
-    dqmask[wh_sat == dqflags.pixel['NO_SAT_CHECK']] = dqflags.pixel['NO_SAT_CHECK']
-    satmask[wh_sat == dqflags.pixel['NO_SAT_CHECK']] = HUGE_NUM
-    # Correct saturation values for NaNs in the ref file
-    correct_for_NaN(satmask, dqmask)
+    # For pixels flagged in reference file as NO_SAT_CHECK,
+    # set the output dq mask to NO_SAT_CHECK and set the
+    # saturation check threshold to the A-to-D converter limit.
+    wh_sat = np.bitwise_and(sat_dq, dqflags.pixel['NO_SAT_CHECK'])
+    sat_dq[wh_sat == dqflags.pixel['NO_SAT_CHECK']] = dqflags.pixel['NO_SAT_CHECK']
+    sat_thresh[wh_sat == dqflags.pixel['NO_SAT_CHECK']] = ATOD_LIMIT
+    del wh_sat
 
-    dq_flag = dqflags.group['SATURATED']
+    # Reset NaN values in the saturation threshold array
+    correct_for_NaN(sat_thresh, sat_dq)
 
-    nints = ramparr.shape[0]
-    ngroups = ramparr.shape[1]
-
-    detector = input_model.meta.instrument.detector
-    flagarray = np.zeros(ramparr.shape[-2:], dtype=groupdq.dtype)
+    # Loop over integrations and groups, checking for pixel values
+    # that are above the saturation threshold
+    flagarray = np.zeros(ramp_array.shape[-2:], dtype=groupdq.dtype)
     for ints in range(nints):
-        for plane in range(ngroups):
+        for group in range(ngroups):
             # Update the 4D groupdq array with the saturation flag. The
-            # flag is set in the current plane and all following planes.
+            # flag is set in the current group and all following groups.
             if is_irs2_format:
-                sci_temp = x_irs2.from_irs2(ramparr[ints, plane, :, :],
-                                            irs2_mask, detector)
-                flag_temp = np.where(sci_temp >= satmask, dq_flag, 0)
+                sci_temp = x_irs2.from_irs2(ramp_array[ints, group, :, :],
+                                            irs2_mask,
+                                            detector)
+                flag_temp = np.where(sci_temp >= sat_thresh, sat_flag, 0)
                 # Copy flag_temp into flagarray.
                 x_irs2.to_irs2(flagarray, flag_temp, irs2_mask, detector)
-            else:
-                flagarray[:, :] = np.where(ramparr[ints, plane, :, :] >= satmask,
-                                          dq_flag, 0)
-            np.bitwise_or(groupdq[ints, plane:, :, :], flagarray,
-                          groupdq[ints, plane:, :, :])
 
+            else:
+                flagarray[:, :] = np.where(ramp_array[ints, group, :, :] >= sat_thresh,
+                                           sat_flag, 0)
+            np.bitwise_or(groupdq[ints, group:, :, :], flagarray,
+                          groupdq[ints, group:, :, :])
+
+    # Save the saturation flags in the output GROUPDQ array
     output_model.groupdq = groupdq
+
+    n_sat = len(np.where(np.any(np.any(groupdq, axis=0), axis=0))[0])
+    log.info(f'Detected {n_sat} saturated pixels')
+
+    # Save the NO_SAT_CHECK flags in the output PIXELDQ array
     if is_irs2_format:
         pixeldq_temp = x_irs2.from_irs2(output_model.pixeldq, irs2_mask,
                                         detector)
-        pixeldq_temp = np.bitwise_or(pixeldq_temp, dqmask)
+        pixeldq_temp = np.bitwise_or(pixeldq_temp, sat_dq)
         x_irs2.to_irs2(output_model.pixeldq, pixeldq_temp, irs2_mask, detector)
     else:
-        output_model.pixeldq = np.bitwise_or(output_model.pixeldq, dqmask)
+        output_model.pixeldq = np.bitwise_or(output_model.pixeldq, sat_dq)
 
     return output_model
 
@@ -112,20 +126,20 @@ def correct_for_NaN(satmask, dqmask):
 
     Parameters
     ----------
-    satmask: 2-d array
+    satmask : 2-d array
         Subarray of saturation thresholds, from the saturation reference
         file.  This may be modified in-place.
 
-    dqmask: ndarray, same shape as `satmask`
+    dqmask : ndarray, same shape as `satmask`
         The DQ array from the saturation reference file, used to update
         the PIXELDQ array in the output.  This may be modified in-place.
     """
     # If there are NaNs as the saturation values, update those values
-    #     to ensure there will not be saturation.
+    # to the A-to-D converter limit.
     wh_nan = np.isnan(satmask)
 
     if np.any(wh_nan):
-        satmask[wh_nan] = HUGE_NUM
+        satmask[wh_nan] = ATOD_LIMIT
         dqmask[wh_nan] |= dqflags.pixel['NO_SAT_CHECK']
 
         log.info("Unflagged pixels having saturation values set to NaN were"

--- a/jwst/saturation/tests/test_saturation.py
+++ b/jwst/saturation/tests/test_saturation.py
@@ -195,7 +195,7 @@ def test_nans_in_mask(setup_nrc_cube):
     ngroups = 5
     nrows = 2048
     ncols = 2048
-    huge_num = 100000.
+    ATOD_LIMIT = 65535.
 
     data, satmap = setup_nrc_cube(ngroups, nrows, ncols)
 
@@ -213,11 +213,11 @@ def test_nans_in_mask(setup_nrc_cube):
     correct_for_NaN(satmap.data, satmap.dq)
     output = do_correction(data, satmap)
 
-    # Check that NaN reference value gets reset to HUGE_NUM
+    # Check that NaN reference value gets reset to ATOD_LIMIT
     # Check that reference DQ is set to NO_SAT_CHECK
     # Check that output GROUPDQ is not flagged as saturated
     # Check that output PIXELDQ is set to NO_SAT_CHECK
-    assert satmap.data[500, 500] == huge_num
+    assert satmap.data[500, 500] == ATOD_LIMIT
     assert satmap.dq[500, 500] == dqflags.pixel['NO_SAT_CHECK']
     assert np.all(output.groupdq[0, :, 500, 500] != dqflags.group['SATURATED'])
     assert output.pixeldq[500, 500] == dqflags.pixel['NO_SAT_CHECK']

--- a/jwst/saturation/tests/test_saturation.py
+++ b/jwst/saturation/tests/test_saturation.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 
 from jwst.saturation import SaturationStep
-from jwst.saturation.saturation import do_correction, ATOD_LIMIT
+from jwst.saturation.saturation import do_correction
 from jwst.datamodels import RampModel, SaturationModel, dqflags
 
 
@@ -131,7 +131,7 @@ def test_subarray_extraction(setup_miri_cube):
     # Check that pixel was flagged 'NO_SAT_CHECK' and that original
     # DQ flag persists (i.e. did not get overwritten)
     assert(output.pixeldq[84, 100] ==
-        dqflags.pixel['NO_SAT_CHECK']) + dqflags.pixel['NONLINEAR']
+           dqflags.pixel['NO_SAT_CHECK'] + dqflags.pixel['NONLINEAR'])
 
 
 def test_dq_propagation(setup_nrc_cube):
@@ -218,11 +218,9 @@ def test_nans_in_mask(setup_nrc_cube):
     # Run the pipeline
     output = do_correction(data, satmap)
 
-    # Check that NaN reference value gets reset to ATOD_LIMIT
-    # Check that reference DQ is set to NO_SAT_CHECK
     # Check that output GROUPDQ is not flagged as saturated
-    # Check that output PIXELDQ is set to NO_SAT_CHECK
     assert np.all(output.groupdq[0, :, 5, 5] != dqflags.group['SATURATED'])
+    # Check that output PIXELDQ is set to NO_SAT_CHECK
     assert output.pixeldq[5, 5] == dqflags.pixel['NO_SAT_CHECK']
 
 
@@ -247,10 +245,10 @@ def test_full_step(setup_nrc_cube):
     output = SaturationStep.call(data)
 
     # Check that correct pixel and group 3+ are flagged as saturated
-    # Check that other pixel and groups are not flagged
     assert dqflags.group['SATURATED'] == np.max(output.groupdq[0, :, 5, 5])
-    assert np.all(output.groupdq[0, :3, 5, 5] != dqflags.group['SATURATED'])
     assert np.all(output.groupdq[0, 3:, 5, 5] == dqflags.group['SATURATED'])
+    # Check that other pixel and groups are not flagged
+    assert np.all(output.groupdq[0, :3, 5, 5] != dqflags.group['SATURATED'])
     assert np.all(output.groupdq[0, :, 10, 10] != dqflags.group['SATURATED'])
 
 


### PR DESCRIPTION
Rework the way the saturation step handles pixels flagged with NO_SAT_CHECK in the saturation reference file. There are many occasions where pixels are flagged this way because they never actually go into full-well saturation before hitting the 16-bit A-to-D converter limit of 65535 DN (so no full-well saturation threshold can be determine). This leaves pixels unflagged in the science data, even though they have one or more groups in which the values are pegged at 65535. Without flagging, the ramp_fit step tries to do a fit and results in nonsensical slopes. So this change sets the saturation flagging threshold for NO_SAT_CHECK pixels at 65535, so any that are pegged at that value will get flagged as saturated and hence ramp_fit will ignore them.

This is a follow-on to the saturation-related updates in JP-1731. 