### PR TITLE
JP-1764:Update ami_analyze to extract subarray from full-frame images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@
 ami
 ---
 
-- Update code and unit tests to use new ami analyze algorithm [#5390]
+- Update code and unit tests to use new ami_analyze algorithms [#5390]
+
+- Update ami_analyze to extract a SUB80 subarray from full-frame images [#5437]
 
 assign_wcs
 ----------

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -42,6 +42,21 @@ def apply_LG_plus(input_model, filter_model, oversample, rotation):
         Fringe analysis data
 
     """
+
+    # If the input data were taken in full-frame mode, extract a region
+    # equivalent to the SUB80 subarray mode to make execution time acceptable.
+    if input_model.meta.subarray.name.upper() == 'FULL':
+        log.info("Extracting 80x80 subarray from full-frame data")
+        xstart = 1045
+        ystart = 1
+        xsize = 80
+        ysize = 80
+        xstop = xstart + xsize - 1
+        ystop = ystart + ysize - 1
+        input_model.data = input_model.data[ystart-1:ystop, xstart-1:xstop]
+        input_model.dq = input_model.dq[ystart-1:ystop, xstart-1:xstop]
+        input_model.err = input_model.err[ystart-1:ystop, xstart-1:xstop]
+
     data = input_model.data
     dim = data.shape[1]
 


### PR DESCRIPTION
Update the `ami_analyze` module to extract the equivalent of a SUB80 subarray from input images that were taken in full-frame mode.

Fixes #5436 / [JP-1764](https://jira.stsci.edu/browse/JP-1764)