### PR TITLE
Improve Cube build speed - JP 364

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ cube_build
 ----------
 
 - Fixed typo in cube_build_step spec for grating [#5839]
+- Update code to read in spectral and spatial size of exposure on the sky #5991
+- For calspec2 pipeline skip determining the dq plane in cube_build #5991 
 
 datamodels
 ----------

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -333,7 +333,7 @@ class CubeBuildStep (Step):
                 thiscube.determine_cube_parameters()
             thiscube.setup_ifucube_wcs()
             t5 = time.time()
-            print('Time to set up size of IFU cube',t5-t4)
+            print('Time to set up size of one cube',t5-t4)
 # _______________________________________________________________________________
 # build the IFU Cube
 
@@ -353,7 +353,7 @@ class CubeBuildStep (Step):
                 cube_result = thiscube.build_ifucube()
                 result, status = cube_result
                 t4 = time.time()
-                print('time to cube a 1 cube', t4 - t3)
+                print('Time to build one cube', t4 - t3)
                 cube_container.append(result)
 
             if self.debug_file is not None:

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -326,14 +326,12 @@ class CubeBuildStep (Step):
 # rois, roiw,  weight_power, softrad
 # If not linear wavelength (multi bands) an arrays are created  for:
 # rois, roiw, weight_power, softrad
-            t4 = time.time()
+
             if self.coord_system == 'internal_cal':
                 thiscube.determine_cube_parameters_internal()
             else:
                 thiscube.determine_cube_parameters()
             thiscube.setup_ifucube_wcs()
-            t5 = time.time()
-            print('Time to set up size of one cube',t5-t4)
 # _______________________________________________________________________________
 # build the IFU Cube
 
@@ -365,7 +363,7 @@ class CubeBuildStep (Step):
                 status_cube = 1
 
         t1 = time.time()
-        print('Time to build all cubes',t1-t0)
+        self.log.debug(f'Time to build all cubes {t1-t0}')
         
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -6,7 +6,7 @@ from . import cube_build
 from . import ifu_cube
 from . import data_types
 from ..assign_wcs.util import update_s_region_keyword
-
+import time 
 
 __all__ = ["CubeBuildStep"]
 
@@ -297,6 +297,7 @@ class CubeBuildStep (Step):
         cube_container = datamodels.ModelContainer()
 
         status_cube = 0
+        t0 = time.time()
         for i in range(num_cubes):
             icube = str(i + 1)
             list_par1 = cube_pars[icube]['par1']
@@ -325,12 +326,14 @@ class CubeBuildStep (Step):
 # rois, roiw,  weight_power, softrad
 # If not linear wavelength (multi bands) an arrays are created  for:
 # rois, roiw, weight_power, softrad
-
+            t4 = time.time()
             if self.coord_system == 'internal_cal':
                 thiscube.determine_cube_parameters_internal()
             else:
                 thiscube.determine_cube_parameters()
             thiscube.setup_ifucube_wcs()
+            t5 = time.time()
+            print('Time to set up size of IFU cube',t5-t4)
 # _______________________________________________________________________________
 # build the IFU Cube
 
@@ -346,8 +349,11 @@ class CubeBuildStep (Step):
 
 # Else standard IFU cube building
             else:
+                t3 = time.time()
                 cube_result = thiscube.build_ifucube()
                 result, status = cube_result
+                t4 = time.time()
+                print('time to cube a 1 cube', t4 - t3)
                 cube_container.append(result)
 
             if self.debug_file is not None:
@@ -358,6 +364,9 @@ class CubeBuildStep (Step):
             if status == 1:
                 status_cube = 1
 
+        t1 = time.time()
+        print('Time to build all cubes',t1-t0)
+        
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -6,7 +6,7 @@ from . import cube_build
 from . import ifu_cube
 from . import data_types
 from ..assign_wcs.util import update_s_region_keyword
-import time 
+import time
 
 __all__ = ["CubeBuildStep"]
 
@@ -347,11 +347,8 @@ class CubeBuildStep (Step):
 
 # Else standard IFU cube building
             else:
-                t3 = time.time()
                 cube_result = thiscube.build_ifucube()
                 result, status = cube_result
-                t4 = time.time()
-                print('Time to build one cube', t4 - t3)
                 cube_container.append(result)
 
             if self.debug_file is not None:
@@ -364,7 +361,7 @@ class CubeBuildStep (Step):
 
         t1 = time.time()
         self.log.debug(f'Time to build all cubes {t1-t0}')
-        
+
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -159,7 +159,7 @@ def find_corners_NIRSPEC(input, this_channel, instrument_info, coord_system):
 
             # TODO - fix kludge after figure out how to determine what the units
             # for wavelength are coming out of detector2slicer.
-            # print(input.meta.wcs.output_frame.unit[2])
+
             lmax = np.nanmax(lam.flatten())
             if lmax < 0.0001:
                 lam = lam[valid] * 1.0e6

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -157,9 +157,6 @@ def find_corners_NIRSPEC(input, this_channel, instrument_info, coord_system):
             coord1 = coord1[valid]
             coord2 = coord2[valid]
 
-            # TODO - fix kludge after figure out how to determine what the units
-            # for wavelength are coming out of detector2slicer.
-
             lmax = np.nanmax(lam.flatten())
             if lmax < 0.0001:
                 lam = lam[valid] * 1.0e6

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -658,7 +658,7 @@ class IFUCubeData():
                         self.map_fov_to_dqplane(this_par1, coord1, coord2, wave, roiw_ave, slice_no)
                         t1 = time.time()
                         log.debug("Time to set initial dq values = %.1f s" % (t1 - t0,))
-
+                        print("Time to set initial dq values = ", (t1 - t0))
                     if no_data:
                         log.warning(f'No valid data found on file {ifile.meta.filename}')
                     if self.weighting == 'msm' or self.weighting == 'emsm':
@@ -684,6 +684,7 @@ class IFUCubeData():
 
                         t1 = time.time()
                         log.info("Time to match pixels to cube spaxels = %.1f s" % (t1 - t0,))
+                        print("Time to match pixels to cube spaxels = ",  (t1 - t0,))
 # ________________________________________________________________________________
                     elif self.weighting == 'miripsf':
                         with datamodels.IFUImageModel(ifile) as input_model:

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -683,7 +683,7 @@ class IFUCubeData():
                                                       self.debug_file)
 
                         t1 = time.time()
