### PR TITLE
Remove references to stspec

### DIFF
--- a/docs/jwst/stpipe/user_pipeline.rst
+++ b/docs/jwst/stpipe/user_pipeline.rst
@@ -58,26 +58,11 @@ Just like a ``Step``, it must have ``name`` and ``class`` values.
 Here the ``class`` must refer to a subclass of `stpipe.Pipeline`.
 
 Following ``name`` and ``class`` is the ``steps`` section.  Under
-this section is a subsection for each step in the pipeline.  To figure
-out what parameters are available, use the `stspec`
-script (just as with a regular step):
-
-.. code-block:: python
-
-    > stspec stpipe.test.test_pipeline.TestPipeline
-    science_filename = input_file()  # The input science filename
-    flat_filename = input_file()     # The input flat filename
-    skip = bool(default=False)   # Skip this step
-    output_filename = output_file()  # The output filename
-    [steps]
-    [[combine]]
-    config_file = string(default=None)
-    skip = bool(default=False)   # Skip this step
-    [[flat_field]]
-    threshold = float(default=0.0)# The threshold below which to remove
-    multiplier = float(default=1.0)# Multiply by this number
-    skip = bool(default=False)   # Skip this step
-    config_file = string(default=None)
+this section is a subsection for each step in the pipeline.  The easiest
+way to get started on a parameter file is to call ``Step.export_config`` and
+then edit the file that is created.  This will generate an ASDF config file
+that includes every available parameter, which can then be trimmed to the
+parameters that require customization.
 
 For each Step’s section, the parameters for that step may either be
 specified inline, or specified by referencing an external

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -51,37 +51,14 @@ into :ref:`stpipe-user-pipelines`, a Pipeline may use the same Step class
 multiple times, each with different configuration parameters.
 
 The parameters specific to the Step all reside under the key ``parameters``. The
-set of accepted parameters is defined in the Step’s spec member. You can print
-out a Step’s configspec using the ``stspec`` commandline utility. For example,
-to print the configspec for an imaginary step called `stpipe.cleanup`::
+set of accepted parameters is defined in the Step’s spec member.  The easiest
+way to get started on a parameter file is to call ``Step.export_config`` and
+then edit the file that is created.  This will generate an ASDF config file
+that includes every available parameter, which can then be trimmed to the
+parameters that require customization.
 
-    $ stspec stpipe.cleanup
-    # The threshold below which to apply cleanup
-    threshold = float()
-
-    # A scale factor
-    scale = float()
-
-    # The output file to save to
-    output_file = output_file(default = None)
-
-.. note::
-
-    Configspec information can also be displayed from Python, just
-    call ``print_configspec`` on any Step class.
-
-.. doctest-skip::
-
-  >>> from jwst.stpipe import cleanup
-  >>> cleanup.print_configspec()
-  >>> # The threshold below which to apply cleanup
-  >>> threshold = float()
-  >>> # A scale factor
-  >>> scale = float()
-
-Using this information, one can write a parameter file to use this step. For
-example, here is a parameter file (``do_cleanup.asdf``) that runs the
-``stpipe.cleanup`` step to clean up an image.
+Here is an example parameter file (``do_cleanup.asdf``) that runs the (imaginary)
+step ``stpipe.cleanup`` to clean up an image.
 
 .. code-block::
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

This PR removes references to the `stspec` CLI tool from the documentation.  `stspec` is provided by the stpipe package, but is being removed in the next release.  The `strun --save-parameters` option and the `Step.export_config` method are available to users who need to know what parameters are available.


Checklist
- [ ] Tests

- [x] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
