### PR TITLE
TST: Add weekly cron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - '*'
   pull_request:
+  schedule:
+    # Weekly Monday 9AM build
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 9 * * 1'
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu


### PR DESCRIPTION
To catch upstream changes. I guess you might find daily too daunting, so I have it run weekly. If you only want subset of the jobs to run in cron, we can either add a `if` or have a separate YAML.

cc @jdavies-st 