### PR TITLE
JP-2084: Add a regression test for aligning to GAIA

### DIFF
--- a/jwst/regtest/test_nircam_align_to_gaia.py
+++ b/jwst/regtest/test_nircam_align_to_gaia.py
@@ -1,5 +1,4 @@
 import pytest
-from astropy.io.fits.diff import FITSDiff
 from gwcs.wcstools import grid_from_bounding_box
 from numpy.testing import assert_allclose
 

--- a/jwst/regtest/test_nircam_align_to_gaia.py
+++ b/jwst/regtest/test_nircam_align_to_gaia.py
@@ -1,0 +1,46 @@
+import pytest
+from astropy.io.fits.diff import FITSDiff
+from gwcs.wcstools import grid_from_bounding_box
+from numpy.testing import assert_allclose
+
+from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
+from jwst.stpipe import Step
+from jwst import datamodels
+
+
+@pytest.fixture(scope="module")
+def run_image3pipeline(rtdata_module, jail):
+    ''' Run calwebb_image3 on NIRCam imaging and align to gaia '''
+
+    collect_pipeline_cfgs("config")
+
+    rtdata = rtdata_module
+    rtdata.get_asn("nircam/image/level3_F277W_3img_asn.json")
+    args = ["config/calwebb_image3.cfg", rtdata.input,
+            "--steps.tweakreg.align_to_gaia=True",
+            "--steps.tweakreg.save_results=True",
+            "--steps.tweakreg.output_use_model=True"
+            ]
+    Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("root", ["jw01069002001_01101_00001",
+                                  "jw01069002003_01101_00009",
+                                  "jw01069002004_01101_00013"])
+def test_tweakreg_with_gaia(run_image3pipeline, rtdata_module, root):
+    """ Test that WCS object works as expected """
+    rtdata = rtdata_module
+    rtdata.input = root + "_nrca5_cal.fits"
+    output_crf = root + "_nrca5_a3001_crf.fits"
+    rtdata.output = output_crf
+    rtdata.get_truth("truth/test_nircam_align_to_gaia/" + output_crf)
+
+    with datamodels.open(rtdata.output) as model, datamodels.open(rtdata.truth) as model_truth:
+        grid = grid_from_bounding_box(model.meta.wcs.bounding_box)
+
+        ra, dec = model.meta.wcs(*grid)
+        ra_truth, dec_truth = model_truth.meta.wcs(*grid)
+
+        assert_allclose(ra, ra_truth)
+        assert_allclose(dec, dec_truth)


### PR DESCRIPTION
Closes https://github.com/spacetelescope/jwst/issues/6034
Resolves [JP-2084](https://jira.stsci.edu/browse/JP-2084)

This is a follow-on to changes in downstream packages that fix #5455 

Dataset is the LMC calibration field, simulated in `mirage`.