### PR TITLE
JP-1954: Changed tests to parametrize the choice of ramp fitting algorithm

### DIFF
--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -209,7 +209,7 @@ class TestMethods:
     def test_nocrs_noflux_firstrows_are_nan(self, method):
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
         model1.data[0, :, 0:12, :] = np.nan
-        slopes = ramp_fit(model1, 60000, False, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 60000, False, rnModel, gain, method, 'optimal', 'none')
         assert(0 == np.max(slopes[0].data))
         assert(0 == np.min(slopes[0].data))
 
@@ -218,7 +218,7 @@ class TestMethods:
         # all pixel values are zero. So slope should be zero
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
         model1.meta.exposure.frame_time = None
-        slopes = ramp_fit(model1, 64000, False, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 64000, False, rnModel, gain, method, 'optimal', 'none')
         assert(0 == np.max(slopes[0].data))
         assert(0 == np.min(slopes[0].data))
 
@@ -242,7 +242,7 @@ class TestMethods:
         model1.data[1, 2, 50, 50] = 25.0
         model1.data[1, 3, 50, 50] = 33.0
         model1.data[1, 4, 50, 50] = 160.0
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         out_slope = slopes[0].data[50, 50]
         deltaDN1 = 50
         deltaDN2 = 150
@@ -252,7 +252,7 @@ class TestMethods:
         # all pixel values are zero. So slope should be zero
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
         model1.meta.exposure.ngroups = 11
-        slopes = ramp_fit(model1, 64000, False, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 64000, False, rnModel, gain, method, 'optimal', 'none')
         assert(0 == np.max(slopes[0].data))
         assert(0 == np.min(slopes[0].data))
 
@@ -262,7 +262,7 @@ class TestMethods:
         model1.meta.exposure.ngroups = 11
         gain.data[10, 10] = -10
         gain.data[20, 20] = np.nan
-        slopes = ramp_fit(model1, 64000, False, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 64000, False, rnModel, gain, method, 'optimal', 'none')
         assert(0 == np.max(slopes[0].data))
         assert(0 == np.min(slopes[0].data))
         assert slopes[0].dq[10, 10] == 524288 + 1
@@ -285,7 +285,7 @@ class TestMethods:
         xvalues = np.arange(5) * 1.0
         yvalues = np.array([10, 15, 25, 33, 60])
         coeff = np.polyfit(xvalues, yvalues, 1)
-        slopes = ramp_fit(model1, 64000, False, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 64000, False, rnModel, gain, method, 'optimal', 'none')
         np.testing.assert_allclose(slopes[0].data[12, 1], coeff[0], 1e-6)
 
     def test_simple_ramp(self, method):
@@ -301,7 +301,7 @@ class TestMethods:
         model1.data[0, 7, 50, 50] = 150.0
         model1.data[0, 8, 50, 50] = 170.0
         model1.data[0, 9, 50, 50] = 190.0
-        slopes = ramp_fit(model1, 64000, True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 64000, True, rnModel, gain, method, 'optimal', 'none')
         # take the ratio of the slopes to get the relative error
         np.testing.assert_allclose(slopes[0].data[50, 50], (20.0 / 3), 1e-6)
 
@@ -312,7 +312,7 @@ class TestMethods:
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         xvalues = np.arange(5) * 1.0
         yvalues = np.array([10, 15, 25, 33, 60])
         coeff = np.polyfit(xvalues, yvalues, 1)
@@ -325,7 +325,7 @@ class TestMethods:
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         cds_slope = (model1.data[0, 4, 50, 50] - model1.data[0, 0, 50, 50]) / 4.0
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-2)
 
@@ -337,7 +337,7 @@ class TestMethods:
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
         model1.groupdq[0, 4, :, :] = DO_NOT_USE
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         cds_slope = (model1.data[0, 3, 50, 50] - model1.data[0, 0, 50, 50]) / 3.0
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-2)
 
@@ -348,7 +348,7 @@ class TestMethods:
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 15.0
         model1.groupdq[0, 1, :, :] = DO_NOT_USE
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         cds_slope = (model1.data[0, 1, 50, 50] - model1.data[0, 0, 50, 50]) / 1.0
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
 
