### PR TITLE
pin `certifi` to `2022.5.18.1`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     asdf>=2.12.0
     astropy>=5.0.4
     BayesicFitting>=3.0.1
+    certifi==2022.5.18.1
     crds>=11.16.5
     drizzle>=1.13.4
     gwcs>=0.18.0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
`certifi` has an issue with `pip freeze` (see https://github.com/conda/conda/issues/11580) that fails the DMS build pipeline on Jenkins (see https://plwishmaster.stsci.edu:8081/job/Releases/job/JWSTDP/62/console)

Thus, `certifi` should be pinned to a previous version until this issue is resolved.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
