### PR TITLE
Fix residual fringe data model name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -256,7 +256,7 @@ resample
 residual_fringe
 ---------------
  - Added documentation on step [#6387]
- - Fixed incorrect data model name []
+ - Fixed incorrect data model name [#6487]
 
 skymatch
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -256,6 +256,7 @@ resample
 residual_fringe
 ---------------
  - Added documentation on step [#6387]
+ - Fixed incorrect data model name []
 
 skymatch
 --------

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -91,7 +91,7 @@ class ResidualFringeCorrection():
         output_data /= normalization_factor
 
         # Load the fringe reference file
-        residual_fringe_model = datamodels.ResidualFringeModel(self.residual_fringe_reference_file)
+        residual_fringe_model = datamodels.FringeFreqModel(self.residual_fringe_reference_file)
 
         # read in the band
         band = self.input_model.meta.instrument.band.lower()


### PR DESCRIPTION
This PR fixes a bug in the residual fringe code; one instance of ResidualFringeModel was missed previously when the change was made to use FringeFreqModel.

Without this change, the pipeline returns 
AttributeError: module 'jwst.datamodels' has no attribute 'ResidualFringeModel'

With this change, the residual fringe step runs ok.