### PR TITLE
JP-1834: remove defaults from cfg files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 0.18.1 (unreleased)
 ===================
 
+pipeline
+--------
+
+- Removed all unnecessary parameter settings from cfg files for all steps
+  and pipelines, and removed references to step config files from most
+  pipeline modules (only kept those that are necessary for intended
+  functionality). [#5574]
+
 skymatch
 --------
 

--- a/jwst/pipeline/ami_analyze.cfg
+++ b/jwst/pipeline/ami_analyze.cfg
@@ -1,4 +1,2 @@
 name = "ami_analyze"
 class = "jwst.ami.AmiAnalyzeStep"
-oversample=3
-rotation=0.0

--- a/jwst/pipeline/assign_wcs.cfg
+++ b/jwst/pipeline/assign_wcs.cfg
@@ -1,4 +1,2 @@
 name = "assign_wcs"
 class = "jwst.assign_wcs.AssignWcsStep"
-slit_y_low = -.55  # used by Nirspec only
-slit_y_high = .55  # used by Nirspec only

--- a/jwst/pipeline/background.cfg
+++ b/jwst/pipeline/background.cfg
@@ -1,4 +1,2 @@
 name = "background" 
 class = "jwst.background.BackgroundStep"
-
-sigma = 3.0

--- a/jwst/pipeline/calwebb_ami3.cfg
+++ b/jwst/pipeline/calwebb_ami3.cfg
@@ -4,9 +4,6 @@ save_averages = True
 
     [steps]
       [[ami_analyze]]
-        config_file = ami_analyze.cfg
       [[ami_average]]
-        config_file = ami_average.cfg
       [[ami_normalize]]
-        config_file = ami_normalize.cfg
 

--- a/jwst/pipeline/calwebb_dark.cfg
+++ b/jwst/pipeline/calwebb_dark.cfg
@@ -4,22 +4,13 @@ suffix = "dark"
 
     [steps]
       [[group_scale]]
-        config_file = group_scale.cfg
       [[dq_init]]
-        config_file = dq_init.cfg
       [[saturation]]
-        config_file = saturation.cfg
       [[ipc]]
         skip = True
       [[superbias]]
-        config_file = superbias.cfg
       [[refpix]]
-        config_file = refpix.cfg
       [[rscd]]
-        config_file = rscd.cfg
       [[firstframe]]
-        config_file = firstframe.cfg
       [[lastframe]]
-        config_file = lastframe.cfg
       [[linearity]]
-        config_file = linearity.cfg

--- a/jwst/pipeline/calwebb_detector1.cfg
+++ b/jwst/pipeline/calwebb_detector1.cfg
@@ -4,34 +4,19 @@ save_calibrated_ramp = False
 
     [steps]
       [[group_scale]]
-        config_file = group_scale.cfg
       [[dq_init]]
-        config_file = dq_init.cfg
       [[saturation]]
-        config_file = saturation.cfg
       [[ipc]]
         skip = True
       [[superbias]]
-        config_file = superbias.cfg
       [[refpix]]
-        config_file = refpix.cfg
       [[rscd]]
-        config_file = rscd.cfg
       [[firstframe]]
-        config_file = firstframe.cfg
       [[lastframe]]
-        config_file = lastframe.cfg
       [[reset]]
-        config_file = reset.cfg
       [[linearity]]
-        config_file = linearity.cfg
       [[dark_current]]
-        config_file = dark_current.cfg
       [[persistence]]
-        config_file = persistence.cfg
       [[jump]]
-        config_file = jump.cfg
       [[ramp_fit]]
-        config_file = ramp_fit.cfg
       [[gain_scale]]
-        config_file = gain_scale.cfg

--- a/jwst/pipeline/calwebb_image3.cfg
+++ b/jwst/pipeline/calwebb_image3.cfg
@@ -3,12 +3,7 @@ class = "jwst.pipeline.Image3Pipeline"
 
     [steps]
       [[tweakreg]]
-        config_file = tweakreg.cfg
       [[skymatch]]
-        config_file = skymatch.cfg
       [[outlier_detection]]
-        config_file = outlier_detection.cfg
       [[resample]]
-        config_file = resample.cfg
       [[source_catalog]]
-        config_file = source_catalog.cfg

--- a/jwst/pipeline/calwebb_tso-image2.cfg
+++ b/jwst/pipeline/calwebb_tso-image2.cfg
@@ -6,10 +6,7 @@ save_results = True
       [[bkg_subtract]]
         skip = true
       [[assign_wcs]]
-        config_file = assign_wcs.cfg
       [[flat_field]]
-        config_file = flat_field.cfg
       [[photom]]
-        config_file = photom.cfg
       [[resample]]
         skip = true

--- a/jwst/pipeline/calwebb_tso3.cfg
+++ b/jwst/pipeline/calwebb_tso3.cfg
@@ -8,6 +8,4 @@ scale_detection = False
         config_file = outlier_detection_tso.cfg
       [[tso_photometry]]
       [[extract_1d]]
-        config_file = extract_1d.cfg
       [[white_light]]
-        config_file = white_light.cfg

--- a/jwst/pipeline/calwebb_tso3.cfg
+++ b/jwst/pipeline/calwebb_tso3.cfg
@@ -1,8 +1,6 @@
 name = "Tso3Pipeline"
 class = "jwst.pipeline.Tso3Pipeline"
 
-scale_detection = False
-
     [steps]
       [[outlier_detection]]
         config_file = outlier_detection_tso.cfg

--- a/jwst/pipeline/calwebb_wfs-image2.cfg
+++ b/jwst/pipeline/calwebb_wfs-image2.cfg
@@ -5,10 +5,7 @@ save_results = True
     [steps]
       [[bkg_subtract]]
       [[assign_wcs]]
-        config_file = assign_wcs.cfg
       [[flat_field]]
-        config_file = flat_field.cfg
       [[photom]]
-        config_file = photom.cfg
       [[resample]]
         skip = true

--- a/jwst/pipeline/calwebb_wfs-image3.cfg
+++ b/jwst/pipeline/calwebb_wfs-image3.cfg
@@ -1,3 +1,2 @@
 name = "WfsCombine"
 class = "jwst.wfs_combine.wfs_combine_step.WfsCombineStep"
-do_refine = False

--- a/jwst/pipeline/combine_1d.cfg
+++ b/jwst/pipeline/combine_1d.cfg
@@ -1,4 +1,2 @@
 name = "combine_1d"
 class = "jwst.combine_1d.Combine1dStep"
-
-exptime_key = "exposure_time"

--- a/jwst/pipeline/cube_build.cfg
+++ b/jwst/pipeline/cube_build.cfg
@@ -1,16 +1,3 @@
 name = "cube_build"
 class = "jwst.cube_build.CubeBuildStep"
-channel = "all"
-band = "all"
-filter = "all"
-grating = "all"
-scale1 = 0.0
-scale2 = 0.0
-scalew = 0.0
-weighting = "emsm"
-coord_system = 'skyalign'
-rois = 0.0
-roiw = 0.0
 weight_power = 2.0
-single = false
-output_type = "band"

--- a/jwst/pipeline/extract_1d.cfg
+++ b/jwst/pipeline/extract_1d.cfg
@@ -1,5 +1,2 @@
 name = "extract_1d"
 class = "jwst.extract_1d.Extract1dStep"
-
-log_increment = 50
-smoothing_length = 0

--- a/jwst/pipeline/hlsp.cfg
+++ b/jwst/pipeline/hlsp.cfg
@@ -1,3 +1,2 @@
 name = "hlsp"
 class = "jwst.coron.HlspStep"
-annuli_width = 2

--- a/jwst/pipeline/jump.cfg
+++ b/jwst/pipeline/jump.cfg
@@ -1,5 +1,2 @@
 name = "jump"
 class = "jwst.jump.JumpStep"
-
-rejection_threshold = 4.0
-

--- a/jwst/pipeline/klip.cfg
+++ b/jwst/pipeline/klip.cfg
@@ -1,3 +1,2 @@
 name = "klip"
 class = "jwst.coron.KlipStep"
-truncate = 50

--- a/jwst/pipeline/mrs_imatch.cfg
+++ b/jwst/pipeline/mrs_imatch.cfg
@@ -1,4 +1,2 @@
 name = "mrs_imatch" 
 class = "jwst.mrs_imatch.MRSIMatchStep"
-bkg_degree = 1
-subtract = False

--- a/jwst/pipeline/outlier_detection.cfg
+++ b/jwst/pipeline/outlier_detection.cfg
@@ -1,15 +1,2 @@
 name = "outlier_detection" 
 class = "jwst.outlier_detection.OutlierDetectionStep"
-
-weight_type = 'exptime'
-pixfrac = 1.0
-kernel = 'square'
-fillval = 'INDEF'
-maskpt = 0.7
-grow = 1
-snr = '4.0 3.0'
-scale = '0.5 0.4'
-backg = 0.0        
-save_intermediate_results = False
-resample_data = True
-good_bits = '~DO_NOT_USE'

--- a/jwst/pipeline/outlier_detection_scaled.cfg
+++ b/jwst/pipeline/outlier_detection_scaled.cfg
@@ -1,16 +1,2 @@
 name = "outlier_detection_scaled" 
 class = "jwst.outlier_detection.OutlierDetectionScaledStep"
-
-weight_type = 'exptime'
-pixfrac = 1.0
-kernel = 'square'
-fillval = 'INDEF'
-nlow = 0
-nhigh = 0
-maskpt = 0.7
-grow = 1
-snr = '4.0 3.0'
-scale = '0.5 0.4'
-backg = 0.0        
-save_intermediate_results = False
-good_bits = '~DO_NOT_USE'

--- a/jwst/pipeline/outlier_detection_stack.cfg
+++ b/jwst/pipeline/outlier_detection_stack.cfg
@@ -1,17 +1,4 @@
 name = "outlier_detection_stack" 
 class = "jwst.outlier_detection_stack.OutlierDetectionStackStep"
 
-weight_type = 'exptime'
-pixfrac = 1.0
-kernel = 'square'
-fillval = 'INDEF'
-nlow = 0
-nhigh = 0
-maskpt = 0.7
-grow = 1
-snr = '4.0 3.0'
-scale = '0.5 0.4'
-backg = 0.0        
-save_intermediate_results = False
 resample_data = False
-good_bits = '~DO_NOT_USE'

--- a/jwst/pipeline/outlier_detection_stack.cfg
+++ b/jwst/pipeline/outlier_detection_stack.cfg
@@ -1,4 +1,2 @@
 name = "outlier_detection_stack" 
 class = "jwst.outlier_detection_stack.OutlierDetectionStackStep"
-
-resample_data = False

--- a/jwst/pipeline/outlier_detection_tso.cfg
+++ b/jwst/pipeline/outlier_detection_tso.cfg
@@ -1,17 +1,4 @@
 name = "outlier_detection" 
 class = "jwst.outlier_detection.OutlierDetectionStep"
 
-weight_type = 'exptime'
-pixfrac = 1.0
-kernel = 'square'
-fillval = 'INDEF'
-nlow = 0
-nhigh = 0
-maskpt = 0.7
-grow = 1
-snr = '4.0 3.0'
-scale = '0.5 0.4'
-backg = 0.0        
-save_intermediate_results = False
 resample_data = False
-good_bits = '~DO_NOT_USE'

--- a/jwst/pipeline/persistence.cfg
+++ b/jwst/pipeline/persistence.cfg
@@ -1,6 +1,2 @@
 name = "persistence"
 class = "jwst.persistence.PersistenceStep"
-
-input_trapsfilled = ""
-flag_pers_cutoff = 40.
-save_persistence = False

--- a/jwst/pipeline/ramp_fit.cfg
+++ b/jwst/pipeline/ramp_fit.cfg
@@ -1,4 +1,2 @@
 name = "RampFit"
 class = "jwst.ramp_fitting.RampFitStep"
-save_opt = False
-opt_name = ""

--- a/jwst/pipeline/refpix.cfg
+++ b/jwst/pipeline/refpix.cfg
@@ -1,7 +1,2 @@
 name = "refpix"
 class = "jwst.refpix.RefPixStep"
-odd_even_columns = True
-use_side_ref_pixels = True
-side_smoothing_length=11
-side_gain=1.0
-odd_even_rows = True

--- a/jwst/pipeline/skymatch.cfg
+++ b/jwst/pipeline/skymatch.cfg
@@ -1,13 +1,2 @@
 name = "skymatch"
 class = "jwst.skymatch.SkyMatchStep"
-
-skymethod = 'global+match'
-match_down =True
-subtract = False
-skystat = 'mode'
-dqbits = 0
-nclip = 5
-lsigma = 4.0
-usigma = 4.0
-binwidth = 0.1
-

--- a/jwst/pipeline/source_catalog.cfg
+++ b/jwst/pipeline/source_catalog.cfg
@@ -1,12 +1,2 @@
 name = "source_catalog"
 class = "jwst.source_catalog.SourceCatalogStep"
-
-kernel_fwhm = 3.0
-snr_threshold = 3.0
-npixels = 50
-deblend = False
-aperture_ee1 = 30
-aperture_ee2 = 50
-aperture_ee3 = 70
-ci1_star_threshold = 2.0
-ci2_star_threshold = 1.8

--- a/jwst/pipeline/straylight.cfg
+++ b/jwst/pipeline/straylight.cfg
@@ -1,5 +1,2 @@
 name = "straylight"
 class = "jwst.straylight.StraylightStep"
-method = "ModShepard"
-roi = 50
-power = 1

--- a/jwst/pipeline/tweakreg.cfg
+++ b/jwst/pipeline/tweakreg.cfg
@@ -1,24 +1,2 @@
 name = "tweakreg"
 class = "jwst.tweakreg.TweakRegStep"
-
-save_catalogs = False
-catalog_format = 'ecsv'
-kernel_fwhm = 2.5
-snr_threshold = 10.
-brightest = 100
-enforce_user_order = False
-expand_refcat = False
-minobj = 15
-searchrad = 1.0
-use2dhist = True
-separation = 0.5
-tolerance = 1.0
-xoffset = 0.0
-yoffset = 0.0
-fitgeometry = 'general'
-nclip = 3
-sigma = 3.0
-align_to_gaia = False
-gaia_catalog = 'GAIADR2'
-min_gaia = 5
-save_gaia_catalog = False

--- a/jwst/pipeline/wfs_combine.cfg
+++ b/jwst/pipeline/wfs_combine.cfg
@@ -1,5 +1,2 @@
 name = "WfsCombine"
 class = "jwst.wfs_combine.wfs_combine_step.WfsCombineStep"
-do_refine = False
-
-


### PR DESCRIPTION
Remove the non-default param values from the `source_catalog.cfg` file, allowing the step to always run with defaults. This fixes the errors reported in [JP-1834](https://jira.stsci.edu/browse/JP-1834).

At the same time, I've also gone through *all* cfg files and removed all default param values, including pointers to cfg files in some of the pipeline module cfg's, leaving only non-default param settings that are in fact needed for special cases.

Fixes #5573 / [JP-1834](https://jira.stsci.edu/browse/JP-1834)