### PR TITLE
JP-1735: Reduce jump step memory usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,11 @@ flatfield
 
 - Updated branch logic to handle NRS_LAMP exposures as spectroscopic. [#5370]
 
+jump
+----
+
+- Various rework to reduce memory usage and increase readability. [#5404]
+
 master_background
 -----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2064,10 +2064,12 @@ imprint
 
 ipc
 ---
+
 - Updated the docstrings [#2822]
 
 jump
 ----
+
  - Updated twopoint_difference.py to not use groups with groupdq set to DO_NOT_USE [#3495]
 
 jwpsf

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -506,7 +506,7 @@ def test_proc(setup_inputs):
     ngroups = 10
 
     model1, gdq, rnModel, pixdq, err, gain = \
-        setup_inputs( ngroups=ngroups, nrows=5, ncols=6, nints=2, gain=ingain, readnoise=inreadnoise,
+        setup_inputs( ngroups=ngroups, nrows=25, ncols=6, nints=2, gain=ingain, readnoise=inreadnoise,
                       deltatime=grouptime )
 
     model1.data[0, 0, 2, 3] = 15.0
@@ -520,11 +520,11 @@ def test_proc(setup_inputs):
     model1.data[0, 8, 2, 3] = 170.0
     model1.data[0, 9, 2, 3] = 180.0
 
-    out_model_a = detect_jumps( model1, gain, rnModel, 4.0, 'half', 200, 4, True )
-    out_model_b = detect_jumps( model1, gain, rnModel, 4.0, None, 200, 4, True )
+    out_model_a = detect_jumps( model1, gain, rnModel, 4.0, None, 200, 4, True )
+    out_model_b = detect_jumps( model1, gain, rnModel, 4.0, 'half', 200, 4, True )
     assert( out_model_a.groupdq == out_model_b.groupdq ).all()
 
-    out_model_c = detect_jumps( model1, gain, rnModel, 4.0, 'All', 200, 4, True )
+    out_model_c = detect_jumps( model1, gain, rnModel, 4.0, 'all', 200, 4, True )
     assert( out_model_a.groupdq == out_model_c.groupdq ).all()
 
 
@@ -538,7 +538,7 @@ def test_adjacent_CRs( setup_inputs ):
     inreadnoise = np.float64(7)
     ngroups = 10
     model1, gdq, rnModel, pixdq, err, gain = \
-        setup_inputs( ngroups=ngroups, nrows=5, ncols=6, gain=ingain,
+        setup_inputs( ngroups=ngroups, nrows=15, ncols=6, gain=ingain,
                       readnoise=inreadnoise, deltatime=grouptime )
 
     # Populate arrays for 1st CR, centered at (x=2, y=3)
@@ -611,13 +611,14 @@ def setup_inputs():
 
         pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
         read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
-        gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint32)
         if subarray:
             data = np.zeros(shape=(nints, ngroups, 20, 20), dtype=np.float64)
             err = np.ones(shape=(nints, ngroups, 20, 20), dtype=np.float64)
+            gdq = np.zeros(shape=(nints, ngroups, 20, 20), dtype=np.uint32)
         else:
             data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
             err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
+            gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint32)
         model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
         model1.meta.instrument.name = 'MIRI'
         model1.meta.instrument.detector = 'MIRIMAGE'

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 
 from jwst.datamodels import GainModel, ReadnoiseModel
@@ -139,6 +140,80 @@ def test_twoints_onecr_each_10_groups_neighbors_flagged(setup_inputs):
     assert (4 == out_model.groupdq[1, 7, 15, 4])
     assert (4 == out_model.groupdq[1, 7, 16, 5])
     assert (4 == out_model.groupdq[1, 7, 14, 5])
+
+def test_multiple_neighbor_jumps_firstlastbad(setup_inputs):
+    grouptime = 3.0
+    ingain = 5.5
+    inreadnoise = 6.5
+    ngroups = 10
+    nrows = 10
+    ncols = 10
+
+    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(
+        ngroups=ngroups, nints=1, nrows=nrows, ncols=ncols,
+        gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+
+    model1.data[0,:,1,1] = [10019.966, 10057.298, 10078.248, 10096.01,
+       20241.627, 20248.752, 20268.047, 20284.895, 20298.705, 20314.25]
+    model1.data[0,:,1,2] = [10016.457, 10053.907, 10063.568, 10076.166,
+       11655.773, 11654.063, 11681.795, 11693.763, 11712.788, 11736.994]
+    model1.data[0,:,1,3] = [10013.259, 10050.348, 10070.398, 10097.658, 10766.534, 10787.84 ,
+       10802.418, 10818.872, 10832.695, 10861.175]
+    model1.data[0,:,1,4] = [10016.422, 10053.959, 10070.934, 10090.381, 10104.014, 10127.665,
+       10143.687, 10172.227, 10178.138, 10199.59]
+    model1.data[0,:,2,1] = [10021.067, 10042.973, 10059.062, 10069.323, 18732.406, 18749.602,
+       18771.908, 18794.695, 18803.223, 18819.523]
+    model1.data[0,:,2,2] = [10019.651, 10043.371, 10056.423, 10085.121, 40584.703, 40606.08 ,
+       40619.51 , 40629.574, 40641.9  , 40660.145]
+    model1.data[0,:,2,3] = [10021.223, 10042.112, 10052.958, 10067.142, 28188.316, 28202.922,
+       28225.557, 28243.79 , 28253.883, 28273.586]
+    model1.data[0,:,2,4] = [10022.608, 10037.174, 10069.476, 10081.729, 11173.748, 11177.344,
+       11201.127, 11219.607, 11229.468, 11243.174]
+    model1.data[0,:,2,5] = [10011.095, 10047.422, 10061.066, 10079.375, 10106.405, 10116.071,
+       10129.348, 10136.305, 10161.373, 10181.479]
+    model1.data[0,:,3,1] = [10011.877, 10052.809, 10075.108, 10085.111, 10397.106, 10409.291,
+       10430.475, 10445.3  , 10462.004, 10484.906]
+    model1.data[0,:,3,2] = [10012.124 , 10059.202, 10078.984, 10092.74, 11939.488,
+       11958.45, 11977.5625, 11991.776, 12025.897, 12027.326]
+    model1.data[0,:,3,3] = [10013.282, 10046.887, 10062.308, 10085.447, 28308.426, 28318.957,
+       28335.55 , 28353.832, 28371.746, 28388.848]
+    model1.data[0,:,3,4] = [10016.784, 10048.249, 10060.097, 10074.606, 21506.082, 21522.027,
+       21542.309, 21558.34 , 21576.365, 21595.58]
+    model1.data[0,:,3,5] = [10014.916 , 10052.995 , 10063.7705, 10092.866, 10538.075,
+       10558.318, 10570.754, 10597.343, 10608.488, 10628.104]
+    model1.data[0,:,4,1] = [10017.438, 10038.94 , 10057.657, 10069.987, 10090.22 , 10114.296,
+       10133.543, 10148.657, 10158.109, 10172.842]
+    model1.data[0,:,4,2] = [10011.129, 10037.982, 10054.445, 10079.703, 10097.964, 10110.593,
+       10135.701, 10149.448, 10171.771, 10185.874]
+    model1.data[0,:,4,3] = [10021.109, 10043.658, 10063.909, 10072.364, 10766.232, 10774.402,
+       10790.677, 10809.337, 10833.65 , 10849.55]
+    model1.data[0,:,4,4] = [10023.877, 10035.997, 10052.321, 10077.937, 10529.645, 10541.947,
+       10571.127, 10577.249, 10599.716, 10609.544]
+
+    model1.groupdq[0,0,:,:] = 1  # Flag first frame as DO_NOT_USE
+    model1.groupdq[0,-1,:,:] = 1  # Flag last frame as DO_NOT_USE
+
+    out_model = detect_jumps(model1, gain, rnModel, rejection_threshold=200.0,
+                             max_cores=None, max_jump_to_flag_neighbors=200,
+                             min_jump_to_flag_neighbors=10, flag_4_neighbors=True)
+
+    assert_array_equal(out_model.groupdq[0,:,1,1], [1, 0, 0, 0, 4, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,1,2], [1, 0, 0, 0, 4, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,1,3], [1, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,1,4], [1, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,2,1], [1, 0, 0, 0, 4, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,2,2], [1, 0, 0, 0, 4, 0, 0, 0, 0, 1])  # <--
+    assert_array_equal(out_model.groupdq[0,:,2,3], [1, 0, 0, 0, 4, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,2,4], [1, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,3,1], [1, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,3,2], [1, 0, 0, 0, 4, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,3,3], [1, 0, 0, 0, 4, 0, 0, 0, 0, 1])  # <--
+    assert_array_equal(out_model.groupdq[0,:,3,4], [1, 0, 0, 0, 4, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,4,1], [1, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,4,2], [1, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,4,3], [1, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    assert_array_equal(out_model.groupdq[0,:,4,4], [1, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+
 
 def test_flagging_of_CRs_across_slice_boundaries(setup_inputs):
     """"
@@ -605,20 +680,19 @@ def setup_inputs():
     def _setup(ngroups=10, readnoise=10, nints=1,
                nrows=1024, ncols=1032, nframes=1, grouptime=1.0, gain=1, deltatime=1,
                gain_subarray = False, readnoise_subarray = False, subarray = False):
+
         times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
         gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
-
-
-        pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
+        pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
         read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
         if subarray:
             data = np.zeros(shape=(nints, ngroups, 20, 20), dtype=np.float64)
             err = np.ones(shape=(nints, ngroups, 20, 20), dtype=np.float64)
-            gdq = np.zeros(shape=(nints, ngroups, 20, 20), dtype=np.uint32)
+            gdq = np.zeros(shape=(nints, ngroups, 20, 20), dtype=np.uint8)
         else:
             data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
             err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-            gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint32)
+            gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
         model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
         model1.meta.instrument.name = 'MIRI'
         model1.meta.instrument.detector = 'MIRIMAGE'

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -1,8 +1,8 @@
 """
-Two-Point Difference method for finding outliers in a 3-d ramp data cube.
+Two-Point Difference method for finding outliers in a 4-D ramp data array.
 The scheme used in this variation of the method uses numpy array methods
 to compute first-differences and find the max outlier in each pixel while
-still working in the full 3-d data array. This makes detection of the first
+still working in the full 4-D data array. This makes detection of the first
 outlier very fast. We then iterate pixel-by-pixel over only those pixels
 that are already known to contain an outlier, to look for any additional
 outliers and set the appropriate DQ mask for all outliers in the pixel.
@@ -18,6 +18,10 @@ log.setLevel(logging.DEBUG)
 
 HUGE_NUM = np.finfo(np.float32).max
 
+JUMP_DET = dqflags.group["JUMP_DET"]
+SATURATED = dqflags.group["SATURATED"]
+DO_NOT_USE = dqflags.group["DO_NOT_USE"]
+
 
 def find_crs(data, group_dq, read_noise, rej_threshold, nframes, flag_4_neighbors,
              max_jump_to_flag_neighbors, min_jump_to_flag_neighbors):
@@ -28,65 +32,57 @@ def find_crs(data, group_dq, read_noise, rej_threshold, nframes, flag_4_neighbor
     electrons.
     """
     gdq = group_dq.copy()
+
     # Get data characteristics
-    (nints, ngroups, nrows, ncols) = data.shape
+    nints, ngroups, nrows, ncols = data.shape
+    ndiffs = ngroups - 1
 
     # Create arrays for output
-    median_slopes = np.zeros((nints, nrows, ncols), dtype=np.float32)
-    all_ratios =  np.zeros((nints, nrows, ncols, ngroups-1), dtype=np.float32)
     row_above_gdq = np.zeros((nints, ngroups, ncols), dtype=np.uint8)
     row_below_gdq = np.zeros((nints, ngroups, ncols), dtype=np.uint8)
 
     # Square the read noise values, for use later
-    read_noise_2 = read_noise**2
+    read_noise_2 = read_noise ** 2
 
-    # Reset saturated values in input data array to NaN, so they don't get
+    # Set saturated values in the input data array to NaN, so they don't get
     # used in any of the subsequent calculations
-    saturated_pixels = np.where(np.bitwise_and(gdq, dqflags.group['SATURATED']))
-    data[saturated_pixels] = np.NaN
+    data[np.where(np.bitwise_and(gdq, SATURATED))] = np.nan
 
-    # Reset groups set to DO_NOT_USE in the input data array to NaN, so they don't get
-    # used in any of the subsequent calculations. For MIRI data the first and last group
-    # can be set to DO_NOT_USE.
-    wh_donotuse = np.where(np.bitwise_and(gdq, dqflags.group['DO_NOT_USE']))
-    data[wh_donotuse] = np.NaN
+    # Set pixels flagged as DO_NOT_USE in the input to NaN, so they don't get
+    # used in any of the subsequent calculations. MIRI exposures can sometimes have
+    # all pixels in the first and last groups flagged with DO_NOT_USE.
+    data[np.where(np.bitwise_and(gdq, DO_NOT_USE))] = np.nan
 
     # Loop over multiple integrations
-    for integration in range(nints):
+    for integ in range(nints):
 
-        log.info(' working on integration %d' % (integration+1))
-
-        # Roll the ngroups axis of data arrays to the end, to make
-        # memory access to the values for a given pixel faster
-        # new array has dimensions of [nrows, ncols, ngroups]
-        rolled_data = np.rollaxis(data[integration], 0, 3)
+        log.info(f'Working on integration {integ+1}:')
 
         # Compute first differences of adjacent groups up the ramp
-        first_diffs = np.diff(rolled_data, axis=2)
-        nan_pixels = np.where(np.isnan(first_diffs))
-        first_diffs[nan_pixels] = 100000.
-
+        # note: roll the ngroups axis of data array to the end, to make
+        # memory access to the values for a given pixel faster.
+        # New form of the array has dimensions [nrows, ncols, ngroups].
+        first_diffs = np.diff(np.rollaxis(data[integ], axis=0, start=3), axis=2)
         positive_first_diffs = np.abs(first_diffs)
+
+        # sat_groups is a 3D array that is true when the group is saturated
+        sat_groups = np.isnan(positive_first_diffs)
+
+        # number_sat_groups is a 2D array with the count of saturated groups for each pixel
+        number_sat_groups = sat_groups.sum(axis=2)
 
         # Make all the first diffs for saturated groups be equal to
         # 100,000 to put them above the good values in the sorted index
-        matching_array = np.ones(shape=(positive_first_diffs.shape[0],
-                                        positive_first_diffs.shape[1],
-                                        positive_first_diffs.shape[2])) * 100000
-        #sat_groups is a 3D array that is true when the group is saturated
-        sat_groups = (positive_first_diffs == matching_array)
-        #number_sat_groups is a 2D array with the count of saturated groups for each pixel
-        number_sat_groups = (sat_groups * 1).sum(axis=2)
-        ndiffs = ngroups - 1
-        #Here we sort the 3D array along the last axis which is the group axis.
-        #np.argsort returns a 3D array with the last axis containing the indexes that would yield the groups in
-        #order.
-        sort_index = np.argsort(positive_first_diffs)
-        #median_diffs is a 2D array with the clipped median of each pixel
-        median_diffs = get_clipped_median(ndiffs, number_sat_groups, first_diffs, sort_index)
+        first_diffs[np.isnan(first_diffs)] = 100000.
 
-        # Save initial estimate of the median slope for all pixels
-        median_slopes[integration] = median_diffs
+        # Here we sort the 3D array along the last axis, which is the group axis.
+        # np.argsort returns a 3D array with the last axis containing the indices
+        # that would yield the groups in order.
+        sort_index = np.argsort(positive_first_diffs)
+        del positive_first_diffs
+
+        # median_diffs is a 2D array with the clipped median of each pixel
+        median_diffs = get_clipped_median(ndiffs, number_sat_groups, first_diffs, sort_index)
 
         # Compute uncertainties as the quadrature sum of the poisson noise
         # in the first difference signal and read noise. Because the first
@@ -96,45 +92,49 @@ def find_crs(data, group_dq, read_noise, rej_threshold, nframes, flag_4_neighbor
         # Sigma is a 2D array.
         poisson_noise = np.sqrt(np.abs(median_diffs))
         sigma = np.sqrt(poisson_noise * poisson_noise + read_noise_2 / nframes)
+        del poisson_noise
 
         # Reset sigma to exclude pixels with both readnoise and signal=0
         sigma_0_pixels = np.where(sigma == 0.)
         if len(sigma_0_pixels[0] > 0):
-            log.debug('Twopt found %d pixels with sigma=0' % (len(sigma_0_pixels[0])))
+            log.debug(f'Twopt found {len(sigma_0_pixels[0])} pixels with sigma=0')
             log.debug('which will be reset so that no jump will be detected')
             sigma[sigma_0_pixels] = HUGE_NUM
+        del sigma_0_pixels
 
         # Compute distance of each sample from the median in units of sigma;
-        # note that the use of "abs" means we'll detect both positive and
-        # negative outliers.
-        #ratio is a 2D array with the units of sigma deviation of the difference from the median.
+        # note that the use of "abs" means we'll detect positive and negative outliers.
+        # ratio is a 2D array with the units of sigma deviation of the difference from the median.
         ratio = np.abs(first_diffs - median_diffs[:, :, np.newaxis]) / sigma[:, :, np.newaxis]
-        all_ratios[integration] = ratio
+        del sigma
+        del median_diffs
 
-        # get the rows and columns of pixels of all pixels
-        # This seems like an obtuse way to set row and column.
-        row, col = np.where(number_sat_groups >= 0)
-        # Get the group index for each pixel of the largest non-saturated group, assuming the indicies are sorted.
-        # 2 is subtracted from ngroups because we are using differences and there is one less difference than the
-        # number of groups.
+        # Get the group index for each pixel of the largest non-saturated group,
+        # assuming the indices are sorted. 2 is subtracted from ngroups because we are using
+        # differences and there is one less difference than the number of groups.
         # This is a 2-D array.
         max_value_index = ngroups - 2 - number_sat_groups
 
-        # Extract from the sorted group index the index of the largest non-saturated group.
+        # Extract from the sorted group indices the index of the largest non-saturated group.
+        row, col = np.where(number_sat_groups >= 0)
         max_index1d = sort_index[row, col, max_value_index[row, col]]
-        # Reshape the list of max indicies to be a 2-day array
-        max_index1 = np.reshape(max_index1d, (nrows, ncols))
+        max_index1 = np.reshape(max_index1d, (nrows, ncols))  # reshape to a 2-D array
+        del max_index1d
+        del max_value_index
 
-        #Is this redundant? Are r and c different than row and column?
-        r, c = np.indices(max_index1.shape)
         # Get the row and column indices of pixels whose largest non-saturated ratio is above the threshold
+        r, c = np.indices(max_index1.shape)
         row1, col1 = np.where(ratio[r, c, max_index1] > rej_threshold)
-        log.info('From highest outlier Two point found %d pixels with at least one CR' % (len(row1)))
-        number_pixels_with_cr = len(row1)
+        del max_index1
+        log.info(f'From highest outlier Two-point found {len(row1)} pixels with at least one CR')
+
         # Loop over all pixels that we found the first CR in
+        number_pixels_with_cr = len(row1)
         for j in range(number_pixels_with_cr):
-            # Extract the first diffs for the this pixel with at least one CR yielding a 1D array
+
+            # Extract the first diffs for this pixel with at least one CR, yielding a 1D array
             pixel_masked_diffs = first_diffs[row1[j], col1[j]]
+
             # Get the scalar readnoise^2 and number of saturated groups for this pixel.
             pixel_rn2 = read_noise_2[row1[j], col1[j]]
             pixel_sat_groups = number_sat_groups[row1[j], col1[j]]
@@ -144,7 +144,7 @@ def find_crs(data, group_dq, read_noise, rej_threshold, nframes, flag_4_neighbor
             pixel_cr_mask = np.ones(pixel_masked_diffs.shape, dtype=bool)
             number_CRs_found = 1
             pixel_sorted_index = sort_index[row1[j], col1[j], :]
-            pixel_cr_mask[pixel_sorted_index[ndiffs - pixel_sat_groups - 1]] = 0  #setting largest diff to be a CR
+            pixel_cr_mask[pixel_sorted_index[ndiffs - pixel_sat_groups - 1]] = 0  # setting largest diff to be a CR
             new_CR_found = True
 
             # Loop and see if there is more than one CR, setting the mask as you go
@@ -153,8 +153,9 @@ def find_crs(data, group_dq, read_noise, rej_threshold, nframes, flag_4_neighbor
                 # For this pixel get a new median difference excluding the number of CRs found and
                 # the number of saturated groups
                 pixel_med_diff = get_clipped_median(ndiffs, number_CRs_found + pixel_sat_groups,
-                                                       pixel_masked_diffs, pixel_sorted_index)
-                #recalculate the noise and ratio for this pixel now that we have rejected a CR
+                                                    pixel_masked_diffs, pixel_sorted_index)
+
+                # Recalculate the noise and ratio for this pixel now that we have rejected a CR
                 pixel_poisson_noise = np.sqrt(np.abs(pixel_med_diff))
                 pixel_sigma = np.sqrt(pixel_poisson_noise * pixel_poisson_noise + pixel_rn2 / nframes)
                 pixel_ratio = np.abs(pixel_masked_diffs - pixel_med_diff) / pixel_sigma
@@ -166,51 +167,43 @@ def find_crs(data, group_dq, read_noise, rej_threshold, nframes, flag_4_neighbor
                     number_CRs_found += 1
 
             # Found all CRs for this pixel. Set CR flags in input DQ array for this pixel
-            gdq[integration, 1:, row1[j], col1[j]] = \
-                np.bitwise_or(gdq[integration, 1:, row1[j], col1[j]],
-                              dqflags.group['JUMP_DET'] * np.invert(pixel_cr_mask))
+            gdq[integ, 1:, row1[j], col1[j]] = \
+                np.bitwise_or(gdq[integ, 1:, row1[j], col1[j]], JUMP_DET * np.invert(pixel_cr_mask))
 
-            # Save the CR-cleaned median slope for this pixel
-            if not new_CR_found:  # the while loop ran at least one time
-                median_slopes[integration, row1[j], col1[j]] = pixel_med_diff
+        # Flag neighbors of pixels with detected jumps, if requested
+        if flag_4_neighbors:
+            cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq[integ], JUMP_DET))
+            for j in range(len(cr_group)):
 
-        # Next pixel with an outlier (j loop)
-    # Next integration (integration loop)
-    if flag_4_neighbors: # We need to flag the neighbors of jumps
+                # Jumps must be within a certain range to have neighbors flagged
+                if ratio[cr_row[j], cr_col[j], cr_group[j] - 1] < max_jump_to_flag_neighbors and \
+                    ratio[cr_row[j], cr_col[j], cr_group[j] - 1] > min_jump_to_flag_neighbors:
 
-        cr_int, cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq, dqflags.group['JUMP_DET']))
-        number_pixels_with_cr = len(cr_int)
-        #loop over all jumps
-        for j in range(number_pixels_with_cr):
-            #jumps must be within a certain range to have neighbors flagged
-            if all_ratios[cr_int[j], cr_row[j], cr_col[j], cr_group[j] - 1] < max_jump_to_flag_neighbors and \
-                    all_ratios[cr_int[j], cr_row[j], cr_col[j], cr_group[j] - 1] > min_jump_to_flag_neighbors:
-                # This section saves flagged neighbors that are above or below the current range of row. If this
-                # method is running in a single process, the row above and below are not used. If it is running in
-                # multiprocessing mode, then the rows above and below need to be returned to find_jumps to use when
-                # it reconstructs the full group dq array from the slices.
-                if cr_row[j] != 0:
-                    gdq[cr_int[j], cr_group[j], cr_row[j] - 1, cr_col[j]] = np.bitwise_or(
-                        gdq[cr_int[j], cr_group[j], cr_row[j] - 1, cr_col[j]],
-                        dqflags.group['JUMP_DET'])
-                else:
-                    row_below_gdq[cr_int[j], cr_group[j], cr_col[j]] =  dqflags.group['JUMP_DET']
-                if cr_row[j] != nrows - 1:
-                    gdq[cr_int[j], cr_group[j], cr_row[j] + 1, cr_col[j]] = np.bitwise_or(
-                        gdq[cr_int[j], cr_group[j], cr_row[j] + 1, cr_col[j]],
-                        dqflags.group['JUMP_DET'])
-                else:
-                    row_above_gdq[cr_int[j], cr_group[j], cr_col[j]] = dqflags.group['JUMP_DET']
-                # Here we are just checking that we don't flag neighbors of jumps that are off the detector.
-                if cr_col[j] != 0:
-                    gdq[cr_int[j], cr_group[j], cr_row[j], cr_col[j] - 1] = np.bitwise_or(
-                        gdq[cr_int[j], cr_group[j], cr_row[j], cr_col[j] - 1],
-                        dqflags.group['JUMP_DET'])
-                if cr_col[j] != ncols - 1:
-                    gdq[cr_int[j], cr_group[j], cr_row[j], cr_col[j] + 1] = np.bitwise_or(
-                        gdq[cr_int[j], cr_group[j], cr_row[j], cr_col[j] + 1],
-                        dqflags.group['JUMP_DET'])
+                    # This section saves flagged neighbors that are above or below the current range of row. If this
+                    # method is running in a single process, the row above and below are not used. If it is running in
+                    # multiprocessing mode, then the rows above and below need to be returned to find_jumps to use when
+                    # it reconstructs the full group dq array from the slices.
+                    if cr_row[j] != 0:
+                        gdq[integ, cr_group[j], cr_row[j] - 1, cr_col[j]] = np.bitwise_or(
+                            gdq[integ, cr_group[j], cr_row[j] - 1, cr_col[j]], JUMP_DET)
+                    else:
+                        row_below_gdq[integ, cr_group[j], cr_col[j]] = JUMP_DET
 
+                    if cr_row[j] != nrows - 1:
+                        gdq[integ, cr_group[j], cr_row[j] + 1, cr_col[j]] = np.bitwise_or(
+                            gdq[integ, cr_group[j], cr_row[j] + 1, cr_col[j]], JUMP_DET)
+                    else:
+                        row_above_gdq[integ, cr_group[j], cr_col[j]] = JUMP_DET
+
+                    # Here we are just checking that we don't flag neighbors of jumps that are off the detector.
+                    if cr_col[j] != 0:
+                        gdq[integ, cr_group[j], cr_row[j], cr_col[j] - 1] = np.bitwise_or(
+                            gdq[integ, cr_group[j], cr_row[j], cr_col[j] - 1], JUMP_DET)
+                    if cr_col[j] != ncols - 1:
+                        gdq[integ, cr_group[j], cr_row[j], cr_col[j] + 1] = np.bitwise_or(
+                            gdq[integ, cr_group[j], cr_row[j], cr_col[j] + 1], JUMP_DET)
+
+    # All done
     return gdq, row_below_gdq, row_above_gdq
 
 
@@ -232,21 +225,19 @@ def get_clipped_median(num_differences, diffs_to_ignore, differences, sorted_ind
         pixel_med_index = sorted_index[row, col, (num_differences - (diffs_to_ignore[row, col] + 1))//2]
         pixel_med_diff = differences[row, col, pixel_med_index]
 
-
         # For pixels with an even number of differences the median is the mean of the two central values.
         # So we need to get the value the other central difference one lower in the sorted index that the one found
         # above.
         even_group_rows, even_group_cols = np.where((num_differences - diffs_to_ignore - 1) % 2 == 0)
         pixel_med_index2 = np.zeros_like(pixel_med_index)
-        pixel_med_index2[even_group_rows, even_group_cols] = sorted_index[even_group_rows,
-                                                                          even_group_cols,
-                                                                          (num_differences
-                                                                           - (diffs_to_ignore[even_group_rows,
-                                                                                              even_group_cols] + 3))//2]
+        pixel_med_index2[even_group_rows, even_group_cols] = \
+            sorted_index[even_group_rows, even_group_cols,
+                         (num_differences - (diffs_to_ignore[even_group_rows, even_group_cols] + 3))//2]
+
         # Average together the two central values
-        pixel_med_diff[even_group_rows, even_group_cols] = (pixel_med_diff[even_group_rows, even_group_cols] +
-                                                            differences[even_group_rows, even_group_cols,
-                                                            pixel_med_index2[even_group_rows, even_group_cols]])/2.0
+        pixel_med_diff[even_group_rows, even_group_cols] = (
+            pixel_med_diff[even_group_rows, even_group_cols] +
+            differences[even_group_rows, even_group_cols, pixel_med_index2[even_group_rows, even_group_cols]])/2.0
 
     # The 1-D array case is a lot simplier.
     else:


### PR DESCRIPTION
Updated the `twopoint_difference` module in the `jump` step to try to eliminate some of the largest memory hogs. The single biggest change with the largest effect on memory usage is moving the flagging of neighbors from the end of the routine (after all integrations have been processed) to being inside the main loop over integrations. This completely eliminates the need for the `all_ratios` array, which was a huge 4-D float array the same size as the 4-D SCI data.

Also eliminated some of the smaller intermediate arrays that were used to do things like storing indexes of bad or saturated pixels. In addition, there's been just a huge amount of cosmetic cleanup to try to make the code more readable and just more efficient overall.

Somehow, these changes actually fixed some previously undetected problems with the wrong groups getting flagged as having a jump (e.g. a jump is detected in group 5 for a pixel, but group 1 ended up getting the DQ flag set). Differences in the regressions show that the new code is producing the correct results in all cases.

Fixes #5368 / [JP-1735](https://jira.stsci.edu/browse/JP-1735)