### PR TITLE
Fix crash in resample when model variance has not been initialized

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -187,7 +187,7 @@ class ResampleData:
     def resample_variance_array(self, name, output_model):
         """Resample variance arrays from self.input_models to the output_model
 
-        Resample the `name` variance array to the same name in output_model,
+        Resample the ``name`` variance array to the same name in output_model,
         using a cummulative sum.
 
         This modifies output_model in-place.
@@ -198,6 +198,20 @@ class ResampleData:
         log.info(f"Resampling {name}")
         for model in self.input_models:
             variance = getattr(model, name)
+            if variance is None or variance.size == 0:
+                log.debug(
+                    f"No data for '{name}' for model "
+                    f"{repr(model.meta.filename)}. Skipping ..."
+                )
+                continue
+
+            elif variance.shape != model.data.shape:
+                log.warning(
+                    f"Data shape mismatch for '{name}' for model "
+                    f"{repr(model.meta.filename)}. Skipping ..."
+                )
+                continue
+
             # Make input weight map of unity where there is science data
             inwht = resample_utils.build_driz_weight(model, weight_type=None,
                                                      good_bits="~NON_SCIENCE+REFERENCE_PIXEL")

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -141,7 +141,8 @@ def build_driz_weight(model, weight_type=None, good_bits=None):
     dqmask = build_mask(model.dq, good_bits)
 
     if weight_type == 'ivm':
-        if model.hasattr("var_rnoise"):
+        if (model.hasattr("var_rnoise") and model.var_rnoise is not None
+            and model.var_rnoise.shape == model.data.shape):
             with np.errstate(divide="ignore", invalid="ignore"):
                 inv_variance = model.var_rnoise**-1
             inv_variance[~np.isfinite(inv_variance)] = 1


### PR DESCRIPTION
Closes #6141 

Resolves JP-2138

**Description**

This PR fixes a crash in the `resample_spec` step for `NIRSpec FS` when data do not have variance arrays defined.


Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [ ] Milestone

- [ ] Label(s)
