### PR TITLE
Update region.py in skymatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ cube_build
 
 - Moved variable definitions to top of code in C extension to
   support changes in #6093. [#6255]
-- Added weighting option driz (3D drizzling) [#6297] 
+- Added weighting option driz (3D drizzling) [#6297]
 
 - Using assign_wsc.utils.in_ifu_slice function to determine which NIRSpec
   sky values mapped to each detector slice. [#6326]
@@ -101,7 +101,7 @@ datamodels
 
 - Updated data products documentation to indicate that variance and error arrays
   are now included in resampled products. [#6420]
-  
+
 - Added SOSS-specific extraction parameters to core schema; add new
   datamodel to store SOSS model traces and aperture weights [#6422]
 
@@ -228,6 +228,9 @@ skymatch
 
 - Improved reliability when matching sky in images with very close sky
   footprints. [#6421]
+
+- Updated code in ``skymatch.region.py`` with latest improvements and bug fixes
+  from ``stsci.skypac.regions.py``. [#6451]
 
 source_catalog
 --------------


### PR DESCRIPTION
Closes #5304
Closes #6439
Resolves [JP-1670](https://jira.stsci.edu/browse/JP-1670)

**Description**

Fixes issues in `skymatch` reported in #5304 and #6439 which are due to old `region.py` file used in the pipeline compared to the one in `stsci.skypac` which includes improvement and bug fixes that address the crashes reported in the above mentioned issues.

Bug fixes applied in `stsci.skypac` that are being ported to `jwst.skymatch.region` are:

- https://github.com/spacetelescope/stsci.skypac/pull/55
- https://github.com/spacetelescope/stsci.skypac/pull/52

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
