### PR TITLE
JP-2495: Move jitter exclusion constraint from Lv2ImageNonScience to Lv2WFSC

### DIFF
--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -102,22 +102,6 @@ class Asn_Lv2ImageNonScience(
             Constraint_Base(),
             Constraint_Image_Nonscience(),
             Constraint_Single_Science(self.has_science),
-            Constraint(
-                [
-                    DMSAttrConstraint(
-                        name='dms_note',
-                        sources=['dms_note'],
-                        value=['wfsc_los_jitter'],
-                    ),
-                    DMSAttrConstraint(
-                        name='exp_type',
-                        sources=['exp_type'],
-                        value='nrc_image'
-                    ),
-
-                ],
-                reduce=Constraint.notall
-            )
         ])
 
         # Now check and continue initialization.
@@ -984,6 +968,22 @@ class Asn_Lv2WFSC(
             Constraint_Image_Science(),
             Constraint_Single_Science(self.has_science),
             Constraint_WFSC(),
+            Constraint(
+                [
+                    DMSAttrConstraint(
+                        name='dms_note',
+                        sources=['dms_note'],
+                        value=['wfsc_los_jitter'],
+                    ),
+                    DMSAttrConstraint(
+                        name='exp_type',
+                        sources=['exp_type'],
+                        value='nrc_image'
+                    ),
+
+                ],
+                reduce=Constraint.notall
+            )
         ])
 
         # Now check and continue initialization.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #5655 
Resolves [JP-2495](https://jira.stsci.edu/browse/JP-2495)

**Description**

This PR moves the added, then edited, constraint that excludes NRC_IMAGE + "DMS_NOTE":"WFSC_LOS_JITTER" pool members from generating a 2b association. The initial constraint was being applied to members with exp_type NRC_TACQ, which if not constrained would generate a Lv2ImageNonScience asn. The change to exp_type changed which asn to constrain - now Lv2WFSC.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
