### PR TITLE
Fix nn_label for only 1 detected source

### DIFF
--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1143,6 +1143,8 @@ class JWSTSourceCatalog:
         """
         The label number of the nearest neighbor.
         """
+        if np.isnan(self._ckdtree_query[1]):  # only one detected source
+            return np.nan
         return self.label[self._ckdtree_query[1]]
 
     @lazyproperty
@@ -1150,6 +1152,7 @@ class JWSTSourceCatalog:
         """
         The distance in pixels to the nearest neighbor.
         """
+        # self._ckdtree_query[0] is NaN if only one detected source
         return self._ckdtree_query[0] * u.pixel
 
     @lazyproperty


### PR DESCRIPTION
This PR is a followup fix to #5998 where a source catalog with only 1 detected source would raise an error.