@@ -359,7 +359,7 @@ class TestMethods:
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'unweighted', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'unweighted', 'none')
         # cds_slope = (model1.data[0,4,500,500] - model1.data[0,0,500,500])/ 4.0
         xvalues = np.arange(5) * 1.0
         yvalues = np.array([10, 15, 25, 33, 60])
@@ -380,7 +380,7 @@ class TestMethods:
         # 1st group is saturated
         model1.groupdq[0, 0, 50, 52] = SATURATED
         model1.groupdq[0, 1, 50, 52] = SATURATED  # should not be set this way
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         cds_slope = (model1.data[0, 1, 50, 50] - model1.data[0, 0, 50, 50])
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
         # expect SATURATED
@@ -395,7 +395,7 @@ class TestMethods:
         model1.data[0, 2, 50, 50] = 20.0
         model1.data[0, 3, 50, 50] = 145.0
         model1.groupdq[0, 3, 50, 50] = JUMP_DET
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         cds_slope = (model1.data[0, 1, 50, 50] - model1.data[0, 0, 50, 50])
 
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
@@ -409,7 +409,7 @@ class TestMethods:
         model1.data[0, 3, 50, 50] = 145.0
         model1.groupdq[0, 2, 50, 50] = JUMP_DET
         model1.groupdq[0, 3, 50, 50] = JUMP_DET
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         cds_slope = (model1.data[0, 1, 50, 50] - model1.data[0, 0, 50, 50])
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
 
@@ -424,7 +424,7 @@ class TestMethods:
         model1.groupdq[0, 1, 50, 50] = JUMP_DET
         model1.groupdq[0, 2, 50, 50] = JUMP_DET
         model1.groupdq[0, 3, 50, 50] = JUMP_DET
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         np.testing.assert_allclose(slopes[0].data[50, 50], 0, 1e-6)
 
     def test_four_groups_three_CRs_at_end(self, method):
@@ -436,7 +436,7 @@ class TestMethods:
         model1.groupdq[0, 1, 50, 50] = JUMP_DET
         model1.groupdq[0, 2, 50, 50] = JUMP_DET
         model1.groupdq[0, 3, 50, 50] = JUMP_DET
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         expected_slope = 10.0
         np.testing.assert_allclose(slopes[0].data[50, 50], expected_slope, 1e-6)
 
@@ -447,14 +447,14 @@ class TestMethods:
         model1.data[0, 2, 50, 50] = 145.0
         model1.data[0, 3, 50, 50] = 165.0
         model1.groupdq[0, 1, 50, 50] = JUMP_DET
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         expected_slope = 20.0
         np.testing.assert_allclose(slopes[0].data[50, 50], expected_slope, 1e-6)
 
     def test_one_group_fit(self, method):
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=1, gain=1, readnoise=10)
         model1.data[0, 0, 50, 50] = 10.0
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         np.testing.assert_allclose(slopes[0].data[50, 50], 10.0, 1e-6)
 
     def test_two_groups_unc(self, method):
@@ -468,7 +468,7 @@ class TestMethods:
                                                               deltatime=grouptime)
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 10.0 + deltaDN
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         # delta_electrons = deltaDN * ingain
         single_sample_readnoise = inreadnoise / np.sqrt(2)
         np.testing.assert_allclose(slopes[0].var_poisson[50, 50],
@@ -494,7 +494,7 @@ class TestMethods:
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
-        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, 'OLS', 'optimal', 'none')
+        slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         # out_slope=slopes[0].data[500, 500]
         median_slope = np.median(np.diff(model1.data[0, :, 50, 50])) / grouptime
         # deltaDN = 50
@@ -529,10 +529,9 @@ class TestMethods:
         model1.data[0, 8, 50, 50] = 170.0
         model1.data[0, 9, 50, 50] = 180.0
         model1.groupdq[0, 5, 50, 50] = JUMP_DET
-        slopes, int_model, opt_model, gls_opt_model = ramp_fit(model1,
-                                                               1024 * 30000., True,
-                                                               rnModel, gain, 'OLS',
-                                                               'optimal', 'none')
+        slopes, int_model, opt_model, gls_opt_model = \
+            ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
+
         segment_groups = 5
         single_sample_readnoise = np.float64(inreadnoise / np.sqrt(2))
         # check that the segment variance is as expected
