### PR TITLE
JP-1959: Update NIRSpec GWA tilt keyword comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ datamodels
 
 - Added is_star to slitmeta [#5788]
 
+- Update keyword comments for NIRSpec grating wheel (GWA) keywords [#5844]
+
 extract_2d
 ----------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -536,32 +536,32 @@ properties:
             fits_keyword: OPMODE
             blend_table: True
           gwa_xtilt:
-            title: Grating Y tilt angle relative to mirror
+            title: Grating wheel tilt along instrmnt model Y axis
             type: number
             fits_keyword: GWA_XTIL
             blend_table: True
           gwa_ytilt:
-            title: Grating X tilt angle relative to mirror
+            title: Grating wheel tilt along instrmnt model X axis
             type: number
             fits_keyword: GWA_YTIL
             blend_table: True
           gwa_xp_v:
-            title: GWA X-position/tilt sensor calib
+            title: GWA X-position/tilt sensor calibrated
             type: number
             fits_keyword: GWA_XP_V
             blend_table: True
           gwa_yp_v:
-            title: GWA Y-position/tilt sensor calib
+            title: GWA Y-position/tilt sensor calibrated
             type: number
             fits_keyword: GWA_YP_V
             blend_table: True
           gwa_pxav:
-            title: GWA REC avg X-pos/tilt sensor calib
+            title: GWA REC avg X-pos/tilt sensor calibrated
             type: number
             fits_keyword: GWA_PXAV
             blend_table: True
           gwa_pyav:
-            title: GWA REC avg Y-pos/tilt sensor calib
+            title: GWA REC avg Y-pos/tilt sensor calibrated
             type: number
             fits_keyword: GWA_PYAV
             blend_table: True


### PR DESCRIPTION
Updated the keyword titles for several of the NIRSpec GWA (grating wheel assembly) keywords, to keep in synch with JWSTKD values. Triggered by [JWSTKD-423](https://jira.stsci.edu/browse/JWSTKD-423).

Resolves [JP-1959](https://jira.stsci.edu/browse/JP-1959)
Resolves #5834 