### PR TITLE
JP-2051: WFS combine align dithers and Update Refine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3781,6 +3781,11 @@ tweakreg
 wfs_combine
 -----------
 
+-- add option to flip the dither locations so that images with different
+   filters will have the same pixel locations [#2051]
+-- Fixed the refine option to correctly use the cross correlation to align
+   the images if the WCS is off [#2051]
+
 white_light
 -----------
 

--- a/docs/jwst/wfs_combine/arguments.rst
+++ b/docs/jwst/wfs_combine/arguments.rst
@@ -7,3 +7,21 @@ The ``wfs_combine`` step has one step-specific argument::
 
 If set to ``True``, the nominal image offsets computed from the WCS information are
 refined using image cross-correlation. See the algorithm description section for details.
+
+  --flip_dithers boolean default=True
+
+When set to True the output star in the combined image from the pairs of WFS images will
+always be at the same pixel location.
+
+  --psf_size float default=100
+
+The largest PSF size in pixels to use for the alignment. This is only used when do_refine==True.
+
+  --blur_size flost default=10
+
+The smoothing that is applied for the initial centroiding. his is only used when do_refine==True.
+
+  --n_size int default=2
+
+This controls the size of the box used to interpolate in the input images. Should never need to be
+changed.

--- a/docs/jwst/wfs_combine/main.rst
+++ b/docs/jwst/wfs_combine/main.rst
@@ -6,11 +6,19 @@ The input images are aligned with one another and then combined using a pixel
 replacement technique, described in detail below. The images are aligned to only the nearest
 integer pixel in each direction. No sub-pixel resampling is done.
 
+Due to the WFS dither patterns osscilating between two locations, the first image of the pair
+will oscillate between the two dither locations. Because the WSS software works in pixel space,
+we need to change which input image is "image 1" to get star to have the same pixel location in
+the output image. When the input parameter "flip_dithers" is set to True (the default)
+and the x offset between image 1 and image 2 is negative, the two images will be switched before
+any processing is performed.
+
 Algorithm
 ---------
-Creation of the output combined image is a three-step process: first the offsets between the images
-are computed, the offsets are used to shift image 2 to be in alignment with image 1, and finally
-the aligned data from the two images are combined.
+Creation of the output combined image is a three-step process: first the offsets between the
+images are computed using the World Coordinate System, then the offsets are used to shift
+image 2 to be in alignment with image 1, and finally the aligned data from the two images
+are combined.
 
 Computing Offsets
 ^^^^^^^^^^^^^^^^^
@@ -27,10 +35,12 @@ refined using a cross-correlation technique. The steps in the refinement are as 
    separately in the x and y axes, of all pixel values that are above 50% of the peak signal
    in the smoothed image.
 3. Create subarrays from image 1 and 2 centered on the computed source centroid.
-4. For a range of +/- 2 pixels on either side of the nominal offsets computed from the WCS info,
-   compute the cross-correlation between the two images.
-5. Use the pixel offsets corresponding to the cross-correlation minimum as delta offsets to add
-   to the nominal offsets computed from the WCS info.
+4. Create the cross-correlation image of the two input images.
+5. Find the peak intensity of the cross-correlation image and use this to determine the
+    refined offset.
+6. Use the find the difference between the cross-correlation pixel offsets and the WCS offsets.
+    Add these deltas to the nominal offsets computed from the WCS info to form the refined offsets.
+
 
 Creating the Combined Image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -5,6 +5,7 @@ from jwst.assign_wcs import AssignWcsStep
 from jwst.associations.asn_from_list import asn_from_list
 from jwst.wfs_combine import WfsCombineStep
 from jwst.wfs_combine import wfs_combine
+import astropy.modeling as modeling
 import numpy as np
 
 
@@ -26,11 +27,15 @@ def add_point_source(inarray, scale, xcen, ycen, sigx, sigy):
     for y in range(inarray.shape[0]):
         for x in range(inarray.shape[1]):
             outarray[y, x] = scale * gaussian2d(x, y, xcen, ycen, sigx, sigy)
+#            outarray[y, x] = modeling.functional_models.Gaussian2D(amplitude=scale,
+#                                                                   x_mean=xcen, y_mean=ycen,
+#                                                                   x_stddev=sigx, y_stddev=sigy)
     return outarray
 
 
 @pytest.fixture(scope="module")
-def wfs_association(tmp_path_factory, imsize=10):
+def wfs_association(tmp_path_factory):
+    imsize = 10
     tmp_path = tmp_path_factory.mktemp("wfs")
     im1 = datamodels.ImageModel((imsize, imsize))
     im1.meta.observation.exposure_number = 1

--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -14,7 +14,7 @@ SATURATED = datamodels.dqflags.pixel["SATURATED"]
 
 
 def gaussian(x, mu, sig):
-    return 1. /(np.sqrt(2 * np.pi) * sig) * np.exp(-np.power((x - mu) /sig, 2) /2)
+    return 1. / (np.sqrt(2 * np.pi) * sig) * np.exp(-np.power((x - mu) / sig, 2) / 2)
 
 
 def gaussian2d(x, y, mux, muy, sigx, sigy):
@@ -121,7 +121,7 @@ def test_create_combined(_jail, wfs_association,
 
 def test_shift_order_no_refine_no_flip(wfs_association):
     path_asn, path1, path2 = wfs_association
-    nircam_pixel_size = 0.031 /3600.
+    nircam_pixel_size = 0.031 / 3600.
     delta_pixel = 5
     with datamodels.open(path2) as im2:
         im2.meta.wcsinfo = {

--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -6,7 +6,6 @@ from jwst.associations.asn_from_list import asn_from_list
 from jwst.wfs_combine import WfsCombineStep
 from jwst.wfs_combine import wfs_combine
 import numpy as np
-from astropy.io import fits
 
 
 GOOD = datamodels.dqflags.pixel["GOOD"]
@@ -15,7 +14,7 @@ SATURATED = datamodels.dqflags.pixel["SATURATED"]
 
 
 def gaussian(x, mu, sig):
-    return 1./(np.sqrt(2 * np.pi) * sig) * np.exp(-np.power((x - mu)/sig, 2)/2)
+    return 1. /(np.sqrt(2 * np.pi) * sig) * np.exp(-np.power((x - mu) /sig, 2) /2)
 
 
 def gaussian2d(x, y, mux, muy, sigx, sigy):
@@ -122,7 +121,7 @@ def test_create_combined(_jail, wfs_association,
 
 def test_shift_order_no_refine_no_flip(wfs_association):
     path_asn, path1, path2 = wfs_association
-    nircam_pixel_size = 0.031/3600.
+    nircam_pixel_size = 0.031 /3600.
     delta_pixel = 5
     with datamodels.open(path2) as im2:
         im2.meta.wcsinfo = {
@@ -135,7 +134,7 @@ def test_shift_order_no_refine_no_flip(wfs_association):
         im2.save(path2)
     wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=False, flip_dithers=False, psf_size=50,
                               blur_size=10, n_size=2)
-    output_model = wfs.do_all
+    wfs.do_all
     assert wfs.input_1.meta.observation.exposure_number == '1'
     assert wfs.input_2.meta.observation.exposure_number == '2'
     assert wfs.off_x == abs(delta_pixel)
@@ -160,7 +159,7 @@ def test_shift_order_no_refine_with_flip(wfs_association):
         im2.save(path2)
     wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=False, flip_dithers=True, psf_size=50,
                               blur_size=10, n_size=2)
-    output_model = wfs.do_all
+    wfs.do_all
     wfs.input_1.close()
     wfs.input_2.close()
 #    assert wfs.input_1.meta.observation.exposure_number == '2'
@@ -223,7 +222,7 @@ def test_refine_no_error(wfs_association, xshift, yshift, xerror, yerror, flip_d
         im2.save(path2)
     wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=True, flip_dithers=flip_dithers, psf_size=50,
                               blur_size=10, n_size=2)
-    output_model = wfs.do_all
+    wfs.do_all
     assert np.max(abs(wfs.diff)) < 0.001
     if delta_x_pixel + xerror >= 0 or not flip_dithers:
         assert wfs.off_x == delta_x_pixel + xerror
@@ -259,7 +258,7 @@ def test_refine_with_error(wfs_association):
         im2.save(path2)
     wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=True, flip_dithers=True, psf_size=50,
                               blur_size=10, n_size=2)
-    output_model = wfs.do_all
+    wfs.do_all
     assert wfs.input_1.meta.observation.exposure_number == '1'
     assert wfs.input_2.meta.observation.exposure_number == '2'
     assert wfs.off_x == delta_pixel + shift_error

--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -138,7 +138,7 @@ def test_shift_order_no_refine_no_flip(wfs_association):
         im2.save(path2)
     wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=False, flip_dithers=False, psf_size=50,
                               blur_size=10, n_size=2)
-    wfs.do_all
+    wfs.do_all()
     assert wfs.input_1.meta.observation.exposure_number == '1'
     assert wfs.input_2.meta.observation.exposure_number == '2'
     assert wfs.off_x == abs(delta_pixel)
@@ -163,7 +163,7 @@ def test_shift_order_no_refine_with_flip(wfs_association):
         im2.save(path2)
     wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=False, flip_dithers=True, psf_size=50,
                               blur_size=10, n_size=2)
-    wfs.do_all
+    wfs.do_all()
     wfs.input_1.close()
     wfs.input_2.close()
 #    assert wfs.input_1.meta.observation.exposure_number == '2'
@@ -226,7 +226,7 @@ def test_refine_no_error(wfs_association, xshift, yshift, xerror, yerror, flip_d
         im2.save(path2)
     wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=True, flip_dithers=flip_dithers, psf_size=50,
                               blur_size=10, n_size=2)
-    wfs.do_all
+    wfs.do_all()
     assert np.max(abs(wfs.diff)) < 0.001
     if delta_x_pixel + xerror >= 0 or not flip_dithers:
         assert wfs.off_x == delta_x_pixel + xerror
@@ -262,7 +262,7 @@ def test_refine_with_error(wfs_association):
         im2.save(path2)
     wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=True, flip_dithers=True, psf_size=50,
                               blur_size=10, n_size=2)