-                        log.info("Time to match file to ifucube = %.1f s" % (t1 - t0,))
+                        log.info("Time to match pixels to cube spaxels = %.1f s" % (t1 - t0,))
 # ________________________________________________________________________________
                     elif self.weighting == 'miripsf':
                         with datamodels.IFUImageModel(ifile) as input_model:

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1224,9 +1224,7 @@ class IFUCubeData():
                 detector2alpha_beta = input_model.meta.wcs.get_transform('detector',
                                                                          'alpha_beta')
                 alpha, beta, lam = detector2alpha_beta(x, y)
-                valid1 = ~np.isnan(lam)
-                lam = lam[valid1]
-                lam_med = np.median(lam)
+                lam_med = np.nanmedian(lam)
                 # pick two alpha, beta values to determine rotation angle
                 # values in arc seconds
                 alpha_beta2world = input_model.meta.wcs.get_transform('alpha_beta',
@@ -1240,9 +1238,7 @@ class IFUCubeData():
                 x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box, step=(1, 1), center=True)
                 detector2slicer = slice_wcs.get_transform('detector', 'slicer')
                 across, along, lam = detector2slicer(x, y)  # lam ~0 for this transform
-                valid1 = ~np.isnan(lam)
-                lam = lam[valid1]
-                lam_med = np.median(lam)
+                lam_med = np.nanmedian(lam)
 
                 # pick two along sice, across slice  values to determine rotation angle
                 # values in meters

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -21,6 +21,7 @@ from . import cube_build_wcs_util
 from . import cube_overlap
 from . import cube_cloud
 from . import coord
+from ..mrs_imatch.mrs_imatch_step import apply_background_2d
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -622,11 +623,11 @@ class IFUCubeData():
 # ________________________________________________________________________________
 # loop over the files that cover the spectral range the cube is for
             for k in range(nfiles):
-                ifile = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
-                # set up ifile_ref to be first file used to copy in basic header info
+                input_model = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
+                # set up input_model to be first file used to copy in basic header info
                 # to ifucube meta data
                 if i == 0 and k == 0:
-                    ifile_ref = ifile
+                    input_model_ref = input_model
 
                 log.debug(f"Working on Band defined by: {this_par1} {this_par2}")
                 # --------------------------------------------------------------------------------
@@ -636,7 +637,7 @@ class IFUCubeData():
                     t0 = time.time()
                     pixelresult = self.map_detector_to_outputframe(this_par1,
                                                                    subtract_background,
-                                                                   ifile)
+                                                                   input_model)
 
                     coord1, coord2, wave, flux, err, slice_no, rois_pixel, roiw_pixel, weight_pixel,\
                         softrad_pixel, scalerad_pixel, alpha_det, beta_det = pixelresult
@@ -661,7 +662,7 @@ class IFUCubeData():
                         log.debug("Time to set initial dq values = %.1f s" % (t1 - t0,))
 
                     if no_data:
