### PR TITLE
Update NIRISS SOSS tso3 regression test

### DIFF
--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -33,7 +33,9 @@ def run_tso_spec3(jail, rtdata_module, run_tso_spec2):
     # Get the level3 assocation json file (though not its members) and run
     # the tso3 pipeline on all _calints files listed in association
     rtdata.get_data("niriss/soss/jw00625-o023_20191210t204036_tso3_001_asn.json")
-    args = ["config/calwebb_tso3.cfg", rtdata.input]
+    args = ["config/calwebb_tso3.cfg", rtdata.input,
+            "--steps.outlier_detection.snr='13.0 10.0'"
+           ]
     Step.from_cmdline(args)
 
 

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -34,8 +34,8 @@ def run_tso_spec3(jail, rtdata_module, run_tso_spec2):
     # the tso3 pipeline on all _calints files listed in association
     rtdata.get_data("niriss/soss/jw00625-o023_20191210t204036_tso3_001_asn.json")
     args = ["config/calwebb_tso3.cfg", rtdata.input,
-            "--steps.outlier_detection.snr='13.0 10.0'"
-           ]
+            "--steps.outlier_detection.snr='13.0 10.0'",
+            ]
     Step.from_cmdline(args)
 
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

This PR addresses an issue in the calwebb_tso3 regression test using NIRISS SOSS data. Recent updates to the outlier_detection step algorithm resulted in massive numbers of false positive detections in the particular dataset used in the regression test, just due to unrealistically noisy data. This update simply increases the value of the "snr" parameter in the outlier_detection step used in the test to reduce the number of detections.


Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [X] Milestone
- [X] Label(s)