### PR TITLE
JP-1693: Fix extract_1d for SourceContainer with 1 slit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,7 @@ datamodels
 extract_1d
 ----------
 
-- Fixed bug invovling the determination of source RA/Dec for resampled Slit
+- Fixed bug involving the determination of source RA/Dec for resampled Slit
   data. [#5353]
 
 - Updated to use an EXTRACT1D reference file for NIRCam TSGRISM exposures;
@@ -51,6 +51,9 @@ extract_1d
   computation, in addition to the existing polynomial fit; fixed bug in
   background computation that was preventing background subtraction from
   ever happening. [#5414]
+
+- Fixed bug involving the processing of WFSS observations when there's only
+  one spectrum instance for a given source. [#5439]
 
 flatfield
 ---------

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2730,7 +2730,12 @@ def do_extract1d(
     # Handle inputs that contain one or more slit models
     if was_source_model or isinstance(input_model, datamodels.MultiSlitModel):
         if was_source_model:   # SourceContainer has a single list of SlitModels
-            slits = input_model
+            if isinstance(input_model, datamodels.SlitModel):
+                # If input is a single SlitModel, as opposed to a list of SlitModels,
+                # put it into a list so that it's iterable later on
+                slits = [input_model]
+            else:
+                slits = input_model
 
             # The subsequent work on data uses the individual SlitModels, but there are many places where meta
             # attributes are retreived from input_model, so set this to allow that to work.


### PR DESCRIPTION
Updated the branch of extract_1d that loops over slit models in an input `SourceContainerModel` to handle the case where there's only 1 `SlitModel` and hence it's not in the form of a list. This can occur in level 3 processing of WFSS observations, for example, when there's only 1 instance of a given source in all of the input exposures.

Fixes #5331 / [JP-1693](https://jira.stsci.edu/browse/JP-1693)