### PR TITLE
Add back codecov to dependencies for regtests

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -10,6 +10,7 @@ attrs==20.3.0
 certifi==2020.12.5
 chardet==3.0.4
 ci-watson==0.5
+codecov==2.1.11
 coverage==5.3
 crds==10.3.1
 cycler==0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ test =
     requests_mock>=1.0
     pytest-openfiles>=0.5.0
     pytest-cov>=2.9.0
+    codecov>=1.6.0
     flake8>=3.6.0
 aws =
     stsci-aws-utils>=0.1.2


### PR DESCRIPTION
I had removed this in #5569 as we now use a Github action for codecov uploads from our Github CI, but I forgot we still need this for uploading coverage from our regression test runs on Jenkins.  So adding it back.

Funny enough (or not funny?), the step didn't fail, even though the codecov executable was not found.  🤔 

https://plwishmaster.stsci.edu:8081/job/RT/job/JWST/999/execution/node/198/log/