### PR TITLE
Split up some long-running regtest modules

### DIFF
--- a/jwst/regtest/test_miri_mrs_spec2.py
+++ b/jwst/regtest/test_miri_mrs_spec2.py
@@ -60,51 +60,6 @@ def run_spec2(jail, rtdata_module):
     return rtdata, asn_path
 
 
-@pytest.fixture(scope='module')
-def run_spec3(jail, run_spec2):
-    """Run the Spec3Pipeline on the results from the Spec2Pipeline run"""
-    rtdata, asn_path = run_spec2
-
-    # The presumption is that `run_spec2` has set the input to the
-    # original association. To use this default, and not re-download
-    # the association, simply do not specify `step_params["input_path"]`
-    rtdata.input = asn_path
-    step_params = {
-        'step': 'calwebb_spec3.cfg',
-        'args': [
-            '--steps.master_background.save_results=true',
-            '--steps.mrs_imatch.save_results=true',
-            '--steps.outlier_detection.save_results=true',
-            '--steps.resample_spec.save_results=true',
-            '--steps.cube_build.save_results=true',
-            '--steps.extract_1d.save_results=true',
-            '--steps.combine_1d.save_results=true',
-        ]
-    }
-
-    return rt.run_step_from_dict(rtdata, **step_params)
-
-
-@pytest.fixture(scope='module')
-def run_spec3_multi(jail, rtdata_module):
-    """Run the Spec3Pipeline on multi channel/multi filter data"""
-    step_params = {
-        'input_path': INPUT_PATH + '/' + 'ifushort_set2_asn3.json',
-        'step': 'calwebb_spec3.cfg',
-        'args': [
-            '--steps.master_background.save_results=true',
-            '--steps.mrs_imatch.save_results=true',
-            '--steps.outlier_detection.save_results=true',
-            '--steps.resample_spec.save_results=true',
-            '--steps.cube_build.save_results=true',
-            '--steps.extract_1d.save_results=true',
-            '--steps.combine_1d.save_results=true',
-        ]
-    }
-
-    return rt.run_step_from_dict(rtdata_module, **step_params)
-
-
 @pytest.mark.slow
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
@@ -116,54 +71,6 @@ def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
     rtdata, asn_path = run_spec2
     rt.is_like_truth(rtdata, fitsdiff_default_kwargs, suffix,
                      truth_path=TRUTH_PATH)
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-@pytest.mark.parametrize(
-    'output',
-    [
-        'ifushort_ch12_spec3_mrs_imatch.fits',
-        'ifushort_ch12_spec3_ch1-medium_s3d.fits',
-        'ifushort_ch12_spec3_ch2-medium_s3d.fits',
-        'ifushort_ch12_spec3_ch1-medium_x1d.fits',
-        'ifushort_ch12_spec3_ch2-medium_x1d.fits',
-    ],
-    ids=["mrs_imatch", "ch1-s3d", "ch2-s3d", "ch1-x1d", "ch2-x1d"]
-)
-def test_spec3(run_spec3, fitsdiff_default_kwargs, output):
-    """Regression test matching output files"""
-    rt.is_like_truth(
-        run_spec3, fitsdiff_default_kwargs, output,
-        truth_path=TRUTH_PATH,
-        is_suffix=False
-    )
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-@pytest.mark.parametrize(
-    'output',
-    [
-        'ifushort_set2_0_mrs_imatch.fits',
-        'ifushort_set2_1_mrs_imatch.fits',
-        'ifushort_set2_0_a3001_crf.fits',
-        'ifushort_set2_1_a3001_crf.fits',
-        'ifushort_set2_ch1-short_s3d.fits',
-        'ifushort_set2_ch2-short_s3d.fits',
-        'ifushort_set2_ch1-short_x1d.fits',
-        'ifushort_set2_ch2-short_x1d.fits',
-    ],
-    ids=["ch1-mrs_imatch", "ch2-mrs_imatch", "ch1-crf", "ch2-crf",
-        "ch1-s3d", "ch2-s3d", "ch1-x1d", "ch2-x1d"]
-)
-def test_spec3_multi(run_spec3_multi, fitsdiff_default_kwargs, output):
-    """Regression test matching output files"""
-    rt.is_like_truth(
-        run_spec3_multi, fitsdiff_default_kwargs, output,
-        truth_path=TRUTH_PATH,
-        is_suffix=False
-    )
 
 
 @pytest.mark.slow

