### PR TITLE
JP-2654  Fix bug in NIRSPEC DQ flagging  and JP-2662 for MIRI moving target

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ assign_wcs
   module to allow easy updating of FITS WCS stored in ``datamodel.meta.wcsinfo``
   from data model's GWCS. [#6935]
 
+cube_build
+----------
+
+- Re-wrote c code for NIRSpec dq flagging. In addition,if data is moving_target data, then do not
+  use s_region values in cal files, but map all the pixels to sky to find cube footprint. [6957]
+
 datamodels
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,8 @@ cube_build
 ----------
 
 - Re-wrote c code for NIRSpec dq flagging. In addition,if data is moving_target data, then do not
-  use s_region values in cal files, but map all the pixels to sky to find cube footprint. [6957]
+  use s_region values in cal files, but map all the pixels to sky to find cube footprint.
+  Updated drizzle code to use wcs of output frame to account for moving target data .[#6957]
 
 datamodels
 ----------

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -12,7 +12,7 @@ log.setLevel(logging.DEBUG)
 
 # ******************************************************************************
 def find_corners_MIRI(input, this_channel, instrument_info, coord_system):
-    """ For MIRI channel data find the foot of this data on the sky
+    """ For MIRI channel data find the footprint of this data on the sky
 
     For a specific channel on an exposure find the min and max of the
     spatial coordinates, either in alpha,beta or ra,dec depending
@@ -153,7 +153,7 @@ def find_corners_NIRSPEC(input, instrument_info, coord_system):
     lambda_slice = np.zeros(nslices * 2)
     k = 0
     # for NIRSPEC there are 30 regions
-    log.info('Looping over slices to determine cube size .. this takes a while')
+    log.info('Looping over slices to determine cube size')
 
     for i in range(nslices):
         slice_wcs = nirspec.nrs_wcs_set_input(input, i)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -311,7 +311,7 @@ class IFUCubeData():
         ystart = eta_min + self.cdelt2 / 2.0
         self.ycoord = np.arange(start=ystart, stop=ystart + self.naxis2 * self.cdelt2, step=self.cdelt2)
 
-        xv,yv = np.meshgrid(self.xcoord, self.ycoord)
+        xv, yv = np.meshgrid(self.xcoord, self.ycoord)
         self.xcenters = xv.flatten()
         self.ycenters = yv.flatten()
         # _______________________________________________________________________
@@ -538,7 +538,7 @@ class IFUCubeData():
         self.output_name = self.define_cubename()
         total_num = self.naxis1 * self.naxis2 * self.naxis3
 
-        self.spaxel_flux = np.zeros(total_num,dtype=np.float64)
+        self.spaxel_flux = np.zeros(total_num, dtype=np.float64)
         self.spaxel_weight = np.zeros(total_num, dtype=np.float64)
         self.spaxel_var = np.zeros(total_num, dtype=np.float64)
         self.spaxel_iflux = np.zeros(total_num, dtype=np.float64)
@@ -624,12 +624,11 @@ class IFUCubeData():
                         self.spaxel_flux = self.spaxel_flux + np.asarray(result[0], np.float64)
                         self.spaxel_weight = self.spaxel_weight + np.asarray(result[1], np.float64)
                         self.spaxel_var = self.spaxel_var + np.asarray(result[2], np.float64)
-                        self.spaxel_iflux = self.spaxel_iflux + np.asarray(result[3],np.float64)
+                        self.spaxel_iflux = self.spaxel_iflux + np.asarray(result[3], np.float64)
                         spaxel_dq.astype(np.uint)
                         self.spaxel_dq = np.bitwise_or(self.spaxel_dq, spaxel_dq)
                         result = None
                     if self.weighting == 'drizzle':
-                        print('calling drizzle')
                         cdelt3_mean = np.nanmean(self.cdelt3_normal)
                         xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4 = corner_coord
                         linear = 0
@@ -643,13 +642,12 @@ class IFUCubeData():
                                                    xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4,
                                                    dwave,
                                                    self.cdelt3_normal,
-                                                   self.cdelt1, self.cdelt2, cdelt3_mean,linear)
-                        print('return from drizzle')
+                                                   self.cdelt1, self.cdelt2, cdelt3_mean, linear)
                         spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq = result
                         self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)
                         self.spaxel_weight = self.spaxel_weight + np.asarray(spaxel_weight, np.float64)
                         self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
