### PR TITLE
Add utility asn_gather

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ assign_wcs
 associations
 ------------
 
+- Add utility asn_gather [#5468]
+
 - Do not allow target acqs to be considered TSO [#5385]
 
 - Add NRS_VERIFY to the list of target acq/confirmation images [#5395]

--- a/docs/jwst/associations/asn_from_list.rst
+++ b/docs/jwst/associations/asn_from_list.rst
@@ -122,9 +122,12 @@ API
 ---
 
 There are two programmatic entry points: The
-:class:`~jwst.associations.asn_from_list.Main` is the highest level
+:py:class:`~jwst.associations.asn_from_list.Main` is the highest level
 entry and is what is instantiated when the command line
 ``asn_from_list`` is used. ``Main`` handles the command line interface.
 
-:func:`~jwst.associations.asn_from_list.asn_from_list` is the main
+:py:func:`~jwst.associations.asn_from_list.asn_from_list` is the main
 mid-level entry point.
+
+
+.. automodapi:: jwst.associations.asn_from_list

--- a/docs/jwst/associations/asn_gather.rst
+++ b/docs/jwst/associations/asn_gather.rst
@@ -1,0 +1,21 @@
+.. _asn-gather:
+
+asn_gather
+==========
+
+Copy members of an association from one location to another.
+
+The association is copied into the destination, re-written such that the member
+list points to the new location of the members.
+
+Command Line
+------------
+
+.. code-block:: shell
+
+   asn_gather --help
+
+API
+---
+
+.. automodapi:: jwst.associations.asn_gather

--- a/docs/jwst/associations/commands.rst
+++ b/docs/jwst/associations/commands.rst
@@ -6,3 +6,4 @@ Association Commands
 
    asn_generate.rst
    asn_from_list.rst
+   asn_gather.rst

--- a/jwst/associations/__init__.py
+++ b/jwst/associations/__init__.py
@@ -26,7 +26,6 @@ def libpath(filepath):
 
 from .association import *
 from .association_io import *
-from .asn_gather import *
 from .exceptions import *
 from .generate import *
 from .lib.process_list import *

--- a/jwst/associations/__init__.py
+++ b/jwst/associations/__init__.py
@@ -26,6 +26,7 @@ def libpath(filepath):
 
 from .association import *
 from .association_io import *
+from .asn_gather import *
 from .exceptions import *
 from .generate import *
 from .lib.process_list import *

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -12,7 +12,7 @@ logger.addHandler(logging.NullHandler())
 LogLevels = [logging.WARNING, logging.INFO, logging.DEBUG]
 
 
-def asn_gather(association, destination=None, exp_types=None,
+def asn_gather(association, destination=None, exp_types=None, exclude_types=None,
                shellcmd='rsync -urv --no-perms --chmod=ugo=rwX'):
     """Copy/Move members of an association from one location to another
 
@@ -36,6 +36,9 @@ def asn_gather(association, destination=None, exp_types=None,
         List of exposure types to gather.
         If None, all are gathered.
 
+    exclude_types : [str[,...]] or None
+        List of exposure types to exclude.
+
     shellcmd : str
         The shell command to use to do the copying of the
         individual members.
@@ -48,6 +51,7 @@ def asn_gather(association, destination=None, exp_types=None,
     from .load_as_asn import LoadAsAssociation
     from . import Association
 
+    exclude_types = exclude_types if exclude_types is not None else []
     source_asn_path = Path(association)
     source_folder = source_asn_path.parent
     if destination is None:
@@ -66,7 +70,8 @@ def asn_gather(association, destination=None, exp_types=None,
             {'expname': src_member['expname'],
              'exptype': src_member['exptype']}
             for src_member in src_product['members']
-            if exp_types is None or src_member['exptype'] in exp_types
+            if src_member['exptype'] not in exclude_types and \
+            (exp_types is None or src_member['exptype'] in exp_types)
         ]
         if members:
             product = {

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -5,8 +5,8 @@ import subprocess
 __all__ = ['asn_gather']
 
 
-def asn_gather(source_asn_path, destination=None, exp_types=None, copy=True,
-               recurse=False, member_root=None, shellcmd='rsync -ur --no-perms --chmod=ugo=rwX'):
+def asn_gather(source_asn_path, destination=None, exp_types=None,
+               shellcmd='rsync -ur --no-perms --chmod=ugo=rwX'):
     """Copy/Move members of an association from one location to another
 
     The association is copied into the destination, re-written such that the member
@@ -28,6 +28,10 @@ def asn_gather(source_asn_path, destination=None, exp_types=None, copy=True,
     exp_types : [str[,...]] or None
         List of exposure types to gather.
         If None, all are gathered.
+
+    shellcmd : str
+        The shell command to use to do the copying of the
+        individual members.
 
     Returns
     -------
@@ -92,3 +96,26 @@ def asn_gather(source_asn_path, destination=None, exp_types=None, copy=True,
 
 def from_cmdline():
     """Collect asn_gather arguments from the commandline"""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Gather an association to a new location'
+    )
+
+    parser.add_argument(
+        src_asn_path,
+        help='Association to gather'
+    )
+    parser.add_argument(
+        destination, default='./'
+        help='Folder to copy the association to. Default: %(default)s)'
+    )
+    parser.add_argument(
+        '-t', '--exp-types', default=None,
+        action='append'
+        help='Exposure types to gather. If not specified, all exposure types are used.'
+    )
+    parser.add_argument(
+        '-c', '--cmd',g
+        help='Shell command to use to perform the copy. Specify as a single string.'
+    )

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -1,0 +1,49 @@
+"""asn_gather: Copy or Move data that is listed in an association"""
+__all__ = ['asn_gather']
+
+
+def asn_gather(asn_path, destination=None, exp_types=None, copy=True, recurse=False, member_root=None):
+    """Copy/Move members of an association from one location to another
+
+    The association is copied into the destination, re-written such that the member
+    list points to the new location of the members. If `copy` is `False`, the member
+    list will simply point back to the original location of the members.
+
+    If members cannot be copied, warnings will be generated and the member information
+    in the copied association will be left untouched.
+
+    Parameters
+    ----------
+    asn_path : str, pathlib.Path, Association, or dict-like
+        The association to gather.
+
+    destination : str, pathlib.Path, or None
+        The folder to place the association and its members.
+        If None, the current working directory is used.
+
+    exp_types : [str[,...]] or None
+        List of exposure types to gather.
+        If None, all are copied.
+
+    copy : bool
+        Copy the members to the destination. Otherwise, just copy
+        the association itself with the members pointing to the original
+        location.
+
+    recurse : bool
+        If members appear to come from other associations, attempt
+        to gather.
+
+    member_root : str, pathlib.Path, or None
+        The folder where the members are found.
+        If None, the folder path of the requested association is used.
+
+    Returns
+    -------
+    asn : Association
+        The association
+    """
+
+
+def from_cmdline():
+    """Collect asn_gather arguments from the commandline"""

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -6,7 +6,7 @@ __all__ = ['asn_gather']
 
 
 def asn_gather(source_asn_path, destination=None, exp_types=None, copy=True,
-               recurse=False, member_root=None, shellcmd='rsync -Pur --no-perms --chmod=ugo=rwX'):
+               recurse=False, member_root=None, shellcmd='rsync -ur --no-perms --chmod=ugo=rwX'):
     """Copy/Move members of an association from one location to another
 
     The association is copied into the destination, re-written such that the member

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -91,9 +91,8 @@ def asn_gather(association, destination=None, exp_types=None, exclude_types=None
             dest_path = dest_folder / src_path.name
             process_args = shellcmd_args + [str(src_path), str(dest_path)]
             logger.debug(f'Shell command in use: {process_args}')
-            result = subprocess.run(process_args, capture_output=True, check=True)
+            result = subprocess.run(process_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
             logger.debug(result.stdout.decode())
-            logger.debug(result.stderr.decode())
             logger.info('...done')
             member['expname'] = dest_path.name
 

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -143,6 +143,11 @@ def from_cmdline(args=None):
         help='Exposure types to gather. If not specified, all exposure types are used.'
     )
     parser.add_argument(
+        '-x', '--exclude-types', default=None, dest='exclude_types',
+        action='append',
+        help='Exposure types to exclude.'
+    )
+    parser.add_argument(
         '-v', '--verbose', action='count', default=0,
         help='Increase verbosity. Specifying multiple times adds more output.'
     )

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -1,8 +1,10 @@
 """asn_gather: Copy or Move data that is listed in an association"""
+from pathlib import Path
+
 __all__ = ['asn_gather']
 
 
-def asn_gather(asn_path, destination=None, exp_types=None, copy=True, recurse=False, member_root=None):
+def asn_gather(source_asn_path, destination=None, exp_types=None, copy=True, recurse=False, member_root=None):
     """Copy/Move members of an association from one location to another
 
     The association is copied into the destination, re-written such that the member
@@ -14,7 +16,7 @@ def asn_gather(asn_path, destination=None, exp_types=None, copy=True, recurse=Fa
 
     Parameters
     ----------
-    asn_path : str, pathlib.Path, Association, or dict-like
+    source_asn_path : str, pathlib.Path, Association, or dict-like
         The association to gather.
 
     destination : str, pathlib.Path, or None
@@ -40,9 +42,31 @@ def asn_gather(asn_path, destination=None, exp_types=None, copy=True, recurse=Fa
 
     Returns
     -------
-    asn : Association
-        The association
+    dest_asn : pathlib.Path
+        The association.
     """
+    from .load_as_asn import LoadAsAssociation
+
+    if destination is None:
+        dest_folder = Path('./')
+    else:
+        dest_folder = Path(destination)
+
+    # Open the source association
+    dest_asn = LoadAsAssociation.load(source_asn_path)
+
+    # Copy the members
+
+    # Create the new association.
+
+    # Save new association.
+    dest_path = dest_folder / source_asn_path.name
+    _, serialized = dest_asn.dump()
+    with open(dest_path, 'w') as fh:
+        fh.write(serialized)
+
+    # That's all folks
+    return dest_path
 
 
 def from_cmdline():

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -1,4 +1,4 @@
-"""asn_gather: Copy or Move data that is listed in an association"""
+"""asn_gather: Copy data that is listed in an association"""
 import logging
 from pathlib import Path
 import subprocess
@@ -14,14 +14,10 @@ LogLevels = [logging.WARNING, logging.INFO, logging.DEBUG]
 
 def asn_gather(association, destination=None, exp_types=None, exclude_types=None,
                shellcmd='rsync -urv --no-perms --chmod=ugo=rwX'):
-    """Copy/Move members of an association from one location to another
+    """Copy members of an association from one location to another
 
     The association is copied into the destination, re-written such that the member
-    list points to the new location of the members. If `copy` is `False`, the member
-    list will simply point back to the original location of the members.
-
-    If members cannot be copied, warnings will be generated and the member information
-    in the copied association will be left untouched.
+    list points to the new location of the members.
 
     Parameters
     ----------
@@ -46,7 +42,7 @@ def asn_gather(association, destination=None, exp_types=None, exclude_types=None
     Returns
     -------
     dest_asn : pathlib.Path
-        The association.
+        The copied association.
     """
     from .load_as_asn import LoadAsAssociation
     from . import Association

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -567,7 +567,7 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_BkgScience):
                 ],
                 reduce=Constraint.any
                 ),
-                ])
+        ])
 
         # Check and continue initialization.
         super(Asn_Lv3SpecAux, self).__init__(*args, **kwargs)

