### PR TITLE
JP-824: Add option to save combined background image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ background
 
 - Remove unused ``SubtractImagesStep`` [#5919]
 
+- Added new step parameter to optionally save the combined, average
+  background image: ``save_combined_background``. [#5954]
+
 calwebb_spec2
 -------------
 

--- a/docs/jwst/background_step/arguments.rst
+++ b/docs/jwst/background_step/arguments.rst
@@ -16,3 +16,7 @@ control the sigma clipping, and are passed as arguments to the astropy
   The number of clipping iterations to perform, or ``None`` to clip until
   convergence is achieved. Defaults to ``None``.
 
+``--save_combined_background``
+  Saves the combined, averaged background image used for background
+  subtraction. Defaults to ``False``.
+

--- a/docs/jwst/background_step/description.rst
+++ b/docs/jwst/background_step/description.rst
@@ -53,6 +53,9 @@ subtracted from it. If the target exposure is in the form of a 3-D CubeModel
 (e.g. the result of a time series exposure), the background image
 is subtracted from each plane of the CubeModel.
 
+The combined, averaged background image can be saved using the step parameter
+``save_combined_background``.
+
 WFSS Mode
 ---------
 For Wide-Field Slitless Spectroscopy expsoures (NIS_WFSS and NRC_WFSS),

--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -13,12 +13,16 @@ class BackgroundStep(Step):
     """
 
     spec = """
+        save_combined_background = boolean(default=False)  # Save combined background image
         sigma = float(default=3.0)  # Clipping threshold
         maxiters = integer(default=None)  # Number of clipping iterations
     """
 
     # These reference files are only used for WFSS/GRISM data.
     reference_file_types = ["wfssbkg", "wavelengthrange"]
+
+    # Define a suffix for optional saved output of the combined background
+    bkg_suffix = 'combinedbackground'
 
     def process(self, input, bkg_list):
         """
@@ -77,11 +81,15 @@ class BackgroundStep(Step):
                                 break
                 # Do the background subtraction
                 if do_sub:
-                    result = background_sub.background_sub(input_model,
+                    bkg_model, result = background_sub.background_sub(input_model,
                                                            bkg_list,
                                                            self.sigma,
                                                            self.maxiters)
                     result.meta.cal_step.back_sub = 'COMPLETE'
+                    if self.save_combined_background:
+                        comb_bkg_path = self.save_model(bkg_model, suffix=self.bkg_suffix, force=True)
+                        self.log.info(f'Interpolated flat written to "{comb_bkg_path}".')
+
                 else:
                     result = input_model.copy()
                     result.meta.cal_step.back_sub = 'SKIPPED'

--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -82,9 +82,9 @@ class BackgroundStep(Step):
                 # Do the background subtraction
                 if do_sub:
                     bkg_model, result = background_sub.background_sub(input_model,
-                                                           bkg_list,
-                                                           self.sigma,
-                                                           self.maxiters)
+                                                                      bkg_list,
+                                                                      self.sigma,
+                                                                      self.maxiters)
                     result.meta.cal_step.back_sub = 'COMPLETE'
                     if self.save_combined_background:
                         comb_bkg_path = self.save_model(bkg_model, suffix=self.bkg_suffix, force=True)

--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -88,7 +88,7 @@ class BackgroundStep(Step):
                     result.meta.cal_step.back_sub = 'COMPLETE'
                     if self.save_combined_background:
                         comb_bkg_path = self.save_model(bkg_model, suffix=self.bkg_suffix, force=True)
-                        self.log.info(f'Interpolated flat written to "{comb_bkg_path}".')
+                        self.log.info(f'Combined background written to "{comb_bkg_path}".')
 
                 else:
                     result = input_model.copy()

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def background_sub(input_model, bkg_list, sigma, maxiters):
+def background_sub(input_model, bkg_list, sigma, maxiters, save_combined_background):
     """
     Short Summary
     -------------
@@ -45,7 +45,7 @@ def background_sub(input_model, bkg_list, sigma, maxiters):
     bkg_model.close()
 
     # We're done. Return the result.
-    return result
+    return bkg_model, result
 
 
 def average_background(bkg_list, sigma, maxiters):

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -42,7 +42,7 @@ def background_sub(input_model, bkg_list, sigma, maxiters):
     result = subtract_images.subtract(input_model, bkg_model)
 
     # Close the average background image and update the step status
-    #bkg_model.close()
+    # bkg_model.close()
 
     # We're done. Return the result.
     return bkg_model, result

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -99,7 +99,6 @@ def average_background(bkg_list, sigma, maxiters):
 
     # Compute the combined ERR as the uncertainty in the mean
     avg_bkg.err = (np.sqrt(merr.sum(axis=0)) / (num_bkg - merr.mask.sum(axis=0))).data
-    # avg_bkg.err[merr.mask.sum(axis=0)] = np.nan
 
     return avg_bkg
 

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -42,7 +42,7 @@ def background_sub(input_model, bkg_list, sigma, maxiters):
     result = subtract_images.subtract(input_model, bkg_model)
 
     # Close the average background image and update the step status
-    bkg_model.close()
+    #bkg_model.close()
 
     # We're done. Return the result.
     return bkg_model, result

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def background_sub(input_model, bkg_list, sigma, maxiters, save_combined_background):
+def background_sub(input_model, bkg_list, sigma, maxiters):
     """
     Short Summary
     -------------

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -41,9 +41,6 @@ def background_sub(input_model, bkg_list, sigma, maxiters):
     log.debug(' subtracting avg bkg from {}'.format(input_model.meta.filename))
     result = subtract_images.subtract(input_model, bkg_model)
 
-    # Close the average background image and update the step status
-    # bkg_model.close()
-
     # We're done. Return the result.
     return bkg_model, result
 
@@ -101,7 +98,8 @@ def average_background(bkg_list, sigma, maxiters):
     merr = np.ma.masked_array(cerr, mask=mdata.mask)
 
     # Compute the combined ERR as the uncertainty in the mean
-    avg_bkg.err = np.sqrt(merr.sum(axis=0)) / (num_bkg - merr.mask.sum(axis=0))
+    avg_bkg.err = (np.sqrt(merr.sum(axis=0)) / (num_bkg - merr.mask.sum(axis=0))).data
+    # avg_bkg.err[merr.mask.sum(axis=0)] = np.nan
 
     return avg_bkg
 

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -26,7 +26,6 @@ def run_pipeline(jail, rtdata_module):
     # NOTE: THE RESAMPLE_SPEC STEP IS SKIPPED FOR NOW, BECAUSE IT HAS A BUG
     # (the s2d image is all zeros)
     args = ["config/calwebb_spec2.cfg", rtdata.input,
-            "--steps.resample_spec.skip=true",       # remove when bug fixed
             "--save_bsub=true",
             "--steps.assign_wcs.save_results=true",
             "--steps.flat_field.save_results=true",

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -30,7 +30,8 @@ def run_pipeline(jail, rtdata_module):
             "--save_bsub=true",
             "--steps.assign_wcs.save_results=true",
             "--steps.flat_field.save_results=true",
-            "--steps.srctype.save_results=true"]
+            "--steps.srctype.save_results=true",
+            "--steps.bkg_subtract.save_combined_background=true"]
     Step.from_cmdline(args)
 
     return rtdata
@@ -38,7 +39,7 @@ def run_pipeline(jail, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output", [
-    "bsub", "flat_field", "assign_wcs", "srctype", "cal", "x1d"])
+    "bsub", "flat_field", "assign_wcs", "srctype", "cal", "x1d", "combinedbackground"])
 def test_miri_lrs_slit_spec2(run_pipeline, fitsdiff_default_kwargs, output):
     """Regression test of the calwebb_spec2 pipeline on MIRI
        LRS fixedslit data using along-slit-nod pattern for


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #3746

Resolves [JP-824](https://jira.stsci.edu/browse/JP-824)

**Description**

This PR adds the option to save the combined background image model, in a method pulled directly from the optional flat_field output. Currently will not work as written, oops. Do we really need to close that bkg_model?


Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)