### PR TITLE
JP-2633: Add unit to time keyword comment strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ datamodels
 - Added new MIRI MRS dither pattern "SCAN-CALIBRATION" to list of allowed
   values for the "PATTTYPE" keyword. [#6908]
 
+- Added MJD unit to keyword comment strings for barycentric and heliocentric
+  start, mid, and end times. [#6910]
+
 extract_1d
 ----------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1406,17 +1406,17 @@ properties:
             fits_keyword: BARTDELT
             blend_table: True
           barycentric_expstart:
-            title: [d] Barycentric exposure start time in MJD
+            title: "[d] Barycentric exposure start time in MJD"
             type: number
             fits_keyword: BSTRTIME
             blend_table: True
           barycentric_expend:
-            title: [d] Barycentric exposure end time in MJD
+            title: "[d] Barycentric exposure end time in MJD"
             type: number
             fits_keyword: BENDTIME
             blend_table: True
           barycentric_expmid:
-            title: [d] Barycentric exposure mid time in MJD
+            title: "[d] Barycentric exposure mid time in MJD"
             type: number
             fits_keyword: BMIDTIME
             blend_table: True
@@ -1426,17 +1426,17 @@ properties:
             fits_keyword: HELIDELT
             blend_table: True
           heliocentric_expstart:
-            title: [d] Heliocentric exposure start time in MJD
+            title: "[d] Heliocentric exposure start time in MJD"
             type: number
             fits_keyword: HSTRTIME
             blend_table: True
           heliocentric_expend:
-            title: [d] Heliocentric exposure end time in MJD
+            title: "[d] Heliocentric exposure end time in MJD"
             type: number
             fits_keyword: HENDTIME
             blend_table: True
           heliocentric_expmid:
-            title: [d] Heliocentric exposure mid time in MJD
+            title: "[d] Heliocentric exposure mid time in MJD"
             type: number
             fits_keyword: HMIDTIME
             blend_table: True

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1406,17 +1406,17 @@ properties:
             fits_keyword: BARTDELT
             blend_table: True
           barycentric_expstart:
-            title: Barycentric exposure start time in MJD
+            title: [d] Barycentric exposure start time in MJD
             type: number
             fits_keyword: BSTRTIME
             blend_table: True
           barycentric_expend:
-            title: Barycentric exposure end time in MJD
+            title: [d] Barycentric exposure end time in MJD
             type: number
             fits_keyword: BENDTIME
             blend_table: True
           barycentric_expmid:
-            title: Barycentric exposure mid time in MJD
+            title: [d] Barycentric exposure mid time in MJD
             type: number
             fits_keyword: BMIDTIME
             blend_table: True
@@ -1426,17 +1426,17 @@ properties:
             fits_keyword: HELIDELT
             blend_table: True
           heliocentric_expstart:
-            title: Heliocentric exposure start time in MJD
+            title: [d] Heliocentric exposure start time in MJD
             type: number
             fits_keyword: HSTRTIME
             blend_table: True
           heliocentric_expend:
-            title: Heliocentric exposure end time in MJD
+            title: [d] Heliocentric exposure end time in MJD
             type: number
             fits_keyword: HENDTIME
             blend_table: True
           heliocentric_expmid:
-            title: Heliocentric exposure mid time in MJD
+            title: [d] Heliocentric exposure mid time in MJD
             type: number
             fits_keyword: HMIDTIME
             blend_table: True

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1406,17 +1406,17 @@ properties:
             fits_keyword: BARTDELT
             blend_table: True
           barycentric_expstart:
-            title: Barycentric exposure start time
+            title: Barycentric exposure start time in MJD
             type: number
             fits_keyword: BSTRTIME
             blend_table: True
           barycentric_expend:
-            title: Barycentric exposure end time
+            title: Barycentric exposure end time in MJD
             type: number
             fits_keyword: BENDTIME
             blend_table: True
           barycentric_expmid:
-            title: Barycentric exposure mid time
+            title: Barycentric exposure mid time in MJD
             type: number
             fits_keyword: BMIDTIME
             blend_table: True
@@ -1426,17 +1426,17 @@ properties:
             fits_keyword: HELIDELT
             blend_table: True
           heliocentric_expstart:
-            title: Heliocentric exposure start time
+            title: Heliocentric exposure start time in MJD
             type: number
             fits_keyword: HSTRTIME
             blend_table: True
           heliocentric_expend:
-            title: Heliocentric exposure end time
+            title: Heliocentric exposure end time in MJD
             type: number
             fits_keyword: HENDTIME
             blend_table: True
           heliocentric_expmid:
-            title: Heliocentric exposure mid time
+            title: Heliocentric exposure mid time in MJD
             type: number
             fits_keyword: HMIDTIME
             blend_table: True


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2633](https://jira.stsci.edu/browse/JP-2633)

**Description**

This PR adds the unit (MJD) to the barycentric and heliocentric start, mid and end time header keyword comment strings.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
