### PR TITLE
JP-1863: Modify evaluation of grism bounding box center - Changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.1.1 (unreleased)
 ==================
 
+assign_wcs
+----------
+
+- Changed evaluation of grism bounding box center from averaged extrema of
+  transformed bounding box to transformed centroid of source_cat object [#5809]
+
 associations
 ------------
 


### PR DESCRIPTION
Managed to sneak a PR through without a requisite changelog entry - this adds the entry for #5809.