### PR TITLE
TST: Action needs long hash now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # This should only run if we did not skip CI
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@ce17749
+      uses: styfle/cancel-workflow-action@ce177499ccf9fd2aded3b0426c97e5434c2e8a73
       if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Action needs long hash now. https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions

You merged #5675 too fast... 😆 