-                        log.warning(f'No valid data found on file {ifile.meta.filename}')
+                        log.warning(f'No valid data found on file {input_model.meta.filename}')
                     if self.weighting == 'msm' or self.weighting == 'emsm':
                         t0 = time.time()
                         cube_cloud.match_det2cube_msm(self.naxis1, self.naxis2, self.naxis3,
@@ -685,50 +686,47 @@ class IFUCubeData():
 
                         t1 = time.time()
                         log.debug("Time to match pixels to cube spaxels = %.1f s" % (t1 - t0,))
-# ________________________________________________________________________________
+                    # ________________________________________________________________________________
                     elif self.weighting == 'miripsf':
-                        with datamodels.IFUImageModel(ifile) as input_model:
-                            wave_resol = self.instrument_info.Get_RP_ave_Wave(this_par1,
-                                                                              this_par2)
+                        wave_resol = self.instrument_info.Get_RP_ave_Wave(this_par1,
+                                                                          this_par2)
 
-                            alpha_resol = self.instrument_info.Get_psf_alpha_parameters()
-                            beta_resol = self.instrument_info.Get_psf_beta_parameters()
-                            wcsobj = input_model.meta.wcs
-                            worldtov23 = wcsobj.get_transform(wcsobj.output_frame.name, "v2v3")
-                            v2ab_transform = wcsobj.get_transform('v2v3', 'alpha_beta')
+                        alpha_resol = self.instrument_info.Get_psf_alpha_parameters()
+                        beta_resol = self.instrument_info.Get_psf_beta_parameters()
+                        wcsobj = input_model.meta.wcs
+                        worldtov23 = wcsobj.get_transform(wcsobj.output_frame.name, "v2v3")
+                        v2ab_transform = wcsobj.get_transform('v2v3', 'alpha_beta')
+                        
+                        spaxel_v2, spaxel_v3, zl = worldtov23(spaxel_ra,
+                                                              spaxel_dec,
+                                                              spaxel_wave)
 
-                            spaxel_v2, spaxel_v3, zl = worldtov23(spaxel_ra,
-                                                                  spaxel_dec,
-                                                                  spaxel_wave)
-
-                            spaxel_alpha, spaxel_beta, spaxel_wave = v2ab_transform(spaxel_v2,
-                                                                                    spaxel_v3,
-                                                                                    zl)
-                            cube_cloud.match_det2cube_miripsf(alpha_resol,
-                                                              beta_resol,
-                                                              wave_resol,
-                                                              self.naxis1, self.naxis2, self.naxis3,
-                                                              self.xcenters, self.ycenters, self.zcoord,
-                                                              self.spaxel_flux,
-                                                              self.spaxel_weight,
-                                                              self.spaxel_iflux,
-                                                              self.spaxel_var,
-                                                              spaxel_alpha, spaxel_beta, spaxel_wave,
-                                                              flux,
-                                                              err,
-                                                              coord1, coord2, wave,
-                                                              alpha_det, beta_det,
-                                                              'emsm',
-                                                              rois_pixel, roiw_pixel,
-                                                              weight_pixel,
-                                                              softrad_pixel,
-                                                              scalerad_pixel)
-                # --------------------------------------------------------------------------------
-                # AREA - 2d method only works for single files local slicer plane (internal_cal)
-                # --------------------------------------------------------------------------------
-                elif self.interpolation == 'area':
-                    with datamodels.IFUImageModel(ifile) as input_model:
-
+                        spaxel_alpha, spaxel_beta, spaxel_wave = v2ab_transform(spaxel_v2,
+                                                                                spaxel_v3,
+                                                                                zl)
+                        cube_cloud.match_det2cube_miripsf(alpha_resol,
+                                                          beta_resol,
+                                                          wave_resol,
+                                                          self.naxis1, self.naxis2, self.naxis3,
+                                                          self.xcenters, self.ycenters, self.zcoord,
+                                                          self.spaxel_flux,
+                                                          self.spaxel_weight,
+                                                          self.spaxel_iflux,
+                                                          self.spaxel_var,
+                                                          spaxel_alpha, spaxel_beta, spaxel_wave,
+                                                          flux,
+                                                          err,
+                                                          coord1, coord2, wave,
+                                                          alpha_det, beta_det,
+                                                          'emsm',
+                                                          rois_pixel, roiw_pixel,
+                                                          weight_pixel,
+                                                          softrad_pixel,
+                                                          scalerad_pixel)
+                    # --------------------------------------------------------------------------------
+                    # AREA - 2d method only works for single files local slicer plane (internal_cal)
+                    # --------------------------------------------------------------------------------
+                    elif self.interpolation == 'area':
                         # --------------------------------------------------------------------------------
                         # MIRI
                         # --------------------------------------------------------------------------------
@@ -802,7 +800,7 @@ class IFUCubeData():
         self.set_final_dq_flags()
 
         # result consist of ifu_cube and status
-        result = self.setup_final_ifucube_model(ifile_ref)
+        result = self.setup_final_ifucube_model(input_model_ref)
 # _______________________________________________________________________
 # shove Flux and iflux in the  final IFU cube
 
@@ -830,7 +828,7 @@ class IFUCubeData():
 # ________________________________________________________________________________
 # loop over the files that cover the spectral range the cube is for
             for k in range(nfiles):
-                ifile = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
+                input_model = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
                 cube_debug = None
                 log.debug("Working on next Single IFU Cube = %i" % (j + 1))
                 t0 = time.time()
@@ -846,7 +844,7 @@ class IFUCubeData():
 
                 pixelresult = self.map_detector_to_outputframe(this_par1,
                                                                subtract_background,
-                                                               ifile)
+                                                               input_model)
 
                 coord1, coord2, wave, flux, err, slice_no, rois_pixel, roiw_pixel, weight_pixel, \
                     softrad_pixel, scalerad_pixel, alpha_det, beta_det = pixelresult
@@ -879,7 +877,7 @@ class IFUCubeData():
 
             # determine Cube Spaxel flux
                 status = 0
-                result = self.setup_final_ifucube_model(ifile)
+                result = self.setup_final_ifucube_model(input_model)
                 ifucube_model, status = result
                 t1 = time.time()
                 log.debug("Time to Create Single ifucube = %.1f s" % (t1 - t0,))
@@ -1217,45 +1215,44 @@ class IFUCubeData():
             this_b = parameter2[0]  # 0 is first band - this_b is sub-channel
             log.info(f'Defining rotation between ra-dec and IFU plane using {this_a}, {this_b}')
             # first file for this band
-            ifile = self.master_table.FileMap[self.instrument][this_a][this_b][0]
-            with datamodels.IFUImageModel(ifile) as input_model:
+            input_file = self.master_table.FileMap[self.instrument][this_a][this_b][0]
 
-                if self.instrument == 'MIRI':
-                    xstart, xend = self.instrument_info.GetMIRISliceEndPts(this_a)
-                    ysize = input_model.data.shape[0]
-                    y, x = np.mgrid[:ysize, xstart:xend]
-                    detector2alpha_beta = input_model.meta.wcs.get_transform('detector',
-                                                                             'alpha_beta')
-                    alpha, beta, lam = detector2alpha_beta(x, y)
-                    valid1 = ~np.isnan(lam)
-                    lam = lam[valid1]
-                    lam_med = np.median(lam)
-                    # pick two alpha, beta values to determine rotation angle
-                    # values in arc seconds
-                    alpha_beta2world = input_model.meta.wcs.get_transform('alpha_beta', input_model.meta.wcs.output_frame.name)
+            if self.instrument == 'MIRI':
+                xstart, xend = self.instrument_info.GetMIRISliceEndPts(this_a)
+                ysize = input_model.data.shape[0]
+                y, x = np.mgrid[:ysize, xstart:xend]
+                detector2alpha_beta = input_model.meta.wcs.get_transform('detector',
+                                                                         'alpha_beta')
+                alpha, beta, lam = detector2alpha_beta(x, y)
+                valid1 = ~np.isnan(lam)
+                lam = lam[valid1]
+                lam_med = np.median(lam)
+                # pick two alpha, beta values to determine rotation angle
+                # values in arc seconds
+                alpha_beta2world = input_model.meta.wcs.get_transform('alpha_beta', input_model.meta.wcs.output_frame.name)
 
-                    temp_ra1, temp_dec1, lam_temp = alpha_beta2world(0, 0, lam_med)
-                    temp_ra2, temp_dec2, lam_temp = alpha_beta2world(0, 2, lam_med)
+                temp_ra1, temp_dec1, lam_temp = alpha_beta2world(0, 0, lam_med)
+                temp_ra2, temp_dec2, lam_temp = alpha_beta2world(0, 2, lam_med)
 
