### PR TITLE
Add automatic meta.date management to JwstDataModel

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -73,6 +73,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'stable-deps'
 bc0.env_vars = env_vars
+bc0.conda_ver = '4.9.2'
 bc0.conda_packages = [
     "python=${python_version}",
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -73,7 +73,6 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'stable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '4.8.4'
 bc0.conda_packages = [
     "python=${python_version}",
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -74,6 +74,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'unstable-deps'
 bc0.env_vars = env_vars
+bc0.conda_ver = '4.9.2'
 bc0.conda_packages = [
     "python=${python_version}",
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -74,7 +74,6 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'unstable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '4.8.4'
 bc0.conda_packages = [
     "python=${python_version}",
 ]

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -1,5 +1,3 @@
-import datetime
-
 from astropy.time import Time
 from stdatamodels import DataModel as _DataModel
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -1,3 +1,6 @@
+import datetime
+
+from astropy.time import Time
 from stdatamodels import DataModel as _DataModel
 
 # from ..lib.basic_utils import deprecate_class
@@ -30,6 +33,25 @@ class JwstDataModel(_DataModel):
             key: val for key, val in self.to_flat_dict(include_arrays=False).items()
             if isinstance(val, (str, int, float, complex, bool))
         }
+
+    def on_init(self, init):
+        """
+        Hook invoked by the base class before returning a newly
+        created model instance.
+        """
+        super().on_init(init)
+
+        if not self.meta.hasattr("date"):
+            self.meta.date =  Time.now().isot
+
+    def on_save(self, init):
+        """
+        Hook invoked by the base class before writing a model
+        to a file (FITS or ASDF).
+        """
+        super().on_save(init)
+
+        self.meta.date = Time.now().isot
 
 
 # We may want to deprecate DataModel

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -3,6 +3,7 @@ import warnings
 
 from astropy.io import fits
 from astropy.table import Table
+from astropy.time import Time
 from numpy.testing import assert_allclose, assert_array_equal
 import numpy as np
 import pytest
@@ -396,3 +397,13 @@ def test_all_datamodels_init(model):
             model()
     else:
         model()
+
+
+def test_meta_date_management(tmp_path):
+    model = JwstDataModel({"meta": {"date": "2000-01-01T00:00:00.000"}})
+    assert model.meta.date == "2000-01-01T00:00:00.000"
+    model.save(str(tmp_path/"test.fits"))
+    assert abs((Time.now() - Time(model.meta.date)).value) < 1.0
+
+    model = JwstDataModel()
+    assert abs((Time.now() - Time(model.meta.date)).value) < 1.0

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -17,6 +17,7 @@ import numpy as np
 from astropy.io import fits
 from stdatamodels import filetype
 from stdatamodels import s3_utils
+from stdatamodels.model_base import _FileReference
 
 from ..lib.basic_utils import bytes2human
 
@@ -194,7 +195,9 @@ def open(init=None, memmap=False, **kwargs):
 
     # Close the hdulist if we opened it
     if file_to_close is not None:
-        model._files_to_close.append(file_to_close)
+        # TODO: We need a better solution than messing with DataModel
+        # internals.
+        model._file_references.append(_FileReference(file_to_close))
 
     if not has_model_type:
         class_name = new_class.__name__.split('.')[-1]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     scipy>=1.1.0
     spherical-geometry>=1.2.18
     stdatamodels>=0.2.0,<1.0
-    stpipe>=0.1.0
+    stpipe>=0.1.0,<1.0
     stsci.image>=2.3.3
     tweakwcs>=0.7.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     requests>=2.22
     scipy>=1.1.0
     spherical-geometry>=1.2.18
-    stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git
+    stdatamodels>=0.2.0,<1.0
     stpipe>=0.1.0
     stsci.image>=2.3.3
     tweakwcs>=0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     requests>=2.22
     scipy>=1.1.0
     spherical-geometry>=1.2.18
-    stdatamodels~=0.1.0
+    stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git
     stpipe>=0.1.0
     stsci.image>=2.3.3
     tweakwcs>=0.7.0


### PR DESCRIPTION
To support Roman storing astropy.time.Time objects in meta.date, the code that automatically maintains that attribute will be removed from stdatamodels starting in version 0.2.0 (not yet released).  This PR re-implements that feature in JwstDataModel using a new hook that we added to the base DataModel class.

This PR should *not* be merged before jwst 0.18.0 is released, since stdatamodels 0.2.0 will include other changes that may cause trouble for jwst.  I'm mainly opening the PR now so I don't forget about it.