### PR TITLE
JP-2153: Enable spectral order as input to WCS in NIRIS SOSS mode.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ assign_wcs
 - Fixed bug in NIRSpec MOS slitlet meta data calculations for background slits
   consisting of multiple shutters. [#6454]
 
+- Enabled spectral order as input to WCS for NIRISS SOSS mode. [#6496]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -4,8 +4,7 @@ import asdf
 from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling.models import Const1D, Mapping, Identity, Shift
-# from astropy.modeling.utils import ComplexBoundingBox
-from gwcs.bounding_box import CompoundBoundingBox
+from astropy.modeling.bounding_box import CompoundBoundingBox
 import gwcs.coordinate_frames as cf
 from gwcs import wcs
 
@@ -106,9 +105,10 @@ def _niriss_order_bounding_box(input_model, order):
 
 
 def niriss_bounding_box(input_model):
-    bbox = {order: _niriss_order_bounding_box(input_model, order)
+    bbox = {(order,): _niriss_order_bounding_box(input_model, order)
             for order in [1, 2, 3]}
-    return CompoundBoundingBox(bbox, slice_args=[('spectral_order', True, 2)])
+    model = input_model.meta.wcs.forward_transform
+    return CompoundBoundingBox.validate(model, bbox, slice_args=[('spectral_order', True)])
 
 
 def niriss_soss(input_model, reference_files):

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -108,7 +108,7 @@ def niriss_bounding_box(input_model):
     bbox = {(order,): _niriss_order_bounding_box(input_model, order)
             for order in [1, 2, 3]}
     model = input_model.meta.wcs.forward_transform
-    return CompoundBoundingBox.validate(model, bbox, slice_args=[('spectral_order', True)])
+    return CompoundBoundingBox.validate(model, bbox, slice_args=[('spectral_order', True)], order='F')
 
 
 def niriss_soss(input_model, reference_files):
@@ -136,9 +136,6 @@ def niriss_soss(input_model, reference_files):
 
     It uses the "specwcs" reference file.
     """
-
-    print("Running niriss_soss")
-    # raise RuntimeError("Please say something")
 
     # Get the target RA and DEC, they will be used for setting the WCS RA
     # and DEC based on a conversation with Kevin Volk.

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -4,7 +4,8 @@ import asdf
 from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling.models import Const1D, Mapping, Identity, Shift
-from astropy.modeling.utils import ComplexBoundingBox
+# from astropy.modeling.utils import ComplexBoundingBox
+from gwcs.bounding_box import CompoundBoundingBox
 import gwcs.coordinate_frames as cf
 from gwcs import wcs
 
@@ -107,7 +108,7 @@ def _niriss_order_bounding_box(input_model, order):
 def niriss_bounding_box(input_model):
     bbox = {order: _niriss_order_bounding_box(input_model, order)
             for order in [1, 2, 3]}
-    return ComplexBoundingBox(bbox, slice_arg=2, remove_slice_arg=True)
+    return CompoundBoundingBox(bbox, slice_args=[('spectral_order', True, 2)])
 
 
 def niriss_soss(input_model, reference_files):

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -97,9 +97,9 @@ def _niriss_order_bounding_box(input_model, order):
     if order == 1:
         return (tuple(bbox_y), tuple(bbox_x))
     elif order == 2:
-        return (tuple(2 * bbox_y), tuple(2 * bbox_x))
+        return (tuple(bbox_y), tuple(bbox_x))
     elif order == 3:
-        return (tuple(3 * bbox_y), tuple(3 * bbox_x))
+        return (tuple(bbox_y), tuple(bbox_x))
     else:
         raise ValueError(f'Invalid spectral order: {order} provided. Spectral order must be 1, 2, or 3.')
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -198,7 +198,6 @@ def niriss_soss(input_model, reference_files):
         cm_order2 = subarray2full | cm_order2
         cm_order3 = subarray2full | cm_order3
 
-        print("Assigning bounding_box")
         bbox = ((-0.5, input_model.meta.subarray.ysize - 0.5),
                 (-0.5, input_model.meta.subarray.xsize - 0.5))
         cm_order1.bounding_box = bbox


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2153](https://jira.stsci.edu/browse/JP-2153)

**Description**

This uses the new astropy compound bounding box in order to enable usage of spectral order as a direct input to the wcs in NIRIS SOSS mode.

Note this PR requires the changes from #6205 (so that it passes with the recent changes to gwcs) and spacetelescope/gwcs#375 (to enable the use of compound bounding boxes in gwcs).

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
