### PR TITLE
JP-2103 : Update slit.source_x(y)pos (NRS FS mode) after computing them in wavecorr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,12 @@ source_catalog
 
 - Fixed issue with non-finite positions for aperture photometry. [#6206]
 
+wavecorr
+--------
+
+- Location of source in NIRspec fixed slit updated
+  (keywords ``SCRCXPOS``, ``SRCYPOS``). [#6243]
+
 wfss_contam
 -----------
 

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -8,10 +8,12 @@ from jwst import datamodels
 from jwst.assign_wcs import AssignWcsStep
 from jwst.extract_2d import Extract2dStep
 from jwst.srctype import SourceTypeStep
+from jwst.transforms import models
 from jwst.wavecorr import WavecorrStep
 from jwst.wavecorr import wavecorr
 
 from jwst.assign_wcs.tests.test_nirspec import create_nirspec_mos_file
+from jwst.assign_wcs.tests.test_nirspec import create_nirspec_fs_file
 
 
 def test_wavecorr():
@@ -47,3 +49,15 @@ def test_wavecorr():
     zero_point2 = wavecorr.compute_zero_point_correction(lam, freference, source_xpos2, 'MOS', dispersion)
     diff_correction = np.abs(zero_point1[1] - zero_point2[1])
     assert_allclose(diff_correction[diff_correction.nonzero()].mean(), 0.02, atol=0.01)
+
+
+def test_ideal_to_v23_fs():
+    hdul = create_nirspec_fs_file(grating='G140H', filter='F070LP')
+    # create data model, populate wcs_info
+    v3yangle = 138.78
+    v2_ref = 321.87
+    v3_ref = -477.94
+    vparity = -1
+    id2v=models.IdealToV2V3(v3yangle, v2_ref, v3_ref, vparity)
+    assert_allclose(id2v(0, 0), (v2_ref, v3_ref))
+    assert_allclose(id2v.inverse(v2_ref, v3_ref), (0, 0))

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -13,7 +13,6 @@ from jwst.wavecorr import WavecorrStep
 from jwst.wavecorr import wavecorr
 
 from jwst.assign_wcs.tests.test_nirspec import create_nirspec_mos_file
-from jwst.assign_wcs.tests.test_nirspec import create_nirspec_fs_file
 
 
 def test_wavecorr():
@@ -52,12 +51,11 @@ def test_wavecorr():
 
 
 def test_ideal_to_v23_fs():
-    hdul = create_nirspec_fs_file(grating='G140H', filter='F070LP')
-    # create data model, populate wcs_info
+    """Test roundtripping between Ideal and V2V3 frames."""
     v3yangle = 138.78
     v2_ref = 321.87
     v3_ref = -477.94
     vparity = -1
-    id2v=models.IdealToV2V3(v3yangle, v2_ref, v3_ref, vparity)
+    id2v = models.IdealToV2V3(v3yangle, v2_ref, v3_ref, vparity)
     assert_allclose(id2v(0, 0), (v2_ref, v3_ref))
     assert_allclose(id2v.inverse(v2_ref, v3_ref), (0, 0))

--- a/jwst/wavecorr/wavecorr.py
+++ b/jwst/wavecorr/wavecorr.py
@@ -253,9 +253,21 @@ def get_source_xpos(slit, slit_wcs, lam, msa_model):
     # Compute the location in V2,V3 [in arcsec]
     xv, yv = idl2v23(xoffset, yoffset)
 
-    v2v3_to_msa_frame = slit_wcs.get_transform("v2v3", "msa_frame")
-    xpos_abs, ypos_abs, lam = v2v3_to_msa_frame(xv, yv, lam)
+    v2v3_to_msa = slit_wcs.get_transform("v2v3", "msa_frame")
+    msa_to_slit = slit_wcs.get_transform("msa_frame", "slit_frame")
+
+    # Position in the MSA
+    xpos_abs, ypos_abs, lam = v2v3_to_msa(xv, yv, lam)
     xpos_frac = absolute2fractional(msa_model, slit, xpos_abs, ypos_abs)
+    # Position in the virtual slit
+    xpos_slit, ypos_slit, lam_slit = msa_to_slit(xpos_abs, ypos_abs, lam)
+    # Update slit.source_xpos, slit.source_ypos
+    slit.source_xpos = xpos_slit
+    slit.source_ypos = ypos_slit
+    log.debug('Source X/Y position in the slit: {0}, {1}'.format(xpos_slit, ypos_slit))
+
+    log.debug('Source X/Y position in the MSA: {0}, {1}'.format(xpos_abs, ypos_abs))
+    log.debug('Fractional position of source in aperture {}'.format(xpos_frac))
     return xpos_frac
 
 


### PR DESCRIPTION

<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6074 

Resolves [JP-2103](https://jira.stsci.edu/browse/JP-2103)

**Description**

In Nirspec FS mode the wavecorr step computes the position of the source in 
the aperture using `meta.dither.x_offset` and `meta.dither.y_offset` but did not update `slit.source_xpos` and `slit.source_ypos`. This PR updates the two attributes with the computed [position of the source in the slit.


Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)