### PR TITLE
Move ifu cube blotting to c extension: JP-2207

### DIFF
--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -7,7 +7,7 @@ from .. import datamodels
 from ..assign_wcs import nirspec
 from gwcs import wcstools
 from . import instrument_defaults
-
+from .blot_median import blot_wrapper  # c extension
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -16,7 +16,6 @@ class CubeBlot():
 
     def __init__(self, median_model, input_models):
         """Class Blot holds the main varibles for blotting sky cube to detector
-
 
         Information is pulled out of the median sky cube created by a previous
         run of cube_build in single mode and stored in the ClassBlot.These
@@ -117,6 +116,8 @@ class CubeBlot():
 
         log.info('Number of input models %i ', len(self.input_models))
 
+    # ***********************************************************************
+
     def blot_images(self):
         if self.instrument == 'MIRI':
             blotmodels = self.blot_images_miri()
@@ -135,17 +136,10 @@ class CubeBlot():
         2. Loop over every input model and using the inverse (backwards) transform
            convert the median sky cube values ra, dec, lambda to the blotted
            x, y detector value (x_cube, y_cube).
-
         3. For each input model loop over the blotted x,y values and find
-            The x, y detector values that fall within the roi region. We loop
-            over the blotted values instead of the detector x, y (the more
-            obvious method) because of speed. We can break down the x, y detector
-            pixels into a regular grid represented by an array of xcenters and
-            ycenters. Because we are really intereseted finding all those blotted
-            pixels that fall with the roi of a detector pixel we need to
-            keep track of the blot flux and blot weight as we loop.
-            c. The blotted flux  = the weighted flux determined in
-            step b and stored in blot.data
+           the x, y detector values that fall within the roi region.
+           The blotted flux  = the weighted flux, where the weight is based on
+           distance between the center of the blotted pixel and the detector pixel.
         """
         blot_models = datamodels.ModelContainer()
         instrument_info = instrument_defaults.InstrumentInfo()
@@ -168,8 +162,8 @@ class CubeBlot():
             self.ycenter_grid, self.xcenter_grid = np.mgrid[0:ysize,
                                                             0:xsize]
 
-            xsize = xend - xstart + 1
-            xcenter = np.arange(xsize) + xstart
+            xsize2 = xend - xstart + 1
+            xcenter = np.arange(xsize2) + xstart
             ycenter = np.arange(ysize)
             valid_channel = np.logical_and(xdet >= xstart, xdet <= xend)
 
@@ -182,85 +176,45 @@ class CubeBlot():
             x_cube = np.ndarray.flatten(x_cube)
             y_cube = np.ndarray.flatten(y_cube)
             flux_cube = np.ndarray.flatten(self.cube_flux)
+
             valid = ~np.isnan(y_cube)
-            x_cube = x_cube[valid]
-            y_cube = y_cube[valid]
-            flux_cube = flux_cube[valid]
             valid_channel = np.logical_and(x_cube >= xstart, x_cube <= xend)
-            x_cube = x_cube[valid_channel]
-            y_cube = y_cube[valid_channel]
-            flux_cube = flux_cube[valid_channel]
-            # ___________________________________________________________________
+            valid_flux = (flux_cube != 0)
+
+            fuse = np.where(valid & valid_channel & valid_flux)
+            x_cube = x_cube[fuse]
+            y_cube = y_cube[fuse]
+            flux_cube = flux_cube[fuse]
+
             log.info('Blotting back to %s', model.meta.filename)
             # ______________________________________________________________________________
-            # For every detector pixel find the overlapping median cube spaxels.
+            # blot_wrapper is a c extension that finds:
+            # the overlapping median cube spaxels with the detector pixels
             # A median spaxel that falls withing the ROI of the center of the
-            # detector pixel in the tangent plane is flagged as an overlapping
-            # pixel.
-            # the Regular grid is on the x,y detector
+            # detector pixel  is flagged as an overlapping pixel.
 
