### PR TITLE
JP-2494: Change association 'asn_pool' to include file extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ associations
 ------------
 
 - Include filename extension for `asn_pool` entry, to maintain consistency
-  with `asntable` entry [#6695]
+  with `asntable` entry [#6699]
 
 1.4.2 (2022-01-20)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 1.4.3 (unreleased)
 ==================
 
+associations
+------------
 
+- Include filename extension for `asn_pool` entry, to maintain consistency
+  with `asntable` entry [#6695]
 
 1.4.2 (2022-01-20)
 ==================

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -227,7 +227,7 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         self.data['program'] = '{:0>5s}'.format(item['program'])
         self.data['asn_pool'] = basename(
             item.meta['pool_file']
-        ).split('.')[0]
+        )
         self.data['constraints'] = str(self.constraints)
         self.data['asn_id'] = self.acid.id
         self.new_product(self.dms_product_name())

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -242,9 +242,9 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
             if self.data['asn_pool'] == 'none':
                 self.data['asn_pool'] = basename(
                     item.meta['pool_file']
-                ).split('.')[0]
+                )
                 parsed_name = re.search(
-                    _DMS_POOLNAME_REGEX, self.data['asn_pool']
+                    _DMS_POOLNAME_REGEX, self.data['asn_pool'].split()[0]
                 )
                 if parsed_name is not None:
                     pool_meta = {

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -244,7 +244,7 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
                     item.meta['pool_file']
                 )
                 parsed_name = re.search(
-                    _DMS_POOLNAME_REGEX, self.data['asn_pool'].split()[0]
+                    _DMS_POOLNAME_REGEX, self.data['asn_pool'].split('.')[0]
                 )
                 if parsed_name is not None:
                     pool_meta = {

--- a/jwst/associations/tests/test_level3_basics.py
+++ b/jwst/associations/tests/test_level3_basics.py
@@ -21,7 +21,7 @@ def test_meta():
     assert data['target'] == 't001'
     assert data['asn_type'] == 'image3'
     assert data['asn_id'] == 'a3001'
-    assert data['asn_pool'] == 'pool_002_image_miri'
+    assert data['asn_pool'] == 'pool_002_image_miri.csv'
     assert data['asn_rule'] == 'Asn_Lv3Image'
     assert data['degraded_status'] == 'No known degraded exposures in association.'
     assert data['version_id'] is None


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6680 
Resolves [JP-2494](https://jira.stsci.edu/browse/JP-2494)

**Description**

This PR adds the file extension to the `asn_pool` entry in associations during their creation. I tested this with asn_generate locally, but I don't know that I've covered all cases.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
