### PR TITLE
JP-2590: Implement drizzle core wrapper for Single type cubes used by mrs_imatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ cube_build
 
 - Fix bug for internal_cal cubes produces by move to drizzle default. [#6826]
 
+- Fix bug for Single type cubes called by mrs_imatch using drizzle. [#6827]
+
 cube_skymatch
 -------------
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -794,13 +794,13 @@ class IFUCubeData():
 
                 if self.interpolation == 'pointcloud':
                     result = cube_wrapper(instrument, flag_dq_plane, weight_type, start_region, end_region,
-                                        self.overlap_partial, self.overlap_full,
-                                        self.xcoord, self.ycoord, self.zcoord,
-                                        coord1, coord2, wave, flux, err, slice_no,
-                                        rois_pixel, roiw_pixel, scalerad_pixel,
-                                        weight_pixel, softrad_pixel,
-                                        self.cdelt3_normal,
-                                        roiw_ave, self.cdelt1, self.cdelt2)
+                                          self.overlap_partial, self.overlap_full,
+                                          self.xcoord, self.ycoord, self.zcoord,
+                                          coord1, coord2, wave, flux, err, slice_no,
+                                          rois_pixel, roiw_pixel, scalerad_pixel,
+                                          weight_pixel, softrad_pixel,
+                                          self.cdelt3_normal,
+                                          roiw_ave, self.cdelt1, self.cdelt2)
                     spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, _ = result
 
                     self.spaxel_flux = self.spaxel_flux + np.asarray(result[0], np.float64)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -791,21 +791,46 @@ class IFUCubeData():
                     instrument = 1
 
                 result = None
-                result = cube_wrapper(instrument, flag_dq_plane, weight_type, start_region, end_region,
-                                      self.overlap_partial, self.overlap_full,
-                                      self.xcoord, self.ycoord, self.zcoord,
-                                      coord1, coord2, wave, flux, err, slice_no,
-                                      rois_pixel, roiw_pixel, scalerad_pixel,
-                                      weight_pixel, softrad_pixel,
-                                      self.cdelt3_normal,
-                                      roiw_ave, self.cdelt1, self.cdelt2)
-                spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, _ = result
 
-                self.spaxel_flux = self.spaxel_flux + np.asarray(result[0], np.float64)
-                self.spaxel_weight = self.spaxel_weight + np.asarray(result[1], np.float64)
-                self.spaxel_var = self.spaxel_var + np.asarray(result[2], np.float64)
-                self.spaxel_iflux = self.spaxel_iflux + np.asarray(result[3],np.float64)
-                result = None
+                if self.interpolation == 'pointcloud':
+                    result = cube_wrapper(instrument, flag_dq_plane, weight_type, start_region, end_region,
+                                        self.overlap_partial, self.overlap_full,
+                                        self.xcoord, self.ycoord, self.zcoord,
+                                        coord1, coord2, wave, flux, err, slice_no,
+                                        rois_pixel, roiw_pixel, scalerad_pixel,
+                                        weight_pixel, softrad_pixel,
+                                        self.cdelt3_normal,
+                                        roiw_ave, self.cdelt1, self.cdelt2)
+                    spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, _ = result
+
+                    self.spaxel_flux = self.spaxel_flux + np.asarray(result[0], np.float64)
+                    self.spaxel_weight = self.spaxel_weight + np.asarray(result[1], np.float64)
+                    self.spaxel_var = self.spaxel_var + np.asarray(result[2], np.float64)
+                    self.spaxel_iflux = self.spaxel_iflux + np.asarray(result[3],np.float64)
+                    result = None
+
+                if self.weighting == 'drizzle':
+                    cdelt3_mean = np.nanmean(self.cdelt3_normal)
+                    xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4 = corner_coord
+                    linear = 0
+                    if self.linear_wavelength:
+                        linear = 1
+                    result = cube_wrapper_driz(instrument, flag_dq_plane,
+                                               start_region, end_region,
+                                               self.overlap_partial, self.overlap_full,
+                                               self.xcoord, self.ycoord, self.zcoord,
+                                               coord1, coord2, wave, flux, err, slice_no,
+                                               xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4,
+                                               dwave,
+                                               self.cdelt3_normal,
+                                               self.cdelt1, self.cdelt2, cdelt3_mean, linear)
+
+                    spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, _ = result
+                    self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)
+                    self.spaxel_weight = self.spaxel_weight + np.asarray(spaxel_weight, np.float64)
+                    self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
+                    self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
+                    result = None
                 # ______________________________________________________________________
                 # shove Flux and iflux in the  final ifucube
                 self.find_spaxel_flux()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

**Description**

This PR fixes a failure of mrs_imatch to properly use the drizzle algorithm for Single type cubes as reported in comments to https://github.com/spacetelescope/jwst/pull/6820

Tests well on jw01024_o001

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
