### PR TITLE
JP-2016: Flat_field step should ignore flatfield pixels with NO_FLAT_FIELD DQ bit set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,12 @@ extract_1d
   ImageModel uses the F277W filter (similar to #6840, which only dealt with
   input CubeModels), and another for bad DataModel input type [#6877]
 
+flatfield
+---------
+
+- Set DO_NOT_USE DQ bit in flatfield if NO_FLAT_FIELD DQ bit is set in flat
+  reference file [#6882]
+
 pipeline
 --------
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -191,6 +191,11 @@ def apply_flat_field(science, flat, inverse=False):
     flat_zero = np.where(flat_data == 0.)
     flat_dq[flat_zero] = np.bitwise_or(flat_dq[flat_zero], bad_flag)
 
+    # Find pixels in the flat that have the DQ bit for NO_FLAT_FIELD set
+    # Set the DO_NOT_USE flag for such pixels
+    flat_noflat = np.where(np.bitwise_and(flat_dq, dqflags.pixel['NO_FLAT_FIELD']))
+    flat_dq[flat_noflat] = np.bitwise_or(flat_dq[flat_noflat], dqflags.pixel['DO_NOT_USE'])
+
     # Find all pixels in the flat that have a DQ value of DO_NOT_USE
     flat_bad = np.bitwise_and(flat_dq, dqflags.pixel['DO_NOT_USE'])
 
@@ -1040,6 +1045,10 @@ def combine_dq(f_flat_dq, s_flat_dq, d_flat_dq, default_shape):
     else:
         for dq_component in dq_list:
             flat_dq = np.bitwise_or(flat_dq, dq_component)
+
+    # Flag DO_NOT_USE where some or all of the flats had NO_FLAT_FIELD set
+    do_not_use_loc = np.where(np.bitwise_and(flat_dq, dqflags.pixel['NO_FLAT_FIELD']))
+    flat_dq[do_not_use_loc] = np.bitwise_or(flat_dq[do_not_use_loc], dqflags.pixel['DO_NOT_USE'])
 
     # Flag DO_NOT_USE, NO_FLAT_FIELD and UNRELIABLE_FLAT where some or all the
     # flats had DO_NOT_USE set


### PR DESCRIPTION

<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2016](https://jira.stsci.edu/browse/JP-2016)

**Description**

Set the DO_NOT_USE DQ bit in the flatfield if the NO_FLAT_FIELD dq bit is set.  This will ensure the flatfield value is set to 1.0 at those pixels.

Code now agrees with the documentation

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
