### PR TITLE
JP-2045: Use Python 3.9 for SDP CI and regtests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,19 +90,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{ hashFiles('**/requirements-sdp.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Get CRDS context
         id: crds-context
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,14 +86,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Upgrade pip
-        run: |
-          python -m pip install --upgrade pip
-
       - name: Get CRDS context
         id: crds-context
         run: |
-          pip install crds
+          pip install crds asdf
           echo "::set-output name=pmap::$(crds list --resolve-contexts --contexts | cut -f 1 -d ".")"
 
       - name: Restore CRDS cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
           - name: SDP dependencies in requirements-sdp.txt
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             toxenv: sdpdeps
 
           - name: Installed package with --pyargs
@@ -70,6 +70,11 @@ jobs:
             os: macos-latest
             python-version: 3.9
             toxenv: py39
+
+          - name: Linux Python 3.10-dev
+            os: ubuntu-latest
+            python-version: 3.10-dev
+            toxenv: py310
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,6 @@ jobs:
             os: macos-latest
             python-version: 3.9
             toxenv: py39
-
-          - name: Linux Python 3.10-dev
-            os: ubuntu-latest
-            python-version: 3.10-dev
-            toxenv: py310
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Restore CRDS cache
         uses: actions/cache@v2
         with:
-          path: ~/crds_cache
-          key: crds-${{ matrix.toxenv }}-${{ steps.crds-context.outputs.pmap }}
+          path: ${{ env.CRDS_PATH }}
+          key: crds-${{ steps.crds-context.outputs.pmap }}
 
       - name: Install tox
         run: |

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -47,14 +47,14 @@ jobs:
       - name: Get CRDS context
         id: crds-context
         run: |
-          pip install crds
+          pip install crds asdf
           echo "::set-output name=pmap::$(crds list --resolve-contexts --contexts | cut -f 1 -d ".")"
 
       - name: Restore CRDS cache
         uses: actions/cache@v2
         with:
           path: ~/crds_cache
-          key: crds-${{ matrix.toxenv }}-${{ steps.crds-context.outputs.pmap }}
+          key: crds-${{ steps.crds-context.outputs.pmap }}
 
       - name: Install tox
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,7 +20,7 @@ jobs:
           # Check out the commit containing this workflow file.
           - name: checkout repo
             uses: actions/checkout@v2
-         
+
           - name: custom action
             uses: spacetelescope/action-publish_to_pypi@master
             id: custom_action_0

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -43,7 +43,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
-python_version = "3.8"
+python_version = "3.9"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -43,7 +43,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
-python_version = "3.8"
+python_version = "3.9"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"

--- a/jwst/stpipe/tests/test_config.py
+++ b/jwst/stpipe/tests/test_config.py
@@ -56,7 +56,7 @@ def test_step_config_to_asdf(config):
     assert asdf_file["parameters"] == config.parameters
     assert asdf_file["steps"] == [s.to_asdf().tree for s in config.steps]
     assert asdf_file["meta"]["author"] == "<SPECIFY>"
-    assert (datetime.utcnow() - datetime.fromisoformat(asdf_file["meta"]["date"])) < timedelta(seconds=1)
+    assert (datetime.utcnow() - datetime.fromisoformat(asdf_file["meta"]["date"])) < timedelta(seconds=10)
     assert asdf_file["meta"]["description"] == "Parameters for calibration step some.PipelineClass"
     assert asdf_file["meta"]["instrument"]["name"] == "<SPECIFY>"
     assert asdf_file["meta"]["origin"] == "<SPECIFY>"


### PR DESCRIPTION
Closes #5957 
Closes #5747
Resolves [JP-2045](https://jira.stsci.edu/browse/JP-2045)

**Description**

This PR does the following:
   - use Python 3.9 for SDP CI and nightly regtest builds
   - ~add Python 3.10-dev to the CI matrix~ Oops, the numpy folks accidentally prevented their code from being built under Python 3.10 because they pinned `wheel` version in pyproject.toml
   - remove pip caching in CI workflow (it masks build issues, see #5744 )
   - add `asdf` install so `crds` caching works in CI workflow

Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
