### PR TITLE
JP-1914: Remove references to deprecated numpy globals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,12 @@ photom
 - Fixed handling of NIRSpec IFU extended source data, so that the flux
   calibration gets converted to surface brightness [#5761]
 
+pipeline
+--------
+
+- Remove references to Numpy globals ``np.int``, ``np.float``, ``np.bool`` and
+  ``np.str`` in the package. [#5769]
+
 ramp_fitting
 ------------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -728,7 +728,7 @@ def _shutter_id_to_str(open_shutters, ycen):
     for i in open_shutters:
         all_shutters[all_shutters == i] = 1
     all_shutters[all_shutters != 1] = 0
-    all_shutters = all_shutters.astype(np.str)
+    all_shutters = all_shutters.astype(str)
     all_shutters[cen_ind] = 'x'
     return "".join(all_shutters)
 

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -144,7 +144,7 @@ def subtract_wfss_bkg(input_model, bkg_filename, wl_range_name):
     if got_catalog:
         bkg_mask = mask_from_source_cat(input_model, wl_range_name)
     else:
-        bkg_mask = np.ones(input_model.data.shape, dtype=np.bool)
+        bkg_mask = np.ones(input_model.data.shape, dtype=bool)
 
     # Compute the mean values of science image and background reference
     # image, including only regions where there are no identified sources.
@@ -223,7 +223,7 @@ def mask_from_source_cat(input_model, wl_range_name):
     """
 
     shape = input_model.data.shape
-    bkg_mask = np.ones(shape, dtype=np.bool)
+    bkg_mask = np.ones(shape, dtype=bool)
 
     reference_files = {"wavelengthrange": wl_range_name}
     grism_obj_list = create_grism_bbox(input_model, reference_files)

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -166,7 +166,7 @@ def subtract_wfss_bkg(input_model, bkg_filename, wl_range_name):
         subtract_this = (sci_mean / bkg_mean) * bkg_ref.data
         result.data = input_model.data - subtract_this
         log.debug("Average of values subtracted = {}"
-                  .format(subtract_this.mean(dtype=np.float)))
+                  .format(subtract_this.mean(dtype=float)))
     else:
         log.warning("Background file has zero mean; "
                     "nothing will be subtracted.")
@@ -270,6 +270,6 @@ def robust_mean(x, lowlim=25., highlim=75.):
 
     limits = np.percentile(x, (lowlim, highlim))
     mask = np.logical_and(x >= limits[0], x <= limits[1])
-    mean_value = x[mask].mean(dtype=np.float)
+    mean_value = x[mask].mean(dtype=float)
 
     return mean_value

--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -117,7 +117,7 @@ def fourier_imshift(image, shift):
             raise ValueError("The number of provided shifts must be equal "
                              "to the number of slices in the input image.")
 
-        offset = np.empty_like(image, dtype=np.float)
+        offset = np.empty_like(image, dtype=float)
         for k in range(nslices):
             offset[k] = fourier_imshift(image[k], shift[k])
 
@@ -164,7 +164,7 @@ def align_array(reference, target, mask=None):
 
     elif len(target.shape) == 3:
         nslices = target.shape[0]
-        shifts = np.empty((nslices, 3), dtype=np.float)
+        shifts = np.empty((nslices, 3), dtype=float)
         aligned = np.empty_like(target)
 
         for m in range(nslices):

--- a/jwst/coron/tests/test_coron.py
+++ b/jwst/coron/tests/test_coron.py
@@ -10,7 +10,8 @@ def test_fourier_imshift():
     """ Test of fourier_imshift() in imageregistration.py """
 
     image = np.zeros((5,5), dtype=np.float32)
-    image[1:4,1:4] += 1.; image[2,2] += 2.
+    image[1:4,1:4] += 1.
+    image[2,2] += 2.
     shift = [1.2, 0.6]
     result = imageregistration.fourier_imshift( image, shift)
 
@@ -26,11 +27,12 @@ def test_fourier_imshift():
 def test_shift_subtract():
     """ Test of shift_subtract() in imageregistration.py """
 
-    target = np.arange((15), dtype = np.float32)
-    target = target.reshape((3,5))
+    target = np.arange((15), dtype=np.float32).reshape((3, 5))
     reference = target +.1
     reference[1,0] -= 0.2; reference[2,0] += 2.3
-    mask = target * 0 + 1; mask[1,1]= 0 ; mask[1,2]= 0
+    mask = target * 0 + 1
+    mask[1,1]= 0
+    mask[1,2]= 0
     params = (0.2,-0.3,1)
 
     result = imageregistration.shift_subtract(params, reference, target, mask)
@@ -46,11 +48,13 @@ def test_shift_subtract():
 def test_align_fourierLSQ():
     """ Test of align_fourierLSQ() in imageregistration.py """
 
-    target = np.arange((15), dtype = np.float32)
-    target = target.reshape((3,5))
+    target = np.arange((15), dtype=np.float32).reshape((3, 5))
     reference = target +.1
-    reference[1,0] -= 0.2; reference[2,0] += 2.3
-    mask = target * 0 + 1; mask[1,1]= 0 ; mask[1,2]= 0
+    reference[1,0] -= 0.2
+    reference[2,0] += 2.3
+    mask = target * 0 + 1
+    mask[1,1]= 0
+    mask[1,2]= 0
 
     shifts = imageregistration.align_fourierLSQ( reference, target, mask )
     truth = np.array([-0.0899215, -0.01831958, 0.96733475])
@@ -61,7 +65,7 @@ def test_align_fourierLSQ():
 def test_align_array():
     """ Test of align_array() in imageregistration.py """
 
-    temp = np.arange((15), dtype = np.float32); temp = temp.reshape((3,5))
+    temp = np.arange((15), dtype=np.float32).reshape((3, 5))
     targ = np.zeros((3,3,5))
     targ[:] = temp
     targ[0,1,1] += 0.3; targ[0,2,1] += 0.7; targ[0,0,3] -= 0.5; targ[0,1,2] -= 1.3
@@ -102,7 +106,7 @@ def test_align_array():
 def test_align_models():
     """ Test of align_models() in imageregistration.py """
 
-    temp = np.arange((15), dtype = np.float32); temp = temp.reshape((3,5))
+    temp = np.arange((15), dtype=np.float32).reshape((3, 5))
     targ = np.zeros((3,3,5))
     targ[:] = temp
     targ[0,1,1] += 0.3; targ[0,2,1] += 0.7; targ[0,0,3] -= 0.5; targ[0,1,2] -= 1.3
@@ -141,8 +145,7 @@ def test_align_models():
 def test_KLT():
     """ Test of KarhunenLoeveTransform() in klip.py """
 
-    temp = np.arange((15), dtype = np.float32)
-    temp = temp.reshape((3,5))
+    temp = np.arange((15), dtype=np.float32).reshape((3, 5))
     refs = np.zeros((3,3,5))
     refs[:] = temp
     refs[0,1,1] += 0.3; refs[0,2,1] += 0.7; refs[0,0,3] -= 0.5; refs[0,1,2] -= 1.3

--- a/jwst/cube_skymatch/cube_skymatch_step.py
+++ b/jwst/cube_skymatch/cube_skymatch_step.py
@@ -234,8 +234,8 @@ class CubeSkyMatchStep(Step):
         y = y.ravel()
 
         # convert to RA/DEC:
-        r, d, l = model2d.meta.wcs(x.astype(dtype=np.float),
-                                   y.astype(dtype=np.float))
+        r, d, l = model2d.meta.wcs(x.astype(dtype=float),
+                                   y.astype(dtype=float))
 
         # some pixels may be NaNs and so throw them out:
         m = np.logical_and(

--- a/jwst/cube_skymatch/cube_skymatch_step.py
+++ b/jwst/cube_skymatch/cube_skymatch_step.py
@@ -88,7 +88,7 @@ class CubeSkyMatchStep(Step):
                     cm.dq,
                     self._dqbits,
                     good_mask_value=0,
-                    dtype=np.bool
+                    dtype=bool
                 )
                 weights[dq] = 0.0
 

--- a/jwst/cube_skymatch/skycube.py
+++ b/jwst/cube_skymatch/skycube.py
@@ -179,7 +179,7 @@ class SkyCube():
     def weights(self, weights):
         if weights is None:
             self._weights = np.ones_like(self.data, dtype=np.float)
-            self._mask = np.ones_like(self.data, dtype=np.bool)
+            self._mask = np.ones_like(self.data, dtype=bool)
         else:
             if weights.shape != self.data.shape:
                 raise ValueError("Weight map must have the same shape as "

--- a/jwst/cube_skymatch/skycube.py
+++ b/jwst/cube_skymatch/skycube.py
@@ -141,7 +141,7 @@ class SkyCube():
         self._set_bkg_center(bkg_center)
 
         bkg_degree_p1 = tuple((i + 1 for i in self._bkg_degree))
-        self._bkg_coeff = np.zeros(bkg_degree_p1, dtype=np.float)
+        self._bkg_coeff = np.zeros(bkg_degree_p1, dtype=float)
         self._bkg_status = 1 # not computed
         self._bkg_cube = None
         self._bkg_cube_dirty = True
@@ -178,7 +178,7 @@ class SkyCube():
     @weights.setter
     def weights(self, weights):
         if weights is None:
-            self._weights = np.ones_like(self.data, dtype=np.float)
+            self._weights = np.ones_like(self.data, dtype=float)
             self._mask = np.ones_like(self.data, dtype=bool)
         else:
             if weights.shape != self.data.shape:
@@ -279,7 +279,7 @@ class SkyCube():
         # This function should be called ONLY AFTER _data, _wcs, _x0, _y0, _z0,
         # _bkg_degree
 
-        z, y, x = np.indices(self._data.shape, dtype=np.float)
+        z, y, x = np.indices(self._data.shape, dtype=float)
         if self._wcs is not None:
             # TODO: the need to use ravel/reshape is due to a bug in
             # astropy.modeling that is affecting gwcs. In future, all the code

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2296,8 +2296,8 @@ class ImageExtractModel(ExtractBase):
             y_array = y_array[trim_slc]
 
         if got_wavelength:
-            indx = np.around(x_array).astype(np.int)
-            indy = np.around(y_array).astype(np.int)
+            indx = np.around(x_array).astype(int)
+            indy = np.around(y_array).astype(int)
             indx = np.where(indx < 0, 0, indx)
             indx = np.where(indx >= shape[1], shape[1] - 1, indx)
             indy = np.where(indy < 0, 0, indy)

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2206,14 +2206,14 @@ class ImageExtractModel(ExtractBase):
         (mask_target, mask_bkg) = self.separate_target_and_background(ref)
 
         # This is the number of pixels in the cross-dispersion direction, in the target extraction region.
-        n_target = mask_target.sum(axis=axis, dtype=np.float)
+        n_target = mask_target.sum(axis=axis, dtype=float)
 
         # Extract the data.
-        gross = (data * mask_target).sum(axis=axis, dtype=np.float)
+        gross = (data * mask_target).sum(axis=axis, dtype=float)
 
         # Compute the number of pixels that were added together to get gross.
         temp = np.ones_like(data)
-        npixels = (temp * mask_target).sum(axis=axis, dtype=np.float)
+        npixels = (temp * mask_target).sum(axis=axis, dtype=float)
 
         if self.subtract_background is not None:
             if not self.subtract_background:
@@ -2226,10 +2226,10 @@ class ImageExtractModel(ExtractBase):
 
         # Extract the background.
         if mask_bkg is not None:
-            n_bkg = mask_bkg.sum(axis=axis, dtype=np.float)
+            n_bkg = mask_bkg.sum(axis=axis, dtype=float)
             n_bkg = np.where(n_bkg == 0., -1., n_bkg)  # -1 is used as a flag, and also to avoid dividing by zero.
 
-            background = (data * mask_bkg).sum(axis=axis, dtype=np.float)
+            background = (data * mask_bkg).sum(axis=axis, dtype=float)
 
             scalefactor = n_target / n_bkg
             scalefactor = np.where(n_bkg > 0., scalefactor, 0.)
@@ -2261,9 +2261,9 @@ class ImageExtractModel(ExtractBase):
         # Used for computing the celestial coordinates and the 1-D array of wavelengths.
         flag = (mask_target > 0.)
         grid = np.indices(shape)
-        masked_grid = flag.astype(np.float) * grid[axis]
+        masked_grid = flag.astype(float) * grid[axis]
         g_sum = masked_grid.sum(axis=axis)
-        f_sum = flag.sum(axis=axis, dtype=np.float)
+        f_sum = flag.sum(axis=axis, dtype=float)
         f_sum_zero = np.where(f_sum <= 0.)
         f_sum[f_sum_zero] = 1.  # to avoid dividing by zero
 
@@ -2277,11 +2277,11 @@ class ImageExtractModel(ExtractBase):
         # Near the left and right edges, there might not be any non-zero values in mask_target, so a slice will be
         # extracted from both x_array and y_array in order to exclude pixels that are not within the extraction region.
         if self.dispaxis == HORIZONTAL:
-            x_array = np.arange(shape[1], dtype=np.float)
+            x_array = np.arange(shape[1], dtype=float)
             y_array = spectral_trace
         else:
             x_array = spectral_trace
-            y_array = np.arange(shape[0], dtype=np.float)
+            y_array = np.arange(shape[0], dtype=float)
 
         # Trim off the ends, if there's no data there.
         # Save trim_slc.
@@ -2355,9 +2355,9 @@ class ImageExtractModel(ExtractBase):
 
         if wavelength is None:
             if self.dispaxis == HORIZONTAL:
-                wavelength = np.arange(shape[1], dtype=np.float)
+                wavelength = np.arange(shape[1], dtype=float)
             else:
-                wavelength = np.arange(shape[0], dtype=np.float)
+                wavelength = np.arange(shape[0], dtype=float)
 
             wavelength = wavelength[trim_slc]
 

--- a/jwst/extract_1d/spec_wcs.py
+++ b/jwst/extract_1d/spec_wcs.py
@@ -45,7 +45,7 @@ def create_spectral_wcs(ra, dec, wavelength):
                             axes_names=('wavelength',))
     world = cf.CompositeFrame([sky, spec], name='world')
 
-    pixel = np.arange(len(wavelength), dtype=np.float)
+    pixel = np.arange(len(wavelength), dtype=float)
     tab = Mapping((0, 0, 0)) | \
           Const1D(ra) & Const1D(dec) & Tabular1D(points=pixel,
                                                  lookup_table=wavelength,

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -218,7 +218,7 @@ def apply_flat_field(science, flat, inverse=False):
     # Find all pixels in the flat that have a DQ value of NON_SCIENCE
     # add the DO_NOT_USE flag to these pixels. We don't want to use these pixels
     # in futher steps
-    flag_nonsci = np.bitwise_and(science.dq, dqflags.pixel['NON_SCIENCE']).astype(np.bool)
+    flag_nonsci = np.bitwise_and(science.dq, dqflags.pixel['NON_SCIENCE']).astype(bool)
     science.dq[flag_nonsci] = np.bitwise_or(science.dq[flag_nonsci], dqflags.pixel['DO_NOT_USE'])
 
 #

--- a/jwst/ipc/x_irs2.py
+++ b/jwst/ipc/x_irs2.py
@@ -199,7 +199,7 @@ def make_mask(input_model, n=None, r=None):
     # Number of normal pixels per amplifier output.
     n_output = (irs2_nx - refout) // 4 - k * n_ref
 
-    irs2_mask = np.ones(irs2_nx, dtype=np.bool)
+    irs2_mask = np.ones(irs2_nx, dtype=bool)
     irs2_mask[0:refout] = False
 
     # Check that the locations of interspersed reference pixels is
@@ -212,7 +212,7 @@ def make_mask(input_model, n=None, r=None):
     else:
         # Set the flags for each readout direction separately.
         nelem = (irs2_nx - refout) // 4         # number of elements per output
-        temp = np.ones(nelem, dtype=np.bool)
+        temp = np.ones(nelem, dtype=bool)
         for i in range(n_norm // 2, nelem + 1, n_norm + n_ref):
             temp[i:i + n_ref] = False
         j = refout

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -128,7 +128,7 @@ def test_one_CR(generate_miri_reffiles, max_cores, setup_inputs):
     grouptime = 3.0
     deltaDN = 5
     ingain = 6
-    inreadnoise = np.float64(7)
+    inreadnoise = 7
     ngroups = 100
     CR_fraction = 3
     xsize = 103
@@ -165,7 +165,7 @@ def test_nircam(generate_nircam_reffiles, setup_inputs, max_cores):
     grouptime = 3.0
     deltaDN = 5
     ingain = 6
-    inreadnoise = np.float64(7)
+    inreadnoise = 7
     ngroups = 100
     CR_fraction = 5
     nrows = 20
@@ -200,7 +200,7 @@ def test_two_CRs(generate_miri_reffiles, max_cores, setup_inputs):
     grouptime = 3.0
     deltaDN = 5
     ingain = 6
-    inreadnoise = np.float64(7)
+    inreadnoise = 7
     ngroups = 100
     CR_fraction = 5
     xsize = 103
@@ -235,7 +235,7 @@ def test_two_group_integration(generate_miri_reffiles, max_cores, setup_inputs):
     override_gain, override_readnoise = generate_miri_reffiles
     grouptime = 3.0
     ingain = 6
-    inreadnoise = np.float64(7)
+    inreadnoise = 7
     ngroups = 2
     xsize = 103
     ysize = 102
@@ -251,7 +251,7 @@ def test_four_group_integration(generate_miri_reffiles, setup_inputs):
     override_gain, override_readnoise = generate_miri_reffiles
     grouptime = 3.0
     ingain = 6
-    inreadnoise = np.float64(7)
+    inreadnoise = 7
     ngroups = 4
     xsize = 103
     ysize = 102
@@ -267,7 +267,7 @@ def test_five_group_integration(generate_miri_reffiles, setup_inputs):
     override_gain, override_readnoise = generate_miri_reffiles
     grouptime = 3.0
     ingain = 6
-    inreadnoise = np.float64(7)
+    inreadnoise = 7
     ngroups = 5
     xsize = 103
     ysize = 102

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -141,7 +141,7 @@ def test_one_CR(generate_miri_reffiles, max_cores, setup_inputs):
     first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
     CR_locs = [x for x in range(xsize*ysize) if x % CR_fraction == 0]
     CR_x_locs = [x % ysize for x in CR_locs]
-    CR_y_locs = [np.int(x / xsize) for x in CR_locs]
+    CR_y_locs = [int(x / xsize) for x in CR_locs]
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
@@ -177,7 +177,7 @@ def test_nircam(generate_nircam_reffiles, setup_inputs, max_cores):
     first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
     CR_locs = [x for x in range(nrows*ncols) if x % CR_fraction == 0]
     CR_x_locs = [x % ncols for x in CR_locs]
-    CR_y_locs = [np.int(x / nrows) for x in CR_locs]
+    CR_y_locs = [int(x / nrows) for x in CR_locs]
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
@@ -213,7 +213,7 @@ def test_two_CRs(generate_miri_reffiles, max_cores, setup_inputs):
     first_CR_group_locs = [x for x in range(1,89) if x % 5 == 0]
     CR_locs = [x for x in range(xsize*ysize) if x % CR_fraction == 0]
     CR_x_locs = [x % ysize for x in CR_locs]
-    CR_y_locs = [np.int(x / xsize) for x in CR_locs]
+    CR_y_locs = [int(x / xsize) for x in CR_locs]
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -207,8 +207,8 @@ def apply_background_2d(model2d, channel=None, subtract=True):
     y = y.ravel()
 
     # convert to RA/DEC:
-    r, d, l = model2d.meta.wcs(x.astype(dtype=np.float),
-                               y.astype(dtype=np.float))
+    r, d, l = model2d.meta.wcs(x.astype(dtype=float),
+                               y.astype(dtype=float))
 
     # some pixels may be NaNs and so throw them out:
     m = np.logical_and(

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -456,7 +456,7 @@ def flag_cr(sci_image, blot_image, **pars):
     # recast cr_mask to int for manipulations below; will recast to
     # Bool at end
     cr_mask_orig_bool = cr_mask.copy()
-    cr_mask = cr_mask_orig_bool.astype(np.int8)
+    cr_mask = cr_mask_orig_bool.astype(np.uint8)
 
     # make radial convolution kernel and convolve it with original cr_mask
     cr_grow_kernel = np.ones((grow, grow))

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -384,7 +384,7 @@ def create_photom_nrs_fs(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
     #  4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0]
     photmj = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
     uncertainty = np.zeros(nrows, dtype=np.float32)
-    nelem = np.zeros(nrows, np.int32) + nx
+    nelem = np.zeros(nrows, dtype=np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
     wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
@@ -445,7 +445,7 @@ def create_photom_nrs_msa(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
     # [3.1, 3.2, 3.3, 3.4]
     photmj = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
     uncertainty = np.zeros(nrows, dtype=np.float32)
-    nelem = np.zeros(nrows, np.int32) + nx
+    nelem = np.zeros(nrows, dtype=np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
     wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
@@ -506,7 +506,7 @@ def create_photom_niriss_wfss(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
     # [3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
     uncertainty = np.zeros(nrows, dtype=np.float32)
-    nelem = np.zeros(nrows, np.int32) + nx
+    nelem = np.zeros(nrows, dtype=np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
     wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
@@ -560,7 +560,7 @@ def create_photom_niriss_soss(min_r=8.0, max_r=9.0):
     # [3.1, 3.2]
     photmj = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
     uncertainty = np.zeros(nrows, dtype=np.float32)
-    nelem = np.zeros(nrows, np.int32) + nx
+    nelem = np.zeros(nrows, dtype=np.int32) + nx
     wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[0, :] = np.linspace(0.9, 2.8, nx, dtype=np.float32)
     wavelength[1, :] = np.linspace(0.6, 1.4, nx, dtype=np.float32)
@@ -692,7 +692,7 @@ def create_photom_miri_lrs(min_wl=5.0, max_wl=10.0, min_r=8.0, max_r=9.0):
     # [3.1, 3.2, 3.3]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
     uncertainty = np.zeros(nrows, dtype=np.float32)
-    nelem = np.zeros(nrows, np.int32) + nx
+    nelem = np.zeros(nrows, dtype=np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
     wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
@@ -833,7 +833,7 @@ def create_photom_nircam_wfss(min_wl=2.4, max_wl=5.0, min_r=8.0, max_r=9.0):
     # [3.1, 3.2, 3.3, 3.4, 3.5]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
     uncertainty = np.zeros(nrows, dtype=np.float32)
-    nelem = np.zeros(nrows, np.int32) + nx
+    nelem = np.zeros(nrows, dtype=np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
     wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -383,15 +383,15 @@ def create_photom_nrs_fs(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
     # [3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0,
     #  4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0]
     photmj = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
     nelem = np.zeros(nrows, np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
-    wavelength = np.zeros((nrows, nx), np.float32)
+    wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
     y = np.linspace(min_r, max_r, nx, dtype=np.float32).reshape(1, nx)
-    relresponse = np.zeros((nrows, nx), np.float32)
+    relresponse = np.zeros((nrows, nx), dtype=np.float32)
     relresponse[:] = y.copy()
-    reluncertainty = np.ones((nrows, nx), np.float32)
+    reluncertainty = np.ones((nrows, nx), dtype=np.float32)
 
     nx = wavelength.shape[-1]
 
@@ -444,15 +444,15 @@ def create_photom_nrs_msa(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
 
     # [3.1, 3.2, 3.3, 3.4]
     photmj = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
     nelem = np.zeros(nrows, np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
-    wavelength = np.zeros((nrows, nx), np.float32)
+    wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
     y = np.linspace(min_r, max_r, nx, dtype=np.float32).reshape(1, nx)
-    relresponse = np.zeros((nrows, nx), np.float32)
+    relresponse = np.zeros((nrows, nx), dtype=np.float32)
     relresponse[:] = y.copy()
-    reluncertainty = np.ones((nrows, nx), np.float32)
+    reluncertainty = np.ones((nrows, nx), dtype=np.float32)
 
     dtype = np.dtype([('filter', 'S12'),
                       ('grating', 'S15'),
@@ -505,15 +505,15 @@ def create_photom_niriss_wfss(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
 
     # [3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
     nelem = np.zeros(nrows, np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
-    wavelength = np.zeros((nrows, nx), np.float32)
+    wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
     y = np.linspace(min_r, max_r, nx, dtype=np.float32).reshape(1, nx)
-    relresponse = np.zeros((nrows, nx), np.float32)
+    relresponse = np.zeros((nrows, nx), dtype=np.float32)
     relresponse[:] = y.copy()
-    reluncertainty = np.ones((nrows, nx), np.float32)
+    reluncertainty = np.ones((nrows, nx), dtype=np.float32)
 
     dtype = np.dtype([('filter', 'S12'),
                       ('pupil', 'S15'),
@@ -559,15 +559,15 @@ def create_photom_niriss_soss(min_r=8.0, max_r=9.0):
 
     # [3.1, 3.2]
     photmj = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
     nelem = np.zeros(nrows, np.int32) + nx
-    wavelength = np.zeros((nrows, nx), np.float32)
+    wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[0, :] = np.linspace(0.9, 2.8, nx, dtype=np.float32)
     wavelength[1, :] = np.linspace(0.6, 1.4, nx, dtype=np.float32)
     y = np.linspace(min_r, max_r, nx, dtype=np.float32).reshape(1, nx)
-    relresponse = np.zeros((nrows, nx), np.float32)
+    relresponse = np.zeros((nrows, nx), dtype=np.float32)
     relresponse[:] = y.copy()
-    reluncertainty = np.ones((nrows, nx), np.float32)
+    reluncertainty = np.ones((nrows, nx), dtype=np.float32)
 
     dtype = np.dtype([('filter', 'S12'),
                       ('pupil', 'S12'),
@@ -612,7 +612,7 @@ def create_photom_niriss_image(min_r=8.0, max_r=9.0):
 
     # [3.1, 3.2, 3.3]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
 
     dtype = np.dtype([('filter', 'S12'),
                       ('pupil', 'S12'),
@@ -691,15 +691,15 @@ def create_photom_miri_lrs(min_wl=5.0, max_wl=10.0, min_r=8.0, max_r=9.0):
 
     # [3.1, 3.2, 3.3]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
     nelem = np.zeros(nrows, np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
-    wavelength = np.zeros((nrows, nx), np.float32)
+    wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
     y = np.linspace(min_r, max_r, nx, dtype=np.float32).reshape(1, nx)
-    relresponse = np.zeros((nrows, nx), np.float32)
+    relresponse = np.zeros((nrows, nx), dtype=np.float32)
     relresponse[:] = y.copy()
-    reluncertainty = np.ones((nrows, nx), np.float32)
+    reluncertainty = np.ones((nrows, nx), dtype=np.float32)
 
     dtype = np.dtype([('filter', 'S12'),
                       ('subarray', 'S15'),
@@ -749,7 +749,7 @@ def create_photom_miri_image(min_wl=16.5, max_wl=19.5,
 
     # [3.1, 3.2, 3.3]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
 
     dtype = np.dtype([('filter', 'S12'),
                       ('subarray', 'S15'),
@@ -786,7 +786,7 @@ def create_photom_nircam_image(min_r=8.0, max_r=9.0):
 
     # [3.1, 3.2, 3.3, 3.4]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
 
     dtype = np.dtype([('filter', 'S12'),
                       ('pupil', 'S12'),
@@ -832,15 +832,15 @@ def create_photom_nircam_wfss(min_wl=2.4, max_wl=5.0, min_r=8.0, max_r=9.0):
 
     # [3.1, 3.2, 3.3, 3.4, 3.5]
     photmjsr = np.linspace(3.1, 3.1 + (nrows - 1.) * 0.1, nrows)
-    uncertainty = np.zeros(nrows, np.float32)
+    uncertainty = np.zeros(nrows, dtype=np.float32)
     nelem = np.zeros(nrows, np.int32) + nx
     x = np.linspace(min_wl, max_wl, nx, dtype=np.float32).reshape(1, nx)
-    wavelength = np.zeros((nrows, nx), np.float32)
+    wavelength = np.zeros((nrows, nx), dtype=np.float32)
     wavelength[:] = x.copy()
     y = np.linspace(min_r, max_r, nx, dtype=np.float32).reshape(1, nx)
-    relresponse = np.zeros((nrows, nx), np.float32)
+    relresponse = np.zeros((nrows, nx), dtype=np.float32)
     relresponse[:] = y.copy()
-    relunc = np.zeros((nrows, nx), np.float32)
+    relunc = np.zeros((nrows, nx), dtype=np.float32)
 
     dtype = np.dtype([('filter', 'S12'),
                       ('pupil', 'S15'),

--- a/jwst/ramp_fitting/create_cube.py
+++ b/jwst/ramp_fitting/create_cube.py
@@ -4,7 +4,7 @@
 # Program: create_cube.py
 # Purpose: routine to create data cube for a specified readout mode for JWST data
 # History: 03/24/10 - first version
-#          08/17/10 - changed datatype to float64 for compatibility with other programs
+#          08/17/10 - changed datatype to np.float64 for compatibility with other programs
 #
 # The 9 NIRCAM readout modes are:
 #  DEEP8, DEEP2, MEDIUM8, MEDIUM2, SHALLOW4, SHALLOW2, BRIGHT2, BRIGHT1, RAPID
@@ -147,7 +147,7 @@ class create_cube:
         t_read = t_int / float(nread)
         print(' The integration time per single read = ', t_read)
 
-###        acube = np.zeros((n_ind_reads, asize_2, asize_1), dtype = np.float32)  # < 080210
+###        acube = np.zeros((n_ind_reads, asize_2, asize_1), dtype=np.float32)  # < 080210
         acube = np.zeros((n_ind_reads, asize_2, asize_1), dtype=np.float64)  # try 080210
 
         print(' The output cube will have dimensions:', n_ind_reads, asize_2, asize_1)

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -2006,7 +2006,7 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
 
     # Create array to set when each good pixel is classified for the current
     #   semiramp (to enable unclassified pixels to have their arrays updated)
-    got_case = np.zeros((asize1*asize2), dtype=np.bool)
+    got_case = np.zeros((asize1*asize2), dtype=bool)
 
     # CASE A) Long enough (semiramp has >2 groups), at end of ramp
     #    - set start to -1 to designate all fitting done

--- a/jwst/ramp_fitting/tests/check_gls_stats.py
+++ b/jwst/ramp_fitting/tests/check_gls_stats.py
@@ -23,7 +23,7 @@ def setup_inputs(ngroups=10, readnoise=10, nints=1,
         gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
         err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
         data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
-        pixdq = np.zeros(shape=(nrows, ncols), dtype= np.float64)
+        pixdq = np.zeros(shape=(nrows, ncols), dtype=np.float64)
         read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
         gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
         model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -489,7 +489,7 @@ class TestMethods:
         # deltaDN = 50
         delta_time = (ngroups - 1) * grouptime
         # delta_electrons = median_slope * ingain *delta_time
-        single_sample_readnoise = np.float64(inreadnoise/np.sqrt(2))
+        single_sample_readnoise = np.float64(inreadnoise / np.sqrt(2))
         np.testing.assert_allclose(slopes[0].var_poisson[50,50],
             ((median_slope)/(ingain*delta_time)), 1e-6)
         np.testing.assert_allclose(slopes[0].var_rnoise[50,50],
@@ -501,7 +501,7 @@ class TestMethods:
         grouptime=3.0
         # deltaDN = 5
         ingain = 200 # use large gain to show that Poisson noise doesn't affect the recombination
-        inreadnoise = np.float64(7)
+        inreadnoise = 7
         ngroups=10
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
             gain=ingain, readnoise=inreadnoise, deltatime=grouptime)

--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -531,7 +531,7 @@ def calc_slope_vars(rn_sect, gain_sect, gdq_sect, group_time, max_seg):
 
     # Counter of semiramp for each pixel
     sr_index = np.zeros( npix, dtype=np.uint8 )
-    pix_not_done = np.ones( npix, dtype=np.bool)  # initialize to True
+    pix_not_done = np.ones( npix, dtype=bool)  # initialize to True
 
     i_read = 0
     # Loop over reads for all pixels to get segments (segments per pixel)

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -196,7 +196,7 @@ def make_irs2_mask(output_model, scipix_n, refpix_r):
     stuff_at_end = part - k * (scipix_n + refpix_r)
 
     # Create the mask which flags normal pixels as True.
-    irs2_mask = np.ones(irs2_nx, dtype=np.bool)
+    irs2_mask = np.ones(irs2_nx, dtype=bool)
     irs2_mask[0:refout] = False
 
     # Check whether the interspersed reference pixels are in the same
@@ -209,7 +209,7 @@ def make_irs2_mask(output_model, scipix_n, refpix_r):
     else:
         # Set the flags for each readout direction separately.
         nelem = refout                  # number of elements per output
-        temp = np.ones(nelem, dtype=np.bool)
+        temp = np.ones(nelem, dtype=bool)
         for i in range(scipix_n // 2, nelem + 1,
                        scipix_n + refpix_r):
             temp[i:i + refpix_r] = False

--- a/jwst/refpix/tests/test_clobber_ref.py
+++ b/jwst/refpix/tests/test_clobber_ref.py
@@ -58,7 +58,7 @@ def test_decode_mask():
                     dtype=np.uint32)
 
     nrows = len(output)
-    check = np.zeros(nrows, dtype=np.bool)
+    check = np.zeros(nrows, dtype=bool)
     compare = [[5, 20],
                [],
                [18, 23, 27],

--- a/jwst/regtest/test_infrastructure.py
+++ b/jwst/regtest/test_infrastructure.py
@@ -43,7 +43,7 @@ def two_tables(tmpdir):
     """Return identical astropy tables written to 2 .ecsv file paths"""
     path1 = str(tmpdir.join("catalog1.ecsv"))
     path2 = str(tmpdir.join("catalog2.ecsv"))
-    a = np.array([1, 4, 5], dtype=np.float)
+    a = np.array([1, 4, 5], dtype=float)
     b = [2.0, 5.0, 8.5]
     c = ['x', 'y', 'z']
     d = [10, 20, 30] * u.m / u.s

--- a/jwst/regtest/test_infrastructure.py
+++ b/jwst/regtest/test_infrastructure.py
@@ -111,7 +111,7 @@ def test_diff_astropy_tables_dtype(diff_astropy_tables, two_tables):
     path1, path2 = two_tables
 
     t1 = Table.read(path1)
-    t1['a'] = np.array([1, 4, 6], dtype=np.int)
+    t1['a'] = np.array([1, 4, 6], dtype=int)
     t1.write(path1, overwrite=True, format="ascii.ecsv")
 
     with pytest.raises(AssertionError, match="dtype does not match"):
@@ -122,11 +122,11 @@ def test_diff_astropy_tables_all_equal(diff_astropy_tables, two_tables):
     path1, path2 = two_tables
 
     t1 = Table.read(path1)
-    t1['a'] = np.array([1, 4, 6], dtype=np.int)
+    t1['a'] = np.array([1, 4, 6], dtype=int)
     t1.write(path1, overwrite=True, format="ascii.ecsv")
 
     t2 = Table.read(path2)
-    t2['a'] = np.array([1, 4, 7], dtype=np.int)
+    t2['a'] = np.array([1, 4, 7], dtype=int)
     t2.write(path2, overwrite=True, format="ascii.ecsv")
 
     with pytest.raises(AssertionError, match="values do not match"):

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -152,7 +152,7 @@ def make_mask(input_model, n=None, r=None):
     # Number of normal pixels per amplifier output.
     n_output = (irs2_nx - refout) // 4 - k * n_ref
 
-    irs2_mask = np.ones(irs2_nx, dtype=np.bool)
+    irs2_mask = np.ones(irs2_nx, dtype=bool)
     irs2_mask[0:refout] = False
 
     # Check that the locations of interspersed reference pixels is
@@ -165,7 +165,7 @@ def make_mask(input_model, n=None, r=None):
     else:
         # Set the flags for each readout direction separately.
         nelem = (irs2_nx - refout) // 4         # number of elements per output
-        temp = np.ones(nelem, dtype=np.bool)
+        temp = np.ones(nelem, dtype=bool)
         for i in range(n_norm // 2, nelem + 1, n_norm + n_ref):
             temp[i:i + n_ref] = False
         j = refout

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -254,15 +254,15 @@ class SkyImage:
             nintx = max(2, int(np.ceil((nx + 1.0) / stepsize)))
             ninty = max(2, int(np.ceil((ny + 1.0) / stepsize)))
 
-        xs = np.linspace(-0.5, nx - 0.5, nintx, dtype=np.float)
-        ys = np.linspace(-0.5, ny - 0.5, ninty, dtype=np.float)[1:-1]
+        xs = np.linspace(-0.5, nx - 0.5, nintx, dtype=float)
+        ys = np.linspace(-0.5, ny - 0.5, ninty, dtype=float)[1:-1]
         nptx = xs.size
         npty = ys.size
 
         npts = 2 * (nptx + npty)
 
-        borderx = np.empty((npts + 1,), dtype=np.float)
-        bordery = np.empty((npts + 1,), dtype=np.float)
+        borderx = np.empty((npts + 1,), dtype=float)
+        bordery = np.empty((npts + 1,), dtype=float)
 
         # "bottom" points:
         borderx[:nptx] = xs

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -122,7 +122,7 @@ class SkyImage:
             if image is None:
                 raise ValueError("'mask' must be None when 'image' is None")
 
-            self.mask = np.asanyarray(mask, dtype=np.bool)
+            self.mask = np.asanyarray(mask, dtype=bool)
 
             if self.mask.shape != image.shape:
                 raise ValueError("'mask' must have the same shape as 'image'.")

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -545,7 +545,7 @@ def _find_optimum_sky_deltas(images, apply_sky=True):
     except np.linalg.LinAlgError:
         log.warning("Unable to compute sky: No valid data in common "
                     "image areas")
-        deltas = np.full(ns, np.nan, dtype=np.float)
+        deltas = np.full(ns, np.nan, dtype=float)
         return deltas
 
     if rank < ns - 1:

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -1081,7 +1081,7 @@ def _toindex(value):
     >>> _toindex(np.array([1.5, 2.49999]))
     array([2, 2])
     """
-    indx = np.asarray(np.floor(np.asarray(value) + 0.5), dtype=np.int)
+    indx = np.asarray(np.floor(np.asarray(value) + 0.5), dtype=int)
     return indx
 
 

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -224,9 +224,9 @@ class Snell(Model):
     def __init__(self, angle, kcoef, lcoef, tcoef, tref, pref,
                  temperature, pressure, name=None):
         self.prism_angle = angle
-        self.kcoef = np.array(kcoef, dtype=np.float)
-        self.lcoef = np.array(lcoef, dtype=np.float)
-        self.tcoef = np.array(tcoef, dtype=np.float)
+        self.kcoef = np.array(kcoef, dtype=float)
+        self.lcoef = np.array(lcoef, dtype=float)
+        self.tcoef = np.array(tcoef, dtype=float)
         self.tref = tref
         self.pref = pref
         self.temp = temperature
@@ -607,7 +607,7 @@ class Rotation3D(Model):
                 "Number of angles must equal number of axes in axes_order.")
         matrices = []
         for angle, axis in zip(angles, axes_order):
-            matrix = np.zeros((3, 3), dtype=np.float)
+            matrix = np.zeros((3, 3), dtype=float)
             if axis == 'x':
                 mat = Rotation3D.rotation_matrix_from_angle(angle)
                 matrix[0, 0] = 1

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -81,7 +81,7 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
     if sources:
         catalog = sources[columns]
     else:
-        catalog = Table(names=columns, dtype=(np.int_, float_, float_,
-                                              float_))
+        catalog = Table(names=columns, dtype=(np.int_, np.float_, np.float_,
+                                              np.float_))
 
     return catalog

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -73,7 +73,7 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
                             peakmax=peakmax)
 
     # Mask the non-imaging area (e.g. MIRI)
