### PR TITLE
JP-2597: Fix call to filteroffset in assign_wcs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,8 +34,11 @@ ami
 assign_wcs
 ----------
 
-Corrected computation of crpix by backward transform of fiducial, allow
-for reference outside of detector frame [#6789]
+- Corrected computation of crpix by backward transform of fiducial, allow
+  for reference outside of detector frame [#6789]
+
+- Fixed parsing the ``filteroffset`` file which resulted in the offset
+  not being used by the WCS. [#6831]
 
 background
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ assign_wcs
 - Fixed parsing the ``filteroffset`` file which resulted in the offset
   not being used by the WCS. [#6831]
 
+- Fixed assignment of ``wcs.bounding_box`` in MIRI, NIRISS and NIRCAM imaging mode. [#6831]
+
 background
 ----------
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -128,7 +128,7 @@ def imaging_distortion(input_model, reference_files):
     try:
         distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = transform_bbox_from_shape(input_model.data.shape)
+        distortion.bounding_box = None
 
     # Add an offset for the filter
     obsfilter = input_model.meta.instrument.filter
@@ -145,7 +145,10 @@ def imaging_distortion(input_model, reference_files):
 
     if (col_offset is not None) and (row_offset is not None):
         distortion = models.Shift(col_offset) & models.Shift(row_offset) | distortion
-
+    if bbox is None:
+        distortion.bounding_box = transform_bbox_from_shape(input_model.data.shape)
+    else:
+        distortion.bounding_box = bbox
     return distortion
 
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -126,9 +126,9 @@ def imaging_distortion(input_model, reference_files):
     # Check if the transform in the reference file has a ``bounding_box``.
     # If not set a ``bounding_box`` equal to the size of the image.
     try:
-        distortion.bounding_box
+        bbox = distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = None
+        bbox = distortion.bounding_box = None
 
     # Add an offset for the filter
     obsfilter = input_model.meta.instrument.filter

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -120,11 +120,12 @@ def imaging_distortion(input_model, reference_files):
     transform = dist.model
 
     try:
-        transform.bounding_box
+        bbox = transform.bounding_box
     except NotImplementedError:
         # Check if the transform in the reference file has a ``bounding_box``.
-        # If not set a ``bounding_box`` equal to the size of the image.
-        transform.bounding_box = transform_bbox_from_shape(input_model.data.shape)
+        # If not set a ``bounding_box`` equal to the size of the image after
+        # assembling all distortion corrections.
+        bbox = None
     dist.close()
 
     # Add an offset for the filter
@@ -144,6 +145,10 @@ def imaging_distortion(input_model, reference_files):
                 transform = Shift(col_offset) & Shift(row_offset) | transform
         else:
             log.debug("No match in fitleroffset file.")
+    if bbox is None:
+        transform.bounding_box = transform_bbox_from_shape(input_model.data.shape)
+    else:
+        transform.bounding_box = bbox
     return transform
 
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -139,10 +139,11 @@ def imaging_distortion(input_model, reference_files):
         if row is not None:
             col_offset = row.get('column_offset', 'N/A')
             row_offset = row.get('row_offset', 'N/A')
-
+            log.debug(f"Offsets from filteroffset file are {col_offset}, {row_offset}")
             if col_offset != 'N/A' and row_offset != 'N/A':
                 transform = Shift(col_offset) & Shift(row_offset) | transform
-
+        else:
+            log.debug("No match in fitleroffset file.")
     return transform
 
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -137,7 +137,7 @@ def imaging_distortion(input_model, reference_files):
         match_keys = {'filter': obsfilter, 'pupil': obspupil}
         row = find_row(filters, match_keys)
         if row is not None:
-            col_offset = row.get('col_offset', 'N/A')
+            col_offset = row.get('column_offset', 'N/A')
             row_offset = row.get('row_offset', 'N/A')
 
             if col_offset != 'N/A' and row_offset != 'N/A':

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -304,7 +304,7 @@ def imaging_distortion(input_model, reference_files):
         match_keys = {'filter': obsfilter, 'pupil': obspupil}
         row = find_row(filters, match_keys)
         if row is not None:
-            col_offset = row.get('col_offset', 'N/A')
+            col_offset = row.get('column_offset', 'N/A')
             row_offset = row.get('row_offset', 'N/A')
 
             if col_offset != 'N/A' and row_offset != 'N/A':

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -306,9 +306,12 @@ def imaging_distortion(input_model, reference_files):
         if row is not None:
             col_offset = row.get('column_offset', 'N/A')
             row_offset = row.get('row_offset', 'N/A')
+            log.info(f"Offsets from filteroffset file are {col_offset}, {row_offset}")
 
             if col_offset != 'N/A' and row_offset != 'N/A':
                 distortion = Shift(col_offset) & Shift(row_offset) | distortion
+        else:
+            log.debug("No match in fitleroffset file.")
     return distortion
 
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -287,11 +287,12 @@ def imaging_distortion(input_model, reference_files):
     distortion = dist.model
 
     try:
-        # Check if the model has a bounding box.
-        distortion.bounding_box
+        bbox = distortion.bounding_box
     except NotImplementedError:
-        distortion.bounding_box = transform_bbox_from_shape(input_model.data.shape)
-
+        # Check if the transform in the reference file has a ``bounding_box``.
+        # If not set a ``bounding_box`` equal to the size of the image after
+        # assembling all distortion corrections.
+        bbox = None
     dist.close()
 
     # Add an offset for the filter
@@ -312,6 +313,10 @@ def imaging_distortion(input_model, reference_files):
                 distortion = Shift(col_offset) & Shift(row_offset) | distortion
         else:
             log.debug("No match in fitleroffset file.")
+    if bbox is None:
+        distortion.bounding_box = transform_bbox_from_shape(input_model.data.shape)
+    else:
+        distortion.bounding_box = bbox
     return distortion
 
 

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -253,14 +253,14 @@ def test_sip_approx(tmpdir):
     wcs_info = result.meta.wcsinfo.instance
 
     # make sure all expected keys are there
-    assert set(true_wcs.keys()).issubset(set((wcs_info.keys())))
+    assert set(list(true_wcs.keys())).issubset(set((list(wcs_info.keys()))))
 
     # and make sure they match
     for key in true_wcs:
         if 'ctype' in key:
             assert true_wcs[key] == wcs_info[key]
         else:
-            assert_allclose(true_wcs[key], wcs_info[key], rtol=5e-7)
+            assert_allclose(true_wcs[key], wcs_info[key], rtol=2e-4, atol=1e-10)
 
     # evaluate fits wcs and gwcs, make sure they agree
     grid = grid_from_bounding_box(result.meta.wcs.bounding_box)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2597](https://jira.stsci.edu/browse/JP-2597)

**Description**

This PR fixes a typo in parsing the `filteroffset` file for nircam and niriss which resulted in the WCS not using this file.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
