### PR TITLE
Update TestDescriptionPlugin docstring

### DIFF
--- a/jwst/conftest.py
+++ b/jwst/conftest.py
@@ -81,13 +81,11 @@ def pytest_configure(config):
     config.pluginmanager.register(TestDescriptionPlugin(terminal_reporter), 'testdescription')
 
 class TestDescriptionPlugin:
-    """
-    TestDescriptionPlugin: When pytests are run with the -vv or -vvv options, this plug-in 
-    prints the docstring for the test. Otherwise, when run as a simple pytest or with the 
-    -v option, there is no change in behavior. This plug-in was added to support JWST 
-    instrument team testing and reporting for the JWST calibration pipeline. 
-    """    
+    """Pytest plugin to print the test docstring when `pytest -vv` is used.
 
+    This plug-in was added to support JWST instrument team testing and
+    reporting for the JWST calibration pipeline.
+    """
     def __init__(self, terminal_reporter):
         self.terminal_reporter = terminal_reporter
         self.desc = None


### PR DESCRIPTION
Missed that there was trailing whitespace in the docstring, causing a failing `flake8` check on master branch.  Fixing and making the docstring a bit cleaner.

A follow-on to #5680