### PR TITLE
JP-1863: Correct offset in cross-dispersion axis for NIRISS WFSS extraction boxes 

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -659,6 +659,9 @@ def _create_grism_bbox(input_model, mmag_extract=99.0,
                                                          obj.sky_centroid.icrs.dec.value,
                                                          1, 1)
 
+                print(f"Transform fit to x, y : {xcenter}, {ycenter}\n")
+                print(f"Sourcecat provided x, y: {obj.xcentroid}, {obj.ycentroid}\n")
+
                 order_bounding = {}
                 waverange = {}
                 partial_order = {}
@@ -697,11 +700,17 @@ def _create_grism_bbox(input_model, mmag_extract=99.0,
 
                     if wfss_extract_half_height is not None and obj.is_star:
                         if input_model.meta.wcsinfo.dispersion_direction == 2:
-                            center = (xmax + xmin) / 2
+                            rac, decc = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
+                            center, _, _, _, _ = sky_to_grism(rac, decc, (lmin + lmax) / 2, order)
+
+                            # center = (xmax + xmin) / 2
                             xmin = center - wfss_extract_half_height
                             xmax = center + wfss_extract_half_height
                         elif input_model.meta.wcsinfo.dispersion_direction == 1:
-                            center = (ymax + ymin) / 2
+                            rac, decc = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
+                            _, center, _, _, _ = sky_to_grism(rac, decc, (lmin + lmax) / 2, order)
+
+                            # center = (ymax + ymin) / 2
                             ymin = center - wfss_extract_half_height
                             ymax = center + wfss_extract_half_height
                         else:
@@ -711,7 +720,7 @@ def _create_grism_bbox(input_model, mmag_extract=99.0,
                     # off the detector partial_order marks partial
                     # off-detector objects which are near enough to
                     # cause spectra to be observed on the detector.
-                    # This is usefull because the catalog often is
+                    # This is useful because the catalog often is
                     # created from a resampled direct image that is
                     # bigger than the detector FOV for a single grism
                     # exposure.

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -659,9 +659,6 @@ def _create_grism_bbox(input_model, mmag_extract=99.0,
                                                          obj.sky_centroid.icrs.dec.value,
                                                          1, 1)
 
-                print(f"Transform fit to x, y : {xcenter}, {ycenter}\n")
-                print(f"Sourcecat provided x, y: {obj.xcentroid}, {obj.ycentroid}\n")
-
                 order_bounding = {}
                 waverange = {}
                 partial_order = {}
@@ -700,18 +697,13 @@ def _create_grism_bbox(input_model, mmag_extract=99.0,
 
                     if wfss_extract_half_height is not None and obj.is_star:
                         if input_model.meta.wcsinfo.dispersion_direction == 2:
-                            #rac, decc = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
-                            #center, _, _, _, _ = sky_to_grism(rac, decc, (lmin + lmax) / 2, order)
-                            #center = xcenter
-                            center = (xmax + xmin) / 2
+                            ra_center, dec_center = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
+                            center, _, _, _, _ = sky_to_grism(ra_center, dec_center, (lmin + lmax) / 2, order)
                             xmin = center - wfss_extract_half_height
                             xmax = center + wfss_extract_half_height
                         elif input_model.meta.wcsinfo.dispersion_direction == 1:
-                            #rac, decc = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
-                            #_, center, _, _, _ = sky_to_grism(rac, decc, (lmin + lmax) / 2, order)
-                            #print(f"Transform fit to y : {center}\n")
-                            #center = ycenter
-                            center = (ymax + ymin) / 2
+                            ra_center, dec_center = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
+                            _, center, _, _, _ = sky_to_grism(ra_center, dec_center, (lmin + lmax) / 2, order)
                             ymin = center - wfss_extract_half_height
                             ymax = center + wfss_extract_half_height
                         else:

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -700,17 +700,18 @@ def _create_grism_bbox(input_model, mmag_extract=99.0,
 
                     if wfss_extract_half_height is not None and obj.is_star:
                         if input_model.meta.wcsinfo.dispersion_direction == 2:
-                            rac, decc = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
-                            center, _, _, _, _ = sky_to_grism(rac, decc, (lmin + lmax) / 2, order)
-
-                            # center = (xmax + xmin) / 2
+                            #rac, decc = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
+                            #center, _, _, _, _ = sky_to_grism(rac, decc, (lmin + lmax) / 2, order)
+                            #center = xcenter
+                            center = (xmax + xmin) / 2
                             xmin = center - wfss_extract_half_height
                             xmax = center + wfss_extract_half_height
                         elif input_model.meta.wcsinfo.dispersion_direction == 1:
-                            rac, decc = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
-                            _, center, _, _, _ = sky_to_grism(rac, decc, (lmin + lmax) / 2, order)
-
-                            # center = (ymax + ymin) / 2
+                            #rac, decc = obj.sky_centroid.ra.value, obj.sky_centroid.dec.value
+                            #_, center, _, _, _ = sky_to_grism(rac, decc, (lmin + lmax) / 2, order)
+                            #print(f"Transform fit to y : {center}\n")
+                            #center = ycenter
+                            center = (ymax + ymin) / 2
                             ymin = center - wfss_extract_half_height
                             ymax = center + wfss_extract_half_height
                         else:


### PR DESCRIPTION
Resolves [JP-1863](https://jira.stsci.edu/browse/JP-1863)
Resolves #5640 

This changes the center of the extraction bounding box from: 
     - an average in grism pixel space 
 to:
     - the sky position, transformed to the grism pixel space.
     
This has **not** fixed all offset issues, but my best guess in location of the remaining error would be in some combination of source astrometry and transform polynomials. Would like feedback from INS team.