### PR TITLE
JP-1931: Add/Rename V2-V3 frame axes names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,15 @@ assign_wcs
 - Added velocity aberration-corrected frame ``'v2v3vacorr'`` to the WCS
   pipeline which takes into account DVA effects. [#5602]
 
+- Renamed MIRI frame ``'V2_V3_spatial'`` to ``'v2v3_spatial'`` and
+  ``'V2_V3_vacorr_spatial'`` to ``'v2v3vacorr_spatial'``. Added axes names
+  to the ``'v2v3'`` frame for ``nircam``, ``niriss``, ``miri``, and ``fgs``.
+  Renamed axes for ``nirspec`` from ``V2`` and ``V3`` to
+  ``v2`` and ``v3``. [#5765]
+
+- Changed units of the ``'v2v3'`` frame for ``nircam`` from ``u.deg`` to
+  ``u.arcsec`` [#5765]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -60,8 +60,10 @@ def imaging(input_model, reference_files):
     """
     # Create coordinate frames for the ``imaging`` mode.
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
-    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), axes_names=('v2', 'v3'),
+                      unit=(u.arcsec, u.arcsec))
+    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1),
+                            axes_names=('v2', 'v3'), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(name='world', reference_frame=coord.ICRS())
 
     # Create the v2v3 to sky transform.

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -66,8 +66,10 @@ def imaging(input_model, reference_files):
 
     # Create the Frames
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
-    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), axes_names=('v2', 'v3'),
+                      unit=(u.arcsec, u.arcsec))
+    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1),
+                            axes_names=('v2', 'v3'), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
     # Create the transforms
@@ -387,9 +389,9 @@ def ifu(input_model, reference_files):
     spec_local = cf.SpectralFrame(name='alpha_beta_spectral', axes_order=(2,),
                                   unit=(u.micron,), axes_names=('lambda',))
     miri_focal = cf.CompositeFrame([alpha_beta, spec_local], name='alpha_beta')
-    v23_spatial = cf.Frame2D(name='V2_V3_spatial', axes_order=(0, 1),
+    v23_spatial = cf.Frame2D(name='v2v3_spatial', axes_order=(0, 1),
                              unit=(u.arcsec, u.arcsec), axes_names=('v2', 'v3'))
-    v2v3vacorr_spatial = cf.Frame2D(name='V2_V3_vacorr_spatial', axes_order=(0, 1),
+    v2v3vacorr_spatial = cf.Frame2D(name='v2v3vacorr_spatial', axes_order=(0, 1),
                                     unit=(u.arcsec, u.arcsec), axes_names=('v2', 'v3'))
 
     spec = cf.SpectralFrame(name='spectral', axes_order=(2,), unit=(u.micron,),

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -73,8 +73,10 @@ def imaging(input_model, reference_files):
     and uses the "distortion" reference file.
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
-    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), axes_names=('v2', 'v3'),
+                      unit=(u.arcsec, u.arcsec))
+    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1),
+                            axes_names=('v2', 'v3'), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
     distortion = imaging_distortion(input_model, reference_files)
@@ -183,8 +185,10 @@ def tsgrism(input_model, reference_files):
 
     gdetector = cf.Frame2D(name='grism_detector', axes_order=(0, 1), unit=(u.pix, u.pix))
     detector = cf.Frame2D(name='full_detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.deg, u.deg))
-    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1), unit=(u.deg, u.deg))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), axes_names=('v2', 'v3'),
+                      unit=(u.arcsec, u.arcsec))
+    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1),
+                            axes_names=('v2', 'v3'), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
     # translate the x,y detector-in to x,y detector out coordinates

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -221,8 +221,10 @@ def imaging(input_model, reference_files):
     It uses the "distortion" reference file.
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
-    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), axes_names=('v2', 'v3'),
+                      unit=(u.arcsec, u.arcsec))
+    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1),
+                            axes_names=('v2', 'v3'), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
     distortion = imaging_distortion(input_model, reference_files)

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1451,10 +1451,10 @@ def create_frames():
     slit_spatial = cf.Frame2D(name='slit_spatial', axes_order=(0, 1), unit=("", ""),
                              axes_names=('x_slit', 'y_slit'))
     sky = cf.CelestialFrame(name='sky', axes_order=(0, 1), reference_frame=coord.ICRS())
-    v2v3_spatial = cf.Frame2D(name='v2v3_spatial', axes_order=(0, 1), unit=(u.arcsec, u.arcsec),
-                             axes_names=('V2', 'V3'))
+    v2v3_spatial = cf.Frame2D(name='v2v3_spatial', axes_order=(0, 1),
+                              unit=(u.arcsec, u.arcsec), axes_names=('v2', 'v3'))
     v2v3vacorr_spatial = cf.Frame2D(name='v2v3vacorr_spatial', axes_order=(0, 1),
-                                    unit=(u.arcsec, u.arcsec), axes_names=('V2', 'V3'))
+                                    unit=(u.arcsec, u.arcsec), axes_names=('v2', 'v3'))
 
     # The oteip_to_v23 incorporates a scale to convert the spectral units from
     # meters to microns.  So the v2v3 output frame will be in u.deg, u.deg, u.micron
@@ -1485,8 +1485,8 @@ def create_imaging_frames():
                      axes_names=('x_msa', 'y_msa'))
     v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec),
                       axes_names=('v2', 'v3'))
-    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1), unit=(u.arcsec, u.arcsec),
-                            axes_names=('v2', 'v3'))
+    v2v3vacorr = cf.Frame2D(name='v2v3vacorr', axes_order=(0, 1),
+                            unit=(u.arcsec, u.arcsec), axes_names=('v2', 'v3'))
     oteip = cf.Frame2D(name='oteip', axes_order=(0, 1), unit=(u.deg, u.deg),
                        axes_names=('x_oteip', 'y_oteip'))
     world = cf.CelestialFrame(name='world', axes_order=(0, 1), reference_frame=coord.ICRS())


### PR DESCRIPTION
This PR changes the case of V2-V3 axes for NIRSPEC from `V2`->`v2` and adds axes names for `v2v3` frames for other instruments. This takes care of https://github.com/spacetelescope/jwst/pull/5602#discussion_r577934002 and item `#4` in https://github.com/spacetelescope/jwst/issues/5746#issue-807568325

This PR also fixes units for the `v2v3` frame for NIRCAM (`u.deg`->`u.arcsec`) as described in item `#2` in https://github.com/spacetelescope/jwst/issues/5746#issue-807568325.

However, I have noticed many other (than `v2v3`) frames also do not have axes names.

Resolves #5770 / [JP-1931](https://jira.stsci.edu/browse/JP-1931)