### PR TITLE
JP-1751 Retrieve step parameter references from CRDS instrument "calpars"

### DIFF
--- a/jwst/ami/tests/test_ami_interface.py
+++ b/jwst/ami/tests/test_ami_interface.py
@@ -35,7 +35,7 @@ def test_ami_analyze_no_reffile_fail(monkeypatch):
     model.meta.observation.date = "2019-01-01"
     model.meta.observation.time = "00:00:00"
 
-    def mockreturn(input_model, reftype, observatory=None, asn_exptypes=None):
+    def mockreturn(input_model, reftype, observatory=None, asn_exptypes=None, extra_pars=None):
         return("N/A")
     monkeypatch.setattr(jwst.stpipe.crds_client, 'get_reference_file', mockreturn)
 

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -54,7 +54,8 @@ SUFFIXES_TO_ADD = [
 
 # Suffixes that are discovered but should not be considered.
 # Used by `find_suffixes` to remove undesired values it has found.
-SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline', 'step', 'systemcall']
+SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline',
+                       'step', 'systemcall', 'testlinearpipeline']
 
 
 # Calculated suffixes.

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -20,14 +20,13 @@ Hence, to update `KNOW_SUFFIXES`, update both `SUFFIXES_TO_ADD` and
 `SUFFIXES_TO_DISCARD` as necessary, then use the output of
 `find_suffixes`.
 """
-from copy import copy
 from importlib import import_module
-from inspect import (getmembers, isclass)
 import itertools
 import logging
-from os import (listdir, path, walk)
+from os import (listdir, path)
 import re
-import sys
+
+from jwst.stpipe.utilities import all_steps
 
 __all__ = ['remove_suffix']
 
@@ -55,7 +54,7 @@ SUFFIXES_TO_ADD = [
 
 # Suffixes that are discovered but should not be considered.
 # Used by `find_suffixes` to remove undesired values it has found.
-SUFFIXES_TO_DISCARD = ['functionwrapper', 'systemcall']
+SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline', 'step', 'systemcall']
 
 
 # Calculated suffixes.
@@ -274,20 +273,16 @@ def find_suffixes():
     """
     from jwst.stpipe import Step
 
-    suffixes = set()
-
     jwst = import_module('jwst')
     jwst_fpath = path.split(jwst.__file__)[0]
 
     # First traverse the code base and find all
     # `Step` classes. The default suffix is the
     # class name.
-    for module in load_local_pkg(jwst_fpath):
-        for klass_name, klass in getmembers(
-            module,
-            lambda o: isclass(o) and issubclass(o, Step)
-        ):
-            suffixes.add(klass_name.lower())
+    suffixes = set(
+        klass_name.lower()
+        for klass_name, klass in all_steps().items()
+    )
 
     # Instantiate Steps/Pipelines from their configuration files.
     # Different names and suffixes can be defined in this way.
@@ -308,74 +303,6 @@ def find_suffixes():
 
     # That's all folks
     return list(suffixes)
-
-
-def load_local_pkg(fpath):
-    """Generator producing all modules under fpath
-
-    Parameters
-    ----------
-    fpath: string
-        File path to the package to load.
-
-    Returns
-    -------
-    generator
-        `module` for each module found in the package.
-    """
-    package_fpath, package = path.split(fpath)
-    package_fpath_len = len(package_fpath) + 1
-    sys_path = copy(sys.path)
-    sys.path.insert(0, package_fpath)
-    try:
-        for module_fpath in folder_traverse(
-            fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='tests'
-        ):
-            folder_path, fname = path.split(module_fpath[package_fpath_len:])
-            module_path = folder_path.split('/')
-            module_path.append(path.splitext(fname)[0])
-            module_path = '.'.join(module_path)
-            try:
-                module = import_module(module_path)
-            except Exception as err:
-                logger.debug(f'Cannot load module "{module_path}": {str(err)}')
-            else:
-                yield module
-    except Exception as err:
-        logger.debug(f'Cannot complete package loading: Exception occurred: "{str(err)}"')
-    finally:
-        sys.path = sys_path
-
-
-def folder_traverse(folder_path, basename_regex='.+', path_exclude_regex='^$'):
-    """Generator of full file paths for all files
-    in a folder.
-
-    Parameters
-    ----------
-    folder_path: str
-        The folder to traverse
-
-    basename_regex: str
-        Regular expression that must match
-        the `basename` part of the file path.
-
-    path_exclude_regex: str
-        Regular expression to exclude a path.
-
-    Returns
-    -------
-    generator
-        A generator, return the next file.
-    """
-    basename_regex = re.compile(basename_regex)
-    path_exclude_regex = re.compile(path_exclude_regex)
-    for root, dirs, files in walk(folder_path):
-        if path_exclude_regex.search(root):
-            continue
-        for file in files:
-            if basename_regex.match(file):
-                yield path.join(root, file)
 
 
 # --------------------------------------------------

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -26,8 +26,6 @@ import logging
 from os import (listdir, path)
 import re
 
