### PR TITLE
JP-2291: Fix bug in barshadow for off-center sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ assign_wcs
 - Changed in_ifu_slice in util.py to return the indices of elements in slice.
   Also the x tolerance on finding slice elements was increased. [#6326]
 
+- Fixed bug in NIRSpec MOS slitlet meta data calculations for background slits
+  consisting of multiple shutters. [#6454]
+
 associations
 ------------
 
@@ -41,6 +44,15 @@ associations
 - Added constraint to Asn_Lv2ImageNonScience to prevent creation of asns
   for NRC_TACQ exposures with WFSC_LOS_JITTER in the DMS_NOTE. Also added
   new reduce method, Constraint.notall [#6404]
+
+barshadow
+---------
+
+- Modify computation of correction array to remove dependencies on the
+  centering of the source within the slitlet, because for extended/uniform
+  sources the centering is irrelevant. This fixes bugs encountered when
+  computing the correction for background signal contained within slits with
+  an off-center point source. [#6454]
 
 cube_build
 ----------

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -634,8 +634,8 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
             else:
                 jmin = min([s['shutter_column'] for s in slitlets_sid])
                 jmax = max([s['shutter_column'] for s in slitlets_sid])
-                j = jmin + (jmax - jmin) // 2 + 1
-            ymax = 0.5 + margin + (jmax - j) * 1.15
+                j = jmin + (jmax - jmin) // 2
+            ymax = yhigh + margin + (jmax - j) * 1.15
             ymin = -(-ylow + margin) + (jmin - j) * 1.15
             quadrant = slitlets_sid[0]['shutter_quadrant']
             ycen = j

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -308,7 +308,7 @@ def test_msa_configuration_all_background():
     dither_position = 1
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
-    ref_slit = trmodels.Slit(57, 8646, 1, 251, 24, -2.85, .55, 4, 0, '11x', 'background_57', 'bkg_57',
+    ref_slit = trmodels.Slit(57, 8281, 1, 251, 23, -1.7, 1.7, 4, 0, '1x1', 'background_57', 'bkg_57',
                              0, -0.5, -0.5)
     _compare_slits(slitlet_info[0], ref_slit)
 

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -133,14 +133,20 @@ def _calc_correction(slitlet, barshadow_model, source_type):
             # Use this transformation to calculate x, y, and wavelength
             xslit, yslit, wavelength = det2slit(x, y)
 
+            # Renormalize the yslit values so that it appears as if the source is always
+            # centered in the slitlet, which is appropriate for extended/uniform sources
+            yslit -= np.nanmean(yslit)
+
             # The returned y values are scaled to where the slit height is 1
             # (i.e. a slit goes from -0.5 to 0.5).  The barshadow array is scaled
             # so that the separation between the slit centers is 1,
             # i.e. slit height + interslit bar
             yslit = yslit / SLITRATIO
 
-            # Convert the Y and wavelength to a pixel location in the  bar shadow array
-            index_of_fiducial = shutter_status.find('x')
+            # Convert the Y and wavelength to a pixel location in the  bar shadow array;
+            # the fiducial should always be at the center of the slitlet, regardless of
+            # where the source is centered.
+            index_of_fiducial = (len(shutter_status) - 1) / 2.0
 
             # The shutters go downwards, i.e. the first shutter in shutter_status corresponds to
             # the last in the shadow array.  So the center of the first shutter referred to in


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6365
Resolves [JP-2291](https://jira.stsci.edu/browse/JP-2291)

**Description**

This PR fixes a bug in the barshadow step that was leading to the correction array being calculated incorrectly for slitlets in which the source is indicated as being off-center (in the spatial direction) in the slitlet. The bar-shadow correction only applies to extended/uniform sources in the first place, which are assumed to fill the slitlet (or at best the distribution is not known), hence the correction should not depend at all on any information from the MSA meta data that indicates which shutter within the slitlet contains the center of the source. It should be completely independent of source location in the slitlet. The fix removes all effects on the calculation of the correction that were due to source location within the slitlet.

The previously incorrect results were affecting the results of the master_background subtraction in instances where a point source is located off-center in a slitlet (e.g. due to nodding) and the barshadow correction is computed for the background/sky signal in the slitlet. The resulting correction applied to the slitlet was asymmetric, leading to incorrect background/sky subtraction.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)