### PR TITLE
Add entry point for registering lists of step classes and implement Step.class_alias

### DIFF
--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -26,6 +26,8 @@ class Ami3Pipeline(Pipeline):
     ami_normalize (normalize results by reference target)
     """
 
+    class_alias = "calwebb_ami3"
+
     spec = """
         save_averages = boolean(default=False)
     """

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -29,6 +29,8 @@ class Coron3Pipeline(Pipeline):
 
     """
 
+    class_alias = "calwebb_coron3"
+
     spec = """
         suffix = string(default='i2d')
     """

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -33,6 +33,8 @@ class DarkPipeline(Pipeline):
 
     """
 
+    class_alias = "calwebb_dark"
+
     # Define aliases to steps
     step_defs = {'group_scale': group_scale_step.GroupScaleStep,
                  'dq_init': dq_init_step.DQInitStep,

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -37,6 +37,8 @@ class Detector1Pipeline(Pipeline):
     ramp_fit, and gain_scale.
     """
 
+    class_alias = "calwebb_detector1"
+
     spec = """
         save_calibrated_ramp = boolean(default=False)
     """

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -22,6 +22,8 @@ class GuiderPipeline(Pipeline):
     Included steps are: dq_init, guider_cds, and flat_field.
     """
 
+    class_alias = "calwebb_guider"
+
     # Define aliases to steps
     step_defs = {'dq_init': dq_init_step.DQInitStep,
                  'guider_cds': guider_cds_step.GuiderCdsStep,

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -26,6 +26,8 @@ class Image2Pipeline(Pipeline):
     background_subtraction, assign_wcs, flat_field, photom and resample.
     """
 
+    class_alias = "calwebb_image2"
+
     spec = """
         save_bsub = boolean(default=False) # Save background-subracted science
     """

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -26,6 +26,8 @@ class Image3Pipeline(Pipeline):
         source_catalog
     """
 
+    class_alias = "calwebb_image3"
+
     spec = """
     """
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -48,6 +48,8 @@ class Spec2Pipeline(Pipeline):
     resample_spec, cube_build, and extract_1d.
     """
 
+    class_alias = "calwebb_spec2"
+
     spec = """
         save_bsub = boolean(default=False)        # Save background-subracted science
         fail_on_exception = boolean(default=True) # Fail if any product fails.

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -43,6 +43,8 @@ class Spec3Pipeline(Pipeline):
     1-D spectral combination (combine_1d)
     """
 
