### PR TITLE
JP-2022: Fix flat field crash when given slit with single pixel wavelength range

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1631,7 +1631,7 @@ def validate_open_slits(input_model, open_slits, reference_files):
         ylow, yhigh = domain[1]
         if (xlow >= 2048 or ylow >= 2048 or
             xhigh <= 0 or yhigh <= 0 or
-                xhigh - xlow < 1 or yhigh - ylow < 1):
+                xhigh - xlow < 2 or yhigh - ylow < 1):
             return False
         else:
             return True


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5921 
Resolves [JP-2022](https://jira.stsci.edu/browse/JP-2022)

**Description**

This PR changes the slit validation requirement from needing one pixel in wavelength extent to two.


Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)