### PR TITLE
Add P_SUBARR to the DarkModel schema (JP-2656)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ datamodels
 
 - Updated keyword titles in data model schemas to match those in keyword
   dictionary. [#6941]
+
+- Add P_SUBARR keyword to the `DarkModel` schema. [#9999]
   
 skymatch
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ datamodels
 - Updated keyword titles in data model schemas to match those in keyword
   dictionary. [#6941]
 
-- Add P_SUBARR keyword to the `DarkModel` schema. [#9999]
+- Add P_SUBARR keyword to the `DarkModel` schema. [#6951]
   
 skymatch
 --------

--- a/jwst/datamodels/schemas/dark.schema.yaml
+++ b/jwst/datamodels/schemas/dark.schema.yaml
@@ -13,6 +13,7 @@ allOf:
 - $ref: keyword_ngroups.schema
 - $ref: keyword_groupgap.schema
 - $ref: keyword_gainfact.schema
+- $ref: keyword_psubarray.schema
 - $ref: subarray.schema
 - type: object
   properties:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2656](https://jira.stsci.edu/browse/JP-2656)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2656

<!-- describe the changes comprising this PR here -->
This PR simplifies the creation of reference files regarding multiple subarray values, by adding the ability to add these values into the header of the file when using the DarkModel.

**Checklist**
- [X] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant milestone
- [X] added relevant label(s)
