### PR TITLE
Revert "JP-2012 Bug fix: Change MasterBackgroundNrsSlitsStep name"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,12 +66,6 @@ lib
 - Updated default suffix names for RampFit and GuiderCDS steps to
   'ramp_fit' and 'guider_cds' to match alias convention [#6158]
 
-master_background
------------------
-
-- Renamed MasterBackgroundNrsSlitsStep with alias master_background_nrs
-  to MasterBackgroundMosStep with alias master_background_mos [#6321]
-
 outlier_detection
 -----------------
 

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -338,7 +338,7 @@ During :ref:`calwebb_spec2 <calwebb_spec2>` processing, all source and backgroun
 slits are first partially calibrated up through the :ref:`extract_2d <extract_2d_step>`
 and :ref:`srctype <srctype_step>` steps of :ref:`calwebb_spec2 <calwebb_spec2>`,
 which results in 2D cutouts for each slit with the source type identified. At this
-point the `master_background_mos` step is applied, which is a unique version
+point the `master_background_nrs_slits` step is applied, which is a unique version
 of the step specifically tailored to NIRSpec MOS mode. 
 
 This version of the master background step completes the remaining calibration
@@ -369,7 +369,7 @@ as follows:
 
 1) Process all slitlets in the MOS exposure up through the
    :ref:`extract_2d <extract_2d_step>` and :ref:`srctype <srctype_step>` steps
-2) The `master_background_mos` step temporarily applies remaining calibration
+2) The `master_background_nrs_slits` step temporarily applies remaining calibration
    steps up through :ref:`photom <photom_step>` to all slits, treating them all as
    extended sources (appropriate for background signal), and saving the extended
    source correction arrays for each slit in an internal copy of the data model

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -58,7 +58,7 @@ SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline', 'rscd_step
 # Calculated suffixes.
 # This is produced by the `find_suffixes` function below
 _calculated_suffixes = {
-    'masterbackgroundmosstep',
+    'masterbackgroundnrsslitsstep',
     'ami3pipeline',
     'whitelightstep',
     'ami_average',

--- a/jwst/master_background/__init__.py
+++ b/jwst/master_background/__init__.py
@@ -1,4 +1,4 @@
 from .master_background_step import MasterBackgroundStep
-from .master_background_mos_step import MasterBackgroundMosStep
+from .master_background_nrs_slits_step import MasterBackgroundNrsSlitsStep
 
-__all__ = ['MasterBackgroundStep', 'MasterBackgroundMosStep']
+__all__ = ['MasterBackgroundStep', 'MasterBackgroundNrsSlitsStep']

--- a/jwst/master_background/master_background_nrs_slits_step.py
+++ b/jwst/master_background/master_background_nrs_slits_step.py
@@ -1,4 +1,4 @@
-"""Master Background Pipeline for applying Master Background to NIRSpec MOS data"""
+"""Master Background Pipeline for applying Master Background to NIRSpec Slit-like data"""
 from stpipe.step import preserve_step_pars
 
 from . import nirspec_utils
@@ -9,15 +9,15 @@ from ..pathloss import pathloss_step
 from ..photom import photom_step
 from ..stpipe import Pipeline
 
-__all__ = ['MasterBackgroundMosStep']
+__all__ = ['MasterBackgroundNrsSlitsStep']
 
 # Step parameters to generally ignore when copying from the parent steps.
 GLOBAL_PARS_TO_IGNORE = ['output_ext', 'output_file', 'output_use_model', 'output_use_index',
                          'inverse', 'pre_hooks', 'post_hooks', 'save_results', 'suffix']
 
 
-class MasterBackgroundMosStep(Pipeline):
-    """Apply master background processing to NIRSpec MOS data
+class MasterBackgroundNrsSlitsStep(Pipeline):
+    """Apply master background processing to NIRSpec Slit-like data
 
     For MOS, and ignoring FS, the calibration process needs to occur
     twice: Once to calibrate background slits and create a master background.
@@ -42,7 +42,7 @@ class MasterBackgroundMosStep(Pipeline):
       - Subtract the background from the input slit data
     """
 
-    class_alias = "master_background_mos"
+    class_alias = "master_background_nrs"
 
     spec = """
         force_subtract = boolean(default=False)  # Force subtracting master background

--- a/jwst/regtest/test_nirspec_masterbackground.py
+++ b/jwst/regtest/test_nirspec_masterbackground.py
@@ -4,7 +4,7 @@ from astropy.io.fits.diff import FITSDiff
 import numpy as np
 
 import jwst.datamodels as dm
-from jwst.master_background import MasterBackgroundMosStep
+from jwst.master_background import MasterBackgroundNrsSlitsStep
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
 
@@ -27,8 +27,8 @@ def run_spec2_mbkg(jail, rtdata_module):
     step_params = {
         'step': 'calwebb_spec2.cfg',
         'args': [
-            '--steps.master_background_mos.skip=false',
-            '--steps.master_background_mos.save_background=true'
+            '--steps.master_background.skip=false',
+            '--steps.master_background.save_background=true'
         ]
     }
     rtdata = rt.run_step_from_dict(rtdata, **step_params)
@@ -50,8 +50,8 @@ def run_spec2_mbkg_user(jail, rtdata_module):
     step_params = {
         'step': 'calwebb_spec2.cfg',
         'args': [
-            '--steps.master_background_mos.skip=false',
-            '--steps.master_background_mos.user_background=jw00626030001_02103_00001_nrs1_masterbg1d.fits'
+            '--steps.master_background.skip=false',
+            '--steps.master_background.user_background=jw00626030001_02103_00001_nrs1_masterbg1d.fits'
         ]
     }
     rtdata = rt.run_step_from_dict(rtdata, **step_params)
@@ -61,7 +61,7 @@ def run_spec2_mbkg_user(jail, rtdata_module):
 def test_masterbkg_rerun(rtdata):
     """Test to ensure sequential runs of the step are consistent"""
     with dm.open(rtdata.get_data('nirspec/mos/nrs_mos_with_bkgslits_srctype.fits')) as data:
-        mbs = MasterBackgroundMosStep()
+        mbs = MasterBackgroundNrsSlitsStep()
         corrected = mbs.run(data)
         corrected_again = mbs.run(data)
 
@@ -76,7 +76,7 @@ def test_masterbkg_rerun(rtdata):
 def test_masterbkg_corrpars(rtdata):
     """Test for correction parameters"""
     with dm.open(rtdata.get_data('nirspec/mos/nrs_mos_with_bkgslits_srctype.fits')) as data:
-        mbs = MasterBackgroundMosStep()
+        mbs = MasterBackgroundNrsSlitsStep()
         corrected = mbs.run(data)
 
         mbs.use_correction_pars = True

--- a/jwst/step.py
+++ b/jwst/step.py
@@ -28,7 +28,7 @@ from .jump.jump_step import JumpStep
 from .lastframe.lastframe_step import LastFrameStep
 from .linearity.linearity_step import LinearityStep
 from .master_background.master_background_step import MasterBackgroundStep
-from .master_background.master_background_mos_step import MasterBackgroundMosStep
+from .master_background.master_background_nrs_slits_step import MasterBackgroundNrsSlitsStep
 from .mrs_imatch.mrs_imatch_step import MRSIMatchStep
 from .msaflagopen.msaflagopen_step import MSAFlagOpenStep
 from .outlier_detection.outlier_detection_step import OutlierDetectionStep
@@ -88,7 +88,7 @@ __all__ = [
     "LastFrameStep",
     "LinearityStep",
     "MasterBackgroundStep",
-    "MasterBackgroundMosStep",
+    "MasterBackgroundNrsSlitsStep",
     "MRSIMatchStep",
     "MSAFlagOpenStep",
     "OutlierDetectionStep",

--- a/jwst/stpipe/integration.py
+++ b/jwst/stpipe/integration.py
@@ -61,7 +61,7 @@ def get_steps():
         ("jwst.step.LastFrameStep", 'lastframe', False),
         ("jwst.step.LinearityStep", 'linearity', False),
         ("jwst.step.MasterBackgroundStep", 'master_background', False),
-        ("jwst.step.MasterBackgroundMosStep", 'master_background_mos', False),
+        ("jwst.step.MasterBackgroundNrsSlitsStep", 'master_background_nrs', False),
         ("jwst.step.MRSIMatchStep", 'mrs_imatch', False),
         ("jwst.step.MSAFlagOpenStep", 'msa_flagging', False),
         ("jwst.step.OutlierDetectionStep", 'outlier_detection', False),


### PR DESCRIPTION
Reverts spacetelescope/jwst#6321

The current CRDS server setup restricts modifications to jwst that would break the backward compatibility of the current OPS CRDS server state with jwst release b7.8.2. This PR requires edits to step parameter reference files that would break the compatibility of OPS with b7.8.2, so needs to be reverted until either b7.9 or a new CRDS server configuration is created.