### PR TITLE
JP-1706 added updating only PRIMARY header of output_file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ extract_1d
 ----------
 
 - Adding writing SRCTYPE, EXTR_X, and EXTR_Y to extracted spec for IFU data [#5685]
+- Only update the output x1d data using the PRIMARY input data. Prevents SCI data in x1d data [#5694]
 
 lib
 ---

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2697,7 +2697,7 @@ def do_extract1d(
     if hasattr(input_temp, "int_times"):
         output_model.int_times = input_temp.int_times.copy()
 
-    output_model.update(input_temp)
+    output_model.update(input_temp,only='PRIMARY')
 
     spec_dtype = datamodels.SpecModel().spec_table.dtype  # This data type is used for creating an output table.
 


### PR DESCRIPTION
This PR address [JP-1706](https://jira.stsci.edu/browse/JP-1706), GitHub issue #5344

X1d files for NIRISS WFSS data have SCI extensions

The code change will affect other types of data run with extract1d since the change is in do_extract1d in extract.py This should fix the science header being in all the x1d products. IFU data is handled a bit differently but there was already a fix for IFU extract1d data. 