### PR TITLE
JP-2085: Remove attached tweakreg catalog from datamodel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,12 @@ scripts
 - Add migrate_data command with support for migrating spec_table in
   x1d files produced with <= 1.1.0 of this package. [#6055]
 
+tweakreg
+--------
+
+- Remove attached tweakreg catalog from datamodel before exiting step [#6102]
+
+
 1.2.0 (2021-05-24)
 ==================
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Addresses #6039 /  [JP-2085](https://jira.stsci.edu/browse/JP-2085)

**Description**

This PR

- ~avoids a bug in `asdf` which was making `_crf.fits` files unreadable due to the attaching of an `astropy.table.Table` object to the datamodel as an attribute not indicated in the schema in `TweakregStep`.  The solution is to delete the table before ending the step.~
- Regression test added, and added `use_output_model=True` as a default for this step so that output naming of saved results is based off the input name and not a stream of indices.
- Fixes a bug where sources outside of the bounding box of the WCS were not being masked.

Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)