### PR TITLE
JP-2653: Fix IFU variance propagation in extract_1d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ extract_1d
   input CubeModels), and another for bad DataModel input type [#6877]
 
 - Fix variance propagation for IFU cube extraction in calculations of surface
-  brightness []
+  brightness [#6892]
 
 flatfield
 ---------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ extract_1d
   ImageModel uses the F277W filter (similar to #6840, which only dealt with
   input CubeModels), and another for bad DataModel input type [#6877]
 
+- Fix variance propagation for IFU cube extraction in calculations of surface
+  brightness []
+
 flatfield
 ---------
 

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -131,13 +131,13 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
 
     # Convert the sum to an average, for surface brightness.
     surf_bright = temp_flux / npixels_temp
-    sb_var_poisson = f_var_poisson / npixels_temp
-    sb_var_rnoise = f_var_rnoise / npixels_temp
-    sb_var_flat = f_var_flat / npixels_temp
+    sb_var_poisson = f_var_poisson / npixels_temp / npixels_temp
+    sb_var_rnoise = f_var_rnoise / npixels_temp / npixels_temp
+    sb_var_flat = f_var_flat / npixels_temp / npixels_temp
     background /= npixels_bkg_temp
-    b_var_poisson /= npixels_bkg_temp
-    b_var_rnoise /= npixels_bkg_temp
-    b_var_flat /= npixels_bkg_temp
+    b_var_poisson /= npixels_bkg_temp / npixels_temp
+    b_var_rnoise /= npixels_bkg_temp / npixels_temp
+    b_var_flat /= npixels_bkg_temp / npixels_temp
 
     del npixels_temp
     del npixels_bkg_temp

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -130,14 +130,15 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
     npixels_bkg_temp = np.where(npixels_bkg > 0., npixels_bkg, 1.)
 
     # Convert the sum to an average, for surface brightness.
+    # Remember variance requires dividing by N^2
     surf_bright = temp_flux / npixels_temp
     sb_var_poisson = f_var_poisson / npixels_temp / npixels_temp
     sb_var_rnoise = f_var_rnoise / npixels_temp / npixels_temp
     sb_var_flat = f_var_flat / npixels_temp / npixels_temp
-    background /= npixels_bkg_temp
-    b_var_poisson /= npixels_bkg_temp / npixels_temp
-    b_var_rnoise /= npixels_bkg_temp / npixels_temp
-    b_var_flat /= npixels_bkg_temp / npixels_temp
+    background = background / npixels_bkg_temp
+    b_var_poisson = b_var_poisson / npixels_bkg_temp / npixels_bkg_temp
+    b_var_rnoise = b_var_rnoise / npixels_bkg_temp / npixels_bkg_temp
+    b_var_flat = b_var_flat / npixels_bkg_temp / npixels_bkg_temp
 
     del npixels_temp
     del npixels_bkg_temp

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -224,6 +224,10 @@ def copy_background_to_surf_bright(spectrum):
         spec.spec_table['BACKGROUND'][:] = 0
         # Set BERROR to dummy val of 0.0, as in extract_1d currently
         spec.spec_table['BKGD_ERROR'][:] = 0.
+        # Temporary hack to deal with DQ not being properly set to DO_NOT_USE
+        # in regions between the two MRS bands
+        indx = np.where(spec.spec_table['SURF_BRIGHT'] == 0)
+        spec.spec_table['DQ'][indx] = 1
 
 
 def split_container(container):

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -224,10 +224,6 @@ def copy_background_to_surf_bright(spectrum):
         spec.spec_table['BACKGROUND'][:] = 0
         # Set BERROR to dummy val of 0.0, as in extract_1d currently
         spec.spec_table['BKGD_ERROR'][:] = 0.
-        # Temporary hack to deal with DQ not being properly set to DO_NOT_USE
-        # in regions between the two MRS bands
-        indx = np.where(spec.spec_table['SURF_BRIGHT'] == 0)
-        spec.spec_table['DQ'][indx] = 1
 
 
 def split_container(container):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2653](https://jira.stsci.edu/browse/JP-2653)

**Description**

This PR fixes incorrect variance propagation for surface brightness computations in IFU Extract 1D.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
