### PR TITLE
JP-2667: Fix calwebb_tso3 failure when checking for null results

### DIFF
--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -187,7 +187,8 @@ class Tso3Pipeline(Pipeline):
         input_models.close()
 
         # Check for all null photometry results before saving
-        if phot_result_list.count(None) == len(phot_result_list):
+        all_none = np.all([(x is None) for x in phot_result_list])
+        if all_none:
             self.log.warning("Could not create a photometric catalog; all results are null")
         else:
             # Otherwise, save results to a photometry catalog file


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2667](https://jira.stsci.edu/browse/JP-2667)

**Description**

This PR makes a change to the logic used near the end of the pipeline to check for all null results coming back from either the `tso_photometry` or `white_light` steps. A recent numpy update (1.23.0) changed a FutureWarning to an actual error, related to the behavior of astropy.tables objects. The new, simpler logic works with numpy 1.23 and is backwards compatible with previous versions.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [ ] Label(s)
