### PR TITLE
JP-2081 remove unneeded wcs keywords from IFU Cube 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,7 +75,7 @@ cube_build
 - Fixed typo in cube_build_step spec for grating [#5839]
 - Update code to read in spectral and spatial size of exposure on the sky #5991
 - For calspec2 pipeline skip determining the dq plane in cube_build #5991
-
+- Remove certain WCS keywords that are irrelevant after cube_building. [#6032]
 datamodels
 ----------
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -374,7 +374,7 @@ class CubeBuildStep (Step):
             # remove certain WCS keywords that are irrelevant after combine data into IFUCubes
             for key in rm_keys:
                 if key in cube.meta.wcsinfo.instance:
-                    del cube.meta.wcsinfo.instance[key]            
+                    del cube.meta.wcsinfo.instance[key]
         if status_cube == 1:
             self.skip = True
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -362,10 +362,19 @@ class CubeBuildStep (Step):
         t1 = time.time()
         self.log.debug(f'Time to build all cubes {t1-t0}')
 
+        # irrelevant WCS keywords we will remove from final product
+        rm_keys = ['v2_ref', 'v3_ref', 'ra_ref', 'dec_ref', 'roll_ref',
+                   'v3yangle', 'vparity']
+
         for cube in cube_container:
             footprint = cube.meta.wcs.footprint(axis_type="spatial")
             update_s_region_keyword(cube, footprint)
             cube.meta.filetype = '3d ifu cube'
+
+            # remove certain WCS keywords that are irrelevant after combine data into IFUCubes
+            for key in rm_keys:
+                if key in cube.meta.wcsinfo.instance:
+                    del cube.meta.wcsinfo.instance[key]            
         if status_cube == 1:
             self.skip = True
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6029 

Resolves [JP-2081](https://jira.stsci.edu/browse/JP-2081)

**Description**

This PR Removes unneeded WCS keywords from IFU cube output: ['v2_ref', 'v3_ref', 'ra_ref', 'dec_ref', 'roll_ref',
                   'v3yangle', 'vparity']


Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)