### PR TITLE
Fix a crash in skymatch when using mode on 1 pixel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 0.18.1 (unreleased)
 ===================
 
+skymatch
+--------
 
+- Fixed a bug due to which sky matching may fail under certain circumstances
+  such as using 'mode' statistics on a single pixel (after sigma-clipping). [#5567]
 
 
 0.18.0 (2020-12-21)

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -454,11 +454,11 @@ None, optional
 
         # Calculate sky
         try:
-
             skyval, npix = self._skystat(data)
-
         except ValueError:
+            return (None, 0, 0.0)
 
+        if not np.isfinite(skyval):
             return (None, 0, 0.0)
 
         if delta:


### PR DESCRIPTION
Fixes https://github.com/spacetelescope/jwst/issues/5565 (SKYMATCH GLOBAL is NAN)