### PR TITLE
MRS Residual Fringe Correction update of reference file data model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1996,6 +1996,8 @@ residual_fringe
 - Fixed suffix defined in spec [#6347]
 
 - Fixed an error when a filename was give as the input to apply the residual fringe correction [#6349]
+
+- Updated residual fringe reference data model to support new delivery of reference files [#6357]
   
 
 set_telescope_pointing

--- a/jwst/datamodels/schemas/residual_fringe.schema.yaml
+++ b/jwst/datamodels/schemas/residual_fringe.schema.yaml
@@ -6,84 +6,67 @@ title: Default MIRI Residual Fringe Correction
 allOf:
 - $ref: referencefile.schema
 - type: object
+  title: MIRI MRS fringe frequencies model
   properties:
     rfc_freq_short_table:
-      title: default residual fringe short table
+      title: residual fringe short table
       fits_hdu: RFC_FREQ_SHORT
       datatype:
       - name: slice
-        datatype: float32
+        datatype: float64
       - name: ffreq
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: dffreq
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: min_nfringes
-        datatype: int32
-        ndim: 2
+        datatype: int64
       - name: max_nfringes
-        datatype: int32
-        ndim: 2
+        datatype: int64
       - name: min_snr
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: pgram_res
-        datatype: float32
-        ndim: 2
+        datatype: float64
     rfc_freq_medium_table:
       title: default residual fringe medium table
       fits_hdu: RFC_FREQ_MEDIUM
       datatype:
       - name: slice
-        datatype: float32
+        datatype: float64
       - name: ffreq
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: dffreq
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: min_nfringes
-        datatype: int32
-        ndim: 2
+        datatype: int64
       - name: max_nfringes
-        datatype: int32
-        ndim: 2
+        datatype: int64
       - name: min_snr
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: pgram_res
-        datatype: float32
-        ndim: 2
+        datatype: float64
     rfc_freq_long_table:
       title: default residual fringe long table
       fits_hdu: RFC_FREQ_LONG
       datatype:
       - name: slice
-        datatype: float32
+        datatype: float64
       - name: ffreq
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: dffreq
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: min_nfringes
-        datatype: int32
-        ndim: 2
+        datatype: int64
       - name: max_nfringes
-        datatype: int32
-        ndim: 2
+        datatype: int64
       - name: min_snr
-        datatype: float32
-        ndim: 2
+        datatype: float64
       - name: pgram_res
-        datatype: float32
-        ndim: 2
+        datatype: float64
     max_amp_table:
       title: default residual fringe max amp table
       fits_hdu: MAX_AMP
       datatype:
       - name: wavelength
-        datatype: float32
+        datatype: float64
       - name: amplitude
-        datatype: float32
+        datatype: float64

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -183,12 +183,12 @@ class ResidualFringeCorrection():
                 log.debug('Row in reference file for slice {}'.format(this_row))
 
                 slice_row = self.freq_table[(self.freq_table['slice'] == float(ss))]
-                ffreq = slice_row['ffreq'][0][0]
-                dffreq = slice_row['dffreq'][0][0]
-                min_nfringes = slice_row['min_nfringes'][0][0]
-                max_nfringes = slice_row['max_nfringes'][0][0]
-                min_snr = slice_row['min_snr'][0][0]
-                pgram_res = slice_row['pgram_res'][0][0]
+                ffreq = slice_row['ffreq'][0]
+                dffreq = slice_row['dffreq'][0]
+                min_nfringes = slice_row['min_nfringes'][0]
+                max_nfringes = slice_row['max_nfringes'][0]
+                min_snr = slice_row['min_snr'][0]
+                pgram_res = slice_row['pgram_res'][0]
 
                 # cycle through the cols and fit the fringes
                 for col in np.arange(slice_x_ranges[n,1], slice_x_ranges[n,2]):


### PR DESCRIPTION
…rmat

<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->



Continued work on  JP-1273

**Description**

Two new MRS residual fringe correction files have been delivered to STScI from the MIRI instrument team. These files are for IFUSHORT and IFULONG. The format of the files was a little different and required a change the data models for these reference files and slight change in the residual_fringe code to access the  data in the tables. 

These files have not yet be added to CRDS. Misty Cracraft has the delivered files and will get them into CRDS. In the meanwhile, to test the residual fringe code the files can be found at:
/grp/jwst/ssb/morrison/MIRI_MRS_FRINGEDATA/
Checklist
- [ ] Tests

- [ ] Documentation

- [X] Change log

- [X] Milestone

- [X] Label(s)
