### PR TITLE
Implement utility function all_steps and fix crds reference file retrieval for non-datamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -144,6 +144,11 @@ skymatch
   contains ``'global'`` and the *single image group*'s sky cannot be computed
   (e.g., because all pixels are flagged as "bad"). [#5440]
 
+stpipe
+------
+
+- Implement utility function all_steps and fix crds reference file retrieval for non-datamodels [#5492]
+
 tweakreg
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ assign_wcs
 associations
 ------------
 
+- Asn_Lv3SpecAux: Add optical element constraint [#5479]
+
 - Add utility asn_gather [#5468]
 
 - Do not allow target acqs to be considered TSO [#5385]

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -52,7 +52,7 @@ SUFFIXES_TO_ADD = [
 
 # Suffixes that are discovered but should not be considered.
 # Used by `find_suffixes` to remove undesired values it has found.
-SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline', 'rscd_step', 'step', 'systemcall']
+SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline', 'rscd_step', 'step', 'systemcall', 'testlinearpipeline']
 
 
 # Calculated suffixes.

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -20,14 +20,13 @@ Hence, to update `KNOW_SUFFIXES`, update both `SUFFIXES_TO_ADD` and
 `SUFFIXES_TO_DISCARD` as necessary, then use the output of
 `find_suffixes`.
 """
-from copy import copy
 from importlib import import_module
-from inspect import (getmembers, isclass)
 import itertools
 import logging
-from os import (listdir, path, walk)
+from os import (listdir, path)
 import re
-import sys
+
+from jwst.stpipe.utilities import all_steps
 
 __all__ = ['remove_suffix']
 
@@ -55,7 +54,7 @@ SUFFIXES_TO_ADD = [
 
 # Suffixes that are discovered but should not be considered.
 # Used by `find_suffixes` to remove undesired values it has found.
-SUFFIXES_TO_DISCARD = ['functionwrapper', 'systemcall','rscd_step']
+SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline', 'rscd_step', 'step', 'systemcall']
 
 
 # Calculated suffixes.
@@ -274,20 +273,16 @@ def find_suffixes():
     """
     from jwst.stpipe import Step
 
-    suffixes = set()
-
     jwst = import_module('jwst')
     jwst_fpath = path.split(jwst.__file__)[0]
 
     # First traverse the code base and find all
     # `Step` classes. The default suffix is the
     # class name.
-    for module in load_local_pkg(jwst_fpath):
-        for klass_name, klass in getmembers(
-            module,
-            lambda o: isclass(o) and issubclass(o, Step)
-        ):
-            suffixes.add(klass_name.lower())
+    suffixes = set(
+        klass_name.lower()
+        for klass_name, klass in all_steps().items()
+    )
 
     # Instantiate Steps/Pipelines from their configuration files.
     # Different names and suffixes can be defined in this way.
@@ -308,74 +303,6 @@ def find_suffixes():
 
     # That's all folks
     return list(suffixes)
-
-
-def load_local_pkg(fpath):
-    """Generator producing all modules under fpath
-
-    Parameters
-    ----------
-    fpath: string
-        File path to the package to load.
-
-    Returns
-    -------
-    generator
-        `module` for each module found in the package.
-    """
-    package_fpath, package = path.split(fpath)
-    package_fpath_len = len(package_fpath) + 1
-    sys_path = copy(sys.path)
-    sys.path.insert(0, package_fpath)
-    try:
-        for module_fpath in folder_traverse(
-            fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='tests'
-        ):
-            folder_path, fname = path.split(module_fpath[package_fpath_len:])
-            module_path = folder_path.split('/')
-            module_path.append(path.splitext(fname)[0])
-            module_path = '.'.join(module_path)
-            try:
-                module = import_module(module_path)
-            except Exception as err:
-                logger.debug(f'Cannot load module "{module_path}": {str(err)}')
-            else:
-                yield module
-    except Exception as err:
-        logger.debug(f'Cannot complete package loading: Exception occurred: "{str(err)}"')
-    finally:
-        sys.path = sys_path
-
-
-def folder_traverse(folder_path, basename_regex='.+', path_exclude_regex='^$'):
-    """Generator of full file paths for all files
-    in a folder.
-
-    Parameters
-    ----------
-    folder_path: str
-        The folder to traverse
-
-    basename_regex: str
-        Regular expression that must match
-        the `basename` part of the file path.
-
-    path_exclude_regex: str
-        Regular expression to exclude a path.
-
-    Returns
-    -------
-    generator
-        A generator, return the next file.
-    """
-    basename_regex = re.compile(basename_regex)
-    path_exclude_regex = re.compile(path_exclude_regex)
-    for root, dirs, files in walk(folder_path):
-        if path_exclude_regex.search(root):
-            continue
-        for file in files:
-            if basename_regex.match(file):
-                yield path.join(root, file)
 
 
 # --------------------------------------------------

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -26,8 +26,6 @@ import logging
 from os import (listdir, path)
 import re
 
-from jwst.stpipe.utilities import all_steps
-
 __all__ = ['remove_suffix']
 
 # Configure logging
@@ -272,6 +270,7 @@ def find_suffixes():
     a static list.
     """
     from jwst.stpipe import Step
+    from jwst.stpipe.utilities import all_steps
 
     jwst = import_module('jwst')
     jwst_fpath = path.split(jwst.__file__)[0]

--- a/jwst/lib/tests/test_suffix.py
+++ b/jwst/lib/tests/test_suffix.py
@@ -25,7 +25,8 @@ def test_suffix_existence(enable_logging):
         to_add=(calculated_suffixes, s.SUFFIXES_TO_ADD),
         to_remove=(s.SUFFIXES_TO_DISCARD, )
     )
-    assert set(found_suffixes) == set(s.KNOW_SUFFIXES)
+    diff = set(found_suffixes).symmetric_difference(s.KNOW_SUFFIXES)
+    assert not diff, f'Suffixes unaccounted for:\n{diff}'
 
 
 @pytest.mark.parametrize(

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -727,7 +727,7 @@ class Step():
         try:
             model = dm_open(dataset)
         except (IOError, TypeError, ValueError):
-            logger.warning(f'Input dataset is not a DataModel.')
+            logger.warning('Input dataset is not a DataModel.')
             disable = True
 
         # Check if retrieval should be attempted.

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -722,6 +722,14 @@ class Step():
         logger = log.delegator.log
         pars_model = cls.get_pars_model()
 
+        # If the dataset is not an operable DataModel, log as such and return
+        # an empty config object
+        try:
+            model = dm_open(dataset)
+        except (IOError, TypeError, ValueError):
+            logger.warning(f'Input dataset is not a DataModel.')
+            disable = True
+
         # Check if retrieval should be attempted.
         if disable is None:
             disable = get_disable_crds_steppars()
@@ -733,7 +741,7 @@ class Step():
         logger.debug(f'Retrieving step {pars_model.meta.reftype.upper()} parameters from CRDS')
         exceptions = crds_client.get_exceptions_module()
         try:
-            ref_file = crds_client.get_reference_file(dataset,
+            ref_file = crds_client.get_reference_file(model,
                                                       pars_model.meta.reftype,
                                                       observatory=observatory,
                                                       asn_exptypes=['science'])

--- a/jwst/stpipe/tests/test_utilities.py
+++ b/jwst/stpipe/tests/test_utilities.py
@@ -1,0 +1,34 @@
+"""Test utility funcs"""
+from jwst.stpipe.utilities import all_steps
+
+
+# Snapshot of known steps
+KNOWN_STEPS = set([
+    'AlignRefsStep','Ami3Pipeline', 'AmiAnalyzeStep', 'AmiAverageStep',
+    'AmiNormalizeStep', 'AssignMTWcsStep', 'AssignWcsStep',
+    'BackgroundStep', 'BarShadowStep',
+    'Combine1dStep', 'Coron3Pipeline', 'CubeBuildStep', 'CubeSkyMatchStep',
+    'DQInitStep', 'DarkCurrentStep', 'DarkPipeline', 'Detector1Pipeline',
+    'Extract1dStep', 'Extract2dStep',
+    'FirstFrameStep', 'FlatFieldStep', 'FringeStep',
+    'GainScaleStep', 'GroupScaleStep', 'GuiderCdsStep', 'GuiderPipeline',
+    'HlspStep',
+    'IPCStep', 'Image2Pipeline', 'Image3Pipeline', 'ImprintStep',
+    'JumpStep',
+    'KlipStep',
+    'LastFrameStep', 'LinearPipeline', 'LinearityStep',
+    'MRSIMatchStep', 'MSAFlagOpenStep', 'MasterBackgroundNrsSlitsStep', 'MasterBackgroundStep',
+    'OutlierDetectionScaledStep', 'OutlierDetectionStackStep', 'OutlierDetectionStep',
+    'PathLossStep', 'PersistenceStep', 'PhotomStep',
+    'RSCD_Step', 'RampFitStep', 'RefPixStep', 'ResampleSpecStep', 'ResampleStep', 'ResetStep',
+    'SaturationStep', 'SkyMatchStep', 'SourceCatalogStep', 'SourceTypeStep', 'Spec2Pipeline', 'Spec3Pipeline',
+    'StackRefsStep', 'StraylightStep', 'SubtractImagesStep', 'SuperBiasStep',
+    'TSOPhotometryStep', 'TestLinearPipeline', 'Tso3Pipeline', 'TweakRegStep',
+    'WavecorrStep', 'WfsCombineStep', 'WhiteLightStep',
+])
+
+def test_all_steps():
+    """Test finding all defined steps and pipelines"""
+    found_steps = all_steps()
+    diff = KNOWN_STEPS.symmetric_difference(found_steps)
+    assert not diff, f'Steps not accounted for. Confirm and check suffix and CRDS calpars.\n{diff}'

--- a/jwst/stpipe/tests/test_utilities.py
+++ b/jwst/stpipe/tests/test_utilities.py
@@ -20,7 +20,7 @@ KNOWN_STEPS = set([
     'MRSIMatchStep', 'MSAFlagOpenStep', 'MasterBackgroundNrsSlitsStep', 'MasterBackgroundStep',
     'OutlierDetectionScaledStep', 'OutlierDetectionStackStep', 'OutlierDetectionStep',
     'PathLossStep', 'PersistenceStep', 'PhotomStep',
-    'RSCD_Step', 'RampFitStep', 'RefPixStep', 'ResampleSpecStep', 'ResampleStep', 'ResetStep',
+    'RscdStep', 'RSCD_Step', 'RampFitStep', 'RefPixStep', 'ResampleSpecStep', 'ResampleStep', 'ResetStep',
     'SaturationStep', 'SkyMatchStep', 'SourceCatalogStep', 'SourceTypeStep', 'Spec2Pipeline', 'Spec3Pipeline',
     'StackRefsStep', 'StraylightStep', 'SubtractImagesStep', 'SuperBiasStep',
     'TSOPhotometryStep', 'Tso3Pipeline', 'TweakRegStep',

--- a/jwst/stpipe/tests/test_utilities.py
+++ b/jwst/stpipe/tests/test_utilities.py
@@ -23,7 +23,7 @@ KNOWN_STEPS = set([
     'RSCD_Step', 'RampFitStep', 'RefPixStep', 'ResampleSpecStep', 'ResampleStep', 'ResetStep',
     'SaturationStep', 'SkyMatchStep', 'SourceCatalogStep', 'SourceTypeStep', 'Spec2Pipeline', 'Spec3Pipeline',
     'StackRefsStep', 'StraylightStep', 'SubtractImagesStep', 'SuperBiasStep',
-    'TSOPhotometryStep', 'TestLinearPipeline', 'Tso3Pipeline', 'TweakRegStep',
+    'TSOPhotometryStep', 'Tso3Pipeline', 'TweakRegStep',
     'WavecorrStep', 'WfsCombineStep', 'WhiteLightStep',
 ])
 

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -49,6 +49,7 @@ NON_STEPS = [
     'Pipeline',
     'Step',
     'SystemCall',
+    'TestLinearPipeline',
 ]
 
 

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -34,7 +34,6 @@ from importlib import import_module
 import inspect
 import logging
 import os
-from os import path
 import re
 import sys
 
@@ -149,7 +148,7 @@ def all_steps():
     from jwst.stpipe import Step
 
     jwst = import_module('jwst')
-    jwst_fpath = path.split(jwst.__file__)[0]
+    jwst_fpath = os.path.split(jwst.__file__)[0]
 
     steps = {}
     for module in load_local_pkg(jwst_fpath):
@@ -179,7 +178,7 @@ def load_local_pkg(fpath):
     generator
         `module` for each module found in the package.
     """
-    package_fpath, package = path.split(fpath)
+    package_fpath, package = os.path.split(fpath)
     package_fpath_len = len(package_fpath) + 1
     sys_path = copy(sys.path)
     sys.path.insert(0, package_fpath)
@@ -187,9 +186,9 @@ def load_local_pkg(fpath):
         for module_fpath in folder_traverse(
             fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='tests'
         ):
-            folder_path, fname = path.split(module_fpath[package_fpath_len:])
+            folder_path, fname = os.path.split(module_fpath[package_fpath_len:])
             module_path = folder_path.split('/')
-            module_path.append(path.splitext(fname)[0])
+            module_path.append(os.path.splitext(fname)[0])
             module_path = '.'.join(module_path)
             try:
                 module = import_module(module_path)
@@ -231,4 +230,4 @@ def folder_traverse(folder_path, basename_regex='.+', path_exclude_regex='^$'):
             continue
         for file in files:
             if basename_regex.match(file):
-                yield path.join(root, file)
+                yield os.path.join(root, file)

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -29,9 +29,27 @@
 """
 Utilities
 """
+from copy import copy
+from importlib import import_module
 import inspect
+import logging
 import os
+from os import path
+import re
 import sys
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+# Step classes that are not user-api steps
+NON_STEPS = [
+    'EngDBLogStep',
+    'FunctionWrapper',
+    'Pipeline',
+    'Step',
+    'SystemCall',
+]
 
 
 def import_class(full_name, subclassof=object, config_file=None):
@@ -117,3 +135,99 @@ def islist_tuple(obj):
     Return True if `obj` is either a list or a tuple. False otherwise.
     """
     return isinstance(obj, tuple) or isinstance(obj, list)
+
+
+def all_steps():
+    """List all classes subclassed from Step
+
+    Returns
+    -------
+    steps : dict
+        Key is the classname, value is the class
+    """
+    from jwst.stpipe import Step
+
+    jwst = import_module('jwst')
+    jwst_fpath = path.split(jwst.__file__)[0]
+
+    steps = {}
+    for module in load_local_pkg(jwst_fpath):
+        more_steps = {
+            klass_name: klass
+            for klass_name, klass in inspect.getmembers(
+                    module,
+                    lambda o: inspect.isclass(o) and issubclass(o, Step)
+            )
+            if klass_name not in NON_STEPS
+        }
+        steps.update(more_steps)
+
+    return steps
+
+
+def load_local_pkg(fpath):
+    """Generator producing all modules under fpath
+
+    Parameters
+    ----------
+    fpath: string
+        File path to the package to load.
+
+    Returns
+    -------
+    generator
+        `module` for each module found in the package.
+    """
+    package_fpath, package = path.split(fpath)
+    package_fpath_len = len(package_fpath) + 1
+    sys_path = copy(sys.path)
+    sys.path.insert(0, package_fpath)
+    try:
+        for module_fpath in folder_traverse(
+            fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='tests'
+        ):
+            folder_path, fname = path.split(module_fpath[package_fpath_len:])
+            module_path = folder_path.split('/')
+            module_path.append(path.splitext(fname)[0])
+            module_path = '.'.join(module_path)
+            try:
+                module = import_module(module_path)
+            except Exception as err:
+                logger.debug(f'Cannot load module "{module_path}": {str(err)}')
+            else:
+                yield module
+    except Exception as err:
+        logger.debug(f'Cannot complete package loading: Exception occurred: "{str(err)}"')
+    finally:
+        sys.path = sys_path
+
+
+def folder_traverse(folder_path, basename_regex='.+', path_exclude_regex='^$'):
+    """Generator of full file paths for all files
+    in a folder.
+
+    Parameters
+    ----------
+    folder_path: str
+        The folder to traverse
+
+    basename_regex: str
+        Regular expression that must match
+        the `basename` part of the file path.
+
+    path_exclude_regex: str
+        Regular expression to exclude a path.
+
+    Returns
+    -------
+    generator
+        A generator, return the next file.
+    """
+    basename_regex = re.compile(basename_regex)
+    path_exclude_regex = re.compile(path_exclude_regex)
+    for root, dirs, files in os.walk(folder_path):
+        if path_exclude_regex.search(root):
+            continue
+        for file in files:
+            if basename_regex.match(file):
+                yield path.join(root, file)


### PR DESCRIPTION
This is code that is fallout from various other issues, JP-1751, CCD-381, and CCD-783.

The changes are

- `jwst.stpipe.utilities.all_steps`: Return all classes defined in the package that are subclassed from `Step`. This includes a slight refactor of the `suffix` code.
- Bug fix in `jwst.stpipe.Step.get_config_from_reference` to not attempt retrieval of step parameter references files when input is not a `DataModel`.