### PR TITLE
JP-2333: Load level3 ASN using method rather than force-load with datamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -264,6 +264,13 @@ wavecorr
 - Location of source in NIRSpec fixed slit updated
   (keywords ``SCRCXPOS``, ``SRCYPOS``). [#6243, #6261]
 
+wfs_combine
+-----------
+
+- Changed method of loading input association from datamodels.load() to
+  Step.load_as_level3_asn() to prevent error when target acq exposure
+  not present [#6464]
+
 wfss_contam
 -----------
 

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -31,46 +31,46 @@ class WfsCombineStep(Step):
         self.name_format = False
 
         # Load the input ASN table
-        with datamodels.open(input_table) as asn_table:
+        asn_table = self.load_as_level3_asn(input_table)
 
-            self.log.info('Using input table: %s', input_table)
-            self.log.info('The number of pairs of input files: %g', len(asn_table.meta.asn_table.products))
+        self.log.info('Using input table: %s', input_table)
+        self.log.info('The number of pairs of input files: %g', len(asn_table['products']))
 
-            output_container = datamodels.ModelContainer()
+        output_container = datamodels.ModelContainer()
 
-            # Process each pair of input images listed in the association table
-            for which_set in asn_table.meta.asn_table.products:
+        # Process each pair of input images listed in the association table
+        for which_set in asn_table['products']:
 
-                # Get the list of science members in this pair
-                science_members = [
-                    member
-                    for member in which_set.members
-                    if member.exptype.lower() == 'science'
-                ]
-                infile_1 = science_members[0].expname
-                infile_2 = science_members[1].expname
-                outfile = which_set.name
+            # Get the list of science members in this pair
+            science_members = [
+                member
+                for member in which_set['members']
+                if member['exptype'].lower() == 'science'
+            ]
+            infile_1 = science_members[0]['expname']
+            infile_2 = science_members[1]['expname']
+            outfile = which_set['name']
 
-                # Create the step instance
-                wfs = wfs_combine.DataSet(
-                    infile_1, infile_2, outfile, self.do_refine, self.flip_dithers, self.psf_size,
-                    self.blur_size, self.n_size
-                )
+            # Create the step instance
+            wfs = wfs_combine.DataSet(
+                infile_1, infile_2, outfile, self.do_refine, self.flip_dithers, self.psf_size,
+                self.blur_size, self.n_size
+            )
 
-                # Do the processing
-                output_model = wfs.do_all()
+            # Do the processing
+            output_model = wfs.do_all()
 
-                # The DataSet class does not close its resources.  Do that here.
-                wfs.input_1.close()
-                wfs.input_2.close()
+            # The DataSet class does not close its resources.  Do that here.
+            wfs.input_1.close()
+            wfs.input_2.close()
 
-                # Update necessary meta info in the output
-                output_model.meta.cal_step.wfs_combine = 'COMPLETE'
-                output_model.meta.asn.pool_name = asn_table.meta.asn_table.asn_pool
-                output_model.meta.asn.table_name = os.path.basename(input_table)
-                output_model.meta.filename = which_set.name
+            # Update necessary meta info in the output
+            output_model.meta.cal_step.wfs_combine = 'COMPLETE'
+            output_model.meta.asn.pool_name = asn_table['asn_pool']
+            output_model.meta.asn.table_name = os.path.basename(input_table)
+            output_model.meta.filename = which_set['name']
 
-                output_container.append(output_model)
+            output_container.append(output_model)
 
         # Return the output so it can be tested.
         return output_container


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6463 
Resolves [JP-2333](https://jira.stsci.edu/browse/JP-2333)

**Description**

This PR changes the wfs_combine step (pipeline?) to use the Step.load_as_level3_asn() method rather than datamodels.load() for ingesting the association - this allows for operations on the contents of the association file without requiring all listed files in the association to be present.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
