### PR TITLE
Use parent datamodels_open method if available

### DIFF
--- a/jwst/stpipe/function_wrapper.py
+++ b/jwst/stpipe/function_wrapper.py
@@ -29,7 +29,7 @@
 """
 A Step whose only purpose is to wrap an ordinary function.
 """
-from . import Step
+from .step import Step
 
 
 class FunctionWrapper(Step):

--- a/jwst/stpipe/hooks.py
+++ b/jwst/stpipe/hooks.py
@@ -31,7 +31,7 @@ Pre- and post-hooks
 """
 import types
 
-from . import Step
+from .step import Step
 from . import utilities
 
 def hook_from_string(step, type, num, command):

--- a/jwst/stpipe/jwst.py
+++ b/jwst/stpipe/jwst.py
@@ -15,7 +15,7 @@ from ..lib.suffix import remove_suffix
 
 class JwstStep(Step):
     @classmethod
-    def datamodels_open(cls, init, **kwargs):
+    def _datamodels_open(cls, init, **kwargs):
         return datamodels.open(init, **kwargs)
 
     def load_as_level2_asn(self, obj):

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -189,7 +189,7 @@ class Pipeline(Step):
         log.debug('Retrieving all substep parameters from CRDS')
         #
         # Iterate over the steps in the pipeline
-        with cls.datamodels_open(dataset, asn_n_members=1) as model:
+        with cls._datamodels_open(dataset, asn_n_members=1) as model:
             for cal_step in cls.step_defs.keys():
                 cal_step_class = cls.step_defs[cal_step]
                 refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(model)

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -757,7 +757,7 @@ class Step:
         # If the dataset is not an operable DataModel, log as such and return
         # an empty config object
         try:
-            model = cls.datamodels_open(dataset)
+            model = cls._datamodels_open(dataset)
         except (IOError, TypeError, ValueError):
             logger.warning('Input dataset is not a DataModel.')
             disable = True
@@ -1093,11 +1093,11 @@ class Step:
         gc.collect()
 
     @classmethod
-    def datamodels_open(cls, init, **kwargs):
+    def _datamodels_open(cls, init, **kwargs):
         """
         Wrapper around observatory-specific datamodels.open function.
         """
-        raise NotImplementedError(f"{cls.__name__} does not implement datamodels_open")
+        raise NotImplementedError(f"{cls.__name__} does not implement _datamodels_open")
 
     def open_model(self, init, **kwargs):
         """Open a datamodel
@@ -1118,9 +1118,9 @@ class Step:
         # Use the parent method if available, since this step
         # might be a hook that doesn't implement datamodels_open.
         if self.parent is None:
-            datamodels_open = self.datamodels_open
+            datamodels_open = self._datamodels_open
         else:
-            datamodels_open = self.parent.datamodels_open
+            datamodels_open = self.parent._datamodels_open
 
         return datamodels_open(self.make_input_path(init), **kwargs)
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -1,7 +1,6 @@
 """
 Step
 """
-import abc
 from collections.abc import Sequence
 from contextlib import contextmanager
 from functools import partial
@@ -35,7 +34,7 @@ from . import utilities
 from .format_template import FormatTemplate
 
 
-class Step(abc.ABC):
+class Step:
     """
     Step
     """
@@ -1093,12 +1092,12 @@ class Step(abc.ABC):
                 self.log.debug("An error has occurred: %s", error)
         gc.collect()
 
-    @abc.abstractclassmethod
+    @classmethod
     def datamodels_open(cls, init, **kwargs):
         """
         Wrapper around observatory-specific datamodels.open function.
         """
-        pass
+        raise NotImplementedError(f"{cls.__name__} does not implement datamodels_open")
 
     def open_model(self, init, **kwargs):
         """Open a datamodel
@@ -1116,7 +1115,14 @@ class Step(abc.ABC):
         datamodel : DataModel
             Object opened as a datamodel
         """
-        return self.datamodels_open(self.make_input_path(init), **kwargs)
+        # Use the parent method if available, since this step
+        # might be a hook that doesn't implement datamodels_open.
+        if self.parent is None:
+            datamodels_open = self.datamodels_open
+        else:
+            datamodels_open = self.parent.datamodels_open
+
+        return datamodels_open(self.make_input_path(init), **kwargs)
 
     def make_input_path(self, file_path):
         """Create an input path for a given file path

--- a/jwst/stpipe/subproc.py
+++ b/jwst/stpipe/subproc.py
@@ -29,7 +29,7 @@
 import os
 import subprocess
 
-from . import Step
+from .step import Step
 
 
 class SystemCall(Step):


### PR DESCRIPTION
This is a sneaky dependence on `JwstStep` that I hadn't noticed before.  I updated `Step.datamodels_open` to use the parent class's implementation if available, which allows the hook subclasses to be mission-agnostic.