### PR TITLE
JP-2693: Flag groups do_not_use after detected ramp jumps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,12 @@ extract_1d
 - Update ``int_times`` keywords and copy the ``INT_TIMES`` table extension to SOSS
   spectral output (x1d) files [#6930]
 
+jump
+----
+
+- Added flagging after detected ramp jumps based on two DN thresholds and
+  two number of groups to flag [#6943]
+
 master_background
 -----------------
 

--- a/docs/jwst/jump/arguments.rst
+++ b/docs/jwst/jump/arguments.rst
@@ -38,14 +38,14 @@ The ``jump`` step has five optional arguments that can be set by the user:
   not have its neighbors flagged. The goal is to prevent flagging jumps that would be too
   small to significantly affect the slope determination.  The default value is 10.
 
-*  ``--after_jump_flag_dn1'': A floating point value in units of DN that gives the
+*  ``--after_jump_flag_dn1``: A floating point value in units of DN that gives the
    minimum ramp jump for after jump flagging for the 1st after ramp flagging.
 
-* ``--after_jump_flag_time1'': A floating point value in units of seconds that gives the
+* ``--after_jump_flag_time1``: A floating point value in units of seconds that gives the
   time since the ramp jump to flag groups as ramp jumps for the 1st after jump flagging.
 
-*  ``--after_jump_flag_dn1'': A floating point value in units of DN that gives the
+*  ``--after_jump_flag_dn1``: A floating point value in units of DN that gives the
    minimum ramp jump for after jump flagging for the 2nd after ramp flagging.
 
-* ``--after_jump_flag_time1'': A floating point value in units of seconds that gives the
+* ``--after_jump_flag_time1``: A floating point value in units of seconds that gives the
   time since the ramp jump to flag groups as ramp jumps for the 2nd after jump flagging.

--- a/docs/jwst/jump/arguments.rst
+++ b/docs/jwst/jump/arguments.rst
@@ -38,4 +38,14 @@ The ``jump`` step has five optional arguments that can be set by the user:
   not have its neighbors flagged. The goal is to prevent flagging jumps that would be too
   small to significantly affect the slope determination.  The default value is 10.
 
+*  ``--after_jump_flag_dn1'': A floating point value in units of DN that gives the
+   minimum ramp jump for after jump flagging for the 1st after ramp flagging.
 
+* ``--after_jump_flag_time1'': A floating point value in units of seconds that gives the
+  time since the ramp jump to flag groups as ramp jumps for the 1st after jump flagging.
+
+*  ``--after_jump_flag_dn1'': A floating point value in units of DN that gives the
+   minimum ramp jump for after jump flagging for the 2nd after ramp flagging.
+
+* ``--after_jump_flag_time1'': A floating point value in units of seconds that gives the
+  time since the ramp jump to flag groups as ramp jumps for the 2nd after jump flagging.

--- a/docs/jwst/jump/description.rst
+++ b/docs/jwst/jump/description.rst
@@ -34,7 +34,7 @@ output PIXELDQ array.
 The SCI and ERR arrays of the input data are not modified.
 
 The current implementation uses the two-point difference method described
-in Anderson&Gordon2011_.
+in `Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_.
 
 Two-Point Difference Method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -59,6 +59,15 @@ The two-point difference method is applied to each integration as follows:
   is used rather than the clipped median.
 * If there are only two differences (three groups), the smallest one is compared to the larger
   one and if the larger one is above a threshold, it is flagged as a jump.
+
+* If flagging of the 4 neighbors is requested, then the 4 adjacent pixels will
+  have ramp jumps flagged in the same group as the central pixel as long as it has
+  a jump between the min and max requested levels for this option.
+
+* If flagging of groups after a ramp jump is requested, then the groups in the
+  requested time since a detected ramp jump will be flagged as ramp jumps if
+  the ramp jump is above the requested threshold.  Two thresholds and times are
+  possible for this option.
 
 Note that any ramp values flagged as SATURATED in the input GROUPDQ array
 are not used in any of the above calculations and hence will never be
@@ -87,5 +96,3 @@ The use of the reference files is flexible. Full-frame reference
 files can be used for all science exposures, in which case subarrays will be
 extracted from the reference file data to match the science exposure, or
 subarray-specific reference files may be used.
-
-.. _Anderson&Gordon2011: https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -11,7 +11,9 @@ log.setLevel(logging.DEBUG)
 def run_detect_jumps(input_model, gain_model, readnoise_model,
                      rejection_thresh, three_grp_thresh, four_grp_thresh,
                      max_cores, max_jump_to_flag_neighbors,
-                     min_jump_to_flag_neighbors, flag_4_neighbors):
+                     min_jump_to_flag_neighbors, flag_4_neighbors,
+                     after_jump_flag_dn1, after_jump_flag_time1,
+                     after_jump_flag_dn2, after_jump_flag_time2):
 
     # Runs `detect_jumps` in stcal
 
@@ -22,6 +24,12 @@ def run_detect_jumps(input_model, gain_model, readnoise_model,
     pdq = input_model.pixeldq
     err = input_model.err
     output_model = input_model.copy()
+
+    # determine the number of groups that coorespond to the after_jump times
+    # needed as the group time is not passed to detect_jumps
+    gtime = input_model.meta.exposure.group_time
+    after_jump_flag_n1 = int(after_jump_flag_time1 // gtime)
+    after_jump_flag_n2 = int(after_jump_flag_time2 // gtime)
 
     # Get 2D gain and read noise values from their respective models
     if reffile_utils.ref_matches_sci(input_model, gain_model):
@@ -43,7 +51,10 @@ def run_detect_jumps(input_model, gain_model, readnoise_model,
                                     four_grp_thresh, max_cores,
                                     max_jump_to_flag_neighbors,
                                     min_jump_to_flag_neighbors,
-                                    flag_4_neighbors, dqflags.pixel)
+                                    flag_4_neighbors,
+                                    after_jump_flag_dn1, after_jump_flag_n1,
+                                    after_jump_flag_dn2, after_jump_flag_n2,
+                                    dqflags.pixel)
 
     # Update the DQ arrays of the output model with the jump detection results
     output_model.groupdq = new_gdq

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -13,9 +13,9 @@ def run_detect_jumps(input_model, gain_model, readnoise_model,
                      max_cores, max_jump_to_flag_neighbors,
                      min_jump_to_flag_neighbors, flag_4_neighbors,
                      after_jump_flag_dn1=0.0,
-                     after_jump_flag_time1=0,
+                     after_jump_flag_time1=0.0,
                      after_jump_flag_dn2=0.0,
-                     after_jump_flag_time2=0):
+                     after_jump_flag_time2=0.0):
 
     # Runs `detect_jumps` in stcal
 
@@ -27,8 +27,8 @@ def run_detect_jumps(input_model, gain_model, readnoise_model,
     err = input_model.err
     output_model = input_model.copy()
 
-    # determine the number of groups that coorespond to the after_jump times
-    # needed as the group time is not passed to detect_jumps
+    # determine the number of groups that correspond to the after_jump times
+    # needed because the group time is not passed to detect_jumps
     gtime = input_model.meta.exposure.group_time
     after_jump_flag_n1 = int(after_jump_flag_time1 // gtime)
     after_jump_flag_n2 = int(after_jump_flag_time2 // gtime)
@@ -54,10 +54,10 @@ def run_detect_jumps(input_model, gain_model, readnoise_model,
                                     max_jump_to_flag_neighbors,
                                     min_jump_to_flag_neighbors,
                                     flag_4_neighbors, dqflags.pixel,
-                                    after_jump_flag_dn1=after_jump_flag_dn1,
-                                    after_jump_flag_n1=after_jump_flag_n1,
-                                    after_jump_flag_dn2=after_jump_flag_dn2,
-                                    after_jump_flag_n2=after_jump_flag_n2)
+                                    after_jump_flag_dn1,
+                                    after_jump_flag_n1,
+                                    after_jump_flag_dn2,
+                                    after_jump_flag_n2)
 
     # Update the DQ arrays of the output model with the jump detection results
     output_model.groupdq = new_gdq

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -12,8 +12,10 @@ def run_detect_jumps(input_model, gain_model, readnoise_model,
                      rejection_thresh, three_grp_thresh, four_grp_thresh,
                      max_cores, max_jump_to_flag_neighbors,
                      min_jump_to_flag_neighbors, flag_4_neighbors,
-                     after_jump_flag_dn1, after_jump_flag_time1,
-                     after_jump_flag_dn2, after_jump_flag_time2):
+                     after_jump_flag_dn1=0.0,
+                     after_jump_flag_time1=0,
+                     after_jump_flag_dn2=0.0,
+                     after_jump_flag_time2=0):
 
     # Runs `detect_jumps` in stcal
 
@@ -51,10 +53,11 @@ def run_detect_jumps(input_model, gain_model, readnoise_model,
                                     four_grp_thresh, max_cores,
                                     max_jump_to_flag_neighbors,
                                     min_jump_to_flag_neighbors,
-                                    flag_4_neighbors,
-                                    after_jump_flag_dn1, after_jump_flag_n1,
-                                    after_jump_flag_dn2, after_jump_flag_n2,
-                                    dqflags.pixel)
+                                    flag_4_neighbors, dqflags.pixel,
+                                    after_jump_flag_dn1=after_jump_flag_dn1,
+                                    after_jump_flag_n1=after_jump_flag_n1,
+                                    after_jump_flag_dn2=after_jump_flag_dn2,
+                                    after_jump_flag_n2=after_jump_flag_n2)
 
     # Update the DQ arrays of the output model with the jump detection results
     output_model.groupdq = new_gdq

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -79,8 +79,10 @@ class JumpStep(Step):
                                       rej_thresh, three_grp_rej_thresh, four_grp_rej_thresh, max_cores,
                                       max_jump_to_flag_neighbors, min_jump_to_flag_neighbors,
                                       flag_4_neighbors,
-                                      after_jump_flag_dn1, after_jump_flag_time1,
-                                      after_jump_flag_dn2, after_jump_flag_time2)
+                                      after_jump_flag_dn1=after_jump_flag_dn1,
+                                      after_jump_flag_time1=after_jump_flag_time1,
+                                      after_jump_flag_dn2=after_jump_flag_dn2,
+                                      after_jump_flag_time2=after_jump_flag_time2)
             gain_model.close()
             readnoise_model.close()
             tstop = time.time()

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -79,10 +79,10 @@ class JumpStep(Step):
                                       rej_thresh, three_grp_rej_thresh, four_grp_rej_thresh, max_cores,
                                       max_jump_to_flag_neighbors, min_jump_to_flag_neighbors,
                                       flag_4_neighbors,
-                                      after_jump_flag_dn1=after_jump_flag_dn1,
-                                      after_jump_flag_time1=after_jump_flag_time1,
-                                      after_jump_flag_dn2=after_jump_flag_dn2,
-                                      after_jump_flag_time2=after_jump_flag_time2)
+                                      after_jump_flag_dn1,
+                                      after_jump_flag_time1,
+                                      after_jump_flag_dn2,
+                                      after_jump_flag_time2)
             gain_model.close()
             readnoise_model.close()
             tstop = time.time()

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -22,6 +22,10 @@ class JumpStep(Step):
         flag_4_neighbors = boolean(default=True) # flag the four perpendicular neighbors of each CR
         max_jump_to_flag_neighbors = float(default=1000) # maximum jump sigma that will trigger neighbor flagging
         min_jump_to_flag_neighbors = float(default=10) # minimum jump sigma that will trigger neighbor flagging
+        after_jump_flag_dn1 = float(default=0) # 1st flag groups after jump above DN threshold
+        after_jump_flag_time1 = float(default=0) # 1st flag groups after jump groups within specified time
+        after_jump_flag_dn2 = float(default=0) # 2nd flag groups after jump above DN threshold
+        after_jump_flag_time2 = float(default=0) # 2nd flag groups after jump groups within specified time
     """
 
     reference_file_types = ['gain', 'readnoise']
@@ -49,6 +53,10 @@ class JumpStep(Step):
             max_jump_to_flag_neighbors = self.max_jump_to_flag_neighbors
             min_jump_to_flag_neighbors = self.min_jump_to_flag_neighbors
             flag_4_neighbors = self.flag_4_neighbors
+            after_jump_flag_dn1 = self.after_jump_flag_dn1
+            after_jump_flag_time1 = self.after_jump_flag_time1
+            after_jump_flag_dn2 = self.after_jump_flag_dn2
+            after_jump_flag_time2 = self.after_jump_flag_time2
 
             self.log.info('CR rejection threshold = %g sigma', rej_thresh)
             if self.maximum_cores != 'none':
@@ -70,7 +78,9 @@ class JumpStep(Step):
             result = run_detect_jumps(input_model, gain_model, readnoise_model,
                                       rej_thresh, three_grp_rej_thresh, four_grp_rej_thresh, max_cores,
                                       max_jump_to_flag_neighbors, min_jump_to_flag_neighbors,
-                                      flag_4_neighbors)
+                                      flag_4_neighbors,
+                                      after_jump_flag_dn1, after_jump_flag_time1,
+                                      after_jump_flag_dn2, after_jump_flag_time2)
             gain_model.close()
             readnoise_model.close()
             tstop = time.time()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2693](https://jira.stsci.edu/browse/JP-2693)

<!-- describe the changes comprising this PR here -->
This PR implements the enhancement to the jump step where groups after detected jumps are flagged do_not_use. This "corrects" transients that have been seen to make the slope after a jump different than before. This PR allows for flagging to be different for two different jump thresholds.

The main changes are in `stcal` and this PR provides the needed interface for `jwst`.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
