### PR TITLE
Fix crashes in skymatch when some footprints almost entirely overlap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -190,6 +190,12 @@ residual_fringe
 ---------------
  - Added documentation on step [#6387]
 
+skymatch
+--------
+
+- Improved reliability when matching sky in images with very close sky
+  footprints. [#6421]
+
 source_catalog
 --------------
 

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -228,9 +228,17 @@ class SkyImage:
 
         """
         if isinstance(skyimage, (SkyImage, SkyGroup)):
-            return self._polygon.intersection(skyimage.polygon)
+            other = skyimage.polygon
         else:
-            return self._polygon.intersection(skyimage)
+            other = skyimage
+
+        pts1 = np.sort(list(self._polygon.points)[0], axis=0)
+        pts2 = np.sort(list(other.points)[0], axis=0)
+        if np.allclose(pts1, pts2, rtol=0, atol=5e-9):
+            intersect_poly = self._polygon.copy()
+        else:
+            intersect_poly = self._polygon.intersection(other)
+        return intersect_poly
 
     def calc_bounding_polygon(self, stepsize=None):
         """ Compute image's bounding polygon.


### PR DESCRIPTION
This PR extends the fix from https://github.com/spacetelescope/jwst/pull/3557 to the `SkyImage` class in order to mitigate issues reported by @jemorrison in https://jira.stsci.edu/browse/JP-1670