### PR TITLE
Update some regtests with real data

### DIFF
--- a/jwst/regtest/test_miri_cubebuild.py
+++ b/jwst/regtest/test_miri_cubebuild.py
@@ -10,12 +10,11 @@ from jwst.stpipe import Step
 def run_cube_build_single_output(rtdata_module):
     """Run cube_build on multiple inputs but single output"""
     rtdata = rtdata_module
-    rtdata.get_asn('miri/mrs/two_spec3_asn.json')
+    rtdata.get_asn('miri/mrs/jw01024-o001_20220501t155404_spec3_002_asn.json')
 
     args = [
         'jwst.cube_build.CubeBuildStep',
         rtdata.input,
-        '--save_results=true'
     ]
     Step.from_cmdline(args)
 
@@ -23,10 +22,9 @@ def run_cube_build_single_output(rtdata_module):
 
 
 @pytest.mark.bigdata
-@pytest.mark.slow
 @pytest.mark.parametrize(
     'output',
-    ['outtest_ch1-short_s3d.fits', 'outtest_ch2-short_s3d.fits']
+    ['jw01024-o001_t002_miri_ch1-short_s3d.fits', 'jw01024-o001_t002_miri_ch2-short_s3d.fits']
 )
 def test_cube_build_single_output(run_cube_build_single_output, output, fitsdiff_default_kwargs):
     """Test just running cube build and ensure that output happens"""
@@ -44,13 +42,12 @@ def test_cube_build_single_output(run_cube_build_single_output, output, fitsdiff
 @pytest.mark.bigdata
 def test_cube_build_miri_internal_cal(rtdata, fitsdiff_default_kwargs):
     """Run cube_build on single file using coord system = internal_cal"""
-    input_file = 'det_image_seq2_MIRIFUSHORT_12SHORTexp1_cal.fits'
+    input_file = 'jw01024001001_04101_00001_mirifushort_cal.fits'
     rtdata.get_data(f"miri/mrs/{input_file}")
 
     args = [
         'jwst.cube_build.CubeBuildStep',
         input_file,
-        '--save_results=true',
         '--coord_system=internal_cal'
     ]
     Step.from_cmdline(args)

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -10,21 +10,20 @@ from jwst import datamodels
 def run_detector1(rtdata_module):
     """Run detector1 pipeline on MIRI imaging data."""
     rtdata = rtdata_module
-    rtdata.get_data("miri/image/det_image_1_MIRIMAGE_F770Wexp1_5stars_uncal.fits")
+    rtdata.get_data("miri/image/jw01024001001_04101_00001_mirimage_uncal.fits")
 
     # Run detector1 pipeline only on one of the _uncal files
     args = ["jwst.pipeline.Detector1Pipeline", rtdata.input,
             "--save_calibrated_ramp=True",
             "--steps.dq_init.save_results=True",
             "--steps.saturation.save_results=True",
-            "--steps.refpix.save_results=True",
-            "--steps.rscd.save_results=True",
-            "--steps.lastframe.save_results=True",
             "--steps.firstframe.save_results=True",
+            "--steps.lastframe.save_results=True",
             "--steps.reset.save_results=True",
             "--steps.linearity.save_results=True",
+            "--steps.rscd.save_results=True",
             "--steps.dark_current.save_results=True",
-            "--steps.jump.rejection_threshold=200",
+            "--steps.refpix.save_results=True",
             ]
     Step.from_cmdline(args)
 
@@ -33,7 +32,7 @@ def run_detector1(rtdata_module):
 def run_image2(run_detector1, rtdata_module):
     """Run image2 pipeline on the _rate file, saving intermediate products"""
     rtdata = rtdata_module
-    rtdata.input = 'det_image_1_MIRIMAGE_F770Wexp1_5stars_rate.fits'
+    rtdata.input = 'jw01024001001_04101_00001_mirimage_rate.fits'
     args = ["jwst.pipeline.Image2Pipeline", rtdata.input,
             "--steps.assign_wcs.save_results=True",
             "--steps.flat_field.save_results=True"
@@ -44,9 +43,9 @@ def run_image2(run_detector1, rtdata_module):
     # produce fresh _cal files for the image3 pipeline.  We won't check these
     # or look at intermediate products, and skip resample (don't need i2d image)
     rate_files = [
-        "miri/image/det_image_1_MIRIMAGE_F770Wexp2_5stars_rate.fits",
-        "miri/image/det_image_2_MIRIMAGE_F770Wexp1_5stars_rate.fits",
-        "miri/image/det_image_2_MIRIMAGE_F770Wexp2_5stars_rate.fits",
+        "miri/image/jw01024001001_04101_00002_mirimage_rate.fits",
+        "miri/image/jw01024001001_04101_00003_mirimage_rate.fits",
+        "miri/image/jw01024001001_04101_00004_mirimage_rate.fits",
     ]
     for rate_file in rate_files:
         rtdata.get_data(rate_file)
@@ -60,45 +59,39 @@ def run_image3(run_image2, rtdata_module):
     """Get the level3 association json file (though not its members) and run
     image3 pipeline on all _cal files listed in association"""
     rtdata = rtdata_module
-    rtdata.get_data("miri/image/det_dithered_5stars_image3_asn.json")
-    args = ["jwst.pipeline.Image3Pipeline", rtdata.input,
-            # Set some unique param values needed for these data
-            "--steps.tweakreg.snr_threshold=200",
-            "--steps.tweakreg.use2dhist=False",
-            "--steps.tweakreg.minobj=4",
-            "--steps.source_catalog.snr_threshold=10",
-            ]
+    rtdata.get_data("miri/image/jw01024-o001_20220501t155404_image3_001_asn.json")
+    args = ["jwst.pipeline.Image3Pipeline", rtdata.input]
     Step.from_cmdline(args)
 
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("suffix", ["dq_init", "saturation", "refpix", "rscd",
-                                    "firstframe", "lastframe", "reset", "linearity", "dark_current", "ramp", "rate",
+@pytest.mark.parametrize("suffix", ["dq_init", "saturation", "firstframe", "lastframe", "reset",
+                                    "linearity", "rscd", "dark_current", "refpix", "ramp", "rate",
                                     "rateints"])
 def test_miri_image_detector1(run_detector1, rtdata_module, fitsdiff_default_kwargs, suffix):
-    """Regression test of detector1 pipeline performed on MIRI data."""
+    """Regression test of detector1 pipeline performed on MIRI imaging data."""
     _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix)
 
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["assign_wcs", "flat_field", "cal", "i2d"])
 def test_miri_image_image2(run_image2, rtdata_module, fitsdiff_default_kwargs, suffix):
-    """Regression test of image2 pipeline performed on MIRI data."""
+    """Regression test of image2 pipeline performed on MIRI imaging data."""
     _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix)
 
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("suffix", ["a3001_crf"])
+@pytest.mark.parametrize("suffix", ["o001_crf"])
 def test_miri_image_image3(run_image3, rtdata_module, fitsdiff_default_kwargs, suffix):
-    """Regression test of image3 pipeline performed on MIRI data."""
+    """Regression test of image3 pipeline performed on MIRI imaging data."""
     _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix)
 
 
 def _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix):
     """Assertion helper for the above tests"""
     rtdata = rtdata_module
