### PR TITLE
JP-2339 Move setting of the default method to `calc_transforms`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,6 +173,8 @@ lib
 
 - Use TRACK algorithms for moving target exposures. [#6452]
 
+- Move setting of the default method to calc_transforms. [#6482]
+
 linearity
 --------
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -928,6 +928,8 @@ def calc_transforms(t_pars: TransformParameters):
     transforms : `Transforms`
         The list of coordinate matrix transformations
     """
+    t_pars.method = t_pars.method if t_pars.method else Methods.default
+
     transforms = t_pars.method.func(t_pars)
     return transforms
 
@@ -3249,7 +3251,6 @@ def t_pars_from_model(model, **t_pars_kwargs):
         The initialized parameters.
     """
     t_pars = TransformParameters(**t_pars_kwargs)
-    t_pars.method = t_pars.method if t_pars.method else Methods.default
 
     # Retrieve SIAF information
     if t_pars.siaf is None:

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -333,7 +333,7 @@ class TransformParameters:
     #: The [DX, DY, DZ] barycentri velocity vector
     jwst_velocity: np.array = None
     #: The method, or algorithm, to use in calculating the transform. If not specified, the default method is used.
-    method: Methods = None
+    method: Methods = Methods.default
     #: Observation end time
     obsend: float = None
     #: Observation start time


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->
Resolves [JP-2339](https://jira.stsci.edu/browse/JP-2339)

**Description**

This PR moves the use of the default method to the function that actually needs to use a method: calc_transforms

This should address an incompatibility introduced in a previous PR.

Checklist
- [x] Tests
- [ ] ~~Documentation~~
- [x] Change log
- [x] Milestone
- [x] Label(s)
