### PR TITLE
JP-1762: Add VA correction to WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ assign_mtwcs
 
 - Fixed a bug which caused the step to fail with ``MultiSlitModel`` input. [#JP-1907]
 
+assign_wcs
+----------
+
+- Added velocity aberration-corrected frame ``'v2v3vacorr'`` to the WCS
+  pipeline which takes into account DVA effects. [#5602]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -89,6 +89,11 @@ def imaging_distortion(input_model, reference_files):
     dist = DistortionModel(reference_files['distortion'])
     transform = dist.model
 
+    # Apply differential velocity aberration (DVA) correction:
+    va_corr = pointing.va_corr_model(input_model)
+    if va_corr is not None:
+        transform |= va_corr
+
     # Check if the transform in the reference file has a ``bounding_box``.
     # If not set a ``bounding_box`` equal to the size of the image.
     try:

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -78,7 +78,11 @@ def imaging(input_model, reference_files):
         distortion.bounding_box = bounding_box_from_subarray(input_model)
 
     # Compute differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.dva_corr_model(
+        va_scale=input_model.meta.velocity_aberration.scale_factor,
+        v2_ref=input_model.meta.wcsinfo.v2_ref,
+        v3_ref=input_model.meta.wcsinfo.v3_ref
+    )
 
     pipeline = [(detector, distortion),
                 (v2v3, va_corr),

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -90,7 +90,7 @@ def imaging_distortion(input_model, reference_files):
     transform = dist.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
+    va_corr = pointing.va_corr_model(input_model)
     if va_corr is not None:
         transform |= va_corr
 

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -90,7 +90,7 @@ def imaging_distortion(input_model, reference_files):
     transform = dist.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
     if va_corr is not None:
         transform |= va_corr
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -113,7 +113,7 @@ def imaging_distortion(input_model, reference_files):
         distortion = dist.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
+    va_corr = pointing.va_corr_model(input_model)
     if va_corr is not None:
         distortion |= va_corr
 
@@ -202,7 +202,7 @@ def lrs_distortion(input_model, reference_files):
         distortion = dist.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
+    va_corr = pointing.va_corr_model(input_model)
     if va_corr is not None:
         distortion |= va_corr
 
@@ -494,7 +494,7 @@ def abl_to_v2v3l(input_model, reference_files):
     # used to read the wavelength range
     channels = [c + band for c in channel]
 
-    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
+    va_corr = pointing.va_corr_model(input_model)
 
     with DistortionMRSModel(reference_files['distortion']) as dist:
         v23 = dict(zip(dist.abv2v3_model.channel_band, dist.abv2v3_model.model))

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -113,7 +113,7 @@ def imaging_distortion(input_model, reference_files):
         distortion = dist.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
     if va_corr is not None:
         distortion |= va_corr
 
@@ -202,7 +202,7 @@ def lrs_distortion(input_model, reference_files):
         distortion = dist.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
     if va_corr is not None:
         distortion |= va_corr
 
@@ -494,7 +494,7 @@ def abl_to_v2v3l(input_model, reference_files):
     # used to read the wavelength range
     channels = [c + band for c in channel]
 
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
 
     with DistortionMRSModel(reference_files['distortion']) as dist:
         v23 = dict(zip(dist.abv2v3_model.channel_band, dist.abv2v3_model.model))

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -87,7 +87,11 @@ def imaging(input_model, reference_files):
             distortion.bounding_box = bb
 
     # Compute differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.dva_corr_model(
+        va_scale=input_model.meta.velocity_aberration.scale_factor,
+        v2_ref=input_model.meta.wcsinfo.v2_ref,
+        v3_ref=input_model.meta.wcsinfo.v3_ref
+    )
 
     tel2sky = pointing.v23tosky(input_model)
 
@@ -187,7 +191,11 @@ def lrs(input_model, reference_files):
     teltosky = v2v3tosky & models.Identity(1)
 
     # Compute differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model) & models.Identity(1)
+    va_corr = pointing.dva_corr_model(
+        va_scale=input_model.meta.velocity_aberration.scale_factor,
+        v2_ref=input_model.meta.wcsinfo.v2_ref,
+        v3_ref=input_model.meta.wcsinfo.v3_ref
+    ) & models.Identity(1)
 
     # Put the transforms together into a single pipeline
     pipeline = [(detector, dettotel),
@@ -398,7 +406,11 @@ def ifu(input_model, reference_files):
     abl2v2v3l = (abl_to_v2v3l(input_model, reference_files)).rename("abl_to_v2v3l")
 
     # Compute differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model) & models.Identity(1)
+    va_corr = pointing.dva_corr_model(
+        va_scale=input_model.meta.velocity_aberration.scale_factor,
+        v2_ref=input_model.meta.wcsinfo.v2_ref,
+        v3_ref=input_model.meta.wcsinfo.v3_ref
+    ) & models.Identity(1)
 
     tel2sky = pointing.v23tosky(input_model) & models.Identity(1)
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -133,7 +133,7 @@ def imaging_distortion(input_model, reference_files):
                 transform = Shift(col_offset) & Shift(row_offset) | transform
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
+    va_corr = pointing.va_corr_model(input_model)
     if va_corr is not None:
         transform |= va_corr
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -84,7 +84,11 @@ def imaging(input_model, reference_files):
         distortion.bounding_box = bounding_box_from_subarray(input_model)
 
     # Compute differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.dva_corr_model(
+        va_scale=input_model.meta.velocity_aberration.scale_factor,
+        v2_ref=input_model.meta.wcsinfo.v2_ref,
+        v3_ref=input_model.meta.wcsinfo.v3_ref
+    )
 
     tel2sky = pointing.v23tosky(input_model)
     pipeline = [(detector, distortion),
@@ -259,7 +263,11 @@ def tsgrism(input_model, reference_files):
     distortion = imaging_distortion(input_model, reference_files) & Identity(2)
 
     # Compute differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model) & Identity(2)
+    va_corr = pointing.dva_corr_model(
+        va_scale=input_model.meta.velocity_aberration.scale_factor,
+        v2_ref=input_model.meta.wcsinfo.v2_ref,
+        v3_ref=input_model.meta.wcsinfo.v3_ref
+    ) & Identity(2)
 
     # v2v3 to the sky
     # remap the tel2sky inverse as well since we can feed it the values of

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -133,7 +133,7 @@ def imaging_distortion(input_model, reference_files):
                 transform = Shift(col_offset) & Shift(row_offset) | transform
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
     if va_corr is not None:
         transform |= va_corr
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -93,7 +93,6 @@ def imaging_distortion(input_model, reference_files):
     """
     Create the "detector" to "v2v3" transform for imaging mode.
 
-
     Parameters
     ----------
     input_model : `~jwst.datamodel.DataModel`
@@ -132,6 +131,11 @@ def imaging_distortion(input_model, reference_files):
 
             if col_offset != 'N/A' and row_offset != 'N/A':
                 transform = Shift(col_offset) & Shift(row_offset) | transform
+
+    # Apply differential velocity aberration (DVA) correction:
+    va_corr = pointing.va_corr_model(input_model)
+    if va_corr is not None:
+        transform |= va_corr
 
     return transform
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -255,6 +255,12 @@ def imaging_distortion(input_model, reference_files):
     """
     dist = DistortionModel(reference_files['distortion'])
     distortion = dist.model
+
+    # Apply differential velocity aberration (DVA) correction:
+    va_corr = pointing.va_corr_model(input_model)
+    if va_corr is not None:
+        distortion |= va_corr
+
     try:
         # Check if the model has a bounding box.
         distortion.bounding_box

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -222,9 +222,13 @@ def imaging(input_model, reference_files):
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
     v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
     distortion = imaging_distortion(input_model, reference_files)
+
+    # Compute differential velocity aberration (DVA) correction:
+    va_corr = pointing.va_corr_model(input_model)
 
     subarray2full = subarray_transform(input_model)
     if subarray2full is not None:
@@ -233,7 +237,8 @@ def imaging(input_model, reference_files):
 
     tel2sky = pointing.v23tosky(input_model)
     pipeline = [(detector, distortion),
-                (v2v3, tel2sky),
+                (v2v3, va_corr),
+                (v2v3vacorr, tel2sky),
                 (world, None)]
     return pipeline
 
@@ -255,11 +260,6 @@ def imaging_distortion(input_model, reference_files):
     """
     dist = DistortionModel(reference_files['distortion'])
     distortion = dist.model
-
-    # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
-    if va_corr is not None:
-        distortion |= va_corr
 
     try:
         # Check if the model has a bounding box.

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -257,7 +257,7 @@ def imaging_distortion(input_model, reference_files):
     distortion = dist.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
+    va_corr = pointing.va_corr_model(input_model)
     if va_corr is not None:
         distortion |= va_corr
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -257,7 +257,7 @@ def imaging_distortion(input_model, reference_files):
     distortion = dist.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
     if va_corr is not None:
         distortion |= va_corr
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -228,7 +228,11 @@ def imaging(input_model, reference_files):
     distortion = imaging_distortion(input_model, reference_files)
 
     # Compute differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.dva_corr_model(
+        va_scale=input_model.meta.velocity_aberration.scale_factor,
+        v2_ref=input_model.meta.wcsinfo.v2_ref,
+        v3_ref=input_model.meta.wcsinfo.v3_ref
+    )
 
     subarray2full = subarray_transform(input_model)
     if subarray2full is not None:

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -126,7 +126,7 @@ def imaging(input_model, reference_files):
             oteip2v23 = f.model
 
         # Apply differential velocity aberration (DVA) correction:
-        va_corr = pointing.va_corr_model(input_model, fast_corr=True)
+        va_corr = pointing.va_corr_model(input_model)
         if va_corr is not None:
             oteip2v23 |= va_corr
 
@@ -1406,7 +1406,7 @@ def oteip_to_v23(reference_files, input_model):
         ote = f.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
+    va_corr = pointing.va_corr_model(input_model)
     if va_corr is not None:
         ote |= va_corr
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -126,7 +126,11 @@ def imaging(input_model, reference_files):
             oteip2v23 = f.model
 
         # Compute differential velocity aberration (DVA) correction:
-        va_corr = pointing.va_corr_model(input_model)
+        va_corr = pointing.dva_corr_model(
+            va_scale=input_model.meta.velocity_aberration.scale_factor,
+            v2_ref=input_model.meta.wcsinfo.v2_ref,
+            v3_ref=input_model.meta.wcsinfo.v3_ref
+        )
 
         # V2, V3 to world (RA, DEC) transform
         tel2sky = pointing.v23tosky(input_model)
@@ -243,7 +247,11 @@ def ifu(input_model, reference_files, slit_y_range=[-.55, .55]):
         oteip2v23 = oteip_to_v23(reference_files, input_model)
 
         # Compute differential velocity aberration (DVA) correction:
-        va_corr = pointing.va_corr_model(input_model) & Identity(1)
+        va_corr = pointing.dva_corr_model(
+            va_scale=input_model.meta.velocity_aberration.scale_factor,
+            v2_ref=input_model.meta.wcsinfo.v2_ref,
+            v3_ref=input_model.meta.wcsinfo.v3_ref
+        ) & Identity(1)
 
         # V2, V3 to sky
         tel2sky = pointing.v23tosky(input_model) & Identity(1)
@@ -364,7 +372,11 @@ def slitlets_wcs(input_model, reference_files, open_slits_id):
         oteip2v23.name = "oteip2v23"
 
         # Compute differential velocity aberration (DVA) correction:
-        va_corr = pointing.va_corr_model(input_model) & Identity(1)
+        va_corr = pointing.dva_corr_model(
+            va_scale=input_model.meta.velocity_aberration.scale_factor,
+            v2_ref=input_model.meta.wcsinfo.v2_ref,
+            v3_ref=input_model.meta.wcsinfo.v3_ref
+        ) & Identity(1)
 
         # V2, V3 to sky
         tel2sky = pointing.v23tosky(input_model) & Identity(1)

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -126,7 +126,7 @@ def imaging(input_model, reference_files):
             oteip2v23 = f.model
 
         # Apply differential velocity aberration (DVA) correction:
-        va_corr = pointing.va_corr_model(input_model)
+        va_corr = pointing.va_corr_model(input_model, fast_corr=True)
         if va_corr is not None:
             oteip2v23 |= va_corr
 
@@ -1406,7 +1406,7 @@ def oteip_to_v23(reference_files, input_model):
         ote = f.model
 
     # Apply differential velocity aberration (DVA) correction:
-    va_corr = pointing.va_corr_model(input_model)
+    va_corr = pointing.va_corr_model(input_model, fast_corr=True)
     if va_corr is not None:
         ote |= va_corr
 

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -2,7 +2,7 @@ import numpy as np
 from astropy import units as u
 from astropy import coordinates as coords
 from astropy.modeling import models as astmodels
-from astropy.modeling.models import Shift, Scale, Identity, RotationSequence3D
+from astropy.modeling.models import Shift, Scale, RotationSequence3D
 from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 from gwcs import utils as gwutils
 from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
@@ -239,7 +239,7 @@ def create_fitswcs(inp, input_frame=None):
     return wcsobj
 
 
-def va_corr_model(datamodel, fast_corr=True, **kwargs):
+def va_corr_model(datamodel, **kwargs):
     """
     Create transformation that accounts for differential velocity aberration (scale).
 
@@ -249,11 +249,6 @@ def va_corr_model(datamodel, fast_corr=True, **kwargs):
     datamodel : `~stdatamodels.DataModel`, None
         A full data model. If ``datamodel`` is `None`, all optional parameters
         must be provided (``v2_ref``, ``v3_ref``, and ``va_scale`` - see below).
-
-    fast_corr : bool, optional
-        Indicates whether to implement linear approximation by which coordinates
-        in the tangent plane are approximated by angles ``v2`` and ``v3``.
-        This correction is faster than full scale correction in a tangent plane.
 
     Other Parameters
     ----------------
@@ -303,42 +298,47 @@ def va_corr_model(datamodel, fast_corr=True, **kwargs):
         except (AttributeError, TypeError):
             return None
 
-    if fast_corr:
-        v2_shift = (1 - va_scale) * v2_ref
-        v3_shift = (1 - va_scale) * v3_ref
+    v2_shift = (1 - va_scale) * v2_ref
+    v3_shift = (1 - va_scale) * v3_ref
 
-        #  NOTE: it is assumed that v2, v3 angles are small enough so that
-        #  for expected scale factors the issue of angle wrapping (180 degrees)
-        #  can be neglected.
-        va_corr = (
-            (Scale(va_scale, name='va_scale_v2') & Scale(va_scale, name='va_scale_v3')) |
-            (Shift(v2_shift, name='va_v2_shift') & Shift(v3_shift, name='va_v3_shift'))
-        )
+    #  NOTE: it is assumed that v2, v3 angles are small enough so that
+    #  for expected scale factors the issue of angle wrapping (180 degrees)
+    #  can be neglected.
+    va_corr = (
+        (Scale(va_scale, name='va_scale_v2') & Scale(va_scale, name='va_scale_v3')) |
+        (Shift(v2_shift, name='va_v2_shift') & Shift(v3_shift, name='va_v3_shift'))
+    )
 
-    else:
-
-        s2c = SphericalToCartesian(name='s2c', wrap_lon_at=180)
-        c2s = CartesianToSpherical(name='c2s', wrap_lon_at=180)
-
-        unit_conv = Scale(1.0 / 3600.0, name='arcsec_to_deg_1D')
-        unit_conv = unit_conv & unit_conv
-        unit_conv.name = 'arcsec_to_deg_2D'
-
-        va_scale_corr = (Identity(1, name='I_1D') &
-                         Scale(va_scale, name='va_scale_1Dy') &
-                         Scale(va_scale, name='va_scale_1Dz'))
-        va_scale_corr.name = 'va_scale_2D'
-
-        rot = RotationSequence3D(
-            [v2_ref / 3600.0, -v3_ref / 3600.0],
-            'zy',
-            name='det_to_optic_axis'
-        )
-
-        va_corr = (
-            unit_conv | s2c | rot | va_scale_corr |
-            rot.inverse | c2s | unit_conv.inverse
-        )
+    # INFO: Code below does not assume small angle approximation and performs
+    # complete computations (Euler rotations and tangent plane projection).
+    # This code may be useful if VA code will be used with instruments further
+    # away from the optical axis (velocity is assumed parallel to the optical
+    # axis).
+    #
+    # from astropy.modeling.models import Identity
+    #
+    # s2c = SphericalToCartesian(name='s2c', wrap_lon_at=180)
+    # c2s = CartesianToSpherical(name='c2s', wrap_lon_at=180)
+    #
+    # unit_conv = Scale(1.0 / 3600.0, name='arcsec_to_deg_1D')
+    # unit_conv = unit_conv & unit_conv
+    # unit_conv.name = 'arcsec_to_deg_2D'
+    #
+    # va_scale_corr = (Identity(1, name='I_1D') &
+    #                  Scale(va_scale, name='va_scale_1Dy') &
+    #                  Scale(va_scale, name='va_scale_1Dz'))
+    # va_scale_corr.name = 'va_scale_2D'
+    #
+    # rot = RotationSequence3D(
+    #     [v2_ref / 3600.0, -v3_ref / 3600.0],
+    #     'zy',
+    #     name='det_to_optic_axis'
+    # )
+    #
+    # va_corr = (
+    #     unit_conv | s2c | rot | va_scale_corr |
+    #     rot.inverse | c2s | unit_conv.inverse
+    # )
 
     va_corr.name = 'VA_Correction'
 

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -2,7 +2,7 @@ import numpy as np
 from astropy import units as u
 from astropy import coordinates as coords
 from astropy.modeling import models as astmodels
-from astropy.modeling.models import Shift, Scale, RotationSequence3D
+from astropy.modeling.models import Shift, Scale, RotationSequence3D, Identity
 from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 from gwcs import utils as gwutils
 from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
@@ -265,9 +265,10 @@ def va_corr_model(datamodel, **kwargs):
 
     Returns
     -------
-    va_corr : astropy.modeling.CompoundModel, None
+    va_corr : astropy.modeling.CompoundModel, astropy.modeling.models.Identity
         A 2D compound model that corrects DVA. If input model does not contain
-        enough information to compute correction then `None` will be returned.
+        enough information to compute correction then
+        `astropy.modeling.models.Identity` will be returned.
 
     """
     if datamodel is None:
@@ -296,7 +297,7 @@ def va_corr_model(datamodel, **kwargs):
             v2_ref = float(datamodel.meta.wcsinfo.v2_ref)
             v3_ref = float(datamodel.meta.wcsinfo.v3_ref)
         except (AttributeError, TypeError):
-            return None
+            return Identity(2)
 
     v2_shift = (1 - va_scale) * v2_ref
     v3_shift = (1 - va_scale) * v3_ref

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -24,11 +24,11 @@ from .. import nircam
 # Allowed settings for nircam
 tsgrism_filters = ['F277W', 'F444W', 'F322W2', 'F356W']
 
-nircam_wfss_frames = ['grism_detector', 'detector', 'v2v3', 'world']
+nircam_wfss_frames = ['grism_detector', 'detector', 'v2v3', 'v2v3vacorr', 'world']
 
-nircam_tsgrism_frames = ['grism_detector', 'full_detector', 'v2v3', 'world']
+nircam_tsgrism_frames = ['grism_detector', 'full_detector', 'v2v3', 'v2v3vacorr', 'world']
 
-nircam_imaging_frames = ['detector', 'v2v3', 'world']
+nircam_imaging_frames = ['detector', 'v2v3', 'v2v3vacorr', 'world']
 
 
 # Default wcs information

--- a/jwst/assign_wcs/tests/test_niriss.py
+++ b/jwst/assign_wcs/tests/test_niriss.py
@@ -21,8 +21,8 @@ from .. import niriss
 
 
 # Allowed settings for niriss
-niriss_wfss_frames = ['grism_detector', 'detector', 'v2v3', 'world']
-niriss_imaging_frames = ['detector', 'v2v3', 'world']
+niriss_wfss_frames = ['grism_detector', 'detector', 'v2v3', 'v2v3vacorr', 'world']
+niriss_imaging_frames = ['detector', 'v2v3', 'v2v3vacorr', 'world']
 niriss_grisms = ['GR150R', 'GR150C']
 
 # default wcs information

--- a/jwst/assign_wcs/tests/test_pointing.py
+++ b/jwst/assign_wcs/tests/test_pointing.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 
 from jwst.assign_wcs import pointing

--- a/jwst/assign_wcs/tests/test_pointing.py
+++ b/jwst/assign_wcs/tests/test_pointing.py
@@ -1,0 +1,65 @@
+import pytest
+import numpy as np
+
+from jwst.assign_wcs import pointing
+from jwst.datamodels.image import ImageModel
+
+from .test_nircam import create_hdul
+
+
+def create_imaging_datamodel(v2_ref, v3_ref, va_scale):
+    hdul = create_hdul()
+    datamodel = ImageModel(hdul)
+    datamodel.meta.velocity_aberration.scale_factor = va_scale
+    datamodel.meta.wcsinfo.v2_ref = v2_ref
+    datamodel.meta.wcsinfo.v3_ref = v3_ref
+    return datamodel
+
+
+def test_va_corr_valid_args():
+    v2_ref = 86.103458
+    v3_ref = -493.227512
+    va_scale = 1.0001
+    dm = create_imaging_datamodel(v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
+
+    with pytest.raises(KeyError) as e:
+        pointing.va_corr_model(None, v2_ref=v2_ref)
+    assert str(e.value.args[0]) ==  ("'v2_ref', 'v3_ref', and 'va_scale' are all "
+                                     "required when 'datamodel' is set to None.")
+
+    with pytest.raises(TypeError) as e:
+        pointing.va_corr_model(None, v2_ref='I', v3_ref='II', va_scale='III')
+    assert str(e.value.args[0]) ==  "'v2_ref', 'v3_ref', and 'va_scale' must be numbers."
+
+    with pytest.raises(ValueError) as e:
+        pointing.va_corr_model(dm, v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
+    assert str(e.value.args[0]) ==  ("'v2_ref', 'v3_ref', and 'va_scale' cannot be "
+                                     "provided when 'datamodel' is not None.")
+
+
+def test_va_corr_noop_missing_meta_values():
+    dm = create_imaging_datamodel(v2_ref=None, v3_ref=None, va_scale=None)
+    assert pointing.va_corr_model(dm) is None
+
+
+def test_va_corr_valid_match():
+    v2_ref = 86.103458
+    v3_ref = -493.227512
+    va_scale = 1.0001
+    dm1 = create_imaging_datamodel(v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
+    m1 = pointing.va_corr_model(dm1)
+    m2 = pointing.va_corr_model(None, v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
+    assert np.allclose(m1(1, 10), m2(1, 10))
+
+
+def test_va_corr_inverse():
+    v2_ref = 86.103458
+    v3_ref = -493.227512
+    va_scale = 1.0001
+    test_v2 = 2300
+    test_v3 = 5600
+    fdm = create_imaging_datamodel(v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
+    idm = create_imaging_datamodel(v2_ref=v2_ref, v3_ref=v3_ref, va_scale=1 / va_scale)
+    fm = pointing.va_corr_model(fdm)
+    im = pointing.va_corr_model(idm)
+    assert np.allclose(im(*fm(test_v2, test_v3)), (test_v2, test_v3))

--- a/jwst/assign_wcs/tests/test_pointing.py
+++ b/jwst/assign_wcs/tests/test_pointing.py
@@ -42,19 +42,17 @@ def test_va_corr_noop_missing_meta_values():
     assert pointing.va_corr_model(dm) is None
 
 
-@pytest.mark.parametrize(('fcorr'), [True, False])
-def test_va_corr_valid_match(fcorr):
+def test_va_corr_valid_match():
     v2_ref = -380
     v3_ref = -770
     va_scale = 1.001
     dm1 = create_imaging_datamodel(v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
-    m1 = pointing.va_corr_model(dm1, fast_corr=fcorr)
-    m2 = pointing.va_corr_model(None, fast_corr=fcorr, v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
+    m1 = pointing.va_corr_model(dm1)
+    m2 = pointing.va_corr_model(None, v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
     assert np.allclose(m1(1, 10), m2(1, 10))
 
 
-@pytest.mark.parametrize(('fcorr'), [True, False])
-def test_va_corr_inverse(fcorr):
+def test_va_corr_inverse():
     v2_ref = -380
     v3_ref = -770
     va_scale = 1.001
@@ -62,19 +60,6 @@ def test_va_corr_inverse(fcorr):
     test_v3 = 5600
     fdm = create_imaging_datamodel(v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
     idm = create_imaging_datamodel(v2_ref=v2_ref, v3_ref=v3_ref, va_scale=1 / va_scale)
-    fm = pointing.va_corr_model(fdm, fast_corr=fcorr)
-    im = pointing.va_corr_model(idm, fast_corr=fcorr)
+    fm = pointing.va_corr_model(fdm)
+    im = pointing.va_corr_model(idm)
     assert np.allclose(im(*fm(test_v2, test_v3)), (test_v2, test_v3))
-
-
-def test_va_corr_fast():
-    v2_ref = 120.67
-    v3_ref = -527.39
-    va_scale = 1.00103
-    v2 = 88
-    v3 = -490
-
-    m1 = pointing.va_corr_model(None, fast_corr=True, v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
-    m2 = pointing.va_corr_model(None, fast_corr=False, v2_ref=v2_ref, v3_ref=v3_ref, va_scale=va_scale)
-
-    assert np.allclose((v2, v3), m1.inverse(*m2(v2, v3)), rtol=0, atol=1e-7)

--- a/jwst/assign_wcs/tests/test_pointing.py
+++ b/jwst/assign_wcs/tests/test_pointing.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from jwst.assign_wcs import pointing
 from jwst.datamodels.image import ImageModel
+from astropy.modeling.models import Identity
 
 from .test_nircam import create_hdul
 
@@ -39,7 +40,7 @@ def test_va_corr_valid_args():
 
 def test_va_corr_noop_missing_meta_values():
     dm = create_imaging_datamodel(v2_ref=None, v3_ref=None, va_scale=None)
-    assert pointing.va_corr_model(dm) is None
+    assert isinstance(pointing.va_corr_model(dm), Identity)
 
 
 def test_va_corr_valid_match():

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     stdatamodels>=0.2.0,<1.0
     stpipe>=0.1.0,<1.0
     stsci.image>=2.3.3
-    tweakwcs>=0.7.0
+    tweakwcs>=0.7.1
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
This PR adds support for velocity aberration correction in WCS. It needs thorough review.

It was decided, after a couple of iterations, that DVA correction will be applied as a separate transformation from the `v2v3` frame to a new, VA-corrected, `v2v3` frame that will be called `'v2v3vacorr'` in WCS pipeline.

The code applies a constant scale DVA correction in the (almost-)tangent plane `v2-v3` at Colin Cox suggestion. However, for when non-linear effects may become important, this PR also includes commented out full set of transformations from the spherical `v2,v3` coordinates to a tangent plane and then applying constant scale transformation in that plane and then backward transformation to the (DVA-corrected) spherical coordinates `v2,v3`.