--- a/jwst/associations/load_as_asn.py
+++ b/jwst/associations/load_as_asn.py
@@ -96,7 +96,8 @@ class LoadAsAssociation(dict):
             )
             asn.filename = DEFAULT_NAME
         else:
-            asn = cls(pure_asn)
+            asn = rule()
+            asn.update(pure_asn)
             asn.filename = obj
 
         return asn

--- a/jwst/associations/tests/test_asn_gather.py
+++ b/jwst/associations/tests/test_asn_gather.py
@@ -35,8 +35,7 @@ def source_folder(tmp_path_factory):
 def gather(source_folder, tmp_path_factory):
     """Do the actual gathering"""
     dest_folder = tmp_path_factory.mktemp('asn_gather_dest')
-    with pushdir(dest_folder):
-        asn_path = asnpkg.asn_gather(source_folder / PRIMARY_PATH)
+    asn_path = asnpkg.asn_gather(source_folder / PRIMARY_PATH, destination=dest_folder)
 
     return dest_folder, asn_path, source_folder
 
@@ -52,7 +51,7 @@ def test_all_members(gather):
     dest_folder, asn_path, source_folder = gather
 
     source_asn = LoadAsAssociation.load(source_folder / PRIMARY_PATH)
-    asn = LoadAsAssociation.load(dest_folder / PRIMARY_PATH)
+    asn = LoadAsAssociation.load(asn_path)
 
     assert len(source_asn['products']) == len(asn['products'])
     for source_product, product in zip(source_asn['products'], asn['products']):
