### PR TITLE
JP-2511: Reorder spec2 for SOSS, alter photom behavior for SOSS input as 1D spectra

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,15 +64,11 @@ extract_1d
 - Add separate behavior for 2D vs (3D data with only one image)
   by passing appropriate integ value [#6745]
 
-regtest
--------
+photom
+------
 
-- Added a residual fringe correction test [#6771]
-
-reset
------
-
-- Fix bug in how segemented data is corrected [#6784]
+- Allow SOSS input as MultiSpecModel, and do correction on extracted 1d
+  spectra [#6734]
 
 pipeline
 --------
@@ -81,6 +77,9 @@ pipeline
 
 - Update the `calwebb_spec2` pipeline to allow for the creation of an
   optional WFSS product that's in units of e-/sec [#6783]
+
+- Updated `calwebb_spec2`, `calwebb_spec3`, and `calwebb_tso3` to reorder
+  step processing for SOSS data - `photom` now comes after `extract_1d` [#6734]
 
 ramp_fitting
 ------------
@@ -92,6 +91,11 @@ ramp_fitting
 - Adding feature to turn off calculations of ramps with good 0th group,
   but all other groups are saturated. [#6737]
 
+regtest
+-------
+
+- Added a residual fringe correction test [#6771]
+
 resample
 --------
 
@@ -100,6 +104,14 @@ resample
 
 - Re-designed algorithm for computation of the output WCS for the
   ``resemple_spec`` step for ``NIRSpec`` data. [#6747, #6780]
+
+reset
+-----
+
+- Fix bug in how segemented data is corrected [#6784]
+
+- Remove temporary `soss_atoca` parameter and make ATOCA the default
+  algorithm for SOSS data [#6734]
 
 residual_fringe
 ---------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,9 @@ extract_1d
 
 - Propagate non-differentiated errors for IFU mode observations [#6732]
 
+- Remove temporary `soss_atoca` parameter and make ATOCA the default
+  algorithm for SOSS data [#6734]
+
 - Add separate behavior for 2D vs (3D data with only one image)
   by passing appropriate integ value [#6745]
 
@@ -109,9 +112,6 @@ reset
 -----
 
 - Fix bug in how segemented data is corrected [#6784]
-
-- Remove temporary `soss_atoca` parameter and make ATOCA the default
-  algorithm for SOSS data [#6734]
 
 residual_fringe
 ---------------

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -38,6 +38,10 @@ The ``extract_1d`` step has the following step-specific arguments.
   0 for that particular column (or row). If "bkg_fit" is not "poly", this
   parameter will be ignored.
 
+``--bkg_sigma_clip``
+  The background values will be sigma-clipped to remove outlier values from
+  the determination of the background. The default value is a 3.0 sigma clip.
+
 ``--log_increment``
   Most log messages are suppressed while looping over integrations, i.e. when
   the input is a CubeModel or a 3-D SlitModel.  Messages will be logged while
@@ -82,3 +86,40 @@ The ``extract_1d`` step has the following step-specific arguments.
 ``--apply_apcorr``
   Switch to select whether or not to apply an APERTURE correction during the
   Extract1dStep processing. Default is ``True``
+
+``soss_threshold``
+  This is a NIRISS-SOSS algorithm-specific parameter; this sets the threshold
+  value for a pixel to be included when modelling the spectral trace. The default
+  value is 0.01.
+
+``soss_n_os``
+  This is a NIRISS-SOSS algorithm-specific parameter; this is an integer that sets]
+  the oversampling factor of the underlying wavelength grid used when modeling the
+  trace. The default value is 2.
+
+``soss_transform``
+  This is a NIRISS-SOSS algorithm-specific parameter; this defines a rotation to
+  apply to the reference files to match the observation. It should be specified as
+  a list of three floats, with default values of None.
+
+``soss_tikfac``
+  This is a NIRISS-SOSS algorithm-specific parameter; this is the regularization
+  factor used in the SOSS extraction. If not specified, ATOCA will calculate a
+  best-fit value for the Tikhonov factor.
+
+``soss_width``
+  This is a NIRISS-SOSS algorithm-specific parameter; this specifies the aperture
+  width used to extract the 1D spectrum from the decontaminated trace. The default
+  value is 40.0 pixels.
+
+``soss_bad_pix``
+  This is a NIRISS-SOSS algorithm-specific parameter; this parameter sets the method
+  used to handle bad pixels. There are currently two options: "model" will replace
+  the bad pixel values with a modeled value, while "masking" will omit those pixels
+  from the spectrum. The default value is "model".
+
+``soss_modelname``
+  This is a NIRISS-SOSS algorithm-specific parameter; if set, this will provide
+  the optional ATOCA model output of traces and pixel weights, with the filename
+  set by this parameter. By default this is set to None and this output is
+  not provided.

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -113,7 +113,6 @@ class Extract1dStep(Step):
     use_source_posn = boolean(default=None)  # use source coords to center extractions?
     center_xy = int_list(min=2, max=2, default=None)  # IFU extraction x/y center
     apply_apcorr = boolean(default=True)  # apply aperture corrections?
-    soss_atoca = boolean(default=False)  # use ATOCA algorithm - should have photom off and not fully tested
     soss_threshold = float(default=1e-2)  # threshold value for a pixel to be included when modelling the trace.
     soss_n_os = integer(default=2)  # oversampling factor of the underlying wavelength grid used when modeling trace.
     soss_transform = float_list(default=None, min=3, max=3)  # rotation applied to the ref files to match observation.
@@ -297,7 +296,7 @@ class Extract1dStep(Step):
         # Data that is not a ModelContainer (IFUCube and other single models)
         else:
             # Data is NRISS SOSS observation.
-            if input_model.meta.exposure.type == 'NIS_SOSS' and self.soss_atoca:
+            if input_model.meta.exposure.type == 'NIS_SOSS':
 
                 self.log.info(
                     'Input is a NIRISS SOSS observation, the specialized SOSS extraction (ATOCA) will be used.')

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.interpolate import UnivariateSpline
 
 from ... import datamodels
-from ...datamodels.dqflags import pixel
+from ...datamodels import dqflags
 from astropy.nddata.bitmask import bitfield_to_boolean_mask
 
 from .soss_syscor import make_background_mask, soss_background
@@ -654,8 +654,9 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
             # Unpack the i-th image, set dtype to float64 and convert DQ to boolean mask.
             scidata = input_model.data[i].astype('float64')
             scierr = input_model.err[i].astype('float64')
-            scimask = np.bitwise_and(input_model.dq[i], 1).astype(bool)
-            refmask = bitfield_to_boolean_mask(input_model.dq[i], ignore_flags=pixel['REFERENCE_PIXEL'], flip_bits=True)
+            scimask = np.bitwise_and(input_model.dq[i], dqflags.pixel['DO_NOT_USE']).astype(bool)
+            refmask = bitfield_to_boolean_mask(input_model.dq[i], ignore_flags=dqflags.pixel['REFERENCE_PIXEL'],
+                                               flip_bits=True)
 
             # Perform background correction.
             bkg_mask = make_background_mask(scidata, width=40)

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -538,7 +538,9 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
         scidata = input_model.data.astype('float64')
         scierr = input_model.err.astype('float64')
         scimask = input_model.dq > 0  # Mask bad pixels with True.
-        refmask = bitfield_to_boolean_mask(input_model.dq, ignore_flags=pixel['REFERENCE_PIXEL'], flip_bits=True)
+        refmask = bitfield_to_boolean_mask(input_model.dq,
+                                           ignore_flags=dqflags.pixel['REFERENCE_PIXEL'],
+                                           flip_bits=True)
 
         # Perform background correction.
         bkg_mask = make_background_mask(scidata, width=40)

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -944,9 +944,7 @@ class DataSet():
         return conversion, no_cal
 
     def create_1d_conversion(self, model, conversion, waves, relresps):
-        """Is this function a good idea?
-
-        Create a 1D array of photometric conversion values based on
+        """Create a 1D array of photometric conversion values based on
         wavelength array of input spectrum and response as a function of wavelength.
 
         Parameters

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -972,12 +972,29 @@ class DataSet():
         # Get the 2D wavelength array corresponding to the input
         # image pixel values
         wl_array = model.spec_table['WAVELENGTH']
+
+        flip_wl = False
+        if (np.nanargmax(wl_array) - np.nanargmin(wl_array)) < 0:
+            # Need monotonically increasing wavelengths for interp
+            # Bool flag to flip fit if True
+            flip_wl = True
+            wl_array = wl_array[::-1]
+
         wl_array[np.isnan(wl_array)] = -1.
+
+        if (np.nanargmax(waves) - np.nanargmin(waves)) < 0:
+            # Need monotonically increasing wavelengths for interp
+            # This shouldn't have effects external to method.
+            waves = waves[::-1]
+            relresps = relresps[::-1]
 
         # Interpolate the photometric response values onto the
         # 1D wavelength grid
         conv_1d = np.interp(wl_array, waves, relresps, left=np.NaN, right=np.NaN)
 
+        if flip_wl:
+            # If wl_array was flipped, flip the conversion before returning it.
+            conv_1d = conv_1d[::-1]
         # Combine the scalar and 1D conversion factors
         conversion = conversion * conv_1d
         no_cal = np.isnan(conv_1d)

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -63,7 +63,7 @@ def find_row(fits_table, match_fields):
     if len(row) > 1:
         raise MatchFitsTableRowError(f"Expected to find one matching row in table, found {len(row)}.")
     if len(row) == 0:
-        warnings.warn("Expected to find one matching row in table, found 0.")
+        log.warning("Expected to find one matching row in table, found 0.")
         return None
     return row[0]
 
@@ -133,6 +133,7 @@ class DataSet():
 
         # Initialize other non-correction pars attributes.
         self.slitnum = -1
+        self.specnum = -1
         self.inverse = inverse
         self.source_type = source_type
         if self.source_type is None and model.meta.target.source_type is not None:
@@ -391,14 +392,14 @@ class DataSet():
                 self.photom_io(ftab.phot_table[row])
 
         elif self.exptype in ['NIS_SOSS']:
-            # NIRISS SOSS
-            # Hardwire the science data order number to 1 for now
-            order = 1
-            fields_to_match = {'filter': self.filter, 'pupil': self.pupil, 'order': order}
-            row = find_row(ftab.phot_table, fields_to_match)
-            if row is None:
-                return
-            self.photom_io(ftab.phot_table[row], order)
+            for spec in self.input.spec:
+                self.specnum += 1
+                self.order = spec.spectral_order
+                fields_to_match = {'filter': self.filter, 'pupil': self.pupil, 'order': self.order}
+                row = find_row(ftab.phot_table, fields_to_match)
+                if row is None:
+                    return
+                self.photom_io(ftab.phot_table[row], self.order)
         else:
             fields_to_match = {'filter': self.filter, 'pupil': self.pupil}
             row = find_row(ftab.phot_table, fields_to_match)
@@ -701,6 +702,9 @@ class DataSet():
                         conversion /= slit.meta.photometry.pixelarea_steradians
                 else:
                     unit_is_surface_brightness = False
+            elif isinstance(self.input, datamodels.MultiSpecModel):
+                # MultiSpecModel output from extract1d should not require this area conversion?
+                unit_is_surface_brightness = False
             else:
                 if self.source_type is None or self.source_type != 'POINT':
                     if self.input.meta.photometry.pixelarea_steradians is None:
@@ -720,6 +724,9 @@ class DataSet():
                 conversion
             self.input.slits[self.slitnum].meta.photometry.conversion_microjanskys = \
                 conversion * MJSR_TO_UJA2
+        elif isinstance(self.input, datamodels.MultiSpecModel):
+            # No place in MultiSpecModel schema to store photometry info
+            pass
         else:
             self.input.meta.photometry.conversion_megajanskys = conversion
             self.input.meta.photometry.conversion_microjanskys = conversion * MJSR_TO_UJA2
@@ -796,6 +803,12 @@ class DataSet():
                     conversion, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
                                                                    self.exptype, conversion,
                                                                    waves, relresps, order)
+            elif isinstance(self.input, datamodels.MultiSpecModel):
+
+                # This input does not require a 2d conversion, just an application of the
+                # relresponse to the DN/s input.
+                conversion, no_cal = self.create_1d_conversion(self.input.spec[self.specnum],
+                                                               conversion, waves, relresps)
             else:
                 conversion, no_cal = self.create_2d_conversion(self.input, self.exptype, conversion,
                                                                waves, relresps, order)
@@ -827,7 +840,31 @@ class DataSet():
             else:
                 self.input.meta.bunit_data = 'DN/s'
                 self.input.meta.bunit_err = 'DN/s'
-
+        elif isinstance(self.input, datamodels.MultiSpecModel):
+            # Does this block need to address SB columns as well, or will
+            # they (presumably) never be populated for SOSS?
+            # It appears flux_error is the only error column populated?
+            spec = self.input.spec[self.specnum]
+            spec.spec_table.FLUX *= conversion
+            spec.spec_table.FLUX_ERROR *= conversion
+            spec.spec_table.FLUX_VAR_POISSON *= conversion ** 2.
+            spec.spec_table.FLUX_VAR_RNOISE *= conversion ** 2.
+            spec.spec_table.FLUX_VAR_FLAT *= conversion ** 2.
+            spec.spec_table.BACKGROUND *= conversion
+            spec.spec_table.BKGD_ERROR *= conversion
+            spec.spec_table.BKGD_VAR_POISSON *= conversion ** 2.
+            spec.spec_table.BKGD_VAR_RNOISE *= conversion ** 2.
+            spec.spec_table.BKGD_VAR_FLAT *= conversion ** 2.
+            spec.spec_table.columns['FLUX'].unit = 'Jy'
+            spec.spec_table.columns['FLUX_ERROR'].unit = 'Jy'
+            spec.spec_table.columns['FLUX_VAR_POISSON'].unit = 'Jy^2'
+            spec.spec_table.columns['FLUX_VAR_RNOISE'].unit = 'Jy^2'
+            spec.spec_table.columns['FLUX_VAR_FLAT'].unit = 'Jy^2'
+            spec.spec_table.columns['BACKGROUND'].unit = 'Jy'
+            spec.spec_table.columns['BKGD_ERROR'].unit = 'Jy'
+            spec.spec_table.columns['BKGD_VAR_POISSON'].unit = 'Jy^2'
+            spec.spec_table.columns['BKGD_VAR_RNOISE'].unit = 'Jy^2'
+            spec.spec_table.columns['BKGD_VAR_FLAT'].unit = 'Jy^2'
         else:
             if not self.inverse:
                 self.input.data *= conversion
@@ -902,6 +939,48 @@ class DataSet():
         # Combine the scalar and 2D conversion factors
         conversion = conversion * conv_2d
         no_cal = np.isnan(conv_2d)
+        conversion[no_cal] = 0.
+
+        return conversion, no_cal
+
+    def create_1d_conversion(self, model, conversion, waves, relresps):
+        """Is this function a good idea?
+
+        Create a 1D array of photometric conversion values based on
+        wavelength array of input spectrum and response as a function of wavelength.
+
+        Parameters
+        ----------
+        model : `~jwst.datamodels.DataModel`
+            Input data model containing the necessary wavelength information
+        conversion : float
+            Initial scalar photometric conversion value
+        waves : float
+            1D wavelength vector on which relative response values are
+            sampled
+        relresps : float
+            1D photometric response values, as a function of waves
+
+        Returns
+        -------
+        conversion : float
+            2D array of computed photometric conversion values
+        no_cal : int
+            2D mask indicating where no conversion is available
+        """
+
+        # Get the 2D wavelength array corresponding to the input
+        # image pixel values
+        wl_array = model.spec_table['WAVELENGTH']
+        wl_array[np.isnan(wl_array)] = -1.
+
+        # Interpolate the photometric response values onto the
+        # 1D wavelength grid
+        conv_1d = np.interp(wl_array, waves, relresps, left=np.NaN, right=np.NaN)
+
+        # Combine the scalar and 1D conversion factors
+        conversion = conversion * conv_1d
+        no_cal = np.isnan(conv_1d)
         conversion[no_cal] = 0.
 
         return conversion, no_cal
@@ -1099,7 +1178,8 @@ class DataSet():
 
         # Load the pixel area reference file, if it exists, and attach the
         # reference data to the science model
-        self.save_area_info(ftab, area_fname)
+        if self.exptype != 'NIS_SOSS':
+            self.save_area_info(ftab, area_fname)
 
         if self.instrument == 'NIRISS':
             self.calc_niriss(ftab)

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -805,8 +805,8 @@ class DataSet():
                                                                    waves, relresps, order)
             elif isinstance(self.input, datamodels.MultiSpecModel):
 
-                # This input does not require a 2d conversion, just an application of the
-                # relresponse to the DN/s input.
+                # This input does not require a 2d conversion, but a 1d interpolation on the
+                # input wavelength vector to find the relresponse.
                 conversion, no_cal = self.create_1d_conversion(self.input.spec[self.specnum],
                                                                conversion, waves, relresps)
             else:
@@ -964,9 +964,9 @@ class DataSet():
         Returns
         -------
         conversion : float
-            2D array of computed photometric conversion values
+            1D array of computed photometric conversion values
         no_cal : int
-            2D mask indicating where no conversion is available
+            1D mask indicating where no conversion is available
         """
 
         # Get the 2D wavelength array corresponding to the input
@@ -1195,6 +1195,8 @@ class DataSet():
 
         # Load the pixel area reference file, if it exists, and attach the
         # reference data to the science model
+        # SOSS data are in a MultiSpecModel, which will not allow for
+        # saving the area info.
         if self.exptype != 'NIS_SOSS':
             self.save_area_info(ftab, area_fname)
 

--- a/jwst/photom/photom_step.py
+++ b/jwst/photom/photom_step.py
@@ -32,10 +32,11 @@ class PhotomStep(Step):
         model_type = input_model.__class__.__name__
         self.log.debug("Input is {}".format(model_type))
         if model_type not in ('CubeModel', 'ImageModel', 'SlitModel',
-                              'IFUImageModel', 'MultiSlitModel'):
+                              'IFUImageModel', 'MultiSlitModel',
+                              'MultiSpecModel', 'SpecModel'):
             self.log.warning("Input is not one of the supported model types: "
-                             "CubeModel, ImageModel, IFUImageModel or "
-                             "MultiSlitModel.")
+                             "CubeModel, ImageModel, IFUImageModel, "
+                             "MultiSlitModel, MultiSpecModel or SpecModel.")
 
         # Setup reference files and whether previous correction information
         # should be used.

--- a/jwst/photom/photom_step.py
+++ b/jwst/photom/photom_step.py
@@ -33,10 +33,10 @@ class PhotomStep(Step):
         self.log.debug("Input is {}".format(model_type))
         if model_type not in ('CubeModel', 'ImageModel', 'SlitModel',
                               'IFUImageModel', 'MultiSlitModel',
-                              'MultiSpecModel', 'SpecModel'):
+                              'MultiSpecModel'):
             self.log.warning("Input is not one of the supported model types: "
                              "CubeModel, ImageModel, IFUImageModel, "
-                             "MultiSlitModel, MultiSpecModel or SpecModel.")
+                             "MultiSlitModel, or MultiSpecModel.")
 
         # Setup reference files and whether previous correction information
         # should be used.

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -7,6 +7,7 @@ import numpy as np
 from astropy import units as u
 
 from jwst import datamodels
+from jwst.datamodels import SpecModel, MultiSpecModel
 from jwst.photom import photom
 
 MJSR_TO_UJA2 = (u.megajansky / u.steradian).to(u.microjansky / (u.arcsecond**2))
@@ -90,6 +91,41 @@ def mk_wavelength(shape, min_wl, max_wl, dispaxis=1):
     return wl
 
 
+def mk_soss_spec(settings, speclen):
+    """Create a 2-D array of wavelengths, linearly spaced in one axis.
+
+    Parameters
+    ----------
+    settings : list
+        Each entry in the list should be a dict of settings to match
+        to photom reference file entries - filter, pupil, and order.
+
+    speclen : list
+        Length of spectrum for each entry in settings; list lengths
+        must match
+
+    Returns
+    -------
+    model : MultiSpecModel
+        The simulated output of extract_1d to be calibrated; this is
+        the SOSS-specific ordering to be tested.
+    """
+    model = MultiSpecModel()
+    for i, inspec in enumerate(settings):
+        # Make number of columns equal to length of SpecModel's spec_table dtype, then assign
+        # dtype to each column. Use to initialize SpecModel for entry into output MultiSpecModel
+        otab = np.array(list(zip(*([np.linspace(0.6, 4.0, speclen[i])]+
+                                   [np.ones(speclen[i]) for _ in range(len(SpecModel().spec_table.dtype)-1)]))),
+                        dtype=SpecModel().spec_table.dtype)
+        specmodel = datamodels.SpecModel(spec_table=otab)
+        model.meta.instrument.filter = inspec['filter']
+        model.meta.instrument.pupil = inspec['pupil']
+        specmodel.spectral_order = inspec['order']
+        model.spec.append(specmodel)
+
+    return model
+
+
 def create_input(instrument, detector, exptype,
                  filter=None, pupil=None, grating=None, band=None):
     """Create dummy data (an open model) of the appropriate type.
@@ -156,19 +192,12 @@ def create_input(instrument, detector, exptype,
                 slit.meta.photometry.pixelarea_steradians = 0.0025 * A2_TO_SR
                 input_model.slits.append(slit.copy())
         elif exptype == 'NIS_SOSS':
-            shape = (96, 2048)
-            (data, dq, err, var_p, var_r, var_f) = mk_data(shape)
-            input_model = datamodels.ImageModel(data=data, dq=dq, err=err)
-            # There is no wavelength attribute for ImageModel, but this
-            # should work anyway.
-            wl = mk_wavelength(shape, 0.6, 4.0, dispaxis=1)
-            input_model.meta.target.source_type = 'POINT'  # output will be MJy
-            input_model.wavelength = wl.copy()
-            input_model.var_poisson = var_p
-            input_model.var_rnoise = var_r
-            input_model.var_flat = var_f
-            input_model.meta.photometry.pixelarea_arcsecsq = 0.0025
-            input_model.meta.photometry.pixelarea_steradians = 0.0025 * A2_TO_SR
+            settings = [
+                {'filter': filter, 'pupil': pupil, 'order': 1},
+                {'filter': filter, 'pupil': pupil, 'order': 2},
+            ]
+            speclen = [200, 200]
+            input_model = mk_soss_spec(settings, speclen)
         else:                                   # NIS_IMAGE
             shape = (96, 128)
             (data, dq, err, var_p, var_r, var_f) = mk_data(shape)
@@ -1244,8 +1273,8 @@ def test_niriss_soss():
     ftab = create_photom_niriss_soss(min_r=8.0, max_r=9.0)
     ds.calc_niriss(ftab)
 
-    input = save_input.data
-    output = ds.input.data                      # ds.input is the output
+    input = save_input.spec[0].spec_table['FLUX']
+    output = ds.input.spec[0].spec_table['FLUX']                      # ds.input is the output
     sp_order = 1                                # to agree with photom.py
     rownum = find_row_in_ftab(save_input, ftab, ['filter', 'pupil'],
                               slitname=None, order=sp_order)
@@ -1253,15 +1282,13 @@ def test_niriss_soss():
     nelem = ftab.phot_table['nelem'][rownum]
     wavelength = ftab.phot_table['wavelength'][rownum][0:nelem]
     relresponse = ftab.phot_table['relresponse'][rownum][0:nelem]
-    shape = input.shape
-    ix = shape[1] // 2
-    iy = shape[0] // 2
-    wl = input_model.wavelength[iy, ix]
+    test_ind = len(input) // 2
+    wl = input_model.spec[0].spec_table['WAVELENGTH'][test_ind]
     rel_resp = np.interp(wl, wavelength, relresponse,
                          left=np.nan, right=np.nan)
     compare = photmj * rel_resp
     # Compare the values at the center pixel.
-    ratio = output[iy, ix] / input[iy, ix]
+    ratio = output[test_ind] / input[test_ind]
     assert(np.allclose(ratio, compare, rtol=1.e-7))
 
 
@@ -1589,7 +1616,5 @@ def test_find_row():
     ind = photom.find_row(ftab.phot_table, {'filter': 'F444W', 'pupil': 'GRISMR', 'order': 1})
     assert ind == 4
 
-    with warnings.catch_warnings(record=True) as caught:
-        ind = photom.find_row(ftab.phot_table, {'filter': 'F444W', 'pupil': 'GRISMR', 'order': 2})
-        assert ind is None
-        assert len(caught) == 1
+    ind = photom.find_row(ftab.phot_table, {'filter': 'F444W', 'pupil': 'GRISMR', 'order': 2})
+    assert ind is None

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -1,5 +1,4 @@
 import math
-import warnings
 
 import pytest
 import numpy as np
@@ -114,8 +113,8 @@ def mk_soss_spec(settings, speclen):
     for i, inspec in enumerate(settings):
         # Make number of columns equal to length of SpecModel's spec_table dtype, then assign
         # dtype to each column. Use to initialize SpecModel for entry into output MultiSpecModel
-        otab = np.array(list(zip(*([np.linspace(0.6, 4.0, speclen[i])]+
-                                   [np.ones(speclen[i]) for _ in range(len(SpecModel().spec_table.dtype)-1)]))),
+        otab = np.array(list(zip(*([np.linspace(0.6, 4.0, speclen[i])] +
+                                   [np.ones(speclen[i]) for _ in range(len(SpecModel().spec_table.dtype) - 1)]))),
                         dtype=SpecModel().spec_table.dtype)
         specmodel = datamodels.SpecModel(spec_table=otab)
         model.meta.instrument.filter = inspec['filter']

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -472,7 +472,6 @@ class Spec2Pipeline(Pipeline):
 
         return calibrated
 
-
     def _process_common(self, data):
         """Common spectral processing"""
         calibrated = self.srctype(data)

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -286,15 +286,21 @@ class Spec2Pipeline(Pipeline):
         if exp_type in ['MIR_MRS', 'NRS_IFU'] and self.cube_build.skip:
             # Skip extract_1d for IFU modes where no cube was built
             self.extract_1d.skip = True
-        x1d = self.extract_1d(resampled)
 
+        # SOSS data need to run photom on x1d products and optionally save the photom
+        # output, while all other exptypes simply run extract_1d.
         if exp_type == 'NIS_SOSS':
             if multi_int:
                 self.photom.suffix = 'x1dints'
             else:
                 self.photom.suffix = 'x1d'
+            self.extract_1d.save_results = False
+            x1d = self.extract_1d(resampled)
+
             self.photom.save_results = self.save_results
             x1d = self.photom(x1d)
+        else:
+            x1d = self.extract_1d(resampled)
 
         resampled.close()
         x1d.close()

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -223,7 +223,7 @@ class Spec3Pipeline(Pipeline):
                     result = self.photom(result)
                 else:
                     result = self.extract_1d(result)
-                self.combine_1d.exptime_key = 'unit_weight'
+
                 result = self.combine_1d(result)
 
             elif resample_complete is not None and resample_complete.upper() == 'COMPLETE':

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -18,6 +18,7 @@ from ..mrs_imatch import mrs_imatch_step
 from ..outlier_detection import outlier_detection_step
 from ..resample import resample_spec_step
 from ..combine_1d import combine_1d_step
+from ..photom import photom_step
 
 
 __all__ = ['Spec3Pipeline']
@@ -40,6 +41,7 @@ class Spec3Pipeline(Pipeline):
     2-D spectroscopic resampling (resample_spec)
     3-D spectroscopic resampling (cube_build)
     1-D spectral extraction (extract_1d)
+    Absolute Photometric Calibration (photom)
     1-D spectral combination (combine_1d)
     """
 
@@ -57,6 +59,7 @@ class Spec3Pipeline(Pipeline):
         'resample_spec': resample_spec_step.ResampleSpecStep,
         'cube_build': cube_build_step.CubeBuildStep,
         'extract_1d': extract_1d_step.Extract1dStep,
+        'photom': photom_step.PhotomStep,
         'combine_1d': combine_1d_step.Combine1dStep
     }
 
@@ -211,10 +214,16 @@ class Spec3Pipeline(Pipeline):
 
                 if exptype in ['NIS_SOSS']:
                     # For NIRISS SOSS, don't save the extract_1d results,
-                    # they're identical to the calwebb_spec2 x1d products
+                    # instead run photom on the extract_1d results and save
+                    # those instead.
                     self.extract_1d.save_results = False
-
-                result = self.extract_1d(result)
+                    self.photom.save_results = self.save_results
+                    self.photom.suffix = 'x1d'
+                    result = self.extract_1d(result)
+                    result = self.photom(result)
+                else:
+                    result = self.extract_1d(result)
+                self.combine_1d.exptime_key = 'unit_weight'
                 result = self.combine_1d(result)
 
             elif resample_complete is not None and resample_complete.upper() == 'COMPLETE':

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -10,6 +10,7 @@ from ..outlier_detection import outlier_detection_step
 from ..tso_photometry import tso_photometry_step
 from ..extract_1d import extract_1d_step
 from ..white_light import white_light_step
+from ..photom import photom_step
 
 from ..lib.pipe_utils import is_tso
 
@@ -26,6 +27,7 @@ class Tso3Pipeline(Pipeline):
         * outlier_detection
         * tso_photometry
         * extract_1d
+        * photom
         * white_light
     """
 
@@ -40,6 +42,7 @@ class Tso3Pipeline(Pipeline):
                  outlier_detection_step.OutlierDetectionStep,
                  'tso_photometry': tso_photometry_step.TSOPhotometryStep,
                  'extract_1d': extract_1d_step.Extract1dStep,
+                 'photom': photom_step.PhotomStep,
                  'white_light': white_light_step.WhiteLightStep
                  }
     reference_file_types = ['gain', 'readnoise']
@@ -159,6 +162,12 @@ class Tso3Pipeline(Pipeline):
                 # extract 1D
                 self.log.info("Extracting 1-D spectra ...")
                 result = self.extract_1d(cube)
+
+                if input_exptype == 'NIS_SOSS':
+                    # SOSS data have yet to be photometrically calibrated
+                    # Calibrate 1D spectra here.
+                    result = self.photom(result)
+
                 x1d_result.spec.extend(result.spec)
 
                 # perform white-light photometry on 1d extracted data


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6710 
Resolves [JP-2511](https://jira.stsci.edu/browse/JP-2511)

**Description**

This PR modifies the behavior of both calwebb_spec2 and photom, such that for NIS_SOSS exposures photom is run after extract_1d, on extracted 1D spectra. This PR also removes the spec flag put in to toggle ATOCA on and off, as the toggle doesn't affect the Spec2Pipeline reordering, which would cause incorrect output if used.

Note to SOSS IDT: Please check at your convenience for expected output behavior! @loicalbert @AntoineDarveau 

Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
