### PR TITLE
JP-2569: Change fitgeom default value from general to rshift

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,11 +16,18 @@ extract_1d
 
 - Fix bug in SOSS algorithm for bad data by replacing source of possible
   infinite values with NaNs, caused by zero division [#6836]
-  
+
 stpipe
 ------
 
 - Log the CRDS context for pipeline and standalone step processing [#6835]
+
+tweakreg
+--------
+
+- Changed default value of ``fitgeom`` from ``'general'`` to ``'rshift'``
+  at the request of CalWG. [#6838]
+
 
 1.5.0 (2022-05-05)
 ==================

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -123,9 +123,26 @@ The ``tweakreg`` step has the following optional arguments:
   to be considered when fitting catalogs. Allowed values:
 
   - ``'shift'``: x/y shifts only
-  - ``'rscale'``: rotation and scale
   - ``'rshift'``: rotation and shifts
-  - ``'general'``: shift, rotation, and scale (Default="general")
+  - ``'rscale'``: rotation and scale
+  - ``'general'``: shift, rotation, and scale
+
+  The default value is "rshift".
+
+  .. note::
+      Mathematically, alignment of images observed in different tangent planes
+      requires ``fitgeometry='general'`` in order to fit source catalogs
+      in the different images even if mis-alignment is caused only by a shift
+      or rotation in the tangent plane of one of the images.
+
+      However, under certain circumstances, such as small alignment errors or
+      minimal dithering during observations that keep tangent planes of the
+      images to be aligned almost parallel, then it may be more robust to
+      use a ``fitgeometry`` setting with fewer degrees of freedom such as
+      ``'rshift'``, especially for "ill-conditioned" source catalogs such as
+      catalogs with very few sources, or large errors in source positions, or
+      sources placed along a line or bunched in a corner of the image (not
+      spread across/covering the entire image).
 
 * ``nclip``: A non-negative integer number of clipping iterations
   to use in the fit. (Default = 3)

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -48,7 +48,7 @@ class TweakRegStep(Step):
         tolerance = float(default=0.7) # Matching tolerance for xyxymatch in arcsec
         xoffset = float(default=0.0), # Initial guess for X offset in arcsec
         yoffset = float(default=0.0) # Initial guess for Y offset in arcsec
-        fitgeometry = option('shift', 'rshift', 'rscale', 'general', default='general') # Fitting geometry
+        fitgeometry = option('shift', 'rshift', 'rscale', 'general', default='rshift') # Fitting geometry
         nclip = integer(min=0, default=3) # Number of clipping iterations in fit
         sigma = float(min=0.0, default=3.0) # Clipping limit in sigma units
         align_to_gaia = boolean(default=False)  # Align to GAIA catalog


### PR DESCRIPTION
Resolves [JP-2562](https://jira.stsci.edu/browse/JP-2562)
Resolves [JP-2569](https://jira.stsci.edu/browse/JP-2569)

**Description**

At the CalWG meeting it was requested that the default value for ``fitgeometry`` be changed from its current value of `'general'` to `'rshift'`.

I want to note here that the 'general' setting is required for solving exact mathematical equations needed to solve for mis-alignments containing caused by just shifts and/or rotations. However, CalWG believes that keeping the number of degrees of freedom low is more important for the type of alignment that will be encountered in the pipeline. 

Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
