### PR TITLE
JP-2707: Fix excessive zeroes in resampled variance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,14 @@ datamodels
   dictionary. [#6941]
 
 - Add P_SUBARR keyword to the `DarkModel` schema. [#6951]
-  
+
+resample
+--------
+
+- Fixed a bug in how variance arrays were resampled due to which the resulting
+  resampled error map contained an excessive number of zero-valued
+  pixel. [#6954]
+
 skymatch
 --------
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -281,15 +281,16 @@ class ResampleData:
             outwht = np.zeros_like(output_model.data)
             outcon = np.zeros_like(output_model.con)
 
-            # Resample the variance array.  Use fillval=np.inf so that when we
-            # take the reciprocal for summing, it is zero where there is zero weight
+            # Resample the variance array. Fill "unpopulated" pixels with NaNs.
             self.drizzle_arrays(variance, inwht, model.meta.wcs,
                                 output_wcs, resampled_variance, outwht, outcon,
                                 pixfrac=self.pixfrac, kernel=self.kernel,
                                 fillval=np.nan)
 
-            # Add the inverse of the resampled variance to a running sum
-            mask = (outwht > 0) & (resampled_variance > 0)
+            # Add the inverse of the resampled variance to a running sum.
+            # Update only pixels (in the running sum) with valid new values:
+            mask = np.logical_and(outcon, resampled_variance > 0)
+
             inverse_variance_sum[mask] = np.nansum(
                 [inverse_variance_sum[mask], np.reciprocal(resampled_variance[mask])],
                  axis=0

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -289,11 +289,11 @@ class ResampleData:
 
             # Add the inverse of the resampled variance to a running sum.
             # Update only pixels (in the running sum) with valid new values:
-            mask = np.logical_and(outcon, resampled_variance > 0)
+            mask = resampled_variance > 0
 
             inverse_variance_sum[mask] = np.nansum(
                 [inverse_variance_sum[mask], np.reciprocal(resampled_variance[mask])],
-                 axis=0
+                axis=0
             )
 
         # We now have a sum of the inverse resampled variances.  We need the


### PR DESCRIPTION
This PR fixes a bug in how resampled variances are computed due to which resampled error array tends to have an excessive number of zero-valued pixels. By this I mean that even though there were multiple images contributing to one output pixel in SCI, the corresponding pixel in the ERR extension was 0. The reason for this was that current algorithm computes a sum of inverse variances from each resampled image. If variance of a pixel in an input image is 0 then `1/variance` would be `np.inf`. Even if other input images have valid pixels and contribute to the output pixel, their variances, even if finite and >0 cannot clear `np.inf`. In the end, the final error array computed as `1/sum(1/variances)` resulting in the final value being 0 (for resampled variance). That is, something like this would happen for a single pixel:

```
1/(1/0 + 1/finite2a + 1/finite3a + ...) = 1/(inf + finite2b + finite 3b + ...) = 1/inf = 0
```

This PR fixes this bug by tracking more carefully individual pixel contribution and removing from computations pixels with zero weights or zero variance.

The issue of excessive number of zero-valued pixels was reported in the help desk ticket INC0180024.

This PR does not address the validity of resampled variance or error computations in itself - only the excessive zeroes issue.

Resolves [JP-2707](https://jira.stsci.edu/browse/JP-2707)

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
