### PR TITLE
JP-2577: Add reset step back into calwebb_dark

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,8 @@ pipeline
 - Updated `calwebb_spec2`, `calwebb_spec3`, and `calwebb_tso3` to reorder
   step processing for SOSS data - `photom` now comes after `extract_1d` [#6734]
 
+- Added ResetStep back into `calwebb_dark` for MIRI exposures [#6798]
+
 ramp_fitting
 ------------
 

--- a/docs/jwst/pipeline/calwebb_dark.rst
+++ b/docs/jwst/pipeline/calwebb_dark.rst
@@ -27,7 +27,9 @@ pipeline, the order of steps is a bit different for MIRI exposures.
 +---------------------------------------+-----------------------------------------+
 | :ref:`refpix <refpix_step>`           | :ref:`lastframe <lastframe_step>`       |
 +---------------------------------------+-----------------------------------------+
-| :ref:`linearity <linearity_step>`     | :ref:`linearity <linearity_step>`       |
+| :ref:`linearity <linearity_step>`     | :ref:`reset <reset_step>`               |
++---------------------------------------+-----------------------------------------+
+|                                       | :ref:`linearity <linearity_step>`       |
 +---------------------------------------+-----------------------------------------+
 |                                       | :ref:`rscd <rscd_step>`                 |
 +---------------------------------------+-----------------------------------------+

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -11,6 +11,7 @@ from ..saturation import saturation_step
 from ..ipc import ipc_step
 from ..superbias import superbias_step
 from ..refpix import refpix_step
+from ..reset import reset_step
 from ..rscd import rscd_step
 from ..firstframe import firstframe_step
 from ..lastframe import lastframe_step
@@ -42,6 +43,7 @@ class DarkPipeline(Pipeline):
                  'ipc': ipc_step.IPCStep,
                  'superbias': superbias_step.SuperBiasStep,
                  'refpix': refpix_step.RefPixStep,
+                 'reset': reset_step.ResetStep,
                  'rscd': rscd_step.RscdStep,
                  'firstframe': firstframe_step.FirstFrameStep,
                  'lastframe': lastframe_step.LastFrameStep,
@@ -68,6 +70,7 @@ class DarkPipeline(Pipeline):
             input = self.ipc(input)
             input = self.firstframe(input)
             input = self.lastframe(input)
+            input = self.reset(input)
             input = self.linearity(input)
             input = self.rscd(input)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2577](https://jira.stsci.edu/browse/JP-2577)

**Description**

This PR adds the reset step back into calwebb_dark for MIRI exposures.

Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
