### PR TITLE
JP-1918: Remove errant background exposures from Coron3 associations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 1.0.1 (unreleased)
 ==================
 
+associations
+------------
 
+- Constraint added to Asn_Lv3Coron to remove background exposures [#5781]
 
 
 

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -166,6 +166,14 @@ class Asn_Lv3Coron(AsnMixin_Science):
                     force_reprocess=ProcessList.EXISTING,
                     only_on_match=True,
                 ),
+                Constraint(
+                    [DMSAttrConstraint(
+                        name='bkgdtarg',
+                        sources=['bkgdtarg'],
+                        force_unique=False,
+                    )],
+                    reduce=Constraint.notany
+                ),
             ],
             name='asn_coron'
         )


### PR DESCRIPTION
Resolves [#1918](https://jira.stsci.edu/browse/JP-1918)
Resolves #5732 

In the end, the solution to the errant x1dints entry in the initial association was to have it removed with a new constraint, as it was a background exposure. This caused a duplicate association warning, as the group association entries now exactly overlapped with the coronography association. The end result removes an association from the output of asn_generate.