### PR TITLE
JP-1944: Resample error and variance arrays for 2D spectral data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -192,7 +192,9 @@ resample
 
 - Remove certain WCS keywords that are irrelevant after resampling. [#5971]
 
-- Propgagate error and variance arrays in ``ResampleStep`` for imaging data. [#6036]
+- Propagate error and variance arrays in ``ResampleStep`` for imaging data. [#6036]
+
+- Propagate error and variance arrays in ``ResampleSpecStep`` for 2D spectral data [#6041]
 
 source_catalog
 --------------

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -101,12 +101,6 @@ class ResampleSpecStep(ResampleStep):
                 model.meta.cal_step.resample = "COMPLETE"
                 model.meta.asn.pool_name = input_models.meta.pool_name
                 model.meta.asn.table_name = input_models.meta.table_name
-
-                # Delete the BUNIT keyword for the ERR extension, so that datamodels
-                # doesn't create an empty ERR extension (just for that keyword)
-                if hasattr(model.meta, "bunit_err") and model.meta.bunit_err is not None:
-                    del model.meta.bunit_err
-
                 update_s_region_spectral(model)
 
             # Everything resampled to single output model
@@ -139,28 +133,12 @@ class ResampleSpecStep(ResampleStep):
 
         resamp = resample_spec.ResampleSpecData(input_models, **self.drizpars)
 
-        # Only drizzle the area within the bounding box
-        if input_models[0].meta.exposure.type == "MIR_LRS-FIXEDSLIT":
-            bb = input_models[0].meta.wcs.bounding_box
-            ((x1, x2), (y1, y2)) = bb
-            xmin = int(min(x1, x2))
-            ymin = int(min(y1, y2))
-            xmax = int(max(x1, x2))
-            ymax = int(max(y1, y2))
-            drizzled_models = resamp.do_drizzle(xmin=xmin, xmax=xmax,
-                                                ymin=ymin, ymax=ymax)
-        else:
-            drizzled_models = resamp.do_drizzle()
+        drizzled_models = resamp.do_drizzle()
 
         result = drizzled_models[0]
         result.meta.cal_step.resample = "COMPLETE"
         result.meta.asn.pool_name = input_models.meta.pool_name
         result.meta.asn.table_name = input_models.meta.table_name
-
-        # Delete BUNIT keyword for ERR extension to prevent datamodels from
-        # creating an empty ERR extension (just for the keyword)
-        if hasattr(result.meta, "bunit_err") and result.meta.bunit_err is not None:
-            del result.meta.bunit_err
 
         update_s_region_spectral(result)
         result.meta.bunit_data = drizzled_models[0].meta.bunit_data

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -89,13 +89,6 @@ class ResampleStep(Step):
         if len(result) == 1:
             result = result[0]
 
-        # remove irrelevant WCS keywords
-        rm_keys = ['v2_ref', 'v3_ref', 'ra_ref', 'dec_ref', 'roll_ref',
-                   'v3yangle', 'vparity']
-        for key in rm_keys:
-            if key in result.meta.wcsinfo.instance:
-                del result.meta.wcsinfo.instance[key]
-
         return result
 
     def update_phot_keywords(self, model):

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -383,8 +383,8 @@ def test_build_interpolated_output_wcs(miri_rate_pair):
 
 
 def test_wcs_keywords(nircam_rate):
-    # make sure certain wcs keywords are removed after resample
-
+    """Make sure certain wcs keywords are removed after resample
+    """
     im = AssignWcsStep.call(nircam_rate)
     result = ResampleStep.call(im)
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Resolves #5798 / [JP-1944](https://jira.stsci.edu/browse/JP-1944)

**Description**

This PR adds resampled variance and error arrays for spectral data run through `resample_spec`.  The new error arrays in the resampled `s2d` files have the same names as in the `cal` files:

 - `ERR`
 - `VAR_RNOISE`
 - `VAR_POISSON`
 - `VAR_FLAT`

This PR also:

 - Makes the calling of drizzle from `ResampleStep` and `ResampleSpecStep` much more similar.
 - Use the refactored code already implemented in `ResampleData` by subclassing it for `ResampleSpecData`.  In a future PR, we will get rid of `ResampleSpecData` altogether and have spectral/imaging differences handled at the top level by the `Step` code.
 - No longer delete `bunit_err`.  We need it.

This branch contains all the changes from #6036, so that should be merged first and this rebased.  Reviewers feel free to hold off until the other is merged and this is rebased.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
