### PR TITLE
Residual Fringe fix for applying step on a file instead of an asn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1990,6 +1990,9 @@ residual_fringe
 
 - Fixed suffix defined in spec [#6347]
 
+- Fixed an error when a filename was give as the input to apply the residual fringe correction [#6349]
+  
+
 set_telescope_pointing
 ----------------------
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->
Resolves JP-1273

**Description**

The PR 6211 for adding the residual fringe step to the pipeline  did not work correctly if the input was a filename instead of an association.
This PR allows the input to be a filename.  Now the residual_fringe step can take either an association or a filename.
This PR also fixed an error in how suffix was initially defined. 


Checklist
- [ ] Tests
- [ ] Documentation
- [X] Change log
- [X] Milestone
- [X] Label(s)