### PR TITLE
Fix incorrect removal of PC and CDELT info from FITS WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ assign_wcs
 - Changed in_ifu_slice in util.py to return the indices of elements in slice.
   Also the x tolerance on finding slice elements was increased. [#6326]
 
+- Fix a bug due to which, under certain circumstances, ``PC``-matrix and
+  ``CDELT`` coefficients may be removed from FITS WCS of data products. [#6453]
+
 - Fixed bug in NIRSpec MOS slitlet meta data calculations for background slits
   consisting of multiple shutters. [#6454]
 
@@ -66,7 +69,7 @@ cube_build
 
 - Moved variable definitions to top of code in C extension to
   support changes in #6093. [#6255]
-- Added weighting option driz (3D drizzling) [#6297] 
+- Added weighting option driz (3D drizzling) [#6297]
 
 - Using assign_wsc.utils.in_ifu_slice function to determine which NIRSpec
   sky values mapped to each detector slice. [#6326]
@@ -113,7 +116,7 @@ datamodels
 
 - Updated data products documentation to indicate that variance and error arrays
   are now included in resampled products. [#6420]
-  
+
 - Added SOSS-specific extraction parameters to core schema; add new
   datamodel to store SOSS model traces and aperture weights [#6422]
 
@@ -121,7 +124,7 @@ datamodels
 
 - Added new column 'reference_order' to 'planned_star_table' in
   guider_raw and guider_cal schemas [#6368]
-  
+
 dark_current
 ------------
 

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -114,15 +114,11 @@ class AssignWcsStep(Step):
         except ValueError:
             return result
 
+        # update meta.wcs_info with fit keywords except for naxis*
+        del fit_sip_hdr['naxis*']
+
         # maintain convention of lowercase keys
         fit_sip_hdr = {k.lower(): v for k, v in fit_sip_hdr.items()}
-
-        # update meta.wcs_info with fit keywords except for naxis*
-        for key in ['naxis1', 'naxis2']:
-            del fit_sip_hdr[key]
-
-        # update meta.wcs_info with fit keywords
-        result.meta.wcsinfo.instance.update(fit_sip_hdr)
 
         # delete naxis, cdelt, pc from wcsinfo
         rm_keys = ['naxis', 'cdelt1', 'cdelt2',
@@ -130,5 +126,8 @@ class AssignWcsStep(Step):
         for key in rm_keys:
             if key in result.meta.wcsinfo.instance:
                 del result.meta.wcsinfo.instance[key]
+
+        # update meta.wcs_info with fit keywords
+        result.meta.wcsinfo.instance.update(fit_sip_hdr)
 
         return result


### PR DESCRIPTION
Resolves [AL-607](https://jira.stsci.edu/browse/AL-607)

**Description**

This PR fixes a bug in `assign_wcs` due to which WCS elements (`CD` matrix, `CDELT`, ...) are removed _after_ header has been updated with the new header from `to_sip_fits()`. Instead this clean-up, if needed, should happen before header is updated.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
