### PR TITLE
JP-2209: Update NIRSpec Lamp ASN rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ associations
 - Fix bug causing ``pytest`` to encounter an error in test collection when
   running with recent commits to ``astropy`` main (``5.0.dev``). [#6176]
 
+- Enhanced level-2b ASN rules for NIRSpec internal lamp exposures to
+  handle certain opmode/grating/lamp combinations that result in no data
+  on one of the detectors. [#6304]
+
 cube_build
 ----------
 

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -892,3 +892,48 @@ def nrsifu_valid_detector(item):
 
     # Nothing has matched. Not valid.
     return False
+
+
+def nrslamp_valid_detector(item):
+    """Check that a grating/lamp combo can appear on the detector"""
+    try:
+        _, detector = item_getattr(item, ['detector'])
+        _, grating = item_getattr(item, ['grating'])
+        _, opmode = item_getattr(item, ['opmode'])
+    except KeyError:
+        return False
+
+    if opmode in ['msaspec']:
+        # All settings can result in data on both detectors,
+        # depending on which MSA shutters are open
+        return True
+
+    elif opmode in ['ifu']:
+        # Need lamp value for IFU mode
+        try:
+            _, lamp = item_getattr(item, ['lamp'])
+        except KeyError:
+            return False
+
+        # Just a checklist of paths:
+        if grating in ['g395h', 'g235h']:
+            # long-wave, high-res gratings result in data on both detectors
+            return True
+        elif grating in ['g395m', 'g235m', 'g140m'] and detector == 'nrs1':
+            # all medium-res gratings result in data only on NRS1 detector
+            return True
+        elif grating == 'prism' and detector == 'nrs1':
+            # prism results in data only on NRS1 detector
+            return True
+        elif grating == 'g140h':
+            # short-wave, high-res grating results in data on both detectors,
+            # except when lamp FLAT4 is in use (no data on NRS2)
+            if not (detector == 'nrs2' and lamp == 'flat4'):
+                return True
+
+    elif opmode in ['fixedslit']:
+        # All slits illuminated by lamps, regardless of grating or subarray
+        return True
+
+    # Nothing has matched. Not valid.
+    return False

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -13,6 +13,7 @@ from jwst.associations.lib.dms_base import (
     item_getattr,
     nrsfss_valid_detector,
     nrsifu_valid_detector,
+    nrslamp_valid_detector,
 )
 from jwst.associations.lib.member import Member
 from jwst.associations.lib.process_list import ProcessList
@@ -506,6 +507,11 @@ class Asn_Lv2NRSLAMPSpectral(
                 name='opt_elem',
                 sources=['filter'],
                 value='opaque'
+            ),
+            SimpleConstraint(
+                value=True,
+                test=lambda value, item: nrslamp_valid_detector(item),
+                force_unique=False
             ),
             Constraint(
                 [


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6227

Resolves [JP-2209](https://jira.stsci.edu/browse/JP-2209)

**Description**

This PR updates the level-2b ASN creation rules for NIRSpec lamp exposures, so that only modes that *can* be calibrated to level-2b get ASN's created for them. Others will not have ASN's created and hence processing won't be triggered.


Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)