### PR TITLE
JP-2561 Add option --force-level1bmodel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,14 @@ srctype
 
 - Add command line option to override source type [#6720]
 
+1.4.6 (2022-03-25)
+==================
+
+set_telescope_pointing
+----------------------
+
+- Add option --force-level1bmodel. [#6778]
+
 1.4.5 (2022-03-23)
 ==================
 

--- a/scripts/set_telescope_pointing.py
+++ b/scripts/set_telescope_pointing.py
@@ -71,6 +71,10 @@ if __name__ == '__main__':
         help='Attempt to update WCS for any file or model. Default: False'
     )
     parser.add_argument(
+        '--force-level1bmodel', action='store_true', default=False,
+        help='Force unrecognized files to be opened as Level1bModel. Default: False'
+    )
+    parser.add_argument(
         '--allow-default', action='store_true',
         help='If pointing information cannot be determine, use header information.'
     )
@@ -144,6 +148,7 @@ if __name__ == '__main__':
             stp.add_wcs(
                 filename,
                 allow_any_file=args.allow_any_file,
+                force_level1bmodel=args.force_level1bmodel,
                 siaf_path=args.siaf,
                 engdb_url=args.engdb_url,
                 fgsid=args.fgsid,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->
Resolves [JP-2561](https://jira.stsci.edu/browse/JP-2561)

**Description**

This PR adds the command-line option `--force-level1bmodel` for the situation where an input file
does not define the DATAMODL keyword and, instead of attempting to guess at the model type,
force the file to be opened as a `Level1bModel`.

Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
