### PR TITLE
JP-2289: Fix specwcs in wcs_ref_models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,8 +68,7 @@ datamodels
 
 - Fix a bug in wcs_ref_models where SpecwcsModel was failing the SimpleModel
   validation as it contains a list of models rather than one simple model.
-  Also add an on_save setting of self.meta.reftype and
-  add some missing allowed BAND values for MIRI MRS distortion
+  Also add some missing allowed BAND values for MIRI MRS distortion
   and regions files.  Fix an incorrect comment on
   FilteroffsetModel. [#6362]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,10 +66,11 @@ datamodels
 - Implement memmap argument when calling ``datamodels.open`` on an ASDF
   file. [#6327]
 
-- Fix a bug in wcs_ref_models where SpecwcsModel was not of type
-  ReferenceFileModel, and add an on_save setting of self.meta.reftype
-  Also add some missing allowed BAND values for MIRI MRS distortion
-  and regions files, and fix an incorrect comment on
+- Fix a bug in wcs_ref_models where SpecwcsModel was failing the SimpleModel
+  validation as it contains a list of models rather than one simple model.
+  Also add an on_save setting of self.meta.reftype and
+  add some missing allowed BAND values for MIRI MRS distortion
+  and regions files.  Fix an incorrect comment on
   FilteroffsetModel. [#6362]
 
 extract_1d

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,12 @@ datamodels
 - Implement memmap argument when calling ``datamodels.open`` on an ASDF
   file. [#6327]
 
+- Fix a bug in wcs_ref_models where SpecwcsModel was not of type
+  ReferenceFileModel, and add an on_save setting of self.meta.reftype
+  Also add some missing allowed BAND values for MIRI MRS distortion
+  and regions files, and fix an incorrect comment on
+  FilteroffsetModel.
+
 extract_1d
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,7 +70,7 @@ datamodels
   ReferenceFileModel, and add an on_save setting of self.meta.reftype
   Also add some missing allowed BAND values for MIRI MRS distortion
   and regions files, and fix an incorrect comment on
-  FilteroffsetModel.
+  FilteroffsetModel. [#6362]
 
 extract_1d
 ----------

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -138,7 +138,8 @@ class DistortionMRSModel(ReferenceFileModel):
             assert self.meta.instrument.name == "MIRI"
             assert self.meta.exposure.type == "MIR_MRS"
             assert self.meta.instrument.channel in ("12", "34", "1", "2", "3", "4")
-            assert self.meta.instrument.band in ("SHORT", "LONG", "MEDIUM")
+            assert self.meta.instrument.band in ("SHORT", "LONG", "MEDIUM", "SHORT-LONG", "SHORT-MEDIUM",
+                                                 "MEDIUM-SHORT", "MEDIUM-LONG", "LONG-SHORT", "LONG-MEDIUM")
             assert self.meta.instrument.detector in ("MIRIFUSHORT", "MIRIFULONG")
             assert all([isinstance(m, Model) for m in self.x_model])
             assert all([isinstance(m, Model) for m in self.y_model])
@@ -153,7 +154,7 @@ class DistortionMRSModel(ReferenceFileModel):
                 warnings.warn(traceback.format_exc(), ValidationWarning)
 
 
-class SpecwcsModel(_SimpleModel):
+class SpecwcsModel(ReferenceFileModel):
     """
     A model for a reference file of type "specwcs".
 
@@ -165,6 +166,9 @@ class SpecwcsModel(_SimpleModel):
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs.schema"
     reftype = "specwcs"
+
+    def on_save(self, path=None):
+        self.meta.reftype = self.reftype
 
     def validate(self):
         super().validate()
@@ -372,7 +376,8 @@ class RegionsModel(ReferenceFileModel):
             assert self.meta.instrument.name == "MIRI"
             assert self.meta.exposure.type == "MIR_MRS"
             assert self.meta.instrument.channel in ("12", "34", "1", "2", "3", "4")
-            assert self.meta.instrument.band in ("SHORT", "LONG")
+            assert self.meta.instrument.band in ("SHORT", "MEDIUM", "LONG", "SHORT-LONG", "SHORT-MEDIUM",
+                                                 "MEDIUM-SHORT", "MEDIUM-LONG", "LONG-SHORT", "LONG-MEDIUM")
             assert self.meta.instrument.detector in ("MIRIFUSHORT", "MIRIFULONG")
         except AssertionError:
             if self._strict_validation:
@@ -689,7 +694,7 @@ class DisperserModel(ReferenceFileModel):
 
 class FilteroffsetModel(ReferenceFileModel):
     """
-    A model for a NIRSPEC reference file of type "disperser".
+    A model for filter-dependent boresight offsets.
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/filteroffset.schema"
     reftype = "filteroffset"

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -52,7 +52,7 @@ class _SimpleModel(ReferenceFileModel):
     def validate(self):
         super().validate()
         try:
-            assert isinstance(self.model, Model)
+            assert isinstance(self.model, Model) or all([isinstance(m, Model) for m in self.model])
             assert self.meta.instrument.name in ["NIRCAM", "NIRSPEC", "MIRI", "TFI", "FGS", "NIRISS"]
         except AssertionError:
             if self._strict_validation:
@@ -154,7 +154,7 @@ class DistortionMRSModel(ReferenceFileModel):
                 warnings.warn(traceback.format_exc(), ValidationWarning)
 
 
-class SpecwcsModel(ReferenceFileModel):
+class SpecwcsModel(_SimpleModel):
     """
     A model for a reference file of type "specwcs".
 

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -167,9 +167,6 @@ class SpecwcsModel(_SimpleModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs.schema"
     reftype = "specwcs"
 
-    def on_save(self, path=None):
-        self.meta.reftype = self.reftype
-
     def validate(self):
         super().validate()
         try:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Resolves JP-2289

This PR fixes a bug in wcs_ref_models where SpecwcsModel was not of type ReferenceFileModel, causing validation to attempt to compare against astropy standard models instead of JWST specwcs models.  Also add an on_save setting of self.meta.reftype that was missing and causing validation errors, and add some missing allowed BAND values for MIRI MRS distortion and regions files.  Fix an incorrect comment on FilteroffsetModel.
