### PR TITLE
JP-1873: Fix set_telescope_pointing TSO logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ ramp_fitting
 - Fix a bug in estimating the max number of segments that will be needed
   to fit any pixel [#5653]
 
+set_telescope_pointing
+----------------------
+
+- Update the check in set_telescope_pointing that determines whether an
+  exposure is TSO mode to always consider hardwired TSO EXP_TYPEs as TSO,
+  regardless of TSOVISIT and NINTS settings. [#5657]
+
 white_light
 -----------
 
@@ -57,8 +64,8 @@ outlier_detection
 set_telescope_pointing
 ----------------------
 
-- Updated to populate XREF_SCI, YREF_SCI keywords for all TSO exposures,
-  not just NRC_TSGRISM mode. [#5616]
+- Updated to populate XREF_SCI, YREF_SCI keywords for all exposures with
+  TSOVISIT=True, not just NRC_TSGRISM mode. [#5616]
 
 0.18.1 (2021-01-08)
 ===================

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -12,7 +12,6 @@ import numpy as np
 
 from ..assign_wcs.util import update_s_region_keyword, calc_rotation_matrix
 from ..assign_wcs.pointing import v23tosky
-from ..associations.lib.dms_base import TSO_EXP_TYPES
 from ..datamodels import Level1bModel
 from ..lib.engdb_tools import ENGDB_Service
 from ..lib.pipe_utils import is_tso
@@ -1523,7 +1522,7 @@ def populate_model_from_siaf(model, siaf):
     # a check on EXP_TYPE, because there are rare corner cases
     # where EXP_TIME=NRC_TSGRISM, TSOVISIT=False, NINTS=1, which
     # normally return False, but we want to treat it as TSO anyway.
-    if is_tso(model) or model.meta.exposure.type.lower() in TSO_EXP_TYPES:
+    if is_tso(model) or model.meta.exposure.type.lower() in ['nrc_tsimage', 'nrc_tsgrism']:
         logger.info('TSO exposure:')
         logger.info(' setting xref_sci to {}'.format(siaf.crpix1))
         logger.info(' setting yref_sci to {}'.format(siaf.crpix2))

--- a/jwst/lib/tests/test_pipe_utils.py
+++ b/jwst/lib/tests/test_pipe_utils.py
@@ -54,12 +54,16 @@ def test_is_tso_nrcgrism_nints1():
     model.meta.exposure.type = "NRC_TSGRISM"
     model.meta.visit.tsovisit = False
     model.meta.exposure.nints = 10
-    assert pipe_utils.is_tso(model) is True
 
+    # with NINTS>1, should be True
+    assert pipe_utils.is_tso(model)
+
+    # with NINTS=1, should be False
     model.meta.exposure.nints = 1
-    assert pipe_utils.is_tso(model) is False
+    assert not pipe_utils.is_tso(model)
 
-    assert (is_tso(model) or model.meta.exposure.type.lower() in dms_base.TSO_EXP_TYPES) is True
+    # with hardwired TSO EXP_TYPE's, should always be True
+    assert (is_tso(model) or model.meta.exposure.type.lower() in dms_base.TSO_EXP_TYPES)
 
 
 def test_is_irs2_1():

--- a/jwst/lib/tests/test_pipe_utils.py
+++ b/jwst/lib/tests/test_pipe_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 from jwst.lib import pipe_utils
 from jwst import datamodels
 from jwst.associations.lib import dms_base
+from jwst.lib.pipe_utils import is_tso
 
 all_exp_types = dms_base.IMAGE2_NONSCIENCE_EXP_TYPES + \
             dms_base.IMAGE2_SCIENCE_EXP_TYPES + \
@@ -45,6 +46,20 @@ def test_is_tso_from_tsoflag(tsovisit, expected):
     model = datamodels.JwstDataModel()
     model.meta.visit.tsovisit = tsovisit
     assert pipe_utils.is_tso(model) is expected
+
+
+def test_is_tso_nrcgrism_nints1():
+    """Test is_tso with NRC_TSGRISM and NINTS=1"""
+    model = datamodels.JwstDataModel()
+    model.meta.exposure.type = "NRC_TSGRISM"
+    model.meta.visit.tsovisit = False
+    model.meta.exposure.nints = 10
+    assert pipe_utils.is_tso(model) is True
+
+    model.meta.exposure.nints = 1
+    assert pipe_utils.is_tso(model) is False
+
+    assert (is_tso(model) or model.meta.exposure.type.lower() in dms_base.TSO_EXP_TYPES) is True
 
 
 def test_is_irs2_1():

--- a/jwst/lib/tests/test_pipe_utils.py
+++ b/jwst/lib/tests/test_pipe_utils.py
@@ -63,7 +63,7 @@ def test_is_tso_nrcgrism_nints1():
     assert not pipe_utils.is_tso(model)
 
     # with hardwired TSO EXP_TYPE's, should always be True
-    assert (is_tso(model) or model.meta.exposure.type.lower() in dms_base.TSO_EXP_TYPES)
+    assert (is_tso(model) or model.meta.exposure.type.lower() in ['nrc_tsimage', 'nrc_tsgrism'])
 
 
 def test_is_irs2_1():


### PR DESCRIPTION
Updated the TSO check in set_telescope_pointing to use a combination of the `is_tso()` function and EXP_TYPE values, instead of relying solely on the value of TSOVISIT. This handles corner cases that have TSOVISIT=False and NINTS=1, which would normally come back as False for the TSO test, to come back as True when EXP_TYPE is a hardwired TSO mode.

Fixes #5656 / [JP-1873](https://jira.stsci.edu/browse/JP-1873)