### PR TITLE
JP-2650: Fix SourceCatalogStep bug with input filename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,11 @@ skymatch
 
 - Reduced memory usage when input is an ASN. [#6874]
 
+source_catalog
+--------------
+
+- Fix bug in passing filename rather than datamodel [#6889]
+
 straylight
 ----------
 

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -66,7 +66,7 @@ class SourceCatalogStep(Step):
                            self.aperture_ee3)
 
             try:
-                refdata = ReferenceData(input_model, reffile_paths,
+                refdata = ReferenceData(model, reffile_paths,
                                         aperture_ee)
                 aperture_params = refdata.aperture_params
                 abvega_offset = refdata.abvega_offset


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2650](https://jira.stsci.edu/browse/JP-2650)

**Description**

This PR fixes a bug when using standalone SourceCatalogStep while providing the step a filename as input - the code was passing along the filename and not an opened datamodel.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
