### PR TITLE
JP-1622: Combine1D should output separate extensions for each spectral order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ associations
 
 - Update MIRI LRS-Fixedslit ALONG-SLIT-NOD backgrounds strategies [#5620]
 
+combine1d
+---------
+
+- Fixed code error in combine1d, creating extensions per spectral order
+  with the same input data [#5644]
+
 cube_build
 ----------
 

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -565,8 +565,8 @@ def combine_1d_spectra(input_model, exptime_key):
 
     for order in input_spectra:
         output_spectra[order] = OutputSpectrumModel()
-        output_spectra[order].assign_wavelengths(input_spectra[spectral_order])
-        output_spectra[order].accumulate_sums(input_spectra[spectral_order])
+        output_spectra[order].assign_wavelengths(input_spectra[order])
+        output_spectra[order].accumulate_sums(input_spectra[order])
         output_spectra[order].compute_combination()
 
     for order in input_spectra:


### PR DESCRIPTION
Resolves [JP-1622](https://jira.stsci.edu/browse/JP-1622)
Resolves #5204

First PR had a code error, using an incorrect index parameter. This fix should create distinct extensions with appropriate wavelength and flux vectors.