### PR TITLE
JP-2087: Updates for JWST_XYZ keyword changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,11 @@ datamodels
 - Added ``FULLP`` to SUBARRAY enum list in core, subarray,
   and keyword_psubarray schemas [#5947]
 
+- Moved JWST_[XYZ] and JWST_[DXDYDZ] keywords from primary to SCI extension
+  header and updated their comment fields to indicate they'll now be in the
+  barycentric frame. Also added the new OBSGEO[XYZ] keywords to the SCI
+  extension header, which are in the geocentric frame. [#6050]
+
 documentation
 -------------
 
@@ -155,6 +160,9 @@ lib
 - moved ``basic_utils.multiple_replace`` to stcal. [#5898]
 
 - Implemented window clipping algorithm for WFSS contamination corrections. [#5978]
+
+- Updated ``set_velocity_aberration`` and ``utc_to_tdb`` to access the JWST position
+  and velocity keywords from the SCI extension header, rather than the primary header. [#6050]
 
 master_background
 -----------------

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1234,46 +1234,91 @@ properties:
             title: Ephemeris reference frame
             type: string
             fits_keyword: REFFRAME
+            fits_hdu: SCI
             blend_table: True
           type:
             title: Definitive or Predicted
             type: string
             fits_keyword: EPH_TYPE
+            fits_hdu: SCI
             blend_table: True
           time:
             title: UTC time of position and velocity vectors in ephemeris (MJD)
             type: number
             fits_keyword: EPH_TIME
+            fits_hdu: SCI
             blend_table: True
-          spatial_x:
-            title: "[km] X spatial coordinate of JWST"
+          spatial_x_bary:
+            title: "[km] barycentric JWST X coordinate at MJD_AVG"
             type: number
             fits_keyword: JWST_X
+            fits_hdu: SCI
             blend_table: True
-          spatial_y:
-            title: "[km] Y spatial coordinate of JWST"
+          spatial_y_bary:
+            title: "[km] barycentric JWST Y coordinate at MJD_AVG"
             type: number
             fits_keyword: JWST_Y
+            fits_hdu: SCI
             blend_table: True
-          spatial_z:
-            title: "[km] Z spatial coordinate of JWST"
+          spatial_z_bary:
+            title: "[km] barycentric JWST Z coordinate at MJD_AVG"
             type: number
             fits_keyword: JWST_Z
+            fits_hdu: SCI
             blend_table: True
-          velocity_x:
-            title: "[km/s] X component of JWST velocity"
+          spatial_x_geo:
+            title: "[m] geocentric JWST X coordinate at MJD_AVG"
+            type: number
+            fits_keyword: OBSGEO-X
+            fits_hdu: SCI
+            blend_table: True
+          spatial_y_geo:
+            title: "[m] geocentric JWST Y coordinate at MJD_AVG"
+            type: number
+            fits_keyword: OBSGEO-Y
+            fits_hdu: SCI
+            blend_table: True
+          spatial_z_geo:
+            title: "[m] geocentric JWST Z coordinate at MJD_AVG"
+            type: number
+            fits_keyword: OBSGEO-Z
+            fits_hdu: SCI
+            blend_table: True
+          velocity_x_bary:
+            title: "[km/s] barycentric JWST X velocity at MJD_AVG"
             type: number
             fits_keyword: JWST_DX
+            fits_hdu: SCI
             blend_table: True
-          velocity_y:
-            title: "[km/s] Y component of JWST velocity"
+          velocity_y_bary:
+            title: "[km/s] barycentric JWST Y velocity at MJD_AVG"
             type: number
             fits_keyword: JWST_DY
+            fits_hdu: SCI
             blend_table: True
-          velocity_z:
-            title: "[km/s] Z component of JWST velocity"
+          velocity_z_bary:
+            title: "[km/s] barycentric JWST Z velocity at MJD_AVG"
             type: number
             fits_keyword: JWST_DZ
+            fits_hdu: SCI
+            blend_table: True
+          velocity_x_geo:
+            title: "[m/s] geocentric JWST X velocity at MJD_AVG"
+            type: number
+            fits_keyword: OBSGEODX
+            fits_hdu: SCI
+            blend_table: True
+          velocity_y_geo:
+            title: "[m/s] geocentric JWST Y velocity at MJD_AVG"
+            type: number
+            fits_keyword: OBSGEODY
+            fits_hdu: SCI
+            blend_table: True
+          velocity_z_geo:
+            title: "[m/s] geocentric JWST Z velocity at MJD_AVG"
+            type: number
+            fits_keyword: OBSGEODZ
+            fits_hdu: SCI
             blend_table: True
       aperture:
         title: Aperture information

--- a/jwst/lib/set_velocity_aberration.py
+++ b/jwst/lib/set_velocity_aberration.py
@@ -96,9 +96,9 @@ def add_dva(filename):
 
     # compute the velocity aberration information
     scale_factor, apparent_ra, apparent_dec = compute_va_effects(
-        velocity_x=pheader['JWST_DX'],
-        velocity_y=pheader['JWST_DY'],
-        velocity_z=pheader['JWST_DZ'],
+        velocity_x=sheader['JWST_DX'],
+        velocity_y=sheader['JWST_DY'],
+        velocity_z=sheader['JWST_DZ'],
         ra=sheader['RA_REF'],
         dec=sheader['DEC_REF']
     )

--- a/jwst/lib/tests/test_utc_to_tdb.py
+++ b/jwst/lib/tests/test_utc_to_tdb.py
@@ -16,12 +16,12 @@ def data_file():
     model.meta.target.ra = 0.
     model.meta.target.dec = 0.
     model.meta.ephemeris.time = 55727.0
-    model.meta.ephemeris.spatial_x = -34305.4075983316
-    model.meta.ephemeris.spatial_y = 1049528.04998405
-    model.meta.ephemeris.spatial_z = 679175.58185602
-    model.meta.ephemeris.velocity_x = -0.548663244644384
-    model.meta.ephemeris.velocity_y = -0.103904924724239
-    model.meta.ephemeris.velocity_z = 0.000982870964178323
+    model.meta.ephemeris.spatial_x_bary = -34305.4075983316
+    model.meta.ephemeris.spatial_y_bary = 1049528.04998405
+    model.meta.ephemeris.spatial_z_bary = 679175.58185602
+    model.meta.ephemeris.velocity_x_bary = -0.548663244644384
+    model.meta.ephemeris.velocity_y_bary = -0.103904924724239
+    model.meta.ephemeris.velocity_z_bary = 0.000982870964178323
 
     # Assign dummy values to the last three columns.
     model.int_times = \
@@ -42,17 +42,17 @@ def test_utc_to_tdb(data_file):
 
     model = datamodels.open(data_file)
     assert np.isclose(model.meta.ephemeris.time, 55727.0, rtol=1.e-10)
-    assert np.isclose(model.meta.ephemeris.spatial_x, -34305.4075983316,
+    assert np.isclose(model.meta.ephemeris.spatial_x_bary, -34305.4075983316,
                       rtol=1.e-10)
-    assert np.isclose(model.meta.ephemeris.spatial_y, 1049528.04998405,
+    assert np.isclose(model.meta.ephemeris.spatial_y_bary, 1049528.04998405,
                       rtol=1.e-10)
-    assert np.isclose(model.meta.ephemeris.spatial_z, 679175.58185602,
+    assert np.isclose(model.meta.ephemeris.spatial_z_bary, 679175.58185602,
                       rtol=1.e-10)
-    assert np.isclose(model.meta.ephemeris.velocity_x, -0.548663244644384,
+    assert np.isclose(model.meta.ephemeris.velocity_x_bary, -0.548663244644384,
                       rtol=1.e-10)
-    assert np.isclose(model.meta.ephemeris.velocity_y, -0.103904924724239,
+    assert np.isclose(model.meta.ephemeris.velocity_y_bary, -0.103904924724239,
                       rtol=1.e-10)
-    assert np.isclose(model.meta.ephemeris.velocity_z, 0.000982870964178323,
+    assert np.isclose(model.meta.ephemeris.velocity_z_bary, 0.000982870964178323,
                       rtol=1.e-10)
     # These are the last three columns.
     start_tdb = model.int_times['int_start_BJD_TDB']

--- a/jwst/lib/tests/test_velocity_aberration.py
+++ b/jwst/lib/tests/test_velocity_aberration.py
@@ -34,9 +34,9 @@ def test_velocity_aberration_script(tmpdir):
     """Test the whole script on a FITS file"""
     path = str(tmpdir.join("velocity_aberration_tmpfile.fits"))
     hdulist = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(name='SCI')])
-    hdulist[0].header['JWST_DX'] = GOOD_VELOCITY[0]
-    hdulist[0].header['JWST_DY'] = GOOD_VELOCITY[1]
-    hdulist[0].header['JWST_DZ'] = GOOD_VELOCITY[2]
+    hdulist['SCI'].header['JWST_DX'] = GOOD_VELOCITY[0]
+    hdulist['SCI'].header['JWST_DY'] = GOOD_VELOCITY[1]
+    hdulist['SCI'].header['JWST_DZ'] = GOOD_VELOCITY[2]
     hdulist['SCI'].header['RA_REF'] = GOOD_POS[0]
     hdulist['SCI'].header['DEC_REF'] = GOOD_POS[1]
     hdulist.writeto(path)

--- a/jwst/lib/utc_to_tdb.py
+++ b/jwst/lib/utc_to_tdb.py
@@ -307,15 +307,15 @@ def compute_bary_helio_time2(targetcoord, times, jwstpos,
 def get_jwst_keywords(fd):
 
     # TT MJD time at which JWST has position jwst_pos and velocity jwst_vel.
-    eph_time = to_tt(fd[0].header['eph_time'])
+    eph_time = to_tt(fd['SCI'].header['eph_time'])
 
-    jwst_pos = np.array((fd[0].header['jwst_x'],
-                         fd[0].header['jwst_y'],
-                         fd[0].header['jwst_z']), dtype=np.float64)
+    jwst_pos = np.array((fd['SCI'].header['jwst_x'],
+                         fd['SCI'].header['jwst_y'],
+                         fd['SCI'].header['jwst_z']), dtype=np.float64)
 
-    jwst_vel = np.array((fd[0].header['jwst_dx'],
-                         fd[0].header['jwst_dy'],
-                         fd[0].header['jwst_dz']), dtype=np.float64)
+    jwst_vel = np.array((fd['SCI'].header['jwst_dx'],
+                         fd['SCI'].header['jwst_dy'],
+                         fd['SCI'].header['jwst_dz']), dtype=np.float64)
 
     return(eph_time, jwst_pos, jwst_vel)
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6048 

Resolves [JP-2087](https://jira.stsci.edu/browse/JP-2087)

**Description**

This PR makes updates for recent changes in the KWD and SDP to the JWST position/velocity keywords, in particular the movement of the JWST_[XYZ] and JWST_[DXYZ] keywords from the primary header to the SCI extension header. Scripts that use these keywords have been updated to account for that change. The core datamodel schema has also been updated to move those keywords to the SCI header, and to add the new OBSGEO-xyz keywords. The OBSGEO-xyz keywords give the JWST position and velocity in the geocentric frame (in units of meters and meters/sec), while the old JWST_xyz keywords are being changed to give the position and velocity in the barycentric frame (in units of km and km/s). Note that the datamodel attribute names for all of the keywords have been modified, to distinguish between the bary and geo frames.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [X] Milestone
- [X] Label(s)