### PR TITLE
JP-2012 Bug fix: Change MasterBackgroundNrsSlitsStep name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,12 @@ lib
 - Updated default suffix names for RampFit and GuiderCDS steps to
   'ramp_fit' and 'guider_cds' to match alias convention [#6158]
 
+master_background
+-----------------
+
+- Renamed MasterBackgroundNrsSlitsStep with alias master_background_nrs
+  to MasterBackgroundMosStep with alias master_background_mos [#6321]
+
 outlier_detection
 -----------------
 

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -338,7 +338,7 @@ During :ref:`calwebb_spec2 <calwebb_spec2>` processing, all source and backgroun
 slits are first partially calibrated up through the :ref:`extract_2d <extract_2d_step>`
 and :ref:`srctype <srctype_step>` steps of :ref:`calwebb_spec2 <calwebb_spec2>`,
 which results in 2D cutouts for each slit with the source type identified. At this
-point the `master_background_nrs_slits` step is applied, which is a unique version
+point the :ref:`master_background_mos <master_background_mos_step` step is applied, which is a unique version
 of the step specifically tailored to NIRSpec MOS mode. 
 
 This version of the master background step completes the remaining calibration
@@ -369,7 +369,7 @@ as follows:
 
 1) Process all slitlets in the MOS exposure up through the
    :ref:`extract_2d <extract_2d_step>` and :ref:`srctype <srctype_step>` steps
-2) The `master_background_nrs_slits` step temporarily applies remaining calibration
+2) The :ref:`master_background_mos <master_background_mos_step>` step temporarily applies remaining calibration
    steps up through :ref:`photom <photom_step>` to all slits, treating them all as
    extended sources (appropriate for background signal), and saving the extended
    source correction arrays for each slit in an internal copy of the data model

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -338,7 +338,7 @@ During :ref:`calwebb_spec2 <calwebb_spec2>` processing, all source and backgroun
 slits are first partially calibrated up through the :ref:`extract_2d <extract_2d_step>`
 and :ref:`srctype <srctype_step>` steps of :ref:`calwebb_spec2 <calwebb_spec2>`,
 which results in 2D cutouts for each slit with the source type identified. At this
-point the :ref:`master_background_mos_step` step is applied, which is a unique version
+point the `master_background_mos_step` step is applied, which is a unique version
 of the step specifically tailored to NIRSpec MOS mode. 
 
 This version of the master background step completes the remaining calibration

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -338,7 +338,7 @@ During :ref:`calwebb_spec2 <calwebb_spec2>` processing, all source and backgroun
 slits are first partially calibrated up through the :ref:`extract_2d <extract_2d_step>`
 and :ref:`srctype <srctype_step>` steps of :ref:`calwebb_spec2 <calwebb_spec2>`,
 which results in 2D cutouts for each slit with the source type identified. At this
-point the :ref:`master_background_mos <master_background_mos_step` step is applied, which is a unique version
+point the :ref:`master_background_mos_step` step is applied, which is a unique version
 of the step specifically tailored to NIRSpec MOS mode. 
 
 This version of the master background step completes the remaining calibration
@@ -369,7 +369,7 @@ as follows:
 
 1) Process all slitlets in the MOS exposure up through the
    :ref:`extract_2d <extract_2d_step>` and :ref:`srctype <srctype_step>` steps
-2) The :ref:`master_background_mos <master_background_mos_step>` step temporarily applies remaining calibration
+2) The `master_background_mos_step` step temporarily applies remaining calibration
    steps up through :ref:`photom <photom_step>` to all slits, treating them all as
    extended sources (appropriate for background signal), and saving the extended
    source correction arrays for each slit in an internal copy of the data model

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -338,7 +338,7 @@ During :ref:`calwebb_spec2 <calwebb_spec2>` processing, all source and backgroun
 slits are first partially calibrated up through the :ref:`extract_2d <extract_2d_step>`
 and :ref:`srctype <srctype_step>` steps of :ref:`calwebb_spec2 <calwebb_spec2>`,
 which results in 2D cutouts for each slit with the source type identified. At this
-point the `master_background_mos_step` step is applied, which is a unique version
+point the `master_background_mos` step is applied, which is a unique version
 of the step specifically tailored to NIRSpec MOS mode. 
 
 This version of the master background step completes the remaining calibration
@@ -369,7 +369,7 @@ as follows:
 
 1) Process all slitlets in the MOS exposure up through the
    :ref:`extract_2d <extract_2d_step>` and :ref:`srctype <srctype_step>` steps
