### PR TITLE
JP-2103: Fix calculation of source_xpos in wavecorr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -270,14 +270,16 @@ wavecorr
 - Location of source in NIRSpec fixed slit updated
   (keywords ``SCRCXPOS``, ``SRCYPOS``). [#6243, #6261]
 
-- Changed method of loading input association from datamodels.load() to
-  Step.load_as_level3_asn() to prevent error when target acq exposure
-  not present [#6464]
-
 - Fixed the computation of ``model.slits[i].source_xpos``
   for Nirspec fixed slit data. [#6457]
 
+wfs_combine
+-----------
 
+- Changed method of loading input association from datamodels.load() to
+  Step.load_as_level3_asn() to prevent error when target acq exposure
+  not present [#6464]
+  
 wfss_contam
 -----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,7 +279,7 @@ wfs_combine
 - Changed method of loading input association from datamodels.load() to
   Step.load_as_level3_asn() to prevent error when target acq exposure
   not present [#6464]
-  
+
 wfss_contam
 -----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -270,12 +270,13 @@ wavecorr
 - Location of source in NIRSpec fixed slit updated
   (keywords ``SCRCXPOS``, ``SRCYPOS``). [#6243, #6261]
 
-wfs_combine
------------
-
 - Changed method of loading input association from datamodels.load() to
   Step.load_as_level3_asn() to prevent error when target acq exposure
   not present [#6464]
+
+- Fixed the computation of ``model.slits[i].source_xpos``
+  for Nirspec fixed slit data. [#6457]
+
 
 wfss_contam
 -----------

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -997,8 +997,8 @@ class IdealToV2V3(Model):
         """
         v3idlyangle = np.deg2rad(v3idlyangle)
 
-        v2 = v2ref + vparity * xidl * np.cos(v3idlyangle) + yidl * np.sin(v3idlyangle)
-        v3 = v3ref - vparity * xidl * np.sin(v3idlyangle) + yidl * np.cos(v3idlyangle)
+        v2 = v2ref + xidl * np.cos(v3idlyangle) + yidl * np.sin(v3idlyangle)
+        v3 = v3ref - xidl * np.sin(v3idlyangle) + yidl * np.cos(v3idlyangle)
         return v2, v3
 
     def inverse(self):

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -997,8 +997,8 @@ class IdealToV2V3(Model):
         """
         v3idlyangle = np.deg2rad(v3idlyangle)
 
-        v2 = v2ref + xidl * np.cos(v3idlyangle) + yidl * np.sin(v3idlyangle)
-        v3 = v3ref - xidl * np.sin(v3idlyangle) + yidl * np.cos(v3idlyangle)
+        v2 = v2ref + vparity * xidl * np.cos(v3idlyangle) + yidl * np.sin(v3idlyangle)
+        v3 = v3ref - vparity * xidl * np.sin(v3idlyangle) + yidl * np.cos(v3idlyangle)
         return v2, v3
 
     def inverse(self):

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -156,11 +156,11 @@ def test_wavecorr_fs():
     src_result = SourceTypeStep.call(result)
     result = WavecorrStep.call(src_result)
 
-    assert_allclose(result.slits[0].source_xpos, -0.1271444347)
+    assert_allclose(result.slits[0].source_xpos, 0.127111, atol=1e-6)
 
     slit = result.slits[0]
     source_xpos = wavecorr.get_source_xpos(slit, slit.meta.wcs, lam=2)
-    assert_allclose(result.slits[0].source_xpos, source_xpos)
+    assert_allclose(result.slits[0].source_xpos, source_xpos, atol=1e-6)
 
     mean_correction = np.abs(src_result.slits[0].wavelength - result.slits[0].wavelength)
     assert_allclose(np.nanmean(mean_correction), 0.003, atol=.001)

--- a/jwst/wavecorr/wavecorr.py
+++ b/jwst/wavecorr/wavecorr.py
@@ -4,7 +4,9 @@ slits in which the source is off center. The correction is applied
 only to point sources.
 
 The algorithm uses a reference file which is a look up table of
-wavelenght_correction as a function of slit_x_position and wavelength.
+wavelength_correction as a function of slit_x_position and wavelength.
+The ``x`` direction is the one parallel to dispersion/wavelength for
+both MOS and FS slits.
 
 The slit_x_position is determined in the following way.
 
@@ -279,7 +281,7 @@ def get_source_xpos(slit, slit_wcs, lam):
     log.debug("wcsinfo: {0}, {1}, {2}, {3}".format(v2ref, v3ref, v3idlyangle, vparity))
     # Compute the location in V2,V3 [in arcsec]
     xv, yv = idl2v23(xoffset, yoffset)
-    log.info(f'xoffset, yoffset, {xoffset}, {yoffset}, {lam}')
+    log.info(f'xoffset, yoffset, {xoffset}, {yoffset}')
 
     # Position in the virtual slit
     xpos_slit, ypos_slit, lam_slit = slit.meta.wcs.get_transform('v2v3', 'slit_frame')(
@@ -288,6 +290,6 @@ def get_source_xpos(slit, slit_wcs, lam):
     slit.source_xpos = xpos_slit
     slit.source_ypos = ypos_slit
     log.debug('Source X/Y position in V2V3: {0}, {1}'.format(xv, yv))
-    log.info('Source X/Y position in the slit: {0}, {1}, {2}, {3}'.format(xpos_slit, ypos_slit, lam, lam_slit))
+    log.info('Source X/Y position in the slit: {0}, {1}'.format(xpos_slit, ypos_slit))
 
     return xpos_slit


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6074
Resolves [JP-2103](https://jira.stsci.edu/browse/JP-2103)
Closes #6287
Resolves [JP-2253](https://jira.stsci.edu/browse/JP-2253)


**Description**

This PR corrects the computation of the position of the source in the NRS fixed slit.

It also removes `vparity` from the transform from Ideal to V2V3 which was found to be incorrect.
The method `absolute2fractional` was removed because the returned `source_xpos` position is essentially
the fractional position.

Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
