### PR TITLE
JP-2603: Exit SOSS Extract_1D gracefully for F277W data, avoid SUBSTRIP96 bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ extract_1d
 
 - Fix bug in SOSS algorithm for bad data by replacing source of possible
   infinite values with NaNs, caused by zero division [#6836]
+
+- Exit gracefully if data is with F277W filter; avoid masking entire wavemap
+  if subarray is SUBSTRIP96 [#6840]
   
 stpipe
 ------

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -364,17 +364,20 @@ class Extract1dStep(Step):
                     soss_kwargs)
 
                 # Set the step flag to complete
-                result.meta.cal_step.extract_1d = 'COMPLETE'
-                result.meta.target.source_type = None
+                if result is None:
+                    return None
+                else:
+                    result.meta.cal_step.extract_1d = 'COMPLETE'
+                    result.meta.target.source_type = None
 
-                input_model.close()
+                    input_model.close()
 
-                if self.soss_modelname:
-                    soss_modelname = self.make_output_path(
-                        basepath=self.soss_modelname,
-                        suffix='SossExtractModel'
-                    )
-                    ref_outputs.save(soss_modelname)
+                    if self.soss_modelname:
+                        soss_modelname = self.make_output_path(
+                            basepath=self.soss_modelname,
+                            suffix='SossExtractModel'
+                        )
+                        ref_outputs.save(soss_modelname)
 
             else:
                 # Get the reference file names

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -572,7 +572,8 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
         ref_file_args = get_ref_file_args(ref_files, transform)
 
         # Make sure wavelength maps cover only parts where the centroid is inside the detector image
-        _mask_wv_map_centroid_outside(ref_file_args[0], ref_files, transform, scidata_bkg.shape[0])
+        if subarray != 'SUBSTRIP96':
+            _mask_wv_map_centroid_outside(ref_file_args[0], ref_files, transform, scidata_bkg.shape[0])
 
         # Model the traces based on optics filter configuration (CLEAR or F277W)
         if soss_filter == 'CLEAR':
@@ -709,7 +710,7 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
                 # No model can be fit for F277W yet, missing throughput reference files.
                 msg = f"No extraction possible for filter {soss_filter}."
                 log.critical(msg)
-                raise ValueError(msg)
+                return None, None
 
             # Save trace models for output reference
             for order in tracemodels:

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -297,13 +297,18 @@ class Spec2Pipeline(Pipeline):
             self.extract_1d.save_results = False
             x1d = self.extract_1d(resampled)
 
-            self.photom.save_results = self.save_results
-            x1d = self.photom(x1d)
+            # Possible that no fit was possible - if so, skip photom
+            if x1d is not None:
+                self.photom.save_results = self.save_results
+                x1d = self.photom(x1d)
+            else:
+                self.log.warning("Extract_1d did not return a DataModel - skipping photom.")
         else:
             x1d = self.extract_1d(resampled)
 
         resampled.close()
-        x1d.close()
+        if x1d is not None:
+            x1d.close()
 
         # That's all folks
         self.log.info(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Addresses [JP-2603](https://jira.stsci.edu/browse/JP-2603)

**Description**

This PR addresses two more bugs found in SOSS testing - one which ends processing prematurely for F277W data, and one which was caused by noise in a SUBSTRIP96 subarray configuration.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
