### PR TITLE
Revert "Add pupil and filter to filteroffset schema to support niriss"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,8 +16,6 @@ datamodels
 
 - Update keyword comments/titles for V2_REF, V3_REF, FITXOFFS, FITYOFFS [#6822]
 
-- Add keywords ``filter``, ``pupil`` and ``ppupil`` to the filteroffset schema. [#6839]
-
 extract_1d
 ----------
 

--- a/jwst/datamodels/schemas/filteroffset.schema.yaml
+++ b/jwst/datamodels/schemas/filteroffset.schema.yaml
@@ -9,9 +9,6 @@ allOf:
 - $ref: keyword_pfilter.schema
 - $ref: keyword_channel.schema
 - $ref: keyword_module.schema
-- $ref: keyword_filter.schema
-- $ref: keyword_pupil.schema
-- $ref: keyword_ppupil.schema
 - type: object
   properties:
     meta:


### PR DESCRIPTION
Reverts spacetelescope/jwst#6839

`pupil` and `filter` are not selectors for NIRISS after all.