### PR TITLE
Use Codecov carryforward flags

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,14 +1,23 @@
 coverage:
   status:
     project:
-      default: off
+      default:
+        target: auto
+        threshold: 0.1%
+        flags:
+          - unit
+          - nightly
       unit:
-        flags: unit
+        target: auto
+        flags:
+          - unit
       nightly:
-        flags: nightly
+        target: auto
+        flags:
+          - nightly
 
 flags:
   unit:
-    joined: true
+    carryforward: false
   nightly:
-    joined: false
+    carryforward: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,9 +4,6 @@ coverage:
       default:
         target: auto
         threshold: 0.1%
-        flags:
-          - unit
-          - nightly
       unit:
         target: auto
         flags:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,3 +21,6 @@ flags:
     carryforward: false
   nightly:
     carryforward: true
+
+comment:
+  show_carryforward_flags: true

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -86,7 +86,7 @@ bc0.build_cmds = [
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
-    "pytest --cov-report=xml --cov -r sxf -n 30 --bigdata --slow \
+    "pytest --cov-report=xml --cov=./ -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -89,6 +89,7 @@ bc0.test_cmds = [
     "pytest --cov-report=xml --cov=./ -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
+    "codecov --token=${codecov_token} -F nightly",
 ]
 bc0.test_configs = [data_config]
 


### PR DESCRIPTION
Make the `nightly` tests flag _carryforward_ so that we can see the coverage of the repo from both unit and nightly tests combined.  This should also only compare CI unit tests to previous coverage of CI unit tests, not to coverage of the nightly tests.  🤞 

Also, make threshold be 0.1% so that when a few lines of code are deleted, the `codecov/project` check doesn't fail because the denominator has gotten smaller.

Resolves #4920 