### PR TITLE
Remove redundant level-setting, logs in Pipelines, use logging ancestry

### DIFF
--- a/jwst/__init__.py
+++ b/jwst/__init__.py
@@ -1,9 +1,13 @@
 import re
 import sys
+import logging
 from pkg_resources import get_distribution, DistributionNotFound
 
 __version_commit__ = ''
 _regex_git_hash = re.compile(r'.*\+g(\w+)')
+
+log = logging.getLogger('jwst')
+log.setLevel(logging.DEBUG)
 
 try:
     __version__ = get_distribution(__name__).version

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -10,7 +10,6 @@ from .utils import img_median_replace
 from astropy import units as u
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def apply_LG_plus(input_model, filter_model, oversample, rotation,

--- a/jwst/ami/find_affine2d_parameters.py
+++ b/jwst/ami/find_affine2d_parameters.py
@@ -9,7 +9,6 @@ from . import lg_model
 from . import utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def create_afflist_rot(rotdegs):

--- a/jwst/ami/instrument_data.py
+++ b/jwst/ami/instrument_data.py
@@ -10,7 +10,6 @@ from .mask_definitions import NRM_mask_definitions
 from . import utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 um = 1.0e-6
 

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -7,7 +7,6 @@ import numpy as np
 import numpy.fft as fft
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 log.addHandler(logging.NullHandler())
 
 

--- a/jwst/assign_mtwcs/assign_mtwcs_step.py
+++ b/jwst/assign_mtwcs/assign_mtwcs_step.py
@@ -5,7 +5,6 @@ from .. import datamodels
 from .moving_target_wcs import assign_moving_target_wcs
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["AssignMTWcsStep"]
 

--- a/jwst/assign_mtwcs/moving_target_wcs.py
+++ b/jwst/assign_mtwcs/moving_target_wcs.py
@@ -16,7 +16,6 @@ from gwcs import coordinate_frames as cf
 from jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["assign_moving_target_wcs"]
 

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -7,7 +7,6 @@ from ..lib.exposure_types import IMAGING_TYPES, SPEC_TYPES, NRS_LAMP_MODE_SPEC_T
 from ..lib.dispaxis import get_dispersion_direction
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["load_wcs"]
 

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -8,7 +8,6 @@ from .util import MSAFileError
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["AssignWcsStep"]
 

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -13,7 +13,6 @@ from . import pointing
 from ..datamodels import DistortionModel
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["create_pipeline", "imaging"]

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -20,7 +20,6 @@ from stdatamodels import s3_utils
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["create_pipeline", "imaging", "lrs", "ifu"]

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -18,7 +18,6 @@ from ..lib.reffile_utils import find_row
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["create_pipeline", "imaging", "tsgrism", "wfss"]

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -20,7 +20,6 @@ from stdatamodels import s3_utils
 from ..lib.reffile_utils import find_row
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["create_pipeline", "imaging", "niriss_soss", "niriss_soss_set_input", "wfss"]
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -33,7 +33,6 @@ from ..datamodels import (CollimatorModel, CameraModel, DisperserModel, FOREMode
 from ..lib.exposure_types import is_nrs_ifu_lamp
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["create_pipeline", "imaging", "ifu", "slits_wcs", "get_open_slits", "nrs_wcs_set_input",

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -27,7 +27,6 @@ from ..datamodels import WavelengthrangeModel
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["reproject", "wcs_from_footprints", "velocity_correction",

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -8,7 +8,6 @@ from astropy.stats import sigma_clip
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def background_sub(input_model, bkg_list, sigma, maxiters):

--- a/jwst/background/subtract_images.py
+++ b/jwst/background/subtract_images.py
@@ -2,7 +2,6 @@ import numpy as np
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def subtract(model1, model2):

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -9,7 +9,6 @@ from gwcs import wcstools
 from jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 SLITRATIO = 1.15     # Ratio of slit spacing to slit height
 

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -10,7 +10,6 @@ from .. import datamodels
 from ..extract_1d.spec_wcs import create_spectral_wcs
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class InputSpectrumModel:

--- a/jwst/coron/hlsp.py
+++ b/jwst/coron/hlsp.py
@@ -13,7 +13,6 @@ from .. import datamodels
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def snr_image(target_model):

--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -7,7 +7,6 @@ from ..datamodels import QuadModel
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def align_fourierLSQ(reference, target, mask=None):

--- a/jwst/coron/klip.py
+++ b/jwst/coron/klip.py
@@ -10,7 +10,6 @@ import numpy as np
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def klip(target_model, refs_model, truncate):

--- a/jwst/coron/median_replace_img.py
+++ b/jwst/coron/median_replace_img.py
@@ -5,7 +5,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def median_fill_value(input_array, input_dq_array, bsize, bad_bitvalue, xc, yc):

--- a/jwst/coron/stack_refs.py
+++ b/jwst/coron/stack_refs.py
@@ -10,7 +10,6 @@ from .. import datamodels
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def make_cube(input_models):

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -9,7 +9,6 @@ from jwst.assign_wcs.util import in_ifu_slice
 from . import instrument_defaults
 from .blot_median import blot_wrapper  # c extension
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class CubeBlot():

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -6,7 +6,6 @@ from . import file_table
 from . import instrument_defaults
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class CubeData():

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -3,7 +3,6 @@
 from .. import datamodels
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def read_cubepars(par_filename,

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -7,7 +7,6 @@ from gwcs import wcstools
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 # ******************************************************************************

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -6,7 +6,6 @@ import os
 from .. import datamodels
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 # ******************************************************************************

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -3,7 +3,6 @@
 from .. import datamodels
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class FileTable():

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -24,7 +24,6 @@ from ..mrs_imatch.mrs_imatch_step import apply_background_2d
 from .cube_match_sky import cube_wrapper  # c extension
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class IFUCubeData():

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -3,7 +3,6 @@
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class InstrumentInfo():

--- a/jwst/cube_skymatch/__init__.py
+++ b/jwst/cube_skymatch/__init__.py
@@ -15,7 +15,6 @@ __all__ = ["CubeSkyMatchStep"]
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def help():

--- a/jwst/cube_skymatch/skymatch.py
+++ b/jwst/cube_skymatch/skymatch.py
@@ -17,7 +17,6 @@ __author__ = 'Mihai Cara'
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def match(skycubes, subtract=False):

--- a/jwst/dark_current/dark_sub.py
+++ b/jwst/dark_current/dark_sub.py
@@ -7,7 +7,6 @@ import logging
 from .. import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, dark_model, dark_output=None):

--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -6,7 +6,6 @@ from .. import datamodels
 from ..lib import reffile_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 # FGS guide star mode exposure types

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -13,7 +13,6 @@ from stdatamodels.properties import merge_tree
 __all__ = ['exp_to_source', 'multislit_to_container']
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def exp_to_source(inputs):

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -30,7 +30,6 @@ from .apply_apcorr import select_apcorr
 from json.decoder import JSONDecodeError
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM']

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -19,7 +19,6 @@ __taskname__ = 'extract1d'
 __author__ = 'Mihai Cara'
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def extract1d(image, var_poisson, var_rnoise, var_flat, lambdas, disp_range,

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -13,7 +13,6 @@ from . import spec_wcs
 from scipy.interpolate import interp1d
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # These values are used to indicate whether the input extract1d reference file
 # (if any) is ASDF (default) or IMAGE

--- a/jwst/extract_1d/spec_wcs.py
+++ b/jwst/extract_1d/spec_wcs.py
@@ -9,7 +9,6 @@ from gwcs.wcs import WCS
 from gwcs import coordinate_frames as cf
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def create_spectral_wcs(ra, dec, wavelength):

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -8,7 +8,6 @@ from .nirspec import nrs_extract2d
 from .grisms import extract_grism_objects, extract_tso_object
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def extract2d(input_model,

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -15,7 +15,6 @@ from ..assign_wcs import util
 from ..datamodels import WavelengthrangeModel
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def extract_tso_object(input_model,

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -13,7 +13,6 @@ from ..assign_wcs import util
 from ..lib import pipe_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def nrs_extract2d(input_model, slit_name=None):

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -7,7 +7,6 @@ import logging
 from ..datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model):

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -14,7 +14,6 @@ from .. lib import reffile_utils
 from .. assign_wcs import nirspec
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 MICRONS_100 = 1.e-4                     # 100 microns, in meters
 

--- a/jwst/fringe/fringe.py
+++ b/jwst/fringe/fringe.py
@@ -6,7 +6,6 @@ import numpy as np
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, fringe_model):

--- a/jwst/gain_scale/gain_scale.py
+++ b/jwst/gain_scale/gain_scale.py
@@ -2,7 +2,6 @@ import numpy as np
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, gain_factor):

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -6,7 +6,6 @@
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(model):

--- a/jwst/guider_cds/guider_cds.py
+++ b/jwst/guider_cds/guider_cds.py
@@ -8,7 +8,6 @@ import logging
 from .. import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def guider_cds(model):

--- a/jwst/guider_cds/guider_cds_step.py
+++ b/jwst/guider_cds/guider_cds_step.py
@@ -6,7 +6,6 @@ from . import guider_cds
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["GuiderCdsStep"]
 

--- a/jwst/ipc/ipc_corr.py
+++ b/jwst/ipc/ipc_corr.py
@@ -10,7 +10,6 @@ from ..lib import pipe_utils
 from . import x_irs2
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 NumRefPixels = namedtuple("NumRefPixels",
                           ["bottom_rows", "top_rows",

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -5,7 +5,6 @@ from ..lib import reffile_utils
 from stcal.jump.jump import detect_jumps
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def run_detect_jumps(input_model, gain_model, readnoise_model,

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -6,7 +6,6 @@ import logging
 from ..datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model):

--- a/jwst/lib/dispaxis.py
+++ b/jwst/lib/dispaxis.py
@@ -1,7 +1,6 @@
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def get_dispersion_direction(exposure_type, grating="ANY", filter_wh="ANY",

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -4,7 +4,6 @@ from jwst import datamodels
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def is_subarray(input_model):

--- a/jwst/lib/utc_to_tdb.py
+++ b/jwst/lib/utc_to_tdb.py
@@ -19,7 +19,6 @@ except Exception:
     USE_TIMECONVERSION = False
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # This is an interface to call
 #    timeconversion.compute_bary_helio_time(targetcoord, times)

--- a/jwst/linearity/linearity.py
+++ b/jwst/linearity/linearity.py
@@ -6,7 +6,6 @@ import numpy as np
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, lin_model):

--- a/jwst/linearity/linearity_func.py
+++ b/jwst/linearity/linearity_func.py
@@ -2,7 +2,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def apply_linearity_func(ramparr, dqarr, coeffarr, dq_flag):

--- a/jwst/master_background/create_master_bkg.py
+++ b/jwst/master_background/create_master_bkg.py
@@ -5,7 +5,6 @@ import numpy as np
 from .. import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def create_background(wavelength, surf_bright):

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -9,7 +9,6 @@ from .. datamodels import dqflags
 from ..lib.wcs_utils import get_wavelengths
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
 

--- a/jwst/master_background/nirspec_utils.py
+++ b/jwst/master_background/nirspec_utils.py
@@ -3,7 +3,6 @@ import logging
 from jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def apply_master_background(source_model, bkg_model, inverse=False):

--- a/jwst/mrs_imatch/__init__.py
+++ b/jwst/mrs_imatch/__init__.py
@@ -12,4 +12,3 @@ __author__ = 'Mihai Cara'
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)

--- a/jwst/msaflagopen/msaflag_open.py
+++ b/jwst/msaflagopen/msaflag_open.py
@@ -11,7 +11,6 @@ from ..transforms.models import Slit
 from gwcs.wcs import WCS
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 FAILEDOPENFLAG = datamodels.dqflags.pixel['MSA_FAILED_OPEN']

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -15,7 +15,6 @@ from jwst.resample.resample_utils import build_driz_weight, calc_gwcs_pixmap
 from jwst.stpipe import Step
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 DO_NOT_USE = datamodels.dqflags.pixel['DO_NOT_USE']
 OUTLIER = datamodels.dqflags.pixel['OUTLIER']

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -12,7 +12,6 @@ from .. import datamodels
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["OutlierDetectionIFU"]
 

--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -13,7 +13,6 @@ from .outlier_detection import OutlierDetection
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class OutlierDetectionScaled(OutlierDetection):

--- a/jwst/outlier_detection/outlier_detection_spec.py
+++ b/jwst/outlier_detection/outlier_detection_spec.py
@@ -7,7 +7,6 @@ from .outlier_detection import OutlierDetection
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["OutlierDetectionSpec"]

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -10,7 +10,6 @@ from jwst.assign_wcs import nirspec, util
 import jwst.datamodels as datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 # There are 30 slices in the NIRSpec IFU, numbered from 0 to 29

--- a/jwst/persistence/persistence.py
+++ b/jwst/persistence/persistence.py
@@ -8,7 +8,6 @@ from .. import datamodels
 from .. datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 SCALEFACTOR = 2.
 """This factor is to account for the difference in gain for charges freed

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -10,7 +10,6 @@ from .. datamodels import dqflags
 from .. lib.wcs_utils import get_wavelengths
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 PHOT_TOL = 0.001  # relative tolerance between PIXAR_* keys
 

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -12,9 +12,6 @@ from ..model_blender import blendmeta
 
 __all__ = ['Ami3Pipeline']
 
-# Define logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class Ami3Pipeline(Pipeline):
@@ -40,7 +37,7 @@ class Ami3Pipeline(Pipeline):
 
     def process(self, input):
 
-        log.info('Starting calwebb_ami3')
+        self.log.info('Starting calwebb_ami3')
 
         # Load the input association table
         asn = self.load_as_level3_asn(input)
@@ -65,21 +62,21 @@ class Ami3Pipeline(Pipeline):
 
         # Make sure we found some science target members
         if len(targ_files) == 0:
-            log.error('No science target members found in association table')
-            log.error('Calwebb_ami3 processing will be aborted')
+            self.log.error('No science target members found in association table')
+            self.log.error('Calwebb_ami3 processing will be aborted')
             return
 
         # If there aren't any PSF images, we can't do the normalize step
         if len(psf_files) == 0:
-            log.info('No PSF reference members found in association table')
-            log.info('ami_normalize step will be skipped')
+            self.log.info('No PSF reference members found in association table')
+            self.log.info('ami_normalize step will be skipped')
 
         # Run ami_analyze on all the target members
         targ_lg = []
         for input_file in targ_files:
 
             # Do the LG analysis for this image
-            log.debug('Do LG processing for member %s', input_file)
+            self.log.debug('Do LG processing for member %s', input_file)
             result = self.ami_analyze(input_file)
 
             # Save the LG analysis results to a file
@@ -96,7 +93,7 @@ class Ami3Pipeline(Pipeline):
         for input_file in psf_files:
 
             # Do the LG analysis for this image
-            log.debug('Do LG processing for member %s', input_file)
+            self.log.debug('Do LG processing for member %s', input_file)
             result = self.ami_analyze(input_file)
 
             # Save the LG analysis results to a file
@@ -166,6 +163,6 @@ class Ami3Pipeline(Pipeline):
             del targ_avg
 
         # We're done
-        log.info('... ending calwebb_ami3')
+        self.log.info('... ending calwebb_ami3')
 
         return

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import logging
 import os.path as op
 
 from ..stpipe import Pipeline
@@ -11,7 +10,6 @@ from ..ami import ami_normalize_step
 from ..model_blender import blendmeta
 
 __all__ = ['Ami3Pipeline']
-
 
 
 class Ami3Pipeline(Pipeline):

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -18,9 +18,6 @@ from ..linearity import linearity_step
 
 __all__ = ['DarkPipeline']
 
-# Define logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class DarkPipeline(Pipeline):
@@ -51,7 +48,7 @@ class DarkPipeline(Pipeline):
     # start the actual processing
     def process(self, input):
 
-        log.info('Starting calwebb_dark ...')
+        self.log.info('Starting calwebb_dark ...')
 
         # open the input
         input = datamodels.RampModel(input)
@@ -60,7 +57,7 @@ class DarkPipeline(Pipeline):
 
             # process MIRI exposures;
             # the steps are in a different order than NIR
-            log.debug('Processing a MIRI exposure')
+            self.log.debug('Processing a MIRI exposure')
 
             input = self.group_scale(input)
             input = self.dq_init(input)
@@ -74,7 +71,7 @@ class DarkPipeline(Pipeline):
         else:
 
             # process Near-IR exposures
-            log.debug('Processing a Near-IR exposure')
+            self.log.debug('Processing a Near-IR exposure')
 
             input = self.group_scale(input)
             input = self.dq_init(input)
@@ -84,7 +81,7 @@ class DarkPipeline(Pipeline):
             input = self.refpix(input)
             input = self.linearity(input)
 
-        log.info('... ending calwebb_dark')
+        self.log.info('... ending calwebb_dark')
 
         # reset FILETYPE in the output
         input.meta.filetype = 'calibrated ramp'

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import logging
-
 from ..stpipe import Pipeline
 from .. import datamodels
 
@@ -17,7 +15,6 @@ from ..lastframe import lastframe_step
 from ..linearity import linearity_step
 
 __all__ = ['DarkPipeline']
-
 
 
 class DarkPipeline(Pipeline):

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -23,10 +23,6 @@ from ..gain_scale import gain_scale_step
 
 __all__ = ['Detector1Pipeline']
 
-# Define logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 
 class Detector1Pipeline(Pipeline):
     """
@@ -65,7 +61,7 @@ class Detector1Pipeline(Pipeline):
     # start the actual processing
     def process(self, input):
 
-        log.info('Starting calwebb_detector1 ...')
+        self.log.info('Starting calwebb_detector1 ...')
 
         # open the input as a RampModel
         input = datamodels.RampModel(input)
@@ -78,7 +74,7 @@ class Detector1Pipeline(Pipeline):
 
             # process MIRI exposures;
             # the steps are in a different order than NIR
-            log.debug('Processing a MIRI exposure')
+            self.log.debug('Processing a MIRI exposure')
 
             result = self.group_scale(input)
             result = self.dq_init(result)
@@ -98,7 +94,7 @@ class Detector1Pipeline(Pipeline):
         else:
 
             # process Near-IR exposures
-            log.debug('Processing a Near-IR exposure')
+            self.log.debug('Processing a Near-IR exposure')
 
             result = self.group_scale(input)
             result = self.dq_init(result)
@@ -149,7 +145,7 @@ class Detector1Pipeline(Pipeline):
         self.setup_output(result)
         result.meta.filetype = 'countrate'
 
-        log.info('... ending calwebb_detector1')
+        self.log.info('... ending calwebb_detector1')
 
         return result
 

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import logging
 from ..stpipe import Pipeline
 from .. import datamodels
 

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -10,10 +10,6 @@ from ..guider_cds import guider_cds_step
 
 __all__ = ['GuiderPipeline']
 
-# Define logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 
 class GuiderPipeline(Pipeline):
     """
@@ -36,14 +32,14 @@ class GuiderPipeline(Pipeline):
         # Set the output product type
         self.suffix = 'cal'
 
-        log.info('Starting calwebb_guider ...')
+        self.log.info('Starting calwebb_guider ...')
 
         # Open the input:
         # If the first two steps are set to be skipped, assume
         # they've been run before and open the input as a Cal
         # model, appropriate for input to flat_field
         if (self.dq_init.skip and self.guider_cds.skip):
-            log.info("dq_init and guider_cds are set to skip; assume they"
+            self.log.info("dq_init and guider_cds are set to skip; assume they"
                      " were run before and load data as GuiderCalModel")
             input = datamodels.GuiderCalModel(input)
         else:
@@ -56,6 +52,6 @@ class GuiderPipeline(Pipeline):
 
         input.meta.filetype = 'countrate'
 
-        log.info('... ending calwebb_guider')
+        self.log.info('... ending calwebb_guider')
 
         return input

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from ..stpipe import Pipeline
-import logging
 from .. import datamodels
 
 # step imports
@@ -40,7 +39,7 @@ class GuiderPipeline(Pipeline):
         # model, appropriate for input to flat_field
         if (self.dq_init.skip and self.guider_cds.skip):
             self.log.info("dq_init and guider_cds are set to skip; assume they"
-                     " were run before and load data as GuiderCalModel")
+                          " were run before and load data as GuiderCalModel")
             input = datamodels.GuiderCalModel(input)
         else:
             input = datamodels.GuiderRawModel(input)

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -14,7 +14,6 @@ from ..lib import pipe_utils
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["RampFitStep"]

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -4,7 +4,6 @@ import numpy as np
 from scipy.ndimage.filters import convolve1d
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def correct_model(input_model, irs2_model,

--- a/jwst/refpix/reference_pixels.py
+++ b/jwst/refpix/reference_pixels.py
@@ -48,7 +48,6 @@ from ..datamodels import dqflags
 from ..lib import reffile_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 #
 # NIR Reference section dictionaries are zero indexed and specify the values

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -6,7 +6,6 @@ from . import resample_utils
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class GWCSDrizzle:

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -12,7 +12,7 @@ from ..lib.basic_utils import bytes2human
 from ..model_blender import blendmeta
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
+
 
 __all__ = ["OutputTooLargeError", "ResampleData"]
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -17,7 +17,6 @@ from .resample import ResampleData
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class ResampleSpecData(ResampleData):

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -11,7 +11,6 @@ from .. import datamodels
 from ..assign_wcs import util
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["ResampleStep"]
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -14,7 +14,6 @@ from jwst.datamodels.dqflags import pixel
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def make_output_wcs(input_models, pscale_ratio=1.0):

--- a/jwst/reset/reset_sub.py
+++ b/jwst/reset/reset_sub.py
@@ -5,7 +5,6 @@ import numpy as np
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, reset_model):

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -15,7 +15,6 @@ from . import utils
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class ResidualFringeCorrection():

--- a/jwst/residual_fringe/utils.py
+++ b/jwst/residual_fringe/utils.py
@@ -14,7 +14,6 @@ from numpy.linalg.linalg import LinAlgError
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 #
 
 # hard coded parameters, have been selected based on testing but can be changed

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -7,7 +7,6 @@ import logging
 from ..datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, rscd_model, type):

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -11,7 +11,6 @@ from . import x_irs2
 from stcal.saturation.saturation import flag_saturated_pixels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 DONOTUSE = dqflags.pixel['DO_NOT_USE']
 SATURATED = dqflags.pixel['SATURATED']

--- a/jwst/skymatch/__init__.py
+++ b/jwst/skymatch/__init__.py
@@ -10,6 +10,5 @@ __author__ = 'Mihai Cara'
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["SkyMatchStep"]

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -22,7 +22,6 @@ __author__ = 'Mihai Cara'
 __local_debug__ = True
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def match(images, skymethod='global+match', match_down=True, subtract=False):

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -55,7 +55,6 @@ class SkyMatchStep(Step):
     reference_file_types = []
 
     def process(self, input):
-        self.log.setLevel(logging.DEBUG)
         img = datamodels.ModelContainer(input)
 
         self._dqbits = interpret_bit_flags(self.dqbits)

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -9,7 +9,6 @@ JWST pipeline step for sky matching.
 
 import collections
 import numpy as np
-import logging
 
 from ..stpipe import Step
 from .. import datamodels

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -33,7 +33,6 @@ from ..datamodels import ImageModel, ABVegaOffsetModel
 from ._wcs_helpers import pixel_scale_angle_at_skycoord
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class ReferenceData:

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -4,7 +4,6 @@ from ..lib import pipe_utils
 from .. import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def set_source_type(input_model):

--- a/jwst/straylight/straylight.py
+++ b/jwst/straylight/straylight.py
@@ -15,7 +15,6 @@ from ..datamodels import dqflags
 from astropy.convolution import convolve, Box2DKernel
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def correct_mrs(input_model, slice_map):

--- a/jwst/superbias/bias_sub.py
+++ b/jwst/superbias/bias_sub.py
@@ -7,7 +7,6 @@ import logging
 from ..lib import reffile_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, bias_model):

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -11,7 +11,6 @@ from photutils.aperture import CircularAperture, CircularAnnulus
 from ..datamodels import CubeModel
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,

--- a/jwst/wavecorr/wavecorr.py
+++ b/jwst/wavecorr/wavecorr.py
@@ -10,7 +10,6 @@ from .. import datamodels
 from ..transforms import models as trmodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, wavecorr_file):

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -9,7 +9,6 @@ from ..datamodels import dqflags
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
 

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -10,7 +10,6 @@ from .disperse import dispersed_pixel
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class Observation:

--- a/jwst/wfss_contam/sens1d.py
+++ b/jwst/wfss_contam/sens1d.py
@@ -4,7 +4,6 @@ from jwst.photom.photom import find_row
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def get_photom_data(phot_model, filter, pupil, order):

--- a/jwst/wfss_contam/wfss_contam.py
+++ b/jwst/wfss_contam/wfss_contam.py
@@ -10,7 +10,6 @@ from .observations import Observation
 from .sens1d import get_photom_data
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def contam_corr(input_model, waverange, photom, max_cores):

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -6,7 +6,6 @@ from astropy.table import QTable
 from astropy.time import Time, TimeDelta
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def white_light(input, min_wave=None, max_wave=None):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #[TBD]
Resolves [JP-TBD](https://jira.stsci.edu/browse/JP-TBD)

**Description**

This PR addresses some hanging questions about logging implementation and utilizes the logging ancestry by defining the package logger in jwst/__init__.py - from here, loggers underneath jwst will inherit the level set there. Additionally, a few of the pipelines were using loggers set in calwebb_{pipeline}.py, when they have a log already defined when created as a sub-class of Pipeline with self.log.

I've tested this with a variety of calls with strun and pipelines/steps, using --verbose and without, and no features appear to have changed, but I could be missing something. I'd appreciate any suggestions on how this might have snuck a broken thing into the logging setup that I could have missed.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
