### PR TITLE
JP-1774: Update datamodels to include flat and photom arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ datamodels
 - Updated keyword schemas for EXP_TYPE and MODULE, to keep in sync with the
   JWST Keyword Dictionary [#5452]
 
+- Added flatfield and photom correction arrays to slit data models [#5460]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/multiexposure.py
+++ b/jwst/datamodels/multiexposure.py
@@ -67,8 +67,12 @@ class MultiExposureModel(DataModel):
             self.exposures[0].var_flat = init.var_flat
             self.exposures[0].wavelength = init.wavelength
             self.exposures[0].barshadow = init.barshadow
+            self.exposures[0].flatfield_point = init.flatfield_point
+            self.exposures[0].flatfield_uniform = init.flatfield_uniform
             self.exposures[0].pathloss_point = init.pathloss_point
             self.exposures[0].pathloss_uniform = init.pathloss_uniform
+            self.exposures[0].photom_point = init.photom_point
+            self.exposures[0].photom_uniform = init.photom_uniform
             self.exposures[0].area = init.area
             return
 

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -49,11 +49,23 @@ class MultiSlitModel(model_base.DataModel):
     slits.items.barshadow : numpy float32 array
          Bar shadow correction
 
+    slits.items.flatfield_point : numpy float32 array
+         flatfield array for point source
+
+    slits.items.flatfield_uniform : numpy float32 array
+         flatfield array for uniform source
+
     slits.items.pathloss_point : numpy float32 array
          pathloss array for point source
 
     slits.items.pathloss_uniform : numpy float32 array
          pathloss array for uniform source
+
+    slits.items.photom_point : numpy float32 array
+         photom array for point source
+
+    slits.items.photom_uniform : numpy float32 array
+         photom array for uniform source
 
     slits.items.area : numpy float32 array
          Pixel area map array

--- a/jwst/datamodels/schemas/flatcorr.schema.yaml
+++ b/jwst/datamodels/schemas/flatcorr.schema.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/flatcorr.schema"
+type: object
+properties:
+  flatfield_point:
+    title: Flat-field point source correction
+    fits_hdu: FLATFIELD_PS
+    ndim: 2
+    datatype: float32
+  flatfield_uniform:
+    title: Flat-field uniform source correction
+    fits_hdu: FLATFIELD_UN
+    ndim: 2
+    datatype: float32

--- a/jwst/datamodels/schemas/pathlosscorr.schema.yaml
+++ b/jwst/datamodels/schemas/pathlosscorr.schema.yaml
@@ -10,7 +10,7 @@ properties:
     ndim: 2
     datatype: float32
   pathloss_uniform:
-    title: Pathloss uniformsource correction
+    title: Pathloss uniform source correction
     fits_hdu: PATHLOSS_UN
     ndim: 2
     datatype: float32

--- a/jwst/datamodels/schemas/photomcorr.schema.yaml
+++ b/jwst/datamodels/schemas/photomcorr.schema.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/photomcorr.schema"
+type: object
+properties:
+  photom_point:
+    title: Photometric point source correction
+    fits_hdu: PHOTOM_PS
+    ndim: 2
+    datatype: float32
+  photom_uniform:
+    title: Photometric uniform source correction
+    fits_hdu: PHOTOM_UN
+    ndim: 2
+    datatype: float32

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -48,7 +48,9 @@ allOf:
       default: 0
       datatype: int32
 - $ref: variance.schema
+- $ref: flatcorr.schema
 - $ref: pathlosscorr.schema
+- $ref: photomcorr.schema
 - $ref: slitmeta.schema
 - $ref: bunit.schema
 - $ref: photometry.schema

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -7,7 +7,7 @@ __all__ = ['SlitModel', 'SlitDataModel']
 
 class SlitDataModel(DataModel):
     """
-    A data model for 2D images.
+    A data model for 2D slit images.
 
     Parameters
     __________
@@ -32,11 +32,23 @@ class SlitDataModel(DataModel):
     barshadow : numpy float32 array
          Bar shadow correction
 
+    flatfield_point : numpy float32 array
+         flatfield array for point source
+
+    flatfield_uniform : numpy float32 array
+         flatfield array for uniform source
+
     pathloss_point : numpy float32 array
          pathloss array for point source
 
     pathloss_uniform : numpy float32 array
          pathloss array for uniform source
+
+    photom_point : numpy float32 array
+         photom array for point source
+
+    photom_uniform : numpy float32 array
+         photom array for uniform source
 
     area : numpy float32 array
          Pixel area map array
@@ -98,11 +110,23 @@ class SlitModel(DataModel):
     barshadow : numpy float32 array
          Bar shadow correction
 
+    flatfield_point : numpy float32 array
+         flatfield array for point source
+
+    flatfield_uniform : numpy float32 array
+         flatfield array for uniform source
+
     pathloss_point : numpy float32 array
          pathloss array for point source
 
     pathloss_uniform : numpy float32 array
          pathloss array for uniform source
+
+    photom_point : numpy float32 array
+         photom array for point source
+
+    photom_uniform : numpy float32 array
+         photom array for uniform source
 
     area : numpy float32 array
          Pixel area map array


### PR DESCRIPTION
Update the slit-related data models to include flatfield and photom correction arrays needed for the NIRSpec fixed-slit master background correction step. All NIRSpec fixed-slit exposures use a `MultiSlitModel` when being processed by calspec2 steps following `extract_2d`. They also get reorganized by the `exp_to_source` step at the beginning of `calwebb_spec3` processing. The arrays are optional and hence only appear in the data models when actually used.

Fixes #5456 / [JP-1774](https://jira.stsci.edu/browse/JP-1774)