### PR TITLE
Update default parameters for source catalog step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,12 @@ skymatch
 
 - Fixed a couple errors in the step documentation. [#6891]
 
+source_catalog
+--------------
+
+- Updated the default background box size and minimum number of pixels.
+  [#6911]
+
 tweakreg
 --------
 

--- a/docs/jwst/source_catalog/arguments.rst
+++ b/docs/jwst/source_catalog/arguments.rst
@@ -7,25 +7,25 @@ The ``source_catalog`` step uses the following user-settable arguments:
   size in pixels
 
 * ``--kernel_fwhm``: A floating-point value giving the Gaussian kernel
-  FWHM in pixels [default=2.0]
+  FWHM in pixels
 
 * ``--snr_threshold``: A floating-point value that sets the SNR
-  threshold (above background) for source detection [default=3.0]
+  threshold (above background) for source detection
 
 * ``--npixels``: An integer value that sets the minimum number of
-  pixels in a source [default=5]
+  pixels in a source
 
 * ``--deblend``: A boolean indicating whether to deblend sources
-  [default=False]
+
 
 * ``--aperture_ee1``: An integer value of the smallest aperture
-  encircled energy value [default=30]
+  encircled energy value
 
 * ``--aperture_ee2``: An integer value of the middle aperture encircled
-  energy value [default=50]
+  energy value
 
 * ``--aperture_ee3``: An integer value of the largest aperture encircled
-  energy value [default=70]
+  energy value
 
 * ``--ci1_star_threshold``: A floating-point value of the threshold
   compared to the concentration index calculated from aperture_ee1

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -29,10 +29,10 @@ class SourceCatalogStep(Step):
     class_alias = "source_catalog"
 
     spec = """
-        bkg_boxsize = integer(default=100)    # background mesh box size in pixels
+        bkg_boxsize = integer(default=1000)   # background mesh box size in pixels
         kernel_fwhm = float(default=2.0)      # Gaussian kernel FWHM in pixels
         snr_threshold = float(default=3.0)    # SNR threshold above the bkg
-        npixels = integer(default=5)          # min number of pixels in source
+        npixels = integer(default=25)         # min number of pixels in source
         deblend = boolean(default=False)      # deblend sources?
         aperture_ee1 = integer(default=30)    # aperture encircled energy 1
         aperture_ee2 = integer(default=50)    # aperture encircled energy 2


### PR DESCRIPTION
**Description**

This PR updates the default background boxsize and minimum number of pixels in the source catalog step:
 * The background boxsize was increased to prevent oversubtraction of the background in sources smaller than the boxsize.  A larger size gives a more "global" vs. "local" background and prevents oversubtraction.  I recently observed this in simulated ERS (CEERS) data.
 * The number of pixels was increased to prevent the detection of many tiny sources (which may not be real sources).

Ideally the source catalog default parameters would be instrument/detector specific and set by parameter reference files, but I don't think those have been delivered yet by the instrument teams.

Checklist
- [ ] Tests
- [x] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
