### PR TITLE
fixed setting suffix in residual_fringe step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1986,7 +1986,9 @@ refpix
 residual_fringe
 ---------------
 
-- First implementation of step. Added third party package (BayesicFitting) to setup.cfg [#6211] 
+- First implementation of step. Added third party package (BayesicFitting) to setup.cfg [#6211]
+
+- Fixed suffix defined in spec [#6347]
 
 set_telescope_pointing
 ----------------------

--- a/jwst/pipeline/residual_fringe.cfg
+++ b/jwst/pipeline/residual_fringe.cfg
@@ -1,0 +1,3 @@
+name = "residual_fringe" 
+class = "jwst.residual_fringe.ResidualFringeStep"
+

--- a/jwst/residual_fringe/residual_fringe_step.py
+++ b/jwst/residual_fringe/residual_fringe_step.py
@@ -22,7 +22,7 @@ class ResidualFringeStep(Step):
         save_intermediate_results  = boolean(default = False)
         transmission_level = integer(default=80) # transmission level to use to define slice locations
         search_output_file = boolean(default = False)
-        self.suffix = string('residual_fringe')
+        suffix = string('residual_fringe')
     """
 
     reference_file_types = ['fringefreq','regions']


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Resolves JP-1273 - fixing a typo in spec in #6211

**Description**

The 'suffix' for the step was defined incorrectly in PR6211. This pr fixes it. 


Checklist
- [ ] Tests
- [ ] Documentation
- [X] Change log
- [X] Milestone
- [X] Label(s)