### PR TITLE
Remove pip cache dir caching from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,19 +85,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{ hashFiles('**/requirements-sdp.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Get CRDS context
         id: crds-context
         run: |

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -3,3 +3,5 @@
 #     pip install -e .[test]
 #     pip install pytest-xdist
 #     pip freeze | grep -v jwst.git >> requirements-sdp.txt
+
+numpy==1.19.4


### PR DESCRIPTION
An attempt to reproduce #5744 / [JP-1922](https://jira.stsci.edu/browse/JP-1922)

This should cause the SDP dependencies job to fail, and reproduce the issue seen above.