### PR TITLE
Description of output_ext attribute misleading ( JP-998 )

### DIFF
--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -16,7 +16,7 @@ from ..lib.suffix import remove_suffix
 class JwstStep(Step):
 
     spec = """
-    output_ext         = string(default='.fits')     # Default type of output
+    output_ext = string(default='.fits')  # Default output suffix, not output type
     """
 
     @classmethod

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -16,7 +16,7 @@ from ..lib.suffix import remove_suffix
 class JwstStep(Step):
 
     spec = """
-    output_ext = string(default='.fits')  # Default output suffix, not output type
+    output_ext = string(default='.fits')  # Output file type
     """
 
     @classmethod

--- a/jwst/white_light/white_light_step.py
+++ b/jwst/white_light/white_light_step.py
@@ -16,7 +16,7 @@ class WhiteLightStep(Step):
     spec = """
     min_wavelength     = float(default=None)      # Default wavelength minimum for integration
     max_wavelength     = float(default=None)      # Default wavelength maximum for integration
-    output_ext         = string(default='.ecsv')  # Default type of output
+    output_ext         = string(default='.ecsv')  # Output file type
     suffix             = string(default='whtlt')  # Default suffix for output files
     """
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #4031
Resolves [JP-998](https://jira.stsci.edu/browse/JP-998)

**Description**

The Step parameter output_ext has the following description:

Default type of output

The parameter only changes the extension of the output file, not necessarily the type.  Update the description to be more accurate.


Checklist
- [ ] Tests
- [X] Documentation
- [ ] Change log
- [X] Milestone
- [X] Label(s)
