### PR TITLE
JP-1876: Add new Lvl2 association rule for NRSLAMPImage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ associations
 
 - Warn about duplicate product names and do not write duplicate associations [#5721]
 
+- Added new Lvl2 rule, Asn_Lv2NRSLAMPImage, to run Image2 pipeline for NRSLAMP
+  exposures with OPMODE=image [#5740]
+
 datamodels
 ----------
 

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -423,6 +423,45 @@ class Asn_Lv2MIRLRSFixedSlitNod(
 
 
 @RegistryMarker.rule
+class Asn_Lv2NRSLAMPImage(
+        AsnMixin_Lv2Image,
+        AsnMixin_Lv2Special,
+        DMSLevel2bBase
+):
+    """Level2b NIRSpec image Lamp Calibrations Association
+
+    Characteristics:
+        - Association type: ``image2``
+        - Pipeline: ``calwebb_image2``
+        - Image-based calibration exposures
+        - Single science exposure
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Setup constraints
+        self.constraints = Constraint([
+            Constraint_Base(),
+            Constraint_Single_Science(self.has_science),
+            DMSAttrConstraint(
+                name='exp_type',
+                sources=['exp_type'],
+                value='nrs_lamp'
+            ),
+            DMSAttrConstraint(
+                sources=['grating'],
+                value='mirror'
+            ),
+            DMSAttrConstraint(
+                sources=['opmode'],
+                value='image',
+                required=False
+            ),
+        ])
+
+        super(Asn_Lv2NRSLAMPImage, self).__init__(*args, **kwargs)
+
+
+@RegistryMarker.rule
 class Asn_Lv2NRSLAMPSpectral(
         AsnMixin_Lv2Special,
         DMSLevel2bBase


### PR DESCRIPTION
Resolves [JP-1876](https://jira.stsci.edu/browse/JP-1876)
Resolves #5664 

Added new association rule, modified regression test results for two association pools.

NOTE: This PR requires edits to the regtest truth files.