### PR TITLE
Allow packages installed from GitHub to pass through the minimum_deps script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ jobs:
       install:
         - pip install -U pip certifi
         - pip install -r requirements-min.txt -e .[test]
-        # Since there is no version of stdatamodels on PyPI, install from
-        # Github master until it is released to PyPI
-        - pip install git+https://github.com/spacetelescope/stdatamodels
 
     - name: Installed package with --pyargs
       before_script: cd /

--- a/scripts/minimum_deps
+++ b/scripts/minimum_deps
@@ -37,12 +37,11 @@ def write_minimum_requirements_file():
 
     with open("requirements-min.txt", "w") as fd:
         for requirement in dist.requires(extras=extras):
-            if "git+http" not in requirement.name:
+            if requirement.url is None:
                 version = get_minimum_version(requirement)
                 fd.write(f'{requirement.name}=={version}\n')
             else:
-                raise RuntimeError(f"{requirement.name} is not a package "
-                    "that can by installed from PyPi.")
+                fd.write(f'{requirement}\n')
 
 
 def main():


### PR DESCRIPTION
This will hopefully prevent the "oldest dependency versions" job from failing when a package (like stdatamodels) is being installed from GitHub instead of pypi.