### PR TITLE
Documentation update on ways to call the pipeline

### DIFF
--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -162,7 +162,7 @@ step instance directly.
 
 The ``call`` method creates a new instance of the class and runs the pipeline or
 step. Optional parameter settings can be specified by supplying a configuration file,
-or via keyword. Examples are shown on the :ref:`Execute via call()<call_examples>` page.
+or via keyword arguments. Examples are shown on the :ref:`Execute via call()<call_examples>` page.
 ::
 
  from jwst.pipeline import Detector1Pipeline

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -162,7 +162,7 @@ step instance directly.
 
 The ``call`` method creates a new instance of the class and runs the pipeline or
 step. Optional parameter settings can be specified by supplying a configuration file,
-or via keyword. Examples are shown on the :ref:`Execute via call()<call-examples>` page.
+or via keyword. Examples are shown on the :ref:`Execute via call()<call_examples>` page.
 ::
 
  from jwst.pipeline import Detector1Pipeline
@@ -174,7 +174,7 @@ or via keyword. Examples are shown on the :ref:`Execute via call()<call-examples
 
 Another way to call the pipeline is by calling the instance of the pipeline directly.
 First create an instance, then set any desired parameter
-values and finally, execute. Examples are shown on the :ref:`Execute via run()<run-examples>` page.
+values and finally, execute. Examples are shown on the :ref:`Execute via run()<run_examples>` page.
 ::
 
  pipe = Detector1Pipeline()
@@ -182,7 +182,7 @@ values and finally, execute. Examples are shown on the :ref:`Execute via run()<r
  result = pipe('jw00017001001_01101_00001_nrca1_uncal.fits')
 
 A functionally identical way to execute the pipeline or step is to use the ``run``
-method. Examples are shown on the :ref:`Execute via run()<run-examples>` page.
+method. Examples are shown on the :ref:`Execute via run()<run_examples>` page.
 ::
 
  pipe = Detector1Pipeline()

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -37,7 +37,7 @@ team and any other ground subsystem that needs access to them.
 Information about all the reference files used by the Calibration Pipeline can be found at
 :ref:`reference_file_information`,
 as well as in the documentation for each Calibration Step that uses a reference file.
- 
+
 CRDS
 ====
 
@@ -157,7 +157,12 @@ Running From Within Python
 ==========================
 
 You can execute a pipeline or a step from within python by using the
-``call`` method of the class:
+``call`` or ``run`` methods of the class, or by calling the pipeline or
+step instance directly.
+
+The ``call`` method creates a new instance of the class and runs the pipeline or
+step. Optional parameter settings can be specified by supplying a configuration file,
+or via keyword. Examples are shown on the :ref:`Execute via call()<call-examples>` page.
 ::
 
  from jwst.pipeline import Detector1Pipeline
@@ -166,12 +171,26 @@ You can execute a pipeline or a step from within python by using the
  from jwst.linearity import LinearityStep
  result = LinearityStep.call('jw00001001001_01101_00001_mirimage_uncal.fits')
 
-The easiest way to use optional arguments when calling a pipeline from
-within python is to set those parameters in the pipeline configuration file and
-then supply the file as a keyword argument:
+
+Another way to call the pipeline is by calling the instance of the pipeline directly.
+First create an instance, then set any desired parameter
+values and finally, execute. Examples are shown on the :ref:`Execute via run()<run-examples>` page.
 ::
 
- Detector1Pipeline.call('jw00017001001_01101_00001_nrca1_uncal.fits', config_file='calwebb_detector1.cfg')
+ pipe = Detector1Pipeline()
+ pipe.jump.rejection_threshold = 5
+ result = pipe('jw00017001001_01101_00001_nrca1_uncal.fits')
+
+A functionally identical way to execute the pipeline or step is to use the ``run``
+method. Examples are shown on the :ref:`Execute via run()<run-examples>` page.
+::
+
+ pipe = Detector1Pipeline()
+ pipe.jump.rejection_threshold = 5
+ result = pipe.run('jw00017001001_01101_00001_nrca1_uncal.fits')
+
+For more details on the different ways to run a pipeline step, see
+the :ref:`Configuring a Step<configuring-a-step>` page.
 
 
 .. _intro_file_conventions:
@@ -315,7 +334,7 @@ suffix of the step is always appended to any given name.
 You can also specify a particular file name for saving the end result of
 the entire pipeline using the ``--output_file`` argument also
 ::