+    class_alias = "calwebb_spec3"
+
     spec = """
     """
 

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -29,6 +29,8 @@ class Tso3Pipeline(Pipeline):
         * white_light
     """
 
+    class_alias = "calwebb_tso3"
+
     spec = """
         scale_detection = boolean(default=False)
     """

--- a/jwst/step.py
+++ b/jwst/step.py
@@ -1,0 +1,120 @@
+from .ami.ami_analyze_step import AmiAnalyzeStep
+from .ami.ami_average_step import AmiAverageStep
+from .ami.ami_normalize_step import AmiNormalizeStep
+from .assign_mtwcs.assign_mtwcs_step import AssignMTWcsStep
+from .assign_wcs.assign_wcs_step import AssignWcsStep
+from .background.subtract_images_step import SubtractImagesStep
+from .background.background_step import BackgroundStep
+from .barshadow.barshadow_step import BarShadowStep
+from .combine_1d.combine_1d_step import Combine1dStep
+from .coron.stack_refs_step import StackRefsStep
+from .coron.align_refs_step import AlignRefsStep
+from .coron.klip_step import KlipStep
+from .coron.hlsp_step import HlspStep
+from .cube_build.cube_build_step import CubeBuildStep
+from .cube_skymatch.cube_skymatch_step import CubeSkyMatchStep
+from .dark_current.dark_current_step import DarkCurrentStep
+from .dq_init.dq_init_step import DQInitStep
+from .extract_1d.extract_1d_step import Extract1dStep
+from .extract_2d.extract_2d_step import Extract2dStep
+from .firstframe.firstframe_step import FirstFrameStep
+from .flatfield.flat_field_step import FlatFieldStep
+from .fringe.fringe_step import FringeStep
+from .gain_scale.gain_scale_step import GainScaleStep
+from .group_scale.group_scale_step import GroupScaleStep
+from .guider_cds.guider_cds_step import GuiderCdsStep
+from .imprint.imprint_step import ImprintStep
+from .ipc.ipc_step import IPCStep
+from .jump.jump_step import JumpStep
+from .lastframe.lastframe_step import LastFrameStep
+from .linearity.linearity_step import LinearityStep
+from .master_background.master_background_step import MasterBackgroundStep
+from .master_background.master_background_nrs_slits_step import MasterBackgroundNrsSlitsStep
+from .mrs_imatch.mrs_imatch_step import MRSIMatchStep
+from .msaflagopen.msaflagopen_step import MSAFlagOpenStep
+from .outlier_detection.outlier_detection_step import OutlierDetectionStep
+from .outlier_detection.outlier_detection_scaled_step import OutlierDetectionScaledStep
+from .outlier_detection.outlier_detection_stack_step import OutlierDetectionStackStep
+from .pathloss.pathloss_step import PathLossStep
+from .persistence.persistence_step import PersistenceStep
+from .photom.photom_step import PhotomStep
+from .ramp_fitting.ramp_fit_step import RampFitStep
+from .refpix.refpix_step import RefPixStep
+from .resample.resample_step import ResampleStep
+from .resample.resample_spec_step import ResampleSpecStep
+from .reset.reset_step import ResetStep
+from .rscd.rscd_step import RscdStep
+from .rscd.rscd_step import RSCD_Step
+from .saturation.saturation_step import SaturationStep
+from .skymatch.skymatch_step import SkyMatchStep
+from .source_catalog.source_catalog_step import SourceCatalogStep
+from .srctype.srctype_step import SourceTypeStep
+from .straylight.straylight_step import StraylightStep
+from .superbias.superbias_step import SuperBiasStep
+from .tso_photometry.tso_photometry_step import TSOPhotometryStep
+from .tweakreg.tweakreg_step import TweakRegStep
+from .wavecorr.wavecorr_step import WavecorrStep
+from .wfs_combine.wfs_combine_step import WfsCombineStep
+from .white_light.white_light_step import WhiteLightStep
+
+
+__all__ = [
+    "AmiAnalyzeStep",
+    "AmiAverageStep",
+    "AmiNormalizeStep",
+    "AssignMTWcsStep",
+    "AssignWcsStep",
+    "SubtractImagesStep",
+    "BackgroundStep",
+    "BarShadowStep",
+    "Combine1dStep",
+    "StackRefsStep",
+    "AlignRefsStep",
+    "KlipStep",
+    "HlspStep",
+    "CubeBuildStep",
+    "CubeSkyMatchStep",
+    "DarkCurrentStep",
+    "DQInitStep",
+    "Extract1dStep",
+    "Extract2dStep",
+    "FirstFrameStep",
+    "FlatFieldStep",
+    "FringeStep",
+    "GainScaleStep",
+    "GroupScaleStep",
+    "GuiderCdsStep",
+    "ImprintStep",
+    "IPCStep",
+    "JumpStep",
+    "LastFrameStep",
+    "LinearityStep",
+    "MasterBackgroundStep",
+    "MasterBackgroundNrsSlitsStep",
+    "MRSIMatchStep",
+    "MSAFlagOpenStep",
+    "OutlierDetectionStep",
+    "OutlierDetectionScaledStep",
+    "OutlierDetectionStackStep",
+    "PathLossStep",
+    "PersistenceStep",
+    "PhotomStep",
+    "RampFitStep",
+    "RefPixStep",
+    "ResampleStep",
+    "ResampleSpecStep",
+    "ResetStep",
+    "RscdStep",
+    "RSCD_Step",
+    "SaturationStep",
+    "SkyMatchStep",
+    "SourceCatalogStep",
+    "SourceTypeStep",
+    "StraylightStep",
+    "SuperBiasStep",
+    "TSOPhotometryStep",
+    "TweakRegStep",
+    "WavecorrStep",
+    "WfsCombineStep",
+    "WhiteLightStep",
+]

--- a/jwst/stpipe/cmdline.py
+++ b/jwst/stpipe/cmdline.py
@@ -38,7 +38,7 @@ def _get_config_and_class(identifier):
             config, config_file=config_file)
     else:
         try:
-            step_class = utilities.import_class(identifier, Step)
+            step_class = utilities.import_class(utilities.resolve_step_class_alias(identifier), Step)
         except (ImportError, AttributeError, TypeError):
             raise ValueError(
                 '{0!r} is not a path to a config file or a Python Step '

--- a/jwst/stpipe/entry_points.py
+++ b/jwst/stpipe/entry_points.py
@@ -1,0 +1,45 @@
+from pkg_resources import iter_entry_points
+from collections import namedtuple
+import warnings
+
+
+STEPS_GROUP = "stpipe.steps"
+
+
+StepInfo = namedtuple("StepInfo", ["class_name", "class_alias", "is_pipeline", "package_name", "package_version"])
+
+
+def get_steps():
+    """
+    Get the list of steps registered with stpipe's entry point group.  Each entry
+    point is expected to return a list of tuples, where the first tuple element
+    is a fully-qualified Step subclass name, the second element is an optional
+    class alias, and the third is a bool indicating whether the class is to be
+    listed as a pipeline in the CLI output.
+
+    Returns
+    -------
+    list of StepInfo
+    """
+    steps = []
+
+    for entry_point in iter_entry_points(group=STEPS_GROUP):
+        package_name = entry_point.dist.project_name
+        package_version = entry_point.dist.version
+        package_steps = []
+
+        try:
+            elements = entry_point.load()()
+
+            for element in elements:
+                package_steps.append(StepInfo(*element, package_name, package_version))
+        except Exception as e:
+            warnings.warn(
+                f"{STEPS_GROUP} plugin from package {package_name}=={package_version} "
+                f"failed to load:\n\n"
+                f"{e.__class__.__name__}: {e}"
+            )
+
+        steps.extend(package_steps)
+
+    return steps

--- a/jwst/stpipe/integration.py
+++ b/jwst/stpipe/integration.py
@@ -12,6 +12,10 @@ def get_steps():
     Returns
     -------
     list of tuple (str, str, bool)
+        The first element each tuple is a fully-qualified Step
+        subclass name.  The second element is an optional class
+        alias.  The third element indicates that the class
+        is a subclass of Pipeline.
     """
     # Unit tests ensure that this list is kept in sync with the actual
     # class definitions.  We need to avoid importing jwst.pipeline and

