### PR TITLE
JP-820: Add support for rshift fitting mode in tweakreg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -144,6 +144,12 @@ skymatch
   contains ``'global'`` and the *single image group*'s sky cannot be computed
   (e.g., because all pixels are flagged as "bad"). [#5440]
 
+tweakreg
+--------
+
+- Add support for the new ``fitgeom`` mode: ``'rshift'`` that can fit only
+  for shifts and a rotation. [#5475]
+
 0.17.1 (2020-09-15)
 ===================
 

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -44,7 +44,7 @@ class TweakRegStep(Step):
         tolerance = float(default=1.0) # Matching tolerance for xyxymatch in arcsec
         xoffset = float(default=0.0), # Initial guess for X offset in arcsec
         yoffset = float(default=0.0) # Initial guess for Y offset in arcsec
-        fitgeometry = option('shift', 'rscale', 'general', default='general') # Fitting geometry
+        fitgeometry = option('shift', 'rshift', 'rscale', 'general', default='general') # Fitting geometry
         nclip = integer(min=0, default=3) # Number of clipping iterations in fit
         sigma = float(min=0.0, default=3.0) # Clipping limit in sigma units
         align_to_gaia = boolean(default=False)  # Align to GAIA catalog

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     spherical-geometry>=1.2.18
     stdatamodels @ git+https://github.com/spacetelescope/stdatamodels
     stsci.image>=2.3.3
-    tweakwcs>=0.6.4
+    tweakwcs>=0.7.0
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
Fixes https://github.com/spacetelescope/jwst/issues/3739.
Fixes [JP-820](https://jira.stsci.edu/browse/JP-820)

Also see https://github.com/spacetelescope/tweakwcs/pull/128