### PR TITLE
Clean up stpipe unit tests that leave behind files

### DIFF
--- a/jwst/stpipe/tests/steps/python_pipeline.cfg
+++ b/jwst/stpipe/tests/steps/python_pipeline.cfg
@@ -7,7 +7,7 @@ name = "MyPipeline"
 class = "jwst.stpipe.tests.test_pipeline.MyPipeline"
 
 science_filename = "../data/science.fits"
-output_filename = "DUMMY.fits"
+output_file = "DUMMY.fits"
 
 [steps]
   [[flat_field]]

--- a/jwst/stpipe/tests/test_pipeline.py
+++ b/jwst/stpipe/tests/test_pipeline.py
@@ -85,29 +85,27 @@ class MyPipeline(Pipeline):
     spec = """
     science_filename = input_file()  # The input science filename
     flat_filename = input_file(default=None)     # The input flat filename
-    output_filename = output_file()  # The output filename
     """
 
     def process(self, *args):
         science = datamodels.open(self.science_filename)
         if self.flat_filename is None:
-            self.flat_filename = join(dirname(__file__), "data/flat.fits")
+            self.flat_filename = join(dirname(__file__), "data", "flat.fits")
         flat = datamodels.open(self.flat_filename)
         calibrated = []
         calibrated.append(self.flat_field(science, flat))
         combined = self.combine(calibrated)
         self.display(combined)
         dm = datamodels.ImageModel(combined)
-        dm.save(self.output_filename)
+        self.save_model(dm)
         science.close()
         flat.close()
         return dm
 
 
-def test_pipeline(_jail):
-    pipeline_fn = join(dirname(__file__), 'steps', 'python_pipeline.cfg')
-    pipe = Pipeline.from_config_file(pipeline_fn)
-    pipe.output_filename = "output.fits"
+def test_pipeline_from_config_file(_jail):
+    config_file_path = join(dirname(__file__), 'steps', 'python_pipeline.cfg')
+    pipe = Pipeline.from_config_file(config_file_path)
 
     assert pipe.flat_field.threshold == 42.0
     assert pipe.flat_field.multiplier == 2.0
@@ -122,11 +120,10 @@ def test_pipeline_python(_jail):
 
     pipe = MyPipeline(
         "MyPipeline",
-        config_file=__file__,
         steps=steps,
         science_filename=abspath(join(dirname(__file__), 'data', 'science.fits')),
         flat_filename=abspath(join(dirname(__file__), 'data', 'flat.fits')),
-        output_filename="output.fits")
+        output_file="python.fits")
 
     assert pipe.flat_field.threshold == 42.0
     assert pipe.flat_field.multiplier == 1.0
@@ -174,7 +171,7 @@ def test_prefetch(_jail, monkeypatch):
     assert not mock_get_ref.called
 
 
-def test_pipeline_commandline(_jail):
+def test_pipeline_from_cmdline_cfg(_jail):
     args = [
         join(dirname(__file__), 'steps', 'python_pipeline.cfg'),
         '--steps.flat_field.threshold=47',
@@ -188,11 +185,11 @@ def test_pipeline_commandline(_jail):
     pipe.run()
 
 
-def test_pipeline_commandline_class(_jail):
+def test_pipeline_from_cmdline_class(_jail):
     args = [
         'jwst.stpipe.tests.test_pipeline.MyPipeline',
         f"--science_filename={join(dirname(__file__), 'data', 'science.fits')}",
-        '--output_filename=output.fits',
+        '--output_file=output.fits',
         '--steps.flat_field.threshold=47'
         ]
 


### PR DESCRIPTION
The following unit tests

```
jwst/stpipe/tests/test_pipeline.py::test_pipeline
jwst/stpipe/tests/test_pipeline.py::test_pipeline_commandline
```

leave behind some FITS files after you run the unit tests which show up as untracked files

```
$ git status
On branch pep8-more-checks
Your branch and 'upstream/master' have diverged,
and have 14 and 2 different commits each, respectively.
  (use "git pull" to merge the remote branch into yours)

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	jwst/stpipe/tests/output.fits
	jwst/stpipe/tests/steps/DUMMY.fits

nothing added to commit but untracked files present (use "git add" to track)
```

The bug is because these tests are so old, they don't actually test properly the current `stpipe` infrastructure.  They each use a custom `output_filename` when it should be using the built-in `self.output_file` which keeps track of the location from which the pipeline is run.

This PR fixes them both, and gives the tests more descriptive names to indicate the path through `stpipe` that is being tested.