### PR TITLE
JP-2691: Update FITS WCS wcsinfo field at the end of tweakreg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,12 @@ skymatch
 - Fixed a bug in ``skymatch`` due to which computed background values were
   not subtracted from image data when ``subtract=True``. [#6934]
 
+tweakreg
+--------
+
+- ``tweakreg`` step now updates FITS WCS stored in ``datamodel.meta.wcsinfo``
+  from data model's tweaked GWCS. [#6936]
+
 
 1.6.2 (2022-07-19)
 ==================

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -16,7 +16,7 @@ from tweakwcs.matchutils import TPMatch
 # LOCAL
 from ..stpipe import Step
 from .. import datamodels
-
+from ..assign_wcs.util import update_fits_wcsinfo
 from . import astrometric_utils as amutils
 from .tweakreg_catalog import make_tweakreg_catalog
 
@@ -319,16 +319,9 @@ class TweakRegStep(Step):
 
                 imcat.meta['image_model'].meta.wcs = imcat.wcs
 
-                """
                 # Also update FITS representation in input exposures for
                 # subsequent reprocessing by the end-user.
-                # Not currently enabled, but may be requested later...
-                gwcs_header = imcat.wcs.to_fits_sip(max_pix_error=0.1,
-                                                max_inv_pix_error=0.1,
-                                                degree=3,
-                                                npoints=128)
-                imcat.meta['image_model'].wcs = wcs.WCS(header=gwcs_header)
-                """
+                update_fits_wcsinfo(imcat.meta['image_model'])
 
         return images
 


### PR DESCRIPTION
Resolves [JP-2691](https://jira.stsci.edu/browse/JP-2691)
Resolves [JP-2586](https://jira.stsci.edu/browse/JP-2586)

This PR implements `FITS WCS` update at the end of `tweakreg` step if the `GWCS` of a data model was "tweaked" by `tweakreg`.

This PR will need to be rebased after #6935 is merged. It depends on that #6935. Initially unit tests will fail because of this.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
