### PR TITLE
Switch to absolute imports in tests

### DIFF
--- a/jwst/assign_mtwcs/tests/test_mtwcs.py
+++ b/jwst/assign_mtwcs/tests/test_mtwcs.py
@@ -2,7 +2,7 @@ import os
 
 from jwst import datamodels
 from jwst.assign_mtwcs import AssignMTWcsStep
-from . import data
+from jwst.assign_mtwcs.tests import data
 
 data_path = os.path.split(os.path.abspath(data.__file__))[0]
 

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -15,10 +15,10 @@ import pytest
 from astropy.io import fits
 from gwcs import wcs
 
-from ...datamodels.image import ImageModel
-from ...datamodels import CubeModel
-from ..assign_wcs_step import AssignWcsStep
-from .. import nircam
+from jwst.datamodels.image import ImageModel
+from jwst.datamodels import CubeModel
+from jwst.assign_wcs.assign_wcs_step import AssignWcsStep
+from jwst.assign_wcs import nircam
 
 
 # Allowed settings for nircam

--- a/jwst/assign_wcs/tests/test_niriss.py
+++ b/jwst/assign_wcs/tests/test_niriss.py
@@ -14,10 +14,10 @@ from astropy.io import fits
 from gwcs import wcs
 import pytest
 
-from ...datamodels.image import ImageModel
+from jwst.datamodels.image import ImageModel
 
-from ..assign_wcs_step import AssignWcsStep
-from .. import niriss
+from jwst.assign_wcs.assign_wcs_step import AssignWcsStep
+from jwst.assign_wcs import niriss
 
 
 # Allowed settings for niriss

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -20,7 +20,7 @@ from jwst import datamodels
 from jwst.transforms import models as trmodels
 from jwst.assign_wcs import nirspec
 from jwst.assign_wcs import assign_wcs_step
-from . import data
+from jwst.assign_wcs.tests import data
 from jwst.assign_wcs.util import MSAFileError
 
 

--- a/jwst/assign_wcs/tests/test_util.py
+++ b/jwst/assign_wcs/tests/test_util.py
@@ -7,13 +7,15 @@ import os
 from astropy.modeling.models import Shift, Identity
 from astropy.table import QTable
 
-from ...lib.catalog_utils import SkyObject
-from ... import datamodels
+from jwst.lib.catalog_utils import SkyObject
+from jwst import datamodels
 
-from ..util import (get_object_info, wcs_bbox_from_shape, subarray_transform,
-                    bounding_box_from_subarray, transform_bbox_from_shape)
+from jwst.assign_wcs.util import (
+    get_object_info, wcs_bbox_from_shape, subarray_transform,
+    bounding_box_from_subarray, transform_bbox_from_shape
+)
 
-from . import data
+from jwst.assign_wcs.tests import data
 
 data_path = os.path.split(os.path.abspath(data.__file__))[0]
 

