### PR TITLE
JP-1347: Add SIP approximation to meta.wcsinfo for imaging modes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ assign_wcs
 
 - Enable resample_spec for NIRSpec line lamp exposures [#5484]
 
+- Added SIP approximation to WCS for imaging modes. FITS WCS keywords added to meta.wcsinfo. [#5507]
+
 associations
 ------------
 

--- a/docs/jwst/assign_wcs/main.rst
+++ b/docs/jwst/assign_wcs/main.rst
@@ -22,6 +22,12 @@ input frame ``detector`` to a frame ``v2v3``. This part of the WCS pipeline may 
 intermediate coordinate frames. The basic WCS keywords are used to create
 the transform from frame ``v2v3`` to frame ``world``.
 
+For image display with software like DS9 that relies on specific WCS information, a SIP-based
+approximation to the WCS is fit. The results are FITS keywords stored in
+``model.meta.wcsinfo``. This is not an exact fit, but is accurate to ~0.25 pixel and is sufficient
+for display purposes. This step, which occurs for imaging modes early, is performed by default but
+can be switched off, and parameters controlling the fit can also be adjusted. 
+
 
 
 Basic WCS keywords and the transform from ``v2v3`` to ``world``

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -1,13 +1,53 @@
 import pytest
+from numpy import zeros
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy import wcs
 from astropy.io import fits
 from asdf.tests import helpers
 
-from jwst.assign_wcs import pointing
+from jwst.assign_wcs import AssignWcsStep, pointing
 from jwst.transforms import models
-from jwst.datamodels import ImageModel, CubeModel
+from jwst.datamodels import ImageModel, CubeModel, open
+from gwcs.wcstools import grid_from_bounding_box
+
+
+def create_hdul(wcskeys={
+                      'wcsaxes': 2,
+                      'ra_ref': 22.02351763251896,
+                      'dec_ref': 11.99875540218638,
+                      'v2_ref': 86.039011,
+                      'v3_ref': -493.385704,
+                      'roll_ref': 0.005076934167039675},
+                data_shape=(2048, 2048)):
+
+    """Create nircam hdulist specifically for the SIP test."""
+    hdul = fits.HDUList()
+    phdu = fits.PrimaryHDU()
+    phdu.header['DATAMODL'] = 'ImageModel'
+    phdu.header['TELESCOP'] = "JWST"
+    phdu.header['FILENAME'] = "test+F444W"
+    phdu.header['INSTRUME'] = 'NIRCAM'
+    phdu.header['CHANNEL'] = 'LONG'
+    phdu.header['DETECTOR'] = 'NRCALONG'
+    phdu.header['FILTER'] = 'F444W'
+    phdu.header['PUPIL'] = 'CLEAR'
+    phdu.header['MODULE'] = 'A'
+    phdu.header['TIME-OBS'] = '16:58:27.258'
+    phdu.header['DATE-OBS'] = '2021-10-25'
+    phdu.header['EXP_TYPE'] = 'NRC_IMAGE'
+    scihdu = fits.ImageHDU()
+    scihdu.header['EXTNAME'] = "SCI"
+    scihdu.header['SUBARRAY'] = 'FULL'
+
+    scihdu.header.update(wcskeys)
+
+    scihdu.data = zeros(data_shape)
+
+    hdul.append(phdu)
+    hdul.append(scihdu)
+
+    return hdul
 
 
 @pytest.fixture
@@ -83,15 +123,15 @@ def test_v23_to_sky():
     """
     Test taken from INS report.
     """
-    ra_ref = 165 # in deg
-    dec_ref = 54 # in deg
-    v2_ref = -503.654472 / 3600 # in deg
-    v3_ref = -318.742464 / 3600 # in deg
-    r0 = 37 # in deg
+    ra_ref = 165  # in deg
+    dec_ref = 54  # in deg
+    v2_ref = -503.654472 / 3600  # in deg
+    v3_ref = -318.742464 / 3600  # in deg
+    r0 = 37  # in deg
 
-    v2 = 210 # in deg
-    v3 = -75 # in deg
-    expected_ra_dec = (107.12810484789563, -35.97940247128502) # in deg
+    v2 = 210  # in deg
+    v3 = -75  # in deg
+    expected_ra_dec = (107.12810484789563, -35.97940247128502)  # in deg
     angles = [-v2_ref, v3_ref, -r0, -dec_ref, ra_ref]
     axes = "zyxyz"
     v2s = models.V23ToSky(angles, axes_order=axes)
@@ -155,3 +195,93 @@ def test_create_fitswcs(tmpdir, create_model_3d):
     # test serialization
     tree = {'wcs': w3d}
     helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_sip_approx(tmpdir):
+    # some of the wcs info
+    true_wcs = {
+                'ctype1': 'RA---TAN-SIP',
+                'ctype2': 'DEC--TAN-SIP',
+                'crpix1': 1025.0,
+                'crpix2': 1025.0,
+                'crval1': 22.023508708126627,
+                'crval2': 11.998764139672561,
+                'cd1_1': -1.7436649443640038e-05,
+                'cd1_2': -2.0849272804435688e-08,
+                'cd2_1': -4.616114099568815e-08,
+                'cd2_2': 1.7519905482510155e-05,
+                'a_order': 3,
+                'b_order': 3,
+                'a_0_2': -1.5520006349224245e-06,
+                'a_0_3': 4.3714933936267264e-13,
+                'a_1_1': -1.1604291350572094e-05,
+                'a_1_2': 1.7125037791723067e-09,
+                'a_2_0': 1.9225112320436695e-06,
+                'a_2_1': -7.926931183344235e-11,
+                'a_3_0': 1.5974716218080076e-09,
+                'b_0_2': -6.7554035599749904e-06,
+                'b_0_3': 1.6911444547233376e-09,
+                'b_1_1': 3.6345928479129676e-06,
+                'b_1_2': -8.64927324063469e-11,
+                'b_2_0': 4.915411904251364e-06,
+                'b_2_1': 1.5701011999755348e-09,
+                'b_3_0': -2.9577497324389284e-12,
+                'sipmxerr': 3.950294659161568e-11,
+                'sipiverr': 0.11047793758675752,
+                'ap_0_1': 3.988114493629691e-07,
+                'ap_0_2': 1.5486628623564042e-06,
+                'ap_0_3': 3.784084622814559e-11,
+                'ap_1_0': -7.65706188115184e-06,
+                'ap_1_1': 1.149989280312782e-05,
+                'ap_1_2': -1.4994544929498265e-09,
+                'ap_2_0': -1.904283418222981e-06,
+                'ap_2_1': -4.507459210843236e-11,
+                'ap_3_0': -1.630572028632995e-09,
+                'bp_0_1': -7.46518175488653e-06,
+                'bp_0_2': 6.690996263911794e-06,
+                'bp_0_3': -1.5898038512674783e-09,
+                'bp_1_0': 4.524878821020556e-07,
+                'bp_1_1': -3.60126568682908e-06,
+                'bp_1_2': -4.4691036548847474e-11,
+                'bp_2_0': -4.9044713849991446e-06,
+                'bp_2_1': -1.7110976247273783e-09,
+                'bp_3_0': 3.895381500452847e-11,
+                'ap_order': 3,
+                'bp_order': 3}
+
+    hdu1 = create_hdul()
+    im = ImageModel(hdu1)
+
+    pipe = AssignWcsStep()
+    result = pipe.call(im)
+
+    # check that result.meta.wcsinfo has correct
+    # values after SIP approx.
+    wcs_info = result.meta.wcsinfo.instance
+
+    # make sure all expected keys are there
+    assert set(true_wcs.keys()).issubset(set((wcs_info.keys())))
+
+    # and make sure they match
+    for key in true_wcs:
+        if 'ctype' in key:
+            assert true_wcs[key] == wcs_info[key]
+        else:
+            assert_allclose(true_wcs[key], wcs_info[key])
+
+    # evaulate fits wcs and gwcs, make sure they agree
+    grid = grid_from_bounding_box(result.meta.wcs.bounding_box)
+    gwcs_ra, gwcs_dec = result.meta.wcs(*grid)
+    fits_wcs = wcs.WCS(wcs_info)
+    fitswcs_res = fits_wcs.pixel_to_world(*grid)
+
+    assert_allclose(fitswcs_res.ra.deg, gwcs_ra)
+    assert_allclose(fitswcs_res.dec.deg, gwcs_dec, atol=1.5e-6)
+
+    # now write the file out, read it back in, and check that the fit values are preserved
+    path = str(tmpdir.join("tmp_sip_wcs.fits"))
+    result.write(path)
+
+
+    with open(path) as result_read:
+        result.meta.wcsinfo == result_read.meta.wcsinfo

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -215,6 +215,30 @@ properties:
             fits_keyword: PC3_3
             fits_hdu: SCI
             blend_table: True
+          cd1_1:
+            title: linear transformation matrix element, CD matrix
+            type: number
+            fits_keyword: CD1_1
+            fits_hdu: SCI
+            blend_table: True
+          cd1_2:
+            title: linear transformation matrix element, CD matrix
+            type: number
+            fits_keyword: CD1_2
+            fits_hdu: SCI
+            blend_table: True
+          cd2_1:
+            title: linear transformation matrix element, CD matrix
+            type: number
+            fits_keyword: CD2_1
+            fits_hdu: SCI
+            blend_table: True
+          cd2_2:
+            title: linear transformation matrix element, CD matrix
+            type: number
+            fits_keyword: CD2_2
+            fits_hdu: SCI
+            blend_table: True
           ps3_0:
             title: Coordinate table extension name
             type: string
@@ -337,4 +361,524 @@ properties:
             title: "[deg] Moving target average Dec over exposures"
             type: number
             fits_keyword: MT_AVDEC
+            fits_hdu: SCI
+          a_order:
+            title: "Degree of forward SIP polynomial"
+            type: integer
+            fits_keyword: A_ORDER
+            fits_hdu: SCI
+          b_order:
+            title: "Degree of forward SIP polynomial"
+            type: integer
+            fits_keyword: B_ORDER
+            fits_hdu: SCI
+          ap_order:
+            title: "Degree of inverse SIP polynomial"
+            type: integer
+            fits_keyword: AP_ORDER
+            fits_hdu: SCI
+          bp_order:
+            title: "Degree of inverse SIP polynomial"
+            type: integer
+            fits_keyword: BP_ORDER
+            fits_hdu: SCI
+          a_0_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_0_2
+            fits_hdu: SCI
+          a_0_3:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_0_3
+            fits_hdu: SCI
+          a_0_4:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_0_4
+            fits_hdu: SCI
+          a_0_5:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_0_5
+            fits_hdu: SCI
+          a_0_6:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_0_6
+            fits_hdu: SCI
+          a_1_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_1_1
+            fits_hdu: SCI
+          a_1_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_1_2
+            fits_hdu: SCI
+          a_1_3:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_1_3
+            fits_hdu: SCI
+          a_1_4:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_1_4
+            fits_hdu: SCI
+          a_1_5:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_1_5
+            fits_hdu: SCI
+          a_2_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_2_0
+            fits_hdu: SCI
+          a_2_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_2_1
+            fits_hdu: SCI
+          a_2_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_2_2
+            fits_hdu: SCI
+          a_2_3:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_2_3
+            fits_hdu: SCI
+          a_2_4:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_2_4
+            fits_hdu: SCI
+          a_3_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_3_0
+            fits_hdu: SCI
+          a_3_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_3_1
+            fits_hdu: SCI
+          a_3_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_3_2
+            fits_hdu: SCI
+          a_3_3:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_3_3
+            fits_hdu: SCI
+          a_4_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_4_0
+            fits_hdu: SCI
+          a_4_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_4_1
+            fits_hdu: SCI
+          a_4_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_4_2
+            fits_hdu: SCI
+          a_5_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_5_0
+            fits_hdu: SCI
+          a_5_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_5_1
+            fits_hdu: SCI
+          a_6_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: A_6_0
+            fits_hdu: SCI
+          b_0_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_0_2
+            fits_hdu: SCI
+          b_0_3:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_0_3
+            fits_hdu: SCI
+          b_0_4:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_0_4
+            fits_hdu: SCI
+          b_0_5:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_0_5
+            fits_hdu: SCI
+          b_0_6:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_0_6
+            fits_hdu: SCI
+          b_1_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_1_1
+            fits_hdu: SCI
+          b_1_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_1_2
+            fits_hdu: SCI
+          b_1_3:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_1_3
+            fits_hdu: SCI
+          b_1_4:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_1_4
+            fits_hdu: SCI
+          b_1_5:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_1_5
+            fits_hdu: SCI
+          b_2_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_2_0
+            fits_hdu: SCI
+          b_2_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_2_1
+            fits_hdu: SCI
+          b_2_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_2_2
+            fits_hdu: SCI
+          b_2_3:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_2_3
+            fits_hdu: SCI
+          b_2_4:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_2_4
+            fits_hdu: SCI
+          b_3_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_3_0
+            fits_hdu: SCI
+          b_3_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_3_1
+            fits_hdu: SCI
+          b_3_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_3_2
+            fits_hdu: SCI
+          b_3_3:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_3_3
+            fits_hdu: SCI
+          b_4_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_4_0
+            fits_hdu: SCI
+          b_4_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_4_1
+            fits_hdu: SCI
+          b_4_2:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_4_2
+            fits_hdu: SCI
+          b_5_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_5_0
+            fits_hdu: SCI
+          b_5_1:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_5_1
+            fits_hdu: SCI
+          b_6_0:
+            title: "SIP coefficient, forward transform"
+            type: number
+            fits_keyword: B_6_0
+            fits_hdu: SCI
+          ap_0_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_0_2
+            fits_hdu: SCI
+          ap_0_3:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_0_3
+            fits_hdu: SCI
+          ap_0_4:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_0_4
+            fits_hdu: SCI
+          ap_0_5:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_0_5
+            fits_hdu: SCI
+          ap_0_6:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_0_6
+            fits_hdu: SCI
+          ap_1_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_1_1
+            fits_hdu: SCI
+          ap_1_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_1_2
+            fits_hdu: SCI
+          ap_1_3:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_1_3
+            fits_hdu: SCI
+          ap_1_4:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_1_4
+            fits_hdu: SCI
+          ap_1_5:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_1_5
+            fits_hdu: SCI
+          ap_2_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_2_0
+            fits_hdu: SCI
+          ap_2_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_2_1
+            fits_hdu: SCI
+          ap_2_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_2_2
+            fits_hdu: SCI
+          ap_2_3:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_2_3
+            fits_hdu: SCI
+          ap_2_4:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_2_4
+            fits_hdu: SCI
+          ap_3_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_3_0
+            fits_hdu: SCI
+          ap_3_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_3_1
+            fits_hdu: SCI
+          ap_3_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_3_2
+            fits_hdu: SCI
+          ap_3_3:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_3_3
+            fits_hdu: SCI
+          ap_4_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_4_0
+            fits_hdu: SCI
+          ap_4_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_4_1
+            fits_hdu: SCI
+          ap_4_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_4_2
+            fits_hdu: SCI
+          ap_5_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_5_0
+            fits_hdu: SCI
+          ap_5_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_5_1
+            fits_hdu: SCI
+          ap_6_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: AP_6_0
+            fits_hdu: SCI
+          bp_0_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_0_2
+            fits_hdu: SCI
+          bp_0_3:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_0_3
+            fits_hdu: SCI
+          bp_0_4:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_0_4
+            fits_hdu: SCI
+          bp_0_5:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_0_5
+            fits_hdu: SCI
+          bp_0_6:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_0_6
+            fits_hdu: SCI
+          bp_1_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_1_1
+            fits_hdu: SCI
+          bp_1_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_1_2
+            fits_hdu: SCI
+          bp_1_3:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_1_3
+            fits_hdu: SCI
+          bp_1_4:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_1_4
+            fits_hdu: SCI
+          bp_1_5:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_1_5
+            fits_hdu: SCI
+          bp_2_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_2_0
+            fits_hdu: SCI
+          bp_2_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_2_1
+            fits_hdu: SCI
+          bp_2_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_2_2
+            fits_hdu: SCI
+          bp_2_3:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_2_3
+            fits_hdu: SCI
+          bp_2_4:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_2_4
+            fits_hdu: SCI
+          bp_3_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_3_0
+            fits_hdu: SCI
+          bp_3_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_3_1
+            fits_hdu: SCI
+          bp_3_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_3_2
+            fits_hdu: SCI
+          bp_3_3:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_3_3
+            fits_hdu: SCI
+          bp_4_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_4_0
+            fits_hdu: SCI
+          bp_4_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_4_1
+            fits_hdu: SCI
+          bp_4_2:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_4_2
+            fits_hdu: SCI
+          bp_5_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_5_0
+            fits_hdu: SCI
+          bp_5_1:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_5_1
+            fits_hdu: SCI
+          bp_6_0:
+            title: "SIP coefficient, inverse transform"
+            type: number
+            fits_keyword: BP_6_0
             fits_hdu: SCI

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -212,7 +212,7 @@ def test_miri_wcs_roundtrip(miri_rate):
 
 @pytest.mark.parametrize("ratio", [0.5, 0.7, 1.0])
 def test_pixel_scale_ratio_spec(miri_rate, ratio):
-    im = AssignWcsStep.call(miri_rate)
+    im = AssignWcsStep.call(miri_rate, sip_approx=False)
     result1 = ResampleSpecStep.call(im)
     result2 = ResampleSpecStep.call(im, pixel_scale_ratio=ratio)
 
@@ -221,7 +221,7 @@ def test_pixel_scale_ratio_spec(miri_rate, ratio):
 
 @pytest.mark.parametrize("ratio", [0.5, 0.7, 1.0])
 def test_pixel_scale_ratio_imaging(nircam_rate, ratio):
-    im = AssignWcsStep.call(nircam_rate)
+    im = AssignWcsStep.call(nircam_rate, sip_approx=False)
     result1 = ResampleStep.call(im)
     result2 = ResampleStep.call(im, pixel_scale_ratio=ratio)
 

--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -38,7 +38,7 @@ def wfs_association(tmp_path_factory):
     im1.meta.exposure = {
         'type': 'NRC_IMAGE'}
 
-    im1 = AssignWcsStep.call(im1)
+    im1 = AssignWcsStep.call(im1, sip_approx=False)
 
     im2 = im1.copy()
 


### PR DESCRIPTION
This adds a SIP approximation to the assign_wcs step for imaging modes.

gwcs.to_fits_sip is used to compute the linear & polynomial distortion terms. The degree of the polynomial is not supplied, but chosen from the best fit of degrees <= 6. The PC/cdelt/naxis keywords in wcsinfo are removed, and the CD matrix terms as well as all the polynomial coefficients are added. The updated wcsinfo schema includes these new keywords. 

@cshanahan1 Remaining tasks:

- [x] Add a `True/False` parameter to `assign_wcs` which enables/disables the approximation
- [x] Add a test which creates a FITS WCS object, evaluates it and compares the results to the GWCS object (I'm curious what the difference is, should be small).

- [x] Figure out what conditions creates a FITS WCS header without SIP coefficients (The Travis failure)

- [x] Add the rest of the `to_fits_sip` arguments as parameters to the `assign_wcs` step. These (with defaults) are: `max_pix_error=0.25`, `degree=None`,`max_inv_pix_error=0.25`, `inv_degree=None`,`npoints=32`

- [x] Add a Changelog entry

Resolves #4673 / [JP-1347](https://jira.stsci.edu/browse/JP-1347)