### PR TITLE
Fix source catalog coverage mask

### DIFF
--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -72,7 +72,7 @@ class SourceCatalogStep(Step):
                 self.log.warning(msg)
                 return
 
-            coverage_mask = np.isnan(model.err)
+            coverage_mask = np.isnan(model.err) | (model.wht == 0)
             if coverage_mask.all():
                 self.log.warning('There are no valid pixels. Source catalog '
                                  'will not be created.')


### PR DESCRIPTION
This is a followup to #5997.  In that PR, I changed the `coverage_mask = np.isnan(model.err)`.  However, `model.err` is currently an array of all zeros (until @jdavies-st completes updates to `model.err`), thus i2d pixels with no data are not being masked (until `model.err` is populated).  In this PR, I've updated the coverage_mask to also include pixels where `model.wht == 0`, which fixes this issue (and should work fine after the upcoming updates).

I've tested this with `det_dithered_5stars_f770w_i2d.fits`.