### PR TITLE
Add environmental and pytest argument parameters to the Jenkins build parameters

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -17,9 +17,9 @@ if (env.ARTIFACTORY_ENV) {
     artifactoryenv = env.ARTIFACTORY_ENV
 }
 
-test_items = ""
-if (env.TEST_ITEMS) {
-    test_items = env.TEST_ITEMS
+pytest_args = ""
+if (env.PYTEST_ARGS) {
+    test_items = env.PYTEST_ARGS
 }
 
 withCredentials([string(
@@ -78,7 +78,7 @@ bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
-    --env=${artifactoryenv} ${test_items}",
+    --env=${artifactoryenv} ${pytest_args}",
 ]
 bc0.test_configs = [data_config]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -18,7 +18,7 @@ def MultiLineToArray(String reqs) {
         return result
     }
     for (req in reqs.split('\n')) {
-        result += $req
+        result += req
     }
     return result
 }

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -19,7 +19,7 @@ if (env.ARTIFACTORY_ENV) {
 
 pytest_args = ""
 if (env.PYTEST_ARGS) {
-    test_items = env.PYTEST_ARGS
+    pytest_args = env.PYTEST_ARGS
 }
 
 withCredentials([string(

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -17,6 +17,11 @@ if (env.ARTIFACTORY_ENV) {
     artifactoryenv = env.ARTIFACTORY_ENV
 }
 
+test_items = ""
+if (env.TEST_ITEMS) {
+    test_items = env.TEST_ITEMS
+}
+
 withCredentials([string(
     credentialsId: 'jwst-codecov',
     variable: 'codecov_token')]) {
@@ -39,6 +44,9 @@ env_vars = [
 //    "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
     "CRDS_CONTEXT=jwst-edit",
 ]
+if (env.ENV_VARS) {
+    env_vars.addAll(PipInject(env.ENV_VARS))
+}
 
 // Set pytest basetemp output directory
 pytest_basetemp = "test_outputs"
@@ -70,7 +78,7 @@ bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
-    --env=${artifactoryenv}",
+    --env=${artifactoryenv} ${test_items}",
 ]
 bc0.test_configs = [data_config]
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -12,6 +12,17 @@ def PipInject(String reqs) {
     return result
 }
 
+def MultiLineToArray(String reqs) {
+    def result = []
+    if (reqs.trim().isEmpty()) {
+        return result
+    }
+    for (req in reqs.split('\n')) {
+        result += $req
+    }
+    return result
+}
+
 artifactoryenv = "dev"
 if (env.ARTIFACTORY_ENV) {
     artifactoryenv = env.ARTIFACTORY_ENV
@@ -45,7 +56,7 @@ env_vars = [
     "CRDS_CONTEXT=jwst-edit",
 ]
 if (env.ENV_VARS) {
-    env_vars.addAll(PipInject(env.ENV_VARS))
+    env_vars.addAll(MultiLineToArray(env.ENV_VARS))
 }
 
 // Set pytest basetemp output directory


### PR DESCRIPTION
Adding two new build parameters to the Jenkins build. Neither of these parameters need be defined in the Jenkins build; defaults will be used.

PYTEST_ARGS: A `String` parameter that specifies the additional arguments to the `pytest` command, nominally the list of files to include in the test. If unspecified or blank, all files in the project will be considered for testing. For example, to search for tests in only `jwst/regtest`, set to:

```
jwst/regtest
```

ENV_VARS: A `MultiLine String` specifying a list of environmental variables to set. If unspecified or blank, no extra envrionmental variables are set. For example, to change the CRDS server to use the DEV server:

```
CRDS_PATH=/data1/crds_caches/crds_cache_dev
CRDS_SERVER_URL=https://jwst-crds-dev.stsci.edu
```

Note about the above example: The path is a path on the Jenkins server, currently `jwcalibdev`. Any path writeable by the Jenkins process can be used. The example does show a valid path.