### PR TITLE
JP-2672: Remove trailing dash from end of full subchannel listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@ assign_wcs
 cube_build
 ----------
 
-- Remove trailing dash from IFU cube filenames built from all subchannels [#6959]
+- Remove trailing dash from IFU cube filenames built from all subchannels.
+  Sort subchannels present by inverse alphabetical order to ensure
+  consistent filename creation across processing runs. [#6959]
 
 datamodels
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ assign_wcs
   module to allow easy updating of FITS WCS stored in ``datamodel.meta.wcsinfo``
   from data model's GWCS. [#6935]
 
+cube_build
+----------
+
+- Remove trailing dash from IFU cube filenames built from all subchannels [#6959]
+
 datamodels
 ----------
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -190,8 +190,6 @@ class IFUCubeData():
                 b_name = ''
                 for i in range(number_subchannels):
                     b_name = b_name + subchannels[i]
-                    if i > 1:
-                        b_name = b_name + '-'
                 b_name = b_name.lower()
                 newname = self.output_name_base + ch_name + '-' + b_name + \
                     '_s3d.fits'

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -185,7 +185,9 @@ class IFUCubeData():
                         if i < number_channels - 1:
                             ch_name = ch_name + '-'
 
-                subchannels = list(set(self.list_par2))
+                # Sort by inverse alphabetical, e.g. short -> medium -> long
+                subchannels = sorted(list(set(self.list_par2)))[::-1]
+                log.info(f"Subchannel listing: {subchannels}")
                 number_subchannels = len(subchannels)
                 b_name = ''
                 for i in range(number_subchannels):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2672](https://jira.stsci.edu/browse/JP-2672)
Resolves [JP-2673](https://jira.stsci.edu/browse/JP-2673)

<!-- describe the changes comprising this PR here -->
This PR removes code that is only triggered if all three subchannels are present in cube building a channel's cube, i.e. short+medium+long. The code likely was not working as intended, and it will no longer add any dashes apart from the pre-existing dash between channel and subchannel, i.e. ch1-shortmediumlong. If dashes are wanted between the subchannel names, that could be added but doesn't seem necessary.

After realizing I reproduced the bug in JP-2673, I added that to this PR and sorted the subchannel list by inverse alphabetical order so that the presented order is increasing in wavelength (aesthetics?).

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
