### PR TITLE
Don't cache CRDS reffiles between Github Actions jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,18 +81,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Get CRDS context
-        id: crds-context
-        run: |
-          pip install crds
-          echo "::set-output name=pmap::$(crds list --resolve-contexts --contexts | cut -f 1 -d ".")"
-
-      - name: Restore CRDS cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ matrix.toxenv }}-${{ steps.crds-context.outputs.pmap }}
-
       - name: Install tox
         run: |
           pip install tox

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -40,18 +40,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Get CRDS context
-        id: crds-context
-        run: |
-          pip install crds
-          echo "::set-output name=pmap::$(crds list --resolve-contexts --contexts | cut -f 1 -d ".")"
-
-      - name: Restore CRDS cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ matrix.toxenv }}-${{ steps.crds-context.outputs.pmap }}
-
       - name: Install tox
         run: |
           pip install tox
@@ -65,3 +53,4 @@ jobs:
         with:
           file: ./coverage.xml
           flags: unit
+          fail_ci_if_error: true


### PR DESCRIPTION
This turns off Github Actions caching between jobs.  It has not been working correctly lately, and seems to be causing issues as well.

Using a cache only seems to work on common branches, i.e. so `master` can use caches created on `master`, but not those created on branches on forks.  See the following:

https://github.community/t/actions-cache-cache-not-being-hit-despite-of-being-present/17956

These issues need to be resolved before it is turned on again.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [ ] Label(s)