--- a/jwst/regtest/test_miri_mrs_spec3.py
+++ b/jwst/regtest/test_miri_mrs_spec3.py
@@ -1,0 +1,123 @@
+"""Regression tests for MIRI MRS modes"""
+import os
+import pytest
+
+from . import regtestdata as rt
+
+from astropy.io.fits.diff import FITSDiff
+from jwst.stpipe import Step
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.associations.asn_from_list import asn_from_list
+
+# Define artifactory source and truth
+INPUT_PATH = 'miri/mrs'
+TRUTH_PATH = 'truth/test_miri_mrs'
+
+
+@pytest.fixture(scope='module')
+def run_spec3(jail, rtdata_module):
+    """Run the Spec3Pipeline on the single cal result from the Spec2Pipeline run"""
+    rtdata = rtdata_module
+
+    collect_pipeline_cfgs("config")
+
+    # Note that we use the truth file from spec2 processing as the input to spec3
+    rtdata.get_data(TRUTH_PATH + '/' + 'ifushort_ch12_cal.fits')
+
+    asn = asn_from_list([rtdata.input], product_name='ifushort_ch12_spec3')
+    asn.data["program"] = "00024"
+    asn.data["asn_type"] = "spec3"
+    asn.sequence = 1
+    asn_name, serialized = asn.dump(format="json")
+    with open(asn_name, "w") as f:
+        f.write(serialized)
+
+    rtdata.input = asn_name
+
+    args = [
+        "config/calwebb_spec3.cfg",
+        rtdata.input,
+        '--steps.master_background.save_results=true',
+        '--steps.mrs_imatch.save_results=true',
+        '--steps.outlier_detection.save_results=true',
+        '--steps.resample_spec.save_results=true',
+        '--steps.cube_build.save_results=true',
+        '--steps.extract_1d.save_results=true',
+        '--steps.combine_1d.save_results=true',
+    ]
+
+    Step.from_cmdline(args)
+    return rtdata
+
+
+@pytest.fixture(scope='module')
+def run_spec3_multi(jail, rtdata_module):
+    """Run the Spec3Pipeline on multi channel/multi filter data"""
+    rtdata = rtdata_module
+
+    step_params = {
+        'input_path': INPUT_PATH + '/' + 'ifushort_set2_asn3.json',
+        'step': 'calwebb_spec3.cfg',
+        'args': [
+            '--steps.master_background.save_results=true',
+            '--steps.mrs_imatch.save_results=true',
+            '--steps.outlier_detection.save_results=true',
+            '--steps.resample_spec.save_results=true',
+            '--steps.cube_build.save_results=true',
+            '--steps.extract_1d.save_results=true',
+            '--steps.combine_1d.save_results=true',
+        ]
+    }
+
+    return rt.run_step_from_dict(rtdata_module, **step_params)
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+@pytest.mark.parametrize(
+    'output',
+    [
+        'ifushort_ch12_spec3_mrs_imatch.fits',
+        'ifushort_ch12_spec3_ch1-medium_s3d.fits',
+        'ifushort_ch12_spec3_ch2-medium_s3d.fits',
+        'ifushort_ch12_spec3_ch1-medium_x1d.fits',
+        'ifushort_ch12_spec3_ch2-medium_x1d.fits',
+    ],
+    ids=["mrs_imatch", "ch1-s3d", "ch2-s3d", "ch1-x1d", "ch2-x1d"]
+)
+def test_spec3(run_spec3, fitsdiff_default_kwargs, output):
+    """Regression test matching output files"""
+
+    rtdata = run_spec3
+    rtdata.output = output
+
+    rtdata.get_truth(os.path.join(TRUTH_PATH, rtdata.output))
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+@pytest.mark.parametrize(
+    'output',
+    [
+        'ifushort_set2_0_mrs_imatch.fits',
+        'ifushort_set2_1_mrs_imatch.fits',
+        'ifushort_set2_0_a3001_crf.fits',
+        'ifushort_set2_1_a3001_crf.fits',
+        'ifushort_set2_ch1-short_s3d.fits',
+        'ifushort_set2_ch2-short_s3d.fits',
+        'ifushort_set2_ch1-short_x1d.fits',
+        'ifushort_set2_ch2-short_x1d.fits',
+    ],
+    ids=["ch1-mrs_imatch", "ch2-mrs_imatch", "ch1-crf", "ch2-crf",
+         "ch1-s3d", "ch2-s3d", "ch1-x1d", "ch2-x1d"]
+)
+def test_spec3_multi(run_spec3_multi, fitsdiff_default_kwargs, output):
+    """Regression test matching output files"""
+    rt.is_like_truth(
+        run_spec3_multi, fitsdiff_default_kwargs, output,
+        truth_path=TRUTH_PATH,
+        is_suffix=False
+    )

