### PR TITLE
JP-1357: Code, tests, and docs to update saturation step to test for groups at the A/D floor (0 DN)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -152,7 +152,7 @@ saturation
 - Set saturation threshold to A-to-D limit of 65535 for pixels flagged with
   NO_SAT_CHECK in the saturation reference file, instead of skipping any
   test of those pixels. [#5394]
-- Add check for low saturation (A/D floor) (#5422)
+- Flag groups values below A/D floor (0 DN) (#5422)
 
 set_telescope_pointing
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -152,6 +152,7 @@ saturation
 - Set saturation threshold to A-to-D limit of 65535 for pixels flagged with
   NO_SAT_CHECK in the saturation reference file, instead of skipping any
   test of those pixels. [#5394]
+- Add check for low saturation (A/D floor) (#5422)
 
 set_telescope_pointing
 ----------------------

--- a/docs/jwst/saturation/description.rst
+++ b/docs/jwst/saturation/description.rst
@@ -2,11 +2,9 @@ Description
 ============
 
 The ``saturation`` step flags pixels at or below the A/D floor or above the
-saturation threshold.  Pixels values are flagged as saturated if the the pixel
-value is larger than the defined saturation threshold.  Pixel values are flagged
-as below the A/D floor if they have a value of zero DN.  Saturation can be due
-to saturating the detector (hard saturation) or going above the valid
-Analog-to-Digital (A/D) converter range (A/D saturation).
+saturation threshold.  Pixels values are flagged as saturated if the pixel value
+is larger than the defined saturation threshold.  Pixel values are flagged as
+below the A/D floor if they have a value of zero DN.
 
 This step loops over all integrations within an exposure, examining each one
 group-by-group, comparing the pixel values in the SCI array with defined
@@ -14,12 +12,12 @@ saturation thresholds for each pixel. When it finds a pixel value in a given
 group that is above the saturation threshold (high saturation), it sets the
 "SATURATED" flag in the corresponding location of the "GROUPDQ" array in the
 science exposure.  When it finds a pixel in a given group that has a zero or
-negative value (below  the A/D floor), it sets the "AD_FLOOR" flag in the
-corresponding location of the "GROUPDQ" array in the science exposure  For the
-saturation case, it also flags all subsequent groups for that pixel as
-saturated. For example, if there are 10 groups in an integration and group 7 is
-the first one to cross the saturation threshold for a given pixel, then groups 7
-through 10 will all be flagged for that pixel.
+negative value (below  the A/D floor), it sets the "AD_FLOOR" and "DO_NOT_USE"
+flags in the corresponding location of the "GROUPDQ" array in the science
+exposure  For the saturation case, it also flags all subsequent groups for that
+pixel as saturated. For example, if there are 10 groups in an integration and
+group 7 is the first one to cross the saturation threshold for a given pixel,
+then groups 7 through 10 will all be flagged for that pixel.
 
 Pixels with thresholds set to NaN or flagged as "NO_SAT_CHECK" in the saturation
 reference file have their thresholds set to the 16-bit A-to-D converter limit

--- a/docs/jwst/saturation/description.rst
+++ b/docs/jwst/saturation/description.rst
@@ -1,24 +1,25 @@
 Description
 ============
 
-The ``saturation`` step flags saturated pixel values.  Pixels values are flagged
-as saturated if the the pixel value is larger than the defined saturation
-threshold (high saturation)  or if it has a value of 0 or lower (low
-saturation). High saturation can be due to saturating the detector (hard
-saturation) or going above the valid Analog-to-Digital (A/D) converter range
-(A/D saturation). Low saturation is due to going below the valid A/D converter
-range (A/D floor).
+The ``saturation`` step flags pixels at or below the A/D floor or above the
+saturation threshold.  Pixels values are flagged as saturated if the the pixel
+value is larger than the defined saturation threshold.  Pixel values are flagged
+as below the A/D floor if they have a value of zero DN.  Saturation can be due
+to saturating the detector (hard saturation) or going above the valid
+Analog-to-Digital (A/D) converter range (A/D saturation).
 
 This step loops over all integrations within an exposure, examining each one
 group-by-group, comparing the pixel values in the SCI array with defined
 saturation thresholds for each pixel. When it finds a pixel value in a given
-group that is zero or negative (low saturation) or above the saturation
-threshold (high saturation), it sets the "SATURATED" flag in the corresponding
-location of the "GROUPDQ" array in the science exposure. For the high saturation
-case, it also flags all subsequent groups for that pixel as saturated. For
-example, if there are 10 groups in an integration and group 7 is the first one
-to cross the saturation threshold for a given pixel, then groups 7 through 10
-will all be flagged for that pixel.
+group that is above the saturation threshold (high saturation), it sets the
+"SATURATED" flag in the corresponding location of the "GROUPDQ" array in the
+science exposure.  When it finds a pixel in a given group that has a zero or
+negative value (below  the A/D floor), it sets the "AD_FLOOR" flag in the
+corresponding location of the "GROUPDQ" array in the science exposure  For the
+saturation case, it also flags all subsequent groups for that pixel as
+saturated. For example, if there are 10 groups in an integration and group 7 is
+the first one to cross the saturation threshold for a given pixel, then groups 7
+through 10 will all be flagged for that pixel.
 
 Pixels with thresholds set to NaN or flagged as "NO_SAT_CHECK" in the saturation
 reference file have their thresholds set to the 16-bit A-to-D converter limit

--- a/docs/jwst/saturation/description.rst
+++ b/docs/jwst/saturation/description.rst
@@ -1,16 +1,24 @@
 Description
 ============
 
-The ``saturation`` step flags saturated pixel values. It loops over all
-integrations within an exposure, examining each one group-by-group, comparing the
-pixel values in the SCI array against pixel-by-pixel thresholds stored in a
-saturation reference file.
-When it finds a pixel value in a given group that is above the threshold, it
-sets the "SATURATED" flag in the corresponding location of the "GROUPDQ"
-array in the science exposure. It also flags all subsequent groups for that
-pixel as saturated. For example, if there are 10 groups in an integration and
-group 7 is the first one to cross the saturation threshold for a given pixel,
-then groups 7 through 10 will all be flagged for that pixel.
+The ``saturation`` step flags saturated pixel values.  Pixels values are flagged
+as saturated if the the pixel value is larger than the defined saturation
+threshold (high saturation)  or if it has a value of 0 or lower (low
+saturation). High saturation can be due to saturating the detector (hard
+saturation) or going above the valid Analog-to-Digital (A/D) converter range
+(A/D saturation). Low saturation is due to going below the valid A/D converter
+range (A/D floor).
+
+This step loops over all integrations within an exposure, examining each one
+group-by-group, comparing the pixel values in the SCI array with defined
+saturation thresholds for each pixel. When it finds a pixel value in a given
+group that is zero or negative (low saturation) or above the saturation
+threshold (high saturation), it sets the "SATURATED" flag in the corresponding
+location of the "GROUPDQ" array in the science exposure. For the high saturation
+case, it also flags all subsequent groups for that pixel as saturated. For
+example, if there are 10 groups in an integration and group 7 is the first one
+to cross the saturation threshold for a given pixel, then groups 7 through 10
+will all be flagged for that pixel.
 
 Pixels with thresholds set to NaN or flagged as "NO_SAT_CHECK" in the saturation
 reference file have their thresholds set to the 16-bit A-to-D converter limit

--- a/jwst/datamodels/dqflags.py
+++ b/jwst/datamodels/dqflags.py
@@ -28,7 +28,7 @@ pixel = {'GOOD':             0,      # No bits set, all is good
          'DROPOUT':          2**3,   # Data lost in transmission
          'OUTLIER':          2**4,   # Flagged by outlier detection (was RESERVED_1)
          'PERSISTENCE':      2**5,   # High persistence (was RESERVED_2)
-         'RESERVED_3':       2**6,   #
+         'AD_FLOOR':         2**6,   # Below A/D floor (0 DN, was RESERVED_3)
          'RESERVED_4':       2**7,   #
          'UNRELIABLE_ERROR': 2**8,   # Uncertainty exceeds quoted error
          'NON_SCIENCE':      2**9,   # Pixel not on science portion of detector
@@ -64,6 +64,7 @@ group = {'GOOD':       pixel['GOOD'],
          'SATURATED':  pixel['SATURATED'],
          'JUMP_DET':   pixel['JUMP_DET'],
          'DROPOUT':    pixel['DROPOUT'],
+         'AD_FLOOR':   pixel['AD_FLOOR'],
 }
 
 

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -39,7 +39,8 @@ def do_correction(input_model, ref_model):
     Returns
     -------
     output_model : `~jwst.datamodels.RampModel`
-        Data model with saturation and A/D floor flags set in GROUPDQ array
+        Data model with saturation, A/D floor, and do not use flags set in
+        the GROUPDQ array
     """
 
     ramp_array = input_model.data
@@ -85,35 +86,35 @@ def do_correction(input_model, ref_model):
             if is_irs2_format:
                 sci_temp = x_irs2.from_irs2(ramp_array[ints, group, :, :],
                                             irs2_mask, detector)
-                # check for high saturation
+                # check for saturation
                 flag_temp = np.where(sci_temp >= sat_thresh, SATURATED, 0)
-                # check for low saturation
+                # check for A/D floor
                 flaglow_temp = np.where(sci_temp <= 0, AD_FLOOR | DONOTUSE, 0)
                 # Copy temps into flagarrays.
                 x_irs2.to_irs2(flagarray, flag_temp, irs2_mask, detector)
                 x_irs2.to_irs2(flaglowarray, flaglow_temp, irs2_mask, detector)
             else:
-                # check for high saturation
+                # check for saturation
                 flagarray[:, :] = np.where(ramp_array[ints, group, :, :] >= sat_thresh,
                                            SATURATED, 0)
-                # check for low saturation
+                # check for A/D floor
                 flaglowarray[:, :] = np.where(ramp_array[ints, group, :, :] <= 0,
                                               AD_FLOOR | DONOTUSE, 0)
-            # for high saturation, the flag is set in the current plane
+            # for saturation, the flag is set in the current plane
             # and all following planes.
             np.bitwise_or(groupdq[ints, group:, :, :], flagarray,
                           groupdq[ints, group:, :, :])
-            # for low saturation, the flag is only set of the current plane
+            # for A/D floor, the flag is only set of the current plane
             np.bitwise_or(groupdq[ints, group, :, :], flaglowarray,
                           groupdq[ints, group, :, :])
 
-    # Save the saturation flags in the output GROUPDQ array
+    # Save the flags in the output GROUPDQ array
     output_model.groupdq = groupdq
 
     n_sat = np.any(np.any(np.bitwise_and(groupdq, SATURATED), axis=0), axis=0).sum()
     log.info(f'Detected {n_sat} saturated pixels')
     n_floor = np.any(np.any(np.bitwise_and(groupdq, AD_FLOOR), axis=0), axis=0).sum()
-    log.info(f'Detected {n_floor} AD FLOOR pixels')
+    log.info(f'Detected {n_floor} A/D floor pixels')
 
     # Save the NO_SAT_CHECK flags in the output PIXELDQ array
     if is_irs2_format:

--- a/jwst/saturation/tests/test_saturation.py
+++ b/jwst/saturation/tests/test_saturation.py
@@ -42,8 +42,8 @@ def test_basic_saturation_flagging(setup_nrc_cube):
     assert np.all(output.groupdq[0, satindex:, 5, 5] == dqflags.group['SATURATED'])
 
 
-def test_low_saturation_flagging(setup_nrc_cube):
-    """Check that the saturation flag is set when a pixel value is zero or
+def test_ad_floor_flagging(setup_nrc_cube):
+    """Check that the ad_floor flag is set when a pixel value is zero or
     negative."""
 
     # Create inputs, data, and saturation maps
@@ -71,12 +71,12 @@ def test_low_saturation_flagging(setup_nrc_cube):
     output = do_correction(data, satmap)
 
     # Check if the right frames are flagged as saturated
-    assert np.all(output.groupdq[0, satindxs, 5, 5] == dqflags.group['SATURATED'])
+    assert np.all(output.groupdq[0, satindxs, 5, 5] == dqflags.group['AD_FLOOR'])
 
 
-def test_low_and_high_saturation_flagging(setup_nrc_cube):
-    """Check that the saturation flag is set when a pixel value is zero or
-    negative and when the pixel is above the high saturation threshold."""
+def test_ad_floor_and_saturation_flagging(setup_nrc_cube):
+    """Check that the ad_floor flag is set when a pixel value is zero or
+    negative and the saturation flag when the pixel is above the saturation threshold."""
 
     # Create inputs, data, and saturation maps
     ngroups = 5
@@ -93,8 +93,10 @@ def test_low_and_high_saturation_flagging(setup_nrc_cube):
     data.data[0, 3, 5, 5] = 40
     data.data[0, 4, 5, 5] = 61000  # Signal above the saturation threshold
 
-    # frames that should be flagged as saturation (low)
-    satindxs = [0, 1, 4]
+    # framest hat should be flagged as ad_floor
+    floorindxs = [0, 1]
+    # frames that should be flagged as saturation
+    satindxs = [4]
 
     # Set saturation value in the saturation model
     satmap.data[5, 5] = satvalue
@@ -102,6 +104,8 @@ def test_low_and_high_saturation_flagging(setup_nrc_cube):
     # Run the pipeline
     output = do_correction(data, satmap)
 
+    # Check if the right frames are flagged as ad_floor
+    assert np.all(output.groupdq[0, floorindxs, 5, 5] == dqflags.group['AD_FLOOR'])
     # Check if the right frames are flagged as saturated
     assert np.all(output.groupdq[0, satindxs, 5, 5] == dqflags.group['SATURATED'])
 

--- a/jwst/saturation/tests/test_saturation.py
+++ b/jwst/saturation/tests/test_saturation.py
@@ -48,8 +48,8 @@ def test_low_saturation_flagging(setup_nrc_cube):
 
     # Create inputs, data, and saturation maps
     ngroups = 5
-    nrows = 2048
-    ncols = 2048
+    nrows = 20
+    ncols = 20
     satvalue = 60000
 
     data, satmap = setup_nrc_cube(ngroups, nrows, ncols)
@@ -65,7 +65,7 @@ def test_low_saturation_flagging(setup_nrc_cube):
     satindxs = [0, 1]
 
     # Set saturation value in the saturation model
-    satmap.data[500, 500] = satvalue
+    satmap.data[5, 5] = satvalue
 
     # Run the pipeline
     output = do_correction(data, satmap)
@@ -80,8 +80,8 @@ def test_low_and_high_saturation_flagging(setup_nrc_cube):
 
     # Create inputs, data, and saturation maps
     ngroups = 5
-    nrows = 2048
-    ncols = 2048
+    nrows = 20
+    ncols = 20
     satvalue = 60000
 
     data, satmap = setup_nrc_cube(ngroups, nrows, ncols)
@@ -97,7 +97,7 @@ def test_low_and_high_saturation_flagging(setup_nrc_cube):
     satindxs = [0, 1, 4]
 
     # Set saturation value in the saturation model
-    satmap.data[500, 500] = satvalue
+    satmap.data[5, 5] = satvalue
 
     # Run the pipeline
     output = do_correction(data, satmap)

--- a/jwst/saturation/tests/test_saturation.py
+++ b/jwst/saturation/tests/test_saturation.py
@@ -103,7 +103,7 @@ def test_low_and_high_saturation_flagging(setup_nrc_cube):
     output = do_correction(data, satmap)
 
     # Check if the right frames are flagged as saturated
-    assert np.all(output.groupdq[0, satindxs, 500, 500] == dqflags.group['SATURATED'])
+    assert np.all(output.groupdq[0, satindxs, 5, 5] == dqflags.group['SATURATED'])
 
 
 def test_signal_fluctuation_flagging(setup_nrc_cube):

--- a/jwst/saturation/tests/test_saturation.py
+++ b/jwst/saturation/tests/test_saturation.py
@@ -71,7 +71,8 @@ def test_ad_floor_flagging(setup_nrc_cube):
     output = do_correction(data, satmap)
 
     # Check if the right frames are flagged as saturated
-    assert np.all(output.groupdq[0, satindxs, 5, 5] == dqflags.group['AD_FLOOR'])
+    assert np.all(output.groupdq[0, satindxs, 5, 5]
+                  == dqflags.group['DO_NOT_USE'] | dqflags.group['AD_FLOOR'])
 
 
 def test_ad_floor_and_saturation_flagging(setup_nrc_cube):
@@ -105,7 +106,8 @@ def test_ad_floor_and_saturation_flagging(setup_nrc_cube):
     output = do_correction(data, satmap)
 
     # Check if the right frames are flagged as ad_floor
-    assert np.all(output.groupdq[0, floorindxs, 5, 5] == dqflags.group['AD_FLOOR'])
+    assert np.all(output.groupdq[0, floorindxs, 5, 5]
+                  == dqflags.group['DO_NOT_USE'] | dqflags.group['AD_FLOOR'])
     # Check if the right frames are flagged as saturated
     assert np.all(output.groupdq[0, satindxs, 5, 5] == dqflags.group['SATURATED'])
 


### PR DESCRIPTION
Closes #4690.

Fixes [JP-1357](https://jira.stsci.edu/browse/JP-1357)

One side effect of this update to the saturation check is that values of zero for a group is now flagged as AD_FLOOR and DO_NOT_USE.  This is fine for real data, but for simulated data where it might be common to initialize all the values to zero, this might now cause issues.