### PR TITLE
JP-2688: Skymatch - Update datamodel data when subtract is True

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ general
 
 -
 
+skymatch
+--------
+
+- Fixed a bug in ``skymatch`` due to which computed background values were
+  not subtracted from image data when ``subtract=True``. [#6934]
+
+
 1.6.2 (2022-07-19)
 ==================
 
@@ -28,7 +35,7 @@ residual_fringe
 skymatch
 --------
 
-- Fixed a bug in `skymatch` due to which subtracted values were not saved
+- Fixed a bug in ``skymatch`` due to which subtracted values were not saved
   in the inputs when input was an association table. [#6922]
 
 source_catalog


### PR DESCRIPTION
Resolves [JP-2688](https://jira.stsci.edu/browse/JP-2688)

Memory saving features introduced a bug in the `skymatch` step due to which background value is not subtracted from image model data even though step parameter `subtract` is set to True. This is due to how data now are written/saved to temporary files and the machinery involved in this. Due to these changes, the background was subtracted from a copy of the datamodel's array instead from original array.

This PR makes sure that model data are updated with matched/subtracted data values at the end of the step upon successful completion of the step.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
