### PR TITLE
Add stpipe and stcal to dev deps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,6 @@ git+https://github.com/spacetelescope/crds
 git+https://github.com/spacetelescope/gwcs
 git+https://github.com/astropy/photutils
 git+https://github.com/spacetelescope/stdatamodels
+git+https://github.com/spacetelescope/stpipe
+git+https://github.com/spacetelescope/stcal
 git+https://github.com/spacetelescope/tweakwcs


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

This PR adds `stpipe` and `stcal` to the dev dependencies listed in `requirements-dev.txt`.  This file is used to specify dev dependencies in our weekly dev run of the regression tests in the RT/JWST-devdeps Jenkins job.


Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
