### PR TITLE
Fix _apply_sky in skymatch for single group input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,6 +115,13 @@ saturation
   NO_SAT_CHECK in the saturation reference file, instead of skipping any
   test of those pixels. [#5394]
 
+skymatch
+--------
+
+- Fix a bug in ``skymatch`` that would result in a crash when ``skymethod``
+  contains ``'global'`` and the *single image group*'s sky cannot be computed
+  (e.g., because all pixels are flagged as "bad"). [#5440]
+
 0.17.1 (2020-09-15)
 ===================
 

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -183,7 +183,6 @@ class SkyImage:
     def sky(self, sky):
         self._sky = sky
 
-
     @property
     def is_sky_valid(self):
         """

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -359,9 +359,7 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
             log.info(" ")
             if minsky is None:
                 log.warning("   Unable to compute \"global\" sky value")
-                sky_deltas = len(sky_deltas) * [None]
-            else:
-                sky_deltas = len(sky_deltas) * [minsky]
+            sky_deltas = len(sky_deltas) * [minsky]
             log.info("   \"Global\" sky value correction: {} "
                      "[not converted]".format(minsky))
 
@@ -382,24 +380,26 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
 
 
 def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
+    img_type = ['Image', 'Group']
+
     for img, sky in zip(images, sky_deltas):
-        img_type = 'Image' if isinstance(img, SkyImage) else 'Group'
+        is_group = not isinstance(img, SkyImage)
 
         if do_global:
             if sky is None:
-                valid = img.is_sky_valid
+                valid = img[0].is_sky_valid if is_group else img.is_sky_valid
                 sky = 0.0
             else:
                 valid = True
 
         else:
-            valid = sky is None
-            if valid:
+            valid = sky is not None
+            if not valid:
                 log.warning("   *  {:s} ID={}: Unable to compute sky value"
-                            .format(img_type, img.id))
+                            .format(img_type[is_group], img.id))
                 sky = 0.0
 
-        if img_type == 'Group':
+        if is_group:
             # apply sky change:
             old_img_sky = [im.sky for im in img]
             if do_skysub:

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -380,8 +380,6 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
 
 
 def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
-    img_type = ['Image', 'Group']
-
     for img, sky in zip(images, sky_deltas):
         is_group = not isinstance(img, SkyImage)
 
@@ -396,7 +394,7 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             valid = sky is not None
             if not valid:
                 log.warning("   *  {:s} ID={}: Unable to compute sky value"
-                            .format(img_type[is_group], img.id))
+                            .format('Group' if is_group else 'Image', img.id))
                 sky = 0.0
 
         if is_group:


### PR DESCRIPTION
Fixes a bug in `skymatch.skymatch._apply_sky()` that would result in a crash when `skymethod` contains 'global' and input image is a single image group whose sky cannot be computed, e.g., because its images contains no "good" pixels.

This bug was revealed after PR #5423 which permitted processing of single image/group inputs.

Fixes failing test `test_nircam_image.py::test_image3_closedfile`. The test will still be failing for two reasons:
1. Extra keyword 'S_SKYMAT' - that's expected
2. Small differences in many image pixels. This failure is not related to this PR and probably is caused by unrelated changes. This test was not OKified before because it was crashing.