### PR TITLE
JP-2536 Reset model updates 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ datamodels
 - Added the new keyword "BKGMETH" for use in the ``skymatch`` step.
   [#6736]
 
+- Updated reset model to include NINTS, NGROUPS keywords and the subarray.schema [#6749]
+
 extract_1d
 ----------
 
@@ -60,6 +62,12 @@ ramp_fitting
   the various flavors of variance and ERR stored in the output
   products [#6715]
 
+reset
+-----
+
+- Reading nints and ngroups from  model.meta for reset reference file and data instead of using the
+  shape of the data to define these values [#6749]
+  
 set_telescope_pointing
 ----------------------
 

--- a/jwst/datamodels/schemas/keyword_nints.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_nints.schema.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_nints.schema"
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      exposure:
+        type: object
+        properties:
+          nints:
+            title: Number of integrations
+            type: integer
+            fits_keyword: NINTS

--- a/jwst/datamodels/schemas/reset.schema.yaml
+++ b/jwst/datamodels/schemas/reset.schema.yaml
@@ -6,6 +6,8 @@ title: Reset Correction data model
 allOf:
 - $ref: referencefile.schema
 - $ref: keyword_readpatt.schema
+- $ref: keyword_ngroups.schema
+- $ref: keyword_nints.schema
 - $ref: subarray.schema
 - type: object
   properties:

--- a/jwst/datamodels/schemas/reset.schema.yaml
+++ b/jwst/datamodels/schemas/reset.schema.yaml
@@ -5,6 +5,8 @@ id: "http://stsci.edu/schemas/jwst_datamodel/reset.schema"
 title: Reset Correction data model
 allOf:
 - $ref: referencefile.schema
+- $ref: keyword_readpatt.schema
+- $ref: subarray.schema
 - type: object
   properties:
     data:

--- a/jwst/reset/reset_sub.py
+++ b/jwst/reset/reset_sub.py
@@ -45,8 +45,7 @@ def do_correction(input_model, reset_model):
 
     # Replace NaN's in the reset with zeros (should not happen but just in case)
     reset_model.data[np.isnan(reset_model.data)] = 0.0
-    log.debug("Reset Sub using: nints=%d, ngroups=%d" %
-              (sci_nints, sci_ngroups))
+    log.debug("Reset Sub using: nints = {}, ngroups = {}".format(sci_nints, sci_ngroups))
 
     # Create output as a copy of the input science data model
     output = input_model.copy()

--- a/jwst/reset/reset_sub.py
+++ b/jwst/reset/reset_sub.py
@@ -36,13 +36,12 @@ def do_correction(input_model, reset_model):
     """
 
     # Save some data params for easy use later
-    sci_nints = input_model.data.shape[0]           # number of integrations in input data
-
-    sci_ngroups = input_model.data.shape[1]           # number of groups in input data
+    sci_nints = input_model.meta.exposure.nints        # number of integrations in input data
+    sci_ngroups = input_model.meta.exposure.ngroups           # number of groups in input data
     # could also grab this information from input_model.meta.exposure.nints (ngroups)
 
-    reset_nints = reset_model.data.shape[0]           # number of integrations in reset reference file
-    reset_ngroups = reset_model.data.shape[1]         # number of groups
+    reset_nints = reset_model.meta.exposure.nints           # number of integrations in reset reference file
+    reset_ngroups = reset_model.meta.exposure.ngroups         # number of groups
 
     # Replace NaN's in the reset with zeros (should not happen but just in case)
     reset_model.data[np.isnan(reset_model.data)] = 0.0

--- a/jwst/reset/tests/test_reset_sub.py
+++ b/jwst/reset/tests/test_reset_sub.py
@@ -27,7 +27,7 @@ def test_correction(make_rampmodel, make_resetmodel):
 
     refgroups = 12
     # create reset reference file model with frames less than science data
-    reset = make_resetmodel(refgroups, ysize, xsize)
+    reset = make_resetmodel(nints, refgroups, ysize, xsize)
 
     # populate data array of reference file
     for i in range(0, refgroups):
@@ -69,7 +69,7 @@ def test_nan(make_rampmodel, make_resetmodel):
 
     # create reset reference file model with more frames than science data
     refgroups = 15
-    reset = make_resetmodel(refgroups, ysize, xsize)
+    reset = make_resetmodel(nints, refgroups, ysize, xsize)
 
     # populate data array of reference file
     for i in range(0, refgroups - 1):
@@ -104,7 +104,7 @@ def test_dq_combine(make_rampmodel, make_resetmodel):
 
     # create reset reference file model with more frames than science data
     refgroups = 12
-    reset = make_resetmodel(refgroups, ysize, xsize)
+    reset = make_resetmodel(nints, refgroups, ysize, xsize)
 
     jump_det = dqflags.pixel['JUMP_DET']
     saturated = dqflags.pixel['SATURATED']
@@ -146,7 +146,7 @@ def test_2_int(make_rampmodel, make_resetmodel):
 
     # create reset reference file model with more frames than science data
     refgroups = 10
-    reset = make_resetmodel(refgroups, ysize, xsize)
+    reset = make_resetmodel(nints, refgroups, ysize, xsize)
 
     # populate data array of reference file
     for i in range(0, refgroups - 1):
@@ -183,6 +183,8 @@ def make_rampmodel():
         dm_ramp.meta.subarray.xsize = xsize
         dm_ramp.meta.subarray.ystart = 1
         dm_ramp.meta.subarray.ysize = ysize
+        dm_ramp.meta.exposure.nints = nints
+        dm_ramp.meta.exposure.ngroups = ngroups
         dm_ramp.meta.description = 'Fake data.'
 
         return dm_ramp
@@ -193,7 +195,7 @@ def make_rampmodel():
 @pytest.fixture(scope='function')
 def make_resetmodel():
     '''Make MIRI Reset model for testing'''
-    def _reset(ngroups, ysize, xsize):
+    def _reset(nints, ngroups, ysize, xsize):
         # create the data and groupdq arrays
         nints = 2
         csize = (nints, ngroups, ysize, xsize)
@@ -201,6 +203,8 @@ def make_resetmodel():
 
         # create a JWST datamodel for MIRI data
         reset = ResetModel(data=data)
+        reset.meta.exposure.nints = nints
+        reset.meta.exposure.ngroups = ngroups
         reset.meta.instrument.name = 'MIRI'
         reset.meta.date = '2018-01-01'
         reset.meta.time = '00:00:00'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->
Resolves [JP-2536](https://jira.stsci.edu/browse/JP-2536)

**Description**

This PR updates the reset model to be in line with what CRDS is expecting. The reset model is an integration and group dependent correction. CRDS is expected the NINTS and NGROUPS keywords as part of the reset model. This was discovered as J Morrison was creating new reset reference files to be delivered to CRDS.
There are also updates to the reset step to use the NINTS and NGROUP instead of the shape of the data to determine how many integration and groups there are to be corrected. 

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)