### PR TITLE
JP-2611: Update saturation handling of NO_SAT_CHECK

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.5.4 (unreleased)
 ==================
 
+saturation
+----------
+
+- Updated to set the internal threshold for NO_SAT_CHECK and NaN pixels above the
+  A-to-D limit, so that they never get flagged as saturated. [#6901]
+
 skymatch
 --------
 

--- a/docs/jwst/saturation/description.rst
+++ b/docs/jwst/saturation/description.rst
@@ -28,9 +28,9 @@ group 7 is the first one to cross the saturation threshold for a given pixel,
 then groups 7 through 10 will all be flagged for that pixel.
 
 Pixels with thresholds set to NaN or flagged as "NO_SAT_CHECK" in the saturation
-reference file have their thresholds set to the 16-bit A-to-D converter limit
-of 65535 and hence will only be flagged as saturated if the pixel reaches that
-hard limit in at least one group. The "NO_SAT_CHECK" flag is propagated to the
+reference file have their thresholds set above the 16-bit A-to-D converter limit
+of 65535 and hence will never be flagged as saturated.
+The "NO_SAT_CHECK" flag is propagated to the
 PIXELDQ array in the output science data to indicate which pixels fall into
 this category.
 

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -136,13 +136,14 @@ def irs2_flag_saturation(input_model, ref_model, n_pix_grow_sat):
         ref_sub_model.close()
 
     # For pixels flagged in reference file as NO_SAT_CHECK,
-    # set the saturation check threshold to the A-to-D converter limit.
-    sat_thresh[np.bitwise_and(sat_dq, NO_SAT_CHECK) == NO_SAT_CHECK] = ATOD_LIMIT
+    # set the saturation check threshold to above the A-to-D converter limit,
+    # so no pixels will ever be above that level and hence not get flagged.
+    sat_thresh[np.bitwise_and(sat_dq, NO_SAT_CHECK) == NO_SAT_CHECK] = ATOD_LIMIT + 1
 
-    # Also reset NaN values in the saturation threshold array to the
-    # A-to-D limit and flag them with NO_SAT_CHECK
+    # Also reset NaN values in the saturation threshold array to above
+    # the A-to-D limit and flag them with NO_SAT_CHECK
     sat_dq[np.isnan(sat_thresh)] |= NO_SAT_CHECK
-    sat_thresh[np.isnan(sat_thresh)] = ATOD_LIMIT
+    sat_thresh[np.isnan(sat_thresh)] = ATOD_LIMIT + 1
 
     flagarray = np.zeros(data.shape[-2:], dtype=groupdq.dtype)
     flaglowarray = np.zeros(data.shape[-2:], dtype=groupdq.dtype)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2611](https://jira.stsci.edu/browse/JP-2611)

**Description**

This PR updates the NIRSpec IRS2 branch for handling pixels flagged as NO_SAT_CHECK in the saturation reference file DQ array or have thresholds of NaN in the saturation reference file. These pixels used to have their internal thresholds set to the A-to-D limit of 65535, but some pixels can attain that value and hence would get flagged when we don't want them to be. So now the internal threshold is set above the A-to-D limit, ensuring that they'll never get flagged (because no pixels can ever have values above the 65535 limit). Also updated the documentation to reflect this change.

The corresponding change for non-IRS2 data has been made in the `stcal` package in https://github.com/spacetelescope/stcal/pull/106

Checklist
- [ ] ~Tests~  (unit tests have been updated in the stcal package)
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
