### PR TITLE
JP-2068: Fix invalid ECSV test data headers

### DIFF
--- a/jwst/lib/tests/data/calc_deltas_truth.ecsv
+++ b/jwst/lib/tests/data/calc_deltas_truth.ecsv
@@ -1,7 +1,7 @@
 # %ECSV 0.9
 # ---
 # datatype:
-# - {name: exposure, datatype: object}
+# - {name: exposure, datatype: string}
 # - {name: target.ra, unit: deg, datatype: float64}
 # - {name: target.dec, unit: deg, datatype: float64}
 # - {name: v1.ra, unit: deg, datatype: float64}

--- a/jwst/lib/tests/data/v1_calc_truth.ecsv
+++ b/jwst/lib/tests/data/v1_calc_truth.ecsv
@@ -1,7 +1,7 @@
 # %ECSV 0.9
 # ---
 # datatype:
-# - {name: source, datatype: object}
+# - {name: source, datatype: string}
 # - {name: obstime, datatype: string}
 # - {name: ra, datatype: float64}
 # - {name: dec, datatype: float64}

--- a/jwst/lib/tests/test_v1_calculate.py
+++ b/jwst/lib/tests/test_v1_calculate.py
@@ -8,7 +8,7 @@ from astropy.table import Table
 from astropy.time import Time
 from astropy.utils.diff import report_diff_values
 
-import jwst.datamodels as dm
+from jwst.datamodels import ImageModel
 from jwst.lib import engdb_tools
 import jwst.lib.v1_calculate as v1c
 
@@ -25,13 +25,12 @@ GOOD_ENDTIME = '2016-01-19'
 def engdb():
     """Setup the service to operate through the mock service"""
     with EngDB_Mocker():
-        engdb = engdb_tools.ENGDB_Service()
-        yield engdb
+        yield engdb_tools.ENGDB_Service()
 
 
 def test_from_models(engdb):
     """Test v1_calculate_from_models for basic running"""
-    model = dm.ImageModel()
+    model = ImageModel()
     model.meta.exposure.start_time = Time(GOOD_STARTTIME).mjd
     model.meta.exposure.end_time = Time(GOOD_ENDTIME).mjd
 
@@ -39,7 +38,6 @@ def test_from_models(engdb):
     v1_formatted = v1c.simplify_table(v1_table)
 
     truth = Table.read(DATA_PATH / 'v1_calc_truth.ecsv')
-
     assert report_diff_values(truth, v1_formatted, fileobj=sys.stderr)
 
 
@@ -51,5 +49,4 @@ def test_over_tiome(engdb):
     v1_formatted = v1c.simplify_table(v1_table)
 
     truth = Table.read(DATA_PATH / 'v1_time_truth.ecsv')
-
     assert report_diff_values(truth, v1_formatted, fileobj=sys.stderr)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Resolves #6003 / [JP-2068](https://jira.stsci.edu/browse/JP-2068)

**Description**

This PR fixes 2 truth tables that have `dtype=object` in the ECSV headers.  That is apparently no longer allowed in astropy dev.  Changing it to `string` solves the problem.

The failing `Table.read()` call was also causing open file handle errors, which probably means that the internals of that function are not quite handling files correctly.  Will file an issue in `astropy` for both of these.

Also cleaned up reading of the FITS files with a context manager.  Apparently there is no `with` context manager for `Table.read`.

- [x] Tests
- [ ] ~Documentation~
- [ ] ~Change log~
- [x] Milestone
- [x] Label(s)