### PR TITLE
JP-1743: Update FILETYPE keyword in standard products

### DIFF
--- a/jwst/combine_1d/combine_1d_step.py
+++ b/jwst/combine_1d/combine_1d_step.py
@@ -24,5 +24,6 @@ class Combine1dStep(Step):
         with datamodels.open(input_file) as input_model:
             result = combine1d.combine_1d_spectra(input_model,
                                                   self.exptime_key)
+        result.meta.filetype = '1d combined spectrum'
 
         return result

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -354,7 +354,8 @@ class CubeBuildStep (Step):
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)
-        if status_cube ==1:
+            cube.meta.filetype = '3d ifu cube'
+        if status_cube == 1:
             self.skip = True
 
         return cube_container

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -159,6 +159,7 @@ class Extract1dStep(Step):
                     )
                     # Set the step flag to complete
                     result.meta.cal_step.extract_1d = 'COMPLETE'
+                    result.meta.filetype = '1d spectrum'
 
                 else:
 
@@ -193,6 +194,7 @@ class Extract1dStep(Step):
                         )
                         # Set the step flag to complete in each MultiSpecModel
                         temp.meta.cal_step.extract_1d = 'COMPLETE'
+                        temp.meta.filetype = '1d spectrum'
                         result.append(temp)
                         del temp
 
@@ -228,6 +230,7 @@ class Extract1dStep(Step):
 
                 # Set the step flag to complete
                 result.meta.cal_step.extract_1d = 'COMPLETE'
+                result.meta.filetype = '1d spectrum'
             else:
                 self.log.error('Input model is empty;')
                 self.log.error('extract_1d will be skipped.')
@@ -268,6 +271,7 @@ class Extract1dStep(Step):
 
             # Set the step flag to complete
             result.meta.cal_step.extract_1d = 'COMPLETE'
+            result.meta.filetype = '1d spectrum'
 
         input_model.close()
 

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -171,8 +171,10 @@ class OutlierDetectionStep(Step):
             if self.input_container:
                 for model in self.input_models:
                     model.meta.cal_step.outlier_detection = state
+                    model.meta.filetype = 'cosmic-ray flagged'
             else:
                 self.input_models.meta.cal_step.outlier_detection = state
+                self.input_models.meta.filetype = 'cosmic-ray flagged'
 
             return self.input_models
 

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -83,6 +83,7 @@ class Ami3Pipeline(Pipeline):
             # Save the LG analysis results to a file
             result.meta.asn.pool_name = asn['asn_pool']
             result.meta.asn.table_name = op.basename(asn.filename)
+            result.meta.filetype = 'ami'
             self.save_model(result, output_file=input_file, suffix='ami', asn_id=asn_id)
 
             # Save the result for use as input to ami_average
@@ -99,6 +100,7 @@ class Ami3Pipeline(Pipeline):
             # Save the LG analysis results to a file
             result.meta.asn.pool_name = asn['asn_pool']
             result.meta.asn.table_name = op.basename(asn.filename)
+            result.meta.filetype = 'ami'
             self.save_model(result, output_file=input_file, suffix='ami', asn_id=asn_id)
 
             # Save the result for use as input to ami_average
@@ -119,6 +121,7 @@ class Ami3Pipeline(Pipeline):
                 # output file
                 self.log.info('Blending metadata for averaged psf')
                 blendmeta.blendmodels(psf_avg, inputs=psf_lg)
+                psf_avg.meta.filetype = 'ami averaged'
                 self.save_model(psf_avg, suffix='psf-amiavg')
                 del psf_lg
 
@@ -136,6 +139,7 @@ class Ami3Pipeline(Pipeline):
                 # output file
                 self.log.info('Blending metadata for averaged target')
                 blendmeta.blendmodels(targ_avg, inputs=targ_lg)
+                targ_avg.meta.filetype = 'ami averaged'
                 self.save_model(targ_avg, suffix='amiavg')
                 del targ_lg
 
@@ -153,6 +157,7 @@ class Ami3Pipeline(Pipeline):
             # Perform blending of metadata for all inputs to this output file
             self.log.info('Blending metadata for PSF normalized target')
             blendmeta.blendmodels(result, inputs=[targ_avg, psf_avg])
+            result.meta.filetype = 'ami normalized'
             self.save_model(result, suffix='aminorm')
             result.close()
             del psf_avg

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -110,6 +110,7 @@ class Coron3Pipeline(Pipeline):
         psf_models.close()
 
         # Save the resulting PSF stack
