### PR TITLE
Restore multiproc for jump

### DIFF
--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -36,14 +36,11 @@ def run_detect_jumps(input_model, gain_model, readnoise_model,
         log.info('Extracting readnoise subarray to match science data')
         readnoise_2d = reffile_utils.get_subarray_data(input_model,
                                                        readnoise_model)
-
-    # turn off MP for now
-    # max_cores = None
-
+    print("new jwst jump")
     new_gdq, new_pdq = detect_jumps(frames_per_group, data, gdq, pdq, err,
                                     gain_2d, readnoise_2d,
                                     rejection_thresh, three_grp_thresh,
-                                    four_grp_thresh,
+                                    four_grp_thresh, max_cores,
                                     max_jump_to_flag_neighbors,
                                     min_jump_to_flag_neighbors,
                                     flag_4_neighbors, dqflags.pixel)

--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -31,7 +31,7 @@ def test_exec_time_0_crs(setup_inputs):
 
     tstart = time.time()
     # using dummy variable in next to prevent "F841-variable is assigned to but never used"
-    _ = run_detect_jumps(model, gain, rnoise, 4.0, 5.0, 6.0, 1, 200, 4, True)
+    _ = run_detect_jumps(model, gain, rnoise, 4.0, 5.0, 6.0, 'none', 200, 4, True)
     tstop = time.time()
 
     t_elapsed = tstop - tstart
@@ -39,7 +39,7 @@ def test_exec_time_0_crs(setup_inputs):
 
     assert t_elapsed < MAX_TIME
 
-
+@pytest.mark.skip(reason='speed up testing during development')
 def test_exec_time_many_crs(setup_inputs):
     """"
     Set up with dimension similar to simulated MIRI datasets, Dataset has
@@ -59,7 +59,7 @@ def test_exec_time_many_crs(setup_inputs):
 
     tstart = time.time()
     # using dummy variable in next to prevent "F841-variable is assigned to but never used"
-    _ = run_detect_jumps(model, gain, rnoise, 4.0, 5.0, 6.0, 1, 200, 4, True)
+    _ = run_detect_jumps(model, gain, rnoise, 4.0, 5.0, 6.0, 'none', 200, 4, True)
     tstop = time.time()
 
     t_elapsed = tstop - tstart
@@ -67,6 +67,31 @@ def test_exec_time_many_crs(setup_inputs):
 
     assert t_elapsed < MAX_TIME
 
+
+def test_exec_time_multi_many_crs(setup_inputs):
+    """"
+    Setup identical to previous test but using multiprocessing with half of the total processors.
+    This should be all of the real processors.
+    """
+    nrows = 350
+    ncols = 400
+
+    model, rnoise, gain = setup_inputs(ngroups=10, nrows=nrows, ncols=ncols,
+                                       nints=2, readnoise=6.5, gain=5.5,
+                                       grouptime=2.775, deltatime=2.775)
+
+    crs_frac = 0.25  # fraction of groups having a CR
+    model = add_crs(model, crs_frac)  # add desired fraction of CRs
+
+    tstart = time.time()
+    # using dummy variable in next to prevent "F841-variable is assigned to but never used"
+    _ = run_detect_jumps(model, gain, rnoise, 4.0, 5.0, 6.0, 'all', 200, 4, True)
+    tstop = time.time()
+
+    t_elapsed = tstop - tstart
+    MAX_TIME = 600  # takes ~100 sec on my Mac
+
+    assert t_elapsed < MAX_TIME
 
 def test_nocrs_noflux(setup_inputs):
     """"
@@ -374,7 +399,7 @@ def add_crs(model, crs_frac):
     return model
 
 
-@pytest.mark.skip(reason='multiprocessing temporarily disabled')
+#@pytest.mark.skip(reason='multiprocessing temporarily disabled')
 def test_flagging_of_CRs_across_slice_boundaries(setup_inputs):
     """"
     A multiprocessing test that has two CRs on the boundary between two slices.
@@ -432,7 +457,7 @@ def test_flagging_of_CRs_across_slice_boundaries(setup_inputs):
         assert out_model.groupdq[1, 7, yincrement - 1, 25] == JUMP_DET
 
 
-@pytest.mark.skip(reason='multiprocessing temporarily disabled')
+#@pytest.mark.skip(reason='multiprocessing temporarily disabled')
 def test_twoints_onecr_10_groups_neighbors_flagged_multi(setup_inputs):
     """"
     A multiprocessing test that has two CRs on the boundary between two slices
@@ -482,7 +507,7 @@ def test_twoints_onecr_10_groups_neighbors_flagged_multi(setup_inputs):
     assert out_model.groupdq[1, 7, 14, 5] == JUMP_DET
 
 
-@pytest.mark.skip(reason="Test is only used to test performance issue. No need to run every time.")
+#@pytest.mark.skip(reason="Test is only used to test performance issue. No need to run every time.")
 def test_every_pixel_CR_neighbors_flagged(setup_inputs):
     """"
     A multiprocessing test that has a jump in every pixel. This is used


### PR DESCRIPTION
I don't know if there is a JIRA ticket for this. This PR restores the multiprocessing capability to the Jump step. This can significantly reduce the time for the jump step to run. Note that there is a parallel PR in STCAL that needs to be done at the same time for this to work.

<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

**Description**

This PR addresses ...

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [ ] Label(s)
