### PR TITLE
Fix failing resample unit test

### DIFF
--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -441,7 +441,7 @@ def test_resample_undefined_variance(nircam_rate, shape):
 @pytest.mark.parametrize('ratio', [0.7, 1.2])
 @pytest.mark.parametrize('rotation', [0, 15, 135])
 @pytest.mark.parametrize('crpix', [(256, 488), (700, 124)])
-@pytest.mark.parametrize('crval', [(50, 77), (250, -30)])
+@pytest.mark.parametrize('crval', [(50, 77), (20, -30)])
 @pytest.mark.parametrize('shape', [(1205, 1100)])
 def test_custom_wcs_resample_imaging(nircam_rate, ratio, rotation, crpix, crval, shape):
     im = AssignWcsStep.call(nircam_rate, sip_approx=False)


### PR DESCRIPTION
Fixes failing `test_custom_wcs_resample_imaging` due to a bad test parameter. Changes in `astropy` master are less tolerant to bad parameters.

Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
