### PR TITLE
Switch default interpolation method in blot back to linear

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 1.2.4 (unreleased)
 ==================
 
+outlier_detection
+-----------------
 
+- Revert back to using 'linear' interpolation method as default for ``blot``.
+  The bug in the implimentation of the bilinear interpolator in the ``drizzle``
+  package is now fixed. [#6146]
 
 
 1.2.3 (2021-06-08)

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -304,7 +304,7 @@ class OutlierDetection:
 
     def blot_median(self, median_model):
         """Blot resampled median image back to the detector images."""
-        interp = self.outlierpars.get('interp', 'poly5')
+        interp = self.outlierpars.get('interp', 'linear')
         sinscl = self.outlierpars.get('sinscl', 1.0)
 
         # Initialize container for output blot images


### PR DESCRIPTION
This reverts commit 0a692e80572d1f9daa18894b12b3f0e19b975838.

<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Resolves #6116 / [JP-2128](https://jira.stsci.edu/browse/JP-2128)

**Description**

This reverts the blotting interpolation to linear in `outlier_detection`.

This will cause some changes in regression tests, flagging more outliers in `outlier_detection` for 2D data, i.e. _crf, _s2d and _i2d and subsequent catalogs and segmaps that use them.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)