-                elif self.instrument == 'NIRSPEC':
-                    slice_wcs = nirspec.nrs_wcs_set_input(input_model, 0)
-                    x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box, step=(1, 1), center=True)
-                    detector2slicer = slice_wcs.get_transform('detector', 'slicer')
-                    across, along, lam = detector2slicer(x, y)  # lam ~0 for this transform
-                    valid1 = ~np.isnan(lam)
-                    lam = lam[valid1]
-                    lam_med = np.median(lam)
-
-                    # pick two along sice, across slice  values to determine rotation angle
-                    # values in meters
-                    slicer2world = slice_wcs.get_transform('slicer', slice_wcs.output_frame.name)
-                    temp_ra1, temp_dec1, lam_temp = slicer2world(0, 0, lam_med)
-                    temp_ra2, temp_dec2, lam_temp = slicer2world(0, 0.005, lam_med)
-                # ________________________________________________________________________________
-                # temp_dec1 is in degrees
-                dra, ddec = (temp_ra2 - temp_ra1) * np.cos(temp_dec1 * np.pi / 180.0), (temp_dec2 - temp_dec1)
-                self.rot_angle = np.arctan2(dra, ddec) * 180. / np.pi
-                log.info(f'Rotation angle between ifu and sky: {self.rot_angle}')
+            elif self.instrument == 'NIRSPEC':
+                slice_wcs = nirspec.nrs_wcs_set_input(input_model, 0)
+                x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box, step=(1, 1), center=True)
+                detector2slicer = slice_wcs.get_transform('detector', 'slicer')
+                across, along, lam = detector2slicer(x, y)  # lam ~0 for this transform
+                valid1 = ~np.isnan(lam)
+                lam = lam[valid1]
+                lam_med = np.median(lam)
+                
+                # pick two along sice, across slice  values to determine rotation angle
+                # values in meters
+                slicer2world = slice_wcs.get_transform('slicer', slice_wcs.output_frame.name)
+                temp_ra1, temp_dec1, lam_temp = slicer2world(0, 0, lam_med)
+                temp_ra2, temp_dec2, lam_temp = slicer2world(0, 0.005, lam_med)
+            # ________________________________________________________________________________
+            # temp_dec1 is in degrees
+            dra, ddec = (temp_ra2 - temp_ra1) * np.cos(temp_dec1 * np.pi / 180.0), (temp_dec2 - temp_dec1)
+            self.rot_angle = np.arctan2(dra, ddec) * 180. / np.pi
+            log.info(f'Rotation angle between ifu and sky: {self.rot_angle}')
 
 # ________________________________________________________________________________
 # now loop over data and find min and max ranges data covers
@@ -1278,59 +1275,56 @@ class IFUCubeData():
                 lmin = 0.0
                 lmax = 0.0
 
-                ifile = self.master_table.FileMap[self.instrument][this_a][this_b][k]
-# ______________________________________________________________________________
-# Open the input data model
-# Find the footprint of the image
-                with datamodels.IFUImageModel(ifile) as input_model:
-                    spectral_found = hasattr(input_model.meta.wcsinfo,'spectral_region')
-                    spatial_found = hasattr(input_model.meta.wcsinfo,'s_region')
+                input_model = self.master_table.FileMap[self.instrument][this_a][this_b][k]
 
-                    if(spectral_found & spatial_found):
-                        [lmin,lmax] = input_model.meta.wcsinfo.spectral_region
-                        spatial_box = input_model.meta.wcsinfo.s_region
-                        s = spatial_box.split(' ')
-                        ca1 = float(s[3])
-                        cb1 = float(s[4])
-                        ca2 = float(s[5])
-                        cb2 = float(s[6])
-                        ca3 = float(s[7])
-                        cb3 = float(s[8])
-                        ca4 = float(s[9])
-                        cb4 = float(s[10])
-                    else:
-                        log.info('Using old method of mapping all pixels to output to determine IFU foot print')
+                # Find the footprint of the image
+                spectral_found = hasattr(input_model.meta.wcsinfo,'spectral_region')
+                spatial_found = hasattr(input_model.meta.wcsinfo,'s_region')
 
-                        if self.instrument == 'NIRSPEC':
-                            ch_corners = cube_build_wcs_util.find_corners_NIRSPEC(
-                                input_model,
-                                this_a,
-                                self.instrument_info,
-                                self.coord_system)
+                if(spectral_found & spatial_found):
+                    [lmin,lmax] = input_model.meta.wcsinfo.spectral_region
+                    spatial_box = input_model.meta.wcsinfo.s_region
+                    s = spatial_box.split(' ')
+                    ca1 = float(s[3])
+                    cb1 = float(s[4])
+                    ca2 = float(s[5])
+                    cb2 = float(s[6])
+                    ca3 = float(s[7])
+                    cb3 = float(s[8])
+                    ca4 = float(s[9])
+                    cb4 = float(s[10])
+                else:
+                    log.info('Using old method of mapping all pixels to output to determine IFU foot print')
 
-                            ca1, cb1, ca2, cb2, ca3, cb3, ca4, cb4, lmin, lmax = ch_corners
-                        if self.instrument == 'MIRI':
-                            ch_corners = cube_build_wcs_util.find_corners_MIRI(
-                                input_model,
-                                this_a,
-                                self.instrument_info,
-                                self.coord_system)
+                    if self.instrument == 'NIRSPEC':
+                        ch_corners = cube_build_wcs_util.find_corners_NIRSPEC(
+                            input_model,
+                            this_a,
+                            self.instrument_info,
+                            self.coord_system)
+                        ca1, cb1, ca2, cb2, ca3, cb3, ca4, cb4, lmin, lmax = ch_corners
+                    if self.instrument == 'MIRI':
+                        ch_corners = cube_build_wcs_util.find_corners_MIRI(
+                            input_model,
+                            this_a,
+                            self.instrument_info,
+                            self.coord_system)
 
