### PR TITLE
Pin astropy min version to 5.0.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     asdf>=2.8.2
-    astropy>=5.0.1
+    astropy>=5.0.4
     BayesicFitting>=2.7.2
     crds>=11.6.0
     drizzle>=1.13.4


### PR DESCRIPTION
**Description**

This PR pins the astropy min version to 5.0.4

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [ ] Label(s)
