### PR TITLE
Fix bug in assign_wcs.util.bounding_box_from_subarray function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ assign_wcs
 
 - Added SIP approximation to WCS for imaging modes. FITS WCS keywords added to meta.wcsinfo. [#5507]
 
+- Fix bug where subarray bounding boxes were 1 pixel too small. [#5543]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/tests/test_util.py
+++ b/jwst/assign_wcs/tests/test_util.py
@@ -101,4 +101,4 @@ def test_bounding_box_from_subarray():
     im.meta.subarray.ystart = 6
     im.meta.subarray.xsize = 400
     im.meta.subarray.ysize = 600
-    assert bounding_box_from_subarray(im) == ((-.5, 598.5), (-.5, 398.5))
+    assert bounding_box_from_subarray(im) == ((-.5, 599.5), (-.5, 399.5))

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -830,10 +830,9 @@ def bounding_box_from_subarray(input_model):
     bb_yend = -0.5
 
     if input_model.meta.subarray.xsize is not None:
-        # Implicitely there's bb_xstart + 0.5 and xsize -1 - 0.5
-        bb_xend = input_model.meta.subarray.xsize - 1 - 0.5
+        bb_xend = input_model.meta.subarray.xsize - 0.5
     if input_model.meta.subarray.ysize is not None:
-        bb_yend = input_model.meta.subarray.ysize - 1 - 0.5
+        bb_yend = input_model.meta.subarray.ysize - 0.5
 
     bbox = ((bb_ystart, bb_yend), (bb_xstart, bb_xend))
     return bbox


### PR DESCRIPTION
Subarray bounding boxes are now the correct size.  Before they were 1 pixel too small.

Resolves #5542 / [JP-1818](https://jira.stsci.edu/browse/JP-1818)