### PR TITLE
JP-2263 Update the input model list sent to blenders 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,10 @@ cube_build
   support changes in #6093. [#6255]
 
 - Using assign_wsc.utils.in_ifu_slice function to determine which NIRSpec
-  sky values mapped to each detector slice. [#6326] 
+  sky values mapped to each detector slice. [#6326]
+
+- Fixed error final exposure times calculated by blend headers.Only the input models
+  used in the IFU cube are past to blend headers. [#6360]
 
 datamodels
 ----------

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -44,6 +44,8 @@ class IFUCubeData():
         """ Class IFUCube holds the high level data for each IFU Cube
         """
         self.new_code = 0
+        self.input_models_this_cube = []  # list of files use to make cube working on
+
         self.input_filenames = input_filenames
         self.pipeline = pipeline
 
@@ -563,6 +565,7 @@ class IFUCubeData():
             # loop over the files that cover the spectral range the cube is for
             for k in range(nfiles):
                 input_model = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
+                self.input_models_this_cube.append(input_model)
                 # set up input_model to be first file used to copy in basic header info
                 # to ifucube meta data
                 if ib == 0 and k == 0:
@@ -733,7 +736,7 @@ class IFUCubeData():
             # loop over the files that cover the spectral range the cube is for
             for k in range(nfiles):
                 input_model = self.master_table.FileMap[self.instrument][this_par1][this_par2][k]
-
+                self.input_models_this_cube.append(input_model)
                 log.debug("Working on next Single IFU Cube = %i" % (j + 1))
 
                 # for each new data model create a new spaxel
@@ -2019,7 +2022,7 @@ class IFUCubeData():
         """Create new output metadata based on blending all input metadata."""
         # Run fitsblender on output product
         output_file = IFUCube.meta.filename
-        blendmeta.blendmodels(IFUCube, inputs=self.input_models,
+        blendmeta.blendmodels(IFUCube, inputs=self.input_models_this_cube,
                               output=output_file)
 
 


### PR DESCRIPTION
…ifu cube

<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #

Resolves JP-2263

**Description**

This PR addresses fixes the problem that all the input models were sent to the blender routine instead of just the input models used to create the IFU cube. This resulted in final exposure times reported in the IFU header as being in correct. 


Checklist
- [ ] Tests

- [ ] Documentation

- [X] Change log

- [X] Milestone

- [X] Label(s)
