### PR TITLE
Add NRS BOTS interpolated flat regtest

### DIFF
--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -71,6 +71,20 @@ def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
 
 
 @pytest.mark.bigdata
+def test_flat_field_bots_interp_flat(rtdata, fitsdiff_default_kwargs):
+    """Test the interpolated flat for a NRS BOTS exposure"""
+    data = rtdata.get_data('nirspec/tso/jw93056001001_short_nrs1_wavecorr.fits')
+
+    data_flat_fielded = FlatFieldStep.call(data, save_interpolated_flat=True)
+    rtdata.output = 'jw93056001001_short_nrs1_wavecorr_interpolatedflat.fits'
+    #data_flat_fielded.write(rtdata.output)
+
+    rtdata.get_truth('truth/test_nirspec_brightobj_spec2/jw93056001001_short_nrs1_wavecorr_interpolatedflat.fits')
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
 def test_ff_inv(rtdata, fitsdiff_default_kwargs):
     """Test flat field inversion"""
     with dm.open(rtdata.get_data('nirspec/tso/nrs2_wavecorr.fits')) as data:

--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -75,9 +75,8 @@ def test_flat_field_bots_interp_flat(rtdata, fitsdiff_default_kwargs):
     """Test the interpolated flat for a NRS BOTS exposure"""
     data = rtdata.get_data('nirspec/tso/jw93056001001_short_nrs1_wavecorr.fits')
 
-    data_flat_fielded = FlatFieldStep.call(data, save_interpolated_flat=True)
+    FlatFieldStep.call(data, save_interpolated_flat=True)
     rtdata.output = 'jw93056001001_short_nrs1_wavecorr_interpolatedflat.fits'
-    #data_flat_fielded.write(rtdata.output)
 
     rtdata.get_truth('truth/test_nirspec_brightobj_spec2/jw93056001001_short_nrs1_wavecorr_interpolatedflat.fits')
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
**Description**

This PR adds another regression test to the NIRSpec BOTS test suite to test the interpolated flat created for a BOTS exposure on NRS1, which was the problematic case reported and fixed in [JP-2224](https://jira.stsci.edu/browse/JP-2224).


Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)