### PR TITLE
JP-2615: Change align_refs warning message to debug

### DIFF
--- a/jwst/coron/median_replace_img.py
+++ b/jwst/coron/median_replace_img.py
@@ -57,7 +57,7 @@ def median_fill_value(input_array, input_dq_array, bsize, bad_bitvalue, xc, yc):
 
     if np.isnan(median_value):
         # If the median fails return 0
-        log.warning('Median filter returned NaN setting value to 0.')
+        log.debug('Median filter returned NaN; setting value to 0.')
         median_value = 0.
 
     return median_value


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2615](https://jira.stsci.edu/browse/JP-2615)

**Description**

This PR simply changes the logging level of a message in the align_refs step from warning to debug, because it can be issued thousands of times, depending on the kind of input data to the step.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [ ] Label(s)
