### PR TITLE
JP-2140: Log number of flagged outliers in outlier_detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ outlier_detection
   The bug in the implimentation of the bilinear interpolator in the ``drizzle``
   package is now fixed. [#6146]
 
+- Log number of flagged outliers in ``outlier_detection`` [#6260]
+
 pipeline
 --------
 

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -17,9 +17,8 @@ from jwst.stpipe import Step
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-CRBIT = np.uint32(
-    datamodels.dqflags.pixel['DO_NOT_USE'] + datamodels.dqflags.pixel['OUTLIER']
-)
+DO_NOT_USE = datamodels.dqflags.pixel['DO_NOT_USE']
+OUTLIER = datamodels.dqflags.pixel['OUTLIER']
 
 
 __all__ = ["OutlierDetection", "flag_cr", "abs_deriv"]
@@ -351,7 +350,7 @@ class OutlierDetection:
             The dq array in each input model is modified in place
 
         """
-
+        log.info("Flagging outliers")
         for image, blot in zip(self.input_models, blot_models):
             image_copy = image.copy()
             flag_cr(image_copy, blot, **self.outlierpars)
@@ -385,7 +384,6 @@ def flag_cr(sci_image, blot_image, **pars):
     snr      = "5.0 4.0"       # Signal-to-noise ratio
     scale    = "1.2 0.7"       # scaling factor applied to the derivative
     backg    = 0               # Background value
-
     """
     backg = pars.get('backg', 0)
     snr1, snr2 = [float(val) for val in pars.get('snr', '5.0 4.0').split()]
@@ -408,46 +406,49 @@ def flag_cr(sci_image, blot_image, **pars):
 
     err_data = np.nan_to_num(sci_image.err)
 
-    # Define output cosmic ray mask to populate
-    cr_mask = np.zeros(sci_image.shape, dtype=np.uint8)
-
     # create the outlier mask
     if pars.get('resample_data', True):  # dithered outlier detection
         blot_data += subtracted_background
         diff_noise = np.abs(sci_data - blot_data)
 
-        # create an initial mask based on
-        # a scaled version of the derivative image (dealing with interpolating issues?)
+        # Create an initial boolean mask based on a scaled version of
+        # the derivative image (dealing with interpolating issues?)
         # and the standard n*sigma above the noise
-        t2 = scl1 * blot_deriv + snr1 * err_data
-        # in this mask
-        init_mask = np.logical_not(np.greater(diff_noise, t2))
+        threshold1 = scl1 * blot_deriv + snr1 * err_data
+        init_mask = np.logical_not(np.greater(diff_noise, threshold1))
 
-        # Convolve mask with 3x3 kernel
-        kernel = np.ones((3, 3), dtype=np.uint8)
-        init_mask_smoothed = np.zeros(init_mask.shape, dtype=np.int32)
-        ndimage.convolve(init_mask, kernel, output=init_mask_smoothed, mode='nearest', cval=0)
+        # Convert mask to integer mask and convolve with 3x3 boxcar kernel
+        kernel = np.ones((3, 3), dtype=int)
+        init_mask_smoothed = ndimage.convolve(init_mask.astype(int), kernel,
+                                              mode='nearest')
+        mask1 = np.less(init_mask_smoothed, 9)
 
-        # create a 2nd mask like the first, but based on the 2nd set of
+        # Create a 2nd boolean mask based on the 2nd set of
         # scale and threshold values
-        mask_2ndpass = scl2 * blot_deriv + snr2 * err_data
+        threshold2 = scl2 * blot_deriv + snr2 * err_data
+        mask2 = np.greater(diff_noise, threshold2)
 
-        cr_mask = np.logical_not(np.greater(diff_noise, mask_2ndpass) & np.less(init_mask_smoothed, 9))
+        # Final boolean mask
+        cr_mask = mask1 & mask2
 
     else:  # stack outlier detection
         diff_noise = np.abs(sci_data - blot_data)
 
-        # straightforward detection of outliers for non-dithered data
-        #   as err_data includes all noise sources (photon, read, and flat for baseline)
-        cr_mask = np.logical_not(np.greater(diff_noise, snr1 * err_data))
+        # straightforward detection of outliers for non-dithered data since
+        # err_data includes all noise sources (photon, read, and flat for baseline)
+        cr_mask = np.greater(diff_noise, snr1 * err_data)
 
-    count_sci = np.count_nonzero(sci_image.dq)
-    count_cr = np.count_nonzero(cr_mask)
-    log.debug("Pixels in input DQ: {}".format(count_sci))
-    log.debug("Pixels in cr_mask:  {}".format(count_cr))
+    # Count existing DO_NOT_USE pixels
+    count_existing = np.count_nonzero(sci_image.dq & DO_NOT_USE)
 
     # Update the DQ array in the input image.
-    sci_image.dq = np.bitwise_or(sci_image.dq, np.invert(cr_mask) * CRBIT)
+    sci_image.dq = np.bitwise_or(sci_image.dq, cr_mask * (DO_NOT_USE | OUTLIER))
+
+    # Report number (and percent) of new DO_NOT_USE pixels found
+    count_outlier = np.count_nonzero(sci_image.dq & DO_NOT_USE)
+    count_added = count_outlier - count_existing
+    percent_cr = count_added / (sci_image.shape[0] * sci_image.shape[1]) * 100
+    log.info(f"New pixels flagged as outliers: {count_added} ({percent_cr:.2f}%)")
 
 
 def abs_deriv(array):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6145
Resolves [JP-2140](https://jira.stsci.edu/browse/JP-2140)

**Description**

This PR adds logging of the number of new DO_NOT_USE pixels found in `OutlierDetectionStep`.

Also some general code cleanup to reduce the number of double negatives, unnecessary casting, improved docstrings, comment strings, etc.

Logging now looks like:

```
2021-08-03 10:13:45,375 - stpipe.Image3Pipeline.outlier_detection - INFO - Performing outlier detection on 4 inputs
2021-08-03 10:13:47,393 - stpipe.Image3Pipeline.outlier_detection - INFO - Drizzling (2048, 2048) --> (2071, 2050)
2021-08-03 10:13:50,942 - stpipe.Image3Pipeline.outlier_detection - INFO - Drizzling (2048, 2048) --> (2071, 2050)
2021-08-03 10:13:54,479 - stpipe.Image3Pipeline.outlier_detection - INFO - Drizzling (2048, 2048) --> (2071, 2050)
2021-08-03 10:13:58,025 - stpipe.Image3Pipeline.outlier_detection - INFO - Drizzling (2048, 2048) --> (2071, 2050)
2021-08-03 10:14:01,694 - stpipe.Image3Pipeline.outlier_detection - INFO - Generating median from 4 images
2021-08-03 10:14:02,632 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting median...
2021-08-03 10:14:04,420 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting (2048, 2048) <-- (2071, 2050)
2021-08-03 10:14:06,287 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting (2048, 2048) <-- (2071, 2050)
2021-08-03 10:14:08,160 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting (2048, 2048) <-- (2071, 2050)
2021-08-03 10:14:10,043 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting (2048, 2048) <-- (2071, 2050)
2021-08-03 10:14:10,102 - stpipe.Image3Pipeline.outlier_detection - INFO - Detecting outliers
2021-08-03 10:14:10,563 - stpipe.Image3Pipeline.outlier_detection - INFO - New pixels flagged as outliers: 7739 (0.18%)
2021-08-03 10:14:11,035 - stpipe.Image3Pipeline.outlier_detection - INFO - New pixels flagged as outliers: 7537 (0.18%)
2021-08-03 10:14:11,511 - stpipe.Image3Pipeline.outlier_detection - INFO - New pixels flagged as outliers: 8011 (0.19%)
2021-08-03 10:14:11,978 - stpipe.Image3Pipeline.outlier_detection - INFO - New pixels flagged as outliers: 6480 (0.15%)
```

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)