### PR TITLE
JP-2198: Handle MIRI LRS SRCTYPE keyword in extract_1d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ datamodels
 
 - Remove astropy.io registration of JwstDataModel. [#6179]
 
+extract_1d
+----------
+
+- Updated to propagate SRCTYPE keyword during extraction of MIRI LRS
+  fixed-slit inputs that are in `SlitModel` form. [#6212]
+
 outlier_detection
 -----------------
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -3125,6 +3125,7 @@ def do_extract1d(
             source_type = input_model.source_type
             if source_type is None:
                 source_type = input_model.meta.target.source_type
+                input_model.source_type = source_type
         else:
             source_type = input_model.meta.target.source_type
 

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -116,7 +116,7 @@ class Extract1dStep(Step):
         elif isinstance(input_model, datamodels.IFUCubeModel):
             self.log.debug('Input is an IFUCubeModel')
         elif isinstance(input_model, datamodels.SlitModel):
-            # NRS_BRIGHTOBJ mode
+            # NRS_BRIGHTOBJ and MIRI LRS fixed-slit (resampled) modes
             self.log.debug('Input is a SlitModel')
         else:
             self.log.error(f'Input is a {str(type(input_model))}, ')


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6208 

Resolves [JP-2198](https://jira.stsci.edu/browse/JP-2198)

**Description**

This PR fixes a problem with the SRCTYPE keyword not getting copied over to the x1d output of the extract_1d step when processing resampled MIRI LRS fixed-slit exposures. The problem lies in the fact that the `source_type` attribute is defined in the core schema within the `target` tree of meta data and also defined in the slitmeta.schema (for `SlitModel`). When the `resample_spec` step is applied to MIRI LRS fixed-slit exposures, the input is an `ImageModel` with SRCTYPE defined within the `target` part of the meta tree, but the output of `resample_spec` is a `SlitModel`, which is created without the SRCTYPE value getting copied to the `SlitModel`. The `extract_1d` is clever enough to look for SRCTYPE in both `model.source_type` (if the input is a `SlitModel`) and if that's blank - which it is in this case - then look for `model.meta.target.source_type`, where it finds the value. However, `model.source_type` was still blank (None) when slit-related keywords are copied to the output x1d model, so the keyword didn't show up.

This change simply copies the `source_type` value to the `SlitModel` in this situation, so it's available to be copied to the x1d output later in the flow.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)