-from jwst.stpipe.utilities import all_steps
-
 __all__ = ['remove_suffix']
 
 # Configure logging
@@ -273,6 +271,7 @@ def find_suffixes():
     a static list.
     """
     from jwst.stpipe import Step
+    from jwst.stpipe.utilities import all_steps
 
     jwst = import_module('jwst')
     jwst_fpath = path.split(jwst.__file__)[0]

--- a/jwst/lib/tests/test_suffix.py
+++ b/jwst/lib/tests/test_suffix.py
@@ -25,7 +25,8 @@ def test_suffix_existence(enable_logging):
         to_add=(calculated_suffixes, s.SUFFIXES_TO_ADD),
         to_remove=(s.SUFFIXES_TO_DISCARD, )
     )
-    assert set(found_suffixes) == set(s.KNOW_SUFFIXES)
+    diff = set(found_suffixes).symmetric_difference(s.KNOW_SUFFIXES)
+    assert not diff, f'Suffixes unaccounted for:\n{diff}'
 
 
 @pytest.mark.parametrize(

--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -205,10 +205,12 @@ def get_reference_file(dataset, reference_file_type, observatory=None,
         from jwst import datamodels
         with datamodels.open(dataset, asn_exptypes=asn_exptypes) as model:
             return get_multiple_reference_paths(
-                model, [reference_file_type], observatory, extra_pars)[reference_file_type]
+                model, [reference_file_type],
+                observatory=observatory, extra_pars=extra_pars)[reference_file_type]
     else:
         return get_multiple_reference_paths(
-            dataset, [reference_file_type], observatory, extra_pars)[reference_file_type]
+            dataset, [reference_file_type],
+            observatory=observatory, extra_pars=extra_pars)[reference_file_type]
 
 
 def get_override_name(reference_file_type):

--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -205,10 +205,10 @@ def get_reference_file(dataset, reference_file_type, observatory=None,
         from jwst import datamodels
         with datamodels.open(dataset, asn_exptypes=asn_exptypes) as model:
             return get_multiple_reference_paths(
-                model, [reference_file_type], observatory)[reference_file_type]
+                model, [reference_file_type], observatory, extra_pars)[reference_file_type]
     else:
         return get_multiple_reference_paths(
-            dataset, [reference_file_type], observatory)[reference_file_type]
+            dataset, [reference_file_type], observatory, extra_pars)[reference_file_type]
 
 
 def get_override_name(reference_file_type):

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -192,7 +192,6 @@ class Pipeline(Step):
 
 
         log.log.debug('Retrieving all substep parameters from CRDS')
-        #
         # Iterate over the steps in the pipeline
         with dm_open(dataset, asn_n_members=1) as model:
             for cal_step in cls.step_defs.keys():
@@ -200,23 +199,29 @@ class Pipeline(Step):
                 refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(
                     model, observatory=observatory
                 )
-        #
-        # Now merge any config parameters from the step cfg file
-        log.log.debug(f'Retrieving pipeline {pars_model.meta.reftype.upper()} parameters from CRDS')
-        exceptions = crds_client.get_exceptions_module()
-        try:
-            ref_file = crds_client.get_reference_file(model,
-                                                      pars_model.meta.reftype,
-                                                      observatory=observatory,
-                                                      asn_exptypes=['science'])
-        except (AttributeError, exceptions.CrdsError, exceptions.CrdsLookupError):
-            log.log.debug(f'{pars_model.meta.reftype.upper()}: No parameters found')
-        else:
-            if ref_file != 'N/A':
-                log.log.info(f'{pars_model.meta.reftype.upper()} parameters found: {ref_file}')
-                refcfg = cls.merge_pipeline_config(refcfg, ref_file)
+
+            # Reassign and remember the instrument.
+            instrument = model.meta.instrument.name
+            extra_pars = {'calpars_instrument': instrument,
+                          'meta.instrument.name': 'calpars'}
+
+            # Now merge any config parameters from the step cfg file
+            log.log.debug(f'Retrieving pipeline {pars_model.meta.reftype.upper()} parameters from CRDS')
+            exceptions = crds_client.get_exceptions_module()
+            try:
+                ref_file = crds_client.get_reference_file(model,
+                                                          pars_model.meta.reftype,
+                                                          observatory=observatory,
+                                                          asn_exptypes=['science'],
+                                                          extra_pars=extra_pars)
+            except (AttributeError, exceptions.CrdsError, exceptions.CrdsLookupError):
+                log.log.debug(f'{pars_model.meta.reftype.upper()}: No parameters found')
             else:
-                log.log.debug(f'No {pars_model.meta.reftype.upper()} reference files found.')
+                if ref_file != 'N/A':
+                    log.log.info(f'{pars_model.meta.reftype.upper()} parameters found: {ref_file}')
+                    refcfg = cls.merge_pipeline_config(refcfg, ref_file)
+                else:
+                    log.log.debug(f'No {pars_model.meta.reftype.upper()} reference files found.')
 
         return refcfg
 

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -192,7 +192,7 @@ class Pipeline(Step):
 
 
         log.log.debug('Retrieving all substep parameters from CRDS')
-        #
+
         # Iterate over the steps in the pipeline
         with dm_open(dataset, asn_n_members=1) as model:
             for cal_step in cls.step_defs.keys():
@@ -200,23 +200,27 @@ class Pipeline(Step):
                 refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(
                     model, observatory=observatory
                 )
-        #
-        # Now merge any config parameters from the step cfg file
-        log.log.debug(f'Retrieving pipeline {pars_model.meta.reftype.upper()} parameters from CRDS')
-        exceptions = crds_client.get_exceptions_module()
-        try:
-            ref_file = crds_client.get_reference_file(model,
-                                                      pars_model.meta.reftype,
-                                                      observatory=observatory,
-                                                      asn_exptypes=['science'])
-        except (AttributeError, exceptions.CrdsError, exceptions.CrdsLookupError):
-            log.log.debug(f'{pars_model.meta.reftype.upper()}: No parameters found')
-        else:
-            if ref_file != 'N/A':
-                log.log.info(f'{pars_model.meta.reftype.upper()} parameters found: {ref_file}')
-                refcfg = cls.merge_pipeline_config(refcfg, ref_file)
+
+            # Now merge any config parameters from the step cfg file
+            log.log.debug(f'Retrieving pipeline {pars_model.meta.reftype.upper()} parameters from CRDS')
+            exceptions = crds_client.get_exceptions_module()
+            instrument = model.meta.instrument.name
+            extra_pars = {'calpars_instrument': instrument,
+                          'meta.instrument.name': 'calpars'}
+            try:
+                ref_file = crds_client.get_reference_file(model,
+                                                          pars_model.meta.reftype,
+                                                          observatory=observatory,
+                                                          asn_exptypes=['science'],
+                                                          extra_pars=extra_pars)
+            except (AttributeError, exceptions.CrdsError, exceptions.CrdsLookupError):
+                log.log.debug(f'{pars_model.meta.reftype.upper()}: No parameters found')
             else:
-                log.log.debug(f'No {pars_model.meta.reftype.upper()} reference files found.')
+                if ref_file != 'N/A':
+                    log.log.info(f'{pars_model.meta.reftype.upper()} parameters found: {ref_file}')
+                    refcfg = cls.merge_pipeline_config(refcfg, ref_file)
+                else:
+                    log.log.debug(f'No {pars_model.meta.reftype.upper()} reference files found.')
 
         return refcfg
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -729,6 +729,14 @@ class Step():
         logger = log.delegator.log
         pars_model = cls.get_pars_model()
 
+        # If the dataset is not an operable DataModel, log as such and return
+        # an empty config object
+        try:
+            model = dm_open(dataset)
+        except (IOError, TypeError, ValueError):
+            logger.warning(f'Input dataset is not a DataModel.')
+            disable = True
+
         # Check if retrieval should be attempted.
         if disable is None:
             disable = get_disable_crds_steppars()
@@ -737,14 +745,18 @@ class Step():
             return config_parser.ConfigObj()
 
         # Reassign and remember the instrument.
-        extra_pars = {'calpars_instrument': dataset.meta.instrument.name,
+        if isinstance(model, ModelContainer):
+            instrument = model[0].meta.instrument.name
+        else:
+            instrument = model.meta.instrument.name
+        extra_pars = {'calpars_instrument': instrument,
                       'meta.instrument.name': 'calpars'}
 
         # Retrieve step parameters from CRDS
         logger.debug(f'Retrieving step {pars_model.meta.reftype.upper()} parameters from CRDS')
         exceptions = crds_client.get_exceptions_module()
         try:
-            ref_file = crds_client.get_reference_file(dataset,
+            ref_file = crds_client.get_reference_file(model,
                                                       pars_model.meta.reftype,
                                                       observatory=observatory,
                                                       asn_exptypes=['science'],

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -734,7 +734,7 @@ class Step():
         try:
             model = dm_open(dataset)
         except (IOError, TypeError, ValueError):
-            logger.warning(f'Input dataset is not a DataModel.')
+            logger.warning(f'Input dataset is not a DataModel: {dataset}')
             disable = True
 
         # Check if retrieval should be attempted.

--- a/jwst/stpipe/tests/test_pipeline.py
+++ b/jwst/stpipe/tests/test_pipeline.py
@@ -144,7 +144,7 @@ def test_prefetch(_jail, monkeypatch):
     class MockGetRef:
         called = False
 
-        def mock(self, dataset_model, reference_file_types, observatory=None):
+        def mock(self, dataset_model, reference_file_types, observatory=None, extra_pars=None):
             if 'flat' in reference_file_types:
                 self.called = True
             result = {

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -655,7 +655,8 @@ def test_step_from_commandline_par_precedence(command_line_pars, command_line_co
 
         reference_file_map[reference_type] = str(reference_path)
 
-    def mock_get_reference_file(dataset, reference_file_type, observatory=None, asn_exptypes=None):
+    def mock_get_reference_file(dataset, reference_file_type, observatory=None,
+                                asn_exptypes=None, extra_pars=None):
         if reference_file_type in reference_file_map:
             return reference_file_map[reference_file_type]
         else:

--- a/jwst/stpipe/tests/test_utilities.py
+++ b/jwst/stpipe/tests/test_utilities.py
@@ -1,0 +1,34 @@
+"""Test utility funcs"""
+from jwst.stpipe.utilities import all_steps
+
+
+# Snapshot of known steps
+KNOWN_STEPS = set([
+    'AlignRefsStep','Ami3Pipeline', 'AmiAnalyzeStep', 'AmiAverageStep',
+    'AmiNormalizeStep', 'AssignMTWcsStep', 'AssignWcsStep',
+    'BackgroundStep', 'BarShadowStep',
+    'Combine1dStep', 'Coron3Pipeline', 'CubeBuildStep', 'CubeSkyMatchStep',
+    'DQInitStep', 'DarkCurrentStep', 'DarkPipeline', 'Detector1Pipeline',
+    'Extract1dStep', 'Extract2dStep',
+    'FirstFrameStep', 'FlatFieldStep', 'FringeStep',
+    'GainScaleStep', 'GroupScaleStep', 'GuiderCdsStep', 'GuiderPipeline',
+    'HlspStep',
+    'IPCStep', 'Image2Pipeline', 'Image3Pipeline', 'ImprintStep',
+    'JumpStep',
+    'KlipStep',
+    'LastFrameStep', 'LinearPipeline', 'LinearityStep',
+    'MRSIMatchStep', 'MSAFlagOpenStep', 'MasterBackgroundNrsSlitsStep', 'MasterBackgroundStep',
+    'OutlierDetectionScaledStep', 'OutlierDetectionStackStep', 'OutlierDetectionStep',
+    'PathLossStep', 'PersistenceStep', 'PhotomStep',
+    'RSCD_Step', 'RampFitStep', 'RefPixStep', 'ResampleSpecStep', 'ResampleStep', 'ResetStep',
+    'SaturationStep', 'SkyMatchStep', 'SourceCatalogStep', 'SourceTypeStep', 'Spec2Pipeline', 'Spec3Pipeline',
+    'StackRefsStep', 'StraylightStep', 'SubtractImagesStep', 'SuperBiasStep',
+    'TSOPhotometryStep', 'TestLinearPipeline', 'Tso3Pipeline', 'TweakRegStep',
+    'WavecorrStep', 'WfsCombineStep', 'WhiteLightStep',
+])
+
+def test_all_steps():
+    """Test finding all defined steps and pipelines"""
+    found_steps = all_steps()
+    diff = KNOWN_STEPS.symmetric_difference(found_steps)
+    assert not diff, f'Steps not accounted for. Confirm and check suffix and CRDS calpars.\n{diff}'

--- a/jwst/stpipe/tests/test_utilities.py
+++ b/jwst/stpipe/tests/test_utilities.py
@@ -23,7 +23,7 @@ KNOWN_STEPS = set([
     'RSCD_Step', 'RampFitStep', 'RefPixStep', 'ResampleSpecStep', 'ResampleStep', 'ResetStep',
     'SaturationStep', 'SkyMatchStep', 'SourceCatalogStep', 'SourceTypeStep', 'Spec2Pipeline', 'Spec3Pipeline',
     'StackRefsStep', 'StraylightStep', 'SubtractImagesStep', 'SuperBiasStep',
-    'TSOPhotometryStep', 'TestLinearPipeline', 'Tso3Pipeline', 'TweakRegStep',
+    'TSOPhotometryStep', 'Tso3Pipeline', 'TweakRegStep',
     'WavecorrStep', 'WfsCombineStep', 'WhiteLightStep',
 ])
 

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -49,6 +49,7 @@ NON_STEPS = [
     'Pipeline',
     'Step',
     'SystemCall',
+    'TestLinearPipeline',
 ]
 
 

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -29,9 +29,27 @@
 """
 Utilities
 """
+from copy import copy
+from importlib import import_module
 import inspect
+import logging
 import os
+from os import path
+import re
 import sys
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+# Step classes that are not user-api steps
+NON_STEPS = [
+    'EngDBLogStep',
+    'FunctionWrapper',
+    'Pipeline',
+    'Step',
+    'SystemCall',
+]
 
 
 def import_class(full_name, subclassof=object, config_file=None):
@@ -117,3 +135,99 @@ def islist_tuple(obj):
     Return True if `obj` is either a list or a tuple. False otherwise.
     """
     return isinstance(obj, tuple) or isinstance(obj, list)
