### PR TITLE
JP-2664: Fix NRS-MOS source ids to be 5 digits and positive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ pipeline
 - Fixed the logic used in the `calwebb_tso3` pipeline to check for null
   photometry results. [#6912]
 
+- Check source_ids in `calwebb_spec3` and force into 5 digit positive number,
+  if available [#6915]
+
 ramp_fitting
 ------------
 

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -185,10 +185,13 @@ class Spec3Pipeline(Pipeline):
             src_id = int(src_id)
             # Replace ids that aren't positive 5-digit integers
             if src_id < 0 or src_id > 99999:
-                src_id = available_src_ids.pop()
+                src_id_new = available_src_ids.pop()
+                self.log.info(f"Source ID {src_id} falls outside allowed range.")
+                self.log.info(f"Reassigning {src_id} to {str(src_id_new).zfill(5)}.")
                 # Replace source_id for each model in the SourceModelContainers
                 for contained_model in model:
-                    contained_model.source_id = src_id
+                    contained_model.source_id = src_id_new
+                src_id = src_id_new
             hotfixed_sources.append((str(src_id), model))
 
         sources = hotfixed_sources

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -183,8 +183,12 @@ class Spec3Pipeline(Pipeline):
         for src in sources:
             src_id, model = src
             src_id = int(src_id)
+            # Replace ids that aren't positive 5-digit integers
             if src_id < 0 or src_id > 99999:
                 src_id = available_src_ids.pop()
+                # Replace source_id for each model in the SourceModelContainers
+                for contained_model in model:
+                    contained_model.source_id = src_id
             hotfixed_sources.append((str(src_id), model))
 
         sources = hotfixed_sources

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from collections import defaultdict
 import os.path as op
+import numpy as np
 
 from .. import datamodels
 from ..associations.lib.rules_level3_base import format_product
@@ -161,6 +162,28 @@ class Spec3Pipeline(Pipeline):
                 (name, model)
                 for name, model in multislit_to_container(source_models).items()
             ]
+
+        # Check for negative and large source_id values
+        n_srcs = len(sources)
+        available_src_ids=set(np.arange(99999) + 1)
+        used_src_ids = set()
+        for src in sources:
+            src_id, model = src
+            src_id = int(src_id)
+            used_src_ids.add(src_id)
+            if src_id > 0 and src_id <= 99999:
+                available_src_ids.remove(src_id)
+
+        hotfixed_sources = []
+        # now find and reset bad source_id values
+        for src in sources:
+            src_id, model = src
+            src_id = int(src_id)
+            if src_id < 0 or src_id > 99999:
+                src_id = available_src_ids.pop()
+            hotfixed_sources.append((str(src_id), model))
+
+        sources = hotfixed_sources
 
         # Process each source
         for source in sources:

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -165,17 +165,17 @@ class Spec3Pipeline(Pipeline):
 
         # Check for negative and large source_id values
         if len(sources) > 99999:
-            self.log.critical(f"Data contain more than 100,000 sources;"
-                              f"filename does not support 6 digit source ids.")
+            self.log.critical("Data contain more than 100,000 sources;"
+                              "filename does not support 6 digit source ids.")
             raise Exception
 
-        available_src_ids=set(np.arange(99999) + 1)
+        available_src_ids = set(np.arange(99999) + 1)
         used_src_ids = set()
         for src in sources:
             src_id, model = src
             src_id = int(src_id)
             used_src_ids.add(src_id)
-            if src_id > 0 and src_id <= 99999:
+            if 0 < src_id <= 99999:
                 available_src_ids.remove(src_id)
 
         hotfixed_sources = []

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -164,7 +164,11 @@ class Spec3Pipeline(Pipeline):
             ]
 
         # Check for negative and large source_id values
-        n_srcs = len(sources)
+        if len(sources) > 99999:
+            self.log.critical(f"Data contain more than 100,000 sources;"
+                              f"filename does not support 6 digit source ids.")
+            raise Exception
+
         available_src_ids=set(np.arange(99999) + 1)
         used_src_ids = set()
         for src in sources:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #
Resolves [JP-2664](https://jira.stsci.edu/browse/JP-2664)

**Description**

This PR adds a check on the source_id created in calwebb_spec3, and modifies values that fall outside 0-99999. The wording in the JP ticket indicated this is a temporary fix, so it has been worded/coded as such; if I misinterpreted the level of 'hotfix' involved, I can edit the addition.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)