@@ -567,9 +566,9 @@ class TestMethods:
         model1.data[0, 8, 50, 50] = 168.0
         model1.data[0, 9, 50, 50] = 180.0
         model1.groupdq[0, 5, 50, 50] = JUMP_DET
-        slopes, int_model, opt_model, gls_opt_model = ramp_fit(model1, 1024 * 30000., True,
-                                                               rnModel, gain, 'OLS',
-                                                               'optimal', 'none')
+        slopes, int_model, opt_model, gls_opt_model = \
+            ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
+
         avg_slope = (opt_model.slope[0, 0, 50, 50] + opt_model.slope[0, 1, 50, 50]) / 2.0
         # even with noiser second segment, final slope should be just the
         # average since they have the same number of groups

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -630,14 +630,15 @@ class TestMethods:
 
     # FAIL GPS
     def test_oneCR_10_groups_combination_noisy2ndSegment(self, method):
-        grouptime = 3.0
-        # deltaDN = 5
-        ingain = 200  # use large gain to show that Poisson noise doesn't affect the recombination
-        inreadnoise = 7
-        ngroups = 10
-        model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
-                                                              gain=ingain, readnoise=inreadnoise,
-                                                              deltatime=grouptime)
+        # Reason: opt_res is None
+        # Reason: Computed slope is different by 0.033539
+
+        # use large gain to show that Poisson noise doesn't affect the recombination
+        grouptime, ingain, inreadnoise, ngroups = 3.0, 200, 7, 10
+
+        model1, gdq, rnModel, pixdq, err, gain = setup_inputs(
+            ngroups=ngroups, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+
         # two segments perfect fit, second segment has twice the slope
         model1.data[0, 0, 50, 50] = 15.0
         model1.data[0, 1, 50, 50] = 20.0
@@ -649,11 +650,14 @@ class TestMethods:
         model1.data[0, 7, 50, 50] = 160.0
         model1.data[0, 8, 50, 50] = 168.0
         model1.data[0, 9, 50, 50] = 180.0
+
         model1.groupdq[0, 5, 50, 50] = JUMP_DET
+
         slopes, int_model, opt_model, gls_opt_model = \
             ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
 
         avg_slope = (opt_model.slope[0, 0, 50, 50] + opt_model.slope[0, 1, 50, 50]) / 2.0
+
         # even with noiser second segment, final slope should be just the
         # average since they have the same number of groups
         np.testing.assert_allclose(slopes.data[50, 50], avg_slope, rtol=1e-5)

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -206,7 +206,10 @@ class TestMethods:
         assert(0 == np.max(slopes[0].data))
         assert(0 == np.min(slopes[0].data))
 
+    # FAIL GPS
     def test_nocrs_noflux_firstrows_are_nan(self, method):
+        # Reason: GLS return NaN as max slope, whereas OLS returns 0.
+
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
         model1.data[0, :, 0:12, :] = np.nan
         slopes = ramp_fit(model1, 60000, False, rnModel, gain, method, 'optimal', 'none')
@@ -256,9 +259,15 @@ class TestMethods:
         assert(0 == np.max(slopes[0].data))
         assert(0 == np.min(slopes[0].data))
 
+    # FAIL GPS
     def test_bad_gain_values(self, method):
+        # Reason: Max and min slope is NaN for GLS, but 0 for OLS.
+
         # all pixel values are zero. So slope should be zero
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5)
+
+        # Why does this get changed?  Can this happen?  Can exposure ngroups be different
+        # from the number of groups in an integration?
         model1.meta.exposure.ngroups = 11
         gain.data[10, 10] = -10
         gain.data[20, 20] = np.nan
@@ -268,24 +277,28 @@ class TestMethods:
         assert slopes[0].dq[10, 10] == 524288 + 1
         assert slopes[0].dq[20, 20] == 524288 + 1
 
+    # FAIL GPS
     def test_subarray_5groups(self, method):
+        # Reason: Code failure.  Will need to debug this.
+
         # all pixel values are zero. So slope should be zero
