### PR TITLE
Make fit_quality_is_good private and rename it

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -122,6 +122,13 @@ srctype
 
 - Add command line option to override source type [#6720]
 
+tweakreg
+--------
+
+- Make ``fit_quality_is_good()`` member private and rename it to
+  ``_is_wcs_correction_small()``. [#6781]
+
+
 1.4.6 (2022-03-25)
 ==================
 
@@ -2288,6 +2295,7 @@ tweakreg
 --------
 
 - Updated step arguments in the documentation. [#4723]
+
 
 wfs_combine
 -----------

--- a/jwst/tweakreg/tests/test_tweakreg.py
+++ b/jwst/tweakreg/tests/test_tweakreg.py
@@ -9,7 +9,7 @@ from jwst.tweakreg import TweakRegStep
 
 
 @pytest.mark.parametrize("offset, is_good", [(1 / 3600, True), (11 / 3600, False)])
-def test_fit_quality_is_good(offset, is_good):
+def test_is_wcs_correction_small(offset, is_good):
     path = os.path.join(os.path.dirname(__file__), "mosaic_long_i2d_gwcs.asdf")
     with asdf.open(path) as af:
         wcs = af.tree["wcs"]
@@ -22,4 +22,4 @@ def test_fit_quality_is_good(offset, is_good):
 
     step = TweakRegStep()
 
-    assert step.fit_quality_is_good(wcs, twcs) == is_good
+    assert step._is_wcs_correction_small(wcs, twcs) == is_good

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -212,7 +212,9 @@ class TweakRegStep(Step):
         for imcat in imcats:
             wcs = imcat.meta['image_model'].meta.wcs
             twcs = imcat.wcs
-            if not self.fit_quality_is_good(wcs, twcs):
+            if not self._is_wcs_correction_small(wcs, twcs):
+                # Large corrections are typically a result of source
+                # mis-matching or poorly-conditioned fit. Skip such models.
                 self.log.warning(f"WCS has been tweaked by more than {10 * self.tolerance} arcsec")
                 self.log.warning("Skipping 'TweakRegStep'...")
                 self.skip = True
@@ -313,7 +315,7 @@ class TweakRegStep(Step):
 
         return images
 
-    def fit_quality_is_good(self, wcs, twcs):
+    def _is_wcs_correction_small(self, wcs, twcs):
         """Check that the newly tweaked wcs hasn't gone off the rails"""
         tolerance = 10.0 * self.tolerance * u.arcsec
 


### PR DESCRIPTION
**Description**

This PR is basically a maintenance edition. Here I make method `fit_quality_is_good()` of the `tweakreg` step private (I do not think there is a reason for it to be public) and also I rename it to something that is better suited for what it tests. This function was first introduced in https://github.com/spacetelescope/jwst/pull/6252

@hbushouse Please let me know if you think I should officially deprecate this method instead of renaming it right away. IMO, it is highly unlikely anyone would have used it since it was introduced.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
