### PR TITLE
JP-1936 Ignore duplicate product names while handling Level 2 associations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,10 @@
 1.0.1 (unreleased)
 ==================
 
+associations
+------------
 
-
-
-
-
+- Ignore duplicate product names while handling Level 2 associations [#5780]
 
 
 1.0.0 (2021-02-22)

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -8,6 +8,7 @@ from os.path import (
     splitext
 )
 import re
+import warnings
 
 from jwst.associations import (
     Association,
@@ -521,7 +522,12 @@ class Utility():
                     lv2_asns.extend(finalized)
             else:
                 finalized_asns.append(asn)
-        lv2_asns = prune_duplicate_products(lv2_asns)
+
+        # Having duplicate Level 2 associations is expected.
+        # Suppress warnings.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            lv2_asns = prune_duplicate_products(lv2_asns)
 
         # Ensure sequencing is correct.
         Utility_Level3.resequence(lv2_asns)

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -96,6 +96,8 @@ SPECIAL_POOLS = {
 # #####
 class TestSDPPools(SDPPoolsSource):
     """Test creation of association from SDP-created pools"""
+
+    @pytest.mark.filterwarnings('error')
     def test_against_standard(self, pool_path, slow):
         """Compare a generated association against a standard
 

--- a/jwst/regtest/test_associations_standards.py
+++ b/jwst/regtest/test_associations_standards.py
@@ -100,6 +100,7 @@ class TestAgainstStandards(BaseJWSTTest):
     test_dir = 'standards'
     ref_loc = [test_dir, 'truth']
 
+    @pytest.mark.filterwarnings('error')
     @pytest.mark.parametrize('standard_pars', standards, ids=generate_id)
     def test_against_standard(self, standard_pars):
         """Compare a generated association against a standard


### PR DESCRIPTION
Resolves [JP-1936](https://jira.stsci.edu/browse/JP-1936) / #5779 

JP-1903 #5721 introduced a warning when duplicate associations product names are found. For Level 3 this is a crucial warning. However, for Level 2, this warning is meaningless; duplicate product names are expected, since all product names are just exposure names. Hide the warning while processing Level 2 associations.

Side note: the duplicate products are filtered out, regardless of the warning level.