### PR TITLE
Fix insecure interpolation in Jenkinsfile

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -88,7 +88,9 @@ bc0.test_cmds = [
     "pytest --cov-report=xml --cov=./ -r sxf -n 30 --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
-    "codecov --token=${codecov_token} -F nightly",
+    // The following line needs single quotes to avoid insecure interpolation
+    // of the codecov_token
+    'codecov --token=${codecov_token} -F nightly',
 ]
 bc0.test_configs = [data_config]
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

This PR fixes an insecure interpolation warning seen in the upgraded Jenkins version we are running.  Single quotes make sure this line doesn't get echoed to the log.

Warning is here

https://plwishmaster.stsci.edu:8081/view/all/job/RT/job/JWST/1163/

The fix in this branch is here

https://plwishmaster.stsci.edu:8081/view/all/job/RT/job/jdavies-dev/230/

Ignore the failing Codecov checks below, as I only ran `pytest jwst/datamodels` tests to have it complete quickly on `plwishmaster`.  I only wanted to make sure the interpolation issue was fixed and that the codecov report worked.  The fact that the actual coverage of the repo went down is expected as I only ran a fraction of the tests.


- [x] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)