### PR TITLE
Try restricting sphinx-automodapi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ docs =
     sphinx
     sphinx-asdf>=0.1.1
     sphinx-astropy
-    sphinx-automodapi
+    sphinx-automodapi<0.14.0
     sphinx-rtd-theme
     stsci-rtd-theme
     mistune~=0.8.4


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

**Description**

This PR restricts sphinx-automodapi to < 0.14.0 to avoid https://github.com/astropy/sphinx-automodapi/issues/141 which is causing the jwst doc build to fail.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
