### PR TITLE
JP-2128: Switch default interpolation method in blot to poly5 instead of linear

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -240,6 +240,10 @@ master_background
 outlier_detection
 -----------------
 
+- Avoid using 'linear' interpolation method as default for ``blot`` due to
+  a bug in the implimentation of the bilinear interpolator in the ``drizzle``
+  package. Now the default value will be 'poly5'. [#6116]
+
 - Outlier detection on non-dithered images is implemented with a simple sigma
   clipping, dithered outlier detection cleaned up and HST specific steps removed
   and additional tests added. [#5822]

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -304,7 +304,7 @@ class OutlierDetection:
 
     def blot_median(self, median_model):
         """Blot resampled median image back to the detector images."""
-        interp = self.outlierpars.get('interp', 'linear')
+        interp = self.outlierpars.get('interp', 'poly5')
         sinscl = self.outlierpars.get('sinscl', 1.0)
 
         # Initialize container for output blot images


### PR DESCRIPTION
Resolves #6116 / [JP-2128](https://jira.stsci.edu/browse/JP-2128)

This PR replaces the default interpolator ('linear') in blot (used in `outlier_detection`) used when interpolator is not specified with `'poly5'`. The `'poly5'` interpolator is the default one used in `drizzlepac` and it is extensively used (~= tested).

This PR does not solve the underlying issue in the `drizzle` package but should alleviate the issue described in #6116.

NOTE to maintainers. This is not a bug in the `outlier_detection` step per se and so I did not add the `bug` label but feel free to classify it as you wish.

