### PR TITLE
JP-2304: Fix arguments to DarkCurrentStep's make_output_path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,12 @@ datamodels
 
 - Added the ``MirLrsPathlossModel`` for use in the ``pathloss` step. [#6435]
 
+dark_current
+------------
+
+- Fixed bug during save of optional averaged darks output, bug with
+  providing step a file instead of a datamodel, added regression test [#6450]
+
 extract_1d
 ----------
 

--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -55,13 +55,13 @@ class DarkCurrentStep(Step):
                 input_model, dark_model, dark_output
             )
 
-        out_data, dark_data = result
+            out_data, dark_data = result
 
-        if dark_data is not None and dark_data.save:
-            save_dark_data_as_dark_model(dark_data, dark_model, instrument)
-        dark_model.close()
+            if dark_data is not None and dark_data.save:
+                save_dark_data_as_dark_model(dark_data, dark_model, instrument)
+            dark_model.close()
 
-        out_ramp = dark_output_data_2_ramp_model(out_data, input_model)
+            out_ramp = dark_output_data_2_ramp_model(out_data, input_model)
 
         return out_ramp
 

--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -39,12 +39,13 @@ class DarkCurrentStep(Step):
             dark_output = self.dark_output
             if dark_output is not None:
                 dark_output = self.make_output_path(
-                    None, basepath=dark_output, ignore_use_model=True
+                    basepath=dark_output,
+                    suffix=False
                 )
 
             # Open the dark ref file data model - based on Instrument
             instrument = input_model.meta.instrument.name
-            if(instrument == 'MIRI'):
+            if instrument == 'MIRI':
                 dark_model = datamodels.DarkMIRIModel(self.dark_name)
             else:
                 dark_model = datamodels.DarkModel(self.dark_name)

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -192,7 +192,7 @@ def test_image3_closedfile(run_image3_closedfile, rtdata, fitsdiff_default_kwarg
 @pytest.mark.bigdata
 def test_nircam_frame_averaged_darks(rtdata, fitsdiff_default_kwargs):
     """Test optional frame-averaged darks output from DarkCurrentStep"""
-    rtdata.get_data(f"nircam/image/jw00312007001_02102_00001_nrcblong_ramp.fits")
+    rtdata.get_data("nircam/image/jw00312007001_02102_00001_nrcblong_ramp.fits")
 
     args = ["jwst.dark_current.DarkCurrentStep", rtdata.input,
             "--dark_output='frame_averaged_darks.fits'",

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -187,3 +187,20 @@ def test_image3_closedfile(run_image3_closedfile, rtdata, fitsdiff_default_kwarg
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_nircam_frame_averaged_darks(rtdata, fitsdiff_default_kwargs):
+    """Test optional frame-averaged darks output from DarkCurrentStep"""
+    rtdata.get_data(f"nircam/image/jw00312007001_02102_00001_nrcblong_ramp.fits")
+
+    args = ["jwst.dark_current.DarkCurrentStep", rtdata.input,
+            "--dark_output='frame_averaged_darks.fits'",
+            ]
+    Step.from_cmdline(args)
+    rtdata.output = "frame_averaged_darks.fits"
+
+    rtdata.get_truth("truth/test_nircam_image/frame_averaged_darks.fits")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6402 
Resolves [JP-2304](https://jira.stsci.edu/browse/JP-2304)

**Description**

This PR changes the arguments provided to the DarkCurrentStep's make_output_path, such that the step parameter `dark_output` will now provide the frame-averaged darks in the filename specified, as per the documentation.

Aside: is anyone utilizing this output? With this sitting broken for so long, does this mean there are no tests verifying the contents of this file? 😨 

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
