### PR TITLE
MNT: action-skip-ci has moved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run_next: ${{ steps.skip_ci_step.outputs.run_next }}
     steps:
     - name: Set output for skip CI
-      uses: pllim/action-skip-ci@main
+      uses: OpenAstronomy/action-skip-ci@main
       id: skip_ci_step
       with:
         NO_FAIL: true


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to because `action-skip-ci` has moved to a proper organization! You can report issues to @pllim.

xref OpenAstronomy/action-skip-ci#8