--- a/jwst/stpipe/integration.py
+++ b/jwst/stpipe/integration.py
@@ -1,0 +1,88 @@
+"""
+Entry point implementations.
+"""
+
+
+def get_steps():
+    """
+    Return tuples describing the stpipe.Step subclasses provided
+    by this package.  This method is registered with the stpipe.steps
+    entry point.
+
+    Returns
+    -------
+    list of tuple (str, str, bool)
+    """
+    # Unit tests ensure that this list is kept in sync with the actual
+    # class definitions.  We need to avoid importing jwst.pipeline and
+    # jwst.step to keep the CLI snappy.
+    return [
+        ("jwst.pipeline.Ami3Pipeline", 'calwebb_ami3', True),
+        ("jwst.pipeline.Coron3Pipeline", 'calwebb_coron3', True),
+        ("jwst.pipeline.DarkPipeline", 'calwebb_dark', True),
+        ("jwst.pipeline.Detector1Pipeline", 'calwebb_detector1', True),
+        ("jwst.pipeline.GuiderPipeline", 'calwebb_guider', True),
+        ("jwst.pipeline.Image2Pipeline", 'calwebb_image2', True),
+        ("jwst.pipeline.Image3Pipeline", 'calwebb_image3', True),
+        ("jwst.pipeline.Spec2Pipeline", 'calwebb_spec2', True),
+        ("jwst.pipeline.Spec3Pipeline", 'calwebb_spec3', True),
+        ("jwst.pipeline.Tso3Pipeline", 'calwebb_tso3', True),
+        ("jwst.step.AmiAnalyzeStep", None, False),
+        ("jwst.step.AmiAverageStep", None, False),
+        ("jwst.step.AmiNormalizeStep", None, False),
+        ("jwst.step.AssignMTWcsStep", None, False),
+        ("jwst.step.AssignWcsStep", None, False),
+        ("jwst.step.SubtractImagesStep", None, False),
+        ("jwst.step.BackgroundStep", None, False),
+        ("jwst.step.BarShadowStep", None, False),
+        ("jwst.step.Combine1dStep", None, False),
+        ("jwst.step.StackRefsStep", None, False),
+        ("jwst.step.AlignRefsStep", None, False),
+        ("jwst.step.KlipStep", None, False),
+        ("jwst.step.HlspStep", None, False),
+        ("jwst.step.CubeBuildStep", None, False),
+        ("jwst.step.CubeSkyMatchStep", None, False),
+        ("jwst.step.DarkCurrentStep", None, False),
+        ("jwst.step.DQInitStep", None, False),
+        ("jwst.step.Extract1dStep", None, False),
+        ("jwst.step.Extract2dStep", None, False),
+        ("jwst.step.FirstFrameStep", None, False),
+        ("jwst.step.FlatFieldStep", None, False),
+        ("jwst.step.FringeStep", None, False),
+        ("jwst.step.GainScaleStep", None, False),
+        ("jwst.step.GroupScaleStep", None, False),
+        ("jwst.step.GuiderCdsStep", None, False),
+        ("jwst.step.ImprintStep", None, False),
+        ("jwst.step.IPCStep", None, False),
+        ("jwst.step.JumpStep", None, False),
+        ("jwst.step.LastFrameStep", None, False),
+        ("jwst.step.LinearityStep", None, False),
+        ("jwst.step.MasterBackgroundStep", None, False),
+        ("jwst.step.MasterBackgroundNrsSlitsStep", None, False),
+        ("jwst.step.MRSIMatchStep", None, False),
+        ("jwst.step.MSAFlagOpenStep", None, False),
+        ("jwst.step.OutlierDetectionStep", None, False),
+        ("jwst.step.OutlierDetectionScaledStep", None, False),
+        ("jwst.step.OutlierDetectionStackStep", None, False),
+        ("jwst.step.PathLossStep", None, False),
+        ("jwst.step.PersistenceStep", None, False),
+        ("jwst.step.PhotomStep", None, False),
+        ("jwst.step.RampFitStep", None, False),
+        ("jwst.step.RefPixStep", None, False),
+        ("jwst.step.ResampleStep", None, False),
+        ("jwst.step.ResampleSpecStep", None, False),
+        ("jwst.step.ResetStep", None, False),
+        ("jwst.step.RscdStep", None, False),
+        ("jwst.step.RSCD_Step", None, False),
+        ("jwst.step.SaturationStep", None, False),
+        ("jwst.step.SkyMatchStep", None, False),
+        ("jwst.step.SourceCatalogStep", None, False),
+        ("jwst.step.SourceTypeStep", None, False),
+        ("jwst.step.StraylightStep", None, False),
+        ("jwst.step.SuperBiasStep", None, False),
+        ("jwst.step.TSOPhotometryStep", None, False),
+        ("jwst.step.TweakRegStep", None, False),
+        ("jwst.step.WavecorrStep", None, False),
+        ("jwst.step.WfsCombineStep", None, False),
+        ("jwst.step.WhiteLightStep", None, False),
+    ]

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -57,6 +57,9 @@ class Step():
     search_output_file = boolean(default=True)       # Use outputfile define in parent step
     input_dir          = string(default=None)        # Input directory
     """
+    # Nickname used to refer to this class in lieu of the fully-qualified class
+    # name.  Must be globally unique!
+    class_alias = None
 
     # Correction parameters. These store and use whatever information a Step
     # may need to perform its operations without re-calculating, or to use
@@ -166,7 +169,7 @@ class Step():
     @classmethod
     def _parse_class_and_name(cls, config, parent=None, name=None, config_file=None):
         if 'class' in config:
-            step_class = utilities.import_class(config['class'],
+            step_class = utilities.import_class(utilities.resolve_step_class_alias(config['class']),
                                                 config_file=config_file)
             if not issubclass(step_class, cls):
                 raise TypeError(

--- a/jwst/stpipe/tests/conftest.py
+++ b/jwst/stpipe/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from jwst.stpipe import integration
+
+
+@pytest.fixture
+def mock_stpipe_entry_points(monkeypatch):
+    def get_steps():
+        return [
+            ("jwst.stpipe.tests.steps.AnotherDummyStep", "stpipe_dummy", False),
+        ]
+    monkeypatch.setattr(integration, "get_steps", get_steps)

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -44,6 +44,7 @@ class AnotherDummyStep(Step):
     [foo]
 
     """
