### PR TITLE
JP-2607: Minimize memory usage in mrs_imatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,19 @@ general
 
 -
 
+mrs_imatch
+----------
+
+- Use data containers from ``wiimatch`` to reduce memory usage by storing
+  data arrays in temporary files and loading them as necessary instead of
+  keeping them loaded in memory at all times. [#6931]
+
+skymatch
+--------
+
+- Replace data "accessor" classes with data containers from ``wiimatch``. [#6931]
+
+
 1.6.2 (2022-07-19)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     stsci.imagestats>=1.6.3
     tweakwcs>=0.7.2
     asdf-astropy>=0.2.1
-    wiimatch>=0.2.1
+    wiimatch>=0.3.1
 
 [options.extras_require]
 aws =


### PR DESCRIPTION
Resolves [JP-2607](https://jira.stsci.edu/browse/JP-2607)

This PR uses data container machinery implemented in `wiimatch version>=0.3.0` to reduce memory usage by the `mrs_imatch` step. Further memory reduction can be implemented separately in `wiimatch` (not expected to be significant) and also by not opening or returning all input files to the step at once. This last issue (not opening all files at once) requires some changes to how pipeline handles ASN tables - see some discussion of issues in https://github.com/spacetelescope/jwst/pull/6922.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
