### PR TITLE
Open specwcs reffile with context manager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.2.4 (unreleased)
 ==================
 
+assign_wcs
+----------
+
+- Open the specwcs reference file for WFSS modes using the ``with`` context
+  manger. [#6160]
+
 cube_build
 ----------
 - Fix bug when creating cubes using output_type=channel [#6138]

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -137,15 +137,15 @@ def niriss_soss(input_model, reference_files):
         # the S3 URI handling to one place.  The S3-related code here can
         # be removed once we have a specwcs DataModel subclass.
         if s3_utils.is_s3_uri(reference_files['specwcs']):
-            uri = s3_utils.get_object(reference_files['specwcs'])
+            bytesio_or_path = s3_utils.get_object(reference_files['specwcs'])
         else:
-            uri = reference_files['specwcs']
-        with asdf.open(uri) as af:
+            bytesio_or_path = reference_files['specwcs']
+        with asdf.open(bytesio_or_path) as af:
             wl1 = af.tree[1].copy()
             wl2 = af.tree[2].copy()
             wl3 = af.tree[3].copy()
     except Exception as e:
-        raise IOError(f'Error reading wavelength correction from {uri}') from e
+        raise IOError(f"Error reading wavelength correction from {reference_files['specwcs']}") from e
 
     velosys = input_model.meta.wcsinfo.velosys
     if velosys is not None:


### PR DESCRIPTION
This PR fixes a problem we saw in a unit test where the `specwcs` reffile was incompletely downloaded from CRDS and so `asdf.open()` failed.  When it failed, it was not closed, as it never went through `__exit__`.

~Not sure if this is a problem with the `with` context manager in `asdf.open()`, i.e. is heavy-lifting happening in `AsdfFile.__init__` that should be happening in `AsdfFile.__enter__`?  Not sure.~

~Regardless, in this case, as soon as `asdf.open(file)` was called, it opens it without using `__enter__`.  Is this a bug or feature in `asdf` @eslavich ?  Or just a small bug here.~

Separate issue filed in https://github.com/asdf-format/asdf/issues/1006

Also cleaned up a try/except block below.  `velosys` is guaranteed to be an attribute as it is in the schema.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)