### PR TITLE
Remove V1 readthedocs config file

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,0 @@
-conda:
-    file: .rtd-environment.yml
-python:
-    setup_py_install: true


### PR DESCRIPTION
We've had this lingering V1-style config file which only recently started breaking the readthedocs build.  It seems like they must have changed the order of precedence of the files when multiple are present?  In any case, removing the old config seems to fix the build, here's a pass on this branch:

https://readthedocs.org/projects/jwst-pipeline/builds/12209132/