### PR TITLE
JP-1748 Refactor DataTypes handling of ModelContainer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ cube_build
 - If outlier detection has flagged all the data on a input file as DO_NOT_USE, then
   skip the file in creating an ifucube [*5347]
 
+- Refactor DataTypes handling of ModelContainer. [#5409]
+
 datamodels
 ----------
 

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -83,21 +83,16 @@ class DataTypes():
             self.output_name = self.build_product_name(self.filenames[0])
 
         elif isinstance(input_try, datamodels.ModelContainer):
-            # print('this is a model container type or association read in a ModelContainer')
             self.output_name = 'Temp'
             if not single:  # find the name of the output file from the association
-                with datamodels.ModelContainer(input_try) as input_model:
-                    self.output_name = input_model.meta.asn_table.products[0].name
-            for i in range(len(input_try)):
+                self.output_name = input_try.meta.asn_table.products[0].name
+            for model in input_try:
                 # check if input data is an IFUImageModel
-                if not isinstance(input_try[i], datamodels.IFUImageModel):
-                    serror = str(type(input_try[i]))
+                if not isinstance(model, datamodels.IFUImageModel):
                     raise NotIFUImageModel(
-                        "Input data is not a IFUImageModel, instead it is %s", serror)
-
-                model = datamodels.IFUImageModel(input_try[i])
-                self.input_models.append(model)
+                        f"Input data is not a IFUImageModel, instead it is {model}")
                 self.filenames.append(model.meta.filename)
+            self.input_models = input_try
 
         else:
             raise TypeError("Failed to process file type {}".format(type(input_try)))

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -4,9 +4,11 @@ Data model class heirarchy
 
 import copy
 import datetime
+import logging
 import os
 from pathlib import PurePath
 import sys
+import traceback
 import warnings
 
 import numpy as np
@@ -37,6 +39,9 @@ from .util import get_envar_as_boolean
 from ..lib import s3_utils
 
 from .history import HistoryList
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class DataModel(properties.ObjectNode, ndmodel.NDModel):
@@ -333,6 +338,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             for fd in self._files_to_close:
                 if fd is not None:
+                    log_with_traceback(f'{__name__}: {self}: Closing {fd}')
                     fd.close()
 
     @staticmethod
@@ -1107,3 +1113,30 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if attribute in self.instance:
             return getattr(self, attribute)
         raise AttributeError(f'{self} has no attribute "{attribute}"')
+
+
+def log_with_traceback(message):
+    """Log with optional stack traceback
+
+    If the logging level is anything less than `logging.DEBUG`,
+    add the current stack traceback to the `logging.DEBUG` message.
+
+    Parameters
+    ----------
+    message : str
+        The basic message to be logged.
+    """
+    if logger.getEffectiveLevel() < logging.DEBUG:
+
+        # Attempt not to log things that occur while handling
+        # and exception.
+        exec_type, exec_value, exec_tb = sys.exc_info()
+        if exec_type is None:
+            stack = ''.join(traceback.format_stack())
+            message = (
+                '\n#############\n'
+                f'{message}\n'
+                f'{stack}'
+                '\n#############\n'
+            )
+    logger.debug(message)

--- a/jwst/regtest/test_miri_cubebuild.py
+++ b/jwst/regtest/test_miri_cubebuild.py
@@ -1,0 +1,41 @@
+"""Test CubeBuildStep on MIRI MRS"""
+import pytest
+
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope='module')
+def run_cube_build_single_output(rtdata_module):
+    """Run cube_build on multiple inputs but single output"""
+    rtdata = rtdata_module
+    rtdata.get_asn('miri/mrs/two_spec3_asn.json')
+
+    args = [
+        'jwst.cube_build.CubeBuildStep',
+        rtdata.input,
+        '--save_results=true'
+    ]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    'output',
+    ['outtest_ch1-short_s3d.fits', 'outtest_ch2-short_s3d.fits']
+)
+def test_cube_build_single_output(run_cube_build_single_output, output, fitsdiff_default_kwargs):
+    """Test just running cube build and ensure that output happens"""
+    rtdata = run_cube_build_single_output
+    rtdata.output = output
+
+    # Get the truth files
+    rtdata.get_truth('truth/test_miri_cubebuild/' +  output)
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_mrs.py
+++ b/jwst/regtest/test_miri_mrs.py
@@ -201,7 +201,8 @@ def run_cube_build_single_output(rtdata_module):
 
     args = [
         'jwst.cube_build.CubeBuildStep',
-        rtdata.input
+        rtdata.input,
+        '--save_results=true'
     ]
     Step.from_cmdline(args)
 
@@ -211,14 +212,12 @@ def run_cube_build_single_output(rtdata_module):
 @pytest.mark.bigdata
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    'suffix',
-    ['cube_build',]
+    'output',
+    ['outtest_ch1-short_s3d.fits', 'outtest_ch2-short_s3d.fits']
 )
-def test_cube_build_single_output(run_cube_build_single_output, suffix, **fitsdiff_default_kwargs):
+def test_cube_build_single_output(run_cube_build_single_output, output, fitsdiff_default_kwargs):
     """Test just running cube build and ensure that output happens"""
     rtdata = run_cube_build_single_output
-    output = replace_suffix(
-            Path(rtdata.input).stem, suffix) + '.fits'
     rtdata.output = output
 
     # Get the truth files

--- a/jwst/regtest/test_miri_mrs.py
+++ b/jwst/regtest/test_miri_mrs.py
@@ -191,38 +191,3 @@ def test_miri_mrs_wcs(run_spec2, fitsdiff_default_kwargs):
         xtruth, ytruth = im_truth.meta.wcs.backward_transform(ratruth, dectruth, lamtruth)
         assert_allclose(xtest, xtruth)
         assert_allclose(ytest, ytruth)
-
-
-@pytest.fixture(scope='module')
-def run_cube_build_single_output(rtdata_module):
-    """Run cube_build on multiple inputs but single output"""
-    rtdata = rtdata_module
-    rtdata.get_asn('miri/mrs/two_spec3_asn.json')
-
-    args = [
-        'jwst.cube_build.CubeBuildStep',
-        rtdata.input,
-        '--save_results=true'
-    ]
-    Step.from_cmdline(args)
-
-    return rtdata
-
-
-@pytest.mark.bigdata
-@pytest.mark.slow
-@pytest.mark.parametrize(
-    'output',
-    ['outtest_ch1-short_s3d.fits', 'outtest_ch2-short_s3d.fits']
-)
-def test_cube_build_single_output(run_cube_build_single_output, output, fitsdiff_default_kwargs):
-    """Test just running cube build and ensure that output happens"""
-    rtdata = run_cube_build_single_output
-    rtdata.output = output
-
-    # Get the truth files
-    rtdata.get_truth('truth/test_miri_mrs/' +  output)
-
-    # Compare the results
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_mrs.py
+++ b/jwst/regtest/test_miri_mrs.py
@@ -3,14 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from astropy.io.fits.diff import FITSDiff
 from gwcs.wcstools import grid_from_bounding_box
 from numpy.testing import assert_allclose
 
 from jwst import datamodels
 from jwst.associations import load_asn
 from jwst.lib.suffix import replace_suffix
-from jwst.stpipe import Step
 
 from . import regtestdata as rt
 


### PR DESCRIPTION
Resolves [JP-1748](https://jira.stsci.edu/browse/JP-1748)
Resolves #5405 

Refactored `DataTypes` handling of `ModelContainer` to be more simplified and avoid premature closing of models before usage is completed.