### PR TITLE
JP-1848: Schema updates for new and modified keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ cube_build
 - Do not allow varibles defined in spec (part of the cube_build_step class) to be changed, to allow
   calspec2 to loop over a list of files and run the pipeline. [#5603]
 
+datamodels
+----------
+
+- Updated schemas for new keywords CROWDFLD, PRIDTYPE, PRIDTPTS, PATTNPTS, SMGRDPAT,
+  changed name of SUBPXPNS to SUBPXPTS, and new allowed values for PATTTYPE. [#5618]
+
 set_telescope_pointing
 ----------------------
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1536,11 +1536,13 @@ class IFUCubeData():
             # Note that the cube lambda refer to the spaxel midpoints, so we must account for both
             # the spaxel width and the ROI size
             if self.linear_wavelength:
-                min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0]) / 2. - self.roiw
-                max_wave_tolerance = self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2]) / 2. + self.roiw
+                min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0]) / 2 - self.roiw
+                max_wave_tolerance = (self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2]) / 2
+                                      + self.roiw)
             else:
-                min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0]) / 2. - np.max(self.roiw_table)
-                max_wave_tolerance = self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2]) / 2. + np.max(self.roiw_table)
+                min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0]) / 2 - np.max(self.roiw_table)
+                max_wave_tolerance = (self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2]) / 2
+                                      + np.max(self.roiw_table))
 
             valid_min = np.where(wave >= min_wave_tolerance)
             not_mapped_low = wave.size - len(valid_min[0])

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -297,6 +297,10 @@ properties:
             type: boolean
             fits_keyword: EXP_ONLY
             blend_table: True
+          crowded_field:
+            title: Are the FGSes in a crowded field?
+            type: boolean
+            fits_keyword: CROWDFLD
       target:
         title: Target information
         type: object
