### PR TITLE
Increase tolerance for considering two polygons to be identical

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -166,6 +166,8 @@ skymatch
 
 - Updated to populate the "BKGMETH" keyword in output files. [#6736]
 
+- Increased tolerance value for considering two sky polygons identical. [#6805]
+
 source_catalog
 --------------
 

--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -700,7 +700,7 @@ class SkyGroup:
 
         pts1 = np.sort(list(self._polygon.points)[0], axis=0)
         pts2 = np.sort(list(other.points)[0], axis=0)
-        if np.allclose(pts1, pts2, rtol=0, atol=5e-9):
+        if np.allclose(pts1, pts2, rtol=0, atol=1e-8):
             intersect_poly = self._polygon.copy()
         else:
             intersect_poly = self._polygon.intersection(other)


### PR DESCRIPTION
**Description**

@stsci-hack reported - see [#65](https://github.com/spacetelescope/stsci.skypac/issues/65) - that in a small number of cases there still are some crashes due to accuracy loss in the spherical geometry package. The workaround to this loss of accuracy issue was to identify two polygons as being identical if their vertices are within a specific proximity to each other. @stsci-hack reports that increasing tolerance by 2x would solve the issue for those HST data sets for which current tolerance was too small.

In my estimates, for ACS/HRC detectors with 0.025'' pixel scale, increasing tolerance to 1e-8 would be an equivalent to a tolerance of about 0.08 pixels in input image pixels.

This is a port of https://github.com/spacetelescope/stsci.skypac/pull/66 to JWST

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
