### PR TITLE
XFail NRS unit tests for new ref files

### DIFF
--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -416,6 +416,7 @@ def test_open_slits():
     assert len(slits) == 1
 
 
+@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 def test_shutter_size_on_sky():
     """
     Test the size of a MOS shutter on sky is ~ .2 x .4 arcsec.
@@ -452,6 +453,7 @@ def test_shutter_size_on_sky():
     assert sep_y.value < 0.46
 
 
+@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 @pytest.mark.parametrize(('mode'), ['fs', 'msa'])
 def test_functional_fs_msa(mode):
     #     """
@@ -591,6 +593,7 @@ def wcs_ifu_grating():
     return _create_image_model
 
 
+@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 def test_functional_ifu_grating(wcs_ifu_grating):
     """Compare Nirspec instrument model with IDT model for IFU grating."""
 
@@ -747,6 +750,7 @@ def test_functional_ifu_grating(wcs_ifu_grating):
     assert_allclose(v3, ins_tab['yV2V3'])
 
 
+@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 def test_functional_ifu_prism():
     """Compare Nirspec instrument model with IDT model for IFU prism."""
     # setup test
@@ -970,6 +974,7 @@ def ifu_world_coord(wcs_ifu_grating):
     return ra_all, dec_all, lam_all
 
 
+@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 @pytest.mark.parametrize("slice", [1, 17])
 def test_in_slice(slice, wcs_ifu_grating, ifu_world_coord):
     """ Test that the number of valid outputs from a slice forward transform

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -194,6 +194,7 @@ def nircam_rate():
     return im
 
 
+@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 def test_nirspec_wcs_roundtrip(nirspec_rate):
     im = AssignWcsStep.call(nirspec_rate)
     im = Extract2dStep.call(im)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->


**Description**

This PR temporarily xfails several NIRSpec WCS unit tests, due to differences from in-flight updates to wcs reference files. Will take some time before we can determine if the new results are valid and update the truth values.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [ ] Label(s)
