### PR TITLE
JP-1886: Add '1LOS' to PATTTYPE enum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ datamodels
 - Added extr_x and extr_y to multispec datamodel. These values are center
   of extraction region for IFU data [#5685]
 
+- Added '1LOS' to PATTTYPE enum list in core.schema datamodel [#5728]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1068,7 +1068,7 @@ properties:
               # NIRCam
               FULL, FULLBOX, FULL-TIGHT,
               INTRAMODULE, INTRAMODULEBOX, INTRAMODULEX, INTRASCA,
-              SUBARRAY-DITHER, WFSC,
+              SUBARRAY-DITHER, WFSC, 1LOS,
 
               # NIRISS
               AMI, IMAGING, MIMF, WFSS,


### PR DESCRIPTION
Resolves [JP-1886](https://jira.stsci.edu/browse/JP-1886)
Resolves #5690 

Added '1LOS' to PATTTYPE enum list in core.schema datamodel.