### PR TITLE
update `certifi` dependency version to use new version (now works with `pip freeze`)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     asdf>=2.12.0
     astropy>=5.0.4
     BayesicFitting>=3.0.1
-    certifi==2022.5.18.1
+    certifi>=2022.6.5
     crds>=11.16.5
     drizzle>=1.13.6
     gwcs>=0.18.0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
The issue that caused `pip freeze` to provide an invalid version definition for `certifi` when in a `conda` environment (https://github.com/spacetelescope/jwst/pull/6927) seems to be resolved with the latest version. I tested this by running `pip freeze` locally.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
