### PR TITLE
JP-1860: Fix ramp_fit counting of segments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,11 @@
 0.18.3 (unreleased)
 ===================
 
+ramp_fitting
+------------
 
-
+- Fix a bug in estimating the max number of segments that will be needed
+  to fit any pixel [#5653]
 
 
 

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -30,6 +30,9 @@ from . import utils
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+DO_NOT_USE = dqflags.group['DO_NOT_USE']
+JUMP_DET = dqflags.group['JUMP_DET']
+
 BUFSIZE = 1024 * 300000  # 300Mb cache size for data section
 
 
@@ -201,6 +204,7 @@ def ols_ramp_fit_multi(input_model, buffsize, save_opt, readnoise_2d, gain_2d,
     # Call ramp fitting for the single processor (1 data slice) case
     if number_slices == 1:
         max_segments, max_CRs = calc_num_seg(input_model.groupdq, number_of_integrations)
+        log.debug(f"Max segments={max_segments}")
         int_model, opt_model, out_model = create_output_models(input_model,
                                             number_of_integrations, save_opt, total_cols, total_rows,
                                             max_segments, max_CRs)
@@ -2941,11 +2945,10 @@ def calc_num_seg(gdq, n_int):
     max_cr = 0  # max number of CRS for all integrations
 
     # For all 2d pixels, get max number of CRs or DO_NOT_USE flags along their
-    # ramps, to use as a surrogate for the number of semiramps along the ramps
-    for nint in range(n_int):  # loop over integrations
-        gdq_cr = np.bitwise_and(gdq[nint], dqflags.group['JUMP_DET'] | dqflags.group['DO_NOT_USE'])
-        temp_max_cr = int((gdq_cr.sum(axis=0)).max())
-        max_cr = max(max_cr, temp_max_cr)
+    # ramps, to use as a surrogate for the number of segments along the ramps
+    # Note that we only care about flags that are NOT in the first or last groups,
+    # because exclusion of a first or last group won't result in an additional segment.
+    max_cr = np.count_nonzero(np.bitwise_and(gdq[:, 1:-1], JUMP_DET | DO_NOT_USE), axis=1).max()
 
     # Do not want to return a value > the number of groups, which can occur if
     #  this is a MIRI dataset in which the first or last group was flagged as

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -2940,12 +2940,12 @@ def calc_num_seg(gdq, n_int):
     """
     max_cr = 0  # max number of CRS for all integrations
 
-    # For all 2d pixels, get max number of CRs along their ramps
-    # to use as a surrogate for the number of semiramps along the ramps
+    # For all 2d pixels, get max number of CRs or DO_NOT_USE flags along their
+    # ramps, to use as a surrogate for the number of semiramps along the ramps
     for nint in range(n_int):  # loop over integrations
-        gdq_cr = np.bitwise_and( gdq[nint, :, :, :], dqflags.group['JUMP_DET'])
-        temp_max_cr = int((gdq_cr.sum(axis=0)).max()/dqflags.group['JUMP_DET'])
-        max_cr = max( max_cr, temp_max_cr )
+        gdq_cr = np.bitwise_and(gdq[nint], dqflags.group['JUMP_DET'] | dqflags.group['DO_NOT_USE'])
+        temp_max_cr = int((gdq_cr.sum(axis=0)).max())
+        max_cr = max(max_cr, temp_max_cr)
 
     # Do not want to return a value > the number of groups, which can occur if
     #  this is a MIRI dataset in which the first or last group was flagged as

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -719,13 +719,14 @@ def setup_small_cube(ngroups=10, nints=1, nrows=2, ncols=2, deltatime=10.,
 def setup_inputs(ngroups=10, readnoise=10, nints=1,
                  nrows=103, ncols=102, nframes=1, grouptime=1.0,gain=1, deltatime=1):
 
+    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
+    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
+    pixdq = np.zeros(shape=(nrows, ncols), dtype= np.uint32)
+    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint32)
-    pixdq = np.zeros(shape=(nrows, ncols), dtype= np.float64)
-    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
-    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
+    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float32)
     int_times = np.zeros((nints,))
+
     model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, int_times=int_times)
     model1.meta.instrument.name='MIRI'
     model1.meta.instrument.detector='MIRIMAGE'
@@ -764,13 +765,14 @@ def setup_subarray_inputs(ngroups=10, readnoise=10, nints=1,
                  subxsize=1024, subysize=1032, nframes=1,
                  grouptime=1.0,gain=1, deltatime=1):
 
-    times = np.array(list(range(ngroups)),dtype=np.float64) * deltatime
+    data = np.zeros(shape=(nints, ngroups, subysize, subxsize), dtype=np.float32)
+    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
+    pixdq = np.zeros(shape=(subysize, subxsize), dtype= np.uint32)
+    gdq = np.zeros(shape=(nints, ngroups, subysize, subxsize), dtype=np.uint8)
     gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-    data = np.zeros(shape=(nints, ngroups, subysize, subxsize), dtype=np.float64)
-    pixdq = np.zeros(shape=(subysize, subxsize), dtype= np.float64)
-    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
-    gdq = np.zeros(shape=(nints, ngroups, subysize, subxsize), dtype=np.int32)
+    read_noise = np.full((nrows, ncols), readnoise, dtype=np.float32)
+    times = np.array(list(range(ngroups)),dtype=np.float64) * deltatime
+
     model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
     model1.meta.instrument.name='MIRI'
     model1.meta.instrument.detector='MIRIMAGE'

--- a/jwst/ramp_fitting/tests/test_ramp_fit_cases.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_cases.py
@@ -613,7 +613,7 @@ def create_mod_arrays(ngroups, nints, nrows, ncols, deltatime, gain, readnoise):
     gain = np.ones(shape=(nrows, ncols), dtype=np.float32) * gain
     err = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    pixdq = np.zeros(shape=(nrows, ncols), dtype=np.int32)
+    pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     read_noise = np.full((nrows, ncols), readnoise, dtype=np.float32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
 


### PR DESCRIPTION
Update the function in ramp_fitting that attempts to estimate the max number of segments that will be needed to fit any pixel, given the number of CR and DO_NOT_USE flags that break up each pixel's ramp. Previously the function only looked for CR (JUMP_DET) flags, but a recent update to the saturation step allows for adding DO_NOT_USE flags to groups with values below the A-to-D floor (< 0). So now the ramp for a given pixel can be broken into multiple segments due to both JUMP_DET and DO_NOT_USE flags, so we need to check for both. Checking for only JUMP_DET was causing the data arrays to be created too small to hold data from all segments, leading to an "index out of bounds" error when trying to stuff data into the array.

Fixes #5630 / [JP-1860](https://jira.stsci.edu/browse/JP-1860)