### PR TITLE
JP-2134: Speed up CI by a factor of 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-${{ steps.crds-context.outputs.pmap }}
+          key: crds-${{ matrix.toxenv }}-${{ steps.crds-context.outputs.pmap }}
 
       - name: Install tox
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-  CRDS_PATH: ~/crds_cache
+  CRDS_PATH: $HOME/crds_cache
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-${{ steps.crds-context.outputs.pmap }}
+          key: crds-${{ matrix.toxenv }}-${{ steps.crds-context.outputs.pmap }}
 
       - name: Install tox
         run: |

--- a/jwst/regtest/test_nircam_mtimage.py
+++ b/jwst/regtest/test_nircam_mtimage.py
@@ -7,7 +7,7 @@ from jwst.stpipe import Step
 
 
 @pytest.mark.bigdata
-def test_nircam_image_moving_target(rtdata, fitsdiff_default_kwargs):
+def test_nircam_image_moving_target_i2d(rtdata, fitsdiff_default_kwargs):
     """Test resampled i2d of moving target exposures for NIRCam imaging"""
     rtdata.get_asn("nircam/image/mt_asn.json")
     rtdata.output = "mt_assoc_i2d.fits"

--- a/tox.ini
+++ b/tox.ini
@@ -40,10 +40,11 @@ passenv =
 usedevelop = true
 
 commands =
-    !cov: pytest {posargs}
-    cov: pytest --cov-report=xml --cov=. --cov-config=setup.cfg {posargs}
+    !cov: pytest -n auto {posargs}
+    cov: pytest -n auto --cov-report=xml --cov=. --cov-config=setup.cfg {posargs}
 
 deps =
+    pytest-xdist
     devdeps: -rrequirements-dev.txt
     sdpdeps: -rrequirements-sdp.txt
 
@@ -64,12 +65,12 @@ commands_pre =
 changedir = {homedir}
 usedevelop = false
 commands =
-    pyargs: pytest {toxinidir}/docs --pyargs {posargs:jwst}
+    pyargs: pytest -n auto {toxinidir}/docs --pyargs {posargs:jwst}
 
 [testenv:regtests]
 description = run tests with --bigdata and --slow flags
 commands =
-    pytest --bigdata --slow --basetemp={homedir}/scratch {posargs}
+    pytest -n auto --bigdata --slow --basetemp={homedir}/test_outputs {posargs}
 
 [testenv:twine]
 description = check that the package builds sdist/wheel and that twine uploads


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
Addresses #6126 / [JP-2134](https://jira.stsci.edu/browse/JP-2134)

**Description**

 - Fix CRDS caching between CI workflows
 - Parallelize CI jobs via `pytest-xdist` across both cores of each worker

Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [x] Label(s)