### PR TITLE
JP-2079: Fix a bug in tweakreg due to grouped models not being a list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -216,6 +216,9 @@ transforms
 tweakreg
 --------
 
+- Fix a bug due to ``models_grouped`` now returning ``odict_values`` instead
+  of lists. [#6022]
+
 - Updated documentation to include the new "rshift" option for fit geometry [#5899]
 
 wfss_contam

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -123,7 +123,7 @@ class TweakRegStep(Step):
             raise ValueError("Input must contain at least one image model.")
 
         # group images by their "group id":
-        grp_img = images.models_grouped
+        grp_img = list(images.models_grouped)
 
         self.log.info('')
         self.log.info("Number of image groups to be aligned: {:d}."


### PR DESCRIPTION
Fixes #4601 / [JP-2079](https://jira.stsci.edu/browse/JP-2079)