-    wfs.do_all
+    wfs.do_all()
     assert wfs.input_1.meta.observation.exposure_number == '1'
     assert wfs.input_2.meta.observation.exposure_number == '2'
     assert wfs.off_x == delta_pixel + shift_error

--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -5,7 +5,6 @@ from jwst.assign_wcs import AssignWcsStep
 from jwst.associations.asn_from_list import asn_from_list
 from jwst.wfs_combine import WfsCombineStep
 from jwst.wfs_combine import wfs_combine
-import astropy.modeling as modeling
 import numpy as np
 
 

--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -4,6 +4,8 @@ from jwst import datamodels
 from jwst.assign_wcs import AssignWcsStep
 from jwst.associations.asn_from_list import asn_from_list
 from jwst.wfs_combine import WfsCombineStep
+from jwst.wfs_combine import wfs_combine
+import numpy as np
 from astropy.io import fits
 
 
@@ -12,11 +14,27 @@ DO_NOT_USE = datamodels.dqflags.pixel["DO_NOT_USE"]
 SATURATED = datamodels.dqflags.pixel["SATURATED"]
 
 
-@pytest.fixture(scope="module")
-def wfs_association(tmp_path_factory):
-    tmp_path = tmp_path_factory.mktemp("wfs")
-    im1 = datamodels.ImageModel((10, 10))
+def gaussian(x, mu, sig):
+    return 1./(np.sqrt(2 * np.pi) * sig) * np.exp(-np.power((x - mu)/sig, 2)/2)
 
