### PR TITLE
JP-2603: Catch None return from SOSS F277W in Level3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.5.3 (unreleased)
 ==================
 
+pipeline
+--------
+
+- Add check to ensure SOSS `extract_1d` return is not None, to
+  avoid photom errors in Spec3Pipeline and Tso3Pipeline [#6863]
 straylight
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ pipeline
 
 - Add check to ensure SOSS `extract_1d` return is not None, to
   avoid photom errors in Spec3Pipeline and Tso3Pipeline [#6863]
+
 straylight
 ----------
 

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -217,10 +217,13 @@ class Spec3Pipeline(Pipeline):
                     # instead run photom on the extract_1d results and save
                     # those instead.
                     self.extract_1d.save_results = False
-                    self.photom.save_results = self.save_results
-                    self.photom.suffix = 'x1d'
                     result = self.extract_1d(result)
-                    result = self.photom(result)
+
+                    # SOSS F277W may return None - don't bother with that.
+                    if result is not None:
+                        self.photom.save_results = self.save_results
+                        self.photom.suffix = 'x1d'
+                        result = self.photom(result)
                 else:
                     result = self.extract_1d(result)
 

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -163,16 +163,18 @@ class Tso3Pipeline(Pipeline):
                 self.log.info("Extracting 1-D spectra ...")
                 result = self.extract_1d(cube)
 
-                if input_exptype == 'NIS_SOSS':
-                    # SOSS data have yet to be photometrically calibrated
-                    # Calibrate 1D spectra here.
-                    result = self.photom(result)
+                # SOSS F277W may return None - don't bother with that
+                if result is not None:
+                    if input_exptype == 'NIS_SOSS':
+                        # SOSS data have yet to be photometrically calibrated
+                        # Calibrate 1D spectra here.
+                        result = self.photom(result)
 
-                x1d_result.spec.extend(result.spec)
+                    x1d_result.spec.extend(result.spec)
 
-                # perform white-light photometry on 1d extracted data
-                self.log.info("Performing white-light photometry ...")
-                phot_result_list.append(self.white_light(result))
+                    # perform white-light photometry on 1d extracted data
+                    self.log.info("Performing white-light photometry ...")
+                    phot_result_list.append(self.white_light(result))
 
             # Update some metadata from the association
             x1d_result.meta.asn.pool_name = input_models.meta.asn_table.asn_pool


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Addresses [JP-2603](https://jira.stsci.edu/browse/JP-2603)

**Description**

This PR addresses a bug, found earlier in Spec2Pipeline, which was missed but was also present in Spec3 and Tso3. The new SOSS algorithm currently cannot process data taken through the F277W filter and returns None; if this is passed on in pipeline flow, errors will occur. Gracefully avoid photom processing of None in the pipeline code.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
