### PR TITLE
Temp fix for failing NRS lamp regtests

### DIFF
--- a/jwst/regtest/test_nirspec_lamp_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_lamp_fs_spec2.py
@@ -23,7 +23,9 @@ def run_pipeline(rtdata_module):
             "--steps.extract_2d.save_results=true",
             "--steps.flat_field.save_results=true",
             # The pars file skips resampling by default.  We want to test it.
-            "--steps.resample_spec.skip=False",]
+            "--steps.resample_spec.skip=False",
+            # Skip extract_1d until the APCORR ref file issue is fixed.
+            "--steps.extract_1d.skip=True",]
     Step.from_cmdline(args)
 
     return rtdata

--- a/jwst/regtest/test_nirspec_lamp_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_lamp_ifu_spec2.py
@@ -21,7 +21,9 @@ def run_pipeline(rtdata_module):
             "--steps.assign_wcs.save_results=true",
             "--steps.msa_flagging.save_results=true",
             "--steps.extract_2d.save_results=true",
-            "--steps.flat_field.save_results=true"]
+            "--steps.flat_field.save_results=true",
+            # Turn off extract_1d until APCORR ref file issue is fixed
+            "--steps.extract_1d.skip=true"]
     Step.from_cmdline(args)
 
     return rtdata


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

**Description**

This PR makes a temporary change to 2 NIRSpec lamp exposure regression tests, to avoid a failure caused by recent updates to CRDS ref files. The NIRSpec team recently submitted new pars-spec2pipeline ref files that enable the extract_1d step for lamp exposures, but skip the aperture correction. The CRDS bestref that runs at the beginning of pipeline instantiation doesn't know apcorr is going to be skipped and hence tries to find an appropriate APCORR ref file and fails (there aren't any for lamp modes). This will be fixed, but not for a while yet. So in the meantime I've modified the 2 failing regtests to skip the extract_1d step for lamp exposures. This can be reactivated once CRDS updates are in place (post-B7.9?).

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [x] Label(s)
