### PR TITLE
JP-2808: Fix handling of SRCTYPE in master background

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ master_background
 - Fix MRS sigma-clipped background use in cases where EXTENDED keyword not
   properly set. [#6960]
 
+- Fix reading of the source_type attribute for NIRSpec IFU data. [#6980]
+
 resample
 --------
 

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -109,20 +109,20 @@ class MasterBackgroundStep(Step):
                     asn_id = input_data.meta.asn_table.asn_id
 
                     for model in background_data:
-                        # Check if the background members are nodded x1d extractions.
-                        # Or background from dedicated background exposures
+                        # Check if the background members are nodded x1d extractions
+                        # or background from dedicated background exposures.
                         # Use "bkgdtarg == False" so we don't also get None cases
                         # for simulated data that didn't bother populating this
-                        # keyword
+                        # keyword.
                         this_is_ifu_extended = False
-                        if (model.meta.exposure.type == 'NRS_IFU' and model.meta.target.source_type == 'EXTENDED'):
+                        if (model.meta.exposure.type == 'NRS_IFU' and model.spec[0].source_type == 'EXTENDED'):
                             this_is_ifu_extended = True
                         if (model.meta.exposure.type == 'MIR_MRS'):
+                            # always treat as extended for MIRI MRS
                             this_is_ifu_extended = True
 
                         if model.meta.observation.bkgdtarg is False or this_is_ifu_extended:
-                            self.log.debug("Copying BACKGROUND column "
-                                           "to SURF_BRIGHT")
+                            self.log.debug("Copying BACKGROUND column to SURF_BRIGHT")
                             copy_background_to_surf_bright(model)
 
                     master_background = combine_1d_spectra(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2808](https://jira.stsci.edu/browse/JP-2808)

<!-- describe the changes comprising this PR here -->
This PR fixes the retrieval of the SRCTYPE value in the master_background step for the case of NIRSpec IFU data. The input background spectra (from x1d products) are always in the form of a `SpecModel` or `MultiSpecModel`, in which case the SRCTYPE must be read from the "spec" attribute of the data model, not from the generic `model.meta.target.source_type` attribute (which is None for these kinds of models).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
