### PR TITLE
JP-2506: Adding a conditional to the creation of the ZEROFRAME array.

### DIFF
--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -44,14 +44,15 @@ class RampModel(JwstDataModel):
         self.groupdq = self.groupdq
         self.err = self.err
 
-        try:
-            self.getarray_noinit("zeroframe")
-        except AttributeError:
-            # If "zeroframe" is not in the instance, create a zero array with
-            # the correct dimensions.
-            nints, ngroups, nrows, ncols = self.data.shape
-            dims = (nints, nrows, ncols)
-            self.zeroframe = np.zeros(dims, dtype=self.data.dtype)
+        if isinstance(init, tuple) or self.meta.exposure.zero_frame == True:
+            try:
+                self.getarray_noinit("zeroframe")
+            except AttributeError:
+                # If "zeroframe" is not in the instance, create a zero array with
+                # the correct dimensions.
+                nints, ngroups, nrows, ncols = self.data.shape
+                dims = (nints, nrows, ncols)
+                self.zeroframe = np.zeros(dims, dtype=self.data.dtype)
 
 
 @deprecate_class(RampModel)

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -44,7 +44,7 @@ class RampModel(JwstDataModel):
         self.groupdq = self.groupdq
         self.err = self.err
 
-        if isinstance(init, tuple) or self.meta.exposure.zero_frame == True:
+        if isinstance(init, tuple) or self.meta.exposure.zero_frame is True:
             try:
                 self.getarray_noinit("zeroframe")
             except AttributeError:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2506](https://jira.stsci.edu/browse/JP-2506)

**Description**

This PR addresses creating the ZEROFRAME array when desired in the RampModel.  A conditional has now been added to the `__init__` function to check if the model is being created with a tuple or the `self.meta.exposure.zero_frame` flag is set to `True`.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