-                            ca1, cb1, ca2, cb2, ca3, cb3, ca4, cb4, lmin, lmax = ch_corners
+                        ca1, cb1, ca2, cb2, ca3, cb3, ca4, cb4, lmin, lmax = ch_corners
 
-                    # now append this model spatial and spectral corner
-                    corner_a.append(ca1)
-                    corner_a.append(ca2)
-                    corner_a.append(ca3)
-                    corner_a.append(ca4)
+                # now append this model spatial and spectral corner
+                corner_a.append(ca1)
+                corner_a.append(ca2)
+                corner_a.append(ca3)
+                corner_a.append(ca4)
 
-                    corner_b.append(cb1)
-                    corner_b.append(cb2)
-                    corner_b.append(cb3)
-                    corner_b.append(cb4)
+                corner_b.append(cb1)
+                corner_b.append(cb2)
+                corner_b.append(cb3)
+                corner_b.append(cb4)
 
-                    lambda_min.append(lmin)
-                    lambda_max.append(lmax)
+                lambda_min.append(lmin)
+                lambda_max.append(lmax)
     # ________________________________________________________________________________
     # done looping over files determine final size of cube
 
@@ -1395,8 +1389,8 @@ class IFUCubeData():
 
     def map_detector_to_outputframe(self, this_par1,
                                     subtract_background,
-                                    ifile):
-        from ..mrs_imatch.mrs_imatch_step import apply_background_2d
+                                    input_model):
+
 # **************************************************************************
         """Loop over a file and map the detector pixels to the output cube
 
@@ -1415,8 +1409,9 @@ class IFUCubeData():
            for MIRI this is the channel # for NIRSPEC this is the grating name
            only need for MIRI to distinguish which channel on the detector we have
         subtract_background : boolean
-           if TRUE then subtract the background found in the mrs_imatch step
-        ifile : datamodel
+           if TRUE then subtract the background found in the mrs_imatch step only
+           needed for MIRI data 
+        input: datamodel
            input data model
 
         Returns
@@ -1444,8 +1439,8 @@ class IFUCubeData():
         beta_det : numpy.ndarray
            beta coordinate of pixel
         """
-# intitalize alpha_det and beta_det to None. These are filled in
-# if the instrument is MIRI and the weighting is miripsf
+        # intitalize alpha_det and beta_det to None. These are filled in
+        # if the instrument is MIRI and the weighting is miripsf
 
         alpha_det = None
         beta_det = None
@@ -1455,217 +1450,281 @@ class IFUCubeData():
         err = None
         wave = None
         slice_no = None  # Slice number
-# Open the input data model
-        with datamodels.IFUImageModel(ifile) as input_model:
-            # check if background sky matching as been done
-            # mrs_imatch step. THis is only for MRS data at this time
-            # but go head and check it before splitting by instrument
-            # the polynomial should be empty for NIRSPEC
 
-            num_ch_bgk = len(input_model.meta.background.polynomial_info)
-            if(num_ch_bgk > 0 and subtract_background):
-                for ich_num in range(num_ch_bgk):
-                    poly = input_model.meta.background.polynomial_info[ich_num]
-                    poly_ch = poly.channel
-                    if(poly_ch == this_par1):
-                        apply_background_2d(input_model, poly_ch, subtract=True)
-# --------------------------------------------------------------------------------
-            if self.instrument == 'MIRI':
+        if self.instrument == 'MIRI':
+            sky_result = self.map_miri_pixel_to_sky(input_model, this_par1, subtract_background)
+            (x, y, ra, dec, wave, slice_no, alpha, beta) = sky_result
+            
+        elif self.instrument == 'NIRSPEC':
+            sky_result = self.map_nirspec_pixel_to_sky(input_model)
+            (x, y, ra, dec, wave ,slice_no) = sky_result
 
-                # find the slice number of each pixel and fill in slice_det
-                ysize, xsize = input_model.data.shape
-                slice_det = np.zeros((ysize, xsize), dtype=int)
-                det2ab_transform = input_model.meta.wcs.get_transform('detector',
-                                                                      'alpha_beta')
-                start_region = self.instrument_info.GetStartSlice(this_par1)
-                end_region = self.instrument_info.GetEndSlice(this_par1)
-                regions = list(range(start_region, end_region + 1))
-                for i in regions:
-                    ys, xs = (det2ab_transform.label_mapper.mapper == i).nonzero()
-                    xind = _toindex(xs)
-                    yind = _toindex(ys)
-                    xind = np.ndarray.flatten(xind)
-                    yind = np.ndarray.flatten(yind)
-                    slice_det[yind, xind] = i
+        # ______________________________________________________________________________
+        # The following is for both MIRI and NIRSPEC
 
-                # define the x,y detector values of channel to be mapped to desired coordinate system
-                xstart, xend = self.instrument_info.GetMIRISliceEndPts(this_par1)
-                y, x = np.mgrid[:ysize, xstart:xend]
-                y = np.reshape(y, y.size)
-                x = np.reshape(x, x.size)
+        flux_all = input_model.data[y, x]
+        err_all = input_model.err[y, x]
+        dq_all = input_model.dq[y, x]
+        valid2 = np.isfinite(flux_all)
 
-                # if self.coord_system == 'skyalign' or self.coord_system == 'ifualign':
-                ra, dec, wave = input_model.meta.wcs(x, y)
-                valid1 = ~np.isnan(ra)
-                ra = ra[valid1]
-                dec = dec[valid1]
-                wave = wave[valid1]
-                x = x[valid1]
-                y = y[valid1]
+        # Pre-select only data within a given wavelength range
+        # This range is defined to include all pixels for which the chosen wavelength region
+        # of interest would have them fall within one of the cube spectral planes
+        # Note that the cube lambda refer to the spaxel midpoints, so we must account for both
+        # the spaxel width and the ROI size
+        if self.linear_wavelength:
+            min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0]) / 2 - self.roiw
+            max_wave_tolerance = (self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2]) / 2
+                                  + self.roiw)
+        else:
+            min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0]) / 2 - np.max(self.roiw_table)
+            max_wave_tolerance = (self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2]) / 2
+                                  + np.max(self.roiw_table))
 
