### PR TITLE
JP-2166: Add NOUTPUTS to DarkModel schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ datamodels
 
 - Remove astropy.io registration of JwstDataModel. [#6179]
 
+- Add NOUTPUTS keyword to the `DarkModel` schema. [#6213]
+
 extract_1d
 ----------
 

--- a/docs/jwst/references_general/dark_selection.inc
+++ b/docs/jwst/references_general/dark_selection.inc
@@ -6,12 +6,12 @@ CRDS selects appropriate DARK references based on the following keywords.
 DARK is not applicable for instruments not in the table.
 
 ========== ==================================================================================================
-Instrument Keywords                                                                                           
+Instrument Keywords
 ========== ==================================================================================================
-FGS        INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
-MIRI       INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
-NIRCam     INSTRUME, DETECTOR, SUBARRAY, DATE-OBS, TIME-OBS                                                   
-NIRISS     INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS                                         
-NIRSpec    INSTRUME, DETECTOR, READPATT, SUBARRAY, SUBSTRT1, SUBSTRT2, SUBSIZE1, SUBSIZE2, DATE-OBS, TIME-OBS 
+FGS        INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS
+MIRI       INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS
+NIRCam     INSTRUME, DETECTOR, EXP_TYPE, NOUTPUTS, SUBARRAY, DATE-OBS, TIME-OBS
+NIRISS     INSTRUME, DETECTOR, READPATT, SUBARRAY, DATE-OBS, TIME-OBS
+NIRSpec    INSTRUME, DETECTOR, READPATT, SUBARRAY, SUBSTRT1, SUBSTRT2, SUBSIZE1, SUBSIZE2, DATE-OBS, TIME-OBS
 ========== ==================================================================================================
 

--- a/docs/jwst/references_general/dark_specific.inc
+++ b/docs/jwst/references_general/dark_specific.inc
@@ -9,6 +9,8 @@ because they are used as CRDS selectors
 Keyword    Data Model Name                 Instruments
 =========  ==============================  ==========================
 DETECTOR   model.meta.instrument.detector  All
+EXP_TYPE   model.meta.exposure.type        NIRCam
+NOUTPUTS   model.meta.exposure.noutputs    NIRCam
 READPATT   model.meta.exposure.readpatt    FGS, MIRI, NIRISS, NIRSpec
 SUBARRAY   model.meta.subarray.name        All
 SUBSTRT1   model.meta.subarray.xstart      NIRSpec

--- a/jwst/datamodels/schemas/dark.schema.yaml
+++ b/jwst/datamodels/schemas/dark.schema.yaml
@@ -8,6 +8,7 @@ allOf:
 - $ref: keyword_exptype.schema
 - $ref: keyword_readpatt.schema
 - $ref: keyword_preadpatt.schema
+- $ref: keyword_noutputs.schema
 - $ref: keyword_nframes.schema
 - $ref: keyword_ngroups.schema
 - $ref: keyword_groupgap.schema

--- a/jwst/datamodels/schemas/keyword_noutputs.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_noutputs.schema.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_noutputs.schema"
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      exposure:
+        type: object
+        properties:
+          noutputs:
+            title: Number of detector outputs used
+            type: integer
+            enum: [1, 4]
+            fits_keyword: NOUTPUTS


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6168 

Resolves [JP-2166](https://jira.stsci.edu/browse/JP-2166)

**Description**

This PR adds the NOUTPUTS keyword to the `DarkModel` schema for DARK reference files, at the request of the NIRCam team. Also updated the relevant sections of the DARK docs (*not* part of the dark web ...)


Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)