### PR TITLE
JP-1932: Update DARK model schemas to use uint32 for DQ

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ datamodels
 
 - Add NOUTPUTS keyword to the `DarkModel` schema. [#6213]
 
+- Update `DarkModel` to use uint32 for DQ array. [#6228]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/dark.py
+++ b/jwst/datamodels/dark.py
@@ -15,7 +15,7 @@ class DarkModel(ReferenceFileModel):
     data : numpy float32 array
          Dark current array
 
-    dq : numpy uint16 array
+    dq : numpy uint32 array
          2-D data quality array for all planes
 
     err : numpy float32 array

--- a/jwst/datamodels/darkMIRI.py
+++ b/jwst/datamodels/darkMIRI.py
@@ -15,7 +15,7 @@ class DarkMIRIModel(ReferenceFileModel):
     data : numpy float32 array
          Dark current array
 
-    dq : numpy uint16 array
+    dq : numpy uint32 array
          2-D data quality array for all planes
 
     err : numpy float32 array

--- a/jwst/datamodels/schemas/dark.schema.yaml
+++ b/jwst/datamodels/schemas/dark.schema.yaml
@@ -27,7 +27,7 @@ allOf:
       fits_hdu: DQ
       default: 0
       ndim: 2
-      datatype: uint16
+      datatype: uint32
     err:
       title: Error array
       fits_hdu: ERR


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5775

Resolves [JP-1932](https://jira.stsci.edu/browse/JP-1932)

**Description**

This PR updates the DQ array definition in the DARK ref file data model schema to be uint32, instead of the old uint16. This model apparently got missed when all the others were updated to uint32.

Checklist
- [ ] ~~Tests~~
- [ ] ~~Documentation~~
- [x] Change log
- [x] Milestone
- [x] Label(s)