### PR TITLE
Ignore timeconversion in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,7 @@ ignore =
 minversion = 4.6
 norecursedirs =
     docs/_build
+    jwst/timeconversion
     scripts
     .tox
 asdf_schema_tests_enabled = true


### PR DESCRIPTION
Having removed this line in #5837, it seems we need it there, as our nightly regression tests are recursing into `jwst/timeconversion` and throwing the following error:

```
jwst/timeconversion/time_conversion.py:53: in <module>
    EPHEMERIS_PATH = os.environ['JPL_EPHEMERIS']
../miniconda/envs/tmp_env0/lib/python3.8/os.py:675: in __getitem__
    raise KeyError(key) from None
E   KeyError: 'JPL_EPHEMERIS'

During handling of the above exception, another exception occurred:
jwst/timeconversion/__init__.py:1: in <module>
    from .time_conversion import compute_bary_helio_time
jwst/timeconversion/time_conversion.py:55: in <module>
    raise KeyError('Environmental variable JPL_EPHEMERIS not found')
E   KeyError: 'Environmental variable JPL_EPHEMERIS not found'
```