### PR TITLE
add exact version to sidebar

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,25 @@
+{%- extends "stsci_rtd_theme/layout.html" %}
+{% block sidebartitle %}
+
+{{ super() }}
+
+        {% if nav_version %}
+          <div class="version">
+            {% if nav_version == "stable" %}
+            	stable version
+            	{% if version and version != "stable" %}
+            		<small>({{ version }})</small>
+            	{% endif %}
+            {% elif nav_version == "latest" %}
+            	development version
+            	{% if commit %}
+            		<small>(<tt>{{ commit }}</tt>)</small>
+            	{% endif %}
+            {% else %}
+            	version {{ nav_version }}
+            {% endif %}
+          </div>
+        {% endif %}
+
+
+  {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ else:
 
 
 # Add any paths that contain templates here, relative to this directory.
-# templates_path = ['_templates']
+templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -222,6 +222,7 @@ asdf_schema_reference_mappings = [
 ]
 
 # -- Options for HTML output ----------------------------------------------
+
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.


### PR DESCRIPTION
Documentation will now display the exact version in the left navigation bar. If you're looking at the 'stable' version, it will be the last release, and if you are looking at 'latest', it will reference the last commit.

Closes [#5673](https://github.com/spacetelescope/jwst/issues/5673)