### PR TITLE
JP-1748 Remove logging from DataModel.close

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ datamodels
 
 - Add NRS_VERIFY to the core schema as an allowed EXP_TYPE [#5395]
 
+- Remove logging from DataModel.close [#5413]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -338,7 +338,12 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
             for fd in self._files_to_close:
                 if fd is not None:
-                    log_with_traceback(f'{__name__}: {self}: Closing {fd}')
+
+                    # Logging is normally disabled since this method is called
+                    # from __del__, which does not guarantee that logging
+                    # is available.
+                    # log_with_traceback(f'{__name__}: {self}: Closing {fd}')
+
                     fd.close()
 
     @staticmethod


### PR DESCRIPTION
Resolves followup issue with JP-1748.

Since `DataModel.close` is called from `DataModel.__del__`, a `DataModel` that is still open when a Python process closes, it is possible that the logging module is no longer available, resulting in the error

```
ImportError: sys.meta_path is None, Python is likely shutting down
```

Since logging at this point is normally not required, simply remove the logging statement.