### PR TITLE
JP-1883: Remove PATTTYPE constraint for undithered MIRI MRS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ associations
   instrument channel when matching direct images with grism images in
   NIRCam WFSS observations. [#5786]
 
-- Removed PATTTYPE='none' constraint from Lv3MIRMRS association rule to
+- Removed PATTTYPE='None' constraint from Lv3MIRMRS association rule to
   generate spec3 associations for undithered MRS observations. [#5804]
 
 general

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ associations
   instrument channel when matching direct images with grism images in
   NIRCam WFSS observations. [#5786]
 
+- Removed PATTTYPE='none' constraint from Lv3MIRMRS association rule to
+  generate spec3 associations for undithered MRS observations. [#5804]
+
 general
 -------
 

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -303,11 +303,6 @@ class Asn_Lv3MIRMRS(AsnMixin_Spectrum):
             Constraint(
                 [
                     Constraint_TSO(),
-                    DMSAttrConstraint(
-                        name='patttype',
-                        sources=['patttype'],
-                        value=['none'],
-                    )
                 ],
                 reduce=Constraint.notany
             ),


### PR DESCRIPTION
Resolves [JP-1883](https://jira.stsci.edu/browse/JP-1883)
Resolves #5683 

Removing the constraint disallowing PATTTYPE='none' fixes the pool provided in the ticket, and existing pools with no PATTTYPE provided also generate spec3 associations. 

The mistyped EXP_TYPE in the provided ticket will create a spec3 association despite the included exposures all being external flats - this is being addressed in [JSDP-1749](https://jira.stsci.edu/browse/JSDP-1749)