--- a/jwst/assign_wcs/tests/test_wfss.py
+++ b/jwst/assign_wcs/tests/test_wfss.py
@@ -7,13 +7,13 @@ from astropy.modeling.models import (Polynomial1D, Polynomial2D, Shift,
 from gwcs import wcs
 from gwcs.wcstools import grid_from_bounding_box
 
-from ...datamodels import SlitModel
-from ...transforms import models as transforms
-from ...extract_2d.grisms import compute_wavelength_array
+from jwst.datamodels import SlitModel
+from jwst.transforms import models as transforms
+from jwst.extract_2d.grisms import compute_wavelength_array
 
 import pytest
 
-from . import data
+from jwst.assign_wcs.tests import data
 data_path = os.path.split(os.path.abspath(data.__file__))[0]
 
 

--- a/jwst/associations/lib/callback_registry.py
+++ b/jwst/associations/lib/callback_registry.py
@@ -1,6 +1,6 @@
 """Callback registry"""
 
-from ...lib.signal_slot import Signal
+from jwst.lib.signal_slot import Signal
 
 __all__ = ['CallbackRegistry']
 

--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -5,7 +5,7 @@ from copy import copy
 import logging
 import re
 
-from ..load_asn import load_asn
+from jwst.associations.load_asn import load_asn
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -1,5 +1,5 @@
 """Association attributes common to DMS-based Rules"""
-from .counter import Counter
+from jwst.associations.lib.counter import Counter
 
 from jwst.associations.exceptions import (
     AssociationNotAConstraint,

--- a/jwst/associations/lib/tests/test_callback.py
+++ b/jwst/associations/lib/tests/test_callback.py
@@ -1,5 +1,5 @@
 """Test callback_registry"""
-from ..callback_registry import CallbackRegistry
+from jwst.associations.lib.callback_registry import CallbackRegistry
 
 
 def fn_single_1(arg):

--- a/jwst/associations/registry.py
+++ b/jwst/associations/registry.py
@@ -62,6 +62,7 @@ class AssociationRegistry(dict):
     The general workflow is as follows:
 
         * Create the registry
+            >>> from jwst.associations.registry import AssociationRegistry
             >>> registry = AssociationRegistry()
 
         * Create associations from an item

--- a/jwst/associations/tests/helpers.py
+++ b/jwst/associations/tests/helpers.py
@@ -10,10 +10,10 @@ from tempfile import TemporaryDirectory
 
 from astropy.table import (Table, vstack)
 
-from .. import (AssociationRegistry, AssociationPool, generate)
-from ..lib.counter import Counter
-from ..lib.diff import compare_asns
-from ..lib.utilities import is_iterable
+from jwst.associations import (AssociationRegistry, AssociationPool, generate)
+from jwst.associations.lib.counter import Counter
+from jwst.associations.lib.diff import compare_asns
+from jwst.associations.lib.utilities import is_iterable
 
 
 # Define how to setup initial conditions with pools.

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -3,10 +3,10 @@
 import os
 import pytest
 
-from .. import (Association, AssociationRegistry, load_asn)
-from ..asn_from_list import (Main, asn_from_list)
-from ..exceptions import AssociationNotValidError
-from ..lib.rules_level2_base import DMSLevel2bBase
+from jwst.associations import (Association, AssociationRegistry, load_asn)
+from jwst.associations.asn_from_list import (Main, asn_from_list)
+from jwst.associations.exceptions import AssociationNotValidError
+from jwst.associations.lib.rules_level2_base import DMSLevel2bBase
 
 
 def test_level2():

--- a/jwst/associations/tests/test_asn_names.py
+++ b/jwst/associations/tests/test_asn_names.py
@@ -1,10 +1,10 @@
 import pytest
 import re
 
-from . import helpers
+from jwst.associations.tests import helpers
 
-from .. import generate
-from ..main import constrain_on_candidates
+from jwst.associations import generate
+from jwst.associations.main import constrain_on_candidates
 
 LEVEL3_ASN_ACID_NAME_REGEX = (
     r'jw'

--- a/jwst/associations/tests/test_associations.py
+++ b/jwst/associations/tests/test_associations.py
@@ -1,17 +1,17 @@
 """test_associations: Test of general Association functionality."""
 import pytest
 
-from . import helpers
+from jwst.associations.tests import helpers
 
-from .. import (
+from jwst.associations import (
     Association,
     AssociationError,
     AssociationRegistry,
     generate)
-from ..registry import (
+from jwst.associations.registry import (
     import_from_file,
 )
-from ..lib.dms_base import DMSAttrConstraint
+from jwst.associations.lib.dms_base import DMSAttrConstraint
 
 
 # Basic Association object

--- a/jwst/associations/tests/test_case.py
+++ b/jwst/associations/tests/test_case.py
@@ -1,13 +1,13 @@
 """Test case insensitivity"""
 import pytest
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     level3_rule_path,
     mkstemp_pool_file,
     t_path,
 )
 
-from ..main import Main
+from jwst.associations.main import Main
 
 
 @pytest.mark.parametrize(

--- a/jwst/associations/tests/test_constraints.py
+++ b/jwst/associations/tests/test_constraints.py
@@ -1,7 +1,7 @@
 """Constraint Tests"""
 import pytest
 
-from ..lib.constraint import (
+from jwst.associations.lib.constraint import (
     Constraint,
     SimpleConstraint,
     SimpleConstraintABC,

--- a/jwst/associations/tests/test_dms.py
+++ b/jwst/associations/tests/test_dms.py
@@ -4,7 +4,7 @@ from os import path
 import pytest
 import re
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     t_path
 )
 

--- a/jwst/associations/tests/test_exposerr.py
+++ b/jwst/associations/tests/test_exposerr.py
@@ -1,15 +1,15 @@
 """Test degraded exposure info"""
-from .helpers import (
+from jwst.associations.tests.helpers import (
     combine_pools,
     t_path
 )
 
-from ..lib.dms_base import (
+from jwst.associations.lib.dms_base import (
     _DEGRADED_STATUS_OK,
     _DEGRADED_STATUS_NOTOK,
     _EMPTY
     )
-from ..main import Main
+from jwst.associations.main import Main
 
 
 def test_exposerr():

--- a/jwst/associations/tests/test_generate.py
+++ b/jwst/associations/tests/test_generate.py
@@ -1,8 +1,8 @@
 """Test basic generate operations"""
 
-from .helpers import t_path
+from jwst.associations.tests.helpers import t_path
 
-from .. import (
+from jwst.associations import (
     AssociationPool,
     AssociationRegistry,
     generate,

--- a/jwst/associations/tests/test_level2_background.py
+++ b/jwst/associations/tests/test_level2_background.py
@@ -1,12 +1,12 @@
 """Test Level2 background nods"""
-from .helpers import (
+from jwst.associations.tests.helpers import (
     combine_pools,
     registry_level2_only,
     t_path
 )
 
-from .. import generate
-from ..main import constrain_on_candidates
+from jwst.associations import generate
+from jwst.associations.main import constrain_on_candidates
 
 DITHER_PATTERN_MULTIPLIER = {
     '0': 1,  # No pattern, 1-to-1 exposure count

--- a/jwst/associations/tests/test_level2_basics.py
+++ b/jwst/associations/tests/test_level2_basics.py
@@ -1,17 +1,17 @@
 """Test basic usage of Level2 associations"""
 import re
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     combine_pools,
     registry_level2_only,
     t_path
 )
 
-from .. import (
+from jwst.associations import (
     generate,
     load_asn,
 )
-from ..main import Main
+from jwst.associations.main import Main
 
 NONSSCIENCE = ['background']
 REGEX_LEVEL2A = r'(?P<path>.+)(?P<type>_rate(ints)?)(?P<extension>\..+)'

--- a/jwst/associations/tests/test_level2_candidates.py
+++ b/jwst/associations/tests/test_level2_candidates.py
@@ -1,13 +1,13 @@
 """Test Level2 candidate operation"""
 import pytest
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     level2_rule_path,
     mkstemp_pool_file,
     t_path,
 )
 
-from ..main import Main
+from jwst.associations.main import Main
 
 
 @pytest.mark.parametrize(

--- a/jwst/associations/tests/test_level3_basics.py
+++ b/jwst/associations/tests/test_level3_basics.py
@@ -1,13 +1,13 @@
 """Test general Level 3 rules environment"""
 import pytest
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     combine_pools,
     registry_level3_only,
     t_path
 )
 
-from .. import generate
+from jwst.associations import generate
 
 
 def test_meta():

--- a/jwst/associations/tests/test_level3_candidates.py
+++ b/jwst/associations/tests/test_level3_candidates.py
@@ -1,13 +1,13 @@
 """test_level3_dithers: Test of dither rules."""
 import pytest
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     level3_rule_path,
     mkstemp_pool_file,
     t_path,
 )
 
-from ..main import Main
+from jwst.associations.main import Main
 
 
 @pytest.mark.parametrize(

--- a/jwst/associations/tests/test_level3_duplicate.py
+++ b/jwst/associations/tests/test_level3_duplicate.py
@@ -1,14 +1,14 @@
 """Test for duplication/missing associations"""
 import pytest
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     level3_rule_path,
     registry_level3_only,
     t_path,
 )
 
-from .. import (AssociationPool, generate)
-from ..main import (Main, constrain_on_candidates)
+from jwst.associations import (AssociationPool, generate)
+from jwst.associations.main import (Main, constrain_on_candidates)
 
 
 def test_duplicate_names():

--- a/jwst/associations/tests/test_level3_image.py
+++ b/jwst/associations/tests/test_level3_image.py
@@ -5,7 +5,7 @@ processed by CALIMAGE3.
 
 Such associations are mosaics and dithers.
 """
-from .helpers import BasePoolRule, PoolParams, t_path
+from jwst.associations.tests.helpers import BasePoolRule, PoolParams, t_path
 
 
 class TestLevel3Image(BasePoolRule):

--- a/jwst/associations/tests/test_level3_product_names.py
+++ b/jwst/associations/tests/test_level3_product_names.py
@@ -3,14 +3,14 @@ import re
 
 import pytest
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     combine_pools,
     registry_level3_only,
     t_path,
 )
 
-from .. import (AssociationPool, generate)
-from ..lib.dms_base import DMSAttrConstraint
+from jwst.associations import (AssociationPool, generate)
+from jwst.associations.lib.dms_base import DMSAttrConstraint
 
 
 LEVEL3_PRODUCT_NAME_REGEX = (

--- a/jwst/associations/tests/test_level3_spectrographic.py
+++ b/jwst/associations/tests/test_level3_spectrographic.py
@@ -2,7 +2,7 @@
 import pytest
 import re
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     BasePoolRule,
     PoolParams,
     combine_pools,
@@ -10,8 +10,8 @@ from .helpers import (
     t_path
 )
 
-from .. import generate
-from ..main import constrain_on_candidates
+from jwst.associations import generate
+from jwst.associations.main import constrain_on_candidates
 
 
 class TestLevel3Spec(BasePoolRule):

--- a/jwst/associations/tests/test_level3_wfs.py
+++ b/jwst/associations/tests/test_level3_wfs.py
@@ -1,9 +1,9 @@
 """test_level3_dithers: Test of WFS rules."""
 
-from . import helpers
+from jwst.associations.tests import helpers
 
-from .. import generate
-from ..main import constrain_on_candidates
+from jwst.associations import generate
+from jwst.associations.main import constrain_on_candidates
 
 # Generate Level3 assocations
 all_candidates = constrain_on_candidates(None)

--- a/jwst/associations/tests/test_load_as_asn.py
+++ b/jwst/associations/tests/test_load_as_asn.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from . import helpers
-from ...datamodels import ImageModel
-from ..load_as_asn import (
+from jwst.associations.tests import helpers
+from jwst.datamodels import ImageModel
+from jwst.associations.load_as_asn import (
     LoadAsLevel2Asn
 )
 

--- a/jwst/associations/tests/test_mkpool.py
+++ b/jwst/associations/tests/test_mkpool.py
@@ -7,9 +7,9 @@ import pytest
 
 from astropy.io import fits
 
-from . import helpers
-from .. import (AssociationRegistry, AssociationPool)
-from ..mkpool import mkpool
+from jwst.associations.tests import helpers
+from jwst.associations import (AssociationRegistry, AssociationPool)
+from jwst.associations.mkpool import mkpool
 
 REQUIRED_PARAMS = set(('PROGRAM', 'FILENAME'))
 

--- a/jwst/associations/tests/test_pool.py
+++ b/jwst/associations/tests/test_pool.py
@@ -1,6 +1,6 @@
-from .helpers import t_path
+from jwst.associations.tests.helpers import t_path
 
-from .. import AssociationPool
+from jwst.associations import AssociationPool
 
 POOL_FILE = t_path('data/jw93060_20150312T160130_pool.csv')
 

--- a/jwst/associations/tests/test_process_list.py
+++ b/jwst/associations/tests/test_process_list.py
@@ -1,11 +1,11 @@
 """Test ProcessList, ProcessQueue, ProcessQueueSorted"""
 
-from .helpers import (
+from jwst.associations.tests.helpers import (
     combine_pools,
     t_path
 )
 
-from ..lib.process_list import *
+from jwst.associations.lib.process_list import *
 
 
 def test_item():

--- a/jwst/associations/tests/test_update_path.py
+++ b/jwst/associations/tests/test_update_path.py
@@ -1,7 +1,7 @@
 """Test utility update_path"""
-from ..asn_from_list import asn_from_list
-from ..lib.rules_level2_base import DMSLevel2bBase
-from ..lib.update_path import update_path
+from jwst.associations.asn_from_list import asn_from_list
+from jwst.associations.lib.rules_level2_base import DMSLevel2bBase
+from jwst.associations.lib.update_path import update_path
 
 
 def test_update_path_level2():

--- a/jwst/associations/tests/test_validate.py
+++ b/jwst/associations/tests/test_validate.py
@@ -1,8 +1,8 @@
 import pytest
 
-from . import helpers
+from jwst.associations.tests import helpers
 
-from .. import (
+from jwst.associations import (
     AssociationRegistry,
     AssociationNotValidError,
     load_asn

--- a/jwst/associations/tests/test_version.py
+++ b/jwst/associations/tests/test_version.py
@@ -1,7 +1,7 @@
 """Test versioning consistency"""
 
-from ..asn_from_list import asn_from_list
-from ... import __version__
+from jwst.associations.asn_from_list import asn_from_list
+from jwst import __version__
 
 
 def test_asn_version():

--- a/jwst/associations/tests/test_wfss.py
+++ b/jwst/associations/tests/test_wfss.py
@@ -1,9 +1,9 @@
 """Test for various WFSS modes"""
 from os import path
 
-from .. import AssociationPool
-from ..main import Main
-from .helpers import t_path
+from jwst.associations import AssociationPool
+from jwst.associations.main import Main
+from jwst.associations.tests.helpers import t_path
 
 REQUIRED_ASN_TYPES = set(['image2', 'spec2', 'image3', 'spec3'])
 

--- a/jwst/csv_tools/tests/test_csv_tools.py
+++ b/jwst/csv_tools/tests/test_csv_tools.py
@@ -3,10 +3,10 @@ import sys
 
 import pytest
 
-from ..csv_to_hdulist import csv_to_hdulist
-from ..csv_to_table import csv_to_table
-from ..table_to_json import table_to_json
-from . import data
+from jwst.csv_tools.csv_to_hdulist import csv_to_hdulist
+from jwst.csv_tools.csv_to_table import csv_to_table
+from jwst.csv_tools.table_to_json import table_to_json
+from jwst.csv_tools.tests import data
 
 
 json_mixed_result = "".join([

--- a/jwst/datamodels/multicombinedspec.py
+++ b/jwst/datamodels/multicombinedspec.py
@@ -12,7 +12,7 @@ class MultiCombinedSpecModel(JwstDataModel):
     This model has a special member `spec` that can be used to
     deal with an entire spectrum at a time.  It behaves like a list::
 
-       >>> from jwst.datamodels.combinedspec import CombinedSpecModel
+       >>> from jwst.datamodels import CombinedSpecModel
        >>> multispec_model = MultiCombinedSpecModel()
        >>> multispec_model.spec.append(CombinedSpecModel())
        >>> multispec_model.spec[0] # doctest: +SKIP

--- a/jwst/datamodels/multicombinedspec.py
+++ b/jwst/datamodels/multicombinedspec.py
@@ -12,7 +12,7 @@ class MultiCombinedSpecModel(JwstDataModel):
     This model has a special member `spec` that can be used to
     deal with an entire spectrum at a time.  It behaves like a list::
 
-       >>> from . import CombinedSpecModel
+       >>> from jwst.datamodels.combinedspec import CombinedSpecModel
        >>> multispec_model = MultiCombinedSpecModel()
        >>> multispec_model.spec.append(CombinedSpecModel())
        >>> multispec_model.spec[0] # doctest: +SKIP

--- a/jwst/datamodels/multiextract1d.py
+++ b/jwst/datamodels/multiextract1d.py
@@ -12,7 +12,7 @@ class MultiExtract1dImageModel(ReferenceFileModel):
     This model has a special member `images` that can be used to
     deal with each image separately.  It behaves like a list::
 
-       >>> from jwst.datamodels.extract1dimage import Extract1dImageModel
+       >>> from jwst.datamodels import Extract1dImageModel
        >>> multiextr1d_img_model = MultiExtract1dImageModel()
        >>> multiextr1d_img_model.images.append(Extract1dImageModel())
        >>> multiextr1d_img_model.images[0]  # doctest: +SKIP

--- a/jwst/datamodels/multiextract1d.py
+++ b/jwst/datamodels/multiextract1d.py
@@ -12,7 +12,7 @@ class MultiExtract1dImageModel(ReferenceFileModel):
     This model has a special member `images` that can be used to
     deal with each image separately.  It behaves like a list::
 
-       >>> from . import Extract1dImageModel
+       >>> from jwst.datamodels.extract1dimage import Extract1dImageModel
        >>> multiextr1d_img_model = MultiExtract1dImageModel()
        >>> multiextr1d_img_model.images.append(Extract1dImageModel())
        >>> multiextr1d_img_model.images[0]  # doctest: +SKIP

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -13,7 +13,7 @@ class MultiSlitModel(JwstDataModel):
     This model has a special member `slits` that can be used to
     deal with an entire slit at a time.  It behaves like a list::
 
-       >>> from jwst.datamodels.slit import SlitModel
+       >>> from jwst.datamodels import SlitModel
        >>> multislit_model = MultiSlitModel()
        >>> multislit_model.slits.append(SlitModel())
        >>> multislit_model[0]

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -13,7 +13,7 @@ class MultiSlitModel(JwstDataModel):
     This model has a special member `slits` that can be used to
     deal with an entire slit at a time.  It behaves like a list::
 
-       >>> from .slit import SlitModel
+       >>> from jwst.datamodels.slit import SlitModel
        >>> multislit_model = MultiSlitModel()
        >>> multislit_model.slits.append(SlitModel())
        >>> multislit_model[0]

--- a/jwst/datamodels/multispec.py
+++ b/jwst/datamodels/multispec.py
@@ -12,7 +12,7 @@ class MultiSpecModel(JwstDataModel):
     This model has a special member `spec` that can be used to
     deal with an entire spectrum at a time.  It behaves like a list::
 
-       >>> from . import SpecModel
+       >>> from jwst.datamodels.spec import SpecModel
        >>> multispec_model = MultiSpecModel()
        >>> multispec_model.spec.append(SpecModel())
        >>> multispec_model.spec[0] # doctest: +SKIP

--- a/jwst/datamodels/multispec.py
+++ b/jwst/datamodels/multispec.py
@@ -12,7 +12,7 @@ class MultiSpecModel(JwstDataModel):
     This model has a special member `spec` that can be used to
     deal with an entire spectrum at a time.  It behaves like a list::
 
-       >>> from jwst.datamodels.spec import SpecModel
+       >>> from jwst.datamodels import SpecModel
        >>> multispec_model = MultiSpecModel()
        >>> multispec_model.spec.append(SpecModel())
        >>> multispec_model.spec[0] # doctest: +SKIP

--- a/jwst/datamodels/specprofile.py
+++ b/jwst/datamodels/specprofile.py
@@ -11,7 +11,7 @@ class SpecProfileModel(ReferenceFileModel):
     This model has a special member `profile` that can be used to
     deal with an entire spectral profile at a time.  It behaves like a list::
 
-       >>> from . import SpecProfileSingleModel
+       >>> from jwst.datamodels.specprofile import SpecProfileSingleModel
        >>> specprofile_model = SpecProfileModel()
        >>> specprofile_model.profile.append(SpecProfileSingleModel())
        >>> specprofile_model.profile[0] # doctest: +SKIP

--- a/jwst/datamodels/specprofile.py
+++ b/jwst/datamodels/specprofile.py
@@ -11,7 +11,7 @@ class SpecProfileModel(ReferenceFileModel):
     This model has a special member `profile` that can be used to
     deal with an entire spectral profile at a time.  It behaves like a list::
 
-       >>> from jwst.datamodels.specprofile import SpecProfileSingleModel
+       >>> from jwst.datamodels import SpecProfileSingleModel
        >>> specprofile_model = SpecProfileModel()
        >>> specprofile_model.profile.append(SpecProfileSingleModel())
        >>> specprofile_model.profile[0] # doctest: +SKIP

--- a/jwst/datamodels/spectrace.py
+++ b/jwst/datamodels/spectrace.py
@@ -11,7 +11,7 @@ class SpecTraceModel(ReferenceFileModel):
     This model has a special member `trace` that can be used to
     deal with an entire spectral trace at a time.  It behaves like a list::
 
-       >>> from . import SpecTraceSingleModel
+       >>> from jwst.datamodels.spectrace import SpecTraceSingleModel
        >>> spectrace_model = SpecTraceModel()
        >>> spectrace_model.trace.append(SpecTraceSingleModel())
        >>> spectrace_model.trace[0] # doctest: +SKIP

--- a/jwst/datamodels/spectrace.py
+++ b/jwst/datamodels/spectrace.py
@@ -11,7 +11,7 @@ class SpecTraceModel(ReferenceFileModel):
     This model has a special member `trace` that can be used to
     deal with an entire spectral trace at a time.  It behaves like a list::
 
-       >>> from jwst.datamodels.spectrace import SpecTraceSingleModel
+       >>> from jwst.datamodels import SpecTraceSingleModel
        >>> spectrace_model = SpecTraceModel()
        >>> spectrace_model.trace.append(SpecTraceSingleModel())
        >>> spectrace_model.trace[0] # doctest: +SKIP

--- a/jwst/datamodels/wavemap.py
+++ b/jwst/datamodels/wavemap.py
@@ -11,7 +11,7 @@ class WaveMapModel(ReferenceFileModel):
     This model has a special member `map` that can be used to
     deal with an entire wavelength map at a time.  It behaves like a list::
 
-       >>> from jwst.datamodels.wavemap import WaveMapSingleModel, WaveMapModel
+       >>> from jwst.datamodels import WaveMapSingleModel, WaveMapModel
        >>> wavemap_model = WaveMapModel()
        >>> wavemap_model.map.append(WaveMapSingleModel())
        >>> wavemap_model.map[0] # doctest: +SKIP

--- a/jwst/datamodels/wavemap.py
+++ b/jwst/datamodels/wavemap.py
@@ -11,7 +11,7 @@ class WaveMapModel(ReferenceFileModel):
     This model has a special member `map` that can be used to
     deal with an entire wavelength map at a time.  It behaves like a list::
 
-       >>> from . import WaveMapSingleModel
+       >>> from jwst.datamodels.wavemap import WaveMapSingleModel, WaveMapModel
        >>> wavemap_model = WaveMapModel()
        >>> wavemap_model.map.append(WaveMapSingleModel())
        >>> wavemap_model.map[0] # doctest: +SKIP

--- a/jwst/exp_to_source/tests/test_exp_to_source.py
+++ b/jwst/exp_to_source/tests/test_exp_to_source.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import numpy as np
 
-from . import helpers
+from jwst.exp_to_source.tests import helpers
 from jwst.datamodels import (MultiExposureModel, MultiSlitModel, ModelContainer)
 from jwst.exp_to_source import exp_to_source, multislit_to_container
 

--- a/jwst/exp_to_source/tests/test_main.py
+++ b/jwst/exp_to_source/tests/test_main.py
@@ -1,7 +1,7 @@
 from glob import glob
 import os
 
-from . import helpers
+from jwst.exp_to_source.tests import helpers
 from jwst.exp_to_source.main import Main
 
 

--- a/jwst/extract_1d/tests/test_wcs.py
+++ b/jwst/extract_1d/tests/test_wcs.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .. import spec_wcs
+from jwst.extract_1d import spec_wcs
 
 import pytest
 

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -21,15 +21,14 @@ import numpy as np
 from astropy.io import fits
 from gwcs import wcs
 
-from ...datamodels.image import ImageModel
-from ...datamodels import CubeModel, SlitModel, MultiSlitModel
-from ...assign_wcs.util import create_grism_bbox
-from ...assign_wcs import AssignWcsStep, nircam
+from jwst.datamodels.image import ImageModel
+from jwst.datamodels import CubeModel, SlitModel, MultiSlitModel
+from jwst.assign_wcs.util import create_grism_bbox
+from jwst.assign_wcs import AssignWcsStep, nircam
 
-from ..extract_2d_step import Extract2dStep
-from ..grisms import extract_tso_object, extract_grism_objects
-
-from . import data
+from jwst.extract_2d.extract_2d_step import Extract2dStep
+from jwst.extract_2d.grisms import extract_tso_object, extract_grism_objects
+from jwst.extract_2d.tests import data
 
 
 # Allowed settings for nircam

--- a/jwst/lib/tests/test_engdb_mock.py
+++ b/jwst/lib/tests/test_engdb_mock.py
@@ -9,8 +9,8 @@ import warnings
 
 from astropy.time import Time
 
-from . import engdb_mock
-from .. import engdb_tools
+from jwst.lib.tests import engdb_mock
+from jwst.lib import engdb_tools
 
 GOOD_MNEMONIC = 'inrsi_gwa_y_tilt_avged'
 GOOD_STARTTIME = '2016-01-23 00:00:00'

--- a/jwst/lib/tests/test_engdb_tools.py
+++ b/jwst/lib/tests/test_engdb_tools.py
@@ -14,8 +14,8 @@ import requests
 
 from astropy.time import Time
 
-from .. import engdb_tools
-from .engdb_mock import EngDB_Mocker
+from jwst.lib import engdb_tools
+from jwst.lib.tests.engdb_mock import EngDB_Mocker
 
 GOOD_MNEMONIC = 'INRSI_GWA_Y_TILT_AVGED'
 GOOD_STARTTIME = '2016-01-18'

--- a/jwst/lib/tests/test_fgs_pointing.py
+++ b/jwst/lib/tests/test_fgs_pointing.py
@@ -3,8 +3,8 @@ import os.path
 import logging
 from numpy import array
 
-from ...datamodels import Level1bModel
-from .. import set_telescope_pointing as stp
+from jwst.datamodels import Level1bModel
+from jwst.lib import set_telescope_pointing as stp
 
 
 # Set logging for the module to be tested.

--- a/jwst/lib/tests/test_pointing_summary.py
+++ b/jwst/lib/tests/test_pointing_summary.py
@@ -11,7 +11,7 @@ import jwst.datamodels as dm
 from jwst.lib import engdb_tools
 import jwst.lib.pointing_summary as ps
 
-from .engdb_mock import EngDB_Mocker
+from jwst.lib.tests.engdb_mock import EngDB_Mocker
 
 DATA_PATH = Path(__file__).parent / 'data'
 

--- a/jwst/lib/tests/test_reffile_utils.py
+++ b/jwst/lib/tests/test_reffile_utils.py
@@ -1,4 +1,4 @@
-from ..reffile_utils import find_row
+from jwst.lib.reffile_utils import find_row
 
 
 def test_find_row():

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -10,11 +10,11 @@ from tempfile import TemporaryDirectory
 
 from astropy.time import Time
 
-from .. import engdb_tools
-from .engdb_mock import EngDB_Mocker
-from .. import set_telescope_pointing as stp
-from ... import datamodels
-from ...tests.helpers import word_precision_check
+from jwst.lib import engdb_tools
+from jwst.lib.tests.engdb_mock import EngDB_Mocker
+from jwst.lib import set_telescope_pointing as stp
+from jwst import datamodels
+from jwst.tests.helpers import word_precision_check
 
 # Ensure that `set_telescope_pointing` logs.
 stp.logger.setLevel(logging.DEBUG)

--- a/jwst/lib/tests/test_signal_slot.py
+++ b/jwst/lib/tests/test_signal_slot.py
@@ -1,6 +1,6 @@
 """Test signal_slot.py"""
 
-from .. import signal_slot as ss
+from jwst.lib import signal_slot as ss
 
 
 REFLECT_CALLED = 'reflect: called.'

--- a/jwst/lib/tests/test_suffix.py
+++ b/jwst/lib/tests/test_suffix.py
@@ -5,7 +5,7 @@ import pytest
 
 from jwst.lib.basic_utils import LoggingContext
 
-from .. import suffix as s
+from jwst.lib import suffix as s
 
 
 @pytest.fixture(scope='module')

--- a/jwst/lib/tests/test_utc_to_tdb.py
+++ b/jwst/lib/tests/test_utc_to_tdb.py
@@ -6,8 +6,8 @@ import os
 import pytest
 from tempfile import TemporaryDirectory
 
-from .. import utc_to_tdb
-from ... import datamodels
+from jwst.lib import utc_to_tdb
+from jwst import datamodels
 
 
 @pytest.fixture

--- a/jwst/lib/tests/test_v1_calculate.py
+++ b/jwst/lib/tests/test_v1_calculate.py
@@ -12,7 +12,7 @@ import jwst.datamodels as dm
 from jwst.lib import engdb_tools
 import jwst.lib.v1_calculate as v1c
 
-from .engdb_mock import EngDB_Mocker
+from jwst.lib.tests.engdb_mock import EngDB_Mocker
 
 DATA_PATH = Path(__file__).parent / 'data'
 

--- a/jwst/master_background/tests/test_nirspec_corrections.py
+++ b/jwst/master_background/tests/test_nirspec_corrections.py
@@ -4,7 +4,9 @@ Unit tests for master background NIRSpec corrections
 import numpy as np
 
 from jwst import datamodels
-from ..nirspec_utils import correct_nrs_ifu_bkg, correct_nrs_fs_bkg
+from jwst.master_background.nirspec_utils import (
+    correct_nrs_ifu_bkg, correct_nrs_fs_bkg
+)
 
 
 def test_ifu_pathloss_existence():

--- a/jwst/pipeline/tests/test_calwebspec2.py
+++ b/jwst/pipeline/tests/test_calwebspec2.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..calwebb_spec2 import Spec2Pipeline
+from jwst.pipeline.calwebb_spec2 import Spec2Pipeline
 
 
 def test_filenotfounderror_raised(capsys):

--- a/jwst/refpix/tests/test_clobber_ref.py
+++ b/jwst/refpix/tests/test_clobber_ref.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..irs2_subtract_reference import decode_mask, clobber_ref
+from jwst.refpix.irs2_subtract_reference import decode_mask, clobber_ref
 
 
 def test_clobber_ref():

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -5,7 +5,7 @@ from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.resample.resample import OutputTooLargeError
 from jwst.stpipe import Step
 
-from . import regtestdata as rt
+from jwst.regtest import regtestdata as rt
 
 
 file_roots = ['exptype_fgs_acq1', 'exptype_fgs_fineguide', 'exptype_fgs_id_image', 'exptype_fgs_id_stack']

--- a/jwst/regtest/test_infrastructure.py
+++ b/jwst/regtest/test_infrastructure.py
@@ -5,7 +5,7 @@ import pytest
 from astropy.table import Table
 import astropy.units as u
 import numpy as np
-from .regtestdata import text_diff
+from jwst.regtest.regtestdata import text_diff
 
 
 @pytest.mark.bigdata

--- a/jwst/regtest/test_miri_mrs_spec2.py
+++ b/jwst/regtest/test_miri_mrs_spec2.py
@@ -10,7 +10,7 @@ from jwst import datamodels
 from jwst.associations import load_asn
 from jwst.lib.suffix import replace_suffix
 
-from . import regtestdata as rt
+from jwst.regtest import regtestdata as rt
 
 # Define artifactory source and truth
 INPUT_PATH = 'miri/mrs'

--- a/jwst/regtest/test_miri_mrs_spec3.py
+++ b/jwst/regtest/test_miri_mrs_spec3.py
@@ -2,7 +2,7 @@
 import os
 import pytest
 
-from . import regtestdata as rt
+from jwst.regtest import regtestdata as rt
 
 from astropy.io.fits.diff import FITSDiff
 from jwst.stpipe import Step

--- a/jwst/regtest/test_niriss_wfss.py
+++ b/jwst/regtest/test_niriss_wfss.py
@@ -2,7 +2,7 @@
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
-from . import regtestdata as rt
+from jwst.regtest import regtestdata as rt
 
 
 @pytest.fixture(scope='module')

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -1,7 +1,7 @@
 """Regression tests for NIRSpec IFU"""
 import pytest
 
-from . import regtestdata as rt
+from jwst.regtest import regtestdata as rt
 
 # Define artifactory source and truth
 INPUT_PATH = 'nirspec/ifu'

--- a/jwst/regtest/test_nirspec_ifu_spec3.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3.py
@@ -1,7 +1,7 @@
 """Regression tests for NIRSpec IFU"""
 import pytest
 
-from . import regtestdata as rt
+from jwst.regtest import regtestdata as rt
 
 # Define artifactory source and truth
 INPUT_PATH = 'nirspec/ifu'

--- a/jwst/regtest/test_nirspec_masterbackground.py
+++ b/jwst/regtest/test_nirspec_masterbackground.py
@@ -8,7 +8,7 @@ from jwst.master_background import MasterBackgroundNrsSlitsStep
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
-from . import regtestdata as rt
+from jwst.regtest import regtestdata as rt
 
 pytestmark = pytest.mark.bigdata
 

--- a/jwst/stpipe/tests/test_asdf_parameters.py
+++ b/jwst/stpipe/tests/test_asdf_parameters.py
@@ -5,8 +5,8 @@ import pytest
 from stpipe.config_parser import ValidationError
 from stpipe import Step
 
-from .steps import MakeListStep, MakeListPipeline
-from .util import t_path
+from jwst.stpipe.tests.steps import MakeListStep, MakeListPipeline
+from jwst.stpipe.tests.util import t_path
 
 DEFAULT_PAR1 = 42.0
 DEFAULT_PAR2 = 'Yes, a string'

--- a/jwst/stpipe/tests/test_config.py
+++ b/jwst/stpipe/tests/test_config.py
@@ -5,7 +5,7 @@ import asdf
 
 from stpipe.config import export_config, StepConfig, _validate_asdf
 
-from .steps import MakeListPipeline, WithDefaultsStep
+from jwst.stpipe.tests.steps import MakeListPipeline, WithDefaultsStep
 
 
 @pytest.fixture

--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 
 from stpipe import crds_client
 
-from .. import Step
+from jwst.stpipe import Step
 import crds
 
 TMP_DIR = None

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -7,8 +7,8 @@ from jwst.stpipe import Step
 from jwst.datamodels import JwstDataModel, ModelContainer
 from jwst import datamodels
 
-from .steps import StepWithModel
-from .util import t_path
+from jwst.stpipe.tests.steps import StepWithModel
+from jwst.stpipe.tests.util import t_path
 
 
 def test_default_input_with_container(mk_tmp_dirs):

--- a/jwst/stpipe/tests/test_pipeline.py
+++ b/jwst/stpipe/tests/test_pipeline.py
@@ -9,7 +9,7 @@ from stpipe import crds_client
 from jwst import datamodels
 from jwst.stpipe import Step, Pipeline
 
-from .steps import PipeWithReference, StepWithReference
+from jwst.stpipe.tests.steps import PipeWithReference, StepWithReference
 
 
 def library_function():

--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -4,7 +4,7 @@ import os
 from os import path
 import shutil
 
-from .. import Step
+from jwst.stpipe import Step
 
 data_fn = 'flat.fits'
 data_fn_path = path.join(path.dirname(__file__), 'data', data_fn)

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -18,8 +18,11 @@ from jwst import datamodels
 from jwst.refpix import RefPixStep
 from jwst.stpipe import Step
 
-from .steps import EmptyPipeline, MakeListPipeline, MakeListStep, ProperPipeline, AnotherDummyStep
-from .util import t_path
+from jwst.stpipe.tests.steps import (
+    EmptyPipeline, MakeListPipeline, MakeListStep,
+    ProperPipeline, AnotherDummyStep
+)
+from jwst.stpipe.tests.util import t_path
 
 import asdf
 from crds.core.exceptions import CrdsLookupError
@@ -322,8 +325,6 @@ def test_step():
     step_fn = join(dirname(__file__), 'steps', 'some_other_step.cfg')
     step = Step.from_config_file(step_fn)
 
-    from .steps import AnotherDummyStep
-
     assert isinstance(step, AnotherDummyStep)
     assert step.name == 'SomeOtherStepOriginal'
     assert step.par2 == 'abc def'
@@ -332,8 +333,6 @@ def test_step():
 
 
 def test_step_from_python():
-    from .steps import AnotherDummyStep
-
     step = AnotherDummyStep("SomeOtherStepOriginal", par1=42.0, par2="abc def")
 
     assert step.par1 == 42.0
@@ -346,16 +345,12 @@ def test_step_from_python():
 
 
 def test_step_from_python_simple():
-    from .steps import AnotherDummyStep
-
     result = AnotherDummyStep.call(1, 2, par1=42.0, par2="abc def")
 
     assert result == 3
 
 
 def test_step_from_python_simple2():
-    from .steps import AnotherDummyStep
-
     step_fn = join(dirname(__file__), 'steps', 'some_other_step.cfg')
 
     result = AnotherDummyStep.call(1, 2, config_file=step_fn)
@@ -574,14 +569,11 @@ def test_step_with_local_class():
 
 
 def test_extra_parameter():
-    from .steps import AnotherDummyStep
     with pytest.raises(ValidationError):
         AnotherDummyStep("SomeOtherStepOriginal", par5='foo')
 
 
 def test_crds_override():
-    from .steps import AnotherDummyStep
-
     step = AnotherDummyStep(
         "SomeOtherStepOriginal",
         par1=42.0, par2="abc def",
@@ -592,14 +584,14 @@ def test_crds_override():
 
 
 def test_omit_ref_file():
-    from .steps import OptionalRefTypeStep
+    from jwst.stpipe.tests.steps import OptionalRefTypeStep
 
     step = OptionalRefTypeStep(override_to_be_ignored_ref_type="")
     step.process()
 
 
 def test_search_attr():
-    from .steps import SavePipeline
+    from jwst.stpipe.tests.steps import SavePipeline
 
     value = '/tmp'
     pipeline = SavePipeline('afile.fits', output_dir=value)

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -23,6 +23,7 @@ from jwst.stpipe.tests.steps import (
     ProperPipeline, AnotherDummyStep
 )
 from jwst.stpipe.tests.util import t_path
+from jwst.stpipe.tests.steps import OptionalRefTypeStep, SavePipeline
 
 import asdf
 from crds.core.exceptions import CrdsLookupError
@@ -584,15 +585,11 @@ def test_crds_override():
 
 
 def test_omit_ref_file():
-    from jwst.stpipe.tests.steps import OptionalRefTypeStep
-
     step = OptionalRefTypeStep(override_to_be_ignored_ref_type="")
     step.process()
 
 
 def test_search_attr():
-    from jwst.stpipe.tests.steps import SavePipeline
-
     value = '/tmp'
     pipeline = SavePipeline('afile.fits', output_dir=value)
 

--- a/jwst/tests/test_infrastructure.py
+++ b/jwst/tests/test_infrastructure.py
@@ -7,12 +7,12 @@ import pytest
 
 from ci_watson.artifactory_helpers import get_bigdata_root
 
-from .base_classes import (
+from jwst.tests.base_classes import (
     BaseJWSTTest,
     _data_glob_local,
     _data_glob_url
 )
-from .helpers import word_precision_check
+from jwst.tests.helpers import word_precision_check
 
 
 def test_word_precision_check():

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -1075,6 +1075,7 @@ def _toindex(value):
 
     Examples
     --------
+    >>> from jwst.transforms.models import _toindex
     >>> _toindex(np.array([-0.5, 0.49999]))
     array([0, 0])
     >>> _toindex(np.array([0.5, 1.49999]))

--- a/jwst/transforms/tags/tests/test_models.py
+++ b/jwst/transforms/tags/tests/test_models.py
@@ -3,10 +3,12 @@
 import numpy as np
 from astropy.modeling.models import Shift, Rotation2D
 from asdf.tests import helpers
-from ...import jwextension
-from ...models import (AngleFromGratingEquation, WavelengthFromGratingEquation,
-                       Unitless2DirCos, DirCos2Unitless, Rotation3DToGWA, Gwa2Slit,
-                       Snell, Logical, V23ToSky, Slit)
+from jwst.transforms import jwextension
+from jwst.transforms.models import (
+    AngleFromGratingEquation, WavelengthFromGratingEquation,
+    Unitless2DirCos, DirCos2Unitless, Rotation3DToGWA, Gwa2Slit,
+    Snell, Logical, V23ToSky, Slit
+)
 import pytest
 
 

--- a/jwst/tso_photometry/tests/test_tso_photometry_step.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry_step.py
@@ -2,7 +2,7 @@ import pytest
 
 from astropy.io import fits
 
-from ..tso_photometry_step import TSOPhotometryStep
+from jwst.tso_photometry.tso_photometry_step import TSOPhotometryStep
 
 
 @pytest.fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     drizzle>=1.13.1
     gwcs>=0.16.1
     jsonschema>=3.0.2
-    numpy>=1.16
+    numpy>=1.17
     photutils>=1.1.0
     psutil>=5.7.2
     poppy>=0.9.0
@@ -122,17 +122,14 @@ norecursedirs =
     docs/_build
     jwst/timeconversion
     scripts
-    .tox
 asdf_schema_tests_enabled = true
 asdf_schema_validate_default = false
 asdf_schema_root = jwst/transforms/schemas jwst/datamodels/schemas
 junit_family = xunit2
 inputs_root = jwst-pipeline
 results_root = jwst-pipeline-results
-doctest_plus = true
-doctest_rst = true
 text_file_format = rst
-addopts = --show-capture=no --open-files --doctest-ignore-import-errors
+addopts = --show-capture=no --open-files --import-mode append
 filterwarnings =
     ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,7 +129,7 @@ junit_family = xunit2
 inputs_root = jwst-pipeline
 results_root = jwst-pipeline-results
 text_file_format = rst
-addopts = --show-capture=no --open-files --import-mode append
+addopts = --show-capture=no --open-files
 filterwarnings =
     ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     py{37,38,39}{,-oldestdeps,-devdeps,-sdpdeps}{,-pyargs}{,-cov}
     style
-    docs
     security
 isolated_build = true
 
@@ -59,7 +58,6 @@ install_command = python -m pip install --no-deps {packages}
 commands_pre =
     # Generate a requirements-min.txt file
     minimum_deps
-    python -m pip install --upgrade pip
     pip install -r requirements-min.txt
 
 [testenv:pyargs]
@@ -71,12 +69,10 @@ commands =
 [testenv:regtests]
 description = run tests with --bigdata and --slow flags
 commands =
-    python -m pip install --upgrade pip
     pytest --bigdata --slow --basetemp={homedir}/scratch {posargs}
 
 [testenv:twine]
 description = check that the package builds sdist/wheel and that twine uploads
-changedir = {toxinidir}
 deps =
     twine>=3.3
     pep517
@@ -87,7 +83,6 @@ commands =
 
 [testenv:style]
 description = check code style, e.g. with flake8
-changedir = {toxinidir}
 skip_install = true
 deps =
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{37,38,39}{,-oldestdeps,-devdeps,-sdpdeps}{,-pyargs}{,-cov}
     style
+    docs
     security
 isolated_build = true
 
@@ -58,6 +59,7 @@ install_command = python -m pip install --no-deps {packages}
 commands_pre =
     # Generate a requirements-min.txt file
     minimum_deps
+    python -m pip install --upgrade pip
     pip install -r requirements-min.txt
 
 [testenv:pyargs]
@@ -69,10 +71,12 @@ commands =
 [testenv:regtests]
 description = run tests with --bigdata and --slow flags
 commands =
+    python -m pip install --upgrade pip
     pytest --bigdata --slow --basetemp={homedir}/scratch {posargs}
 
 [testenv:twine]
 description = check that the package builds sdist/wheel and that twine uploads
+changedir = {toxinidir}
 deps =
     twine>=3.3
     pep517
@@ -83,6 +87,7 @@ commands =
 
 [testenv:style]
 description = check code style, e.g. with flake8
+changedir = {toxinidir}
 skip_install = true
 deps =
     flake8


### PR DESCRIPTION
Use absolute import for unit tests. + an attempt to fix issues related to pytest/tox/c-extensions interaction.

Follow-on to #6001.
Addresses #5989 / [JP-2059](https://jira.stsci.edu/browse/JP-2059)