### PR TITLE
Revert "Update .readthedocs.yml to use python 3.9"

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Reverts spacetelescope/jwst#5631

Well that didn't work.  Apparently RTD doesn't support python 3.9 yet.

Approve and merge this at will.