### PR TITLE
JP-1734: Return correct DataModel subclass when reading an ASDF file

### DIFF
--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -257,3 +257,12 @@ def t_path(partial_path):
     """Construction the full path for test files"""
     test_dir = os.path.join(os.path.dirname(__file__), 'data')
     return os.path.join(test_dir, partial_path)
+
+
+def test_open_asdf_datamodel_class(tmpdir):
+    path = str(tmpdir.join("image_model.asdf"))
+    model = ImageModel((10, 10))
+    model.save(path)
+
+    with datamodels.open(path) as m:
+        assert isinstance(m, ImageModel)

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -17,6 +17,8 @@ from jwst.datamodels import (DataModel, ModelContainer, ImageModel,
 from jwst import datamodels
 from jwst.datamodels import util
 
+import asdf
+
 # Define artificial memory size
 MEMORY = 100  # 100 bytes
 
@@ -278,3 +280,15 @@ def test_open_asdf_no_datamodel_class(tmpdir, suffix):
 
     with datamodels.open(path) as m:
         assert isinstance(m, DataModel)
+
+
+def test_open_asdf(tmpdir):
+    path = str(tmpdir.join(f"straight_asdf.asdf"))
+    tree = {"foo": 42, "bar": 13, "seq": np.arange(100)}
+    with asdf.AsdfFile(tree) as af:
+        af.write_to(path)
+
+    with datamodels.open(path) as m:
+        assert isinstance(m, DataModel)
+
+

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -283,7 +283,7 @@ def test_open_asdf_no_datamodel_class(tmpdir, suffix):
 
 
 def test_open_asdf(tmpdir):
-    path = str(tmpdir.join(f"straight_asdf.asdf"))
+    path = str(tmpdir.join("straight_asdf.asdf"))
     tree = {"foo": 42, "bar": 13, "seq": np.arange(100)}
     with asdf.AsdfFile(tree) as af:
         af.write_to(path)

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -290,5 +290,3 @@ def test_open_asdf(tmpdir):
 
     with datamodels.open(path) as m:
         assert isinstance(m, DataModel)
-
-

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -259,10 +259,22 @@ def t_path(partial_path):
     return os.path.join(test_dir, partial_path)
 
 
-def test_open_asdf_datamodel_class(tmpdir):
-    path = str(tmpdir.join("image_model.asdf"))
+@pytest.mark.parametrize("suffix", ["asdf", "fits"])
+def test_open_asdf_datamodel_class(tmpdir, suffix):
+    path = str(tmpdir.join(f"image_model.{suffix}"))
     model = ImageModel((10, 10))
     model.save(path)
 
     with datamodels.open(path) as m:
         assert isinstance(m, ImageModel)
+
+
+@pytest.mark.parametrize("suffix", ["asdf", "fits"])
+def test_open_asdf_no_datamodel_class(tmpdir, suffix):
+    path = str(tmpdir.join(f"no_model.{suffix}"))
+    # model = DataModel()
+    with DataModel() as dm:
+        dm.save(path)
+
+    with datamodels.open(path) as m:
+        assert isinstance(m, DataModel)

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -227,10 +227,9 @@ def _class_from_model_type(init):
             primary = init[0]
             model_type = primary.header.get('DATAMODL')
         elif isinstance(init, asdf.AsdfFile):
-            tree = init.tree
-            if 'meta' in tree and 'model_type' in tree['meta']:
-                model_type = tree['meta']['model_type']
-            else:
+            try:
+                model_type = init.tree['meta']['model_type']
+            except KeyError:
                 model_type = None
 
         if model_type is None:

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -208,7 +208,7 @@ def open(init=None, memmap=False, **kwargs):
     return model
 
 
-def _class_from_model_type(init): 
+def _class_from_model_type(init):
     """
     Get the model type from the primary header, lookup to get class
     """

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -10,6 +10,8 @@ from platform import system as platform_system
 import psutil
 import traceback
 
+import asdf
+
 import numpy as np
 from astropy.io import fits
 
@@ -20,7 +22,6 @@ import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-import asdf
 
 
 class NoTypeWarning(Warning):
@@ -114,7 +115,6 @@ def open(init=None, memmap=False, **kwargs):
             return container.ModelContainer(init, **kwargs)
 
         elif file_type == "asdf":
-            # Add a case statement here.
             if s3_utils.is_s3_uri(init):
                 asdffile = asdf.open(s3_utils.get_object(init), **kwargs)
             else:
@@ -211,6 +211,14 @@ def open(init=None, memmap=False, **kwargs):
 def _class_from_model_type(init):
     """
     Get the model type from the primary header, lookup to get class
+
+    Parameter
+    ---------
+    init: AsdfFile or HDUList
+
+    Return
+    ------
+    new_class: str or None
     """
     from . import _defined_models as defined_models
 


### PR DESCRIPTION
JP-1734: Datamodels should be able to read and write ASDF files

Changed datamodel.open to read an ASDF file and instantiate a datamodel class listed in the ASDF file.

Fixes #5153 / [JP-1734](https://jira.stsci.edu/browse/JP-1734)