-2) The `master_background_mos_step` step temporarily applies remaining calibration
+2) The `master_background_mos` step temporarily applies remaining calibration
    steps up through :ref:`photom <photom_step>` to all slits, treating them all as
    extended sources (appropriate for background signal), and saving the extended
    source correction arrays for each slit in an internal copy of the data model

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -58,7 +58,7 @@ SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline', 'rscd_step
 # Calculated suffixes.
 # This is produced by the `find_suffixes` function below
 _calculated_suffixes = {
-    'masterbackgroundnrsslitsstep',
+    'masterbackgroundmosstep',
     'ami3pipeline',
     'whitelightstep',
     'ami_average',

--- a/jwst/master_background/__init__.py
+++ b/jwst/master_background/__init__.py
@@ -1,4 +1,4 @@
 from .master_background_step import MasterBackgroundStep
-from .master_background_nrs_slits_step import MasterBackgroundNrsSlitsStep
+from .master_background_mos_step import MasterBackgroundMosStep
 
-__all__ = ['MasterBackgroundStep', 'MasterBackgroundNrsSlitsStep']
+__all__ = ['MasterBackgroundStep', 'MasterBackgroundMosStep']

--- a/jwst/master_background/master_background_mos_step.py
+++ b/jwst/master_background/master_background_mos_step.py
@@ -107,7 +107,7 @@ class MasterBackgroundMosStep(Pipeline):
             if not self.force_subtract and \
                'COMPLETE' in [data_model.meta.cal_step.back_sub, data_model.meta.cal_step.master_background]:
                 self.log.info('Background subtraction has already occurred. Skipping.')
-                self.record_step_status(data, 'master_background_mos', False)
+                self.record_step_status(data, 'master_background', False)
                 return data
 
             if self.user_background:
@@ -122,11 +122,11 @@ class MasterBackgroundMosStep(Pipeline):
                 num_bkg, num_src = self._classify_slits(data_model)
                 if num_bkg == 0:
                     self.log.warning('No background slits available for creating master background. Skipping')
-                    self.record_step_status(data, 'master_background_mos', False)
+                    self.record_step_status(data, 'master_background', False)
                     return data
                 elif num_src == 0:
                     self.log.warning('No source slits for applying master background. Skipping')
-                    self.record_step_status(data, 'master_background_mos', False)
+                    self.record_step_status(data, 'master_background', False)
                     return data
 
                 self.log.info('Calculating master background')
@@ -135,14 +135,14 @@ class MasterBackgroundMosStep(Pipeline):
             # Check that a master background was actually determined.
             if master_background is None:
                 self.log.info('No master background could be calculated. Skipping.')
-                self.record_step_status(data, 'master_background_mos', False)
+                self.record_step_status(data, 'master_background', False)
                 return data
 
             # Now apply the de-calibrated background to the original science
             result = nirspec_utils.apply_master_background(data_model, mb_multislit, inverse=self.inverse)
 
             # Mark as completed and setup return data
-            self.record_step_status(result, 'master_background_mos', True)
+            self.record_step_status(result, 'master_background', True)
             self.correction_pars = {
                 'masterbkg_1d': master_background,
                 'masterbkg_2d': mb_multislit

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -18,7 +18,7 @@ from ..extract_2d import extract_2d_step
 from ..flatfield import flat_field_step
 from ..fringe import fringe_step
 from ..imprint import imprint_step
-from ..master_background import master_background_nrs_slits_step
+from ..master_background import master_background_mos_step
 from ..msaflagopen import msaflagopen_step
 from ..pathloss import pathloss_step
 from ..photom import photom_step
@@ -63,7 +63,7 @@ class Spec2Pipeline(Pipeline):
         'imprint_subtract': imprint_step.ImprintStep,
         'msa_flagging': msaflagopen_step.MSAFlagOpenStep,
         'extract_2d': extract_2d_step.Extract2dStep,
-        'master_background_nrs': master_background_nrs_slits_step.MasterBackgroundNrsSlitsStep,
+        'master_background_mos': master_background_mos_step.MasterBackgroundMosStep,
         'wavecorr': wavecorr_step.WavecorrStep,
         'flat_field': flat_field_step.FlatFieldStep,
         'srctype': srctype_step.SourceTypeStep,
@@ -77,12 +77,6 @@ class Spec2Pipeline(Pipeline):
         'cube_build': cube_build_step.CubeBuildStep,
         'extract_1d': extract_1d_step.Extract1dStep
     }
-
-    def __init__(self, *args, **kwargs):
-
-        Pipeline.__init__(self, *args, **kwargs)
-
-        self.master_background = self.master_background_nrs
 
     # Main processing
     def process(self, data):
@@ -371,9 +365,9 @@ class Spec2Pipeline(Pipeline):
             self.barshadow.skip = True
 
         # Apply master background only to NIRSPEC MSA exposures
-        if not self.master_background.skip and exp_type != 'NRS_MSASPEC':
-            self.log.debug('Science data does not allow master background correction. Skipping "master_background".')
-            self.master_background.skip = True
+        if not self.master_background_mos.skip and exp_type != 'NRS_MSASPEC':
+            self.log.debug('Science data does not allow master background correction. Skipping "master_background_mos".')
+            self.master_background_mos.skip = True
 
         # Apply WFSS contamination correction only to WFSS exposures
         if not self.wfss_contam.skip and exp_type not in WFSS_TYPES:
@@ -405,7 +399,7 @@ class Spec2Pipeline(Pipeline):
         """
         calibrated = self.extract_2d(data)
         calibrated = self.srctype(calibrated)
-        calibrated = self.master_background(calibrated)
+        calibrated = self.master_background_mos(calibrated)
         calibrated = self.wavecorr(calibrated)
         calibrated = self.flat_field(calibrated)
         calibrated = self.pathloss(calibrated)

--- a/jwst/regtest/test_nirspec_masterbackground.py
+++ b/jwst/regtest/test_nirspec_masterbackground.py
@@ -4,7 +4,7 @@ from astropy.io.fits.diff import FITSDiff
 import numpy as np
 
 import jwst.datamodels as dm
-from jwst.master_background import MasterBackgroundNrsSlitsStep
+from jwst.master_background import MasterBackgroundMosStep
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
@@ -27,8 +27,8 @@ def run_spec2_mbkg(jail, rtdata_module):
     step_params = {
         'step': 'calwebb_spec2.cfg',
         'args': [
-            '--steps.master_background.skip=false',
-            '--steps.master_background.save_background=true'
+            '--steps.master_background_mos.skip=false',
+            '--steps.master_background_mos.save_background=true'
         ]
     }
     rtdata = rt.run_step_from_dict(rtdata, **step_params)
@@ -50,8 +50,8 @@ def run_spec2_mbkg_user(jail, rtdata_module):
     step_params = {
         'step': 'calwebb_spec2.cfg',
         'args': [
-            '--steps.master_background.skip=false',
-            '--steps.master_background.user_background=jw00626030001_02103_00001_nrs1_masterbg1d.fits'
+            '--steps.master_background_mos.skip=false',
+            '--steps.master_background_mos.user_background=jw00626030001_02103_00001_nrs1_masterbg1d.fits'
         ]
     }
     rtdata = rt.run_step_from_dict(rtdata, **step_params)
@@ -61,7 +61,7 @@ def run_spec2_mbkg_user(jail, rtdata_module):
 def test_masterbkg_rerun(rtdata):
     """Test to ensure sequential runs of the step are consistent"""
     with dm.open(rtdata.get_data('nirspec/mos/nrs_mos_with_bkgslits_srctype.fits')) as data:
-        mbs = MasterBackgroundNrsSlitsStep()
+        mbs = MasterBackgroundMosStep()
         corrected = mbs.run(data)
         corrected_again = mbs.run(data)
 
@@ -76,7 +76,7 @@ def test_masterbkg_rerun(rtdata):
 def test_masterbkg_corrpars(rtdata):
     """Test for correction parameters"""
     with dm.open(rtdata.get_data('nirspec/mos/nrs_mos_with_bkgslits_srctype.fits')) as data:
-        mbs = MasterBackgroundNrsSlitsStep()
+        mbs = MasterBackgroundMosStep()
         corrected = mbs.run(data)
 
         mbs.use_correction_pars = True

--- a/jwst/step.py
+++ b/jwst/step.py
@@ -28,7 +28,7 @@ from .jump.jump_step import JumpStep
 from .lastframe.lastframe_step import LastFrameStep
 from .linearity.linearity_step import LinearityStep
 from .master_background.master_background_step import MasterBackgroundStep
-from .master_background.master_background_nrs_slits_step import MasterBackgroundNrsSlitsStep
+from .master_background.master_background_mos_step import MasterBackgroundMosStep
 from .mrs_imatch.mrs_imatch_step import MRSIMatchStep
 from .msaflagopen.msaflagopen_step import MSAFlagOpenStep
 from .outlier_detection.outlier_detection_step import OutlierDetectionStep
@@ -88,7 +88,7 @@ __all__ = [
     "LastFrameStep",
     "LinearityStep",
     "MasterBackgroundStep",
-    "MasterBackgroundNrsSlitsStep",
+    "MasterBackgroundMosStep",
     "MRSIMatchStep",
     "MSAFlagOpenStep",
     "OutlierDetectionStep",

--- a/jwst/stpipe/integration.py
+++ b/jwst/stpipe/integration.py
@@ -61,7 +61,7 @@ def get_steps():
         ("jwst.step.LastFrameStep", 'lastframe', False),
         ("jwst.step.LinearityStep", 'linearity', False),
         ("jwst.step.MasterBackgroundStep", 'master_background', False),
-        ("jwst.step.MasterBackgroundNrsSlitsStep", 'master_background_nrs', False),
+        ("jwst.step.MasterBackgroundMosStep", 'master_background_mos', False),
         ("jwst.step.MRSIMatchStep", 'mrs_imatch', False),
         ("jwst.step.MSAFlagOpenStep", 'msa_flagging', False),
         ("jwst.step.OutlierDetectionStep", 'outlier_detection', False),


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5910

Resolves [JP-2012](https://jira.stsci.edu/browse/JP-2012)

**Description**

This PR addresses issues caused by JP-2012 to the regression tests - namely, that step parameter reference files link to the old naming scheme and refer to the MasterBackgroundNrsSlitsStep as master_background, while this had changed to master_background_nrs so that step_def names could match the aliases introduced. To fix this bug (as well as modify the existing name that no longer applies), this PR clears up some naming discrepancies but also changes MasterBackgroundNrsSlitsStep to a more reasonable MasterBackgroundMosStep.


Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)