### PR TITLE
TST: Allow skip and cancel CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,19 @@ jobs:
   cancel_ci:
     name: Mandatory checks before CI
     runs-on: ubuntu-latest
+    outputs:
+      run_next: ${{ steps.skip_ci_step.outputs.run_next }}
     steps:
     - name: Failure means CI is skipped on purpose
       uses: pllim/action-skip-ci@main
+      id: skip_ci_step
       with:
+        NO_FAIL: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # This should only run if we did not skip CI
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@ce17749
+      if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -40,6 +45,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: cancel_ci
+    if: needs.cancel_ci.outputs.run_next == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -159,6 +165,7 @@ jobs:
   #   name: ${{ matrix.name }}
   #   runs-on: ${{ matrix.os }}
   #   needs: cancel_ci
+  #   if: needs.cancel_ci.outputs.run_next == 'true'
   #   continue-on-error: ${{ matrix.allowed-failure }}
   #   strategy:
   #     fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       run_next: ${{ steps.skip_ci_step.outputs.run_next }}
     steps:
-    - name: Failure means CI is skipped on purpose
+    - name: Set output for skip CI
       uses: pllim/action-skip-ci@main
       id: skip_ci_step
       with:
@@ -160,7 +160,7 @@ jobs:
           file: ./coverage.xml
           flags: unit
 
-  # # A matrix of jobs with allowed failures.  Not enabled for now.
+  # # A matrix of jobs with allowed failures. Not enabled for now.
   # allowed_failures:
   #   name: ${{ matrix.name }}
   #   runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,26 @@ env:
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
 jobs:
+  cancel_ci:
+    name: Mandatory checks before CI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Failure means CI is skipped on purpose
+      uses: pllim/action-skip-ci@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # This should only run if we did not skip CI
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@ce17749
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # The rest only run if above are done
+
   tox:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: cancel_ci
     strategy:
       fail-fast: false
       matrix:
@@ -141,6 +158,7 @@ jobs:
   # allowed_failures:
   #   name: ${{ matrix.name }}
   #   runs-on: ${{ matrix.os }}
+  #   needs: cancel_ci
   #   continue-on-error: ${{ matrix.allowed-failure }}
   #   strategy:
   #     fail-fast: false


### PR DESCRIPTION
Allow skipping and cancelling CI in GitHub Actions.

The skip CI part is demonstrated in this PR. I have `[skip ci]` in the commit message, so the skip CI job would fail and prevent the rest from running.

cc @jdavies-st @eslavich 

Close #5591