### PR TITLE
Jp-2046: Refpix subarray 4amp tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,6 +136,8 @@ refpix
 - Fixed a bug introduced in #5926 that affected refpix calibration of 1-amp NIR
   subarrays [#5937]
 
+- Added regression test and unit test for NIR 4-amp subarray correction
+
 resample
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,7 +136,7 @@ refpix
 - Fixed a bug introduced in #5926 that affected refpix calibration of 1-amp NIR
   subarrays [#5937]
 
-- Added regression test and unit test for NIR 4-amp subarray correction
+- Added regression test and unit test for NIR 4-amp subarray correction [#5967]
 
 resample
 --------

--- a/jwst/refpix/tests/test_refpix.py
+++ b/jwst/refpix/tests/test_refpix.py
@@ -400,6 +400,75 @@ def test_do_corrections_subarray(setup_subarray_cube):
     np.testing.assert_almost_equal(np.mean(input_model.data[0, 0, 4:-4, 4:-4]), dataval - rmean, decimal=0)
 
 
+def test_do_corrections_subarray_4amp(setup_subarray_cube):
+    '''Test all corrections for subarray data.'''
+
+    # Create inputs and subarray SUBGRISM64 data, and set correction parameters
+    ngroups = 3
+    nrows = 64
+    ncols = 2048
+    xstart = 1
+    ystart = 1
+
+    odd_even_columns = True
+    use_side_ref_pixels = True
+    side_smoothing_length = 11
+    side_gain = 1.0
+    odd_even_rows = False
+
+    left_rpix = 0
+    right_rpix = 1
+    side_rpix_mean = 0.5 * (left_rpix + right_rpix)
+    bottom_rpix_a_odd = 7
+    bottom_rpix_a_even = 7.4
+    bottom_rpix_b_odd = 9
+    bottom_rpix_b_even = 9.4
+    bottom_rpix_c_odd = 6
+    bottom_rpix_c_even = 6.4
+    bottom_rpix_d_odd = 8
+    bottom_rpix_d_even = 8.4
+    dataval = 150
+
+    input_model = setup_subarray_cube('SUBGRISM64', 'NRCA1', xstart, ystart, ngroups, nrows, ncols)
+    input_model.meta.exposure.noutputs = 4
+    input_model.data[0, 0, 4:-4, 4:512:2] = dataval + bottom_rpix_a_odd + side_rpix_mean
+    input_model.data[0, 0, 4:-4, 5:512:2] = dataval + bottom_rpix_a_even + side_rpix_mean
+    input_model.data[0, 0, 4:-4, 512:1024:2] = dataval + bottom_rpix_b_odd + side_rpix_mean
+    input_model.data[0, 0, 4:-4, 513:1024:2] = dataval + bottom_rpix_b_even + side_rpix_mean
+    input_model.data[0, 0, 4:-4, 1024:1536:2] = dataval + bottom_rpix_c_odd + side_rpix_mean
+    input_model.data[0, 0, 4:-4, 1025:1536:2] = dataval + bottom_rpix_c_even + side_rpix_mean
+    input_model.data[0, 0, 4:-4, 1536:2044:2] = dataval + bottom_rpix_d_odd + side_rpix_mean
+    input_model.data[0, 0, 4:-4, 1537:2044:2] = dataval + bottom_rpix_d_even + side_rpix_mean
+
+    input_model.data[0, 0, :4, 0:512:2] = bottom_rpix_a_odd
+    input_model.data[0, 0, :4, 1:512:2] = bottom_rpix_a_even
+    input_model.data[0, 0, :4, 512:1024:2] = bottom_rpix_b_odd
+    input_model.data[0, 0, :4, 513:1024:2] = bottom_rpix_b_even
+    input_model.data[0, 0, :4, 1024:1536:2] = bottom_rpix_c_odd
+    input_model.data[0, 0, :4, 1025:1536:2] = bottom_rpix_c_even
+    input_model.data[0, 0, :4, 1536:2048:2] = bottom_rpix_d_odd
+    input_model.data[0, 0, :4, 1537:2048:2] = bottom_rpix_d_even
+
+    input_model.data[0, 0, :, :4:2] = left_rpix + bottom_rpix_a_odd
+    input_model.data[0, 0, :, 1:4:2] = left_rpix + bottom_rpix_a_even
+    input_model.data[0, 0, :, -4::2] = right_rpix + bottom_rpix_d_odd
+    input_model.data[0, 0, :, -3::2] = right_rpix + bottom_rpix_d_even
+    input_model.pixeldq[:4, :] = dqflags.pixel['REFERENCE_PIXEL']
+    input_model.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
+    input_model.pixeldq[:, -4:] = dqflags.pixel['REFERENCE_PIXEL']
+
+    init_dataset = create_dataset(input_model,
+                                  odd_even_columns,
+                                  use_side_ref_pixels,
+                                  side_smoothing_length,
+                                  side_gain,
+                                  odd_even_rows)
+
+    init_dataset.do_corrections()
+
+    np.testing.assert_almost_equal(np.mean(input_model.data[0, 0, 4:-4, 4:-4]), dataval, decimal=4)
+
+
 def test_get_restore_group_subarray(setup_subarray_cube):
     '''Test subarray input model data is replaced with group data.'''
 

--- a/jwst/regtest/test_nircam_subarray_4amp.py
+++ b/jwst/regtest/test_nircam_subarray_4amp.py
@@ -1,0 +1,45 @@
+import os
+
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+
+"""
+jw00617196001_02102_00001_nrca4_uncal.fits       the input (uncal) file
+jw00617196001_02102_00001_nrca4_rate.fits        rate file
+jw00617196001_02102_00001_nrca4_rateints.fits        rateints file
+jw00617196001_02102_00001_nrca4_trapsfilled.fits        trapsfilled file
+"""
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(jail, rtdata_module):
+    """Run calwebb_detector1 pipeline on NIRCAM subarray data."""
+    rtdata = rtdata_module
+    rtdata.get_data("nircam/subarray/jw00617196001_02102_00001_nrca4_uncal.fits")
+
+    args = ["jwst.pipeline.Detector1Pipeline", rtdata.input]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("output", [
+    'jw00617196001_02102_00001_nrca4_rate.fits',
+    'jw00617196001_02102_00001_nrca4_rateints.fits',
+    'jw00617196001_02102_00001_nrca4_trapsfilled.fits', ],
+    ids=['rate', 'rateints', 'trapsfilled'])
+
+def test_nircam_detector1_subarray(run_pipeline, fitsdiff_default_kwargs, output):
+    """
+    Regression test of calwebb_detector1 pipeline performed on NIRSpec data.
+    """
+    rtdata = run_pipeline
+    rtdata.output = output
+    rtdata.get_truth(os.path.join("truth/test_nircam_subarray_4amp", output))
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_nircam_subarray_4amp.py
+++ b/jwst/regtest/test_nircam_subarray_4amp.py
@@ -3,7 +3,6 @@ import os
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
-from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
 """
@@ -32,7 +31,6 @@ def run_pipeline(jail, rtdata_module):
     'jw00617196001_02102_00001_nrca4_rateints.fits',
     'jw00617196001_02102_00001_nrca4_trapsfilled.fits', ],
     ids=['rate', 'rateints', 'trapsfilled'])
-
 def test_nircam_detector1_subarray(run_pipeline, fitsdiff_default_kwargs, output):
     """
     Regression test of calwebb_detector1 pipeline performed on NIRSpec data.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5959

Resolves [JP-2046](https://jira.stsci.edu/browse/JP-2046)

**Description**
Added regression test and unit test for NIR 4-amp readout subarrays.

This PR addresses JP-2046


Checklist
- [X] Tests
- [ ] Documentation
- [X] Change log
- [x] Milestone
- [x] Label(s)