### PR TITLE
JP-488 and JP-1920: NIRSpec `bounding_box` is sometimes too large.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ assign_wcs
   manger. [#6160]
 
 - Fix bug in NIRspec where ``bounding_box`` can be oversized in height for
-  some of the slits.
+  some of the slits. [#6257]
 
 associations
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ assign_wcs
 - Open the specwcs reference file for WFSS modes using the ``with`` context
   manger. [#6160]
 
+- Fix bug in NIRspec where ``bounding_box`` can be oversized in height for
+  some of the slits.
+
 associations
 ------------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1250,10 +1250,7 @@ def compute_bounding_box(transform, wavelength_range, slit_ymin=-.55, slit_ymax=
     lam_grid = np.linspace(lam_min, lam_max, nsteps)
 
     def check_range(lower, upper):
-        if lower <= upper:
-            return lower, upper
-        else:
-            return -0.5, 2047.5
+        return lower <= upper
 
     def bbox_from_range(x_range, y_range):
         # The -1 on both is technically because the output of slit2detector is 1-based coordinates.
@@ -1265,7 +1262,7 @@ def compute_bounding_box(transform, wavelength_range, slit_ymin=-.55, slit_ymax=
         pad_y = (max(0, y_range.min() - 1 - 2) - 0.5,
                  min(2047, y_range.max() - 1 + 2) + 0.5)
 
-        return check_range(*pad_x), check_range(*pad_y)
+        return pad_x, pad_y
 
     x_range_low, y_range_low = slit2detector([0] * nsteps, [slit_ymin] * nsteps, lam_grid)
     x_range_high, y_range_high = slit2detector([0] * nsteps, [slit_ymax] * nsteps, lam_grid)
@@ -1276,7 +1273,7 @@ def compute_bounding_box(transform, wavelength_range, slit_ymin=-.55, slit_ymax=
     bbox = bbox_from_range(x_range, y_range)
 
     # Run inverse model to narrow range
-    if detector2slit is not None:
+    if detector2slit is not None and check_range(*bbox[0]) and check_range(*bbox[1]):
         x, y = grid_from_bounding_box(bbox)
         _, _, lam = detector2slit(x, y)
         y_range = y[np.isfinite(lam)]

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1249,6 +1249,12 @@ def compute_bounding_box(transform, wavelength_range, slit_ymin=-.55, slit_ymax=
     nsteps = int((lam_max - lam_min) / step)
     lam_grid = np.linspace(lam_min, lam_max, nsteps)
 
+    def check_range(lower, upper):
+        if lower <= upper:
+            return lower, upper
+        else:
+            return -0.5, 2047.5
+
     def bbox_from_range(x_range, y_range):
         # The -1 on both is technically because the output of slit2detector is 1-based coordinates.
 
@@ -1259,7 +1265,7 @@ def compute_bounding_box(transform, wavelength_range, slit_ymin=-.55, slit_ymax=
         pad_y = (max(0, y_range.min() - 1 - 2) - 0.5,
                  min(2047, y_range.max() - 1 + 2) + 0.5)
 
-        return pad_x, pad_y
+        return check_range(*pad_x), check_range(*pad_y)
 
     x_range_low, y_range_low = slit2detector([0] * nsteps, [slit_ymin] * nsteps, lam_grid)
     x_range_high, y_range_high = slit2detector([0] * nsteps, [slit_ymax] * nsteps, lam_grid)

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1252,12 +1252,12 @@ def compute_bounding_box(slit2detector, wavelength_range, slit_ymin=-.55, slit_y
     x_range, y_range = bounding_range(slit_ymin, slit_ymax)
 
     # Run inverse model to narrow range
-    inverse_range = slit2detector.inverse(x_range, y_range)
-    inverse_range_low = np.nanmin(inverse_range)
-    inverse_range_high = np.nanmax(inverse_range)
+    y_slit_range = slit2detector.inverse(x_range, y_range)[1]
+    y_slit_low = np.nanmin(y_slit_range)
+    y_slit_high = np.nanmax(y_slit_range)
 
     # Narrow ranges
-    x_range, y_range = bounding_range(inverse_range_low, inverse_range_high)
+    x_range, y_range = bounding_range(y_slit_low, y_slit_high)
 
     # add 10 px margin
     # The -1 is technically because the output of slit2detector is 1-based coordinates.

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1230,7 +1230,8 @@ def compute_bounding_box(transform, wavelength_range, slit_ymin=-.55, slit_ymax=
     Parameters
     ----------
     transform : `astropy.modeling.core.Model`
-        The transform from slit to detector, or detector to slit
+        The transform from slit to detector, or detector to slit.
+        `nrs_wcs_set_input` uses "detector to slit", validate_open_slits uses "slit to detector".
     wavelength_range : tuple
         The wavelength range for the combination of grating and filter.
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1650,17 +1650,13 @@ def nrs_wcs_set_input(input_model, slit_name, wavelength_range=None,
         _, wavelength_range = spectral_order_wrange_from_model(input_model)
 
     slit_wcs = _nrs_wcs_set_input(input_model, slit_name)
-    # slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
     transform = slit_wcs.get_transform('detector', 'slit_frame')
     is_nirspec_ifu = is_nrs_ifu_lamp(input_model) or input_model.meta.exposure.type.lower() == 'nrs_ifu'
     if is_nirspec_ifu:
-        # bb = compute_bounding_box(slit2detector, wavelength_range)
         bb = compute_bounding_box(transform, wavelength_range)
     else:
         if slit_y_low is None or slit_y_high is None:
             slit_y_low, slit_y_high = _get_y_range(input_model)
-        # bb = compute_bounding_box(slit2detector, wavelength_range,
-        #                           slit_ymin=slit_y_low, slit_ymax=slit_y_high)
         bb = compute_bounding_box(transform, wavelength_range,
                                   slit_ymin=slit_y_low, slit_ymax=slit_y_high)
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5736 
Closes #2958 
Resolves [JP-488](https://jira.stsci.edu/browse/JP-488) and [JP-1920](https://jira.stsci.edu/browse/JP-1920)

**Description**
The `bounding_box` for NIRSpec is sometimes significantly oversized in height (`y` direction). This was because the `~jwst.assign_wcs.compute_bounding_box` was very naive in how it computed the range of acceptable `y` values. The changes here take the bounding box "guessed" by this naive method and evaluate the transform, and then finds the exact bounds of where the spectral trace actually lands (the non-NaN values). These bounds are then used to compute an improved bounding box.


Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)