### PR TITLE
JP-2606: Catch two more SOSS errors raised.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ documentation
   steps to include information on the handling of NIRCam "Frame 0" data.
   [#6868]
 
+extract_1d
+----------
+
+- Catch two more errors raised, one if an input ImageModel uses the F277W
+  filter (similar to #6840, which only dealt with input CubeModels) [#6877]
+
 pipeline
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,8 +25,9 @@ documentation
 extract_1d
 ----------
 
-- Catch two more errors raised, one if an input ImageModel uses the F277W
-  filter (similar to #6840, which only dealt with input CubeModels) [#6877]
+- Catch two more errors raised in the SOSS ATOCA algorithm; one, if an input
+  ImageModel uses the F277W filter (similar to #6840, which only dealt with
+  input CubeModels), and another for bad DataModel input type [#6877]
 
 pipeline
 --------

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -594,7 +594,7 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
             # No model can be fit for F277W yet, missing throughput reference files.
             msg = f"No extraction possible for filter {soss_filter}."
             log.critical(msg)
-            raise ValueError(msg)
+            return None, None
 
         # Save trace models for output reference
         for order in tracemodels:
@@ -768,7 +768,7 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
     else:
         msg = "Only ImageModel and CubeModel are implemented for the NIRISS SOSS extraction."
         log.critical(msg)
-        raise ValueError(msg)
+        return None, None
 
     # Save output references
     for order in all_tracemodels:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2606](https://jira.stsci.edu/browse/JP-2606)

**Description**

This PR addresses one more SOSS error raised if F277W is used - a previous PR dealt with the CubeModel branch, but I missed that a similar error is raised in a separate code branch for ImageModel inputs (i.e. rate files).

After seeing this ticket, I did a quick search for other errors being raised in ATOCA, and there are many. Considering a separate PR that prevents SOSS from hitting the eject button during OPS processing - maybe a JIRA ticket first.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
