### PR TITLE
Require drizzle>=1.13.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     BayesicFitting>=3.0.1
     certifi==2022.5.18.1
     crds>=11.16.5
-    drizzle>=1.13.4
+    drizzle>=1.13.6
     gwcs>=0.18.0
     jsonschema>=4.0.1
     numpy>=1.20


### PR DESCRIPTION
Due to a bug in the `drizzle` version `1.13.5`, I am modifying `setup.cfg` to require use of bug-fixed version `1.13.6`. For more details, see https://github.com/spacetelescope/drizzle/pull/85

**Checklist**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
