### PR TITLE
JP-2613: ZEROFRAME is all zeros after the linearity step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 ==================
 
 
+linearity
+---------
+
+- Correcting bug when using ZEROFRAME data. [#6851]
+
+
 1.5.1 (2022-05-17)
 ==================
 

--- a/jwst/linearity/linearity.py
+++ b/jwst/linearity/linearity.py
@@ -37,7 +37,8 @@ def do_correction(input_model, lin_model):
 
     # Call linearity correction function in stcal
     new_data, new_pdq, new_zframe = linearity_correction(
-        output_model.data, gdq, pdq, lin_coeffs, lin_dq, dqflags.pixel)
+        output_model.data, gdq, pdq, lin_coeffs, lin_dq, dqflags.pixel,
+        zframe=zframe)
 
     output_model.data = new_data
     output_model.pixeldq = new_pdq


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2613](https://jira.stsci.edu/browse/JP-2613)

**Description**

The `ZEROFRAME` array is all zeros after the linearity step.  This is caused by an error in calling the `linearity_correction` function in STCAL.  The `zframe` parameter is defaulted to `None`.  The default value was being passed, instead of the `ZEROFRAME` array when present.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