+
+def gaussian2d(x, y, mux, muy, sigx, sigy):
+    return gaussian(x, mux, sigx) * gaussian(y, muy, sigy)
+
+
+def add_point_source(inarray, scale, xcen, ycen, sigx, sigy):
+    outarray = np.zeros_like(inarray)
+    for y in range(inarray.shape[0]):
+        for x in range(inarray.shape[1]):
+            outarray[y, x] = scale * gaussian2d(x, y, xcen, ycen, sigx, sigy)
+    return outarray
+
+
+@pytest.fixture(scope="module")
+def wfs_association(tmp_path_factory, imsize=10):
+    tmp_path = tmp_path_factory.mktemp("wfs")
+    im1 = datamodels.ImageModel((imsize, imsize))
+    im1.meta.observation.exposure_number = 1
     im1.meta.wcsinfo = {
         'dec_ref': 11.99875540218638,
         'ra_ref': 22.02351763251896,
@@ -34,6 +52,7 @@ def wfs_association(tmp_path_factory):
         'name': 'NIRCAM',
         'pupil': 'CLEAR'}
     im1.meta.observation = {
+        'exposure_number': '1',
         'date': '2021-10-25',
         'time': '16:58:27.258'}
     im1.meta.exposure = {
@@ -42,7 +61,10 @@ def wfs_association(tmp_path_factory):
     im1 = AssignWcsStep.call(im1, sip_approx=False)
 
     im2 = im1.copy()
-
+    im2.meta.observation = {
+        'exposure_number': '2',
+        'date': '2021-10-25',
+        'time': '17:58:27.258'}
     path1 = str(tmp_path / "image1_cal.fits")
     path2 = str(tmp_path / "image2_cal.fits")
     im1.save(path1)
@@ -90,27 +112,157 @@ def test_create_combined(_jail, wfs_association,
         im1.save(path1)
         im2.save(path2)
 
-    result = WfsCombineStep.call(path_asn, do_refine=False)
+    result = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=False, psf_size=50,
+                                 blur_size=10, n_size=2)
 
     # Check that results are as expected
     assert result.data[5, 5] == result_data
     assert result.dq[5, 5] == result_dq
 
 
-def test_shift_order():
-    local_path = "/users/mregan/Documents/wfsc/"
-    path1 = str(local_path + "jw01465091001_02105_00001_nrca3_cal.fits")
-    path2 = str(local_path + "jw01465091001_02105_00002_nrca3_cal.fits")
-    asn = asn_from_list([path1, path2],
-                        product_name='jw00077_02105_nrca3_combine')
-    asn.data["program"] = "00077"
-    asn.data["asn_type"] = "wfs-image2"
-    asn.sequence = 1
-    asn_name, serialized = asn.dump(format="json")
-    path_asn = local_path + asn_name
-    with open(path_asn, "w") as f:
-        f.write(serialized)
-    result = WfsCombineStep.call(path_asn, do_refine=False)
-    fits.writeto(local_path+"combined_image"+asn.data["program"]+".fits", result.data, overwrite=True)
-    result = WfsCombineStep.call(path_asn, do_refine=True)
-    fits.writeto(local_path + "combined_image_refined" + asn.data["program"] + ".fits", result.data, overwrite=True)
+def test_shift_order_no_refine_no_flip(wfs_association):
+    path_asn, path1, path2 = wfs_association
+    nircam_pixel_size = 0.031/3600.
+    delta_pixel = 5
+    with datamodels.open(path2) as im2:
+        im2.meta.wcsinfo = {
+            'dec_ref': 11.99875540218638,
+            'ra_ref': 22.02351763251896 + delta_pixel * nircam_pixel_size,
+            'roll_ref': 0.005076934167039675, 'v2_ref': 86.039011, 'v3_ref': -493.385704,
+            'v3yangle': -0.07385127, 'vparity': -1, 'wcsaxes': 2}
+        im2 = AssignWcsStep.call(im2, sip_approx=False)
+
+        im2.save(path2)
+    wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=False, flip_dithers=False, psf_size=50,
+                              blur_size=10, n_size=2)
+    output_model = wfs.do_all
+    assert wfs.input_1.meta.observation.exposure_number == '1'
+    assert wfs.input_2.meta.observation.exposure_number == '2'
+    assert wfs.off_x == abs(delta_pixel)
+    assert wfs.off_y == 0
+    wfs.input_1.close()
+    wfs.input_2.close()
+
+
+def test_shift_order_no_refine_with_flip(wfs_association):
+    # change the sign of the the dither and check that we get the same delta pix but with switched
+    # order of images.
+    path_asn, path1, path2 = wfs_association
+    nircam_pixel_size = 0.031 / 3600.
+    delta_pixel = -5
+    with datamodels.open(path2) as im2:
+        im2.meta.wcsinfo = {
+            'dec_ref': 11.99875540218638,
+            'ra_ref': 22.02351763251896 + delta_pixel * nircam_pixel_size,
+            'roll_ref': 0.005076934167039675, 'v2_ref': 86.039011, 'v3_ref': -493.385704,
+            'v3yangle': -0.07385127, 'vparity': -1, 'wcsaxes': 2}
+        im2 = AssignWcsStep.call(im2, sip_approx=False)
+        im2.save(path2)
+    wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=False, flip_dithers=True, psf_size=50,
+                              blur_size=10, n_size=2)
+    output_model = wfs.do_all
+    wfs.input_1.close()
+    wfs.input_2.close()
+#    assert wfs.input_1.meta.observation.exposure_number == '2'
+#    assert wfs.input_2.meta.observation.exposure_number == '1'
+    assert wfs.off_x == -1 * delta_pixel
+
+
+@pytest.mark.parametrize(
+    "xshift, yshift, xerror, yerror, flip_dithers",
+    [
+        (5, 0, 0, 0, True),
+        (-5, 0, 0, 0, True),
+        (0, 6, 0, 0, True),
+        (0, -6, 0, 0, True),
+        (5, 5, 0, 0, True),
+        (5, 5, 1, 1, True),
+        (5, 5, -1, 1, True),
+        (6, -5, 0, 0, True),
+        (-5, 6, 0, 0, True),
+        (5, -5, 1, -1, True),
+        (-5, -5, 1, -1, True),
+        (-5, 5, -1, 1, True),
+        (5, 0, 0, 0, False),
+        (-5, 0, 0, 0, False),
+        (0, 6, 0, 0, False),
+        (0, -6, 0, 0, False),
+        (5, 5, 0, 0, False),
+        (5, 5, 1, 1, False),
+        (5, 5, -1, 1, False),
+        (6, -5, 0, 0, False),
+        (-5, 6, 0, 0, False),
+        (5, -5, 1, -1, False),
+        (-5, -5, 1, -1, False),
+        (-5, 5, -1, 1, False),
+    ]
+)
+def test_refine_no_error(wfs_association, xshift, yshift, xerror, yerror, flip_dithers):
+    data_size = 201
+    path_asn, path1, path2 = wfs_association
+    nircam_pixel_size = 0.031 / 3600.
+    delta_x_pixel = xshift
+    # postive y pixel changes are negative declination changes
+    delta_y_pixel = -1.0 * yshift
+    with datamodels.open(path1) as im1:
+        im1.data = np.zeros(shape=(data_size, data_size), dtype=np.float32)
+        im1.dq = np.zeros(shape=(data_size, data_size), dtype=np.int32)
+        im1.data = add_point_source(im1.data, 200, 100, 100, 4, 4)
+        im1.save(path1)
+    with datamodels.open(path2) as im2:
+        im2.data = np.zeros(shape=(data_size, data_size), dtype=np.float32)
+        im2.dq = np.zeros(shape=(data_size, data_size), dtype=np.int32)
+        im2.meta.wcsinfo = {
+            'dec_ref': 11.99875540218638 + delta_y_pixel * nircam_pixel_size,
+            'ra_ref': 22.02351763251896 + delta_x_pixel * nircam_pixel_size,
+            'roll_ref': 0.005076934167039675, 'v2_ref': 86.039011, 'v3_ref': -493.385704,
+            'v3yangle': -0.07385127, 'vparity': -1, 'wcsaxes': 2}
+        im2 = AssignWcsStep.call(im2, sip_approx=False)
+        # shift the actual location of the 2nd image including the error in the WCS position
+        im2.data = add_point_source(im2.data, 200, 100 + delta_x_pixel + xerror, 100 + delta_y_pixel - yerror, 4, 4)
+        im2.save(path2)
+    wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=True, flip_dithers=flip_dithers, psf_size=50,
+                              blur_size=10, n_size=2)
+    output_model = wfs.do_all
+    assert np.max(abs(wfs.diff)) < 0.001
+    if delta_x_pixel + xerror >= 0 or not flip_dithers:
+        assert wfs.off_x == delta_x_pixel + xerror
+        # Positive y pixel errors are negative in declination
+        assert wfs.off_y == delta_y_pixel - yerror
+    else:  # Order of exposures and sign of shifts have switched to always align the dithers
+        assert wfs.off_x == abs(delta_x_pixel + xerror)
+        # Postive y pixel errors are negative in declination
+        assert wfs.off_y == -1.0 * (delta_y_pixel - yerror)
+    wfs.input_1.close()
+    wfs.input_2.close()
+
+
+def test_refine_with_error(wfs_association):
+    data_size = 201
+    path_asn, path1, path2 = wfs_association
+    nircam_pixel_size = 0.031 / 3600.
+    shift_error = 2
+    delta_pixel = 5
+    with datamodels.open(path1) as im1:
+        im1.data = np.zeros(shape=(data_size, data_size), dtype=np.float32)
+        im1.data = add_point_source(im1.data, 200, 100, 100, 4, 4)
+        im1.save(path1)
+    with datamodels.open(path2) as im2:
+        im2.meta.wcsinfo = {
+            'dec_ref': 11.99875540218638,
+            'ra_ref': 22.02351763251896 + delta_pixel * nircam_pixel_size,
+            'roll_ref': 0.005076934167039675, 'v2_ref': 86.039011, 'v3_ref': -493.385704,
+            'v3yangle': -0.07385127, 'vparity': -1, 'wcsaxes': 2}
+        im2 = AssignWcsStep.call(im2, sip_approx=False)
+        im2.data = np.zeros(shape=(data_size, data_size), dtype=np.float32)
+        im2.data = add_point_source(im2.data, 200, 100 + delta_pixel + shift_error, 100, 4, 4)
+        im2.save(path2)
+    wfs = wfs_combine.DataSet(path1, path2, 'outfile.fits', do_refine=True, flip_dithers=True, psf_size=50,
+                              blur_size=10, n_size=2)
+    output_model = wfs.do_all
+    assert wfs.input_1.meta.observation.exposure_number == '1'
+    assert wfs.input_2.meta.observation.exposure_number == '2'
+    assert wfs.off_x == delta_pixel + shift_error
+    assert wfs.off_y == 0
+    wfs.input_1.close()
+    wfs.input_2.close()

