### PR TITLE
JP-1793: Standardize wfs_combine Step

### DIFF
--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -119,8 +119,8 @@ def test_create_combined(_jail, wfs_association,
                                  blur_size=10, n_size=2)
 
     # Check that results are as expected
-    assert result.data[5, 5] == result_data
-    assert result.dq[5, 5] == result_dq
+    assert result[0].data[5, 5] == result_data
+    assert result[0].dq[5, 5] == result_dq
 
 
 def test_shift_order_no_refine_no_flip(wfs_association):

--- a/jwst/wfs_combine/tests/test_wfs_combine_step.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine_step.py
@@ -75,7 +75,7 @@ def test_step_pos_shift_no_refine_no_flip(wfs_association):
 
     wfs = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=False, psf_size=50,
                               blur_size=10, n_size=2)
-    assert wfs.meta.wcsinfo.ra_ref == 22.02351763251896
+    assert wfs[0].meta.wcsinfo.ra_ref == 22.02351763251896
 
 
 def test_step_neg_shift_no_refine_no_flip(wfs_association):
@@ -93,7 +93,7 @@ def test_step_neg_shift_no_refine_no_flip(wfs_association):
 
     wfs = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=False, psf_size=50,
                               blur_size=10, n_size=2)
-    assert wfs.meta.wcsinfo.ra_ref == 22.02351763251896
+    assert wfs[0].meta.wcsinfo.ra_ref == 22.02351763251896
 
 
 def test_step_neg_order_no_refine_with_flip(wfs_association):
@@ -111,7 +111,7 @@ def test_step_neg_order_no_refine_with_flip(wfs_association):
 
     wfs = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=True, psf_size=50,
                               blur_size=10, n_size=2)
-    assert wfs.meta.wcsinfo.ra_ref == 22.02351763251896 + delta_pixel * nircam_pixel_size
+    assert wfs[0].meta.wcsinfo.ra_ref == 22.02351763251896 + delta_pixel * nircam_pixel_size
 
 
 def test_step_pos_order_no_refine_with_flip(wfs_association):
@@ -129,4 +129,4 @@ def test_step_pos_order_no_refine_with_flip(wfs_association):
 
     wfs = WfsCombineStep.call(path_asn, do_refine=False, flip_dithers=True, psf_size=50,
                               blur_size=10, n_size=2)
-    assert wfs.meta.wcsinfo.ra_ref == 22.02351763251896
+    assert wfs[0].meta.wcsinfo.ra_ref == 22.02351763251896

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -26,60 +26,51 @@ class WfsCombineStep(Step):
 
     def process(self, input_table):
 
-        # Load the input ASN table
-        asn_table = self.load_as_level3_asn(input_table)
-        num_sets = len(asn_table['products'])
-
         self.suffix = 'wfscmb'
         self.output_use_model = True
-        self.log.info('Using input table: %s', input_table)
-        self.log.info('The number of pairs of input files: %g', num_sets)
+        self.output_use_format = False
 
-        output_container = datamodels.ModelContainer()
+        # Load the input ASN table
+        with datamodels.open(input_table) as asn_table:
 
-        # Process each pair of input images listed in the association table
-        for which_set in asn_table['products']:
+            self.log.info('Using input table: %s', input_table)
+            self.log.info('The number of pairs of input files: %g', len(asn_table.meta.asn_table.products))
 
-            # Get the list of science members in this pair
-            science_members = [
-                member
-                for member in which_set['members']
-                if member['exptype'].lower() == 'science'
-            ]
-            infile_1 = science_members[0]['expname']
-            infile_2 = science_members[1]['expname']
-            outfile = which_set['name']
+            model_list = []
 
-            # Create the step instance
-            wfs = wfs_combine.DataSet(
-                infile_1, infile_2, outfile, self.do_refine, self.flip_dithers, self.psf_size,
-                self.blur_size, self.n_size
-            )
+            # Process each pair of input images listed in the association table
+            for which_set in asn_table.meta.asn_table.products:
 
-            # Do the processing
-            output_model = wfs.do_all()
+                # Get the list of science members in this pair
+                science_members = [
+                    member
+                    for member in which_set.members
+                    if member.exptype.lower() == 'science'
+                ]
+                infile_1 = science_members[0].expname
+                infile_2 = science_members[1].expname
+                outfile = which_set.name
 
