### PR TITLE
MNT: Remove distutils

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,12 +15,11 @@ import datetime
 import importlib
 import sys
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 from configparser import ConfigParser
 
 import sphinx
 import stsci_rtd_theme
-import sphinx_astropy
 
 
 def setup(app):
@@ -50,8 +49,8 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 
 def check_sphinx_version(expected_version):
-    sphinx_version = LooseVersion(sphinx.__version__)
-    expected_version = LooseVersion(expected_version)
+    sphinx_version = Version(sphinx.__version__)
+    expected_version = Version(expected_version)
     if sphinx_version < expected_version:
         raise RuntimeError(
             "At least Sphinx version {0} is required to build this "
@@ -102,7 +101,7 @@ extensions = [
 if on_rtd:
     extensions.append('sphinx.ext.mathjax')
 
-elif LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
+elif Version(sphinx.__version__) < Version('1.4'):
     extensions.append('sphinx.ext.pngmath')
 else:
     extensions.append('sphinx.ext.imgmath')

--- a/docs/jwst/datamodels/new_model.rst
+++ b/docs/jwst/datamodels/new_model.rst
@@ -49,8 +49,8 @@ custom model is as below::
   |--- setup.py
 
 The main pieces are the new schema in ``bad_pixel_mask.schema.yaml``,
-the custom model class in ``bad_pixel_mask.py``, a distutils-based
-`setup.py` file to install the package, and some unit tests and
+the custom model class in ``bad_pixel_mask.py``, a
+``setup.py`` file to install the package, and some unit tests and
 associated data.  Normally, you would also have some code that *uses*
 the custom model included in the package, but that isn't included in
 this minimal example.
@@ -354,9 +354,9 @@ right before saving also happen.
 The `setup.py` script
 ---------------------
 
-Writing a distutils `setup.py` script is beyond the scope of this
+Writing a ``setup.py`` script is beyond the scope of this
 tutorial but it's worth noting one thing.  Since the schema files are
-not Python files, they are not automatically picked up by distutils,
+not Python files, they are not automatically picked up by ``setuptools``,
 and must be included in the ``package_data`` option.  A complete, yet
 minimal, ``setup.py`` is presented below:
 
@@ -364,7 +364,7 @@ minimal, ``setup.py`` is presented below:
 
   #!/usr/bin/env python
 
-  from distutils.core import setup
+  from setuptools import setup
 
   setup(
       name='custom_model',
@@ -445,4 +445,3 @@ simple:
         A data model for NIRISS SOSS photom reference files.
         """
         schema_url = "nissoss_photom.schema"
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
 aws =
     stsci-aws-utils>=0.1.2
 docs =
+    packaging
     matplotlib
     sphinx
     sphinx-asdf>=0.1.1


### PR DESCRIPTION
Remove `distutils` because it is deprecated. Using `packaging` for version check.

I did not see anything affected by astropy/astropy#12633 though it was my original intent.