### PR TITLE
JP-2516: Add catch for no data case in MRS Extract1D statistics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ extract_1d
 - Clean the logging statements made by `extract_1d` to make the log
   more useful [#6696]
 
+- Check for non-zero array size before computing sigma-clipped
+  statistics in IFU mode [#6728]
+
 ramp_fitting
 ------------
 

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -634,7 +634,7 @@ def extract_ifu(input_model, source_type, extract_params):
             # If there are good data, work out the statistics
             if (len(bkg_stat_data) > 0):
                 bkg_mean, _, bkg_stddev = stats.sigma_clipped_stats(bkg_stat_data,
-                                                                sigma=bkg_sigma_clip, maxiters=5)
+                                                                    sigma=bkg_sigma_clip, maxiters=5)
                 low = bkg_mean - bkg_sigma_clip * bkg_stddev
                 high = bkg_mean + bkg_sigma_clip * bkg_stddev
 
@@ -642,22 +642,22 @@ def extract_ifu(input_model, source_type, extract_params):
                 maskclip = np.logical_or(bkg_data < low, bkg_data > high)
 
                 bkg_table = aperture_photometry(bkg_data, aperture, mask=maskclip,
-                                            method=method, subpixels=subpixels)
+                                                method=method, subpixels=subpixels)
                 background[k] = float(bkg_table['aperture_sum'][0])
                 phot_table = aperture_photometry(temp_weightmap, aperture, mask=maskclip,
-                                             method=method, subpixels=subpixels)
+                                                 method=method, subpixels=subpixels)
                 npixels_bkg[k] = float(phot_table['aperture_sum'][0])
 
                 var_poisson_table = aperture_photometry(var_poisson[k, :, :], aperture, mask=maskclip,
-                                                    method=method, subpixels=subpixels)
+                                                        method=method, subpixels=subpixels)
                 b_var_poisson[k] = float(var_poisson_table['aperture_sum'][0])
 
                 var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], aperture, mask=maskclip,
-                                                   method=method, subpixels=subpixels)
+                                                       method=method, subpixels=subpixels)
                 b_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
 
                 var_flat_table = aperture_photometry(var_flat[k, :, :], aperture, mask=maskclip,
-                                                 method=method, subpixels=subpixels)
+                                                     method=method, subpixels=subpixels)
                 b_var_flat[k] = float(var_flat_table['aperture_sum'][0])
 
         del temp_weightmap

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -631,32 +631,34 @@ def extract_ifu(input_model, source_type, extract_params):
             # the edge data that is zero to define the statistics on clipping
             bkg_stat_data = bkg_data[temp_weightmap == 1]
 
-            bkg_mean, _, bkg_stddev = stats.sigma_clipped_stats(bkg_stat_data,
+            # If there are good data, work out the statistics
+            if (len(bkg_stat_data) > 0):
+                bkg_mean, _, bkg_stddev = stats.sigma_clipped_stats(bkg_stat_data,
                                                                 sigma=bkg_sigma_clip, maxiters=5)
-            low = bkg_mean - bkg_sigma_clip * bkg_stddev
-            high = bkg_mean + bkg_sigma_clip * bkg_stddev
+                low = bkg_mean - bkg_sigma_clip * bkg_stddev
+                high = bkg_mean + bkg_sigma_clip * bkg_stddev
 
-            # set up the mask to flag data that should not be used in aperture photometry
-            maskclip = np.logical_or(bkg_data < low, bkg_data > high)
+                # set up the mask to flag data that should not be used in aperture photometry
+                maskclip = np.logical_or(bkg_data < low, bkg_data > high)
 
-            bkg_table = aperture_photometry(bkg_data, aperture, mask=maskclip,
+                bkg_table = aperture_photometry(bkg_data, aperture, mask=maskclip,
                                             method=method, subpixels=subpixels)
-            background[k] = float(bkg_table['aperture_sum'][0])
-            phot_table = aperture_photometry(temp_weightmap, aperture, mask=maskclip,
+                background[k] = float(bkg_table['aperture_sum'][0])
+                phot_table = aperture_photometry(temp_weightmap, aperture, mask=maskclip,
                                              method=method, subpixels=subpixels)
-            npixels_bkg[k] = float(phot_table['aperture_sum'][0])
+                npixels_bkg[k] = float(phot_table['aperture_sum'][0])
 
-            var_poisson_table = aperture_photometry(var_poisson[k, :, :], aperture, mask=maskclip,
+                var_poisson_table = aperture_photometry(var_poisson[k, :, :], aperture, mask=maskclip,
                                                     method=method, subpixels=subpixels)
-            b_var_poisson[k] = float(var_poisson_table['aperture_sum'][0])
+                b_var_poisson[k] = float(var_poisson_table['aperture_sum'][0])
 
-            var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], aperture, mask=maskclip,
+                var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], aperture, mask=maskclip,
                                                    method=method, subpixels=subpixels)
-            b_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
+                b_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
 
-            var_flat_table = aperture_photometry(var_flat[k, :, :], aperture, mask=maskclip,
+                var_flat_table = aperture_photometry(var_flat[k, :, :], aperture, mask=maskclip,
                                                  method=method, subpixels=subpixels)
-            b_var_flat[k] = float(var_flat_table['aperture_sum'][0])
+                b_var_flat[k] = float(var_flat_table['aperture_sum'][0])
 
         del temp_weightmap
         # done looping over wavelength bins


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves https://jira.stsci.edu/browse/JP-2516

**Description**

This PR fixes a bug in MRS Extract1D where the sigma_clipped_stats algorithm is applied to a wavelength range of the IFU data cube that can contain no valid data when run in spec2 mode.  sigma_clipped_stats has started reporting excessive warnings in this case, which now overflows thousands of pages of the pipeline log.  This PR now checks if the relevant array has non-zero size before computing statistics.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
