### PR TITLE
JP-2067: Add units to combine1d product table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ combine_1d
 - Added SRCTYPE to COMBINE1D output extension headers, propagated from
   EXTRACT1D inputs [#6079]
 
+- Added units to CombinedSpecModel table output [#6082]
+
 general
 -------
 

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -67,6 +67,8 @@ class InputSpectrumModel:
         self.declination = np.zeros_like(self.wavelength)
         self.source_id = spec.source_id
         self.source_type = spec.source_type
+        self.flux_unit = spec.spec_table.columns['flux'].unit
+        self.sb_unit = spec.spec_table.columns['surf_bright'].unit
 
         self.weight = np.ones_like(self.wavelength)
         if exptime_key == "integration_time":
@@ -128,6 +130,8 @@ class OutputSpectrumModel:
         self.wcs = None
         self.normalized = False
         self.source_id = None
+        self.flux_unit = None
+        self.sb_unit = None
 
     def assign_wavelengths(self, input_spectra):
         """Create an array of wavelengths to use for the output spectrum.
@@ -189,6 +193,9 @@ class OutputSpectrumModel:
         self.dq = np.zeros(nelem, dtype=dq_dtype)
         self.weight = np.zeros(nelem, dtype=np.float64)
         self.count = np.zeros(nelem, dtype=np.float64)
+
+        self.flux_unit = input_spectra[0].flux_unit
+        self.sb_unit = input_spectra[0].sb_unit
 
         n_nan = 0                                       # initial value
         ninputs = 0
@@ -282,6 +289,12 @@ class OutputSpectrumModel:
                                  self.weight,
                                  self.count)), dtype=cmb_dtype)
         output_model = datamodels.CombinedSpecModel(spec_table=data)
+
+        output_model.spec_table.columns['wavelength'].unit = 'um'
+        output_model.spec_table.columns['flux'].unit = self.flux_unit
+        output_model.spec_table.columns['error'].unit = self.flux_unit
+        output_model.spec_table.columns['surf_bright'].unit = self.sb_unit
+        output_model.spec_table.columns['sb_error'].unit = self.sb_unit
 
         return output_model
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6002 

Resolves [JP-2067](https://jira.stsci.edu/browse/JP-2067)

**Description**

This PR adds units to the CombinedSpecModel table output of the Combine1D step. Flux and SB units are checked from the input spectra, while wavelength units are set to um.


Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)