-        model1, gdq, rnModel, pixdq, err, gain = setup_subarray_inputs(ngroups=5,
-                                                                       subxstart=10,
-                                                                       subystart=20,
-                                                                       subxsize=5,
-                                                                       subysize=15,
-                                                                       readnoise=50)
+        model1, gdq, rnModel, pixdq, err, gain = setup_subarray_inputs(
+            ngroups=5, subxstart=10, subystart=20, subxsize=5, subysize=15, readnoise=50)
+
         model1.meta.exposure.ngroups = 11
+
         model1.data[0, 0, 12, 1] = 10.0
         model1.data[0, 1, 12, 1] = 15.0
         model1.data[0, 2, 12, 1] = 25.0
         model1.data[0, 3, 12, 1] = 33.0
         model1.data[0, 4, 12, 1] = 60.0
+
         xvalues = np.arange(5) * 1.0
         yvalues = np.array([10, 15, 25, 33, 60])
+
         coeff = np.polyfit(xvalues, yvalues, 1)
         slopes = ramp_fit(model1, 64000, False, rnModel, gain, method, 'optimal', 'none')
+
         np.testing.assert_allclose(slopes[0].data[12, 1], coeff[0], 1e-6)
 
     def test_simple_ramp(self, method):
@@ -305,40 +318,60 @@ class TestMethods:
         # take the ratio of the slopes to get the relative error
         np.testing.assert_allclose(slopes[0].data[50, 50], (20.0 / 3), 1e-6)
 
+    # FAIL GPS
     def test_read_noise_only_fit(self, method):
+        # Reason: The difference between polyfit and GLS estimate is only 0.022575
+        #         It is desired to be less than 1e-6.
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5, readnoise=50)
+
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 15.0
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
+
         xvalues = np.arange(5) * 1.0
         yvalues = np.array([10, 15, 25, 33, 60])
         coeff = np.polyfit(xvalues, yvalues, 1)
+
         np.testing.assert_allclose(slopes[0].data[50, 50], coeff[0], 1e-6)
 
+    # FAIL GPS
     def test_photon_noise_only_fit(self, method):
+        # Reason: The model data is multiplied by the gain, so the value cds_slope is 
+        #         a multiple of the gain, so it is 1000 times too large.
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5, gain=1000, readnoise=1)
+
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 15.0
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         cds_slope = (model1.data[0, 4, 50, 50] - model1.data[0, 0, 50, 50]) / 4.0
+
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-2)
 
+    # FAIL GPS
     def test_photon_noise_only_bad_last_frame(self, method):
+        # Reason: The slope is bad.  It appears to not ignore the last group.
+        #         The cds_slope is off by a factor of 1000.
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5, gain=1000, readnoise=1)
+
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 15.0
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
+
         model1.groupdq[0, 4, :, :] = DO_NOT_USE
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
         cds_slope = (model1.data[0, 3, 50, 50] - model1.data[0, 0, 50, 50]) / 3.0
+
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-2)
 
     @pytest.mark.xfail(reason="Fails, bad last frame yields only one good one. \
@@ -352,13 +385,17 @@ class TestMethods:
         cds_slope = (model1.data[0, 1, 50, 50] - model1.data[0, 0, 50, 50]) / 1.0
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
 
+    # FAIL GPS
     def test_photon_noise_with_unweighted_fit(self, method):
+        # Reason: The difference between slopes and coeff is too large, only 0.055.
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=5, gain=1000, readnoise=1)
+
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 15.0
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 33.0
         model1.data[0, 4, 50, 50] = 60.0
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'unweighted', 'none')
         # cds_slope = (model1.data[0,4,500,500] - model1.data[0,0,500,500])/ 4.0
         xvalues = np.arange(5) * 1.0
@@ -366,22 +403,33 @@ class TestMethods:
         coeff = np.polyfit(xvalues, yvalues, 1)
         np.testing.assert_allclose(slopes[0].data[50, 50], coeff[0], 1e-6)
 
+    # FAIL GPS
     def test_two_groups_fit(self, method):
+        # Reason: Incorrect dimensions in the following line of 
+        #         code in gls_fits_all_integrations:
+        # temp_dq[:, :][s_mask] = UNRELIABLE_SLOPE
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=2, gain=1, readnoise=10)
+
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 15.0
         model1.data[0, 0, 50, 51] = 20.0
         model1.data[0, 1, 50, 51] = 60.0
         model1.data[0, 0, 50, 52] = 200.0
         model1.data[0, 1, 50, 52] = 600.0