-                        self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux,np.float64)
+                        self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
                         spaxel_dq.astype(np.uint)
                         self.spaxel_dq = np.bitwise_or(self.spaxel_dq, spaxel_dq)
                         result = None
@@ -689,7 +687,7 @@ class IFUCubeData():
                             self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)
                             self.spaxel_weight = self.spaxel_weight + np.asarray(spaxel_weight, np.float64)
                             self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
-                            self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux,np.float64)
+                            self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
                             result = None
 
                     # --------------------------------------------------------------------------------
@@ -720,7 +718,7 @@ class IFUCubeData():
                             self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)
                             self.spaxel_weight = self.spaxel_weight + np.asarray(spaxel_weight, np.float64)
                             self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
-                            self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux,np.float64)
+                            self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
                             result = None
             # _______________________________________________________________________
             # done looping over files
@@ -763,11 +761,11 @@ class IFUCubeData():
 
                 # for each new data model create a new spaxel
                 total_num = self.naxis1 * self.naxis2 * self.naxis3
-                self.spaxel_flux = np.zeros(total_num,dtype=np.float64)
+                self.spaxel_flux = np.zeros(total_num, dtype=np.float64)
                 self.spaxel_weight = np.zeros(total_num, dtype=np.float64)
                 self.spaxel_iflux = np.zeros(total_num)
                 self.spaxel_dq = np.zeros(total_num, dtype=np.uint32)
-                self.spaxel_var = np.zeros(total_num,dtype=np.float64)
+                self.spaxel_var = np.zeros(total_num, dtype=np.float64)
 
                 subtract_background = False
 
@@ -807,7 +805,7 @@ class IFUCubeData():
                     self.spaxel_flux = self.spaxel_flux + np.asarray(result[0], np.float64)
                     self.spaxel_weight = self.spaxel_weight + np.asarray(result[1], np.float64)
                     self.spaxel_var = self.spaxel_var + np.asarray(result[2], np.float64)
-                    self.spaxel_iflux = self.spaxel_iflux + np.asarray(result[3],np.float64)
+                    self.spaxel_iflux = self.spaxel_iflux + np.asarray(result[3], np.float64)
                     result = None
 
                 if self.weighting == 'drizzle':
@@ -1247,8 +1245,8 @@ class IFUCubeData():
                 input_model = self.master_table.FileMap[self.instrument][this_a][this_b][k]
 
                 # Find the footprint of the image
-                spectral_found = hasattr(input_model.meta.wcsinfo,'spectral_region')
-                spatial_found = hasattr(input_model.meta.wcsinfo,'s_region')
+                spectral_found = hasattr(input_model.meta.wcsinfo, 'spectral_region')
+                spatial_found = hasattr(input_model.meta.wcsinfo, 's_region')
                 world = False
                 if self.coord_system == 'skyalign':
                     world = True
@@ -1264,7 +1262,7 @@ class IFUCubeData():
                         spectral_found = False
 
                 if(spectral_found & spatial_found & world):
-                    [lmin,lmax] = input_model.meta.wcsinfo.spectral_region
+                    [lmin, lmax] = input_model.meta.wcsinfo.spectral_region
                     spatial_box = input_model.meta.wcsinfo.s_region
                     s = spatial_box.split(' ')
                     ca1 = float(s[3])
@@ -1526,7 +1524,7 @@ class IFUCubeData():
                 # for each wavelength find the closest point in the self.wavelength_table
 
                 for iw, w in enumerate(wave):
