### PR TITLE
JP-2224: Fixed a bug in flatfield for brightobj mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ flatfield
 - Updated flatfield step docs to include complete details on how the
   variance and error arrays are updated. [#6245]
 
+- Fixed a bug in flatfield for brightobj mode where the S-flat cutout
+  was calculated incorrectly by not accounting for the slit offset [#6332]
+
 jump
 ----
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -1786,8 +1786,8 @@ def flat_for_nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_
     shape = output_model.data.shape
     ysize, xsize = shape[-2:]
     # pixels with respect to the original image
-    xstart = output_model.meta.subarray.xstart - 1
-    ystart = output_model.meta.subarray.ystart - 1
+    xstart = output_model.meta.subarray.xstart - 1 + output_model.xstart - 1
+    ystart = output_model.meta.subarray.ystart - 1 + output_model.ystart - 1
     xstop = xstart + xsize
     ystop = ystart + ysize
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6268 

Resolves [JP-2224](https://jira.stsci.edu/browse/JP-2224)

**Description**

This PR addresses JP-2224.  The cutout of the S-flat component of the flatfield was calculated incorrectly by not including the slit offset as well as the subarray offset. 


Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)