### PR TITLE
Update resample to handle SIP coeffs in input data

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -184,13 +184,13 @@ class ResampleData:
         Update FITS WCS keywords of the resampled image.
         """
         # Delete any SIP-related keywords first
-        pattern = r"(cd[123]_[123]|ap?_|bp?_)"
+        pattern = r"^(cd[12]_[12]|[ab]p?_\d_\d|[ab]p?_order)$"
         regex = re.compile(pattern)
-        # Make a copy so we don't delete keys in the model while iterating
-        wcsinfo = model.meta.wcsinfo.instance.copy()
-        for item in wcsinfo:
-            if regex.match(item):
-                del model.meta.wcsinfo.instance[item]
+
+        keys = list(model.meta.wcsinfo.instance.keys())
+        for key in keys:
+            if regex.match(key):
+                del model.meta.wcsinfo.instance[key]
 
         # Write new PC-matrix-based WCS based on GWCS model
         transform = model.meta.wcs.forward_transform

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -235,3 +235,23 @@ def test_pixel_scale_ratio_imaging(nircam_rate, ratio):
     area1 = result1.meta.photometry.pixelarea_steradians
     area2 = result2.meta.photometry.pixelarea_steradians
     assert_allclose(area1 * ratio**2, area2, rtol=1e-6)
+
+
+def test_sip_coeffs_do_not_propagate(nircam_rate):
+    im = AssignWcsStep.call(nircam_rate, sip_degree=2)
+
+    # Check some SIP keywords produced above
+    assert im.meta.wcsinfo.cd1_1 is not None
+    assert im.meta.wcsinfo.ctype1 == "RA---TAN-SIP"
+
+    # Make sure no PC matrix stuff is there
+    assert im.meta.wcsinfo.pc1_1 is None
+
+    result = ResampleStep.call(im)
+
+    # Verify that SIP-related keywords do not propagate to resampled output
+    assert result.meta.wcsinfo.cd1_1 is None
+    assert result.meta.wcsinfo.ctype1 == "RA---TAN"
+
+    # Make sure we have a PC matrix
+    assert result.meta.wcsinfo.pc1_1 is not None


### PR DESCRIPTION
A follow-on from #5507 to allow `resample` to handle input data that now has CD matrix and SIP coeffs.

Addresses #4673 / [JP-1347](https://jira.stsci.edu/browse/JP-1347)