### PR TITLE
Fix warnings in datamodels

### DIFF
--- a/jwst/datamodels/tests/data/collimator_fake.asdf
+++ b/jwst/datamodels/tests/data/collimator_fake.asdf
@@ -1,10 +1,10 @@
 #ASDF 1.0.0
-#ASDF_STANDARD 1.2.0
+#ASDF_STANDARD 1.5.0
 %YAML 1.1
 %TAG ! tag:stsci.edu:asdf/
 --- !core/asdf-1.1.0
 asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
-  name: asdf, version: 2.1.0.dev1406}
+  name: asdf, version: 2.7.1}
 history:
   entries:
   - !core/history_entry-1.0.0
@@ -15,10 +15,10 @@ history:
   extensions:
   - !core/extension_metadata-1.0.0
     extension_class: astropy.io.misc.asdf.extension.AstropyAsdfExtension
-    software: {name: astropy, version: 3.1.dev21950}
+    software: !core/software-1.0.0 {name: astropy, version: 4.0.1.post1}
   - !core/extension_metadata-1.0.0
     extension_class: asdf.extension.BuiltinExtension
-    software: {name: asdf, version: 2.1.0.dev1406}
+    software: !core/software-1.0.0 {name: asdf, version: 2.7.1}
 meta:
   author: p_FM2_08F_fitCOL_back.py.py v. 1.0
   date: '2017-07-11T13:02:23.370'
@@ -33,7 +33,7 @@ meta:
   telescope: JWST
   title: NIRSPEC COLLIMATOR file
   useafter: '2016-02-04T09:35:22'
-model: !transform/concatenate-1.1.0
+model: !transform/concatenate-1.2.0
   forward:
   - !transform/shift-1.2.0 {offset: 1.0}
   - !transform/shift-1.2.0 {offset: 2.0}

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -74,7 +74,8 @@ def make_models(tmpdir_factory):
     path_just_fits = str(path / 'just_fits.fits')
     path_model = str(path / 'model.fits')
     primary_hdu = fits.PrimaryHDU()
-    primary_hdu.header['exp_type'] = 'NRC_IMAGE'
+    primary_hdu.header['EXP_TYPE'] = 'NRC_IMAGE'
+    primary_hdu.header['DATAMODL'] = "DataModel"
     hduls = fits.HDUList([primary_hdu])
     hduls.writeto(path_just_fits)
     model = DataModel(hduls)

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -21,18 +21,19 @@ from jwst.datamodels import util
 MEMORY = 100  # 100 bytes
 
 
-def test_mirirampmodel_deprecation(_jail):
+def test_mirirampmodel_deprecation(tmpdir):
     """Test that a deprecated MIRIRampModel can be opened"""
-
+    path = str(tmpdir.join("ramp.fits"))
     # Create a MIRIRampModel, working around the deprecation.
     model = datamodels.RampModel((1, 1, 10, 10))
-    model.save('ramp.fits')
-    hduls = fits.open('ramp.fits', mode='update')
+    model.save(path)
+    hduls = fits.open(path, mode='update')
     hduls[0].header['datamodl'] = 'MIRIRampModel'
     hduls.close()
 
     # Test it.
-    miri_ramp = datamodels.open('ramp.fits')
+    with pytest.warns(DeprecationWarning):
+        miri_ramp = datamodels.open(path)
     assert isinstance(miri_ramp, datamodels.RampModel)
 
 
@@ -62,7 +63,7 @@ def test_check_memory_allocation_env(monkeypatch, mock_get_available_memory,
     if allowed_env is None:
         monkeypatch.delenv('DMODEL_ALLOWED_MEMORY', raising=False)
     else:
-        monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', allowed_env)
+        monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', str(allowed_env))
 
     # Allocate amount that would fit at 100% + swap.
     can_allocate, required = util.check_memory_allocation(


### PR DESCRIPTION
Fixes the following recently-introduced warnings in our tests:

```
jwst/datamodels/tests/test_models.py::test_skip_fits_update[False-open-just_fits-None-FGS_DARK]
jwst/datamodels/tests/test_models.py::test_skip_fits_update[False-open-just_fits-False-FGS_DARK]
jwst/datamodels/tests/test_models.py::test_skip_fits_update[False-open-just_fits-True-FGS_DARK]
jwst/datamodels/tests/test_models.py::test_skip_fits_update[True-open-just_fits-None-FGS_DARK]
jwst/datamodels/tests/test_models.py::test_skip_fits_update[True-open-just_fits-False-FGS_DARK]
jwst/datamodels/tests/test_models.py::test_skip_fits_update[True-open-just_fits-True-FGS_DARK]
  /Users/jdavies/dev/jwst/jwst/datamodels/util.py:188: NoTypeWarning: model_type not found. Opening /private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-28/skip_fits_update0/just_fits.fits as a DataModel
    warnings.warn(f"model_type not found. Opening {file_name} as a {class_name}",

jwst/datamodels/tests/test_models.py::test_open_asdf_model[/Users/jdavies/dev/jwst/jwst/datamodels/tests/data/collimator_fake.asdf]
  /Users/jdavies/miniconda3/envs/jwst/lib/python3.8/site-packages/asdf/asdf.py:1354: AsdfConversionWarning: No explicit ExtensionType support provided for tag 'tag:stsci.edu:asdf/transform/concatenate-1.1.0'. The ExtensionType subclass for tag 'tag:stsci.edu:asdf/transform/concatenate-1.2.0' will be used instead. This fallback behavior will be removed in asdf 3.0.
    warnings.warn(message, AsdfConversionWarning)

jwst/datamodels/tests/test_open.py::test_mirirampmodel_deprecation
  /Users/jdavies/dev/jwst/jwst/lib/basic_utils.py:24: DeprecationWarning: "MIRIRampModel" is deprecated and will be removed. Use RampModel
    warnings.warn(message.format(old_class=old_class.__name__, new_class=new_class.__name__),

jwst/datamodels/tests/test_open.py::test_check_memory_allocation_env[0.1-None-False]
jwst/datamodels/tests/test_open.py::test_check_memory_allocation_env[0.1-1.0-True]
  /Users/jdavies/dev/jwst/jwst/datamodels/tests/test_open.py:65: PytestWarning: Value of environment variable DMODEL_ALLOWED_MEMORY type should be str, but got 0.1 (type: float); converted to str implicitly
    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', allowed_env)

jwst/datamodels/tests/test_open.py::test_check_memory_allocation_env[1.0-0.1-False]
  /Users/jdavies/dev/jwst/jwst/datamodels/tests/test_open.py:65: PytestWarning: Value of environment variable DMODEL_ALLOWED_MEMORY type should be str, but got 1.0 (type: float); converted to str implicitly
    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', allowed_env)
```
