### PR TITLE
Jump flags all pixels for MIRI 3 & 4 group ints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ datamodels
 
 - Update `DarkModel` to use uint32 for DQ array. [#6228]
 
+- Add new PATTTYPE values for MIRI Coronagraphic flats:
+  4QPM_LFLAT, 4QPM_PFLAT, LYOT_LFLAT, LYOT_PFLAT. [#6232]
+
 extract_1d
 ----------
 
@@ -51,12 +54,19 @@ ramp_fitting
 - Update ``RampFitStep`` to pass DQ flags as a parameter to the ``ramp_fit``
   algorithm code in stcal.  Bump version requirement for stcal.  [#6072]
 
+source_catalog
+--------------
+
+- Fixed issue with non-finite positions for aperture photometry. [#6206]
+
 wfss_contam
 -----------
 
 - Updated to process all defined spectral orders for the grism mode [#6175]
 
 - Added step documentation [#6210]
+
+- Fixed handling of filter/pupil names for NIRISS WFSS mode [#6233]
 
 1.2.3 (2021-06-08)
 ==================
@@ -3930,7 +3940,8 @@ ipc
 
 jump
 ----
-
+=- Fix to stop the flagging of all groups as jumps for 3 & 4 group
+   MIRI integrations when the first frame is flagged as DO_NOT_USE[#2206]
 jwpsf
 -----
 
@@ -4052,6 +4063,11 @@ tweakreg
 
 wfs_combine
 -----------
+
+-- add option to flip the dither locations so that images with different
+   filters will have the same pixel locations [#2051]
+-- Fixed the refine option to correctly use the cross correlation to align
+   the images if the WCS is off [#2051]
 
 white_light
 -----------

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -73,11 +73,13 @@ def detect_jumps(input_model, gain_model, readnoise_model,
     if len(wh_g[0] > 0):
         pdq[wh_g] = np.bitwise_or(pdq[wh_g], dqflags.pixel['NO_GAIN_VALUE'])
         pdq[wh_g] = np.bitwise_or(pdq[wh_g], dqflags.pixel['DO_NOT_USE'])
+        gain_2d[wh_g] == 0
 
     wh_g = np.where(np.isnan(gain_2d))
     if len(wh_g[0] > 0):
         pdq[wh_g] = np.bitwise_or(pdq[wh_g], dqflags.pixel['NO_GAIN_VALUE'])
         pdq[wh_g] = np.bitwise_or(pdq[wh_g], dqflags.pixel['DO_NOT_USE'])
+        gain_2d[wh_g] = 0.0  # a pixel with all NaNs messes up the two point difference step
 
     # Apply gain to the SCI, ERR, and readnoise arrays so they're in units
     # of electrons

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -290,9 +290,9 @@ def test_nirspec_saturated_pix(setup_inputs):
     # Check the results. There should not be any pixels with DQ values of 6, which
     # is saturated (2) plus jump (4). All the DQ's should be either just 2 or just 4.
     assert_array_equal(out_model.groupdq[0, :, 1, 1], [0, 4, 4, 4, 0, 2, 2])
-    assert_array_equal(out_model.groupdq[0, :, 2, 2], [0, 4, 2, 2, 2, 2, 2])
+    assert_array_equal(out_model.groupdq[0, :, 2, 2], [0, 0, 2, 2, 2, 2, 2])  # cannot find jump with just one grp
     assert_array_equal(out_model.groupdq[0, :, 3, 3], [0, 4, 4, 0, 0, 4, 2])
-    assert_array_equal(out_model.groupdq[0, :, 4, 4], [0, 4, 2, 2, 2, 2, 2])
+    assert_array_equal(out_model.groupdq[0, :, 4, 4], [0, 0, 2, 2, 2, 2, 2])  # cannot find jump with just one grp
 
 
 def test_flagging_of_CRs_across_slice_boundaries(setup_inputs):

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -5,7 +5,7 @@ from jwst.jump.twopoint_difference import find_crs
 from jwst.jump.twopoint_difference import get_clipped_median_vector
 from jwst.jump.twopoint_difference import get_clipped_median_array
 from jwst.datamodels import dqflags
-
+from astropy.io import fits
 
 def test_nocrs_noflux(setup_cube):
     ngroups = 5
@@ -714,7 +714,7 @@ def test_first_last_3group(setup_cube):
     #  and group 6-7. Add a jump between 3 and 4 just to make sure jump detection is working
     #  set group 1 to be 10,000
     data[0, 0, 0, 0] = 10000.0
-    data[0, 1, 0, 0] = 10010.0
+    data[0, 1, 0, 0] = 10100.0
     data[0, 2, 0, 0] = 30020.0
 
     gdq[0, 2, 0, 0] = dqflags.group['DO_NOT_USE']  # only flag the last group

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -121,7 +121,8 @@ def find_crs(data, group_dq, read_noise, normal_rejection_threshold,
                                                  max_ratio2d > three_diff_rejection_threshold))
         # Finally, for pixels with only two good groups, compare the SNR of the last good group to the two diff
         # threshold
-        row2cr, col2cr = np.where(max_ratio2d > two_diff_rejection_threshold)
+        row2cr, col2cr = np.where(np.logical_and(ndiffs - number_sat_groups == 2,
+                                                 max_ratio2d > two_diff_rejection_threshold))
         log.info(
             f'From highest outlier Two-point found {len(row4cr)} pixels with at least one CR and at least four groups')
         log.info(


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-2206: <Fix a bug>
**
-->

Closes #6223 

Resolves JP-2206


This PR addresses the problem that when the MIRI first frame is flagged as DO_NOT_USE the jump step would flag all the pixels in three and four group integrations. This fix also address a bug that caused it flag single good group pixels under certain conditions. Both problems were recreated with new tests.


Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [ ] Milestone

- [ ] Label(s)
