### PR TITLE
Add details on when crds environmentals be defined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 general
 -------
 
--  Add details on when crds environmentals be defined. [#6953]
+-
 
 assign_wcs
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 general
 -------
 
--
+-  Add details on when crds environmentals be defined. [#6953]
 
 assign_wcs
 ----------

--- a/docs/jwst/datamodels/models.rst
+++ b/docs/jwst/datamodels/models.rst
@@ -316,10 +316,10 @@ returns a dictionary of of the instance at the model._extra_fits node.
 `_instance` can be used at any node in the tree to return a dictionary
 of rest of the tree structure at that node.
 
-Environmental Variables
------------------------
+Environment Variables
+---------------------
 
-There are a number of environmental variables that affect how models are read.
+There are a number of environment variables that affect how models are read.
 
 PASS_INVALID_VALUES
   Used by `~jwst.datamodels.DataModel` when instantiating
@@ -357,7 +357,7 @@ For flag or boolean variables, any value in ``('true', 't', 'yes', 'y')`` or a
 non-zero number, will evaluate as ``True``. Any value in ``('false', 'f', 'no',
 'n', '0')`` will evaluate as ``False``. The values are case-insensitive.
 
-All of the environmental variables have equivalent function arguments in the API
+All of the environment variables have equivalent function arguments in the API
 for the relevant code. The environment variables are used only if explicit
 values had not been used in a script. In other words, values in code override
-environmental variables.
+environment variables.

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -461,14 +461,14 @@ see :ref:`Execute via call()<call_examples>`::
 For more details on the different ways to run a pipeline step, see
 the :ref:`Configuring a Step<configuring-a-step>` page.
 
-CRDS Environmentals
--------------------
+CRDS Environment Variables
+--------------------------
 
-The CRDS environmental variables need to be defined *before* importing anything
-from `jwst` or `crds`. In general, any scripts should assume the environmentals
-have been set before the scripts have run. If one needs to define the CRDS
-environmentals within a script, the following code snippet is the suggested
-method. These lines should be the first executable lines:
+The CRDS environment variables need to be defined *before* importing anything
+from `jwst` or `crds`. In general, any scripts should assume the environment
+variables have been set before the scripts have run. If one needs to define the
+CRDS environment variables within a script, the following code snippet is the
+suggested method. These lines should be the first executable lines:
 
 ::
 

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -461,6 +461,25 @@ see :ref:`Execute via call()<call_examples>`::
 For more details on the different ways to run a pipeline step, see
 the :ref:`Configuring a Step<configuring-a-step>` page.
 
+CRDS Environmentals
+-------------------
+
+The CRDS environmental variables need to be defined *before* importing anything
+from `jwst` or `crds`. In general, any scripts should assume the environmentals
+have been set before the scripts have run. If one needs to define the CRDS
+environmentals within a script, the following code snippet is the suggested
+method. These lines should be the first executable lines:
+
+::
+
+   import os
+   os.environ['CRDS_PATH'] = 'path_to_local_cache'
+   os.environ['CRDS_SERVER_URL'] = 'url-of-server-to-use'
+
+   # Now import anything else needed
+   import jwst
+
+
 Available Pipelines
 ===================
 There are many pre-defined pipeline modules for processing

--- a/docs/jwst/outlier_detection/arguments.rst
+++ b/docs/jwst/outlier_detection/arguments.rst
@@ -70,7 +70,7 @@ that control the behavior of the processing:
 ``--allowed_memory`` (float, default=None)
   Specifies the fractional amount of
   free memory to allow when creating the resampled image. If ``None``, the
-  environmental variable ``DMODEL_ALLOWED_MEMORY`` is used. If not defined, no
+  environment variable ``DMODEL_ALLOWED_MEMORY`` is used. If not defined, no
   check is made. If the resampled image would be larger than specified, an
   ``OutputTooLargeError`` exception will be generated.
 

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -74,7 +74,7 @@ image.
 
 ``--allowed_memory`` (float, default=None)
   Specifies the fractional amount of free memory to allow when creating the
-  resampled image. If ``None``, the environmental variable
+  resampled image. If ``None``, the environment variable
   ``DMODEL_ALLOWED_MEMORY`` is used. If not defined, no check is made. If the
   resampled image would be larger than specified, an ``OutputTooLargeError``
   exception will be generated.

--- a/docs/jwst/stpipe/parameter_files.rst
+++ b/docs/jwst/stpipe/parameter_files.rst
@@ -15,7 +15,7 @@ how a parameter gets its final value.
 
    Retrieval of ``Step`` parameters from CRDS can be completely disabled by
    using the ``--disable-crds-steppars`` command-line switch, or setting the
-   environmental variable ``STPIPE_DISABLE_CRDS_STEPPARS`` to ``true``.
+   environment variable ``STPIPE_DISABLE_CRDS_STEPPARS`` to ``true``.
 
 A parameter file should be used when there are parameters a user wishes to
 change from the default/CRDS version for a custom run of the step. To create a

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -175,7 +175,7 @@ qualifying member, usually of type ``science`` is used.
 
 Retrieval of ``Step`` parameters from CRDS can be completely disabled by
 using the ``--disable-crds-steppars`` command-line switch, or setting the
-environmental variable ``STPIPE_DISABLE_CRDS_STEPPARS`` to ``true``.
+environment variable ``STPIPE_DISABLE_CRDS_STEPPARS`` to ``true``.
 
 .. _run_step_from_python:
 


### PR DESCRIPTION
This PR clarifies when CRDS environmental variables should be defined when using Python scripts.

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- ~updated or added relevant tests~
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