--- a/jwst/wfs_combine/tests/test_wfs_combine_step.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine_step.py
@@ -1,0 +1,139 @@
+import pytest
+from jwst import datamodels
+from jwst.assign_wcs import AssignWcsStep
+from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
+from jwst.associations.lib.rules_level2_base import DMSLevel2bBase
+from jwst.associations import asn_from_list
+from jwst.wfs_combine import WfsCombineStep
+
+
+@pytest.fixture(scope="module")
+def wfs_association(tmp_path_factory):
+    imsize = 10
+    tmp_path = tmp_path_factory.mktemp("wfs")
+    im1 = datamodels.ImageModel((imsize, imsize))
+    im1.meta.observation.exposure_number = 1
+    im1.meta.wcsinfo = {
+        'dec_ref': 11.99875540218638,
+        'ra_ref': 22.02351763251896,
+        'roll_ref': 0.005076934167039675,
+        'v2_ref': 86.039011,
+        'v3_ref': -493.385704,
+        'v3yangle': -0.07385127,
+        'vparity': -1,
+        'wcsaxes': 2}
+    im1.meta.instrument = {
+        'channel': 'SHORT',
+        'detector': 'NRCA4',
+        'filter': 'F212N',
+        'module': 'A',
+        'name': 'NIRCAM',
+        'pupil': 'CLEAR'}
+    im1.meta.observation = {
+        'exposure_number': '1',
+        'date': '2021-10-25',
+        'time': '16:58:27.258'}
+    im1.meta.exposure = {
+        'type': 'NRC_IMAGE'}
+
+    im1 = AssignWcsStep.call(im1, sip_approx=False)
+
+    im2 = im1.copy()
+    im2.meta.observation = {
+        'exposure_number': '2',
+        'date': '2021-10-25',
+        'time': '17:58:27.258'}
+    path1 = str(tmp_path / "image1_cal.fits")
+    path2 = str(tmp_path / "image2_cal.fits")
+    im1.save(path1)
+    im2.save(path2)
+
+    asn = asn_from_list.asn_from_list([path1, path2], product_name="combined",
+                                      rule=DMS_Level3_Base)
+    asn.data["program"] = "00024"
+    asn.data["asn_type"] = "wfs-image2"
+    asn.sequence = 1
+    asn_json, serialized = asn.dump(format="json")
+    path_asn = tmp_path / asn_json
+    with open(path_asn, "w") as f:
+        f.write(serialized)
+
+    return path_asn, path1, path2
+
+
+def test_image1_location(_jail, wfs_association):
+    path_asn, path1, path2 = wfs_association
+    out_model = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=False, psf_size=50,
+                                    blur_size=10, n_size=2)
+
+
+def test_step_pos_shift_no_refine_no_flip(wfs_association):
+    path_asn, path1, path2 = wfs_association
+    nircam_pixel_size = 0.031 / 3600.
+    delta_pixel = 5
+    with datamodels.open(path2) as im2:
+        im2.meta.wcsinfo = {
+            'dec_ref': 11.99875540218638,
+            'ra_ref': 22.02351763251896 + delta_pixel * nircam_pixel_size,
+            'roll_ref': 0.005076934167039675, 'v2_ref': 86.039011, 'v3_ref': -493.385704,
+            'v3yangle': -0.07385127, 'vparity': -1, 'wcsaxes': 2}
+        im2 = AssignWcsStep.call(im2, sip_approx=False)
+        im2.save(path2)
+
+    wfs = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=False, psf_size=50,
+                              blur_size=10, n_size=2)
+    assert wfs.meta.wcsinfo.ra_ref == 22.02351763251896
+
+
+def test_step_neg_shift_no_refine_no_flip(wfs_association):
+    path_asn, path1, path2 = wfs_association
+    nircam_pixel_size = 0.031 / 3600.
+    delta_pixel = -5
+    with datamodels.open(path2) as im2:
+        im2.meta.wcsinfo = {
+            'dec_ref': 11.99875540218638,
+            'ra_ref': 22.02351763251896 + delta_pixel * nircam_pixel_size,
+            'roll_ref': 0.005076934167039675, 'v2_ref': 86.039011, 'v3_ref': -493.385704,
+            'v3yangle': -0.07385127, 'vparity': -1, 'wcsaxes': 2}
+        im2 = AssignWcsStep.call(im2, sip_approx=False)
+        im2.save(path2)
+
+    wfs = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=False, psf_size=50,
+                              blur_size=10, n_size=2)
+    assert wfs.meta.wcsinfo.ra_ref == 22.02351763251896
+
+
+def test_step_neg_order_no_refine_with_flip(wfs_association):
+    path_asn, path1, path2 = wfs_association
+    nircam_pixel_size = 0.031 / 3600.
+    delta_pixel = -5
+    with datamodels.open(path2) as im2:
+        im2.meta.wcsinfo = {
+            'dec_ref': 11.99875540218638,
+            'ra_ref': 22.02351763251896 + delta_pixel * nircam_pixel_size,
+            'roll_ref': 0.005076934167039675, 'v2_ref': 86.039011, 'v3_ref': -493.385704,
+            'v3yangle': -0.07385127, 'vparity': -1, 'wcsaxes': 2}
+        im2 = AssignWcsStep.call(im2, sip_approx=False)
+        im2.save(path2)
+
+    wfs = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=True, psf_size=50,
+                              blur_size=10, n_size=2)
+    assert wfs.meta.wcsinfo.ra_ref == 22.02351763251896 + delta_pixel * nircam_pixel_size
+
+
+def test_step_pos_order_no_refine_with_flip(wfs_association):
+    path_asn, path1, path2 = wfs_association
+    nircam_pixel_size = 0.031 / 3600.
+    delta_pixel = 5
+    with datamodels.open(path2) as im2:
+        im2.meta.wcsinfo = {
+            'dec_ref': 11.99875540218638,
+            'ra_ref': 22.02351763251896 + delta_pixel * nircam_pixel_size,
+            'roll_ref': 0.005076934167039675, 'v2_ref': 86.039011, 'v3_ref': -493.385704,
+            'v3yangle': -0.07385127, 'vparity': -1, 'wcsaxes': 2}
+        im2 = AssignWcsStep.call(im2, sip_approx=False)
+        im2.save(path2)
+
+    wfs = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=True, psf_size=50,
+                              blur_size=10, n_size=2)
+    assert wfs.meta.wcsinfo.ra_ref == 22.02351763251896

