### PR TITLE
JP-1667: Typo in documentation math

### DIFF
--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -147,7 +147,7 @@ The signal-to-noise ratio :math:`S` used for weighting selection is calculated f
 last sample as:
 
 .. math::
-    S = \frac{data \times gain} { \sqrt{(read\_noise)^2} + (data \times gain) } \,,
+    S = \frac{data \times gain} { \sqrt{(read\_noise)^2 + (data \times gain) } } \,,
 
 The weighting for a sample :math:`i` is given as:
 


### PR DESCRIPTION
Resolves [JP-1667](https://jira.stsci.edu/browse/JP-1667)

Re: [this page.](https://jwst-pipeline.readthedocs.io/en/latest/jwst/ramp_fitting/description.html)

Needed to make my square root longer.

