### PR TITLE
JP-2596: Eliminate duplicate copies in dark step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ cube_build
 
 - Fix for residual spectral tearing in MIRI MRS multiband cubes [#6786]
 
+dark_current
+------------
+
+- Eliminated extra copying of input model when step gets skipped [#6841]
+
 datamodels
 ----------
 

--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -119,15 +119,17 @@ def dark_output_data_2_ramp_model(out_data, input_model):
     out_model: RampModel
         The output ramp model from the dark current step.
     """
-    out_model = input_model.copy()
-    out_model.meta.cal_step.dark_sub = out_data.cal_step
 
     if out_data.cal_step == "SKIPPED":
+        # If processing was skipped in the lower-level routines,
+        # just return the unmodified input model
+        input_model.meta.cal_step.dark_sub = "SKIPPED"
+        return input_model
+    else:
+        out_model = input_model.copy()
+        out_model.meta.cal_step.dark_sub = out_data.cal_step
+        out_model.data = out_data.data
+        out_model.groupdq = out_data.groupdq
+        out_model.pixeldq = out_data.pixeldq
+        out_model.err = out_data.err
         return out_model
-
-    out_model.data = out_data.data
-    out_model.groupdq = out_data.groupdq
-    out_model.pixeldq = out_data.pixeldq
-    out_model.err = out_data.err
-
-    return out_model


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2596](https://jira.stsci.edu/browse/JP-2596)

**Description**

This PR removes the copy operation from input to output models in the event the lower-level dark subtraction routines end up skipping processing. A copy is already being made in the lower-level routines, so this eliminates yet another (unnecessary) copy of the whole input data model, thus saving memory.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
