### PR TITLE
JP-1880: added source_type, x & y extraction center to extracted 1d spec for IFU data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ datamodels
 - Updated keyword_readpatt, core, preadpatt schemas for new MIRI detector
   readout patterns 'FASTR1', 'FASTR100' and 'SLOWR1' [#5667]
 
-- Added extr_x and extr_y to multispec and slitmeta. These values are center
+- Added extr_x and extr_y to multispec datamodel. These values are center
   of extraction region for IFU data [#5685]
 
 extract_1d

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,14 @@ datamodels
 - Updated keyword_readpatt, core, preadpatt schemas for new MIRI detector
   readout patterns 'FASTR1', 'FASTR100' and 'SLOWR1' [#5667]
 
+- Added extr_x and extr_y to multispec and slitmeta. These values are center
+  of extraction region for IFU data [#5685]
+
+extract_1d
+----------
+
+- Adding writing SRCTYPE, EXTR_X, and EXTR_Y to extracted spec for IFU data [#5685]
+
 lib
 ---
 

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -74,6 +74,18 @@ allOf:
             type: number
             fits_keyword: SRCDEC
             fits_hdu: EXTRACT1D
+          extr_x:
+            title: X center of extraction region
+            type: number
+            default: 0.0
+            fits_keyword: EXTR_X
+            fits_hdu: EXTRACT1D
+          extr_y:
+            title: Y center of extraction region
+            type: number
+            default: 0.0
+            fits_keyword: EXTR_Y
+            fits_hdu: EXTRACT1D
           shutter_state:
             title: All (open and close) shutters in a slit
             type: string

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -74,16 +74,14 @@ allOf:
             type: number
             fits_keyword: SRCDEC
             fits_hdu: EXTRACT1D
-          extr_x:
+          extraction_x:
             title: X center of extraction region
             type: number
-            default: 0.0
             fits_keyword: EXTR_X
             fits_hdu: EXTRACT1D
-          extr_y:
+          extraction_y:
             title: Y center of extraction region
             type: number
-            default: 0.0
             fits_keyword: EXTR_Y
             fits_hdu: EXTRACT1D
           shutter_state:

--- a/jwst/datamodels/schemas/slitmeta.schema.yaml
+++ b/jwst/datamodels/schemas/slitmeta.schema.yaml
@@ -79,6 +79,18 @@ properties:
     default: 0.0
     fits_keyword: SRCYPOS
     fits_hdu: SCI
+  extr_x:
+    title: X center of extraction region
+    type: number
+    default: 0.0
+    fits_keyword: EXTR_X
+    fits_hdu: SCI
+  extr_y:
+    title: Y center of extraction region
+    type: number
+    default: 0.0
+    fits_keyword: EXTR_Y
+    fits_hdu: SCI
   shutter_state:
     title: All (open and closed) shutters in a slit
     type: string

--- a/jwst/datamodels/schemas/slitmeta.schema.yaml
+++ b/jwst/datamodels/schemas/slitmeta.schema.yaml
@@ -79,18 +79,6 @@ properties:
     default: 0.0
     fits_keyword: SRCYPOS
     fits_hdu: SCI
-  extr_x:
-    title: X center of extraction region
-    type: number
-    default: 0.0
-    fits_keyword: EXTR_X
-    fits_hdu: SCI
-  extr_y:
-    title: Y center of extraction region
-    type: number
-    default: 0.0
-    fits_keyword: EXTR_Y
-    fits_hdu: SCI
   shutter_state:
     title: All (open and closed) shutters in a slit
     type: string

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -156,7 +156,10 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background, apcor
     if slitname is not None and slitname != "ANY":
         spec.name = slitname
 
-    copy_keyword_info_ifu(source_type, x_center, y_center, slitname, spec)
+    spec.source_type = source_type
+    spec.extraction_x = x_center
+    spec.extraction_y = y_center
+        
     if source_type == 'POINT' and apcorr_ref_model is not None:
         log.info('Applying Aperture correction.')
 
@@ -1078,24 +1081,3 @@ def shift_ref_image(mask, delta_y, delta_x, fill=0):
     return temp
 
 
-def copy_keyword_info_ifu( source_type, x_center, y_center, slitname , spec: SpecModel):
-    """Copy metadata from the input IFU cube to the output spectrum.
-
-    Parameters
-    ----------
-    input_model : An IFUCubeM object
-        Metadata will be copied from the input IFUcube to output `spec`.
-
-    slitname : str or None
-        The name of the slit.
-
-    spec : One element of MultiSpecModel.spec
-        Metadata attributes will be updated in-place.
-
-    """
-    if slitname is not None and slitname != "ANY":
-        spec.name = slitname
-
-    spec.source_type = source_type
-    spec.extr_x = x_center
-    spec.extr_y = y_center

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -82,7 +82,7 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background, apcor
     input_units_are_megajanskys = (source_type == 'POINT' and instrument == 'NIRSPEC')
 
     output_model = datamodels.MultiSpecModel()
-    output_model.update(input_model)
+    output_model.update(input_model, only="PRIMARY")
 
     slitname = input_model.meta.exposure.type
     if slitname is None:
@@ -159,8 +159,7 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background, apcor
     spec.source_type = source_type
     spec.extraction_x = x_center
     spec.extraction_y = y_center
-    print('parameters',spec.source_type,spec.extraction_x, spec.extraction_y)
-          
+
     if source_type == 'POINT' and apcorr_ref_model is not None:
         log.info('Applying Aperture correction.')
 

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -159,7 +159,7 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background, apcor
     spec.source_type = source_type
     spec.extraction_x = x_center
     spec.extraction_y = y_center
-        
+
     if source_type == 'POINT' and apcorr_ref_model is not None:
         log.info('Applying Aperture correction.')
 
@@ -1079,5 +1079,3 @@ def shift_ref_image(mask, delta_y, delta_x, fill=0):
     temp[..., oslice_y, oslice_x] = mask[..., islice_y, islice_x]
 
     return temp
-
-

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -9,7 +9,7 @@ from .apply_apcorr import select_apcorr
 from ..assign_wcs.util import compute_scale
 
 from .. import datamodels
-from ..datamodels import dqflags, SpecModel
+from ..datamodels import dqflags
 
 from . import spec_wcs
 from scipy.interpolate import interp1d

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -102,7 +102,8 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background, apcor
              radius_match, x_center, y_center) = \
                     extract_ifu(input_model, source_type, extract_params)
         else:                                   # FILE_TYPE_IMAGE
-            (ra, dec, wavelength, temp_flux, background, npixels, dq, npixels_bkg, x_center, y_center) = \
+            (ra, dec, wavelength, temp_flux, background, npixels, dq, npixels_bkg,
+             x_center, y_center) = \
                     image_extract_ifu(input_model, source_type, extract_params)
     else:
         log.critical('Missing extraction parameters.')
@@ -797,7 +798,7 @@ def image_extract_ifu(input_model, source_type, extract_params):
     (wavelength, temp_flux, background, npixels, dq, n_bkg) = \
         nans_in_wavelength(wavelength, temp_flux, background, npixels, dq, n_bkg)
 
-    return (ra, dec, wavelength, temp_flux, background, npixels, dq, n_bkg)
+    return (ra, dec, wavelength, temp_flux, background, npixels, dq, n_bkg, x_center, y_center)
 
 
 def get_coordinates(input_model, x0, y0):

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -159,7 +159,8 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background, apcor
     spec.source_type = source_type
     spec.extraction_x = x_center
     spec.extraction_y = y_center
-
+    print('parameters',spec.source_type,spec.extraction_x, spec.extraction_y)
+          
     if source_type == 'POINT' and apcorr_ref_model is not None:
         log.info('Applying Aperture correction.')
 


### PR DESCRIPTION
This address JP-1880 - adding SRCTYPE to x1d products for IFU data. In addition, the datamodels.multispec was added updated to include the x and y center of the extraction region:  extraction_x & extraction_y. 

Fixes #5674 / [JP-1880](https://jira.stsci.edu/browse/JP-1880)