### PR TITLE
remove asdf-standard from dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 git+https://github.com/asdf-format/asdf
-git+https://github.com/asdf-format/asdf-standard
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-coordinates-schemas
 git+https://github.com/asdf-format/asdf-wcs-schemas


### PR DESCRIPTION
The [Jenkins job with dev dependencies ](https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-devdeps/562/execution/node/164/log/) stopped running because of version mismatches. The error is
```
ERROR: Cannot install -r requirements-dev.txt (line 1) and asdf-standard 1.0.1.dev22+g80a2fb1 (from git+https://github.com/asdf-format/asdf-standard) because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested asdf-standard 1.0.1.dev22+g80a2fb1 (from git+https://github.com/asdf-format/asdf-standard)
    asdf 2.10.1.dev25+g2bd66ce depends on asdf-standard>=1.0.1

```
Removing `asdf-standard` from the list of packages to be installed from the `master` branch will resolve this. I'm not aware of another way to fix it.