### PR TITLE
Update scipy and numpy intersphinx inventory URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,8 @@ def check_sphinx_version(expected_version):
 # Configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'numpy': ('https://numpy.org/devdocs', None),
+    'scipy': ('http://scipy.github.io/devdocs', None),
     'matplotlib': ('http://matplotlib.org/', None),
     }
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

**Description**

This PR addresses the doc build failures due to a change in the location of the scipy and numpy intersphinx inventory files.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
