### PR TITLE
JP-2291: minor tweak to barshadow update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,7 +52,7 @@ barshadow
   centering of the source within the slitlet, because for extended/uniform
   sources the centering is irrelevant. This fixes bugs encountered when
   computing the correction for background signal contained within slits with
-  an off-center point source. [#6454]
+  an off-center point source. [#6454, #6459]
 
 cube_build
 ----------

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -133,9 +133,15 @@ def _calc_correction(slitlet, barshadow_model, source_type):
             # Use this transformation to calculate x, y, and wavelength
             xslit, yslit, wavelength = det2slit(x, y)
 
-            # Renormalize the yslit values so that it appears as if the source is always
-            # centered in the slitlet, which is appropriate for extended/uniform sources
-            yslit -= np.nanmean(yslit)
+            # If the source position is off-center in the slit, renormalize the yslit
+            # values so that it appears as if the source is centered, which is the appropriate
+            # way to compute the shadow correction for extended/uniform sources (doesn't
+            # depend on source location).
+            if len(shutter_status) > 1:
+                middle = (len(shutter_status) - 1) / 2.0
+                src_loc = shutter_status.find('x')
+                if src_loc != -1 and float(src_loc) != middle:
+                    yslit -= np.nanmean(yslit)
 
             # The returned y values are scaled to where the slit height is 1
             # (i.e. a slit goes from -0.5 to 0.5).  The barshadow array is scaled


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2291](https://jira.stsci.edu/browse/JP-2291)

**Description**

This PR adds a minor tweak to the `bar_shadow` updates implemented in PR #6454. In the original PR, small changes were made to the bar shadow correction array even for slits that contained a centered source, while the update was intended to fix only slits that have off-center sources. So this adds an extra hook to first check to see if the source position is at the center of the slitlet shutter list and, if it is, don't modify the original `yslit` data. This has the benefit of keeping regressions to a minimum and also keeps us in sync with the NIRSpec team results for slitlets that have a centered source (otherwise there is a small difference).

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)