-            blot_flux = self.blot_overlap(model, xcenter, ycenter,
-                                          xstart, x_cube, y_cube,
-                                          flux_cube)
+            xsize2 = xcenter.shape[0]
+            roi_det = 1.0  # Just large enough that we don't get holes
+
+            t0 = time.time()
+            # set up c wrapper for blotting
+            result = blot_wrapper(roi_det, xsize, ysize, xstart, xsize2,
+                                  xcenter, ycenter,
+                                  x_cube, y_cube, flux_cube)
+            blot_flux, blot_weight = result
+            igood = np.where(blot_weight > 0)
+            blot_flux[igood] = blot_flux[igood] / blot_weight[igood]
+            blot_flux = blot_flux.reshape((ysize, xsize))
+
+            t1 = time.time()
+            log.debug(f"Time to blot median image to input model =  {t1-t0:.1f}")
+
             blot.data = blot_flux
             blot_models.append(blot)
         return blot_models
-    # ________________________________________________________________________________
-
-    def blot_overlap(self, model, xcenter, ycenter, xstart,
-                           x_cube, y_cube, flux_cube):
-
-        # blot_overlap finds to overlap between the blotted sky values
-        # (x_cube, y_cube) and the detector pixels.
-        # Looping is done over irregular arrays (x_cube, y_cube) and mapping
-        # to xcenter ycenter is quicker than looping over detector x,y and
-        # finding overlap with large array for x_cube, y_cube
-
-        blot_flux = np.zeros(model.shape, dtype=np.float32)
-        blot_weight = np.zeros(model.shape, dtype=np.float32)
-        blot_ysize, blot_xsize = blot_flux.shape
-        blot_flux = np.ndarray.flatten(blot_flux)
-
-        # loop over valid points in cube (not empty edge pixels)
-        roi_det = 1.0  # Just large enough that we don't get holes
-
-        code = 'Python'
-        if code == 'CPython': 
-        
-        ivalid = np.nonzero(np.absolute(flux_cube))
-        blot_weight = np.ndarray.flatten(blot_weight)
-        t0 = time.time()
-        for ipt in ivalid[0]:
-            # search xcenter and ycenter seperately. These arrays are smallsh.
-            # xcenter size = naxis1 on detector (for MIRI only 1/2 array)
-            # ycenter size = naxis2 on detector
-            xdistance = np.absolute(x_cube[ipt] - xcenter)
-            ydistance = np.absolute(y_cube[ipt] - ycenter)
-
-            index_x = np.where(xdistance <= roi_det)
-            index_y = np.where(ydistance <= roi_det)
-
-            if len(index_x[0]) > 0 and len(index_y[0]) > 0:
-                d1pix = np.array(x_cube[ipt] - xcenter[index_x])
-                d2pix = np.array(y_cube[ipt] - ycenter[index_y])
-
-                dxy = [(dx * dx + dy * dy) for dy in d2pix for dx in d1pix]
-                dxy = np.sqrt(dxy)
-                weight_distance = np.exp(-dxy)
-                weighted_flux = weight_distance * flux_cube[ipt]
-                index2d = [iy * blot_xsize + ix for iy in index_y[0] for ix in (index_x[0] + xstart)]
-                blot_flux[index2d] = blot_flux[index2d] + weighted_flux
-                blot_weight[index2d] = blot_weight[index2d] + weight_distance
-
-        t1 = time.time()
-        log.debug(f"Time to blot median image to input model =  {t1-t0:.1f}")
-        # done mapping blotted x,y (x_cube, y_cube) to detector
-        igood = np.where(blot_weight > 0)
-        blot_flux[igood] = blot_flux[igood] / blot_weight[igood]
-        blot_flux = blot_flux.reshape((blot_ysize, blot_xsize))
-        return blot_flux
 
     # ************************************************************************