-                xind = _toindex(x)
-                yind = _toindex(y)
-                xind = np.ndarray.flatten(xind)
-                yind = np.ndarray.flatten(yind)
-                slice_no = slice_det[yind, xind]
+        valid_min = np.where(wave >= min_wave_tolerance)
+        not_mapped_low = wave.size - len(valid_min[0])
 
-                if self.weighting == 'miripsf':
-                    alpha, beta, lam = det2ab_transform(x, y)
+        valid_max = np.where(wave <= max_wave_tolerance)
+        not_mapped_high = wave.size - len(valid_max[0])
+        if not_mapped_low > 0:
+            log.info('# of detector pixels not mapped to output plane: '
+                     f'{not_mapped_low} with wavelength below {min_wave_tolerance}')
 
-                    valid1 = ~np.isnan(alpha)
-                    alpha = alpha[valid1]
-                    beta = beta[valid1]
-                    wave = wave[valid1]
-                    x = x[valid1]
-                    y = y[valid1]
-# ________________________________________________________________________________
-            elif self.instrument == 'NIRSPEC':
-                # initialize the ra,dec, and wavelength arrays
-                # we will loop over slice_nos and fill in values
-                # the flag_det will be set when a slice_no pixel is filled in
-                # at the end we will use this flag to pull out valid data
+        if not_mapped_high > 0:
+            log.info('# of detector pixels not mapped to output plane: '
+                     f'{not_mapped_high} with wavelength above {max_wave_tolerance}')
 
-                ysize, xsize = input_model.data.shape
-                ra_det = np.zeros((ysize, xsize))
-                dec_det = np.zeros((ysize, xsize))
-                lam_det = np.zeros((ysize, xsize))
-                flag_det = np.zeros((ysize, xsize))
-                slice_det = np.zeros((ysize, xsize), dtype=int)
-                # for NIRSPEC each file has 30 slices
-                # wcs information access seperately for each slice
-                nslices = 30
-                log.info("Mapping each NIRSpec slice to sky")
-                # t80 = time.time()
-                for ii in range(nslices):
-                    slice_wcs = nirspec.nrs_wcs_set_input(input_model, ii)
-                    x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
-                    ra, dec, lam = slice_wcs(x, y)
+        # ______________________________________________________________________________
+        # using the DQFlags from the input_image find pixels that should be excluded
+        # from the cube mapping
+        all_flags = (dqflags.pixel['DO_NOT_USE'] +
+                     dqflags.pixel['NON_SCIENCE'])
 
-                    # the slices are curved on detector so a rectangular region
-                    # returns NaNs
-                    valid = ~np.isnan(lam)
-                    ra = ra[valid]
-                    dec = dec[valid]
-                    lam = lam[valid]
-                    x = x[valid]
-                    y = y[valid]
+        valid3 = np.logical_and((wave >= min_wave_tolerance),
+                                (wave <= max_wave_tolerance))
 
-                    xind = _toindex(x)
-                    yind = _toindex(y)
-                    xind = np.ndarray.flatten(xind)
-                    yind = np.ndarray.flatten(yind)
-                    ra = np.ndarray.flatten(ra)
-                    dec = np.ndarray.flatten(dec)
-                    lam = np.ndarray.flatten(lam)
-                    ra_det[yind, xind] = ra
-                    dec_det[yind, xind] = dec
-                    lam_det[yind, xind] = lam
-                    flag_det[yind, xind] = 1
-                    slice_det[yind, xind] = ii + 1
+        # find the location of good data
+        good_data = np.where((np.bitwise_and(dq_all, all_flags) == 0) &
+                             (valid2) & (valid3))
 
-                # t81 = time.time()
-                # print('Time to loop over 30 slices map x,y to ra,dec',t81-t80)
-                # after looping over slices  - pull out valid values
-                valid_data = np.where(flag_det == 1)
-                y, x = valid_data
+        # good data holds the location of pixels we want to map to cube
+        flux = flux_all[good_data]
+        err = err_all[good_data]
+        wave = wave[good_data]
+        slice_no = slice_no[good_data]
 
-                ra = ra_det[valid_data]
-                dec = dec_det[valid_data]
-                wave = lam_det[valid_data]
-                slice_no = slice_det[valid_data]
-# ______________________________________________________________________________
-# The following is for both MIRI and NIRSPEC
-# grab the flux and DQ values for these pixels
-            flux_all = input_model.data[y, x]
-            err_all = input_model.err[y, x]
-            dq_all = input_model.dq[y, x]
-            valid2 = np.isfinite(flux_all)
+        # based on the wavelength define the sroi, wroi, weight_power and
+        # softrad to use in matching detector to spaxel values
+        rois_det = np.zeros(wave.shape)
+        roiw_det = np.zeros(wave.shape)
+        weight_det = np.zeros(wave.shape)
+        softrad_det = np.zeros(wave.shape)
+        scalerad_det = np.zeros(wave.shape)
 
