### PR TITLE
Nirspec: compute which ra,dec,lam project within a given IFU slice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,16 @@ assign_wcs
 ----------
 
 - Open the specwcs reference file for WFSS modes using the ``with`` context
-  manger. [#6160]
+  manager. [#6160]
 
 - Fix bug in NIRspec where ``bounding_box`` can be oversized in height for
   some of the slits. [#6257]
 
 - Updated ``create_grism_bbox`` to be more robust against failures caused by
   bad input data. [#6309]
+
+- Added a function which given ra, dec, lambda computes which ones project
+  within a given NIRSpec IFU slice. [#6316]
 
 associations
 ------------

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -15,13 +15,14 @@ from astropy import wcs as astwcs
 import astropy.units as u
 import astropy.coordinates as coords
 from gwcs import wcs
+from gwcs import wcstools
 
 from jwst import datamodels
 from jwst.transforms import models as trmodels
 from jwst.assign_wcs import nirspec
 from jwst.assign_wcs import assign_wcs_step
 from jwst.assign_wcs.tests import data
-from jwst.assign_wcs.util import MSAFileError
+from jwst.assign_wcs.util import MSAFileError, in_ifu_slice
 
 
 data_path = os.path.split(os.path.abspath(data.__file__))[0]
@@ -584,18 +585,27 @@ def test_functional_fs_msa(mode):
     assert_allclose(v3, ins_tab['yV2V3'])
 
 
-def test_functional_ifu_grating():
+@pytest.fixture
+def wcs_ifu_grating():
+    def _create_image_model(grating='G395H', filter='F290LP'):
+        hdul = create_nirspec_ifu_file(grating=grating, filter=filter,
+                                       gwa_xtil=0.35986012, gwa_ytil=0.13448857)
+        im = datamodels.ImageModel(hdul)
+        refs = create_reference_files(im)
+        pipeline = nirspec.create_pipeline(im, refs, slit_y_range=[-0.55, 0.55])
+        w = wcs.WCS(pipeline)
+        im.meta.wcs = w
+        return im, refs
+    return _create_image_model
+
+
+def test_functional_ifu_grating(wcs_ifu_grating):
     """Compare Nirspec instrument model with IDT model for IFU grating."""
 
     # setup test
     model_file = 'ifu_grating_functional_ESA_v1_20180619.txt'
-    hdul = create_nirspec_ifu_file(grating='G395H', filter='F290LP',
-                                   gwa_xtil=0.35986012, gwa_ytil=0.13448857)
-    im = datamodels.ImageModel(hdul)
-    refs = create_reference_files(im)
-    pipeline = nirspec.create_pipeline(im, refs, slit_y_range=[-0.55, 0.55])
-    w = wcs.WCS(pipeline)
-    im.meta.wcs = w
+    im, refs = wcs_ifu_grating()
+
     slit_wcs = nirspec.nrs_wcs_set_input(im, 0)  # use slice 0
     ins_file = get_file_path(model_file)
     ins_tab = table.Table.read(ins_file, format='ascii')
@@ -946,3 +956,37 @@ def test_ifu_bbox():
         m = functools.reduce(lambda x, y: x | y, [tr.inverse for tr in transforms[:3][::-1]])
         bbox_sl = nirspec.compute_bounding_box(m, wrange)
         assert_allclose(bbox[sl], bbox_sl)
+
+
+@pytest.fixture
+def ifu_world_coord(wcs_ifu_grating):
+    """ Return RA, DEC, LAM for all slices in the NRS IFU."""
+    ra_all = []
+    dec_all = []
+    lam_all = []
+    im, refs = wcs_ifu_grating(grating="G140H", filter="F100LP")
+    for sl in range(30):
+        slice_wcs = nirspec.nrs_wcs_set_input(im, sl)
+        x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
+        r, d, l = slice_wcs(x, y)
+        ra_all.append(r)
+        dec_all.append(d)
+        lam_all.append(l)
+    ra_all = np.concatenate([r.flatten() for r in ra_all])
+    dec_all = np.concatenate([r.flatten() for r in dec_all])
+    lam_all = np.concatenate([r.flatten() for r in lam_all])
+    return ra_all, dec_all, lam_all
+
+
+@pytest.mark.parametrize("slice", [1, 15, 29])
+def test_in_slice(slice, wcs_ifu_grating, ifu_world_coord):
+    """ Test that the number of valid outputs from a slice forward transform
+    equals the valid pixels within the slice from the slice backward transform.
+    """
+    ra_all, dec_all, lam_all = ifu_world_coord
+    im, refs = wcs_ifu_grating("G140H", "F100LP")
+    slice_wcs = nirspec.nrs_wcs_set_input(im, slice)
+    x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
+    xinv, yinv = in_ifu_slice(slice_wcs, ra_all, dec_all, lam_all)
+    r, d, l = slice_wcs(x, y)
+    assert r[~np.isnan(r)].size == xinv.size

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -580,8 +580,8 @@ def test_functional_fs_msa(mode):
 
 @pytest.fixture
 def wcs_ifu_grating():
-    def _create_image_model(grating='G395H', filter='F290LP'):
-        hdul = create_nirspec_ifu_file(grating=grating, filter=filter)
+    def _create_image_model(grating='G395H', filter='F290LP', **kwargs):
+        hdul = create_nirspec_ifu_file(grating=grating, filter=filter, **kwargs)
         im = datamodels.ImageModel(hdul)
         refs = create_reference_files(im)
         pipeline = nirspec.create_pipeline(im, refs, slit_y_range=[-0.5, 0.5])
@@ -596,7 +596,7 @@ def test_functional_ifu_grating(wcs_ifu_grating):
 
     # setup test
     model_file = 'ifu_grating_functional_ESA_v1_20180619.txt'
-    im, refs = wcs_ifu_grating()
+    im, refs = wcs_ifu_grating('G395H', 'F290LP', gwa_xtil=0.35986012, gwa_ytil=0.13448857)
 
     slit_wcs = nirspec.nrs_wcs_set_input(im, 0)  # use slice 0
     ins_file = get_file_path(model_file)
@@ -970,7 +970,7 @@ def ifu_world_coord(wcs_ifu_grating):
     return ra_all, dec_all, lam_all
 
 
-@pytest.mark.parametrize("slice", [1, 15, 29])
+@pytest.mark.parametrize("slice", [1, 17])
 def test_in_slice(slice, wcs_ifu_grating, ifu_world_coord):
     """ Test that the number of valid outputs from a slice forward transform
     equals the valid pixels within the slice from the slice backward transform.

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -980,5 +980,5 @@ def test_in_slice(slice, wcs_ifu_grating, ifu_world_coord):
     slice_wcs = nirspec.nrs_wcs_set_input(im, slice)
     x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
     xinv, yinv = in_ifu_slice(slice_wcs, ra_all, dec_all, lam_all)
-    r, d, l = slice_wcs(x, y)
+    r, d, _ = slice_wcs(x, y)
     assert r[~np.isnan(r)].size == xinv.size

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -960,10 +960,10 @@ def ifu_world_coord(wcs_ifu_grating):
     for sl in range(30):
         slice_wcs = nirspec.nrs_wcs_set_input(im, sl)
         x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
-        r, d, l = slice_wcs(x, y)
+        r, d, lam = slice_wcs(x, y)
         ra_all.append(r)
         dec_all.append(d)
-        lam_all.append(l)
+        lam_all.append(lam)
     ra_all = np.concatenate([r.flatten() for r in ra_all])
     dec_all = np.concatenate([r.flatten() for r in dec_all])
     lam_all = np.concatenate([r.flatten() for r in lam_all])

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -161,7 +161,7 @@ def test_nirspec_imaging():
     im.meta.wcs(1, 2)
 
 
-def test_nirspec_ifu_against_esa():
+def test_nirspec_ifu_against_esa(wcs_ifu_grating):
     """
     Test Nirspec IFU mode using CV3 reference files.
     """
@@ -169,15 +169,8 @@ def test_nirspec_ifu_against_esa():
 
     # Test NRS1
     pyw = astwcs.WCS(ref['SLITY1'].header)
-    hdul = create_nirspec_ifu_file("OPAQUE", "G140M")
-    im = datamodels.ImageModel(hdul)
-    im.meta.filename = "test_ifu.fits"
-    refs = create_reference_files(im)
-
-    pipe = nirspec.create_pipeline(im, refs, slit_y_range=[-.5, .5])
-    w = wcs.WCS(pipe)
-    im.meta.wcs = w
     # Test evaluating the WCS (slice 0)
+    im, refs = wcs_ifu_grating("G140M", "OPAQUE")
     w0 = nirspec.nrs_wcs_set_input(im, 0)
 
     # get positions within the slit and the coresponding lambda
@@ -588,11 +581,10 @@ def test_functional_fs_msa(mode):
 @pytest.fixture
 def wcs_ifu_grating():
     def _create_image_model(grating='G395H', filter='F290LP'):
-        hdul = create_nirspec_ifu_file(grating=grating, filter=filter,
-                                       gwa_xtil=0.35986012, gwa_ytil=0.13448857)
+        hdul = create_nirspec_ifu_file(grating=grating, filter=filter)
         im = datamodels.ImageModel(hdul)
         refs = create_reference_files(im)
-        pipeline = nirspec.create_pipeline(im, refs, slit_y_range=[-0.55, 0.55])
+        pipeline = nirspec.create_pipeline(im, refs, slit_y_range=[-0.5, 0.5])
         w = wcs.WCS(pipeline)
         im.meta.wcs = w
         return im, refs

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -1117,3 +1117,30 @@ def wrap_ra(ravalues):
         ravalues = ravalues_wrap.tolist()
 
     return ravalues_wrap
+
+
+def in_ifu_slice(slice_wcs, ra, dec, lam):
+    """
+    Given RA, DEC and LAM return the x, y positions within a slice.
+
+    Parameters
+    ----------
+    slice_wcs : `~gwcs.WCS`
+        Slice WCS object.
+    ra, dec, lam : float, ndarray
+        Physical Coordinates.
+
+    Returns
+    -------
+    x, y : float, ndarray
+        x, y locations within the slice.
+    """
+    detector2slicer = slice_wcs.get_transform('detector', 'slicer')
+    slicer2world = slice_wcs.get_transform('slicer', 'world')
+    slx, sly, sllam = slicer2world.inverse(ra, dec, lam)
+
+    # Compute the slice X coordinate using the center of the slit.
+    SLX, _, _ = slice_wcs.get_transform('slit_frame', 'slicer')(0, 0, 2e-6)
+    onslice_ind = np.isclose(slx, SLX)
+    x, y = detector2slicer.inverse(slx[onslice_ind], sly[onslice_ind], sllam[onslice_ind])
+    return x, y


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

This PR adds a function specific to NIRSpec IFU which given arbitrary RA, DEC, LAM computes which ones project on the detector as part of a specific slice. Needed for blotting in outlier detection. Algorithm confirmed by INS.


Checklist
- [x] Tests

- [x] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