+
     def blot_images_nirspec(self):
         """ Core blotting routine for NIRSPEC
 
@@ -275,36 +229,40 @@ class CubeBlot():
         a. the x,y bounding box of slice
         b. the ra, dec, lambda values for the x,y pixels in the slice
         c. from step b, determine the min and max ra and dec for slice values
-        d. pull out the valid ra, dec and lambda values from the median sky cube that fall within
-           the min and max ra,dec determined in step c
-        e. invert the valid ra,dec, and lambda values for the slice determined in step d to the detector.
-        f. blot the inverted x,y values to the detector plane. This steps finds the determines the overlap
-           of the blotted x,y values with a regular grid setup in the detector plane which is the blotted image.
+        d. pull out the valid ra, dec and lambda values from the median sky cube that
+           fall within the min and max ra,dec determined in step c
+        e. invert the valid ra,dec, and lambda values for the slice determined in
+           step d to the detector.
+        f. blot the inverted x,y values to the detector plane. This steps finds the
+           determines the overlap of the blotted x,y values with a regular grid setup
+           in the detector plane which is the blotted image.
 
         """
         blot_models = datamodels.ModelContainer()
 
         for model in self.input_models:
-            blot_flux = np.zeros(model.shape, dtype=np.float32)
-            blot_weight = np.zeros(model.shape, dtype=np.float32)
-            blot_ysize, blot_xsize = blot_flux.shape
-            blot_flux = np.ndarray.flatten(blot_flux)
-            blot_weight = np.ndarray.flatten(blot_weight)
+            blot_ysize, blot_xsize = model.shape
+            ntotal = blot_ysize * blot_xsize
+            blot_flux = np.zeros(ntotal, dtype=np.float32)
+            blot_weight = np.zeros(ntotal, dtype=np.float32)
             blot = model.copy()
             blot.err = None
             blot.dq = None
+
             # ___________________________________________________________________
-            ysize, xsize = model.data.shape
-            ycenter = np.arange(ysize)
-            xcenter = np.arange(xsize)
+            ycenter = np.arange(blot_ysize)
+            xcenter = np.arange(blot_xsize)
 
             # for NIRSPEC wcs information accessed seperately for each slice
             nslices = 30
-            log.info('Looping over 30 slices on NIRSPEC detector, this takes a little while')
+            log.info('Blotting  30 slices on NIRSPEC detector, this takes a little while')
             t0 = time.time()
             roi_det = 1.0  # Just large enough that we don't get holes
+
+            x_total = []
+            y_total = []
+            flux_total = []
             for ii in range(nslices):
-                ts0 = time.time()
                 # for each slice pull out the blotted values that actually fall on the slice region
                 # use the bounding box of each slice to determine the slice limits
                 slice_wcs = nirspec.nrs_wcs_set_input(model, ii)
@@ -327,47 +285,51 @@ class CubeBlot():
 
                 # median cube ra,dec,wave -> x_slice, y_slice
                 x_slice, y_slice = slice_wcs.invert(ra_use, dec_use, wave_use)
-
                 x_slice = np.ndarray.flatten(x_slice)
                 y_slice = np.ndarray.flatten(y_slice)
                 flux_slice = np.ndarray.flatten(flux_use)
 
+                # only use values what fall in bounding box of the slice
                 xlimit, ylimit = slice_wcs.bounding_box
                 xuse = np.logical_and(x_slice >= xlimit[0], x_slice <= xlimit[1])
                 yuse = np.logical_and(y_slice >= ylimit[0], y_slice <= ylimit[1])
+                fgood = (flux_slice != 0)  # edge cube pixel may = 0
 
-                fuse = np.logical_and(xuse, yuse)
+                # fuse = np.logical_and(xuse, yuse)
+                fuse = np.where(fgood & xuse & yuse)
                 x_slice = x_slice[fuse]
                 y_slice = y_slice[fuse]
                 flux_slice = flux_slice[fuse]
 
-                nn = flux_slice.size
-                for ipt in range(nn):
-                    # search xcenter and ycenter seperately. These arrays are smallish.
-                    # xcenter size = naxis1 on detector
-                    # ycenter size = naxis2 on detector
-                    xdistance = np.absolute(x_slice[ipt] - xcenter)
-                    ydistance = np.absolute(y_slice[ipt] - ycenter)
+                nslice = len(x_slice)
+                for i in range(nslice):
+                    x_total.append(x_slice[i])
+                    y_total.append(y_slice[i])
+                    flux_total.append(flux_slice[i])
 
