### PR TITLE
JP-2587 Check spec2 data is IFUImageModel for straylight step 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.5.3 (unreleased)
 ==================
 
+straylight
+----------
+
+- Add a check that input data is IFUImageModel [#6861]
+
 
 1.5.2 (2022-05-20)
 ==================

--- a/jwst/straylight/straylight_step.py
+++ b/jwst/straylight/straylight_step.py
@@ -24,13 +24,13 @@ class StraylightStep (Step):
     reference_file_types = ['regions']
 
     def process(self, input):
-        # Open the input data model
-        with datamodels.IFUImageModel(input) as input_model:
 
-            # check the data is MIRI data
+        with datamodels.open(input) as input_model:
+
             detector = input_model.meta.instrument.detector
+            # check the data is MIRI IFUSHORT and data is an IFUImageModel (not TSO)
 
-            if detector == 'MIRIFUSHORT':
+            if detector == 'MIRIFUSHORT' and isinstance(input_model, (datamodels.ImageModel, datamodels.IFUImageModel)):
                 # If Modified Shepard  test  input parameters for weighting
                 if self.method == 'ModShepard':
                     # reasonable power variable defined as: 0.1 < power < 5
@@ -96,8 +96,12 @@ class StraylightStep (Step):
                 result.meta.cal_step.straylight = 'COMPLETE'
 
             else:
-                self.log.warning('Straylight correction not defined for detector %s',
-                                 detector)
+                if detector != 'MIRIFUSHORT':
+                    self.log.warning('Straylight correction not defined for detector %s',
+                                     detector)
+                if isinstance(input_model, (datamodels.ImageModel, datamodels.IFUImageModel)) is False:
+                    self.log.warning('Straylight correction not defined for datatype %s',
+                                     input_model)
                 self.log.warning('Straylight step will be skipped')
                 result = input_model.copy()
                 result.meta.cal_step.straylight = 'SKIPPED'

--- a/jwst/straylight/tests/test_straylight_step.py
+++ b/jwst/straylight/tests/test_straylight_step.py
@@ -2,7 +2,7 @@
 Unit tests for straylight step configuration
 """
 
-from jwst.datamodels import IFUImageModel
+from jwst.datamodels import IFUImageModel, CubeModel
 from jwst.straylight import StraylightStep
 import numpy as np
 import pytest
@@ -25,7 +25,30 @@ def miri_mrs_long():
     return image
 
 
+@pytest.fixture(scope='module')
+def miri_mrs_short_tso():
+    """Set up MIRI MRS SHORT TSO data"""
+
+    image = CubeModel((5, 1024, 1032))
+    image.data = np.random.random((5, 1024, 1032))
+    image.meta.instrument.name = 'MIRI'
+    image.meta.instrument.detector = 'MIRIFUSHORT'
+    image.meta.exposure.type = 'MIR_MRS'
+    image.meta.instrument.channel = '12'
+    image.meta.instrument.band = 'SHORT'
+    image.meta.filename = 'test_miri_short_tso.fits'
+    image.meta.observation.date = '2019-01-01'
+    image.meta.observation.time = '10:10:10'
+    return image
+
+
 def test_call_straylight_mrslong(_jail, miri_mrs_long):
     """Test step is skipped for MRS IFULONG data"""
     result = StraylightStep.call(miri_mrs_long)
+    assert result.meta.cal_step.straylight == 'SKIPPED'
+
+
+def test_call_straylight_mrsshort_tso(_jail, miri_mrs_short_tso):
+    """Test step is skipped for MRS IFUSHORT TSO data"""
+    result = StraylightStep.call(miri_mrs_short_tso)
     assert result.meta.cal_step.straylight == 'SKIPPED'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2587](https://jira.stsci.edu/browse/JP-2587)

**Description**

This PR checks that the input data to the straylight step has a data model type = IFUImageModel. If it does not, then the step is skipped. 

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [X] Milestone
- [X] Label(s)
