### PR TITLE
JP-2211: Fix wfss_contam handling of filter names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,8 @@ wfss_contam
 
 - Added step documentation [#6210]
 
+- Fixed handling of filter/pupil names for NIRISS WFSS mode [#6233]
+
 1.2.3 (2021-06-08)
 ==================
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6231 

Resolves [JP-2211](https://jira.stsci.edu/browse/JP-2211)

**Description**

This PR fixes a bug in the `wfss_contam` step when processing NIRISS WFSS grism exposures. The filters used in NIRISS WFSS are physically located in the PUPIL wheel, so you have to use the PUPIL keyword value for the filter name everywhere in the step code where the filter name is needed.


Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)