### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux
 dist: xenial
 language: python
-python: 3.8.5
+python: 3.8.6
 
 env:
   global:
@@ -30,7 +30,7 @@ jobs:
         - codecov -F unit
 
     - name: Oldest dependency versions
-      python: 3.6.10
+      python: 3.7.9
       before_install:
         - pip install . --no-deps
         - minimum_deps

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![STScI Logo](docs/_static/stsci_logo.png)
 
-**JWST requires Python 3.6 or above and a C compiler for dependencies.**
+**JWST requires Python 3.7 or above and a C compiler for dependencies.**
 
 **Linux and MacOS platforms are tested and supported.  Windows is not currently supported.**
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =


### PR DESCRIPTION
Since Astropy 4.2 is now dropping support for Python 3.6, we will do the same.