### PR TITLE
JP-2074: Update wfss_contam to process multiple orders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ outlier_detection
   The bug in the implimentation of the bilinear interpolator in the ``drizzle``
   package is now fixed. [#6146]
 
+wfss_contam
+-----------
+
+- Updated to process all defined spectral orders for the grism mode [#6175]
+
 1.2.3 (2021-06-08)
 ==================
 

--- a/jwst/regtest/test_nircam_wfss_contam.py
+++ b/jwst/regtest/test_nircam_wfss_contam.py
@@ -1,0 +1,40 @@
+"""Regression test for WFSS contam correction of NIRCam data"""
+import pytest
+
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.regtest import regtestdata as rt
+
+
+@pytest.fixture(scope='module')
+def run_wfss_contam(jail, rtdata_module):
+    """Run the wfss_contam step"""
+    rtdata = rtdata_module
+
+    # Get input data files
+    rtdata.get_data('nircam/wfss/jw01076_nircam_f322w2_i2d.fits')
+    rtdata.get_data('nircam/wfss/jw01076_nircam_f322w2_segm.fits')
+    rtdata.get_data('nircam/wfss/jw01076003001_01101_00001_nrca5_srctype.fits')
+
+    # Run the step
+    step_params = {
+        'step': 'jwst.wfss_contam.WfssContamStep',
+        'args': [
+            '--save_simulated_image=True',
+            '--save_contam_images=True',
+        ]
+    }
+    rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize(
+    'suffix',
+    ['simul', 'contam', 'wfsscontamstep']
+)
+def test_nrc_wfss_contam(run_wfss_contam, fitsdiff_default_kwargs, suffix):
+    """Regression test for wfss_contam applied to NIRCam WFSS data"""
+    rt.is_like_truth(
+        run_wfss_contam, fitsdiff_default_kwargs, suffix, 'truth/test_nircam_wfss_contam'
+    )

--- a/jwst/regtest/test_nircam_wfss_contam.py
+++ b/jwst/regtest/test_nircam_wfss_contam.py
@@ -1,8 +1,6 @@
 """Regression test for WFSS contam correction of NIRCam data"""
 import pytest
 
-from astropy.io.fits.diff import FITSDiff
-
 from jwst.regtest import regtestdata as rt
 
 

--- a/jwst/wfss_contam/sens1d.py
+++ b/jwst/wfss_contam/sens1d.py
@@ -87,7 +87,7 @@ def create_1d_sens(data_waves, ref_waves, relresps):
     # 1D wavelength grid of the data
     sens_1d = np.interp(data_waves, ref_waves, relresps, left=np.NaN, right=np.NaN)
 
-    no_cal = np.isnan(sens_1d)
-    sens_1d[no_cal] = 0.
+    sens_1d[np.isnan(sens_1d)] = 0
+    no_cal = sens_1d == 0
 
     return sens_1d, no_cal

--- a/jwst/wfss_contam/wfss_contam_step.py
+++ b/jwst/wfss_contam/wfss_contam_step.py
@@ -14,6 +14,9 @@ class WfssContamStep(Step):
     """
 
     spec = """
+        save_simulated_image = boolean(default=False)  # Save full-frame simulated image
+        save_contam_images = boolean(default=False)  # Save source contam estimates
+        maximum_cores = option('none', 'quarter', 'half', 'all', default='none')
     """
 
     reference_file_types = ['photom', 'wavelengthrange']
@@ -21,6 +24,8 @@ class WfssContamStep(Step):
     def process(self, input_model, *args, **kwargs):
 
         with datamodels.open(input_model) as dm:
+
+            max_cores = self.maximum_cores
 
             # Get the wavelengthrange ref file
             waverange_ref = self.get_reference_file(dm, 'wavelengthrange')
@@ -32,6 +37,18 @@ class WfssContamStep(Step):
             self.log.info(f'Using PHOTOM reference file {photom_ref}')
             photom_model = datamodels.open(photom_ref)
 
-            output_model = wfss_contam.contam_corr(dm, waverange_model, photom_model)
+            result, simul, contam = wfss_contam.contam_corr(dm,
+                                                            waverange_model,
+                                                            photom_model,
+                                                            max_cores)
 
-        return output_model
+            # Save intermediate results, if requested
+            if self.save_simulated_image:
+                simul_path = self.save_model(simul, suffix="simul", force=True)
+                self.log.info(f'Full-frame simulated grism image saved to "{simul_path}"')
+            if self.save_contam_images:
+                contam_path = self.save_model(contam, suffix="contam", force=True)
+                self.log.info(f'Contamination estimates saved to "{contam_path}"')
+
+        # Return the corrected data
+        return result


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6015

Resolves [JP-2074](https://jira.stsci.edu/browse/JP-2074)

**Description**

This PR addresses updates the baseline wfss_contam step code to process all available spectral orders in a given grism exposure. Some restructuring of the underlying INS code was necessary to do this in a simple way, such that the initialization of the Observation class for the grism exposure no longer does anything that's order-dependent. All of the order dependencies are now contained in the functions that actually create the dispersed spectra.

Also includes some code cleanup and adds hooks for saving 2 kinds of intermediate data files.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)