### PR TITLE
Al 578: Prepping dark current code for move to STCAL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,8 @@ assign_wcs
 - Updated ``create_grism_bbox`` to be more robust against failures caused by
   bad input data. [#6309]
 
-- Added a function which given ra, dec, lambda computes which ones project
-  within a given NIRSpec IFU slice. [#6316]
+- Added a function that, when given RA, Dec, lambda, computes which ones project
+  into a given NIRSpec IFU slice. [#6316]
 
 - Changed in_ifu_slice in util.py to return the indices of elements in slice.
   Also the x tolerance on finding slice elements was increased. [#6326]
@@ -91,6 +91,9 @@ datamodels
   FilteroffsetModel. [#6362]
 
  - Changed reference file model name from ResidualFringeModel to FringeFreq [#6385]
+
+ - Updated data products documentation to indicate that variance and error arrays
+   are now included in resampled products. [#6420]
 
 extract_1d
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,11 @@ cube_build
 
 - Fix a bug when creating internal_cal type cubes [#6398]
 
+dark_current
+----------
+
+- Refactored the code in preparation for moving the code to STCAL. [#6336]
+
 datamodels
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,12 @@ residual_fringe
 ---------------
  - Added documentation on step [#6387]
 
+skymatch
+--------
+
+- Improved reliability when matching sky in images with very close sky
+  footprints. [#6421]
+
 source_catalog
 --------------
 

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -371,7 +371,7 @@ Resampled 2-D data: ``i2d`` and ``s2d``
 Images and spectra that have been resampled by the :ref:`resample <resample_step>` step use a
 different set of data arrays than other science products. Resampled 2-D images are stored in
 ``i2d`` products and resampled 2-D spectra are stored in ``s2d`` products.
-The FITS file structure for ``i2d`` products is as follows:
+The FITS file structure for ``i2d`` and ``s2d`` products is as follows:
 
 +-----+-------------+----------+-----------+---------------+
 | HDU | EXTNAME     | HDU Type | Data Type | Dimensions    |
@@ -380,53 +380,37 @@ The FITS file structure for ``i2d`` products is as follows:
 +-----+-------------+----------+-----------+---------------+
 |  1  | SCI         | IMAGE    | float32   | ncols x nrows |
 +-----+-------------+----------+-----------+---------------+
-|  2  | CON         | IMAGE    | int32     | ncols x nrows |
+|  2  | ERR         | IMAGE    | float32   | ncols x nrows |
 +-----+-------------+----------+-----------+---------------+
-|  3  | WHT         | IMAGE    | float32   | ncols x nrows |
+|  3  | CON         | IMAGE    | int32     | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  4  | WHT         | IMAGE    | float32   | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  5  | VAR_POISSON | IMAGE    | float32   | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  6  | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows |
++-----+-------------+----------+-----------+---------------+
+|  7  | VAR_FLAT    | IMAGE    | float32   | ncols x nrows |
 +-----+-------------+----------+-----------+---------------+
 |     | HDRTAB*     | BINTABLE | N/A       | variable      |
 +-----+-------------+----------+-----------+---------------+
 |     | ASDF        | BINTABLE | N/A       | variable      |
 +-----+-------------+----------+-----------+---------------+
 
- - SCI: 2-D data array containing the pixel values, in units of surface brightness.
+ - SCI: 2-D data array containing the pixel values, in units of surface brightness
+ - ERR: 2-D data array containing resampled uncertainty estimates, given as standard deviation
  - CON: 2-D context image, which encodes information about which input images contribute
-   to a specific output pixel.
- - WHT: 2-D weight image giving the relative weight of the output pixels (effectively a
-   relative exposure time map).
+   to a specific output pixel
+ - WHT: 2-D weight image giving the relative weight of the output pixels
+ - VAR_POISSON: 2-D resampled Poisson variance estimates for each pixel
+ - VAR_RNOISE: 2-D resampled read noise variance estimates for each pixel
+ - VAR_FLAT: 2-D resampled flat-field variance estimates for each pixel
  - HDRTAB: A table containing meta data (FITS keyword values) for all of the input images
    that were combined to produce the output image. Only appears when multiple inputs are used.
  - ADSF: The data model meta data.
  
-The FITS file structure for ``s2d`` products is as follows:
-
-+-----+-------------+----------+-----------+---------------+
-| HDU | EXTNAME     | HDU Type | Data Type | Dimensions    |
-+=====+=============+==========+===========+===============+
-|  0  | N/A         | primary  | N/A       | N/A           |
-+-----+-------------+----------+-----------+---------------+
-|  1  | SCI         | IMAGE    | float32   | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|  2  | CON         | IMAGE    | int32     | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|  3  | WHT         | IMAGE    | float32   | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|     | HDRTAB*     | BINTABLE | N/A       | variable      |
-+-----+-------------+----------+-----------+---------------+
-|     | ASDF        | BINTABLE | N/A       | variable      |
-+-----+-------------+----------+-----------+---------------+
-
- - SCI: 2-D data array containing the pixel values, in units of surface brightness.
- - CON: 2-D context image, which encodes information about which input images contribute
-   to a specific output pixel.
- - WHT: 2-D weight image giving the relative weight of the output pixels (effectively a
-   relative exposure time map).
- - HDRTAB: A table containing meta data (FITS keyword values) for all of the input images
-   that were combined to produce the output image. Only appears when multiple inputs are used.
- - ADSF: The data model meta data.
-
-For exposure-based products that contain spectra for more than one source or slit
-(e.g. NIRSpec MOS) there will be multiple tuples of the SCI, CON, and WHT
+For spectroscopic exposure-based products that contain spectra for more than one source or slit
+(e.g. NIRSpec MOS) there will be multiple tuples of the SCI, ERR, CON, WHT, and variance
 extensions, one set for each source or slit. FITS "EXTVER" keywords are used in each
 extension header to segregate the multiple instances of each extension type by
 source.
@@ -447,7 +431,7 @@ files with the following structure:
 +-----+-------------+----------+-----------+------------------------+
 |  2  | ERR         | IMAGE    | float32   | ncols x nrows x nwaves |
 +-----+-------------+----------+-----------+------------------------+
-|  3  | DQ          | IMAGE    | int32     | ncols x nrows x nwaves |
+|  3  | DQ          | IMAGE    | uint32    | ncols x nrows x nwaves |
 +-----+-------------+----------+-----------+------------------------+
 |  4  | WMAP        | IMAGE    | float32   | ncols x nrows x nwaves |
 +-----+-------------+----------+-----------+------------------------+
@@ -459,9 +443,9 @@ files with the following structure:
 +-----+-------------+----------+-----------+------------------------+
 
  - SCI: 3-D data array containing the spaxel values, in units of surface brightness.
- - DQ: 3-D data array containing DQ flags for each spaxel.
  - ERR: 3-D data array containing uncertainty estimates for each spaxel.
- - WMAP: 3-D weight image giving the relative weight of the output spaxels.
+ - DQ: 3-D data array containing DQ flags for each spaxel.
+ - WMAP: 3-D weight image giving the relative weights of the output spaxels.
  - WCS-TABLE: A table listing the wavelength to be associated with each plane of the
    third axis in the SCI, DQ, ERR, and WMAP arrays, in a format that conforms to the
    FITS spectroscopic WCS standards. Column 1 of the table ("nelem") gives the number of

--- a/jwst/dark_current/dark_class.py
+++ b/jwst/dark_current/dark_class.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+
+class DarkData:
+    """
+    Class removing data model dependencies.
+    """
+    def __init__(self, dims=None, dark_model=None):
+        """
+        Creates a class to remove data model dependencies in the internals of
+        the dark current code.  The data contained in this class comes from the
+        dark reference data file.
+
+        Paramters
+        ---------
+        dims: tuple
+            A tuple of integers to describe the dimensions of the arrays used
+            during the dark current step.
+
+        dark_model: data model
+            Input data model, assumed to be a JWST DarkModel like model.
+        """
+        if dark_model is not None:
+            self.data = dark_model.data
+            self.groupdq = dark_model.dq
+            self.err = dark_model.err
+
+            self.exp_nframes = dark_model.meta.exposure.nframes
+            self.exp_ngroups = dark_model.meta.exposure.ngroups
+            self.exp_groupgap = dark_model.meta.exposure.groupgap
+
+        elif dims is not None:
+            self.data = np.zeros(dims, dtype=np.float32)
+            self.groupdq = np.zeros(dims, dtype=np.uint32)
+            self.err = np.zeros(dims, dtype=np.float32)
+
+            self.exp_nframes = None
+            self.exp_ngroups = None
+            self.exp_groupgap = None
+
+        else:
+            self.data = None
+            self.groupdq = None
+            self.err = None
+
+            self.exp_nframes = None
+            self.exp_ngroups = None
+            self.exp_groupgap = None
+
+        self.save = False
+        self.output_name = None
+
+
+class ScienceData:
+    def __init__(self, science_model):
+        """
+        Creates a class to remove data model dependencies in the internals of
+        the dark current code.  The data in this class are for the science
+        exposure data on which to do the dark current step.
+
+        Paramters
+        ---------
+        science_model: data model
+            Input data model, assumed to be a JWST RampModel like model.
+        """
+        self.data = science_model.data
+        self.groupdq = science_model.groupdq
+        self.pixeldq = science_model.pixeldq
+        self.err = science_model.err
+
+        self.instrument_name = science_model.meta.instrument.name
+        self.exp_nframes = science_model.meta.exposure.nframes
+        self.exp_groupgap = science_model.meta.exposure.groupgap
+
+        self.cal_step = None

--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -53,6 +53,78 @@ class DarkCurrentStep(Step):
             result = dark_sub.do_correction(
                 input_model, dark_model, dark_output
             )
-            dark_model.close()
 
-        return result
+        out_data, dark_data = result
+
+        if dark_data is not None and dark_data.save:
+            save_dark_data_as_dark_model(dark_data, dark_model, instrument)
+        dark_model.close()
+
+        out_ramp = dark_output_data_2_ramp_model(out_data, input_model)
+
+        return out_ramp
+
+
+def save_dark_data_as_dark_model(dark_data, dark_model, instrument):
+    """
+    Save dark data from the dark current step as the appropriate dark model.
+
+    Parameters
+    ----------
+    dark_data: DarkData
+        Dark data used in the dark current step.
+
+    dark_model: DarkMIRIModel or DarkModel
+        The input dark model from reference.
+
+    instrument: str
+        The instrument name.
+    """
+    if instrument == "MIRI":
+        out_dark_model = datamodels.DarkMIRIModel(
+            data=dark_data.data,
+            dq=dark_data.groupdq,
+            err=dark_data.err)
+    else:
+        out_dark_model = datamodels.DarkModel(
+            data=dark_data.data,
+            dq=dark_data.groupdq,
+            err=dark_data.err)
+    out_dark_model.update(dark_model)
+
+    out_dark_model.meta.exposure.nframes = dark_data.exp_nframes
+    out_dark_model.meta.exposure.ngroups = dark_data.exp_ngroups
+    out_dark_model.meta.exposure.groupgap = dark_data.exp_groupgap
+    out_dark_model.save(dark_data.output_name)
+    out_dark_model.close()
+
+
+def dark_output_data_2_ramp_model(out_data, input_model):
+    """
+    Convert computed output data from the dark step to a RampModel.
+
+    Parameters
+    ----------
+    out_data: ScienceData
+        Computed science data from the dark current step.
+
+    input_model: RampModel
+        The input ramp model from which to subtract the dark current.
+
+    Return
+    ------
+    out_model: RampModel
+        The output ramp model from the dark current step.
+    """
+    out_model = input_model.copy()
+    out_model.meta.cal_step.dark_sub = out_data.cal_step
+
+    if out_data.cal_step == "SKIPPED":
+        return out_model
+
+    out_model.data = out_data.data
+    out_model.groupdq = out_data.groupdq
+    out_model.pixeldq = out_data.pixeldq
+    out_model.err = out_data.err
+
+    return out_model

--- a/jwst/dark_current/dark_sub.py
+++ b/jwst/dark_current/dark_sub.py
@@ -2,9 +2,11 @@
 #  Module for dark subtracting science data sets
 #
 
+import copy
 import numpy as np
 import logging
-from .. import datamodels
+
+from . import dark_class
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -12,16 +14,47 @@ log.setLevel(logging.DEBUG)
 
 def do_correction(input_model, dark_model, dark_output=None):
     """
+    Convert models to classes to remove internal dependence on data models.
+    After the creation of internal classes, the dark current subtraction is
+    done.
+
+    Parameters
+    ----------
+    input_model: data model
+        Input model assumed to be like a JWST RampModel.
+
+    dark_model: data model
+        Input model assumed to be like a JWST DarkModel.
+
+    dark_output: str
+        A path to denote where to save the dark model, if desired.
+
+    Returns
+    -------
+    output_data: ScienceData
+        dark-subtracted science data
+
+    averaged_dark: DarkData
+        New dark object with averaged frames
+    """
+    science_data = dark_class.ScienceData(input_model)
+    dark_data = dark_class.DarkData(dark_model=dark_model)
+
+    return do_correction_data(science_data, dark_data, dark_output)
+
+
+def do_correction_data(science_data, dark_data, dark_output=None):
+    """
     Short Summary
     -------------
     Execute all tasks for Dark Current Subtraction
 
     Parameters
     ----------
-    input_model: data model object
+    science_data: ScienceData
         science data to be corrected
 
-    dark_model: dark model object
+    dark_data: dark model object
         dark data
 
     dark_output: string
@@ -29,26 +62,29 @@ def do_correction(input_model, dark_model, dark_output=None):
 
     Returns
     -------
-    output_model: data model object
+    output_data: ScienceData
         dark-subtracted science data
 
+    averaged_dark: DarkData
+        New dark object with averaged frames
     """
 
     # Save some data params for easy use later
-    instrument = input_model.meta.instrument.name
-    sci_nints = input_model.data.shape[0]
-    sci_ngroups = input_model.data.shape[1]
-    sci_nframes = input_model.meta.exposure.nframes
-    sci_groupgap = input_model.meta.exposure.groupgap
+    instrument = science_data.instrument_name
+    sci_nints = science_data.data.shape[0]
+    sci_ngroups = science_data.data.shape[1]
+    sci_nframes = science_data.exp_nframes
+    sci_groupgap = science_data.exp_groupgap
 
     if instrument == 'MIRI':
-        drk_nints = dark_model.data.shape[0]
-        drk_ngroups = dark_model.data.shape[1]
+        drk_nints = dark_data.data.shape[0]
+        drk_ngroups = dark_data.data.shape[1]
     else:
         drk_nints = 1
-        drk_ngroups = dark_model.data.shape[0]
-    drk_nframes = dark_model.meta.exposure.nframes
-    drk_groupgap = dark_model.meta.exposure.groupgap
+        drk_ngroups = dark_data.data.shape[0]
+
+    drk_nframes = dark_data.exp_nframes
+    drk_groupgap = dark_data.exp_groupgap
 
     log.info(
         'Science data nints=%d, ngroups=%d, nframes=%d, groupgap=%d',
@@ -69,8 +105,10 @@ def do_correction(input_model, dark_model, dark_output=None):
             "science data."
         )
         log.warning("Input will be returned without subtracting dark current.")
-        input_model.meta.cal_step.dark_sub = 'SKIPPED'
-        return input_model.copy()
+        science_data.cal_step = 'SKIPPED'
+        out_data = copy.deepcopy(science_data)
+
+        return out_data, None
 
     # Check that the value of nframes and groupgap in the dark
     # are not greater than those of the science data
@@ -80,25 +118,28 @@ def do_correction(input_model, dark_model, dark_output=None):
             "greater than that of the science data."
             "Input will be returned without subtracting dark current."
         )
-        input_model.meta.cal_step.dark_sub = 'SKIPPED'
-        return input_model.copy()
+        science_data.cal_step = 'SKIPPED'
+        out_data = copy.deepcopy(science_data)
+        return out_data, None
 
     # Replace NaN's in the dark with zeros
-    dark_model.data[np.isnan(dark_model.data)] = 0.0
+    dark_data.data[np.isnan(dark_data.data)] = 0.0
 
     # Check whether the dark and science data have matching
     # nframes and groupgap settings.
+    averaged_dark = None
     if sci_nframes == drk_nframes and sci_groupgap == drk_groupgap:
 
         # They match, so we can subtract the dark ref file data directly
-        output_model = subtract_dark(input_model, dark_model)
+        output_data = subtract_dark(science_data, dark_data)
 
         # If the user requested to have the dark file saved,
         # save the reference model as this file. This will
         # ensure consistency from the user's standpoint
         if dark_output is not None:
-            log.info('Writing dark current data to %s', dark_output)
-            dark_model.save(dark_output)
+            averaged_dark = dark_data
+            averaged_dark.save = True
+            averaged_dark.output_name = dark_output
 
     else:
 
@@ -109,30 +150,28 @@ def do_correction(input_model, dark_model, dark_output=None):
 
         if instrument == 'MIRI':
             averaged_dark = average_MIRIdark_frames(
-                dark_model, sci_nints, sci_ngroups, sci_nframes, sci_groupgap
+                dark_data, sci_nints, sci_ngroups, sci_nframes, sci_groupgap
             )
         else:
             averaged_dark = average_dark_frames(
-                dark_model, sci_ngroups, sci_nframes, sci_groupgap
+                dark_data, sci_ngroups, sci_nframes, sci_groupgap
             )
 
         # Save the frame-averaged dark data that was just created,
         # if requested by the user
         if dark_output is not None:
-            log.info('Writing dark current data to %s', dark_output)
-            averaged_dark.save(dark_output)
+            averaged_dark.save = True
+            averaged_dark.output_name = dark_output
 
         # Subtract the frame-averaged dark data from the science data
-        output_model = subtract_dark(input_model, averaged_dark)
+        output_data = subtract_dark(science_data, averaged_dark)
 
-        averaged_dark.close()
+    output_data.cal_step = 'COMPLETE'
 
-    output_model.meta.cal_step.dark_sub = 'COMPLETE'
-
-    return output_model
+    return output_data, averaged_dark
 
 
-def average_dark_frames(input_dark, ngroups, nframes, groupgap):
+def average_dark_frames(dark_data, ngroups, nframes, groupgap):
     """
     Averages the individual frames of data in a dark reference
     file to match the group structure of a science data set.
@@ -140,7 +179,7 @@ def average_dark_frames(input_dark, ngroups, nframes, groupgap):
 
     Parameters
     ----------
-    input_dark: dark data model
+    dark_data: DarkData
         the input dark data
 
     ngroups: int
@@ -154,19 +193,18 @@ def average_dark_frames(input_dark, ngroups, nframes, groupgap):
 
     Returns
     -------
-    avg_dark: dark data model
+    avg_dark: DarkData
         New dark object with averaged frames
-
     """
 
     # Create a model for the averaged dark data
-    dny = input_dark.data.shape[1]
-    dnx = input_dark.data.shape[2]
-    avg_dark = datamodels.DarkModel((ngroups, dny, dnx))
-    avg_dark.update(input_dark)
+    dny = dark_data.data.shape[1]
+    dnx = dark_data.data.shape[2]
+    dims = (ngroups, dny, dnx)
+    avg_dark = dark_class.DarkData(dims=dims)
 
     # Do a direct copy of the 2-d DQ array into the new dark
-    avg_dark.dq = input_dark.dq
+    avg_dark.groupdq = dark_data.groupdq
 
     # Loop over the groups of the input science data, copying or
     # averaging the dark frames to match the group structure
@@ -178,29 +216,29 @@ def average_dark_frames(input_dark, ngroups, nframes, groupgap):
         # If there's only 1 frame per group, just copy the dark frames
         if nframes == 1:
             log.debug('copy dark frame %d', start)
-            avg_dark.data[group] = input_dark.data[start]
-            avg_dark.err[group] = input_dark.err[start]
+            avg_dark.data[group] = dark_data.data[start]
+            avg_dark.err[group] = dark_data.err[start]
 
         # Otherwise average nframes into a new group: take the mean of
         # the SCI arrays and the quadratic sum of the ERR arrays.
         else:
             log.debug('average dark frames %d to %d', start + 1, end)
-            avg_dark.data[group] = input_dark.data[start:end].mean(axis=0)
+            avg_dark.data[group] = dark_data.data[start:end].mean(axis=0)
             avg_dark.err[group] = np.sqrt(np.add.reduce(
-                input_dark.err[start:end]**2, axis=0)) / (end - start)
+                dark_data.err[start:end]**2, axis=0)) / (end - start)
 
         # Skip over unused frames
         start = end + groupgap
 
     # Reset some metadata values for the averaged dark
-    avg_dark.meta.exposure.nframes = nframes
-    avg_dark.meta.exposure.ngroups = ngroups
-    avg_dark.meta.exposure.groupgap = groupgap
+    avg_dark.exp_nframes = nframes
+    avg_dark.exp_ngroups = ngroups
+    avg_dark.exp_groupgap = groupgap
 
     return avg_dark
 
 
-def average_MIRIdark_frames(input_dark, nints, ngroups, nframes, groupgap):
+def average_MIRIdark_frames(dark_data, nints, ngroups, nframes, groupgap):
     """
     Averages the individual frames of data in a dark reference
     file to match the group structure of a science data set.
@@ -209,7 +247,7 @@ def average_MIRIdark_frames(input_dark, nints, ngroups, nframes, groupgap):
 
     Parameters
     ----------
-    input_dark: dark data model
+    dark_data: DarkData
         the input dark data
 
     nints: int
@@ -228,18 +266,17 @@ def average_MIRIdark_frames(input_dark, nints, ngroups, nframes, groupgap):
     -------
     avg_dark: dark data model
         New dark object with averaged frames
-
     """
 
     # Create a model for the averaged dark data
-    dint = input_dark.data.shape[0]
-    dny = input_dark.data.shape[2]
-    dnx = input_dark.data.shape[3]
-    avg_dark = datamodels.DarkMIRIModel((dint, ngroups, dny, dnx))
-    avg_dark.update(input_dark)
+    dint = dark_data.data.shape[0]
+    dny = dark_data.data.shape[2]
+    dnx = dark_data.data.shape[3]
+    dims = (dint, ngroups, dny, dnx)
+    avg_dark = dark_class.DarkData(dims)
 
     # Do a direct copy of the 2-d DQ array into the new dark
-    avg_dark.dq = input_dark.dq
+    avg_dark.groupdq = dark_data.groupdq
 
     # check if the number of integrations in dark reference file
     # is less than science data, if so then we only need to find the
@@ -262,29 +299,29 @@ def average_MIRIdark_frames(input_dark, nints, ngroups, nframes, groupgap):
             # If there's only 1 frame per group, just copy the dark frames
             if nframes == 1:
                 log.debug('copy dark frame %d', start)
-                avg_dark.data[it, group] = input_dark.data[it, start]
-                avg_dark.err[it, group] = input_dark.err[it, start]
+                avg_dark.data[it, group] = dark_data.data[it, start]
+                avg_dark.err[it, group] = dark_data.err[it, start]
 
             # Otherwise average nframes into a new group: take the mean of
             # the SCI arrays and the quadratic sum of the ERR arrays.
             else:
                 log.debug('average dark frames %d to %d', start + 1, end)
-                avg_dark.data[it, group] = input_dark.data[it, start:end].mean(axis=0)
+                avg_dark.data[it, group] = dark_data.data[it, start:end].mean(axis=0)
                 avg_dark.err[it, group] = np.sqrt(np.add.reduce(
-                    input_dark.err[it, start:end]**2, axis=0)) / (end - start)
+                    dark_data.err[it, start:end]**2, axis=0)) / (end - start)
 
         # Skip over unused frames
             start = end + groupgap
 
     # Reset some metadata values for the averaged dark
-    avg_dark.meta.exposure.nframes = nframes
-    avg_dark.meta.exposure.ngroups = ngroups
-    avg_dark.meta.exposure.groupgap = groupgap
+    avg_dark.exp_nframes = nframes
+    avg_dark.exp_ngroups = ngroups
+    avg_dark.exp_groupgap = groupgap
 
     return avg_dark
 
 
-def subtract_dark(input, dark):
+def subtract_dark(science_data, dark_data):
     """
     Subtracts dark current data from science arrays, combines
     error arrays in quadrature, and updates data quality array based on
@@ -292,60 +329,59 @@ def subtract_dark(input, dark):
 
     Parameters
     ----------
-    input: data model object
+    science_data: ScienceData
         the input science data
 
-    dark: dark model object
+    dark_data: DarkData
         the dark current data
 
     Returns
     -------
     output: data model object
         dark-subtracted science data
-
     """
 
-    instrument = input.meta.instrument.name
+    instrument = science_data.instrument_name
     if instrument == 'MIRI':
-        dark_nints = dark.data.shape[0]
+        dark_nints = dark_data.data.shape[0]
     else:
         dark_nints = 1
 
     log.debug("subtract_dark: nints=%d, ngroups=%d, size=%d,%d",
-              input.data.shape[0], input.data.shape[1],
-              input.data.shape[2], input.data.shape[3])
+              science_data.data.shape[0], science_data.data.shape[1],
+              science_data.data.shape[2], science_data.data.shape[3])
 
     # Create output as a copy of the input science data model
-    output = input.copy()
+    output = copy.deepcopy(science_data)
 
     if instrument == 'MIRI':
         # MIRI dark reference file has a DQ plane for each integration,
         # so we collapse the dark DQ planes into a single 2-D array
-        darkdq = dark.dq[0, 0, :, :].copy()
+        darkdq = dark_data.groupdq[0, 0, :, :].copy()
         for i in range(1, dark_nints):
-            darkdq = np.bitwise_or(darkdq, dark.dq[i, 0, :, :])
+            darkdq = np.bitwise_or(darkdq, dark_data.groupdq[i, 0, :, :])
     else:
         # All other instruments have a single 2D dark DQ array
-        darkdq = dark.dq
+        darkdq = dark_data.groupdq
 
     # Combine the dark and science DQ data
-    output.pixeldq = np.bitwise_or(input.pixeldq, darkdq)
+    output.pixeldq = np.bitwise_or(science_data.pixeldq, darkdq)
 
     # loop over all integrations and groups in input science data
-    for i in range(input.data.shape[0]):
+    for i in range(science_data.data.shape[0]):
 
         if instrument == 'MIRI':
             if i < dark_nints:
-                dark_int = dark.data[i]
+                dark_int = dark_data.data[i]
             else:
-                dark_int = dark.data[dark_nints - 1]
+                dark_int = dark_data.data[dark_nints - 1]
 
-        for j in range(input.data.shape[1]):
+        for j in range(science_data.data.shape[1]):
             # subtract the SCI arrays
             if instrument == 'MIRI':
                 output.data[i, j] -= dark_int[j]
             else:
-                output.data[i, j] -= dark.data[j]
+                output.data[i, j] -= dark_data.data[j]
 
             # combine the ERR arrays in quadrature
             # NOTE: currently stubbed out until ERR handling is decided

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -228,9 +228,17 @@ class SkyImage:
 
         """
         if isinstance(skyimage, (SkyImage, SkyGroup)):
-            return self._polygon.intersection(skyimage.polygon)
+            other = skyimage.polygon
         else:
-            return self._polygon.intersection(skyimage)
+            other = skyimage
+
+        pts1 = np.sort(list(self._polygon.points)[0], axis=0)
+        pts2 = np.sort(list(other.points)[0], axis=0)
+        if np.allclose(pts1, pts2, rtol=0, atol=5e-9):
+            intersect_poly = self._polygon.copy()
+        else:
+            intersect_poly = self._polygon.intersection(other)
+        return intersect_poly
 
     def calc_bounding_polygon(self, stepsize=None):
         """ Compute image's bounding polygon.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Resolves [AL-578](https://jira.stsci.edu/browse/AL-578)

**Description**

This PR removes internal dependence on data models in order to move the code to STCAL.  The files `dark_sub.py` and `dark_class.py` can be moved to STCAL with no change and `dark_current_step.py` only needs to have the import path to `dark_sub` updated.  The import paths for `tests/test_dark_sub.py` will need to be updated as well, when the above files get moved to STCAL.

All unit tests and regression tests pass.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)