### PR TITLE
JP-2565 Implement PoolRow to avoid deep copy of the AssociationPool table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 associations
 ------------
 
+- Implement PoolRow to avoid deep copy of the AssociationPool table [#6787]
+
 - Added valid optical paths for NRS_LAMP observations to generate
   or exclude associations using lamp, disperser and detector [#6695]
 

--- a/jwst/associations/generate.py
+++ b/jwst/associations/generate.py
@@ -1,12 +1,11 @@
 import logging
 
-from .association import (
-    make_timestamp
-)
+from .association import make_timestamp
 from .lib.process_list import (
     ProcessList,
     ProcessQueueSorted
 )
+from .pool import PoolRow
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -61,6 +60,8 @@ def generate(pool, rules, version_id=None):
         #     f'\n\trules {process_list.rules}'
         # )
         for item in process_list.items:
+            item = PoolRow(item)
+
             # logger.debug(f'Processing item {item}')
             existing_asns, new_asns, to_process = generate_from_item(
                 item,

--- a/jwst/associations/lib/constraint.py
+++ b/jwst/associations/lib/constraint.py
@@ -14,6 +14,7 @@ from .utilities import (
     getattr_from_list,
     is_iterable
 )
+from ..pool import PoolRow
 
 __all__ = [
     'AttrConstraint',
@@ -468,7 +469,7 @@ class AttrConstraint(SimpleConstraintABC):
             if is_iterable(evaled):
                 reprocess_items = []
                 for avalue in evaled:
-                    new_item = deepcopy(item)
+                    new_item = PoolRow(item)
                     new_item[source] = str(avalue)
                     reprocess_items.append(new_item)
                 reprocess.append(ProcessList(

--- a/jwst/associations/pool.py
+++ b/jwst/associations/pool.py
@@ -4,9 +4,10 @@ Association Pools
 
 from pkg_resources import parse_version, get_distribution
 
-from astropy.io.ascii import convert_numpy
+from collections import UserDict
 
-from astropy.table import Table
+from astropy.io.ascii import convert_numpy
+from astropy.table import Row, Table
 
 __all__ = ['AssociationPool']
 
@@ -105,6 +106,20 @@ class AssociationPool(Table):
             super(AssociationPool, self).write(
                 *args, format=format, **kwargs
             )
+
+class PoolRow(UserDict):
+    """A row from an AssociationPool
+
+    Class to create a copy of an AssociationPool row without copying
+    all of the astropy.Table.Row private attributes.
+    """
+    def __init__(self, init=None):
+        dict_init = dict(init)
+        super().__init__(dict_init)
+        try:
+            self.meta = init.meta
+        except AttributeError:
+            self.meta = dict()
 
 
 def _convert_to_str():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->
Resolves [JP-2565](https://jira.stsci.edu/browse/JP-2565)

**Description**
A necessary operation during generation is the deep copying of rows from the `AssociationPool`. However, because `AssociationPool` is subclassed from`astropy.table.Table`, each row has a pointer back to the table it belongs to, each row deep copy would copy the whole table. This causes exponential memory use as the tables grow in length.

A new class, `PoolRow`, is implemented to return a stripped-down version of each row, without the extra baggage.

Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
