### PR TITLE
DOC: Blender rules need __all__

### DIFF
--- a/docs/jwst/model_blender/blender_rules.rst
+++ b/docs/jwst/model_blender/blender_rules.rst
@@ -40,6 +40,4 @@ above.  This definition illustrates how several rules are simply interfaces for
 numpy array operations, while others are defined internally to `model_blender`.
 
 .. automodapi:: jwst.model_blender.blendrules
-   :skip: OrderedDict
-   :skip: Time
-   :skip: time
+  :no-inheritance-diagram:

--- a/jwst/model_blender/blendrules.py
+++ b/jwst/model_blender/blendrules.py
@@ -20,6 +20,11 @@ from . import blender
 # with this code
 __rules_version__ = 2.1
 
+__all__ = ['find_keywords_in_section', 'first', 'float_one', 'int_one',
+           'interpret_attr_line', 'interpret_entry', 'last', 'maxdate',
+           'maxdatetime', 'maxtime', 'mindate', 'mindatetime', 'mintime',
+           'multi', 'multi1', 'zero', 'KeywordRules', 'KwRule']
+
 
 # Custom blending functions
 def multi(vals):

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ docs =
     sphinx
     sphinx-asdf>=0.1.1
     sphinx-astropy
-    sphinx-automodapi<0.14.0
+    sphinx-automodapi
     sphinx-rtd-theme
     stsci-rtd-theme
     mistune~=0.8.4


### PR DESCRIPTION
Reverts spacetelescope/jwst#6520

Instead of pinning automodapi, just don't try to import everything.

Because I am lazy, I am using GitHub interface. I will fix the `__all__` in subsequent commit.