### PR TITLE
Update cube_build weight_power default value

### DIFF
--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -45,7 +45,7 @@ class CubeBuildStep (Step):
          coord_system = option('skyalign','world','internal_cal','ifualign',default='skyalign') # Output Coordinate system.
          rois = float(default=0.0) # region of interest spatial size, arc seconds
          roiw = float(default=0.0) # region of interest wavelength size, microns
-         weight_power = float(default=0.0) # Weighting option to use for Modified Shepard Method
+         weight_power = float(default=2.0) # Weighting option to use for Modified Shepard Method
          wavemin = float(default=None)  # Minimum wavelength to be used in the IFUCube
          wavemax = float(default=None)  # Maximum wavelength to be used in the IFUCube
          single = boolean(default=false) # Internal pipeline option used by mrs_imatch & outlier detection

--- a/jwst/pipeline/cube_build.cfg
+++ b/jwst/pipeline/cube_build.cfg
@@ -1,3 +1,2 @@
 name = "cube_build"
 class = "jwst.cube_build.CubeBuildStep"
-weight_power = 2.0


### PR DESCRIPTION
This is a follow-on to https://github.com/spacetelescope/jwst/pull/5574 which fixed issues related to param settings in cfg files. @drlaw1558 reported that the default value for `weight_power` should be 2, which it was set to in the `cube_build.cfg` file, but in the step spec it was set to zero. So if the step is ever run without the .cfg file you'd get the wrong value. This updates the default value in the step spec to 2.0 and removes the param from the .cfg file.