### PR TITLE
Fix invalid meta assignment in wfs_combine test

### DIFF
--- a/jwst/wfs_combine/tests/test_wfs_combine.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine.py
@@ -37,7 +37,6 @@ def wfs_association(tmp_path_factory):
     imsize = 10
     tmp_path = tmp_path_factory.mktemp("wfs")
     im1 = datamodels.ImageModel((imsize, imsize))
-    im1.meta.observation.exposure_number = 1
     im1.meta.wcsinfo = {
         'dec_ref': 11.99875540218638,
         'ra_ref': 22.02351763251896,

--- a/jwst/wfs_combine/tests/test_wfs_combine_step.py
+++ b/jwst/wfs_combine/tests/test_wfs_combine_step.py
@@ -11,7 +11,6 @@ def wfs_association(tmp_path_factory):
     imsize = 10
     tmp_path = tmp_path_factory.mktemp("wfs")
     im1 = datamodels.ImageModel((imsize, imsize))
-    im1.meta.observation.exposure_number = 1
     im1.meta.wcsinfo = {
         'dec_ref': 11.99875540218638,
         'ra_ref': 22.02351763251896,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

**Description**

This fixes the following warning in our unit tests.

```
jwst/wfs_combine/tests/test_wfs_combine.py::test_create_combined[1-3-0-0-2-0]
  /Users/jdavies/miniconda3/envs/jwst/lib/python3.9/site-packages/stdatamodels/validate.py:38: ValidationWarning: While validating exposure_number the following error occurred:
  1 is not of type 'string'
  
  Failed validating 'type' in schema:
      OrderedDict([('title', 'Exposure request number'),
                   ('type', 'string'),
                   ('fits_keyword', 'EXPOSURE'),
                   ('blend_table', True)])
  
  On instance:
      1
    warnings.warn(errmsg, ValidationWarning)

jwst/wfs_combine/tests/test_wfs_combine.py: 28 warnings
```

The assignment is not needed as it is done properly several lines down, and it is assigning an integer when the schema requires a string.

**Future bonus work for anyone who wants to do it**:  Since the`wfs_association` fixtures in the 2 separate test modules are virtually identical, define them instead in a confest.py in the test directory, or move all the tests into a single module and have only 1 fixture defined in that module.  _Delete some boilerplate test code!_ 🚀 

Checklist
- [x] Tests