@@ -1012,29 +1016,88 @@ properties:
             enum:
               # MIRI coron
              [5-POINT-SMALL-GRID, 9-POINT-SMALL-GRID,
+
               # MIRI imaging
-              4-POINT-SETS, CYCLING, GAUSSIAN, REULEAUX, WFSC,
+              CYCLING, REULEAUX, SPARSE-CYCLING,
+              2-POINT, 4-POINT-SETS,
+              2-POINT-MIRI-F770W-WITH-NIRCam, 3-POINT-MIRI-F770W-WITH-NIRCam,
+              4-POINT-MIRI-F770W-WITH-NIRCam, 9-POINT-MIRI-F770W-WITH-NIRCam,
+              3-POINT-MIRI-F1000W-WITH-NIRCam, 4-POINT-MIRI-F1000W-WITH-NIRCam,
+              2-POINT-MIRI-F1280W-WITH-NIRCam, 3-POINT-MIRI-F1280W-WITH-NIRCam,
+              4-POINT-MIRI-F1280W-WITH-NIRCam, 9-POINT-MIRI-F1280W-WITH-NIRCam,
+              2-POINT-MIRI-F1500W-WITH-NIRCam, 3-POINT-MIRI-F1500W-WITH-NIRCam,
+              4-POINT-MIRI-F1500W-WITH-NIRCam, 9-POINT-MIRI-F1500W-WITH-NIRCam,
+              2-POINT-MIRI-F1800W-WITH-NIRCam, 3-POINT-MIRI-F1800W-WITH-NIRCam,
+              4-POINT-MIRI-F1800W-WITH-NIRCam,
+              2-POINT-MIRI-F2100W-WITH-NIRCam, 3-POINT-MIRI-F2100W-WITH-NIRCam,
+              4-POINT-MIRI-F2100W-WITH-NIRCam, 9-POINT-MIRI-F2100W-WITH-NIRCam,
+              2-POINT-MIRI-F2550W-WITH-NIRCam, 3-POINT-MIRI-F2550W-WITH-NIRCam,
+              4-POINT-MIRI-F2550W-WITH-NIRCam, 9-POINT-MIRI-F2550W-WITH-NIRCam,
+              2-POINT-MIRI-F560W-WITH-NIRISS,
+              3-POINT-MIRI-F770W-WITH-NIRISS, 4-POINT-MIRI-F770W-WITH-NIRISS,
+              9-POINT-MIRI-F770W-WITH-NIRISS,
+              3-POINT-MIRI-F1000W-WITH-NIRISS, 4-POINT-MIRI-F1000W-WITH-NIRISS,
+              9-POINT-MIRI-F1000W-WITH-NIRISS,
+              2-POINT-MIRI-F1280W-WITH-NIRISS, 3-POINT-MIRI-F1280W-WITH-NIRISS,
+              4-POINT-MIRI-F1280W-WITH-NIRISS, 9-POINT-MIRI-F1280W-WITH-NIRISS,
+              2-POINT-MIRI-F1800W-WITH-NIRISS, 3-POINT-MIRI-F1800W-WITH-NIRISS,
+              4-POINT-MIRI-F1800W-WITH-NIRISS, 9-POINT-MIRI-F1800W-WITH-NIRISS,
+              2-POINT-MIRI-F2100W-WITH-NIRISS, 3-POINT-MIRI-F2100W-WITH-NIRISS,
+              4-POINT-MIRI-F2100W-WITH-NIRISS,
+              2-POINT-MIRI-F2550W-WITH-NIRISS, 3-POINT-MIRI-F2550W-WITH-NIRISS,
+              4-POINT-MIRI-F2550W-WITH-NIRISS, 9-POINT-MIRI-F2550W-WITH-NIRISS,
+
               # MIRI LRS slit
-              7PIX-5PIX-SLIT-SCAN, ALONG-SLIT-NOD, MAPPING,
+              7X3-PIXEL-MAP-CENTER, 7X3-PIXEL-MAP-NOD1, 7X3-PIXEL-MAP-NOD2,
+              1PIXEL-SLIT-SCAN, 2PIXEL-SLIT-SCAN, 7PIXEL-SLIT-SCAN, 7PIX-5PIX-SLIT-SCAN,
+              ALONG-SLIT-NOD, MAPPING,
+              INTRAPIXEL-SLIT-SCAN-CENTER, INTRAPIXEL-SLIT-SCAN-NOD1, INTRAPIXEL-SLIT-SCAN-NOD2,
+              LONG-CROSS-SCAN-CENTER, LONG-CROSS-SCAN-NOD1, LONG-CROSS-SCAN-NOD2,
+              SHORT-CROSS-SCAN-CENTER, SHORT-CROSS-SCAN-NOD1, SHORT-CROSS-SCAN-NOD2,
+
               # MIRI LRS sliteless
-              2PIXEL-SLITLESS-SCAN-SHORT, EXTENDED-FLAT-SLITLESS,
+              5PIXEL-8x4-MAP-SLITLESS, 7PIXEL-9x3-MAP-SLITLESS,
+              5PIXEL-SLITLESS-SCAN, 7PIXEL-SLITLESS-SCAN,
+              1PIXEL-SLITLESS-SCAN-LONG, 1PIXEL-SLITLESS-SCAN-SHORT,
+              2PIXEL-SLITLESS-SCAN-SHORT,
+              7x3-PIXEL-MAP-SLITLESS, 9x3-8x4-SCAN-MAPS-SLITLESS,
+
               # MIRI MRS
-              2-POINT, 4-POINT, EXTENDED-SOURCE, POINT-SOURCE,
+              2-POINT, 4-POINT,
+
               # NIRCam
               FULL, FULLBOX, FULL-TIGHT,
               INTRAMODULE, INTRAMODULEBOX, INTRAMODULEX, INTRASCA,
-              SUBARRAY-DITHER,
+              SUBARRAY-DITHER, WFSC,
+
               # NIRISS
-              AMI, IMAGING, MIMF, PARALLEL, WFSS,
+              AMI, IMAGING, MIMF, WFSS,
+              NIS_NRC_2L, NIS_NRC_2M,
+              NIS_NRC_3L, NIS_NRC_3M, NIS_NRC_3S,
+              NIS_NRC_4L, NIS_NRC_4M, NIS_NRC_4S,
+              NIS_NRC_9L, NIS_NRC_9M, NIS_NRC_9S,
+
               # NIRSpec FS, IFU, and MOS
+              2-POINT-NOD, 3-POINT-NOD, 5-POINT-NOD,
               2-POINT-WITH-NIRCAM-SIZE1, 2-POINT-WITH-NIRCAM-SIZE2, 2-POINT-WITH-NIRCAM-SIZE3,
               3-POINT-WITH-NIRCAM-SIZE1, 3-POINT-WITH-NIRCAM-SIZE2, 3-POINT-WITH-NIRCAM-SIZE3,
-              2-POINT-NOD, 3-POINT-NOD, 5-POINT-NOD,
+
               # NIRSpec IFU
               4-POINT-NOD, 4-POINT-DITHER, CYCLING, SPARSE-CYCLING,
+
               # Misc
               N/A, NONE, ANY]
             fits_keyword: PATTTYPE
