### PR TITLE
JP-2329 Add pysiaf to SDP dependency

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -76,7 +76,7 @@ bc0.conda_packages = [
 ]
 bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
-    "pip install -e .[test,ephem] --no-cache-dir",
+    "pip install -e .[test,sdp] --no-cache-dir",
     "pip install pytest-xdist",
     "pip freeze",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ install_requires =
     tweakwcs>=0.7.2
     
 [options.extras_require]
+aws =
+    stsci-aws-utils>=0.1.2
 docs =
     matplotlib
     sphinx
@@ -59,6 +61,10 @@ docs =
     stsci-rtd-theme
     sphinx-astropy
     sphinx-asdf>=0.1.1
+sdp =
+    jplephem>=2.9
+    pymssql>=2.1.6
+    pysiaf>=0.13.0
 test =
     ci-watson>=0.5.0
     colorama>=0.4.1
@@ -70,11 +76,6 @@ test =
     pytest-cov>=2.9.0
     codecov>=1.6.0
     flake8>=3.6.0
-aws =
-    stsci-aws-utils>=0.1.2
-ephem =
-    pymssql>=2.1.6
-    jplephem>=2.9
 
 [options.entry_points]
 asdf_extensions =


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2329](https://jira.stsci.edu/browse/JP-2329)

**Description**

This PR addresses adds `pysiaf` to the SDP dependencies.

Also, the list of SDP dependencies is now `sdp`, instead of just `ephem`.

Checklist
- [ ] Tests
- [ ] ~~Documentation~~
- [ ] ~~Change log~~
- [x] Milestone
- [x] Label(s)
