### PR TITLE
JP-2152: Add an upper tweak threshold to tweakreg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,11 @@ source_catalog
 
 - Fixed issue with non-finite positions for aperture photometry. [#6206]
 
+tweakreg
+--------
+
+- Add an upper tweak threshold of 10 arcsec to tweakreg [#6252]
+
 wavecorr
 --------
 

--- a/jwst/tweakreg/tests/test_tweakreg.py
+++ b/jwst/tweakreg/tests/test_tweakreg.py
@@ -1,0 +1,25 @@
+from copy import deepcopy
+import os
+
+import asdf
+from astropy.modeling.models import Shift
+import pytest
+
+from jwst.tweakreg import TweakRegStep
+
+
+@pytest.mark.parametrize("offset, is_good", [(1 / 3600, True), (11 / 3600, False)])
+def test_fit_quality_is_good(offset, is_good):
+    path = os.path.join(os.path.dirname(__file__), "mosaic_long_i2d_gwcs.asdf")
+    with asdf.open(path) as af:
+        wcs = af.tree["wcs"]
+
+    # Make a copy and add an offset at the end of the transform
+    twcs = deepcopy(wcs)
+    step = twcs.pipeline[0]
+    step.transform = step.transform | Shift(offset) & Shift(offset)
+    twcs.bounding_box = wcs.bounding_box
+
+    step = TweakRegStep()
+
+    assert step.fit_quality_is_good(wcs, twcs) == is_good


### PR DESCRIPTION
Resolves #6154 / [JP-2152](https://jira.stsci.edu/browse/JP-2152)

**Description**

This PR adds an upper tweak threshold to `TweakregStep`.  I.e. any tweaks larger than 10 arcsec are probably due to poor data, poor catalogs, or both, and should be rejected.

This hard codes the threshold to be 10 arcsec.  But honestly, we could also use the existing `self.threshold` parameter in tweakreg of 1.0 arcsec as well.  Thoughts?  I don't want to add a separate parameter yet, as I don't think this is something users need to play with right now.  There are already too many knobs in this step to play with.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
