### PR TITLE
Remove outdated docstring

### DIFF
--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -970,13 +970,6 @@ class SourceCatalog:
     def _ci_ee_indices(self):
         """
         The EE indicies for the concentration indices.
-
-        The three concentration indices are the difference in
-        AB magnitudes between:
-
-            * the smallest and middle aperture radii/EE;  idx = (0, 1)
-            * the middle and largest aperture radii/EE; idx (1, 2)
-            * the smallest and largest aperture radii/EE; idx (0, 2)
         """
         # NOTE: the EE values are always in increasing order
         return ((0, 1), (1, 2), (0, 2))


### PR DESCRIPTION
The PR removes an outdated and unneeded docstring in a private method (as mentioned in a comment in https://jira.stsci.edu/browse/JP-1839).  The CI calculation is fully described starting on line 1003 in the `concentration_indices` method.