### PR TITLE
 Update Ami analyze to input two new input parameters: JP-1742

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 ami
 ---
+- Update code to use two new input parameters: psf_offset,rotation_search [#5548]
 
 - Update code and unit tests to use new ami_analyze algorithms [#5390]
 

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -17,7 +17,7 @@ log.addHandler(logging.NullHandler())
 
 
 def apply_LG_plus(input_model, filter_model, oversample, rotation,
-                  psf_offset_find_rotation, rotsearch_parameters):
+                  psf_offset, rotsearch_parameters):
     """
     Short Summary
     -------------
@@ -79,7 +79,7 @@ def apply_LG_plus(input_model, filter_model, oversample, rotation,
     filt = "F430M"
     rotsearch_d = np.arange(rotsearch_parameters[0], rotsearch_parameters[1], rotsearch_parameters[2])
 
-    affine2d = find_rotation(data[:,:], psf_offset_find_rotation, rotsearch_d,
+    affine2d = find_rotation(data[:,:], psf_offset, rotsearch_d,
                    mx, my, sx, sy, xo, yo,
                    PIXELSCALE_r, dim, bandpass, oversample, holeshape)
 

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -16,7 +16,8 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-def apply_LG_plus(input_model, filter_model, oversample, rotation):
+def apply_LG_plus(input_model, filter_model, oversample, rotation,
+                  psf_offset_find_rotation, rotsearch_parameters):
     """
     Short Summary
     -------------
@@ -66,9 +67,7 @@ def apply_LG_plus(input_model, filter_model, oversample, rotation):
     #   x0, y0: offsets in pupil space
     mx,my,sx,sy,xo,yo, = (1.0,1.0, 0.0,0.0, 0.0,0.0)
 
-    psf_offset_find_rotation = (0.0,0.0)
     psf_offset_ff = None
-    rotsearch_d = None
 
     lamc = 4.3e-6
     oversample = 11
@@ -78,7 +77,7 @@ def apply_LG_plus(input_model, filter_model, oversample, rotation):
     PIXELSCALE_r = pixelscale_as * arcsec2rad
     holeshape = 'hex'
     filt = "F430M"
-    rotsearch_d = np.arange(-3, 3.1, 1)
+    rotsearch_d = np.arange(rotsearch_parameters[0], rotsearch_parameters[1], rotsearch_parameters[2])
 
     affine2d = find_rotation(data[:,:], psf_offset_find_rotation, rotsearch_d,
                    mx, my, sx, sy, xo, yo,

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -12,7 +12,7 @@ class AmiAnalyzeStep(Step):
         oversample = integer(default=3, min=1)  # Oversampling factor
         rotation = float(default=0.0)           # Rotation initial guess [deg]
         psf_offset = string(default='0.0 0.0') # Psf offset values to use to create the model array
-        rotation_search = string(default='-3 3.1 1.') # Set of values to use for the rotation search (start, stop, step)
+        rotation_search = string(default='-3 3.1 1.') # Rotation search parameters: start, stop, step
     """
 
     reference_file_types = ['throughput']

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -12,7 +12,7 @@ class AmiAnalyzeStep(Step):
         oversample = integer(default=3, min=1)  # Oversampling factor
         rotation = float(default=0.0)           # Rotation initial guess [deg]
         psf_offset = string(default='0.0 0.0') # Psf offset values to use to create the model array
-        rotation_search = string(default='-3 3.1 1.') # Set of values to use for the rotation search
+        rotation_search = string(default='-3 3.1 1.') # Set of values to use for the rotation search (start, stop, step)
     """
 
     reference_file_types = ['throughput']

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -11,8 +11,8 @@ class AmiAnalyzeStep(Step):
     spec = """
         oversample = integer(default=3, min=1)  # Oversampling factor
         rotation = float(default=0.0)           # Rotation initial guess [deg]
-        set_psf_offset_find_rotation = string(default='0.0 0.0') # Psf offset values to use to create the model array
-        set_rotsearch_d = string(default='-3 3.1 1.') # Set of values to use for the rotation search
+        psf_offset = string(default='0.0 0.0') # Psf offset values to use to create the model array
+        rotation_search = string(default='-3 3.1 1.') # Set of values to use for the rotation search
     """
 
     reference_file_types = ['throughput']
@@ -36,15 +36,12 @@ class AmiAnalyzeStep(Step):
         rotate = self.rotation
 
         # pull out parameters that are strings and change to floats
-
-        psf_offset = self.set_psf_offset_find_rotation.split(' ')
-        psf_offset_find_rotation = (float(psf_offset[0]), float(psf_offset[1]))
-        rotsearch = self.set_rotsearch_d.split(' ')
-        rotsearch_parameters= [float(rotsearch[0]), float(rotsearch[1]), float(rotsearch[2])]
+        psf_offset = [float(a) for a in self.psf_offset.split()]
+        rotsearch_parameters = [float(a) for a in self.rotation_search.split()]
 
         self.log.info(f'Oversampling factor =  {oversample}')
         self.log.info(f'Initial rotation guess = {rotate} deg')
-        self.log.info(f'Initial values to use for psf offset = {psf_offset_find_rotation}')
+        self.log.info(f'Initial values to use for psf offset = {psf_offset}')
         self.log.info(f'Initial values to use for rotation search {rotsearch_parameters}')
 
         # Open the input data model
@@ -71,7 +68,7 @@ class AmiAnalyzeStep(Step):
 
                 result = ami_analyze.apply_LG_plus(input_model, throughput_model,
                                                    oversample, rotate,
-                                                   psf_offset_find_rotation,
+                                                   psf_offset,
                                                    rotsearch_parameters)
 
                 # Close the reference file and update the step status

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -11,6 +11,8 @@ class AmiAnalyzeStep(Step):
     spec = """
         oversample = integer(default=3, min=1)  # Oversampling factor
         rotation = float(default=0.0)           # Rotation initial guess [deg]
+        set_psf_offset_find_rotation = string(default='0.0 0.0') # Psf offset values to use to create the model array
+        set_rotsearch_d = string(default='-3 3.1 1.') # Set of values to use for the rotation search
     """
 
     reference_file_types = ['throughput']
@@ -32,8 +34,18 @@ class AmiAnalyzeStep(Step):
         # Retrieve the parameter values
         oversample = self.oversample
         rotate = self.rotation
-        self.log.info('Oversampling factor = %d', oversample)
-        self.log.info('Initial rotation guess = %g deg', rotate)
+
+        # pull out parameters that are strings and change to floats
+
+        psf_offset = self.set_psf_offset_find_rotation.split(' ')
+        psf_offset_find_rotation = (float(psf_offset[0]), float(psf_offset[1]))
+        rotsearch = self.set_rotsearch_d.split(' ')
+        rotsearch_parameters= [float(rotsearch[0]), float(rotsearch[1]), float(rotsearch[2])]
+
+        self.log.info(f'Oversampling factor =  {oversample}')
+        self.log.info(f'Initial rotation guess = {rotate} deg')
+        self.log.info(f'Initial values to use for psf offset = {psf_offset_find_rotation}')
+        self.log.info(f'Initial values to use for rotation search {rotsearch_parameters}')
 
         # Open the input data model
         try:
@@ -58,7 +70,9 @@ class AmiAnalyzeStep(Step):
                 throughput_model = datamodels.ThroughputModel(throughput_reffile)
 
                 result = ami_analyze.apply_LG_plus(input_model, throughput_model,
-                                             oversample, rotate)
+                                                   oversample, rotate,
+                                                   psf_offset_find_rotation,
+                                                   rotsearch_parameters)
 
                 # Close the reference file and update the step status
                 throughput_model.close()


### PR DESCRIPTION
Updates for ami analyze for JP-1742
The two new input parameters are 'set_psf_offset_find_rotation' and 'set_rotsearch_d' 

These seems a bit long. When I was testing I tripped up the exact name of the parameter. Maybe we could use something shorter- maybe 'set_psf_offset'  'set_rotsearch' - suggestions - or just leave it as it is.

Fixes #5388 / [JP-1742](https://jira.stsci.edu/browse/JP-1742)