### PR TITLE
JP-2352: Add EXP_TYPE to PsfMaskModel schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,6 +143,8 @@ datamodels
 - Updated documentation to point to stdatamodels.util
   for calls to create_history_entry [#6537]
 
+- Added keyword EXP_TYPE to PsfMaskModel schema [#6540]
+  
 - Updated FILTEROFFSET reference file docs to add NIRCam information. [#6541]
 
 dark_current

--- a/jwst/datamodels/schemas/psfmask.schema.yaml
+++ b/jwst/datamodels/schemas/psfmask.schema.yaml
@@ -7,6 +7,7 @@ allOf:
 - $ref: referencefile.schema
 - $ref: keyword_filter.schema
 - $ref: keyword_coronmsk.schema
+- $ref: keyword_exptype.schema
 - $ref: subarray.schema
 - type: object
   properties:
@@ -16,8 +17,4 @@ allOf:
       default: 1.0
       ndim: 2
       datatype: float32
-    exposure:
-      title: exposure type
-      type: string
-      fits_keyword: EXP_TYPE
-      fits_hdu: SCI
+

--- a/jwst/datamodels/schemas/psfmask.schema.yaml
+++ b/jwst/datamodels/schemas/psfmask.schema.yaml
@@ -16,3 +16,8 @@ allOf:
       default: 1.0
       ndim: 2
       datatype: float32
+    exposure:
+      title: exposure type
+      type: string
+      fits_keyword: EXP_TYPE
+      fits_hdu: SCI


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6511 
Resolves [JP-2352](https://jira.stsci.edu/browse/JP-2352)

**Description**
Adds EXP_TYPE to PsfMaskModel schema (JP-2352). This is a required matching keyword for CRDS.
This PR addresses JP-2352

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [X] Label(s)