### PR TITLE
JP-2604 Bugfix: remove log message for environment variable

### DIFF
--- a/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/jwst/datamodels/tests/test_schema_against_crds.py
@@ -167,8 +167,6 @@ def test_crds_selectors_vs_datamodel(jail_environ, instrument):
 
     os.environ["CRDS_SERVER_URL"] = 'https://jwst-crds-pub.stsci.edu'
 
-    log.info(f"CRDS_PATH: {os.environ['CRDS_PATH']}")
-
     import crds
     from crds.client.api import cache_references
     from crds.core.exceptions import IrrelevantReferenceTypeError


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #6887 
Resolves [JP-2604](https://jira.stsci.edu/browse/JP-2604)

**Description**

This PR removes a logging message that would cause an error if a CRDS environment variable isn't set. It's not a required log message and likely isn't helpful anyways.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
