### PR TITLE
Silence traceback of associations diff test helpers

### DIFF
--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -69,6 +69,7 @@ def compare_asn_files(left_paths, right_paths):
         If there are differences. The message will contain
         all the differences.
     """
+    __tracebackhide__ = True
     # Read in all the associations, separating out the products into separate associations.
     left_asns = []
     for path in left_paths:
@@ -113,6 +114,7 @@ def compare_asn_lists(left_asns, right_asns):
         If there are differences. The message will contain
         all the differences.
     """
+    __tracebackhide__ = True
     diffs = MultiDiffError()
 
     # Ensure that product names are unique


### PR DESCRIPTION
This makes the failure traceback reporting much more compact in Pytest by not printing the full code of the assertion helpers when a test fails.  If `compare_asn_files()` is used outside of Pytest, this has no effect.

There may be more of these assertion helpers, but these are the ones I came across.

Traceback with this PR:

```
___________________ TestSDPPools.test_against_standard[jw00626_20190605t025021_pool] ____________________

self = <jwst.regtest.test_associations_sdp_pools.TestSDPPools object at 0x7ff6d04f0a90>
pool_path = 'sdp/pools/jw00626_20190605t025021_pool.csv', slow = False

    def test_against_standard(self, pool_path, slow):
        """Compare a generated association against a standard
    
        Success is when no other AssertionError occurs.
        """
    
        # Parse pool name
        pool = Path(pool_path).stem
        proposal, version_id = pool_regex.match(pool).group('proposal', 'versionid')
        special = SPECIAL_POOLS.get(pool, SPECIAL_DEFAULT)
    
        if special['slow'] and not slow:
            pytest.skip('Pool {pool} requires "--slow" option')
    
        # Create the generator running arguments
        generated_path = Path('generate')
        generated_path.mkdir()
        args = special['args'] + [
            '-p', str(generated_path),
            '--version-id', version_id,
            self.get_data(pool_path)
        ]
    
        # Create the associations
        asn_generate(args)
    
        # Retrieve the truth files
        asn_regex = re.compile(
            r'.+{proposal}.+{version_id}(_[^_]+?_[^_]+?_asn\.json)$'.format(
                proposal=proposal, version_id=version_id
            ),
            flags=re.IGNORECASE
        )
        truth_paths = [
            self.get_data(truth_path)
            for truth_path in self.truth_paths
            if asn_regex.match(truth_path)
        ]
    
        # Compare the association sets.
        try:
>           compare_asn_files(generated_path.glob('*.json'), truth_paths)
E           jwst.associations.lib.diff.MultiDiffError: Following diffs found:
E           
E           ****
E           Right associations have duplicate products ['jw00626-c1004_t005_nirspec_g235h']
E           
E           ****
E           Left and right associations do not share a common set of products: {'jw00626-c1001_t005_nirspec_g235h', 'jw00626-c1001_t005_nirspec_g395h', 'jw00626-c1003_t005_nirspec_g235h', 'jw00626-c1001_t006_nirspec_g395h', 'jw00626-a3001_t004_nirspec_g395h', 'jw00626-c1001_t006_nirspec_g235h', 'jw00626-c1004_t006_nirspec_g235h', 'jw00626-c1003_t006_nirspec_g395h', 'jw00626-c1003_t006_nirspec_g235h', 'jw00626-c1003_t005_nirspec_g395h'}

/Users/jdavies/dev/jwst/jwst/regtest/test_associations_sdp_pools.py:140: MultiDiffError
```