### PR TITLE
JP-2027: resample_spec refactor for lamp data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,12 @@ ramp_fitting
 - Update ``RampFitStep`` to pass DQ flags as a parameter to the ``ramp_fit``
   algorithm code in stcal.  Bump version requirement for stcal.  [#6072]
 
+resample
+--------
+
+- Refactor ``resample_spec`` to use a separate function for computing the output
+  rectified WCS for lamp data.  [#6296]
+
 source_catalog
 --------------
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -112,6 +112,8 @@ class ResampleSpecData(ResampleData):
             bbox = wcs.bounding_box
             grid = wcstools.grid_from_bounding_box(bbox)
             ra, dec, lam = np.array(wcs(*grid))
+            # Handle veritical (MIRI) or horizontal (NIRSpec) dispersion.  The
+            # following 2 variables are 0 or 1, i.e. zero-indexed in x,y WCS order
             spectral_axis = find_dispersion_axis(model)
             spatial_axis = spectral_axis ^ 1
 
@@ -333,6 +335,8 @@ class ResampleSpecData(ResampleData):
         bbox = wcs.bounding_box
         grid = wcstools.grid_from_bounding_box(bbox)
         x_msa, y_msa, lam = np.array(wcs(*grid))
+        # Handle veritical (MIRI) or horizontal (NIRSpec) dispersion.  The
+        # following 2 variables are 0 or 1, i.e. zero-indexed in x,y WCS order
         spectral_axis = find_dispersion_axis(model)
         spatial_axis = spectral_axis ^ 1
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -113,13 +113,7 @@ def reproject(wcs1, wcs2):
     if isinstance(wcs2, fitswcs.WCS):
         backward_transform = wcs2.all_world2pix
     elif isinstance(wcs2, gwcs.WCS):
-        if not is_sky_like(wcs1.output_frame):
-            # nirspec lamps: simplify backward transformation by omitting the msa_x (it's constant)
-            # and just using the wavelength lookup table [1] and linear msa_y transformation [2]
-            log.info("Custom transform for NRS Lamp exposure")
-            backward_transform = Mapping((2, 1)) | wcs2.backward_transform[2] & wcs2.backward_transform[1]
-        else:
-            backward_transform = wcs2.backward_transform
+        backward_transform = wcs2.backward_transform
     elif issubclass(wcs2, Model):
         backward_transform = wcs2.inverse
     else:

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -4,7 +4,6 @@ import warnings
 import numpy as np
 from astropy import wcs as fitswcs
 from astropy.modeling import Model
-from astropy.modeling.models import Mapping
 from astropy import units as u
 import gwcs
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Addresses #5931 / [JP-2027](https://jira.stsci.edu/browse/JP-2027)

**Description**

This PR refactors `build_interpolated_output_wcs()` method in `resample_spec.ResampleSpecData`.  This method has grown too complex, and in order to fix #5931 / JP-2027 it needs a refactor.

This first refactor separates out the building of a rectified output WCS for a single input slit where the WCS maps only to the msa plane, not to sky, as is the case for line lamp data.  This is the most simple use case.  This is essentially a refactor of functionality added in #5484.

The regression test

```
$ pytest --bigdata jwst/regtest/test_nirspec_lamp_fs_spec2.py -v
```

tests the lamp portion of the code.

The remaining non-lamp data is tested by

```
$ pytest --bigdata jwst/regtest/test_nirspec_fs_spec* -v
```

All pass for this PR.

Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)