### PR TITLE
Add pupil and filter to filteroffset schema to support niriss

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ datamodels
 
 - Update keyword comments/titles for V2_REF, V3_REF, FITXOFFS, FITYOFFS [#6822]
 
+- Add keywords ``filter``, ``pupil`` and ``ppupil`` to the filteroffset schema. [#6839]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/schemas/filteroffset.schema.yaml
+++ b/jwst/datamodels/schemas/filteroffset.schema.yaml
@@ -9,6 +9,9 @@ allOf:
 - $ref: keyword_pfilter.schema
 - $ref: keyword_channel.schema
 - $ref: keyword_module.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_pupil.schema
+- $ref: keyword_ppupil.schema
 - type: object
   properties:
     meta:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->


**Description**

This PR adds entries for the FILTER and PUPIL keywords to the datamodels schema for the FILTEROFFSET reference file. Those keywords are selectors for NIRISS filteroffset ref files.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
