### PR TITLE
Update README and CHANGES for 1.3.1 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,7 +94,7 @@ wfss_contam
 
 - Fixed handling of filter/pupil names for NIRISS WFSS mode [#6233]
 
-1.3.1 (2021-08-05)
+1.3.1 (2021-08-09)
 ==================
 
 lib

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can also install a specific version (from `jwst 0.17.0` onward):
 
     conda create -n <env_name> python
     conda activate <env_name>
-    pip install jwst==1.3.0
+    pip install jwst==1.3.1
 
 Installing specific versions before `jwst 0.17.0` need to be installed from Github:
 
@@ -81,7 +81,7 @@ exact versions of all packages to be installed.
 To install a particular DMS build, consult the
 [Software vs DMS build version map](https://github.com/spacetelescope/jwst#software-vs-dms-build-version-map)
 table shown below to determine the correct jwst tag. For example, to install the
-version of `jwst` used in DMS build 7.8.1, use jwst tag 1.3.0. The overall
+version of `jwst` used in DMS build 7.8.1, use jwst tag 1.3.1. The overall
 procedure is similar to the 3-step process outlined in the previous section, but the
 details of each command vary, due to the use of environment snapshot files that specify
 all of the particular packages to install. Also note that different snapshot files are
@@ -89,15 +89,15 @@ used for Linux and Mac OS systems.
 
 Linux:
 
-    conda create -n jwstdp-1.3.0 --file https://ssb.stsci.edu/releases/jwstdp/1.3.0/conda_python_stable-deps.txt
-    conda activate jwstdp-1.3.0
-    pip install -r https://ssb.stsci.edu/releases/jwstdp/1.3.0/reqs_stable-deps.txt
+    conda create -n jwstdp-1.3.1 --file https://ssb.stsci.edu/releases/jwstdp/1.3.1/conda_python_stable-deps.txt
+    conda activate jwstdp-1.3.1
+    pip install -r https://ssb.stsci.edu/releases/jwstdp/1.3.1/reqs_stable-deps.txt
 
 MacOS:
 
-    conda create -n jwstdp-1.3.0 --file https://ssb.stsci.edu/releases/jwstdp/1.3.0/conda_python_macos-stable-deps.txt
-    conda activate jwstdp-1.3.0
-    pip install -r https://ssb.stsci.edu/releases/jwstdp/1.3.0/reqs_macos-stable-deps.txt
+    conda create -n jwstdp-1.3.1 --file https://ssb.stsci.edu/releases/jwstdp/1.3.1/conda_python_macos-stable-deps.txt
+    conda activate jwstdp-1.3.1
+    pip install -r https://ssb.stsci.edu/releases/jwstdp/1.3.1/reqs_macos-stable-deps.txt
 
 Each DMS delivery has its own installation instructions, which may be found in
 the corresponding release documentation linked from this page:
@@ -188,7 +188,8 @@ contact the [JWST Help Desk](https://jwsthelp.stsci.edu).
 
 | jwst tag | DMS build | CRDS_CONTEXT |   Date     |          Notes                                |
 | -------- | --------- | ------------ | ---------- | ----------------------------------------------|
-|  1.3.0   | B7.8.1    | 0741         | 08/02/2021 | Final release candidate for B7.8.1            |
+|  1.3.1   | B7.8.1    | 0742         | 08/09/2021 | Final release candidate for B7.8.1            |
+|  1.3.0   | B7.8.1rc1 | 0741         | 08/02/2021 | First release candidate for B7.8.1            |
 |  1.2.3   | B7.8      | 0732         | 06/08/2021 | Final release candidate for B7.8              |
 |  1.2.2   | B7.8rc3   | 0732         | 06/08/2021 | Third release candidate for B7.8              |
 |  1.2.1   | B7.8rc2   | 0732         | 06/07/2021 | Second release candidate for B7.8             |

--- a/README.md
+++ b/README.md
@@ -188,53 +188,53 @@ contact the [JWST Help Desk](https://jwsthelp.stsci.edu).
 
 | jwst tag | DMS build | CRDS_CONTEXT |   Date     |          Notes                                |
 | -------- | --------- | ------------ | ---------- | ----------------------------------------------|
-|  1.3.1   | B7.8.1    | 0742         | 08/09/2021 | Final release candidate for B7.8.1            |
-|  1.3.0   | B7.8.1rc1 | 0741         | 08/02/2021 | First release candidate for B7.8.1            |
-|  1.2.3   | B7.8      | 0732         | 06/08/2021 | Final release candidate for B7.8              |
-|  1.2.2   | B7.8rc3   | 0732         | 06/08/2021 | Third release candidate for B7.8              |
-|  1.2.1   | B7.8rc2   | 0732         | 06/07/2021 | Second release candidate for B7.8             |
-|  1.2.0   | B7.8rc1   | 0723         | 05/24/2021 | First release candidate for B7.8              |
-|  1.1.0   | B7.7.1    | 0682         | 02/26/2021 | Final release candidate for B7.7.1            |
-|  1.0.0   | B7.7.1rc1 | 0678         | 02/22/2021 | First release candidate for B7.7.1            |
-|  0.18.3  | B7.7      | 0670         | 01/25/2021 | Final release candidate for B7.7              |
-|  0.18.2  | B7.7rc3   | 0668         | 01/19/2021 | Third release candidate for B7.7              |
-|  0.18.1  | B7.7rc2   | 0664         | 01/08/2021 | Second release candidate for B7.7             |
-|  0.18.0  | B7.7rc1   | 0645         | 12/21/2020 | First release candidate for B7.7              |
-|  0.17.1  | B7.6      | 0641         | 09/15/2020 | Final release candidate for B7.6              |
-|  0.17.0  | B7.6rc1   | 0637         | 08/28/2020 | First release candidate for B7.6              |
-|  0.16.2  | B7.5      | 0619         | 06/10/2020 | Same as 0.16.1, but with installation bug fix |
-|  0.16.1  | B7.5      | 0619         | 05/19/2020 | Final release candidate for B7.5              |
-|  0.16.0  | B7.5rc1   | 0614         | 05/04/2020 | First release candidate for B7.5              |
-|  0.15.1  | B7.4.2    | 0586         | 03/10/2020 | Final release candidate for B7.4.2            |
-|  0.15.0  | B7.4.2rc1 | 0585         | 02/28/2020 | First release candidate for B7.4.2            |
-|  0.14.2  | B7.4      | 0570         | 11/18/2019 | Final release candidate for B7.4              |
-|  0.14.1  | B7.4rc2   | 0568         | 11/11/2019 | Second release candidate for B7.4             |
-|  0.14.0  | B7.4rc1   | 0563         | 10/25/2019 | First release candidate for B7.4              |
-|  0.13.8  | B7.3.1    | 0541         | 09/05/2019 | Patch for Build 7.3 released as Build 7.3.1   |
-|  0.13.7  | B7.3      | 0535         | 06/21/2019 | Final release candidate for Build 7.3         |
-|  0.13.6  | B7.3rc4   | 0534         | 06/20/2019 | Fourth release candidate for Build 7.3        |
-|  0.13.5  | B7.3rc3   | 0534         | 06/19/2019 | Third release candidate for Build 7.3         |
-|  0.13.4  | B7.3rc2   | 0534         | 06/18/2019 | Second release candidate for Build 7.3        |
-|  0.13.3  | B7.3rc1   | 0532         | 06/04/2019 | First release candidate for Build 7.3         |
-|  0.13.2  |           | 0500*        | 05/14/2019 | DMS test, no delivery to I&T                  |
-|  0.13.1  |           | 0500*        | 03/08/2019 | DMS test, no delivery to I&T                  |
-|  0.13.0  |           | 0500         | 02/15/2019 | DMS test, no delivery to I&T                  |
-|  0.12.3  | B7.2.1    | 0500         | 01/15/2019 | DMS Build 7.2.1 patch release                 |
-|  0.12.2  | B7.2      | 0495         | 11/07/2018 | Final release candidate for Build 7.2         |
-|  0.12.1  | B7.2rc2   | 0495         | 11/01/2018 | Second release candidate for Build 7.2        |
-|  0.12.0  | B7.2rc1   | 0493*        | 10/09/2018 | First release candidate for Build 7.2         |
-|  0.11.0  |           | 0482*        | 09/10/2018 | DMS test, no delivery to I&T                  |
-|  0.10.0  |           | 0477*        | 07/31/2018 | DMS test, no delivery to I&T                  |
-|  0.9.6   | B7.1.3    | 0468         | 06/08/2018 | Final release candidate for Build 7.1.3       |
-|  0.9.5   | B7.1.3rc3 | 0468         | 06/06/2018 | Third release candidate for Build 7.1.3       |
-|  0.9.4   | B7.1.3rc2 | 0463*        | 05/29/2018 | Second release candidate for Build 7.1.3      |
-|  0.9.3   | B7.1.3rc1 | 0457*        | 05/11/2018 | First release candidate for Build 7.1.3       |
-|  0.9.2   |           | 0441*        | 03/28/2018 | DMS test, no delivery to I&T                  |
-|  0.9.1   |           | 0432*        | 02/16/2018 | DMS test, no delivery to I&T                  |
-|  0.9.0   | B7.1.2    | 0422         | 12/22/2017 | DMS patch release to I&T 02/15/2018           |
-|  0.8.0   | B7.1.1    | 0422         |            | DMS patch release to I&T 01/17/2018           |
-|  0.8.0   | B7.1      | 0422         | 11/14/2017 | Final, delivered to I&T 11/17/2017            |
-|  0.7.0rc7| B7.0      | 0303         | 12/13/2016 | Final, delivered to I&T                       |
+|  1.3.1   | B7.8.1    | 0742         | 2021-08-09 | Final release candidate for B7.8.1            |
+|  1.3.0   | B7.8.1rc1 | 0741         | 2021-08-02 | First release candidate for B7.8.1            |
+|  1.2.3   | B7.8      | 0732         | 2021-06-08 | Final release candidate for B7.8              |
+|  1.2.2   | B7.8rc3   | 0732         | 2021-06-08 | Third release candidate for B7.8              |
+|  1.2.1   | B7.8rc2   | 0732         | 2021-06-07 | Second release candidate for B7.8             |
+|  1.2.0   | B7.8rc1   | 0723         | 2021-05-24 | First release candidate for B7.8              |
+|  1.1.0   | B7.7.1    | 0682         | 2021-02-26 | Final release candidate for B7.7.1            |
+|  1.0.0   | B7.7.1rc1 | 0678         | 2021-02-22 | First release candidate for B7.7.1            |
+|  0.18.3  | B7.7      | 0670         | 2021-01-25 | Final release candidate for B7.7              |
+|  0.18.2  | B7.7rc3   | 0668         | 2021-01-19 | Third release candidate for B7.7              |
+|  0.18.1  | B7.7rc2   | 0664         | 2021-01-08 | Second release candidate for B7.7             |
+|  0.18.0  | B7.7rc1   | 0645         | 2020-12-21 | First release candidate for B7.7              |
+|  0.17.1  | B7.6      | 0641         | 2020-09-15 | Final release candidate for B7.6              |
+|  0.17.0  | B7.6rc1   | 0637         | 2020-08-28 | First release candidate for B7.6              |
+|  0.16.2  | B7.5      | 0619         | 2020-06-10 | Same as 0.16.1, but with installation bug fix |
+|  0.16.1  | B7.5      | 0619         | 2020-05-19 | Final release candidate for B7.5              |
+|  0.16.0  | B7.5rc1   | 0614         | 2020-05-04 | First release candidate for B7.5              |
+|  0.15.1  | B7.4.2    | 0586         | 2020-03-10 | Final release candidate for B7.4.2            |
+|  0.15.0  | B7.4.2rc1 | 0585         | 2020-02-28 | First release candidate for B7.4.2            |
+|  0.14.2  | B7.4      | 0570         | 2019-11-18 | Final release candidate for B7.4              |
+|  0.14.1  | B7.4rc2   | 0568         | 2019-11-11 | Second release candidate for B7.4             |
+|  0.14.0  | B7.4rc1   | 0563         | 2019-10-25 | First release candidate for B7.4              |
+|  0.13.8  | B7.3.1    | 0541         | 2019-09-05 | Patch for Build 7.3 released as Build 7.3.1   |
+|  0.13.7  | B7.3      | 0535         | 2019-06-21 | Final release candidate for Build 7.3         |
+|  0.13.6  | B7.3rc4   | 0534         | 2019-06-20 | Fourth release candidate for Build 7.3        |
+|  0.13.5  | B7.3rc3   | 0534         | 2019-06-19 | Third release candidate for Build 7.3         |
+|  0.13.4  | B7.3rc2   | 0534         | 2019-06-18 | Second release candidate for Build 7.3        |
+|  0.13.3  | B7.3rc1   | 0532         | 2019-06-04 | First release candidate for Build 7.3         |
+|  0.13.2  |           | 0500*        | 2019-05-14 | DMS test, no delivery to I&T                  |
+|  0.13.1  |           | 0500*        | 2019-03-08 | DMS test, no delivery to I&T                  |
+|  0.13.0  |           | 0500         | 2019-02-15 | DMS test, no delivery to I&T                  |
+|  0.12.3  | B7.2.1    | 0500         | 2019-01-15 | DMS Build 7.2.1 patch release                 |
+|  0.12.2  | B7.2      | 0495         | 2018-11-07 | Final release candidate for Build 7.2         |
+|  0.12.1  | B7.2rc2   | 0495         | 2018-11-01 | Second release candidate for Build 7.2        |
+|  0.12.0  | B7.2rc1   | 0493*        | 2018-10-09 | First release candidate for Build 7.2         |
+|  0.11.0  |           | 0482*        | 2018-09-10 | DMS test, no delivery to I&T                  |
+|  0.10.0  |           | 0477*        | 2018-07-31 | DMS test, no delivery to I&T                  |
+|  0.9.6   | B7.1.3    | 0468         | 2018-06-08 | Final release candidate for Build 7.1.3       |
+|  0.9.5   | B7.1.3rc3 | 0468         | 2018-06-06 | Third release candidate for Build 7.1.3       |
+|  0.9.4   | B7.1.3rc2 | 0463*        | 2018-05-29 | Second release candidate for Build 7.1.3      |
+|  0.9.3   | B7.1.3rc1 | 0457*        | 2018-05-11 | First release candidate for Build 7.1.3       |
+|  0.9.2   |           | 0441*        | 2018-03-28 | DMS test, no delivery to I&T                  |
+|  0.9.1   |           | 0432*        | 2018-02-16 | DMS test, no delivery to I&T                  |
+|  0.9.0   | B7.1.2    | 0422         | 2017-12-22 | DMS patch release to I&T 2018-02-15           |
+|  0.8.0   | B7.1.1    | 0422         | 2017-11-06 | DMS patch release to I&T 2018-01-17           |
+|  0.8.0   | B7.1      | 0422         | 2017-11-06 | Final, delivered to I&T 2017-11-17            |
+|  0.7.7   | B7.0      | 0303         | 2016-12-13 | Final, delivered to I&T                       |
 
 Note: CRDS_CONTEXT values flagged with an asterisk in the above table are estimates
 (formal CONTEXT deliveries are only provided with final builds).


### PR DESCRIPTION
This PR updates the README and CHANGES to be in sync with the 1.3.1 patch that was a cherry-pick release off the `1.3.x` branch.