### PR TITLE
Fail CI if codecov upload fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,4 @@ jobs:
         with:
           file: ./coverage.xml
           flags: unit
+          fail_ci_if_error: true


### PR DESCRIPTION
This doesn't let codecov uploads fail silently.