### PR TITLE
Change names of NIRCam TS setpointing regression tests

### DIFF
--- a/jwst/regtest/test_nircam_tsgrism.py
+++ b/jwst/regtest/test_nircam_tsgrism.py
@@ -76,7 +76,7 @@ def test_nircam_tsgrism_stage3_whtlt(run_pipelines):
 
 
 @pytest.mark.bigdata
-def test_nircam_setpointing(_jail, rtdata, fitsdiff_default_kwargs):
+def test_nircam_setpointing_tsgrism(_jail, rtdata, fitsdiff_default_kwargs):
     """
     Regression test of the set_telescope_pointing script on a level-1b NIRCam file.
     """

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -63,7 +63,7 @@ def test_nircam_tsimage_stage3_phot(run_pipelines):
 
 
 @pytest.mark.bigdata
-def test_nircam_setpointing(_jail, rtdata, fitsdiff_default_kwargs):
+def test_nircam_setpointing_tsimg(_jail, rtdata, fitsdiff_default_kwargs):
     """
     Regression test of the set_telescope_pointing script on a level-1b
     NIRCam TSO imaging file.


### PR DESCRIPTION
**Description**

This PR makes the names of these tests unique.  If they both fail, because they have the same name, it makes OKifying them a 2-step process as the artifacts overwrite each other when pushed to artifactory.


Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)