### PR TITLE
Fix distortion reffile schema and unit test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,9 @@ datamodels
 - Update Moving Target CHEBY table extension schema for changes to column
   definitions in the JWSTKD and SDP [#5558]
 
+- Update distortion reference file schema to have ``meta.instrument.channel``
+  keyword [#5553]
+
 extract_1d
 ----------
 

--- a/jwst/assign_wcs/tests/test_schemas.py
+++ b/jwst/assign_wcs/tests/test_schemas.py
@@ -1,5 +1,7 @@
 from astropy.modeling import models
 from astropy import units as u
+import pytest
+
 from jwst.datamodels import DistortionModel
 
 
@@ -16,13 +18,29 @@ def test_distortion_schema(tmpdir):
     dist.meta.exposure.type = "NRC_IMAGE"
     dist.meta.psubarray = "FULL|SUB64P|SUB160)|SUB160P|SUB320|SUB400P|SUB640|"
     dist.meta.subarray.name = "FULL"
+
+    # Populate the following so that no validation warnings or errors happen
+    dist.meta.instrument.module = "A"
+    dist.meta.instrument.channel = "SHORT"
+    dist.meta.input_units = u.degree
+    dist.meta.output_units = u.degree
+    dist.meta.description = "NIRCam distortion reference file"
+    dist.meta.author = "Hank the Septopus"
+    dist.meta.pedigree = "Cleveland"
+    dist.meta.useafter = "2000-01-01T00:00:00"
+
     path = str(tmpdir.join("test_dist.asdf"))
     dist.save(path)
 
-    with DistortionModel(path) as dist1:
-        assert dist1.meta.instrument.p_pupil == dist.meta.instrument.p_pupil
-        assert dist1.meta.instrument.pupil == dist.meta.instrument.pupil
-        assert dist1.meta.exposure.p_exptype == dist.meta.exposure.p_exptype
-        assert dist1.meta.exposure.type == dist.meta.exposure.type
-        assert dist1.meta.psubarray == dist.meta.psubarray
-        assert dist1.meta.subarray.name == dist.meta.subarray.name
+    with pytest.warns(None) as report:
+        with DistortionModel(path) as dist1:
+            assert dist1.meta.instrument.p_pupil == dist.meta.instrument.p_pupil
+            assert dist1.meta.instrument.pupil == dist.meta.instrument.pupil
+            assert dist1.meta.exposure.p_exptype == dist.meta.exposure.p_exptype
+            assert dist1.meta.exposure.type == dist.meta.exposure.type
+            assert dist1.meta.psubarray == dist.meta.psubarray
+            assert dist1.meta.subarray.name == dist.meta.subarray.name
+        assert len(report) == 0
+
+    with DistortionModel(path, strict_validation=True) as dist2:
+        dist2.validate()

--- a/jwst/assign_wcs/tests/test_schemas.py
+++ b/jwst/assign_wcs/tests/test_schemas.py
@@ -1,15 +1,29 @@
+import inspect
+import sys
+
 from astropy.modeling import models
 from astropy import units as u
 import pytest
 
-from jwst.datamodels import DistortionModel
+from jwst.datamodels import DistortionModel, ReferenceFileModel
+from jwst.datamodels import wcs_ref_models
+from jwst.datamodels.wcs_ref_models import _SimpleModel
 
 
-def test_distortion_schema(tmpdir):
-    """Make sure DistortionModel roundtrips"""
+def find_all_wcs_ref_models_classes():
+    clsmembers = inspect.getmembers(sys.modules[wcs_ref_models.__name__], inspect.isclass)
+    classes = [cls for name,cls in clsmembers if issubclass(cls, ReferenceFileModel)]
+    classes.remove(_SimpleModel)
+    return classes
+
+
+@pytest.fixture
+def distortion_model():
+    """Create a distortion model that should pass all validation"""
     m = models.Shift(1) & models.Shift(2)
     dist = DistortionModel(model=m, input_units=u.pixel, output_units=u.arcsec)
 
+    dist.meta.reftype = "distortion"
     dist.meta.instrument.name = "NIRCAM"
     dist.meta.instrument.detector = "NRCA1"
     dist.meta.instrument.p_pupil = "F162M|F164N|CLEAR|"
@@ -29,7 +43,13 @@ def test_distortion_schema(tmpdir):
     dist.meta.pedigree = "Cleveland"
     dist.meta.useafter = "2000-01-01T00:00:00"
 
+    return dist
+
+
+def test_distortion_schema(distortion_model, tmpdir):
+    """Make sure DistortionModel roundtrips"""
     path = str(tmpdir.join("test_dist.asdf"))
+    dist = distortion_model
     dist.save(path)
 
     with pytest.warns(None) as report:
@@ -42,5 +62,38 @@ def test_distortion_schema(tmpdir):
             assert dist1.meta.subarray.name == dist.meta.subarray.name
         assert len(report) == 0
 
-    with DistortionModel(path, strict_validation=True) as dist2:
-        dist2.validate()
+
+def test_distortion_strict_validation(distortion_model):
+    """Make sure strict validation works"""
+    distortion_model.validate()
+
+
+def test_distortion_schema_bad_valueerror(distortion_model):
+    """Check that ValueError is raised for ReferenceFile missing items"""
+    dist = DistortionModel(distortion_model, strict_validation=True)
+    dist.meta.author = None
+
+    with pytest.raises(ValueError):
+        dist.validate()
+
+
+def test_distortion_schema_bad_assertionerror(distortion_model):
+    """Check that AssertionError is raised for distortion-specific missing items"""
+    dist = DistortionModel(distortion_model, strict_validation=True)
+    dist.meta.instrument.channel = None
+
+    with pytest.raises(AssertionError):
+        dist.validate()
+
+
+@pytest.mark.parametrize("cls", find_all_wcs_ref_models_classes())
+def test_simplemodel_subclasses(cls):
+    """Test that expected validation errors are raised"""
+    model = cls()
+    with pytest.warns(None) as report:
+        model.validate()
+    assert len(report) >= 1
+
+    model = cls(strict_validation=True)
+    with pytest.raises((ValueError, KeyError)):
+        model.validate()

--- a/jwst/datamodels/schemas/distortion.schema.yaml
+++ b/jwst/datamodels/schemas/distortion.schema.yaml
@@ -10,6 +10,7 @@ allOf:
 - $ref: keyword_pupil.schema
 - $ref: keyword_ppupil.schema
 - $ref: keyword_module.schema
+- $ref: keyword_channel.schema
 - $ref: keyword_exptype.schema
 - $ref: keyword_pexptype.schema
 - $ref: subarray.schema

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -50,15 +50,15 @@ class _SimpleModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
-        super(_SimpleModel, self).validate()
+        super().validate()
         try:
             assert isinstance(self.model, Model)
             assert self.meta.instrument.name in ["NIRCAM", "NIRSPEC", "MIRI", "TFI", "FGS", "NIRISS"]
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
 class DistortionModel(_SimpleModel):
     """
@@ -68,7 +68,7 @@ class DistortionModel(_SimpleModel):
     reftype = "distortion"
 
     def validate(self):
-        super(DistortionModel, self).validate()
+        super().validate()
         try:
             assert isinstance(self.meta.input_units, (str, u.NamedUnit))
             assert isinstance(self.meta.output_units, (str, u.NamedUnit))
@@ -92,7 +92,7 @@ class DistortionMRSModel(ReferenceFileModel):
     def __init__(self, init=None, x_model=None, y_model=None, alpha_model=None, beta_model=None,
                  bzero=None, bdel=None, input_units=None, output_units=None, **kwargs):
 
-        super(DistortionMRSModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
 
         if x_model is not None:
             self.x_model = x_model
@@ -129,7 +129,7 @@ class DistortionMRSModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
-        super(DistortionMRSModel, self).validate()
+        super().validate()
         try:
             assert isinstance(self.meta.input_units, (str, u.NamedUnit))
             assert isinstance(self.meta.output_units, (str, u.NamedUnit))
@@ -144,11 +144,12 @@ class DistortionMRSModel(ReferenceFileModel):
             assert all([isinstance(m, Model) for m in self.beta_model])
             assert len(self.abv2v3_model.model) == 2
             assert len(self.abv2v3_model.channel_band) == 2
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
+
 
 class SpecwcsModel(_SimpleModel):
     """
@@ -164,7 +165,7 @@ class SpecwcsModel(_SimpleModel):
     reftype = "specwcs"
 
     def validate(self):
-        super(SpecwcsModel, self).validate()
+        super().validate()
         try:
             assert isinstance(self.meta.input_units, (str, u.NamedUnit))
             assert isinstance(self.meta.output_units, (str, u.NamedUnit))
@@ -174,11 +175,12 @@ class SpecwcsModel(_SimpleModel):
                                                  "TFI",
                                                  "FGS",
                                                  "NIRISS"]
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
+
 
 class NIRCAMGrismModel(ReferenceFileModel):
     """
@@ -218,7 +220,7 @@ class NIRCAMGrismModel(ReferenceFileModel):
                        invdispy=None,
                        orders=None,
                        **kwargs):
-        super(NIRCAMGrismModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
 
         if init is None:
             self.populate_meta()
@@ -243,18 +245,18 @@ class NIRCAMGrismModel(ReferenceFileModel):
         self.meta.reftype = self.reftype
 
     def validate(self):
-        super(NIRCAMGrismModel, self).validate()
+        super().validate()
         try:
             assert isinstance(self.meta.input_units, (str, u.NamedUnit))
             assert isinstance(self.meta.output_units, (str, u.NamedUnit))
             assert self.meta.instrument.name == "NIRCAM"
             assert self.meta.exposure.type == "NRC_WFSS"
             assert self.meta.reftype == self.reftype
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
     def to_fits(self):
         raise NotImplementedError("FITS format is not supported for this file.")
@@ -295,7 +297,7 @@ class NIRISSGrismModel(ReferenceFileModel):
                        orders=None,
                        fwcpos_ref=None,
                        **kwargs):
-        super(NIRISSGrismModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
 
         if init is None:
             self.populate_meta()
@@ -327,11 +329,11 @@ class NIRISSGrismModel(ReferenceFileModel):
             assert self.meta.exposure.type == "NIS_WFSS"
             assert self.meta.instrument.detector == "NIS"
             assert self.meta.reftype == self.reftype
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
     def to_fits(self):
         raise NotImplementedError("FITS format is not supported for this file.")
@@ -345,7 +347,7 @@ class RegionsModel(ReferenceFileModel):
     reftype = "regions"
 
     def __init__(self, init=None, regions=None, **kwargs):
-        super(RegionsModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
         if regions is not None:
             self.regions = regions
         if init is None:
@@ -362,7 +364,7 @@ class RegionsModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
-        super(RegionsModel, self).validate()
+        super().validate()
         try:
             assert isinstance(self.regions, np.ndarray)
             assert self.meta.instrument.name == "MIRI"
@@ -370,11 +372,11 @@ class RegionsModel(ReferenceFileModel):
             assert self.meta.instrument.channel in ("12", "34", "1", "2", "3", "4")
             assert self.meta.instrument.band in ("SHORT", "LONG")
             assert self.meta.instrument.detector in ("MIRIFUSHORT", "MIRIFULONG")
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
 
 class WavelengthrangeModel(ReferenceFileModel):
@@ -402,7 +404,7 @@ class WavelengthrangeModel(ReferenceFileModel):
     def __init__(self, init=None, wrange_selector=None, wrange=None,
                  order=None, extract_orders=None, wunits=None, **kwargs):
 
-        super(WavelengthrangeModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
         if wrange_selector is not None:
             self.waverange_selector = wrange_selector
         if wrange is not None:
@@ -421,14 +423,14 @@ class WavelengthrangeModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file")
 
     def validate(self):
-        super(WavelengthrangeModel, self).validate()
+        super().validate()
         try:
             assert self.meta.instrument.name in ("MIRI", "NIRSPEC", "NIRCAM", "NIRISS")
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
     def get_wfss_wavelength_range(self, filter, orders):
         """ Retrieve the wavelength range for a WFSS observation.
@@ -461,7 +463,7 @@ class FPAModel(ReferenceFileModel):
 
     def __init__(self, init=None, nrs1_model=None, nrs2_model=None, **kwargs):
 
-        super(FPAModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
         if nrs1_model is not None:
             self.nrs1_model = nrs1_model
         if nrs2_model is not None:
@@ -484,15 +486,15 @@ class FPAModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
-        super(FPAModel, self).validate()
+        super().validate()
         try:
             assert isinstance(self.nrs1_model, Model)
             assert isinstance(self.nrs2_model, Model)
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
 
 class IFUPostModel(ReferenceFileModel):
@@ -519,7 +521,7 @@ class IFUPostModel(ReferenceFileModel):
 
     def __init__(self, init=None, slice_models=None, **kwargs):
 
-        super(IFUPostModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
         if slice_models is not None:
             if len(slice_models) != 30:
                 raise ValueError("Expected 30 slice models, got {0}".format(len(slice_models)))
@@ -542,7 +544,7 @@ class IFUPostModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
-        super(IFUPostModel, self).validate()
+        super().validate()
 
 
 class IFUSlicerModel(ReferenceFileModel):
@@ -554,7 +556,7 @@ class IFUSlicerModel(ReferenceFileModel):
 
     def __init__(self, init=None, model=None, data=None, **kwargs):
 
-        super(IFUSlicerModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
         if model is not None:
             self.model = model
         if data is not None:
@@ -575,7 +577,7 @@ class IFUSlicerModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
-        super(IFUSlicerModel, self).validate()
+        super().validate()
 
 
 class MSAModel(ReferenceFileModel):
@@ -586,7 +588,7 @@ class MSAModel(ReferenceFileModel):
     reftype = "msa"
 
     def __init__(self, init=None, models=None, data=None, **kwargs):
-        super(MSAModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
         if models is not None and data is not None:
             self.Q1 = {'model': models['Q1'], 'data': data['Q1']}
             self.Q2 = {'model': models['Q2'], 'data': data['Q2']}
@@ -611,7 +613,7 @@ class MSAModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
-        super(MSAModel, self).validate()
+        super().validate()
 
 
 class DisperserModel(ReferenceFileModel):
@@ -625,7 +627,7 @@ class DisperserModel(ReferenceFileModel):
                  kcoef=None, lcoef=None, tcoef=None, pref=None, tref=None,
                  theta_x=None, theta_y=None,theta_z=None,
                  groovedensity=None, **kwargs):
-        super(DisperserModel, self).__init__(init=init, **kwargs)
+        super().__init__(init=init, **kwargs)
         if groovedensity is not None:
             self.groovedensity = groovedensity
         if angle is not None:
@@ -672,15 +674,15 @@ class DisperserModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
-        super(DisperserModel, self).validate()
+        super().validate()
         try:
             assert self.meta.instrument.grating in ["G140H", "G140M", "G235H", "G235M",
                                                     "G395H", "G395M", "MIRROR", "PRISM"]
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
 
 class FilteroffsetModel(ReferenceFileModel):
@@ -691,7 +693,7 @@ class FilteroffsetModel(ReferenceFileModel):
     reftype = "filteroffset"
 
     def __init__(self, init=None, filters=None, instrument=None, **kwargs):
-        super(FilteroffsetModel, self).__init__(init, **kwargs)
+        super().__init__(init, **kwargs)
         if filters is not None:
             self.filters = filters
             if instrument is None or instrument not in ("NIRCAM", "MIRI", "NIRISS"):
@@ -714,7 +716,7 @@ class FilteroffsetModel(ReferenceFileModel):
             raise ValueError(f"Unsupported instrument: {self.meta.instrument.name}")
 
     def validate(self):
-        super(FilteroffsetModel, self).validate()
+        super().validate()
 
         instrument_name = self.meta.instrument.name
         nircam_channels = ["SHORT", "LONG"]
@@ -811,15 +813,15 @@ class FOREModel(_SimpleModel):
         self.meta.reftype = self.reftype
 
     def validate(self):
-        super(FOREModel, self).validate()
+        super().validate()
         try:
             assert self.meta.instrument.filter in ["CLEAR", "F070LP", "F100LP", "F110W",
                                                    "F140X", "F170LP", "F290LP"]
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
 
 class WaveCorrModel(ReferenceFileModel):
@@ -828,7 +830,7 @@ class WaveCorrModel(ReferenceFileModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/wavecorr.schema"
 
     def __init__(self, init=None, apertures=None, **kwargs):
-        super(WaveCorrModel, self).__init__(init, **kwargs)
+        super().__init__(init, **kwargs)
         if apertures is not None:
             self.apertures = apertures
         if init is None:
@@ -845,12 +847,12 @@ class WaveCorrModel(ReferenceFileModel):
         self.meta.reftype = self.reftype
 
     def validate(self):
-        super(WaveCorrModel, self).validate()
+        super().validate()
         try:
             assert self.aperture_names is not None
             assert self.apertures is not None
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -1,5 +1,7 @@
-import numpy as np
+import traceback
 import warnings
+
+import numpy as np
 from astropy.modeling.core import Model
 from astropy import units as u
 from stdatamodels.validate import ValidationWarning
@@ -74,11 +76,11 @@ class DistortionModel(_SimpleModel):
                 assert self.meta.instrument.module is not None
                 assert self.meta.instrument.channel is not None
                 assert self.meta.instrument.p_pupil is not None
-        except AssertionError as errmsg:
+        except AssertionError:
             if self._strict_validation:
-                raise AssertionError(errmsg)
+                raise
             else:
-                warnings.warn(str(errmsg), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
 class DistortionMRSModel(ReferenceFileModel):
     """


### PR DESCRIPTION
In debugging #5543 yesterday, warnings in the `assign_wcs` tests indicated that there was an inconsistency between the distortion model schema and what the `validate()` method for that model was requiring.  `validate()` was requiring that `meta.instrument.channel` be populated, but the `channel` node was not actually in the schema.  And this issue was being masked by the `validate()` code short-circuiting the real validation error message.  So we were seeing the below:

```
$ pytest jwst/assign_wcs/tests/test_schemas.py 
=============================== test session starts ===============================
platform darwin -- Python 3.9.0, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /Users/jdavies/dev/jwst, configfile: setup.cfg
plugins: asdf-2.7.1, requests-mock-1.8.0, doctestplus-0.8.0, ci-watson-0.5, cov-2.10.1, openfiles-0.5.0
collected 1 item                                                                  

jwst/assign_wcs/tests/test_schemas.py .                                     [100%]

================================ warnings summary =================================
jwst/assign_wcs/tests/test_schemas.py::test_distortion_schema
  /Users/jdavies/dev/jwst/jwst/datamodels/reference.py:45: ValidationWarning: Model.meta is missing values for ['description', 'author', 'pedigree', 'useafter']
    warnings.warn(message, ValidationWarning)

jwst/assign_wcs/tests/test_schemas.py::test_distortion_schema
  /Users/jdavies/dev/jwst/jwst/datamodels/wcs_ref_models.py:81: ValidationWarning: 
    warnings.warn(str(errmsg), ValidationWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================== 1 passed, 2 warnings in 0.71s ==========================
```

Once the masking of the real exception or warnings was fixed, it turns out the schema was not correct:

```pytb
$ pytest jwst/assign_wcs/tests/test_schemas.py 
================================================== test session starts ==================================================
platform darwin -- Python 3.9.0, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /Users/jdavies/dev/jwst, configfile: setup.cfg
plugins: asdf-2.7.1, requests-mock-1.8.0, doctestplus-0.8.0, ci-watson-0.5, cov-2.10.1, openfiles-0.5.0
collected 1 item                                                                                                        

jwst/assign_wcs/tests/test_schemas.py F                                                                           [100%]

======================================================= FAILURES ========================================================
________________________________________________ test_distortion_schema _________________________________________________

self = <stdatamodels.properties.ObjectNode object at 0x7fc550447c70>, attr = 'channel'

    def __getattr__(self, attr):
        from . import ndmodel
    
        if attr.startswith('_'):
            raise AttributeError('No attribute {0}'.format(attr))
    
        schema = _get_schema_for_property(self._schema, attr)
        try:
>           val = self._instance[attr]
E           KeyError: 'channel'

../../miniconda3/envs/jwst/lib/python3.9/site-packages/stdatamodels/properties.py:287: KeyError

During handling of the above exception, another exception occurred:

tmpdir = local('/private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-84/test_distortion_schema0')

    def test_distortion_schema(tmpdir):
        """Make sure DistortionModel roundtrips"""
        m = models.Shift(1) & models.Shift(2)
        dist = DistortionModel(model=m, input_units=u.pixel, output_units=u.arcsec)
    
        dist.meta.instrument.name = "NIRCAM"
        dist.meta.instrument.detector = "NRCA1"
        dist.meta.instrument.p_pupil = "F162M|F164N|CLEAR|"
        dist.meta.instrument.pupil = "F162M"
        dist.meta.exposure.p_exptype = "NRC_IMAGE|NRC_TSIMAGE|NRC_FLAT|NRC_LED|NRC_WFSC|"
        dist.meta.exposure.type = "NRC_IMAGE"
        dist.meta.psubarray = "FULL|SUB64P|SUB160)|SUB160P|SUB320|SUB400P|SUB640|"
        dist.meta.subarray.name = "FULL"
    
        dist.meta.instrument.module = "A"
        path = str(tmpdir.join("test_dist.asdf"))
>       dist.save(path)

jwst/assign_wcs/tests/test_schemas.py:22: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../miniconda3/envs/jwst/lib/python3.9/site-packages/stdatamodels/model_base.py:512: in save
    self.to_asdf(output_path, *args, **kwargs)
../../miniconda3/envs/jwst/lib/python3.9/site-packages/stdatamodels/model_base.py:578: in to_asdf
    self.validate()
jwst/datamodels/wcs_ref_models.py:77: in validate
    assert self.meta.instrument.channel is not None
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <stdatamodels.properties.ObjectNode object at 0x7fc550447c70>, attr = 'channel'

    def __getattr__(self, attr):
        from . import ndmodel
    
        if attr.startswith('_'):
            raise AttributeError('No attribute {0}'.format(attr))
    
        schema = _get_schema_for_property(self._schema, attr)
        try:
            val = self._instance[attr]
        except KeyError:
            if schema == {}:
>               raise AttributeError("No attribute '{0}'".format(attr))
E               AttributeError: No attribute 'channel'

../../miniconda3/envs/jwst/lib/python3.9/site-packages/stdatamodels/properties.py:290: AttributeError
=================================================== warnings summary ====================================================
jwst/assign_wcs/tests/test_schemas.py::test_distortion_schema
  /Users/jdavies/dev/jwst/jwst/datamodels/reference.py:45: ValidationWarning: Model.meta is missing values for ['description', 'author', 'pedigree', 'useafter']
    warnings.warn(message, ValidationWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================ short test summary info ================================================
FAILED jwst/assign_wcs/tests/test_schemas.py::test_distortion_schema - AttributeError: No attribute 'channel'
============================================= 1 failed, 1 warning in 0.79s ==============================================
```

Looking at existing reffiles for NIRCam and NIRISS, they actually have different metadata formats, and it's not clear there's consistency.  Not sure I understand what is happening there.

But this PR at least makes the test and the schema in sync, and it also reports what the actual validation error/warning is now.