### PR TITLE
JP-1949: MOS 0-sized bounding box extraction bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ assign_wcs
 - Changed evaluation of grism bounding box center from averaged extrema of
   transformed bounding box to transformed centroid of source_cat object [#5809]
 
+- Added pixel shift to non-fixed slits due to 0-indexing in NIRSpec slit
+  validation code, fixing difference between bounding box locations during the
+  separate halves of assign_wcs runs [#5927]
+
 associations
 ------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ assign_wcs
 - Changed evaluation of grism bounding box center from averaged extrema of
   transformed bounding box to transformed centroid of source_cat object [#5809]
 
-- Added pixel shift to non-fixed slits due to 0-indexing in NIRSpec slit
+- Added pixel shift to msa slits due to 0-indexing in NIRSpec slit
   validation code, fixing difference between bounding box locations during the
   separate halves of assign_wcs runs [#5927]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,9 +12,9 @@ assign_wcs
 - Changed evaluation of grism bounding box center from averaged extrema of
   transformed bounding box to transformed centroid of source_cat object [#5809]
 
-- Added pixel shift to msa slits due to 0-indexing in NIRSpec slit
-  validation code, fixing difference between bounding box locations during the
-  separate halves of assign_wcs runs [#5927]
+- Added pixel shift to MSA slits due to 0-indexing in NIRSpec slit validation
+  code, fixing difference between bounding box locations during the separate
+  halves of assign_wcs runs [#5927]
 
 associations
 ------------

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1658,38 +1658,11 @@ def validate_open_slits(input_model, open_slits, reference_files):
     # collimator to GWA
     collimator2gwa = collimator_to_gwa(reference_files, disperser)
 
-    #msa = MSAModel(reference_files['msa'])
-
     col2det = collimator2gwa & Identity(1) | Mapping((3, 0, 1, 2)) | agreq | \
         gwa2det | det2dms
 
     slit2msa = slit_to_msa(open_slits,reference_files['msa'])
-    '''
-    for quadrant in range(1, 6):
-        slits_in_quadrant = [s for s in open_slits if s.quadrant == quadrant]
-        if any(slits_in_quadrant):
-            msa_quadrant = getattr(msa, "Q{0}".format(quadrant))
-            msa_model = msa_quadrant.model
-            msa_data = msa_quadrant.data
-            for slit in slits_in_quadrant:
-                slit_id = slit.shutter_id
-                # Shutters are numbered starting from 1.
-                # Fixed slits (Quadrant 5) are mapped starting from 0.
-                if quadrant != 5:
-                    slit_id = slit_id - 1
-                slitdata = msa_data[slit_id]
-                slitdata_model = get_slit_location_model(slitdata)
-                msa_transform = slitdata_model | msa_model
-                msa2det = msa_transform & Identity(1) | col2det
-                bb = compute_bounding_box(msa2det, wrange, slit.ymin, slit.ymax)
 
-                valid = _is_valid_slit(bb)
-                if not valid:
-                    log.info("Removing slit {0} from the list of open slits because the "
-                             "WCS bounding_box is completely outside the detector.".format(slit.name))
-                    idx = np.nonzero([s.name == slit.name for s in open_slits])[0][0]
-                    open_slits.pop(idx)
-    '''
     for slit in slit2msa.slits:
         msa_transform = slit2msa.get_model(slit.name)
         msa2det = msa_transform & Identity(1) | col2det
@@ -1703,7 +1676,6 @@ def validate_open_slits(input_model, open_slits, reference_files):
             idx = np.nonzero([s.name == slit.name for s in open_slits])[0][0]
             open_slits.pop(idx)
 
-    # msa.close()
     return open_slits
 
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1595,15 +1595,14 @@ def nrs_wcs_set_input(input_model, slit_name, wavelength_range=None):
     else:
         slit_wcs.set_transform('slit_frame', 'msa_frame',
                                wcsobj.pipeline[3].transform.get_model(slit_name) & Identity(1))
-    #slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
-    msa2detector = slit_wcs.get_transform('msa_frame', 'detector')
+
+    slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
 
     if is_nirspec_ifu:
         bb = compute_bounding_box(slit2detector, wrange)
     else:
         slit = [s for s in open_slits if s.name == slit_name][0]
-        # bb = compute_bounding_box(slit2detector, wrange,
-        bb = compute_bounding_box(msa2detector, wrange,
+        bb = compute_bounding_box(slit2detector, wrange,
                                   slit_ymin=slit.ymin, slit_ymax=slit.ymax)
 
     slit_wcs.bounding_box = bb
@@ -1659,9 +1658,13 @@ def validate_open_slits(input_model, open_slits, reference_files):
     # collimator to GWA
     collimator2gwa = collimator_to_gwa(reference_files, disperser)
 
-    msa = MSAModel(reference_files['msa'])
+    #msa = MSAModel(reference_files['msa'])
+
     col2det = collimator2gwa & Identity(1) | Mapping((3, 0, 1, 2)) | agreq | \
         gwa2det | det2dms
+
+    slit2msa = slit_to_msa(open_slits,reference_files['msa'])
+    '''
     for quadrant in range(1, 6):
         slits_in_quadrant = [s for s in open_slits if s.quadrant == quadrant]
         if any(slits_in_quadrant):
@@ -1670,25 +1673,37 @@ def validate_open_slits(input_model, open_slits, reference_files):
             msa_data = msa_quadrant.data
             for slit in slits_in_quadrant:
                 slit_id = slit.shutter_id
+                # Shutters are numbered starting from 1.
+                # Fixed slits (Quadrant 5) are mapped starting from 0.
+                if quadrant != 5:
+                    slit_id = slit_id - 1
                 slitdata = msa_data[slit_id]
                 slitdata_model = get_slit_location_model(slitdata)
                 msa_transform = slitdata_model | msa_model
                 msa2det = msa_transform & Identity(1) | col2det
                 bb = compute_bounding_box(msa2det, wrange, slit.ymin, slit.ymax)
 
-                #slit2det = slitdata_model & Identity(1) | col2det
-                #bb = compute_bounding_box(slit2det, wrange, slit.ymin, slit.ymax)
-
                 valid = _is_valid_slit(bb)
-                log.warning(f"Slit bounding_box is {bb}")
                 if not valid:
                     log.info("Removing slit {0} from the list of open slits because the "
                              "WCS bounding_box is completely outside the detector.".format(slit.name))
-                    log.debug("Slit bounding_box is {0}".format(bb))
                     idx = np.nonzero([s.name == slit.name for s in open_slits])[0][0]
                     open_slits.pop(idx)
+    '''
+    for slit in slit2msa.slits:
+        msa_transform = slit2msa.get_model(slit.name)
+        msa2det = msa_transform & Identity(1) | col2det
 
-    msa.close()
+        bb = compute_bounding_box(msa2det, wrange, slit.ymin, slit.ymax)
+
+        valid = _is_valid_slit(bb)
+        if not valid:
+            log.info("Removing slit {0} from the list of open slits because the "
+                    "WCS bounding_box is completely outside the detector.".format(slit.name))
+            idx = np.nonzero([s.name == slit.name for s in open_slits])[0][0]
+            open_slits.pop(idx)
+
+    # msa.close()
     return open_slits
 
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1595,7 +1595,6 @@ def nrs_wcs_set_input(input_model, slit_name, wavelength_range=None):
     else:
         slit_wcs.set_transform('slit_frame', 'msa_frame',
                                wcsobj.pipeline[3].transform.get_model(slit_name) & Identity(1))
-
     slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
 
     if is_nirspec_ifu:

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1671,7 +1671,7 @@ def validate_open_slits(input_model, open_slits, reference_files):
         valid = _is_valid_slit(bb)
         if not valid:
             log.info("Removing slit {0} from the list of open slits because the "
-                    "WCS bounding_box is completely outside the detector.".format(slit.name))
+                     "WCS bounding_box is completely outside the detector.".format(slit.name))
             idx = np.nonzero([s.name == slit.name for s in open_slits])[0][0]
             open_slits.pop(idx)
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1595,15 +1595,15 @@ def nrs_wcs_set_input(input_model, slit_name, wavelength_range=None):
     else:
         slit_wcs.set_transform('slit_frame', 'msa_frame',
                                wcsobj.pipeline[3].transform.get_model(slit_name) & Identity(1))
-    slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
-    #msa2detector = slit_wcs.get_transform('msa_frame', 'detector')
+    #slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
+    msa2detector = slit_wcs.get_transform('msa_frame', 'detector')
 
     if is_nirspec_ifu:
         bb = compute_bounding_box(slit2detector, wrange)
     else:
         slit = [s for s in open_slits if s.name == slit_name][0]
-        bb = compute_bounding_box(slit2detector, wrange,
-        # bb = compute_bounding_box(msa2detector, wrange,
+        # bb = compute_bounding_box(slit2detector, wrange,
+        bb = compute_bounding_box(msa2detector, wrange,
                                   slit_ymin=slit.ymin, slit_ymax=slit.ymax)
 
     slit_wcs.bounding_box = bb
@@ -1676,8 +1676,8 @@ def validate_open_slits(input_model, open_slits, reference_files):
                 msa2det = msa_transform & Identity(1) | col2det
                 bb = compute_bounding_box(msa2det, wrange, slit.ymin, slit.ymax)
 
-                slit2det = slitdata_model & Identity(1) | col2det
-                bb = compute_bounding_box(slit2det, wrange, slit.ymin, slit.ymax)
+                #slit2det = slitdata_model & Identity(1) | col2det
+                #bb = compute_bounding_box(slit2det, wrange, slit.ymin, slit.ymax)
 
                 valid = _is_valid_slit(bb)
                 log.warning(f"Slit bounding_box is {bb}")

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1660,7 +1660,7 @@ def validate_open_slits(input_model, open_slits, reference_files):
     col2det = collimator2gwa & Identity(1) | Mapping((3, 0, 1, 2)) | agreq | \
         gwa2det | det2dms
 
-    slit2msa = slit_to_msa(open_slits,reference_files['msa'])
+    slit2msa = slit_to_msa(open_slits, reference_files['msa'])
 
     for slit in slit2msa.slits:
         msa_transform = slit2msa.get_model(slit.name)

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1224,7 +1224,7 @@ def compute_bounding_box(slit2detector, wavelength_range, slit_ymin=-.55, slit_y
     of the projection of the slit on the detector.
     Because the trace is curved and the wavelength_range may span the
     two detectors, y_min of the projection may be at an arbitrary wavelength.
-    The transform is run with a regularly sampled wavelengths to determin y_min.
+    The transform is run with a regularly sampled wavelengths to determine y_min.
 
     Parameters
     ----------
@@ -1596,12 +1596,14 @@ def nrs_wcs_set_input(input_model, slit_name, wavelength_range=None):
         slit_wcs.set_transform('slit_frame', 'msa_frame',
                                wcsobj.pipeline[3].transform.get_model(slit_name) & Identity(1))
     slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
+    #msa2detector = slit_wcs.get_transform('msa_frame', 'detector')
 
     if is_nirspec_ifu:
         bb = compute_bounding_box(slit2detector, wrange)
     else:
         slit = [s for s in open_slits if s.name == slit_name][0]
         bb = compute_bounding_box(slit2detector, wrange,
+        # bb = compute_bounding_box(msa2detector, wrange,
                                   slit_ymin=slit.ymin, slit_ymax=slit.ymax)
 
     slit_wcs.bounding_box = bb
@@ -1673,7 +1675,12 @@ def validate_open_slits(input_model, open_slits, reference_files):
                 msa_transform = slitdata_model | msa_model
                 msa2det = msa_transform & Identity(1) | col2det
                 bb = compute_bounding_box(msa2det, wrange, slit.ymin, slit.ymax)
+
+                slit2det = slitdata_model & Identity(1) | col2det
+                bb = compute_bounding_box(slit2det, wrange, slit.ymin, slit.ymax)
+
                 valid = _is_valid_slit(bb)
+                log.warning(f"Slit bounding_box is {bb}")
                 if not valid:
                     log.info("Removing slit {0} from the list of open slits because the "
                              "WCS bounding_box is completely outside the detector.".format(slit.name))

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -1918,10 +1918,7 @@ def flat_for_nirspec_slit(slit, f_flat_model, s_flat_model, d_flat_model,
         wl = slit.wavelength.copy()         # a 2-D array
     except AttributeError:
         got_wl_attribute = False
-    # if not got_wl_attribute or len(wl) == 0:
-    if 0 in np.shape(wl):
-        log.warning(f"")
-        wl = [0.]
+    if not got_wl_attribute or len(wl) == 0:
         got_wl_attribute = False
     return_dummy = False
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -1918,7 +1918,10 @@ def flat_for_nirspec_slit(slit, f_flat_model, s_flat_model, d_flat_model,
         wl = slit.wavelength.copy()         # a 2-D array
     except AttributeError:
         got_wl_attribute = False
-    if not got_wl_attribute or len(wl) == 0:
+    # if not got_wl_attribute or len(wl) == 0:
+    if 0 in np.shape(wl):
+        log.warning(f"")
+        wl = [0.]
         got_wl_attribute = False
     return_dummy = False
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5807 

Resolves [JP-1949](https://jira.stsci.edu/browse/JP-1949)

**Description**

This PR addresses a bug found when validating slits in the assign_wcs/nirspec code. Near-duplicate code had a missing slit_id shift caused by 0- vs 1- indexing of fixed slits vs msa slitlets - a slit on the edge of the detector in one bounding box was off the detector when calculated correctly. This near-duplicate code has also been cleaned up by calling a common function instead.

Note: Have not yet checked existing regtests, but could reasonably expect this to cause issues, as this moved the bounding box by ~2.5 pixels. Checking on this. 

Note2: Checked, the two nirspec_mos_spec2 regtests run without error.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)