### PR TITLE
Add dev dependencies workflow as weekly cron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ on:
   pull_request:
   schedule:
     # Weekly Monday 9AM build
-    # * is a special character in YAML so you have to quote this string
-    - cron: '0 9 * * 1'
+    - cron: "0 9 * * 1"
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu
@@ -20,9 +19,6 @@ env:
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
 jobs:
-
-  # The rest only run if above are done
-
   tox:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -137,39 +133,3 @@ jobs:
         with:
           file: ./coverage.xml
           flags: unit
-
-  # # A matrix of jobs with allowed failures. Not enabled for now.
-  # allowed_failures:
-  #   name: ${{ matrix.name }}
-  #   runs-on: ${{ matrix.os }}
-  #   continue-on-error: ${{ matrix.allowed-failure }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - name: (Allowed Failure) Dev dependencies in requirements-dev.txt
-  #           os: ubuntu-latest
-  #           allowed-failure: true
-  #           python-version: 3.9
-  #           toxenv: devdeps
-
-  #         - name: (Allowed Failure) Warnings treated as Exceptions
-  #           os: ubuntu-latest
-  #           allowed-failure: true
-  #           python-version: 3.9
-  #           toxenv: warnings
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install tox
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install tox
-  #     - name: Run tox
-  #       run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,0 +1,70 @@
+name: Weekly cron
+
+on:
+  schedule:
+    # Weekly Monday 6AM build
+    - cron: "0 6 * * 1"
+
+env:
+  CRDS_SERVER_URL: https://jwst-crds.stsci.edu
+  CRDS_PATH: ~/crds_cache
+  CRDS_CLIENT_RETRY_COUNT: 3
+  CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+
+jobs:
+  tox:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Dev dependencies in requirements-dev.txt
+            os: ubuntu-latest
+            python-version: 3.9
+            toxenv: devdeps
+    steps:
+      - name: Install system packages
+        if: ${{ contains(matrix.toxenv,'docs') }}
+        run: |
+          sudo apt-get install graphviz texlive-latex-extra dvipng
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Get CRDS context
+        id: crds-context
+        run: |
+          pip install crds
+          echo "::set-output name=pmap::$(crds list --resolve-contexts --contexts | cut -f 1 -d ".")"
+
+      - name: Restore CRDS cache
+        uses: actions/cache@v2
+        with:
+          path: ~/crds_cache
+          key: crds-${{ matrix.toxenv }}-${{ steps.crds-context.outputs.pmap }}
+
+      - name: Install tox
+        run: |
+          pip install tox
+
+      - name: Run tests
+        run: tox -e ${{ matrix.toxenv }}
+
+      - name: Upload coverage to codecov
+        if: ${{ contains(matrix.toxenv,'-cov') }}
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unit

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Weekly Monday 6AM build
     - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -5,7 +5,6 @@ on:
     # Weekly Monday 6AM build
     - cron: "0 6 * * 1"
   workflow_dispatch:
-  pull_request:
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -5,6 +5,7 @@ on:
     # Weekly Monday 6AM build
     - cron: "0 6 * * 1"
   workflow_dispatch:
+  pull_request:
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu


### PR DESCRIPTION
We are not running unit tests using `requirements-dev.txt`.  This remedies that problem by running it at least weekly.  If it fails, it will not interfere with approval of PRs, though we will get emails about it.  And it can also be triggered manually if needed.