### PR TITLE
Move utility functions out of datamodels.schema

### DIFF
--- a/jwst/datamodels/schema.py
+++ b/jwst/datamodels/schema.py
@@ -34,66 +34,6 @@ def find_fits_keyword(schema, keyword, return_result=False):
 
     return results
 
-def build_fits_dict(schema):
-    """
-    Utility function to create a dict that maps FITS keywords to their
-    metadata attribute in a input schema.
-
-    Parameters
-    ----------
-    schema : JSON schema fragment
-        The schema in which to search.
-
-    Returns
-    -------
-    results : dict
-        Dictionary with FITS keywords as keys and schema metadata
-        attributes as values
-
-    """
-    def build_fits_dict(subschema, path, combiner, ctx, recurse):
-        if len(path) and path[0] == 'extra_fits':
-            return True
-        kw = subschema.get('fits_keyword')
-        if kw is not None:
-            results[kw] = '.'.join(path)
-
-    results = {}
-    walk_schema(schema, build_fits_dict, results)
-
-    return results
-
-
-def build_schema2fits_dict(schema):
-    """
-    Utility function to create a dict that maps metadata attributes to thier
-    FITS keyword and FITS HDU locations (if any).
-
-    Parameters
-    ----------
-    schema : JSON schema fragment
-        The schema in which to search.
-
-    Returns
-    -------
-    results : dict
-        Dictionary with schema metadata path as keys and a tuple of FITS
-        keyword and FITS HDU as values.
-
-    """
-    def build_schema_dict(subschema, path, combiner, ctx, recurse):
-        if len(path) and path[0] == 'extra_fits':
-            return True
-        kw = subschema.get('fits_keyword')
-        hdu = subschema.get('fits_hdu')
-        if kw is not None:
-            results['.'.join(path)] = (kw, hdu)
-
-    results = {}
-    walk_schema(schema, build_schema_dict, results)
-
-    return results
-
 
 class SearchSchemaResults(list):
     def __repr__(self):

--- a/jwst/model_blender/tests/test_blend.py
+++ b/jwst/model_blender/tests/test_blend.py
@@ -5,7 +5,7 @@ from astropy.table import Table
 import numpy as np
 
 from jwst.datamodels import ImageModel
-from jwst.datamodels.schema import build_fits_dict
+from jwst.datamodels.schema import walk_schema
 
 from .. import blendmeta
 
@@ -104,6 +104,36 @@ def test_blendmeta(blend):
 
     for attr in input_values:
         assert newmeta[attr] == output_values[attr]
+
+
+def build_fits_dict(schema):
+    """
+    Utility function to create a dict that maps FITS keywords to their
+    metadata attribute in a input schema.
+
+    Parameters
+    ----------
+    schema : JSON schema fragment
+        The schema in which to search.
+
+    Returns
+    -------
+    results : dict
+        Dictionary with FITS keywords as keys and schema metadata
+        attributes as values
+
+    """
+    def build_fits_dict(subschema, path, combiner, ctx, recurse):
+        if len(path) and path[0] == 'extra_fits':
+            return True
+        kw = subschema.get('fits_keyword')
+        if kw is not None:
+            results[kw] = '.'.join(path)
+
+    results = {}
+    walk_schema(schema, build_fits_dict, results)
+
+    return results
 
 
 def test_blendtab(blend):


### PR DESCRIPTION
This PR moves a couple of utility functions out of `datamodels.schema` and into the only modules that use them, so that they can be removed from stdatamodels without impacting jwst.

See https://github.com/spacetelescope/stdatamodels/pull/25