### PR TITLE
Match FITS keywords to KWD (JP-1754)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,19 @@ general
 
 -
 
+assign_wcs
+----------
+
+- Added convenience function ``update_fits_wcsinfo()`` to ``assign_wcs.util``
+  module to allow easy updating of FITS WCS stored in ``datamodel.meta.wcsinfo``
+  from data model's GWCS. [#6935]
+
+datamodels
+----------
+
+- Updated keyword titles in data model schemas to match those in keyword
+  dictionary. [#6937]
+  
 skymatch
 --------
 

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -644,7 +644,7 @@ properties:
             fits_keyword: EXP_TYPE
             blend_table: True
           start_time:
-            title: UTC exposure start time
+            title: "[d] exposure start time in MJD"
             type: number
             fits_keyword: EXPSTART
             blend_table: True
@@ -657,7 +657,7 @@ properties:
             blend_table: True
             blend_rule: min
           mid_time:
-            title: UTC exposure mid time
+            title: "[d] exposure mid time in MJD"
             type: number
             fits_keyword: EXPMID
             blend_table: True
@@ -670,7 +670,7 @@ properties:
             blend_table: True
             blend_rule: mean
           end_time:
-            title: UTC exposure end time
+            title: "[d] exposure end time in MJD"
             type: number
             fits_keyword: EXPEND
             blend_table: True
@@ -798,12 +798,12 @@ properties:
             fits_keyword: GROUPGAP
             blend_table: True
           drop_frames1:
-            title: Frames dropped at start of each integration
+            title: Number of frames dropped prior to first integration
             type: integer
             fits_keyword: DRPFRMS1
             blend_table: True
           drop_frames3:
-            title: Frames dropped at end of each integration
+            title: Number of frames dropped between integrations
             type: integer
             fits_keyword: DRPFRMS3
             blend_table: True
@@ -1148,7 +1148,7 @@ properties:
             fits_keyword: PRIDTPTS
             blend_table: True
           position_number:
-            title: Position number in primary pattern
+            title: Position number within dither pattern
             type: integer
             fits_keyword: PATT_NUM
             blend_table: True
@@ -1296,7 +1296,7 @@ properties:
             fits_hdu: SCI
             blend_table: True
           time:
-            title: UTC time of position and velocity vectors in ephemeris (MJD)
+            title: [d] MJD time of position and velocity vectors
             type: number
             fits_keyword: EPH_TIME
             fits_hdu: SCI

--- a/jwst/datamodels/schemas/mirlrs_pathloss.schema.yaml
+++ b/jwst/datamodels/schemas/mirlrs_pathloss.schema.yaml
@@ -61,24 +61,24 @@ allOf:
               fits_keyword: CRVAL2
               fits_hdu: PATHLOSS
             cdelt1:
-              title: Axis 1 increment per pixel
+              title: Axis 1 coordinate increment at reference point 
               type: number
               default: 1.0
               fits_keyword: CDELT1
               fits_hdu: PATHLOSS
             cdelt2:
-              title: Axis 2 increment per pixel
+              title: Axis 2 coordinate increment at reference point 
               type: number
               default: 1.0
               fits_keyword: CDELT2
               fits_hdu: PATHLOSS
             ctype1:
-              title: Axis 1 coordinate type
+              title: Axis 1 type
               type: string
               fits_keyword: CTYPE1
               fits_hdu: PATHLOSS
             ctype2:
-              title: Axis 2 coordinate type
+              title: Axis 2 type
               type: string
               fits_keyword: CTYPE2
               fits_hdu: PATHLOSS

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -108,55 +108,55 @@ properties:
             fits_hdu: SCI
             blend_table: True
           ctype1:
-            title: first axis coordinate type
-            type: string
+            title: Axis 1 type
+            type: string 
             fits_keyword: CTYPE1
             fits_hdu: SCI
             blend_table: True
           ctype2:
-            title: second axis coordinate type
+            title: Axis 2 type
             type: string
             fits_keyword: CTYPE2
             fits_hdu: SCI
             blend_table: True
           ctype3:
-            title: third axis coordinate type
+            title: Axis 3 type
             type: string
             fits_keyword: CTYPE3
             fits_hdu: SCI
             blend_table: True
           cunit1:
-            title: first axis units
+            title: Axis 1 units
             type: string
             fits_keyword: CUNIT1
             fits_hdu: SCI
             blend_table: True
           cunit2:
-            title: second axis units
+            title: Axis 2 units
             type: string
             fits_keyword: CUNIT2
             fits_hdu: SCI
             blend_table: True
           cunit3:
-            title: third axis units
+            title: Axis 3 units
             type: string
             fits_keyword: CUNIT3
             fits_hdu: SCI
             blend_table: True
           cdelt1:
-            title: first axis increment per pixel
+            title: Axis 1 coordinate increment at reference point
             type: number
             fits_keyword: CDELT1
             fits_hdu: SCI
             blend_table: True
           cdelt2:
-            title: second axis increment per pixel
+            title: Axis 2 coordinate increment at reference point
             type: number
             fits_keyword: CDELT2
             fits_hdu: SCI
             blend_table: True
           cdelt3:
-            title: third axis increment per pixel
+            title: Axis 3 coordinate increment at reference point
             type: number
             fits_keyword: CDELT3
             fits_hdu: SCI


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-1754](https://jira.stsci.edu/browse/JP-1754)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses inconsistencies between the descriptions (titles) of keywords in FITS files and their descriptions in the Keyword Dictionary. In many cases, the data models schemas are updated to match the KWD. In other cases, the keyword titles are written by astropy.io so are left unchanged. 

**Checklist**
- [X] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
