### PR TITLE
JP-1395: Remove emmision.cfg

### DIFF
--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -174,6 +174,7 @@ _calculated_suffixes = set([
     'resetstep',
     'combine1dstep',
     'outlier_detection_scaled',
+    'outlier_detection_stack',
     'srctype',
     'outlier_detection',
     'engdblogstep',

--- a/jwst/pipeline/emission.cfg
+++ b/jwst/pipeline/emission.cfg
@@ -1,2 +1,0 @@
-name = "emission" 
-class = "jwst.emission.EmissionStep"

--- a/jwst/pipeline/outlier_detection_stack.cfg
+++ b/jwst/pipeline/outlier_detection_stack.cfg
@@ -1,2 +1,2 @@
 name = "outlier_detection_stack" 
-class = "jwst.outlier_detection_stack.OutlierDetectionStackStep"
+class = "jwst.outlier_detection.OutlierDetectionStackStep"


### PR DESCRIPTION
Resolves #4754 / [JP-1395](https://jira.stsci.edu/browse/JP-1395)
Resolves #3278

This removes `emission.cfg` for the no-longer-existing emission step that was removed in #4253.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