+            blend_table: True
+          primary_dither_type:
+            title: Primary dither points and packing
+            type: string
+            fits_keyword: PRIDTYPE
+            blend_table: True
+          primary_points:
+            title: Number of points in primary dither pattern
+            type: integer
+            fits_keyword: PRIDTPTS
             blend_table: True
           position_number:
             title: Position number in primary pattern
@@ -1051,6 +1114,11 @@ properties:
             type: integer
             fits_keyword: NUMDTHPT
             blend_table: True
+          total_cycling_points:
+            title: Number of points in CYCLING pattern
+            type: integer
+            fits_keyword: PATTNPTS
+            blend_table: True
           dither_points:
             title: Total number of points in image dither pattern
             fits_keyword: NRIMDTPT
@@ -1060,18 +1128,18 @@ properties:
             type: string
             fits_keyword: PATTSIZE
             blend_table: True
-          subpixel_number:
-            title: Subpixel pattern number
-            type: integer
-            fits_keyword: SUBPXNUM
+          small_grid_pattern:
+            title: Name of small grid dither pattern
+            type: string
+            fits_keyword: SMGRDPAT
             blend_table: True
           subpixel_total_points:
-            title: Total number of points in subpixel pattern
+            title: Number of points in subpixel dither pattern
             type: integer
-            fits_keyword: SUBPXPNS
+            fits_keyword: SUBPXPTS
             blend_table: True
-          subpixel_dither_pattern:
-            title: subpixel dither pattern
+          subpixel_pattern:
+            title: Subpixel dither pattern type
             type: string
             fits_keyword: SUBPXPAT
             blend_table: True

--- a/jwst/datamodels/schemas/referencefile.schema.yaml
+++ b/jwst/datamodels/schemas/referencefile.schema.yaml
@@ -75,7 +75,7 @@ properties:
             type: string
             enum: [NRCA1, NRCA2, NRCA3, NRCA4, NRCALONG, NRCB1, NRCB2, NRCB3, NRCB4,
               NRCBLONG, NRS1, NRS2, ANY, MIRIMAGE, MIRIFULONG, MIRIFUSHORT,
-              NIS, GUIDER1, GUIDER2, N/A]
+              NIS, GUIDER1, GUIDER2, MULTIPLE, N/A]
             description: Detector name.
             fits_keyword: DETECTOR
 


### PR DESCRIPTION
Update datamodels schemas for all keyword changes documented in [JP-1799](https://jira.stsci.edu/browse/JP-1799), in order to keep our schemas in sync with the Keyword Dictionary.

Fixes #5610
Fixes [JP-1848](https://jira.stsci.edu/browse/JP-1848)
Fixes [JP-1849](https://jira.stsci.edu/browse/JP-1849)