### PR TITLE
Add logging to srctype WFSS branch

### DIFF
--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -162,6 +162,7 @@ def set_source_type(input_model):
                 slit.source_type = 'POINT'
             else:
                 slit.source_type = 'EXTENDED'
+            log.info(f'source_id={slit.source_id}, type={slit.source_type}')
 
     # Unrecognized exposure type; set to UNKNOWN as default
     else:


### PR DESCRIPTION
Trivial update to add logging info when setting SRCTYPE values for WFSS exposures, as is already done for MOS mode.