### PR TITLE
Add pupil to NIRCam distortion reffile selection criteria

### DIFF
--- a/docs/jwst/references_general/distortion_reffile.rst
+++ b/docs/jwst/references_general/distortion_reffile.rst
@@ -14,14 +14,14 @@ CRDS selects appropriate DISTORTION references based on the following keywords.
 DISTORTION is not applicable for instruments not in the table.
 All keywords used for file selection are *required*.
 
-========== =================================================================
+========== ========================================================================
 Instrument Keywords
-========== =================================================================
+========== ========================================================================
 FGS        INSTRUME, DETECTOR, EXP_TYPE, DATE-OBS, TIME-OBS
 MIRI       INSTRUME, DETECTOR, EXP_TYPE, CHANNEL, BAND, DATE-OBS, TIME-OBS
-NIRCam     INSTRUME, DETECTOR, EXP_TYPE, CHANNEL, FILTER, DATE-OBS, TIME-OBS
+NIRCam     INSTRUME, DETECTOR, EXP_TYPE, CHANNEL, FILTER, PUPIL, DATE-OBS, TIME-OBS
 NIRISS     INSTRUME, EXP_TYPE, PUPIL, DATE-OBS, TIME-OBS
-========== =================================================================
+========== ========================================================================
 
 .. include:: ../includes/standard_keywords.inc
 


### PR DESCRIPTION
This PR modifies the documentation page for distortion reference files. It adds PUPIL to the selection criteria for the NIRCam distortion reference file. This was previously missing in the list of selection criteria.

