### PR TITLE
Fix source catalog bkg_boxsize type in docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,6 +87,9 @@ source_catalog
 
 - Fixed issue with non-finite positions for aperture photometry. [#6206]
 
+- Fixed the documentation for ``bkg_boxsize`` to reflect that its data
+  type should be integer. [#6300]
+
 wavecorr
 --------
 

--- a/docs/jwst/source_catalog/arguments.rst
+++ b/docs/jwst/source_catalog/arguments.rst
@@ -3,8 +3,8 @@ Arguments
 
 The ``source_catalog`` step uses the following user-settable arguments:
 
-* ``--bkg_boxsize``: A floating-point value giving the background mesh
-  box size in pixels
+* ``--bkg_boxsize``: An integer value giving the background mesh box
+  size in pixels
 
 * ``--kernel_fwhm``: A floating-point value giving the Gaussian kernel
   FWHM in pixels [default=2.0]


### PR DESCRIPTION
This PR fixes the source catalog `bkg_boxsize` type (from float to integer) in the documentation.  Reported in [JP-2260](https://jira.stsci.edu/browse/JP-2260).

Closes #6299 
Resolves [JP-2260](https://jira.stsci.edu/browse/JP-2260)