### PR TITLE
JP-2257: Fix bad link in refpix docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,8 @@ refpix
 - Refactored the ``subtract_reference`` routine for NRS IRS2 data to reduce
   memory usage. [#6356]
 
+- Updated bad link to JDox in the step documentation. [#6372]
+
 regtest
 -------
 

--- a/docs/jwst/refpix/description.rst
+++ b/docs/jwst/refpix/description.rst
@@ -210,5 +210,5 @@ For each ``k``, the inverse Fourier transform of ``ft_refpix_corr[k]`` is
 the processed array of reference pixel data, which is then subtracted from
 the normal pixel data over the range of pixels for output ``k``.
 
-.. _JdoxIRS2: https://jwst-docs.stsci.edu/display/JDOX/NIRSpec+IRS2+Detector+Readout+Mode
+.. _JdoxIRS2: https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-instrumentation/nirspec-detectors/nirspec-detector-readout-modes-and-patterns/nirspec-irs2-detector-readout-mode
 .. _Rauscher2017: http://adsabs.harvard.edu/abs/2017PASP..129j5003R


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #6293

Resolves [JP-2257](https://jira.stsci.edu/browse/JP-2257)

**Description**

This PR fixes the link in the `refpix` step docs that points to information in JDox about the NIRSpec IRS2 readout mode.


Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)