### PR TITLE
JP-2298: Update docs to show create_history_entry() moved to stdatamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -140,6 +140,9 @@ datamodels
 
 - Update PATTTYPE enum values to match spellings used in keyword dictionary [#6501]
 
+- Updated documentation to point to stdatamodels.util
+  for calls to create_history_entry [#6537]
+
 dark_current
 ------------
 

--- a/docs/jwst/datamodels/models.rst
+++ b/docs/jwst/datamodels/models.rst
@@ -139,10 +139,11 @@ To get to the history::
       pass
 
 To add an entry to the history, first create the entry by calling
-`util.create_history_entry` and appending the entry to the model
+`stdatamodels.util.create_history_entry` and appending the entry to the model
 history::
 
-    entry =  util.create_history_entry("Processed through the frobulator step")
+    import stdatamodels
+    entry = stdatamodels.util.create_history_entry("Processed through the frobulator step")
     model.history.append(entry)
 
 These history entries are stored in ``HISTORY`` keywords when saving
@@ -158,7 +159,7 @@ following keys:
 The calling sequence to create  a history entry with the software
 description is::
 
-  entry =  util.create_history_entry(description, software=software_dict)
+  entry =  stdatamodels.util.create_history_entry(description, software=software_dict)
 
 where the second argument is the dictionary with the keywords
 mentioned.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6380 
Resolves [JP-2298](https://jira.stsci.edu/browse/JP-2298)

**Description**

This PR addresses outdated documentation that instructed users to call create_history_entry() from jwst.datamodels.util; it is now located in stdatamodels.util. Docs updated to reflect this. 

Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