-            # Pre-select only data within a given wavelength range
-            # This range is defined to include all pixels for which the chosen wavelength region
-            # of interest would have them fall within one of the cube spectral planes
-            # Note that the cube lambda refer to the spaxel midpoints, so we must account for both
-            # the spaxel width and the ROI size
-            if self.linear_wavelength:
-                min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0]) / 2 - self.roiw
-                max_wave_tolerance = (self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2]) / 2
-                                      + self.roiw)
-            else:
-                min_wave_tolerance = self.crval3 - np.absolute(self.zcoord[1] - self.zcoord[0]) / 2 - np.max(self.roiw_table)
-                max_wave_tolerance = (self.zcoord[-1] + np.absolute(self.zcoord[-1] - self.zcoord[-2]) / 2
-                                      + np.max(self.roiw_table))
+        if self.linear_wavelength:
+            rois_det[:] = self.rois
+            roiw_det[:] = self.roiw
+            weight_det[:] = self.weight_power
+            softrad_det[:] = self.soft_rad
+            scalerad_det[:] = self.scalerad
+        else:
+            # for each wavelength find the closest point in the self.wavelength_table
+            for iw, w in enumerate(wave):
+                ifound = (np.abs(self.wavelength_table - w)).argmin()
+                rois_det[iw] = self.rois_table[ifound]
+                roiw_det[iw] = self.roiw_table[ifound]
+                softrad_det[iw] = self.softrad_table[ifound]
+                weight_det[iw] = self.weight_power_table[ifound]
+                scalerad_det[iw] = self.scalerad_table[ifound]
 
-            valid_min = np.where(wave >= min_wave_tolerance)
-            not_mapped_low = wave.size - len(valid_min[0])
+        ra_use = ra[good_data]
+        dec_use = dec[good_data]
+        coord1, coord2 = coord.radec2std(self.crval1,
+                                         self.crval2,
+                                         ra_use, dec_use,
+                                         self.rot_angle)
 
-            valid_max = np.where(wave <= max_wave_tolerance)
-            not_mapped_high = wave.size - len(valid_max[0])
-            if not_mapped_low > 0:
-                log.info('# of detector pixels not mapped to output plane: '
-                         f'{not_mapped_low} with wavelength below {min_wave_tolerance}')
-
-            if not_mapped_high > 0:
-                log.info('# of detector pixels not mapped to output plane: '
-                         f'{not_mapped_high} with wavelength above {max_wave_tolerance}')
-
-# ______________________________________________________________________________
-# using the DQFlags from the input_image find pixels that should be excluded
-# from the cube mapping
-            all_flags = (dqflags.pixel['DO_NOT_USE'] +
-                         dqflags.pixel['NON_SCIENCE'])
-
-            valid3 = np.logical_and((wave >= min_wave_tolerance),
-                                    (wave <= max_wave_tolerance))
-
-            # find the location of good data
-            good_data = np.where((np.bitwise_and(dq_all, all_flags) == 0) &
-                                 (valid2) & (valid3))
-
-            # good data holds the location of pixels we want to map to cube
-            flux = flux_all[good_data]
-            err = err_all[good_data]
-            wave = wave[good_data]
-            slice_no = slice_no[good_data]
-
-            # based on the wavelength define the sroi, wroi, weight_power and
-            # softrad to use in matching detector to spaxel values
-            rois_det = np.zeros(wave.shape)
-            roiw_det = np.zeros(wave.shape)
-            weight_det = np.zeros(wave.shape)
-            softrad_det = np.zeros(wave.shape)
-            scalerad_det = np.zeros(wave.shape)
-
-            if self.linear_wavelength:
-                rois_det[:] = self.rois
-                roiw_det[:] = self.roiw
-                weight_det[:] = self.weight_power
-                softrad_det[:] = self.soft_rad
-                scalerad_det[:] = self.scalerad
-            else:
-                # for each wavelength find the closest point in the self.wavelength_table
-                for iw, w in enumerate(wave):
-                    ifound = (np.abs(self.wavelength_table - w)).argmin()
-                    rois_det[iw] = self.rois_table[ifound]
-                    roiw_det[iw] = self.roiw_table[ifound]
-                    softrad_det[iw] = self.softrad_table[ifound]
-                    weight_det[iw] = self.weight_power_table[ifound]
-                    scalerad_det[iw] = self.scalerad_table[ifound]
-
-            ra_use = ra[good_data]
-            dec_use = dec[good_data]
-            coord1, coord2 = coord.radec2std(self.crval1,
-                                             self.crval2,
-                                             ra_use, dec_use,
-                                             self.rot_angle)
-
-            if self.weighting == 'miripsf':
-                alpha_det = alpha[good_data]
-                beta_det = beta[good_data]
+        if self.weighting == 'miripsf':
+            alpha_det = alpha[good_data]
+            beta_det = beta[good_data]
 
         return coord1, coord2, wave, flux, err, slice_no, rois_det, roiw_det, weight_det, \
             softrad_det, scalerad_det, alpha_det, beta_det
-# ********************************************************************************
 
