### PR TITLE
JP-2669: Updating tests due to new STCAL behavior for NaNs in rateints product.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,13 @@ outlier_detection
 
 - Fix reading of the source_type attribute for NIRSpec IFU data. [#6980]
 
+ramp_fitting
+------------
+
+- Updating tests due to new behavior in STCAL (spacetelescope/stcal#112)
+  removing NaNs from the rateints product and setting appropriate DQ
+  flags. [#6949]
+
 resample
 --------
 

--- a/jwst/ramp_fitting/tests/test_ramp_fit_step.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_step.py
@@ -373,7 +373,7 @@ def test_one_group_suppressed_one_integration(setup_inputs):
     check = np.array([[0., 0., 1.0000002]])
     np.testing.assert_allclose(slopes.data, check, tol)
 
-    check = np.array([[3, 2, 0]])
+    check = np.array([[3, 3, 0]])
     np.testing.assert_allclose(slopes.dq, check, tol)
 
     check = np.array([[0., 0., 0.01]])
@@ -386,10 +386,10 @@ def test_one_group_suppressed_one_integration(setup_inputs):
     np.testing.assert_allclose(slopes.err, check, tol)
 
     # Check slopes information
-    check = np.array([[[0., np.nan, 1.0000001]]])
+    check = np.array([[[0., 0., 1.0000001]]])
     np.testing.assert_allclose(cube.data, check, tol)
 
-    check = np.array([[[3, 2, 0]]])
+    check = np.array([[[3, 3, 0]]])
     np.testing.assert_allclose(cube.dq, check, tol)
 
     check = np.array([[[0., 0., 0.01]]])
@@ -489,11 +489,11 @@ def test_one_group_suppressed_two_integration(setup_inputs):
     np.testing.assert_allclose(slopes.err, check, tol)
 
     # Check slopes information
-    check = np.array([[[0., np.nan, 1.0000001]],
+    check = np.array([[[0., 0., 1.0000001]],
                       [[1.0000001, 1.0000001, 1.0000001]]])
     np.testing.assert_allclose(cube.data, check, tol)
 
-    check = np.array([[[3, 2, 0]],
+    check = np.array([[[3, 3, 0]],
                       [[0, 0, 0]]])
     np.testing.assert_allclose(cube.dq, check, tol)
 


### PR DESCRIPTION
…es and their corresponding DQ flags.  The rateints product will have all NaNs set to zero with the corresponding DQ flag set to DO_NOT_USE.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2669](https://jira.stsci.edu/browse/JP-2669)

<!-- describe the changes comprising this PR here -->
This PR addresses testing changes needed due to updates in [STCAL PR 112](https://github.com/spacetelescope/stcal/pull/112), which updates the way the rateints gets computed.  NaNs in the rateints products are converted to 0. and the corresponding DQ value has the `DO_NOT_USE` flag set.


**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
