### PR TITLE
JP-2677: Copy int_times keywords to output spectrum extensions for SOSS ATOCA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.6.3 (unreleased)
 ==================
 
+extract_1d
+----------
+
+- Update int_times keywords in SOSS spectral output [#6930]
+
 general
 -------
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -3097,8 +3097,8 @@ def populate_time_keywords(
 
     n = 0  # Counter for spectra in output_model.
 
-    for j in range(num_j):  # for each spectrum or order
-        for k in range(num_integ):  # for each integration
+    for k in range(num_integ):  # for each spectrum or order
+        for j in range(num_j):  # for each integration
             row = k + offset
             spec = output_model.spec[n]  # n is incremented below
             spec.int_num = int_num[row]

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -790,5 +790,6 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
     if pipe_utils.is_tso(input_model):
         log.info("Populating INT_TIMES keywords from input table.")
         populate_time_keywords(input_model, output_model)
+        output_model.int_times = input_model.int_times.copy()
 
     return output_model, output_references

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -3,6 +3,8 @@ import logging
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 
+from ..extract import populate_time_keywords
+from ...lib import pipe_utils
 from ... import datamodels
 from ...datamodels import dqflags
 from astropy.nddata.bitmask import bitfield_to_boolean_mask
@@ -784,5 +786,9 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
         # Save
         order_int = order_str_2_int[order]
         setattr(output_references, f'aperture{order_int}', box_w_ord)
+
+    if pipe_utils.is_tso(input_model):
+        log.info(f"Populating INT_TIMES keywords from input table.")
+        populate_time_keywords(input_model, output_model)
 
     return output_model, output_references

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -788,7 +788,7 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
         setattr(output_references, f'aperture{order_int}', box_w_ord)
 
     if pipe_utils.is_tso(input_model):
-        log.info(f"Populating INT_TIMES keywords from input table.")
+        log.info("Populating INT_TIMES keywords from input table.")
         populate_time_keywords(input_model, output_model)
 
     return output_model, output_references


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2677](https://jira.stsci.edu/browse/JP-2677)

<!-- describe the changes comprising this PR here -->
This PR adds back the int_times keywords to SOSS spectral products that have gone missing since the implementation of the ATOCA algorithm.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
