### PR TITLE
JP-2687: Allow alignment of a single image/group to Gaia bypassing first alignment stage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,8 +16,8 @@ ami_analyze
 -----------
 
 - Revert Fourier Transform code to avoid using Poppy which was recently updated
-  to use a different sign convention.[#6967]  
-  
+  to use a different sign convention.[#6967]
+
 assign_wcs
 ----------
 
@@ -67,6 +67,11 @@ tweakreg
 
 - The ``tweakreg`` step now masks ``NON_SCIENCE`` pixels when
   calculating the source detection theshold. [#6940]
+
+- Allow alignment of a single image (or group) to Gaia while skipping relative
+  alignment (whcih needs 2 images) instead of cancelling  the entire
+  step. [#6938]
+
 
 1.6.2 (2022-07-19)
 ==================


### PR DESCRIPTION
Resolves [JP-2687](https://jira.stsci.edu/browse/JP-2687)

This PR addresses the issue of `tweakreg` step exiting when only one input image is provided. This behavior was the desired one when there was only one "relative alignment" stage in `tweakwcs`. With the addition of alignment to Gaia stage, it now makes sense to bypass first stage and allow single images to align to GAIA. This PR enables this logic.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
