### PR TITLE
JP-1944: Resample error and variance arrays for imaging data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -192,6 +192,8 @@ resample
 
 - Remove certain WCS keywords that are irrelevant after resampling. [#5971]
 
+- Propgagate error and variance arrays in ``ResampleStep`` for imaging data. [#6036]
+
 source_catalog
 --------------
 

--- a/jwst/regtest/test_nirspec_ifu_spec3.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3.py
@@ -31,6 +31,7 @@ def run_spec3_multi(jail, rtdata_module):
     return rtdata
 
 
+@pytest.mark.slow
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'output',

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -84,14 +84,13 @@ class ResampleData:
         self.blank_output = datamodels.ImageModel(self.output_wcs.data_size)
 
         # update meta data and wcs
-        self.blank_output.update(input_models[0], only='PRIMARY')
-        self.blank_output.update(input_models[0], only='SCI')
+        self.blank_output.update(input_models[0])
         self.blank_output.meta.wcs = self.output_wcs
 
         self.output_models = datamodels.ModelContainer()
 
     def do_drizzle(self):
-        """Perform drizzling operation on input images's to create a new output
+        """Pick the correct drizzling mode based on self.single
         """
         if self.single:
             return self.resample_many_to_many()

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -90,18 +90,6 @@ class ResampleData:
 
         self.output_models = datamodels.ModelContainer()
 
-    # TODO: Following method is not used, and never has been.  Find out if needed
-    # def update_driz_outputs(self):
-    #     """ Define output arrays for use with drizzle operations.
-    #     """
-    #     numchips = len(self.input_models)
-    #     numplanes = (numchips // 32) + 1
-
-    #     # Replace CONTEXT array with full set of planes needed for all inputs
-    #     outcon = np.zeros((numplanes, self.output_wcs.data_size[0],
-    #                        self.output_wcs.data_size[1]), dtype=np.int32)
-    #     self.blank_output.con = outcon
-
     def do_drizzle(self):
         """Perform drizzling operation on input images's to create a new output
         """

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -1,8 +1,6 @@
 import logging
 import re
 
-import numpy as np
-
 from . import gwcs_drizzle
 from . import resample_utils
 from .. import datamodels
@@ -75,8 +73,9 @@ class ResampleData:
         )
         if not can_allocate:
             raise OutputTooLargeError(
-                f'Combined ImageModel size {self.output_wcs.data_size} requires {bytes2human(required_memory)}'
-                f'\nModel cannot be instantiated.'
+                f'Combined ImageModel size {self.output_wcs.data_size} '
+                f'requires {bytes2human(required_memory)}. '
+                f'Model cannot be instantiated.'
             )
         self.blank_output = datamodels.ImageModel(self.output_wcs.data_size)
 
@@ -87,84 +86,25 @@ class ResampleData:
 
         self.output_models = datamodels.ModelContainer()
 
-    def update_driz_outputs(self):
-        """ Define output arrays for use with drizzle operations.
-        """
-        numchips = len(self.input_models)
-        numplanes = (numchips // 32) + 1
+    # TODO: Following method is not used, and never has been.  Find out if needed
+    # def update_driz_outputs(self):
+    #     """ Define output arrays for use with drizzle operations.
+    #     """
+    #     numchips = len(self.input_models)
+    #     numplanes = (numchips // 32) + 1
 
-        # Replace CONTEXT array with full set of planes needed for all inputs
-        outcon = np.zeros((numplanes, self.output_wcs.data_size[0],
-                           self.output_wcs.data_size[1]), dtype=np.int32)
-        self.blank_output.con = outcon
+    #     # Replace CONTEXT array with full set of planes needed for all inputs
+    #     outcon = np.zeros((numplanes, self.output_wcs.data_size[0],
+    #                        self.output_wcs.data_size[1]), dtype=np.int32)
+    #     self.blank_output.con = outcon
 
     def do_drizzle(self):
-        """ Perform drizzling operation on input images's to create a new output
+        """Perform drizzling operation on input images's to create a new output
         """
-        # Look for input configuration parameter telling the code to run
-        # in single-drizzle mode (mosaic all detectors in a single observation)
         if self.single:
-            driz_outputs = self.input_models.group_names
-            exposures = self.input_models.models_grouped
-            group_exptime = []
-            for exposure in exposures:
-                group_exptime.append(exposure[0].meta.exposure.exposure_time)
+            return self.resample_many_to_many()
         else:
-            driz_outputs = [self.output_filename]
-            exposures = [self.input_models]
-
-            total_exposure_time = 0.0
-            for exposure in exposures:
-                total_exposure_time += exposure[0].meta.exposure.exposure_time
-            group_exptime = [total_exposure_time]
-        pointings = len(self.input_models.group_names)
-
-        for obs_product, exposure, texptime in zip(driz_outputs, exposures,
-                                                   group_exptime):
-            output_model = self.blank_output.copy()
-            output_model.meta.filename = obs_product
-
-            if self.blendheaders:
-                self.blend_output_metadata(output_model)
-
-            exposure_times = {'start': [], 'end': []}
-
-            # Initialize the output with the wcs
-            driz = gwcs_drizzle.GWCSDrizzle(output_model,
-                                            pixfrac=self.pixfrac,
-                                            kernel=self.kernel,
-                                            fillval=self.fillval)
-
-            for n, img_exp in enumerate(exposure):
-                # Make a copy as this is operated on in-place below
-                img = img_exp.copy()
-                exposure_times['start'].append(img.meta.exposure.start_time)
-                exposure_times['end'].append(img.meta.exposure.end_time)
-
-                # apply sky subtraction
-                blevel = img.meta.background.level
-                if not img.meta.background.subtracted and blevel is not None:
-                    img.data -= blevel
-
-                inwht = resample_utils.build_driz_weight(img,
-                                                         weight_type=self.weight_type,
-                                                         good_bits=self.good_bits)
-                driz.add_image(img.data, img.meta.wcs, inwht=inwht,
-                               expin=img.meta.exposure.exposure_time)
-
-            # Update some basic exposure time values based on all the inputs
-            output_model.meta.exposure.exposure_time = texptime
-            output_model.meta.exposure.start_time = min(exposure_times['start'])
-            output_model.meta.exposure.end_time = max(exposure_times['end'])
-            output_model.meta.resample.product_exposure_time = texptime
-            output_model.meta.resample.weight_type = self.weight_type
-            output_model.meta.resample.pointings = pointings
-
-            self.update_fits_wcs(output_model)
-
-            self.output_models.append(output_model)
-
-        return self.output_models
+            return self.resample_many_to_one()
 
     def blend_output_metadata(self, output_model):
         """Create new output metadata based on blending all input metadata."""
@@ -174,6 +114,90 @@ class ResampleData:
         log.info('Blending metadata for {}'.format(output_file))
         blendmeta.blendmodels(output_model, inputs=self.input_models,
                               output=output_file)
+
+    def resample_many_to_many(self):
+        """Resample many inputs to many outputs where outputs have a common frame.
+
+        Coadd only different detectors of the same exposure, i.e. map NRCA5 and
+        NRCB5 onto the same output image, as they image different areas of the
+        sky.
+
+        Used for outlier detection
+        """
+        for exposure in self.input_models.models_grouped:
+            output_model = self.blank_output.copy()
+            output_model.update(exposure, only="PRIMARY")
+
+            # Initialize the output with the wcs
+            driz = gwcs_drizzle.GWCSDrizzle(output_model, pixfrac=self.pixfrac,
+                                            kernel=self.kernel, fillval=self.fillval)
+            for img in exposure:
+                # TODO: should weight_type=None here?
+                inwht = resample_utils.build_driz_weight(img, weight_type=self.weight_type,
+                                                         good_bits=self.good_bits)
+                # apply sky subtraction
+                blevel = img.meta.background.level
+                if not img.meta.background.subtracted and blevel is not None:
+                    data = img.data - blevel
+                else:
+                    data = img.data
+
+                driz.add_image(data, img.meta.wcs, inwht=inwht)
+
+            self.output_models.append(output_model)
+
+        return self.output_models
+
+    def resample_many_to_one(self):
+        """Resample and coadd many inputs to a single output.
+
+        Used for stage 3 resampling
+        """
+        output_model = self.blank_output.copy()
+        output_model.meta.filename = self.output_filename
+        output_model.meta.resample.weight_type = self.weight_type
+        output_model.meta.resample.pointings = len(self.input_models.group_names)
+
+        if self.blendheaders:
+            self.blend_output_metadata(output_model)
+
+        # Initialize the output with the wcs
+        driz = gwcs_drizzle.GWCSDrizzle(output_model, pixfrac=self.pixfrac,
+                                        kernel=self.kernel, fillval=self.fillval)
+
+        for img in self.input_models:
+            inwht = resample_utils.build_driz_weight(img,
+                                                     weight_type=self.weight_type,
+                                                     good_bits=self.good_bits)
+            # apply sky subtraction
+            blevel = img.meta.background.level
+            if not img.meta.background.subtracted and blevel is not None:
+                data = img.data - blevel
+            else:
+                data = img.data
+
+            driz.add_image(data, img.meta.wcs, inwht=inwht)
+
+        self.update_fits_wcs(output_model)
+        self.update_exposure_times(output_model)
+        self.output_models.append(output_model)
+
+        return self.output_models
+
+    def update_exposure_times(self, output_model):
+        """Modify exposure time metadata in-place"""
+        total_exposure_time = 0.
+        exposure_times = {'start': [], 'end': []}
+        for exposure in self.input_models.models_grouped:
+            total_exposure_time += exposure[0].meta.exposure.exposure_time
+            exposure_times['start'].append(exposure[0].meta.exposure.start_time)
+            exposure_times['end'].append(exposure[0].meta.exposure.end_time)
+
+        # Update some basic exposure time values based on output_model
+        output_model.meta.exposure.exposure_time = total_exposure_time
+        output_model.meta.exposure.start_time = min(exposure_times['start'])
+        output_model.meta.exposure.end_time = max(exposure_times['end'])
+        output_model.meta.resample.product_exposure_time = total_exposure_time
 
     def update_fits_wcs(self, model):
         """

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -1,6 +1,10 @@
 import logging
 import re
 
+import numpy as np
+from drizzle import util
+from drizzle import cdrizzle
+
 from . import gwcs_drizzle
 from . import resample_utils
 from .. import datamodels
@@ -178,11 +182,60 @@ class ResampleData:
 
             driz.add_image(data, img.meta.wcs, inwht=inwht)
 
+        # Resample variances array in self.input_models to output_model
+        self.resample_variance_array("var_rnoise", output_model)
+        self.resample_variance_array("var_poisson", output_model)
+        self.resample_variance_array("var_flat", output_model)
+        output_model.err = np.sqrt(output_model.var_rnoise + output_model.var_poisson
+                                   + output_model.var_flat)
+
         self.update_fits_wcs(output_model)
         self.update_exposure_times(output_model)
         self.output_models.append(output_model)
 
         return self.output_models
+
+    def resample_variance_array(self, name, output_model):
+        """Resample variance arrays from self.input_models to the output_model
+
+        Loop through self.input_models and resampled the `name` variance array
+        to the same name in output_model.  This modifies output_model in-place.
+        """
+        outwht = np.zeros_like(output_model.data)
+        outcon = np.zeros_like(output_model.con)
+        output_wcs = output_model.meta.wcs
+        output_arrays = []
+
+        for model in self.input_models:
+            # Unity weight but ignore pixels that are NON_SCIENCE or REFERENCE_PIXEL
+            inwht = resample_utils.build_driz_weight(model, weight_type=None,
+                                                     good_bits="~NON_SCIENCE+REFERENCE_PIXEL")
+            input_array = getattr(model, name)
+            output_array = np.zeros_like(output_model.data)
+
+            # Resample the variance array
+            self.drizzle_arrays(input_array, inwht, model.meta.wcs,
+                                output_wcs, output_array, outwht, outcon,
+                                pixfrac=self.pixfrac, kernel=self.kernel,
+                                fillval=np.nan)
+            output_arrays.append(output_array)
+
+        # Stack and coadd as inverse variance if there any to stack
+        if len(output_arrays) > 1:
+            stacked = np.stack(output_arrays)
+            with np.errstate(divide="ignore"):
+                inv_var = np.reciprocal(stacked)
+            inv_var[~np.isfinite(inv_var)] = np.nan
+
+            inv_var_mean = np.nanmean(inv_var, axis=0)
+
+            with np.errstate(divide="ignore"):
+                output_err_array = np.reciprocal(inv_var_mean)
+        else:
+            output_err_array = output_arrays[0]
+        output_err_array[~np.isfinite(output_err_array)] = np.nan
+
+        setattr(output_model, name, output_err_array)
 
     def update_exposure_times(self, output_model):
         """Modify exposure time metadata in-place"""
@@ -198,6 +251,169 @@ class ResampleData:
         output_model.meta.exposure.start_time = min(exposure_times['start'])
         output_model.meta.exposure.end_time = max(exposure_times['end'])
         output_model.meta.resample.product_exposure_time = total_exposure_time
+
+    @staticmethod
+    def drizzle_arrays(insci, inwht, input_wcs, output_wcs, outsci, outwht, outcon,
+                       uniqid=1, xmin=0, xmax=0, ymin=0, ymax=0,
+                       pixfrac=1.0, kernel='square', fillval="INDEF"):
+        """
+        Low level routine for performing 'drizzle' operation on one image.
+
+        The interface is compatible with STScI code. All images are Python
+        ndarrays, instead of filenames. File handling (input and output) is
+        performed by the calling routine.
+
+        Parameters
+        ----------
+
+        insci : 2d array
+            A 2d numpy array containing the input image to be drizzled.
+
+        inwht : 2d array
+            A 2d numpy array containing the pixel by pixel weighting.
+            Must have the same dimensions as insci. If none is supplied,
+            the weghting is set to one.
+
+        input_wcs : gwcs.WCS object
+            The world coordinate system of the input image.
+
+        output_wcs : gwcs.WCS object
+            The world coordinate system of the output image.
+
+        outsci : 2d array
+            A 2d numpy array containing the output image produced by
+            drizzling. On the first call it should be set to zero.
+            Subsequent calls it will hold the intermediate results.  This
+            is modified in-place.
+
+        outwht : 2d array
+            A 2d numpy array containing the output counts. On the first
+            call it should be set to zero. On subsequent calls it will
+            hold the intermediate results.  This is modified in-place.
+
+        outcon : 2d or 3d array, optional
+            A 2d or 3d numpy array holding a bitmap of which image was an input
+            for each output pixel. Should be integer zero on first call.
+            Subsequent calls hold intermediate results.  This is modified
+            in-place.
+
+        uniqid : int, optional
+            The id number of the input image. Should be one the first time
+            this function is called and incremented by one on each subsequent
+            call.
+
+        xmin : float, optional
+            This and the following three parameters set a bounding rectangle
+            on the input image. Only pixels on the input image inside this
+            rectangle will have their flux added to the output image. Xmin
+            sets the minimum value of the x dimension. The x dimension is the
+            dimension that varies quickest on the image. If the value is zero,
+            no minimum will be set in the x dimension. All four parameters are
+            zero based, counting starts at zero.
+
+        xmax : float, optional
+            Sets the maximum value of the x dimension on the bounding box
+            of the input image. If the value is zero, no maximum will
+            be set in the x dimension, the full x dimension of the output
+            image is the bounding box.
+
+        ymin : float, optional
+            Sets the minimum value in the y dimension on the bounding box. The
+            y dimension varies less rapidly than the x and represents the line
+            index on the input image. If the value is zero, no minimum  will be
+            set in the y dimension.
+
+        ymax : float, optional
+            Sets the maximum value in the y dimension. If the value is zero, no
+            maximum will be set in the y dimension,  the full x dimension
+            of the output image is the bounding box.
+
+        pixfrac : float, optional
+            The fraction of a pixel that the pixel flux is confined to. The
+            default value of 1 has the pixel flux evenly spread across the image.
+            A value of 0.5 confines it to half a pixel in the linear dimension,
+            so the flux is confined to a quarter of the pixel area when the square
+            kernel is used.
+
+        kernel: str, optional
+            The name of the kernel used to combine the input. The choice of
+            kernel controls the distribution of flux over the kernel. The kernel
+            names are: "square", "gaussian", "point", "tophat", "turbo", "lanczos2",
+            and "lanczos3". The square kernel is the default.
+
+        fillval: str, optional
+            The value a pixel is set to in the output if the input image does
+            not overlap it. The default value of INDEF does not set a value.
+
+        Returns
+        -------
+        A tuple with three values: a version string, the number of pixels
+        on the input image that do not overlap the output image, and the
+        number of complete lines on the input image that do not overlap the
+        output input image.
+
+        """
+
+        # Insure that the fillval parameter gets properly interpreted for use with tdriz
+        if util.is_blank(str(fillval)):
+            fillval = 'INDEF'
+        else:
+            fillval = str(fillval)
+
+        if (insci.dtype > np.float32):
+            insci = insci.astype(np.float32)
+
+        # Add input weight image if it was not passed in
+        if inwht is None:
+            inwht = np.ones_like(insci)
+
+        if xmax is None or xmax == xmin:
+            xmax = insci.shape[1]
+        if ymax is None or ymax == ymin:
+            ymax = insci.shape[0]
+
+        # Compute what plane of the context image this input would
+        # correspond to:
+        planeid = int((uniqid - 1) / 32)
+
+        # Check if the context image has this many planes
+        if outcon.ndim == 3:
+            nplanes = outcon.shape[0]
+        elif outcon.ndim == 2:
+            nplanes = 1
+        else:
+            nplanes = 0
+
+        if nplanes <= planeid:
+            raise IndexError("Not enough planes in drizzle context image")
+
+        # Alias context image to the requested plane if 3d
+        if outcon.ndim == 3:
+            outcon = outcon[planeid]
+
+        # Compute the mapping between the input and output pixel coordinates
+        # for use in drizzle.cdrizzle.tdriz
+        pixmap = resample_utils.calc_gwcs_pixmap(input_wcs, output_wcs, insci.shape)
+
+        log.debug(f"Pixmap shape: {pixmap[:,:,0].shape}")
+        log.debug(f"Input Sci shape: {insci.shape}")
+        log.debug(f"Output Sci shape: {outsci.shape}")
+
+        log.info(f"Drizzling {insci.shape} --> {outsci.shape}")
+
+        _vers, _nmiss, _nskip = cdrizzle.tdriz(
+            insci, inwht, pixmap,
+            outsci, outwht, outcon,
+            uniqid=uniqid,
+            xmin=xmin, xmax=xmax,
+            ymin=ymin, ymax=ymax,
+            pixfrac=pixfrac,
+            kernel=kernel,
+            in_units="cps",
+            expscale=1.0,
+            wtscale=1.0,
+            fillstr=fillval
+        )
 
     def update_fits_wcs(self, model):
         """

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -118,7 +118,6 @@ class ResampleData:
         """
         for exposure in self.input_models.models_grouped:
             output_model = self.blank_output.copy()
-            output_model.update(exposure, only="PRIMARY")
 
             # Initialize the output with the wcs
             driz = gwcs_drizzle.GWCSDrizzle(output_model, pixfrac=self.pixfrac,

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -185,7 +185,7 @@ class ResampleData:
     def resample_variance_array(self, name, output_model):
         """Resample variance arrays from self.input_models to the output_model
 
-        Loop through self.input_models and resampled the `name` variance array
+        Loop through self.input_models and resample the `name` variance array
         to the same name in output_model.  This modifies output_model in-place.
         """
         outwht = np.zeros_like(output_model.data)

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -83,8 +83,6 @@ class ResampleStep(Step):
             util.update_s_region_imaging(model)
             model.meta.asn.pool_name = input_models.meta.pool_name
             model.meta.asn.table_name = input_models.meta.table_name
-            if hasattr(model.meta, "bunit_err") and model.meta.bunit_err is not None:
-                del model.meta.bunit_err
             self.update_phot_keywords(model)
             model.meta.filetype = 'resampled'
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Addresses #5798 / [JP-1944](https://jira.stsci.edu/browse/JP-1944)

**Description**

This PR adds resampled variance and error arrays for imaging data run through `resample`.  The new error arrays in the resampled `i2d` files have the same names as in the `cal` files:

 - `ERR`
 - `VAR_RNOISE`
 - `VAR_POISSON`
 - `VAR_FLAT`

This PR also:

 - Refactors `ResampleData` to split out the processing of `single` resampling, which is used for `outlier_detection` from the case used in stage2 and stage3 `ResampleStep`, where 1 or more inputs get resampled to a single output.
 - Fixes a bug in the computation of total effective exposure time.
 - Removes unused `ResampleData.update_driz_outputs` method (it's never been used as far back as we've been on Github)
 - Marks the NIRSpec IFU regtest as `slow`, same as the other IFU `cube_build` tests.

Expected results of this PR in the regression tests are:
 - Lots of new ERR and VAR_* arrays.
 - New `EFFEXPTM` and `TEXPTIME` keyword values (tripled or quadrupled depending on the dataset).

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
