### PR TITLE
JP-844: Update extract_1d docs

### DIFF
--- a/docs/jwst/extract_1d/description.rst
+++ b/docs/jwst/extract_1d/description.rst
@@ -127,10 +127,13 @@ the characteristics of the source extraction region can be specified in one
 of two different ways. 
 The simplest approach is to use the ``xstart``, ``xstop``, ``ystart``,
 ``ystop``, and ``extract_width`` parameters.  Note that all of these values are
-zero-indexed integers, and that the start and stop limits are inclusive.
+zero-indexed integers, the start and stop limits are inclusive, and the values
+are in the frame of the image being operated on (which could be a cutout of a
+larger original image).
 If ``dispaxis=1``, the limits in the dispersion direction are ``xstart``
 and ``xstop`` and the limits in the cross-dispersion direction are ``ystart``
 and ``ystop``. If ``dispaxis=2``, the rolls are reversed.
+
 If ``extract_width`` is also given, that takes priority over ``ystart`` and
 ``ystop`` (for ``dispaxis=1``) for the extraction width, but ``ystart`` and
 ``ystop`` will still be used to define the centering of the extraction region
@@ -146,8 +149,6 @@ internally set to True for point source data according to the table given in :re
 Any of the extraction location parameters will be modified internally by the step code if the
 extraction region would extend outside the limits of the input image or outside
 the domain specified by the WCS.
-
-
 
 A more flexible way to specify the source extraction region is via the ``src_coeff``
 parameter. ``src_coeff`` is specified as a list of lists of floating-point

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -1,4 +1,3 @@
-
 .. _extract1d_reffile:
 
 EXTRACT1D Reference File
@@ -73,6 +72,13 @@ and background extraction regions.
 * bkg_fit: the type of background fit or computation (string)
 * bkg_order: order of polynomial fit to background regions (int)
 * extract_width: number of pixels in cross-dispersion direction (int)
+
+.. note::
+
+   All parameter values that represent pixel indexes, such as ``xstart``,
+   ``xstop``, and the ``src_coeff`` and ``bkg_coeff`` coefficients, are always
+   in the frame of the image being operated on, which could be a small cutout
+   from a larger original image.
 
 See :ref:`extract-1d-for-slits` for more details on how these parameters
 are used in the extraction process.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
Resolves [JP-844](https://jira.stsci.edu/browse/JP-844)

**Description**

This PR updates the extract_1d step docs to state that all reference file parameter values that give pixel indexes, such as `xstart`, `xstop`, `src_coeff`, `bkg_coeff`, are in the frame of the current image, not the frame of a larger image from which the data may have been extracted.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)