### PR TITLE
Fix units in tso photometry catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -176,6 +176,8 @@ tso_photometry
 - Place aperture using header keywords XREF_SCI and YREF_SCI instead of
   CRPIX1 and CRPIX2 [#5533]
 
+- Fixed the flux units in the output photometry catalog. [#5529]
+
 tweakreg
 --------
 

--- a/jwst/tso_photometry/tests/test_tso_photometry.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry.py
@@ -75,6 +75,12 @@ def set_meta(datamodel, sub64p=False):
         datamodel.meta.instrument.pupil = 'CLEAR'
         datamodel.meta.subarray.name = 'FULL'
 
+    datamodel.meta.bunit_data = 'MJy/sr'
+    datamodel.meta.bunit_err = 'MJy/sr'
+    # NOTE: this is a dummy value that leaves the mock test data values
+    # unchanged during the unit conversion in tso_photometry.
+    datamodel.meta.photometry.pixelarea_steradians = 1.0e-6
+
     datamodel.meta.wcs = dummy_wcs
 
 
@@ -135,17 +141,17 @@ def test_tso_phot_1():
     assert math.isclose(catalog.meta['xcenter'], xcenter, abs_tol=0.01)
     assert math.isclose(catalog.meta['ycenter'], ycenter, abs_tol=0.01)
 
-    assert np.allclose(catalog['aperture_sum'], 1263.4778, rtol=1.e-7)
-    assert np.allclose(catalog['aperture_sum_err'], 0., atol=1.e-7)
-    assert np.allclose(catalog['net_aperture_sum'], 1173., rtol=1.e-7)
-    assert np.allclose(catalog['annulus_sum'], 143.256627, rtol=1.e-7)
-    assert np.allclose(catalog['annulus_sum_err'], 0., atol=1.e-7)
-    assert np.allclose(catalog['annulus_mean'], background, rtol=1.e-7)
+    assert np.allclose(catalog['aperture_sum'].value, 1263.4778, rtol=1.e-7)
+    assert np.allclose(catalog['aperture_sum_err'].value, 0., atol=1.e-7)
+    assert np.allclose(catalog['net_aperture_sum'].value, 1173., rtol=1.e-7)
+    assert np.allclose(catalog['annulus_sum'].value, 143.256627, rtol=1.e-7)
+    assert np.allclose(catalog['annulus_sum_err'].value, 0., atol=1.e-7)
+    assert np.allclose(catalog['annulus_mean'].value, background, rtol=1.e-7)
 
-    assert np.allclose(catalog['annulus_mean'], 0.8, rtol=1.e-6)
-    assert np.allclose(catalog['annulus_mean_err'], 0., rtol=1.e-7)
-    assert np.allclose(catalog['net_aperture_sum'], 1173., rtol=1.e-7)
-    assert np.allclose(catalog['net_aperture_sum_err'], 0., atol=1.e-7)
+    assert np.allclose(catalog['annulus_mean'].value, 0.8, rtol=1.e-6)
+    assert np.allclose(catalog['annulus_mean_err'].value, 0., rtol=1.e-7)
+    assert np.allclose(catalog['net_aperture_sum'].value, 1173., rtol=1.e-7)
+    assert np.allclose(catalog['net_aperture_sum_err'].value, 0., atol=1.e-7)
 
 
 def test_tso_phot_2():
@@ -176,10 +182,10 @@ def test_tso_phot_2():
     assert math.isclose(catalog.meta['xcenter'], xcenter, abs_tol=0.01)
     assert math.isclose(catalog.meta['ycenter'], ycenter, abs_tol=0.01)
 
-    assert np.allclose(catalog['aperture_sum'],
+    assert np.allclose(catalog['aperture_sum'].value,
                        (value + background) * shape[-1] * shape[-2],
                        rtol=1.e-6)
-    assert np.allclose(catalog['aperture_sum_err'], 0., atol=1.e-7)
+    assert np.allclose(catalog['aperture_sum_err'].value, 0., atol=1.e-7)
 
 
 def test_tso_phot_3():

--- a/jwst/tso_photometry/tests/test_tso_photometry.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+import pytest
 
 from jwst import datamodels
 from jwst.tso_photometry.tso_photometry import tso_aperture_photometry
@@ -240,3 +241,22 @@ def test_tso_phot_4():
                           58704.62890, 58704.6290, 58704.6291511,
                           58704.629275])
     assert np.allclose(catalog['MJD'], int_times, rtol=1.e-8)
+
+
+def test_tso_phot_5():
+
+    global shape, xcenter, ycenter
+
+    value = 17.
+    background = 0.8
+    radius = 5.
+    radius_inner = 8.
+    radius_outer = 11.
+    data = mk_data_array(shape, value, background, xcenter, ycenter, radius)
+    datamodel = datamodels.CubeModel(data)
+    set_meta(datamodel, sub64p=False)
+    datamodel.meta.bunit_data = 'MJy'  # unexpected data unit
+
+    with pytest.raises(ValueError):
+        tso_aperture_photometry(datamodel, xcenter, ycenter, radius + 1., radius_inner,
+                                radius_outer)

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 from astropy.table import QTable
 from astropy.time import Time, TimeDelta
+import astropy.units as u
 import photutils
 from photutils import CircularAperture, CircularAnnulus
 
@@ -58,6 +59,15 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
         phot_aper = CircularAperture((xcenter, ycenter), r=radius)
         bkg_aper = CircularAnnulus((xcenter, ycenter), r_in=radius_inner,
                                    r_out=radius_outer)
+
+    # convert the input data and errors from MJy/sr to Jy
+    if datamodel.meta.bunit_data != 'MJy/sr':
+        raise ValueError('data is expected to be in units of MJy/sr')
+    factor = 1.e6 * datamodel.meta.photometry.pixelarea_steradians
+    datamodel.data *= factor
+    datamodel.err *= factor
+    datamodel.meta.bunit_data = 'Jy'
+    datamodel.meta.bunit_err = 'Jy'
 
     aperture_sum = []
     aperture_sum_err = []
@@ -162,13 +172,14 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
                      int_dt)
 
     # populate table columns