--- a/jwst/wfs_combine/tests/test_wfs_combine_step.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine_step.py
@@ -2,7 +2,6 @@ import pytest
 from jwst import datamodels
 from jwst.assign_wcs import AssignWcsStep
 from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
-from jwst.associations.lib.rules_level2_base import DMSLevel2bBase
 from jwst.associations import asn_from_list
 from jwst.wfs_combine import WfsCombineStep
 
@@ -59,12 +58,6 @@ def wfs_association(tmp_path_factory):
         f.write(serialized)
 
     return path_asn, path1, path2
-
-
-def test_image1_location(_jail, wfs_association):
-    path_asn, path1, path2 = wfs_association
-    out_model = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=False, psf_size=50,
-                                    blur_size=10, n_size=2)
 
 
 def test_step_pos_shift_no_refine_no_flip(wfs_association):

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -714,8 +714,8 @@ def calc_refined_offsets(sci_nai_1, sci_nai_2, off_x, off_y, psf_size):
     xmax = maximum_pixel[1] - sub_1_sub.shape[1] + 1
     # Slice out a box center on the peak of the cross correlation image. The centroid of this box will give a
     # accurate estimate of the x and y offsets.
-    central_cutout = cross_cor[maximum_pixel[0] - centroid_size:maximum_pixel[0] + centroid_size+1,
-                               maximum_pixel[1] - centroid_size:maximum_pixel[1] + centroid_size+1]
+    central_cutout = cross_cor[maximum_pixel[0] - centroid_size:maximum_pixel[0] + centroid_size + 1,
+                               maximum_pixel[1] - centroid_size:maximum_pixel[1] + centroid_size + 1]
     centroid = scipy.ndimage.measurements.center_of_mass(central_cutout)
     refined_x = xmax + centroid[1] - centroid_size
     refined_y = ymax + centroid[0] - centroid_size

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -14,6 +14,7 @@ log.setLevel(logging.DEBUG)
 
 DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
 
