### PR TITLE
JP-2112 : assign_mtwcs should work on science asn_exptype only

### DIFF
--- a/jwst/assign_mtwcs/moving_target_wcs.py
+++ b/jwst/assign_mtwcs/moving_target_wcs.py
@@ -26,22 +26,26 @@ def assign_moving_target_wcs(input_model):
     if not isinstance(input_model, datamodels.ModelContainer):
         raise ValueError("Expected a ModelContainer object")
 
+    # get the indices of the science exposures in the ModelContainer
+    ind = input_model.ind_asn_type('science')
+    sci_models = np.asarray(input_model._models)[ind]
     # Get the MT RA/Dec values from all the input exposures
-    mt_ra = np.array([model.meta.wcsinfo.mt_ra for model in input_model._models])
-    mt_dec = np.array([model.meta.wcsinfo.mt_dec for model in input_model._models])
+    mt_ra = np.array([model.meta.wcsinfo.mt_ra for model in sci_models])
+    mt_dec = np.array([model.meta.wcsinfo.mt_dec for model in sci_models])
+
 
     # Compute the mean MT RA/Dec over all exposures
     if (None in mt_ra) or (None in mt_dec):
         log.warning("One or more MT RA/Dec values missing in input images")
         log.warning("Step will be skipped, resulting in target misalignment")
-        for model in input_model:
+        for model in sci_models:
             model.meta.cal_step.assign_mtwcs = 'SKIPPED'
         return input_model
     else:
         mt_avra = mt_ra.mean()
         mt_avdec = mt_dec.mean()
 
-    for model in input_model:
+    for model in sci_models:
         model.meta.wcsinfo.mt_avra = mt_avra
         model.meta.wcsinfo.mt_avdec = mt_avdec
         if isinstance(model, datamodels.MultiSlitModel):

--- a/jwst/assign_mtwcs/moving_target_wcs.py
+++ b/jwst/assign_mtwcs/moving_target_wcs.py
@@ -33,7 +33,6 @@ def assign_moving_target_wcs(input_model):
     mt_ra = np.array([model.meta.wcsinfo.mt_ra for model in sci_models])
     mt_dec = np.array([model.meta.wcsinfo.mt_dec for model in sci_models])
 
-
     # Compute the mean MT RA/Dec over all exposures
     if (None in mt_ra) or (None in mt_dec):
         log.warning("One or more MT RA/Dec values missing in input images")

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -423,7 +423,6 @@ class ModelContainer(JwstDataModel, Sequence):
 
         return datamodel_open(first_exposure)
 
-
     def ind_asn_type(self, asn_exptype):
         """
         Determine the indices of models corresponding to ``asn_exptype``.
@@ -439,8 +438,8 @@ class ModelContainer(JwstDataModel, Sequence):
             Indices of models in ModelContainer._models matching ``asn_exptype``.
         """
         ind = []
-        names = [m.expname for m in self.meta.asn_table.products[0].members \
-                 if m.exptype.lower()==asn_exptype]
+        names = [m.expname for m in self.meta.asn_table.products[0].members
+                 if m.exptype.lower() == asn_exptype]
         for i, model in enumerate(self._models):
             if model.meta.filename in names:
                 ind.append(i)

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -424,6 +424,29 @@ class ModelContainer(JwstDataModel, Sequence):
         return datamodel_open(first_exposure)
 
 
+    def ind_asn_type(self, asn_exptype):
+        """
+        Determine the indices of models corresponding to ``asn_exptype``.
+
+        Parameters
+        ----------
+        asn_exptype : str
+            Exposure type as defined in an association, e.g. "science".
+
+        Returns
+        -------
+        ind : list
+            Indices of models in ModelContainer._models matching ``asn_exptype``.
+        """
+        ind = []
+        names = [m.expname for m in self.meta.asn_table.products[0].members \
+                 if m.exptype.lower()==asn_exptype]
+        for i, model in enumerate(self._models):
+            if model.meta.filename in names:
+                ind.append(i)
+        return ind
+
+
 def make_file_with_index(file_path, idx):
     """Append an index to a filename
 

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -407,3 +407,8 @@ def test_meta_date_management(tmp_path):
 
     model = JwstDataModel()
     assert abs((Time.now() - Time(model.meta.date)).value) < 1.0
+
+
+def test_model_container_ind_asn_exptype(container):
+    ind = container.ind_asn_type('science')
+    assert ind == [0, 1]


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6095

Resolves JP-2112

**Description**

assign_mtwcs gets as input a ModelContainer object and needs to modify the science exposures. instead it worked on all models in the container.l This PR 
- adds a method to ModelContainer which returns the indices of models with a certain "asn_exptype" in modelContainer._models.
- Modifies assign_mtwcs to work with the "science" exposures only.

The DMS failing test passes now. The assign_mtwcs step is still skipped because the data lacks the necessary keywords.



Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
