### PR TITLE
JP-1777: NIRSpec Fixed-Slit master background corrections

### DIFF
--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -301,7 +301,7 @@ even if the secondary slits contain point sources, no wavelength correction can
 be applied, and therefore again the flat-field and photometric calibrations are
 the same as for background spectra. This means only the pathloss correction
 difference between uniform and point sources needs to be accounted for in the
-seconday slits.
+secondary slits.
 
 So if the primary slit (as given by the FXD_SLIT keyword) contains a point source
 (as given by the SRCTYPE keyword) the corrections applied to the 2-D master background
@@ -312,7 +312,7 @@ for that slit are:
                  &* [pathloss(uniform) / pathloss(point)]\\
                  &* [photom(point) / photom(uniform)]
 
-For seconday slits that contain a point source, the corrections applied to the
+For secondary slits that contain a point source, the corrections applied to the
 2-D master background are simply:
 
 .. math::

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -14,9 +14,8 @@ performed on the input images, based on the value of the S_BKDSUB keyword. If S_
 set to "COMPLETE", the master background step is skipped. If the :ref:`calwebb_spec2 <calwebb_spec2>`
 background step was not applied, the master background step will proceed.
 The user can override this logic, if desired, by setting the step argument ``--force_subtract``
-to ``True``, in which case master
-background subtraction will be applied regardless of the value of S_BKDSUB (see
-:ref:`msb_step_args`).
+to ``True``, in which case master background subtraction will be applied regardless of the
+value of S_BKDSUB (see :ref:`msb_step_args`).
 
 Upon successful completion of the step, the S_MSBSUB keyword is set to "COMPLETE" in the
 output product. The background-subtracted results are returned as a new data model, leaving
@@ -37,7 +36,7 @@ The master background signal will be subtracted from all input members designate
 need to be :ref:`cal <cal>` products created from individual exposures by the
 :ref:`calwebb_spec2 <calwebb_spec2>` pipeline.
 
-There are two main observing scenarios that are supported by this step: nodded point sources
+There are two main observing scenarios that are supported by this step: nodded exposures of point sources
 and off-source background exposures of extended targets. A third type of operation is performed
 for NIRSpec MOS observations that include background slits. The details for each mode are explained
 below.
@@ -184,12 +183,23 @@ NIRSpec MOS with Background Slits
 NIRSpec MOS exposures that have one or more slits defined as background require
 unique processing. The background slits take the place of both nodded and off-target
 background exposures, because the background can be measured directly from the spectra
-resulting from those slits. In this observing scenario, all source and background
-slits are processed through all of the :ref:`calwebb_spec2 <calwebb_spec2>` steps,
-resulting in extracted spectra for the sources and backgrounds. The master_background
-step then combines the background spectra into a master background spectrum and
-performs background subtraction on all of the source slit data, the same as the
-other observing scenarios.
+contained in those slits. Because the background spectra come from the same exposure
+as the source spectra, the master background processing is applied within the
+:ref:`calwebb_spec2 <calwebb_spec2>` pipeline as each individual exposure is
+calibrated, rather than during :ref:`calwebb_spec3 <calwebb_spec3>` processing.
+In this scenario, all source and background slits are first partially calibrated up through
+the :ref:`extract_2d <extract_2d_step>` and :ref:`srctype <srctype_step>` steps of
+:ref:`calwebb_spec2 <calwebb_spec2>` to produce 2D cutouts for each slit. At this
+point the `master_background` step is applied, which completes the remaining calibration
+steps for all of the background slits, resulting in multiple 1D extracted background
+spectra. The background spectra are combined (as with other observing modes) to
+create a 1D master background spectrum, and then the master background spectrum is
+interpolated back into the 2D space of each source slit and subtracted. The
+background-subtracted source slits then have all of their remaining
+:ref:`calwebb_spec2 <calwebb_spec2>` calibration steps applied.
+
+Note that special corrections are applied to the 2D master background data before
+being subtracted from each source slit, as explained in detail below.
 
 Creating the 1-D Master Background Spectrum
 -------------------------------------------
@@ -259,7 +269,7 @@ calibration:
   is created from data that had corrections for a uniform source applied to it and hence
   there's a mismatch relative to the point source data.
 
-The 2-D background that's initially created from the 1-D master background is essenentially
+The 2-D background that's initially created from the 1-D master background is essentially
 a perfectly calibrated background signal. However, due to the effects mentioned above, the
 actual background signal contained within a calibrated point source slit (or IFU image) is not
 perfect (e.g. it still has the bar shadow effects in it). So all of these effects need to be
