### PR TITLE
JP-2690: Convenience function for updating FITS WCS info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ general
 
 -
 
+assign_wcs
+----------
+
+- Added convenience function ``update_fits_wcsinfo()`` to ``assign_wcs.util``
+  module to allow easy updating of FITS WCS stored in ``datamodel.meta.wcsinfo``
+  from data model's GWCS. [#6935]
+
 skymatch
 --------
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,6 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 APIDIR        = api
-GENERATEDDIR  = generated
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -47,7 +46,6 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 	-rm -rf $(APIDIR)/*
-	-rm -rf $(GENERATEDDIR)/*
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,7 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 APIDIR        = api
+GENERATEDDIR  = generated
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -46,6 +47,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 	-rm -rf $(APIDIR)/*
+	-rm -rf $(GENERATEDDIR)/*
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,8 +28,8 @@ def setup(app):
     except AttributeError:
         app.add_stylesheet("stsci.css")
 
-conf = ConfigParser()
 
+conf = ConfigParser()
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -43,7 +43,7 @@ conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.3'
+# needs_sphinx = '1.3'
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -64,7 +64,8 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/devdocs', None),
     'scipy': ('http://scipy.github.io/devdocs', None),
     'matplotlib': ('http://matplotlib.org/', None),
-    }
+    'gwcs': ('https://gwcs.readthedocs.io/en/stable/', None),
+}
 
 if sys.version_info[0] == 2:
     intersphinx_mapping['python'] = ('http://docs.python.org/2/', None)
@@ -95,7 +96,7 @@ extensions = [
     'sphinx_automodapi.autodoc_enhancements',
     'sphinx_automodapi.smart_resolver',
     'sphinx_asdf',
-    ]
+]
 
 
 if on_rtd:
@@ -232,13 +233,12 @@ html_theme = 'stsci_rtd_theme'
 # documentation.
 html_theme_options = {
     "collapse_navigation": True
-    }
-#        "nosidebar": "false",
-#        "sidebarbgcolor": "#4db8ff",
-#        "sidebartextcolor": "black",
-#        "sidebarlinkcolor": "black",
-#        "headbgcolor": "white",
-#        }
+    # "nosidebar": "false",
+    # "sidebarbgcolor": "#4db8ff",
+    # "sidebartextcolor": "black",
+    # "sidebarlinkcolor": "black",
+    # "headbgcolor": "white",
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
@@ -328,8 +328,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'jwst.tex', u'JWST Pipeline Documentation',
-   u'jwst', 'manual'),
+    ('index', 'jwst.tex', u'JWST Pipeline Documentation', u'jwst', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -372,9 +371,8 @@ man_show_urls = True
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'jwst', u'JWST Pipeline Documentation',
-   u'jwst', 'jwst', 'JWST Pipeline Documentation',
-   'Miscellaneous'),
+    ('index', 'jwst', u'JWST Pipeline Documentation',
+     u'jwst', 'jwst', 'JWST Pipeline Documentation', 'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/jwst/assign_wcs/__init__.py
+++ b/jwst/assign_wcs/__init__.py
@@ -1,7 +1,7 @@
 from .assign_wcs_step import AssignWcsStep
 from .nirspec import (nrs_wcs_set_input, nrs_ifu_wcs, get_spectral_order_wrange)
 from .niriss import niriss_soss_set_input
-
+from .util import update_fits_wcsinfo
 
 __all__ = ['AssignWcsStep', "nrs_wcs_set_input", "nrs_ifu_wcs", "get_spectral_order_wrange",
-           "niriss_soss_set_input"]
+           "niriss_soss_set_input", "update_fits_wcsinfo"]

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -95,8 +95,6 @@ class AssignWcsStep(Step):
         if not (result.meta.exposure.type.lower() in IMAGING_TYPES and self.sip_approx):
             return result
 
-        (result, )
-
         # fit sip approx., degree is chosen by best fit
         try:
             update_fits_wcsinfo(
@@ -109,7 +107,10 @@ class AssignWcsStep(Step):
                 crpix=None
             )
 
-        except ValueError:
+        except ValueError as e:
+            log.warning("Failed to update 'meta.wcsinfo' with FITS SIP "
+                        f'approximation. Reported error is:\n"{e.args[0]}"')
+
             pass
 
         return result

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -4,16 +4,13 @@ from .. import datamodels
 from ..lib.exposure_types import IMAGING_TYPES
 import logging
 from .assign_wcs import load_wcs
-from .util import MSAFileError
+from .util import MSAFileError, update_fits_wcsinfo
 
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 __all__ = ["AssignWcsStep"]
-
-
-_MAX_SIP_DEGREE = 6
 
 
 class AssignWcsStep(Step):
@@ -98,38 +95,21 @@ class AssignWcsStep(Step):
         if not (result.meta.exposure.type.lower() in IMAGING_TYPES and self.sip_approx):
             return result
 
+        (result, )
+
         # fit sip approx., degree is chosen by best fit
-        sip_degree = range(1, _MAX_SIP_DEGREE) if self.sip_degree is None else self.sip_degree
-        sip_inv_degree = range(1, _MAX_SIP_DEGREE) if self.sip_inv_degree is None else self.sip_inv_degree
-        crpix = [result.meta.wcsinfo.crpix1, result.meta.wcsinfo.crpix2]
-        crpix = None if None in crpix else crpix
         try:
-            fit_sip_hdr = result.meta.wcs.to_fits_sip(
+            update_fits_wcsinfo(
+                result,
                 max_pix_error=self.sip_max_pix_error,
-                degree=sip_degree,
+                degree=self.sip_degree,
                 max_inv_pix_error=self.sip_max_inv_pix_error,
-                inv_degree=sip_inv_degree,
+                inv_degree=self.sip_inv_degree,
                 npoints=self.sip_npoints,
-                crpix=crpix
+                crpix=None
             )
 
         except ValueError:
-            return result
-
-        # update meta.wcs_info with fit keywords except for naxis*
-        del fit_sip_hdr['naxis*']
-
-        # maintain convention of lowercase keys
-        fit_sip_hdr = {k.lower(): v for k, v in fit_sip_hdr.items()}
-
-        # delete naxis, cdelt, pc from wcsinfo
-        rm_keys = ['naxis', 'cdelt1', 'cdelt2',
-                   'pc1_1', 'pc1_2', 'pc2_1', 'pc2_2']
-        for key in rm_keys:
-            if key in result.meta.wcsinfo.instance:
-                del result.meta.wcsinfo.instance[key]
-
-        # update meta.wcs_info with fit keywords
-        result.meta.wcsinfo.instance.update(fit_sip_hdr)
+            pass
 
         return result

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -1258,7 +1258,7 @@ def update_fits_wcsinfo(datamodel, max_pix_error=0.01, degree=None, npoints=32,
     The default mode in using this attempts to achieve roughly 0.01 pixel
     accuracy over the entire image.
 
-    This function uses on the :py:meth:`~gwcs.wcs.WCS.to_fits_sip` to
+    This function uses the :py:meth:`~gwcs.wcs.WCS.to_fits_sip` to
     create FITS WCS representations of GWCS objects. Only most important
     :py:meth:`~gwcs.wcs.WCS.to_fits_sip` parameters are exposed here. Other
     arguments to :py:meth:`~gwcs.wcs.WCS.to_fits_sip` can be passed via

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -30,9 +30,12 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
+_MAX_SIP_DEGREE = 6
+
+
 __all__ = ["reproject", "wcs_from_footprints", "velocity_correction",
            "MSAFileError", "NoDataOnDetectorError", "compute_scale",
-           "calc_rotation_matrix", "wrap_ra"]
+           "calc_rotation_matrix", "wrap_ra", "update_fits_wcsinfo"]
 
 
 class MSAFileError(Exception):
@@ -1243,3 +1246,177 @@ def in_ifu_slice(slice_wcs, ra, dec, lam):
     onslice_ind = np.isclose(slx, SLX,atol=5e-4)
 
     return onslice_ind
+
+
+def update_fits_wcsinfo(datamodel, max_pix_error=0.01, degree=None, npoints=32,
+                        crpix=None, projection='TAN', **kwargs):
+    """
+    For imaging data models *only*, update data model's ``meta.wcsinfo``
+    attribute using a FITS SIP approximation of the current data model's
+    GWCS from ``meta.wcs``.
+
+    The default mode in using this attempts to achieve roughly 0.01 pixel
+    accuracy over the entire image.
+
+    This function uses on the :py:meth:`~gwcs.wcs.WCS.to_fits_sip` to
+    create FITS WCS representations of GWCS objects. Only most important
+    :py:meth:`~gwcs.wcs.WCS.to_fits_sip` parameters are exposed here. Other
+    arguments to :py:meth:`~gwcs.wcs.WCS.to_fits_sip` can be passed via
+    ``kwargs`` - see "Other Parameters" section below.
+    Please refer to the documentation of :py:meth:`~gwcs.wcs.WCS.to_fits_sip`
+    for more details.
+
+    .. warning::
+        This function modifies input data model's ``datamodel.meta.wcsinfo``
+        members.
+
+
+    Parameters
+    ----------
+
+    max_pix_error : float, optional
+        Maximum allowed error over the domain of the pixel array. This
+        error is the equivalent pixel error that corresponds to the maximum
+        error in the output coordinate resulting from the fit based on
+        a nominal plate scale.
+
+    degree : int, iterable, None, optional
+        Degree of the SIP polynomial. Default value `None` indicates that
+        all allowed degree values (``[1...6]``) will be considered and
+        the lowest degree that meets accuracy requerements set by
+        ``max_pix_error`` will be returned. Alternatively, ``degree`` can be
+        an iterable containing allowed values for the SIP polynomial degree.
+        This option is similar to default `None` but it allows caller to
+        restrict the range of allowed SIP degrees used for fitting.
+        Finally, ``degree`` can be an integer indicating the exact SIP degree
+        to be fit to the WCS transformation. In this case
+        ``max_pixel_error`` is ignored.
+
+    npoints : int, optional
+        The number of points in each dimension to sample the bounding box
+        for use in the SIP fit. Minimum number of points is 3.
+
+    crpix : list of float, None, optional
+        Coordinates (1-based) of the reference point for the new FITS WCS.
+        When not provided, i.e., when set to `None` (default) the reference
+        pixel already specified in ``wcsinfo`` will be re-used. If
+        ``wcsinfo`` does not contain ``crpix`` information, then the
+        reference pixel will be chosen near the center of the bounding box
+        for axes corresponding to the celestial frame.
+
+    projection : str, `~astropy.modeling.projections.Pix2SkyProjection`, optional
+        Projection to be used for the created FITS WCS. It can be specified
+        as a string of three characters specifying a FITS projection code
+        from Table 13 in
+        `Representations of World Coordinates in FITS \
+        <https://doi.org/10.1051/0004-6361:20021326>`_
+        (Paper I), Greisen, E. W., and Calabretta, M. R., A & A, 395,
+        1061-1075, 2002. Alternatively, it can be an instance of one of the
+        `astropy's Pix2Sky_* <https://docs.astropy.org/en/stable/modeling/\
+        reference_api.html#module-astropy.modeling.projections>`_
+        projection models inherited from
+        :py:class:`~astropy.modeling.projections.Pix2SkyProjection`.
+
+
+    Other Parameters
+    ----------------
+
+    max_inv_pix_error : float, None, optional
+        Maximum allowed inverse error over the domain of the pixel array
+        in pixel units. With the default value of `None` no inverse
+        is generated.
+
+    inv_degree : int, iterable, None, optional
+        Degree of the SIP polynomial. Default value `None` indicates that
+        all allowed degree values (``[1...6]``) will be considered and
+        the lowest degree that meets accuracy requerements set by
+        ``max_pix_error`` will be returned. Alternatively, ``degree`` can be
+        an iterable containing allowed values for the SIP polynomial degree.
+        This option is similar to default `None` but it allows caller to
+        restrict the range of allowed SIP degrees used for fitting.
+        Finally, ``degree`` can be an integer indicating the exact SIP degree
+        to be fit to the WCS transformation. In this case
+        ``max_inv_pixel_error`` is ignored.
+
+    bounding_box : tuple, None, optional
+        A pair of tuples, each consisting of two numbers
+        Represents the range of pixel values in both dimensions
+        ((xmin, xmax), (ymin, ymax))
+
+    verbose : bool, optional
+        Print progress of fits.
+
+
+    Returns
+    -------
+    FITS header with all SIP WCS keywords
+
+
+    Raises
+    ------
+    ValueError
+        If the WCS is not at least 2D, an exception will be raised. If the
+        specified accuracy (both forward and inverse, both rms and maximum)
+        is not achieved an exception will be raised.
+
+
+    Notes
+    -----
+
+    Use of this requires a judicious choice of required accuracies.
+    Attempts to use higher degrees (~7 or higher) will typically fail due
+    to floating point problems that arise with high powers.
+
+    For more details, see :py:meth:`~gwcs.wcs.WCS.to_fits_sip`.
+
+    """
+    # make a copy of kwargs:
+    kwargs = {k: v for k, v in kwargs.items()}
+
+    # override default values for "other parameters":
+    max_inv_pix_error = kwargs.pop('max_inv_pix_error', None)
+    inv_degree = kwargs.pop('inv_degree', None)
+    if inv_degree is None:
+        inv_degree = range(1, _MAX_SIP_DEGREE)
+
+    # limit default 'degree' range to _MAX_SIP_DEGREE:
+    if degree is None:
+        degree = range(1, _MAX_SIP_DEGREE)
+
+    if crpix is None:
+        crpix = [datamodel.meta.wcsinfo.crpix1, datamodel.meta.wcsinfo.crpix2]
+    if None in crpix:
+        crpix = None
+
+    hdr = datamodel.meta.wcs.to_fits_sip(
+        max_pix_error=max_pix_error,
+        degree=degree,
+        max_inv_pix_error=max_inv_pix_error,
+        inv_degree=inv_degree,
+        npoints=npoints,
+        crpix=crpix,
+        **kwargs
+    )
+
+    # update meta.wcs_info with fit keywords except for naxis*
+    del hdr['naxis*']
+
+    # maintain convention of lowercase keys
+    hdr_dict = {k.lower(): v for k, v in hdr.items()}
+
+    # delete naxis, cdelt, pc from wcsinfo
+    rm_keys = ['naxis', 'cdelt1', 'cdelt2',
+               'pc1_1', 'pc1_2', 'pc2_1', 'pc2_2',
+               'a_order', 'b_order', 'ap_order', 'bp_order']
+
+    rm_keys.extend(f"{s}_{i}_{j}" for i in range(10) for j in range(10)
+                   for s in ['a', 'b', 'ap', 'bp'])
+
+    for key in rm_keys:
+        if key in datamodel.meta.wcsinfo.instance:
+            del datamodel.meta.wcsinfo.instance[key]
+
+    # update meta.wcs_info with fit keywords
+    datamodel.meta.wcsinfo.instance.update(hdr_dict)
+
+    return hdr


### PR DESCRIPTION
Resolves [JP-2690](https://jira.stsci.edu/browse/JP-2690)

Numerous users both on Slack and in the helpdesk are asking about updating FITS WCS info from the current GWCS stored in data model's `meta.wcs`. This PR adds a convenience function `update_fits_wcsinfo()` to `assign_wcs.util` module and modifies `assign_wcs` to call this convenience function.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