--- a/jwst/regtest/test_miri_mrs_spec3.py
+++ b/jwst/regtest/test_miri_mrs_spec3.py
@@ -53,7 +53,6 @@ def run_spec3(jail, rtdata_module):
 @pytest.fixture(scope='module')
 def run_spec3_multi(jail, rtdata_module):
     """Run the Spec3Pipeline on multi channel/multi filter data"""
-    rtdata = rtdata_module
 
     step_params = {
         'input_path': INPUT_PATH + '/' + 'ifushort_set2_asn3.json',

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -3,14 +3,6 @@ import pytest
 
 from . import regtestdata as rt
 
-from astropy.io.fits.diff import FITSDiff
-import numpy as np
-
-import jwst.datamodels as dm
-from jwst.flatfield import FlatFieldStep
-from jwst.flatfield.flat_field import nirspec_ifu
-from jwst.pathloss import PathLossStep
-
 # Define artifactory source and truth
 INPUT_PATH = 'nirspec/ifu'
 TRUTH_PATH = 'truth/test_nirspec_ifu'
@@ -63,89 +55,3 @@ def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test matching output files"""
     rt.is_like_truth(run_spec2, fitsdiff_default_kwargs, suffix,
                      truth_path=TRUTH_PATH)
-
-
-@pytest.mark.bigdata
-def test_nirspec_ifu_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
-    """Test using predefined interpolated flat"""
-    data = dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits'))
-    user_supplied_flat = dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_interpolated_flat.fits'))
-
-    nirspec_ifu(data, None, None, None, None, user_supplied_flat=user_supplied_flat)
-    rtdata.output = 'ff_using_interpolated.fits'
-    data.write(rtdata.output)
-
-    rtdata.get_truth(TRUTH_PATH + '/' + 'ff_using_interpolated.fits')
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()
-
-
-@pytest.mark.bigdata
-def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
-    """Test providing a user-supplied flat field to the FlatFieldStep"""
-    data = rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits')
-    user_supplied_flat = rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_interpolated_flat.fits')
-
-    data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat)
-    rtdata.output = 'flat_fielded_step_user_supplied.fits'
-    data_flat_fielded.write(rtdata.output)
-
-    rtdata.get_truth(TRUTH_PATH + '/' + 'flat_fielded_step_user_supplied.fits')
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-def test_ff_inv(rtdata, fitsdiff_default_kwargs):
-    """Test flat field inversion"""
-    data = dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits'))
-
-    flatted = FlatFieldStep.call(data)
-    unflatted = FlatFieldStep.call(flatted, inverse=True)
-
-    assert np.allclose(data.data, unflatted.data), 'Inversion failed'
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-def test_pathloss_corrpars(rtdata):
-    """Test PathLossStep using correction_pars"""
-    data = dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits'))
-
-    pls = PathLossStep()
-    corrected = pls.run(data)
-
-    pls.use_correction_pars = True
-    corrected_corrpars = pls.run(data)
-
-    assert np.allclose(corrected.data, corrected_corrpars.data, equal_nan=True)
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-def test_pathloss_inverse(rtdata):
-    """Test PathLossStep using correction_pars"""
-    data = dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits'))
-
-    pls = PathLossStep()
-    corrected = pls.run(data)
-
-    pls.inverse = True
-    corrected_inverse = pls.run(corrected)
-
-    non_nan = ~np.isnan(corrected_inverse.data)
-    assert np.allclose(corrected.data[non_nan], corrected_inverse.data[non_nan])
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-def test_pathloss_source_type(rtdata):
-    """Test PathLossStep forcing source type"""
-    data = dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits'))
-
-    pls = PathLossStep()
-    pls.source_type = 'extended'
-    pls.run(data)
-
-    assert np.allclose(pls.correction_pars.data, pls.correction_pars.pathloss_uniform, equal_nan=True)

--- a/jwst/regtest/test_nirspec_steps_spec2.py
+++ b/jwst/regtest/test_nirspec_steps_spec2.py
@@ -1,0 +1,102 @@
+"""Regression tests for NIRSpec IFU"""
+import pytest
+
+from astropy.io.fits.diff import FITSDiff
+import numpy as np
+
+import jwst.datamodels as dm
+from jwst.flatfield import FlatFieldStep
+from jwst.flatfield.flat_field import nirspec_ifu
+from jwst.pathloss import PathLossStep
+
+# Define artifactory source and truth
+INPUT_PATH = 'nirspec/ifu'
+TRUTH_PATH = 'truth/test_nirspec_ifu'
+
+
+@pytest.mark.bigdata
+def test_nirspec_ifu_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
+    """Test using predefined interpolated flat"""
+    data = dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits'))
+    user_supplied_flat = dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_interpolated_flat.fits'))
+
+    nirspec_ifu(data, None, None, None, None, user_supplied_flat=user_supplied_flat)
+    rtdata.output = 'ff_using_interpolated.fits'
+    data.write(rtdata.output)
+
+    rtdata.get_truth(TRUTH_PATH + '/' + 'ff_using_interpolated.fits')
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
+    """Test providing a user-supplied flat field to the FlatFieldStep"""
+    data = rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits')
+    user_supplied_flat = rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_interpolated_flat.fits')
+
+    data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat)
+    rtdata.output = 'flat_fielded_step_user_supplied.fits'
+    data_flat_fielded.write(rtdata.output)
+
+    rtdata.get_truth(TRUTH_PATH + '/' + 'flat_fielded_step_user_supplied.fits')
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+def test_ff_inv(rtdata, fitsdiff_default_kwargs):
+    """Test flat field inversion"""
+    data = dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits'))
+
+    flatted = FlatFieldStep.call(data)
+    unflatted = FlatFieldStep.call(flatted, inverse=True)
+
+    assert np.allclose(data.data, unflatted.data), 'Inversion failed'
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+def test_pathloss_corrpars(rtdata):
+    """Test PathLossStep using correction_pars"""
+    data = dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits'))
+
+    pls = PathLossStep()
+    corrected = pls.run(data)
+
+    pls.use_correction_pars = True
+    corrected_corrpars = pls.run(data)
+
+    assert np.allclose(corrected.data, corrected_corrpars.data, equal_nan=True)
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+def test_pathloss_inverse(rtdata):
+    """Test PathLossStep using correction_pars"""
+    data = dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits'))
+
+    pls = PathLossStep()
+    corrected = pls.run(data)
+
+    pls.inverse = True
+    corrected_inverse = pls.run(corrected)
+
+    non_nan = ~np.isnan(corrected_inverse.data)
+    assert np.allclose(corrected.data[non_nan], corrected_inverse.data[non_nan])
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+def test_pathloss_source_type(rtdata):
+    """Test PathLossStep forcing source type"""
+    data = dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits'))
+
+    pls = PathLossStep()
+    pls.source_type = 'extended'
+    pls.run(data)
+
+    assert np.allclose(pls.correction_pars.data,
+                       pls.correction_pars.pathloss_uniform,
+                       equal_nan=True)


### PR DESCRIPTION
Splitting up some of the regtest modules that contain both spec2 and spec3 tests for MIRI and NIRSpec IFU modes, which are notoriously slow to run. Segregated the spec2 and spec3 tests into their own modules and also put the NIRSpec IFU spec2 step-specific tests into their own module (separate from the generic spec2 pipeline test).