### PR TITLE
JP-1550: Turn off ATOCA by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -176,6 +176,9 @@ extract_1d
 - Delivery of new algorithm `ATOCA` for SOSS extraction, along with four new reference
   files: speckernel, specprofile, spectrace and wavemap. [#6467]
 
+- Added step parameter `soss_atoca` to turn ATOCA algorithm on, with box extraction
+  the default algorithm [#6551]
+
 flatfield
 ---------
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Related to [JP-1550](https://jira.stsci.edu/browse/JP-1550) and #5091 

**Description**

This PR turns off the ATOCA SOSS extraction algorithm by default, as more testing with the photom step turned off will be required before we can verify reasonable results. The algorithm can be activated using a temporary extract_1d step parameter soss_atoca, which defaults to False and triggers box extraction. Additionally, this removes the source_type attribute from the ATOCA output to prevent creation of an extraneous SCI extension in the x1dints output.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)