### PR TITLE
JP-2569: Made defaults for some tweakreg parameters more robust

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -198,6 +198,9 @@ tweakreg
 - Make ``fit_quality_is_good()`` member private and rename it to
   ``_is_wcs_correction_small()``. [#6781]
 
+- Change default settings for ``searchrad``, ``tolerance``, and ``separation``
+  parameters for the ``tweakreg`` step. [#6809]
+
 - Change default value of ``brightest`` parameter in the ``tweakreg`` step. [#6810]
 
 

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -101,14 +101,14 @@ The ``tweakreg`` step has the following optional arguments:
   for matching. (Default=15)
 
 * ``searchrad``: A `float` indicating the search radius in arcsec for a match.
-  (Default=1.0)
+  (Default=2.0)
 
 * ``use2dhist``: A boolean indicating whether to use 2D histogram to find
   initial offset. (Default=True)
 
-* ``separation``: Minimum object separation in arcsec. (Default=0.5)
+* ``separation``: Minimum object separation in arcsec. (Default=1.0)
 
-* ``tolerance``: Matching tolerance for ``xyxymatch`` in arcsec. (Default=1.0)
+* ``tolerance``: Matching tolerance for ``xyxymatch`` in arcsec. (Default=0.7)
 
 * ``xoffset``: Initial guess for X offset in arcsec. (Default=0.0)
 

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -40,10 +40,10 @@ class TweakRegStep(Step):
         enforce_user_order = boolean(default=False) # Align images in user specified order?
         expand_refcat = boolean(default=False) # Expand reference catalog with new sources?
         minobj = integer(default=15) # Minimum number of objects acceptable for matching
-        searchrad = float(default=1.0) # The search radius in arcsec for a match
+        searchrad = float(default=2.0) # The search radius in arcsec for a match
         use2dhist = boolean(default=True) # Use 2d histogram to find initial offset?
-        separation = float(default=0.5) # Minimum object separation in arcsec
-        tolerance = float(default=1.0) # Matching tolerance for xyxymatch in arcsec
+        separation = float(default=1.0) # Minimum object separation in arcsec
+        tolerance = float(default=0.7) # Matching tolerance for xyxymatch in arcsec
         xoffset = float(default=0.0), # Initial guess for X offset in arcsec
         yoffset = float(default=0.0) # Initial guess for Y offset in arcsec
         fitgeometry = option('shift', 'rshift', 'rscale', 'general', default='general') # Fitting geometry


### PR DESCRIPTION
Partially Resolves [JP-2569](https://jira.stsci.edu/browse/JP-2569)

**Description**

This PR updates ``searchrad``, ``tolerance``, and ``separation`` parameters for the ``trweakreg`` step to, hopefully, be more balanced. Also ``separation`` should be larger than ``tolerance``.

Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
