### PR TITLE
JP-2200: Add new MIRI Coron PATTTYPE values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ datamodels
 
 - Update `DarkModel` to use uint32 for DQ array. [#6228]
 
+- Add new PATTTYPE values for MIRI Coronagraphic flats:
+  4QPM_LFLAT, 4QPM_PFLAT, LYOT_LFLAT, LYOT_PFLAT. [#6232]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1038,6 +1038,7 @@ properties:
 
               # MIRI coron
               5-POINT-SMALL-GRID, 9-POINT-SMALL-GRID,
+              4QPM_LFLAT, 4QPM_PFLAT, LYOT_LFLAT, LYOT_PFLAT,
 
               # MIRI imaging
               CYCLING, REULEAUX, SPARSE-CYCLING,


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6214 

Resolves [JP-2200](https://jira.stsci.edu/browse/JP-2200)

**Description**

This PR adds 4 new dither pattern values to the PATTTYPE keyword enum list for MIRI Coronagraphic flats, as outlined in https://jira.stsci.edu/browse/JSOCINT-590


Checklist
- [ ] ~~Tests~~
- [ ] ~~Documentation~~
- [x] Change log
- [x] Milestone
- [x] Label(s)