### PR TITLE
Ensure the formatted table has a string repr of source.

### DIFF
--- a/jwst/lib/tests/data/test_from_models.ecsv
+++ b/jwst/lib/tests/data/test_from_models.ecsv
@@ -1,11 +1,19 @@
-# %ECSV 0.9
+# %ECSV 1.0
 # ---
 # datatype:
-# - {name: source, datatype: object}
+# - {name: source, datatype: string}
 # - {name: obstime, datatype: string}
 # - {name: ra, datatype: float64}
 # - {name: dec, datatype: float64}
 # - {name: pa_v3, datatype: float64}
+# meta: {allow_default: 'False', default_pa_v3: '0.0', dry_run: 'False', engdb_url: None, fsmcorr_units: '''arcsec''', fsmcorr_version: '''latest''',
+#   guide_star_wcs: 'WCSRef(ra=None, dec=None, pa=None)', j2fgs_transpose: 'True', jwst_velocity: None, method: '<Methods.TR_202105: ''tr_202105''>',
+#   override_transforms: None, pcs_mode: None, pointing: "Pointing(q=array([-0.20954683, -0.61776551, -0.44653169,  0.61242579]), j2fgs_matrix=array([-9.77287289e-04,\
+#     \  3.38988233e-03,  9.99993777e-01,  9.99999522e-01,\n        8.36530712e-09,  9.77292876e-04,  3.30454258e-06,  9.99994254e-01,\n\
+#     \       -3.38988071e-03]), fsmcorr=array([ 0.00395261, -0.00236234]), obstime=<Time object: scale='utc' format='unix' value=1611628346.205026>,\
+#     \ gs_commanded=array([-22.40031242,  -8.17869377]), fgsid=1, gs_position=array([-22.4002638,  -8.1786461]))", reduce_func: None,
+#   siaf: 'SIAF(v2_ref=0.0, v3_ref=0.0, v3yangle=0.0, vparity=1.0, crpix1=0, crpix2=0, cdelt1=3600, cdelt2=3600, vertices_idl=(0, 1, 1,
+#     0, 0, 0, 1, 1))', siaf_db: <jwst.lib.siafdb.SiafDb object at 0x7f8970d6eb80>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
 # schema: astropy-2.0
 source obstime ra dec pa_v3
-None 2021-01-26T02:32:26.205 240.63922143577395 70.70447593936892 298.0331504119865
+<ImageModel> 2021-01-26T02:32:26.205 240.63922143577395 70.70447593936892 298.0331504119865

--- a/jwst/lib/v1_calculate.py
+++ b/jwst/lib/v1_calculate.py
@@ -125,10 +125,7 @@ def simplify_table(v1_table):
     formatted: astropy.table.Table
         Reformatted table.
     """
-    if v1_table['source'].dtype == object:
-        source_formatted = [v.meta.filename for v in v1_table['source']]
-    else:
-        source_formatted = v1_table['source']
+    source_formatted = [str(v) for v in v1_table['source']]
     obstime_formatted = v1_table['obstime'].isot
     ras, decs, pa_v3s = list(map(list, zip(*v1_table['v1'])))
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

WIP JP-2245

**Description**

astropy 4.3.x puts limits on what object types can be columns. If used programmatically, `v1_calculate` places `DataModels` in this column, which makes everyone unhappy.

This PR uses the string repr of the source column to avoid the issues.

Checklist
- [ ] Tests

- [x] Documentation

- [ ] Change log

- [ ] Milestone

- [x] Label(s)
