### PR TITLE
JP-1831: white_light incorrectly rejecting int_times table for multi-segment data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,11 @@
 0.18.3 (unreleased)
 ===================
 
+white_light
+-----------
 
-
+- Fixed error causing multi-segment data to reject int_times
+  for MJDs [#5566]
 
 
 

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -93,7 +93,7 @@ def white_light(input, min_wave=None, max_wave=None):
         int_num = input.int_times['integration_number']         # one indexed
         mid_utc = input.int_times['int_mid_MJD_UTC']
         offset = int_start - int_num[0]
-        if offset < 0 or int_end >= int_num[-1]:
+        if offset < 0 or int_end > int_num[-1]:
             log.warning("Range of integration numbers in science data extends "
                         "outside the range in INT_TIMES table.")
             log.warning("Can't use INT_TIMES table.")


### PR DESCRIPTION
Resolves [JP-1831](https://jira.stsci.edu/browse/JP-1831)
Resolves #5566 

Changed a ">=" to a ">" when comparing final integration index to length of array, due to 1-indexing.