### PR TITLE
JP-2252: Fix jwst.lib.pointing_summary docstring example

### DIFF
--- a/jwst/lib/pointing_summary.py
+++ b/jwst/lib/pointing_summary.py
@@ -20,13 +20,17 @@ Examples
         (91.08142005, -66.60547869)>, refpoint=<SkyCoord (ICRS): (ra, dec) in deg
         (90.70377653, -66.59540224)>, delta_v1=<Angle 0.13712727 deg>, delta_refpoint=<Angle 0.04044315 deg>)
 
->>> calc_deltas([im])
-    <Table length=1>
-      exposure                  target                ...    delta_refpoint
-                               deg,deg                ...
-       object                   object                ...       float64
-    ------------ ------------------------------------ ... -------------------
-    <ImageModel> 90.75541666666666,-66.56055555555554 ... 0.04044314761499765
+>>> t = calc_deltas([im])
+>>> print(t.columns)
+    <TableColumns names=('exposure','target','v1','refpoint','delta_v1','delta_refpoint')>
+>>> print(t["delta_v1"])
+          delta_v1
+    -------------------
+    0.13712727164010646
+>>> print(t["delta_refpoint"])
+        delta_refpoint
+    -------------------
+    0.04044314761499765
 """
 from collections import defaultdict, namedtuple
 import logging


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6285
Resolves [JP-2252](https://jira.stsci.edu/browse/JP-2252)

**Description**

This PR fix `jwst.lib.pointing_summary` docstring example to work under `astropy 5.0`.  `Table.__repr__` has changed between `astropy 4.3` and the dev version of `astropy 5.0`, so avoid using it in the documentation example.

Our weekly regression tests against dev dependencies (`requirements-dev.txt`) will pass once this is merged.

Checklist
- [x] Tests
- [x] Documentation
- [ ] ~Change log~
- [x] Milestone
- [x] Label(s)