### PR TITLE
JP-2307: Edit README to avoid issues with default conda env and py3.10

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,12 +88,6 @@ datamodels
 
  - Changed reference file model name from ResidualFringeModel to FringeFreq [#6385]
 
-documentation
--------------
-
-- Temporary edits to README directing conda env creation with python==3.9
-  until conflict between dependencies and python==3.10.0 is solved [#6411]
-
 extract_1d
 ----------
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ including tagged releases, DMS builds used in operations, and development versio
 Remember that all conda operations must be done from within a bash/zsh shell.
 
 NOTE: currently, conda environments default to `python 3.10.0`, which is not 
-yet supported by all package dependencies of `jwst`. Until this changes, `python==3.9`
+yet supported by all package dependencies of `jwst`. Until this changes, `python=3.9`
 should be specified during environment creation to ensure a successful installation.
 
 
@@ -48,19 +48,19 @@ should be specified during environment creation to ensure a successful installat
 
 You can install the latest released version via `pip`.  From a bash/zsh shell:
 
-    conda create -n <env_name> python==3.9
+    conda create -n <env_name> python=3.9
     conda activate <env_name>
     pip install jwst
 
 You can also install a specific version (from `jwst 0.17.0` onward):
 
-    conda create -n <env_name> python==3.9
+    conda create -n <env_name> python=3.9
     conda activate <env_name>
     pip install jwst==1.3.3
 
 Installing specific versions before `jwst 0.17.0` need to be installed from Github:
 
-    conda create -n <env_name> python==3.9
+    conda create -n <env_name> python=3.9
     conda activate <env_name>
     pip install git+https://github.com/spacetelescope/jwst@0.16.2
 
@@ -70,7 +70,7 @@ Installing specific versions before `jwst 0.17.0` need to be installed from Gith
 You can install the latest development version (not as well tested) from the
 Github master branch:
 
-    conda create -n <env_name> python==3.9
+    conda create -n <env_name> python=3.9
     conda activate <env_name>
     pip install git+https://github.com/spacetelescope/jwst
  
@@ -122,7 +122,7 @@ already installed with released versions of the `jwst` package.
 
 As usual, the first two steps are to create and activate an environment:
 
-    conda create -n <env_name> python==3.9
+    conda create -n <env_name> python=3.9
     conda activate <env_name>
 
 To install your own copy of the code into that environment, you first need to


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6409
Resolves [JP-2307](https://jira.stsci.edu/browse/JP-2307)

**Description**

This PR advises the creation of conda environments with python set to 3.9, to avoid build conflicts with the default python==3.10.0. This can be reverted once conflicts no longer exist.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