-                    self.find_closest_wave(iw,w,
+                    self.find_closest_wave(iw, w,
                                            self.wavelength_table,
                                            self.rois_table,
                                            self.roiw_table,
@@ -1667,14 +1665,14 @@ class IFUCubeData():
 
         if self.interpolation == 'drizzle':
             # Delta wavelengths
-            _,_,wave1 = input_model.meta.wcs(x, y - 0.4999)
-            _,_,wave2 = input_model.meta.wcs(x, y + 0.4999)
+            _, _, wave1 = input_model.meta.wcs(x, y - 0.4999)
+            _, _, wave2 = input_model.meta.wcs(x, y + 0.4999)
             dwave = np.abs(wave1 - wave2)
 
             # Pixel corners
             pixfrac = 1.0
-            alpha1,beta,_ = input_model.meta.wcs.transform('detector', 'alpha_beta', x - 0.4999 * pixfrac, y)
-            alpha2,_,_ = input_model.meta.wcs.transform('detector', 'alpha_beta', x + 0.4999 * pixfrac, y)
+            alpha1, beta, _ = input_model.meta.wcs.transform('detector', 'alpha_beta', x - 0.4999 * pixfrac, y)
+            alpha2, _, _ = input_model.meta.wcs.transform('detector', 'alpha_beta', x + 0.4999 * pixfrac, y)
             # Find slice width
             allbetaval = np.unique(beta)
             dbeta = np.abs(allbetaval[1] - allbetaval[0])
@@ -1721,15 +1719,15 @@ class IFUCubeData():
         lam_det = np.zeros((ysize, xsize))
         flag_det = np.zeros((ysize, xsize))
         slice_det = np.zeros((ysize, xsize), dtype=int)
-        dwave_det = np.zeros((ysize,xsize))
-        ra1_det = np.zeros((ysize,xsize))
-        ra2_det = np.zeros((ysize,xsize))
-        ra3_det = np.zeros((ysize,xsize))
-        ra4_det = np.zeros((ysize,xsize))
-        dec1_det = np.zeros((ysize,xsize))
-        dec2_det = np.zeros((ysize,xsize))
-        dec3_det = np.zeros((ysize,xsize))
-        dec4_det = np.zeros((ysize,xsize))
+        dwave_det = np.zeros((ysize, xsize))
+        ra1_det = np.zeros((ysize, xsize))
+        ra2_det = np.zeros((ysize, xsize))
+        ra3_det = np.zeros((ysize, xsize))
+        ra4_det = np.zeros((ysize, xsize))
+        dec1_det = np.zeros((ysize, xsize))
+        dec2_det = np.zeros((ysize, xsize))
+        dec3_det = np.zeros((ysize, xsize))
+        dec4_det = np.zeros((ysize, xsize))
 
         pixfrac = 1.0
 
@@ -1737,14 +1735,14 @@ class IFUCubeData():
         slice_wcs1 = nirspec.nrs_wcs_set_input(input_model, 0)
         detector2slicer = slice_wcs1.get_transform('detector', 'slicer')
         x, y = wcstools.grid_from_bounding_box(slice_wcs1.bounding_box)
-        across1,along1,_ = detector2slicer(x, y - 0.4999 * pixfrac)
+        across1, along1, _ = detector2slicer(x, y - 0.4999 * pixfrac)
         across1 = across1[~np.isnan(across1)]
         slice_loc1 = np.unique(across1)
 
         slice_wcs3 = nirspec.nrs_wcs_set_input(input_model, 2)
         detector2slicer = slice_wcs3.get_transform('detector', 'slicer')
         x, y = wcstools.grid_from_bounding_box(slice_wcs3.bounding_box)
-        across3,along3,_ = detector2slicer(x, y - 0.4999 * pixfrac)
+        across3, along3, _ = detector2slicer(x, y - 0.4999 * pixfrac)
         across3 = across3[~np.isnan(across3)]
         slice_loc3 = np.unique(across3)
 
@@ -1766,19 +1764,18 @@ class IFUCubeData():
             ra = ra[valid]
             dec = dec[valid]
             lam = lam[valid]
-            print('on slice ',ii+1)
             if self.interpolation == 'drizzle':
                 # Delta wavelengths
-                _,_,wave1 = slice_wcs(x - 0.4999, y)
-                _,_,wave2 = slice_wcs(x + 0.4999, y)
+                _, _, wave1 = slice_wcs(x - 0.4999, y)
+                _, _, wave2 = slice_wcs(x + 0.4999, y)
                 dwave = np.abs(wave1 - wave2)
 
                 # Pixel corners
                 pixfrac = 1.0
                 detector2slicer = slice_wcs.get_transform('detector', 'slicer')
-                slicer2world = slice_wcs.get_transform('slicer','world')
-                across1,along1,lam1 = detector2slicer(x, y - 0.49 * pixfrac)
-                across2,along2,lam2 = detector2slicer(x, y + 0.49 * pixfrac)
+                slicer2world = slice_wcs.get_transform('slicer', 'world')
+                across1, along1, lam1 = detector2slicer(x, y - 0.49 * pixfrac)
+                across2, along2, lam2 = detector2slicer(x, y + 0.49 * pixfrac)
 
                 ra1, dec1, _ = slicer2world(across1 - across_width * pixfrac / 2, along1, lam1)
                 ra2, dec2, _ = slicer2world(across1 + across_width * pixfrac / 2, along1, lam1)
@@ -1871,7 +1868,7 @@ class IFUCubeData():
         return sky_result
 
     # ********************************************************************************
-    def find_closest_wave(self,iw,w,
+    def find_closest_wave(self, iw, w,
                           wavelength_table,
                           rois_table,
                           roiw_table,

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -629,6 +629,7 @@ class IFUCubeData():
                         self.spaxel_dq = np.bitwise_or(self.spaxel_dq, spaxel_dq)
                         result = None
                     if self.weighting == 'drizzle':
+                        print('calling drizzle')
                         cdelt3_mean = np.nanmean(self.cdelt3_normal)
                         xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4 = corner_coord
                         linear = 0
@@ -643,7 +644,7 @@ class IFUCubeData():
                                                    dwave,
                                                    self.cdelt3_normal,
                                                    self.cdelt1, self.cdelt2, cdelt3_mean,linear)
-
+                        print('return from drizzle')
                         spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq = result
                         self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)
                         self.spaxel_weight = self.spaxel_weight + np.asarray(spaxel_weight, np.float64)
@@ -1765,7 +1766,7 @@ class IFUCubeData():
             ra = ra[valid]
             dec = dec[valid]
             lam = lam[valid]
-
+            print('on slice ',ii+1)
             if self.interpolation == 'drizzle':
                 # Delta wavelengths
                 _,_,wave1 = slice_wcs(x - 0.4999, y)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1277,7 +1277,7 @@ class IFUCubeData():
                     ca4 = float(s[9])
                     cb4 = float(s[10])
                 else:
-                    log.info('Mapping all pixels to output to determine IFU foot print')
+                    log.info('Mapping all pixels to output to determine IFU footprint')
 
                     if self.instrument == 'NIRSPEC':
                         ch_corners = cube_build_wcs_util.find_corners_NIRSPEC(
@@ -1679,13 +1679,13 @@ class IFUCubeData():
             # Find slice width
             allbetaval = np.unique(beta)
             dbeta = np.abs(allbetaval[1] - allbetaval[0])
-            ra1, dec1, _ = input_model.meta.wcs.transform('alpha_beta', 'world', alpha1,
+            ra1, dec1, _ = input_model.meta.wcs.transform('alpha_beta', input_model.meta.wcs.output_frame, alpha1,
                                                           beta - dbeta * pixfrac / 2., wave)
-            ra2, dec2, _ = input_model.meta.wcs.transform('alpha_beta', 'world', alpha1,
+            ra2, dec2, _ = input_model.meta.wcs.transform('alpha_beta', input_model.meta.wcs.output_frame, alpha1,
                                                           beta + dbeta * pixfrac / 2., wave)
-            ra3, dec3, _ = input_model.meta.wcs.transform('alpha_beta', 'world', alpha2,
+            ra3, dec3, _ = input_model.meta.wcs.transform('alpha_beta', input_model.meta.wcs.output_frame, alpha2,
                                                           beta + dbeta * pixfrac / 2., wave)
-            ra4, dec4, _ = input_model.meta.wcs.transform('alpha_beta', 'world', alpha2,
+            ra4, dec4, _ = input_model.meta.wcs.transform('alpha_beta', input_model.meta.wcs.output_frame, alpha2,
                                                           beta - dbeta * pixfrac / 2., wave)
 
             corner_coord = [ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4]
@@ -1775,7 +1775,7 @@ class IFUCubeData():
                 # Pixel corners
                 pixfrac = 1.0
                 detector2slicer = slice_wcs.get_transform('detector', 'slicer')
-                slicer2world = slice_wcs.get_transform('slicer', 'world')
+                slicer2world = slice_wcs.get_transform('slicer', slice_wcs.output_frame)
                 across1, along1, lam1 = detector2slicer(x, y - 0.49 * pixfrac)
                 across2, along2, lam2 = detector2slicer(x, y + 0.49 * pixfrac)
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1260,7 +1260,10 @@ class IFUCubeData():
                     if ch1 in self.list_par1 or ch3 in self.list_par1:
                         spatial_found = False
                         spectral_found = False
-
+                # If Moving TARGET data then do not use s_region the y are not updated for moving targets
+                target_type = input_model.meta.target.type
+                if target_type == 'MOVING':
+                    spatial_found = False
                 if(spectral_found & spatial_found & world):
                     [lmin, lmax] = input_model.meta.wcsinfo.spectral_region
                     spatial_box = input_model.meta.wcsinfo.s_region
@@ -1756,7 +1759,6 @@ class IFUCubeData():
             slice_wcs = nirspec.nrs_wcs_set_input(input_model, ii)
             x, y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box)
             ra, dec, lam = slice_wcs(x, y)
-
             # the slices are curved on detector so a rectangular region returns NaNs
             valid = ~np.isnan(lam)
             x = x[valid]

--- a/jwst/cube_build/src/cube_dq_utils.c
+++ b/jwst/cube_build/src/cube_dq_utils.c
@@ -376,7 +376,7 @@ int slice_wave_plane_nirspec(int w, int slicevalue,
     // Problem finding limits of slice for wavelength plane
     // This is likely caused the no valid data on wavelength plane
     // The two ends of wavelengths can have DQ detector data set to DO_NOT_USE - setting up no
-    // valid data on thee planes in the IFU Cube. 
+    // valid data on the planes in the IFU Cube. 
 
     status = 1; 
   } 

--- a/jwst/cube_build/src/cube_dq_utils.c
+++ b/jwst/cube_build/src/cube_dq_utils.c
@@ -647,14 +647,14 @@ int dq_nirspec(int overlap_partial,
 					       &c1_min, &c2_min, &c1_max, &c2_max);
       printf( " status_wave %i \n ", status_wave);
       if( status_wave ==0){
-	printf( " calling overlap slice with spaxels %i %i \n ", islice, nxy);
+	printf( " calling overlap slice with spaxels %i %i %i\n ", islice, nxy,w);
 	status = overlap_slice_with_spaxels(overlap_partial,
 					    cdelt1,cdelt2,
 					    nx, ny,
 					    xc, yc,
 					    c1_min, c2_min, c1_max, c2_max,
 					    wave_slice_dq);
-	printf( " done overlap slice with spaxels %i \n ", status);
+	printf( " done overlap slice with spaxels status: %i \n ", status);
       } // end loop over status_wave
 
       istart = nxy*w;

--- a/jwst/cube_build/src/cube_dq_utils.c
+++ b/jwst/cube_build/src/cube_dq_utils.c
@@ -391,7 +391,10 @@ long match_wave_plane_nirspec(double wave_plane,
     for (int i = 0; i< 30; i++){
       if (c1_min[i] != minvalue && c2_min[i] != minvalue &&
 	  c1_max[i] != maxvalue && c2_max[i] != maxvalue){
-	match_slice[i] = 1;
+	
+	if (c1_min[i] != c1_max[i] && c2_min[i] != c2_max[i]){
+	  match_slice[i] = 1;
+	}
       }
     }
   }
@@ -404,7 +407,8 @@ long match_wave_plane_nirspec(double wave_plane,
 int overlap_slice_with_spaxels(int overlap_partial,
 			       double cdelt1, double cdelt2,
 			       int naxis1, int naxis2,
-			       double xcenters[], double ycenters[],
+			       double xstart, double ystart,
+			       // double xcenters[], double ycenters[],
 			       double xi_min, double eta_min,
 			       double xi_max, double eta_max,
 			       int wave_slice_dq[]) {
@@ -436,20 +440,20 @@ int overlap_slice_with_spaxels(int overlap_partial,
 
   */
  
-  int error, ystep, y, x, yuse, xuse, index;
+  int error, ystep, y, x, yuse, xuse;
+  int index;
   //set up line - convert to integer values
-  int x1 = (int)((xi_min - xcenters[0]) / cdelt1);
-  int y1 = (int)((eta_min - ycenters[0]) / cdelt2);
-  int x2 = (int)((xi_max - xcenters[0]) / cdelt1);
-  int y2 = (int)((eta_max - ycenters[0]) / cdelt2);
+  int x1 = (int)((xi_min - xstart) / cdelt1);
+  int y1 = (int)((eta_min - ystart) / cdelt2);
+  int x2 = (int)((xi_max - xstart) / cdelt1);
+  int y2 = (int)((eta_max - ystart) / cdelt2);
 
   int dx = x2 - x1;
   int dy = y2 - y1;
   bool is_steep;
+
   is_steep = abs(dy) > abs(dx);
 
-  // printf(" x1 x2 y1 y2 %i %i %i %i \n", x1,x2,y1,y2);
-  
   // if is_steep switch x and y 
   if (is_steep){
       x1 = y1;
@@ -491,8 +495,7 @@ int overlap_slice_with_spaxels(int overlap_partial,
       }
 
     index = (yuse * naxis1) + xuse;
-    //printf(" index %i %i %i %i %i %i \n", index, yuse, naxis1, xuse, x,y );
-    
+
     wave_slice_dq[index] = overlap_partial;
     error -= abs(dy);
     if (error < 0){
@@ -636,7 +639,7 @@ int dq_nirspec(int overlap_partial,
   }
   
   nxy = nx * ny;
-  
+
   for (w = 0; w  < nz; w++) {
     long imatch = 0;
     double c1_min[30];
@@ -674,10 +677,13 @@ int dq_nirspec(int overlap_partial,
 
 	  // at the wavelength plane find the overlap of each slice on
 	  // output spaxel plane
+
+	  float xstart = xc[0];
+	  float ystart = yc[0];
 	  status = overlap_slice_with_spaxels(overlap_partial,
 					      cdelt1,cdelt2,
 					      nx, ny,
-					      xc, yc,
+					      xstart, ystart,
 					      slice_c1_min, slice_c2_min,
 					      slice_c1_max, slice_c2_max,
 					      wave_slice_dq);

--- a/jwst/cube_build/src/cube_dq_utils.c
+++ b/jwst/cube_build/src/cube_dq_utils.c
@@ -640,7 +640,7 @@ int dq_nirspec(int overlap_partial,
       c2_max = 0;
       printf( " calling slice_wave_plane_nirspec %i %i %i \n  ", islice, w, ncube);
       if(w < nz-1){
-	printf( "wavebin %f \n", zc[w]-zc[w+1]);
+	printf( "wavebin%i %i  %f \n", w, islice, zc[w+1]-zc[w]);
       }
       status_wave =  slice_wave_plane_nirspec( w, islice, roiw_ave, zc,
 					       coord1, coord2, wave, sliceno, ncube, npt,
@@ -663,12 +663,13 @@ int dq_nirspec(int overlap_partial,
       for( in = istart; in < iend; in ++){
 	ii = in - istart;
 	if (status_wave ==0){
+	  printf( " values %i %i \n ", ii, in);
 	  idqv[in] = wave_slice_dq[ii];
 	} else {
 	  idqv[in] = 0;
 	}
       }
-      
+
     } // end loop over slices
 	
   } // end of wavelength

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -97,7 +97,7 @@ extern int dq_miri(int start_region, int end_region, int overlap_partial, int ov
 		   double *xc, double *yc, double *zc,
 		   double *coord1, double *coord2, double *wave,
 		   double *sliceno,
-		   long ncube, int npt, 
+		   long ncube, long npt, 
 		   int **spaxel_dq);
 
 extern int dq_nirspec(int overlap_partial,
@@ -106,7 +106,7 @@ extern int dq_nirspec(int overlap_partial,
 		      double *xc, double *yc, double *zc,
 		      double *coord1, double *coord2, double *wave,
 		      double *sliceno,
-		      long ncube, int npt,
+		      long ncube, long npt,
 		      int **spaxel_dq);
 
 extern int set_dqplane_to_zero(int ncube, int **spaxel_dq);
@@ -128,7 +128,7 @@ int match_driz(double *xc, double *yc, double *zc,
 	       double *dwave,
 	       double *cdelt3,
 	       double cdelt1, double cdelt2,
-	       int nx, int ny, int nwave, int ncube, int npt, int linear, 
+	       int nx, int ny, int nwave, long ncube, long npt, int linear, 
 	       double **spaxel_flux, double **spaxel_weight, double **spaxel_var,
 	       double **spaxel_iflux) {
 
@@ -164,7 +164,6 @@ int match_driz(double *xc, double *yc, double *zc,
  
   // loop over each detector pixel and find which spaxels it overlaps with
   nxy = nx * ny;
-  //printf(" number of cube elements %i \n", npt);
   for (k = 0; k < npt; k++) {
       xpixel[0] = xi1[k];
       xpixel[1] = xi2[k];
@@ -183,7 +182,6 @@ int match_driz(double *xc, double *yc, double *zc,
       xmax = xmin;
       ymax = ymin;
       for (j =1; j< 5; j++){
-	// if(k < 5) {printf("pixel %f %f \n", xpixel[j], ypixel[j]);}
 	if(xpixel[j] > xmax) xmax = xpixel[j];
 	if(ypixel[j] > ymax) ymax = ypixel[j];
 	if(xpixel[j] < xmin) xmin = xpixel[j];
@@ -229,10 +227,7 @@ int match_driz(double *xc, double *yc, double *zc,
 	zreg = fabs(dwave[k] + cdelt3[iw]);
 	// zreg = 0.0025; (roiw size for testing- usually larger than zreg)
 	wdiff = zc[iw] - wave[k];
-	if( k == -40 && iw ==0){
-	  printf(" found %f %f %f %f  %f %f \n ",wdiff, wave[k], zc[0], zreg, dwave[k], cdelt3[iw]);
-	  printf(" x,y overlaps %i %i %i %i \n", ix1, ix2, iy1, iy2);
-	}
+
 	if( fabs(wdiff) < zreg){
 	  // Fractional wavelength overlaps to use for weighting
 	  ptmin = wave[k] - dwave[k]/2;
@@ -261,9 +256,6 @@ int match_driz(double *xc, double *yc, double *zc,
 	      ytop = yc[iy] + cdelt2*0.5;
 
 	      index_xy = iy* nx + ix;
-	      if(index_xy == -1727 && iw ==0){
-		printf(" found %f %f %f %f %f %f %f %f %i %i %i \n", xleft, xright, ybot, ytop, xmax, xmin, ymax, ymin,iw,ix,iy);
-	      }
 	
 	      if(xleft < xmax && xright > xmin && ybot < ymax && ytop > ymin){
 
@@ -327,7 +319,8 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   PyObject *dwaveo;
   
   double cdelt1, cdelt2,cdelt3_mean;
-  int  nwave, npt, nxx, nyy, ncube;
+  int  nwave, nxx, nyy;
+  long npt, ncube;
   int linear;
   int instrument, flag_dq_plane,start_region, end_region, overlap_partial, overlap_full;
   double *spaxel_flux=NULL, *spaxel_weight=NULL, *spaxel_var=NULL;
@@ -393,7 +386,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
 
     }
 
-  npt = (int) PyArray_Size((PyObject *) coord1);
+  npt = (long) PyArray_Size((PyObject *) coord1);
   ny = (int) PyArray_Size((PyObject *) coord2);
   nz = (int) PyArray_Size((PyObject *) wave);
   if (ny != npt || nz != npt ) {
@@ -437,7 +430,6 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   // if flag_dq_plane = 1, Set up the dq plane 
   //______________________________________________________________________
   int status1 = 0;
-  printf("flag dq plane %i \n ", flag_dq_plane);
   
   if(flag_dq_plane){
     if (instrument == 0){
@@ -455,9 +447,8 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
 			&spaxel_dq);
 
     } else{
-      printf(" dq nirspec set up \n");
       status1 = dq_nirspec(overlap_partial,
-			   nxx,nyy,nwave,
+      			   nxx,nyy,nwave,
 			   cdelt1, cdelt2, cdelt3_mean,
 			   (double *) PyArray_DATA(xc),
 			   (double *) PyArray_DATA(yc),
@@ -468,13 +459,11 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
 			   (double *) PyArray_DATA(sliceno),
 			   ncube, npt,
 			   &spaxel_dq);
-      printf(" dq nirspec done set up \n");
     }
   } else{ // set dq plane to 0
     status1 = set_dqplane_to_zero(ncube, &spaxel_dq);
     
   }
-  printf(" drizzling data \n");
   //______________________________________________________________________
   // Driz the mapped detector data onto the IFU cube
   //______________________________________________________________________

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -453,6 +453,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
 			&spaxel_dq);
 
     } else{
+      printf(" dq nirspec set up \n");
       status1 = dq_nirspec(overlap_partial,
 			   nxx,nyy,nwave,
 			   cdelt1, cdelt2, cdelt3_mean,
@@ -465,6 +466,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
 			   (double *) PyArray_DATA(sliceno),
 			   ncube, npt,
 			   &spaxel_dq);
+      printf(" dq nirspec done set up \n");
     }
   } else{ // set dq plane to 0
     status1 = set_dqplane_to_zero(ncube, &spaxel_dq);

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -437,6 +437,8 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   // if flag_dq_plane = 1, Set up the dq plane 
   //______________________________________________________________________
   int status1 = 0;
+  printf("flag dq plane %i \n ", flag_dq_plane);
+  
   if(flag_dq_plane){
     if (instrument == 0){
       status1 = dq_miri(start_region, end_region,overlap_partial, overlap_full,
@@ -472,7 +474,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     status1 = set_dqplane_to_zero(ncube, &spaxel_dq);
     
   }
-
+  printf(" drizzling data \n");
   //______________________________________________________________________
   // Driz the mapped detector data onto the IFU cube
   //______________________________________________________________________


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2654](https://jira.stsci.edu/browse/JP-2654)
Resolves [JP-2662](https://jira.stsci.edu/browse/JP-2662)


<!-- describe the changes comprising this PR here -->
This PR addresses a bug in the C code used by cube_build that sets the DQ flag for NIRSpec IFU data. After a review of the code it was determined the flagging was not being done correctly. I re-wrote the code to make it easier to follow. In the process of re-writing the code I fixed the segmentation fault error. 
When the above bug was fixed, a second bug was discovered. The NIRSpec data for this ticket is moving target data. This second bug was because drizzling was not working correctly for moving target data.  This was fixed and this fix resolved JP-2662

**Checklist**
- [X] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant milestone
- [X] added relevant label(s)
