### PR TITLE
JP-2578: Add P_READPA to ReadnoiseModel schema

### DIFF
--- a/jwst/datamodels/schemas/readnoise.schema.yaml
+++ b/jwst/datamodels/schemas/readnoise.schema.yaml
@@ -6,6 +6,7 @@ allOf:
 - $ref: referencefile.schema
 - $ref: subarray.schema
 - $ref: keyword_readpatt.schema
+- $ref: keyword_preadpatt.schema
 - $ref: keyword_gainfact.schema
 - $ref: bunit.schema
 - type: object


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2578](https://jira.stsci.edu/browse/JP-2578)

<!-- describe the changes comprising this PR here -->
This PR adds the P_READPA keyword to the datamodels schema for the `ReadnoiseModel` (used for readnoise reference files), at the request of the MIRI team.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