@@ -60,4 +59,4 @@ def test_all_members(gather):
 
 
 def test_copy(gather):
-    """Test that members copied"""
+    """Test that members are copied"""

--- a/jwst/associations/tests/test_asn_gather.py
+++ b/jwst/associations/tests/test_asn_gather.py
@@ -3,7 +3,7 @@ import pytest
 
 from pathlib import Path
 
-from jwst import associations as asnpkg
+from jwst.associations import asn_gather
 from jwst.associations.asn_from_list import asn_from_list
 from jwst.associations.load_as_asn import LoadAsAssociation
 from jwst.lib.file_utils import pushdir
@@ -43,7 +43,7 @@ def source_folder(tmp_path_factory):
 def gather(source_folder, tmp_path_factory):
     """Do the actual gathering"""
     dest_folder = tmp_path_factory.mktemp('asn_gather_dest')
-    asn_path = asnpkg.asn_gather(source_folder / PRIMARY_PATH, destination=dest_folder)
+    asn_path = asn_gather.asn_gather(source_folder / PRIMARY_PATH, destination=dest_folder)
 
     return dest_folder, asn_path, source_folder
 

--- a/jwst/associations/tests/test_asn_gather.py
+++ b/jwst/associations/tests/test_asn_gather.py
@@ -21,9 +21,17 @@ def source_folder(tmp_path_factory):
         'primary_3.txt',
         'primary_4.txt',
     ]
