### PR TITLE
Allow skymatch/skysub for one image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,13 @@ outlier_detection
 
 - Implement memory check in resample to prevent huge arrays [#5354]
 
+pipeline
+--------
+
+- Update ``Image3Pipeline`` to allow sky subtraction when input contains
+  only one image (group). [#5423]
+
+
 ramp_fitting
 ------------
 
@@ -413,9 +420,6 @@ pipeline
   input ASN. [#5243]
 
 - Enable NIRSpec lamp processing in calspec2 pipeline. [#5267]
-
-- Update ``Image3Pipeline`` to allow sky subtraction when input contains
-  only one image (group). [#5423]
 
 photom
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -415,7 +415,7 @@ pipeline
 - Enable NIRSpec lamp processing in calspec2 pipeline. [#5267]
 
 - Update ``Image3Pipeline`` to allow sky subtraction when input contains
-  only one image (group). [5423]
+  only one image (group). [#5423]
 
 photom
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ associations
 cube_build
 ----------
 
-- When making SINGLE type cubes for outlier detection or mrs_imatch data not in the 
+- When making SINGLE type cubes for outlier detection or mrs_imatch data not in the
   appropriate channel/grating is skipped [#5347]
 
 - If outlier detection has flagged all the data on a input file as DO_NOT_USE, then
@@ -413,6 +413,9 @@ pipeline
   input ASN. [#5243]
 
 - Enable NIRSpec lamp processing in calspec2 pipeline. [#5267]
+
+- Update ``Image3Pipeline`` to allow sky subtraction when input contains
+  only one image (group). [5423]
 
 photom
 ------

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -85,6 +85,9 @@ class Image3Pipeline(Pipeline):
                 input_models = self.skymatch(input_models)
                 input_models = self.outlier_detection(input_models)
 
+            else:
+                input_models = self.skymatch(input_models)
+
             result = self.resample(input_models)
             if isinstance(result, datamodels.ImageModel) and result.meta.cal_step.resample == 'COMPLETE':
                 self.source_catalog(result)

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -85,6 +85,10 @@ class Image3Pipeline(Pipeline):
                 input_models = self.skymatch(input_models)
                 input_models = self.outlier_detection(input_models)
 
+            elif self.skymatch.skymethod == 'match':
+                self.log.warning("Turning 'skymatch' step off for a single "
+                                 "input image when 'skymethod' is 'match'")
+
             else:
                 input_models = self.skymatch(input_models)
 


### PR DESCRIPTION
This PR allows `skymatch` step to run even for a single input image. This essentially will become simple sky background subtraction without matching. Also see helpdesk issue INC0159018.