### PR TITLE
Set pytest-doctestplus minimum version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ test =
     colorama>=0.4.1
     getch>=1.0.0
     pytest>=4.6.0
-    pytest-doctestplus
+    pytest-doctestplus>=0.10.0
     requests_mock>=1.0
     pytest-openfiles>=0.5.0
     pytest-cov>=2.9.0


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

@hbushouse pointed out that we need at least pytest-doctestplus 0.10.0 to build the docs.

Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [ ] Milestone

- [ ] Label(s)
