### PR TITLE
Nirspec  improvements in blotting for outlier detection, JP-2050 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,11 +16,35 @@ assign_wcs
 - Added a function which given ra, dec, lambda computes which ones project
   within a given NIRSpec IFU slice. [#6316]
 
+- Changed in_ifu_slice in util.py to return the indices of elements in slice.
+  Also the x tolerance on finding slice elements was increased. [#6326] 
+
 associations
 ------------
 
 - Fix bug causing ``pytest`` to encounter an error in test collection when
   running with recent commits to ``astropy`` main (``5.0.dev``). [#6176]
+
+
+- Enhanced level-2b ASN rules for NIRSpec internal lamp exposures to
+  handle certain opmode/grating/lamp combinations that result in no data
+  on one of the detectors. [#6304]
+
+cube_build
+----------
+
+- Fix bug when creating cubes using output_type=channel. [#6138]
+
+- Move computationally intensive routines to C extensions and
+  removed miri psf weight function. [#6093]
+
+- Moved cube blotting to a C extension [#6256]
+
+- Moved variable definitions to top of code in C extension to
+  support changes in #6093. [#6255]
+
+- Using assign_wsc.utils.in_ifu_slice function to determine which NIRSpec
+  sky values mapped to each detector slice. [#6326] 
 
 datamodels
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,6 @@ associations
 - Fix bug causing ``pytest`` to encounter an error in test collection when
   running with recent commits to ``astropy`` main (``5.0.dev``). [#6176]
 
-
 - Enhanced level-2b ASN rules for NIRSpec internal lamp exposures to
   handle certain opmode/grating/lamp combinations that result in no data
   on one of the detectors. [#6304]

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -978,7 +978,13 @@ def test_in_slice(slice, wcs_ifu_grating, ifu_world_coord):
     ra_all, dec_all, lam_all = ifu_world_coord
     im, refs = wcs_ifu_grating("G140H", "F100LP")
     slice_wcs = nirspec.nrs_wcs_set_input(im, slice)
+    slicer2world = slice_wcs.get_transform('slicer','world')
+    detector2slicer = slice_wcs.get_transform('detector','slicer')
     x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
-    xinv, yinv = in_ifu_slice(slice_wcs, ra_all, dec_all, lam_all)
+    onslice_ind = in_ifu_slice(slice_wcs, ra_all, dec_all, lam_all)
+    slx, sly, sllam = slicer2world.inverse(ra_all, dec_all, lam_all)
+    xinv,yinv = detector2slicer.inverse(slx[onslice_ind], sly[onslice_ind],
+                                            sllam[onslice_ind])
+
     r, d, _ = slice_wcs(x, y)
     assert r[~np.isnan(r)].size == xinv.size

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -984,7 +984,7 @@ def test_in_slice(slice, wcs_ifu_grating, ifu_world_coord):
     onslice_ind = in_ifu_slice(slice_wcs, ra_all, dec_all, lam_all)
     slx, sly, sllam = slicer2world.inverse(ra_all, dec_all, lam_all)
     xinv,yinv = detector2slicer.inverse(slx[onslice_ind], sly[onslice_ind],
-                                            sllam[onslice_ind])
+                                        sllam[onslice_ind])
 
     r, d, _ = slice_wcs(x, y)
     assert r[~np.isnan(r)].size == xinv.size

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -1141,6 +1141,8 @@ def in_ifu_slice(slice_wcs, ra, dec, lam):
 
     # Compute the slice X coordinate using the center of the slit.
     SLX, _, _ = slice_wcs.get_transform('slit_frame', 'slicer')(0, 0, 2e-6)
-    onslice_ind = np.isclose(slx, SLX)
-    x, y = detector2slicer.inverse(slx[onslice_ind], sly[onslice_ind], sllam[onslice_ind])
-    return x, y
+    onslice_ind = np.isclose(slx, SLX,atol = 5e-4)
+    #x, y = detector2slicer.inverse(slx[onslice_ind], sly[onslice_ind], sllam[onslice_ind])
+    return onslice_ind
+
+

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -1135,14 +1135,11 @@ def in_ifu_slice(slice_wcs, ra, dec, lam):
     x, y : float, ndarray
         x, y locations within the slice.
     """
-    detector2slicer = slice_wcs.get_transform('detector', 'slicer')
     slicer2world = slice_wcs.get_transform('slicer', 'world')
     slx, sly, sllam = slicer2world.inverse(ra, dec, lam)
 
     # Compute the slice X coordinate using the center of the slit.
     SLX, _, _ = slice_wcs.get_transform('slit_frame', 'slicer')(0, 0, 2e-6)
-    onslice_ind = np.isclose(slx, SLX,atol = 5e-4)
-    #x, y = detector2slicer.inverse(slx[onslice_ind], sly[onslice_ind], sllam[onslice_ind])
+    onslice_ind = np.isclose(slx, SLX,atol=5e-4)
+
     return onslice_ind
-
-

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -202,7 +202,7 @@ class IFUCubeData():
                         '_internal_s3d.fits'
                 if self.output_type == 'single':
                     newname = self.output_name_base + ch_name + '-' + b_name + \
-                        '-single_s3d.fits'
+                        '_single_s3d.fits'
             # ________________________________________________________________________________
             elif self.instrument == 'NIRSPEC':
 
@@ -221,7 +221,7 @@ class IFUCubeData():
                 fg_name = fg_name.lower()
                 newname = self.output_name_base + fg_name + '_s3d.fits'
                 if self.output_type == 'single':
-                    newname = self.output_name_base + fg_name + '-single_s3d.fits'
+                    newname = self.output_name_base + fg_name + '_single_s3d.fits'
                 if self.coord_system == 'internal_cal':
                     newname = self.output_name_base + fg_name + '_internal_s3d.fits'
         # ______________________________________________________________________________

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -202,7 +202,7 @@ class IFUCubeData():
                         '_internal_s3d.fits'
                 if self.output_type == 'single':
                     newname = self.output_name_base + ch_name + '-' + b_name + \
-                        '_single_s3d.fits'
+                        '-single_s3d.fits'
             # ________________________________________________________________________________
             elif self.instrument == 'NIRSPEC':
 
@@ -221,7 +221,7 @@ class IFUCubeData():
                 fg_name = fg_name.lower()
                 newname = self.output_name_base + fg_name + '_s3d.fits'
                 if self.output_type == 'single':
-                    newname = self.output_name_base + fg_name + '_single_s3d.fits'
+                    newname = self.output_name_base + fg_name + '-single_s3d.fits'
                 if self.coord_system == 'internal_cal':
                     newname = self.output_name_base + fg_name + '_internal_s3d.fits'
         # ______________________________________________________________________________
@@ -1878,16 +1878,6 @@ class IFUCubeData():
             # Reset to original
             ifucube_model.meta.model_type = saved_model_type
 # ______________________________________________________________________
-        if self.output_type == 'single':
-            with datamodels.open(model_ref) as input:
-                # define the cubename for each single
-                filename = input.meta.filename
-                indx = filename.rfind('.fits')
-                self.output_name_base = filename[:indx]
-                self.output_file = None
-                newname = self.define_cubename()
-                ifucube_model.meta.filename = newname
-# ______________________________________________________________________
 # fill in Channel for MIRI
         if self.instrument == 'MIRI':
             # fill in Channel output meta data
@@ -1899,6 +1889,27 @@ class IFUCubeData():
             outchannel = "".join(set(outchannel))
             outchannel = "".join(sorted(outchannel))
             ifucube_model.meta.instrument.channel = outchannel
+# ______________________________________________________________________
+# single files are created for a single band,
+
+        if self.output_type == 'single':
+            with datamodels.open(model_ref) as input:
+                # define the cubename for each single
+                filename = input.meta.filename
+                indx = filename.rfind('.fits')
+                self.output_name_base = filename[:indx]
+                self.output_file = None
+                newname = self.define_cubename()
+                ifucube_model.meta.filename = newname
+                # single files
+                if self.instrument == 'MIRI':
+                    outchannel = self.list_par1[0]
+                    outband = self.list_par2[0]
+                    ifucube_model.meta.instrument.channel = outchannel
+                    ifucube_model.meta.instrument.band = outband.upper()
+                else:
+                    outgrating = self.list_par1[0]
+                    ifucube_model.meta.instrument.grating = outgrating.upper()
 # ______________________________________________________________________
         ifucube_model.meta.wcsinfo.crval1 = self.crval1
         ifucube_model.meta.wcsinfo.crval2 = self.crval2

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -74,7 +74,6 @@ class OutlierDetectionStep(Step):
                 self.input_container = False
             else:
                 self.input_container = True
-
             # Setup output path naming if associations are involved.
             asn_id = None
             try:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
Partially resolves [JP-2050](https://jira.stsci.edu/browse/JP-2050)

**Description**

There was a bug in the NIRSpec IFU blotting. An new routine was added to assign_wcs.util.in_ifu_slice that determines which ra, dec, lambda of the median cube fall in a NIRSpec slice. blot_cube_cube.py was updated to use this information

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)