### PR TITLE
Fix Travis dev dependencies job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ jobs:
 
     - name: Dev dependencies in requirements-dev.txt
       install:
-        - pip install -r requirements-dev.txt -e .[test]
+        - pip install -r requirements-dev.txt
+        - pip install -e .[test]
 
     - name: Warnings treated as Exceptions
       script:
@@ -94,7 +95,8 @@ jobs:
   allow_failures:
     - name: Dev dependencies in requirements-dev.txt
       install:
-        - pip install -r requirements-dev.txt -e .[test]
+        - pip install -r requirements-dev.txt
+        - pip install -e .[test]
 
     - name: Warnings treated as Exceptions
       script:


### PR DESCRIPTION
Our dev dependencies job on Travis CI was using released dependencies for the past week since we added `stdatamodels` master to `install_requires`.  It seems having an install from a URL changes the way `pip` resolves dependencies.

Putting the dev dependency install and the package install on separate lines solves this unexpected behavior.