### PR TITLE
JP-1846: Populate X/YREF_SCI keywords for all TSO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,11 @@
 0.18.2 (unreleased)
 ===================
 
+set_telescope_pointing
+----------------------
 
-
+- Updated to populate XREF_SCI, YREF_SCI keywords for all TSO exposures,
+  not just NRC_TSGRISM mode. [#5616]
 
 
 0.18.1 (2021-01-08)

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -1494,14 +1494,14 @@ def populate_model_from_siaf(model, siaf):
     siaf : namedtuple
         The WCS keywords read in from the SIAF.
     """
-    # If not an imaging mode, update the pointing only.
+    # Update values from the SIAF for all exposures.
     model.meta.wcsinfo.v2_ref = siaf.v2_ref
     model.meta.wcsinfo.v3_ref = siaf.v3_ref
     model.meta.wcsinfo.v3yangle = siaf.v3yangle
     model.meta.wcsinfo.vparity = siaf.vparity
+
+    # For imaging modes, also update the basic FITS WCS keywords
     if model.meta.exposure.type.lower() in TYPES_TO_UPDATE:
-        # For imaging modes update the pointing and
-        # the FITS WCS keywords.
         logger.info('Setting basic FITS WCS keywords for imaging')
         model.meta.wcsinfo.ctype1 = 'RA---TAN'
         model.meta.wcsinfo.ctype2 = 'DEC--TAN'
@@ -1513,8 +1513,12 @@ def populate_model_from_siaf(model, siaf):
         model.meta.wcsinfo.cdelt1 = siaf.cdelt1 / 3600  # in deg
         model.meta.wcsinfo.cdelt2 = siaf.cdelt2 / 3600  # in deg
         model.meta.coordinates.reference_frame = "ICRS"
-    elif model.meta.exposure.type.lower() == 'nrc_tsgrism':
-        logger.info('NRC_TSGRISM:')
+
+    # For TSO exposures, also populate XREF_SCI/YREF_SCI keywords,
+    # which are used by the Cal pipeline to determine the
+    # location of the source
+    if model.meta.visit.tsovisit:
+        logger.info('TSO exposure:')
         logger.info(' setting xref_sci to {}'.format(siaf.crpix1))
         logger.info(' setting yref_sci to {}'.format(siaf.crpix2))
         model.meta.wcsinfo.siaf_xref_sci = siaf.crpix1

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -445,6 +445,7 @@ def test_tsgrism_siaf_values(eng_db_ngas, data_file_nosiaf):
         model.meta.aperture.name = "NRCA5_GRISM256_F444W"
         model.meta.observation.date = '1/1/2017'
         model.meta.exposure.type = "NRC_TSGRISM"
+        model.meta.visit.tsovisit = True
         stp.update_wcs(model, siaf_path=siaf_db)
         assert model.meta.wcsinfo.siaf_xref_sci == 887
         assert model.meta.wcsinfo.siaf_yref_sci == 35


### PR DESCRIPTION
The set_telescope_pointing script has been updated to populate the XREF_SCI and YREF_SCI keywords for *all* TSO exposures, as indicated by TSOVISIT=T, instead of only populating them for NIRCam TSO grism exposures. They are needed for imaging modes, since the tso_photometry step was recently updated to use them (instead of CRPIX1, CRPIX2).

Fixes #5612 / [JP-1846](https://jira.stsci.edu/browse/JP-1846)