### PR TITLE
Add logging of the found quaternion information to set_telescope_pointing 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,6 +115,11 @@ saturation
   NO_SAT_CHECK in the saturation reference file, instead of skipping any
   test of those pixels. [#5394]
 
+set_telescope_pointing
+----------------------
+
+- Add logging of the found quaternion information [#5495]
+
 skymatch
 --------
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -1145,6 +1145,9 @@ def get_pointing(obsstart, obsend, engdb_url=None,
     mnemonics = get_mnemonics(obsstart, obsend, tolerance, engdb_url=engdb_url)
     reduced = reduce_func(mnemonics)
 
+    logger.debug(f'Memonics found:\n{mnemonics}')
+    logger.info(f'Reduced set of pointings:\n{reduced}')
+
     return reduced
 
 

--- a/scripts/v1_calculate
+++ b/scripts/v1_calculate
@@ -14,7 +14,7 @@ import jwst.lib.set_telescope_pointing as stp
 log_handler = logging.StreamHandler()
 logger = logging.getLogger('jwst')
 logger.addHandler(log_handler)
-LogLevels = [logging.WARNING, logging.INFO, logging.DEBUG]
+LOGLEVELS = [logging.WARNING, logging.INFO, logging.DEBUG]
 
 # Available reduce functions
 REDUCE_FUNCS_MAPPING = {
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Set output detail.
-    level = LogLevels[min(len(LogLevels)-1, args.verbose)]
+    level = LOGLEVELS[min(len(LOGLEVELS)-1, args.verbose)]
     logger.setLevel(level)
 
     # Determine whether the sources are time specifications or a file list.


### PR DESCRIPTION
Driven by SDP analysis needs, added the logging of the quaternion information to `set_telescope_pointing`.