### PR TITLE
JP-1963: Add rshift fitgeom option to tweakreg docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,11 @@ transforms
 
 - Added ``is_star`` to GrismObject [#5788]
 
+tweakreg
+--------
+
+- Updated documentation to include the new "rshift" option for fit geometry [#5899]
+
 1.1.0 (2021-02-26)
 ==================
 

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -117,8 +117,12 @@ The ``tweakreg`` step has the following optional arguments:
 **Catalog fitting parameters:**
 
 * ``fitgeometry``: A `str` value indicating the type of affine transformation
-  to be considered when fitting catalogs. Allowed values: {``'shift'``,
-  ``'rscale'``, ``'general'``}. (Default="general")
+  to be considered when fitting catalogs. Allowed values:
+
+  - ``'shift'``: x/y shifts only
+  - ``'rscale'``: rotation and scale
+  - ``'rshift'``: rotation and shifts
+  - ``'general'``: shift, rotation, and scale (Default="general")
 
 * ``nclip``: A non-negative integer number of clipping iterations
   to use in the fit. (Default = 3)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5841 
Resolves [JP-1963](https://jira.stsci.edu/browse/JP-1963)

**Description**

This PR updates the "tweakreg" step docs to add the "rshift" option to the list of allowed values for the "fitgeometry" param. It also expands the list of allowed values to add a brief description of the meaning of each value.

Checklist
- [x] Tests
- [X] Documentation
- [x] Change log
- [X] Milestone
- [X] Label(s)