### PR TITLE
JP-2624: Update ami_average for different size inputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 1.5.3 (unreleased)
 ==================
 
+ami_analyze
+-----------
+
+- Fixed the creation of the output product so that it no longer contains
+  an empty "SCI" extension. [#6870]
+
+ami_average
+-----------
+
+- Updated the step to handle inputs with different sizes for `fit_image` and
+  `resid_image`. Larger inputs are trimmed to match the size of the smallest
+  input. [#6870]
+
 documentation
 -------------
 

--- a/docs/jwst/ami_average/description.rst
+++ b/docs/jwst/ami_average/description.rst
@@ -8,8 +8,15 @@ The ``ami_average`` step is one of the AMI-specific steps in the ``ami``
 sub-package and is part of Stage 3 :ref:`calwebb_ami3 <calwebb_ami3>` processing.
 It averages the results of LG processing from the
 :ref:`ami_analyze <ami_analyze_step>` step for multiple exposures of a given target.
-It computes a simple average for all 8 components of the "_ami" product files from all
+It computes a simple average for all 8 components of the "ami" product files from all
 input exposures.
+
+For a given association of exposures, the "ami" products created by the `ami_analyze`
+step may have `fit_image` and `resid_image` images that vary in size from one
+exposure to another. If this is the case, the smallest image size of all the input
+products is used for the averaged product and the averaged `fit_image` and
+`resid_image` images are created by trimming extra rows/columns from the edges of
+images that are larger.
 
 Arguments
 ---------
@@ -23,10 +30,10 @@ LG model parameters
 :Data model: `~jwst.datamodels.AmiLgModel`
 :File suffix: _ami
 
-The only input to the ``ami_average`` step is a list of one or more "_ami" files to be
+The only input to the ``ami_average`` step is a list of one or more "ami" files to be
 processed. These should be output files from the
 :ref:`ami_analyze <ami_analyze_step>` step. The input to the step must be in the form
-of a list of "_ami" **file names**. Passing data models or ASN files is not supported
+of a list of "ami" **file names**. Passing data models or ASN files is not supported
 at this time. Use the :ref:`calwebb_ami3 <calwebb_ami3>` pipeline to conveniently
 process multiple inputs.
 

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -10,7 +10,7 @@ from .utils import img_median_replace
 from astropy import units as u
 
 log = logging.getLogger(__name__)
-#log.setLevel(logging.DEBUG)
+log.setLevel(logging.DEBUG)
 
 
 def apply_LG_plus(input_model, filter_model, oversample, rotation,

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -10,7 +10,7 @@ from .utils import img_median_replace
 from astropy import units as u
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
+#log.setLevel(logging.DEBUG)
 
 
 def apply_LG_plus(input_model, filter_model, oversample, rotation,
@@ -102,6 +102,6 @@ def apply_LG_plus(input_model, filter_model, oversample, rotation,
     output_model = ff_t.fit_fringes_all(input_copy)
 
     # Copy header keywords from input to output
-    output_model.update(input_model)
+    output_model.update(input_model, only="PRIMARY")
 
     return output_model

--- a/jwst/ami/ami_average.py
+++ b/jwst/ami/ami_average.py
@@ -5,7 +5,6 @@ import logging
 from .. import datamodels
 
 log = logging.getLogger(__name__)
-#log.addHandler(logging.NullHandler())
 log.setLevel(logging.DEBUG)
 
 
@@ -26,38 +25,46 @@ def average_LG(lg_products):
         Averaged fringe data
     """
 
-
     # Create the output model as a copy of the first input model
-    log.debug(' Create output as copy of %s', lg_products[0])
+    log.debug('create output as copy of %s', lg_products[0])
     output_model = datamodels.AmiLgModel(lg_products[0]).copy()
 
-    # Find the input product with the smallest fit_image attribute
-    min_size = 2048
+    # Find the input product with the smallest fit_image image size
+    sizes = []
     for input in lg_products:
         prod = datamodels.AmiLgModel(input)
-        if prod.fit_image.shape[0] < min_size:
-            min_size = prod.fit_image.shape[0]
+        sizes.append(prod.fit_image.shape[0])
         prod.close()
-    log.debug(' minimum size of fit_image=%d', min_size)
+    min_size = min(sizes)
+    log.debug('minimum size of fit_image=%d', min_size)
 
     # Loop over inputs, adding their values to the output
     for prod_num, input in enumerate(lg_products):
 
-        log.debug(' Accumulate data from %s', input)
+        log.info('Accumulate data from %s', input)
         prod = datamodels.AmiLgModel(input)
 
         prod_size = prod.fit_image.shape[0]
         if prod_size > min_size:
+            # If the fit_image in this input is bigger than the minimum,
+            # trim extra rows/cols from the edges
             trim = int((prod_size - min_size) / 2)
-            log.debug(' trim fit and resid images by %d pixels', trim)
+            log.debug('trim fit and resid images by %d pixels', trim)
             fit_image = prod.fit_image[trim:-trim, trim:-trim]
             resid_image = prod.resid_image[trim:-trim, trim:-trim]
+
+            # If this is the first input, which was copied to create
+            # the output, replace the original images with the trimmed
+            # versions.
             if prod_num == 0:
                 output_model.fit_image = fit_image
                 output_model.resid_image = resid_image
         else:
+            # Otherwise use the input images as is
             fit_image = prod.fit_image
             resid_image = prod.resid_image
+
+        # For inputs past the first, accumulate the data into the output
         if prod_num > 0:
             output_model.fit_image += fit_image
             output_model.resid_image += resid_image
@@ -70,7 +77,7 @@ def average_LG(lg_products):
         prod.close()
 
     # Take the average of the accumulated results
-    log.debug(' Divide accumulated results by %d', len(lg_products))
+    log.debug('Divide accumulated results by %d', len(lg_products))
     output_model.fit_image /= len(lg_products)
     output_model.resid_image /= len(lg_products)
     output_model.closure_amp_table['coeffs'] /= len(lg_products)

--- a/jwst/ami/lg_model.py
+++ b/jwst/ami/lg_model.py
@@ -8,9 +8,9 @@ from . import leastsqnrm as leastsqnrm
 from . import analyticnrm2
 from . import utils
 
-
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
+log.setLevel(logging.DEBUG)
 
 
 # define phi at the center of F430M band:

--- a/jwst/ami/nrm_core.py
+++ b/jwst/ami/nrm_core.py
@@ -4,6 +4,7 @@
 # Original python was by A. Greenbaum & A. Sivaramakrishnan
 
 import os
+import logging
 
 import numpy as np
 from scipy.special import comb
@@ -12,6 +13,9 @@ from scipy.stats import mstats
 from .. import datamodels
 from . import lg_model
 from . import utils
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 
 class FringeFitter:

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -430,6 +430,7 @@ def center_imagepeak(img, r='default', cntrimg=True):
         Cropped to place the brightest pixel at the center of the img array
     """
     peakx, peaky, h = min_distance_to_edge(img, cntrimg=cntrimg)
+    log.debug(' peakx=%g, peaky=%g, distance to edge=%g', peakx, peaky, h)
     if r == 'default':
         r = h.copy()
     else:

--- a/jwst/regtest/test_niriss_ami3.py
+++ b/jwst/regtest/test_niriss_ami3.py
@@ -77,6 +77,7 @@ def test_ami_analyze_with_nans(rtdata, fitsdiff_default_kwargs):
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
+
 @pytest.mark.bigdata
 def test_ami_average_with_sizes(run_pipeline2, fitsdiff_default_kwargs):
     """Test the AmiAverageStep with inputs of different sizes"""

--- a/jwst/regtest/test_niriss_ami3.py
+++ b/jwst/regtest/test_niriss_ami3.py
@@ -21,6 +21,19 @@ def run_pipeline(jail, rtdata_module):
     return rtdata
 
 
+@pytest.fixture(scope="module")
+def run_pipeline2(jail, rtdata_module):
+    """Run calwebb_ami3 on NIRISS AMI data."""
+    rtdata = rtdata_module
+    rtdata.get_asn("niriss/ami/jw01093_c1000_short_ami3_asn.json")
+
+    # Run the calwebb_ami3 pipeline on the association
+    args = ["calwebb_ami3", rtdata.input]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["c1014_ami"])
 @pytest.mark.parametrize("exposure", ["022", "025"])
@@ -61,5 +74,18 @@ def test_ami_analyze_with_nans(rtdata, fitsdiff_default_kwargs):
     rtdata.output = 'jw00042004001_01101_00005_nis_withNAN_amianalyzestep.fits'
 
     rtdata.get_truth('truth/test_niriss_ami3/jw00042004001_01101_00005_nis_withNAN_amianalyzestep.fits')
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+@pytest.mark.bigdata
+def test_ami_average_with_sizes(run_pipeline2, fitsdiff_default_kwargs):
+    """Test the AmiAverageStep with inputs of different sizes"""
+    rtdata = run_pipeline2
+
+    output = "jw01093-o007_result_short_amiavg.fits"
+    rtdata.output = output
+    rtdata.get_truth("truth/test_niriss_ami3/" + output)
+
+    fitsdiff_default_kwargs['atol'] = 1e-5
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2624](https://jira.stsci.edu/browse/JP-2624)

**Description**

This PR updates the ami_average step to be able to handle inputs coming from the ami_analyze step that have different sizes (from exposure to exposure) for the `fit_image` and `resid_image` images. It gets around this by averaging to the minimum size of all the inputs, trimming extra rows/cols from inputs that are larger. Because they all have the target at the center of each image, this still keeps the target aligned in the averaging process, because the images are trimmed symmetrically from all edges.

Also updated the ami_analyze step to only include the primary header when it calls `model.update()` on the output image, so that the outputs don't end up with empty SCI extensions. The SCI extensions don't belong in this kind of product.

Checklist
- [x] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
