### PR TITLE
JP-1765: Turn off RSCD step for MIRI TSO

### DIFF
--- a/docs/jwst/pipeline/calwebb_detector1.rst
+++ b/docs/jwst/pipeline/calwebb_detector1.rst
@@ -48,7 +48,7 @@ the steps are applied in a different order than for Near-IR (NIR) instrument exp
 +--------------------------------------------+---------+-----------------------------------------+---------+
 | :ref:`linearity <linearity_step>`          | |check| | :ref:`linearity <linearity_step>`       | |check| |
 +--------------------------------------------+---------+-----------------------------------------+---------+
-| :ref:`persistence <persistence_step>` [2]_ |         | :ref:`rscd <rscd_step>`                 | |check| |
+| :ref:`persistence <persistence_step>` [2]_ |         | :ref:`rscd <rscd_step>`                 |         |
 +--------------------------------------------+---------+-----------------------------------------+---------+
 | :ref:`dark_current <dark_current_step>`    | |check| | :ref:`dark_current <dark_current_step>` | |check| |
 +--------------------------------------------+---------+-----------------------------------------+---------+

--- a/jwst/pipeline/calwebb_tso1.cfg
+++ b/jwst/pipeline/calwebb_tso1.cfg
@@ -11,6 +11,7 @@ save_calibrated_ramp = True
       [[superbias]]
       [[refpix]]
       [[rscd]]
+        skip = True
       [[firstframe]]
         skip = True
       [[lastframe]]


### PR DESCRIPTION
Set the `rscd` step to be skipped in the `calwebb_tso1.cfg` pipeline configuration. Update the docs too.

Fixes #5438 / [JP-1765](https://jira.stsci.edu/browse/JP-1765)