### PR TITLE
Fix ENGQLPTG value populated by set_telescope_pointing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@ general
 
 - Make CRDS context reporting pytest plugin disabled by default. [#6070]
 
+lib
+---
+
+- Updated set_telescope_pointing to populate ENGQLPTG keyword with new
+  allowed values [#6088]
+
 1.2.0 (2021-05-24)
 ==================
 
@@ -60,8 +66,6 @@ assign_wcs
 
 associations
 ------------
-
-- Asn_Lv2NRSLAMPSpectral: Allow msaspec only if msametfl is available. [#6085]
 
 - Add rule Asn_MIRMRSBackground to treat background as science. [#6046]
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -469,7 +469,7 @@ def update_wcs_from_telem(
         # compute relevant WCS information
         logger.info('Successful read of engineering quaternions:')
         logger.info('\tPointing = {}'.format(pointing))
-        model.meta.visit.engdb_pointing_quality = "CALCULATED"
+        model.meta.visit.engdb_pointing_quality = "CALCULATED_ORIGINAL"
         try:
             wcsinfo, vinfo = calc_wcs(pointing, siaf, **transform_kwargs)
             logger.info("Setting ENGQLPTG keyword to CALCULATED")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
This PR is a follow on to https://github.com/spacetelescope/jwst/pull/6081/ and JP-2106, which changed the allowed list of values for the ENGQLPTG keyword. The simple value "CALCULATED" is no longer allowed, so the set_telescope_pointing script is being updated to instead use the new allowed value of "CALCULATED_ORIGINAL".

Checklist
- [ ] Tests
- [ ] ~~Documentation~~
- [x] Change log
- [x] Milestone
- [x] Label(s)