### PR TITLE
JP-1910: Fix ramp_fit handling of saturated ngroups=2 data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,11 +25,6 @@ lib
 
 - Make EngDB_Value public for JSDP use [#5669]
 
-ramp_fitting
-------------
-
-- Update documentation to define optimal weighting algorithm [#5682]
-
 - Update code in ``set_velocity_aberration.py`` functions based on Colin Cox
   suggestions: simplify DVA scale computation and improve apparent ``RA`` and
   ``DEC`` aberrated position computation. Also, attributes ``ra_offset`` and
@@ -39,6 +34,15 @@ ramp_fitting
   ``VA_RA`` and ``VA_DEC``. [#5666]
 
 - Make get_wcs_values_from_siaf public for JSDP use [#5669]
+
+ramp_fitting
+------------
+
+- Fixed bug in handling NGROUPS=2 exposures for pixels that saturate in group 2.
+  Proper slope, err, and other quantities are now computed from the good data
+  in group 1. [#5700]
+
+- Update documentation to define optimal weighting algorithm [#5682]
 
 srctype
 -------

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -2895,7 +2895,9 @@ def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s,
     if (len(wh_sat1[0]) > 0):
         data0_slice = data[0, :, :].reshape(npix)
         slope_s[wh_sat1] = data0_slice[wh_sat1]
-        variance_s[wh_sat1] = 0.
+        # set variance non-zero because calling function uses variance=0 to
+        # throw out bad results; this is not bad
+        variance_s[wh_sat1] = 1.
         sig_slope_s[wh_sat1] = 0.
         intercept_s[wh_sat1] = 0.
         sig_intercept_s[wh_sat1] = 0.

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -747,6 +747,10 @@ def ols_ramp_fit(data, err, groupdq, inpixeldq, buffsize, save_opt, readnoise_2d
             median_diffs_2d[ rlo:rhi, : ] += nan_med
 
             # Calculate the slope of each segment
+            # note that the name "opt_res", which stands for "optional results",
+            # is deceiving; this in fact contains all the per-integration and
+            # per-segment results that will eventually be used to compute the
+            # final slopes, sigmas, etc. for the main (non-optional) products
             t_dq_cube, inv_var, opt_res, f_max_seg, num_seg = \
                  calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt,
                             rn_sect, gain_sect, max_seg, ngroups, weighting,
@@ -1744,7 +1748,10 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
         integration time
 
     opt_res : OptRes object
-        contains quantities related to fitting for optional output
+        Contains all quantities derived from fitting all segments in all
+        pixels in all integrations, which will eventually be used to compute
+        per-integration and per-exposure quantities for all pixels. It's
+        also used to populate the optional product, when requested.
 
     save_opt : boolean
        save optional fitting results
@@ -1780,7 +1787,8 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
         values of 1/variance for good pixels
 
     opt_res : OptRes object
-        contains quantities related to fitting for optional output
+        contains all quantities related to fitting for use in computing final
+        slopes, variances, etc. and is used to populate the optional output
 
     f_max_seg : int
         actual maximum number of segments within a ramp, updated here based on
@@ -1943,7 +1951,8 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
         numbers of segments for good pixels
 
     opt_res : OptRes object
-        optional fitting results to output
+        all fitting quantities, used to compute final results
+        and to populate optional output product
 
     save_opt : boolean
        save optional fitting results
@@ -1981,6 +1990,7 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
 
     ramp_mask_sum = mask_2d_init.sum(axis=0)
 
+    # Compute fit quantities for the next segment of all pixels
     # Each returned array below is 1D, for all npix pixels for current segment
     slope, intercept, variance, sig_intercept, sig_slope = fit_lines(data_sect,
               mask_2d, rn_sect, gain_sect, ngroups, weighting)

--- a/jwst/ramp_fitting/tests/test_ramp_fit_cases.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_cases.py
@@ -44,8 +44,8 @@ def test_pix_0():
     o_true = [1.0117551, 4.874572, 0.0020202, 0.00647973,
               15.911023, 27.789335, 4.882449, 13841.038 ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_1():
@@ -77,8 +77,8 @@ def test_pix_1():
     o_true = [ 1.9, 56.870003, 0.02636364, 1.0691562, -3., 56.870003,
               -3.999998, 0.83321977]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_2():
@@ -114,8 +114,8 @@ def test_pix_2():
               [ 12.712313, 0.83321977, 0.83321977],   # weights
              ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_3():
@@ -151,8 +151,8 @@ def test_pix_3():
               [ 4.2576841e+03, 8.458062e-01],
              ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_4():
@@ -180,8 +180,8 @@ def test_pix_4():
     # Set truth values for OPTIONAL results:
     o_true = [ 1.5, 0., 0.02727273, 1.0691562, 0., 0., 0., 0.8318386]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_5():
@@ -218,8 +218,8 @@ def test_pix_5():
               [ 78.34764, 855.78046 ]
              ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_6():
@@ -255,8 +255,8 @@ def test_pix_6():
               [ 8.4580624e-01, 2.0433204e+03 ]
              ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_7():
@@ -284,8 +284,8 @@ def test_pix_7():
     o_true = [ 1.0757396, 6.450687, 0.0025974, 0.01272805, 14.504951,
                27.842508, 4.2426033, 4257.684 ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_8():
@@ -314,8 +314,8 @@ def test_pix_8():
     o_true = [ 1.0101178, 12.385354, 0.00363636, 0.03054732, 16.508228,
                 40.81897, 4.898822, 855.78046 ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_9():
@@ -352,8 +352,8 @@ def test_pix_9():
               [ 0.84580624, 297.23172, 0.84580624]
              ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_10():
@@ -390,8 +390,8 @@ def test_pix_10():
               [ 0.84580624, 13.091425, 297.23172 ]
              ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_pix_11():
@@ -419,8 +419,61 @@ def test_pix_11():
     o_true = [1., 56.870003, 0.01818182, 1.0691562, 15., 56.870003, 5.,
               0.84580624 ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
+
+
+def test_pix_12():
+    """
+    CASE NGROUPS=2: the segment has a good 1st group and a saturated 2nd group,
+      so is a single group. Group 1's data will be used in the 'fit'.
+    """
+
+    ngroups, nints, nrows, ncols, deltatime, gain, readnoise = set_scalars()
+    ngroups = 2
+    nints = 1
+    ncols = 2
+    RampMod, RnMod, GMod, pixdq, groupdq, err = create_mod_arrays( ngroups,
+                           nints, nrows, ncols, deltatime, gain, readnoise )
+
+    # Populate pixel-specific SCI and GROUPDQ arrays
+    RampMod.data[0,:,0,0] = np.array([ 15., 59025.], dtype=np.float32)
+    RampMod.groupdq[0,:,0,0] = np.array([0, 2])
+    RampMod.data[0,:,0,1] = np.array([ 61000., 61000.], dtype=np.float32)
+    RampMod.groupdq[0,:,0,1] = np.array([2, 2])
+
+    # call ramp_fit
+    new_mod, int_mod, opt_mod, gls_opt_mod = ramp_fit( RampMod, 1024*300., True,
+                                                RnMod, GMod, 'OLS', 'optimal', 'none')
+    # Set truth values for PRIMARY results for pixel 1:
+    # slope, dq, err, var_p, var_r
+    # slope = group1 / deltatime = 15 / 10 = 1.5
+    # dq = 2 (saturation) because group2 is saturated, but DO_NOT_USE is *not* set
+    p_true = [1.5, 2, 1.047105, 0.027273, 1.069156]
+
+    # Set truth values for OPTIONAL results:
+    # slope, sig_slope, var_p, var_r, yint, sig_yint, pedestal, weights
+    # slope = group1 / deltatime = 15 / 10 = 1.5
+    # sig_slope, yint, sig_yint, and pedestal are all zero, because only 1 good group
+    o_true = [1.5, 0., 0.027273, 1.069156, 0., 0., 0., 0.831839]
+
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
+
+    # Set truth values for PRIMARY results for pixel 2:
+    # slope, dq, err, var_p, var_r
+    # slope = zero, because no good data
+    # dq = 3 (saturation + do_not_use) because both groups are saturated
+    p_true = [0., 3, 0., 0., 0.]
+
+    # Set truth values for OPTIONAL results:
+    # slope, sig_slope, var_p, var_r, yint, sig_yint, pedestal, weights
+    # all values zero, because no good data
+    o_true = [0., 0., 0., 0., 0., 0., 0., 0.]
+
+    assert_pri( p_true, new_mod, 1 )
+    assert_opt( o_true, opt_mod, 1 )
+
 
 #-------------- start of MIRI tests: all have only a single segment-----
 def test_miri_0():
@@ -448,8 +501,8 @@ def test_miri_0():
     o_true = [1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266, 27.842508,
               14.74146, 4257.684]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_miri_1():
@@ -478,8 +531,8 @@ def test_miri_1():
     o_true = [ 1.1996487, 6.450687, 0.0025974, 0.01272805, 126.110214,
                27.842508, 113.00351, 4257.684 ]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_miri_2():
@@ -508,8 +561,8 @@ def test_miri_2():
     o_true = [ 1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266, 27.842508,
                14.74146, 4257.684]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
 def test_miri_3():
@@ -538,26 +591,26 @@ def test_miri_3():
     o_true = [ 1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266,
               27.842508, 14.74146, 4257.684]
 
-    assert_pri( p_true, new_mod )
-    assert_opt( o_true, opt_mod )
+    assert_pri( p_true, new_mod, 0 )
+    assert_opt( o_true, opt_mod, 0 )
 
 
-def assert_pri( p_true, new_mod ):
+def assert_pri( p_true, new_mod, pix ):
     """
     Compare true and fit values of primary output for extensions
     SCI, DQ, ERR, VAR_POISSSON, VAR_RNOISE.
     """
 
-    npt.assert_allclose( new_mod.data,        p_true[0], atol=2E-5, rtol=2e-5 )
-    npt.assert_allclose( new_mod.dq,          p_true[1], atol=1E-1 )
-    npt.assert_allclose( new_mod.err,         p_true[2], atol=2E-5, rtol=2e-5 )
-    npt.assert_allclose( new_mod.var_poisson, p_true[3], atol=2E-5, rtol=2e-5 )
-    npt.assert_allclose( new_mod.var_rnoise,  p_true[4], atol=2E-5, rtol=2e-5 )
+    npt.assert_allclose( new_mod.data[0,pix],        p_true[0], atol=2E-5, rtol=2e-5 )
+    npt.assert_allclose( new_mod.dq[0,pix],          p_true[1], atol=1E-1 )
+    npt.assert_allclose( new_mod.err[0,pix],         p_true[2], atol=2E-5, rtol=2e-5 )
+    npt.assert_allclose( new_mod.var_poisson[0,pix], p_true[3], atol=2E-5, rtol=2e-5 )
+    npt.assert_allclose( new_mod.var_rnoise[0,pix],  p_true[4], atol=2E-5, rtol=2e-5 )
 
     return None
 
 
-def assert_opt( o_true, opt_mod ):
+def assert_opt( o_true, opt_mod, pix ):
     """
     Compare true and fit values of optional output for extensions SLOPE,
     SIGSLOPE, VAR_POISSSON, VAR_RNOISE, YINT, SIGYINT, PEDESTAL, and WEIGHTS.
@@ -565,14 +618,14 @@ def assert_opt( o_true, opt_mod ):
     [0,:,0,0]
     """
 
-    opt_slope = opt_mod.slope[0,:,0,0]
-    opt_sigslope = opt_mod.sigslope[0,:,0,0]
-    opt_var_poisson = opt_mod.var_poisson[0,:,0,0]
-    opt_var_rnoise = opt_mod.var_rnoise[0,:,0,0]
-    opt_yint = opt_mod.yint[0,:,0,0]
-    opt_sigyint = opt_mod.sigyint[0,:,0,0]
-    opt_pedestal = opt_mod.pedestal[:,0,0]
-    opt_weights = opt_mod.weights[0,:,0,0]
+    opt_slope = opt_mod.slope[0,:,0,pix]
+    opt_sigslope = opt_mod.sigslope[0,:,0,pix]
+    opt_var_poisson = opt_mod.var_poisson[0,:,0,pix]
+    opt_var_rnoise = opt_mod.var_rnoise[0,:,0,pix]
+    opt_yint = opt_mod.yint[0,:,0,pix]
+    opt_sigyint = opt_mod.sigyint[0,:,0,pix]
+    opt_pedestal = opt_mod.pedestal[:,0,pix]
+    opt_weights = opt_mod.weights[0,:,0,pix]
 
     npt.assert_allclose( opt_slope, o_true[0], atol=2E-5, rtol=2e-5 )
     npt.assert_allclose( opt_sigslope, o_true[1], atol=2E-5, rtol=2e-5 )


### PR DESCRIPTION
Updated the low-level `fit_2_group` function in ramp_fitting to properly handle the situation where NGROUPS=2 and the group 2 is saturated, but group 1 is OK. Hence the group 1 value can be used to compute a countrate. The problem in the existing code was that the variance for a pixel like this was being set to 0 in `fit_2_group`, but when those results got returned to the calling function it was throwing out all results with variance=0, so slopes and other quantities were not getting computed.

I've simply set the variance to 1 in this function, which allows for the proper computation of slope, variances, and error once it returns to the calling routine.

Fixes #5715  / [JP-1910](https://jira.stsci.edu/browse/JP-1910)