### PR TITLE
JP-898: Update calwebb_spec2 to create WFSS e/sec product

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.4.6 (unreleased)
+1.4.7 (unreleased)
 ==================
 
 associations
@@ -70,7 +70,10 @@ regtest
 pipeline
 --------
 
-- Improve memory performance of calwebb_detector1 pipeline [#6758]
+- Improve memory performance of `calwebb_detector1` pipeline [#6758]
+
+- Update the `calwebb_spec2` pipeline to allow for the creation of an
+  optional WFSS product that's in units of e-/sec [#6783]
 
 ramp_fitting
 ------------

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -112,7 +112,7 @@ If set to ``True``, an intermediate image product is created for WFSS exposures 
 is in units of electrons/sec, instead of the normal DN/sec units that are used throughout
 the rest of processing. This product can be useful for doing off-line specialized
 processing of WFSS images. This product is created after the :ref:`background <background_step>`
-and :ref:`flat-field <flat_field_step>` steps have been applied, but before the
+and :ref:`flat-field <flatfield_step>` steps have been applied, but before the
 :ref:`extract_2d <extract_2d_step>` step, so that it is the full WFSS image. The conversion
 to units of electrons/sec is accomplished by loading the :ref:`GAIN <gain_reffile>` reference file,
 computing the sigma-clipped mean gain across all pixels, and multiplying the WFSS image by the

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -113,9 +113,9 @@ The ``calwebb_spec2`` pipeline has two optional arguments.
   and :ref:`flat-field <flatfield_step>` steps have been applied, but before the
   :ref:`extract_2d <extract_2d_step>` step, so that it is the full WFSS image. The conversion
   to units of electrons/sec is accomplished by loading the :ref:`GAIN <gain_reffile>` reference file,
-  computing the sigma-clipped mean gain across all pixels, and multiplying the WFSS image by the
-  mean gain.  The intermediate file will have a product type of "_esec". Only applies to
-  WFSS exposures.
+  computing the mean gain across all pixels (excluding reference pixels), and multiplying the WFSS
+  image by the mean gain.  The intermediate file will have a product type of "_esec".
+  Only applies to WFSS exposures.
 
 Inputs
 ------

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -98,25 +98,24 @@ the :ref:`extract_1d <extract_1d_step>` step.
 
 Arguments
 ---------
-The ``calwebb_spec2`` pipeline has two optional arguments::
+The ``calwebb_spec2`` pipeline has two optional arguments.
 
-  --save_bsub  boolean  default=False
+``--save_bsub`` (boolean, default=False)
+  If set to ``True``, the results of the background subtraction step will be saved
+  to an intermediate file, using a product type of "_bsub" or "_bsubints", depending on
+  whether the data are 2D (averaged over integrations) or 3D (per-integration results).
 
-If set to ``True``, the results of the background subtraction step will be saved
-to an intermediate file, using a product type of "_bsub" or "_bsubints", depending on
-whether the data are 2D (averaged over integrations) or 3D (per-integration results).
-
-  --save_wfss_esec  boolean  default=False
-
-If set to ``True``, an intermediate image product is created for WFSS exposures that
-is in units of electrons/sec, instead of the normal DN/sec units that are used throughout
-the rest of processing. This product can be useful for doing off-line specialized
-processing of WFSS images. This product is created after the :ref:`background <background_step>`
-and :ref:`flat-field <flatfield_step>` steps have been applied, but before the
-:ref:`extract_2d <extract_2d_step>` step, so that it is the full WFSS image. The conversion
-to units of electrons/sec is accomplished by loading the :ref:`GAIN <gain_reffile>` reference file,
-computing the sigma-clipped mean gain across all pixels, and multiplying the WFSS image by the
-mean gain.  The intermediate file will have a product type of "_esec".
+``--save_wfss_esec`` (boolean, default=False)
+  If set to ``True``, an intermediate image product is created for WFSS exposures that
+  is in units of electrons/sec, instead of the normal DN/sec units that are used throughout
+  the rest of processing. This product can be useful for doing off-line specialized
+  processing of WFSS images. This product is created after the :ref:`background <background_step>`
+  and :ref:`flat-field <flatfield_step>` steps have been applied, but before the
+  :ref:`extract_2d <extract_2d_step>` step, so that it is the full WFSS image. The conversion
+  to units of electrons/sec is accomplished by loading the :ref:`GAIN <gain_reffile>` reference file,
+  computing the sigma-clipped mean gain across all pixels, and multiplying the WFSS image by the
+  mean gain.  The intermediate file will have a product type of "_esec". Only applies to
+  WFSS exposures.
 
 Inputs
 ------

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -98,13 +98,25 @@ the :ref:`extract_1d <extract_1d_step>` step.
 
 Arguments
 ---------
-The ``calwebb_spec2`` pipeline has one optional argument::
+The ``calwebb_spec2`` pipeline has two optional arguments::
 
   --save_bsub  boolean  default=False
 
 If set to ``True``, the results of the background subtraction step will be saved
 to an intermediate file, using a product type of "_bsub" or "_bsubints", depending on
 whether the data are 2D (averaged over integrations) or 3D (per-integration results).
+
+  --save_wfss_esec  boolean  default=False
+
+If set to ``True``, an intermediate image product is created for WFSS exposures that
+is in units of electrons/sec, instead of the normal DN/sec units that are used throughout
+the rest of processing. This product can be useful for doing off-line specialized
+processing of WFSS images. This product is created after the :ref:`background <background_step>`
+and :ref:`flat-field <flat_field_step>` steps have been applied, but before the
+:ref:`extract_2d <extract_2d_step>` step, so that it is the full WFSS image. The conversion
+to units of electrons/sec is accomplished by loading the :ref:`GAIN <gain_reffile>` reference file,
+computing the sigma-clipped mean gain across all pixels, and multiplying the WFSS image by the
+mean gain.  The intermediate file will have a product type of "_esec".
 
 Inputs
 ------

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import os.path as op
 import traceback
 import numpy as np
+from astropy.stats import sigma_clipped_stats
 
 from .. import datamodels
 from ..assign_wcs.util import NoDataOnDetectorError
@@ -235,33 +236,6 @@ class Spec2Pipeline(Pipeline):
                     else:
                         raise RuntimeError('Cannot determine WCS.')
 
-        # Create and save a WFSS e-/sec image, if requested
-        if exp_type in WFSS_TYPES and self.save_wfss_esec:
-            self.log.info('Creating WFSS e-/sec product')
-
-            # Find and load the gain reference file that we need
-            gain_filename = self.get_reference_file(calibrated, 'gain')
-            self.log.info('Using GAIN reference file %s', gain_filename)
-            with datamodels.GainModel(gain_filename) as gain_model:
-                if reffile_utils.ref_matches_sci(calibrated, gain_model):
-                    gain_image = gain_model.data
-                else:
-                    self.log.info('Extracting gain subarray to match science data')
-                    gain_image = reffile_utils.get_subarray_data(calibrated, gain_model)
-
-                # Apply the gain image to the WFSS image
-                gain_image_squared = gain_image * gain_image
-                wfss_esec = calibrated.copy()
-                wfss_esec.data *= gain_image
-                wfss_esec.var_poisson *= gain_image_squared
-                wfss_esec.var_rnoise *= gain_image_squared
-                wfss_esec.var_flat *= gain_image_squared
-                wfss_esec.err = np.sqrt(wfss_esec.var_poisson + wfss_esec.var_rnoise + wfss_esec.var_flat)
-
-                # Save the WFSS e-/sec image
-                self.save_model(wfss_esec, suffix='esec', force=True)
-                del wfss_esec
-
         # Steps whose order is the same for all types of input.
         calibrated = self.bkg_subtract(calibrated, members_by_type['background'])
         calibrated = self.imprint_subtract(calibrated, members_by_type['imprint'])
@@ -273,7 +247,6 @@ class Spec2Pipeline(Pipeline):
         # srctype and wavecorr before flat_field.
         if exp_type in GRISM_TYPES:
             calibrated = self._process_grism(calibrated)
-            # Apply flat-field correction
         elif exp_type in NRS_SLIT_TYPES:
             calibrated = self._process_nirspec_slits(calibrated)
         else:
@@ -409,7 +382,51 @@ class Spec2Pipeline(Pipeline):
 
         WFSS/Grism data need flat_field before extract_2d.
         """
+
+        # Apply flat-field correction
         calibrated = self.flat_field(data)
+
+        # Create and save a WFSS e-/sec image, if requested
+        if self.save_wfss_esec:
+            self.log.info('Creating WFSS e-/sec product')
+
+            # Find and load the gain reference file that we need
+            gain_filename = self.get_reference_file(calibrated, 'gain')
+            self.log.info('Using GAIN reference file %s', gain_filename)
+            with datamodels.GainModel(gain_filename) as gain_model:
+
+                # WFSS images should always be full-frame, but check for subarrays
+                # anyway, just in case
+                if reffile_utils.ref_matches_sci(calibrated, gain_model):
+                    gain_image = gain_model.data
+                else:
+                    self.log.info('Extracting gain subarray to match science data')
+                    gain_image = reffile_utils.get_subarray_data(calibrated, gain_model)
+
+                # Compute the sigma-clipped mean of the gain image.
+                # The gain ref file doesn't have a DQ array that can be used to
+                # mask bad values, so manually exclude NaN's and gain <= 0.
+                # The clipping does a good job of automatically removing off-nominal
+                # values for the reference pixels around the perimeter.
+                mask = np.bitwise_or(np.isnan(gain_image), gain_image <= 0.)
+                mean_gain, _, _ = sigma_clipped_stats(gain_image, mask=mask)
+                self.log.debug(' mean gain = %s', mean_gain)
+
+                # Apply gain to the intermediate WFSS image
+                wfss_esec = calibrated.copy()
+                mean_gain_sqr = mean_gain ** 2
+                wfss_esec.data *= mean_gain
+                wfss_esec.var_poisson *= mean_gain_sqr
+                wfss_esec.var_rnoise *= mean_gain_sqr
+                wfss_esec.var_flat *= mean_gain_sqr
+                wfss_esec.err = np.sqrt(wfss_esec.var_poisson + wfss_esec.var_rnoise + wfss_esec.var_flat)
+
+                # Save the WFSS e-/sec image
+                self.save_model(wfss_esec, suffix='esec', force=True)
+                del wfss_esec
+
+        # Continue with remaining calibration steps, using the original
+        # DN/sec image
         calibrated = self.extract_2d(calibrated)
         calibrated = self.srctype(calibrated)
         calibrated = self.straylight(calibrated)

--- a/jwst/regtest/test_niriss_wfss.py
+++ b/jwst/regtest/test_niriss_wfss.py
@@ -28,6 +28,7 @@ def run_nis_wfss_spec2(jail, rtdata_module):
             '--steps.resample_spec.save_results=true',
             '--steps.cube_build.save_results=true',
             '--steps.extract_1d.save_results=true',
+            '--save_wfss_esec=true',
         ]
     }
 
@@ -37,7 +38,7 @@ def run_nis_wfss_spec2(jail, rtdata_module):
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix',
-    ['assign_wcs', 'bsub', 'cal', 'extract_2d', 'flat_field', 'photom', 'srctype', 'x1d']
+    ['assign_wcs', 'bsub', 'cal', 'esec', 'extract_2d', 'flat_field', 'photom', 'srctype', 'x1d']
 )
 def test_nis_wfss_spec2(run_nis_wfss_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test for calwebb_spec2 applied to NIRISS WFSS data"""


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #3860
Resolves [JP-898](https://jira.stsci.edu/browse/JP-898)

**Description**

This PR updates the WFSS processing branch of the calwebb_spec2 pipeline to allow it save an optional intermediate product that is a version of the grism image converted to units of e-/sec. The image is saved immediately after the flat-field step, before extract_2d has been applied, so that it is the full grism image before any extractions of spectra have been done. The image data are converted to units of e-/sec by loading the gain reference file, computing the mean gain from the reference data, and multiplying the grism image by the mean gain. The units of the variance and error arrays are also converted. The resulting image is saved as new "esec" product type.

Creating and saving this image is optional and is controlled by a new pipeline param "save_wfss_esec", which has a default setting of `False`.

Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)