### PR TITLE
JP-2811  Update wcs naxis3  when removing wavelength planes from cube

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ cube_build
   Sort subchannels present by inverse alphabetical order to ensure
   consistent filename creation across processing runs. [#6959]
 
+- Update the wcs value for naxis3 when wavelength planes are removed from the
+  IFUCube when there is no valid data. [#6976]
+
 datamodels
 ----------
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -2112,8 +2112,10 @@ class IFUCubeData():
                 dq = dq[remove_start:self.naxis3 - remove_final, :, :]
                 var = var[remove_start:self.naxis3 - remove_final, :, :]
 
+                # update WCS information if removing wavelengths from the IFU Cube
                 if self.linear_wavelength:
                     self.crval3 = self.zcoord[remove_start]
+                    self.naxis3 = self.naxis3 - (remove_start + remove_final)
                 else:
                     self.wavelength_table = self.wavelength_table[remove_start:self.naxis3 - remove_final]
                     self.crval3 = self.wavelength_table[0]

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -2113,13 +2113,13 @@ class IFUCubeData():
                 var = var[remove_start:self.naxis3 - remove_final, :, :]
 
                 # update WCS information if removing wavelengths from the IFU Cube
+                self.naxis3 = self.naxis3 - (remove_start + remove_final) + 1
+
                 if self.linear_wavelength:
                     self.crval3 = self.zcoord[remove_start]
-                    self.naxis3 = self.naxis3 - (remove_start + remove_final)
                 else:
                     self.wavelength_table = self.wavelength_table[remove_start:self.naxis3 - remove_final]
                     self.crval3 = self.wavelength_table[0]
-                    self.naxis3 = self.naxis3 - (remove_start + remove_final)
 
         # end removing empty wavelength planes
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2811](https://jira.stsci.edu/browse/JP-2811)

<!-- describe the changes comprising this PR here -->
This PR updates the wcs naxis3 value if wavelength planes have been removed from the IFUcube because only values of zero were contained in the planes (i.e. no valid data in wavelength plane) 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/383/#showFailuresLink
Failure for imager modes not related to this PR.
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)