+    unit = u.Unit(datamodel.meta.bunit_data)
     tbl['MJD'] = int_times.mjd
-    tbl['aperture_sum'] = aperture_sum
-    tbl['aperture_sum_err'] = aperture_sum_err
+    tbl['aperture_sum'] = aperture_sum << unit
+    tbl['aperture_sum_err'] = aperture_sum_err << unit
 
     if not sub64p_wlp8:
-        tbl['annulus_sum'] = annulus_sum
-        tbl['annulus_sum_err'] = annulus_sum_err
+        tbl['annulus_sum'] = annulus_sum << unit
+        tbl['annulus_sum_err'] = annulus_sum_err << unit
 
         if LooseVersion(photutils.__version__) >= '0.7':
             annulus_mean = annulus_sum / bkg_aper.area
@@ -183,24 +194,24 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
             aperture_bkg = annulus_mean * phot_aper.area()
             aperture_bkg_err = annulus_mean_err * phot_aper.area()
 
-        tbl['annulus_mean'] = annulus_mean
-        tbl['annulus_mean_err'] = annulus_mean_err
+        tbl['annulus_mean'] = annulus_mean << unit
+        tbl['annulus_mean_err'] = annulus_mean_err << unit
 
-        tbl['aperture_bkg'] = aperture_bkg
-        tbl['aperture_bkg_err'] = aperture_bkg_err
+        tbl['aperture_bkg'] = aperture_bkg << unit
+        tbl['aperture_bkg_err'] = aperture_bkg_err << unit
 
         net_aperture_sum = aperture_sum - aperture_bkg
         net_aperture_sum_err = np.sqrt(aperture_sum_err ** 2 +
                                        aperture_bkg_err ** 2)
-        tbl['net_aperture_sum'] = net_aperture_sum
-        tbl['net_aperture_sum_err'] = net_aperture_sum_err
+        tbl['net_aperture_sum'] = net_aperture_sum << unit
+        tbl['net_aperture_sum_err'] = net_aperture_sum_err << unit
     else:
         colnames = ['annulus_sum', 'annulus_sum_err', 'annulus_mean',
                     'annulus_mean_err', 'aperture_bkg', 'aperture_bkg_err']
         for col in colnames:
             tbl[col] = np.full(nimg, np.nan)
 
-        tbl['net_aperture_sum'] = aperture_sum
-        tbl['net_aperture_sum_err'] = aperture_sum_err
+        tbl['net_aperture_sum'] = aperture_sum << unit
+        tbl['net_aperture_sum_err'] = aperture_sum_err << unit
 
     return tbl

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -89,7 +89,7 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
                 'pixels.  Background calculated as the mean in a '
                 'circular annulus with r_inner={1} pixels and '
                 'r_outer={2} pixels.'.format(radius, radius_inner,
-                                                radius_outer))
+                                             radius_outer))
         for i in np.arange(nimg):
             aper_sum, aper_sum_err = phot_aper.do_photometry(
                 datamodel.data[i, :, :], error=datamodel.err[i, :, :])
@@ -130,7 +130,8 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
         nrows = len(datamodel.int_times)
     else:
         nrows = 0
-        log.warning("The INT_TIMES table in the input file is missing or empty.")
+        log.warning("The INT_TIMES table in the input file is missing or "
+                    "empty.")
 
     # load the INT_TIMES table data
     if nrows > 0:

--- a/jwst/tso_photometry/tso_photometry_step.py
+++ b/jwst/tso_photometry/tso_photometry_step.py
@@ -37,6 +37,10 @@ class TSOPhotometryStep(Step):
                 raise ValueError('XREF_SCI is missing.')
             if model.meta.wcsinfo.siaf_yref_sci is None:
                 raise ValueError('YREF_SCI is missing.')
+            if model.meta.bunit_data is None:
+                raise ValueError('BUNIT for data array is missing.')
+            if model.meta.bunit_err is None:
+                raise ValueError('BUNIT for error array is missing.')
 
             xcenter = model.meta.wcsinfo.siaf_xref_sci - 1    # 1-based origin
             ycenter = model.meta.wcsinfo.siaf_yref_sci - 1    # 1-based origin


### PR DESCRIPTION
This PR updates the `tso_photometry` step for input data units in `MJy/sr`.  The output catalog columns are now astropy `Quantity` objects with units of `Jy`.

Addresses part of https://jira.stsci.edu/browse/JP-1559

CC: @hbushouse, @tapastro 