### PR TITLE
JP-2033: Logic to send no open slits data to error message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ assign_wcs
   code, fixing difference between bounding box locations during the separate
   halves of assign_wcs runs [#5927]
 
+- Added logic to prevent the sending of an empty list of slits to the
+  validate_open_slits function, so a proper error message is provided to
+  the user [#5939]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -418,7 +418,7 @@ def get_open_slits(input_model, reference_files=None, slit_y_range=[-.55, .55]):
             slits = get_open_fixed_slits(input_model, slit_y_range)
     else:
         raise ValueError("EXP_TYPE {0} is not supported".format(exp_type.upper()))
-    if reference_files is not None:
+    if reference_files is not None and slits:
         slits = validate_open_slits(input_model, slits, reference_files)
         log.info("Slits projected on detector {0}: {1}".format(input_model.meta.instrument.detector,
                                                                [sl.name for sl in slits]))
@@ -575,7 +575,7 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
         log.error(message)
         raise MSAFileError(message)
 
-    # Get the configuration header from teh _msa.fits file.  The EXTNAME should be 'SHUTTER_INFO'
+    # Get the configuration header from the _msa.fits file.  The EXTNAME should be 'SHUTTER_INFO'
     msa_conf = msa_file[('SHUTTER_INFO', 1)]
     msa_source = msa_file[("SOURCE_INFO", 1)].data
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5938 

Resolves [JP-2033](https://jira.stsci.edu/browse/JP-2033)

**Description**

This PR adds a quick check to make sure slits is not empty before sending it to validate_open_slits, which would fail on the slit_to_msa call if slits were empty.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)