### PR TITLE
Residual fringe regression test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,11 @@ extract_1d
 - Add separate behavior for 2D vs (3D data with only one image)
   by passing appropriate integ value [#6745]
 
+regtest
+-------
+
+- Added a residual fringe correction test [#6771]
+
 pipeline
 --------
 

--- a/jwst/regtest/test_miri_residual_fringe.py
+++ b/jwst/regtest/test_miri_residual_fringe.py
@@ -2,62 +2,27 @@
 import pytest
 
 from astropy.io.fits.diff import FITSDiff
-
 from jwst.stpipe import Step
 
 
-@pytest.fixture(scope='module')
-def run_residual_fringe_output(rtdata_module):
-    """Run residual_fringe t"""
-    rtdata = rtdata_module
-    rtdata.get_asn('miri/mrs/rfc_asn.json')
+@pytest.mark.bigdata
+def test_residual_fringe_cal(rtdata, fitsdiff_default_kwargs):
+    """Run residual fringe correction on MIRI IFUShort """
+
+    input_file = 'MIRM108-SHORT-6021192005_1_495_MIRIFUSHORT_cal.fits'
+    rtdata.get_data(f"miri/mrs/{input_file}")
 
     args = [
         'jwst.residual_fringe.ResidualFringeStep',
-        rtdata.input,
-        '--save_results=true'
+        input_file,
+        '--save_results=true',
     ]
     Step.from_cmdline(args)
 
-    return rtdata
-
-
-@pytest.mark.bigdata
-@pytest.mark.slow
-@pytest.mark.parametrize(
-    'output',
-    ['outtest_residual_fringe.fits']
-)
-def test(run_cube_build_single_output, output, fitsdiff_default_kwargs):
-    """Test just running residual fringe correction"""
-    rtdata = run_residual_fringe_output
+    output = input_file.replace('cal', 'residual_fringe')
     rtdata.output = output
 
-    # Get the truth files
-    rtdata.get_truth(f'truth/test_residual_fringe/{output}')
+    rtdata.get_truth(f"truth/test_miri_residual_fringe/{output}")
 
-    # Compare the results
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
-
-
-#@pytest.mark.bigdata
-#def test_residual_fringe_cal(rtdata, fitsdiff_default_kwargs):
-#    """Run residual fringe correction on MIRI IFUShort
-#    input_file = 'det_image_seq2_MIRIFUSHORT_12SHORTexp1_cal.fits'
-#    rtdata.get_data(f"miri/mrs/{input_file}")
-
-#    args = [
-#        'jwst.residual_fringe.ResidualFringeStep',
-#        input_file,
-#        '--save_results=true',
-#    ]
-#    Step.from_cmdline(args)
-
-#    output = input_file.replace('cal', 'residual_fringe')
-#    rtdata.output = output
-
-#    rtdata.get_truth(f"truth/test_miri_residual_fringe/{output}")
-
-#    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-#    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_residual_fringe.py
+++ b/jwst/regtest/test_miri_residual_fringe.py
@@ -4,6 +4,7 @@ import pytest
 from astropy.io.fits.diff import FITSDiff
 from jwst.stpipe import Step
 
+
 @pytest.mark.slow
 @pytest.mark.bigdata
 def test_residual_fringe_cal(rtdata, fitsdiff_default_kwargs):

--- a/jwst/regtest/test_miri_residual_fringe.py
+++ b/jwst/regtest/test_miri_residual_fringe.py
@@ -1,0 +1,63 @@
+"""Test ResidualFringeStep on MIRI MRS"""
+import pytest
+
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope='module')
+def run_residual_fringe_output(rtdata_module):
+    """Run residual_fringe t"""
+    rtdata = rtdata_module
+    rtdata.get_asn('miri/mrs/rfc_asn.json')
+
+    args = [
+        'jwst.residual_fringe.ResidualFringeStep',
+        rtdata.input,
+        '--save_results=true'
+    ]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    'output',
+    ['outtest_residual_fringe.fits']
+)
+def test(run_cube_build_single_output, output, fitsdiff_default_kwargs):
+    """Test just running residual fringe correction"""
+    rtdata = run_residual_fringe_output
+    rtdata.output = output
+
+    # Get the truth files
+    rtdata.get_truth(f'truth/test_residual_fringe/{output}')
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+#@pytest.mark.bigdata
+#def test_residual_fringe_cal(rtdata, fitsdiff_default_kwargs):
+#    """Run residual fringe correction on MIRI IFUShort
+#    input_file = 'det_image_seq2_MIRIFUSHORT_12SHORTexp1_cal.fits'
+#    rtdata.get_data(f"miri/mrs/{input_file}")
+
+#    args = [
+#        'jwst.residual_fringe.ResidualFringeStep',
+#        input_file,
+#        '--save_results=true',
+#    ]
+#    Step.from_cmdline(args)
+
+#    output = input_file.replace('cal', 'residual_fringe')
+#    rtdata.output = output
+
+#    rtdata.get_truth(f"truth/test_miri_residual_fringe/{output}")
+
+#    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+#    assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_residual_fringe.py
+++ b/jwst/regtest/test_miri_residual_fringe.py
@@ -4,7 +4,7 @@ import pytest
 from astropy.io.fits.diff import FITSDiff
 from jwst.stpipe import Step
 
-
+@pytest.mark.slow
 @pytest.mark.bigdata
 def test_residual_fringe_cal(rtdata, fitsdiff_default_kwargs):
     """Run residual fringe correction on MIRI IFUShort """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

This PR is part of JP-2344 - the parent ticket of the residual fringe correction 


**Description**

This PR adds a regression test for the residual fringe corrrection. Ground test data was converted to DMS format. The ground test data is a good example of data with fringes.  The input and truth files have been added to artifactory

Checklist
- [X] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
