### PR TITLE
JP-2024: Update default value of skymatch's 'skymethod' step parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 1.4.2 (Unreleased)
 ==================
 
+skymatch
+--------
+
+- Changed default value of ``skymethod`` step parameter to 'match' [#6580]
 
 1.4.1 (2022-01-15)
 ==================

--- a/docs/jwst/skymatch/README.rst
+++ b/docs/jwst/skymatch/README.rst
@@ -90,7 +90,7 @@ The ``skymatch`` step has the following optional arguments:
 * ``skymethod`` (str):
   The sky computation algorithm to be used.
   Allowed values: {``local``, ``global``, ``match``, ``global+match``}
-  (Default = ``global+match``)
+  (Default = ``match``)
 
 * ``match_down`` (boolean):
   Specifies whether the sky *differences* should

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -34,7 +34,7 @@ class SkyMatchStep(Step):
 
     spec = """
         # General sky matching parameters:
-        skymethod = option('local', 'global', 'match', 'global+match', default='global+match') # sky computation method
+        skymethod = option('local', 'global', 'match', 'global+match', default='match') # sky computation method
         match_down = boolean(default=True) # adjust sky to lowest measured value?
         subtract = boolean(default=False) # subtract computed sky from image data?
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #5923 
Resolves [JP-2024](https://jira.stsci.edu/browse/JP-2024)

**Description**

This PR addresses background subtraction issues found in the resample step due to its interaction with the default skymatch step parameter skymethod being set to 'global+match'. This was found to have a simple solution of changing the default to 'match'.

Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
