### PR TITLE
tweakreg should proceed on errors when  updating FITS WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ tweakreg
 --------
 
 - ``tweakreg`` step now updates FITS WCS stored in ``datamodel.meta.wcsinfo``
-  from data model's tweaked GWCS. [#6936]
+  from data model's tweaked GWCS. [#6936, #6947]
 
 
 1.6.2 (2022-07-19)

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -321,7 +321,13 @@ class TweakRegStep(Step):
 
                 # Also update FITS representation in input exposures for
                 # subsequent reprocessing by the end-user.
-                update_fits_wcsinfo(imcat.meta['image_model'])
+                try:
+                    update_fits_wcsinfo(imcat.meta['image_model'])
+                except (ValueError, RuntimeError) as e:
+                    self.log.warning(
+                        "Failed to update 'meta.wcsinfo' with FITS SIP "
+                        f'approximation. Reported error is:\n"{e.args[0]}"'
+                    )
 
         return images
 


### PR DESCRIPTION
Occasionally, converting a GWCS to FITS WCS in the `tweakreg_step` may fail due to poor convergence. Instead of raising an exception, the code should log the error and tweakreg step should proceed without updating FITS WCS.

**Checklist**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
