### PR TITLE
Fix jump tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,12 @@ jump
 
 - Updated jump detection step to use common code moved to stcal [#6089]
 
+- In stcal (pr #72), several changes were made to fix existing bugs in the
+  twopoint difference routine for jump detection. Some of these issues
+  resulted in jumps erroneously being flagged for pixels with only two
+  usable groups (i.e one usable difference). This PR on the JWST side
+  fixes one of the unit tests to account for this. [#6552]
+
 lib
 ---
 

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -273,13 +273,11 @@ def test_nirspec_saturated_pix(setup_inputs):
     model.groupdq[0, :, 1, 1] = [0, 0, 0, 0, 0, 2, 2]
     model.data[0, :, 2, 2] = [8.25666812e+05, -1.10471914e+05, 1.95755371e+02, 1.83118457e+03,
                               1.72250879e+03, 1.81733496e+03, 1.65188281e+03]
+    # 2 non-sat groups means only 1 non-sat diff, so no jumps should be flagged
     model.groupdq[0, :, 2, 2] = [0, 0, 2, 2, 2, 2, 2]
     model.data[0, :, 3, 3] = [1228767., 46392.234, -3245.6553, 7762.413,
                               37190.76, 266611.62, 5072.4434]
     model.groupdq[0, :, 3, 3] = [0, 0, 0, 0, 0, 0, 2]
-    model.data[0, :, 4, 4] = [7.5306038e+05, 1.8269953e+04, 1.8352356e+02, 2.1245061e+03,
-                              2.0628525e+03, 2.1039399e+03, 2.0069873e+03]
-    model.groupdq[0, :, 4, 4] = [0, 0, 2, 2, 2, 2, 2]
 
     # run jump detection
     out_model = run_detect_jumps(model, gain, rnoise, rejection_thresh=200.0, three_grp_thresh=200,
@@ -290,9 +288,9 @@ def test_nirspec_saturated_pix(setup_inputs):
     # Check the results. There should not be any pixels with DQ values of 6, which
     # is saturated (2) plus jump (4). All the DQ's should be either just 2 or just 4.
     assert_array_equal(out_model.groupdq[0, :, 1, 1], [0, 4, 4, 4, 0, 2, 2])
-    assert_array_equal(out_model.groupdq[0, :, 2, 2], [0, 4, 2, 2, 2, 2, 2])
+    # assert that no groups are flagged when theres only 1 non-sat. grp
+    assert_array_equal(out_model.groupdq[0, :, 2, 2], [0, 0, 2, 2, 2, 2, 2])
     assert_array_equal(out_model.groupdq[0, :, 3, 3], [0, 4, 4, 0, 0, 4, 2])
-    assert_array_equal(out_model.groupdq[0, :, 4, 4], [0, 4, 2, 2, 2, 2, 2])
 
 
 @pytest.mark.skip(reason='multiprocessing temporarily disabled')


### PR DESCRIPTION
Fixes unit test `test_nirspec_saturated_pix` for jump detection to account for changes in https://github.com/spacetelescope/stcal/pull/72

In this test, a test dataset is constructed and four pixels ((1, 1), (2, 2), (3, 3), 4,4)) are given test scenarios to see if flagging for saturated pixels is done correctly. 

The tests for pixels (1, 1) and (3, 3) did not have different results - while the internal calculations changed based on changes to the code, the resulting pixels flagged as jumps ended up being the same.

for the test case of pixel (2, 2), 5 of the 7 groups in the test data are set to be saturated, meaning there is only one non saturated diff so no jumps should be flagged. previously, it was incorrectly flagging the 3rd group as a jump when NO groups should have been flagged, so the truth value of this test has changed. I kept this test but changed the truth to assert that NO groups are flagged in this case. 

pixel(4, 4) was the same case as (2, 2), where 5 out of 7 groups were saturated so no jumps should be flagged as well.. I deleted this redundant example. 