### PR TITLE
JP-2132: Fix AMI pupil phases sign error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,10 @@
 1.2.2 (unreleased)
 ==================
 
+ami_analyze
+-----------
 
-
+- Fix to AMI pupil phases sign error [#6128]
 
 
 1.2.1 (2021-06-07)

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -85,6 +85,8 @@ def apply_LG_plus(input_model, filter_model, oversample, rotation,
     filt = "F430M"
     rotsearch_d = np.arange(rotsearch_parameters[0], rotsearch_parameters[1], rotsearch_parameters[2])
 
+    log.info(f'Initial values to use for rotation search {rotsearch_d}')
+
     affine2d = find_rotation(data[:, :], psf_offset, rotsearch_d,
                              mx, my, sx, sy, xo, yo,
                              PIXELSCALE_r, dim, bandpass, oversample, holeshape)

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -42,7 +42,6 @@ class AmiAnalyzeStep(Step):
         self.log.info(f'Oversampling factor =  {oversample}')
         self.log.info(f'Initial rotation guess = {rotate} deg')
         self.log.info(f'Initial values to use for psf offset = {psf_offset}')
-        self.log.info(f'Initial values to use for rotation search {rotsearch_parameters}')
 
         # Open the input data model
         try:

--- a/jwst/ami/tests/test_ami_analyze.py
+++ b/jwst/ami/tests/test_ami_analyze.py
@@ -103,7 +103,7 @@ def test_utils_fringes2pistons():
 
     result = utils.fringes2pistons(fringephases, nholes)
 
-    true_result = np.array([0.02, 0.034, 0.02, -0.014, -0.06])
+    true_result = np.array([-0.02, -0.034, -0.02, 0.014, 0.06])
     assert_allclose(result, true_result)
 
 

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -851,7 +851,7 @@ def fringes2pistons(fringephases, nholes):
     Anrm = makeA(nholes)
     Apinv = np.linalg.pinv(Anrm)
 
-    return -np.dot(Apinv, fringephases)
+    return np.dot(Apinv, fringephases)
 
 
 def rebin(a=None, rc=(2, 2)):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
Resolves #6122 / [JP-2132](https://jira.stsci.edu/browse/JP-2132)
Resolves #6108 / [JP-2123](https://jira.stsci.edu/browse/JP-2123)

**Description**

This PR fixes a sign error in calculation of the pupil phase.

Also, it makes the logging of the rotation search parameters more clear.

Merging this will require the ami_analyze regression tests to be okified.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)