### PR TITLE
Add basic installation instructions to docs landing page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.18.3 (2021-01-25)
 ===================
 
+- Update documentation introduction to include installation and CRDS setup
+  instructions. [#5659]
+
 combine1d
 ---------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
-0.18.3 (unreleased)
+0.18.3 (2021-01-25)
 ===================
+
+combine1d
+---------
+
+- Fixed code error in combine1d, creating extensions per spectral order
+  with the same input data [#5644]
 
 ramp_fitting
 ------------
@@ -30,12 +36,6 @@ associations
 - JWSTDMS-410 Asn_Lv2NRSLAMPSpectral: Break out the negative cases [#5635]
 
 - Update MIRI LRS-Fixedslit ALONG-SLIT-NOD backgrounds strategies [#5620]
-
-combine1d
----------
-
-- Fixed code error in combine1d, creating extensions per spectral order
-  with the same input data [#5644]
 
 cube_build
 ----------

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can also install a specific version (from `jwst 0.17.0` onward):
 
     conda create -n <env_name> python
     conda activate <env_name>
-    pip install jwst==0.18.2
+    pip install jwst==0.18.3
 
 Installing specific versions before `jwst 0.17.0` need to be installed from Github:
 
@@ -192,6 +192,7 @@ contact the [JWST Help Desk](https://jwsthelp.stsci.edu).
 
 | jwst tag | DMS build | CRDS_CONTEXT |   Date     |          Notes                                |
 | -------- | --------- | ------------ | ---------- | ----------------------------------------------|
+|  0.18.3  | B7.7      | 0670         | 01/25/2021 | Final release candidate for B7.7              |
 |  0.18.2  | B7.7rc3   | 0668         | 01/19/2021 | Third release candidate for B7.7              |
 |  0.18.1  | B7.7rc2   | 0664         | 01/08/2021 | Second release candidate for B7.7             |
 |  0.18.0  | B7.7rc1   | 0645         | 12/21/2020 | First release candidate for B7.7              |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,48 @@
 
 :ref:`genindex`  |  :ref:`modindex`
 
+============
+Installation
+============
+
+
+Stable releases of the ``jwst`` package are registered at
+`PyPI <https://pypi.org/project/jwst/>`_. The latest released version can be
+installed into a fresh virtualenv or conda environment using pip:
+
+::
+
+   pip install jwst
+
+Installation details (via conda)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``jwst`` package should be installed into a virtualenv or conda
+environment via ``pip``. We recommend that for each installation you
+start by creating a fresh environment that only has Python installed and
+then install the ``jwst`` package into that bare environment.
+
+If using conda environments, first make sure you have a
+recent version of Anaconda or Miniconda installed.
+
+Installation is generally a 3-step process:
+
+-  Create a conda environment
+-  Activate that environment
+-  Install the ``jwst`` package into that environment
+
+In a bash-compatible shell:
+
+::
+
+   conda create -n <env_name> python
+   conda activate <env_name>
+   pip install jwst
+
+For more detailed instructions and alternate installation methods see
+`our Github README <https://github.com/spacetelescope/jwst>`_.
+
+
 ===========
 User Manual
 ===========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ installed into a fresh virtualenv or conda environment using pip:
    pip install jwst
 
 Installation details (via conda)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 
 The ``jwst`` package should be installed into a virtualenv or conda
 environment via ``pip``. We recommend that for each installation you
@@ -42,8 +42,22 @@ In a bash-compatible shell:
    conda activate <env_name>
    pip install jwst
 
-For more detailed instructions and alternate installation methods see
-`our Github README <https://github.com/spacetelescope/jwst>`_.
+For more detailed instructions and alternate installation methods see the
+`Github README <https://github.com/spacetelescope/jwst>`_.
+
+
+Calibration References Data System (CRDS) Setup
+-----------------------------------------------
+
+CRDS is the system that manages the reference files needed to run the
+pipeline. Inside the STScI network, the pipeline works with default CRDS
+setup with no modifications. To run the pipeline outside the STScI
+network, CRDS must be configured by setting two environment variables:
+
+::
+
+   export CRDS_PATH=$HOME/crds_cache
+   export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
 
 
 ===========


### PR DESCRIPTION
Update CHANGES.rst and README.md for 0.18.3 release.

Docs landing page now has an installation section at the top:

<img width="791" alt="Screen Shot 2021-01-24 at 3 18 51 PM" src="https://user-images.githubusercontent.com/17088869/105642412-861ac880-5e57-11eb-9af7-c1677ae8ba6e.png">


Resolves #5617 / [JP-1851](https://jira.stsci.edu/browse/JP-1851)