### PR TITLE
Compile under windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 cube_build
 ----------
 
-- Update C code to allow it to compile under Windows [#7xxx]
+- Update C code to allow it to compile under Windows [#6905]
 
 extract_1d
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.5.4 (unreleased)
 ==================
 
+cube_build
+----------
+
+- Update C code to allow it to compile under Windows [#7xxx]
+
 extract_1d
 ----------
 

--- a/jwst/cube_build/src/cube_dq_utils.c
+++ b/jwst/cube_build/src/cube_dq_utils.c
@@ -498,7 +498,9 @@ int dq_miri(int start_region, int end_region, int overlap_partial, int overlap_f
 
   int status, status_wave, w, nxy, i, istart, iend, in, ii;
   double xi_corner[4], eta_corner[4];
-  
+
+  int *wave_slice_dq;
+
   int *idqv ;  // int vector for spaxel
   if (mem_alloc_dq(ncube, &idqv)) return 1;
 
@@ -511,7 +513,9 @@ int dq_miri(int start_region, int end_region, int overlap_partial, int overlap_f
   // corner of the FOV for each wavelength
 
   nxy = nx * ny;
-  int wave_slice_dq[nxy];
+  wave_slice_dq = (int *) malloc(nxy * sizeof(int));
+  //  int wave_slice_dq[nxy];
+
   // Loop over the wavelength planes and set DQ plane 
   for (w = 0; w  < nz; w++) {
     
@@ -598,6 +602,7 @@ int dq_nirspec(int overlap_partial,
   long istart, in, iend, ii;
   double c1_min, c2_min, c1_max, c2_max;
   int *idqv ;  // int vector for spaxel
+  int *wave_slice_dq;  // int vector for wavelength slices
 
   if (mem_alloc_dq(ncube, &idqv)) return 1;
   
@@ -605,7 +610,8 @@ int dq_nirspec(int overlap_partial,
   //     onto each of the IFU wavelength planes.
 
   nxy = nx * ny;
-  int wave_slice_dq[nxy];
+  wave_slice_dq = (int *) malloc (nxy * sizeof(int));
+  // int wave_slice_dq[nxy];
   
   for (w = 0; w  < nz; w++) {
     for (islice =1; islice< 31 ; islice++){


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

**Description**

This PR contains the simple changes to the C code necessary to allow the C extensions to compile under Windows. These changes swap out an indeterminate array definition with a redefinition using malloc to account for the varying size of the array for each dataset.  

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [ ] Milestone
- [x] Label(s)
