### PR TITLE
JP-1957 fix typo in cube_build spec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ associations
 - Removed PATTTYPE='None' constraint from Lv3MIRMRS association rule to
   generate spec3 associations for undithered MRS observations. [#5804]
 
+cube_build
+----------
+
+- Fixed typo in cube_build_step spec for grating [#5839]
+
 datamodels
 ----------
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -35,7 +35,7 @@ class CubeBuildStep (Step):
     spec = """
          channel = option('1','2','3','4','all',default='all') # Channel
          band = option('short','medium','long','all',default='all') # Band
-         grating   = option('prism','g140m','g140h','g235m','g235h',g395m','g395h','all',default='all') # Grating
+         grating   = option('prism','g140m','g140h','g235m','g235h','g395m','g395h','all',default='all') # Grating
          filter   = option('clear','f100lp','f070lp','f170lp','f290lp','all',default='all') # Filter
          output_type = option('band','channel','grating','multi',default='band') # Type IFUcube to create.
          scale1 = float(default=0.0) # cube sample size to use for axis 1, arc seconds


### PR DESCRIPTION
This PR fixes [JP-1957](https://jira.stsci.edu/browse/JP-1957) the typo in the cube_build_step spec is fixed. Fixes #5830 