### PR TITLE
JP-2514: Bug in extract_1d, processing 3D input data with dim1 of length 1.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ extract_1d
 - Check for non-zero array size before computing sigma-clipped
   statistics in IFU mode [#6728]
 
-- Added separate behavior for 2D vs (3D data with only one image)
+- Add separate behavior for 2D vs (3D data with only one image)
   by passing appropriate integ value [#6745]
 
 ramp_fitting

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ extract_1d
 - Check for non-zero array size before computing sigma-clipped
   statistics in IFU mode [#6728]
 
+- Added separate behavior for 2D vs (3D data with only one image)
+  by passing appropriate integ value [#6745]
+
 ramp_fitting
 ------------
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -3676,7 +3676,9 @@ def create_extraction(extract_ref_dict,
     # Loop over each integration in the input model
     shape = meta_source.data.shape
 
-    if len(shape) == 3 and shape[0] == 1 or len(shape) == 2:
+    if len(shape) == 3 and shape[0] == 1:
+        integrations = [0]
+    elif len(shape) == 2:
         integrations = [-1]
     else:
         log.info(f"Beginning loop over {shape[0]} integrations ...")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6723 
Resolves [JP-2514](https://jira.stsci.edu/browse/JP-2514)

**Description**

This PR addresses spec2 failures when providing a _rateints input file with nints=1, i.e. the input data shape was (1, n, m). This was being collected along with 2D input data and leaving the integration number unused, while slightly separate behavior is required. Now the 3D data is sliced on the integration axis, providing a 2D data array to be extracted.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