+
         model1.meta.exposure.drop_frames1 = 0
+
         # 2nd group is saturated
         model1.groupdq[0, 1, 50, 51] = SATURATED
+
         # 1st group is saturated
         model1.groupdq[0, 0, 50, 52] = SATURATED
         model1.groupdq[0, 1, 50, 52] = SATURATED  # should not be set this way
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
+
         cds_slope = (model1.data[0, 1, 50, 50] - model1.data[0, 0, 50, 50])
+
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
         # expect SATURATED
         assert slopes[0].dq[50, 51] == SATURATED
@@ -413,30 +461,41 @@ class TestMethods:
         cds_slope = (model1.data[0, 1, 50, 50] - model1.data[0, 0, 50, 50])
         np.testing.assert_allclose(slopes[0].data[50, 50], cds_slope, 1e-6)
 
+    # FAIL GPS
     def test_four_groups_four_CRs(self, method):
-        #
+        # Reason: JUMP_DET used in computing slope.
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=4, gain=1, readnoise=10)
+
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 15.0
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 145.0
+
         model1.groupdq[0, 0, 50, 50] = JUMP_DET
         model1.groupdq[0, 1, 50, 50] = JUMP_DET
         model1.groupdq[0, 2, 50, 50] = JUMP_DET
         model1.groupdq[0, 3, 50, 50] = JUMP_DET
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
+
         np.testing.assert_allclose(slopes[0].data[50, 50], 0, 1e-6)
 
+    # FAIL GPS
     def test_four_groups_three_CRs_at_end(self, method):
+        # Reason: JUMP_DET used in computing slope.
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=4, gain=1, readnoise=10)
+
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 15.0
         model1.data[0, 2, 50, 50] = 25.0
         model1.data[0, 3, 50, 50] = 145.0
+
         model1.groupdq[0, 1, 50, 50] = JUMP_DET
         model1.groupdq[0, 2, 50, 50] = JUMP_DET
         model1.groupdq[0, 3, 50, 50] = JUMP_DET
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
+
         expected_slope = 10.0
         np.testing.assert_allclose(slopes[0].data[50, 50], expected_slope, 1e-6)
 
@@ -451,36 +510,53 @@ class TestMethods:
         expected_slope = 20.0
         np.testing.assert_allclose(slopes[0].data[50, 50], expected_slope, 1e-6)
 
+    # FAIL GPS
     def test_one_group_fit(self, method):
+        # Reason: Code for 'determine_slope' assumes always more than one group.
         model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=1, gain=1, readnoise=10)
+
         model1.data[0, 0, 50, 50] = 10.0
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
+
         np.testing.assert_allclose(slopes[0].data[50, 50], 10.0, 1e-6)
 
+    # FAIL GPS
     def test_two_groups_unc(self, method):
+        # Reason: computed var_poisson anc var_rnoise are incorrect.
+        # Reason: Error matrix is only one dimensional havig shape (102,).
         grouptime = 3.0
         deltaDN = 5
         ingain = 2
         inreadnoise = 10
         ngroups = 2
