### PR TITLE
JP 2652  Set DQ flags in  extract 1d for IFU data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ extract_1d
 ----------
 
 - Fix error in variance propagation calculation [#6899]
-- Fix error in setting DQ flags for s3d data when on data is in extraction aperture [#6909]
+
+- Set DO_NOT_USE flag in extracted spectrum when the IFU extraction aperture 
+  has no valid data [#6909]
 
 ramp_fitting
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ extract_1d
 ----------
 
 - Fix error in variance propagation calculation [#6899]
+- Fix error in setting DQ flags for s3d data when on data is in extraction aperture [#6909]
 
 ramp_fitting
 ------------

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -283,9 +283,6 @@ int match_driz(double *xc, double *yc, double *zc,
 		  weightv[index_cube] = weightv[index_cube] + area_weight;
 		  varv[index_cube] = varv[index_cube] + weighted_var;
 		  ifluxv[index_cube] = ifluxv[index_cube] +1.0;
-		  //if(index_cube == 1577){
-		  //  printf(" found value %f %f %f %f \n", area_weight, zoverlap, weighted_flux, flux[k]);
-		  //}
 		}
 	    
 	      } // xleft, xright, ybot, ytop

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -283,9 +283,9 @@ int match_driz(double *xc, double *yc, double *zc,
 		  weightv[index_cube] = weightv[index_cube] + area_weight;
 		  varv[index_cube] = varv[index_cube] + weighted_var;
 		  ifluxv[index_cube] = ifluxv[index_cube] +1.0;
-		  if(index_cube == 1577){
-		    printf(" found value %f %f %f %f \n", area_weight, zoverlap, weighted_flux, flux[k]);
-		  }
+		  //if(index_cube == 1577){
+		  //  printf(" found value %f %f %f %f \n", area_weight, zoverlap, weighted_flux, flux[k]);
+		  //}
 		}
 	    
 	      } // xleft, xright, ybot, ytop

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -623,10 +623,6 @@ def extract_ifu(input_model, source_type, extract_params):
                                              method=method, subpixels=subpixels)
         f_var_flat[k] = float(var_flat_table['aperture_sum'][0])
 
-        var_flat_table = aperture_photometry(var_flat[k, :, :], aperture,
-                                             method=method, subpixels=subpixels)
-        f_var_flat[k] = float(var_flat_table['aperture_sum'][0])
-
         # Point source type of data with defined annulus size
         if subtract_background_plane:
             bkg_table = aperture_photometry(data[k, :, :], annulus,

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -574,7 +574,14 @@ def extract_ifu(input_model, source_type, extract_params):
                                          method=method, subpixels=subpixels)
 
         aperture_area = float(phot_table['aperture_sum'][0])
+        # if aperture_area = 0, then there is no valid data for this wavelength
+        # set the DQ flag to DO_NOT_USE
+        if aperture_area == 0:
+            dq[k] = dqflags.pixel['DO_NOT_USE']
 
+        # There is no valid data for this region. To prevent the code from
+        # crashing set aperture_area to a nonzero value. It will have the dq flag
+        # set to DO_NOT_USE.
         if(aperture_area == 0 and aperture.area > 0):
             aperture_area = aperture.area
 
@@ -595,6 +602,7 @@ def extract_ifu(input_model, source_type, extract_params):
                 subtract_background_plane = False
 
         npixels[k] = aperture_area
+
         npixels_bkg[k] = 0.0
         if annulus is not None:
             npixels_bkg[k] = annulus_area
@@ -611,6 +619,10 @@ def extract_ifu(input_model, source_type, extract_params):
         var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], aperture,
                                                method=method, subpixels=subpixels)
         f_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
+
+        var_flat_table = aperture_photometry(var_flat[k, :, :], aperture,
+                                             method=method, subpixels=subpixels)
+        f_var_flat[k] = float(var_flat_table['aperture_sum'][0])
 
         var_flat_table = aperture_photometry(var_flat[k, :, :], aperture,
                                              method=method, subpixels=subpixels)

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -581,7 +581,6 @@ def extract_ifu(input_model, source_type, extract_params):
 
         # There is no valid data for this region. To prevent the code from
         # crashing set aperture_area to a nonzero value. It will have the dq flag
-        # set to DO_NOT_USE.
         if(aperture_area == 0 and aperture.area > 0):
             aperture_area = aperture.area
 

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -154,8 +154,8 @@ class MasterBackgroundStep(Step):
 
                 # Save the computed background if requested by user
                 if self.save_background:
-                    self.save_model(master_background, suffix='masterbg1d', asn_id=asn_id)
-                    self.save_model(background_2d_collection, suffix='masterbg2d', asn_id=asn_id)
+                    self.save_model(master_background, suffix='masterbg1d', force=True, asn_id=asn_id)
+                    self.save_model(background_2d_collection, suffix='masterbg2d', force=True, asn_id=asn_id)
 
             self.record_step_status(result, 'master_background', success=True)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2652](https://jira.stsci.edu/browse/JP-2652)

**Description**
In IFU data there can be regions in the IFU s3d cube with no valid data. If the IFU cube is built from MRS data of more than 1 channel (as in spec2) the regions between the channels have no valid data. Extract_1d  has been updated to set the DQ flag to DO_NOT_USE if no valid data is found in the extraction aperture. This then allows the master_background step to ignore those regions in combine_1d. Also a fix was made to all the master_background step option, save_background to write the background out.


Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [X] Milestone
- [X] Label(s)