### PR TITLE
JWSTDMS-410 Asn_Lv2NRSLAMPSpectral: Break out the negative cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 associations
 ------------
 
+- JWSTDMS-410 Asn_Lv2NRSLAMPSpectral: Break out the negative cases [#5635]
+
 - Update MIRI LRS-Fixedslit ALONG-SLIT-NOD backgrounds strategies [#5620]
 
 cube_build

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -462,9 +462,19 @@ class Asn_Lv2NRSLAMPSpectral(
             Constraint(
                 [
                     DMSAttrConstraint(
-                        sources=['grating', 'opmode', 'lamp'],
-                        value='mirror|grating-only|nolamp',
-                        force_unique=False
+                        sources=['grating'],
+                        value='mirror',
+                        force_unique=False,
+                    ),
+                    DMSAttrConstraint(
+                        sources=['opmode'],
+                        value='grating-only',
+                        force_unique=False,
+                    ),
+                    DMSAttrConstraint(
+                        sources=['lamp'],
+                        value='nolamp',
+                        force_unique=False,
                     ),
                 ],
                 reduce=Constraint.notany

--- a/jwst/lib/tests/test_engdb_mock.py
+++ b/jwst/lib/tests/test_engdb_mock.py
@@ -158,7 +158,7 @@ def test_mocker_alive(db_cache):
     'mnemonic, count',
     [
         (GOOD_MNEMONIC, 1),
-        ('CAL', 40),
+        ('CAL', 14),
         ('', 2100),
     ]
 )


### PR DESCRIPTION
Original test hid bug in how the constraints were setup. New case using JW00620, which covers a number of different LAMP modes, has been added to the regression.

Note: When this PR is merged, the regression data found in `jwst-pipeline/jwstdms-420-nolamp/associations` need to replace development data `dev/associations`.