### PR TITLE
JP-1911: Bump asdf==2.7.3 in requirements-sdp.txt

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -4,7 +4,7 @@
 #     pip install pytest-xdist
 #     pip freeze | grep -v jwst.git >> requirements-sdp.txt
 apipkg==1.5
-asdf==2.7.2
+asdf==2.7.3
 astropy==4.2
 attrs==20.3.0
 certifi==2020.12.5


### PR DESCRIPTION
Pulls in the bugfix release `asdf 2.7.3` into `requirements-sdp.txt`.  Previously, the `asdf` library was writing out unreadable FITS files for numpy arrays that were views over a larger arrays and were stored in as `AsdfInFITS`.

Resolves #5699 / [JP-1911](https://jira.stsci.edu/browse/JP-1911)