### PR TITLE
xfail NIRCam grism tests until ref files are fixed

### DIFF
--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -190,12 +190,14 @@ def traverse_wfss_trace(pupil):
     assert orderdet == orderin
 
 
+@pytest.mark.xfail
 def test_traverse_wfss_grisms():
     """Check the dispersion polynomials for each grism."""
     for pupil in ['GRISMR', 'GRISMC']:
         traverse_wfss_trace(pupil)
 
 
+@pytest.mark.xfail
 def test_traverse_tso_grism():
     """Make sure that the TSO dispersion polynomials are reversable."""
     wcsobj = create_tso_wcs()

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -190,14 +190,14 @@ def traverse_wfss_trace(pupil):
     assert orderdet == orderin
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="Fails due to V2 NIRCam specwcs ref files delivered to CRDS")
 def test_traverse_wfss_grisms():
     """Check the dispersion polynomials for each grism."""
     for pupil in ['GRISMR', 'GRISMC']:
         traverse_wfss_trace(pupil)
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="Fails due to V2 NIRCam specwcs ref files delivered to CRDS")
 def test_traverse_tso_grism():
     """Make sure that the TSO dispersion polynomials are reversable."""
     wcsobj = create_tso_wcs()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

**Description**

This PR temporarily xfails a couple of unit tests in assign_wcs, which are failing (different results) due to new NIRCam specwcs ref files installed in CRDS recently. They will soon be replaced by yet newer versions. So xfail the tests for now, so that CI tests can pass again.

Checklist
- [x] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [x] Label(s)
