### PR TITLE
JP-1611: Calculate photometric errors using resampled total-error array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -176,6 +176,9 @@ source_catalog
 - Aperture-corrected total fluxes and magnitudes are now computed for
   all sources. [#5996]
 
+- Photometric errors are now computed using the new resampled total
+  error array. [#5997]
+
 srctype
 -------
 

--- a/docs/jwst/source_catalog/main.rst
+++ b/docs/jwst/source_catalog/main.rst
@@ -53,6 +53,10 @@ semimajor and semiminor axis lengths, orientation of the major axis,
 and sky coordinates at corners of the minimal bounding box enclosing
 the source.
 
+Photometric errors are calculated from the resampled total-error
+array contained in the ``ERR`` (``model.err``) array. Note that this
+total-error array includes source Poisson noise.
+
 Output Products
 ---------------
 

--- a/docs/jwst/source_catalog/main.rst
+++ b/docs/jwst/source_catalog/main.rst
@@ -53,12 +53,6 @@ semimajor and semiminor axis lengths, orientation of the major axis,
 and sky coordinates at corners of the minimal bounding box enclosing
 the source.
 
-.. Note::
-
-   Errors are only created when an image has an error extension.  Products
-   created from the resampling step currently do not have an error extension
-   and the error columns are currently filled with a value of NaN.
-
 Output Products
 ---------------
 

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -10,8 +10,7 @@ import numpy as np
 from photutils.utils.exceptions import NoDetectionsWarning
 
 from .source_catalog import (ReferenceData, Background, make_kernel,
-                             make_segment_img, calc_total_error,
-                             JWSTSourceCatalog)
+                             make_segment_img, JWSTSourceCatalog)
 from .. import datamodels
 from ..stpipe import Step
 
@@ -100,13 +99,9 @@ class SourceCatalogStep(Step):
                 return
             self.log.info(f'Detected {segment_img.nlabels} sources')
 
-            # TODO: update when model contains errors
-            total_error = calc_total_error(model)
-
             ci_star_thresholds = (self.ci1_star_threshold,
                                   self.ci2_star_threshold)
-            catobj = JWSTSourceCatalog(model, segment_img, error=total_error,
-                                       kernel=kernel,
+            catobj = JWSTSourceCatalog(model, segment_img, kernel=kernel,
                                        kernel_fwhm=self.kernel_fwhm,
                                        aperture_params=aperture_params,
                                        abvega_offset=abvega_offset,

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -6,6 +6,7 @@ import os
 import warnings
 
 from crds.core.exceptions import CrdsLookupError
+import numpy as np
 from photutils.utils.exceptions import NoDetectionsWarning
 
 from .source_catalog import (ReferenceData, Background, make_kernel,
@@ -72,10 +73,10 @@ class SourceCatalogStep(Step):
                 self.log.warning(msg)
                 return
 
-            coverage_mask = (model.wht == 0)
+            coverage_mask = np.isnan(model.err)
             if coverage_mask.all():
-                self.log.warning('There are no pixels with non-zero weight. '
-                                 'Source catalog will not be created.')
+                self.log.warning('There are no valid pixels. Source catalog '
+                                 'will not be created.')
                 return
 
             bkg = Background(model.data, box_size=self.bkg_boxsize,


### PR DESCRIPTION
This PR can be merged despite the resampled total-error array still being work-in-progress.  The `model.err` arrays are currently all zeros, so the photometry errors in the source catalog will be zeros until `model.err` is populated with the resampled total-error array.

Fixes #5182 / [JP-1611](https://jira.stsci.edu/browse/JP-1611)