### PR TITLE
JP-2173: Add wfss_contam step to calwebb_spec2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,11 @@ outlier_detection
   The bug in the implimentation of the bilinear interpolator in the ``drizzle``
   package is now fixed. [#6146]
 
+pipeline
+--------
+
+- Added wfss_contam step to `calwebb_spec2` pipeline flow for WFSS modes [#6207]
+
 wfss_contam
 -----------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ conf = ConfigParser()
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../'))
+# sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('jwst/'))
 sys.path.insert(0, os.path.abspath('exts/'))
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -26,6 +26,7 @@ from ..resample import resample_spec_step
 from ..srctype import srctype_step
 from ..straylight import straylight_step
 from ..wavecorr import wavecorr_step
+from ..wfss_contam import wfss_contam_step
 
 __all__ = ['Spec2Pipeline']
 
@@ -70,6 +71,7 @@ class Spec2Pipeline(Pipeline):
         'fringe': fringe_step.FringeStep,
         'pathloss': pathloss_step.PathLossStep,
         'barshadow': barshadow_step.BarShadowStep,
+        'wfss_contam': wfss_contam_step.WfssContamStep,
         'photom': photom_step.PhotomStep,
         'resample_spec': resample_spec_step.ResampleSpecStep,
         'cube_build': cube_build_step.CubeBuildStep,
@@ -367,6 +369,11 @@ class Spec2Pipeline(Pipeline):
             self.log.debug('Science data does not allow master background correction. Skipping "master_background".')
             self.master_background.skip = True
 
+        # Apply WFSS contamination correction only to WFSS exposures
+        if not self.wfss_contam.skip and exp_type not in WFSS_TYPES:
+            self.log.debug('Science data does not allow WFSS contamination correction. Skipping "wfss_contam".')
+            self.wfss_contam.skip = True
+
     def _process_grism(self, data):
         """WFSS & Grism processing
 
@@ -379,6 +386,7 @@ class Spec2Pipeline(Pipeline):
         calibrated = self.fringe(calibrated)
         calibrated = self.pathloss(calibrated)
         calibrated = self.barshadow(calibrated)
+        calibrated = self.wfss_contam(calibrated)
         calibrated = self.photom(calibrated)
 
         return calibrated

--- a/jwst/wfss_contam/wfss_contam_step.py
+++ b/jwst/wfss_contam/wfss_contam_step.py
@@ -17,6 +17,7 @@ class WfssContamStep(Step):
         save_simulated_image = boolean(default=False)  # Save full-frame simulated image
         save_contam_images = boolean(default=False)  # Save source contam estimates
         maximum_cores = option('none', 'quarter', 'half', 'all', default='none')
+        skip = boolean(default=True)
     """
 
     reference_file_types = ['photom', 'wavelengthrange']

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,9 +92,6 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[build_ext]
-inplace = 1
-
 [flake8]
 select = F, W, E, C
 # We should set max line length lower eventually

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,9 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
+[build_ext]
+inplace = 1
+
 [flake8]
 select = F, W, E, C
 # We should set max line length lower eventually


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6181 

Resolves [JP-2173](https://jira.stsci.edu/browse/JP-2173)

**Description**

This PR adds the `wfss_contam` step to the `calwebb_spec2` pipeline module, so that it can be applied to WFSS exposures. Note that until the step has gone through more rigorous testing and review by INS, it is being set to be skipped by default. A user has the option to apply the step, when/if desired.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [X] Milestone
- [X] Label(s)