### PR TITLE
Add overrideable remove_suffix method to Step

### DIFF
--- a/jwst/stpipe/jwst.py
+++ b/jwst/stpipe/jwst.py
@@ -10,6 +10,7 @@ from ..datamodels import ModelContainer
 from . import crds_client
 from .step import Step
 from .pipeline import Pipeline
+from ..lib.suffix import remove_suffix
 
 
 class JwstStep(Step):
@@ -104,6 +105,9 @@ class JwstStep(Step):
             datamodel.meta.cal_step._instance[cal_step] = status
 
         # TODO: standardize cal_step naming to point to the offical step name
+
+    def remove_suffix(self, name):
+        return remove_suffix(name)
 
 
 # JwstPipeline needs to inherit from Pipeline, but also

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -501,7 +501,7 @@ class Step(abc.ABC):
         str
             Separator that delimited the original suffix.
         """
-        return name
+        return name, "_"
 
     def prefetch(self, *args):
         """Prefetch reference files,  nominally called when

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -35,7 +35,6 @@ from . import utilities
 from .format_template import FormatTemplate
 
 from ..datamodels import (ModelContainer, StepParsModel)
-from ..lib.suffix import remove_suffix
 
 
 class Step(abc.ABC):
@@ -484,6 +483,25 @@ class Step(abc.ABC):
             a tuple in the form (str reference type, str reference URI).
         """
         pass
+
+    def remove_suffix(name):
+        """
+        Remove a known Step filename suffix from a filename
+        (if present).
+
+        Parameters
+        ----------
+        name : str
+            Filename.
+
+        Returns
+        -------
+        str
+            Filename with any known suffix removed.
+        str
+            Separator that delimited the original suffix.
+        """
+        return name
 
     def prefetch(self, *args):
         """Prefetch reference files,  nominally called when
@@ -987,7 +1005,7 @@ class Step(abc.ABC):
             default_name_format = '{basename}{components}{suffix_sep}{suffix}.{ext}'
             suffix_sep = None
             if suffix is not None:
-                basename, suffix_sep = remove_suffix(basename)
+                basename, suffix_sep = step.remove_suffix(basename)
             if suffix_sep is None:
                 suffix_sep = separator
         else:


### PR DESCRIPTION
This PR adds a `Step.remove_suffix` method that is then overridden in `JwstStep`.  This breaks away more JWST-specific code from the base `Step` class.