### PR TITLE
Reset logging configuration after test

### DIFF
--- a/jwst/stpipe/tests/test_logger.py
+++ b/jwst/stpipe/tests/test_logger.py
@@ -6,7 +6,13 @@ import pytest
 from .. import log as stpipe_log
 
 
-@pytest.mark.openfiles_ignore
+@pytest.fixture(autouse=True)
+def clean_up_logging():
+    yield
+    logging.shutdown()
+    stpipe_log.load_configuration(io.BytesIO(stpipe_log.DEFAULT_CONFIGURATION))
+
+
 def test_configuration(tmpdir):
     logfilename = tmpdir.join('output.log')
 


### PR DESCRIPTION
The test in jwst/stpipe/tests/test_logger.py changes the stpipe logging configuration but doesn't set it back, which I think is responsible for some of the issues we've been seeing with pytest-openfiles checks.  This PR adds a fixture that restores the default logging configuration after that test.