### PR TITLE
JP-2083: Fix issues with resampling multi-slit observations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,12 +72,6 @@ pipeline
 
 - Improve memory performance of calwebb_detector1 pipeline [#6758]
 
-resample
---------
-
-- Re-designed algorithm for computation of the output WCS for the
-  ``resemple_spec`` step for ``NIRSpec`` data. [#6747]
-
 ramp_fitting
 ------------
 
@@ -91,7 +85,11 @@ ramp_fitting
 resample
 --------
 
-- Fixed ``resample_spec`` output spectrum centering issue for MIRI LRS fixed-slit. [#6777]
+- Fixed ``resample_spec`` output spectrum centering issue for MIRI LRS
+  fixed-slit. [#6777]
+
+- Re-designed algorithm for computation of the output WCS for the
+  ``resemple_spec`` step for ``NIRSpec`` data. [#6747, #6780]
 
 residual_fringe
 ---------------


### PR DESCRIPTION
Resolves [JP-2083](https://jira.stsci.edu/browse/JP-2083)

**Description**

#6747 introduced a re-designed algorithm for computation of the output WCS for the ``resemple_spec`` step for ``NIRSpec`` data. Unfortunately, due to how target position is reported in the `model.meta`, the algorithm had issues with multi-slit observations. This PR fixes those issues and another bug in centering of the output spectrum.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
