### PR TITLE
Fix p_grating schema pattern and RegionsModel ndarray validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ assign_wcs
   within a given NIRSpec IFU slice. [#6316]
 
 - Changed in_ifu_slice in util.py to return the indices of elements in slice.
-  Also the x tolerance on finding slice elements was increased. [#6326] 
+  Also the x tolerance on finding slice elements was increased. [#6326]
 
 associations
 ------------
@@ -43,7 +43,7 @@ cube_build
   support changes in #6093. [#6255]
 
 - Using assign_wsc.utils.in_ifu_slice function to determine which NIRSpec
-  sky values mapped to each detector slice. [#6326] 
+  sky values mapped to each detector slice. [#6326]
 
 datamodels
 ----------
@@ -59,6 +59,10 @@ datamodels
 
 - Implement memmap argument when calling ``datamodels.open`` on an ASDF
   file. [#6327]
+
+- Fix bug in schema that disallowed valid p_grating values. [#6333]
+
+- Add ``NDArrayType`` to list of valid types for ``RegionsModel.regions``. [#6333]
 
 extract_1d
 ----------

--- a/jwst/datamodels/schemas/keyword_pgrating.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pgrating.schema.yaml
@@ -13,5 +13,5 @@ properties:
           p_grating:
             title: Name of the grating element used
             type: string
-            pattern: ^((G140M|G235M|G395M|G140H|G235H|G395H|PRISM|MIRROR|N/A|ANY)\\s*\\|\\s*)+$
+            pattern: ^((G140M|G235M|G395M|G140H|G235H|G395H|PRISM|MIRROR|N/A|ANY)\s*\|\s*)+$
             fits_keyword: P_GRATIN

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -1,6 +1,7 @@
 import traceback
 import warnings
 
+from asdf.tags.core import NDArrayType
 import numpy as np
 from astropy.modeling.core import Model
 from astropy import units as u
@@ -368,7 +369,7 @@ class RegionsModel(ReferenceFileModel):
     def validate(self):
         super().validate()
         try:
-            assert isinstance(self.regions, np.ndarray)
+            assert isinstance(self.regions, (np.ndarray, NDArrayType))
             assert self.meta.instrument.name == "MIRI"
             assert self.meta.exposure.type == "MIR_MRS"
             assert self.meta.instrument.channel in ("12", "34", "1", "2", "3", "4")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

**Description**

This PR addresses two datamodel validation issues:

- Removes extra `/` from the regex pattern for p_grating
- Adds NDArrayType to the list of valid types for RegionsModel.regions so that models constructed from ASDF files will validate

Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [ ] Milestone

- [ ] Label(s)
