### PR TITLE
JP-579: Include logcfg keyword in docs where appropriate

### DIFF
--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -345,11 +345,21 @@ Logging Configuration
 =====================
 
 The name of a file in which to save log information, as well as the desired
-level of logging messages, can be specified in an optional configuration file
-"stpipe-log.cfg". This file must be in the same directory in which you run the
-pipeline in order for it to be used. If this file does not exist, the default
-logging mechanism is STDOUT, with a level of INFO. An example of the contents
-of the stpipe-log.cfg file is:
+level of logging messages, can be specified in an optional configuration file.
+Two options exist - if the configuration file should be used for all instances
+of the pipeline, the configuration file should be named "stpipe-log.cfg".
+This file must be in the same directory in which you run the pipeline in order
+for it to be used.
+
+If instead the configuration should be active only when specified,
+you should name it something other than "stpipe-log.cfg"; this filename should be
+specified using either the ``--logcfg`` parameter to the command line ``strun`` or
+using the ``logcfg`` keyword to a .call() execution of either a Step or Pipeline
+instance.
+
+If this file does not exist, the default logging mechanism is STDOUT,
+with a level of INFO. An example of the contents of the stpipe-log.cfg file is:
+
 ::
 
     [*]
@@ -358,15 +368,19 @@ of the stpipe-log.cfg file is:
 
 If there's no ``stpipe-log.cfg`` file in the working directory, which specifies
 how to handle process log information, the default is to display log messages
-to stdout. If you want log information saved to a file, you can specify the
-name of a logging configuration file either on the command line or in the
-pipeline cfg file.
+to stdout.
 
 For example:
 ::
 
     $ strun calwebb_detector1 jw00017001001_01101_00001_nrca1_uncal.fits
         --logcfg=pipeline-log.cfg
+
+Or in an interactive python environment:
+::
+
+    result = Detector1Pipeline.call("jw00017001001_01101_00001_nrca1_uncal.fits",
+                                    logcfg="pipeline-log.cfg")
 
 and the file ``pipeline-log.cfg`` contains:
 ::

--- a/docs/jwst/stpipe/call_via_call.rst
+++ b/docs/jwst/stpipe/call_via_call.rst
@@ -39,6 +39,20 @@ When running a single step with ``call``, parameter values can be supplied more 
 
  result = JumpStep.call("jw00017001001_01101_00001_nrca1_uncal.fits", rejection_threshold=200)
 
+Running steps and pipelines with ``call`` also allows for the specification of a logging
+configuration file using the keyword ``logcfg``:
+
+::
+
+ result = Detector1Pipeline.call("jw00017001001_01101_00001_nrca1_uncal.fits",
+                                 config_file="calwebb_detector1.asdf",
+                                 logcfg="my-logging-config.cfg")
+
+Note that naming the logging configuration file "stpipe-log.cfg" will configure logging
+without assignment of the ``logcfg`` keyword, as ``stpipe`` searches for this filename
+in the local directory during execution. If the configuration should be used only when
+specified, ensure your file is named something other than "stpipe-log.cfg"!
+
 Where are the results?
 ----------------------
 

--- a/docs/jwst/stpipe/user_logging.rst
+++ b/docs/jwst/stpipe/user_logging.rst
@@ -30,6 +30,9 @@ ignored:
     - The file specified with the ``--logcfg`` option to the
       ``strun`` script.
 
+    - The file specified with the ``logcfg`` keyword to a
+      .call() execution of a Step or Pipeline.
+
     - A file called ``stpipe-log.cfg`` in the current working
       directory.
 

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -220,7 +220,8 @@ signature is::
 
 The positional argument ``input`` is the data to be operated on, usually a
 string representing a file path or a :ref:`DataModel<datamodels>`. The optional
-keyword argument ``config_file`` is used to specify a local parameter file.
+keyword argument ``config_file`` is used to specify a local parameter file. The
+optional keyword argument ``logcfg`` is used to specify a logging configuration file.
 Finally, the remaining optional keyword arguments are the parameters that the
 particular step accepts. The method returns the result of the step. A basic
 example is::


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #3217 
Resolves [JP-579](https://jira.stsci.edu/browse/JP-579)

**Description**

This PR adds documentation for the stpipe change that adds the keyword `logcfg` to Step and Pipeline .call().

NOTE: This shouldn't be merged until stpipe pushes a new release including [stpipe PR #32](https://github.com/spacetelescope/stpipe/pull/32) (if I understand how updates to stpipe trickle down to user installs?)

Checklist
- [ ] Tests
- [x] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
