### PR TITLE
JP-1829: Fix resample_spec output size from input images crossing RA=0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,13 +107,17 @@ ramp_fitting
 refpix
 ------
 
-- Added code to handle NIR subarrays that use 4 readout amplifiers.  Uses and applies reference pixel signal from
-  available amplifiers and side reference pixel regions, including odd-even column separation if requested [#5926]
+- Added code to handle NIR subarrays that use 4 readout amplifiers.  Uses and
+  applies reference pixel signal from available amplifiers and side reference
+  pixel regions, including odd-even column separation if requested [#5926]
 
-- Fixed a bug introduced in #5926 that affected refpix calibration of 1-amp NIR subarrays [#5937]
+- Fixed a bug introduced in #5926 that affected refpix calibration of 1-amp NIR
+  subarrays [#5937]
 
 resample
 --------
+
+- Fix ``resample_spec`` output size from input images crossing RA=0 [#5929]
 
 - Propagate variance arrays into ``SlitModel`` used as input for ``ResampleSpecStep`` [#5941]
 

--- a/jwst/assign_mtwcs/tests/test_mtwcs.py
+++ b/jwst/assign_mtwcs/tests/test_mtwcs.py
@@ -9,10 +9,10 @@ data_path = os.path.split(os.path.abspath(data.__file__))[0]
 
 def test_mt_multislit():
     file_path = os.path.join(data.__path__[0], 'test_mt_asn.json')
-    model = datamodels.open(file_path)
-    assert model[0].slits[0].meta.wcs.output_frame.name == 'world'
-    step = AssignMTWcsStep()
-    result = step.run(model)
+    with datamodels.open(file_path) as model:
+        assert model[0].slits[0].meta.wcs.output_frame.name == 'world'
+        step = AssignMTWcsStep()
+        result = step.run(model)
     assert isinstance(result, datamodels.ModelContainer)
     assert len(result[0].slits) == 1
     assert result[0].slits[0].meta.wcs.output_frame.name == 'moving_target'

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -28,6 +28,7 @@ def sci_blot_image_pair():
 
     sci.data = np.random.normal(loc=background, size=shape, scale=sigma)
     sci.err = np.zeros(shape) + sigma
+    sci.var_rnoise += 0
 
     # Add a source in the center
     sci.data[10, 10] += 20 * sigma
@@ -113,6 +114,7 @@ def we_three_sci():
     sci1.meta.wcs = create_fitswcs(sci1)
 
     sci1.err = np.zeros(shape) + sigma
+    sci1.var_rnoise += 0
 
     # Make copies with different noise
     sci2 = sci1.copy()

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -58,8 +58,7 @@ def run_image3pipeline(run_image2pipeline, rtdata_module, jail):
     ]
     for rate_file in rate_files:
         rtdata.get_data(rate_file)
-        args = ["config/calwebb_image2.cfg", rtdata.input,
-                "--steps.resample.skip=True"]
+        args = ["config/calwebb_image2.cfg", rtdata.input]
         Step.from_cmdline(args)
 
     # Get the level3 assocation json file (though not its members) and run

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -205,15 +205,12 @@ class ResampleSpecData:
             this_maxw = np.max(wavelength_array)
             all_minw = np.min(all_wavelength)
             all_maxw = np.max(all_wavelength)
-
             if this_minw < all_minw:
                 addpts = wavelength_array[wavelength_array < all_minw]
-                for ip in range(len(addpts)):
-                    all_wavelength.append(addpts[ip])
+                all_wavelength = np.append(all_wavelength, addpts)
             if this_maxw > all_maxw:
                 addpts = wavelength_array[wavelength_array > all_maxw]
-                for ip in range(len(addpts)):
-                    all_wavelength.append(addpts[ip])
+                all_wavelength = np.append(all_wavelength, addpts)
 
         # done looping over set of models
         all_ra = np.hstack(all_ra_slit)

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -94,6 +94,7 @@ class ResampleSpecStep(ResampleStep):
 
         for container in containers.values():
             resamp = resample_spec.ResampleSpecData(container, **self.drizpars)
+
             drizzled_models = resamp.do_drizzle()
 
             for model in drizzled_models:
@@ -138,6 +139,7 @@ class ResampleSpecStep(ResampleStep):
 
         resamp = resample_spec.ResampleSpecData(input_models, **self.drizpars)
 
+        # Only drizzle the area within the bounding box
         if input_models[0].meta.exposure.type == "MIR_LRS-FIXEDSLIT":
             bb = input_models[0].meta.wcs.bounding_box
             ((x1, x2), (y1, y2)) = bb

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -205,9 +205,6 @@ def test_nirspec_wcs_roundtrip(nirspec_rate):
         assert_allclose(x, xp, atol=1e-8)
         assert_allclose(y, yp, atol=1e-8)
 
-def test_foo(miri_rate):
-    assert miri_rate.hasattr("var_rnoise")
-
 
 def test_miri_wcs_roundtrip(miri_rate):
     im = AssignWcsStep.call(miri_rate)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5564
Resolves [JP-1829](https://jira.stsci.edu/browse/JP-1829)

**Description**

This PR fixes the case where the WCS of the input images spans RA=0.

- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
