### PR TITLE
JP-2027 & JP-2083: fix resample spec spatial offsets

### DIFF
--- a/jwst/datamodels/schemas/slitmeta.schema.yaml
+++ b/jwst/datamodels/schemas/slitmeta.schema.yaml
@@ -107,3 +107,9 @@ properties:
     type: number
     fits_keyword: SRCDEC
     fits_hdu: SCI
+  slit_ymin:
+    title: Bottom of slit in slit_frame relative to (0, 0) center
+    type: number
+  slit_ymax:
+    title: Top of slit in slit_frame relative to (0, 0) center
+    type: number

--- a/jwst/datamodels/schemas/slitmeta.schema.yaml
+++ b/jwst/datamodels/schemas/slitmeta.schema.yaml
@@ -33,6 +33,7 @@ properties:
     title: Slitlet ID
     type: integer
     default: 0
+    
     fits_keyword: SLITID
     fits_hdu: SCI
   shutter_id:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Resolves #5931 / [JP-2027](https://jira.stsci.edu/browse/JP-2027)
Resolves #6032 / [JP-2083](https://jira.stsci.edu/browse/JP-2083)

**Description**

This PR addresses 2 issues seen in resampling NIRSpec spectra where

- Input FS spectra dithered along the spectral axis (orthogonal to slit) end up spatially offset in the resampled output.
- The output footprint of the resampled 2D spectra is the correct size but offset from what it should be.

Some further work is needed to make sure the output resampled 2D spectra has a WCS that round trips.  And tests need to be added.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)