### PR TITLE
Fix CRDS_CONTEXT setting in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,6 @@ jobs:
             os: ubuntu-latest
             python-version: 3.8
             toxenv: sdpdeps
-            env:
-              CRDS_CONTEXT: jwst-edit
 
           - name: Installed package with --pyargs
             os: ubuntu-latest

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+from stpipe.crds_client import get_context_used
+
+
+def pytest_report_header(config):
+    """Add CRDS_CONTEXT to pytest report header"""
+    return f"crds_context: {get_context_used('jwst')}"

--- a/jwst/conftest.py
+++ b/jwst/conftest.py
@@ -5,7 +5,6 @@ import pytest
 import inspect
 
 from stdatamodels import s3_utils
-from stpipe.crds_client import get_context_used
 
 from jwst.associations import (AssociationRegistry, AssociationPool)
 from jwst.associations.tests.helpers import t_path
@@ -112,8 +111,3 @@ class TestDescriptionPlugin:
             yield
             if self.desc:
                     self.terminal_reporter.write(f'\n{self.desc} ')
-
-
-def pytest_report_header(config):
-    """Add CRDS_CONTEXT to pytest report header"""
-    return f"crds_context: {get_context_used('jwst')}"

--- a/jwst/conftest.py
+++ b/jwst/conftest.py
@@ -4,8 +4,8 @@ import tempfile
 import pytest
 import inspect
 
-from crds.client.api import get_mapping_names, get_default_context
 from stdatamodels import s3_utils
+from stpipe.crds_client import get_context_used
 
 from jwst.associations import (AssociationRegistry, AssociationPool)
 from jwst.associations.tests.helpers import t_path
@@ -114,15 +114,6 @@ class TestDescriptionPlugin:
                     self.terminal_reporter.write(f'\n{self.desc} ')
 
 
-def get_crds_context():
-    """Return the in-use CRDS_CONTEXT for pytest report header"""
-    if "CRDS_CONTEXT" in os.environ:
-        pmap = [a for a in get_mapping_names(os.getenv("CRDS_CONTEXT")) if "pmap" in a][0]
-    else:
-        pmap = get_default_context()
-    return pmap
-
-
 def pytest_report_header(config):
     """Add CRDS_CONTEXT to pytest report header"""
-    return f"crds_context: {get_crds_context()}"
+    return f"crds_context: {get_context_used('jwst')}"

--- a/scripts/echo_crds_context
+++ b/scripts/echo_crds_context
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ "${CRDS_CONTEXT}" ]]; then
+    echo $(crds list --contexts ${CRDS_CONTEXT} --resolve-contexts)
+else
+    crds list --operational-context
+fi

--- a/scripts/echo_crds_context
+++ b/scripts/echo_crds_context
@@ -1,7 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python
 
-if [[ "${CRDS_CONTEXT}" ]]; then
-    echo $(crds list --contexts ${CRDS_CONTEXT} --resolve-contexts)
-else
-    crds list --operational-context
-fi
+from jwst.conftest import get_crds_context
+
+if __name__ == "__main__":
+    print(get_crds_context())

--- a/scripts/echo_crds_context
+++ b/scripts/echo_crds_context
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from jwst.conftest import get_crds_context
-
-if __name__ == "__main__":
-    print(get_crds_context())

--- a/tox.ini
+++ b/tox.ini
@@ -51,11 +51,6 @@ setenv =
 # Don't treat positional arguments passed to tox as file system paths
 args_are_paths = false
 
-# Allow commands to use the following commands not specifically installed
-# in the tox env
-allowlist_externals =
-    echo
-
 [testenv:oldestdeps]
 install_command = python -m pip install --no-deps {packages}
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ passenv =
     TEST_BIGDATA
 
 commands =
+    echo_crds_context
     !cov: pytest {posargs}
     cov: pytest --cov-report=xml --cov=. --cov-config=setup.cfg {posargs}
 
@@ -45,8 +46,16 @@ deps =
     devdeps: -rrequirements-dev.txt
     sdpdeps: -rrequirements-sdp.txt
 
+setenv =
+    sdpdeps,regtests: CRDS_CONTEXT = jwst-edit
+
 # Don't treat positional arguments passed to tox as file system paths
 args_are_paths = false
+
+# Allow commands to use the following commands not specifically installed
+# in the tox env
+allowlist_externals =
+    echo
 
 [testenv:oldestdeps]
 install_command = python -m pip install --no-deps {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ passenv =
     TEST_BIGDATA
 
 commands =
-    echo_crds_context
     !cov: pytest {posargs}
     cov: pytest --cov-report=xml --cov=. --cov-config=setup.cfg {posargs}
 


### PR DESCRIPTION
 - Set CRDS_CONTEXT=jwst-edit in tox instead ci.yml
 - Add a header line to the pytest report to show the used CRDS_CONTEXT.

        $ pytest jwst/datamodels/tests/test_validation.py 
        ============================== test session starts ==============================
        platform darwin -- Python 3.9.1, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
        crds_context: jwst_0672.pmap
        rootdir: /Users/jdavies/dev/jwst, configfile: setup.cfg
        plugins: requests-mock-1.8.0, cov-2.11.1, ci-watson-0.5, xdist-2.2.1, asdf-2.7.2, openfiles-0.5.0, forked-1.3.0, doctestplus-0.9.0
        collected 3 items                                                               

        jwst/datamodels/tests/test_validation.py ...                              [100%]

        =============================== 3 passed in 0.81s ===============================


Resolves #5733.