### PR TITLE
JP-2566: Fix resample_spec parameter handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,9 @@ resample
 - Re-designed algorithm for computation of the output WCS for the
   ``resemple_spec`` step for ``NIRSpec`` data. [#6747, #6780]
 
+- Fixed handling of user-supplied ``weight_type`` parameter value for
+  ``resample_spec``. [#6796]
+
 reset
 -----
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -58,12 +58,14 @@ class ResampleSpecStep(ResampleStep):
             kwargs = self._set_spec_defaults()
             kwargs['blendheaders'] = self.blendheaders
 
+        kwargs['allowed_memory'] = self.allowed_memory
+        kwargs['weight_type'] = str(self.weight_type)
+        kwargs['output'] = output
+
         # Issue a warning about the use of exptime weighting
         if self.weight_type == 'exptime':
             self.log.warning("Use of EXPTIME weighting will result in incorrect")
             self.log.warning("propagated errors in the resampled product")
-        kwargs['allowed_memory'] = self.allowed_memory
-        kwargs['output'] = output
 
         # Call resampling
         self.drizpars = kwargs

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -54,10 +54,14 @@ class ResampleSpecStep(ResampleStep):
             kwargs = self.get_drizpars(ref_filename, input_models)
         else:
             # Deal with NIRSpec, which currently has no default drizpars reffile
-            self.log.info("No NIRSpec DIRZPARS reffile")
+            self.log.info("No DRIZPARS reffile")
             kwargs = self._set_spec_defaults()
             kwargs['blendheaders'] = self.blendheaders
 
+        # Issue a warning about the use of exptime weighting
+        if self.weight_type == 'exptime':
+            self.log.warning("Use of EXPTIME weighting will result in incorrect")
+            self.log.warning("propagated errors in the resampled product")
         kwargs['allowed_memory'] = self.allowed_memory
         kwargs['output'] = output
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -78,17 +78,18 @@ class ResampleStep(Step):
         if ref_filename != 'N/A':
             self.log.info('Drizpars reference file: {}'.format(ref_filename))
             kwargs = self.get_drizpars(ref_filename, input_models)
-
         else:
             # If there is no drizpars reffile
             self.log.info("No DRIZPARS reffile")
             kwargs = self._set_spec_defaults()
 
+        kwargs['allowed_memory'] = self.allowed_memory
+        kwargs['weight_type'] = str(self.weight_type)
+
         # Issue a warning about the use of exptime weighting
         if self.weight_type == 'exptime':
             self.log.warning("Use of EXPTIME weighting will result in incorrect")
             self.log.warning("propagated errors in the resampled product")
-        kwargs['allowed_memory'] = self.allowed_memory
 
         # Custom output WCS parameters.
         # Modify get_drizpars if any of these get into reference files:

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -81,14 +81,14 @@ class ResampleStep(Step):
 
         else:
             # If there is no drizpars reffile
-            self.log.info("No DIRZPARS reffile")
+            self.log.info("No DRIZPARS reffile")
             kwargs = self._set_spec_defaults()
 
-        kwargs['allowed_memory'] = self.allowed_memory
-        kwargs['weight_type'] = str(self.weight_type)
+        # Issue a warning about the use of exptime weighting
         if self.weight_type == 'exptime':
             self.log.warning("Use of EXPTIME weighting will result in incorrect")
             self.log.warning("propagated errors in the resampled product")
+        kwargs['allowed_memory'] = self.allowed_memory
 
         # Custom output WCS parameters.
         # Modify get_drizpars if any of these get into reference files:
@@ -225,20 +225,16 @@ class ResampleStep(Step):
         # Force definition of good bits
         kwargs['good_bits'] = GOOD_BITS
 
-        if kwargs['pixfrac'] is None:
-            kwargs['pixfrac'] = 1.0
-        if kwargs['kernel'] is None:
-            kwargs['kernel'] = 'square'
-        if kwargs['fillval'] is None:
-            kwargs['fillval'] = 'INDEF'
-        if kwargs['weight_type'] is None:
-            kwargs['weight_type'] = 'ivm'
+        kwargs['pixfrac'] = self.pixfrac
+        kwargs['kernel'] = str(self.kernel)
+        kwargs['fillval'] = str(self.fillval)
+        kwargs['weight_type'] = str(self.weight_type)
         kwargs['pscale_ratio'] = self.pixel_scale_ratio
         kwargs.pop('pixel_scale_ratio')
 
         for k, v in kwargs.items():
             if k in ['pixfrac', 'kernel', 'fillval', 'weight_type', 'pscale_ratio']:
-                log.info('  setting: %s=%s', k, repr(v))
+                log.info('  using: %s=%s', k, repr(v))
 
         return kwargs
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2566](https://jira.stsci.edu/browse/JP-2566)

**Description**

This PR makes changes to the resample and resample_spec steps to allow for proper use of user-supplied parameter values. In the case where there's no DRIZPARS parameter ref file from which to load parameter values (as is the case for NIRSpec), the old code was hardwiring parameters to default values, thus ignoring any user-supplied parameter values. The function `_set_spec_defaults` has been drastically modified to fix this situation. The current flow is to first initialize the values in `kwargs` from the default values specified in the step "spec". It then applies values retrieved from the active params, thus passing along any user-supplied param values for items like `pixfrac`, `fillval`, and `weight_type`. No hardwired values are assigned any more in the code.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
