### PR TITLE
JP-2368: Update NIRCam FILTEROFFSET ref file info

### DIFF
--- a/docs/jwst/references_general/filteroffset_reffile.rst
+++ b/docs/jwst/references_general/filteroffset_reffile.rst
@@ -4,7 +4,7 @@
 
 
 FILTEROFFSET Reference File
----------------------------------------
+---------------------------
 
 :REFTYPE: FILTEROFFSET
 :Data model: `~jwst.datamodels.FilteroffsetModel`
@@ -15,22 +15,26 @@ CRDS selects appropriate FILTEROFFSET references based on the following keywords
 FILTEROFFSET is not applicable for instruments not in the table.
 All keywords used for file selection are *required*.
 
-========== ===============================================================
+========== ================================================
 Instrument Keywords
-========== ===============================================================
+========== ================================================
 MIRI       INSTRUME, DETECTOR, EXP_TYPE, DATE-OBS, TIME-OBS
-NIRCam     INSTRUME, DETECTOR, FILTER, PUPIL, EXP_TYPE, DATE-OBS, TIME-OBS
-========== ===============================================================
+NIRCam     INSTRUME, CHANNEL, MODULE, DATE-OBS, TIME-OBS
+========== ================================================
 
 .. include:: ../includes/standard_keywords.inc
 
 Reference File Format
 +++++++++++++++++++++
 The filteroffset reference file is an ASDF file that contains a list
-called ``filters``. Every item in the list contains three fields -
-``row_offset``, ``column_offset`` and ``name`` - the name of the filter they are valid for. The offsets, in pixels, are applied in the image science frame.
+called ``filters``. Every item in the list contains one or more entries that
+are used as selectors, as well as the column and row offset values to be applied.
+For the MIRI instrument, there is one selector "filter", which is the name of
+filter to which the offsets apply. For NIRCam, the selectors are "filter" and
+"pupil". The offsets, in pixels, are applied in the image science frame.
 
 :filters:
-    :column_offset: Offset in x (in pix)
-    :row_offset: Offset in y (in pix)
-    :name: Filter name
+    :filter: Filter name
+    :pupil: Pupil name (NIRCam only)
+    :column_offset: Offset in x (in pixels)
+    :row_offset: Offset in y (in pixels)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6530 
Resolves [JP-2368](https://jira.stsci.edu/browse/JP-2368)

**Description**

This PR updates reference file docs with the correct info for the NIRCam (and MIRI) FILTEROFFSET reference files. Supersedes the incorrect info added in #6534.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [X] Milestone
- [X] Label(s)