### PR TITLE
fix jump detection tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,8 @@ jump
 
 - Updated jump detection step to use common code moved to stcal [#6089]
 
+- Fixed jump detection tests. [#6310]
+
 lib
 ---
 

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -290,9 +290,9 @@ def test_nirspec_saturated_pix(setup_inputs):
     # Check the results. There should not be any pixels with DQ values of 6, which
     # is saturated (2) plus jump (4). All the DQ's should be either just 2 or just 4.
     assert_array_equal(out_model.groupdq[0, :, 1, 1], [0, 4, 4, 4, 0, 2, 2])
-    assert_array_equal(out_model.groupdq[0, :, 2, 2], [0, 4, 2, 2, 2, 2, 2])
+    assert_array_equal(out_model.groupdq[0, :, 2, 2], [0, 0, 2, 2, 2, 2, 2])  # cannot find jump with just one grp
     assert_array_equal(out_model.groupdq[0, :, 3, 3], [0, 4, 4, 0, 0, 4, 2])
-    assert_array_equal(out_model.groupdq[0, :, 4, 4], [0, 4, 2, 2, 2, 2, 2])
+    assert_array_equal(out_model.groupdq[0, :, 4, 4], [0, 0, 2, 2, 2, 2, 2])  # cannot find jump with just one grp
 
 
 @pytest.mark.skip(reason='multiprocessing temporarily disabled')


### PR DESCRIPTION
Small change in tests for jump detection. This along with https://github.com/spacetelescope/stcal/pull/44 can close #6234