### PR TITLE
JP-2071: Adding a One Good Group Ramp Suppression Switch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ ramp_fitting
   the various flavors of variance and ERR stored in the output
   products [#6715]
 
+- Added a switch to suppress computations for ramps that have only one
+  good group. [#6727]
+
 srctype
 -------
 

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -182,7 +182,7 @@ class RampFitStep(Step):
         int_name = string(default='')
         save_opt = boolean(default=False) # Save optional output
         opt_name = string(default='')
-        suppress_one_group = boolean(default=False) # Suppress ramps with only one good group
+        suppress_one_group = boolean(default=True) # Suppress ramps with only one good group
         maximum_cores = option('none', 'quarter', 'half', 'all', default='none') # max number of processes to create
     """
 

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -182,6 +182,7 @@ class RampFitStep(Step):
         int_name = string(default='')
         save_opt = boolean(default=False) # Save optional output
         opt_name = string(default='')
+        suppress_one_group = boolean(default=False) # Suppress ramps with only one good group
         maximum_cores = option('none', 'quarter', 'half', 'all', default='none') # max number of processes to create
     """
 
@@ -240,7 +241,8 @@ class RampFitStep(Step):
             image_info, integ_info, opt_info, gls_opt_model = ramp_fit.ramp_fit(
                 input_model, buffsize,
                 self.save_opt, readnoise_2d, gain_2d, self.algorithm,
-                self.weighting, max_cores, dqflags.pixel)
+                self.weighting, max_cores, dqflags.pixel,
+                suppress_one_group=self.suppress_one_group)
 
         # Save the OLS optional fit product, if it exists
         if opt_info is not None:

--- a/jwst/ramp_fitting/tests/test_ramp_fit_step.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_step.py
@@ -254,9 +254,9 @@ def test_int_times2(generate_miri_reffiles, setup_inputs):
 
 def one_group_suppressed(suppress, setup_inputs):
     """
-    Tests three pixel ramps.
+    Creates three pixel ramps.
     The first ramp has no good groups.
-    The second ramp has one good groups.
+    The second ramp has one good group.
     The third ramp has all good groups.
 
     Sets up the models to be used by the tests for the one
@@ -305,7 +305,7 @@ def test_one_group_not_suppressed(setup_inputs):
     """
     Tests three pixel ramps.
     The first ramp has no good groups.
-    The second ramp has one good groups.
+    The second ramp has one good group.
     The third ramp has all good groups.
 
     Verify that when the suppress switch is turned off the second ramp is
@@ -342,7 +342,7 @@ def test_one_group_suppressed(setup_inputs):
     """
     Tests three pixel ramps.
     The first ramp has no good groups.
-    The second ramp has one good groups.
+    The second ramp has one good group.
     The third ramp has all good groups.
 
     Verify that when the suppress switch is turned off the second ramp is

--- a/jwst/ramp_fitting/tests/test_ramp_fit_step.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_step.py
@@ -10,6 +10,7 @@ from jwst.datamodels import GainModel, ReadnoiseModel
 test_dq_flags = dqflags.pixel
 DO_NOT_USE = test_dq_flags["DO_NOT_USE"]
 
+
 @pytest.fixture(scope="module")
 def generate_miri_reffiles():
     ingain = 6
@@ -258,7 +259,7 @@ def one_group_suppressed(suppress, setup_inputs):
     The second ramp has one good groups.
     The third ramp has all good groups.
 
-    Sets up the models to be used by the tests for the one 
+    Sets up the models to be used by the tests for the one
     group suppression flag.
     """
     # Define the data.
@@ -350,7 +351,6 @@ def test_one_group_suppressed(setup_inputs):
     slopes, cube_model, dims = one_group_suppressed(True, setup_inputs)
     nints, ngroups, nrows, ncols = dims
     tol = 1e-5
-
 
     # Check slopes information
     sdata_check = np.zeros((nrows, ncols), dtype=np.float32)

--- a/jwst/ramp_fitting/tests/test_ramp_fit_step.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_step.py
@@ -7,8 +7,7 @@ from jwst.datamodels import dqflags
 from jwst.datamodels import RampModel
 from jwst.datamodels import GainModel, ReadnoiseModel
 
-test_dq_flags = dqflags.pixel
-DO_NOT_USE = test_dq_flags["DO_NOT_USE"]
+DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6013 
Resolves [JP-2071](https://jira.stsci.edu/browse/JP-2071)

**Description**

This PR adds switch to suppress computations for ramps that have only one good group in them.  This is done by find those ramps, then setting the DQ flag for the one good group in that ramp to `DO_NOT_USE`.  This makes that ramp a zero group ramp and all computations will be done for that ramp the same as if the ramp had no good groups.


The `ramp_fit` function in STCAL added `suppress_one_group` to it's signature due to this PR.  This causes many ramp fitting tests to fail, since the STCAL PR has not yet been merged.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
