### PR TITLE
JP-2083: Re-design algorithm for NIRspec output WCS for resample step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,12 @@ pipeline
 
 - Improve memory performance of calwebb_detector1 pipeline [#6758]
 
+resample
+--------
+
+- Re-designed algorithm for computation of the output WCS for the
+  ``resemple_spec`` step for ``NIRSpec`` data. [#6747]
+
 ramp_fitting
 ------------
 
@@ -166,6 +172,7 @@ set_telescope_pointing
 ----------------------
 
 - JP-2509 Update COARSE algorithm to use FGS1 exclusively. [#6700]
+
 
 1.4.2 (2022-01-20)
 ==================

--- a/jwst/datamodels/schemas/slitmeta.schema.yaml
+++ b/jwst/datamodels/schemas/slitmeta.schema.yaml
@@ -107,3 +107,9 @@ properties:
     type: number
     fits_keyword: SRCDEC
     fits_hdu: SCI
+  slit_ymin:
+     title: Bottom of slit in slit_frame relative to (0, 0) center
+     type: number
+  slit_ymax:
+     title: Top of slit in slit_frame relative to (0, 0) center
+     type: number

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -2,13 +2,16 @@ import logging
 import warnings
 
 import numpy as np
+from scipy.optimize import minimize_scalar
 from astropy import coordinates as coord
 from astropy import units as u
-from astropy.modeling.models import (Mapping, Tabular1D, Linear1D,
-                                     Pix2Sky_TAN, RotateNative2Celestial)
+from astropy.modeling.models import (
+    Mapping, Tabular1D, Linear1D, Pix2Sky_TAN, RotateNative2Celestial, Identity
+)
 from astropy.modeling.fitting import LinearLSQFitter
 from gwcs import wcstools, WCS
 from gwcs import coordinate_frames as cf
+from gwcs.geometry import SphericalToCartesian
 
 from ..assign_wcs.util import wrap_ra
 from .. import datamodels
@@ -18,6 +21,8 @@ from .resample import ResampleData
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+
+_S2C = SphericalToCartesian()
 
 
 class ResampleSpecData(ResampleData):
@@ -67,13 +72,175 @@ class ResampleSpecData(ResampleData):
 
         # Define output WCS based on all inputs, including a reference WCS
         if resample_utils.is_sky_like(self.input_models[0].meta.wcs.output_frame):
-            self.output_wcs = self.build_interpolated_output_wcs()
+            if self.input_models[0].meta.instrument.name != "NIRSPEC":
+                self.output_wcs = self.build_interpolated_output_wcs()
+            else:
+                self.output_wcs = self.build_nirspec_output_wcs()
         else:
             self.output_wcs = self.build_nirspec_lamp_output_wcs()
         self.blank_output = datamodels.SlitModel(tuple(self.output_wcs.array_shape))
         self.blank_output.update(self.input_models[0])
         self.blank_output.meta.wcs = self.output_wcs
         self.output_models = datamodels.ModelContainer()
+
+    def build_nirspec_output_wcs(self, refmodel=None):
+        """
+        Create a spatial/spectral WCS covering footprint of the input
+        """
+        all_wcs = [m.meta.wcs for m in self.input_models if m is not refmodel]
+        if refmodel:
+            all_wcs.insert(0, refmodel.meta.wcs)
+        else:
+            refmodel = self.input_models[0]
+
+        refwcs = refmodel.meta.wcs
+
+        s2d = refwcs.get_transform('slit_frame', 'detector')
+        s2w = refwcs.get_transform('slit_frame', 'world')
+
+        # find Y-coord of the target in the reference image in the first column:
+        targ_ra = refmodel.meta.target.ra
+        targ_dec = refmodel.meta.target.dec
+
+        ref_lam = _find_nirspec_output_sampling_wavelengths(
+            all_wcs,
+            targ_ra, targ_dec
+        )
+        ref_lam = np.array(ref_lam)
+
+        n_lam = ref_lam.size
+        if not n_lam:
+            raise ValueError("Not enough data to construct output WCS.")
+
+        x_slit = np.zeros(n_lam)
+        lam = 1e-6 * ref_lam
+
+        # Find the spatial pixel scale:
+        y_slit_min, y_slit_max = self._max_virtual_slit_extent(all_wcs, refwcs)
+
+        xy_min = s2d(
+            5 * [0],
+            5 * [y_slit_min],
+            lam[((0, n_lam // 4, n_lam // 2, (3 * n_lam) // 4, n_lam - 1), )]
+        )
+        xy_max = s2d(
+            5 * [0],
+            5 * [y_slit_max],
+            lam[((0, n_lam // 4, n_lam // 2, (3 * n_lam) // 4, n_lam - 1), )]
+        )
+        good = np.logical_and(np.isfinite(xy_min), np.isfinite(xy_max))
+        if not np.any(good):
+            raise ValueError("Error estimating output WCS pixel scale.")
+
+        xy1 = s2d(x_slit, np.full(n_lam, refmodel.slit_ymin), lam)
+        xy2 = s2d(x_slit, np.full(n_lam, refmodel.slit_ymax), lam)
+        xylen = np.nanmax(np.linalg.norm(np.array(xy1) - np.array(xy2), axis=0)) + 1
+        pscale = (refmodel.slit_ymax - refmodel.slit_ymin) / xylen
+
+        # compute image span along Y-axis (length of the slit in the detector plane)
+        # det_slit_span = np.linalg.norm(np.subtract(xy_max, xy_min))
+        det_slit_span = np.nanmax(np.linalg.norm(np.subtract(xy_max, xy_min), axis=0))
+        ny = int(np.ceil(det_slit_span * self.pscale_ratio + 0.5)) + 1
+
+        border = 0.5 * (ny - det_slit_span * self.pscale_ratio) - 0.5
+
+        if xy_min[1][1] < xy_max[1][1]:
+            y_slit_model = Linear1D(
+                slope=pscale / self.pscale_ratio,
+                intercept=y_slit_min - border * pscale * self.pscale_ratio
+            )
+        else:
+            y_slit_model = Linear1D(
+                slope=-pscale / self.pscale_ratio,
+                intercept=y_slit_min + (ny - border) * pscale * self.pscale_ratio
+            )
+
+        # extrapolate 1/2 pixel at the edges and make tabular model w/inverse:
+        lam = lam.tolist()
+        pixel_coord = list(range(n_lam))
+
+        if len(pixel_coord) > 1:
+            # left:
+            slope = (lam[1] - lam[0]) / pixel_coord[1]
+            lam.insert(0, -0.5 * slope + lam[0])
+            pixel_coord.insert(0, -0.5)
+            # right:
+            slope = (lam[-1] - lam[-2]) / (pixel_coord[-1] - pixel_coord[-2])
+            lam.append(slope * (pixel_coord[-1] + 0.5) + lam[-2])
+            pixel_coord.append(pixel_coord[-1] + 0.5)
+
+        else:
+            lam = 3 * lam
+            pixel_coord = [-0.5, 0, 0.5]
+
+        wavelength_transform = Tabular1D(points=pixel_coord,
+                                         lookup_table=lam,
+                                         bounds_error=False, fill_value=np.nan)
+        wavelength_transform.inverse = Tabular1D(points=lam,
+                                                 lookup_table=pixel_coord,
+                                                 bounds_error=False,
+                                                 fill_value=np.nan)
+        self.data_size = (ny, len(ref_lam))
+
+        # Construct the final transform
+        mapping = Mapping((0, 1, 0))
+        mapping.inverse = Mapping((2, 1))
+        out_det2slit = mapping | Identity(1) & y_slit_model & wavelength_transform
+
+        # Create coordinate frames
+        det = cf.Frame2D(name='detector', axes_order=(0, 1))
+        slit_spatial = cf.Frame2D(name='slit_spatial', axes_order=(0, 1),
+                                  unit=("", ""), axes_names=('x_slit', 'y_slit'))
+        spec = cf.SpectralFrame(name='spectral', axes_order=(2,),
+                                unit=(u.micron,), axes_names=('wavelength',))
+        slit_frame = cf.CompositeFrame([slit_spatial, spec], name='slit_frame')
+        sky = cf.CelestialFrame(name='sky', axes_order=(0, 1),
+                                reference_frame=coord.ICRS())
+        world = cf.CompositeFrame([sky, spec], name='world')
+
+        pipeline = [(det, out_det2slit), (slit_frame, s2w), (world, None)]
+        output_wcs = WCS(pipeline)
+
+        # Compute bounding box and output array shape.  Add one to the y (slit)
+        # height to account for the half pixel at top and bottom due to pixel
+        # coordinates being centers of pixels
+        bounding_box = resample_utils.wcs_bbox_from_shape(self.data_size)
+        output_wcs.bounding_box = bounding_box
+        output_wcs.array_shape = self.data_size
+
+        return output_wcs
+
+    def _max_virtual_slit_extent(self, wcs_list, refwcs):
+        """Compute min & max slit coordinates for all nods in the "virtual" slit frame
+        """
+        y_slit_min = np.inf
+        y_slit_max = -np.inf
+
+        # w2s_ref = refwcs.get_transform('world', 'slit_frame')
+
+        for wcs in wcs_list:
+            d2s = wcs.get_transform('detector', 'slit_frame')
+
+            x, y = wcstools.grid_from_bounding_box(wcs.bounding_box)
+            ra, dec, lam = wcs(x, y)
+
+            good = np.logical_and(np.isfinite(ra), np.isfinite(dec))
+            x = x[good]
+            y = y[good]
+
+            # _, yslit, _ = w2s_ref(ra[good], dec[good], lam[good])
+            _, yslit, _ = d2s(x, y)
+
+            y_slit_min_i = np.min(yslit)
+            y_slit_max_i = np.max(yslit)
+
+            if y_slit_min_i < y_slit_min:
+                y_slit_min = y_slit_min_i
+
+            if y_slit_max_i > y_slit_max:
+                y_slit_max = y_slit_max_i
+
+        return y_slit_min, y_slit_max
 
     def build_interpolated_output_wcs(self, refmodel=None):
         """
@@ -438,3 +605,197 @@ def find_dispersion_axis(refmodel):
     dispaxis = refmodel.meta.wcsinfo.dispersion_direction
     # Change from 1 --> X and 2 --> Y to 0 --> X and 1 --> Y.
     return dispaxis - 1
+
+
+def _spherical_sep(j, k, wcs, xyz_ref):
+    """
+    Objective function that computes the angle between two points
+    on the sphere for small separations.
+    """
+    ra, dec, _ = wcs(k, j, with_bounding_box=False)
+    return 1 - np.dot(_S2C(ra, dec), xyz_ref)
+
+
+def _find_nirspec_output_sampling_wavelengths(wcs_list, targ_ra, targ_dec, fast=True):
+    refwcs = wcs_list[0]
+    bbox = refwcs.bounding_box
+
+    grid = wcstools.grid_from_bounding_box(bbox)
+    ra, dec, lam = np.array(refwcs(*grid))
+
+    ref_lam, _, _ = _find_nirspec_sampling_wavelengths(
+        refwcs,
+        targ_ra, targ_dec,
+        ra, dec
+    )
+
+    lam1 = ref_lam[0]
+    lam2 = ref_lam[-1]
+
+    image_lam = []
+    for w in wcs_list[1:]:
+        bbox = w.bounding_box
+        grid = wcstools.grid_from_bounding_box(bbox)
+        ra, dec, _ = w(*grid)
+        lam, _, _ = _find_nirspec_sampling_wavelengths(
+            w,
+            targ_ra, targ_dec,
+            ra, dec
+        )
+        image_lam.append((lam, np.min(lam), np.max(lam)))
+
+    # The code below is optimized for the case when wavelength is an increasing
+    # function of the pixel index along the X-axis. It will not work correctly
+    # if this assumption does not hold.
+
+    # Estimate overlaps between ranges and decide in which order to combine
+    # them:
+
+    while image_lam:
+        best_overlap = -np.inf
+        best_wcs = 0
+        for k, (lam, lmin, lmax) in enumerate(image_lam):
+            overlap = min(lam2, lmax) - max(lam1, lmin)
+            if best_overlap < overlap:
+                best_overlap = overlap
+                best_wcs = k
+
+        lam, lmin, lmax = image_lam.pop(best_wcs)
+        if lmax < lam1:
+            ref_lam = lam + ref_lam
+            lam1 = lmin
+        elif lmin > lam2:
+            ref_lam.extend(lam)
+            lam2 = lmax
+        else:
+            lam_ar = np.array(lam)
+            if lmin < lam1:
+                idx = np.flatnonzero(lam_ar < lam1)
+                ref_lam = lam_ar[idx].tolist() + ref_lam
+                lam1 = ref_lam[0]
+            if lmax > lam2:
+                idx = np.flatnonzero(lam_ar > lam2)
+                ref_lam = ref_lam + lam_ar[idx].tolist()
+                lam2 = ref_lam[-1]
+
+    return ref_lam
+
+
+def _find_nirspec_sampling_wavelengths(wcs, ra0, dec0, ra, dec, fast=True):
+    xdet = []
+    lms = []
+    ys = []
+    skipped = []
+
+    eps = 10 * np.finfo(float).eps
+
+    xyz_ref = _S2C(ra0, dec0)
+    ymax, xmax = ra.shape
+    good = np.logical_and(np.isfinite(ra), np.isfinite(dec))
+
+    j0 = 0
+
+    for k in range(xmax):
+        if not any(good[:, k]):
+            if xdet:
+                skipped.append(k)
+            continue
+
+        idx = np.flatnonzero(good[:, k]).tolist()
+        if j0 in idx:
+            i = idx.index(j0)
+        else:
+            i = 0
+            j0 = idx[0]
+
+        dmin = _spherical_sep(j0, k, wcs, xyz_ref)
+
+        for j in idx[i + 1:]:
+            d = _spherical_sep(j, k, wcs, xyz_ref)
+            if d < dmin:
+                dmin = d
+                j0 = j
+            elif d > dmin:
+                break
+
+        for j in idx[max(i - 1, 0):None if i else 0:-1]:
+            d = _spherical_sep(j, k, wcs, xyz_ref)
+            if d < dmin:
+                dmin = d
+                j0 = j
+            elif d > dmin:
+                break
+
+        if j0 == 0 or not good[j0 - 1, k]:
+            j1 = j0 - 0.49999
+        else:
+            j1 = j0 - 0.99999
+
+        if j0 == ymax - 1 or not good[j0 + 1, k]:
+            j2 = j0 + 0.49999
+        else:
+            j2 = j0 + 0.99999
+
+        if fast:
+            # parabolic minimization:
+            f0 = dmin
+            f1 = _spherical_sep(j1, k, wcs, xyz_ref)
+            if not np.isfinite(f1):
+                # give another try with 1/2 step:
+                j1 = 0.5 * (j1 + j0)
+                f1 = _spherical_sep(j1, k, wcs, xyz_ref)
+
+            f2 = _spherical_sep(j2, k, wcs, xyz_ref)
+            if not np.isfinite(f2):
+                # give another try with 1/2 step:
+                j2 = 0.5 * (j2 + j0)
+                f2 = _spherical_sep(j2, k, wcs, xyz_ref)
+
+            if np.isfinite(f1) and np.isfinite(f2):
+                dn = (j0 - j1) * (f0 - f2) - (j0 - j2) * (f0 - f1)
+                if np.abs(dn) < eps:
+                    jmin = j0
+                else:
+                    jmin = j0 - 0.5 * ((j0 - j1)**2 * (f0 - f2) -
+                                       (j0 - j2)**2 * (f0 - f1)) / dn
+                    jmin = max(min(jmin, j2), j1)
+            else:
+                jmin = j0
+
+        else:
+            r = minimize_scalar(
+                _spherical_sep,
+                method='golden',
+                bracket=(j1, j2),
+                args=(k, wcs, xyz_ref),
+                tol=None,
+                options={'maxiter': 10, 'xtol': 1e-2 / (j0 + 1)}
+            )
+            jmin = r['x']
+            if np.isfinite(jmin):
+                jmin = max(min(jmin, j2), j1)
+            else:
+                jmin = j0
+
+        targ_lam = wcs(k, jmin)[-1]
+        if not np.isfinite(targ_lam):
+            targ_lam = wcs(k, j0)[-1]
+
+        if not np.isfinite(targ_lam):
+            if xdet:
+                skipped.append(k)
+            continue
+
+        lms.append(targ_lam)
+        ys.append(jmin)
+        xdet.append(k)
+
+    skipped = [s for s in skipped if s <= xdet[-1]]
+    if skipped and skipped[0] < xdet[-1]:
+        # there are columns with all pixels having invalid world,
+        # coordinates. Fill the gaps using linear interpolation.
+        raise NotImplementedError(
+            "Support for discontinuous sampling was not implemented."
+        )
+
+    return lms, xdet, ys

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -18,6 +18,7 @@ def nirspec_rate():
     shape = (ysize, xsize)
     im = ImageModel(shape)
     im.var_rnoise += 1
+    im.meta.target = {'ra': 100, 'dec': 40}
     im.meta.wcsinfo = {
         'dec_ref': 40,
         'ra_ref': 100,
@@ -203,8 +204,8 @@ def test_nirspec_wcs_roundtrip(nirspec_rate):
         ra, dec, lam = slit.meta.wcs(x, y)
         xp, yp = slit.meta.wcs.invert(ra, dec, lam)
 
-        assert_allclose(x, xp, atol=1e-8)
-        assert_allclose(y, yp, atol=1e-8)
+        assert_allclose(x, xp, rtol=0, atol=1e-8)
+        assert_allclose(y, yp, rtol=0, atol=3e-4)
 
 
 def test_miri_wcs_roundtrip(miri_rate):

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -18,7 +18,7 @@ def nirspec_rate():
     shape = (ysize, xsize)
     im = ImageModel(shape)
     im.var_rnoise += 1
-    im.meta.target = {'ra': 100, 'dec': 40}
+    im.meta.target = {'ra': 100.1237, 'dec': 39.86}
     im.meta.wcsinfo = {
         'dec_ref': 40,
         'ra_ref': 100,


### PR DESCRIPTION
Closes #6032 #6324
Resolves [JP-2083](https://jira.stsci.edu/browse/JP-2083)

**Description**

This PR significantly re-designs the algorithm for computing output WCS for `resample_spec` for NIRspec. It solves issues described in https://jira.stsci.edu/browse/JP-2083 with resampled spectra: unexplained shifts and features in the resampled spectra.

The fundamental idea is the same as in https://github.com/spacetelescope/jwst/pull/6324 but with enhanced algorithms and bug fixes.

CC: @hbushouse @nden @jmuzerolle 

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