-    mask = (dqflags.pixel['NON_SCIENCE'] & model.dq).astype(np.bool)
+    mask = (dqflags.pixel['NON_SCIENCE'] & model.dq).astype(bool)
 
     sources = daofind(model.data, mask=mask)
 

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -81,7 +81,7 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
     if sources:
         catalog = sources[columns]
     else:
-        catalog = Table(names=columns, dtype=(np.int_, np.float_, np.float_,
-                                              np.float_))
+        catalog = Table(names=columns, dtype=(np.int_, float_, float_,
+                                              float_))
 
     return catalog

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -139,7 +139,7 @@ class DataSet:
             # 1. Create smoothed image of input SCI data of image #1
             # 1a. create image to smooth by first setting bad DQ pixels equal
             #     to mean of good pixels
-            data_1 = self.input_1.data.astype(np.float)
+            data_1 = self.input_1.data.astype(float)
             bad1 = np.bitwise_and(self.input_1.dq, DO_NOT_USE).astype(bool)
             data_1[bad1] = data_1[~bad1].mean()
 
@@ -314,8 +314,8 @@ class DataSet:
             combined ERR array
         """
 
-        data1 = image1.data.astype(np.float)
-        data2 = image2.data.astype(np.float)
+        data1 = image1.data.astype(float)
+        data2 = image2.data.astype(float)
         dq1 = image1.dq.copy()
         dq2 = image2.dq.copy()
         err1 = image1.err.copy()

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -140,7 +140,7 @@ class DataSet:
             # 1a. create image to smooth by first setting bad DQ pixels equal
             #     to mean of good pixels
             data_1 = self.input_1.data.astype(np.float)
-            bad1 = np.bitwise_and(self.input_1.dq, DO_NOT_USE).astype(np.bool)
+            bad1 = np.bitwise_and(self.input_1.dq, DO_NOT_USE).astype(bool)
             data_1[bad1] = data_1[~bad1].mean()
 
             # 1b. Create smoothed image by smoothing this 'repaired' image
@@ -322,9 +322,9 @@ class DataSet:
         err2 = image2.err.copy()
 
         # Create boolean arrays of bad pixels in each input image
-        bad1 = np.bitwise_and(dq1, DO_NOT_USE).astype(np.bool)
+        bad1 = np.bitwise_and(dq1, DO_NOT_USE).astype(bool)
         good1 = ~bad1
-        bad2 = np.bitwise_and(dq2, DO_NOT_USE).astype(np.bool)
+        bad2 = np.bitwise_and(dq2, DO_NOT_USE).astype(bool)
         good2 = ~bad2
 
         # Combine via algorithm set out above

--- a/jwst/wiimatch/lsq_optimizer.py
+++ b/jwst/wiimatch/lsq_optimizer.py
@@ -120,12 +120,12 @@ def build_lsq_eqs(images, masks, sigmas, degree, center=None,
     Examples
     --------
     >>> import numpy as np
-    >>> im1 = np.zeros((5, 5, 4), dtype=np.float)
+    >>> im1 = np.zeros((5, 5, 4), dtype=float)
     >>> cbg = 1.32 * np.ones_like(im1)
-    >>> ind = np.indices(im1.shape, dtype=np.float)
+    >>> ind = np.indices(im1.shape, dtype=float)
     >>> im3 = cbg + 0.15 * ind[0] + 0.62 * ind[1] + 0.74 * ind[2]
     >>> mask = np.ones_like(im1, dtype=np.int8)
-    >>> sigma = np.ones_like(im1, dtype=np.float)
+    >>> sigma = np.ones_like(im1, dtype=float)
     >>> a, b, ca, ef, cs = build_lsq_eqs([im1, im3],
     ... [mask, mask], [sigma, sigma], degree=(1,1,1), center=(0,0,0))
     >>> print(a)
@@ -199,8 +199,8 @@ def build_lsq_eqs(images, masks, sigmas, degree, center=None,
     )
 
     # allocate array for the coefficients of the system of equations (a*x=b):
-    a = np.zeros((sys_eq_array_size, sys_eq_array_size), dtype=np.float)
-    b = np.zeros(sys_eq_array_size, dtype=np.float)
+    a = np.zeros((sys_eq_array_size, sys_eq_array_size), dtype=float)
+    b = np.zeros(sys_eq_array_size, dtype=float)
 
     for i in range(sys_eq_array_size):
         # decompose first (row, or eq) flat index into "original" indices:
@@ -302,12 +302,12 @@ def pinv_solve(matrix, free_term, nimages, tol=None):
     --------
     >>> from jwst.wiimatch.lsq_optimizer import build_lsq_eqs, pinv_solve
     >>> import numpy as np
-    >>> im1 = np.zeros((5, 5, 4), dtype=np.float)
+    >>> im1 = np.zeros((5, 5, 4), dtype=float)
     >>> cbg = 1.32 * np.ones_like(im1)
-    >>> ind = np.indices(im1.shape, dtype=np.float)
+    >>> ind = np.indices(im1.shape, dtype=float)
     >>> im3 = cbg + 0.15 * ind[0] + 0.62 * ind[1] + 0.74 * ind[2]
     >>> mask = np.ones_like(im1, dtype=np.int8)
-    >>> sigma = np.ones_like(im1, dtype=np.float)
+    >>> sigma = np.ones_like(im1, dtype=float)
     >>> a, b, _, _, _ = build_lsq_eqs([im1, im3], [mask, mask],
     ... [sigma, sigma], degree=(1,1,1), center=(0,0,0))
     >>> pinv_solve(a, b, 2) # doctest: +FLOAT_CMP
@@ -363,12 +363,12 @@ def rlu_solve(matrix, free_term, nimages):
     --------
     >>> from jwst.wiimatch.lsq_optimizer import build_lsq_eqs, rlu_solve
     >>> import numpy as np
-    >>> im1 = np.zeros((5, 5, 4), dtype=np.float)
+    >>> im1 = np.zeros((5, 5, 4), dtype=float)
     >>> cbg = 1.32 * np.ones_like(im1)
-    >>> ind = np.indices(im1.shape, dtype=np.float)
+    >>> ind = np.indices(im1.shape, dtype=float)
     >>> im3 = cbg + 0.15 * ind[0] + 0.62 * ind[1] + 0.74 * ind[2]
     >>> mask = np.ones_like(im1, dtype=np.int8)
-    >>> sigma = np.ones_like(im1, dtype=np.float)
+    >>> sigma = np.ones_like(im1, dtype=float)
     >>> a, b, _, _, _ = build_lsq_eqs([im1, im3], [mask, mask],
     ... [sigma, sigma], degree=(1, 1, 1), center=(0, 0, 0))
     >>> rlu_solve(a, b, 2)   # doctest: +FLOAT_CMP
@@ -382,7 +382,7 @@ def rlu_solve(matrix, free_term, nimages):
     """
     drop =  free_term.size // nimages
     if nimages <= 1:
