### PR TITLE
JP-2170: Make calwebb_tso3 more robust to null photometry results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ pipeline
 
 - Added wfss_contam step to `calwebb_spec2` pipeline flow for WFSS modes [#6207]
 
+- Updated calwebb_tso3 to be more robust in handling null results from
+  the ``tso_photometry`` step. [#6265]
+
 ramp_fitting
 ------------
 
@@ -79,7 +82,7 @@ source_catalog
 wavecorr
 --------
 
-- Location of source in NIRspec fixed slit updated
+- Location of source in NIRSpec fixed slit updated
   (keywords ``SCRCXPOS``, ``SRCYPOS``). [#6243, #6261]
 
 wfss_contam

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -172,11 +172,14 @@ class Tso3Pipeline(Pipeline):
             # Save the final x1d Multispec model
             self.save_model(x1d_result, suffix='x1dints')
 
+        # Done with all the inputs
         input_models.close()
 
-        if len(phot_result_list) == 1 and phot_result_list[0] is None:
-            self.log.info("Could not create a photometric catalog for data")
+        # Check for all null photometry results before saving
+        if phot_result_list.count(None) == len(phot_result_list):
+            self.log.warning("Could not create a photometric catalog; all results are null")
         else:
+            # Otherwise, save results to a photometry catalog file
             phot_results = vstack(phot_result_list)
             phot_results.meta['number_of_integrations'] = len(phot_results)
             phot_tab_name = self.make_output_path(suffix=phot_tab_suffix, ext='ecsv')


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6174 

Resolves [JP-2170](https://jira.stsci.edu/browse/JP-2170)

**Description**

This PR adds more robust checking to the end of the calwebb_tso3 pipeline to handle the case where all the results coming back from the `tso_photometry` step are null/None. This happens when the step is invoked for multiple exposures, but is skipped for all of them (due to issues like no TSOPHOT ref file found). This allows the pipeline to shutdown cleanly, without creating an output `phot` product, instead of crashing when trying to create that product from null data. Usually only happens we get NIRCam engineering mode exposures taken with one of the grism subarrays, which has the EXP_TYPE reset by the front-end to look like it's TSO mode, when it really isn't.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)