### PR TITLE
JP-1776: Update photom to compute uniform and ps corrections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,12 +95,19 @@ outlier_detection
 
 - Implement memory check in resample to prevent huge arrays [#5354]
 
+photom
+------
+
+- Updated NIRSpec fixed-slit processing to compute and save correction
+  values for both point and uniform sources in the primary slit when it
+  contains a point source, in order to support master background corrections.
+  [#5463]
+
 pipeline
 --------
 
 - Update ``Image3Pipeline`` to allow sky subtraction when input contains
   only one image (group). [#5423]
-
 
 ramp_fitting
 ------------

--- a/docs/jwst/flatfield/main.rst
+++ b/docs/jwst/flatfield/main.rst
@@ -66,6 +66,36 @@ the 3-D SCI and ERR arrays.
 In all cases, there is a step option that allows for saving the
 on-the-fly flat field to a file, if desired.
 
+NIRSpec Fixed-Slit Primary Slit
+-------------------------------
+The primary slit in a NIRSpec fixed-slit exposure receives special handling.
+If the primary slit, as given by the "FXD_SLIT" keyword value, contains a
+point source, as given by the "SRCTYPE" keyword, it is necessary to know the
+flatfield conversion factors for both a point source and a uniform source
+for use later in the :ref:`master background <master_background_step>` step
+in Stage 3 processing. The point source version of the flatfield correction
+is applied to the slit data, but that correction is not appropriate for the
+background signal contained in the slit, and hence corrections must be
+applied later in the :ref:`master background <master_background_step>` step.
+
+So in this case the `flatfield` step will compute 2D arrays of conversion
+factors that are appropriate for a uniform source and for a point source,
+and store those correction factors in the "FLATFIELD_UN" and "FLATFIELD_PS"
+extensions, respectively, of the output data product. The point source
+correction array is also applied to the slit data.
+
+Note that this special handling is only needed when the slit contains a
+point source, because in that case corrections to the wavelength grid are
+applied by the :ref:`wavecorr <wavecorr_step>` step to account for any
+source mis-centering in the slit and the flatfield conversion factors are
+wavelength-dependent. A uniform source does not require wavelength corrections
+and hence the flatfield conversions will differ for point and uniform
+sources. Any secondary slits that may be included in a fixed-slit exposure
+do not have source centering information available, so the
+:ref:`wavecorr <wavecorr_step>` step is not applied, and hence there's no
+difference between the point source and uniform source flatfield
+conversions for those slits.
+
 Error Propagation
 -----------------
 The VAR_POISSON and VAR_RNOISE variance arrays of the science exposure

--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -72,6 +72,36 @@ The step also computes the equivalent conversion factor to units of
 microJy/square-arcsecond (or microjanskys) and stores it in the header
 keyword PHOTUJA2.
 
+NIRSpec Fixed-Slit Primary Slit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The primary slit in a NIRSpec fixed-slit exposure receives special handling.
+If the primary slit, as given by the "FXD_SLIT" keyword value, contains a
+point source, as given by the "SRCTYPE" keyword, it is necessary to know the
+photometric conversion factors for both a point source and a uniform source
+for use later in the :ref:`master background <master_background_step>` step
+in Stage 3 processing. The point source version of the photometric correction
+is applied to the slit data, but that correction is not appropriate for the
+background signal contained in the slit, and hence corrections must be
+applied later in the :ref:`master background <master_background_step>` step.
+
+So in this case the `photom` step will compute 2D arrays of conversion
+factors that are appropriate for a uniform source and for a point source,
+and store those correction factors in the "PHOTOM_UN" and "PHOTOM_PS"
+extensions, respectively, of the output data product. The point source
+correction array is also applied to the slit data.
+
+Note that this special handling is only needed when the slit contains a
+point source, because in that case corrections to the wavelength grid are
+applied by the :ref:`wavecorr <wavecorr_step>` step to account for any
+source mis-centering in the slit and the photometric conversion factors are
+wavelength-dependent. A uniform source does not require wavelength corrections
+and hence the photometric conversions will differ for point and uniform
+sources. Any secondary slits that may be included in a fixed-slit exposure
+do not have source centering information available, so the
+:ref:`wavecorr <wavecorr_step>` step is not applied, and hence there's no
+difference between the point source and uniform source photometric
+conversions for those slits.
+
 Pixel Area Data
 ^^^^^^^^^^^^^^^
 For all instrument modes other than NIRSpec the photom step loads a 2-D pixel

--- a/jwst/lib/wcs_utils.py
+++ b/jwst/lib/wcs_utils.py
@@ -6,7 +6,7 @@ from ..assign_wcs import niriss
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
 
 
-def get_wavelengths(model, exp_type="", order=None):
+def get_wavelengths(model, exp_type="", order=None, use_wavecorr=None):
     """Read or compute wavelengths.
 
     Parameters
@@ -21,6 +21,10 @@ def get_wavelengths(model, exp_type="", order=None):
 
     order : int
         Spectral order number, for NIRISS SOSS only.
+
+    use_wavecorr : bool
+        Use the corrected wavelengths in the wavelength attribute or
+        recompute uncorrected wavelengths from the WCS?
 
     Returns
     -------
@@ -38,6 +42,15 @@ def get_wavelengths(model, exp_type="", order=None):
         np.nanmin(wl_array) == 0. and np.nanmax(wl_array) == 0.):
             got_wavelength = False
             wl_array = None
+
+    # If we've been asked to use the corrected wavelengths stored in
+    # the wavelength array, return those wavelengths. Otherwise, the
+    # results computed from the WCS object (below) will be returned.
+    if use_wavecorr is not None:
+        if use_wavecorr:
+            return wl_array
+        else:
+            got_wavelength = False  # force wl computation below
 
     # If no existing wavelength array, compute one
     if hasattr(model.meta, "wcs") and not got_wavelength:


### PR DESCRIPTION
Updated the NIRSpec fixed-slit/MSA branch of the `photom_io` function to compute both uniform and point source conversion factors for the NIRSpec fixed-slit primary slit when it contains a point source. Both versions of the correction are stored in the output slit instance for use later by the `master_background` step, for applying corrections.

Note that the uniform source correction uses the WCS object to compute an uncorrected wavelength grid for the slit, while the point source correction uses the existing 2D wavelength array, because it contains corrected wavelengths. Once the `wavecorr` step gets updated to include the wavelength correction as another transform in the WCS object, the uncorrected wavelengths will need to be computed from the WCS by excluding that new transform.

Fixes #5458 / [JP-1776](https://jira.stsci.edu/browse/JP-1776)