### PR TITLE
JP-2562: Skip tweakreg step when multiple matches to a single reference source are detected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.5.4 (unreleased)
 ==================
 
+tweakreg
+--------
+
+Added check for multiple matches to a single reference source and skip
+``tweakreg`` step when this happens. [#6896]
+
 
 1.5.3 (2022-06-20)
 ==================

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -208,6 +208,20 @@ class TweakRegStep(Step):
                     model.meta.cal_step.tweakreg = "SKIPPED"
                 return images
 
+        except RuntimeError as e:
+            msg = e.args[0]
+            if msg.startswith("Number of output coordinates exceeded allocation"):
+                # we need at least two exposures to perform image alignment
+                self.log.error(msg)
+                self.log.error("Multiple sources within specified tolerance "
+                               "matched to a single reference source. Try to "
+                               "adjust 'tolerance' and/or 'separation' parameters.")
+                self.log.warning("Skipping 'TweakRegStep'...")
+                self.skip = True
+                for model in images:
+                    model.meta.cal_step.tweakreg = "SKIPPED"
+                return images
+
             else:
                 raise e
 


### PR DESCRIPTION
**Description**

Skip tweakreg step when multiple matches to a single reference source are detected. This PR would reduce number of crashes even when match parameters are sub-optimal by skipping `tweakreg` step altogether. See [JP-2562](https://jira.stsci.edu/browse/JP-2562).  Also addresses issues listed in [DMSOPS-445](https://jira.stsci.edu/browse/DMSOPS-445).

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
