### PR TITLE
JP-2371 Remove MIR_FLATMRS from Asn_Lv3MIRMRS rule

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ assign_wcs
 associations
 ------------
 
+- Remove MIR_FLATMRS from Asn_Lv3MIRMRS rule. [#6548]
+
 - Fix bug causing ``pytest`` to encounter an error in test collection when
   running with recent commits to ``astropy`` main (``5.0.dev``). [#6176]
 

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -294,11 +294,7 @@ class Asn_Lv3MIRMRS(AsnMixin_Spectrum):
             DMSAttrConstraint(
                 name='exp_type',
                 sources=['exp_type'],
-                value=(
-                    'mir_mrs'
-                    '|mir_flatmrs'
-                ),
-                force_unique=False
+                value=('mir_mrs'),
             ),
             Constraint(
                 [
@@ -336,11 +332,7 @@ class Asn_Lv3MIRMRSBackground(AsnMixin_AuxData, AsnMixin_Spectrum):
             DMSAttrConstraint(
                 name='exp_type',
                 sources=['exp_type'],
-                value=(
-                    'mir_mrs'
-                    '|mir_flatmrs'
-                ),
-                force_unique=False
+                value=('mir_mrs'),
             ),
             Constraint(
                 [

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -57,6 +57,11 @@ SPECIAL_POOLS = {
         'xfail': None,
         'slow': True,
     },
+    'jw00675_20211225t181823_pool': {
+        'args': [],
+        'xfail': None,
+        'slow': True,
+    },
     'jw00676_20210403t114320_c1007_pool': {
         'args': [],
         'xfail': None,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6538
Resolves [JP-2371](https://jira.stsci.edu/browse/JP-2371)

**Description**

Do not add MIR_FLATMRS exposures to the Level 3 associations for MIRI MRS observations.

Checklist
- [x] Tests
- [ ] ~Documentation~
- [x] Change log
- [x] Milestone
- [x] Label(s)
