### PR TITLE
Update linearity test  in jwst pipeline caused by changes in  STCAL PR 65 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,8 @@ linearity
 
 - Use the common code in STCAL for linearity correction. [#6386]
 
+- Update of linearity test to support STCAL PR65 [#6509]
+
 outlier_detection
 -----------------
 

--- a/jwst/linearity/tests/test_linearity.py
+++ b/jwst/linearity/tests/test_linearity.py
@@ -61,7 +61,7 @@ def test_coeff_dq():
 
     # test case where all coefficients are zero, the linearity reference file may
     # not mark these pixels as NO_LIN_CORR. The code will mark these pixels as
-    # NO_LIN_COR
+    # NO_LIN_CORR
     ref_model.coeffs[:, 25, 25] = 0.0
     im.data[0, 50, 25, 25] = 600.0
 

--- a/jwst/linearity/tests/test_linearity.py
+++ b/jwst/linearity/tests/test_linearity.py
@@ -41,15 +41,18 @@ def test_coeff_dq():
     # Equation is DNcorr = L0 + L1*DN(i) + L2*DN(i)^2 + L3*DN(i)^3 + L4*DN(i)^4
     # DN(i) = signal in pixel, Ln = coefficient from ref file
     # L0 = 0 for all pixels for CDP6
+
+    coeffs = np.asfarray([0.0e+00, 0.85, 4.62e-06, -6.16e-11, 7.23e-16])
+
+    # pixels to test using default coeffs
+    ref_model.coeffs[:, 30, 50] = coeffs
+    ref_model.coeffs[:, 35, 35] = coeffs
+    ref_model.coeffs[:, 35, 36] = coeffs
     L0 = 0
     L1 = 0.85
     L2 = 4.62E-6
     L3 = -6.16E-11
     L4 = 7.23E-16
-
-    coeffs = np.asfarray([0.0e+00, 0.85, 4.62e-06, -6.16e-11, 7.23e-16])
-
-    ref_model.coeffs[:, 30, 50] = coeffs
 
     # check behavior with NaN coefficients: should not alter pixel values
     coeffs2 = np.asfarray([L0, np.nan, L2, L3, L4])
@@ -196,6 +199,14 @@ def test_pixeldqprop():
     ref_model = LinearityModel((numcoeffs, ysize, xsize))
     ref_model.dq = dq
 
+    coeffs = np.asfarray([0.0e+00, 0.85, 4.62e-06, -6.16e-11, 7.23e-16])
+
+    # pixels to test using default coeffs.
+    ref_model.coeffs[:, 550, 550] = coeffs
+    ref_model.coeffs[:, 560, 550] = coeffs
+    ref_model.coeffs[:, 550, 560] = coeffs
+    ref_model.coeffs[:, 500, 300] = coeffs
+
     ref_model.meta.instrument.name = 'MIRI'
     ref_model.meta.instrument.detector = 'MIRIMAGE'
     ref_model.meta.subarray.xstart = 1
@@ -250,6 +261,9 @@ def test_lin_subarray():
     dq[542, 100:105] = 1
 
     ref_model = LinearityModel((numcoeffs, 1024, 1032))
+    # set all the linear terms =1, so it does not trip the check if
+    # the linear terms = 0, which results in DQ of NON_LIN_CORR
+    ref_model.coeffs[1,:,:] = 1
     ref_model.dq = dq
 
     ref_model.meta.instrument.name = 'MIRI'

--- a/jwst/linearity/tests/test_linearity.py
+++ b/jwst/linearity/tests/test_linearity.py
@@ -262,7 +262,7 @@ def test_lin_subarray():
 
     ref_model = LinearityModel((numcoeffs, 1024, 1032))
     # set all the linear terms =1, so it does not trip the check if
-    # the linear terms = 0, which results in DQ of NON_LIN_CORR
+    # the linear terms = 0, which results in DQ of NO_LIN_CORR
     ref_model.coeffs[1,:,:] = 1
     ref_model.dq = dq
 

--- a/jwst/linearity/tests/test_linearity.py
+++ b/jwst/linearity/tests/test_linearity.py
@@ -187,7 +187,7 @@ def test_pixeldqprop():
 
     # Create reference file
     dq = np.zeros((ysize, xsize), dtype=int)
-    numcoeffs = 3
+    numcoeffs = 5
 
     # set PIXELDQ to 'NO_LIN_CORR'
     dq[500, 500] = dqflags.pixel['NO_LIN_CORR']

--- a/jwst/linearity/tests/test_linearity.py
+++ b/jwst/linearity/tests/test_linearity.py
@@ -84,7 +84,7 @@ def test_coeff_dq():
     ref_model.dq[35, 35] = dqflags.pixel['DO_NOT_USE']
     ref_model.dq[35, 36] = dqflags.pixel['NO_LIN_CORR']
     ref_model.dq[30, 50] = dqflags.pixel['GOOD']
-    ref_model.dq[25, 25] = dqflags.pixel['GOOD']
+    ref_model.dq[25, 25] = dqflags.pixel['GOOD']  # Testing the linerity sets this to NO_LIN_CORR
 
     # run through Linearity pipeline
     outfile = lincorr(im, ref_model)

--- a/jwst/linearity/tests/test_linearity.py
+++ b/jwst/linearity/tests/test_linearity.py
@@ -56,6 +56,12 @@ def test_coeff_dq():
     ref_model.coeffs[:, 20, 50] = coeffs2
     im.data[0, 50, 20, 50] = 500.0
 
+    # test case where all coefficients are zero, the linearity reference file may
+    # not mark these pixels as NO_LIN_CORR. The code will mark these pixels as
+    # NO_LIN_COR
+    ref_model.coeffs[:, 25, 25] = 0.0
+    im.data[0, 50, 25, 25] = 600.0
+
     tgroup = 2.775
 
     # set pixel values (DN) for specific pixels up the ramp
@@ -75,6 +81,7 @@ def test_coeff_dq():
     ref_model.dq[35, 35] = dqflags.pixel['DO_NOT_USE']
     ref_model.dq[35, 36] = dqflags.pixel['NO_LIN_CORR']
     ref_model.dq[30, 50] = dqflags.pixel['GOOD']
+    ref_model.dq[25, 25] = dqflags.pixel['GOOD']
 
     # run through Linearity pipeline
     outfile = lincorr(im, ref_model)
@@ -86,10 +93,13 @@ def test_coeff_dq():
     # check that dq value was handled correctly
     assert outfile.pixeldq[35, 35] == dqflags.pixel['DO_NOT_USE']
     assert outfile.pixeldq[35, 36] == dqflags.pixel['NO_LIN_CORR']
+    assert outfile.pixeldq[25, 25] == dqflags.pixel['NO_LIN_CORR']
     # NO_LIN_CORR, sci value should not change
     assert outfile.data[0, 30, 35, 36] == 35
     # NaN coefficient should not change data value
     assert outfile.data[0, 50, 20, 50] == 500.0
+    # coefficients all zero should not change data value
+    assert outfile.data[0, 50, 25, 25] == 600.0
 
 
 def test_saturation():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->
This PR is to support JP-2311  and STCAL PR [#65](https://github.com/spacetelescope/stcal/pull/65)

**Description**

The linearity step on STCAL was updated to deal with the case where all the linearity coefficients =0. It has been assumed that  this is a mistake in the reference file. If the linearity term of the linearity correction is zero then the resulting data will be zero. PR 65 on STCAL checks if the linear term is zero and if it is it sets the value to 1 and sets the DQflag in the linearity model to "NO_LIN_CORR'.  These pixels will have no linearity correction applied to them and their DQFlag will include NO_LIN_CORR. 
One of the CI tests is to run the unit test for the linearity step in the JWST Pipeline.
This PR fixes cases where the test did not set the linear term to a value. The default value was 0, so the returned DQ for the pixel now included NO_LIN_CORR.
.
This PR has to be merged before the STCAL code (PR65) can be merged because the test is failing.

Checklist
- [X] Tests
- [ ] Documentation
- [X] Change log
- [X] Milestone
- [X] Label(s)
