### PR TITLE
Add ability to override source type in Source Type step (JP-2155)

### DIFF
--- a/jwst/srctype/srctype_step.py
+++ b/jwst/srctype/srctype_step.py
@@ -13,17 +13,25 @@ class SourceTypeStep(Step):
     The source type is used in later calibrations to determine the appropriate
     methods to use. Input comes from either the SRCTYAPT keyword value, which
     is populated from user info in the APT, or the NIRSpec MSA planning tool.
+    The source type can be also specified on the command line for exposures
+    containing a single pre-defined target.
     """
 
     spec = """
+        source_type = option('POINT','EXTENDED', default=None)  # user-supplied source type
     """
 
     def process(self, input):
 
+        if (self.source_type is not None):
+            self.source_type = self.source_type.upper()
+
+        source_type = self.source_type  # retrieve command line override
+
         input_model = datamodels.open(input)
 
         # Call the source selection routine
-        result = set_source_type(input_model)
+        result = set_source_type(input_model, source_type)
 
         # Set the step status in the output model
         if result is None:

--- a/jwst/srctype/tests/test_srctype.py
+++ b/jwst/srctype/tests/test_srctype.py
@@ -191,8 +191,23 @@ def test_nrs_fixedslit():
     assert result.slits[2].source_type == 'EXTENDED'
 
 
-@pytest.mark.parametrize("exptype", ["NRS_BRIGHTOBJ", "NRC_TSGRISM", "NIS_SOSS",
-                                     "MIR_LRS-SLITLESS"])
+def test_valid_user_spec():
+    """ Overwrite source_type with valid user-specified value
+    """
+    input = datamodels.ImageModel((10, 10))
+
+    input.meta.exposure.type = 'NRS_IFU'
+    input.meta.target.source_type = 'POINT'
+
+    # User sets to valid value "EXTENDED"
+    output = srctype.set_source_type(input, "EXTENDED")
+
+    # Result should be match user override value
+    assert output.meta.target.source_type == 'EXTENDED'
+
+
+@pytest.mark.parametrize("exptype", ["NRS_BRIGHTOBJ", "NRC_TSGRISM",
+                                     "NIS_SOSS", "MIR_LRS-SLITLESS"])
 def test_tso_types(exptype):
     """ Test for when visit is tso.
     """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6162
Resolves [JP-2155](https://jira.stsci.edu/browse/JP-2155)

**Description**
This update allows the SRCTYPE to be overridden on the command line when processing exposures that contain a single pre-defined target, i.e. MIR_LRS-FIXEDSLIT, MIR_LRS-SLITLESS, MIR_MRS, NRC_TSGRISM, NRS_FIXEDSLIT, NRS_BRI
GHTOBJ, and NRS_IFU. Other EXP_TYPEs will be ignored. The change log and documentation will soon also be updated. This PR supersedes #6692 .

Checklist
- [X] Tests
- [ ] Documentation
- [ ] Change log
- [X] Milestone
- [X] Label(s)