### PR TITLE
JP-1805 Fix premature model closing in group_scale_step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ extract_1d
 - Fixed bug in background region fitting for image columns/rows that have zero weight
   for all pixels [#5696]
 
+group_scale
+-----------
+
+- Fix premature model closing in group_scale_step [#5692]
+
 lib
 ---
 

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def do_correction(input_model):
+def do_correction(model):
     """
     Short Summary
     -------------
@@ -22,34 +22,26 @@ def do_correction(input_model):
 
     Parameters
     ----------
-    input_model: data model object
-        science data to be corrected
-
-    Returns
-    -------
-    output_model: data model object
-        rescaled science data
-
+    model: data model object
+        science data to be corrected. Model is modified in place
+        but also returned.
     """
 
     # Get the meta data values that we need
-    nframes = input_model.meta.exposure.nframes
-    frame_divisor = input_model.meta.exposure.frame_divisor
+    nframes = model.meta.exposure.nframes
+    frame_divisor = model.meta.exposure.frame_divisor
     if (nframes is None) or (frame_divisor is None):
         log.warning('Necessary meta data not found')
         log.warning('Step will be skipped')
-        input_model.meta.cal_step.group_scale = 'SKIPPED'
-        return input_model
-
-    # Create output as a copy of the input science data model
-    output_model = input_model.copy()
+        model.meta.cal_step.group_scale = 'SKIPPED'
+        return
 
     log.info('NFRAMES={}, FRMDIVSR={}'.format(nframes, frame_divisor))
     log.info('Rescaling all groups by {}/{}'.format(frame_divisor, nframes))
 
     # Apply the rescaling to the entire data array
     scale = float(frame_divisor) / nframes
-    output_model.data *= scale
-    output_model.meta.cal_step.group_scale = 'COMPLETE'
+    model.data *= scale
+    model.meta.cal_step.group_scale = 'COMPLETE'
 
-    return output_model
+    return

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -23,8 +23,7 @@ def do_correction(model):
     Parameters
     ----------
     model: data model object
-        science data to be corrected. Model is modified in place
-        but also returned.
+        science data to be corrected. Model is modified in place.
     """
 
     # Get the meta data values that we need

--- a/jwst/group_scale/group_scale_step.py
+++ b/jwst/group_scale/group_scale_step.py
@@ -52,6 +52,6 @@ class GroupScaleStep(Step):
                 return result
 
             # Do the scaling
-            result = group_scale.do_correction(result)
+            group_scale.do_correction(result)
 
         return result

--- a/jwst/group_scale/group_scale_step.py
+++ b/jwst/group_scale/group_scale_step.py
@@ -18,18 +18,21 @@ class GroupScaleStep(Step):
         # Open the input data model
         with datamodels.RampModel(input) as input_model:
 
+            # Always work on a copy
+            result = input_model.copy()
+
             # Try to get values of NFRAMES and FRMDIVSR to see
             # if we need to do any rescaling
-            nframes = input_model.meta.exposure.nframes
-            frame_divisor = input_model.meta.exposure.frame_divisor
+            nframes = result.meta.exposure.nframes
+            frame_divisor = result.meta.exposure.frame_divisor
 
             # If we didn't find NFRAMES, we don't have enough info
             # to continue. Skip the step.
             if nframes is None:
                 self.log.warning('NFRAMES value not found')
                 self.log.warning('Step will be skipped')
-                input_model.meta.cal_step.group_scale = 'SKIPPED'
-                return input_model
+                result.meta.cal_step.group_scale = 'SKIPPED'
+                return result
 
             # If we didn't find FRMDIVSR, then check to see if NFRAMES
             # is a power of 2. If it is, rescaling isn't needed.
@@ -37,18 +40,18 @@ class GroupScaleStep(Step):
                 if (nframes & (nframes - 1) == 0):
                     self.log.info('NFRAMES={} is a power of 2; correction not needed'.format(nframes))
                     self.log.info('Step will be skipped')
-                    input_model.meta.cal_step.group_scale = 'SKIPPED'
-                    return input_model
+                    result.meta.cal_step.group_scale = 'SKIPPED'
+                    return result
 
             # Compare NFRAMES and FRMDIVSR. If they're equal,
             # rescaling isn't needed.
             elif (nframes == frame_divisor):
                 self.log.info('NFRAMES and FRMDIVSR are equal; correction not needed')
                 self.log.info('Step will be skipped')
-                input_model.meta.cal_step.group_scale = 'SKIPPED'
-                return input_model
+                result.meta.cal_step.group_scale = 'SKIPPED'
+                return result
 
             # Do the scaling
-            result = group_scale.do_correction(input_model)
+            result = group_scale.do_correction(result)
 
         return result

--- a/jwst/group_scale/tests/test_group_scale.py
+++ b/jwst/group_scale/tests/test_group_scale.py
@@ -14,9 +14,9 @@ def test_nframes_or_frame_divisor_is_none(make_rampmodel):
     Here I am just setting nframes=None
     """
     datmod = make_rampmodel(2, None, 4, 2048, 2048)
-    output = do_correction(datmod)
+    do_correction(datmod)
 
-    assert(output.meta.cal_step.group_scale == 'SKIPPED')
+    assert(datmod.meta.cal_step.group_scale == 'SKIPPED')
 
 
 def test_nframes_equal_frame_divisor(make_rampmodel):

--- a/jwst/regtest/test_miri_dark.py
+++ b/jwst/regtest/test_miri_dark.py
@@ -6,15 +6,19 @@ from jwst.stpipe import Step
 
 
 @pytest.mark.bigdata
-def test_miri_dark_pipeline(_jail, rtdata, fitsdiff_default_kwargs):
-    rtdata.get_data("miri/image/jw00001001001_01101_00001_mirimage_uncal.fits")
+@pytest.mark.parametrize(
+    'exposure',
+    ['jw00001001001_01101_00001_mirimage', 'jw02201001001_01101_00001_MIRIMAGE']
+)
+def test_miri_dark_pipeline(exposure, _jail, rtdata, fitsdiff_default_kwargs):
+    rtdata.get_data(f"miri/image/{exposure}_uncal.fits")
 
     collect_pipeline_cfgs("config")
     args = ["config/calwebb_dark.cfg", rtdata.input]
     Step.from_cmdline(args)
-    rtdata.output = "jw00001001001_01101_00001_mirimage_dark.fits"
+    rtdata.output = f"{exposure}_dark.fits"
 
-    rtdata.get_truth("truth/test_miri_dark_pipeline/jw00001001001_01101_00001_mirimage_dark.fits")
+    rtdata.get_truth(f"truth/test_miri_dark_pipeline/{exposure}_dark.fits")
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()


### PR DESCRIPTION
Partially resolves [JP-1805](https://jira.stsci.edu/browse/JP-1805)
Blocked by [AL-456](https://jira.stsci.edu/browse/AL-456)

Main issue is inappropriate context manager usage in `group_scale_step`.

Secondary issue is that `stdatamodels.model_base.DataModel` does not manage opened file resources across shallow copies.