### PR TITLE
JP-1919: Fix photom handling of NRS IFU extended sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,12 @@ lib
 
 - Make get_wcs_values_from_siaf public for JSDP use [#5669]
 
+photom
+------
+
+- Fixed handling of NIRSpec IFU extended source data, so that the flux
+  calibration gets converted to surface brightness [#5761]
+
 ramp_fitting
 ------------
 

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -55,3 +55,30 @@ def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test matching output files"""
     rt.is_like_truth(run_spec2, fitsdiff_default_kwargs, suffix,
                      truth_path=TRUTH_PATH)
+
+
+@pytest.fixture(scope='module')
+def run_photom(jail, rtdata_module):
+    """Run the photom step on an NRS IFU exposure with SRCTYPE=EXTENDED"""
+    rtdata = rtdata_module
+
+    # Setup the inputs
+    rate_name = 'jwdata0010010_11010_0001_NRS1_pathloss.fits'
+    rate_path = INPUT_PATH + '/' + rate_name
+
+    # Run the step
+    step_params = {
+        'input_path': rate_path,
+        'step': 'photom.cfg',
+        'args': ['--save_results=True',]
+    }
+
+    rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    return rtdata
+
+
+@pytest.mark.bigdata
+def test_photom(run_photom, fitsdiff_default_kwargs):
+    """Regression test matching output files"""
+    rt.is_like_truth(run_photom, fitsdiff_default_kwargs, 'photom',
+                     truth_path=TRUTH_PATH)


### PR DESCRIPTION
Update the function in the photom step that handles NIRSpec IFU data, so that it checks for SRCTYPE='EXTENDED' and converts the calibration given in MJy to MJy/sr, and update all necessary keyword values appropriately. Previously it had been just applying the point-source calibration (in MJy) to all IFU data, regardless of source type.

Fixes #5735 / [JP-1919](https://jira.stsci.edu/browse/JP-1919)