### PR TITLE
NRS slits should be larger than 1 pixel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ assign_wcs
 
 - Fix bug where subarray bounding boxes were 1 pixel too small. [#5543]
 
+- Mark Nirspec slits which project on less than one pixel as invalid. [#5554]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1599,7 +1599,9 @@ def validate_open_slits(input_model, open_slits, reference_files):
     def _is_valid_slit(domain):
         xlow, xhigh = domain[0]
         ylow, yhigh = domain[1]
-        if xlow >= 2048 or ylow >= 2048 or xhigh <= 0 or yhigh <= 0:
+        if (xlow >= 2048 or ylow >= 2048 or
+            xhigh <= 0 or yhigh <= 0 or
+            xhigh - xlow < 1  or yhigh - ylow < 1):
             return False
         else:
             return True


### PR DESCRIPTION
Resolves #5539 / JWSTDMS-461 / [JP-1816](https://jira.stsci.edu/browse/JP-1816)

Mark Nirspec slits which project on less than one pixel as invalid.