### PR TITLE
Update WFSS spec2 regression test

### DIFF
--- a/jwst/regtest/test_nircam_wfss_spec2.py
+++ b/jwst/regtest/test_nircam_wfss_spec2.py
@@ -11,23 +11,22 @@ def run_pipeline(rtdata_module):
 
     rtdata = rtdata_module
 
-    # Get the custom pars-spec2pipeline ref file needed to run the pipeline
-    rtdata.get_data("nircam/wfss/jwst_nircam_pars-spec2pipeline_custom.asdf")
-
     # Get the input data; load individual data files first, load ASN file last
     rtdata.get_data("nircam/wfss/jw01076-o101_t002_nircam_clear-f356w_cat.ecsv")
     rtdata.get_data("nircam/wfss/jw01076101001_02101_00003_nrcalong_rate.fits")
     rtdata.get_data("nircam/wfss/jw01076-o101_20220403t120233_spec2_002_asn.json")
 
     # Run the calwebb_spec2 pipeline; save results from intermediate steps
-    # use "disable-crds-steppars" to exclude pars-spec2pipeline from CRDS
-    args = ["jwst_nircam_pars-spec2pipeline_custom.asdf", rtdata.input,
+    args = ["calwebb_spec2", rtdata.input,
             "--steps.assign_wcs.save_results=true",
+            "--steps.bkg_subtract.skip=False",
+            "--steps.bkg_subtract.wfss_mmag_extract=20.0",
             "--steps.bkg_subtract.save_results=true",
             "--steps.extract_2d.save_results=true",
+            "--steps.extract_2d.wfss_mmag_extract=19.0",
+            "--steps.extract_2d.wfss_nbright=20",
             "--steps.srctype.save_results=true",
-            "--steps.flat_field.save_results=true",
-            "--disable-crds-steppars"]
+            "--steps.flat_field.save_results=true"]
     Step.from_cmdline(args)
 
     return rtdata


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Related to [JP-2570](https://jira.stsci.edu/browse/JP-2570)

**Description**

Now that updated pars-spec2pipeline ref files are available in CRDS, the custom pars file can be removed from the calwebb_spec2 regression test for a NIRCam WFSS exposure.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)