### PR TITLE
Fix scipy.ndimage.filters deprecation

### DIFF
--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 from jwst.outlier_detection import OutlierDetectionStep
 from jwst.outlier_detection.outlier_detection import flag_cr

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -1,7 +1,7 @@
 import logging
 
 import numpy as np
-from scipy.ndimage.filters import convolve1d
+from scipy.ndimage import convolve1d
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)


### PR DESCRIPTION
**Description**

`scipy` has deprecated the `scipy.ndimage.filters` namespace.  Instead `scipy.ndimage` should be used.  This namespace works for all `scipy` versions supported by this package.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
