### PR TITLE
JP-1763: fix dq flag handling in wfs_combine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,6 +162,12 @@ tweakreg
 - Add support for the new ``fitgeom`` mode: ``'rshift'`` that can fit only
   for shifts and a rotation. [#5475]
 
+wfs_combine
+-----------
+
+- Add checking for bad pixels using DO_NOT_USE rather than !=0.
+
+
 0.17.1 (2020-09-15)
 ===================
 

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -139,8 +139,8 @@ class DataSet():
             # 1a. create image to smooth by first setting bad DQ pixels equal
             #     to mean of good pixels
             data_1 = self.input_1.data.astype(np.float64)
-            wh_bad_1 = np.where(np.bitwise_and(self.input_1.dq, dqflags.pixel['DO_NOT_USE']) == 1)
-            wh_good_1 = np.where(np.bitwise_and(self.input_1.dq, dqflags.pixel['DO_NOT_USE']) == 0)
+            wh_bad_1 = np.where(np.bitwise_and(self.input_1.dq, dqflags.pixel['DO_NOT_USE']))
+            wh_good_1 = np.where(np.logical_not(np.bitwise_and(self.input_1.dq, dqflags.pixel['DO_NOT_USE'])))
 
             data_1[wh_bad_1] = data_1[wh_good_1].mean()
 
@@ -323,10 +323,10 @@ class DataSet():
         err_data_1 = im_1_a.err.copy()
         err_data_2 = im_2_a.err.copy()
 
-        bad1 = np.bitwise_and(dq_data_1, dqflags.pixel['DO_NOT_USE']) = 1
-        good1 = np.bitwise_and(dq_data_1, dqflags.pixel['DO_NOT_USE']) = 0
-        bad2 = np.bitwise_and(dq_data_2, dqflags.pixel['DO_NOT_USE']) = 1
-        good2 = np.bitwise_and(dq_data_2, dqflags.pixel['DO_NOT_USE']) = 0
+        bad1 = np.bitwise_and(dq_data_1, dqflags.pixel['DO_NOT_USE'])
+        good1 = np.logical_not(np.bitwise_and(dq_data_1, dqflags.pixel['DO_NOT_USE']))
+        bad2 = np.bitwise_and(dq_data_2, dqflags.pixel['DO_NOT_USE'])
+        good2 = np.logical_not(np.bitwise_and(dq_data_2, dqflags.pixel['DO_NOT_USE']))
 
         wh_1_bad_2_good = bad1 & good2
         wh_1_bad_2_bad =  bad1 & bad2
@@ -440,7 +440,7 @@ def interp_array(sci_data, dq_data):
     """
 
 
-    wh_bad_dq = np.where(np.bitwise_and(dq_data, dqflags.pixel['DO_NOT_USE']) == 1)
+    wh_bad_dq = np.where(np.bitwise_and(dq_data, dqflags.pixel['DO_NOT_USE']))
     num_bad_dq = len(wh_bad_dq[0])
 
     # Create array of locations of bad DQ pixels

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -139,8 +139,9 @@ class DataSet():
             # 1a. create image to smooth by first setting bad DQ pixels equal
             #     to mean of good pixels
             data_1 = self.input_1.data.astype(np.float64)
-            wh_bad_1 = np.where(self.input_1.dq != 0)
-            wh_good_1 = np.where(self.input_1.dq == 0)
+            wh_bad_1 = np.where(np.bitwise_and(self.input_1.dq, dqflags.pixel['DO_NOT_USE']) == 1)
+            wh_good_1 = np.where(np.bitwise_and(self.input_1.dq, dqflags.pixel['DO_NOT_USE']) == 0)
+
             data_1[wh_bad_1] = data_1[wh_good_1].mean()
 
             # 1b. Create smoothed image by smoothing this 'repaired' image
@@ -322,10 +323,15 @@ class DataSet():
         err_data_1 = im_1_a.err.copy()
         err_data_2 = im_2_a.err.copy()
 
-        wh_1_bad_2_good = (dq_data_1 != 0) & (dq_data_2 == 0)
-        wh_1_bad_2_bad = (dq_data_1 != 0) & (dq_data_2 != 0)
-        wh_1_good_2_good = (dq_data_1 == 0) & (dq_data_2 == 0)
-        wh_1_good_2_bad = (dq_data_1 == 0) & (dq_data_2 != 0)
+        bad1 = np.bitwise_and(dq_data_1, dqflags.pixel['DO_NOT_USE']) = 1
+        good1 = np.bitwise_and(dq_data_1, dqflags.pixel['DO_NOT_USE']) = 0
+        bad2 = np.bitwise_and(dq_data_2, dqflags.pixel['DO_NOT_USE']) = 1
+        good2 = np.bitwise_and(dq_data_2, dqflags.pixel['DO_NOT_USE']) = 0
+
+        wh_1_bad_2_good = bad1 & good2
+        wh_1_bad_2_bad =  bad1 & bad2
+        wh_1_good_2_good = good1 & good2
+        wh_1_good_2_bad = good1 & bad2
 
         # Populate combined SCI, DQ and ERR arrays
         data_comb = sci_data_1 * 0  # Pixels that are bad in both will stay 0
@@ -433,7 +439,8 @@ def interp_array(sci_data, dq_data):
         interpolated SCI image
     """
 
-    wh_bad_dq = np.where(dq_data != 0)
+
+    wh_bad_dq = np.where(np.bitwise_and(dq_data, dqflags.pixel['DO_NOT_USE']) == 1)
     num_bad_dq = len(wh_bad_dq[0])
 
     # Create array of locations of bad DQ pixels


### PR DESCRIPTION
Update DQ handling in `wfs_combine` so that only pixels with the DO_NOT_USE flag are considered bad, rather than any pixel with DQ > 0.

Fixes [JP-1763](https://jira.stsci.edu/browse/JP-1763)
Fixes #5435 