### PR TITLE
JP-2386: Added MIRI-MRS cross band options to outlier detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 outlier_detection
 -----------------
 
-- Added MIRI MRS cross bands to options for the type of ifu cubes being created [#6666]
+- Added MIRI MRS cross bands to options for the type of IFU cubes being created [#6666]
 
 1.4.1 (2022-01-15)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 1.4.2 (Unreleased)
 ==================
 
+outlier_detection
+-----------------
+
+- Added MIRI MRS cross bands to options for the type of ifu cubes being created [#6666]
 
 1.4.1 (2022-01-15)
 ==================

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -34,7 +34,7 @@ class CubeBuildStep (Step):
 
     spec = """
          channel = option('1','2','3','4','all',default='all') # Channel
-         band = option('short','medium','long','all',default='all') # Band
+         band = option('short','medium','long','short-medium','short-long','medium-short','medium-long', 'long-short', 'long-medium','all',default='all') # Band
          grating   = option('prism','g140m','g140h','g235m','g235h','g395m','g395h','all',default='all') # Grating
          filter   = option('clear','f100lp','f070lp','f170lp','f290lp','all',default='all') # Filter
          output_type = option('band','channel','grating','multi',default='band') # Type IFUcube to create.

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -34,7 +34,8 @@ class CubeBuildStep (Step):
 
     spec = """
          channel = option('1','2','3','4','all',default='all') # Channel
-         band = option('short','medium','long','short-medium','short-long','medium-short','medium-long', 'long-short', 'long-medium','all',default='all') # Band
+         band = option('short','medium','long','short-medium','short-long','medium-short', \
+                'medium-long', 'long-short', 'long-medium','all',default='all') # Band
          grating   = option('prism','g140m','g140h','g235m','g235h','g395m','g395h','all',default='all') # Grating
          filter   = option('clear','f100lp','f070lp','f170lp','f290lp','all',default='all') # Filter
          output_type = option('band','channel','grating','multi',default='band') # Type IFUcube to create.

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -79,7 +79,6 @@ class OutlierDetectionIFU(OutlierDetection):
                 nc = len(this_channel)
                 for k in range(nc):
                     self.band_name.append('ch' + this_channel[k] + '_' + this_subchannel)
-
             elif self.instrument == 'NIRSPEC':
                 self.gratings.append(self.input_models[i].meta.instrument.grating.lower())
             else:
@@ -87,7 +86,7 @@ class OutlierDetectionIFU(OutlierDetection):
                 raise ErrorWrongInstrument('Instrument must be MIRI or NIRSPEC')
         if self.instrument == 'MIRI':
             band_no_repeat = list(set(self.band_name))
-            bands = ['short','medium','long']
+            bands = ['short','medium','long','short-medium','short-long','medium-short','medium-long','long-short','long-medium']
             channels = ['1','2','3','4']
             for this_band in band_no_repeat:
                 for j in channels:
@@ -95,11 +94,11 @@ class OutlierDetectionIFU(OutlierDetection):
                     if check_channel in this_band:
                         self.channels.append(j)
                 for k in bands:
-                    if k in this_band:
+                    compare_band = this_band[4:]  # remove the channel part of the name to see which band we have
+                    if k == compare_band:
                         self.subchannels.append(k)
             self.ifu_band1 = self.channels
             self.ifu_band2 = self.subchannels
-
         elif self.instrument == 'NIRSPEC':
             self.gratings = list(set(self.gratings))
             self.ifu_band1 = self.gratings


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6578 
Resolves [JP-2386](https://jira.stsci.edu/browse/JP-2386)

**Description**

This PR adds the cross-band MRS options 'short-medium', 'short-long', 'medium-short', 'medium-long', 'long-short', 'long-medium' outlier_reject (outlier_rejection_ifu.py). Outlier rejection will call cube_build using these band to build a cube. The spec defining 'band' in cube_build also had to be updated to include these options. 

Checklist
- [ ] Tests
- [ ] Documentation
- [X] Change log
- [X] Milestone
- [X] Label(s)