-        return np.zeros((1, drop), dtype=np.float)
+        return np.zeros((1, drop), dtype=float)
     from scipy import linalg
     rmat = matrix[drop:, drop:]
     v = linalg.lu_solve(linalg.lu_factor(rmat),
@@ -415,7 +415,7 @@ def _image_pixel_sum(image_l, image_m, mask_l, mask_m,
 
         return np.sum((image_l[cmask] - image_m[cmask]) /
                       (sigma2_l[cmask] + sigma2_m[cmask]),
-                      dtype=np.float)
+                      dtype=float)
 
     if len(coord_arrays) != len(p):
         raise ValueError("Lengths of the list of pixel index arrays and "
@@ -431,7 +431,7 @@ def _image_pixel_sum(image_l, image_m, mask_l, mask_m,
 
     return np.sum(i[cmask] * (image_l[cmask] - image_m[cmask]) /
                   (sigma2_l[cmask] + sigma2_m[cmask]),
-                  dtype=np.float)
+                  dtype=float)
 
 
 def _sigma_pixel_sum(mask_l, mask_m, sigma2_l, sigma2_m,
@@ -453,7 +453,7 @@ def _sigma_pixel_sum(mask_l, mask_m, sigma2_l, sigma2_m,
                              "must be None as well.")
 
         return np.sum(1.0 / (sigma2_l[cmask] + sigma2_m[cmask]),
-                      dtype=np.float)
+                      dtype=float)
 
     if len(coord_arrays) != len(p) or len(p) != len(pp):
         raise ValueError("Lengths of the list of pixel index arrays and "
@@ -469,4 +469,4 @@ def _sigma_pixel_sum(mask_l, mask_m, sigma2_l, sigma2_m,
         i *= c**(ip + ipp)
 
     return np.sum(i[cmask] / (sigma2_l[cmask] + sigma2_m[cmask]),
-                  dtype=np.float)
+                  dtype=float)

--- a/jwst/wiimatch/match.py
+++ b/jwst/wiimatch/match.py
@@ -156,12 +156,12 @@ c_{1,0,\\ldots}^2,\\ldots).
     Examples
     --------
     >>> import numpy as np
-    >>> im1 = np.zeros((5, 5, 4), dtype=np.float)
+    >>> im1 = np.zeros((5, 5, 4), dtype=float)
     >>> cbg = 1.32 * np.ones_like(im1)
-    >>> ind = np.indices(im1.shape, dtype=np.float)
+    >>> ind = np.indices(im1.shape, dtype=float)
     >>> im3 = cbg + 0.15 * ind[0] + 0.62 * ind[1] + 0.74 * ind[2]
     >>> mask = np.ones_like(im1, dtype=np.int8)
-    >>> sigma = np.ones_like(im1, dtype=np.float)
+    >>> sigma = np.ones_like(im1, dtype=float)
     >>> match_lsq([im1, im3], [mask, mask], [sigma, sigma],   #doctest: +FLOAT_CMP
     ... degree=(1, 1, 1), center=(0, 0, 0))
     array([[-6.60000000e-01, -7.50000000e-02, -3.10000000e-01,
@@ -212,7 +212,7 @@ c_{1,0,\\ldots}^2,\\ldots).
     # check that the number of sigma arrays matches the numbers
     # of input images, and if 'sigmas' is None - set all of them to 1:
     if sigmas is None:
-        sigmas = [np.ones_like(images[0], dtype=np.float) for i in images]
+        sigmas = [np.ones_like(images[0], dtype=float) for i in images]
 
     else:
         if len(sigmas) != nimages:

--- a/jwst/wiimatch/match.py
+++ b/jwst/wiimatch/match.py
@@ -193,7 +193,7 @@ c_{1,0,\\ldots}^2,\\ldots).
     # check that the number of good pixel mask arrays matches the numbers
     # of input images, and if 'masks' is None - set all of them to True:
     if masks is None:
-        masks = [np.ones_like(images[0], dtype=np.bool) for i in images]
+        masks = [np.ones_like(images[0], dtype=bool) for i in images]
 
     else:
         if len(masks) != nimages:

--- a/jwst/wiimatch/utils.py
+++ b/jwst/wiimatch/utils.py
@@ -128,7 +128,7 @@ def create_coordinate_arrays(image_shape, center=None, image2world=None,
             raise ValueError("'center_cs' cannot be 'world' when 'image2world'"
                              " is not defined.")
 
-    ind = np.indices(image_shape, dtype=np.float)[::-1]
+    ind = np.indices(image_shape, dtype=float)[::-1]
 
     if image2world is None:
         coord_system = 'image'


### PR DESCRIPTION
This replaces the deprecated Numpy globals

```python
np.bool
np.float
np.int
np.str
```

with the Python type each points to

```python
bool
float
int
str
```

respectively.

Resolves #5725 / [JP-1914](https://jira.stsci.edu/browse/JP-1914)
Resolves #5724 