@@ -271,16 +281,58 @@ For the NIRSpec IFU mode, the only effect that needs to be accounted for is the 
 between point source and uniform source pathloss corrections, because no wavelength or
 bar shadow corrections are applied to IFU data. The 2-D background generated from the
 master background spectrum must have the uniform source pathloss correction removed from
-it and the point source pathloss correction imposed on it, so the operation performed on
-the 2-D background is:
+it and the point source pathloss correction applied to it, so the operation performed on
+the IFU 2-D background is:
 
 .. math::
- bkg(corr) = bkg * pathloss(point) / pathloss(uniform)
-
-NIRSpec MOS Mode
-^^^^^^^^^^^^^^^^
-**Not yet implemented**
+ bkg(corr) = bkg * pathloss(uniform) / pathloss(point)
 
 NIRSpec Fixed-Slit Mode
 ^^^^^^^^^^^^^^^^^^^^^^^
-**Not yet implemented**
+NIRSpec fixed slit data receive flat-field, pathloss, and photometric calibrations,
+all of which are wavelength-dependent, and the pathloss correction is also source
+type dependent. Fixed slit data do not receive a bar shadow correction. Only slits
+containing a point source can have a wavelength correction applied, to account for
+source centering within the slit, hence slits containing uniform sources receive
+the same flat-field and photometric calibrations as background spectra and
+therefore don't require corrections for those two calibrations. Furthermore, the
+source position in the slit is only known for the primary slit in an exposure, so
+even if the secondary slits contain point sources, no wavelength correction can
+be applied, and therefore again the flat-field and photometric calibrations are
+the same as for background spectra. This means only the pathloss correction
+difference between uniform and point sources needs to be accounted for in the
+seconday slits.
+
+So if the primary slit (as given by the FXD_SLIT keyword) contains a point source
+(as given by the SRCTYPE keyword) the corrections applied to the 2-D master background
+for that slit are:
+
+.. math::
+ bkg(corr) = bkg &* [flatfield(uniform) / flatfield(point)]\\
+                 &* [pathloss(uniform) / pathloss(point)]\\
+                 &* [photom(point) / photom(uniform)]
+
+For seconday slits that contain a point source, the corrections applied to the
+2-D master background are simply:
+
+.. math::
+ bkg(corr) = bkg * pathloss(uniform) / pathloss(point)
+
+NIRSpec MOS Mode
+^^^^^^^^^^^^^^^^
+Because the master background is subtracted from only partially calibrated slit
+data, the number of correction terms is reduced relative to that for fixed slits.
+At the time the 2D master background is subtracted from each source slit, those
+source slits have not yet received any calibrations that are specific to point
+sources and hence the background signal in the source slits has effects in it
+characteristic of uniform source data. Therefore the fully-calibrated 2D
+master background signal needs to have those uniform source effects imposed on it
+(e.g. impose the uniform source flat-field pattern or the bar shadow pattern
+into the background data),
+so that it matches the actual background signal in each slit before being
+subtracted. The corrections applied to the 2D master background for MOS slits are:
+
+.. math::
+ bkg(corr) = bkg &* flatfield(uniform) * pathloss(uniform)\\
+                 &* barshadow(uniform) / photom(uniform)
+

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -184,12 +184,8 @@ def bkg_for_multislit(input, tab_wavelength, tab_background):
         # if the slit contains a point source, in order to make the master bkg
         # match the calibrated science data in the slit
         if input.meta.exposure.type == 'NRS_FIXEDSLIT' and slit.source_type.upper() == 'POINT':
-            if slit.name == input.meta.instrument.fixed_slit:
-                # The primary slit receives special corrections
-                background.slits[k] = correct_nrs_fs_bkg(background.slits[k], primary_slit=True)
-            else:
-                # Secondary slits receive more limited corrections
-                background.slits[k] = correct_nrs_fs_bkg(background.slits[k], primary_slit=False)
+            primary = True if slit.name == input.meta.instrument.fixed_slit else False
+            background.slits[k] = correct_nrs_fs_bkg(background.slits[k], primary)
 
     return background
 