-            # The DataSet class does not close its resources.  Do that here.
-            wfs.input_1.close()
-            wfs.input_2.close()
+                # Create the step instance
+                wfs = wfs_combine.DataSet(
+                    infile_1, infile_2, outfile, self.do_refine, self.flip_dithers, self.psf_size,
+                    self.blur_size, self.n_size
+                )
 
-            # Update necessary meta info in the output
-            output_model.meta.cal_step.wfs_combine = 'COMPLETE'
-            output_model.meta.asn.pool_name = asn_table['asn_pool']
-            output_model.meta.asn.table_name = os.path.basename(input_table)
-            output_model.filename = which_set['name']
+                # Do the processing
+                output_model = wfs.do_all()
 
-            output_container.append(output_model)
+                # The DataSet class does not close its resources.  Do that here.
+                wfs.input_1.close()
+                wfs.input_2.close()
 
-            # Save the output file
-            # if self.save_results:
-            #     self.save_model(
-            #         output_model, output_file=outfile, format=False)
+                # Update necessary meta info in the output
+                output_model.meta.cal_step.wfs_combine = 'COMPLETE'
+                output_model.meta.asn.pool_name = asn_table.meta.asn_table.asn_pool
+                output_model.meta.asn.table_name = os.path.basename(input_table)
+                output_model.meta.filename = which_set.name
 
-        # Short-circuit auto-save of returned model if run from strun, as it is
-        # already done above.  Ideally we would use self.output_use_model,
-        # self.suffix and output_model.meta.filename, but self.save_model(format=False)
-        # also needs to be there, and that is not stored as a class/instance attr.
-        # self.save_results = False
-        # Return the output so it can be tested.  Assumes there is only one product.
-        return output_container
+                model_list.append(output_model)
+
+        # Return the output so it can be tested.
+        return model_list

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -1,6 +1,7 @@
 import os
 
 from ..stpipe import Step
+from .. import datamodels
 from . import wfs_combine
 
 __all__ = ["WfsCombineStep"]
@@ -29,8 +30,12 @@ class WfsCombineStep(Step):
         asn_table = self.load_as_level3_asn(input_table)
         num_sets = len(asn_table['products'])
 
+        self.suffix = 'wfscmb'
+        self.output_use_model = True
         self.log.info('Using input table: %s', input_table)
         self.log.info('The number of pairs of input files: %g', num_sets)
+
+        output_container = datamodels.ModelContainer()
 
         # Process each pair of input images listed in the association table
         for which_set in asn_table['products']:
@@ -63,15 +68,19 @@ class WfsCombineStep(Step):
             output_model.meta.asn.pool_name = asn_table['asn_pool']
             output_model.meta.asn.table_name = os.path.basename(input_table)
 
+            output_container.append(output_model)
+
+            output_container.filename = which_set['name']
+
             # Save the output file
-            if self.save_results:
-                self.save_model(
-                    output_model, output_file=outfile, format=False)
+            # if self.save_results:
+            #     self.save_model(
+            #         output_model, output_file=outfile, format=False)
 
         # Short-circuit auto-save of returned model if run from strun, as it is
         # already done above.  Ideally we would use self.output_use_model,
         # self.suffix and output_model.meta.filename, but self.save_model(format=False)
         # also needs to be there, and that is not stored as a class/instance attr.
-        self.save_results = False
+        # self.save_results = False
         # Return the output so it can be tested.  Assumes there is only one product.
-        return output_model
+        return output_container

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -67,10 +67,9 @@ class WfsCombineStep(Step):
             output_model.meta.cal_step.wfs_combine = 'COMPLETE'
             output_model.meta.asn.pool_name = asn_table['asn_pool']
             output_model.meta.asn.table_name = os.path.basename(input_table)
+            output_model.filename = which_set['name']
 
             output_container.append(output_model)
-
-            output_container.filename = which_set['name']
 
             # Save the output file
             # if self.save_results:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-123: <Fix a bug>
**
-->

Closes #5511 

Resolves JP-1793

**Description**

This PR addresses issues with the Step/Pipeline identity crisis that calwebb_wfs-image3 - err, wfs_combine - found itself in. 

The step now uses datamodels.open() instead of load_as_level3_asn() - this should allow the step to take a ModelContainer as input, though the formatting will need to follow the level 3 associations, i.e. presence of member pairs under products, expnames provided, etc. Documentation might be on the to-do list to make this clear...

The step now follows a more traditional structure for saving results, though this requires an [stpipe PR](https://github.com/spacetelescope/stpipe/pull/29) to be merged that allows for Step instances to access the save_model(format=...) parameter.

Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [x] Milestone

- [x] Label(s)
