### PR TITLE
JP-1618: Allow AmiAverageStep to be run on list in CLI 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,11 @@ align_refs
   MIRI coronagraphy data, due to large contiguous regions of NON_SCIENCE
   pixels [#6722]
 
+ami
+---
+
+- Added functionality for AmiAverageStep use in CLI environment [#6797]
+
 assign_wcs
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ align_refs
 ami
 ---
 
-- Added functionality for AmiAverageStep use in CLI environment [#6797]
+- Allow AmiAverageStep to be run on list in command line interface [#6797]
 
 assign_wcs
 ----------

--- a/jwst/ami/ami_average_step.py
+++ b/jwst/ami/ami_average_step.py
@@ -1,5 +1,4 @@
 from ..stpipe import Step
-
 from . import ami_average
 
 __all__ = ["AmiAverageStep"]
@@ -13,7 +12,17 @@ class AmiAverageStep(Step):
     spec = """
     """
 
-    def process(self, input_list):
+    def flatten_input(self, input_items):
+        """Remove any nested list/tuple structure and return generator
+        to provide iterable simple list with no nested structure.
+        """
+        for item in input_items:
+            if isinstance(item, (list, tuple)):
+                yield from self.flatten_input(item)
+            else:
+                yield item
+
+    def process(self, *input_list):
         """
         Averages the results of LG analysis for a set of multiple NIRISS AMI
         mode exposures.
@@ -28,6 +37,11 @@ class AmiAverageStep(Step):
         result: AmiLgModel object
             Averaged AMI data model
         """
+
+        # Input may be a simple list if run in interactive environment,
+        # but processing from command line wraps list of inputs in a tuple.
+        # Flatten this object into a simple list.
+        input_list = list(self.flatten_input(input_list))
 
         # Call the LG average routine for the list of inputs
         result = ami_average.average_LG(input_list)

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -146,7 +146,6 @@ class ResampleStep(Step):
             drizpars_table = drpt.data
 
         num_groups = len(input_models.group_names)
-        log.warning(f"num_groups: {num_groups} {input_models.group_names}")
         filtname = input_models[0].meta.instrument.filter
         row = None
         filter_match = False
@@ -181,17 +180,17 @@ class ResampleStep(Step):
             fillval=self.fillval,
             pscale_ratio=self.pixel_scale_ratio,
         )
-        log.warning(f"default drizpars: {drizpars}")
+
         # For parameters that are set in drizpars table but not set by the
         # user, use these.  Otherwise, use values set by user.
-        reffile_drizpars = {k: v for k, v in drizpars.items()}
+        reffile_drizpars = {k: v for k, v in drizpars.items() if v is None}
         user_drizpars = {k: v for k, v in drizpars.items() if v is not None}
 
         # read in values from that row for each parameter
         for k in reffile_drizpars:
             if k in drizpars_table.names:
                 reffile_drizpars[k] = drizpars_table[k][row]
-        log.warning(f"reffile_drizpars pixfrac: {reffile_drizpars}")
+
         # Convert the strings in the FITS binary table from np.bytes_ to str
         for k, v in reffile_drizpars.items():
             if isinstance(v, np.bytes_):
@@ -210,7 +209,6 @@ class ResampleStep(Step):
         for k, v in kwargs.items():
             self.log.debug('   {}={}'.format(k, v))
 
-        log.warning(f"kwargs pixfrac: {kwargs['pixfrac']}")
         return kwargs
 
     def _set_spec_defaults(self):

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -146,6 +146,7 @@ class ResampleStep(Step):
             drizpars_table = drpt.data
 
         num_groups = len(input_models.group_names)
+        log.warning(f"num_groups: {num_groups} {input_models.group_names}")
         filtname = input_models[0].meta.instrument.filter
         row = None
         filter_match = False
@@ -180,17 +181,17 @@ class ResampleStep(Step):
             fillval=self.fillval,
             pscale_ratio=self.pixel_scale_ratio,
         )
-
+        log.warning(f"default drizpars: {drizpars}")
         # For parameters that are set in drizpars table but not set by the
         # user, use these.  Otherwise, use values set by user.
-        reffile_drizpars = {k: v for k, v in drizpars.items() if v is None}
+        reffile_drizpars = {k: v for k, v in drizpars.items()}
         user_drizpars = {k: v for k, v in drizpars.items() if v is not None}
 
         # read in values from that row for each parameter
         for k in reffile_drizpars:
             if k in drizpars_table.names:
                 reffile_drizpars[k] = drizpars_table[k][row]
-
+        log.warning(f"reffile_drizpars pixfrac: {reffile_drizpars}")
         # Convert the strings in the FITS binary table from np.bytes_ to str
         for k, v in reffile_drizpars.items():
             if isinstance(v, np.bytes_):
@@ -209,6 +210,7 @@ class ResampleStep(Step):
         for k, v in kwargs.items():
             self.log.debug('   {}={}'.format(k, v))
 
+        log.warning(f"kwargs pixfrac: {kwargs['pixfrac']}")
         return kwargs
 
     def _set_spec_defaults(self):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #5197
Resolves [JP-1618](https://jira.stsci.edu/browse/JP-1618)

**Description**

This PR allows a user to `strun jwst.ami.AmiAverageStep file1.fits file2.fits` - previously, this would cause an error due to formatting of the function input. This required a bit more input handling to preserve functionality in an interactive python session.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
