### PR TITLE
JP-2347: Fix names of SOSS extraction keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,7 +130,9 @@ datamodels
 - Moved new column 'reference_order' in guider schemas' planned
   star table to second in order, after 'guide_star_order' [#6465]
 
- - Updated moving_target schema changing mt_detector_x/y to mt_sci_x/y [#6485]
+- Updated moving_target schema changing mt_detector_x/y to mt_sci_x/y [#6485]
+
+- Fixed names of NIRISS SOSS extract_1d parameter keywords to be legal FITS [#6499]
 
 dark_current
 ------------

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -2481,23 +2481,23 @@ properties:
           width:
             title: Aperture width used in extraction
             type: number
-            fits_keyword: SOSS_WDTH
+            fits_keyword: SOSSWDTH
           tikhonov_factor:
             title: Tikhonov factor used in extraction
             type: number
-            fits_keyword: TIKFAC
+            fits_keyword: TIKFACTR
           delta_x:
             title: X-shift used in extraction
             type: number
-            fits_keyword: SOSS_DLTX
+            fits_keyword: SOSSDLTX
           delta_y:
             title: Y-shift used in extraction
             type: number
-            fits_keyword: SOSS_DLTY
+            fits_keyword: SOSSDLTY
           theta:
             title: Rotation angle used in extraction
             type: number
-            fits_keyword: SOSS_ROTN
+            fits_keyword: SOSSROTN
           oversampling:
             title: Oversampling used in extraction
             type: number


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6498 
Resolves [JP-2347](https://jira.stsci.edu/browse/JP-2347)

**Description**

This PR fixes the names of several keywords related to the new NIRISS SOSS extract_1d operation. The old names were longer than 8 characters and hence illegal.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [X] Milestone
- [X] Label(s)