### PR TITLE
JP-2647 Fixed bug in selecting values from cubepars reference file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ ami_average
   `resid_image`. Larger inputs are trimmed to match the size of the smallest
   input. [#6870]
 
+cube_build
+----------
+
+- Fixed bug in selecting correct values to extract from the cube pars reference file. [#6885]
+
 datamodels
 ----------
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1022,7 +1022,7 @@ class IFUCubeData():
 
             if imin > 1 and table_wavelength[imin] > self.wavemin:
                 imin = imin - 1
-            if (imax < len(table_wavelength) and
+            if (imax < len(table_wavelength-1) and
                     self.wavemax > table_wavelength[imax]):
                 imax = imax + 1
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1022,7 +1022,7 @@ class IFUCubeData():
 
             if imin > 1 and table_wavelength[imin] > self.wavemin:
                 imin = imin - 1
-            if (imax < len(table_wavelength - 1) and
+            if (imax < (len(table_wavelength)-1)  and
                     self.wavemax > table_wavelength[imax]):
                 imax = imax + 1
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1022,7 +1022,7 @@ class IFUCubeData():
 
             if imin > 1 and table_wavelength[imin] > self.wavemin:
                 imin = imin - 1
-            if (imax < (len(table_wavelength)-1)  and
+            if (imax < (len(table_wavelength) - 1)  and
                     self.wavemax > table_wavelength[imax]):
                 imax = imax + 1
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1022,7 +1022,7 @@ class IFUCubeData():
 
             if imin > 1 and table_wavelength[imin] > self.wavemin:
                 imin = imin - 1
-            if (imax < len(table_wavelength-1) and
+            if (imax < len(table_wavelength - 1) and
                     self.wavemax > table_wavelength[imax]):
                 imax = imax + 1
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1022,7 +1022,7 @@ class IFUCubeData():
 
             if imin > 1 and table_wavelength[imin] > self.wavemin:
                 imin = imin - 1
-            if (imax < (len(table_wavelength) - 1)  and
+            if (imax < (len(table_wavelength) - 1) and
                     self.wavemax > table_wavelength[imax]):
                 imax = imax + 1
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2647](https://jira.stsci.edu/browse/JP-nnnn)

**Description**

This PR fixes a bug in the cube_build step when  when reading values from in the cube parameter reference file. The cube pars reference file contains tables for defined wavelength ranges which hold  the parameters for how to run cube build. Based on the input data the program determines the  regions in the table to pull out. This PR fixes a bug when the region selected includes the last row in the table. The program was trying to pull out one beyond the last row. This bug was just found because a new cube parameter reference file was delivered with tables exactly covering the data. Previously the tables had some padding and went beyond the last wavelength of the data. 

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
