### PR TITLE
Reduce memory usage in skymatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,11 @@ straylight
 
 - Add a check that input data is IFUImageModel [#6861]
 
+skymatch
+--------
+
+- Reduced memory usage when input is an ASN. [#6874]
+
 
 1.5.2 (2022-05-20)
 ==================

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -396,7 +396,7 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             old_img_sky = [im.sky for im in img]
             if do_skysub:
                 for im in img:
-                    im.image -= sky
+                    im._image.set_data(im._image.get_data() - sky)
             img.sky += sky
             new_img_sky = [im.sky for im in img]
 
@@ -420,7 +420,7 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             # apply sky change:
             old_sky = img.sky
             if do_skysub:
-                img.image -= sky
+                img._image.set_data(img._image.get_data() - sky)
             img.sky += sky
             new_sky = img.sky
 


### PR DESCRIPTION
**Description**

This PR reduces memory usage when running `skymatch` step when input to the step is an ASN table. This is accomplished by saving large image and mask arrays to temporary files and retrieving them on demand. This PR will have no effect when input to the step is a list of already loaded into memory data models.

NOTE: Modifications to `jwst/datamodels/container.py` were designed by @stsci-hack who provided the file to me. I made minor adjustments, I think to `models_grouped`.

Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
