### PR TITLE
Turn off MacOS job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,12 @@ jobs:
             python-version: 3.9
             toxenv: security
 
-          - name: macOS
-            os: macos-latest
-            python-version: 3.9
-            toxenv: py39
+          # MacOS job is flaky on Github actions and fails routinely.
+          # Re-enable when things get more reliable.
+          # - name: macOS
+          #   os: macos-latest
+          #   python-version: 3.9
+          #   toxenv: py39
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->


**Description**

This PR turns off the MacOS job in our CI workflow.  Github `macos-latest` runners are notoriously slow and these jobs fail more than 50% of the time, which is not good for reliable CI.  We should re-enable these when Github sorts out their MacOS runners to be more reliable.

Hopefully this won't bite as, as almost every developer is developing and running all these tests locally on MacOS.


Checklist
- [ ] ~Tests~
- [ ] ~Documentation~
- [ ] ~Change log~
- [x] Milestone
- [x] Label(s)