### PR TITLE
JP-1939 update target ra,dec for moving targets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ general
 - Update file naming conventions documentation to clarify when optional components will be used. [#5796]
 
 
+lib
+---
+
+- Update ``update_mt_kwds`` function in ``set_telescope_pointing.py`` to  populate the TARG_RA/TARG_DEC [#5808]
 
 1.1.0 (2021-02-26)
 ==================

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -233,6 +233,8 @@ def update_mt_kwds(model):
             f_dec = interp1d(time_mt, dec)
             model.meta.wcsinfo.mt_ra = f_ra(exp_midpt_mjd).item(0)
             model.meta.wcsinfo.mt_dec = f_dec(exp_midpt_mjd).item(0)
+            model.meta.target.ra = f_ra(exp_midpt_mjd).item(0)
+            model.meta.target.dec = f_dec(exp_midpt_mjd).item(0)
         else:
             logger.info('Exposure midpoint {} is not in the moving_target '
                         'table range of {} to {}'.format(exp_midpt_mjd, time_mt[0], time_mt[-1]))


### PR DESCRIPTION
This PR address JP-1939
"update_mt_kwds" function in the "set_telescope_pointing" script populates the TARG_RA/TARG_DEC keywords with the same values computed for the MT_RA/MT_DEC keywords.