+
 class DataSet:
     """
     Two dithered input wavefront sensing images to be combined
@@ -111,9 +112,9 @@ class DataSet:
         print(" Refine value {}".format(self.do_refine))
         new_model.history.append('WFS_COMBINE refine offset = {}'.format(self.do_refine))
         new_model.history.append('WFS_COMBINE X offset applied ' + str(self.off_x) + ' pixels ' +
-                                 'actual offset '+str(round(self.flt_off_x, 2)) + ' pixels')
+                                 'actual offset ' + str(round(self.flt_off_x, 2)) + ' pixels')
         new_model.history.append('WFS_COMBINE Y offset applied ' + str(self.off_y) + ' pixels ' +
-                                 'actual offset '+str(round(self.flt_off_y, 2)) + ' pixels')
+                                 'actual offset ' + str(round(self.flt_off_y, 2)) + ' pixels')
         return new_model
 
     def create_aligned_2(self):
@@ -709,12 +710,12 @@ def calc_refined_offsets(sci_nai_1, sci_nai_2, off_x, off_y, psf_size):
                                          scipy.ndimage.gaussian_filter(sub_1_sub, 5))
     maximum_pixel = np.unravel_index(np.argmax(cross_cor), cross_cor.shape)
 
-    ymax = maximum_pixel[0]-sub_1_sub.shape[0]+1
-    xmax = maximum_pixel[1]-sub_1_sub.shape[1]+1
+    ymax = maximum_pixel[0] - sub_1_sub.shape[0] + 1
+    xmax = maximum_pixel[1] - sub_1_sub.shape[1] + 1
     # Slice out a box center on the peak of the cross correlation image. The centroid of this box will give a
     # accurate estimate of the x and y offsets.
-    central_cutout = cross_cor[maximum_pixel[0]-centroid_size:maximum_pixel[0]+centroid_size+1,
-                               maximum_pixel[1]-centroid_size:maximum_pixel[1]+centroid_size+1]
+    central_cutout = cross_cor[maximum_pixel[0] - centroid_size:maximum_pixel[0] + centroid_size+1,
+                               maximum_pixel[1] - centroid_size:maximum_pixel[1] + centroid_size+1]
     centroid = scipy.ndimage.measurements.center_of_mass(central_cutout)
     refined_x = xmax + centroid[1] - centroid_size
     refined_y = ymax + centroid[0] - centroid_size

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -77,7 +77,6 @@ class DataSet:
         self.blur_size = blur_size
         self.n_size = n_size
 
-    @property
     def do_all(self):
         """
         Short Summary