-    primary = asn_from_list(primary_members, product_name=PRIMARY_NAME)
+
     source_folder = tmp_path_factory.mktemp('asn_gather_source')
     with pushdir(source_folder):
+
+        # Create all the files
+        for member in primary_members:
+            with open(member, 'w') as fh:
+                fh.write(member)
+
+        # Create the association
+        primary = asn_from_list(primary_members, product_name=PRIMARY_NAME)
         _, serialized = primary.dump()
         with open(PRIMARY_PATH, 'w') as fh:
             fh.write(serialized)

--- a/jwst/associations/tests/test_asn_gather.py
+++ b/jwst/associations/tests/test_asn_gather.py
@@ -51,7 +51,7 @@ def gather(source_folder, tmp_path_factory, request):
 
     dest_folder = tmp_path_factory.mktemp('asn_gather_dest')
     asn_path = asn_gather.asn_gather(source_folder / PRIMARY_NAME, destination=dest_folder,
-                                     exp_types=exp_types)
+                                     exp_types=exp_types, exclude_types=excludes)
 
     return dest_folder, asn_path, source_folder, exp_types, excludes
 

--- a/jwst/associations/tests/test_asn_gather.py
+++ b/jwst/associations/tests/test_asn_gather.py
@@ -16,22 +16,22 @@ PRIMARY_NAME = PRIMARY_STEM + '_asn.json'
 def source_folder(tmp_path_factory):
     """Create a set of source associations"""
     primary_members = [
-        'primary_1.txt',
-        'primary_2.txt',
-        'primary_3.txt',
-        'primary_4.txt',
+        ('sci_1.txt', 'science'),
+        ('sci_2.txt', 'science'),
+        ('bkg_1.txt', 'background'),
+        ('imprint_1.txt', 'imprint'),
     ]
 
     source_folder = tmp_path_factory.mktemp('asn_gather_source')
     with pushdir(source_folder):
 
         # Create all the files
-        for member in primary_members:
-            with open(member, 'w') as fh:
-                fh.write(member)
+        for expname, exptype in primary_members:
+            with open(expname, 'w') as fh:
+                fh.write(expname)
 
         # Create the association
-        primary = asn_from_list(primary_members, product_name=PRIMARY_STEM)
+        primary = asn_from_list(primary_members, product_name=PRIMARY_STEM, with_exptype=True)
         _, serialized = primary.dump()
         with open(PRIMARY_NAME, 'w') as fh:
             fh.write(serialized)

--- a/jwst/associations/tests/test_asn_gather.py
+++ b/jwst/associations/tests/test_asn_gather.py
@@ -60,3 +60,11 @@ def test_all_members(gather):
 
 def test_copy(gather):
     """Test that members are copied"""
+    dest_folder, asn_path, source_folder = gather
+
+    asn = LoadAsAssociation.load(asn_path)
+
+    for product in asn['products']:
+        for member in product['members']:
+            path = Path(dest_folder / member['expname'])
+            assert path.exists(), f'File does not exist {path}'