+    class_alias = "stpipe_dummy"
 
     reference_file_types = ['flat_field']
 

--- a/jwst/stpipe/tests/steps/dummy_with_alias.cfg
+++ b/jwst/stpipe/tests/steps/dummy_with_alias.cfg
@@ -1,0 +1,5 @@
+class = "stpipe_dummy"
+
+par1 = 10.3456789
+par2 = "abc def"
+par3 = True

--- a/jwst/stpipe/tests/test_entry_points.py
+++ b/jwst/stpipe/tests/test_entry_points.py
@@ -1,0 +1,24 @@
+from jwst.stpipe.entry_points import get_steps
+import jwst.pipeline
+import jwst.step
+import jwst
+
+
+def test_get_steps():
+    step_info_by_class = {s.class_name: s for s in get_steps()}
+
+    for class_name in jwst.pipeline.__all__:
+        pipeline_class = getattr(jwst.pipeline, class_name)
+        step_info = step_info_by_class[f"jwst.pipeline.{class_name}"]
+        assert step_info.class_alias == pipeline_class.class_alias
+        assert step_info.is_pipeline == True
+        assert step_info.package_name == "jwst"
+        assert step_info.package_version == jwst.__version__
+
+    for class_name in jwst.step.__all__:
+        step_class = getattr(jwst.step, class_name)
+        step_info = step_info_by_class[f"jwst.step.{class_name}"]
+        assert step_info.class_alias == step_class.class_alias
+        assert step_info.is_pipeline == False
+        assert step_info.package_name == "jwst"
+        assert step_info.package_version == jwst.__version__

