### PR TITLE
Fix sharpness and roundness to use source centroid instead of peak

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,11 +104,13 @@ source_catalog
 - Fixed the KDTree calculation to use only finite source positions to
   prevent memory issues on Linux systems. [#6765]
 
+- Updated the roundness and sharpness properties to use the source
+  centroid position instead of the peak position. [#6766]
+
 srctype
 -------
 
 - Add command line option to override source type [#6720]
-
 
 
 1.4.3 (2022-02-03)


### PR DESCRIPTION
**Description**

This PR is a follow-on to #6765.  While investigating that issue, I found that the sharpness and roundness parameters are using the source peak position instead of its centroid.  This PR fixes that.  Sources that have non-finite centroid positions will have `np.nan` for these parameters.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