--- a/jwst/associations/tests/test_asn_gather.py
+++ b/jwst/associations/tests/test_asn_gather.py
@@ -1,0 +1,46 @@
+"""Test asn_gather functionality"""
+import pytest
+
+from jwst import associations as asnpkg
+from jwst.associations.asn_from_list import asn_from_list
+from jwst.lib.file_utils import pushdir
+
+# Testing constants
+PRIMARY_NAME = 'primary'
+
+
+@pytest.fixture(scope='module')
+def source_path(tmp_path_factory):
+    """Create a set of source associations"""
+    primary_members = [
+        'primary_1.txt',
+        'primary_2.txt',
+        'primary_3.txt',
+        'primary_4.txt',
+    ]
+    primary = asn_from_list(primary_members, product_name=PRIMARY_NAME)
+    source_path = tmp_path_factory.mktemp('asn_gather_source')
+    with pushdir(source_path):
+        primary_path = PRIMARY_NAME + '_asn.json'
+        _, serialized = primary.dump()
+        with open(primary_path, 'w') as fh:
+            fh.write(serialized)
+
+    return source_path
+
+
+@pytest.fixture(scope='module')
+def gather(source_path, tmp_path_factory):
+    """Do the actual gathering"""
+    dest_path = tmp_path_factory.mktemp('asn_gather_dest')
+    with pushdir(dest_path):
+        asn = asnpkg.asn_gather(source_path)
+
+    return dest_path, asn, source_path
+
+
+def test_isasn(gather):
+    """Test that an association is generated"""
+    asn_path, asn, source_asn_path = gather
+
+    assert isinstance(asn, (asnpkg.Association, dict)), f'Returned association is not an Association: {asn}'

--- a/jwst/associations/tests/test_asn_gather.py
+++ b/jwst/associations/tests/test_asn_gather.py
@@ -9,8 +9,8 @@ from jwst.associations.load_as_asn import LoadAsAssociation
 from jwst.lib.file_utils import pushdir
 
 # Testing constants
-PRIMARY_NAME = 'primary'
-PRIMARY_PATH = PRIMARY_NAME + '_asn.json'
+PRIMARY_STEM = 'primary'
+PRIMARY_NAME = PRIMARY_STEM + '_asn.json'
 
 @pytest.fixture(scope='module')
 def source_folder(tmp_path_factory):
@@ -31,9 +31,9 @@ def source_folder(tmp_path_factory):
                 fh.write(member)
 
         # Create the association
-        primary = asn_from_list(primary_members, product_name=PRIMARY_NAME)
+        primary = asn_from_list(primary_members, product_name=PRIMARY_STEM)
         _, serialized = primary.dump()
-        with open(PRIMARY_PATH, 'w') as fh:
+        with open(PRIMARY_NAME, 'w') as fh:
             fh.write(serialized)
 
     return source_folder
@@ -43,7 +43,7 @@ def source_folder(tmp_path_factory):
 def gather(source_folder, tmp_path_factory):
     """Do the actual gathering"""
     dest_folder = tmp_path_factory.mktemp('asn_gather_dest')
-    asn_path = asn_gather.asn_gather(source_folder / PRIMARY_PATH, destination=dest_folder)
+    asn_path = asn_gather.asn_gather(source_folder / PRIMARY_NAME, destination=dest_folder)
 
     return dest_folder, asn_path, source_folder
 
@@ -58,7 +58,7 @@ def test_all_members(gather):
     """Test to ensure all members are accounted for"""
     dest_folder, asn_path, source_folder = gather
 
-    source_asn = LoadAsAssociation.load(source_folder / PRIMARY_PATH)
+    source_asn = LoadAsAssociation.load(source_folder / PRIMARY_NAME)
     asn = LoadAsAssociation.load(asn_path)
 
     assert len(source_asn['products']) == len(asn['products'])

--- a/scripts/asn_gather
+++ b/scripts/asn_gather
@@ -4,6 +4,6 @@
 
 from jwst.associations import asn_gather
 
-if __name__ == 'main':
-    path, kwargs = asn_gather.from_cmdline()
-    asn_gather.asn_gather(path, **kwargs)
+if __name__ == '__main__':
+    kwargs = asn_gather.from_cmdline()
+    asn_gather.asn_gather(**kwargs)

--- a/scripts/asn_gather
+++ b/scripts/asn_gather
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+"""asn_gather: Copy or Move data that is listed in an association"""
+
+from jwst.associations import asn_gather
+
+if __name__ == 'main':
+    path, kwargs = asn_gather.from_cmdline()
+    asn_gather.asn_gather(path, **kwargs)


### PR DESCRIPTION
`asn_gather` is a new API and command-line utility that basically allows one to copy an association, and all its members, from one place to another.