### PR TITLE
Add segm to list of data products

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,10 @@ documentation
 
 - Update documentation, deprecating primary use of CFG files [#5901]
 
+- Update pipeline introduction document to include segmentation map (``segm``)
+  in list of data products [#5956]
+
+
 extract_2d
 ----------
 

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -529,6 +529,7 @@ Resampled 3D IFU cube                          s3d
 1D extracted spectra per integration           x1dints
 1D combined spectrum                           c1d
 Source catalog                                 cat
+Segmentation map                               segm
 Time Series photometric catalog                phot
 Time Series white-light catalog                whtlt
 Coronagraphic PSF image stack                  psfstack


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
**Description**

Missed one place in earlier documentation updates where the new segmentation map product needed to be added. This is in the pipeline introduction, which gives a table listing all data product types. Added "segm" to the list.


Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)