### PR TITLE
Revert "JP-2654 JP-2662: Fix bug in NIRSpec IFU DQ flagging and handling of moving target exposures"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,14 +31,6 @@ cube_build
 - Remove trailing dash from IFU cube filenames built from all subchannels.
   Sort subchannels present by inverse alphabetical order to ensure
   consistent filename creation across processing runs. [#6959]
-  
-- Re-wrote c code for NIRSpec dq flagging.[#6971]
-
-- For moving target data removed using  s_region values in cal files to
-  determine the size of the cube, instead all the pixels are mapped to
-  the skip to determine the cube footprint. Also updated the drizzle
-  code to use the  wcs of output frame to account for moving target. [#6971]
- 
 
 datamodels
 ----------

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -12,7 +12,7 @@ log.setLevel(logging.DEBUG)
 
 # ******************************************************************************
 def find_corners_MIRI(input, this_channel, instrument_info, coord_system):
-    """ For MIRI channel data find the footprint of this data on the sky
+    """ For MIRI channel data find the foot of this data on the sky
 
     For a specific channel on an exposure find the min and max of the
     spatial coordinates, either in alpha,beta or ra,dec depending
@@ -153,7 +153,7 @@ def find_corners_NIRSPEC(input, instrument_info, coord_system):
     lambda_slice = np.zeros(nslices * 2)
     k = 0
     # for NIRSPEC there are 30 regions
-    log.info('Looping over slices to determine cube size')
+    log.info('Looping over slices to determine cube size .. this takes a while')
 
     for i in range(nslices):
         slice_wcs = nirspec.nrs_wcs_set_input(input, i)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1262,12 +1262,6 @@ class IFUCubeData():
                         spatial_found = False
                         spectral_found = False
 
-                # If Moving Target data, then do not use S_REGION values.
-                # The S_REGION values contain the footprint
-                # on the sky of the original WCS.
-                target_type = input_model.meta.target.type
-                if target_type == 'MOVING':
-                    spatial_found = False
                 if spectral_found and spatial_found and world:
                     [lmin,lmax] = input_model.meta.wcsinfo.spectral_region
                     spatial_box = input_model.meta.wcsinfo.s_region
@@ -1683,17 +1677,13 @@ class IFUCubeData():
             # Find slice width
             allbetaval = np.unique(beta)
             dbeta = np.abs(allbetaval[1] - allbetaval[0])
-            ra1, dec1, _ = input_model.meta.wcs.transform('alpha_beta',
-                                                          input_model.meta.wcs.output_frame, alpha1,
+            ra1, dec1, _ = input_model.meta.wcs.transform('alpha_beta', 'world', alpha1,
                                                           beta - dbeta * pixfrac / 2., wave)
-            ra2, dec2, _ = input_model.meta.wcs.transform('alpha_beta',
-                                                          input_model.meta.wcs.output_frame, alpha1,
+            ra2, dec2, _ = input_model.meta.wcs.transform('alpha_beta', 'world', alpha1,
                                                           beta + dbeta * pixfrac / 2., wave)
-            ra3, dec3, _ = input_model.meta.wcs.transform('alpha_beta',
-                                                          input_model.meta.wcs.output_frame, alpha2,
+            ra3, dec3, _ = input_model.meta.wcs.transform('alpha_beta', 'world', alpha2,
                                                           beta + dbeta * pixfrac / 2., wave)
-            ra4, dec4, _ = input_model.meta.wcs.transform('alpha_beta',
-                                                          input_model.meta.wcs.output_frame, alpha2,
+            ra4, dec4, _ = input_model.meta.wcs.transform('alpha_beta', 'world', alpha2,
                                                           beta - dbeta * pixfrac / 2., wave)
 
             corner_coord = [ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4]
@@ -1785,7 +1775,7 @@ class IFUCubeData():
                 # Pixel corners
                 pixfrac = 1.0
                 detector2slicer = slice_wcs.get_transform('detector', 'slicer')
-                slicer2world = slice_wcs.get_transform('slicer',slice_wcs.output_frame)
+                slicer2world = slice_wcs.get_transform('slicer','world')
                 across1,along1,lam1 = detector2slicer(x, y - 0.49 * pixfrac)
                 across2,along2,lam2 = detector2slicer(x, y + 0.49 * pixfrac)
 

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -97,7 +97,7 @@ extern int dq_miri(int start_region, int end_region, int overlap_partial, int ov
 		   double *xc, double *yc, double *zc,
 		   double *coord1, double *coord2, double *wave,
 		   double *sliceno,
-		   long ncube, long npt, 
+		   long ncube, int npt, 
 		   int **spaxel_dq);
 
 extern int dq_nirspec(int overlap_partial,
@@ -106,7 +106,7 @@ extern int dq_nirspec(int overlap_partial,
 		      double *xc, double *yc, double *zc,
 		      double *coord1, double *coord2, double *wave,
 		      double *sliceno,
-		      long ncube, long npt,
+		      long ncube, int npt,
 		      int **spaxel_dq);
 
 extern int set_dqplane_to_zero(int ncube, int **spaxel_dq);
@@ -128,7 +128,7 @@ int match_driz(double *xc, double *yc, double *zc,
 	       double *dwave,
 	       double *cdelt3,
 	       double cdelt1, double cdelt2,
-	       int nx, int ny, int nwave, long ncube, long npt, int linear, 
+	       int nx, int ny, int nwave, int ncube, int npt, int linear, 
 	       double **spaxel_flux, double **spaxel_weight, double **spaxel_var,
 	       double **spaxel_iflux) {
 
@@ -164,6 +164,7 @@ int match_driz(double *xc, double *yc, double *zc,
  
   // loop over each detector pixel and find which spaxels it overlaps with
   nxy = nx * ny;
+  //printf(" number of cube elements %i \n", npt);
   for (k = 0; k < npt; k++) {
       xpixel[0] = xi1[k];
       xpixel[1] = xi2[k];
@@ -182,6 +183,7 @@ int match_driz(double *xc, double *yc, double *zc,
       xmax = xmin;
       ymax = ymin;
       for (j =1; j< 5; j++){
+	// if(k < 5) {printf("pixel %f %f \n", xpixel[j], ypixel[j]);}
 	if(xpixel[j] > xmax) xmax = xpixel[j];
 	if(ypixel[j] > ymax) ymax = ypixel[j];
 	if(xpixel[j] < xmin) xmin = xpixel[j];
@@ -227,7 +229,10 @@ int match_driz(double *xc, double *yc, double *zc,
 	zreg = fabs(dwave[k] + cdelt3[iw]);
 	// zreg = 0.0025; (roiw size for testing- usually larger than zreg)
 	wdiff = zc[iw] - wave[k];
-
+	if( k == -40 && iw ==0){
+	  printf(" found %f %f %f %f  %f %f \n ",wdiff, wave[k], zc[0], zreg, dwave[k], cdelt3[iw]);
+	  printf(" x,y overlaps %i %i %i %i \n", ix1, ix2, iy1, iy2);
+	}
 	if( fabs(wdiff) < zreg){
 	  // Fractional wavelength overlaps to use for weighting
 	  ptmin = wave[k] - dwave[k]/2;
@@ -256,6 +261,9 @@ int match_driz(double *xc, double *yc, double *zc,
 	      ytop = yc[iy] + cdelt2*0.5;
 
 	      index_xy = iy* nx + ix;
+	      if(index_xy == -1727 && iw ==0){
+		printf(" found %f %f %f %f %f %f %f %f %i %i %i \n", xleft, xright, ybot, ytop, xmax, xmin, ymax, ymin,iw,ix,iy);
+	      }
 	
 	      if(xleft < xmax && xright > xmin && ybot < ymax && ytop > ymin){
 
@@ -319,8 +327,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   PyObject *dwaveo;
   
   double cdelt1, cdelt2,cdelt3_mean;
-  int  nwave, nxx, nyy;
-  long npt, ncube;
+  int  nwave, npt, nxx, nyy, ncube;
   int linear;
   int instrument, flag_dq_plane,start_region, end_region, overlap_partial, overlap_full;
   double *spaxel_flux=NULL, *spaxel_weight=NULL, *spaxel_var=NULL;
@@ -386,7 +393,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
 
     }
 
-  npt = (long) PyArray_Size((PyObject *) coord1);
+  npt = (int) PyArray_Size((PyObject *) coord1);
   ny = (int) PyArray_Size((PyObject *) coord2);
   nz = (int) PyArray_Size((PyObject *) wave);
   if (ny != npt || nz != npt ) {
@@ -430,7 +437,6 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   // if flag_dq_plane = 1, Set up the dq plane 
   //______________________________________________________________________
   int status1 = 0;
-  
   if(flag_dq_plane){
     if (instrument == 0){
       status1 = dq_miri(start_region, end_region,overlap_partial, overlap_full,
@@ -448,7 +454,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
 
     } else{
       status1 = dq_nirspec(overlap_partial,
-      			   nxx,nyy,nwave,
+			   nxx,nyy,nwave,
 			   cdelt1, cdelt2, cdelt3_mean,
 			   (double *) PyArray_DATA(xc),
 			   (double *) PyArray_DATA(yc),
@@ -464,6 +470,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     status1 = set_dqplane_to_zero(ncube, &spaxel_dq);
     
   }
+
   //______________________________________________________________________
   // Driz the mapped detector data onto the IFU cube
   //______________________________________________________________________


### PR DESCRIPTION
Reverts spacetelescope/jwst#6971 because we're getting C compiler errors, at least on Linux, that didn't exist before.