### PR TITLE
JP-2527: Improve memory usage in outlier_detection and resample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,8 +94,8 @@ pipeline
 
 outlier_detection
 -----------------
-- Improved memory usage during outlier_detection by adding ability to work with
-  input ImageModels that are saved to disk instead of keeping them in memory.
+- Improved memory usage during `outlier_detection` by adding ability to work with
+  input ``ImageModels`` that are saved to disk instead of keeping them in memory.
   New parameters were aded to outlier_detection_step to control this functionality. [#6904]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,14 @@ pipeline
 - Only apply source_id fix from #6915 to models with multiple
   sources [#6917]
 
+
+outlier_detection
+-----------------
+- Improved memory usage during outlier_detection by adding ability to work with
+  input ImageModels that are saved to disk instead of keeping them in memory.
+  New parameters were aded to outlier_detection_step to control this functionality. [#6904]
+
+
 ramp_fitting
 ------------
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -495,7 +495,7 @@ class ModelContainer(JwstDataModel, Sequence):
 
         self.buffer_size = min_buffer_size if buffer_size is None else (buffer_size * _ONE_MB)
 
-        section_nrows = min(imrows, self.buffer_size // min_buffer_size)
+        section_nrows = min(imrows, int(self.buffer_size // min_buffer_size))
 
         if section_nrows == 0:
             self.buffer_size = min_buffer_size

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -183,7 +183,6 @@ class OutlierDetection:
         self.build_suffix(**self.outlierpars)
 
         pars = self.outlierpars
-        save_intermediate_results = pars['save_intermediate_results']
 
         if pars['resample_data']:
             # Start by creating resampled/mosaic images for
@@ -216,7 +215,7 @@ class OutlierDetection:
             basepath=median_model.meta.filename,
             suffix='median')
         median_model.save(median_model_output_path)
-        
+
         if pars['resample_data']:
             # Blot the median image back to recreate each input image specified
             # in the original input list/ASN/ModelContainer
@@ -247,7 +246,7 @@ class OutlierDetection:
         - 'minmed' not implemented as an option
         """
         maskpt = self.outlierpars.get('maskpt', 0.7)
-        
+
         resampled_models.set_buffer(1.0)  # Set buffer at 1Mb
         resampled_sections = resampled_models.get_sections()
         median_image = np.empty((resampled_models.imrows, resampled_models.imcols),
@@ -275,14 +274,13 @@ class OutlierDetection:
                     np.sum(badmask) / len(weight.flat) * 100))
                 badmasks.append(badmask)
 
-           # Fill resampled_sci array with nan's where mask values are True
+            # Fill resampled_sci array with nan's where mask values are True
             for f1, f2 in zip(resampled_sci, badmasks):
                 for elem1, elem2 in zip(f1, f2):
-                   elem1[elem2] = np.nan
-           
+                    elem1[elem2] = np.nan
+
             del badmasks
-                
-            import pdb;pdb.set_trace()
+
             # For a of stack of images with "bad" data replaced with Nan
             # use np.nanmedian to compute the median.
             with warnings.catch_warnings():
@@ -321,7 +319,7 @@ class OutlierDetection:
             # apply blot to re-create model.data from median image
             blotted_median.data = gwcs_blot(median_model, model, interp=interp,
                                             sinscl=sinscl)
-                                            
+
             blotted_median.save(model_path)
             blot_models.append(model_path)
             blotted_median.close()

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -302,7 +302,7 @@ class OutlierDetection:
 
         log.info("Blotting median...")
         for model in self.input_models:
-            blotted_median = model
+            blotted_median = model.copy()
             blot_root = '_'.join(model.meta.filename.replace(
                 '.fits', '').split('_')[:-1])
             model_path = self.make_output_path(

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -309,7 +309,7 @@ class OutlierDetection:
                 basename=blot_root,
                 suffix='blot'
             )
-            
+
             blotted_median.meta.filename = model_path
 
             # clean out extra data not related to blot result

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -203,7 +203,6 @@ class OutlierDetection:
         # Initialize intermediate products used in the outlier detection
         dm0 = datamodel_open(drizzled_models[0])
         median_model = datamodels.ImageModel(dm0.data.shape)
-        # median_model = datamodels.ImageModel(drizzled_models[0].data.shape)
         median_model.update(dm0)
         median_model.meta.wcs = dm0.meta.wcs
         dm0.close()
@@ -323,7 +322,6 @@ class OutlierDetection:
             blotted_median.save(model_path)
             blot_models.append(model_path)
             blotted_median.close()
-            # blot_models.append(blotted_median)
             del blotted_median
 
         return blot_models

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -256,6 +256,9 @@ class OutlierDetection:
         for resampled in resampled_models:
             m = datamodel_open(resampled)
             weight = m.wht
+            # necessary in order to assure that mask gets applied correctly
+            if hasattr(weight, '_mask'):
+                del weight._mask
             mask_zero_weight = np.equal(weight, 0.)
             mask_nans = np.isnan(weight)
             # Combine the masks

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -281,7 +281,7 @@ class OutlierDetection:
 
             del badmasks
 
-            # For a of stack of images with "bad" data replaced with Nan
+            # For a stack of images with "bad" data replaced with Nan
             # use np.nanmedian to compute the median.
             with warnings.catch_warnings():
                 warnings.filterwarnings(action="ignore",

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -74,7 +74,7 @@ class OutlierDetectionStep(Step):
         hp = hpy()
         hp.setrelheap()
         
-        with datamodels.open(input_data) as input_models:
+        with datamodels.open(input_data, save_open=False) as input_models:
             self.input_models = input_models
             if not isinstance(self.input_models, datamodels.ModelContainer):
                 self.input_container = False

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -64,7 +64,9 @@ class OutlierDetectionStep(Step):
         scale_detection = boolean(default=False)
         search_output_file = boolean(default=False)
         allowed_memory = float(default=None)  # Fraction of memory to use for the combined image.
-        in_memory = boolean(default=True)
+        in_memory = boolean(default=False)
+        output_use_index = boolean(default=False)
+        output_use_model = boolean(default=False)
     """
 
     def process(self, input_data):

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -1,8 +1,6 @@
 """Public common step definition for OutlierDetection processing."""
 from functools import partial
 
-from guppy import hpy
-
 from jwst.stpipe import Step
 from jwst import datamodels
 from jwst.lib.pipe_utils import is_tso
@@ -71,9 +69,7 @@ class OutlierDetectionStep(Step):
 
     def process(self, input_data):
         """Perform outlier detection processing on input data."""
-        hp = hpy()
-        hp.setrelheap()
-        
+
         with datamodels.open(input_data, save_open=False) as input_models:
             self.input_models = input_models
             if not isinstance(self.input_models, datamodels.ModelContainer):
@@ -160,18 +156,11 @@ class OutlierDetectionStep(Step):
 
             self.log.debug(f"Using {detection_step.__name__} class for outlier_detection")
             reffiles = {}
-            
-            h = hp.heap()
-            self.log.info(f"MEMORY: Initializing the input models requires {h.size}bytes")
-            hp.setrelheap() 
-            
+
             # Set up outlier detection, then do detection
             step = detection_step(self.input_models, reffiles=reffiles, **pars)
             step.do_detection()
-            
-            h = hp.heap()
-            self.log.info(f"MEMORY: outlier_detection step required {h.size}bytes")
-            
+
             state = 'COMPLETE'
             if self.input_container:
                 for model in self.input_models:

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -65,8 +65,6 @@ class OutlierDetectionStep(Step):
         search_output_file = boolean(default=False)
         allowed_memory = float(default=None)  # Fraction of memory to use for the combined image.
         in_memory = boolean(default=False)
-        output_use_index = boolean(default=False)
-        output_use_model = boolean(default=False)
     """
 
     def process(self, input_data):

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -158,6 +158,20 @@ def we_three_sci():
     return we_many_sci(numsci=3)
 
 
+@pytest.fixture
+def we_three_sci_files():
+    """Provide 3 science images with different noise but identical source
+    and same background level, but written out to disk"""
+    sci_models = we_many_sci(numsci=3)
+    we_many_sci_filenames = [f.meta.filename for f in sci_models]
+    # Write out models to disk to test this mode of ModelContainer
+    for model in sci_models:
+        model.save(model.meta.filename)
+        model.close()
+
+    return we_many_sci_filenames
+
+
 def test_outlier_step_no_outliers(we_three_sci):
     """Test whole step, no outliers"""
     container = datamodels.ModelContainer(list(we_three_sci))
@@ -178,6 +192,29 @@ def test_outlier_step_no_outliers(we_three_sci):
 def test_outlier_step(_jail, we_three_sci):
     """Test whole step with an outlier including saving intermediate and results files"""
     container = datamodels.ModelContainer(list(we_three_sci))
+
+    # Drop a CR on the science array
+    container[0].data[12, 12] += 1
+
+    result = OutlierDetectionStep.call(
+        container, save_results=True, save_intermediate_results=True
+    )
+
+    # Make sure nothing changed in SCI array
+    for image, corrected in zip(container, result):
+        np.testing.assert_allclose(image.data, corrected.data)
+
+    # Verify source is not flagged
+    for r in result:
+        assert r.dq[7, 7] == datamodels.dqflags.pixel["GOOD"]
+
+    # Verify CR is flagged
+    assert result[0].dq[12, 12] == OUTLIER_DO_NOT_USE
+
+
+def test_outlier_step_on_disk(_jail, we_three_sci_files):
+    """Test whole step with an outlier including saving intermediate and results files"""
+    container = datamodels.ModelContainer(we_three_sci_files)
 
     # Drop a CR on the science array
     container[0].data[12, 12] += 1

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import numpy as np
 from scipy.ndimage import gaussian_filter
@@ -214,10 +216,15 @@ def test_outlier_step(_jail, we_three_sci):
 
 def test_outlier_step_on_disk(_jail, we_three_sci_files):
     """Test whole step with an outlier including saving intermediate and results files"""
-    container = datamodels.ModelContainer(we_three_sci_files)
 
-    # Drop a CR on the science array
-    container[0].data[12, 12] += 1
+    # Drop a CR on the science array without reading the model into memory for the test
+    dm0 = datamodels.ImageModel(we_three_sci_files[0])
+    dm0.data[12, 12] += 1
+    dm0.to_fits(os.path.join(os.getcwd(), dm0.meta.filename), overwrite=True)
+    del dm0
+
+    # Initialize inputs for the test based on filenames only
+    container = datamodels.ModelContainer(we_three_sci_files)
 
     result = OutlierDetectionStep.call(
         container, save_results=True, save_intermediate_results=True

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -77,7 +77,7 @@ class GWCSDrizzle:
         self.conext = "CON"
 
         out_units = "cps"
-
+        
         self.outexptime = product.meta.resample.product_exposure_time or 0.0
 
         self.outsci = product.data
@@ -105,6 +105,7 @@ class GWCSDrizzle:
             np.divide(self.outsci, self.outexptime, self.outsci)
         elif out_units != "cps":
             raise ValueError("Illegal value for out_units: %s" % out_units)
+
 
     def add_image(self, insci, inwcs, inwht=None, xmin=0, xmax=0, ymin=0, ymax=0,
                   expin=1.0, in_units="cps", wt_scl=1.0):

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -77,7 +77,7 @@ class GWCSDrizzle:
         self.conext = "CON"
 
         out_units = "cps"
-        
+
         self.outexptime = product.meta.resample.product_exposure_time or 0.0
 
         self.outsci = product.data
@@ -105,7 +105,6 @@ class GWCSDrizzle:
             np.divide(self.outsci, self.outexptime, self.outsci)
         elif out_units != "cps":
             raise ValueError("Illegal value for out_units: %s" % out_units)
-
 
     def add_image(self, insci, inwcs, inwht=None, xmin=0, xmax=0, ymin=0, ymax=0,
                   expin=1.0, in_units="cps", wt_scl=1.0):

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -139,7 +139,7 @@ class ResampleData:
         Used for outlier detection
         """
         for exposure in self.input_models.models_grouped:
-            output_model = self.blank_output  #.copy()
+            output_model = self.blank_output
             output_root = '_'.join(exposure[0].meta.filename.replace(
                 '.fits', '').split('_')[:-1])
             output_model.meta.filename = f'{output_root}_outlier_i2d.fits'
@@ -168,7 +168,7 @@ class ResampleData:
 
             if not self.in_memory:
                 # Write out model to disk, then return filename
-                output_name=output_model.meta.filename
+                output_name = output_model.meta.filename
                 output_model.save(output_name)
                 log.info(f"Exposure {output_name} saved to file")
                 self.output_models.append(output_name)

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -1,8 +1,6 @@
 import logging
 import re
 
-from guppy import hpy
-
 import numpy as np
 from drizzle import util
 from drizzle import cdrizzle
@@ -140,9 +138,6 @@ class ResampleData:
 
         Used for outlier detection
         """
-        he = hpy()
-        he.setrelheap()
-
         for exposure in self.input_models.models_grouped:
             output_model = self.blank_output  #.copy()
             hep = he.heap()
@@ -155,9 +150,6 @@ class ResampleData:
             driz = gwcs_drizzle.GWCSDrizzle(output_model, pixfrac=self.pixfrac,
                                             kernel=self.kernel, fillval=self.fillval)
 
-            hep = he.heap()
-            log.info(f"Memory use for {exposure[0]}: {hep.size / (1024*1024):.3f} Mb")
-            
             log.info(f"{len(exposure)} exposures to drizzle together")
             for img in exposure:
                 img = datamodels.open(img)
@@ -175,10 +167,7 @@ class ResampleData:
                 driz.add_image(data, img.meta.wcs, inwht=inwht)
                 del data
                 img.close()
-                
-            hep = he.heap()
-            log.info(f"Memory use after drizzling: {hep.size / (1024*1024):.3f} Mb")
-                
+
             if not self.in_memory:
                 # Write out model to disk, then return filename
                 output_name=output_model.meta.filename
@@ -190,10 +179,6 @@ class ResampleData:
             output_model.data *= 0.
             output_model.wht *= 0.
 
-        hexp = he.heap()
-        log.info(f"MEMORY: adding all exposures required {hexp.size / (1024*1024):.3f} Mb")
-        he.setrelheap()
-            
         return self.output_models
 
     def resample_many_to_one(self):

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -140,9 +140,7 @@ class ResampleData:
         """
         for exposure in self.input_models.models_grouped:
             output_model = self.blank_output  #.copy()
-            hep = he.heap()
-            log.info(f"Memory use for output_model: {hep.size / (1024*1024):.3f} Mb")
-            output_root = '_'.join(exposure[0].replace(
+            output_root = '_'.join(exposure[0].meta.filename.replace(
                 '.fits', '').split('_')[:-1])
             output_model.meta.filename = f'{output_root}_outlier_i2d.fits'
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -140,9 +140,13 @@ class ResampleData:
         """
         for exposure in self.input_models.models_grouped:
             output_model = self.blank_output
+            # Determine output file type from input exposure filenames
+            # Use this for defining the output filename
+            indx = exposure[0].meta.filename.rfind('.')
+            output_type = exposure[0].meta.filename[indx:]
             output_root = '_'.join(exposure[0].meta.filename.replace(
-                '.fits', '').split('_')[:-1])
-            output_model.meta.filename = f'{output_root}_outlier_i2d.fits'
+                output_type, '').split('_')[:-1])
+            output_model.meta.filename = f'{output_root}_outlier_i2d{output_type}'
 
             # Initialize the output with the wcs
             driz = gwcs_drizzle.GWCSDrizzle(output_model, pixfrac=self.pixfrac,

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -69,6 +69,7 @@ class ResampleSpecData(ResampleData):
         self.fillval = fillval
         self.weight_type = wht_type
         self.good_bits = good_bits
+        self.in_memory = kwargs.get('in_memory', True)
 
         # Define output WCS based on all inputs, including a reference WCS
         if resample_utils.is_sky_like(self.input_models[0].meta.wcs.output_frame):

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -46,6 +46,7 @@ class ResampleStep(Step):
         single = boolean(default=False)
         blendheaders = boolean(default=True)
         allowed_memory = float(default=None)  # Fraction of memory to use for the combined image.
+        in_memory = boolean(default=True)
     """
 
     reference_file_types = ['drizpars']
@@ -102,6 +103,7 @@ class ResampleStep(Step):
         kwargs['crval'] = _check_list_pars(self.crval, 'crval')
         kwargs['rotation'] = self.rotation
         kwargs['pscale'] = self.pixel_scale
+        kwargs['in_memory'] = self.in_memory
 
         # Call the resampling routine
         resamp = resample.ResampleData(input_models, output=output, **kwargs)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-2527 <Implement memory-saving improvements in outlier_detection>
-->

Closes #
Resolves [JP-2527](https://jira.stsci.edu/browse/JP-2527) <Implement memory-saving improvements in outlier_detection>

**Description**

The changes included here update the **outlier_detection** and **resample** steps in order to minimize the memory usage by processing the **ImageModels** on disk instead of memory.  This required updates to the **ModelContainer** class in datamodels to support **ImageModels** on disk rather than keeping them all open in memory.  The initial updates to the **ModelContainer** were implemented in #6874.  The **outlier_detection** step was also modified to compute the median image section-by-section as well.  Finally, new parameters were added to the **outlier_detection** step to control whether or not to process inputs in memory as originally delivered for pipeline use or to work with inputs written out to disk to minimize memory use.  

All these changes resulted in a reduction of memory use during the on-disk processing of the 200 exposure dataset specified in [JP-2527](https://jira.stsci.edu/browse/JP-2527) to allow it to complete processing while using less that 30Gb active memory (according to 'top').  

A new test was also added to the **oulier_detection** step tests to cover the case of working with inputs that are 
on disk instead of in memory.  

Checklist
- [x] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
