### PR TITLE
TST: Pin twine for --strict

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ description =
 extras = test
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = 
+passenv =
     TOXENV
     CI
     CODECOV_*
@@ -68,7 +68,7 @@ commands =
 [testenv:twine]
 description = check that the package builds sdist/wheel and that twine uploads
 deps =
-    twine
+    twine>=3.3
     pep517
 commands =
     python -m pep517.check .


### PR DESCRIPTION
I see that you use the new `--strict` option but it is only available for `twine>=3.3`. This pins `twine` in the setup to prevent developers having older twine in their tox env encountering error. Should be uncontroversial enough?

cc @jdavies-st 