-                    index_x = np.where(xdistance <= roi_det)
-                    index_y = np.where(ydistance <= roi_det)
+            # end looping over the 30 slices
+            t05 = time.time()
+            # set up c wrapper for blotting
+            xstart = 0
+            xsize2 = blot_xsize
+            x_total = np.array(x_total)
+            y_total = np.array(y_total)
+            flux_total = np.array(flux_total)
 
-                    if len(index_x[0]) > 0 and len(index_y[0]) > 0:
-                        d1pix = np.array(x_slice[ipt] - xcenter[index_x])
-                        d2pix = np.array(y_slice[ipt] - ycenter[index_y])
+            result = blot_wrapper(roi_det, blot_xsize, blot_ysize, xstart, xsize2,
+                                  xcenter, ycenter,
+                                  x_total, y_total, flux_total)
+            blot_flux_slice, blot_weight_slice = result
+            blot_flux = blot_flux + blot_flux_slice
+            blot_weight = blot_weight + blot_weight_slice
 
-                        dxy = [(dx * dx + dy * dy) for dy in d2pix for dx in d1pix]
-                        dxy = np.sqrt(dxy)
-                        weight_distance = np.exp(-dxy)
-                        weighted_flux = weight_distance * flux_slice[ipt]
-                        index2d = [iy * blot_xsize + ix for iy in index_y[0] for ix in (index_x[0])]
-                        blot_flux[index2d] = blot_flux[index2d] + weighted_flux
-                        blot_weight[index2d] = blot_weight[index2d] + weight_distance
-                ts1 = time.time()
-                log.debug(f"Time to map 1 slice  =  {ts1-ts0:.1f}")
+            result = None
+            blot_weight_slice = None
+            blot_flux_slice = None
             # done mapping median cube  to this input model
             t1 = time.time()
-            log.debug(f"Time to blot median image to input model =  {t1-t0:.1f}")
+            log.debug(f"Time to blot median image (all 30 slices)  to input model =  {t1-t0:.1f}")
+            log.debug(f"Time in blot_wrapper  =  {t1-t05:.1f}")
             igood = np.where(blot_weight > 0)
             blot_flux[igood] = blot_flux[igood] / blot_weight[igood]
             blot_flux = blot_flux.reshape((blot_ysize, blot_xsize))

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -199,18 +199,18 @@ class CubeBlot():
             # pixel.
             # the Regular grid is on the x,y detector
 
-            blot_flux = self.blot_overlap_quick(model, xcenter, ycenter,
-                                                xstart, x_cube, y_cube,
-                                                flux_cube)
+            blot_flux = self.blot_overlap(model, xcenter, ycenter,
+                                          xstart, x_cube, y_cube,
+                                          flux_cube)
             blot.data = blot_flux
             blot_models.append(blot)
         return blot_models
     # ________________________________________________________________________________
 
