### PR TITLE
JP-2524: Enable use of mnemonic DQ codes in skymatch "dqbits" param

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ associations
 
 - Add constraint on NIRCam TSGRISM exposures, preventing level 2 and 3
   associations for detector NRCBLONG [#6709]
-  
+
 - Add fgsid option to set_telescope_pointing [#6717]
 
 align_refs
@@ -26,6 +26,11 @@ cube_build
 ----------
 
 - Fixed a bug in how the dq plane of NIRspec data is set [#6718]
+
+cube_skymatch
+-------------
+
+- Enabled support for mnemonic DQ codes in the ``cube_skymatch`` step. [#6733]
 
 extract_1d
 ----------
@@ -43,12 +48,20 @@ ramp_fitting
   the various flavors of variance and ERR stored in the output
   products [#6715]
 
+skymatch
+--------
+
+- Enabled support for mnemonic DQ codes in the ``skymatch`` step. Also
+  changed default value for ``dqbits`` from 0 (exclude ALL flagged in DQ
+  pixels) to ``'~DO_NOT_USE+NON_SCIENCE'``. [#6733]
+
 srctype
 -------
 
 - Add command line option to override source type [#6720]
 
-  
+
+
 1.4.3 (2022-02-03)
 ==================
 

--- a/jwst/cube_skymatch/cube_skymatch_step.py
+++ b/jwst/cube_skymatch/cube_skymatch_step.py
@@ -20,6 +20,7 @@ from astropy.nddata.bitmask import (
 from .skymatch import match
 from .skycube import SkyCube
 from ..skymatch.skystatistics import SkyStats
+from ..datamodels.dqflags import pixel
 
 __all__ = ['CubeSkyMatchStep']
 
@@ -52,7 +53,7 @@ class CubeSkyMatchStep(Step):
     def process(self, input1, input2):
         cube_models = datamodels.ModelContainer(input1)
         models2d = datamodels.ModelContainer(input2)
-        dqbits = interpret_bit_flags(self.dqbits)
+        dqbits = interpret_bit_flags(self.dqbits, mnemonic_map=pixel)
 
         # set sky statistics:
         self._skystat = SkyStats(

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -13,6 +13,8 @@ import logging
 
 from ..stpipe import Step
 from .. import datamodels
+from ..datamodels.dqflags import pixel
+
 
 from astropy.nddata.bitmask import (
     bitfield_to_boolean_mask,
@@ -43,7 +45,7 @@ class SkyMatchStep(Step):
 
         # Sky statistics parameters:
         skystat = option('median', 'midpt', 'mean', 'mode', default='mode') # sky statistics
-        dqbits = string(default=0) # "good" DQ bits
+        dqbits = string(default='~DO_NOT_USE+NON_SCIENCE') # "good" DQ bits
         lower = float(default=None) # Lower limit of "good" pixel values
         upper = float(default=None) # Upper limit of "good" pixel values
         nclip = integer(min=0, default=5) # number of sky clipping iterations
@@ -58,7 +60,7 @@ class SkyMatchStep(Step):
         self.log.setLevel(logging.DEBUG)
         img = datamodels.ModelContainer(input)
 
-        self._dqbits = interpret_bit_flags(self.dqbits)
+        self._dqbits = interpret_bit_flags(self.dqbits, mnemonic_map=pixel)
 
         # set sky statistics:
         self._skystat = SkyStats(


### PR DESCRIPTION
**Description**
Resolves [JP-2524](https://jira.stsci.edu/browse/JP-2524)

This PR enables mnemonic DQ codes to be passed via the 'dqbits' param of the skymatch step. It also resets the default value.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)