### PR TITLE
JP-2676: Fix units of source catalog error array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ general
 
 -
 
+source_catalog
+--------------
+
+- Fixed the actual units of the error array used to calculate
+  photometric errors. [#6928]
+
 1.6.1 (2022-07-15)
 ==================
 

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -110,15 +110,20 @@ class JWSTSourceCatalog:
         Convert the data and errors from MJy/sr to Jy and convert to
         `~astropy.unit.Quantity` objects.
         """
-        if self.model.meta.bunit_data != 'MJy/sr':
-            raise ValueError('data is expected to be in units of MJy/sr')
-        self.model.data *= (1.e6
-                            * self.model.meta.photometry.pixelarea_steradians)
-        self.model.meta.bunit_data = 'Jy'
+        in_unit = 'MJy/sr'
+        if (self.model.meta.bunit_data != in_unit
+                or self.model.meta.bunit_err != in_unit):
+            raise ValueError('data and err are expected to be in units of '
+                             'MJy/sr')
 
         unit = u.Jy
+        to_jy = 1.e6 * self.model.meta.photometry.pixelarea_steradians
+        self.model.data *= to_jy
+        self.model.err *= to_jy
         self.model.data <<= unit
         self.model.err <<= unit
+        self.model.meta.bunit_data = unit.name
+        self.model.meta.bunit_err = unit.name
 
     @staticmethod
     def convert_flux_to_abmag(flux, flux_err):

--- a/jwst/source_catalog/tests/test_source_catalog.py
+++ b/jwst/source_catalog/tests/test_source_catalog.py
@@ -20,8 +20,10 @@ def nircam_model():
 
     wht = np.ones(data.shape)
     wht[0:10, :] = 0.
-    model = ImageModel(data, wht=wht)
+    err = np.abs(data) / 10.
+    model = ImageModel(data, wht=wht, err=err)
     model.meta.bunit_data = 'MJy/sr'
+    model.meta.bunit_err = 'MJy/sr'
     model.meta.photometry.pixelarea_steradians = 1.0
     model.meta.wcs = make_gwcs(data.shape)
     model.meta.wcsinfo = {
@@ -67,8 +69,10 @@ def nircam_model_without_apcorr():
 
     wht = np.ones(data.shape)
     wht[0:10, :] = 0.
-    model = ImageModel(data, wht=wht)
+    err = np.abs(data) / 10.
+    model = ImageModel(data, wht=wht, err=err)
     model.meta.bunit_data = 'MJy/sr'
+    model.meta.bunit_err = 'MJy/sr'
     model.meta.photometry.pixelarea_steradians = 1.0
     model.meta.wcs = make_gwcs(data.shape)
     model.meta.wcsinfo = {
@@ -110,6 +114,8 @@ def test_source_catalog(nircam_model, npixels, nsources):
         assert nsources == 0
     else:
         assert len(cat) == nsources
+        min_snr = np.min(cat['isophotal_flux'] / cat['isophotal_flux_err'])
+        assert min_snr >= 100
 
 
 def test_model_without_apcorr_data(nircam_model_without_apcorr):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2676](https://jira.stsci.edu/browse/JP-2676)

<!-- describe the changes comprising this PR here -->
This PR fixes the units on the error array used in the source catalog step to calculate photometric errors. The unit-conversion function was written before the `i2d` data contained an `err` array and unfortunately wasn't updated subsequently to apply the MJy/sr to Jy unit conversion to the error array.

I'm not sure how to milestone this.  Do you want to get it in B8.1?

**Checklist**
- [X] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [X] added relevant label(s)
