### PR TITLE
JP-2172: Fix issue with non-finite aperture positions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,11 @@ ramp_fitting
 - Update ``RampFitStep`` to pass DQ flags as a parameter to the ``ramp_fit``
   algorithm code in stcal.  Bump version requirement for stcal.  [#6072]
 
+source_catalog
+--------------
+
+- Fixed issue with non-finite positions for aperture photometry. [#6206]
+
 wfss_contam
 -----------
 

--- a/jwst/source_catalog/_wcs_helpers.py
+++ b/jwst/source_catalog/_wcs_helpers.py
@@ -1,0 +1,65 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# (taken from photutils: should probably migrate into astropy.wcs)
+"""
+This module provides WCS helper tools.
+"""
+
+import astropy.units as u
+import numpy as np
+
+
+def pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1 * u.arcsec):
+    """
+    Calculate the pixel coordinate and scale and WCS rotation angle at
+    the position of a SkyCoord coordinate.
+
+    Parameters
+    ----------
+    skycoord : `~astropy.coordinates.SkyCoord`
+        The SkyCoord coordinate.
+
+    wcs : WCS object
+        A world coordinate system (WCS) transformation that
+        supports the `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
+    offset : `~astropy.units.Quantity`
+        A small angular offset to use to compute the pixel scale and
+        position angle.
+
+    Returns
+    -------
+    xypos : tuple of float
+        The (x, y) pixel coordinate.
+
+    scale : `~astropy.units.Quantity`
+        The pixel scale in arcsec/pixel.
+
+    angle : `~astropy.units.Quantity`
+        The angle (in degrees) measured counterclockwise from the
+        positive x axis to the "North" axis of the celestial coordinate
+        system.
+
+    Notes
+    -----
+    If distortions are present in the image, the x and y pixel scales
+    likely differ.  This function computes a single pixel scale along
+    the North/South axis.
+    """
+    # Convert to pixel coordinates
+    xpos, ypos = wcs.world_to_pixel(skycoord)
+
+    # We take a point directly North (i.e., latitude offset) the
+    # input sky coordinate and convert it to pixel coordinates,
+    # then we use the pixel deltas between the input and offset sky
+    # coordinate to calculate the pixel scale and angle.
+    skycoord_offset = skycoord.directional_offset_by(0.0, offset)
+    x_offset, y_offset = wcs.world_to_pixel(skycoord_offset)
+
+    dx = x_offset - xpos
+    dy = y_offset - ypos
+    scale = offset.to(u.arcsec) / (np.hypot(dx, dy) * u.pixel)
+    angle = (np.arctan2(dy, dx) * u.radian).to(u.deg)
+
+    return (xpos, ypos), scale, angle

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -13,6 +13,7 @@ from astropy.stats import gaussian_fwhm_to_sigma, SigmaClip
 from astropy.table import QTable
 import astropy.units as u
 from astropy.utils import lazyproperty
+from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 from scipy import __version__ as scipy_version
 from scipy import ndimage
@@ -547,7 +548,7 @@ class JWSTSourceCatalog:
         """
         # ignore RunTimeWarning if flux or flux_err contains NaNs
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=RuntimeWarning)
+            warnings.simplefilter('ignore', category=RuntimeWarning)
 
             abmag = -2.5 * np.log10(flux.value) + 8.9
             abmag_err = 2.5 * np.log10(1.0 + (flux_err.value / flux.value))
@@ -853,15 +854,19 @@ class JWSTSourceCatalog:
         bkg_aper_masks = bkg_aper.to_mask(method='center')
         sigclip = SigmaClip(sigma=3.)
 
-        nvalues = []
-        bkg_median = []
-        bkg_std = []
-        for mask in bkg_aper_masks:
-            bkg_data = mask.get_values(self.model.data.value)
-            values = sigclip(bkg_data, masked=False)
-            nvalues.append(values.size)
-            bkg_median.append(np.median(values))
-            bkg_std.append(np.std(values))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+            warnings.simplefilter('ignore', category=AstropyUserWarning)
+
+            nvalues = []
+            bkg_median = []
+            bkg_std = []
+            for mask in bkg_aper_masks:
+                bkg_data = mask.get_values(self.model.data.value)
+                values = sigclip(bkg_data, masked=False)
+                nvalues.append(values.size)
+                bkg_median.append(np.median(values))
+                bkg_std.append(np.std(values))
 
         nvalues = np.array(nvalues)
         bkg_median = np.array(bkg_median)

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1163,7 +1163,11 @@ class JWSTSourceCatalog:
         """
         if len(self._ckdtree_query[1]) == 1:  # only one detected source
             return np.nan
-        return self.label[self._ckdtree_query[1]]
+
+        idx = self._ckdtree_query[1].copy()
+        mask = idx >= len(self.label)
+        idx[mask] = 0
+        return np.where(mask, self.label, self.label[idx])
 
     @lazyproperty
     def nn_dist(self):

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -25,12 +25,12 @@ from photutils.segmentation import (detect_sources, deblend_sources,
                                     SourceCatalog)
 from photutils.aperture import (CircularAperture, CircularAnnulus,
                                 aperture_photometry)
-from photutils.utils._wcs_helpers import _pixel_scale_angle_at_skycoord
 
 from jwst import __version__ as jwst_version
 
 from .. import datamodels
 from ..datamodels import ImageModel, ABVegaOffsetModel
+from ._wcs_helpers import pixel_scale_angle_at_skycoord
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -703,7 +703,7 @@ class JWSTSourceCatalog:
         # NOTE: crpix1 and crpix2 are 1-based values
         skycoord = self.wcs.pixel_to_world(self.model.meta.wcsinfo.crpix1 - 1,
                                            self.model.meta.wcsinfo.crpix2 - 1)
-        _, angle = _pixel_scale_angle_at_skycoord(skycoord, self.wcs)
+        _, _, angle = pixel_scale_angle_at_skycoord(skycoord, self.wcs)
 
         return (180.0 * u.deg) - angle + self.orientation
 


### PR DESCRIPTION
This PR fixes an issue where non-finite (NaN) positions can be calculated for garbage sources due to invalid 2D image moments, which in turn causes the source catalog step to fail.

Fixes #6180
Fixes #6220
Resolves [JP-2172](https://jira.stsci.edu/browse/JP-2172)
Resolves [JP-2203](https://jira.stsci.edu/browse/JP-2203)