### PR TITLE
JP-2340: Fix incorrect output WCS and image size in ResampleSpecData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -282,6 +282,11 @@ resample
 - Updated step docs to indicate that the default weighting type is
   now "ivm" [#6529]
 
+- Fixed a bug in the ``ResampleSpecData.build_interpolated_output_wcs()``
+  due to which, under cerain circumstances, computed output image shame
+  could be very large resulting in (very) large memory usage and/or
+  incorrect output WCS. [#6533]
+
 residual_fringe
 ---------------
  - Added documentation on step [#6387]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -283,7 +283,7 @@ resample
   now "ivm" [#6529]
 
 - Fixed a bug in the ``ResampleSpecData.build_interpolated_output_wcs()``
-  due to which, under cerain circumstances, computed output image shame
+  due to which, under cerain circumstances, computed output image shape
   could be very large resulting in (very) large memory usage and/or
   incorrect output WCS. [#6533]
 


### PR DESCRIPTION
Closes #6479
Resolves [JP-2340](https://jira.stsci.edu/browse/JP-2340)

**Description**

It seems that the original code intended to swap X<->Y axes when the X-slope was close to 0 (when determining the size of the output image and constructing output WCS) in the `ResampleSpecData.build_interpolated_output_wcs()` function was buggy and did not create correct mapping for the inverse transformation and did not use the Y-slope to estimate image size (when axis swap was needed).

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
