### PR TITLE
TST: Use astropy nightly build

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 git+https://github.com/spacetelescope/asdf
-git+https://github.com/astropy/astropy
+--extra-index-url=https://pkgs.dev.azure.com/astropy-project/astropy/_packaging/nightly/pypi/simple/ --pre astropy
 git+https://github.com/spacetelescope/crds
 git+https://github.com/spacetelescope/gwcs
 git+https://github.com/astropy/photutils


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

This PR attempts to use `astropy` nightly build instead of building from source.

PROS: Faster run time for test suite!

CONS: You won't see new changes from "astropy dev" until they go into the next nightly build. And if build is broken, you need to bug Stuart Mumford.

Checklist

- [x] Tests -- This controls all the dev tests (*my preciousssss*)
- [x] Documentation -- N/A
- [x] Change log -- N/A
- [ ] Milestone -- Up to you
- [ ] Label(s) -- Up to you