-        model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
-                                                              gain=ingain, readnoise=inreadnoise,
-                                                              deltatime=grouptime)
+
+        model1, gdq, rnModel, pixdq, err, gain = setup_inputs(
+            ngroups=ngroups, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+
         model1.data[0, 0, 50, 50] = 10.0
         model1.data[0, 1, 50, 50] = 10.0 + deltaDN
+
         slopes = ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
+
         # delta_electrons = deltaDN * ingain
-        single_sample_readnoise = inreadnoise / np.sqrt(2)
         np.testing.assert_allclose(slopes[0].var_poisson[50, 50],
                                    ((deltaDN / ingain) / grouptime**2), 1e-6)
+
         np.testing.assert_allclose(slopes[0].var_rnoise[50, 50],
                                    (inreadnoise**2 / grouptime**2), 1e-6)
+
+        single_sample_readnoise = inreadnoise / np.sqrt(2)
         np.testing.assert_allclose(slopes[0].var_rnoise[50, 50],
                                    (12 * single_sample_readnoise**2 / (ngroups * (ngroups**2 - 1) * grouptime**2)), 1e-6)
+
         np.testing.assert_allclose(slopes[0].err[50, 50],
                                    (np.sqrt((deltaDN / ingain) / grouptime**2 + (inreadnoise**2 / grouptime**2))), 1e-6)
 
+    # FAIL GPS
     def test_five_groups_unc(self, method):
+        # Reason: computed var_poisson anc var_rnoise are incorrect.
+        # Reason: Error matrix is only one dimensional havig shape (102,).
         grouptime = 3.0
         # deltaDN = 5
         ingain = 2
@@ -508,15 +584,17 @@ class TestMethods:
         np.testing.assert_allclose(slopes[0].err[50, 50],
                                    np.sqrt(slopes[0].var_poisson[50, 50] + slopes[0].var_rnoise[50, 50]), 1e-6)
 
+    # FAIL GPS
     def test_oneCR_10_groups_combination(self, method):
-        grouptime = 3.0
-        # deltaDN = 5
-        ingain = 200  # use large gain to show that Poisson noise doesn't affect the recombination
-        inreadnoise = 7
-        ngroups = 10
-        model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups,
-                                                              gain=ingain, readnoise=inreadnoise,
-                                                              deltatime=grouptime)
+        # Reason: opt_model = None
+        # Reason: slopes.data[50, 50] differs from 2.5 by only 0.00110101
+
+        # use large gain to show that Poisson noise doesn't affect the recombination
+        grouptime, ingain, inreadnoise, ngroups = 3.0, 200, 7, 10
+
+        model1, gdq, rnModel, pixdq, err, gain = setup_inputs(
+            ngroups=ngroups, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
+
         # two segments perfect fit, second segment has twice the slope
         model1.data[0, 0, 50, 50] = 15.0
         model1.data[0, 1, 50, 50] = 20.0
@@ -528,23 +606,29 @@ class TestMethods:
         model1.data[0, 7, 50, 50] = 160.0
         model1.data[0, 8, 50, 50] = 170.0
         model1.data[0, 9, 50, 50] = 180.0
+
         model1.groupdq[0, 5, 50, 50] = JUMP_DET
+
         slopes, int_model, opt_model, gls_opt_model = \
             ramp_fit(model1, 1024 * 30000., True, rnModel, gain, method, 'optimal', 'none')
 
         segment_groups = 5
         single_sample_readnoise = np.float64(inreadnoise / np.sqrt(2))
         # check that the segment variance is as expected
-        np.testing.assert_allclose(opt_model.var_rnoise[0, 0, 50, 50],
-                                   (12.0 * single_sample_readnoise**2 /
-                                    (segment_groups * (segment_groups**2 - 1) * grouptime**2)),
-                                   rtol=1e-6)
+        np.testing.assert_allclose(
+            opt_model.var_rnoise[0, 0, 50, 50],
+            (12.0 * single_sample_readnoise**2
+             / (segment_groups * (segment_groups**2 - 1) * grouptime**2)),
+            rtol=1e-6)
+
         # check the combined slope is the average of the two segments since they have the same number of groups
         np.testing.assert_allclose(slopes.data[50, 50], 2.5, rtol=1e-5)
+
         # check that the slopes of the two segments are correct
         np.testing.assert_allclose(opt_model.slope[0, 0, 50, 50], 5 / 3.0, rtol=1e-5)
         np.testing.assert_allclose(opt_model.slope[0, 1, 50, 50], 10 / 3.0, rtol=1e-5)
 
+    # FAIL GPS
     def test_oneCR_10_groups_combination_noisy2ndSegment(self, method):
         grouptime = 3.0
         # deltaDN = 5


### PR DESCRIPTION
The tests set up a class to parametrize testing `ramp_fitting` using ordinary least squares (OLS) and generalized least squares (GLS) as algorithms to compute slopes and variances for ramps.  However, the tests had OLS hardcoded as the algorithm to use, so the same test twice, instead of testing GLS.

Addresses #5826 
Fixes [JP-1954](https://jira.stsci.edu/browse/JP-1954)