### PR TITLE
JP-2495: Change restriction on Level-2b association creation to nrc_image instead of nrc_tacq

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.4.2 (Unreleased)
 ==================
 
+associations
+------------
+
+- Changed restriction on Level2b creation for ``NRC_TACQ`` exposures
+  to ``NRC_IMAGE`` to allow asn creation for tacq but not science [#6681]
+
 outlier_detection
 -----------------
 

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -112,7 +112,7 @@ class Asn_Lv2ImageNonScience(
                     DMSAttrConstraint(
                         name='exp_type',
                         sources=['exp_type'],
-                        value='nrc_tacq'
+                        value='nrc_image'
                     ),
 
                 ],


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #5655 
Resolves [JP-2495](https://jira.stsci.edu/browse/JP-2495)

**Description**

This PR prohibits the creation of level 2b associations if `dms_note` is `wfsc_los_jitter` and `exptype` = `nrc_image`, rather than the first implementation that prohibited associations for  `exptype` = `nrc_tacq`.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
