### PR TITLE
JP-1478: extract_1d enhancements for NRC_TSGRISM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,12 @@ extract_1d
 - Fixed bug invovling the determination of source RA/Dec for resampled Slit
   data. [#5353]
 
+- Updated to use an EXTRACT1D reference file for NIRCam TSGRISM exposures;
+  added step param "bkg_fit" to allow for mean and median options in background
+  computation, in addition to the existing polynomial fit; fixed bug in
+  background computation that was preventing background subtraction from
+  ever happening. [#5414]
+
 flatfield
 ---------
 

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -1,20 +1,33 @@
 Step Arguments
 ==============
 
-The ``extract_1d`` step has six step-specific arguments.
+The ``extract_1d`` step has the following step-specific arguments.
 
 ``--smoothing_length``
   If ``smoothing_length`` is greater than 1 (and is an odd integer), the
-  background will be smoothed in the dispersion direction with a boxcar of
-  this width.  If ``smoothing_length`` is None (the default), the step will
-  attempt to read the value from the EXTRACT1D reference file.  If a value was
-  specified in the reference file, that will be used.  Note that in this
-  case a different value can be specified for each slit.  If no value was
-  specified either by the user or in the EXTRACT1D reference file, no background
-  smoothing will be done.
+  image data used to perform background extraction will be smoothed in the
+  dispersion direction with a boxcar of this width.  If ``smoothing_length``
+  is None (the default), the step will attempt to read the value from the
+  EXTRACT1D reference file.  If a value is specified in the reference file,
+  that value will be used.  Note that by specifying this parameter in the
+  EXTRACT1D reference file a different value can be designated for each slit.
+  If no value is specified either by the user or in the EXTRACT1D reference
+  file, no background smoothing is done.
+
+``--bkg_fit``
+  The type of fit to perform to the background data in each image column
+  (or row, if the dispersion is vertical). There are three allowed values:
+  "poly" (the default), "mean", and "median". If set to "poly", the background
+  values for each pixel within all background regions in a given column (or
+  row) will be fit with a polynomial of order "bkg_order" (see below).
+  Values of "mean" and "median" compute the simple average and median,
+  respectively, of the background region values in each column (or row).
+  This parameter can also be specified in the EXTRACT1D reference file. If
+  specified in the reference file and given as an argument to the step by
+  the user, the user-supplied value takes precedence.
 
 ``--bkg_order``
-  This is the order of a polynomial function to be fit to the background
+  The order of a polynomial function to be fit to the background
   regions.  The fit is done independently for each column (or row, if the
   dispersion is vertical) of the input image, and the fitted curve will be
   subtracted from the target data.  ``bkg_order`` = 0 (the minimum allowed
@@ -22,7 +35,8 @@ The ``extract_1d`` step has six step-specific arguments.
   overrides the value in the EXTRACT1D reference file.  If neither is specified, a
   value of 0 will be used. If a sufficient number of valid data points is
   unavailable to construct the polynomial fit, the fit will be forced to
-  0 for that particular column (or row).
+  0 for that particular column (or row). If "bkg_fit" is not "poly", this
+  parameter will be ignored.
 
 ``--log_increment``
   Most log messages are suppressed while looping over integrations, i.e. when

--- a/docs/jwst/extract_1d/description.rst
+++ b/docs/jwst/extract_1d/description.rst
@@ -1,30 +1,35 @@
 Description
 ===========
+
+Overview
+--------
 The ``extract_1d`` step extracts a 1D signal from a 2D or 3D dataset and
-writes a spectrum to a product.  This works on all JWST spectroscopic
+writes spectral data to an "x1d" product.  This works on all JWST spectroscopic
 modes, including MIRI LRS (slit and slitless) and MRS, NIRCam WFSS and
 TSGRISM, NIRISS WFSS and SOSS, and NIRSpec fixed-slit, IFU, and MOS.
 
 An EXTRACT1D reference file is used for most modes to specify the location and
 size of the target and background extraction apertures.
 The EXTRACT1D reference file is not used for Wide-Field Slitless Spectroscopy data
-(NIS_WFSS or NRC_WFSS). The extraction region is instead taken to be the full size
-of the input subarray or cutout, or restricted to the region within which the world
-coordinate system (WCS) is defined.
+(NIS_WFSS or NRC_WFSS). For these modes the extraction region is instead taken to be
+the full size of the input 2D subarray or cutout for each source, or restricted to
+the region within which the world coordinate system (WCS) is defined in each cutout.
 
-For IFU data, the extraction options differ depending on
-whether the target is a point source or an extended source.  For a point
+For slit-like 2D input data, source and background extractions are done using
+a rectangular aperture that covers one pixel in the dispersion direction and
+uses a height in the cross-dispersion direction that is defined by parameters in
+the EXTRACT1D reference file.
+For 3D IFU data, on the other hand, the extraction options differ depending on
+whether the target is a point or extended source.  For a point
 source, the spectrum is extracted using circular aperture photometry,
 optionally including background subtraction using a circular annulus.
 For an extended source, rectangular aperture photometry is used, with
 the entire image being extracted, and no background subtraction, regardless
-of what was specified in the reference file or command-line arguments.
-For either point source or extended, the photometry makes use of astropy photutils.
-The region of overlap between an aperture and a pixel can be calculated by
-one of three different methods:  "exact", limited only by finite precision
-arithmetic; "center", i.e. the full value in a pixel will be included if its
-center is within the aperture; or "subsample", which means pixels will be
-subsampled N x N, and the "center" option will be used for each sub-pixel.
+of what was specified in the reference file or step arguments.
+For either point or extended sources, the photometry makes use of the Astropy
+affiliated package
+`photutils <https://photutils.readthedocs.io/en/latest/>`_ to define an aperture
+object and perform extraction.
 
 For most spectral modes an aperture correction will be applied to the extracted
 1D spectral data (unless otherwise selected by the user), in order to put the
@@ -58,7 +63,7 @@ for point sources observed with NIRSpec and NIRISS SOSS, units of flux density
 
 Output
 ------
-The output will be in MultiSpecModel format. For each input slit there will
+The output will be in ``MultiSpecModel`` format. For each input slit there will
 be an output table extension with the name EXTRACT1D.  This extension will
 have columns WAVELENGTH, FLUX, ERROR, SURF_BRIGHT, SB_ERROR, DQ,
 BACKGROUND, BERROR and NPIXELS.
@@ -101,3 +106,158 @@ BACKGROUND is the measured background, scaled to the extraction width used
 for FLUX and SURF_BRIGHT.  BACKGROUND will be zero if background subtraction
 is not requested.
 ERROR, SB_ERROR, BERROR, and DQ are not populated with useful values yet.
+
+
+.. _extract-1d-for-slits:
+
+Extraction for 2D Slit Data
+---------------------------
+The operational details of the 1D extraction depend heavily on the parameter
+values given in the :ref:`EXTRACT1D <extract1d_reffile>` reference file.
+Here we describe their use within the ``extract_1d`` step.
+
+Source Extraction Region
+^^^^^^^^^^^^^^^^^^^^^^^^
+As described in the documentation for the
+:ref:`EXTRACT1D <extract1d_reffile>` reference file,
+the characteristics of the source extraction region can be specified in one
+of two different ways. 
+The simplest approach is to use the ``xstart``, ``xstop``, ``ystart``,
+``ystop``, and ``extract_width`` parameters.  Note that all of these values are
+zero-indexed integers, and that the start and stop limits are inclusive.
+If ``dispaxis=1``, the limits in the dispersion direction are ``xstart``
+and ``xstop`` and the limits in the cross-dispersion direction are ``ystart``
+and ``ystop``. If ``dispaxis=2``, the rolls are reversed.
+If ``extract_width`` is also given, that takes priority over ``ystart`` and
+``ystop`` (for ``dispaxis=1``) for the extraction width, but ``ystart`` and
+``ystop`` will still be used to define the centering of the extraction region
+in the cross-dispersion direction.
+Any of these parameters will be modified internally by the step code if the
+extraction region would extend outside the limits of the input image or outside
+the domain specified by the WCS.
+
+A more flexible way to specify the source extraction region is via the ``src_coeff``
+parameter. ``src_coeff`` is specified as a list of lists of floating-point
+polynomial coefficients that define the lower and upper
+limits of the source extraction region as a function of dispersion. This allows,
+for example, following a tilted or curved spectral trace or simply
+following the variation in cross-dispersion FWHM as a function of wavelength.
+If both ``src_coeff`` and ``ystart``/``ystop`` values are given, ``src_coeff``
+takes precedence. The ``xstart`` and ``xstop`` values can still be used to
+limit the range of the extraction in the dispersion direction. More details on
+the specification and use of polynomial coefficients is given below.
+
+Background Extraction Regions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+One or more background extraction regions for a given aperture instance can
+be specified using the ``bkg_coeff`` parameter in the EXTRACT1D reference file.
+This is directly analogous to the use of ``src_coeff`` for specifiying source
+extraction regions and functions in exactly the same way. More details on the
+use of polynomial coefficients is given in the next section.
+Background subtraction will be done if and only if ``bkg_coeff`` is given in
+the EXTRACT1D reference file. The background is determined independently for
+each column (or row, if dispersion is vertical), using pixel values from all
+background regions within each column (or row).
+
+Parameters related to background subtraction are ``smoothing_length``,
+``bkg_fit``, and ``bkg_order``.
+
+* If ``smoothing_length`` is specified, the 2D image data used to perform
+  background extraction will be smoothed along the dispersion direction using
+  a boxcar of width ``smoothing_length`` (in pixels). If not specified, no
+  smoothing of the input 2D image data is performed.
+
+* ``bkg_fit`` specifies the type of background computation to be performed
+  within each column (or row). The default is "poly", in which case a
+  polynomial of order ``bkg_order`` is fit to the background values within
+  the column (or row). Alternatively, values of "mean" or "median" can be
+  specified in order to compute the simple mean or median of the background
+  values in each column (or row). Note that using "bkg_fit=mean" is
+  mathematically equivalent to "bkg_fit=poly" with "bkg_order=0".
+
+* If ``bkg_fit=poly`` is specified, ``bkg_order`` is used to indicate the
+  polynomial order to be used. The default value is zero, i.e. a constant.
+
+During source extraction, the background fit is evaluated at each pixel within the
+source extraction region for that column (row), and the fitted values will
+be subtracted (pixel by pixel) from the source count rate.
+
+Source and Background Coefficient Lists
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The interpretation and use of polynomial coefficients to specify source and
+background extraction regions via ``src_coeff`` and ``bkg_coeff`` is the same. 
+The coefficients are specified as a list of an even number of lists (an
+even number because both the lower and upper limits of each extraction region
+must be specified).  The source extraction coefficients will normally be
+a list of just two lists, the coefficients for the lower limit function
+and the coefficients for the upper limit function of one extraction
+region.  The limits could just be constant values,
+e.g. \[\[324.5\], \[335.5\]\].  Straight but tilted lines are linear functions:
+
+\[\[324.5, 0.0137\], \[335.5, 0.0137\]\]
+
+Multiple regions may be specified for either the source or background, or
+both.  It will be common to specify more than one background region.  Here
+is an example for specifying two background regions:
+
+\[\[315.2, 0.0135\], \[320.7, 0.0135\], \[341.1, 0.0139\], \[346.8, 0.0139\]\]
+
+This is interpreted as follows:
+
+* \[315.2, 0.0135\]: lower limit for first background region
+* \[320.7, 0.0135\]: upper limit for first background region
+* \[341.1, 0.0139\]: lower limit for second background region
+* \[346.8, 0.0139\]: upper limit for second background region
+
+Note: If the dispersion direction is vertical, replace "lower" with "left" and
+"upper" with "right" in the above description.
+
+Notice especially that ``src_coeff`` and ``bkg_coeff`` contain floating-point
+values.  For interpreting fractions of a pixel, the convention used here
+is that the pixel number at the center of a pixel is a whole number.  Thus,
+if a lower or upper limit is a whole number, that limit splits the pixel
+in two, so the weight for that pixel will be 0.5.  To include all the
+pixels between 325 and 335 inclusive, for example, the lower and upper
+limits would be given as 324.5 and 335.5 respectively.
+
+The order of a polynomial is specified implicitly to be one less than the
+number of coefficients. The number of coefficients for a lower or upper extraction
+region limit must be at least one (i.e. zeroth-order polynomial). There is no
+predefined upper limit on the number of coefficients (and hence polynomial order).
+The various polynomials (lower limits, upper limits, possibly multiple regions) do
+not need to have the same number of coefficients; each of the inner lists specifies
+a separate polynomial. However, the independent variable (wavelength or pixel)
+does need to be the same for all polynomials for a given slit.
+
+Polynomials specified via ``src_coeff`` and ``bkg_coeff`` are functions of either wavelength
+(in microns) or pixel number (pixels in the dispersion direction, with respect to
+the input 2D slit image), which is specified by the parameter ``independent_var``.
+The default is "pixel".  The values of these polynomial functions are pixel numbers in the
+direction perpendicular to dispersion.
+
+.. _extract-1d-for-ifu:
+
+Extraction for 3D IFU Data
+--------------------------
+For IFU cube data, 1D extraction is contolled by a different set of EXTRACT1D
+reference file parameters.
+Note that for an extended source, anything specified in the reference file
+or step arguments will be ignored; the entire image will be
+extracted, and no background subtraction will be done.
+
+For point sources a circular extraction aperture is used, along with an optional
+circular annulus for background extraction and subtraction. The parameters
+``x_center``, ``y_center``, and ``radius`` specify the location and size of the
+source aperture, all of which are given in units of pixels.
+The parameters ``inner_background`` and ``outer_background`` are used to
+specify the limits of an annular background aperture. All radius-related
+parameters can be floating-point values and appropriate partial-pixel scaling
+will be used in the extraction process.
+
+The region of overlap between an aperture and a pixel can be calculated by
+one of three different methods, specified by the ``method`` parameter:  "exact"
+(default), limited only by finite precision arithmetic; "center", the full value
+in a pixel will be included if its center is within the aperture; or "subsample",
+which means pixels will be subsampled N x N and the "center" option will be used
+for each sub-pixel. When ``method`` is "subsample", the parameter ``subpixels``
+is used to set the resampling value. The default value is 5.

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -3,7 +3,7 @@
 EXTRACT1D Reference File
 ------------------------
 The EXTRACT1D reference file contains information needed to guide
-the 1-D extraction process. It is a text file, with the information
+the 1D extraction process. It is a text file, with the information
 in JSON format.
 
 .. include:: ../references_general/extract1d_selection.inc
@@ -51,10 +51,8 @@ dispersion direction within the image.  If ``dispaxis`` is
 not specified, the dispersion direction will be taken to be the axis
 along which the wavelengths change more rapidly.
 Key ``region_type`` can be omitted, but if it is specified, its value must
-be "target".  The source extraction region can be specified with ``ystart``,
-``ystop``, etc., but a more flexible alternative is to use ``src_coeff``.
-If background is to be subtracted, this should be specified by giving
-``bkg_coeff``.  These are described in more detail below.
+be "target".  The remaining keys specify the characteristics of the source
+and background extraction regions.
 
 * id: the slit name, e.g. "S200A1" (string)
 * spectral_order: the spectral order number (optional); this can be either
@@ -71,20 +69,14 @@ If background is to be subtracted, this should be specified by giving
 * independent_var: "wavelength" or "pixel" (string)
 * smoothing_length: width of boxcar for smoothing background regions along
   the dispersion direction (odd int)
+* bkg_fit: the type of background fit or computation (string)
 * bkg_order: order of polynomial fit to background regions (int)
 * extract_width: number of pixels in cross-dispersion direction (int)
 
-If ``src_coeff`` is given, those coefficients take priority for specifying
-the source extraction region in the cross-dispersion direction.  ``xstart``
-and ``xstop`` (or ``ystart`` and ``ystop`` if ``dispaxis`` is 2) will
-still be used for the limits in the dispersion direction.  Background
-subtraction will be done if and only if ``bkg_coeff`` is given.  See below
-for further details.
+See :ref:`extract-1d-for-slits` for more details on how these parameters
+are used in the extraction process.
 
 For IFU cube data, the following keys are used instead of those above.
-Note that for an extended source, anything specified in a reference file
-or command-line argument will be ignored; the entire image will be
-extracted, and no background subtraction will be done.
 
 * id: the slit name, but this can be "ANY" (string)
 * x_center: X pixel coordinate of the target (pixels, float, the default
@@ -106,100 +98,8 @@ extracted, and no background subtraction will be done.
 * subpixels: if ``method`` is "subpixel", pixels will be resampled by this
   factor in each dimension (int, the default is 5)
 
-The rest of this description pertains to the parameters for non-IFU data.
-
-If ``src_coeff`` is not given, the extraction limits can be specified by
-``xstart``, ``xstop``, ``ystart``, ``ystop``, and ``extract_width``.  Note
-that all of these values are integers, and that the start and stop limits
-are inclusive.
-If ``dispaxis``
-is 1, the zero-indexed limits in the dispersion direction are ``xstart``
-and ``xstop``; if ``dispaxis`` is 2, the dispersion limits are ``ystart``
-and ``ystop``.  (The dispersion limits can be given even if ``src_coeff``
-has been used for defining the cross-dispersion limits.)  The limits in
-the cross-dispersion direction can be given by ``ystart`` and ``ystop``
-(or ``xstart`` and ``xstop`` if ``dispaxis`` is 2).  If ``extract_width``
-is also given, that takes priority over ``ystart`` to ``ystop`` (for
-``dispaxis`` = 1) for the extraction width, but ``ystart`` and ``ystop``
-(for ``dispaxis`` = 1) will still be used to define the middle in the
-cross-dispersion direction.  Any of these parameters can be modified
-by the step code if the extraction region would extend outside the input
-image, or outside the domain specified by the WCS.
-
-The source extraction region can be specified more precisely by giving
-``src_coeff``, coefficients for polynomial functions for the lower and
-upper limits of the source extraction region.  As described in the previous
-paragraph, using this key will override the values
-of ``ystart`` and ``ystop`` (if ``dispaxis`` is 1) or ``xstart`` and
-``xstop`` (if ``dispaxis`` is 2), and ``extract_width``.  These polynomials
-are functions of either wavelength (in microns) or pixel number (pixels in
-the dispersion direction, with respect to the input 2-D slit image),
-specified by the key ``independent_var``.  The default is "pixel".
-The values of these polynomial functions are pixel numbers in the
-direction perpendicular to dispersion.  More than one source extraction
-region may be specified, though this is not expected to be a typical case.
-
-Background regions are specified by giving ``bkg_coeff``, coefficients for
-polynomial functions for the lower and upper limits of one or more regions.
-Background subtraction will be done only if ``bkg_coeff`` is given in the
-reference file.  See below for an example.  See also ``bkg_order`` below.
-
-The coefficients are specified as a list of an even number of lists (an
-even number because both the lower and upper limits of each extraction region
-must be specified).  The source extraction coefficients will normally be
-a list of just two lists, the coefficients for the lower limit function
-and the coefficients for the upper limit function of one extraction
-region.  The limits could just be constant values,
-e.g. \[\[324.5\], \[335.5\]\].  Straight but tilted lines are linear functions:
-
-\[\[324.5, 0.0137\], \[335.5, 0.0137\]\]
-
-Multiple regions may be specified for either the source or background, or
-both.  It will be common to specify more than one background region.  Here
-is an example for specifying two background regions:
-
-\[\[315.2, 0.0135\], \[320.7, 0.0135\], \[341.1, 0.0139\], \[346.8, 0.0139\]\]
-
-This is interpreted as follows:
-
-* \[315.2, 0.0135\]: lower limit for first background region
-* \[320.7, 0.0135\]: upper limit for first background region
-* \[341.1, 0.0139\]: lower limit for second background region
-* \[346.8, 0.0139\]: upper limit for second background region
-
-If the dispersion direction is vertical, replace "lower" with "left" and
-"upper" with "right" in the above description.
-
-Note especially that ``src_coeff`` and ``bkg_coeff`` contain floating-point
-values.  For interpreting fractions of a pixel, the convention used here
-is that the pixel number at the center of a pixel is a whole number.  Thus,
-if a lower or upper limit is a whole number, that limit splits the pixel
-in two, so the weight for that pixel will be 0.5.  To include all the
-pixels between 325 and 335 inclusive, for example, the lower and upper
-limits would be given as 324.5 and 335.5 respectively.
-
-The order of a polynomial is specified implicitly to be one less than the
-number of coefficients (this should not be confused with ``bkg_order``,
-described below).  The number of coefficients must be at least one, and
-there is no predefined upper limit.  The various polynomials (lower limits,
-upper limits, possibly multiple regions) do not need to have the same
-number of coefficients; each of the inner lists specifies a separate
-polynomial.  However, the independent variable (wavelength or pixel)
-does need to be the same for all polynomials for a given slit image
-(identified by key ``id``).
-
-The background is determined independently for each column (or row, if
-``dispaxis`` is 2) of the spectrum.  The ``smoothing_length`` parameter
-is the width of a boxcar for smoothing the background in the dispersion
-direction.  If this is not specified, either in the reference file, the
-config file, or on the command line, no smoothing will be done along the
-dispersion direction.  Following background smoothing (if any), for each
-column (row), a polynomial of order ``bkg_order`` will be fit to the pixel
-values in that column (row) in all the background regions.  If not
-specified, a value of 0 will be used, i.e. a constant function, the mean
-value.  The polynomial will then be evaluated at each pixel within the
-source extraction region for that column (row), and the fitted values will
-be subtracted (pixel by pixel) from the source count rate.
+See :ref:`extract-1d-for-ifu` for more details on how these parameters
+are used in the extraction process.
 
 Example EXTRACT1D Reference File
 --------------------------------
@@ -215,7 +115,7 @@ jwst_niriss_extract1d_0003.json::
       "PEDIGREE": "GROUND",
       "DESCRIP": "NIRISS SOSS extraction params for ground testing",
       "AUTHOR": "M.Wolfe, H.Bushouse",
-      "HISTORY": "This reference file is for used in Build 7.1 of the JWST Calibraton pipeline. The regions are rectagular and do not follow the trace.",
+      "HISTORY": "Build 7.1 of the JWST Calibraton pipeline. The regions are rectagular and do not follow the trace.",
       "USEAFTER": "2015-11-01T00:00:00",
       "apertures": [
         {

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -277,7 +277,9 @@ def get_extract_parameters(
         extract_params['src_coeff'] = None
         extract_params['bkg_coeff'] = None  # no background sub.
         extract_params['smoothing_length'] = 0  # because no background sub.
+        extract_params['bkg_fit'] = None  # because no background sub.
         extract_params['bkg_order'] = 0  # because no background sub.
+        extract_params['subtract_background'] = False
 
         if use_source_posn is None:
             extract_params['use_source_posn'] = False
@@ -322,7 +324,9 @@ def get_extract_parameters(
                         shape = input_model.data.shape
                         extract_params['src_coeff'] = None
                         extract_params['bkg_coeff'] = None
+                        extract_params['bkg_fit'] = None
                         extract_params['bkg_order'] = 0
+                        extract_params['subtract_background'] = False
                         extract_params['use_source_posn'] = False
                         extract_params['xstart'] = 0
                         extract_params['xstop'] = shape[-1] - 1
@@ -337,6 +341,9 @@ def get_extract_parameters(
                         if extract_params['bkg_coeff'] is not None:
                             extract_params['subtract_background'] = True
                             extract_params['bkg_fit'] = aper.get('bkg_fit', 'poly')
+                        else:
+                            extract_params['bkg_fit'] = None
+                            extract_params['subtract_background'] = False
                         extract_params['independent_var'] = aper.get('independent_var', 'pixel').lower()
 
                         if bkg_order is None:

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -29,7 +29,8 @@ from .apply_apcorr import select_apcorr
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
+#WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
+WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM']
 """Exposure types to be regarded as wide-field slitless spectroscopy."""
 
 # These values are used to indicate whether the input extract1d reference file
@@ -186,6 +187,7 @@ def get_extract_parameters(
         sp_order: int,
         meta: MetaNode,
         smoothing_length: Union[int, None],
+        bkg_fit: str,
         bkg_order: Union[int, None],
         use_source_posn: Union[bool, None]
 ) -> dict:
@@ -224,6 +226,13 @@ def get_extract_parameters(
         explicitly specified the value, so that value will be used.
         This argument is only used if background regions have been
         specified.
+
+    bkg_fit : str
+        The type of fit to apply to background values in each
+        column (or row, if the dispersion is vertical). The default
+        `poly` results in a polynomial fit of order `bkg_order`. Other
+        options are `mean` and `median`. If `mean` or `median` is selected,
+        `bkg_order` is ignored.
 
     bkg_order : int or None
         Polynomial order for fitting to each column (or row, if the
@@ -266,7 +275,9 @@ def get_extract_parameters(
         extract_params['ystop'] = shape[-2] - 1  # last pixel in Y
         extract_params['extract_width'] = None
         extract_params['src_coeff'] = None
-        extract_params['bkg_coeff'] = None
+        extract_params['bkg_coeff'] = None  # no background sub.
+        extract_params['smoothing_length'] = 0  # because no background sub.
+        extract_params['bkg_order'] = 0  # because no background sub.
 
         if use_source_posn is None:
             extract_params['use_source_posn'] = False
@@ -275,8 +286,6 @@ def get_extract_parameters(
 
         extract_params['position_correction'] = 0
         extract_params['independent_var'] = 'pixel'
-        extract_params['smoothing_length'] = 0  # because no background sub.
-        extract_params['bkg_order'] = 0  # because no background sub.
         # Note that extract_params['dispaxis'] is not assigned.  This will be done later, possibly slit by slit.
 
     elif ref_dict['ref_file_type'] == FILE_TYPE_JSON:
@@ -325,6 +334,9 @@ def get_extract_parameters(
                     else:
                         extract_params['src_coeff'] = aper.get('src_coeff')
                         extract_params['bkg_coeff'] = aper.get('bkg_coeff')
+                        if extract_params['bkg_coeff'] is not None:
+                            extract_params['subtract_background'] = True
+                            extract_params['bkg_fit'] = aper.get('bkg_fit', 'poly')
                         extract_params['independent_var'] = aper.get('independent_var', 'pixel').lower()
 
                         if bkg_order is None:
@@ -408,8 +420,6 @@ def log_initial_parameters(extract_params: dict):
     log.debug("Initial parameters:")
     log.debug(f"dispaxis = {extract_params['dispaxis']}")
     log.debug(f"spectral order = {extract_params['spectral_order']}")
-    log.debug(f"independent_var = {extract_params['independent_var']}")
-    log.debug(f"smoothing_length = {extract_params['smoothing_length']}")
     log.debug(f"initial xstart = {extract_params['xstart']}")
     log.debug(f"initial xstop = {extract_params['xstop']}")
     log.debug(f"initial ystart = {extract_params['ystart']}")
@@ -417,7 +427,10 @@ def log_initial_parameters(extract_params: dict):
     log.debug(f"extract_width = {extract_params['extract_width']}")
     log.debug(f"initial src_coeff = {extract_params['src_coeff']}")
     log.debug(f"initial bkg_coeff = {extract_params['bkg_coeff']}")
+    log.debug(f"bkg_fit = {extract_params['bkg_fit']}")
     log.debug(f"bkg_order = {extract_params['bkg_order']}")
+    log.debug(f"smoothing_length = {extract_params['smoothing_length']}")
+    log.debug(f"independent_var = {extract_params['independent_var']}")
     log.debug(f"use_source_posn = {extract_params['use_source_posn']}")
 
 
@@ -973,14 +986,20 @@ class ExtractBase(abc.ABC):
         This argument must be an odd positive number or zero, and it is
         only used if background regions have been specified.
 
+    bkg_fit : str
+        Type of background fitting to perform in each column (or row, if
+        the dispersion is vertical). Allowed values are `poly` (default),
+        `mean`, and `median`.
+
     bkg_order : int
         Polynomial order for fitting to each column (or row, if the
-        dispersion is vertical) of background.
+        dispersion is vertical) of background. Only used if `bkg_fit` is
+        `poly`.
         This argument must be positive or zero, and it is only used if
         background regions have been specified.
 
     subtract_background : bool or None
-        A flag which indicates whether the background should be subtracted.
+        A flag that indicates whether the background should be subtracted.
         If None, the value in the extract_1d reference file will be used.
         If not None, this parameter overrides the value in the
         extract_1d reference file.
@@ -1008,6 +1027,7 @@ class ExtractBase(abc.ABC):
             bkg_coeff: Union[List[List[float]], None] = None,
             independent_var: str = "pixel",
             smoothing_length: int = 0,
+            bkg_fit: str = "poly",
             bkg_order: int = 0,
             position_correction: float = 0.,
             subtract_background: Union[bool, None] = None,
@@ -1067,6 +1087,10 @@ class ExtractBase(abc.ABC):
         smoothing_length : int
             Width of a boxcar function for smoothing the background
             regions.
+
+        bkg_fit : str
+            Type of fitting to apply to background values in each column
+            (or row, if the dispersion is vertical).
 
         bkg_order : int
             Polynomial order for fitting to each column (or row, if the
@@ -1146,6 +1170,7 @@ class ExtractBase(abc.ABC):
             log.warning(f"smoothing_length was even ({self.smoothing_length}), so incremented by 1")
             self.smoothing_length += 1  # must be odd
 
+        self.bkg_fit = bkg_fit
         self.bkg_order = bkg_order
         self.use_source_posn = use_source_posn
         self.position_correction = position_correction
@@ -1360,11 +1385,10 @@ class ExtractBase(abc.ABC):
         available, e.g. if the wavelength attribute or wcs function is not
         defined.
         """
-        if input_model.meta.exposure.type in WFSS_EXPTYPES:  # WFSS data are not currently supported.
-            log.warning(
-                f"Can't use target coordinates to get location of spectrum for exp type {input_model.meta.exposure.type}"
-            )
-
+        # WFSS data are not currently supported by this function
+        if input_model.meta.exposure.type in WFSS_EXPTYPES:
+            log.warning("Can't use target coordinates to get location of spectrum "
+                        f"for exp type {input_model.meta.exposure.type}")
             return
 
         bb = self.wcs.bounding_box  # ((x0, x1), (y0, y1))
@@ -1490,17 +1514,14 @@ class ExtractModel(ExtractBase):
                     self.subtract_background = False
                     if self.verbosity:
                         log.info("Skipping background subtraction because background regions are not defined.")
-
             else:
                 # If background subtraction was NOT requested, even though background region(s)
                 # were specified, blank out the bkg region info
                 if self.bkg_coeff is not None:
                     self.bkg_coeff = None
                     if self.verbosity:
-                        log.info(
-                            "Background subtraction was specified in the reference file, "
-                            "but it was overridden by the step parameter."
-                        )
+                        log.info("Background subtraction was specified in the reference file,")
+                        log.info("but has been overridden by the step parameter.")
 
     def nominal_locn(self, middle: int, middle_wl: float) -> Union[float, None]:
         """Find the nominal cross-dispersion location of the target spectrum.
@@ -1659,21 +1680,18 @@ class ExtractModel(ExtractBase):
         log.debug("Updated parameters:")
         log.debug(f"position_correction = {self.position_correction}")
 
-        note_x = ""
-        note_y = ""
         if self.src_coeff is not None:
             log.debug(f"src_coeff = {self.src_coeff}")
 
             # Since src_coeff was specified, that will be used instead of xstart & xstop (or ystart & ystop).
             if self.dispaxis == HORIZONTAL:
-                note_y = " (not actually used)"
+                # Only print xstart/xstop, because ystart/ystop are not used
+                log.debug(f"xstart = {self.xstart}")
+                log.debug(f"xstop = {self.xstop}")
             else:
-                note_x = " (not actually used)"
-
-        log.debug(f"xstart = {self.xstart}{note_x}")
-        log.debug(f"xstop = {self.xstop}{note_x}")
-        log.debug(f"ystart = {self.ystart}{note_y}")
-        log.debug(f"ystop = {self.ystop}{note_y}")
+                # Only print ystart/ystop, because xstart/xstop are not used
+                log.debug(f"ystart = {self.ystart}")
+                log.debug(f"ystop = {self.ystop}")
 
         if self.bkg_coeff is not None:
             log.debug(f"bkg_coeff = {self.bkg_coeff}")
@@ -1761,7 +1779,7 @@ class ExtractModel(ExtractBase):
                 lower = create_poly(coeff_list)
             else:
                 upper = create_poly(coeff_list)
-                self.p_src.append([lower, upper])
+                result.append([lower, upper])
 
             expect_lower = not expect_lower
 
@@ -1937,6 +1955,7 @@ class ExtractModel(ExtractBase):
             self.p_bkg,
             self.independent_var,
             self.smoothing_length,
+            self.bkg_fit,
             self.bkg_order,
             weights=None
         )
@@ -2419,6 +2438,7 @@ def run_extract1d(
         extract_ref_name: str,
         apcorr_ref_name: Union[str, None],
         smoothing_length: Union[int, None],
+        bkg_fit: str,
         bkg_order: Union[int, None],
         log_increment: int,
         subtract_background: Union[bool, None],
@@ -2440,9 +2460,14 @@ def run_extract1d(
     smoothing_length : int or None
         Width of a boxcar function for smoothing the background regions.
 
+    bkg_fit : str
+        Type of fitting to apply to background values in each column
+        (or row, if the dispersion is vertical).
+
     bkg_order : int or None
         Polynomial order for fitting to each column (or row, if the
-        dispersion is vertical) of background.
+        dispersion is vertical) of background. Only used if `bkg_fit`
+        is `poly`.
 
     log_increment : int
         if `log_increment` is greater than 0 and the input data are
@@ -2497,6 +2522,7 @@ def run_extract1d(
         ref_dict,
         apcorr_ref_model,
         smoothing_length,
+        bkg_fit,
         bkg_order,
         log_increment,
         subtract_background,
@@ -2554,6 +2580,7 @@ def do_extract1d(
         extract_ref_dict: Union[dict, None],
         apcorr_ref_model = None,
         smoothing_length: Union[int, None] = None,
+        bkg_fit: str = "poly",
         bkg_order: Union[int, None] = None,
         log_increment: int = 50,
         subtract_background: Union[int, None] = None,
@@ -2583,6 +2610,10 @@ def do_extract1d(
 
     smoothing_length : int or None
         Width of a boxcar function for smoothing the background regions.
+
+    bkg_fit : str
+        Type of fitting to perform on background values in each column
+        (or row, if the dispersion is vertical).
 
     bkg_order : int or None
         Polynomial order for fitting to each column (or row, if the
@@ -2622,13 +2653,17 @@ def do_extract1d(
     extract_ref_dict = ref_dict_sanity_check(extract_ref_dict)
 
     if isinstance(input_model, datamodels.SourceModelContainer):
-        log.debug('Input is a SourceModelContainer')
+        #log.debug('Input is a SourceModelContainer')
         was_source_model = True
 
     # Temporarily set "input" to either the first model in a container, or the individual input model, for convenience
     # of retrieving meta attributes in subsequent statements
     if was_source_model:  # input_model is SourceContainer with a single SlitModel
-        input_temp = input_model[0]
+        if isinstance(input_model, datamodels.SlitModel):
+            input_temp = input_model
+        else:
+            #log.debug(f'do_extract1d: len(input_model)={len(input_model)}')
+            input_temp = input_model[0]
     else:
         input_temp = input_model
 
@@ -2692,7 +2727,8 @@ def do_extract1d(
 
             # The subsequent work on data uses the individual SlitModels, but there are many places where meta
             # attributes are retreived from input_model, so set this to allow that to work.
-            input_model = input_model[0]
+            if not isinstance(input_model, datamodels.SlitModel):
+                input_model = input_model[0]
 
         elif isinstance(input_model, datamodels.MultiSlitModel):  # A simple MultiSlitModel, not in a container
             slits = input_model.slits
@@ -2729,7 +2765,15 @@ def do_extract1d(
                 log.info("so setting use_source_posn to False")
 
             extract_params = get_extract_parameters(
-                extract_ref_dict, slit, slit.name, sp_order, input_model.meta, smoothing_length, bkg_order, use_source_posn
+                extract_ref_dict,
+                slit,
+                slit.name,
+                sp_order,
+                input_model.meta,
+                smoothing_length,
+                bkg_fit,
+                bkg_order,
+                use_source_posn
             )
 
             if subtract_background is not None:
@@ -2913,6 +2957,7 @@ def do_extract1d(
                     sp_order,
                     input_model.meta,
                     smoothing_length,
+                    bkg_fit,
                     bkg_order,
                     use_source_posn
                 )
@@ -3062,6 +3107,7 @@ def do_extract1d(
                     sp_order,
                     input_model.meta,
                     smoothing_length,
+                    bkg_fit,
                     bkg_order,
                     use_source_posn
                 )
@@ -3659,11 +3705,20 @@ def extract_one_slit(
     extract_model.assign_polynomial_limits(verbose)
 
     # Log the extraction limits being used
-    log.info("Using extraction limits: "
-             f"xstart={extract_model.xstart}, "
-             f"xstop={extract_model.xstop}, "
-             f"ystart={extract_model.ystart}, "
-             f"ystop={extract_model.ystop}")
+    log.info("Using extraction limits: ")
+    if extract_model.src_coeff is not None:
+        # Because src_coeff was specified, that will be used instead of xstart/xstop (or ystart/ystop).
+        if extract_model.dispaxis == HORIZONTAL:
+            # Only print xstart/xstop, because ystart/ystop are not used
+            log.info(f"xstart={extract_model.xstart}, "
+                     f"xstop={extract_model.xstop}, and src_coeff")
+        else:
+            # Only print ystart/ystop, because xstart/xstop are not used
+            log.info(f"ystart={extract_model.ystart}, "
+                     f"ystop={extract_model.ystop}, and src_coeff")
+
+    if extract_params['subtract_background']:
+        log.info("with background subtraction")
 
     ra, dec, wavelength, temp_flux, background, npixels, dq = extract_model.extract(data, wl_array, verbose)
 

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -23,7 +23,7 @@ log.setLevel(logging.DEBUG)
 
 def extract1d(image, lambdas, disp_range,
               p_src, p_bkg=None, independent_var="wavelength",
-              smoothing_length=0, bkg_order=0, weights=None):
+              smoothing_length=0, bkg_fit="poly", bkg_order=0, weights=None):
     """Extract the spectrum, optionally subtracting background.
 
     Parameters:
@@ -59,12 +59,16 @@ def extract1d(image, lambdas, disp_range,
         This argument is only used if background regions have been
         specified.
 
+    bkg_fit : string
+        Type of fitting to apply to background values in each column (or
+        row, if the dispersion is vertical).
+
     bkg_order : int
         Polynomial order for fitting to each column of background.  A value
         of 0 means that a simple average of the background regions, column
         by column, will be used.
         This argument must be positive or zero, and it is only used if
-        background regions have been specified.
+        background regions have been specified and if `bkg_fit` is `poly`.
 
     weights : function or None
         If not None, this computes the weights for the source extraction
@@ -208,10 +212,10 @@ def extract1d(image, lambdas, disp_range,
 
         if nbkglim > 0:
 
-            # Compute a polynomial fit to the background for the current
-            # column, using the (optionally) smoothed background.
+            # Compute the background for the current column,
+            # using the (optionally) smoothed background.
             bkg_model, bkg_npts = _fit_background_model(
-                temp_image, x, j, bkglim, bkg_order
+                temp_image, x, j, bkglim, bkg_fit, bkg_order
             )
 
             if bkg_npts == 0:
@@ -220,14 +224,13 @@ def extract1d(image, lambdas, disp_range,
                              "for lambda={} (column {:d})".format(lam, x))
 
             elif len(bkg_model) < bkg_order:
-                log.warning("Not enough valid pixels to determine background "
-                             "with the required order for lambda={} "
-                             "(column {:d}).\n"
-                             "Lowering background order to {:d}"
-                             .format(lam, x, len(bkg_model)))
+                log.warning(f"Not enough valid pixels to determine background "
+                            f"with the required order for lambda={lam} "
+                            f"(column {x}).\n"
+                            f"Lowering background order to {len(bkg_model)}")
 
         # Extract the source, and optionally subtract background using the
-        # polynomial fit to the background for this column.  Even if
+        # fit to the background for this column.  Even if
         # background smoothing was done, we must extract the source from
         # the original, unsmoothed image.
         # source total flux, background total flux, area, total weight
@@ -281,9 +284,8 @@ def bxcar(image, smoothing_length):
     return temp_im[..., half:half + width].astype(image.dtype)
 
 
-def _extract_src_flux(image, x, j, lam, srclim,
-                      weights, bkgmodel):
-    """Subtract the background and extract the source.
+def _extract_src_flux(image, x, j, lam, srclim, weights, bkgmodel):
+    """Extract the source and subtract background.
 
     Parameters:
     -----------
@@ -363,10 +365,10 @@ def _extract_src_flux(image, x, j, lam, srclim,
     else:
         bkg = bkgmodel(y)
 
-    # subtract background:
+    # subtract background per pixel:
     val -= bkg
 
-    # brightness -> flux:
+    # scale per pixel values by pixel area included in extraction
     val *= area
     bkg *= area
 
@@ -389,9 +391,9 @@ def _extract_src_flux(image, x, j, lam, srclim,
     return (total_flux, bkg_flux, tarea, twht)
 
 
-def _fit_background_model(image, x, j, bkglim, bkg_order):
-    """Extract background pixels and fit a polynomial. If the number of good data points is <= 1, the fit model will be
-    forced to 0 to avoid divergent
+def _fit_background_model(image, x, j, bkglim, bkg_fit, bkg_order):
+    """Extract background pixels and fit a polynomial. If the number of good data
+    points is <= 1, the fit model will be forced to 0 to avoid divergence.
 
     Parameters:
     -----------
@@ -411,6 +413,11 @@ def _fit_background_model(image, x, j, bkglim, bkg_order):
         are arrays of the lower and upper limits of one of the background
         extraction regions.
 
+    bkg_fit : str
+        Type of "fitting" to perform: "poly" = polynomial, "mean", or
+        "median". Note that mathematically the result for "mean" is
+        identical to "poly" with `bkg_order`=0.
+
     bkg_order : int
         Polynomial order for fitting to the background regions of the
         current column.
@@ -419,6 +426,8 @@ def _fit_background_model(image, x, j, bkglim, bkg_order):
     --------
     bkg_model : function
         Polynomial fit to the background regions for the current column.
+        When the requested fit is either "mean" or "median", the returned
+        model is a 0th-order polynomial with c0 equal to the mean/median.
 
     npts : int
         This is intended to be the number of good values in the background
@@ -443,9 +452,25 @@ def _fit_background_model(image, x, j, bkglim, bkg_order):
     wht = wht[good]
     y = y[good]
 
-    lsqfitter = fitting.LinearLSQFitter()
-    bkg_model = lsqfitter(models.Polynomial1D(min(bkg_order, npts - 1)),
-                          y, val, weights=wht)
+    # Compute the fit
+    if bkg_fit == 'poly':
+
+        # Fit the background values with a polynomial of the requested order
+        lsqfitter = fitting.LinearLSQFitter()
+        bkg_model = lsqfitter(models.Polynomial1D(min(bkg_order, npts - 1)),
+                              y, val, weights=wht)
+
+    elif bkg_fit == 'mean':
+
+        # Compute the mean of the (good) background values
+        # only use values with weight=1
+        bkg_model = models.Polynomial1D(degree=0, c0=np.mean(val[wht==1]))
+
+    elif bkg_fit == 'median':
+
+        # Compute the median of the (good) background values
+        # only use values with weight=1
+        bkg_model = models.Polynomial1D(degree=0, c0=np.median(val[wht==1]))
 
     return bkg_model, npts
 

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -16,9 +16,15 @@ class Extract1dStep(Step):
         with a boxcar function of this width along the dispersion
         direction.  This should be an odd integer.
 
+    bkg_fit : str
+        A string indicating the type of fitting to be applied to
+        background values in each column (or row, if the dispersion is
+        vertical). Allowed values are `poly`, `mean`, and `median`.
+        Default is `poly`.
+
     bkg_order : int or None
         If not None, a polynomial with order `bkg_order` will be fit to
-        each column (or row if the dispersion direction is horizontal)
+        each column (or row, if the dispersion direction is vertical)
         of the background region or regions.  For a given column (row),
         one polynomial will be fit to all background regions.  The
         polynomial will be evaluated at each pixel of the source
@@ -56,20 +62,13 @@ class Extract1dStep(Step):
     """
 
     spec = """
-    # Boxcar smoothing width for background regions.
-    smoothing_length = integer(default=None)
-    # Order of polynomial fit to one column (or row if the dispersion
-    # direction is vertical) of background regions.
-    bkg_order = integer(default=None, min=0)
-    # Log a progress message when processing multi-integration data.
-    log_increment = integer(default=50)
-    # Flag indicating whether the background should be subtracted.
-    subtract_background = boolean(default=None)
-    # If True, the locations of the target and background regions will be
-    # shifted to correct for the computed source location.
-    use_source_posn = boolean(default=None)
-    # Turn aperture correction on or off
-    apply_apcorr = boolean(default=True)
+    smoothing_length = integer(default=None)  # background smoothing size (boxcar width)
+    bkg_fit = option("poly", "mean", "median", default="poly")  # background fitting type
+    bkg_order = integer(default=None, min=0)  # order of background polynomial fit
+    log_increment = integer(default=50)  # increment for multi-integration log messages
+    subtract_background = boolean(default=None)  # subtract background?
+    use_source_posn = boolean(default=None)  # use source coords to center extractions?
+    apply_apcorr = boolean(default=True)  # apply aperture corrections?
     """
 
     reference_file_types = ['extract1d', 'apcorr']
@@ -151,6 +150,7 @@ class Extract1dStep(Step):
                         extract_ref,
                         apcorr_ref,
                         self.smoothing_length,
+                        self.bkg_fit,
                         self.bkg_order,
                         self.log_increment,
                         self.subtract_background,
@@ -184,6 +184,7 @@ class Extract1dStep(Step):
                             extract_ref,
                             apcorr_ref,
                             self.smoothing_length,
+                            self.bkg_fit,
                             self.bkg_order,
                             self.log_increment,
                             self.subtract_background,
@@ -217,6 +218,7 @@ class Extract1dStep(Step):
                     extract_ref,
                     apcorr_ref,
                     self.smoothing_length,
+                    self.bkg_fit,
                     self.bkg_order,
                     self.log_increment,
                     self.subtract_background,
@@ -256,6 +258,7 @@ class Extract1dStep(Step):
                 extract_ref,
                 apcorr_ref,
                 self.smoothing_length,
+                self.bkg_fit,
                 self.bkg_order,
                 self.log_increment,
                 self.subtract_background,

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -62,7 +62,7 @@ class Extract1dStep(Step):
     """
 
     spec = """
-    smoothing_length = integer(default=None)  # background smoothing size (boxcar width)
+    smoothing_length = integer(default=None)  # background smoothing size
     bkg_fit = option("poly", "mean", "median", default="poly")  # background fitting type
     bkg_order = integer(default=None, min=0)  # order of background polynomial fit
     log_increment = integer(default=50)  # increment for multi-integration log messages

--- a/jwst/extract_1d/tests/test_extract_src_flux.py
+++ b/jwst/extract_1d/tests/test_extract_src_flux.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from jwst.extract_1d import extract1d
 
+
 def test_extract_src_flux():
 
     shape = (9, 5)

--- a/jwst/extract_1d/tests/test_fit_background_model.py
+++ b/jwst/extract_1d/tests/test_fit_background_model.py
@@ -38,7 +38,7 @@ def test_fit_background_mean(inputs_constant):
     image, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
     bkg_fit = "mean"
 
-    (bkg_model, npts) = extract1d._fit_background_model(*inputs_constant)
+    (bkg_model, npts) = extract1d._fit_background_model(image, x, j, bkglim, bkg_fit, bkg_order)
 
     assert math.isclose(bkg_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
     assert math.isclose(bkg_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
@@ -50,7 +50,7 @@ def test_fit_background_median(inputs_constant):
     image, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
     bkg_fit = "median"
 
-    (bkg_model, npts) = extract1d._fit_background_model(*inputs_constant)
+    (bkg_model, npts) = extract1d._fit_background_model(image, x, j, bkglim, bkg_fit, bkg_order)
 
     assert math.isclose(bkg_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
     assert math.isclose(bkg_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)

--- a/jwst/extract_1d/tests/test_fit_background_model.py
+++ b/jwst/extract_1d/tests/test_fit_background_model.py
@@ -19,8 +19,9 @@ def inputs_constant():
     b_upper = np.zeros(shape[1], dtype=np.float64) + 4.5    # 4, inclusive
     bkglim = [[b_lower, b_upper]]
     bkg_order = 0
+    bkg_fit = "poly"
 
-    return image, x, j, bkglim, bkg_order
+    return image, x, j, bkglim, bkg_fit, bkg_order
 
 
 def test_fit_background_model(inputs_constant):
@@ -33,11 +34,35 @@ def test_fit_background_model(inputs_constant):
     assert npts == 2
 
 
+def test_fit_background_mean(inputs_constant):
+    image, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
+    bkg_fit = "mean"
+
+    (bkg_model, npts) = extract1d._fit_background_model(*inputs_constant)
+
+    assert math.isclose(bkg_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(bkg_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert npts == 2
+
+
+def test_fit_background_median(inputs_constant):
+    image, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
+    bkg_fit = "median"
+
+    (bkg_model, npts) = extract1d._fit_background_model(*inputs_constant)
+
+    assert math.isclose(bkg_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(bkg_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert npts == 2
+
+
 def test_handles_nan(inputs_constant):
-    image, x, j, bkglim, bkg_order = inputs_constant
+    image, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
     image[:, 2] = np.nan
 
-    (bkg_model, npts) = extract1d._fit_background_model(image, x, j, bkglim, bkg_order)
+    (bkg_model, npts) = extract1d._fit_background_model(image, x, j, bkglim, bkg_fit, bkg_order)
 
     assert math.isclose(bkg_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
     assert math.isclose(bkg_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
@@ -46,11 +71,11 @@ def test_handles_nan(inputs_constant):
 
 
 def test_handles_one_value(inputs_constant):
-    image, x, j, bkglim, bkg_order = inputs_constant
+    image, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
     image[np.where(image == 22)] = np.nan   # During extraction, only two pixels are returned "normally"; set one to Nan
 
     # If only one data point is available, the polynomial fit is forced to 0
-    bkg_model, npts = extract1d._fit_background_model(image, x, j, bkglim, bkg_order)
+    bkg_model, npts = extract1d._fit_background_model(image, x, j, bkglim, bkg_fit, bkg_order)
 
     assert math.isclose(bkg_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
     assert math.isclose(bkg_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)

--- a/jwst/extract_1d/tests/test_ifu_image_ref.py
+++ b/jwst/extract_1d/tests/test_ifu_image_ref.py
@@ -15,6 +15,7 @@ inner_bkg = 11.5
 outer_bkg = 16.5
 method = "exact"
 
+
 def test_ifu_2d():
     """Test 1"""
 
@@ -22,7 +23,6 @@ def test_ifu_2d():
                           x_center=x_center, y_center=y_center,
                           radius=radius,
                           inner_bkg=inner_bkg, outer_bkg=outer_bkg)
-
 
     # Create a reference dictionary to specify the extraction parameters.
     # This will serve as the "truth" for comparison with the results of
@@ -105,13 +105,13 @@ def test_ifu_3d():
                                   inner_bkg=inner_bkg, outer_bkg=outer_bkg)
 
     ref_dict_2d = {"ref_file_type": extract.FILE_TYPE_IMAGE,
-                "ref_model": ref_image_2d}
+                   "ref_model": ref_image_2d}
     truth = extract.do_extract1d(input, ref_dict_2d, smoothing_length=0,
                                  bkg_order=0, log_increment=50,
                                  subtract_background=True)
 
     ref_dict_3d = {"ref_file_type": extract.FILE_TYPE_IMAGE,
-                "ref_model": ref_image_3d}
+                   "ref_model": ref_image_3d}
     output = extract.do_extract1d(input, ref_dict_3d, smoothing_length=0,
                                   bkg_order=0, log_increment=50,
                                   subtract_background=True)
@@ -269,8 +269,8 @@ def make_ifu_cube(data_shape, source=None, background=None,
 # "user-supplied" background data for the tests above.
 
 def make_ref_image(shape,
-                  x_center=None, y_center=None,
-                  radius=None, inner_bkg=None, outer_bkg=None):
+                   x_center=None, y_center=None,
+                   radius=None, inner_bkg=None, outer_bkg=None):
 
     """Create an image reference file for testing.
 

--- a/jwst/extract_1d/tests/test_wcs.py
+++ b/jwst/extract_1d/tests/test_wcs.py
@@ -12,7 +12,7 @@ def test_spec_wcs_monotonic():
     wcsobj = spec_wcs.create_spectral_wcs(ra, dec, wave)
 
     inp_pix = [1.2, 3.5, 0, 1]
-    res = (np.array([ra] * 4), np.array([dec] * 4), np.array([3.62, 6.25, 1.2 , 3.4 ]))
+    res = (np.array([ra] * 4), np.array([dec] * 4), np.array([3.62, 6.25, 1.2, 3.4]))
 
     assert_allclose(wcsobj(inp_pix), res, atol=10**-14)
     assert_allclose(wcsobj.invert(*res), inp_pix, atol=10**-14)

--- a/jwst/regtest/test_nircam_tsgrism.py
+++ b/jwst/regtest/test_nircam_tsgrism.py
@@ -14,18 +14,21 @@ def run_pipelines(jail, rtdata_module):
     collect_pipeline_cfgs("config")
 
     # Run tso-spec2 pipeline on the _rateints file, saving intermediate products
+    rtdata.get_data("nircam/tsgrism/jwst_nircam_tsgrism_extract1d.json")
     rtdata.get_data("nircam/tsgrism/jw00721012001_03103_00001-seg001_nrcalong_rateints.fits")
     args = ["config/calwebb_tso-spec2.cfg", rtdata.input,
         "--steps.flat_field.save_results=True",
         "--steps.extract_2d.save_results=True",
         "--steps.srctype.save_results=True",
+        "--steps.extract_1d.override_extract1d='jwst_nircam_tsgrism_extract1d.json'"
         ]
     Step.from_cmdline(args)
 
     # Get the level3 assocation json file (though not its members) and run
     # the tso3 pipeline on all _calints files listed in association
     rtdata.get_data("nircam/tsgrism/jw00721-o012_20191119t043909_tso3_001_asn.json")
-    args = ["config/calwebb_tso3.cfg", rtdata.input]
+    args = ["config/calwebb_tso3.cfg", rtdata.input,
+        "--steps.extract_1d.override_extract1d='jwst_nircam_tsgrism_extract1d.json'"]
     Step.from_cmdline(args)
 
     return rtdata


### PR DESCRIPTION
Updates to the extract_1d step to allow for an EXTRACT1D reference file to be used for NRC_TSGRISM mode, so that necessary column-by-column background extraction and subtraction can be performed. Previously the code was hardwired to not use EXTRACT1D ref file params for NRC_TSGRISM mode, which defaulted to very simplistic extraction with no background subtraction.

In addition to enabling the use of the reference file for this mode, a new parameter `bkg_fit` has been added, which now allows the user to specify whether to perform the default polynomial fit to background values or do simple mean and median computations. Functions to perform the mean and median background computations have been added to the code. Note that even when mean/median are used, the background model is still created in the form of a polynomial, but in this case it's a zero-order polynomial with the 0th-order coefficient set to the mean/median. That allows the background model to be used as-is in the downstream extraction functions.

Documentation for the extract_1d step and EXTRACT1D reference file have also been updated to account for the changes and to give more details on how the various extraction parameters are actually used in the code.

Fixes #5000 / [JP-1478](https://jira.stsci.edu/browse/JP-1478)