### PR TITLE
Make output_shape to the resample step to be in nx, ny order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -184,6 +184,8 @@ resample
 - Add support for specifying custom output WCS parameters to the resample
   step. [#6364]
 
+- Make ``output_shape`` to be in the "normal" (``nx, ny``) order. [#6417]
+
 residual_fringe
 ---------------
  - Added documentation on step [#6387]

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -33,17 +33,18 @@ image.
     provided.
 
 ``--shape`` (tuple of int, default=None)
-    Shape of the image (data array) using ``numpy.ndarray`` convention
-    (``ny`` first and ``nx`` second). This value will be assigned to
+    Shape of the image (data array) using "standard" ``nx`` first and ``ny``
+    second (as opposite to the ``numpy.ndarray`` convention - ``ny`` first and
+    ``nx`` second). This value will be assigned to
     ``pixel_shape`` and ``array_shape`` properties of the returned
     WCS object. When supplied from command line, it should be a comma-separated
-    list of integers.
+    list of integers ``nx, ny``.
 
 ``--crpix`` (tuple of float, default=None)
-    Position of the reference pixel in the image array.  If ``crpix`` is not
-    specified, it will be set to the center of the bounding box of the
-    returned WCS object. When supplied from command line, it should be a
-    comma-separated list of floats.
+    Position of the reference pixel in the image array in the ``x, y`` order.
+    If ``crpix`` is not specified, it will be set to the center of the bounding
+    box of the returned WCS object. When supplied from command line, it should
+    be a comma-separated list of floats.
 
 ``--crval`` (tuple of float, default=None)
     Right ascension and declination of the reference pixel. Automatically

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -51,7 +51,10 @@ class ResampleData:
             filename for output
 
         kwargs : dict
-            Other parameters
+            Other parameters.
+
+            .. note::
+                ``output_shape`` is in the ``x, y`` order.
         """
         self.input_models = input_models
 
@@ -81,7 +84,7 @@ class ResampleData:
             pscale_ratio=self.pscale_ratio,
             pscale=pscale,
             rotation=rotation,
-            shape=out_shape,
+            shape=out_shape if out_shape is None else out_shape[::-1],
             crpix=crpix,
             crval=crval
         )

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -35,7 +35,7 @@ class ResampleStep(Step):
         kernel = string(default='square')
         fillval = string(default='INDEF')
         weight_type = option('ivm', 'exptime', default='ivm')
-        output_shape = int_list(min=2, max=2, default=None)  # [y, x] - numpy convention
+        output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)
         rotation = float(default=None)

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -442,7 +442,7 @@ def test_resample_undefined_variance(nircam_rate, shape):
 @pytest.mark.parametrize('rotation', [0, 15, 135])
 @pytest.mark.parametrize('crpix', [(256, 488), (700, 124)])
 @pytest.mark.parametrize('crval', [(50, 77), (250, -30)])
-@pytest.mark.parametrize('shape', [(1100, 1205)])
+@pytest.mark.parametrize('shape', [(1205, 1100)])
 def test_custom_wcs_resample_imaging(nircam_rate, ratio, rotation, crpix, crval, shape):
     im = AssignWcsStep.call(nircam_rate, sip_approx=False)
     im.data += 5
@@ -472,7 +472,7 @@ def test_custom_wcs_resample_imaging(nircam_rate, ratio, rotation, crpix, crval,
     assert np.allclose(t(*crpix), crval)
 
     # test output image shape
-    assert result.data.shape == shape
+    assert result.data.shape == shape[::-1]
 
 
 @pytest.mark.parametrize('ratio', [1.3, 1])


### PR DESCRIPTION
Make ``output_shape`` order to be in the "normal" (``nx, ny``) order as opposite to the ``numpy`` convention for arrays.