### PR TITLE
Only cancel duplicate CI on PRs, not merges into master

### DIFF
--- a/.github/workflows/cancel_workflows.yml
+++ b/.github/workflows/cancel_workflows.yml
@@ -6,10 +6,12 @@ on:
     types:
       - requested
 
-# Note: This has to be in workflow_run so it works for PRs from forks.
+# Note: This has to be in workflow_run so it works for PRs from forks.  And only cancel
+# pull_request triggers, not push, i.e. merges into master.
 jobs:
   cancel:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
     - name: Cancel previous runs
       uses: styfle/cancel-workflow-action@3d86a7cc43670094ac248017207be0295edbc31d  # 0.8.0


### PR DESCRIPTION
This changes the duplicate workflow canceling in Github Actions to only cancel duplicates of commits on PRs.  So if you rapid-fire commits to your PR, it will only have CI running on the latest commit, not several concurrently.  Previous runs are cancelled.

Currently this cancelling also happens on merges into `master`.  So if two major PRs get merged into `master` in short order, the 2nd will cancel CI of the first, making it not run to completion, and not report coverage for that commit on `master`.  If a new PR is opened, branched from that commit, then there will be no reported or accurate coverage to check the new PR against.  This PR prevents this from happening.

h.t. @pllim 

Checklist
- [x] Label(s)