-    def blot_overlap_quick(self, model, xcenter, ycenter, xstart,
+    def blot_overlap(self, model, xcenter, ycenter, xstart,
                            x_cube, y_cube, flux_cube):
 
-        # blot_overlap_quick finds to overlap between the blotted sky values
+        # blot_overlap finds to overlap between the blotted sky values
         # (x_cube, y_cube) and the detector pixels.
         # Looping is done over irregular arrays (x_cube, y_cube) and mapping
         # to xcenter ycenter is quicker than looping over detector x,y and
@@ -220,12 +220,15 @@ class CubeBlot():
         blot_weight = np.zeros(model.shape, dtype=np.float32)
         blot_ysize, blot_xsize = blot_flux.shape
         blot_flux = np.ndarray.flatten(blot_flux)
-        blot_weight = np.ndarray.flatten(blot_weight)
 
         # loop over valid points in cube (not empty edge pixels)
         roi_det = 1.0  # Just large enough that we don't get holes
-        ivalid = np.nonzero(np.absolute(flux_cube))
 
+        code = 'Python'
+        if code == 'CPython': 
+        
+        ivalid = np.nonzero(np.absolute(flux_cube))
+        blot_weight = np.ndarray.flatten(blot_weight)
         t0 = time.time()
         for ipt in ivalid[0]:
             # search xcenter and ycenter seperately. These arrays are smallsh.

--- a/jwst/cube_build/src/blot_median.c
+++ b/jwst/cube_build/src/blot_median.c
@@ -1,0 +1,298 @@
+/*
+ 
+Main function for Python: blot_wrapper
+
+Python signature: 
+            result = blot_wrapper(roi_det, blot_xsize, blot_ysize, xstart, xsize2,
+                                  xcenter, ycenter,
+                                  x_cube, y_cube, flux_cube)
+
+This module is used in outlier detection. Each file is mapped to the sky to create a single type
+IFU cube. Using the set of single IFUs a median IFU is determined. This median image is then
+mapped (blotted) back to the detector plane. This routine determines the overlap between
+the median blotted back image and the detector plane.
+
+The output of this function is a tuple of 2 arrays:(blot_flux, blot_weight)
+
+Parameters
+----------
+roi : double
+   Region of interest size for matching median image to detector pixels
+blot_xsize : int
+   X axis detector size
+blot_ysize : int
+   Y axis detector size
+xstart : int
+   Only valid for MIRI. For NIRSpec = 0
+   The left most x detector pixel number the median image is being blotted to
+   Blotting occurs seperately for each channel. We need to know which side
+   of the detector the median image is being blotted to
+xsize2 : int
+   If MIRI xsize2 = x size of the detector side the medina image is being blotted to
+   If NIRSpec, xsize2 = xsize
+xcenter : double array
+   x center pixel values of the detector values. Size xsize2.
+ycenter : double array
+   y center pixel values of the detector values. Size ysize
+x_cube : doube array
+   x coordinate of median cube mapped back to detector
+y_cube : doube array
+   y coordinate of median cube mapped back to detector
+flux_cube : doube array
+   flux of median cube
+
+Returns
+-------
+blot_flux : numpy.ndarray
+  IFU spaxel cflux
+blot_weight : numpy.ndarray
+  IFU spaxel weight 
+*/
+
+#include <stdlib.h>
+#include <math.h>
+#include <stdio.h>
+#include <Python.h>
+#include <stdbool.h>
+#include <numpy/arrayobject.h>
+#include <numpy/npy_math.h>
+
+#define PY_ARRAY_UNIQUE_SYMBOL _jwst_cube_match_sky_numpy_api    //WHAT IS THIS AND WHERE IS IT USED???
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+//_______________________________________________________________________
+// Allocate the memory to for the blotted arrays
+//_______________________________________________________________________
+
+int alloc_blot_arrays(int nelem, double **fluxv, double **weightv) {
+
+    const char *msg = "Couldn't allocate memory for output arrays.";
+
+    // flux:
+    if (!(*fluxv  = (double*)calloc(nelem, sizeof(double)))) {
+        PyErr_SetString(PyExc_MemoryError, msg);
+        goto failed_mem_alloc;
+    }
+    
+    //weight
+    if (!(*weightv  = (double*)calloc(nelem, sizeof(double)))) {
+      PyErr_SetString(PyExc_MemoryError, msg);
+      goto failed_mem_alloc;
+    }  
+    return 0;
+
+ failed_mem_alloc:
+    free(*fluxv);
+    free(*weightv);
+   
+}
+
+
+// Match the median cube mapped to detector space with detector pixels
+// Match occurs when x distance or y distance < roi size (set to 1 pixel)
+// The combined flux for the blotted image is determined using a modified
+// shepard weighting methos. 
+
+// return values: blot_flux, blot_weight
+
+int blot_overlap(double roi, int xsize_det, int ysize_det,
+		 int xstart, int xsize2, int ncube,  
+		 double *xcenter, double *ycenter,
+		 double *x_cube, double *y_cube, double *flux_cube,
+		 double **blot_flux, double **blot_weight) {
+
+  double *fluxv, *weightv;  // vector for blot values
+  int npt = xsize_det * ysize_det;
+
+  // allocate memory to hold output 
+  if (alloc_blot_arrays(npt, &fluxv, &weightv)) return 1;
+
+  for (int k = 0; k < ncube; k++) {
+    for (int ix = 0; ix< xsize2; ix ++){
+      double dx = fabs(x_cube[k] - xcenter[ix]);
+      if( dx <= roi){ 
+	for ( int iy = 0; iy < ysize_det; iy ++){
+	  double dy = fabs(y_cube[k] - ycenter[iy]);
+	  if (dy <= roi){
+	    double dxy = sqrt(dx*dx + dy*dy);		 
+	    double weight_distance = exp(-dxy);
+	    double weighted_flux = weight_distance * flux_cube[k];
+	    long index2d =  iy * xsize_det + (ix + xstart);
+	    fluxv[index2d] = fluxv[index2d] + weighted_flux;
+	    weightv[index2d] = weightv[index2d] + weight_distance;
+	  } // 
+	} //end loop over iy
+      } //
+    } // end loop over ix
+  } // end loop over ncube
+    
+  // assign output values:
+
+  *blot_flux = fluxv;
+  *blot_weight = weightv;
+
+  return 0;
+}
+
+
+//  set up the C extension
+
+PyArrayObject * ensure_array(PyObject *obj, int *is_copy) {
+    if (PyArray_CheckExact(obj) &&
+        PyArray_IS_C_CONTIGUOUS((PyArrayObject *) obj) &&
+        PyArray_TYPE((PyArrayObject *) obj) == NPY_DOUBLE) {
+        *is_copy = 0;
+        return (PyArrayObject *) obj;
+    } else {
+        *is_copy = 1;
+        return (PyArrayObject *) PyArray_FromAny(
+            obj, PyArray_DescrFromType(NPY_DOUBLE), 0, 0,
+            NPY_ARRAY_CARRAY | NPY_ARRAY_FORCECAST, NULL
+        );
+    }
+}
+
+
+static PyObject *blot_wrapper(PyObject *module, PyObject *args) {
+  PyObject *result = NULL, *xcentero, *ycentero, *x_cubeo, *y_cubeo, *flux_cubeo;
+  
+  double roi;
+  int  npt, xstart, xsize_det, ysize_det, xsize2;
+
+  double *blot_flux=NULL, *blot_weight=NULL;
+  int free_xcenter=0, free_ycenter=0, free_xcube=0, free_ycube=0, free_flux =0,status=0;
+
+  PyArrayObject *xcenter, *ycenter, *x_cube, *y_cube, *flux_cube;
+  PyArrayObject *blot_flux_arr=NULL, *blot_weight_arr=NULL;
+
+  npy_intp npy_npt = 0;
+
+  if (!PyArg_ParseTuple(args, "diiiiOOOOO:blot_wrapper",
+			&roi, &xsize_det,  &ysize_det, &xstart, &xsize2, &xcentero, &ycentero,
+			&x_cubeo, &y_cubeo, &flux_cubeo)){
+    return NULL;
+  }
+
+  // ensure we are working with numpy arrays and avoid creating new ones
+  // if possible:
+  if ((!(xcenter = ensure_array(xcentero, &free_xcenter))) ||
+      (!(ycenter = ensure_array(ycentero, &free_ycenter))) ||
+      (!(x_cube = ensure_array(x_cubeo, &free_xcube))) ||
+      (!(y_cube = ensure_array(y_cubeo, &free_ycube))) ||
+      (!(flux_cube = ensure_array(flux_cubeo, &free_flux)))){
+    goto cleanup;
+  }
+
+  int nx = (int) PyArray_Size((PyObject *) x_cube);
+  int ny = (int) PyArray_Size((PyObject *) y_cube);
+  int nz = (int) PyArray_Size((PyObject *) flux_cube);
+  if (ny != nz || nz != nx ) {
+    PyErr_SetString(PyExc_ValueError,
+		    "Input coordinate arrays of unequal size.");
+    goto cleanup;
+
+  }
+
+  npt = xsize_det * ysize_det;
+  
+  if (npt ==0) {
+    // 0-length input arrays. Nothing to clip. Return 0-length arrays
+    blot_flux_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_npt, NPY_DOUBLE, 0);
+    if (!blot_flux_arr) goto fail;
+    
+    blot_weight_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_npt, NPY_DOUBLE, 0);
+    if (!blot_weight_arr) goto fail;
+
+    result = Py_BuildValue("(OO)", blot_flux_arr, blot_weight_arr);
+
+    goto cleanup;
+
+  }
+      
+  int status1 = 0;
+  int ncube = nx;
+  status = blot_overlap(roi, xsize_det, ysize_det, xstart,xsize2, ncube,
+			(double *) PyArray_DATA(xcenter),
+			(double *) PyArray_DATA(ycenter),
+			(double *) PyArray_DATA(x_cube),
+			(double *) PyArray_DATA(y_cube),
+			(double *) PyArray_DATA(flux_cube),
+			&blot_flux, &blot_weight );
+
+
+  if (status || status1) {
+    goto fail;
+
+  } else {
+    // create return tuple:
+    npy_npt = (npy_intp) npt;
+    
+    blot_flux_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_npt, NPY_DOUBLE, blot_flux);
+    if (!blot_flux_arr) goto fail;
+    blot_flux = NULL;
+
+    blot_weight_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_npt, NPY_DOUBLE, blot_weight);
+    if (!blot_weight_arr) goto fail;
+    blot_weight = NULL;
+    
+    PyArray_ENABLEFLAGS(blot_flux_arr, NPY_ARRAY_OWNDATA);
+    PyArray_ENABLEFLAGS(blot_weight_arr, NPY_ARRAY_OWNDATA);
+
+    result = Py_BuildValue("(OO)", blot_flux_arr, blot_weight_arr);	
+    goto cleanup;
+  }
+
+ fail:
+  Py_XDECREF(blot_flux_arr);
+  Py_XDECREF(blot_weight_arr);
+
+  free(blot_flux);
+  free(blot_weight);
+
+  if (!PyErr_Occurred()) {
+    PyErr_SetString(PyExc_MemoryError,
+		    "Unable to allocate memory for output arrays.");
+  }
+
+ cleanup:
+  if (free_xcenter)Py_XDECREF(xcenter);
+  if (free_ycenter) Py_XDECREF(ycenter);
+  if (free_xcube) Py_XDECREF(x_cube);
+  if (free_ycube) Py_XDECREF(y_cube);
+  if (free_flux) Py_XDECREF(flux_cube);
+      
+  return result;
+}
+
+
+static PyMethodDef blot_methods[] =
+{
+    {
+        "blot_wrapper",
+	blot_wrapper,
+	METH_VARARGS,
+        "blot_wrapper()"
+    },
+    {NULL, NULL, 0, NULL}  /* sentinel */
+};
+
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "blot_median",             /* m_name */
+    "blot median to detector space",  /* m_doc */
+    -1,                          /* m_size */
+    blot_methods,      /* m_methods */
+    NULL,                        /* m_reload */
+    NULL,                        /* m_traverse */
+    NULL,                        /* m_clear */
+    NULL,                        /* m_free */
+};
+
+PyMODINIT_FUNC PyInit_blot_median(void)
+{
+    PyObject* m;
+    import_array();
+    m = PyModule_Create(&moduledef);
+    return m;
+}

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,12 @@ setup(
             ['jwst/lib/src/winclip.c'],
             include_dirs=include_dirs,
             define_macros=define_macros
+        ),
+        Extension(
+            'jwst.cube_build.blot_median',
+            ['jwst/cube_build/src/blot_median.c'],
+            include_dirs=include_dirs,
+            define_macros=define_macros
         )
     ],
 )


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
Closes #6225

Resolves [JP-2207](https://jira.stsci.edu/browse/JP-2207)

**Description**

This PR addresses takes the python modules that performed cube blotting and converts them to c to speed up the process. 
A bug in the python blotting for NIRSpec was found and corrected in the conversion to c.


Checklist
- [x] Tests - pytest passed

- [x] Documentation- no real change  in the algorithm, it was just converted to c. 

- [ ] Change log

- [x] Milestone

- [x] Label(s) 
