### PR TITLE
Add scikit-image to dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,9 @@ general
 
 - Added aliases to all steps, following step_defs naming conventions [#6740]
 
+- Require scikit-image as a dependency (for source catalog deblending).
+  [#6816]
+
 lib
 ---
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     poppy>=1.0.2
     pyparsing>=2.2.1
     requests>=2.22
+    scikit-image>=0.15.0
     scipy>=1.6.0
     spherical-geometry>=1.2.22
     stcal>=0.6.4


### PR DESCRIPTION
**Description**

`scikit-image` is required by `photutils` to perform source deblending in the `source_catalog` step.  By default, `deblend=False`, but if a user or an instrument team turns it on (via parameter reference files) the step will raise an `ImportError` if `scikit-image` is not installed.  I thought this used to be in the required dependencies, but perhaps not.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
