### PR TITLE
JP-2243: Implement MIRI LRS pathloss correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,10 +90,13 @@ datamodels
   and regions files.  Fix an incorrect comment on
   FilteroffsetModel. [#6362]
 
- - Changed reference file model name from ResidualFringeModel to FringeFreq [#6385]
+- Changed reference file model name from ``ResidualFringeModel`` to
+  ``FringeFreq`` [#6385]
 
- - Updated data products documentation to indicate that variance and error arrays
-   are now included in resampled products. [#6420]
+- Updated data products documentation to indicate that variance and error arrays
+  are now included in resampled products. [#6420]
+
+- Added the ``MirLrsPathlossModel` for use in the ``pathloss` step. [#6435]
 
 extract_1d
 ----------
@@ -139,6 +142,12 @@ outlier_detection
 
 - Log number of flagged outliers in ``outlier_detection`` [#6260]
 
+pathloss
+--------
+
+- Updated the ``pathloss`` step and documentation to include processing of
+  MIRI LRS fixed-slit exposures. [#6435]
+
 persistence
 -----------
 
@@ -151,6 +160,9 @@ pipeline
 
 - Changed logger from root to `__name__` for Ami3, Detector1, Dark, and Guider
   Pipelines [#6389]
+
+- Updated the ``calwebb_spec2`` pipeline to apply the ``pathloss`` step to
+  MIRI LRS fixed-slit exposures. [#6435]
 
 ramp_fitting
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,7 +96,7 @@ datamodels
 - Updated data products documentation to indicate that variance and error arrays
   are now included in resampled products. [#6420]
 
-- Added the ``MirLrsPathlossModel` for use in the ``pathloss` step. [#6435]
+- Added the ``MirLrsPathlossModel`` for use in the ``pathloss` step. [#6435]
 
 extract_1d
 ----------

--- a/docs/jwst/barshadow/arguments.rst
+++ b/docs/jwst/barshadow/arguments.rst
@@ -1,5 +1,12 @@
 Step Arguments
 ==============
+The ``barshadow`` step has the following optional arguments.
 
-The barshadow step has no step-specific arguments.
+``--inverse`` (boolean, default=False)
+  A flag to indicate whether the math operations used to apply the
+  correction should be inverted (i.e. multiply the correction into
+  the science data, instead of the usual division).
 
+``--source_type`` (string, default=None)
+  Force the processing to use the given source type (POINT, EXTENDED),
+  instead of using the information contained in the input data.

--- a/docs/jwst/flatfield/arguments.rst
+++ b/docs/jwst/flatfield/arguments.rst
@@ -1,10 +1,18 @@
 Step Arguments
 ==============
 
-The ``flat_field`` step has one step-specific argument, and it is only
-relevant for NIRSpec data.
+The ``flat_field`` step has the followig optional arguments to control
+the behavior of the processing.
 
-``--save_interpolated_flat``
-  is a boolean that indicates whether to save to a file the NIRSpec
+``--save_interpolated_flat`` (boolean, default=False)
+  A flag to indicate whether to save to a file the NIRSpec
   flat field that was constructed on-the-fly by the step.
-  The default is False (do not save).
+  Only relevant for NIRSpec data.
+
+``--user_supplied_flat`` (string, default=None)
+  The name of a user-supplied flat-field reference file.
+
+``--inverse`` (boolean, default=False)
+  A flag to indicate whether the math operations used to apply the
+  flat-field should be inverted (i.e. multiply the flat-field into
+  the science data, instead of the usual division).

--- a/docs/jwst/pathloss/arguments.rst
+++ b/docs/jwst/pathloss/arguments.rst
@@ -1,3 +1,14 @@
 Step Arguments
 ==============
-The ``pathloss`` correction has no step-specific arguments.
+The ``pathloss`` step has the followig optional arguments to control
+the behavior of the processing.
+
+``--inverse`` (boolean, default=False)
+  A flag to indicate whether the math operations used to apply the
+  flat-field should be inverted (i.e. multiply the pathloss into
+  the science data, instead of the usual division).
+
+``--source_type`` (string, default=None)
+  Force the processing to use the given source type (POINT, EXTENDED),
+  instead of using the information contained in the input data. Only
+  applicable to NIRSpec data.

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -5,18 +5,19 @@ Overview
 --------
 The ``pathloss`` step calculates and applies corrections that are
 needed to account for various types of signal loss in spectroscopic data.
-The motivation behind the correction
-is different for NIRSpec and NIRISS, while that for MIRI has not been
-implemented yet.  For NIRSpec, this correction accounts for losses
-in the optical system due to light being scattered outside the grating, and
-to light not passing through the aperture, while for NIRISS SOSS data it
-corrects for the flux that falls outside the subarray.
+The motivation behind the correction is different for the MIRI, NIRSpec,
+and NIRISS observing modes.
+For MIRI LRS fixed slit, this correction simply accounts for light not
+passing through the aperture.
+For NIRSpec, this correction accounts aperture losses as well as losses
+in the optical system due to light being scattered outside the grating.
+For NIRISS SOSS data it corrects for the light that falls outside the
+detector subarray in use.
 
 Background
 ----------
-The correction is applicable to NIRSpec IFU, MSA, and FIXEDSLIT exposure types,
-to NIRISS SOSS data, and to MIRI LRS and MRS data, although the MIRI
-correction has not been implemented yet.
+The correction is applicable to MIRI LRS fixed-slit, NIRSpec IFU, MSA,
+and FIXEDSLIT, and NIRISS SOSS data.
 The description of how the NIRSpec reference files were created and how they are to be
 applied to NIRSpec data is given in ESA-JWST-SCI-NRS-TN-2016-004 (P. Ferruit:
 The correction of path losses for uniform and point sources).  The NIRISS algorithm
@@ -45,8 +46,24 @@ The form of the 2-D correction (point or uniform) that's appropriate for the
 data is divided into the SCI and ERR arrays and propagated into the variance
 arrays of the science data.
 
-NIRISS
-++++++
+MIRI LRS
+++++++++
+The algorithm for MIRI LRS mode is largely the same as that for NIRSpec described
+above, with the exception of the format in which the reference data are stored.
+First, the position of the target on the detector is estimated from the target RA/Dec
+given in the exposure header (TARG_RA, TARG_DEC keywords). This position is then
+used to interpolate within the pathloss reference data to compute a 1-D pathloss
+correction array. The 1-D pathloss correction is then interpolated into the 2-D
+space of the data being corrected based on the wavelengths of each pixel in the
+science data. The 2-D correction array is then applied to the science data and
+stored (as a record of what was applied) in the output datamodel ("PATHLOSS_PS"
+extension).
+
+The MIRI LRS correction is only applicable to point source data. The step is
+skipped if the SRCTYPE of the input data does not indicate a point source.
+
+NIRISS SOSS
++++++++++++
 The correction depends on column number in the science data and on the Pupil Wheel
 position (keyword PWCPOS).  It is provided in the reference file as a FITS image of
 3 dimensions (to be compatible with the NIRSpec reference file format).  The first
@@ -64,6 +81,9 @@ as a record of what was applied.
 
 Error Propagation
 -----------------
-As described above, the correction factors are divided into the SCI and ERR
-arrays of the science data, and the square of the correction is divided into the
-variance arrays (VAR_RNOISE, VAR_POISSON, VAR_FLAT) if they exist.
+As described above, the NIRSpec and NIRISS correction factors are divided into the
+SCI and ERR arrays of the science data, and the square of the correction is divided
+into the variance arrays (VAR_RNOISE, VAR_POISSON, VAR_FLAT) if they exist.
+For MIRI LRS, the correction factors are multiplicative, hence they are multiplied
+into the SCI and ERR arrays, and the square of the correction is multiplied into
+the variance arrays.

--- a/docs/jwst/photom/arguments.rst
+++ b/docs/jwst/photom/arguments.rst
@@ -1,3 +1,12 @@
 Arguments
 =========
-The ``photom`` step has no step-specific arguments.
+The ``photom`` step has the following optional arguments.
+
+``--inverse`` (boolean, default=False)
+  A flag to indicate whether the math operations used to apply the
+  correction should be inverted (i.e. divide the calibration data
+  into the science data, instead of the usual multiplication).
+
+``--source_type`` (string, default=None)
+  Force the processing to use the given source type (POINT, EXTENDED),
+  instead of using the information contained in the input data.

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -64,7 +64,7 @@ abbreviations used in the table are as follows:
 +---------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
 | :ref:`fringe <fringe_step>`                       |     |     |     |     |     | |c| |      |      |        |     |
 +---------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
-| :ref:`pathloss <pathloss_step>`                   | |c| | |c| | |c| |     |     |     |  |c| |      |        |     |
+| :ref:`pathloss <pathloss_step>`                   | |c| | |c| | |c| | |c| |     |     |  |c| |      |        |     |
 +---------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
 | :ref:`barshadow <barshadow_step>`                 |     | |c| |     |     |     |     |      |      |        |     |
 +---------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
@@ -86,7 +86,7 @@ flat_field followed by extract_2d (no wavecorr or srctype).
 For all other modes the order is extract_2d, srctype, wavecorr, and flat_field.
 
 Notice that NIRSpec MOS is the only mode to receive master background subtraction
-in the `calwebb_spec2` pipeline. All other spectral modes have master background
+in the ``calwebb_spec2`` pipeline. All other spectral modes have master background
 subtraction applied in the :ref:`calwebb_spec3 <calwebb_spec3>` pipeline.
 
 The :ref:`resample_spec <resample_step>` step produces a resampled/rectified product for

--- a/docs/jwst/references_general/pathloss_reffile.inc
+++ b/docs/jwst/references_general/pathloss_reffile.inc
@@ -147,11 +147,13 @@ arrays.  The other 2 dimensions refer to the number of columns in the correction
 values for the Pupil Wheel position (PWCPOS).
 
 WCS Header Keywords
-~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++
 The headers of the pathloss extensions in all of the above reference
-files should contain the WCS information that describes what variables the
+files should contain WCS information that describes what variables the
 correction depends on and how they relate to the dimensions of the correction array.
 
+NIRSpec
+~~~~~~~
 For the NIRSpec reference files (IFU, Fixed Slit, and MSASPEC), the WCS keywords
 should have the values shown in the tables below.
 Dimension 1 expresses the decenter along the dispersion direction for a point source:
@@ -184,6 +186,8 @@ CDELT3  2.35E-7    Change in coordinate value for unit change in index
 CTYPE3  'METER'    Type of physical coordinate in this dimension
 ======= ========== ==============================================================================
 
+NIRISS SOSS
+~~~~~~~~~~~
 The NIRISS SOSS reference file should also have WCS components, but their
 interpretation is different from those in the NIRSpec reference file.
 Dimension 1 expresses the column number in the science data:
@@ -214,3 +218,30 @@ CRVAL3  1.0               Coordinate value at this reference pixel
 CDELT3  1.0               Change in coordinate value for unit change in index
 CTYPE3  'Dummy'           Type of physical coordinate in this dimension
 ======= ================= ======================================================================
+
+MIRI LRS
+~~~~~~~~
+For the MIRI LRS reference file, the WCS keywords should have the values shown in the tables below.
+Dimension 1 expresses the decenter of a point source in the spatial direction (perpendicular
+to dispersion):
+
+======= ========== ==============================================================================
+Keyword Value      Comment
+======= ========== ==============================================================================
+CRPIX1  1.0        Reference pixel in the spatial direction
+CRVAL1  -25.0      Coordinate value at this reference pixel
+CDELT1  1.0        Change in coordinate value for unit change in index
+CTYPE1  'UNITLESS' Type of physical coordinate in this dimension
+======= ========== ==============================================================================
+
+Dimension 2 expresses the decenter along the dispersion for a point source:
+
+======= ========== ==============================================================================
+CRPIX2  1.0        Reference pixel in dispersion direction
+CRVAL2  -5.0       Coordinate value at this reference pixel
+CDELT2  0.5        Change in coordinate value for unit change in index
+CTYPE2  'UNITLESS' Type of physical coordinate in this dimension
+======= ========== ==============================================================================
+
+Note that WCS keywords related to wavelength are not needed for the MIRI LRS reference file,
+because an array of wavelength values is included in the table of reference data.

--- a/docs/jwst/references_general/pathloss_reffile.inc
+++ b/docs/jwst/references_general/pathloss_reffile.inc
@@ -4,7 +4,7 @@ PATHLOSS Reference File
 -----------------------
 
 :REFTYPE: PATHLOSS
-:Data model: `~jwst.datamodels.PathlossModel`
+:Data model: `~jwst.datamodels.PathlossModel`, `~jwst.datamodels.MirLrsPathlossModel`
 
 The PATHLOSS reference file contains correction factors as functions of
 source position in the aperture and wavelength.
@@ -30,6 +30,34 @@ Reference File Format
 +++++++++++++++++++++
 The PATHLOSS reference files are FITS files with extensions for each
 of the aperture types. The FITS primary HDU does not contain a data array.
+
+MIRI LRS Fixed Slit
+~~~~~~~~~~~~~~~~~~~
+The MIRI LRS Fixed Slit reference file has the following FITS structure:
+
+=== ======== ======== ===== ====================
+HDU EXTNAME  XTENSION NAXIS Dimensions
+=== ======== ======== ===== ====================
+1   PATHLOSS BinTable  2    3 columns x 388 rows
+=== ======== ======== ===== ====================
+
+The PATHLOSS extension contains wavelength, pathloss correction,
+and pathloss uncertainty data. The table has the following format:
+
+============ ========= ======= =============
+Column Name  Data Type Units   Dimensions
+============ ========= ======= =============
+WAVELENGTH   float32   microns 388
+PATHLOSS     float32   N/A     388 x 50 x 20
+PATHLOSS_ERR float32   N/A     388 x 50 x 20
+============ ========= ======= =============
+
+The pathloss data in each table row are stored as a 2-D array, containing
+correction factors as a function of source position (relative to the
+LRS slit reference point) in the spatial and spectral directions,
+respectively. Wavelength dependence runs along the row axis of the table.
+The correction factors are multiplicative and hence get multiplied into
+the science data being corrected.
 
 NIRSpec IFU
 ~~~~~~~~~~~
@@ -120,7 +148,7 @@ values for the Pupil Wheel position (PWCPOS).
 
 WCS Header Keywords
 ~~~~~~~~~~~~~~~~~~~
-The headers of the PS extensions in all of the above reference
+The headers of the pathloss extensions in all of the above reference
 files should contain the WCS information that describes what variables the
 correction depends on and how they relate to the dimensions of the correction array.
 
@@ -186,4 +214,3 @@ CRVAL3  1.0               Coordinate value at this reference pixel
 CDELT3  1.0               Change in coordinate value for unit change in index
 CTYPE3  'Dummy'           Type of physical coordinate in this dimension
 ======= ================= ======================================================================
-

--- a/docs/jwst/references_general/pathloss_selection.inc
+++ b/docs/jwst/references_general/pathloss_selection.inc
@@ -9,6 +9,7 @@ All keywords used for file selection are *required*.
 ========== ======================================
 Instrument Keywords                               
 ========== ======================================
+MIRI       INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS 
 NIRISS     INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS 
 NIRSpec    INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS 
 ========== ======================================

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -43,7 +43,7 @@ from .multislit import MultiSlitModel
 from .multispec import MultiSpecModel
 from .nirspec_flat import NirspecFlatModel, NirspecQuadFlatModel
 from .outlierpars import OutlierParsModel
-from .pathloss import PathlossModel
+from .pathloss import PathlossModel, MirLrsPathlossModel
 from .persat import PersistenceSatModel
 from .photom import FgsImgPhotomModel
 from .photom import MirImgPhotomModel, MirLrsPhotomModel, MirMrsPhotomModel
@@ -119,7 +119,7 @@ __all__ = [
     'NIRCAMGrismModel', 'NIRISSGrismModel',
     'OTEModel',
     'OutlierParsModel',
-    'PathlossModel',
+    'PathlossModel', 'MirLrsPathlossModel',
     'PersistenceSatModel',
     'PixelAreaModel', 'NirspecSlitAreaModel', 'NirspecMosAreaModel', 'NirspecIfuAreaModel',
     'FgsImgPhotomModel',

--- a/jwst/datamodels/pathloss.py
+++ b/jwst/datamodels/pathloss.py
@@ -24,6 +24,7 @@ class PathlossModel(ReferenceFileModel):
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/pathloss.schema"
 
+
 class MirLrsPathlossModel(ReferenceFileModel):
     """
     A data model for MIRI LRS pathloss correction information.

--- a/jwst/datamodels/pathloss.py
+++ b/jwst/datamodels/pathloss.py
@@ -1,7 +1,7 @@
 from .reference import ReferenceFileModel
 
 
-__all__ = ['PathlossModel']
+__all__ = ['PathlossModel', 'MirLrsPathlossModel']
 
 
 class PathlossModel(ReferenceFileModel):
@@ -23,3 +23,12 @@ class PathlossModel(ReferenceFileModel):
          Uniform source pathloss variance
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/pathloss.schema"
+
+class MirLrsPathlossModel(ReferenceFileModel):
+    """
+    A data model for MIRI LRS pathloss correction information.
+
+    Parameters
+    __________
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_pathloss.schema"

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -30,6 +30,12 @@ allOf:
       fits_hdu: ZEROFRAME
       default: 0.0
       datatype: float32
+    wavelength:
+      title: Wavelength array
+      fits_hdu: WAVELENGTH
+      ndim: 2
+      default: 0.0
+      datatype: float32
     area:
       title: Pixel area map array
       fits_hdu: AREA

--- a/jwst/datamodels/schemas/mirlrs_pathloss.schema.yaml
+++ b/jwst/datamodels/schemas/mirlrs_pathloss.schema.yaml
@@ -1,0 +1,120 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mirlrs_pathloss.schema"
+title: MIRI LRS Pathloss correction data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_band.schema
+- $ref: subarray.schema
+- type: object
+  properties:
+    pathloss_table:
+      title: Pathloss correction table
+      fits_hdu: PATHLOSS
+      datatype:
+      - name: wavelength
+        datatype: float32
+        unit: micron
+      - name: pathloss
+        datatype: float32
+        ndim: 2
+      - name: pathloss_err
+        datatype: float32
+        ndim: 2
+    meta:
+      type: object
+      properties:
+        wcsinfo:
+          title: WCS parameters
+          type: object
+          properties:
+            wcsaxes:
+              title: number of World Coordinate System axes
+              type: integer
+              fits_keyword: WCSAXES
+              fits_hdu: PATHLOSS
+            crpix1:
+              title: Axis 1 coordinate of the reference pixel
+              type: number
+              default: 0.0
+              fits_keyword: CRPIX1
+              fits_hdu: PATHLOSS
+            crpix2:
+              title: Axis 2 coordinate of the reference pixel
+              type: number
+              default: 0.0
+              fits_keyword: CRPIX2
+              fits_hdu: PATHLOSS
+            crval1:
+              title: Axis 1 value at the reference pixel
+              type: number
+              fits_keyword: CRVAL1
+              fits_hdu: PATHLOSS
+            crval2:
+              title: Axis 2 value at the reference pixel
+              type: number
+              fits_keyword: CRVAL2
+              fits_hdu: PATHLOSS
+            cdelt1:
+              title: Axis 1 increment per pixel
+              type: number
+              default: 1.0
+              fits_keyword: CDELT1
+              fits_hdu: PATHLOSS
+            cdelt2:
+              title: Axis 2 increment per pixel
+              type: number
+              default: 1.0
+              fits_keyword: CDELT2
+              fits_hdu: PATHLOSS
+            ctype1:
+              title: Axis 1 coordinate type
+              type: string
+              fits_keyword: CTYPE1
+              fits_hdu: PATHLOSS
+            ctype2:
+              title: Axis 2 coordinate type
+              type: string
+              fits_keyword: CTYPE2
+              fits_hdu: PATHLOSS
+            cunit1:
+              title: Axis 1 units
+              type: string
+              fits_keyword: CUNIT1
+              fits_hdu: PATHLOSS
+            cunit2:
+              title: Axis 2 units
+              type: string
+              fits_keyword: CUNIT2
+              fits_hdu: PATHLOSS
+- type: object
+  properties:
+    meta:
+      type: object
+      properties:
+        pathloss_table:
+          type: object
+          properties:
+            tunit1:
+              type: string
+              title: Column 1 units
+              default: micron
+              fits_hdu: PATHLOSS
+              fits_keyword: TUNIT1
+            tunit2:
+              type: string
+              title: Column 2 units
+              default: ''
+              fits_hdu: PATHLOSS
+              fits_keyword: TUNIT2
+            tunit3:
+              type: string
+              title: Column 3 units
+              default: ''
+              fits_hdu: PATHLOSS
+              fits_keyword: TUNIT3

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -563,6 +563,10 @@ def do_correction_lrs(data, pathloss):
     """
     correction = _corrections_for_lrs(data, pathloss)
 
+    if not correction:
+        log.warning("No correction available; skipping step")
+        return
+
     # LRS correction is multiplicative
     data.data *= correction.data
     data.err *= correction.data

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -7,6 +7,7 @@ import numpy as np
 from gwcs import wcstools
 
 from jwst.assign_wcs import nirspec, util
+from jwst.lib.wcs_utils import get_wavelengths
 import jwst.datamodels as datamodels
 
 log = logging.getLogger(__name__)
@@ -41,6 +42,26 @@ def get_center(exp_type, input):
             ycenter = 0.0
         return (xcenter, ycenter)
 
+    elif exp_type in ["MIR_LRS-FIXEDSLIT"]:
+
+        # get slit reference point from wcs object
+        det_to_sky = input.meta.wcs.get_transform('detector', 'world')
+        sky_to_det = input.meta.wcs.get_transform('world', 'detector')
+        imx = -det_to_sky.offset_1  # aperture ref point from specwcs
+        imy = -det_to_sky.offset_2
+
+        # compute location of target on detector
+        ref_ra, ref_dec, ref_wave = det_to_sky(imx, imy)
+        xcenter, ycenter = sky_to_det(input.meta.target.ra,
+                                      input.meta.target.dec,
+                                      ref_wave)
+        log.debug(f"LRS target location from RA/Dec = {xcenter, ycenter}")
+
+        # compute location relative to LRS aperture reference point
+        xcenter -= imx
+        ycenter -= imy
+        return (xcenter, ycenter)
+
     else:
         log.warning(f'No method to get centering for exp_type {exp_type}')
         log.warning("Using (0.0, 0.0)")
@@ -72,7 +93,8 @@ def get_aperture_from_model(input_model, match):
 def calculate_pathloss_vector(pathloss_refdata,
                               pathloss_wcs,
                               xcenter,
-                              ycenter):
+                              ycenter,
+                              calc_wave=True):
     """
     Calculate the pathloss vectors from the pathloss model using the
     coordinates of the center of the target to interpolate the
@@ -126,11 +148,15 @@ def calculate_pathloss_vector(pathloss_refdata,
     # pointsource.data is 3-d, so we have to extract a wavelength vector
     # at the specified location.  We do this using bilinear interpolation
     else:
-        crpix3 = pathloss_wcs.crpix3
-        crval3 = pathloss_wcs.crval3
-        cdelt3 = pathloss_wcs.cdelt3
-        for i in np.arange(wavesize):
-            wavelength[i] = crval3 + (float(i + 1) - crpix3) * cdelt3
+
+        # If requested, calculate a wavelength vector from the ref file
+        # WCS info
+        if calc_wave:
+            crpix3 = pathloss_wcs.crpix3
+            crval3 = pathloss_wcs.crval3
+            cdelt3 = pathloss_wcs.cdelt3
+            for i in np.arange(wavesize):
+                wavelength[i] = crval3 + (float(i + 1) - crpix3) * cdelt3
 
         # Calculate python index of object center
         crpix1 = pathloss_wcs.crpix1
@@ -141,11 +167,13 @@ def calculate_pathloss_vector(pathloss_refdata,
         cdelt2 = pathloss_wcs.cdelt2
         object_colindex = crpix1 + (xcenter - crval1) / cdelt1 - 1
         object_rowindex = crpix2 + (ycenter - crval2) / cdelt2 - 1
+
+        # check whether target is inside slit boundaries
         if (object_colindex < 0 or object_colindex >= (ncols - 1) or
                 object_rowindex < 0 or object_rowindex >= (nrows - 1)):
             is_inside_slitlet = False
-        else:
 
+        else:
             # Do bilinear interpolation to get the array of
             # path loss vs wavelength
             dx1 = object_colindex - int(object_colindex)
@@ -180,7 +208,7 @@ def do_correction(input_model, pathloss_model=None, inverse=False, source_type=N
         pathloss correction data
 
     inverse : boolean
-        Invert the math operations used to apply the flat field.
+        Invert the math operations used to apply the pathloss correction.
 
     source_type : str or None
         Force processing using the specified source type.
@@ -213,6 +241,14 @@ def do_correction(input_model, pathloss_model=None, inverse=False, source_type=N
     elif exp_type == 'NRS_IFU':
         corrections = do_correction_ifu(output_model, pathloss_model,
                                         inverse, source_type, correction_pars)
+    elif exp_type == 'MIR_LRS-FIXEDSLIT':
+        # only apply correction to LRS fixed-slit if target is point source
+        if is_pointsource(output_model.meta.target.source_type):
+            corrections = do_correction_lrs(output_model, pathloss_model)
+        else:
+            log.warning('Not a point source; step will be skipped.')
+            output_model.meta.cal_step.pathloss = 'SKIPPED'
+            corrections = None
     elif exp_type == 'NIS_SOSS':
         if correction_pars:
             log.warning('Use of correction_pars with NIS_SOSS is not implemented. Skipping')
@@ -302,6 +338,7 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
     numerator = wavelength_grid - extended_wavelength_vector[lower_indices]
     denominator = (extended_wavelength_vector[upper_indices]
                    - extended_wavelength_vector[lower_indices])
+    
     fraction = numerator / denominator
 
     pathloss_grid = wavelength_grid * 0.0
@@ -326,18 +363,18 @@ def is_pointsource(srctype):
 def do_correction_mos(data, pathloss, inverse=False, source_type=None, correction_pars=None):
     """Path loss correction for NIRSpec MOS
 
-    Data is modified in-place.
+    Data are modified in-place.
 
     Parameters
     ----------
     data : jwst.datamodel.DataModel
         The NIRSpec MOS data to be corrected.
 
-    pathloss : jwst.datamodel.DataModel or None
+    pathloss : jwst.datamodel.PathlossModel or None
         The pathloss reference data.
 
     inverse : boolean
-        Invert the math operations used to apply the flat field.
+        Invert the math operations used to apply the pathloss correction.
 
     source_type : str or None
         Force processing using the specified source type.
@@ -389,7 +426,7 @@ def do_correction_mos(data, pathloss, inverse=False, source_type=None, correctio
 def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, correction_pars=None):
     """Path loss correction for NIRSpec fixed-slit modes
 
-    Data is modified in-place.
+    Data are modified in-place.
 
     Parameters
     ----------
@@ -400,7 +437,7 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, cor
         The pathloss reference data.
 
     inverse : boolean
-        Invert the math operations used to apply the flat field.
+        Invert the math operations used to apply the pathloss correction.
 
     source_type : str or None
         Force processing using the specified source type.
@@ -461,28 +498,28 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, cor
 def do_correction_ifu(data, pathloss, inverse=False, source_type=None, correction_pars=None):
     """Path loss correction for NIRSpec IFU
 
-    Data is modified in-place.
+    Data are modified in-place.
 
     Parameters
     ----------
     data : jwst.datamodel.DataModel
-        The NIRSpec fixed-slit data to be corrected.
+        The NIRSpec IFU data to be corrected.
 
     pathloss : jwst.datamodel.DataModel
         The pathloss reference data.
 
     inverse : boolean
-        Invert the math operations used to apply the flat field.
+        Invert the math operations used to apply the pathloss correction.
 
     source_type : str or None
         Force processing using the specified source type.
 
-    correction_pars : jwst.datamodels.MultiSlitModel or None
+    correction_pars : jwst.datamodels.DataModel or None
         The precomputed pathloss to apply instead of recalculation.
 
     Returns
     -------
-    corrections : jwst.datamodel.MultiSlitModel
+    corrections : jwst.datamodel.DataModel
         The pathloss corrections applied.
     """
     if correction_pars:
@@ -511,8 +548,41 @@ def do_correction_ifu(data, pathloss, inverse=False, source_type=None, correctio
     return correction
 
 
+def do_correction_lrs(data, pathloss):
+    """Path loss correction for MIRI LRS fixed-slit
+
+    Data are modified in-place.
+
+    Parameters
+    ----------
+    data : jwst.datamodel.DataModel
+        The MIRI LRS fixed-slit data to be corrected.
+
+    pathloss : jwst.datamodel.DataModel
+        The pathloss reference data.
+    """
+    correction = _corrections_for_lrs(data, pathloss)
+
+    # LRS correction is multiplicative
+    data.data *= correction.data
+    data.err *= correction.data
+    data.var_poisson *= correction.data**2
+    data.var_rnoise *= correction.data**2
+    if data.var_flat is not None and np.size(data.var_flat) > 0:
+        data.var_flat *= correction.data**2
+    data.pathloss_point = correction.pathloss_point
+
+    # This might be useful to other steps
+    data.wavelength = correction.wavelength
+
+    # Set the step status to complete
+    data.meta.cal_step.pathloss = 'COMPLETE'
+
+    return
+
+
 def do_correction_soss(data, pathloss):
-    """Path loss correction for NIRSpec SOSS
+    """Path loss correction for NIRISS SOSS
 
     NIRISS SOSS pathloss correction is basically a correction for the
     flux from the 2nd and 3rd order dispersion that falls outside the
@@ -521,12 +591,12 @@ def do_correction_soss(data, pathloss):
     correction by column number, then the only interpolation needed is a
     1-d interpolation into the pupil wheel position dimension.
 
-    Data is modified in-place.
+    Data are modified in-place.
 
     Parameters
     ----------
     data : jwst.datamodel.DataModel
-        The NIRSpec SOSS data to be corrected.
+        The NIRISS SOSS data to be corrected.
 
     pathloss : jwst.datamodel.DataModel
         The pathloss reference data.
@@ -602,7 +672,7 @@ def do_correction_soss(data, pathloss):
 
 
 def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
-    """Calculate the correction arrasy for MOS slit
+    """Calculate the correction arrays for MOS slit
 
     Parameters
     ----------
@@ -691,7 +761,7 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
 
 
 def _corrections_for_fixedslit(slit, pathloss, exp_type, source_type):
-    """Calculate the correction arrasy for Fixed-slit slit
+    """Calculate the correction arrays for Fixed-slit
 
     Parameters
     ----------
@@ -716,6 +786,7 @@ def _corrections_for_fixedslit(slit, pathloss, exp_type, source_type):
 
     # Get centering
     xcenter, ycenter = get_center(exp_type, slit)
+
     # Calculate the 1-d wavelength and pathloss vectors for the source position
     # Get the aperture from the reference file that matches the slit
     aperture = get_aperture_from_model(pathloss, slit.name)
@@ -776,7 +847,7 @@ def _corrections_for_fixedslit(slit, pathloss, exp_type, source_type):
 
 
 def _corrections_for_ifu(data, pathloss, source_type):
-    """Calculate the correction arrasy for MOS slit
+    """Calculate the correction arrays for IFU
 
     Parameters
     ----------
@@ -852,5 +923,65 @@ def _corrections_for_ifu(data, pathloss, source_type):
     correction.pathloss_point = pathloss_2d_ps
     correction.pathloss_uniform = pathloss_2d_un
     correction.wavelength = wavelength_array
+
+    return correction
+
+
+def _corrections_for_lrs(data, pathloss):
+    """Calculate the correction arrays for MIRI LRS slit
+
+    Parameters
+    ----------
+    data : jwst.datamodels.DataModel
+        The LRS data being operated on.
+
+    pathloss : jwst.datamodels.MirLrsPathlossModel
+        The pathloss reference data
+
+    Returns
+    -------
+    correction : jwst.datamodels.DataModel
+        The correction arrays
+    """
+    correction = None
+
+    # Get location of target
+    xcenter, ycenter = get_center(data.meta.exposure.type, data)
+
+    # Get 1-d wavelength vector from reference file data
+    wavelength_vector = pathloss.pathloss_table['wavelength']
+
+    # Calculate the 1-d pathloss vector for the source position
+    pathloss_data = pathloss.pathloss_table['pathloss']
+    pathloss_wcs = pathloss.meta.wcsinfo
+    _, pathloss_vector, is_inside_slit = calculate_pathloss_vector(pathloss_data,
+                                                                   pathloss_wcs,
+                                                                   xcenter, ycenter,
+                                                                   calc_wave=False)
+
+    if is_inside_slit:
+
+        # Populate 2-D wavelength array from WCS info
+        wavelength_array = get_wavelengths(data)
+      
+        # MIRI LRS pathloss reference file data are in reverse order,
+        # so flip them here
+        wavelength_vector = wavelength_vector[::-1]
+        pathloss_vector = pathloss_vector[::-1]
+
+        # Compute the point source pathloss 2D correction
+        pathloss_2d = interpolate_onto_grid(wavelength_array,
+                                            wavelength_vector,
+                                            pathloss_vector)
+
+        # Save the corrections. The `data` portion is the correction used.
+        # The individual ones will be saved in the respective attributes.
+        correction = type(data)(data=pathloss_2d)
+        correction.pathloss_point = pathloss_2d
+        correction.wavelength = wavelength_array
+
+    else:
+        log.warning('Source is outside slit. Skipping '
+                    f'pathloss correction for LRS.')
 
     return correction

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -246,7 +246,7 @@ def do_correction(input_model, pathloss_model=None, inverse=False, source_type=N
         if is_pointsource(output_model.meta.target.source_type):
             corrections = do_correction_lrs(output_model, pathloss_model)
         else:
-            log.warning('Not a point source; step will be skipped.')
+            log.warning('Not a point source; skipping correction for LRS.')
             output_model.meta.cal_step.pathloss = 'SKIPPED'
             corrections = None
     elif exp_type == 'NIS_SOSS':
@@ -338,7 +338,7 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
     numerator = wavelength_grid - extended_wavelength_vector[lower_indices]
     denominator = (extended_wavelength_vector[upper_indices]
                    - extended_wavelength_vector[lower_indices])
-    
+
     fraction = numerator / denominator
 
     pathloss_grid = wavelength_grid * 0.0
@@ -963,7 +963,7 @@ def _corrections_for_lrs(data, pathloss):
 
         # Populate 2-D wavelength array from WCS info
         wavelength_array = get_wavelengths(data)
-      
+
         # MIRI LRS pathloss reference file data are in reverse order,
         # so flip them here
         wavelength_vector = wavelength_vector[::-1]
@@ -981,7 +981,6 @@ def _corrections_for_lrs(data, pathloss):
         correction.wavelength = wavelength_array
 
     else:
-        log.warning('Source is outside slit. Skipping '
-                    f'pathloss correction for LRS.')
+        log.warning('Source is outside slit. Skipping pathloss correction for LRS.')
 
     return correction

--- a/jwst/pathloss/pathloss_step.py
+++ b/jwst/pathloss/pathloss_step.py
@@ -44,7 +44,10 @@ class PathLossStep(Step):
                     return result
 
                 # Open the pathloss ref file data model
-                pathloss_model = datamodels.PathlossModel(self.pathloss_name)
+                if input_model.meta.exposure.type.upper() in ["MIR_LRS-FIXEDSLIT"]:
+                    pathloss_model = datamodels.MirLrsPathlossModel(self.pathloss_name)
+                else:
+                    pathloss_model = datamodels.PathlossModel(self.pathloss_name)
 
             # Do the pathloss correction
             result, self.correction_pars = pathloss.do_correction(

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -522,7 +522,6 @@ class DataSet():
         Returns
         -------
         """
-        log.debug('Starting cal_nircam')
         # Handle WFSS data separately from regular imaging
         if (isinstance(self.input, datamodels.MultiSlitModel) and self.exptype == 'NRC_WFSS'):
             # Loop over the WFSS slits, applying the correct photom ref data

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -354,8 +354,9 @@ class Spec2Pipeline(Pipeline):
             self.log.debug('Science data does not allow fringe correction. Skipping "fringe".')
             self.fringe.skip = True
 
-        # Apply pathloss correction to NIRSpec and NIRISS SOSS exposures
-        if not self.pathloss.skip and exp_type not in ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_IFU', 'NIS_SOSS']:
+        # Apply pathloss correction to MIRI LRS, NIRSpec, and NIRISS SOSS exposures
+        if not self.pathloss.skip and exp_type not in ['MIR_LRS-FIXEDSLIT', 'NRS_FIXEDSLIT',
+                                                       'NRS_MSASPEC', 'NRS_IFU', 'NIS_SOSS']:
             self.log.debug('Science data does not allow pathloss correction. Skipping "pathloss".')
             self.pathloss.skip = True
 

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -15,6 +15,7 @@ def run_pipeline(jail, rtdata_module):
     rtdata = rtdata_module
 
     # Get the spec2 ASN and its members
+    rtdata.get_data("miri/lrs/MIRI_FM_MIRIMAGE_P750L_PATHLOSS_8C.00.00.fits")
     rtdata.get_asn("miri/lrs/jw00623-o032_20191210t195246_spec2_001_asn.json")
 
     # Run the calwebb_spec2 pipeline; save results from intermediate steps
@@ -23,6 +24,8 @@ def run_pipeline(jail, rtdata_module):
             "--steps.assign_wcs.save_results=true",
             "--steps.flat_field.save_results=true",
             "--steps.srctype.save_results=true",
+            "--steps.pathloss.save_results=true",
+            "--steps.pathloss.override_pathloss=MIRI_FM_MIRIMAGE_P750L_PATHLOSS_8C.00.00.fits",
             "--steps.bkg_subtract.save_combined_background=true"
             ]
     Step.from_cmdline(args)
@@ -30,7 +33,8 @@ def run_pipeline(jail, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", [
-    "bsub", "flat_field", "assign_wcs", "srctype", "combinedbackground", "cal", "s2d", "x1d"])
+    "bsub", "flat_field", "assign_wcs", "srctype", "pathloss",
+    "combinedbackground", "cal", "s2d", "x1d"])
 def test_miri_lrs_slit_spec2(run_pipeline, fitsdiff_default_kwargs, suffix, rtdata_module):
     """Regression test of the calwebb_spec2 pipeline on MIRI
        LRS fixedslit data using along-slit-nod pattern for


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6277
Resolves [JP-2243](https://jira.stsci.edu/browse/JP-2243)

**Description**

This PR implements a pathloss correction for MIRI LRS fixed-slit exposures. It builds on the existing pathloss routines for NIRSpec slit-like modes. A new datamodel, `MirLrsPathlossModel`, is also implemented, because the form of the reference file data is different than those for NIRSpec or NIRISS SOSS (tabular instead of image-based). The `calwebb_spec2` pipeline is also updated to enable the pathloss step for LRS fixed-slit mode.

Note that a number of minor cosmetic changes have also been made to some of the existing pathloss functions for other modes, to clean up old errors in text and comments.

Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [X] Milestone
- [X] Label(s)