### PR TITLE
JP-2797: MRS sigma-clipped master background fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ master_background
 -----------------
 
 - Fix MRS sigma-clipped background use in cases where EXTENDED keyword not
-  properly set. [#]
+  properly set. [#6960]
 
 resample
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,12 @@ datamodels
 
 - Add P_SUBARR keyword to the `DarkModel` schema. [#6951]
 
+master_background
+-----------------
+
+- Fix MRS sigma-clipped background use in cases where EXTENDED keyword not
+  properly set. [#]
+
 resample
 --------
 

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -115,8 +115,9 @@ class MasterBackgroundStep(Step):
                         # for simulated data that didn't bother populating this
                         # keyword
                         this_is_ifu_extended = False
-                        if ((model.meta.exposure.type == 'MIR_MRS' or model.meta.exposure.type == 'NRS_IFU')
-                                and model.meta.target.source_type == 'EXTENDED'):
+                        if (model.meta.exposure.type == 'NRS_IFU' and model.meta.target.source_type == 'EXTENDED'):
+                            this_is_ifu_extended = True
+                        if (model.meta.exposure.type == 'MIR_MRS'):
                             this_is_ifu_extended = True
 
                         if model.meta.observation.bkgdtarg is False or this_is_ifu_extended:


### PR DESCRIPTION
This PR fixes an issue where the sigma-clipped background isn't being used as intended for the master background step when the source type is undefined (see https://jira.stsci.edu/browse/JP-2797)

**Checklist**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
