### PR TITLE
Add --report-crds-context pytest option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,10 @@
 1.2.1 (unreleased)
 ==================
 
+general
+-------
 
-
-
+- Make CRDS context reporting pytest plugin disabled by default. [#6070]
 
 1.2.0 (2021-05-24)
 ==================

--- a/pytest_crds/plugin.py
+++ b/pytest_crds/plugin.py
@@ -1,6 +1,13 @@
-from stpipe.crds_client import get_context_used
+def pytest_addoption(parser):
+    parser.addoption("--report-crds-context", action="store_true",
+                     help="Report CRDS context in test suite header")
 
 
 def pytest_report_header(config):
     """Add CRDS_CONTEXT to pytest report header"""
-    return f"crds_context: {get_context_used('jwst')}"
+
+    if config.getoption("report_crds_context"):
+        from stpipe.crds_client import get_context_used
+        return f"crds_context: {get_context_used('jwst')}"
+    else:
+        return []

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,7 +129,7 @@ junit_family = xunit2
 inputs_root = jwst-pipeline
 results_root = jwst-pipeline-results
 text_file_format = rst
-addopts = --show-capture=no --open-files
+addopts = --show-capture=no --open-files --report-crds-context
 filterwarnings =
     ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning
 

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands_pre =
 changedir = {homedir}
 usedevelop = false
 commands =
-    pyargs: pytest {toxinidir}/docs --pyargs {posargs:jwst}
+    pyargs: pytest --report-crds-context {toxinidir}/docs --pyargs {posargs:jwst}
 
 [testenv:regtests]
 description = run tests with --bigdata and --slow flags

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands_pre =
 changedir = {homedir}
 usedevelop = false
 commands =
-    pyargs: pytest --report-crds-context {toxinidir}/docs --pyargs {posargs:jwst}
+    pyargs: pytest {toxinidir}/docs --pyargs {posargs:jwst}
 
 [testenv:regtests]
 description = run tests with --bigdata and --slow flags


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

This PR makes the CRDS context reporting pytest plugin disabled by default, to prevent errors in unrelated test suites when CRDS is not configured.


Checklist
- [ ] Tests

- [ ] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
