### PR TITLE
JP-2032: Fix bug introduced when adding 4-amp subarray processing in refpix step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,6 +106,8 @@ refpix
 - Added code to handle NIR subarrays that use 4 readout amplifiers.  Uses and applies reference pixel signal from
   available amplifiers and side reference pixel regions, including odd-even column separation if requested [#5926]
 
+- Fixed a bug introduced in #5026 that affected refpix calibration of 1-amp NIR subarrays [#5937]
+
 source_catalog
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,7 +106,7 @@ refpix
 - Added code to handle NIR subarrays that use 4 readout amplifiers.  Uses and applies reference pixel signal from
   available amplifiers and side reference pixel regions, including odd-even column separation if requested [#5926]
 
-- Fixed a bug introduced in #5026 that affected refpix calibration of 1-amp NIR subarrays [#5937]
+- Fixed a bug introduced in #5926 that affected refpix calibration of 1-amp NIR subarrays [#5937]
 
 source_catalog
 --------------

--- a/docs/jwst/refpix/description.rst
+++ b/docs/jwst/refpix/description.rst
@@ -108,7 +108,7 @@ NIR Data
 ++++++++
 
 For single amplifier readout (NOUTPUTS keyword = 1):
-----------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the odd_even_columns flag is set to True, then the clipped means of all
 reference pixels in odd-numbered columns and those in even numbered columns
@@ -127,7 +127,7 @@ If the science dataset has at least 1 group with no valid reference pixels,
 the step is skipped and the S_REFPIX header keyword is set to 'SKIPPED'.
 
 For 4 amplifier readout (NOUTPUTS keyword = 4):
------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the NOUTPUTS keyword is 4 for a subarray exposure, then the data are calibrated
 the same as for full-frame exposures.  The top/bottom reference values are obtained from available

--- a/jwst/refpix/reference_pixels.py
+++ b/jwst/refpix/reference_pixels.py
@@ -909,12 +909,13 @@ class NIRDataset(Dataset):
         #  First transform to detector coordinates
         #
         refdq = dqflags.pixel['REFERENCE_PIXEL']
+        donotuse = dqflags.pixel['DO_NOT_USE']
         #
         # This transforms the pixeldq array from DMS to detector coordinates,
         # only needs to be done once
         self.DMS_to_detector_dq()
         # Determined refpix indices to use on each group
-        refpixindices = np.where(np.bitwise_and(self.pixeldq, refdq) == refdq)
+        refpixindices = np.where((self.pixeldq & refdq == refdq) & (self.pixeldq & donotuse != donotuse))
         nrefpixels = len(refpixindices[0])
         if nrefpixels == 0:
             self.bad_reference_pixels = True


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
Closes #5936 

Resolves [JP-2032](https://jira.stsci.edu/browse/JP-2032)

**Description**

This PR addresses JP-2032.  JP-1929 introduced a bug into the refpix step for 1-amp readout NIR subarrays.  This PR fixes it.  Unit tests and regression test now run.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)