### PR TITLE
JP-2027: Restrict fix from 6777 to vertical spectra only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,8 @@ ramp_fitting
 resample
 --------
 
+- Restrict fix from #6777 to "vertical" spectra (i.e., MIRI LRS) only. [#6779]
+
 - Fixed ``resample_spec`` output spectrum centering issue for MIRI LRS fixed-slit. [#6777]
 
 residual_fringe

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -289,9 +289,7 @@ class ResampleSpecData(ResampleData):
         x_min = np.amin(x_tan_all)
         x_max = np.amax(x_tan_all)
         x_size = int(np.ceil((x_max - x_min) / np.absolute(pix_to_tan_slope)))
-        if swap_xy:
-            pix_to_ytan.intercept = -0.5 * (x_size - 1) * pix_to_ytan.slope
-        else:
+        if not swap_xy:
             pix_to_xtan.intercept = -0.5 * (x_size - 1) * pix_to_xtan.slope
 
         # single model use size of x_tan_array


### PR DESCRIPTION
Resolves [JP-2027](https://jira.stsci.edu/browse/JP-2027)

**Description**

@hbushouse reported:

> After merging PR https://github.com/spacetelescope/jwst/pull/6777 we're now seeing expected differences in MIRI LRS fixed-slit data (which is good), but we're also seeing differences in regtest results for NIRSpec fixed-slit and MOS data, which are not expected. 

This PR restricts the fix from #6777 to vertical spectra exclusively. I do not *visually see* significant differences for NIRSpec with unarmed eye but I can see how regtests would report differences.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [ ] Milestone
- [x] Label(s)
