### PR TITLE
Clean up Extract1d logs for multi-integration extractions

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2887,7 +2887,7 @@ def do_extract1d(
                     log.info("Spectral order 0 is a direct image, skipping ...")
                     continue
 
-                log.info(f'Processing spectral order {sp_order}')
+                log.debug(f'Processing spectral order {sp_order}')
 
                 try:
                     output_model = create_extraction(
@@ -2932,7 +2932,7 @@ def do_extract1d(
                         log.info("Spectral order 0 is a direct image, skipping ...")
                         continue
 
-                log.info(f'Processing spectral order {sp_order}')
+                log.debug(f'Processing spectral order {sp_order}')
 
                 try:
                     output_model = create_extraction(
@@ -3372,6 +3372,7 @@ def extract_one_slit(
         exp_type = slit.meta.exposure.type
 
     if integ > -1:
+        log.info(f"Extracting integration {integ}")
         data = input_model.data[integ]
         var_poisson = input_model.var_poisson[integ]
         var_rnoise = input_model.var_rnoise[integ]

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -263,11 +263,11 @@ def extract1d(image, var_poisson, var_rnoise, var_flat, lambdas, disp_range,
 
             if bkg_npts == 0:
                 bkg_model = None
-                log.warning(f"Not enough valid pixels to determine background "
+                log.debug(f"Not enough valid pixels to determine background "
                             f"for lambda={lam:.6f} (column {x:d})")
 
             elif len(bkg_model) < bkg_order:
-                log.warning(f"Not enough valid pixels to determine background "
+                log.debug(f"Not enough valid pixels to determine background "
                             f"with the required order for lambda={lam:.6f} "
                             f"(column {x:d})\n"
                             f"Lowering background order to {len(bkg_model)}")


### PR DESCRIPTION

<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #----
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

**Description**

This PR makes the log more readable for extractions with many to hundreds of integrations, removing repeated warnings and including the integration in the default log output.

Can create an issue if needed for bookkeeping.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
