### PR TITLE
Repair miri and nircam setpointing tests to use actual mock engineering database

### DIFF
--- a/jwst/lib/tests/engdb_mock.py
+++ b/jwst/lib/tests/engdb_mock.py
@@ -58,9 +58,9 @@ class EngDB_Mocker(requests_mock.Mocker):
     Setup a mock of the JWST Engineering DB.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, real_http=True, **kwargs):
         db_path = kwargs.pop('db_path', ENGDB_PATH)
-        super(EngDB_Mocker, self).__init__(*args, **kwargs)
+        super(EngDB_Mocker, self).__init__(*args, real_http=real_http, **kwargs)
 
         # Setup the local engineering cache
         self.cache = EngDB_Local(db_path)

--- a/jwst/regtest/test_miri_setpointing.py
+++ b/jwst/regtest/test_miri_setpointing.py
@@ -1,11 +1,14 @@
 import pytest
 from astropy.io.fits.diff import FITSDiff
+from pathlib import Path
 
+from jwst.lib import engdb_tools
 from jwst.lib.set_telescope_pointing import add_wcs
+from jwst.lib.tests.engdb_mock import EngDB_Mocker
 
 
 @pytest.mark.bigdata
-def test_miri_setpointing(_jail, rtdata, fitsdiff_default_kwargs):
+def test_miri_setpointing(_jail, rtdata, engdb, fitsdiff_default_kwargs):
     """
     Regression test of the set_telescope_pointing script on a level-1b MIRI image.
     """
@@ -20,15 +23,22 @@ def test_miri_setpointing(_jail, rtdata, fitsdiff_default_kwargs):
     rtdata.output = rtdata.input
 
     # Call the WCS routine, using the ENGDB_Service
-    # Note that there aren't any quaternion mnemonics in the ENGDB for the time
-    # range of this exposure, so we set "allow_default" to tell add_wcs to use
-    # default values for the pointing-related keywords. Keyword values retrieved
-    # from the SIAF will be good.
-    add_wcs(rtdata.input, allow_default=True,
-            siaf_path=siaf_path)
+    add_wcs(rtdata.input, allow_default=True, engdb_url='http://localhost', siaf_path=siaf_path)
 
     # Compare the results
     rtdata.get_truth("truth/test_miri_setpointing/jw80600010001_02101_00001_mirimage_uncal.fits")
     fitsdiff_default_kwargs['rtol'] = 1e-6
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
+
+
+# ########
+# Fixtures
+# ########
+@pytest.fixture
+def engdb():
+    """Setup the mock engineering database"""
+    db_path = Path(__file__).parents[1] / 'lib' / 'tests' / 'data' / 'engdb'
+    with EngDB_Mocker(db_path=db_path):
+        engdb = engdb_tools.ENGDB_Service(base_url='http://localhost')
+        yield engdb


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->
Resolves an issue with regression tests and a recent change to `set_telescope_pointing` introduced in PR#6735

**Description**

This PR addresses ...

Checklist
- [x] Tests
- [ ] ~Documentation~
- [ ] ~Change log~
- [x] Milestone
- [x] Label(s)
