### PR TITLE
TST: Move doc check to RTD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,21 +64,11 @@ jobs:
             python-version: 3.9
             toxenv: security
 
-          - name: Build documentation and check warnings
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: docs
-
           - name: macOS
             os: macos-latest
             python-version: 3.9
             toxenv: py39
     steps:
-      - name: Install system packages
-        if: ${{ contains(matrix.toxenv,'docs') }}
-        run: |
-          sudo apt-get install graphviz texlive-latex-extra dvipng
-
       - name: Checkout code
         uses: actions/checkout@v2
         with:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,9 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: html
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:


### PR DESCRIPTION
Pro: RTD gives you rendered doc preview on the PR.

Con: There is no way to manually cancel jobs on RTD.

cc @jdavies-st 

**Requires**

- [x] Enabling RTD PR builder at https://readthedocs.org/projects/jwst-pipeline/
- [x] Enabling PR event on RTD webhook in this repo setting