### PR TITLE
Break stpipe dependence on ModelContainer

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -1,5 +1,6 @@
 import copy
 from collections import OrderedDict
+from collections.abc import Sequence
 import os.path as op
 import re
 import logging
@@ -20,7 +21,7 @@ __all__ = ['ModelContainer']
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-class ModelContainer(JwstDataModel):
+class ModelContainer(JwstDataModel, Sequence):
     """
     A container for holding DataModels.
 

--- a/jwst/stpipe/jwst.py
+++ b/jwst/stpipe/jwst.py
@@ -1,11 +1,11 @@
 """
 JWST-specific Step and Pipeline base classes.
 """
+from collections.abc import Sequence
 from stdatamodels import DataModel
 
 from .. import __version_commit__, __version__
 from .. import datamodels
-from ..datamodels import ModelContainer
 
 from . import crds_client
 from .step import Step
@@ -98,7 +98,7 @@ class JwstStep(Step):
             status = 'SKIPPED'
             self.skip = True
 
-        if isinstance(datamodel, ModelContainer):
+        if isinstance(datamodel, Sequence):
             for model in datamodel:
                 model.meta.cal_step._instance[cal_step] = status
         else:

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -2,6 +2,7 @@
 Step
 """
 import abc
+from collections.abc import Sequence
 from contextlib import contextmanager
 from functools import partial
 import gc
@@ -32,8 +33,6 @@ from . import crds_client
 from . import log
 from . import utilities
 from .format_template import FormatTemplate
-
-from ..datamodels import ModelContainer
 
 
 class Step(abc.ABC):
@@ -424,9 +423,7 @@ class Step(abc.ABC):
                     step_result = hook_results
 
             # Update meta information
-            if not isinstance(
-                    step_result, (list, tuple, ModelContainer)
-            ):
+            if not isinstance(step_result, Sequence):
                 results = [step_result]
             else:
                 results = step_result
@@ -487,7 +484,7 @@ class Step(abc.ABC):
 
         Parameters
         ----------
-        result : stdatamodels.DataModel or jwst.datamodels.ModelContainer
+        result : stdatamodels.DataModel or collections.abc.Sequence
             One step result (potentially of many).
 
         reference_files_used : list of tuple
@@ -899,7 +896,7 @@ class Step(abc.ABC):
            not output_file:
             return
 
-        if isinstance(model, ModelContainer):
+        if isinstance(model, Sequence):
             save_model_func = partial(
                 self.save_model,
                 suffix=suffix,

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -2,7 +2,6 @@ from jwst.stpipe import (Pipeline, Step)
 from jwst import datamodels
 from jwst.datamodels import (
     ImageModel,
-    ModelContainer,
 )
 
 class StepWithReference(Step):
@@ -177,7 +176,7 @@ class StepWithContainer(Step):
     """
 
     def process(self, *args):
-        container = ModelContainer()
+        container = []
         model1 = ImageModel(args[0]).copy()
         model2 = ImageModel(args[0]).copy()
         model1.meta.filename = 'swc_model1.fits'


### PR DESCRIPTION
It turns out, stpipe only uses ModelContainer in its capacity as a sequence -- iterating over the component models and performing operations on them.  This PR makes ModelContainer a subclass of collections.abc.Sequence and changes stpipe to perform `isinstance(foo, Sequence)` checks instead of `isinstance(foo, ModelContainer)`.  This should be enough to allow us to leave ModelContainer behind when we move stpipe to an independent package.

Regression test run: https://plwishmaster.stsci.edu:8081/job/RT/job/eslavich-dev/59