-    rtdata.input = "det_image_1_MIRIMAGE_F770Wexp1_5stars_uncal.fits"
-    output = f"det_image_1_MIRIMAGE_F770Wexp1_5stars_{suffix}.fits"
+    rtdata.input = "jw01024001001_04101_00001_mirimage_uncal.fits"
+    output = f"jw01024001001_04101_00001_mirimage_{suffix}.fits"
     rtdata.output = output
 
     rtdata.get_truth(f"truth/test_miri_image_stages/{output}")
@@ -114,9 +107,9 @@ def _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix):
 @pytest.mark.bigdata
 def test_miri_image3_i2d(run_image3, rtdata_module, fitsdiff_default_kwargs):
     rtdata = rtdata_module
-    rtdata.input = "det_dithered_5stars_image3_asn.json"
-    rtdata.output = "det_dithered_5stars_f770w_i2d.fits"
-    rtdata.get_truth("truth/test_miri_image_stages/det_dithered_5stars_f770w_i2d.fits")
+    rtdata.input = "jw01024-o001_20220501t155404_image3_001_asn.json"
+    rtdata.output = "jw01024-o001_t002_miri_f770w_i2d.fits"
+    rtdata.get_truth("truth/test_miri_image_stages/jw01024-o001_t002_miri_f770w_i2d.fits")
 
     fitsdiff_default_kwargs["rtol"] = 1e-4
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
@@ -126,9 +119,9 @@ def test_miri_image3_i2d(run_image3, rtdata_module, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_miri_image3_catalog(run_image3, rtdata_module, diff_astropy_tables):
     rtdata = rtdata_module
-    rtdata.input = "det_dithered_5stars_image3_asn.json"
-    rtdata.output = "det_dithered_5stars_f770w_cat.ecsv"
-    rtdata.get_truth("truth/test_miri_image_stages/det_dithered_5stars_f770w_cat.ecsv")
+    rtdata.input = "jw01024-o001_20220501t155404_image3_001_asn.json"
+    rtdata.output = "jw01024-o001_t002_miri_f770w_cat.ecsv"
+    rtdata.get_truth("truth/test_miri_image_stages/jw01024-o001_t002_miri_f770w_cat.ecsv")
 
     assert diff_astropy_tables(rtdata.output, rtdata.truth, rtol=1e-4)
 
@@ -138,7 +131,7 @@ def test_miri_image_wcs(run_image2, rtdata_module, fitsdiff_default_kwargs):
     rtdata = rtdata_module
 
     # get input assign_wcs and truth file
-    output = "det_image_1_MIRIMAGE_F770Wexp1_5stars_assign_wcs.fits"
+    output = "jw01024001001_04101_00001_mirimage_assign_wcs.fits"
     rtdata.output = output
     rtdata.get_truth("truth/test_miri_image_stages/" + output)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves: a LONG-standing personal desire to get better data into our regression tests. Replaces the old test datasets used in MIRI imaging and spectroscopic tests with some real on-sky exposures. Input and truth files have been loaded to artifactory.

Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [x] Label(s)