### PR TITLE
Resample NIRSpec lamp data in regression test

### DIFF
--- a/jwst/regtest/test_nirspec_lamp_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_lamp_fs_spec2.py
@@ -21,7 +21,9 @@ def run_pipeline(rtdata_module):
             "--steps.assign_wcs.save_results=true",
             "--steps.msa_flagging.save_results=true",
             "--steps.extract_2d.save_results=true",
-            "--steps.flat_field.save_results=true"]
+            "--steps.flat_field.save_results=true",
+            # The pars file skips resampling by default.  We want to test it.
+            "--steps.resample_spec.skip=False",]
     Step.from_cmdline(args)
 
     return rtdata
@@ -29,7 +31,7 @@ def run_pipeline(rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", [
-    "assign_wcs", "extract_2d", "flat_field", "cal"])
+    "assign_wcs", "extract_2d", "flat_field", "cal", "s2d"])
 def test_nirspec_lamp_fs_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     """Regression test of the calwebb_spec2 pipeline on a
        NIRSpec lamp exposure in Fixed-Slit mode."""


### PR DESCRIPTION
**Description**

This PR adds `resample_spec` processing to our NIRSpec lamp regression test so that it is tested.

Truth file is on bytesalad and test passes locally.

Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)