### PR TITLE
Fix: skymatch not saving subtracted values for input ASN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,13 @@ general
 resample
 --------
 
-- Changed parameters read in from drizpar reference file to have a value of None in Spec [#6921] 
+- Changed parameters read in from drizpar reference file to have a value of None in Spec [#6921]
 
+skymatch
+--------
+
+- Fixed a bug in `skymatch` due to which subtracted values were not saved
+  in the input `cal` files when input was an association table. [#6922]
 
 
 source_catalog

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -63,7 +63,10 @@ class SkyMatchStep(Step):
 
     def process(self, input):
         self.log.setLevel(logging.DEBUG)
-        self._is_asn = datamodels.util.is_association(input) or isinstance(input, str)
+        # for now turn off memory optimization until we have better machinery
+        # to handle outputs in a consistent way.
+        self._is_asn = False
+        # self._is_asn = datamodels.util.is_association(input) or isinstance(input, str)
 
         img = datamodels.ModelContainer(
             input,

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -206,14 +206,18 @@ class SkyMatchStep(Step):
         return sky_im
 
     def _set_sky_background(self, image, sky, step_status):
+
         if self._is_asn:
-            image = datamodel_open(image)
+            dm = datamodel_open(image)
+        else:
+            dm = image
 
         if step_status == "COMPLETE":
-            image.meta.background.method = str(self.skymethod)
-            image.meta.background.level = sky
-            image.meta.background.subtracted = self.subtract
-        image.meta.cal_step.skymatch = step_status
+            dm.meta.background.method = str(self.skymethod)
+            dm.meta.background.level = sky
+            dm.meta.background.subtracted = self.subtract
+        dm.meta.cal_step.skymatch = step_status
 
         if self._is_asn:
-            image.close()
+            dm.save(image)
+            dm.close()


### PR DESCRIPTION
Closes #6920

This PR fixes the bug due to which `skymatch` step was not saving changes to the data models (computed/subtracted sky levels) when inputs are ASN files.

CC: @astroferreira

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