+
+
+def all_steps():
+    """List all classes subclassed from Step
+
+    Returns
+    -------
+    steps : dict
+        Key is the classname, value is the class
+    """
+    from jwst.stpipe import Step
+
+    jwst = import_module('jwst')
+    jwst_fpath = path.split(jwst.__file__)[0]
+
+    steps = {}
+    for module in load_local_pkg(jwst_fpath):
+        more_steps = {
+            klass_name: klass
+            for klass_name, klass in inspect.getmembers(
+                    module,
+                    lambda o: inspect.isclass(o) and issubclass(o, Step)
+            )
+            if klass_name not in NON_STEPS
+        }
+        steps.update(more_steps)
+
+    return steps
+
+
+def load_local_pkg(fpath):
+    """Generator producing all modules under fpath
+
+    Parameters
+    ----------
+    fpath: string
+        File path to the package to load.
+
+    Returns
+    -------
+    generator
+        `module` for each module found in the package.
+    """
+    package_fpath, package = path.split(fpath)
+    package_fpath_len = len(package_fpath) + 1
+    sys_path = copy(sys.path)
+    sys.path.insert(0, package_fpath)
+    try:
+        for module_fpath in folder_traverse(
+            fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='tests'
+        ):
+            folder_path, fname = path.split(module_fpath[package_fpath_len:])
+            module_path = folder_path.split('/')
+            module_path.append(path.splitext(fname)[0])
+            module_path = '.'.join(module_path)
+            try:
+                module = import_module(module_path)
+            except Exception as err:
+                logger.debug(f'Cannot load module "{module_path}": {str(err)}')
+            else:
+                yield module
+    except Exception as err:
+        logger.debug(f'Cannot complete package loading: Exception occurred: "{str(err)}"')
+    finally:
+        sys.path = sys_path
+
+
+def folder_traverse(folder_path, basename_regex='.+', path_exclude_regex='^$'):
+    """Generator of full file paths for all files
+    in a folder.
+
+    Parameters
+    ----------
+    folder_path: str
+        The folder to traverse
+
+    basename_regex: str
+        Regular expression that must match
+        the `basename` part of the file path.
+
+    path_exclude_regex: str
+        Regular expression to exclude a path.
+
+    Returns
+    -------
+    generator
+        A generator, return the next file.
+    """
+    basename_regex = re.compile(basename_regex)
+    path_exclude_regex = re.compile(path_exclude_regex)
+    for root, dirs, files in os.walk(folder_path):
+        if path_exclude_regex.search(root):
+            continue
+        for file in files:
+            if basename_regex.match(file):
+                yield path.join(root, file)

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -171,12 +171,12 @@ def load_local_pkg(fpath):
 
     Parameters
     ----------
