### PR TITLE
JP-1729: Assign int_num to extensions in extract_1d 

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -3860,6 +3860,9 @@ def create_extraction(extract_ref_dict,
         spec.dispersion_direction = extract_params['dispaxis']
         copy_keyword_info(meta_source, slitname, spec)
 
+        if integ > -1:
+            spec.int_num = integ
+
         if source_type is not None and source_type.upper() == 'POINT' and apcorr_ref_model is not None:
             log.info('Applying Aperture correction.')
             # NIRSpec needs to use a wavelength in the middle of the range rather then the beginning of the range


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5360

Resolves JP-1729

**Description**

This PR utilizes the dormant 'INT_NUM' extension keyword in the MultiSpecModel datamodel to track the integration number of each extraction.


Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [x] Milestone

- [x] Label(s)
