### PR TITLE
Update PR template to be less confusing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,13 +16,8 @@ Resolves JP-
 This PR addresses ...
 
 
-Checklist
+Checklist:
+
 - [ ] Tests
-
 - [ ] Documentation
-
 - [ ] Change log
-
-- [ ] Milestone
-
-- [ ] Label(s)


### PR DESCRIPTION
Only people with write access to the repo can set labels and milestones, so there is little point in including those checkboxes because they will confuse people without write access.

If you want to make sure there are labels and milestones, you are better off imposing a check in CI for them rather than relying on checkboxes.