+    
+    #______________________________________________________________________
+    def map_miri_pixel_to_sky(self, input_model, this_par1, subtract_background):
+    
+        """Loop over a file and map the detector pixels to the output cube
+
+        The output frame is on the SKY (ra-dec)
+
+        Return the coordinates of all the detector pixel in the output frame.
+
+        Parameter
+        ----------
+        this_par1 : str
+           for MIRI this is the channel # for NIRSPEC this is the grating name
+           only need for MIRI to distinguish which channel on the detector we have
+        subtract_background : boolean
+           if TRUE then subtract the background found in the mrs_imatch step only
+           needed for MIRI data 
+        input: datamodel
+           input data model
+
+        Returns
+        -------
+
+        x, y, ra, dec, lambda, slice_no  of valid slice pixels
+
+        if weighting = mirispf returns alpha, beta 
+
+        """
+        alpha = None
+        beta = None
+        wave = None
+        slice_no = None  # Slice number
+        
+        # check if background sky matching as been done in mrs_imatch step
+        # If it has not been subtracted and the background has not been
+        # subtracted - subtract it. 
+        num_ch_bgk = len(input_model.meta.background.polynomial_info)
+        if(num_ch_bgk > 0 and subtract_background and input_model.meta.background.subtracted == False):
+            for ich_num in range(num_ch_bgk):
+                poly = input_model.meta.background.polynomial_info[ich_num]
+                poly_ch = poly.channel
+                if(poly_ch == this_par1):
+                    apply_background_2d(input_model, poly_ch, subtract=True)
+
+
+        # find the slice number of each pixel and fill in slice_det
+        ysize, xsize = input_model.data.shape
+        slice_det = np.zeros((ysize, xsize), dtype=int)
+        det2ab_transform = input_model.meta.wcs.get_transform('detector',
+                                                          'alpha_beta')
+        start_region = self.instrument_info.GetStartSlice(this_par1)
+        end_region = self.instrument_info.GetEndSlice(this_par1)
+        regions = list(range(start_region, end_region + 1))
+        for i in regions:
+            ys, xs = (det2ab_transform.label_mapper.mapper == i).nonzero()
+            xind = _toindex(xs)
+            yind = _toindex(ys)
+            xind = np.ndarray.flatten(xind)
+            yind = np.ndarray.flatten(yind)
+            slice_det[yind, xind] = i
+
+        # define the x,y detector values of channel to be mapped to desired coordinate system
+        xstart, xend = self.instrument_info.GetMIRISliceEndPts(this_par1)
+        y, x = np.mgrid[:ysize, xstart:xend]
+        y = np.reshape(y, y.size)
+        x = np.reshape(x, x.size)
+
+        # if self.coord_system == 'skyalign' or self.coord_system == 'ifualign':
+        ra, dec, wave = input_model.meta.wcs(x, y)
+        valid1 = ~np.isnan(ra)
+        ra = ra[valid1]
+        dec = dec[valid1]
+        wave = wave[valid1]
+        x = x[valid1]
+        y = y[valid1]
+
+        xind = _toindex(x)
+        yind = _toindex(y)
+        xind = np.ndarray.flatten(xind)
+        yind = np.ndarray.flatten(yind)
+        slice_no = slice_det[yind, xind]
+
+        if self.weighting == 'miripsf':
+            alpha, beta, lam = det2ab_transform(x, y)
+            
+            valid1 = ~np.isnan(alpha)
+            alpha = alpha[valid1]
+            beta = beta[valid1]
+            wave = wave[valid1]
+            x = x[valid1]
+            y = y[valid1]
+        sky_result = (x, y, ra, dec, wave, slice_no, alpha, beta)
+        return sky_result
+    
+    # ______________________________________________________________________
+    def map_nirspec_pixel_to_sky(self, input_model):
+        
+        """Loop over a file and map the detector pixels to the output cube
+
+        The output frame is on the SKY (ra-dec)
+
+        Return the coordinates of all the detector pixel in the output frame.
+
+        Parameter
+        ----------
+        input: datamodel
+           input data model
+
+        Returns
+        -------
+        x, y, ra, dec, lambda, slice_no
+
+        """
+        # initialize the ra,dec, and wavelength arrays
+        # we will loop over slice_nos and fill in values
+        # the flag_det will be set when a slice_no pixel is filled in
+        # at the end we will use this flag to pull out valid data
+
+        ysize, xsize = input_model.data.shape
+        ra_det = np.zeros((ysize, xsize))
+        dec_det = np.zeros((ysize, xsize))
+        lam_det = np.zeros((ysize, xsize))
+        flag_det = np.zeros((ysize, xsize))
+        slice_det = np.zeros((ysize, xsize), dtype=int)
+        # for NIRSPEC each file has 30 slices
+        # wcs information access seperately for each slice
+        nslices = 30
+        log.info("Mapping each NIRSpec slice to sky for input file")
+
+        t80 = time.time()
+        for ii in range(nslices):
+            slice_wcs = nirspec.nrs_wcs_set_input(input_model, ii)
+            x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
+            ra, dec, lam = slice_wcs(x, y)
+
+            # the slices are curved on detector so a rectangular region returns NaNs
+            valid = ~np.isnan(lam)
+            ra = ra[valid]
+            dec = dec[valid]
+            lam = lam[valid]
+            x = x[valid]
+            y = y[valid]
+
+            xind = _toindex(x)
+            yind = _toindex(y)
+            xind = np.ndarray.flatten(xind)
+            yind = np.ndarray.flatten(yind)
+            ra = np.ndarray.flatten(ra)
+            dec = np.ndarray.flatten(dec)
+            lam = np.ndarray.flatten(lam)
+            ra_det[yind, xind] = ra
+            dec_det[yind, xind] = dec
+            lam_det[yind, xind] = lam
+            flag_det[yind, xind] = 1
+            slice_det[yind, xind] = ii + 1
+
+
+        # after looping over slices  - pull out valid values
+        t81 = time.time()
+        log.debug(f'Time to map slices  {t81-t80} ')
+        
+        valid_data = np.where(flag_det == 1)
+        y, x = valid_data
+
+        ra = ra_det[valid_data]
+        dec = dec_det[valid_data]
+        wave = lam_det[valid_data]
+        slice_no = slice_det[valid_data]
+
+        sky_result = (x, y, ra, dec, wave ,slice_no)
+        return sky_result
+
+    # ______________________________________________________________________
     def map_fov_to_dqplane(self, this_par1, coord1, coord2, wave, roiw_ave, slice_no):
         """ Set an initial DQ flag for the IFU cube based on FOV of input data
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -92,6 +92,7 @@ class Spec2Pipeline(Pipeline):
         self.resample_spec.suffix = 's2d'
         self.cube_build.output_type = 'multi'
         self.cube_build.save_results = False
+        self.cube_build.skip_dqflagging = True
         self.extract_1d.save_results = self.save_results
 
         # Retrieve the input(s)


### PR DESCRIPTION
This is the push of code to try and improve the cube_build speed.
In a separate PR #5969 - reworked NRS ifu wcs set_input to make it more efficient and faster. Also meta.wcsinfo.spectral_region is now filled in assign_wcs. That value along with meta.wcsinfo.s_region can be used to determine the initial size of the IFU to cover all the input data.

Using the above enhancements Cube_build now runs faster. A slight improvement in how the dq plane for MIRI data is determined was added. The calspec2 pipeline was changed and skip_dqflagging is set to True.  The DQ plane for calspec2 output contains all zeros. 

There may be further improvements, so I have left timing information in debug statements. 