### PR TITLE
JP-1828 cube_build creating NIRSPEC lamp mode IFU data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ associations
 - Added new Lvl2 rule, Asn_Lv2NRSLAMPImage, to run Image2 pipeline for NRSLAMP
   exposures with OPMODE=image [#5740]
 
+
 combine_1d
 ----------
 
@@ -30,6 +31,11 @@ cube_build
 ----------
 
 - Added support for cross-dichroic configurations [#5722]
+
+- Added infrastructure to support NIRSpec opaque + grating options to build lamp mode data [#5757]
+  
+- When building MIRI internal_cal type cubes removed the requirement that cdelt1 = cdelt2 [#5757]
+
 
 datamodels
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,7 @@ cube_build
 
 - Added infrastructure to support NIRSpec opaque + grating options to build lamp mode data [#5757]
   
-- When building MIRI internal_cal type cubes removed the requirement that cdelt1 = cdelt2 [#5757]
+- When building MIRI internal_cal type cubes removed the requirement that cdelt1=cdelt2 [#5757]
 
 
 datamodels

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -243,9 +243,9 @@ class CubeData():
         if self.instrument == 'NIRSPEC':
             # 1 to 1 mapping valid_gwa[i] -> valid_fwa[i]
             valid_gwa = ['g140m', 'g140h', 'g140m', 'g140h', 'g235m',
-                         'g235h', 'g395m', 'g395h', 'prism']
+                         'g235h', 'g395m', 'g395h', 'prism','any']
             valid_fwa = ['f070lp', 'f070lp', 'f100lp', 'f100lp', 'f170lp',
-                        'f170lp', 'f290lp', 'f290lp', 'clear']
+                         'f170lp', 'f290lp', 'f290lp', 'clear','opaque']
 
             nbands = len(valid_fwa)
 

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -243,9 +243,11 @@ class CubeData():
         if self.instrument == 'NIRSPEC':
             # 1 to 1 mapping valid_gwa[i] -> valid_fwa[i]
             valid_gwa = ['g140m', 'g140h', 'g140m', 'g140h', 'g235m',
-                         'g235h', 'g395m', 'g395h', 'prism','any']
+                         'g235h', 'g395m', 'g395h', 'prism',
+                         'prism','g140m', 'g140h', 'g235m', 'g235h', 'g395m', 'g395h']
             valid_fwa = ['f070lp', 'f070lp', 'f100lp', 'f100lp', 'f170lp',
-                         'f170lp', 'f290lp', 'f290lp', 'clear','opaque']
+                         'f170lp', 'f290lp', 'f290lp', 'clear',
+                         'opaque', 'opaque','opaque', 'opaque','opaque', 'opaque','opaque']
 
             nbands = len(valid_fwa)
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -327,8 +327,10 @@ class CubeBuildStep (Step):
 # If not linear wavelength (multi bands) an arrays are created  for:
 # rois, roiw, weight_power, softrad
 
-            thiscube.determine_cube_parameters()
-
+            if self.coord_system == 'internal_cal':
+                thiscube.determine_cube_parameters_internal()
+            else:
+                thiscube.determine_cube_parameters()
             thiscube.setup_ifucube_wcs()
 # _______________________________________________________________________________
 # build the IFU Cube
@@ -391,7 +393,7 @@ class CubeBuildStep (Step):
                             'medium-short', 'medium-long', 'long-short', 'long-medium']
 
         valid_fwa = ['f070lp', 'f100lp',
-                     'g170lp', 'f290lp', 'clear', 'all']
+                     'g170lp', 'f290lp', 'clear', 'opaque','all']
         valid_gwa = ['g140m', 'g140h', 'g235m', 'g235h',
                      'g395m', 'g395h', 'prism', 'all']
 # ________________________________________________________________________________

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -108,8 +108,6 @@ class DataTypes():
         if output_dir is not None:
             self.output_name = output_dir + '/' + self.output_name
 
-#        print('*****************',self.output_name)
-
 # _______________________________________________________________________________
     def build_product_name(self, filename):
         """ Determine the base of output name if an input data is a fits filename.

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -81,6 +81,9 @@ class FileTable():
 
         self.FileMap['NIRSPEC']['g395h'] = {}
         self.FileMap['NIRSPEC']['g395h']['f290lp'] = []
+
+        self.FileMap['NIRSPEC']['any']= {}
+        self.FileMap['NIRSPEC']['any']['opaque'] = []
 # ********************************************************************************
 
     def set_file_table(self,
@@ -135,7 +138,9 @@ class FileTable():
                 elif instrument == 'NIRSPEC':
                     fwa = input_model.meta.instrument.filter.lower()
                     gwa = input_model.meta.instrument.grating.lower()
-
+                    fwa.strip()
+                    if fwa == 'opaque':
+                        gwa = 'any'
                     self.FileMap['NIRSPEC'][gwa][fwa].append(input_model)
                 else:
                     pass

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -143,10 +143,6 @@ class FileTable():
                 elif instrument == 'NIRSPEC':
                     fwa = input_model.meta.instrument.filter.lower()
                     gwa = input_model.meta.instrument.grating.lower()
-                    #print('remove this - force to work with existing cube par table')
-                    #if fwa == 'opaque':
-                    #    fwa = 'f170lp'
-
                     self.FileMap['NIRSPEC'][gwa][fwa].append(input_model)
                 else:
                     pass

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -61,29 +61,34 @@ class FileTable():
         self.FileMap['NIRSPEC'] = {}
         self.FileMap['NIRSPEC']['prism'] = {}
         self.FileMap['NIRSPEC']['prism']['clear'] = []
+        self.FileMap['NIRSPEC']['prism']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g140m'] = {}
         self.FileMap['NIRSPEC']['g140m']['f070lp'] = []
         self.FileMap['NIRSPEC']['g140m']['f100lp'] = []
+        self.FileMap['NIRSPEC']['g140m']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g140h'] = {}
         self.FileMap['NIRSPEC']['g140h']['f070lp'] = []
         self.FileMap['NIRSPEC']['g140h']['f100lp'] = []
+        self.FileMap['NIRSPEC']['g140h']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g235m'] = {}
         self.FileMap['NIRSPEC']['g235m']['f170lp'] = []
+        self.FileMap['NIRSPEC']['g235m']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g235h'] = {}
         self.FileMap['NIRSPEC']['g235h']['f170lp'] = []
+        self.FileMap['NIRSPEC']['g235h']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g395m'] = {}
         self.FileMap['NIRSPEC']['g395m']['f290lp'] = []
+        self.FileMap['NIRSPEC']['g395m']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g395h'] = {}
         self.FileMap['NIRSPEC']['g395h']['f290lp'] = []
+        self.FileMap['NIRSPEC']['g395h']['opaque'] = []
 
-        self.FileMap['NIRSPEC']['any']= {}
-        self.FileMap['NIRSPEC']['any']['opaque'] = []
 # ********************************************************************************
 
     def set_file_table(self,
@@ -138,9 +143,10 @@ class FileTable():
                 elif instrument == 'NIRSPEC':
                     fwa = input_model.meta.instrument.filter.lower()
                     gwa = input_model.meta.instrument.grating.lower()
-                    fwa.strip()
-                    if fwa == 'opaque':
-                        gwa = 'any'
+                    #print('remove this - force to work with existing cube par table')
+                    #if fwa == 'opaque':
+                    #    fwa = 'f170lp'
+
                     self.FileMap['NIRSPEC'][gwa][fwa].append(input_model)
                 else:
                     pass

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -906,7 +906,6 @@ class IFUCubeData():
         # no msm or emsm  information is needed
         par1 = self.list_par1[0]
         par2 = self.list_par2[0]
-        print('par1, par2', par1,par2)
 
         a_scale, b_scale, w_scale = self.instrument_info.GetScale(par1,
                                                                       par2)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -925,6 +925,12 @@ class IFUCubeData():
         minwave = np.zeros(number_bands)
         maxwave = np.zeros(number_bands)
 
+        if self.coord_system == 'internal_cal' and self.instrument == 'NIRSPEC':
+            if self.list_par1[0] == 'any' and self.list_par2[0] == 'opaque':
+                self.spaxel_size = 0.1
+                self.spectral_size = 0.005
+                return
+        
         for i in range(number_bands):
             if self.instrument == 'MIRI':
                 par1 = self.list_par1[i]

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -977,7 +977,7 @@ class InstrumentInfo():
         self.Info['g395m']['opaque']['wscale'] = 0.00179
         self.Info['g395m']['opaque']['ascale'] = 0.1
         self.Info['g395m']['opaque']['bscale'] = 0.1
-        
+
         self.Info['g140h'] = {}
         self.Info['g140h']['f070lp'] = {}
         self.Info['g140h']['f070lp']['nslices'] = 30
@@ -1010,7 +1010,7 @@ class InstrumentInfo():
         self.Info['g140h']['opaque']['wscale'] = 0.000235
         self.Info['g140h']['opaque']['ascale'] = 0.1
         self.Info['g140h']['opaque']['bscale'] = 0.1
-        
+
         self.Info['g235h'] = {}
         self.Info['g235h']['f170lp'] = {}
         self.Info['g235h']['f170lp']['nslices'] = 30
@@ -1030,7 +1030,7 @@ class InstrumentInfo():
         self.Info['g235h']['opaque']['wscale'] = 0.000396
         self.Info['g235h']['opaque']['ascale'] = 0.1
         self.Info['g235h']['opaque']['bscale'] = 0.1
-        
+
         self.Info['g395h'] = {}
         self.Info['g395h']['f290lp'] = {}
         self.Info['g395h']['f290lp']['nslices'] = 30

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -899,6 +899,12 @@ class InstrumentInfo():
         self.Info['prism']['clear']['msm_power'] = None
         self.Info['prism']['clear']['scalerad'] = None
 
+        self.Info['prism']['opaque'] = {}
+        self.Info['prism']['opaque']['nslices'] = 30
+        self.Info['prism']['opaque']['wscale'] = 0.005
+        self.Info['prism']['opaque']['ascale'] = 0.1
+        self.Info['prism']['opaque']['bscale'] = 0.1
+
         self.Info['g140m'] = {}
         self.Info['g140m']['f070lp'] = {}
         self.Info['g140m']['f070lp']['nslices'] = 30
@@ -926,6 +932,12 @@ class InstrumentInfo():
         self.Info['g140m']['f100lp']['msm_power'] = None
         self.Info['g140m']['f100lp']['scalerad'] = None
 
+        self.Info['g140m']['opaque'] = {}
+        self.Info['g140m']['opaque']['nslices'] = 30
+        self.Info['g140m']['opaque']['wscale'] = 0.000636
+        self.Info['g140m']['opaque']['ascale'] = 0.1
+        self.Info['g140m']['opaque']['bscale'] = 0.1
+
         self.Info['g235m'] = {}
         self.Info['g235m']['f170lp'] = {}
         self.Info['g235m']['f170lp']['nslices'] = 30
@@ -939,6 +951,12 @@ class InstrumentInfo():
         self.Info['g235m']['f170lp']['softrad'] = None
         self.Info['g235m']['f170lp']['msm_power'] = None
         self.Info['g235m']['f170lp']['scalerad'] = None
+
+        self.Info['g235m']['opaque'] = {}
+        self.Info['g235m']['opaque']['nslices'] = 30
+        self.Info['g235m']['opaque']['wscale'] = 0.00106
+        self.Info['g235m']['opaque']['ascale'] = 0.1
+        self.Info['g235m']['opaque']['bscale'] = 0.1
 
         self.Info['g395m'] = {}
         self.Info['g395m']['f290lp'] = {}
@@ -954,6 +972,12 @@ class InstrumentInfo():
         self.Info['g395m']['f290lp']['msm_power'] = None
         self.Info['g395m']['f290lp']['scalerad'] = None
 
+        self.Info['g395m']['opaque'] = {}
+        self.Info['g395m']['opaque']['nslices'] = 30
+        self.Info['g395m']['opaque']['wscale'] = 0.00179
+        self.Info['g395m']['opaque']['ascale'] = 0.1
+        self.Info['g395m']['opaque']['bscale'] = 0.1
+        
         self.Info['g140h'] = {}
         self.Info['g140h']['f070lp'] = {}
         self.Info['g140h']['f070lp']['nslices'] = 30
@@ -981,6 +1005,12 @@ class InstrumentInfo():
         self.Info['g140h']['f100lp']['msm_power'] = None
         self.Info['g140h']['f100lp']['scalerad'] = None
 
+        self.Info['g140h']['opaque'] = {}
+        self.Info['g140h']['opaque']['nslices'] = 30
+        self.Info['g140h']['opaque']['wscale'] = 0.000235
+        self.Info['g140h']['opaque']['ascale'] = 0.1
+        self.Info['g140h']['opaque']['bscale'] = 0.1
+        
         self.Info['g235h'] = {}
         self.Info['g235h']['f170lp'] = {}
         self.Info['g235h']['f170lp']['nslices'] = 30
@@ -995,6 +1025,12 @@ class InstrumentInfo():
         self.Info['g235h']['f170lp']['msm_power'] = None
         self.Info['g235h']['f170lp']['scalerad'] = None
 
+        self.Info['g235h']['opaque'] = {}
+        self.Info['g235h']['opaque']['nslices'] = 30
+        self.Info['g235h']['opaque']['wscale'] = 0.000396
+        self.Info['g235h']['opaque']['ascale'] = 0.1
+        self.Info['g235h']['opaque']['bscale'] = 0.1
+        
         self.Info['g395h'] = {}
         self.Info['g395h']['f290lp'] = {}
         self.Info['g395h']['f290lp']['nslices'] = 30
@@ -1008,6 +1044,12 @@ class InstrumentInfo():
         self.Info['g395h']['f290lp']['softrad'] = None
         self.Info['g395h']['f290lp']['msm_power'] = None
         self.Info['g395h']['f290lp']['scalerad'] = None
+
+        self.Info['g395h']['opaque'] = {}
+        self.Info['g395h']['opaque']['nslices'] = 30
+        self.Info['g395h']['opaque']['wscale'] = 0.000665
+        self.Info['g395h']['opaque']['ascale'] = 0.1
+        self.Info['g395h']['opaque']['bscale'] = 0.1
 
 # ******************************************************************
 # Functions


### PR DESCRIPTION
This PR closes JP-1828. An update to the NIRSpec cube_pars reference file is required that sets up the default spectral and spatial scaling to use in building the for NIRSpec lamp mode data. This reference file update is being tracked by CRDS-401. Once the reference file has a row for each NIRSpec lamp mode filter/grating combination (opaque + G140M, G140H, G235M, G235H, G395M or G395H) this PR will be able to read this reference file and create internal_cal type IFU cubes. 

Partially resolves #5562 / [JP-1828](https://jira.stsci.edu/browse/JP-1828). Requires [CRDS-401](https://jira.stsci.edu/browse/CRDS-401) for a complete solution.