### PR TITLE
JP-2555 update rscd model to take FASTR1, SLOWR1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ datamodels
 
 - Remove FILETYPE keyword from core schema, and all assignments to it [#6772]
 
+- Update rscd model to increase the size of group_skip_table to allow FASTR1, SLOWR1, FASTR100 [#6776]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/schemas/rscd.schema.yaml
+++ b/jwst/datamodels/schemas/rscd.schema.yaml
@@ -14,7 +14,7 @@ allOf:
       - name: subarray
         datatype: [ascii, 13]
       - name: readpatt
-        datatype: [ascii, 4]
+        datatype: [ascii, 8]
       - name: group_skip
         datatype: int32
     rscd_gen_table:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2555](https://jira.stsci.edu/browse/JP-2555)

**Description**

This PR updates the RSCD schema  to increase the size of the rscd_group_skip_table. The readpatt column size needs to be increased to allow values of FASTR1, SLOWR1, or FASTR100. A new set of RSCD reference files include values for the number of groups to skip for the baseline RSCD correction for a readpatt of FASTR1, SLOWR1, and FASTR100.  The flight data will have a readpatt of either FASTR1 or SLOWR1.

Checklist
- [ ] Tests
- [ ] Documentation
- [X] Change log
- [X] Milestone
- [X] Label(s)