### PR TITLE
AL-595: Add documentation for ramp fitting computation of VAR_POISSON

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,7 +147,8 @@ pipeline
 ramp_fitting
 ------------
 
-- Pixels with negative median rates will have VAR_POISSON set to zero. [STCAL #59]
+- Pixels with negative median rates will have VAR_POISSON set to zero.
+[spacetelecope/stcal#59]
 
 - Update ``RampFitStep`` to pass DQ flags as a parameter to the ``ramp_fit``
   algorithm code in stcal.  Bump version requirement for stcal.  [#6072]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -148,7 +148,7 @@ ramp_fitting
 ------------
 
 - Pixels with negative median rates will have VAR_POISSON set to zero.
-[spacetelecope/stcal#59]
+  [spacetelecope/stcal#59]
 
 - Update ``RampFitStep`` to pass DQ flags as a parameter to the ``ramp_fit``
   algorithm code in stcal.  Bump version requirement for stcal.  [#6072]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,8 @@ pipeline
 ramp_fitting
 ------------
 
+- Pixels with negative median rates will have VAR_POISSON set to zero. [STCAL #59]
+
 - Update ``RampFitStep`` to pass DQ flags as a parameter to the ``ramp_fit``
   algorithm code in stcal.  Bump version requirement for stcal.  [#6072]
 

--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -84,12 +84,11 @@ written as the primary output product.  In this output product, the
 4-D GROUPDQ from all integrations is collapsed into 2-D, merged
 (using a bitwise OR) with the input 2-D PIXELDQ, and stored as a 2-D DQ array. 
 The 3-D VAR_POISSON and VAR_RNOISE arrays from all integrations are averaged
-into corresponding 2-D output arrays.  
-
-There is an edge case that affects the VAR_POISSON computation.  The median rates
-that are used in the numerator for the computation of VAR_POISSON can be negative.
-This case results in negative values for VAR_POISSON, which are nonsense.  In this
-case, the VAR_POISSON is set to zero in all output products.
+into corresponding 2-D output arrays.  There is a case where the median rate
+for a pixel can be computed as negative.  This value is used in the numerator
+when computing the VAR_POISSON.  If the median rate is negative, the VAR_POISSON
+is computed as negative, which is nonsnse.  In this case, the VAR_POISSON is
+set to zero for all output products.
 
 The slope images for each integration are stored as a data cube in a second output data
 product (rateints).  Each plane of the 3-D SCI, ERR, DQ, VAR_POISSON, and VAR_RNOISE

--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -84,11 +84,12 @@ written as the primary output product.  In this output product, the
 4-D GROUPDQ from all integrations is collapsed into 2-D, merged
 (using a bitwise OR) with the input 2-D PIXELDQ, and stored as a 2-D DQ array. 
 The 3-D VAR_POISSON and VAR_RNOISE arrays from all integrations are averaged
-into corresponding 2-D output arrays.  There is an edge case where the median
-rates that is used in the numerator for the computation of VAR_POISSON can be
-negative, which results in a negative values for VAR_POISSON, which are
-nonsense.  In this case, the VAR_POISSON in all products are zero for any pixel
-with a negative median rate.
+into corresponding 2-D output arrays.  
+
+There is an edge case that affects the VAR_POISSON computation.  The median rates
+that are used in the numerator for the computation of VAR_POISSON can be negative.
+This case results in negative values for VAR_POISSON, which are nonsense.  In this
+case, the VAR_POISSON is set to zero in all output products.
 
 The slope images for each integration are stored as a data cube in a second output data
 product (rateints).  Each plane of the 3-D SCI, ERR, DQ, VAR_POISSON, and VAR_RNOISE

--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -84,7 +84,11 @@ written as the primary output product.  In this output product, the
 4-D GROUPDQ from all integrations is collapsed into 2-D, merged
 (using a bitwise OR) with the input 2-D PIXELDQ, and stored as a 2-D DQ array. 
 The 3-D VAR_POISSON and VAR_RNOISE arrays from all integrations are averaged
-into corresponding 2-D output arrays.
+into corresponding 2-D output arrays.  There is an edge case where the median
+rates that is used in the numerator for the computation of VAR_POISSON can be
+negative, which results in a negative values for VAR_POISSON, which are
+nonsense.  In this case, the VAR_POISSON in all products are zero for any pixel
+with a negative median rate.
 
 The slope images for each integration are stored as a data cube in a second output data
 product (rateints).  Each plane of the 3-D SCI, ERR, DQ, VAR_POISSON, and VAR_RNOISE

--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -84,11 +84,9 @@ written as the primary output product.  In this output product, the
 4-D GROUPDQ from all integrations is collapsed into 2-D, merged
 (using a bitwise OR) with the input 2-D PIXELDQ, and stored as a 2-D DQ array. 
 The 3-D VAR_POISSON and VAR_RNOISE arrays from all integrations are averaged
-into corresponding 2-D output arrays.  There is a case where the median rate
-for a pixel can be computed as negative.  This value is used in the numerator
-when computing the VAR_POISSON.  If the median rate is negative, the VAR_POISSON
-is computed as negative, which is nonsnse.  In this case, the VAR_POISSON is
-set to zero for all output products.
+into corresponding 2-D output arrays.  In cases where the median rate
+for a pixel is negative, the VAR_POISSON is set to zero, in order to avoid the
+unphysical situation of having a negative variance.
 
 The slope images for each integration are stored as a data cube in a second output data
 product (rateints).  Each plane of the 3-D SCI, ERR, DQ, VAR_POISSON, and VAR_RNOISE


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Related to https://github.com/spacetelescope/stcal/pull/59 and [JP-2293](https://jira.stsci.edu/browse/JP-2293)

**Description** Changes in ramp fitting in STCAL now sets VAR_POISSON to zero for pixels with negative median rates. (https://github.com/spacetelescope/stcal/pull/59)

Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)