### PR TITLE
Update NIS_SOSS regtest with in-flight data

### DIFF
--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -10,7 +10,7 @@ def run_tso_spec2(jail, rtdata_module):
     rtdata = rtdata_module
 
     # Run tso-spec2 pipeline on the first _rateints file, saving intermediate products
-    rtdata.get_data("niriss/soss/jw00625023001_03101_00001-seg001_nis_rateints.fits")
+    rtdata.get_data("niriss/soss/jw01091002001_03101_00001-seg001_nis_short_rateints.fits")
     args = ["calwebb_spec2", rtdata.input,
             "--steps.flat_field.save_results=True",
             "--steps.srctype.save_results=True",
@@ -19,7 +19,7 @@ def run_tso_spec2(jail, rtdata_module):
 
     # Run tso-spec2 pipeline on the second _rateints file, without saving or
     # checking any results (simply create a fresh input for level-3 test)
-    rtdata.get_data("niriss/soss/jw00625023001_03101_00001-seg002_nis_rateints.fits")
+    rtdata.get_data("niriss/soss/jw01091002001_03101_00001-seg002_nis_short_rateints.fits")
     args = ["calwebb_spec2", rtdata.input]
     Step.from_cmdline(args)
 
@@ -30,10 +30,8 @@ def run_tso_spec3(jail, rtdata_module, run_tso_spec2):
     rtdata = rtdata_module
     # Get the level3 association json file (though not its members) and run
     # the tso3 pipeline on all _calints files listed in association
-    rtdata.get_data("niriss/soss/jw00625-o023_20191210t204036_tso3_001_asn.json")
-    args = ["calwebb_tso3", rtdata.input,
-            "--steps.outlier_detection.snr=13.0 10.0",
-            ]
+    rtdata.get_data("niriss/soss/jw01091-o002_20220714t155100_tso3_001_asn.json")
+    args = ["calwebb_tso3", rtdata.input]
     Step.from_cmdline(args)
 
 
@@ -42,7 +40,7 @@ def run_tso_spec3(jail, rtdata_module, run_tso_spec2):
 def test_niriss_soss_stage2(rtdata_module, run_tso_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test of tso-spec2 pipeline performed on NIRISS SOSS data."""
     rtdata = rtdata_module
-    output = f"jw00625023001_03101_00001-seg001_nis_{suffix}.fits"
+    output = f"jw01091002001_03101_00001-seg001_nis_short_{suffix}.fits"
     rtdata.output = output
 
     rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
@@ -55,7 +53,7 @@ def test_niriss_soss_stage2(rtdata_module, run_tso_spec2, fitsdiff_default_kwarg
 def test_niriss_soss_stage3_crfints(rtdata_module, run_tso_spec3, fitsdiff_default_kwargs):
     """Regression test of tso-spec3 pipeline outlier_detection results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
-    output = "jw00625023001_03101_00001-seg001_nis_o023_crfints.fits"
+    output = "jw01091002001_03101_00001-seg001_nis_short_o002_crfints.fits"
     rtdata.output = output
 
     rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
@@ -69,7 +67,7 @@ def test_niriss_soss_stage3_x1dints(run_tso_spec3, rtdata_module, fitsdiff_defau
     """Regression test of tso-spec3 pipeline extract_1d results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
 
-    output = "jw00625-o023_t001_niriss_clear-gr700xd-substrip256_x1dints.fits"
+    output = "jw01091-o002_t001_niriss_clear-gr700xd-substrip256_x1dints.fits"
     rtdata.output = output
     rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
 
@@ -82,7 +80,7 @@ def test_niriss_soss_stage3_whtlt(run_tso_spec3, rtdata_module, diff_astropy_tab
     """Regression test of tso-spec3 pipeline white_light results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
 
-    output = "jw00625-o023_t001_niriss_clear-gr700xd-substrip256_whtlt.ecsv"
+    output = "jw01091-o002_t001_niriss_clear-gr700xd-substrip256_whtlt.ecsv"
     rtdata.output = output
     rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- describe the changes comprising this PR here -->
This PR addresses updates our regression test of NIRISS SOSS data to use in-flight data. The data itself consists of an exposure that has been segmented (which is usually the case for TSO data), where I'm including just the first 2 segments and have also trimmed down the data in each segment to only contain 10 integrations each (originally 190 each), just to save processing time.

**Checklist**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
