### PR TITLE
Fix bug in latest extract_1d update

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2520,7 +2520,10 @@ def run_extract1d(
 
     """
     # Read and interpret the extract1d reference file.
-    ref_dict = open_extract1d_ref(extract_ref_name, input_model.meta.exposure.type)
+    try:
+        ref_dict = open_extract1d_ref(extract_ref_name, input_model.meta.exposure.type)
+    except AttributeError:  # Input is a ModelContainer of some type
+        ref_dict = open_extract1d_ref(extract_ref_name, input_model[0].meta.exposure.type)
 
     apcorr_ref_model = None
 


### PR DESCRIPTION
Fixes a bug introduced in the latest `extract_1d` updates. There's a certain corner case (WFSS observations) where the data coming into `run_extract1d` are in a ModelContainer, as opposed to a simple data model, hence trying to access `model.meta.exposure.type` throws an AttributeError, because it needs to be `model[0].meta.exposure.type`.