### PR TITLE
JP-2027: Fix horizontal centering of resampled MIRI-LRS spectra

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,11 @@ ramp_fitting
 - Adding feature to turn off calculations of ramps with good 0th group,
   but all other groups are saturated. [#6737]
 
+resample
+--------
+
+- Fixed ``resample_spec`` output spectrum centering issue for MIRI-LRS. [#6777]
+
 residual_fringe
 ---------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,7 +85,7 @@ ramp_fitting
 resample
 --------
 
-- Fixed ``resample_spec`` output spectrum centering issue for MIRI-LRS. [#6777]
+- Fixed ``resample_spec`` output spectrum centering issue for MIRI LRS fixed-slit. [#6777]
 
 residual_fringe
 ---------------

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -289,6 +289,10 @@ class ResampleSpecData(ResampleData):
         x_min = np.amin(x_tan_all)
         x_max = np.amax(x_tan_all)
         x_size = int(np.ceil((x_max - x_min) / np.absolute(pix_to_tan_slope)))
+        if swap_xy:
+            pix_to_ytan.intercept = -0.5 * (x_size - 1) * pix_to_ytan.slope
+        else:
+            pix_to_xtan.intercept = -0.5 * (x_size - 1) * pix_to_xtan.slope
 
         # single model use size of x_tan_array
         # to be consistent with method before


### PR DESCRIPTION
Resolves [JP-2027](https://jira.stsci.edu/browse/JP-2027)

**Description**

This PR fixes the horizontal displacement of resampled spectra for MIRI-LRS. 
This is not a complete re-design of the `build_interpolated_output_wcs()` function but just a patch to fix horizontal displacement.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
