### PR TITLE
JP-1667: Update documentation for optimal weighting in ramp_fitting Pt. 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ lib
 ramp_fitting
 ------------
 
-- Update documentation to define optimal weighting algorithm [#5676]
+- Update documentation to define optimal weighting algorithm [#5682]
 
 set_telescope_pointing
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,23 +5,28 @@ datamodels
 ----------
 
 - Updated keyword_readpatt, core, preadpatt schemas for new MIRI detector
-  readout patterns 'FASTR1', 'FASTR100' and 'SLOWR1' [#5667]
+  readout patterns 'FASTR1', 'FASTR100' and 'SLOWR1' [#5670]
 
 lib
 ---
 
-- Make EngDB_Value public for JSDP use [#5663]
+- Make EngDB_Value public for JSDP use [#5669]
+
+ramp_fitting
+------------
+
+- Update documentation to define optimal weighting algorithm [#5676]
 
 set_telescope_pointing
 ----------------------
 
-- Make get_wcs_values_from_siaf public for JSDP use [#5663]
+- Make get_wcs_values_from_siaf public for JSDP use [#5669]
 
 srctype
 -------
 
 - Changed default SRCTYPE for non-primary NIRSpec slits in a FIXEDSLIT
-  exposure to 'EXTENDED' rather than 'POINT' [#5668]
+  exposure to 'EXTENDED' rather than 'POINT' [#5671]
 
 
 0.18.3 (2021-01-25)

--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -131,10 +131,53 @@ is the following: the type of noise (when appropriate) will appear as the supers
 and the form of the data will appear as the subscript: ‘s’, ‘i’, ‘o’ for segment,
 integration, or overall (for the entire dataset), respectively.
 
+Optimal Weighting Algorithm
+---------------------------
+The slope of each segment is calculated using the least-squares method with optimal
+weighting, as described by Fixsen et al. 2000, PASP, 112, 1350; Regan 2007,
+JWST-STScI-001212. Optimal weighting determines the relative weighting of each sample
+when calculating the least-squares fit to the ramp. When the data have low signal-to-noise
+ratio :math:`S`, the data are read noise dominated and equal weighting of samples is the
+best approach. In the high signal-to-noise regime, data are Poisson-noise dominated and
+the least-squares fit is calculated with the first and last samples. In most practical
+cases, the data will fall somewhere in between, where the weighting is scaled between the
+two extremes.
+
+The signal-to-noise ratio :math:`S` used for weighting selection is calculated from the
+last sample as:
+
+.. math::
+    S = \frac{data \times gain} { \sqrt{(read\_noise)^2} + (data \times gain) } \,,
+
+The weighting for a sample :math:`i` is given as:
+
+.. math::
+    w_i = (i - i_{midpoint})^P \,,
+
+where :math:`i_{midpoint}` is the the sample number of the midpoint of the sequence, and
+:math:`P` is the exponent applied to weights, determined by the value of :math:`S`. Fixsen
+et al. 2000 found that defining a small number of P values to apply to values of S was
+sufficient; they are given as:
+
++-------------------+------------------------+----------+
+| Minimum S         | Maximum S              | P        |
++===================+========================+==========+
+| 0                 | 5                      | 0        |
++-------------------+------------------------+----------+
+| 5                 | 10                     | 0.4      |
++-------------------+------------------------+----------+
+| 10                | 20                     | 1        |
++-------------------+------------------------+----------+
+| 20                | 50                     | 3        |
++-------------------+------------------------+----------+
+| 50                | 100                    | 6        |
++-------------------+------------------------+----------+
+| 100               |                        | 10       |
++-------------------+------------------------+----------+
+
 Segment-specific Computations:
 ------------------------------
-The slope of each segment is calculated using the least-squares method with optimal
-weighting. The variance of the slope of a segment due to read noise is:
+The variance of the slope of a segment due to read noise is:
 
 .. math::  
    var^R_{s} = \frac{12 \ R^2 }{ (ngroups_{s}^3 - ngroups_{s})(tgroup^2) } \,,


### PR DESCRIPTION
Resolves [JP-1667](https://jira.stsci.edu/browse/JP-1667)
Resolves #5300 

Added an explanation of the optimal weighting algorithm to the documentation for the ramp_fitting step.

Also fixing bad PR numbers in changelog for older tickets.