### PR TITLE
JP-2120: Increase test coverage for ImageModel through Extract1dStep

### DIFF
--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -66,7 +66,7 @@ def test_miri_lrs_extract1d_image_ref(run_pipeline, rtdata_module, fitsdiff_defa
     rtdata.get_data("miri/lrs/jw00623032001_03102_00001_mirimage_image_ref.fits")
     rtdata.input = "jw00623032001_03102_00001_mirimage_cal.fits"
     Extract1dStep.call(rtdata.input,
-                       override_extract1d='miri/lrs/jw00623032001_03102_00001_mirimage_image_ref.fits',
+                       override_extract1d="jw00623032001_03102_00001_mirimage_image_ref.fits",
                        suffix='x1dfromrefimage',
                        save_results=True)
     output = "jw00623032001_03102_00001_mirimage_x1dfromrefimage.fits"

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -23,8 +23,8 @@ def run_pipeline(jail, rtdata_module):
             "--steps.assign_wcs.save_results=true",
             "--steps.flat_field.save_results=true",
             "--steps.srctype.save_results=true",
-            "--steps.bkg_subtract.save_combined_background=true",
-            "--verbose"]
+            "--steps.bkg_subtract.save_combined_background=true"
+            ]
     Step.from_cmdline(args)
 
 
@@ -46,17 +46,18 @@ def test_miri_lrs_slit_spec2(run_pipeline, fitsdiff_default_kwargs, suffix, rtda
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
+
 @pytest.mark.bigdata
 def test_miri_lrs_extract1d_from_cal(run_pipeline, rtdata_module, fitsdiff_default_kwargs):
     rtdata = rtdata_module
     rtdata.input = "jw00623032001_03102_00001_mirimage_cal.fits"
     Extract1dStep.call(rtdata.input, save_results=True)
     output = "jw00623032001_03102_00001_mirimage_x1d.fits"
-    truth = "jw00623032001_03102_00001_mirimage_x1d.fits"
     rtdata.output = output
-    rtdata.get_truth(f"truth/test_miri_lrs_slit_spec2/{truth}")
+    rtdata.get_truth(f"truth/test_miri_lrs_slit_spec2/{output}")
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
+
 
 @pytest.mark.bigdata
 def test_miri_lrs_slit_wcs(run_pipeline, rtdata_module, fitsdiff_default_kwargs):

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -5,6 +5,7 @@ import pytest
 
 from jwst.stpipe import Step
 from jwst import datamodels
+from jwst.extract_1d import Extract1dStep
 
 
 @pytest.fixture(scope="module")
@@ -22,7 +23,8 @@ def run_pipeline(jail, rtdata_module):
             "--steps.assign_wcs.save_results=true",
             "--steps.flat_field.save_results=true",
             "--steps.srctype.save_results=true",
-            "--steps.bkg_subtract.save_combined_background=true"]
+            "--steps.bkg_subtract.save_combined_background=true",
+            "--verbose"]
     Step.from_cmdline(args)
 
 
@@ -44,6 +46,17 @@ def test_miri_lrs_slit_spec2(run_pipeline, fitsdiff_default_kwargs, suffix, rtda
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
+@pytest.mark.bigdata
+def test_miri_lrs_extract1d_from_cal(run_pipeline, rtdata_module, fitsdiff_default_kwargs):
+    rtdata = rtdata_module
+    rtdata.input = "jw00623032001_03102_00001_mirimage_cal.fits"
+    Extract1dStep.call(rtdata.input, save_results=True)
+    output = "jw00623032001_03102_00001_mirimage_x1d.fits"
+    truth = "jw00623032001_03102_00001_mirimage_x1d.fits"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/test_miri_lrs_slit_spec2/{truth}")
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
 
 @pytest.mark.bigdata
 def test_miri_lrs_slit_wcs(run_pipeline, rtdata_module, fitsdiff_default_kwargs):

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -52,9 +52,27 @@ def test_miri_lrs_extract1d_from_cal(run_pipeline, rtdata_module, fitsdiff_defau
     rtdata = rtdata_module
     rtdata.input = "jw00623032001_03102_00001_mirimage_cal.fits"
     Extract1dStep.call(rtdata.input, save_results=True)
-    output = "jw00623032001_03102_00001_mirimage_x1d.fits"
+    output = "jw00623032001_03102_00001_mirimage_extract1dstep.fits"
     rtdata.output = output
     rtdata.get_truth(f"truth/test_miri_lrs_slit_spec2/{output}")
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_miri_lrs_extract1d_image_ref(run_pipeline, rtdata_module, fitsdiff_default_kwargs):
+    rtdata = rtdata_module
+
+    rtdata.get_data("miri/lrs/jw00623032001_03102_00001_mirimage_image_ref.fits")
+    rtdata.input = "jw00623032001_03102_00001_mirimage_cal.fits"
+    Extract1dStep.call(rtdata.input,
+                       override_extract1d='miri/lrs/jw00623032001_03102_00001_mirimage_image_ref.fits',
+                       suffix='x1dfromrefimage',
+                       save_results=True)
+    output = "jw00623032001_03102_00001_mirimage_x1dfromrefimage.fits"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/test_miri_lrs_slit_spec2/{output}")
+
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Addresses (but does not close) #6105 

Addresses [JP-2120](https://jira.stsci.edu/browse/JP-2120)

**Description**

This PR adds test coverage for ImageModel inputs to Extract1dStep. **WIP**

Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)