### PR TITLE
JP-2612: Speed up algorithm for computing sampling wavelengths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ straylight
 
 - Add a check that input data is IFUImageModel [#6861]
 
+resample
+--------
+
+- Sped up the algorithm for computing sampling wavelength for the output
+  WCS in ``resample_spec``. [#6860]
+
 
 1.5.2 (2022-05-20)
 ==================


### PR DESCRIPTION
Resolves [JP-2612](https://jira.stsci.edu/browse/JP-2612)

**Description**

This PR modifies the method of estimating sampling wavelengths in `resample_spec` to make it faster at the expense of not reproducing more accurately sampling wavelengths of the input/reference image.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
