### PR TITLE
JP-1755: Rename class RSCD_Step to preserve CRDS functionality. (#5424)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ jobs:
 
     - name: Dev dependencies in requirements-dev.txt
       install:
-        - pip install -r requirements-dev.txt -e .[test]
+        - pip install -r requirements-dev.txt
+        - pip install -e .[test]
 
     - name: Warnings treated as Exceptions
       script:
@@ -94,7 +95,8 @@ jobs:
   allow_failures:
     - name: Dev dependencies in requirements-dev.txt
       install:
-        - pip install -r requirements-dev.txt -e .[test]
+        - pip install -r requirements-dev.txt
+        - pip install -e .[test]
 
     - name: Warnings treated as Exceptions
       script:

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -55,7 +55,7 @@ SUFFIXES_TO_ADD = [
 
 # Suffixes that are discovered but should not be considered.
 # Used by `find_suffixes` to remove undesired values it has found.
-SUFFIXES_TO_DISCARD = ['functionwrapper', 'systemcall']
+SUFFIXES_TO_DISCARD = ['functionwrapper', 'systemcall','rscd_step']
 
 
 # Calculated suffixes.

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -125,7 +125,7 @@ _calculated_suffixes = set([
     'cubeskymatchstep',
     'i2d',
     'group_scale',
-    'rscd_step',
+    'rscdstep',
     'stackrefsstep',
     'flat_field',
     'guidercdsstep',

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -40,7 +40,7 @@ class DarkPipeline(Pipeline):
                  'ipc': ipc_step.IPCStep,
                  'superbias': superbias_step.SuperBiasStep,
                  'refpix': refpix_step.RefPixStep,
-                 'rscd': rscd_step.RSCD_Step,
+                 'rscd': rscd_step.RscdStep,
                  'firstframe': firstframe_step.FirstFrameStep,
                  'lastframe': lastframe_step.LastFrameStep,
                  'linearity': linearity_step.LinearityStep,

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -47,7 +47,7 @@ class Detector1Pipeline(Pipeline):
                  'ipc': ipc_step.IPCStep,
                  'superbias': superbias_step.SuperBiasStep,
                  'refpix': refpix_step.RefPixStep,
-                 'rscd': rscd_step.RSCD_Step,
+                 'rscd': rscd_step.RscdStep,
                  'firstframe': firstframe_step.FirstFrameStep,
                  'lastframe': lastframe_step.LastFrameStep,
                  'linearity': linearity_step.LinearityStep,

--- a/jwst/pipeline/rscd.cfg
+++ b/jwst/pipeline/rscd.cfg
@@ -1,2 +1,2 @@
 name = "rscd" 
-class = "jwst.rscd.RSCD_Step"
+class = "jwst.rscd.RscdStep"

--- a/jwst/pipeline/tests/data/cfgs/rscd.cfg
+++ b/jwst/pipeline/tests/data/cfgs/rscd.cfg
@@ -1,2 +1,2 @@
 name = "rscd" 
-class = "jwst.rscd.RSCD_Step"
+class = "jwst.rscd.RscdStep"

--- a/jwst/rscd/__init__.py
+++ b/jwst/rscd/__init__.py
@@ -1,3 +1,3 @@
-from .rscd_step import RSCD_Step
+from .rscd_step import RscdStep
 
-__all__ = ['RSCD_Step']
+__all__ = ['RscdStep']

--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -1,6 +1,7 @@
 from ..stpipe import Step
 from .. import datamodels
 from . import rscd_sub
+from ..lib.basic_utils import deprecate_class
 
 
 __all__ = ["RscdStep"]
@@ -61,3 +62,16 @@ class RscdStep(Step):
                 result.meta.cal_step.rscd = 'SKIPPED'
 
         return result
+
+
+@deprecate_class(RscdStep)
+class RSCD_Step:
+    """
+    RscdStep: Performs an RSCD correction to MIRI data.
+    Baseline version flags the first N groups as 'DO_NOT_USE' in
+    the 2nd and later integrations in a copy of the input
+    science data model.
+    Enhanced version is not ready nor enabled.
+
+    This class has been deprecated. Please use `RscdStep` instead.
+    """

--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -3,12 +3,12 @@ from .. import datamodels
 from . import rscd_sub
 
 
-__all__ = ["RSCD_Step"]
+__all__ = ["RscdStep"]
 
 
-class RSCD_Step(Step):
+class RscdStep(Step):
     """
-    RSCD_Step: Performs an RSCD correction to MIRI data.
+    RscdStep: Performs an RSCD correction to MIRI data.
     Baseline version flags the first N groups as 'DO_NOT_USE' in
     the 2nd and later integrations in a copy of the input
     science data model.


### PR DESCRIPTION
Fixes #5424 to rename RSCD step.

Addresses JP-1755.