@@ -123,6 +122,7 @@ class DataSet:
         # Create a new model using the combined arrays...
         new_model = datamodels.ImageModel(data=data_c, dq=dq_c, err=err_c)
         new_model.update(self.input_1)
+        new_model.history.append('Flip dithers = {}'.format(self.flip_dithers))
         new_model.history.append('WFS_COMBINE refine offset = {}'.format(self.do_refine))
         new_model.history.append('WFS_COMBINE X offset applied ' + str(self.off_x) + ' pixels ' +
                                  'actual offset ' + str(round(self.flt_off_x, 2)) + ' pixels')

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -199,7 +199,6 @@ class DataSet:
             sci_nai_1, sci_nai_2 = get_overlap(sci_int_1, sci_int_2,
                                                self.off_x, self.off_y)
             # 5. Around this nominal alignment, get refined (delta) offsets
-#            ref_del_off_x, ref_del_off_y = optimize_offs(sci_nai_1, sci_nai_2)
             ref_del_off_x, ref_del_off_y = calc_refined_offsets(sci_nai_1, sci_nai_2, 0, 0, self.psf_size)
             log.info('From the refined offsets calculation,'
                      'the x,y changes in ofsets are: %s %s',
@@ -210,9 +209,6 @@ class DataSet:
             self.flt_off_y = self.off_y + ref_del_off_y
             self.off_x += int(round(ref_del_off_x))
             self.off_y += int(round(ref_del_off_y))
-
-#            log.info('Values for the refined offsets are, for x,y : %s %s',
-#                     self.off_x, self.off_y)
 
         # Do the final alignment for original (not interpolated) image two
         data_2_a, dq_2_a, err_2_a = self.apply_final_offsets()
@@ -716,7 +712,7 @@ def calc_refined_offsets(sci_nai_1, sci_nai_2, off_x, off_y, psf_size):
     ymax = maximum_pixel[0]-sub_1_sub.shape[0]+1
     xmax = maximum_pixel[1]-sub_1_sub.shape[1]+1
     # Slice out a box center on the peak of the cross correlation image. The centroid of this box will give a
-    # accurate estimate of the x and y offsets
+    # accurate estimate of the x and y offsets.
     central_cutout = cross_cor[maximum_pixel[0]-centroid_size:maximum_pixel[0]+centroid_size+1,
                                maximum_pixel[1]-centroid_size:maximum_pixel[1]+centroid_size+1]
     centroid = scipy.ndimage.measurements.center_of_mass(central_cutout)

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -65,7 +65,7 @@ class WfsCombineStep(Step):
             # Save the output file
             if self.save_results:
                 self.save_model(
-                    output_model, suffix='wfscmb.fits', output_file=outfile, format=False
+                    output_model, suffix='wfscmb', output_file=outfile, format=False
                 )
 
         # Short-circuit auto-save of returned model if run from strun, as it is

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -20,6 +20,7 @@ class WfsCombineStep(Step):
         psf_size = integer(default=100)
         blur_size = integer(default=10)
         n_size = integer(default=2)
+        suffix = string(default="wfscmb")
     """
 
     def process(self, input_table):

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -16,6 +16,10 @@ class WfsCombineStep(Step):
 
     spec = """
         do_refine = boolean(default=False)
+        flip_dithers = boolean(default=True) # change the sign and switch order of images when x offset is negative
+        psf_size = integer(default=100)
+        blur_size = integer(default=10)
+        n_size = integer(default=2)
     """
 
     def process(self, input_table):
@@ -42,11 +46,12 @@ class WfsCombineStep(Step):
 
             # Create the step instance
             wfs = wfs_combine.DataSet(
-                infile_1, infile_2, outfile, self.do_refine
+                infile_1, infile_2, outfile, self.do_refine, self.flip_dithers, self.psf_size,
+                self.blur_size, self.n_size
             )
 
             # Do the processing
-            output_model = wfs.do_all()
+            output_model = wfs.do_all
 
             # The DataSet class does not close its resources.  Do that here.
             wfs.input_1.close()
@@ -60,7 +65,7 @@ class WfsCombineStep(Step):
             # Save the output file
             if self.save_results:
                 self.save_model(
-                    output_model, suffix='wfscmb', output_file=outfile, format=False
+                    output_model, suffix='wfscmb.fits', output_file=outfile, format=False
                 )
 
         # Short-circuit auto-save of returned model if run from strun, as it is

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -51,7 +51,7 @@ class WfsCombineStep(Step):
             )
 
             # Do the processing
-            output_model = wfs.do_all
+            output_model = wfs.do_all()
 
             # The DataSet class does not close its resources.  Do that here.
             wfs.input_1.close()
@@ -65,8 +65,7 @@ class WfsCombineStep(Step):
             # Save the output file
             if self.save_results:
                 self.save_model(
-                    output_model, suffix='wfscmb', output_file=outfile, format=False
-                )
+                    output_model, output_file=outfile, format=False)
 
         # Short-circuit auto-save of returned model if run from strun, as it is
         # already done above.  Ideally we would use self.output_use_model,


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5974 

Resolves [JP-2051](https://jira.stsci.edu/browse/JP-2051)

This PR addresses JP-2051 that refers to the location of the combined image when WFS-COMBINE is run. The changes are to always shift the images in the positive x pixel direction. If the calculated offset is negative the first image will be shifted rather than the second image.
  While making the changes for JP-2051, I added test cases for the refine option. This showed that the baseline code's cross correlation algorithm was not correct. It was unable to find the correct offset. I updated the algorithm to be correct, added 27 new unit tests, and updated the output FITS header and logs to contain the calculated shifts.   


Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)