### PR TITLE
Possible  fix for JP-1670

### DIFF
--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -446,8 +446,8 @@ None, optional
 
                 # set pixels in 'fill_mask' that are inside a polygon to True:
                 x, y = self.wcs_inv(ra, dec)
-                xcheck = np.ndarray.round(x)
-                ycheck = np.ndarray.round(y)
+                xcheck = np.ndarray.round(x).astype(int)
+                ycheck = np.ndarray.round(y).astype(int)
                 if np.min(xcheck) == np.max(xcheck) or np.min(ycheck) == np.max(ycheck):
                     continue
                 poly_vert = list(zip(*[x, y]))

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -446,8 +446,6 @@ None, optional
 
                 # set pixels in 'fill_mask' that are inside a polygon to True:
                 x, y = self.wcs_inv(ra, dec)
-                for xi, yi in zip(x, y):
-                    print(f"{xi:.16g},   {yi:.16g")
                 xcheck = np.ndarray.round(x)
                 ycheck = np.ndarray.round(y)
                 if np.min(xcheck) == np.max(xcheck) or np.min(ycheck) == np.max(ycheck):

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -446,6 +446,10 @@ None, optional
 
                 # set pixels in 'fill_mask' that are inside a polygon to True:
                 x, y = self.wcs_inv(ra, dec)
+                xcheck = np.ndarray.round(x)
+                ycheck = np.ndarray.round(y)
+                if np.min(xcheck) == np.max(xcheck) or np.min(ycheck) == np.max(ycheck):
+                    continue
                 poly_vert = list(zip(*[x, y]))
 
                 polygon = region.Polygon(True, poly_vert)

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -446,6 +446,8 @@ None, optional
 
                 # set pixels in 'fill_mask' that are inside a polygon to True:
                 x, y = self.wcs_inv(ra, dec)
+                for xi, yi in zip(x, y):
+                    print(f"{xi:.16g},   {yi:.16g")
                 xcheck = np.ndarray.round(x)
                 ycheck = np.ndarray.round(y)
                 if np.min(xcheck) == np.max(xcheck) or np.min(ycheck) == np.max(ycheck):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #5304
Resolves [JP-1670](https://jira.stsci.edu/browse/JP-1670)

**Description**

This PR addresses a problem in skymatch when one of the overlap sky polygons is just a line.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)