### PR TITLE
JP-2694: reset input model after Source Catalog Step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -241,6 +241,10 @@ tweakreg
 
 - Refactored code to work with changes in ``tweakwcs`` version 0.8.0. [#7006]
 
+source_catalog
+--------------
+- Reset input model (units, re-add backgroud) after source_catalog step. [#6942]
+
 1.6.2 (2022-07-19)
 ==================
 

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -125,6 +125,22 @@ class JWSTSourceCatalog:
         self.model.meta.bunit_data = unit.name
         self.model.meta.bunit_err = unit.name
 
+    def convert_from_jy(self):
+        """
+        Convert the data and errors from Jy to MJy/sr and change from
+        `~astropy.unit.Quantity` objects to `~numpy.ndarray`.
+        """
+
+        to_mjy_sr = 1.e6 * self.model.meta.photometry.pixelarea_steradians
+        self.model.data /= to_mjy_sr
+        self.model.err /= to_mjy_sr
+
+        self.model.data = self.model.data.value  # remove units
+        self.model.err = self.model.err.value  # remove units
+
+        self.model.meta.bunit_data = 'MJy/sr'
+        self.model.meta.bunit_err = 'MJy/sr'
+
     @staticmethod
     def convert_flux_to_abmag(flux, flux_err):
         """
@@ -947,5 +963,8 @@ class JWSTSourceCatalog:
         self.meta['aperture_params'] = self.aperture_params
         self.meta['abvega_offset'] = self.abvega_offset
         catalog.meta.update(self.meta)
+
+        # reset units on input model back to MJy/sr
+        self.convert_from_jy()
 
         return catalog

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -97,6 +97,9 @@ class SourceCatalogStep(Step):
                                        abvega_offset, ci_star_thresholds)
             catalog = catobj.catalog
 
+            # add back background to data so input model is unchanged
+            model.data += bkg.background
+
             if self.save_results:
                 cat_filepath = self.make_output_path(ext='.ecsv')
                 catalog.write(cat_filepath, format='ascii.ecsv',


### PR DESCRIPTION
A copy of the input model is not made in SourceCatalogStep since there is no return model (just the table). In the step, the units of the data/err arrays are converted and the background is subtracted from the data. If someone attempts successive runs of the step, it will fail because of these changes to the input.

This PR resets the model's data/err arrays and metadata information about units so that the input remains unchanged.

Resolves [JP-2694](https://jira.stsci.edu/browse/JP-2694)