### PR TITLE
JP-2814: Exclude pixels flagged with DO_NOT_USE from source finding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,8 +67,9 @@ tweakreg
 - ``tweakreg`` step now updates FITS WCS stored in ``datamodel.meta.wcsinfo``
   from data model's tweaked GWCS. [#6936, #6947, #6955]
 
-- The ``tweakreg`` step now masks ``NON_SCIENCE`` pixels when
-  calculating the source detection theshold. [#6940]
+- The ``tweakreg`` step now masks `both `NON_SCIENCE`` and ``DO_NOT_USE``
+  pixels when calculating the source detection theshold and finding
+  sources. [#6940, #6974]
 
 - Allow alignment of a single image (or group) to Gaia while skipping relative
   alignment (whcih needs 2 images) instead of cancelling  the entire

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -68,7 +68,9 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
         raise TypeError('The input model must be an ImageModel.')
 
     # Mask the non-imaging area (e.g. MIRI)
-    coverage_mask = (dqflags.pixel['NON_SCIENCE'] & model.dq).astype(bool)
+    coverage_mask = ((dqflags.pixel['NON_SCIENCE'] +
+                      dqflags.pixel['DO_NOT_USE']) &
+                     model.dq).astype(bool)
 
     bkg = JWSTBackground(model.data, box_size=bkg_boxsize,
                          coverage_mask=coverage_mask)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2814](https://jira.stsci.edu/browse/JP-2814)

<!-- describe the changes comprising this PR here -->
This PR addresses this comment: https://github.com/spacetelescope/jwst/pull/6940#issuecomment-1212045272 from #6940

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
