### PR TITLE
Fix construction of int_times table in test

### DIFF
--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -683,7 +683,7 @@ def setup_inputs(ngroups=10, readnoise=10, nints=1,
     pixdq = np.zeros(shape=(nrows, ncols), dtype= np.float64)
     read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
-    int_times = np.zeros((nints,7))
+    int_times = np.zeros((nints,))
     model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, int_times=int_times)
     model1.meta.instrument.name='MIRI'
     model1.meta.instrument.detector='MIRIMAGE'


### PR DESCRIPTION
The original version of the test created `int_times` like this:

```
int_times = np.zeros((nints,7))
```

but when this was passed to `np.asanyarray` with the table's dtype, the result was a nints x 7 array of records, each with 7 fields, for a total of 245 numbers.  In other words, the single 0 at each array index was being broadcast to a full record.  I don't think this was the intended result, but we were getting away with it before due to a recently resolved [bug in astropy](https://github.com/astropy/astropy/pull/10768).

The new code:

```
int_times = np.zeros((nints,))
```

results in nints records, each with 7 fields, for a total of 35 numbers.  I confirmed that `test_int_times` now passes with both astropy 4.0.1 and 4.0.2 (the latter contains the bug fix).

Thanks @jdavies-st for suggesting that the test wasn't set up right!

Resolves https://github.com/spacetelescope/jwst/issues/5381