### PR TITLE
JP-2582: Use 0-indexed spectral axis number

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,6 +136,8 @@ resample
 - Fixed handling of user-supplied ``weight_type`` parameter value for
   ``resample_spec``. [#6796]
 
+- Fixed an issue with axis number for the spectral axis in ``resample_spec``. [#6802]
+
 reset
 -----
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -113,7 +113,7 @@ class ResampleSpecData(ResampleData):
             wmean_l = np.sum(ld[good_s]) / total
         else:
             wmean_s = 0.5 * (refmodel.slit_ymax - refmodel.slit_ymin)
-            wmean_l = d2s(*np.mean(bbox, axis=1))[3]
+            wmean_l = d2s(*np.mean(bbox, axis=1))[2]
 
         targ_ra, targ_dec, _ = s2w(0, wmean_s, wmean_l)
 


### PR DESCRIPTION
Partially Resolves [JP-2582](https://jira.stsci.edu/browse/JP-2582)

**Description**

Use 0-based indexing for axes.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