-    fpath: string
+    fpath : string
         File path to the package to load.
 
     Returns
     -------
-    generator
+    modules : generator
         `module` for each module found in the package.
     """
     package_fpath, package = path.split(fpath)
@@ -209,14 +209,14 @@ def folder_traverse(folder_path, basename_regex='.+', path_exclude_regex='^$'):
 
     Parameters
     ----------
-    folder_path: str
+    folder_path : str
         The folder to traverse
 
-    basename_regex: str
+    basename_regex : str
         Regular expression that must match
         the `basename` part of the file path.
 
-    path_exclude_regex: str
+    path_exclude_regex : str
         Regular expression to exclude a path.
 
     Returns

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ setup_requires =
 install_requires =
     asdf>=2.7.1
     astropy>=4.0
-    crds>=7.4.1.3
+    crds@git+https://github.com/stscieisenhamer/crds@ccd-739-calpars
     drizzle>=1.13.1
     gwcs>=0.14.0
     jsonschema>=3.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ setup_requires =
 install_requires =
     asdf>=2.7.1
     astropy>=4.0
-    crds@git+https://github.com/stscieisenhamer/crds@ccd-739-calpars
+    crds>=7.4.1.3
     drizzle>=1.13.1
     gwcs>=0.14.0
     jsonschema>=3.0.2


### PR DESCRIPTION
Resolves [JP-1751](https://jira.stsci.edu/browse/JP-1751)
Resolves #5416 

[CCD-739](https://jira.stsci.edu/browse/CCD-739) implements a new "instrument" called `calpars`. Within this instrument, all the step parameter reference files are located. To retrieve these references, the `meta.instrument.name` must be overridden in the `DataModel` being used as the reference file selector.

In addition, a new utility function, `jwst.stpipe.utilities.all_steps`, is implemented. `all_steps` returns all classes within the package that subclass `Step`.