--- a/jwst/stpipe/tests/test_integration.py
+++ b/jwst/stpipe/tests/test_integration.py
@@ -1,0 +1,19 @@
+from jwst.stpipe.integration import get_steps
+from jwst.stpipe import Step, Pipeline
+from jwst.stpipe.utilities import import_class
+
+import jwst.pipeline
+import jwst.step
+
+
+def test_get_steps():
+    tuples = get_steps()
+
+    assert {t[0].split(".")[-1] for t in tuples} == set(jwst.step.__all__ + jwst.pipeline.__all__)
+
+    for class_name, class_alias, is_pipeline in tuples:
+        step_class = import_class(class_name)
+        assert issubclass(step_class, Step)
+        assert step_class.class_alias == class_alias
+        if is_pipeline:
+            assert issubclass(step_class, Pipeline)

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -14,7 +14,7 @@ from jwst.stpipe import Step, crds_client
 from jwst.stpipe import cmdline
 from jwst.stpipe.config_parser import ValidationError
 
-from .steps import EmptyPipeline, MakeListPipeline, MakeListStep, ProperPipeline
+from .steps import EmptyPipeline, MakeListPipeline, MakeListStep, ProperPipeline, AnotherDummyStep
 from .util import t_path
 
 from crds.core.exceptions import CrdsLookupError
@@ -519,6 +519,37 @@ def test_step_from_commandline_class():
     assert step.par1 == 58.
     assert step.par2 == 'hij klm'
     assert step.par3 is False
+
+    step.run(1, 2)
+
+
+def test_step_from_commandline_class_alias(mock_stpipe_entry_points):
+    args = [
+        'stpipe_dummy', '--par1=58', '--par2=hij klm'
+    ]
+
+    step = Step.from_cmdline(args)
+
+    assert isinstance(step, AnotherDummyStep)
+
+    assert step.par1 == 58.
+    assert step.par2 == 'hij klm'
+    assert step.par3 is False
+
+    step.run(1, 2)
+
+
+def test_step_from_commandline_config_class_alias(mock_stpipe_entry_points):
+    args = [
+        abspath(join(dirname(__file__), 'steps', 'dummy_with_alias.cfg')),
+        '--par1=58', '--par2=hij klm'
+    ]
+
+    step = Step.from_cmdline(args)
+
+    assert step.par1 == 58.
+    assert step.par2 == 'hij klm'
+    assert step.par3 is True
 
     step.run(1, 2)
 

--- a/jwst/stpipe/tests/test_utilities.py
+++ b/jwst/stpipe/tests/test_utilities.py
@@ -1,34 +1,25 @@
 """Test utility funcs"""
