### PR TITLE
JP-2603: SOSS errors for negative infinity, spline fit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.5.2 (unreleased)
 ==================
 
+extract_1d
+----------
+
+- In SOSS ATOCA, catch negative infinite values in centroid finder;
+  catch spline-fit errors in first order flux estimate [#6854]
 
 linearity
 ---------

--- a/jwst/extract_1d/soss_extract/soss_centroids.py
+++ b/jwst/extract_1d/soss_extract/soss_centroids.py
@@ -95,7 +95,7 @@ def get_centroids_com(scidata_bkg, header=None, mask=None, poly_order=11):
     # CoM analysis to find initial positions using all rows.
     with np.errstate(invalid='ignore'):
         ytrace = np.nansum(scidata_norm * ygrid, axis=0) / np.nansum(scidata_norm, axis=0)
-        ytrace = np.where(ytrace == np.inf, np.nan, ytrace)
+        ytrace = np.where(np.abs(ytrace) == np.inf, np.nan, ytrace)
 
     # Second pass - use a windowed CoM at the previous position.
     halfwidth = 30 * yos

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -295,12 +295,14 @@ def model_image(scidata_bkg, scierr, scimask, refmask, ref_file_args, transform=
         log.info('Solving for the optimal Tikhonov factor.')
 
         # Need a rough estimate of the underlying flux to estimate the tikhonov factor
-        # Note: estim_flux func is not strictly necessary and factors could be a simple logspace -
-        #       dq mask caused issues here and this may need a try/except wrap.
-        #       Dev suggested np.logspace(-19, -10, 10)
-        estimate = estim_flux_first_order(scidata_bkg, scierr, scimask, ref_file_args, threshold)
-        # Initial pass 8 orders of magnitude with 10 grid points.
-        factors = engine.estimate_tikho_factors(estimate, log_range=[-4, 4], n_points=10)
+        try:
+            estimate = estim_flux_first_order(scidata_bkg, scierr, scimask, ref_file_args, threshold)
+            # Initial pass 8 orders of magnitude with 10 grid points.
+            factors = engine.estimate_tikho_factors(estimate, log_range=[-4, 4], n_points=10)
+        except Exception as e:
+            log.warning(f"Error caught in first order flux estimation: {e}\n"
+                        f"Using pre-defined array for flux factor estimate.")
+            factors = np.logspace(-19, -10, 10)
         # Find the tikhonov factor.
         tiktests = engine.get_tikho_tests(factors, data=scidata_bkg, error=scierr, mask=scimask)
         tikfac, mode, _ = engine.best_tikho_factor(tests=tiktests, fit_mode='chi2')


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2603](https://jira.stsci.edu/browse/JP-2603)

**Description**

This PR addresses a prior fix that caught infinite values to also catch negative infinity, and it implements a generic try/except to catch errors raised during an optional spline fit to instead use a generic array of estimate values.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
