### PR TITLE
Update NIRCam TSGrism regtest

### DIFF
--- a/jwst/regtest/test_nircam_tsgrism.py
+++ b/jwst/regtest/test_nircam_tsgrism.py
@@ -12,21 +12,18 @@ def run_pipelines(jail, rtdata_module):
     rtdata = rtdata_module
 
     # Run tso-spec2 pipeline on the _rateints file, saving intermediate products
-    rtdata.get_data("nircam/tsgrism/jwst_nircam_tsgrism_extract1d.json")
     rtdata.get_data("nircam/tsgrism/jw00721012001_03103_00001-seg001_nrcalong_rateints.fits")
     args = ["calwebb_spec2", rtdata.input,
             "--steps.flat_field.save_results=True",
             "--steps.extract_2d.save_results=True",
-            "--steps.srctype.save_results=True",
-            "--steps.extract_1d.override_extract1d='jwst_nircam_tsgrism_extract1d.json'"
+            "--steps.srctype.save_results=True"
             ]
     Step.from_cmdline(args)
 
     # Get the level3 association json file (though not its members) and run
     # the tso3 pipeline on all _calints files listed in association
     rtdata.get_data("nircam/tsgrism/jw00721-o012_20191119t043909_tso3_001_asn.json")
-    args = ["calwebb_tso3", rtdata.input,
-            "--steps.extract_1d.override_extract1d='jwst_nircam_tsgrism_extract1d.json'"]
+    args = ["calwebb_tso3", rtdata.input]
     Step.from_cmdline(args)
 
     return rtdata

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -32,7 +32,7 @@ def run_tso_spec3(jail, rtdata_module, run_tso_spec2):
     # the tso3 pipeline on all _calints files listed in association
     rtdata.get_data("niriss/soss/jw00625-o023_20191210t204036_tso3_001_asn.json")
     args = ["calwebb_tso3", rtdata.input,
-            "--steps.outlier_detection.snr='13.0 10.0'",
+            "--steps.outlier_detection.snr=13.0 10.0",
             ]
     Step.from_cmdline(args)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

**Description**

This PR removes the use of a user-supplied extract1d reference file in the NIRCam TSGrism regression tests. It was put there originally because a suitable ref file was not yet available in CRDS. Now there is (and has been for some time). So from now on the test will use the CRDS ref file.

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [x] Milestone
- [x] Label(s)