-   
+
     $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.fits
         --output_file='stage1_processed'
 

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -174,7 +174,8 @@ or via keyword. Examples are shown on the :ref:`Execute via call()<call_examples
 
 Another way to call the pipeline is by calling the instance of the pipeline directly.
 First create an instance, then set any desired parameter
-values and finally, execute. Examples are shown on the :ref:`Execute via run()<run_examples>` page.
+values and finally, execute. In this case, do not instatiate the pipeline
+with a configuration file. Examples are shown on the :ref:`Execute via run()<run_examples>` page.
 ::
 
  pipe = Detector1Pipeline()

--- a/docs/jwst/stpipe/call_via_call.rst
+++ b/docs/jwst/stpipe/call_via_call.rst
@@ -1,0 +1,39 @@
+.. _call-examples
+
+Calling a pipeline or pipeline step via call()
+==============================================
+
+The ``call`` method will create an instance and run a pipeline or pipeline step
+in a single call.
+
+::
+
+ from jwst.pipeline import Detector1Pipeline
+ result = Detector1Pipeline.call('jw00017001001_01101_00001_nrca1_uncal.fits')
+
+ from jwst.linearity import LinearityStep
+ result = LinearityStep.call('jw00001001001_01101_00001_mirimage_uncal.fits')
+
+
+To set custom parameter values when using the ``call`` method, set
+the parameters in the pipeline or step configuration file and
+then supply the file using the ``config_file`` keyword:
+::
+
+ # Calling a pipeline
+ result = Detector1Pipeline.call('jw00017001001_01101_00001_nrca1_uncal.fits', config_file='calwebb_detector1.cfg')
+
+ # Calling a step
+ result = LinearityStep.call('jw00017001001_01101_00001_nrca1_uncal.fits', config_file='linearity.cfg')
+
+
+When running a pipeline, parameter values can also be supplied in the call to ``call`` itself by using a nested dictionary of step and
+parameter names:
+
+::
+ result = Detector1Pipeline.call("jw00017001001_01101_00001_nrca1_uncal.fits", config_file='calwebb_detector1.cfg', steps={"jump":{"rejection_threshold": 200}})
+
+When running a single step with ``call``, parameter values can be supplied more simply:
+
+::
+ result = JumpStep.call("jw00017001001_01101_00001_nrca1_uncal.fits", rejection_threshold=200)

--- a/docs/jwst/stpipe/call_via_call.rst
+++ b/docs/jwst/stpipe/call_via_call.rst
@@ -1,7 +1,7 @@
-.. _call-examples
+.. _call_examples:
 
-Calling a pipeline or pipeline step via call()
-==============================================
+Executing a pipeline or pipeline step via call()
+================================================
 
 The ``call`` method will create an instance and run a pipeline or pipeline step
 in a single call.
@@ -31,9 +31,11 @@ When running a pipeline, parameter values can also be supplied in the call to ``
 parameter names:
 
 ::
+
  result = Detector1Pipeline.call("jw00017001001_01101_00001_nrca1_uncal.fits", config_file='calwebb_detector1.cfg', steps={"jump":{"rejection_threshold": 200}})
 
 When running a single step with ``call``, parameter values can be supplied more simply:
 
 ::
+
  result = JumpStep.call("jw00017001001_01101_00001_nrca1_uncal.fits", rejection_threshold=200)

--- a/docs/jwst/stpipe/call_via_run.rst
+++ b/docs/jwst/stpipe/call_via_run.rst
@@ -1,0 +1,37 @@
+.. _run-examples
+
+Calling a pipeline or pipeline step directly, or via run()
+==========================================================
+
+When calling a pipeline or step instance directly, or using the ``run`` method,
+you can specify individual parameter values manually. In this case, configuration
+files are not used (and will be ignored if provided).
+
+::
+ # Instantiate the class. Do not provide a configuration file.
+ pipe = Detector1Pipeline()
+
+ # Manually set any desired non-default parameter values
+ pipe.refpix.skip = True
+ pipe.jump.rejection_threshold = 5
+ pipe.ramp_fit.override_gain = 'my_gain_file.fits'
+ pipe.save_result = True
+ pipe.output_dir = '/my/data/pipeline_outputs'
+
+ # Run the pipeline
+ result = pipe('jw00017001001_01101_00001_nrca1_uncal.fits')
+
+ # Or, execute the pipeline using the run method
+ result = pipe.run('jw00017001001_01101_00001_nrca1_uncal.fits')
+
+ # Or to run a single step
+ step = LinearityStep()
+ step.override_linearity = 'my_linearity_coefficients.fits'
+ step.save_results = True
+ step.output_dir = '/my/data/linearized_data'
+
+ # Execute by calling the instance directly
+ result = step('jw00017001001_01101_00001_nrca1_superbias.fits')
+
+ # Execute using the run method
+ result = step.run('jw00017001001_01101_00001_nrca1_superbias.fits')

--- a/docs/jwst/stpipe/call_via_run.rst
+++ b/docs/jwst/stpipe/call_via_run.rst
@@ -5,7 +5,9 @@ Executing a pipeline or pipeline step directly, or via run()
 
 When calling a pipeline or step instance directly, or using the ``run`` method,
 you can specify individual parameter values manually. In this case, configuration
-files are not used (and will be ignored if provided).
+files are not used. If you use ``run`` after instatiating with a configuration
+file (as is done when using the :ref:`call<call_examples>` method), the
+configuration file will be ignored.
 
 ::
 

--- a/docs/jwst/stpipe/call_via_run.rst
+++ b/docs/jwst/stpipe/call_via_run.rst
@@ -1,13 +1,14 @@
-.. _run-examples
+.. _run_examples:
 
-Calling a pipeline or pipeline step directly, or via run()
-==========================================================
+Executing a pipeline or pipeline step directly, or via run()
+============================================================
 
 When calling a pipeline or step instance directly, or using the ``run`` method,
 you can specify individual parameter values manually. In this case, configuration
 files are not used (and will be ignored if provided).
 
 ::
+
  # Instantiate the class. Do not provide a configuration file.
  pipe = Detector1Pipeline()
 
@@ -24,14 +25,22 @@ files are not used (and will be ignored if provided).
  # Or, execute the pipeline using the run method
  result = pipe.run('jw00017001001_01101_00001_nrca1_uncal.fits')
 
- # Or to run a single step
- step = LinearityStep()
- step.override_linearity = 'my_linearity_coefficients.fits'
+To run a single step:
+
+::
+
+ from jwst.jump import JumpStep
+
+ # Instantitate the step
+ step = JumpStep()
+
+ # Set parameter values
+ step.rejection_threshold = 5
  step.save_results = True
- step.output_dir = '/my/data/linearized_data'
+ step.output_dir = '/my/data/jump_data'
 
  # Execute by calling the instance directly
- result = step('jw00017001001_01101_00001_nrca1_superbias.fits')
+ result = step('jw00017001001_01101_00001_nrca1_linearity.fits')
 
- # Execute using the run method
- result = step.run('jw00017001001_01101_00001_nrca1_superbias.fits')
+ # Or, execute using the run method
+ result = step.run('jw00017001001_01101_00001_nrca1_linearity.fits')

--- a/docs/jwst/stpipe/index.rst
+++ b/docs/jwst/stpipe/index.rst
@@ -13,7 +13,9 @@ For Users
    user_pipeline.rst
    user_logging.rst
    config_asdf.rst
-   config_cfg.rst 
+   config_cfg.rst
+   call_via_call.rst
+   call_via_run.rst
 
 
 .. _stpipe-devel-steps:
@@ -29,4 +31,4 @@ For Developers
    devel_io_design.rst
 
 .. automodapi:: jwst.stpipe
-  
+

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -205,6 +205,7 @@ Retrieval of ``Step`` parameters from CRDS can be completely disabled by
 using the ``--disable-crds-steppars`` command-line switch, or setting the
 environmental variable ``STPIPE_DISABLE_CRDS_STEPPARS`` to ``true``.
 
+.. _run_step_from_python:
 
 Running a Step in Python
 ------------------------
@@ -224,19 +225,25 @@ very useful if one wants to setup the step's attributes first, then run it::
     mystep.override_sflat = ‘sflat.fits’
     output = mystep.run(input)
 
-Using the `.run()` method is the same as calling the instance or class directly.
+`input` in this case can be a fits file containing the appropriate data, or the output
+of a previously run step/pipeline, which is an instance of a particular :ref:`datamodel<datamodels>`.
+
+Unlike in the use of ``call``, a configuration file supplied whle instantiating ``run()`` will be ignored.
+
+Using the ``.run()`` method is the same as calling the instance or class directly.
 They are equivalent::
 
     output = mystep(input)
 
 call()
-``````
+`````
 
 If one has all the configuration in a configuration file or can pass the
