### PR TITLE
Guard against missing wavecorr metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,7 @@ wavecorr
 --------
 
 - Location of source in NIRspec fixed slit updated
-  (keywords ``SCRCXPOS``, ``SRCYPOS``). [#6243]
+  (keywords ``SCRCXPOS``, ``SRCYPOS``). [#6243, #6261]
 
 wfss_contam
 -----------

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -1,6 +1,7 @@
 import os.path
 import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 
 from gwcs import wcstools
 import jwst
@@ -11,8 +12,10 @@ from jwst.srctype import SourceTypeStep
 from jwst.transforms import models
 from jwst.wavecorr import WavecorrStep
 from jwst.wavecorr import wavecorr
+from crds import CrdsLookupError
 
-from jwst.assign_wcs.tests.test_nirspec import create_nirspec_mos_file
+from jwst.assign_wcs.tests.test_nirspec import (create_nirspec_mos_file,
+    create_nirspec_fs_file)
 
 
 def test_wavecorr():
@@ -59,3 +62,59 @@ def test_ideal_to_v23_fs():
     id2v = models.IdealToV2V3(v3yangle, v2_ref, v3_ref, vparity)
     assert_allclose(id2v(0, 0), (v2_ref, v3_ref))
     assert_allclose(id2v.inverse(v2_ref, v3_ref), (0, 0))
+
+
+def test_skipped():
+    """ Test all conditions that lead to skipping wavecorr."""
+
+    hdul = create_nirspec_fs_file(grating="G140H", filter="F100LP")
+    im = datamodels.ImageModel(hdul)
+
+    # test a non-valid exp_type2transform
+    im.meta.exposure.type='NRS_IMAGE'
+    out = WavecorrStep.call(im)
+    assert out.meta.cal_step.wavecorr == "SKIPPED"
+
+    # Test an error is raised if assign_wcs or extract_2d were not run.
+    im.meta.exposure.type='NRS_FIXEDSLIT'
+    with pytest.raises(AttributeError):
+        WavecorrStep.call(im)
+
+    outa = AssignWcsStep.call(im)
+    oute = Extract2dStep.call(outa)
+    outs = SourceTypeStep.call(oute)
+
+    # Test step is skipped if no coverage in CRDS
+    outs.slits[0].meta.observation.date='2001-08-03'
+    outw = WavecorrStep.call(outs)
+    assert out.meta.cal_step.wavecorr == "SKIPPED"
+
+    outs.meta.observation.date='2017-08-03'
+    outw = WavecorrStep.call(outs)
+    # Primary name not set
+    assert out.meta.cal_step.wavecorr == "SKIPPED"
+
+    outs.meta.instrument.fixed_slit = "S400A1"
+
+    # Test step is skipped if meta.dither is not populated
+    outw = WavecorrStep.call(outs)
+    assert out.meta.cal_step.wavecorr == "SKIPPED"
+
+    dither = {'x_offset': 0.0, 'y_offset': 0.0}
+    ind = np.nonzero([s.name=='S400A1' for s in outs.slits])[0].item()
+    outs.slits[ind].meta.dither = dither
+    outs.slits[ind].meta.wcsinfo.v3yangle = 138.78
+    outs.slits[ind].meta.wcsinfo.vparity = -1
+    outs.slits[ind].meta.wcsinfo.v2_ref = 321.87
+    outs.slits[ind].meta.wcsinfo.v3_ref = -477.94
+    outs.slits[ind].meta.wcsinfo.roll_ref = 15.1234
+
+    # Test step is skipped if source is "EXTENDED"
+    outw = WavecorrStep.call(outs)
+    assert out.meta.cal_step.wavecorr == "SKIPPED"
+
+    outs.slits[ind].source_type = 'POINT'
+    outw = WavecorrStep.call(outs)
+
+    source_pos = (0.004938526981283373, -0.02795306204991911)
+    assert_allclose((outw.slits[ind].source_xpos, outw.slits[ind].source_ypos), source_pos)

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -12,10 +12,9 @@ from jwst.srctype import SourceTypeStep
 from jwst.transforms import models
 from jwst.wavecorr import WavecorrStep
 from jwst.wavecorr import wavecorr
-from crds import CrdsLookupError
 
 from jwst.assign_wcs.tests.test_nirspec import (create_nirspec_mos_file,
-    create_nirspec_fs_file)
+                                                create_nirspec_fs_file)
 
 
 def test_wavecorr():
@@ -71,12 +70,12 @@ def test_skipped():
     im = datamodels.ImageModel(hdul)
 
     # test a non-valid exp_type2transform
-    im.meta.exposure.type='NRS_IMAGE'
+    im.meta.exposure.type = 'NRS_IMAGE'
     out = WavecorrStep.call(im)
     assert out.meta.cal_step.wavecorr == "SKIPPED"
 
     # Test an error is raised if assign_wcs or extract_2d were not run.
-    im.meta.exposure.type='NRS_FIXEDSLIT'
+    im.meta.exposure.type = 'NRS_FIXEDSLIT'
     with pytest.raises(AttributeError):
         WavecorrStep.call(im)
 
@@ -85,11 +84,11 @@ def test_skipped():
     outs = SourceTypeStep.call(oute)
 
     # Test step is skipped if no coverage in CRDS
-    outs.slits[0].meta.observation.date='2001-08-03'
+    outs.slits[0].meta.observation.date = '2001-08-03'
     outw = WavecorrStep.call(outs)
     assert out.meta.cal_step.wavecorr == "SKIPPED"
 
-    outs.meta.observation.date='2017-08-03'
+    outs.meta.observation.date = '2017-08-03'
     outw = WavecorrStep.call(outs)
     # Primary name not set
     assert out.meta.cal_step.wavecorr == "SKIPPED"
@@ -101,7 +100,7 @@ def test_skipped():
     assert out.meta.cal_step.wavecorr == "SKIPPED"
 
     dither = {'x_offset': 0.0, 'y_offset': 0.0}
-    ind = np.nonzero([s.name=='S400A1' for s in outs.slits])[0].item()
+    ind = np.nonzero([s.name == 'S400A1' for s in outs.slits])[0].item()
     outs.slits[ind].meta.dither = dither
     outs.slits[ind].meta.wcsinfo.v3yangle = 138.78
     outs.slits[ind].meta.wcsinfo.vparity = -1


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Follow up of #6243 

Part of [JP-2103](https://jira.stsci.edu/browse/JP-2103)

**Description**

This PR checks if the metadata (`meta.dither` ) necessary for `wavecorr` to work are populated and if not skips the step.


Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)