-from jwst.stpipe.utilities import all_steps
+from jwst.stpipe.utilities import all_steps, resolve_step_class_alias
+import jwst.pipeline
+import jwst.step
 
 
-# Snapshot of known steps
-KNOWN_STEPS = set([
-    'AlignRefsStep','Ami3Pipeline', 'AmiAnalyzeStep', 'AmiAverageStep',
-    'AmiNormalizeStep', 'AssignMTWcsStep', 'AssignWcsStep',
-    'BackgroundStep', 'BarShadowStep',
-    'Combine1dStep', 'Coron3Pipeline', 'CubeBuildStep', 'CubeSkyMatchStep',
-    'DQInitStep', 'DarkCurrentStep', 'DarkPipeline', 'Detector1Pipeline',
-    'Extract1dStep', 'Extract2dStep',
-    'FirstFrameStep', 'FlatFieldStep', 'FringeStep',
-    'GainScaleStep', 'GroupScaleStep', 'GuiderCdsStep', 'GuiderPipeline',
-    'HlspStep',
-    'IPCStep', 'Image2Pipeline', 'Image3Pipeline', 'ImprintStep',
-    'JumpStep',
-    'KlipStep',
-    'LastFrameStep', 'LinearityStep',
-    'MRSIMatchStep', 'MSAFlagOpenStep', 'MasterBackgroundNrsSlitsStep', 'MasterBackgroundStep',
-    'OutlierDetectionScaledStep', 'OutlierDetectionStackStep', 'OutlierDetectionStep',
-    'PathLossStep', 'PersistenceStep', 'PhotomStep',
-    'RscdStep', 'RSCD_Step', 'RampFitStep', 'RefPixStep', 'ResampleSpecStep', 'ResampleStep', 'ResetStep',
-    'SaturationStep', 'SkyMatchStep', 'SourceCatalogStep', 'SourceTypeStep', 'Spec2Pipeline', 'Spec3Pipeline',
-    'StackRefsStep', 'StraylightStep', 'SubtractImagesStep', 'SuperBiasStep',
-    'TSOPhotometryStep', 'Tso3Pipeline', 'TweakRegStep',
-    'WavecorrStep', 'WfsCombineStep', 'WhiteLightStep',
-])
+# All steps available to users should be represented in one
+# of these two modules:
+KNOWN_STEPS = set(jwst.pipeline.__all__ + jwst.step.__all__)
+
 
 def test_all_steps():
     """Test finding all defined steps and pipelines"""
     found_steps = all_steps()
     diff = KNOWN_STEPS.symmetric_difference(found_steps)
     assert not diff, f'Steps not accounted for. Confirm and check suffix and CRDS calpars.\n{diff}'
+
+
+def test_resolve_step_class_alias():
+    for class_name in jwst.pipeline.__all__:
+        pipeline_class = getattr(jwst.pipeline, class_name)
+        full_class_name = f"jwst.pipeline.{class_name}"
+        if pipeline_class.class_alias is not None:
+            assert resolve_step_class_alias(pipeline_class.class_alias) == full_class_name
+        assert resolve_step_class_alias(full_class_name) == full_class_name

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -37,6 +37,8 @@ import os
 import re
 import sys
 
+from . import entry_points
+
 # Configure logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -49,6 +51,27 @@ NON_STEPS = [
     'Step',
     'SystemCall',
 ]
+
+
+def resolve_step_class_alias(name):
+    """
+    If the input is a recognized alias, return the
+    corresponding fully-qualified class name.  Otherwise
+    return the input unmodified.
+
+    Parameters
+    ----------
+    name : str
+
+    Returns
+    -------
+    str
+    """
+    for info in entry_points.get_steps():
+        if info.class_alias is not None and name == info.class_alias:
+            return info.class_name
+
+    return name
 
 
 def import_class(full_name, subclassof=object, config_file=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,8 @@ ephem =
 asdf_extensions =
     jwst_pipeline = jwst.transforms.jwextension:JWSTExtension
     jwst_datamodel = jwst.datamodels.extension:DataModelExtension
+stpipe.steps =
+    jwst = jwst.stpipe.integration:get_steps
 
 [build-sphinx]
 source-dir = docs


### PR DESCRIPTION
This PR:
- Adds support for a `class_alias` class attribute that allows steps/pipelines to define a short name (like "calwebb_detector1") that can be used in lieu of a class name.  This can be used in the "class" field of a config file or as an argument to strun.
- Sets `class_alias` on all existing pipelines to the name of the config file without the .cfg extension.
- Adds a new `jwst.step` module that imports all non-Pipeline steps available to the user.
- Adds an entry point that stpipe uses to gather a list of installed Step subclasses.