### PR TITLE
Updates to resample and dark_current docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,7 +90,7 @@ dark_current
 
 - Moved dark current code from JWST to STCAL. [spacetelecope/stcal#63] [#6444]
 
-- Updates step docs to explain unique form of MIRI dark reference data [#6529]
+- Updated step docs to explain unique form of MIRI dark reference data [#6529]
 
 datamodels
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,9 +86,11 @@ cube_build
 dark_current
 ----------
 
+- Refactored the code in preparation for moving the code to STCAL. [#6336]
+
 - Moved dark current code from JWST to STCAL. [spacetelecope/stcal#63] [#6444]
 
-- Refactored the code in preparation for moving the code to STCAL. [#6336]
+- Updates step docs to explain unique form of MIRI dark reference data [#6529]
 
 datamodels
 ----------
@@ -276,6 +278,9 @@ resample
 - Updated ``drizzle`` version to ``1.13.4`` which contains a fix for the
   bug due to which some 0-weight input pixels may contribute to the output
   image. [#6517]
+
+- Updated step docs to indicate that the default weighting type is
+  now "ivm" [#6529]
 
 residual_fringe
 ---------------

--- a/docs/jwst/dark_current/description.rst
+++ b/docs/jwst/dark_current/description.rst
@@ -3,7 +3,6 @@ Description
 
 Assumptions
 -----------
-
 It is assumed that the input science data have *NOT* had the zero group (or
 bias) subtracted. We also do not want the dark subtraction process to remove
 the bias signal from the science exposure, therefore the dark reference data
@@ -12,21 +11,20 @@ group zero of the dark reference data will effectively be zero-valued.
 
 Algorithm
 ---------
-
-The dark current step removes dark current from a JWST exposure by subtracting
-dark current data stored in a dark reference file.
+The dark current step removes dark current from an exposure by subtracting
+dark current data stored in a dark reference file in CRDS.
 
 The current implementation uses dark reference files that have been
 constructed from exposures using NFRAMES=1 and GROUPGAP=0 (i.e. one
 frame per group and no dropped frames) and the maximum number of frames
 allowed for an integration. If the science exposure that's being processed
 also used NFRAMES=1 and GROUPGAP=0, then the dark reference file data
-are directly subtracted frame-by-frame from the science exposure.
+are directly subtracted group-by-group from the science exposure.
 
 If the science exposure used NFRAMES>1 or GROUPGAP>0, the dark
-reference file data are reconstructed internally to match the frame averaging
-and groupgap settings of the science exposure. The reconstructed dark data are
-created by averaging NFRAMES adjacent dark frames and skipping
+reference file data are reconstructed on-the-fly by the step to match the frame
+averaging and groupgap settings of the science exposure. The reconstructed dark
+data are created by averaging NFRAMES adjacent dark frames and skipping
 GROUPGAP intervening frames.
 
 The frame-averaged dark is constructed using the following scheme:
@@ -35,14 +33,20 @@ The frame-averaged dark is constructed using the following scheme:
 * ERR arrays are computed as the uncertainty in the mean, using
   :math:`\frac{\sqrt {\sum \mathrm{ERR}^2}}{nframes}`
 
-For each integration in the input science exposure, the averaged dark data are
-then subtracted, group-by-group, from the science exposure groups, in which
-each SCI group of the dark data is subtracted from the corresponding SCI
-group of the science data.
+The dark reference data are not integration-dependent for most instruments,
+hence the same group-by-group dark current data are subtracted from every
+integration of the science exposure. An exception to this rule is the JWST
+MIRI instrument, for which the dark signal **is** integration-dependent, at
+least to a certain extent. MIRI dark reference file data is therefore
+4-dimensional (ncols x nrows x ngroups x nintegrations). Typical MIRI dark
+reference files contain data for only 2 or 3 integrations, which are directly
+subtracted from the corresponding first few integrations of the science exposure.
+The data in the last integration of the dark reference file is applied to all
+remaining science integrations.
 
-The ERR arrays of the science data are not modified.
+The ERR arrays of the science data are currently not modified by this step.
 
-The DQ flags from the dark reference file are propagated into science
+The DQ flags from the dark reference file are propagated into the science
 exposure PIXELDQ array using a bitwise OR operation.
 
 Upon successful completion of the dark subtraction the S_DARK keyword is
@@ -50,25 +54,23 @@ set to "COMPLETE".
 
 Special Handling
 ++++++++++++++++
-
 Any pixel values in the dark reference data that are set to NaN will have their
 values reset to zero before being subtracted from the science data, which
 will effectively skip the dark subtraction operation for those pixels.
 
-**Note**: If the input science exposure contains more frames than the available
+**Note**: If the input science exposure contains more groups than the available
 dark reference file, no dark subtraction will be applied and the input data
 will be returned unchanged.
 
 Subarrays
 ---------
-
 It is assumed that dark current will be subarray-dependent, therefore this
 step makes no attempt to extract subarrays from the dark reference file to
 match input subarrays. It instead relies on the presence of matching subarray
 dark reference files in CRDS.
 
-NIRCam Target Acq Subarrays
----------------------------
+JWST/NIRCam Target Acq Subarrays
+--------------------------------
 Due to the very large number of available NIRCam target acquisition (TA) subarrays,
 the instrument team has chosen to not provide dark reference files for any of
 the TA subarrays in CRDS.

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -32,7 +32,7 @@ image.
     approximately to the detector axes. Ignored when ``transform`` is
     provided.
 
-``--shape`` (tuple of int, default=None)
+``--output_shape`` (tuple of int, default=None)
     Shape of the image (data array) using "standard" ``nx`` first and ``ny``
     second (as opposite to the ``numpy.ndarray`` convention - ``ny`` first and
     ``nx`` second). This value will be assigned to
@@ -55,10 +55,14 @@ image.
   The value to assign to output pixels that have zero weight or do not
   receive any flux from any input pixels during drizzling.
 
-``--weight_type`` (str, default='exptime')
-  The weighting type for each input image. If `weight_type=exptime`,
-  the scaling value will be set equal to the exposure time found in
-  the image header.
+``--weight_type`` (str, default='ivm')
+  The weighting type for each input image.
+  If `weight_type=ivm` (the default), the scaling value
+  will be determined per-pixel using the inverse of the read noise
+  (VAR_RNOISE) array stored in each input image. If the VAR_RNOISE array does
+  not exist, the variance is set to 1 for all pixels (equal weighting).
+  If `weight_type=exptime`, the scaling value will be set equal to the exposure
+  time found in the image header.
 
 ``--single`` (bool, default=False)
   If set to `True`, resample each input image into a separate output.  If


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6523 
Closes #6526 
Resolves [JP-2364](https://jira.stsci.edu/browse/JP-2364)
Resolves [JP-2366](https://jira.stsci.edu/browse/JP-2366)

**Description**

This PR updates the docs for dark_current step, to add information regarding the unique way MIRI dark data are subtracted (per integration), and the resample step, to indicate that the default value for weighting is now "ivm".

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)