### PR TITLE
JP-2614: Fix ramp_fit to copy int_times content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.5.2 (unreleased)
 ==================
 
+ramp_fitting
+------------
+
+- Remove the logic that only copied the INT_TIMES table content when processing
+  TSO exposures, so that it shows up in all ``rateints`` products [#6852]
 
 1.5.1 (2022-05-17)
 ==================

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -9,7 +9,6 @@ from stcal.ramp_fitting import ramp_fit
 from jwst.datamodels import dqflags
 
 from ..lib import reffile_utils  # TODO remove
-from ..lib import pipe_utils
 
 import logging
 

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -234,12 +234,6 @@ class RampFitStep(Step):
             if self.algorithm == "GLS":
                 buffsize //= 10
 
-                # Set int_times depending on model meta data.
-            if pipe_utils.is_tso(input_model) and hasattr(input_model, 'int_times'):
-                input_model.int_times = input_model.int_times
-            else:
-                input_model.int_times = None
-
             image_info, integ_info, opt_info, gls_opt_model = ramp_fit.ramp_fit(
                 input_model, buffsize,
                 self.save_opt, readnoise_2d, gain_2d, self.algorithm,

--- a/jwst/ramp_fitting/tests/test_ramp_fit_step.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_step.py
@@ -211,7 +211,7 @@ def test_int_times1(generate_miri_reffiles, setup_inputs):
         ngroups=ngroups, readnoise=inreadnoise, nints=nints, nrows=nrows,
         ncols=ncols, gain=ingain, deltatime=grouptime)
 
-    # Set TSOVISIT false, in which case the int_times table should come back with zero length
+    # Set TSOVISIT false, despite which the int_times table should come back populated
     model.meta.visit.tsovisit = False
 
     # Call ramp fit through the step class
@@ -222,7 +222,7 @@ def test_int_times1(generate_miri_reffiles, setup_inputs):
     assert slopes is not None
     assert cube_model is not None
 
-    assert(len(cube_model.int_times) == 0)
+    assert(len(cube_model.int_times) == 5)
 
 
 def test_int_times2(generate_miri_reffiles, setup_inputs):
@@ -235,7 +235,7 @@ def test_int_times2(generate_miri_reffiles, setup_inputs):
         ngroups=ngroups, readnoise=inreadnoise, nints=nints, nrows=nrows,
         ncols=ncols, gain=ingain, deltatime=grouptime)
 
-    # Set TSOVISIT false, in which case the int_times table should come back with zero length
+    # Set TSOVISIT true, in which case the int_times table should come back with all content
     model.meta.visit.tsovisit = True
 
     # Call ramp fit through the step class


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2614](https://jira.stsci.edu/browse/JP-2614)

**Description**

This PR modifies the top-level ramp_fit_step module to remove the code that had been put in place about a year ago that only copies over the INT_TIMES table content if the exposure is TSO mode. It doesn't hurt to have this info in the rateints products for all exposures.

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
