### PR TITLE
tweakreg should report inverse SIP coefficients in FITS WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,8 +16,8 @@ ami_analyze
 -----------
 
 - Revert Fourier Transform code to avoid using Poppy which was recently updated
-  to use a different sign convention.[#6967]  
-  
+  to use a different sign convention.[#6967]
+
 assign_wcs
 ----------
 
@@ -67,6 +67,9 @@ tweakreg
 
 - The ``tweakreg`` step now masks ``NON_SCIENCE`` pixels when
   calculating the source detection theshold. [#6940]
+
+- ``tweakreg`` will report inverse SIP coefficients in updated
+  FITS WCS. [#6939]
 
 1.6.2 (2022-07-19)
 ==================

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -325,7 +325,8 @@ class TweakRegStep(Step):
                 try:
                     update_fits_wcsinfo(
                         image_model,
-                        max_pix_error=0.005
+                        max_pix_error=0.005,
+                        max_inv_pix_error=0.03  # turn on inverse SIP coefficients
                     )
                 except (ValueError, RuntimeError) as e:
                     self.log.warning(


### PR DESCRIPTION
This PR enables `tweakreg` to report inverse SIP coefficients in data model's `meta.wcsinfo` when computing FITS WCS from GWCS.

I believe it is better not to include these coefficients as most common WCS software would resort to a more accurate iterative solution, but I make this PR for in case it is needed. See #6936 discussions for more details.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
