### PR TITLE
JP-857: Reorder columns in guider schemas to match SDP structure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,7 +125,7 @@ datamodels
 - Added new column 'reference_order' to 'planned_star_table' in
   guider_raw and guider_cal schemas [#6368]
 
-- Moved new column `reference_order` in guider schemas' planned
+- Moved new column 'reference_order' in guider schemas' planned
   star table to second in order, after 'guide_star_order' [#6465]
 
 dark_current

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,6 +125,9 @@ datamodels
 - Added new column 'reference_order' to 'planned_star_table' in
   guider_raw and guider_cal schemas [#6368]
 
+- Moved new column `reference_order` in guider schemas' planned
+  star table to second in order, after 'guide_star_order' [#6465]
+
 dark_current
 ------------
 

--- a/jwst/datamodels/schemas/guider_cal.schema.yaml
+++ b/jwst/datamodels/schemas/guider_cal.schema.yaml
@@ -32,10 +32,10 @@ allOf:
       datatype:
       - name: guide_star_order
         datatype: int32
-      - name: reference_star_id
-        datatype: [ascii, 12]
       - name: reference_order
         datatype: int32
+      - name: reference_star_id
+        datatype: [ascii, 12]
       - name: ra
         datatype: float64
       - name: dec

--- a/jwst/datamodels/schemas/guider_raw.schema.yaml
+++ b/jwst/datamodels/schemas/guider_raw.schema.yaml
@@ -32,10 +32,10 @@ allOf:
       datatype:
       - name: guide_star_order
         datatype: int32
-      - name: reference_star_id
-        datatype: [ascii, 12]
       - name: reference_order
         datatype: int32
+      - name: reference_star_id
+        datatype: [ascii, 12]
       - name: ra
         datatype: float64
       - name: dec


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #3801 
Resolves [JP-857](https://jira.stsci.edu/browse/JP-857)

**Description**

This PR corrects the ordering of columns in the planned reference stars table inside guider_cal and guider_raw schemas to match the order used by SDP, to hopefully clear up some errors found in the nightly SDP Auto run.

Will need to upload new artifacts to fix regtest data with new order after merge.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
