### PR TITLE
JP-2665: Add MIRI dither pattern SCAN-CALIBRATION

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ associations
 - Add finalization for level 3 group association candidates to require
   more than one observation amongst member entries [#6886]
 
+datamodels
+----------
+
+- Added new MIRI MRS dither pattern "SCAN-CALIBRATION" to list of allowed
+  values for the "PATTTYPE" keyword. [#6908]
+
 extract_1d
 ----------
 
@@ -15,7 +21,7 @@ extract_1d
 ramp_fitting
 ------------
 
-- Fixed multirpocessing error by removing ``int_times`` entirely in step code.
+- Fixed multiprocessing error by removing ``int_times`` entirely in step code.
   Also, in order to work better with multiprocessing changed the way one group
   suppression gets handled and changed the location ZEROFRAME gets handled. [#6880]
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1094,7 +1094,7 @@ properties:
               7x3-PIXEL-MAP-SLITLESS, 9x3-8x4-SCAN-MAPS-SLITLESS,
 
               # MIRI MRS
-              2-POINT, 4-POINT,
+              2-POINT, 4-POINT, SCAN-CALIBRATION,
 
               # NIRCam
               FULL, FULLBOX, FULL-TIGHT,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2665](https://jira.stsci.edu/browse/JP-2665)

**Description**

This PR updates core.schema to add the new MIRI dither pattern "SCAN-CALIBRATION" to the list of allowed values for the PATTTYPE (dither.primary_type) keyword.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)