### PR TITLE
JP-1906: Fix handling of SRCTYPE for MOS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,10 @@ srctype
 - Changed default SRCTYPE for non-primary NIRSpec slits in a FIXEDSLIT
   exposure to 'EXTENDED' rather than 'POINT' [#5671]
 
+- Changed logic for handling NIRSpec MOS exposures to blank out the "global"
+  value of SRCTYPE, to ensure that only the individual slit-specific values
+  of SRCTYPE get used downstream. [#5754]
+
 stpipe
 ------
 

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -146,6 +146,10 @@ def set_source_type(input_model):
 
             log.info(f'source_id={slit.source_id}, stellarity={stellarity:.4f}, type={slit.source_type}')
 
+        # Remove the global target source type, so that it never mistakenly
+        # gets used for MOS data, which should always use slit-specific values
+        input_model.meta.target.source_type = None
+
     # Set all TSO exposures to POINT
     elif pipe_utils.is_tso(input_model):
         src_type = 'POINT'


### PR DESCRIPTION
This update to the srctype step simply unsets the value of the global target-based source_type in the data model when processing NIRSpec MOS exposures, so that it can't mistakenly get used later on, because MOS mode data should always and only use the slit-specific value of srctype. This was triggering a problem downstream in the photom step, which was making use of the model.meta.target.source_type value and ignoring the slit-specific values.

Fixes #5714 / [JP-1906](https://jira.stsci.edu/browse/JP-1906)