### PR TITLE
JP-2250: Refactor refpix IRS2 to reduce memory usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,12 @@ ramp_fitting
 - Update ``RampFitStep`` to pass DQ flags as a parameter to the ``ramp_fit``
   algorithm code in stcal.  Bump version requirement for stcal.  [#6072]
 
+refpix
+------
+
+- Refactored the ``subtract_reference`` routine for NRS IRS2 data to reduce
+  memory usage. [#6356]
+
 resample
 --------
 

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -9,7 +9,7 @@ log.setLevel(logging.DEBUG)
 
 def correct_model(input_model, irs2_model,
                   scipix_n_default=16, refpix_r_default=4, pad=8):
-    """Process IRS2 data.
+    """Correct an input NIRSpec IRS2 datamodel using reference pixels.
 
     Parameters
     ----------
@@ -38,9 +38,7 @@ def correct_model(input_model, irs2_model,
         The science data with reference output and reference pixels
         subtracted.
     """
-
-    # ; Part_C applies the calibration as derived from part_A and part_B.
-
+    #
     """Readout parameters
     scipix_n   16         Number of regular samples before stepping out
                           to collect reference samples
@@ -68,11 +66,13 @@ def correct_model(input_model, irs2_model,
     This agrees with the above value of tframe (14.5889 s) if NFOH = 714.
     """
 
-    output_model = input_model.copy()
-    output_model.meta.cal_step.refpix = 'not specified yet'
+    # Only copy in SCI data array for now; that's all we need. The rest
+    # of the input model will be copied to output at the end of the step.
+    data = input_model.data.copy()
+    input_model.meta.cal_step.refpix = 'not specified yet'
 
-    # Get reference data.
-    # The reference data are complex, but they're stored as float, with
+    # Load the reference file data.
+    # The reference file data are complex, but they're stored as float, with
     # alternating real and imaginary parts.  We therefore check for twice
     # as many rows as we actually want, and we'll divide that number by two
     # when allocating the arrays alpha and beta.
@@ -81,31 +81,20 @@ def correct_model(input_model, irs2_model,
     if nrows != expected_nrows:
         log.error("Number of rows in reference file = {},"
                   " but it should be {}.".format(nrows, expected_nrows))
-        output_model.meta.cal_step.refpix = 'SKIPPED'
-        return output_model
+        input_model.meta.cal_step.refpix = 'SKIPPED'
+        return input_model
     alpha = np.ones((4, nrows // 2), dtype=np.complex64)
     beta = np.zeros((4, nrows // 2), dtype=np.complex64)
 
-    alpha[0, :] = float_to_complex(
-        irs2_model.irs2_table.field("alpha_0"))
-    alpha[1, :] = float_to_complex(
-        irs2_model.irs2_table.field("alpha_1"))
-    alpha[2, :] = float_to_complex(
-        irs2_model.irs2_table.field("alpha_2"))
-    alpha[3, :] = float_to_complex(
-        irs2_model.irs2_table.field("alpha_3"))
+    alpha[0, :] = float_to_complex(irs2_model.irs2_table.field("alpha_0"))
+    alpha[1, :] = float_to_complex(irs2_model.irs2_table.field("alpha_1"))
+    alpha[2, :] = float_to_complex(irs2_model.irs2_table.field("alpha_2"))
+    alpha[3, :] = float_to_complex(irs2_model.irs2_table.field("alpha_3"))
 
-    beta[0, :] = float_to_complex(
-        irs2_model.irs2_table.field("beta_0"))
-    beta[1, :] = float_to_complex(
-        irs2_model.irs2_table.field("beta_1"))
-    beta[2, :] = float_to_complex(
-        irs2_model.irs2_table.field("beta_2"))
-    beta[3, :] = float_to_complex(
-        irs2_model.irs2_table.field("beta_3"))
-
-    if beta is None:
-        log.info("Using reference pixels only.")
+    beta[0, :] = float_to_complex(irs2_model.irs2_table.field("beta_0"))
+    beta[1, :] = float_to_complex(irs2_model.irs2_table.field("beta_1"))
+    beta[2, :] = float_to_complex(irs2_model.irs2_table.field("beta_2"))
+    beta[3, :] = float_to_complex(irs2_model.irs2_table.field("beta_3"))
 
     scipix_n = input_model.meta.exposure.nrs_normal
     if scipix_n is None:
@@ -119,9 +108,8 @@ def correct_model(input_model, irs2_model,
                     refpix_r_default)
         refpix_r = refpix_r_default
 
-    data = output_model.data
-    detector = input_model.meta.instrument.detector
     # Convert from sky (DMS) orientation to detector orientation.
+    detector = input_model.meta.instrument.detector
     if detector == "NRS1":
         data = np.swapaxes(data, 2, 3)
     elif detector == "NRS2":
@@ -134,9 +122,9 @@ def correct_model(input_model, irs2_model,
     ny = data.shape[-2]                 # 2048
     nx = data.shape[-1]                 # 3200
 
-    # Boolean mask, True flags normal pixels (as opposed to reference output
-    # or interspersed reference pixels).
-    irs2_mask = make_irs2_mask(output_model, scipix_n, refpix_r)
+    # Create a mask that indicates the locations of normal vs interspersed
+    # reference pixels. True flags normal pixels, False is reference pixels.
+    irs2_mask = make_irs2_mask(nx, ny, scipix_n, refpix_r)
 
     # If the IRS2 reference file includes data quality info, use that to
     # set bad reference pixel values to zero.
@@ -150,18 +138,21 @@ def correct_model(input_model, irs2_model,
     else:
         log.warning("DQ extension not found in reference file")
 
+    # Compute and apply the correction to one integration at a time
     for integ in range(n_int):
+        log.info(f'Working on integration {integ+1}')
+
         # The input data have a length of 3200 for the last axis (X), while
         # the output data have an X axis with length 2048, the same as the
         # Y axis.  This is the reason for the slice `nx-ny:` that is used
         # below.  The last axis of output_model.data should be 2048.
         data0 = data[integ, :, :, :]
-        data0 = subtract_reference(data0, alpha, beta, irs2_mask,
-                                   scipix_n, refpix_r, pad)
+        data0 = subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad)
         data[integ, :, :, nx - ny:] = data0
+
+    # Convert corrected data back to sky orientation
+    output_model = input_model.copy()
     temp_data = data[:, :, :, nx - ny:]
-    del data
-    # Convert back to sky orientation.
     if detector == "NRS1":
         output_model.data = np.swapaxes(temp_data, 2, 3)
     elif detector == "NRS2":
@@ -169,26 +160,25 @@ def correct_model(input_model, irs2_model,
     else:                       # don't change orientation
         output_model.data = temp_data
 
-    # Copy out the normal pixels of the PIXELDQ, GROUPDQ, and ERR extensions.
-    exclude_ref(output_model, irs2_mask)
+    # Strip interleaved ref pixels from the PIXELDQ, GROUPDQ, and ERR extensions.
+    strip_ref_pixels(output_model, irs2_mask)
 
     return output_model
 
 
 def float_to_complex(data):
     """Convert real and imaginary parts to complex"""
-
     nelem = len(data)
 
     return data[0:-1:2] + 1j * data[1:nelem:2]
 
 
-def make_irs2_mask(output_model, scipix_n, refpix_r):
+def make_irs2_mask(nx, ny, scipix_n, refpix_r):
 
     # Number of (scipix_n + refpix_r) per output, assuming four amplifier
     # outputs and one reference output.
-    shape = output_model.pixeldq.shape
-    irs2_nx = max(shape)
+    irs2_nx = max((ny, nx))
+
     # Length of the reference output section.
     refout = irs2_nx // 5
     part = refout - (scipix_n // 2 + refpix_r)
@@ -196,7 +186,7 @@ def make_irs2_mask(output_model, scipix_n, refpix_r):
     # `part` consists of k * (scipix_n + refpix_r) + stuff_at_end
     stuff_at_end = part - k * (scipix_n + refpix_r)
 
-    # Create the mask which flags normal pixels as True.
+    # Create the mask that flags normal pixels as True.
     irs2_mask = np.ones(irs2_nx, dtype=bool)
     irs2_mask[0:refout] = False
 
@@ -226,7 +216,7 @@ def make_irs2_mask(output_model, scipix_n, refpix_r):
     return irs2_mask
 
 
-def exclude_ref(output_model, irs2_mask):
+def strip_ref_pixels(output_model, irs2_mask):
     """Copy out the normal pixels from PIXELDQ, GROUPDQ, and ERR arrays.
 
     Parameters
@@ -397,8 +387,7 @@ def decode_mask(output, mask):
     return bits
 
 
-def subtract_reference(data0, alpha, beta, irs2_mask,
-                       scipix_n, refpix_r, pad):
+def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
     """Subtract reference output and pixels for the current integration.
 
     Parameters
@@ -476,13 +465,12 @@ def subtract_reference(data0, alpha, beta, irs2_mask,
     href = ind_ref + scipix_n * (ind_ref // refpix_r) + scipix_n // 2
 
     hnorm1 = ind_n + (refpix_r + 2) * ((ind_n + scipix_n // 2) // scipix_n)
-    href1 = ind_ref + (scipix_n + 2) * (ind_ref // refpix_r) + \
-        scipix_n // 2 + 1
+    href1 = ind_ref + (scipix_n + 2) * (ind_ref // refpix_r) + scipix_n // 2 + 1
 
     # Subtract the average over the ramp for each pixel.
+    # b_offset is saved so that it can be added back in at the end.
     b_offset = data0.sum(axis=0, dtype=np.float64) / float(ngroups)
     data0 -= b_offset
-    # Save b_offset, and add it back in at the end.
 
     # IDL:  data0 = reform(data0, s[1]/5, 5, s[2], s[3], /over)
     #                             nx/5,   5, ny,   ngroups    (IDL)
@@ -514,19 +502,222 @@ def subtract_reference(data0, alpha, beta, irs2_mask,
     # hnorm1[-1] = 703, and hnorm[-1] = 639, so 703 - 639 = 64.
     # 8 is the pad value.
 
-    # d0.shape will be (5, ngroups, 2048, 712)
-    d0 = np.zeros((5, ngroups, ny, row), dtype=np.float32)
+    d0 = np.zeros((5, ngroups, ny, row), dtype=np.float32)  # (5, ngroups, 2048, 712)
     # IDL:  d0[hnorm1,*,*,*] = data0[hnorm,*,*,*]
     # IDL:  d0[href1,*,*,*] = data0[href,*,*,*]
     # IDL:  data0 = temporary(d0)
     d0[:, :, :, hnorm1] = data0[:, :, :, hnorm]
     d0[:, :, :, href1] = data0[:, :, :, href]
+    del data0
     data0 = d0.copy()
     del d0
 
-    # ; <<<<< Fitting and removal of slopes per frame to remove issues at frame
-    # boundaries.
+    # Fitting and removal of slopes per frame to remove issues at frame boundaries
+    remove_slopes(data0, ngroups, ny, row)
+
+    # Use cosine weighted interpolation to replace 0.0 values and bad
+    # pixels and gaps. (initial guess)
+    replace_bad_pixels(data0, ngroups, ny, row)
+
+    # Fill in bad pixels, gaps, and reference data locations in the normal
+    # data, using Fourier filtering/interpolation
+    fill_bad_regions(data0, ngroups, ny, nx, row, scipix_n, refpix_r, pad, hnorm, hnorm1)
+
+    # Setup various lists of indices that will be used in subsequent
+    # sections for keeping/shuffing reference pixels in various arrays
+    #
+    # The comments are for scipix_n = 16, refpix_r = 4
+    n0 = 512 // scipix_n
+    n1 = scipix_n + refpix_r + 2
+    ht = np.arange(n0 * n1, dtype=np.int32).reshape((n0, n1))   # (32, 22)
+    ht[:, 0:(scipix_n - refpix_r) // 2 + 1] = -1
+    ht[:, scipix_n // 2 + 1 + 3 * refpix_r // 2:] = -1
+    hs = ht.copy()
+    # ht is like href1, but extended over gaps and first and last norm pix
+    mask = (ht >= 0)
+    ht = ht[mask]               # 1-D, length = 2 * refpix_r * 512 / scipix_n
+
+    # IDL:  hs[scipix_n/2 + 1-refpix_r/2:scipix_n/2 + refpix_r + refpix_r/2,*] =
+    #       hs[reform([transpose(reform(indgen(refpix_r),refpix_r/2,2)),
+    #           transpose(reform(indgen(refpix_r),refpix_r/2,2))],refpix_r * 2)
+    #           + scipix_n/2 + 1,*]  ; WIRED for R=2^(int)
+
+    indr = np.arange(refpix_r, dtype=np.intp).reshape((2, refpix_r // 2))
+    # indr_t =
+    # [[0 2]
+    #  [1 3]]
+    indr_t = indr.transpose()
+
+    # Before flattening, two_indr_t =
+    # [[0 2 0 2]
+    #  [1 3 1 3]]
+    # After flattening, two_indr_t = [0 2 0 2 1 3 1 3].
+    two_indr_t = np.concatenate((indr_t, indr_t), axis=1).flatten()
+    two_indr_t += (scipix_n // 2 + 1)     # [9 11 9 11 10 12 10 12]
+    hs[:, scipix_n // 2 + 1 - refpix_r // 2:
+       scipix_n // 2 + 1 + refpix_r // 2 + refpix_r] = hs[:, two_indr_t]
+    mask = (hs >= 0)
+    hs = hs[mask]    # hs is now 1-D
+
+    if refpix_r % 4 == 2:
+        len_hs = len(hs)
+        temp_hs = hs.reshape(len_hs // 2, 2)
+        temp_hs = temp_hs[:, ::-1]
+        hs = temp_hs.flatten()
+
+    # Construct the reference data: this is done in a big loop over the
+    # four "sectors" of data in the image, corresponding to the amp regions.
+    # Data from each sector is operated on independently and ultimately
+    # the corrections are subtracted from each sector independently.
+    shape_d = data0.shape
+    for k in range(1, 5):
+        log.debug(f'processing sector {k}')
+
+        # At this point in the processing data0 has shape (5, ngroups, 2048, 712),
+        # assuming normal IRS2 readout settings. r0k contains a subset of the
+        # data from 1 sector of data0, with shape (ngroups, 2048, 256)
+        r0k = np.zeros((shape_d[1], shape_d[2], shape_d[3]), dtype=np.float32)
+        temp = data0[k, :, :, hs].copy()
+        temp = np.transpose(temp, (1, 2, 0))
+        r0k[:, :, ht] = temp
+        del temp
+
+        # data0 has shape (5, ngroups, ny, row).  See the section above where
+        # d0 was created, then copied (moved) to data0.
+        # sd[1] = shape_d[3]   row (712)
+        # sd[2] = shape_d[2]   ny (2048)
+        # sd[3] = shape_d[1]   ngroups
+        # sd[4] = shape_d[0]   5
+        # s is used below, so for convenience, here are the values again:
+        # s[1] = shape[2] = nx
+        # s[2] = shape[1] = ny
+        # s[3] = shape[0] = ngroups
+
+        # IDL and numpy differ in where they apply the normalization for the
+        # FFT.  This really shouldn't matter.
+        normalization = float(shape_d[2] * shape_d[3])
+
+        if beta is not None:
+            # IDL:  refout0 = reform(data0[*,*,*,0], sd[1] * sd[2], sd[3])
+            refout0 = data0[0, :, :, :].reshape((shape_d[1], shape_d[2] * shape_d[3]))
+
+            # IDL:  refout0 = fft(refout0, dim=1, /over)
+            # Divide by the length of the axis to be consistent with IDL.
+            refout0 = np.fft.fft(refout0, axis=1) / normalization
+
+        # IDL:  r0 = reform(r0, sd[1] * sd[2], sd[3], 5, /over)
+        r0k = r0k.reshape((shape_d[1], shape_d[2] * shape_d[3]))
+        r0k = r0k.astype(np.complex64)
+        r0k_fft = np.fft.fft(r0k, axis=1) / normalization
+
+        # Note that where the IDL code uses alpha, we use beta, and vice versa.
+        # IDL:  for k=0,3 do oBridge[k]->Execute,
+        #           "for i=0, s3-1 do r0[*,i] *= alpha"
+        r0k_fft *= beta[k - 1]
+
+        # IDL:  for k=0,3 do oBridge[k]->Execute,
+        #           "for i=0, s3-1 do r0[*,i] += beta * refout0[*,i]"
+        if beta is not None:
+            r0k_fft += (alpha[k - 1] * refout0)
+        del refout0
+
+        # IDL:  for k=0,3 do oBridge[k]->Execute,
+        #           "r0 = fft(r0, 1, dim=1, /overwrite)", /nowait
+        r0k = np.fft.ifft(r0k_fft, axis=1) * normalization
+        del r0k_fft
+
+        # sd[1] = shape_d[3]   row (712)
+        # sd[2] = shape_d[2]   ny (2048)
+        # sd[3] = shape_d[1]   ngroups
+        # sd[4] = shape_d[0]   5
+        # IDL:  r0 = reform(r0, sd[1], sd[2], sd[3], 5, /over)
+        r0k = r0k.reshape(shape_d[1], shape_d[2], shape_d[3])
+        r0k = r0k.real
+        r0k = r0k[:, :, hnorm1]
+
+        # Subtract the correction from the data in this sector
+        data0[k, :, :, hnorm1] -= np.transpose(r0k, (2, 0, 1))
+        del r0k
+
+    # End of loop over 4 sectors
+
+    # Original data0 array has shape (5, ngroups, 2048, 712). Now that
+    # correction has been applied, remove the interleaved reference pixels.
+    # This leaves data0 with shape (5, ngroups, 2048, 512).
+    data0 = data0[:, :, :, hnorm1]
+
+    # Unflip the data in the sectors that have opposite readout direction
+    data0[2, :, :, :] = data0[2, :, :, ::-1]
+    data0[4, :, :, :] = data0[4, :, :, ::-1]
+
+    # IDL:  data0 = transpose(data0, [0,3,1,2])  0, 1, 2, 3 --> 0, 3, 1, 2
+    # current order:  512, ny, ngroups, 5     (IDL)
+    # current order:  5, ngroups, ny, 512     (numpy)
+    #                 0  1        2   3       current numpy indices
+    # transpose to:   512, 5, ny, ngroups     (IDL)
+    # transpose to:   ngroups, ny, 5, 512     (numpy)
+    #                 1        2   0  3       transpose order for numpy
+    # Therefore:      0 1 2 3  -->  1 2 0 3   transpose order for numpy
+    # After transposing, data0 will have shape (ngroups, 2048, 5, 512).
+    data0 = np.transpose(data0, (1, 2, 0, 3))
+
+    # Reshape data0 back to its normal (ngroups, 2048, 2048), which has
+    # the interleaved reference pixels stripped out.
+    # IDL:  data0 = reform(data0[*, 1:*, *, *], s[2], s[2], s[3], /over)
+    # Note:  ny x ny, not ny x nx.
+    data0 = data0[:, :, 1:, :].reshape((ngroups, ny, ny))
+
+    # b_offset is the average over the ramp that we subtracted near the
+    # beginning; add it back in.
+    # Shape of b_offset is (2048, 3200), but data0 is (ngroups, 2048, 2048),
+    # so a mask is applied to b_offset to remove the reference pix locations.
+    data0 += b_offset[..., irs2_mask]
+
+    return data0
+
+
+def fft_interp_norm(dd0, mask0, row, hnorm, hnorm1, ny, ngroups, aa, n_iter_norm):
+
+    mm = np.zeros((ny, row), dtype=np.int8)
+    mm[:, hnorm1] = mask0[:, hnorm]
+    hm = (mm != 0)                      # 2-D boolean mask
+    for j in range(ngroups):
+        dd = dd0[j, :, :].copy()        # make a copy, not a view
+        p = dd.flatten()
+        for it in range(n_iter_norm):
+            pp = np.fft.fft(p)
+            pp *= aa
+            p[:] = np.fft.ifft(pp).real
+            p[hm.ravel()] = dd[hm]
+        dd0[j, :, :] = p.reshape((ny, row))
+
+
+def ols_line(x, y):
+    """Fit a straight line using ordinary least squares."""
+
+    xf = x.ravel()
+    yf = y.ravel()
+    if len(xf) < 1 or len(yf) < 1:
+        return (0., 0.)
+
+    groups = float(len(xf))
+    mean_x = xf.mean()
+    mean_y = yf.mean()
+    sum_x2 = (xf**2).sum()
+    sum_xy = (xf * yf).sum()
+
+    slope = (sum_xy - groups * mean_x * mean_y) / \
+            (sum_x2 - groups * mean_x**2)
+    intercept = mean_y - slope * mean_x
+
+    return (intercept, slope)
+
+
+def remove_slopes(data0, ngroups, ny, row):
+
+    # Fitting and removal of slopes per frame to remove issues at frame boundaries.
     # IDL:  time = findgen(row, s[2])
+
     time_arr = np.arange(ny * row, dtype=np.float32).reshape((ny, row))
     time_arr -= time_arr.mean(dtype=np.float64)
     row4plus4 = np.array([0, 1, 2, 3, 2044, 2045, 2046, 2047], dtype=np.intp)
@@ -535,23 +726,24 @@ def subtract_reference(data0, alpha, beta, irs2_mask,
     ab_3 = np.zeros((2, ngroups, 5), dtype=np.float32)
     for i in range(5):
         for k in range(ngroups):
-            # mask is 2-D, since both row4plus4 and : have more than one
-            # element.
+            # mask is 2-D, since both row4plus4 and : have more than one element.
             mask = (data0[i, k, row4plus4, :] != 0.)
             (intercept, slope) = ols_line(time_arr[row4plus4, :][mask],
                                           data0[i, k, row4plus4, :][mask])
             ab_3[0, k, i] = intercept
             ab_3[1, k, i] = slope
+
     for i in range(5):
         for k in range(ngroups):
             # weight is 0 where data0 is 0, else 1.
-            weight = (data0[i, k, :, :] != 0.).astype(np.float32)
+            weight = (data0[i, k, :, :] != 0.).astype(np.int8)
             data0[i, k, :, :] -= (ab_3[0, k, i] +
                                   time_arr * ab_3[1, k, i]) * weight
 
-    # <<<<<<<
 
-    # ; Use cosine weighted interpolation to replace 0.0 values and bad
+def replace_bad_pixels(data0, ngroups, ny, row):
+
+    # Use cosine weighted interpolation to replace 0.0 values and bad
     # pixels and gaps. (initial guess)
 
     # s[1] = nx  s[2] = ny  s[3] = ngroups
@@ -572,7 +764,9 @@ def subtract_reference(data0, alpha, beta, irs2_mask,
         # xxx why '+=' instead of just '=' ?
         data0[kk, jj, :, :] += dat * (1. - mask)
 
-    # ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+def fill_bad_regions(data0, ngroups, ny, nx, row, scipix_n, refpix_r, pad, hnorm, hnorm1):
+
     # Use Fourier filter/interpolation to replace
     # (a) bad pixel, gaps, and reference data in the time-ordered normal data
     # (b) gaps and normal data in the time-ordered reference data
@@ -581,12 +775,12 @@ def subtract_reference(data0, alpha, beta, irs2_mask,
     # Parameters for the filter to be used.
     # length of apodization cosine filter
     elen = 110000 // (scipix_n + refpix_r + 2)
+
     # max unfiltered frequency
     blen = (512 + 512 // scipix_n * (refpix_r + 2) + pad) // \
            (scipix_n + refpix_r + 2) * ny // 2 - elen // 2
 
     # Construct the filter [1, cos, 0, cos, 1].
-
     temp_a1 = (np.cos(np.arange(elen, dtype=np.float32) *
                       np.pi / float(elen)) + 1.) / 2.
 
@@ -594,13 +788,13 @@ def subtract_reference(data0, alpha, beta, irs2_mask,
     # blen = 30268
     # row * ny // 2 - 2 * blen - 2 * elen = 658552
     # len(temp_a2) = 729088
-
     temp_a2 = np.concatenate((np.ones(blen, dtype=np.float32),
                               temp_a1.copy(),
                               np.zeros(row * ny // 2 - 2 * blen - 2 * elen,
                                        dtype=np.float32),
                               temp_a1[::-1].copy(),
                               np.ones(blen, dtype=np.float32)))
+
     roll_a2 = np.roll(temp_a2, -1)
     aa = np.concatenate((temp_a2, roll_a2[::-1]))
     del temp_a1, temp_a2, roll_a2
@@ -616,175 +810,6 @@ def subtract_reference(data0, alpha, beta, irs2_mask,
     fft_interp_norm(dd0, np.ones((ny, nx // 4), dtype=np.int64),
                     row, hnorm, hnorm1,
                     ny, ngroups, aa, n_iter_norm)
+
     data0[0, :, :, :] = dd0.copy()
     del aa, dd0
-
-# ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-# ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    # The comments in this section are for scipix_n = 16, refpix_r = 4.
-    # ; indices for keeping/shuffling reference pixels
-    n0 = 512 // scipix_n
-    n1 = scipix_n + refpix_r + 2
-    ht = np.arange(n0 * n1, dtype=np.int32).reshape((n0, n1))   # (32, 22)
-    ht[:, 0:(scipix_n - refpix_r) // 2 + 1] = -1
-    ht[:, scipix_n // 2 + 1 + 3 * refpix_r // 2:] = -1
-    hs = ht.copy()
-    # ht is like href1, but extended over gaps and 1st and last norm pix.
-    mask = (ht >= 0)
-    ht = ht[mask]               # 1-D, length = 2 * refpix_r * 512 / scipix_n
-    # IDL:  hs[scipix_n/2 + 1-refpix_r/2:scipix_n/2 + refpix_r + refpix_r/2,*] =
-    #       hs[reform([transpose(reform(indgen(refpix_r),refpix_r/2,2)),
-    #           transpose(reform(indgen(refpix_r),refpix_r/2,2))],refpix_r * 2)
-    #           + scipix_n/2 + 1,*]  ; WIRED for R=2^(int)
-
-    indr = np.arange(refpix_r, dtype=np.intp).reshape((2, refpix_r // 2))
-    # indr_t =
-    # [[0 2]
-    #  [1 3]]
-    indr_t = indr.transpose()
-    # Before flattening, two_indr_t =
-    # [[0 2 0 2]
-    #  [1 3 1 3]]
-    # After flattening, two_indr_t = [0 2 0 2 1 3 1 3].
-    two_indr_t = np.concatenate((indr_t, indr_t), axis=1).flatten()
-    two_indr_t += (scipix_n // 2 + 1)     # [9 11 9 11 10 12 10 12]
-    hs[:, scipix_n // 2 + 1 - refpix_r // 2:
-       scipix_n // 2 + 1 + refpix_r // 2 + refpix_r] = hs[:, two_indr_t]
-    mask = (hs >= 0)
-    hs = hs[mask]                       # hs is now 1-D
-
-    if refpix_r % 4 == 2:
-        len_hs = len(hs)
-        temp_hs = hs.reshape(len_hs // 2, 2)
-        temp_hs = temp_hs[:, ::-1]
-        hs = temp_hs.flatten()
-
-    # ; construct the reference data
-    r0 = np.zeros_like(data0)
-    r0[:, :, :, ht] = data0[:, :, :, hs]
-    # ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-    # data0 has shape (5, ngroups, ny, row).  See the section above where
-    # d0 was created, then copied (moved) to data0.
-    shape_d = data0.shape
-    # sd[1] = shape_d[3]   row (712)
-    # sd[2] = shape_d[2]   ny (2048)
-    # sd[3] = shape_d[1]   ngroups
-    # sd[4] = shape_d[0]   5
-    # s is used below, so for convenience, here are the values again:
-    # s[1] = shape[2] = nx
-    # s[2] = shape[1] = ny
-    # s[3] = shape[0] = ngroups
-
-    # IDL and numpy differ in where they apply the normalization for the
-    # FFT.  This really shouldn't matter.
-    normalization = float(shape_d[2] * shape_d[3])
-
-    if beta is not None:
-        # IDL:  refout0 = reform(data0[*,*,*,0], sd[1] * sd[2], sd[3])
-        refout0 = data0[0, :, :, :].reshape((shape_d[1],
-                                             shape_d[2] * shape_d[3]))
-        # IDL:  refout0 = fft(refout0, dim=1, /over)
-        # Divide by the length of the axis to be consistent with IDL.
-        refout0 = np.fft.fft(refout0, axis=1) / normalization
-
-    # IDL:  r0 = reform(r0, sd[1] * sd[2], sd[3], 5, /over)
-    r0 = r0.reshape((5, shape_d[1], shape_d[2] * shape_d[3]))
-    r0 = r0.astype(np.complex64)
-    r0f = ["dummy", 1, 1, 1, 1]         # elements 1 - 4 populated in loop
-    for k in range(1, 5):
-        r0f[k] = np.fft.fft(r0[k, :, :], axis=1) / normalization
-
-    # Note that where the IDL code uses alpha, we use beta, and vice versa.
-    # IDL:  for k=0,3 do oBridge[k]->Execute,
-    #           "for i=0, s3-1 do r0[*,i] *= alpha"
-    for k in range(1, 5):
-        for i in range(ngroups):
-            # Each element of r0f is the fft of r0[k, :, :], for some k.
-            r0f[k][i, :] *= beta[k - 1]
-
-    # IDL:  for k=0,3 do oBridge[k]->Execute,
-    #           "for i=0, s3-1 do r0[*,i] += beta * refout0[*,i]"
-    if beta is not None:
-        for k in range(1, 5):
-            for i in range(ngroups):
-                r0f[k][i, :] += (alpha[k - 1] * refout0[i, :])
-
-    # IDL:  for k=0,3 do oBridge[k]->Execute,
-    #           "r0 = fft(r0, 1, dim=1, /overwrite)", /nowait
-    for k in range(1, 5):
-        r0[k, :, :] = np.fft.ifft(r0f[k], axis=1) * normalization
-
-    # sd[1] = shape_d[3]   row (712)
-    # sd[2] = shape_d[2]   ny (2048)
-    # sd[3] = shape_d[1]   ngroups
-    # sd[4] = shape_d[0]   5
-    # IDL:  r0 = reform(r0, sd[1], sd[2], sd[3], 5, /over)
-    r0 = r0.reshape(shape_d)
-    r0 = r0.real
-    r0 = r0[:, :, :, hnorm1]
-    data0 = data0[:, :, :, hnorm1]
-
-    data0 -= r0
-    data0[2, :, :, :] = data0[2, :, :, ::-1]
-    data0[4, :, :, :] = data0[4, :, :, ::-1]
-
-    # IDL:  data0 = transpose(data0, [0,3,1,2])  0, 1, 2, 3 --> 0, 3, 1, 2
-    # current order:  512, ny, ngroups, 5     (IDL)
-    # current order:  5, ngroups, ny, 512     (numpy)
-    #                 0  1        2   3       current numpy indices
-    # transpose to:   512, 5, ny, ngroups     (IDL)
-    # transpose to:   ngroups, ny, 5, 512     (numpy)
-    #                 1        2   0  3       transpose order for numpy
-    # Therefore:      0 1 2 3  -->  1 2 0 3   transpose order for numpy
-    data0 = np.transpose(data0, (1, 2, 0, 3))
-
-    # IDL:  data0 = reform(data0[*, 1:*, *, *], s[2], s[2], s[3], /over)
-    # Note:  ny x ny, not ny x nx.
-    data0 = data0[:, :, 1:, :].reshape((ngroups, ny, ny))
-    # b_offset is the average over the ramp that we subtracted near the
-    # beginning; add it back in.
-    # Shape of b_offset is (2048, 3200), data0 is (ngroups, 2048, 2048).
-    data0 += b_offset[..., irs2_mask]
-
-    return data0
-
-
-def fft_interp_norm(dd0, mask0, row, hnorm, hnorm1,
-                    ny, ngroups, aa, n_iter_norm):
-
-    mm = np.zeros((ny, row), dtype=np.int8)
-    mm[:, hnorm1] = mask0[:, hnorm]
-    hm = (mm != 0)                      # 2-D boolean mask
-    for j in range(ngroups):
-        dd = dd0[j, :, :].copy()
-        p = dd.flatten()                        # make a copy, not a view
-        for it in range(n_iter_norm):
-            pp = np.fft.fft(p)
-            pp *= aa
-            p[:] = np.fft.ifft(pp).real
-            p[hm.ravel()] = dd[hm]
-        dd0[j, :, :] = p.reshape((ny, row))
-
-
-def ols_line(x, y):
-    """Fit a straight line using ordinary least squares."""
-
-    xf = x.ravel()
-    yf = y.ravel()
-    if len(xf) < 1 or len(yf) < 1:
-        return (0., 0.)
-
-    groups = float(len(xf))
-
-    mean_x = xf.mean()
-    mean_y = yf.mean()
-    sum_x2 = (xf**2).sum()
-    sum_xy = (xf * yf).sum()
-
-    slope = (sum_xy - groups * mean_x * mean_y) / \
-            (sum_x2 - groups * mean_x**2)
-    intercept = mean_y - slope * mean_x
-
-    return (intercept, slope)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6282 

Resolves [JP-2250](https://jira.stsci.edu/browse/JP-2250)

**Description**

This PR refactors the parts of the refpix step used to correct NIRSpec exposures using the IRS2 readout mode, in order to reduce the memory usage. The major change is to the `subtract_reference` function in irs2_subtract_reference.py to replace all of the repeated loops over "sectors" (regions of the data readout by the 4 different amps) with one big loop that computes and applies the correction to one "sector" at a time, so that you're not always carrying along the data for all 4 sectors all the time. Other more minor changes, such as moving the copy of input_model -> output_model to the end of the step, because only the SCI (data) array is needed for all of the computations, hence you're not carrying along 2 complete copies of the exposure for the entire duration, and making sure to explicitly delete the large objects as soon as they aren't needed anymore.

Also did some general reorganization and clean-up, just to try to make the code more readable and manageable in the future (such as splitting up the previous single monolithic `subtract_reference` function into several smaller pieces).

For the dataset that initially triggered [JP-2250](https://jira.stsci.edu/browse/JP-2250), which uses NINTS=1 and NGROUPS=200, the old version of the step hit a peak memory usage of ~65GB. The new version peaks at around 35GB. Still quite big, but it's a really big exposure!

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)