### PR TITLE
Streamline FGS image2 pipeline regtest

### DIFF
--- a/jwst/regtest/test_fgs_image2.py
+++ b/jwst/regtest/test_fgs_image2.py
@@ -1,30 +1,28 @@
-""" Test for the image2 pipeline for fgs data. This takes a rate file and
-    generates flat field, i2d and cal files."""
-
-import os
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
-from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
-@pytest.mark.bigdata
-@pytest.mark.parametrize("output", [
-    'jw86500007001_02101_00001_GUIDER2_cal.fits',
-    'jw86500007001_02101_00001_GUIDER2_flat_field.fits',
-    'jw86500007001_02101_00001_GUIDER2_i2d.fits'])
-def test_fgs_image2(_jail, rtdata, fitsdiff_default_kwargs, output):
-    """ Regression test for fgs data in the image2 pipeline"""
+@pytest.fixture(scope="module")
+def run_fgs_image2(rtdata_module):
+    rtdata = rtdata_module
     rtdata.get_data("fgs/image2/jw86500007001_02101_00001_GUIDER2_rate.fits")
 
-    collect_pipeline_cfgs("config")
-    args = ["config/calwebb_image2.cfg", rtdata.input,
+    args = ["calwebb_image2", rtdata.input,
             "--steps.flat_field.save_results=True",
             "--steps.resample.save_results=True"]
     Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ['flat_field', 'cal', 'i2d'])
+def test_fgs_image2(run_fgs_image2, rtdata_module, fitsdiff_default_kwargs, suffix):
+    """Regression test for FGS data in the image2 pipeline"""
+    rtdata = rtdata_module
+    output = f"jw86500007001_02101_00001_GUIDER2_{suffix}.fits"
     rtdata.output = output
 
-    rtdata.get_truth(os.path.join("truth/test_fgs_image2/", output))
+    rtdata.get_truth(f"truth/test_fgs_image2/{output}")
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()


### PR DESCRIPTION
The pipeline was being run 3 times in this regtest.  Instead, it should be run once, with the tests parametrized.

This won't changes the results of the test.  Only make it more efficient.  And the `suffix` labeling will make it easier to read the results.