### PR TITLE
Fix a call to interpret_bits in coron3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ datamodels
 - Moved functions in ``dqflags`` and ``dynamic_mask`` to ``stcal`` [#5898]
 
 - API change - ``stcal.dqflags.interpret_bit_flags`` and ``stcal.dynamicdq.dynamic_mask``
-  now require the ``mnemonic_map`` as input. [#5898]
+  now require the ``mnemonic_map`` as input. [#5898, #5914]
 
 extract_2d
 ----------

--- a/jwst/coron/align_refs_step.py
+++ b/jwst/coron/align_refs_step.py
@@ -1,6 +1,8 @@
 """ Replace bad pixels and align psf image with target image."""
 
-from jwst.datamodels.dqflags import interpret_bit_flags
+from stcal.dqflags import interpret_bit_flags
+
+from jwst.datamodels.dqflags import pixel
 
 from ..stpipe import Step
 from .. import datamodels
@@ -50,7 +52,7 @@ class AlignRefsStep(Step):
 
             # Get the bit value of bad pixels. A value of 0 treats all pixels as good.
             bad_bitvalue = self.bad_bits
-            bad_bitvalue = interpret_bit_flags(bad_bitvalue)
+            bad_bitvalue = interpret_bit_flags(bad_bitvalue, mnemonic_map=pixel)
             if bad_bitvalue is None:
                 bad_bitvalue = 0
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

This fixes a call to `coron.align_refs_step.interpret_bit_flags` which I missed in #5898.



