### PR TITLE
Propagate variance arrays into SlitModel used as input for ResampleSpecStep

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,11 @@ refpix
 
 - Fixed a bug introduced in #5926 that affected refpix calibration of 1-amp NIR subarrays [#5937]
 
+resample
+--------
+
+- Propagate variance arrays into ``SlitModel`` used as input for ``ResampleSpecStep`` [#5941]
+
 source_catalog
 --------------
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -23,18 +23,11 @@ class ResampleSpecStep(ResampleStep):
     """
 
     def process(self, input):
-
-        # Define input_new, because if input is ImageModel, it will
-        # get recreated as a SlitModel
         input_new = datamodels.open(input)
 
+        # Convert ImageModel to SlitModel (needed for MIRI LRS)
         if isinstance(input_new, ImageModel):
-            slit_model = datamodels.SlitModel()
-            slit_model.update(input_new, only="PRIMARY")
-            slit_model.update(input_new, only="SCI")
-            slit_model.meta.wcs = input_new.meta.wcs
-            slit_model.data = input_new.data
-            input_new = slit_model
+            input_new = datamodels.SlitModel(input_new)
 
         # If single DataModel input, wrap in a ModelContainer
         if not isinstance(input_new, ModelContainer):

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -123,6 +123,7 @@ def nircam_rate():
     ysize = 204
     shape = (ysize, xsize)
     im = ImageModel(shape)
+    im.var_rnoise += 0
     im.meta.wcsinfo = {
         'ctype1': 'RA---TAN',
         'ctype2': 'DEC--TAN',


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
Addresses #5798 
Addresses [JP-1944](https://jira.stsci.edu/browse/JP-1944)

**Description**

This PR allows propagation of the variance arrays of the inputs to `ResampleSpecStep`.  Previously these were being dropped on the floor when converting an `ImageModel` into a `SlitModel`, which happens in the case of MIRI LRS.

Regression tests pass on this branch.

This is of course needed if we are to use the variance arrays for weighting and to compute uncertainties in the resampled products.

- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
