### PR TITLE
Add new extract_1d regtest for MIRI MRS

### DIFF
--- a/jwst/regtest/test_miri_mrs_extract1d.py
+++ b/jwst/regtest/test_miri_mrs_extract1d.py
@@ -1,0 +1,22 @@
+"""Test Extract1dStep on MIRI MRS point source"""
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.stpipe import Step
+
+
+@pytest.mark.bigdata
+def test_miri_mrs_extract1d(rtdata, fitsdiff_default_kwargs):
+    """Test running extract_1d on an s3d cube containing a point source"""
+    rtdata.get_data("miri/mrs/miri_003_det_image_seq1_MIRIFUSHORT_12SHORTexp1_s3d.fits")
+
+    args = ["jwst.extract_1d.Extract1dStep", rtdata.input]
+    Step.from_cmdline(args)
+    rtdata.output = "miri_003_det_image_seq1_MIRIFUSHORT_12SHORTexp1_extract1dstep.fits"
+
+    # Get the truth file
+    rtdata.get_truth('truth/test_miri_mrs_extract1d/miri_003_det_image_seq1_MIRIFUSHORT_12SHORTexp1_extract1dstep.fits')
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
Added a new regtest module to run just the `extract_1d` step on a MIRI MRS data cube, with the source type set to POINT, in order to test the point-source branches within `extract_1d`. The data is from a set of simulations created by the MIRI team, which actually contains an extended source, but I just reset the source type value to say POINT.