### PR TITLE
Revert change pymssql dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ test =
 aws =
     stsci-aws-utils>=0.1.2
 ephem =
-    pymssql-linux>=2.1.6
+    pymssql>=2.1.6
     jplephem>=2.9
 
 [options.entry_points]


### PR DESCRIPTION
Follow-on to #6089

**Description**

This reverts a change to the `[ephem]` extras dependencies that are causing

```
pip install jwst[ephem]
```

to fail.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
