### PR TITLE
JP-2580 update loading of drizpars table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ resample
 --------
 
 - Changed parameters read in from drizpar reference file to have a value of None in Spec [#6921] 
--
+
 
 
 1.6.0 (2022-07-11)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,13 @@ general
 
 - Update `stpipe` requirement to `>=0.4.1` [#6925]
 
+resample
+--------
+
+- Changed parameters read in from drizpar reference file to have a value of None in Spec [#6921] 
+-
+
+
 1.6.0 (2022-07-11)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ general
 
 -
 
+resample
+--------
+
+- Changed parameters read in from drizpar reference file to have a value of None in Spec [#6921] 
+
+
+
 source_catalog
 --------------
 
@@ -19,12 +26,6 @@ general
 -------
 
 - Update `stpipe` requirement to `>=0.4.1` [#6925]
-
-resample
---------
-
-- Changed parameters read in from drizpar reference file to have a value of None in Spec [#6921] 
-
 
 
 1.6.0 (2022-07-11)

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -39,7 +39,7 @@ class ResampleData:
     """
 
     def __init__(self, input_models, output=None, single=False, blendheaders=True,
-                 pixfrac=1.0, kernel="square", fillval="INDEF", weight_type="ivm",
+                 pixfrac=1.0, kernel="square", fillval="INDEF", wht_type="ivm",
                  good_bits=0, pscale_ratio=1.0, pscale=None, **kwargs):
         """
         Parameters
@@ -65,8 +65,13 @@ class ResampleData:
         self.pixfrac = pixfrac
         self.kernel = kernel
         self.fillval = fillval
-        self.weight_type = weight_type
+        self.weight_type = wht_type
         self.good_bits = good_bits
+
+        log.info(f"Driz parameter kernal: {self.kernel}")
+        log.info(f"Driz parameter pixfrac: {self.pixfrac}")
+        log.info(f"Driz parameter fillval: {self.fillval}")
+        log.info(f"Driz parameter weight_type: {self.weight_type}")
 
         ref_wcs = kwargs.get('ref_wcs', None)
         out_shape = kwargs.get('out_shape', None)

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -68,7 +68,7 @@ class ResampleData:
         self.weight_type = wht_type
         self.good_bits = good_bits
 
-        log.info(f"Driz parameter kernal: {self.kernel}")
+        log.info(f"Driz parameter kernel: {self.kernel}")
         log.info(f"Driz parameter pixfrac: {self.pixfrac}")
         log.info(f"Driz parameter fillval: {self.fillval}")
         log.info(f"Driz parameter weight_type: {self.weight_type}")

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -43,7 +43,7 @@ class ResampleSpecData(ResampleData):
     """
 
     def __init__(self, input_models, output=None, single=False, blendheaders=False,
-                 pixfrac=1.0, kernel="square", fillval=0, weight_type="ivm",
+                 pixfrac=1.0, kernel="square", fillval=0, wht_type="ivm",
                  good_bits=0, pscale_ratio=1.0, pscale=None, **kwargs):
         """
         Parameters
@@ -67,7 +67,7 @@ class ResampleSpecData(ResampleData):
         self.pixfrac = pixfrac
         self.kernel = kernel
         self.fillval = fillval
-        self.weight_type = weight_type
+        self.weight_type = wht_type
         self.good_bits = good_bits
 
         # Define output WCS based on all inputs, including a reference WCS
@@ -82,6 +82,11 @@ class ResampleSpecData(ResampleData):
         self.blank_output.update(self.input_models[0])
         self.blank_output.meta.wcs = self.output_wcs
         self.output_models = datamodels.ModelContainer()
+
+        log.info(f"Driz parameter kernal: {self.kernel}")
+        log.info(f"Driz parameter pixfrac: {self.pixfrac}")
+        log.info(f"Driz parameter fillval: {self.fillval}")
+        log.info(f"Driz parameter weight_type: {self.weight_type}")
 
     def build_nirspec_output_wcs(self, refmodel=None):
         """

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -25,6 +25,7 @@ class ResampleSpecStep(ResampleStep):
     class_alias = "resample_spec"
 
     def process(self, input):
+        self.wht_type = self.weight_type
         input_new = datamodels.open(input)
 
         # Convert ImageModel to SlitModel (needed for MIRI LRS)
@@ -61,11 +62,10 @@ class ResampleSpecStep(ResampleStep):
             kwargs['blendheaders'] = self.blendheaders
 
         kwargs['allowed_memory'] = self.allowed_memory
-        kwargs['weight_type'] = str(self.weight_type)
         kwargs['output'] = output
 
         # Issue a warning about the use of exptime weighting
-        if self.weight_type == 'exptime':
+        if self.wht_type == 'exptime':
             self.log.warning("Use of EXPTIME weighting will result in incorrect")
             self.log.warning("propagated errors in the resampled product")
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -36,7 +36,7 @@ class ResampleStep(Step):
         pixfrac = float(default=1.0) # change back to None when drizpar reference files are updated
         kernel = string(default='square') # change back to None when drizpar reference files are updated
         fillval = string(default='INDEF' ) # change back to None when drizpar reference files are updated
-        weight_type = option('ivm', 'exptime', None, default='ivm')  # change back to None when drizpar reference files are updated        
+        weight_type = option('ivm', 'exptime', None, default='ivm')  # change back to None when drizpar reference files are updated
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -36,7 +36,7 @@ class ResampleStep(Step):
         pixfrac = float(default=None)
         kernel = string(default=None)
         fillval = string(default=None)
-        weight_type = option('ivm', 'exptime', None,default=None)
+        weight_type = option('ivm', 'exptime', None, default=None)
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)
@@ -228,6 +228,12 @@ class ResampleStep(Step):
         if config.validate(Validator()):
             kwargs = config.dict()
 
+        if self.pixfrac is None:
+            self.pixfrac = 1.0
+        if self.kernel is None:
+            self.kernel = 'square'
+        if self.fillval is None:
+            self.fillval = 'INDEF'
         # Force definition of good bits
         kwargs['good_bits'] = GOOD_BITS
         kwargs['pixfrac'] = self.pixfrac
@@ -237,6 +243,7 @@ class ResampleStep(Step):
         # The other instruments read this parameter from a reference file
         if self.wht_type is None:
             self.wht_type = 'ivm'
+
         kwargs['wht_type'] = str(self.wht_type)
         kwargs['pscale_ratio'] = self.pixel_scale_ratio
         kwargs.pop('pixel_scale_ratio')

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -33,10 +33,10 @@ class ResampleStep(Step):
     class_alias = "resample"
 
     spec = """
-        pixfrac = float(default=None)
-        kernel = string(default=None)
-        fillval = string(default=None)
-        weight_type = option('ivm', 'exptime', None, default=None)
+        pixfrac = float(default=1.0) # change back to None when drizpar reference files are updated
+        kernel = string(default='square') # change back to None when drizpar reference files are updated
+        fillval = string(default='INDEF' ) # change back to None when drizpar reference files are updated
+        weight_type = option('ivm', 'exptime', None, default='ivm')  # change back to None when drizpar reference files are updated        
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -112,6 +112,8 @@ class ResampleStep(Step):
             util.update_s_region_imaging(model)
             model.meta.asn.pool_name = input_models.asn_pool_name
             model.meta.asn.table_name = input_models.asn_table_name
+            model.meta.resample.pixel_scale_ratio = self.pixel_scale_ratio
+            model.meta.resample.pixfrac = kwargs['pixfrac']
             self.update_phot_keywords(model)
 
         if len(result) == 1:
@@ -126,8 +128,6 @@ class ResampleStep(Step):
             model.meta.photometry.pixelarea_steradians *= self.pixel_scale_ratio**2
         if model.meta.photometry.pixelarea_arcsecsq is not None:
             model.meta.photometry.pixelarea_arcsecsq *= self.pixel_scale_ratio**2
-        model.meta.resample.pixel_scale_ratio = self.pixel_scale_ratio
-        model.meta.resample.pixfrac = self.pixfrac
 
     def get_drizpars(self, ref_filename, input_models):
         """

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -33,10 +33,10 @@ class ResampleStep(Step):
     class_alias = "resample"
 
     spec = """
-        pixfrac = float(default=1.0)
-        kernel = string(default='square')
-        fillval = string(default='INDEF')
-        weight_type = option('ivm', 'exptime', default='ivm')
+        pixfrac = float(default=None)
+        kernel = string(default=None)
+        fillval = string(default=None)
+        weight_type = option('ivm', 'exptime', None,default=None)
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)
@@ -74,6 +74,7 @@ class ResampleStep(Step):
             raise RuntimeError("Input {} is not a 2D image.".format(input_models[0]))
 
         # Get drizzle parameters reference file
+        self.wht_type = self.weight_type
         for reftype in self.reference_file_types:
             ref_filename = self.get_reference_file(input_models[0], reftype)
 
@@ -86,10 +87,9 @@ class ResampleStep(Step):
             kwargs = self._set_spec_defaults()
 
         kwargs['allowed_memory'] = self.allowed_memory
-        kwargs['weight_type'] = str(self.weight_type)
 
         # Issue a warning about the use of exptime weighting
-        if self.weight_type == 'exptime':
+        if self.wht_type == 'exptime':
             self.log.warning("Use of EXPTIME weighting will result in incorrect")
             self.log.warning("propagated errors in the resampled product")
 
@@ -140,6 +140,7 @@ class ResampleStep(Step):
         pixfrac = float(default=None)
         kernel = string(default=None)
         fillval = string(default=None)
+        wht_type = option('ivm', 'exptime', None,default=None)
 
         Once the defaults are set from the reference file, if the user has
         used a resample.cfg file or run ResampleStep using command line args,
@@ -177,11 +178,13 @@ class ResampleStep(Step):
         # Define the keys to pull from drizpars reffile table.
         # All values should be None unless the user set them on the command
         # line or in the call to the step
+
         drizpars = dict(
             pixfrac=self.pixfrac,
             kernel=self.kernel,
             fillval=self.fillval,
-            pscale_ratio=self.pixel_scale_ratio,
+            wht_type=self.wht_type
+            # pscale_ratio=self.pixel_scale_ratio, # I think this can be removed JEM (??)
         )
 
         # For parameters that are set in drizpars table but not set by the
@@ -227,16 +230,19 @@ class ResampleStep(Step):
 
         # Force definition of good bits
         kwargs['good_bits'] = GOOD_BITS
-
         kwargs['pixfrac'] = self.pixfrac
         kwargs['kernel'] = str(self.kernel)
         kwargs['fillval'] = str(self.fillval)
-        kwargs['weight_type'] = str(self.weight_type)
+        #  self.weight_type has a default value of None
+        # The other instruments read this parameter from a reference file
+        if self.wht_type is None:
+            self.wht_type = 'ivm'
+        kwargs['wht_type'] = str(self.wht_type)
         kwargs['pscale_ratio'] = self.pixel_scale_ratio
         kwargs.pop('pixel_scale_ratio')
 
         for k, v in kwargs.items():
-            if k in ['pixfrac', 'kernel', 'fillval', 'weight_type', 'pscale_ratio']:
+            if k in ['pixfrac', 'kernel', 'fillval', 'wht_type', 'pscale_ratio']:
                 log.info('  using: %s=%s', k, repr(v))
 
         return kwargs

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -36,7 +36,7 @@ class ResampleStep(Step):
         pixfrac = float(default=1.0) # change back to None when drizpar reference files are updated
         kernel = string(default='square') # change back to None when drizpar reference files are updated
         fillval = string(default='INDEF' ) # change back to None when drizpar reference files are updated
-        weight_type = option('ivm', 'exptime', None, default='ivm')  # change back to None when drizpar reference files are updated
+        weight_type = option('ivm', 'exptime', None, default='ivm')  # change back to None when drizpar ref update
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -140,7 +140,7 @@ class ResampleStep(Step):
         pixfrac = float(default=None)
         kernel = string(default=None)
         fillval = string(default=None)
-        wht_type = option('ivm', 'exptime', None,default=None)
+        wht_type = option('ivm', 'exptime', None, default=None)
 
         Once the defaults are set from the reference file, if the user has
         used a resample.cfg file or run ResampleStep using command line args,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Resolves [JP-2580](https://jira.stsci.edu/browse/JP-2580)

**Description**
The PR updates the resample_step to use the values read in from the drizpars reference file. The parameters in the reference file: pixfrac, weight_type, kernel, and fillval need to have defaults of None in the step spec. If they are not None, then the code assumes that the user has overridden the values.  In addition, the code was expecting pixel_scale_ratio to be in the drizpars reference file, instead of wht_type (weight_type). Since the reference file and data model expect the name of weight_type to be wht_type., self.wht_type was added and set to self.weight_type.

Checklist
- [ ] Tests
- [ ] Documentation
- [x] Change log
- [x] Milestone
- [x] Label(s)