+        psf_stack.meta.filetype = 'psf stack'
         self.save_model(psf_stack, suffix='psfstack')
 
         # Call the sequence of steps outlier_detection, align_refs, and klip
@@ -129,6 +130,7 @@ class Coron3Pipeline(Pipeline):
                 psf_aligned = self.align_refs(target, psf_stack)
 
                 # Save the alignment results
+                psf_aligned.meta.filetype = 'psf aligned'
                 self.save_model(
                     psf_aligned, output_file=target_file,
                     suffix='psfalign', acid=acid
@@ -139,6 +141,7 @@ class Coron3Pipeline(Pipeline):
                 psf_aligned.close()
 
                 # Save the psf subtraction results
+                psf_sub.meta.filetype = 'psf subtracted'
                 self.save_model(
                     psf_sub, output_file=target_file,
                     suffix='psfsub', acid=acid

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -84,4 +84,7 @@ class DarkPipeline(Pipeline):
 
         log.info('... ending calwebb_dark')
 
+        # reset FILETYPE in the output
+        input.meta.filetype = 'calibrated ramp'
+
         return input

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -117,6 +117,7 @@ class Detector1Pipeline(Pipeline):
 
         # save the corrected ramp data, if requested
         if self.save_calibrated_ramp:
+            result.meta.filetype = 'calibrated ramp'
             self.save_model(result, 'ramp')
 
         # apply the ramp_fit step
@@ -139,10 +140,12 @@ class Detector1Pipeline(Pipeline):
         if ints_model is not None:
             self.gain_scale.suffix = 'gain_scaleints'
             ints_model = self.gain_scale(ints_model)
+            ints_model.meta.filetype = 'countrate'
             self.save_model(ints_model, 'rateints')
 
         # setup output_file for saving
         self.setup_output(result)
+        result.meta.filetype = 'countrate'
 
         log.info('... ending calwebb_detector1')
 

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -52,6 +52,8 @@ class GuiderPipeline(Pipeline):
         input = self.guider_cds(input)
         input = self.flat_field(input)
 
+        input.meta.filetype = 'countrate'
+
         log.info('... ending calwebb_guider')
 
         return input

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -72,6 +72,7 @@ class Image2Pipeline(Pipeline):
             if isinstance(result, datamodels.CubeModel):
                 suffix = 'calints'
             result.meta.filename = self.make_output_path(suffix=suffix)
+            result.meta.filetype = 'calibrated'
             results.append(result)
 
         self.log.info('... ending calwebb_image2')

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -244,6 +244,7 @@ class Spec2Pipeline(Pipeline):
         calibrated.meta.asn.pool_name = pool_name
         calibrated.meta.asn.table_name = op.basename(asn_file)
         calibrated.meta.filename = self.make_output_path(suffix=suffix)
+        calibrated.meta.filetype = 'calibrated'
 
         # Produce a resampled product, either via resample_spec for
         # "regular" spectra or cube_build for IFU data. No resampled

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -75,6 +75,7 @@ class ResampleSpecStep(ResampleStep):
 
         # Update ASNTABLE in output
         result.meta.asn.table_name = input_models[0].meta.asn.table_name
+        result.meta.filetype = 'resampled'
 
         return result
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -85,6 +85,7 @@ class ResampleStep(Step):
             if hasattr(model.meta, "bunit_err") and model.meta.bunit_err is not None:
                 del model.meta.bunit_err
             self.update_phot_keywords(model)
+            model.meta.filetype = 'resampled'
 
         if len(resamp.output_models) == 1:
             result = resamp.output_models[0]


### PR DESCRIPTION
Updated all of the pipeline modules to update the FILETYPE value for at least the main product that they produce, as well as intermediate products that are saved by the pipeline module itself. Several of the major level 3 steps, such as `outlier_detection`, `resample`, and `extract_1d`, have their products created by `stpipe` when the step finishes and returns control to the pipeline module. Hence for those the step module itself has to do the updating, because the product has already been saved by the time control is returned to the pipeline module.

This only updates FILETYPE for standard products that are routinely created and archived during Ops processing. It would be far too messy and complicated to have every step make an update. If anyone has suggestions for alternate FILETYPE values for any of the products, feel free to suggest.

Fixes #1699 / [JP-1743](https://jira.stsci.edu/browse/JP-1743)