### PR TITLE
removing wcs keywords after resample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -166,6 +166,8 @@ resample
 
 - Propagate variance arrays into ``SlitModel`` used as input for ``ResampleSpecStep`` [#5941]
 
+- Remove certain WCS keywords that are irrelevant after resampling. [#5971]
+
 source_catalog
 --------------
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -93,6 +93,13 @@ class ResampleStep(Step):
         else:
             result = resamp.output_models
 
+        # remove irrelevant WCS keywords
+        rm_keys = ['v2_ref', 'v3_ref', 'ra_ref', 'dec_ref', 'roll_ref',
+                   'v3yangle', 'vparity']
+        for key in rm_keys:
+            if key in result.meta.wcsinfo.instance:
+                del result.meta.wcsinfo.instance[key]
+
         return result
 
     def update_phot_keywords(self, model):

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -380,3 +380,18 @@ def test_build_interpolated_output_wcs(miri_rate_pair):
     # Make sure the output slit size is larger than the input slit size
     # for this nodded data
     assert driz.data_size[1] > ra.shape[1]
+
+
+def test_wcs_keywords(nircam_rate):
+    # make sure certain wcs keywords are removed after resample
+
+    im = AssignWcsStep.call(nircam_rate)
+    result = ResampleStep.call(im)
+
+    assert result.meta.wcsinfo.v2_ref is None
+    assert result.meta.wcsinfo.v3_ref is None
+    assert result.meta.wcsinfo.ra_ref is None
+    assert result.meta.wcsinfo.dec_ref is None
+    assert result.meta.wcsinfo.roll_ref is None
+    assert result.meta.wcsinfo.v3yangle is None
+    assert result.meta.wcsinfo.vparity is None


### PR DESCRIPTION
WCS keywords ra/dec/roll/v2/v3_ref are removed from im.meta.wcsinfo after ResampleStep.

Fixes #2225 / [JP-2039](https://jira.stsci.edu/browse/JP-2039) 