--- a/jwst/master_background/nirspec_utils.py
+++ b/jwst/master_background/nirspec_utils.py
@@ -184,20 +184,19 @@ def correct_nrs_fs_bkg(input_model, primary_slit):
         An updated (in place) version of the input with the data
         replaced by the corrected 2D background.
     """
-
     log.info('Applying point source updates to FS background')
 
     # Try to load the appropriate pathloss correction arrays
-    try:
-        pl_point = input_model.getarray_noinit('pathloss_point')
-    except AttributeError:
+    if 'pathloss_point' in input_model.instance:
+        pl_point = getattr(input_model, 'pathloss_point')
+    else:
         log.warning('pathloss_point array not found in input')
         log.warning('Skipping background updates')
         return input_model
 
-    try:
-        pl_uniform = input_model.getarray_noinit('pathloss_uniform')
-    except AttributeError:
+    if 'pathloss_uniform' in input_model.instance:
+        pl_uniform = getattr(input_model, 'pathloss_uniform')
+    else:
         log.warning('pathloss_uniform array not found in input')
         log.warning('Skipping background updates')
         return input_model
@@ -205,30 +204,30 @@ def correct_nrs_fs_bkg(input_model, primary_slit):
     if primary_slit:
         # If processing the primary slit, we also need flatfield and
         # photom correction arrays
-        try:
-            ff_point = input_model.getarray_noinit('flatfield_point')
-        except AttributeError:
+        if 'flatfield_point' in input_model.instance:
+            ff_point = getattr(input_model, 'flatfield_point')
+        else:
             log.warning('flatfield_point array not found in input')
             log.warning('Skipping background updates')
             return input_model
 
-        try:
-            ff_uniform = input_model.getarray_noinit('flatfield_uniform')
-        except AttributeError:
+        if 'flatfield_uniform' in input_model.instance:
+            ff_uniform = getattr(input_model, 'flatfield_uniform')
+        else:
             log.warning('flatfield_uniform array not found in input')
             log.warning('Skipping background updates')
             return input_model
 
-        try:
-            ph_point = input_model.getarray_noinit('photom_point')
-        except AttributeError:
+        if 'photom_point' in input_model.instance:
+            ph_point = getattr(input_model, 'photom_point')
+        else:
             log.warning('photom_point array not found in input')
             log.warning('Skipping background updates')
             return input_model
 
-        try:
-            ph_uniform = input_model.getarray_noinit('photom_uniform')
-        except AttributeError:
+        if 'photom_uniform' in input_model.instance:
+            ph_uniform = getattr(input_model, 'photom_uniform')
+        else:
             log.warning('photom_uniform array not found in input')
             log.warning('Skipping background updates')
             return input_model

--- a/jwst/master_background/tests/test_nirspec_corrections.py
+++ b/jwst/master_background/tests/test_nirspec_corrections.py
@@ -4,7 +4,7 @@ Unit tests for master background NIRSpec corrections
 import numpy as np
 
 from jwst import datamodels
-from ..nirspec_utils import correct_nrs_ifu_bkg
+from ..nirspec_utils import correct_nrs_ifu_bkg, correct_nrs_fs_bkg
 
 
 def test_ifu_pathloss_existence():
@@ -20,13 +20,34 @@ def test_ifu_correction():
     """Test application of IFU corrections"""
 
     data = np.ones((5, 5))
-    pl_ps = 2 * data
-    pl_un = data / 2
+    pl_ps = 2.1 * data
+    pl_un = data / 1.9
     input = datamodels.IFUImageModel(data=data,
                                      pathloss_point=pl_ps,
                                      pathloss_uniform=pl_un)
 
-    corrected = input.data * pl_ps / pl_un
+    corrected = input.data * pl_un / pl_ps
     result = correct_nrs_ifu_bkg(input)
 
-    assert np.allclose(corrected, result.data, rtol=1.e-10)
+    assert np.allclose(corrected, result.data, rtol=1.e-7)
+
+
+def test_fs_correction():
+    """Test application of FS corrections"""
+
+    data = np.ones((5, 5))
+    ff_ps = 1.5 * data
+    ff_un = data / 1.2
+    pl_ps = 2 * data
+    pl_un = data / 2.1
+    ph_ps = 1.1 * data
+    ph_un = 1.23 * data
+    input = datamodels.SlitModel(data=data,
+                                 flatfield_point=ff_ps, flatfield_uniform=ff_un,
+                                 pathloss_point=pl_ps, pathloss_uniform=pl_un,
+                                 photom_point=ph_ps, photom_uniform=ph_un)
+
+    corrected = input.data * (ff_un / ff_ps) * (pl_un / pl_ps) * (ph_ps / ph_un)
+    result = correct_nrs_fs_bkg(input, primary_slit=True)
+
+    assert np.allclose(corrected, result.data, rtol=1.e-7)


### PR DESCRIPTION
Update the `master_background` step to apply appropriate flatfield, pathloss, and photom corrections to 2D master background images for NIRSpec fixed slits. For the primary slit it applies all flatfield, pathloss, and photom correction terms, while the secondary slits only get pathloss corrections (because flatfield and photom are identical for secondary slits, which don't have wavelength differences between point and uniform sources).

Fixes #5459 / [JP-1777](https://jira.stsci.edu/browse/JP-1777)