-arguments directly to the step, one can use call(), which creates a new
-instance of the class every time you use the `call()` method.  So::
+arguments directly to the step, one can use the `call()` method, which creates a new
+instance of the class every time you call it.  So::
 
-    output = mystep.call(input)
+    from jwst.jump import JumpStep
+    output = JumpStep.call(input)
 
 makes a new instance of `FlatFieldStep` and then runs. Because it is a new
 instance, it ignores any attributes of `mystep` that one may have set earlier,

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -236,7 +236,7 @@ They are equivalent::
     output = mystep(input)
 
 call()
-`````
+``````
 
 If one has all the configuration in a configuration file or can pass the
 arguments directly to the step, one can use the `call()` method, which creates a new

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -228,7 +228,7 @@ very useful if one wants to setup the step's attributes first, then run it::
 `input` in this case can be a fits file containing the appropriate data, or the output
 of a previously run step/pipeline, which is an instance of a particular :ref:`datamodel<datamodels>`.
 
-Unlike in the use of ``call``, a configuration file supplied whle instantiating ``run()`` will be ignored.
+Unlike in the use of ``call``, a configuration file supplied while instantiating ``run()`` will be ignored.
 
 Using the ``.run()`` method is the same as calling the instance or class directly.
 They are equivalent::


### PR DESCRIPTION
This PR makes some small tweaks/additions to the documentation on the ways to call pipelines and steps from within python. The changes highlight the differences between the `call` and `run` methods and describe how to provide input parameters for each. After numerous questions/errors from users in the building on the details for how to call the pipeline, I was motivated to try and clarify the documentation. 

I realize that there is upcoming work on the methods used to call the pipeline and the details/best practices may change. I figured that these changes will still help people using the pipeline between now and then, and perhaps these changes can be used as a springboard for future documentation updates after any changes to the methods.

Resolves #5425