### PR TITLE
move output_ext to jwst.Step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,7 +75,7 @@ stpipe
 ------
 
 - Make jwst.stpipe independent of the rest of the jwst package and move
-  core code to spacetelescope/stpipe. [#5695, #5720]
+  core code to spacetelescope/stpipe. [#5695, #5720, #5752]
 
 0.18.3 (2021-01-25)
 ===================

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -26,7 +26,6 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-
 class NoTypeWarning(Warning):
     pass
 

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -14,6 +14,11 @@ from ..lib.suffix import remove_suffix
 
 
 class JwstStep(Step):
+    
+    spec = """
+    output_ext         = string(default='.fits')     # Default type of output
+    """
+
     @classmethod
     def _datamodels_open(cls, init, **kwargs):
         return datamodels.open(init, **kwargs)

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -14,7 +14,7 @@ from ..lib.suffix import remove_suffix
 
 
 class JwstStep(Step):
-    
+
     spec = """
     output_ext         = string(default='.fits')     # Default type of output
     """


### PR DESCRIPTION
This PR 

- defines a default `output_ext` from the base `stpipe.Step` class to `JWSTStep` to prevent romancal from writing FITS files by default. I tested this on one step using `strun`.
- Unpinned stdatamodels and tested with the latest release - 0.2.
- This revealed a straggler `Model._files_to_close` attribute which was replaced with the new `FileReference` object.

This PR depends on spacetelescope/stpipe#17

