### PR TITLE
SPB-778 Bugfix: JWST dependency uploads occuring with failed regressions

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -90,6 +90,7 @@ bc0.test_cmds = [
     'codecov --token=${codecov_token} -F nightly',
 ]
 bc0.test_configs = [data_config]
+bc0.failedFailureThresh = 0
 
 // macos-specific buildconfig to cause the creation of counterparts to the linux
 // environment dumps. Packages in a minimal conda environment differ by OS


### PR DESCRIPTION
SPB-778 Added a failure threshold so that failed regressions do not trigger an update during the build process

<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [SPB-778](https://jira.stsci.edu/browse/SPB-778)

**Description**

This PR fixes the creation of python dependency files by jwst regression test runs, so that the dependency files are only created and uploaded to artifactory when there were no failures in the regression test run. Right now they're being created for every run.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)