### PR TITLE
JP-2816: Update outlier docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,7 +68,7 @@ outlier_detection
   New parameters were aded to the step to control this functionality. [#6904]
 
 - Updated documentation of memory model and new parameters for memory use in
-  outlier_detection and resample steps. [#xxxx]
+  outlier_detection and resample steps. [#6983]
 
 resample
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ outlier_detection
 - Updated documentation of memory model and new parameters for memory use in
   outlier_detection and resample steps. [#6983]
 
+- Fix reading of the source_type attribute for NIRSpec IFU data. [#6980]
+
 resample
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ outlier_detection
   input ``ImageModels`` that are saved to disk instead of keeping them in memory.
   New parameters were aded to the step to control this functionality. [#6904]
 
+- Updated documentation of memory model and new parameters for memory use in
+  outlier_detection and resample steps. [#xxxx]
+
 resample
 --------
 

--- a/docs/jwst/outlier_detection/outlier_detection.rst
+++ b/docs/jwst/outlier_detection/outlier_detection.rst
@@ -68,14 +68,16 @@ final output product.  Specifically,
       be on the order of 2Gb or more.
 
     * The median combination step then needs to have all pixels at the same position on
-      the sky in memory in order to perform the median computation.  The simplest implmentation
-      for this step would require keeping all resampled outputs in memory at the same time.
+      the sky in memory in order to perform the median computation.  The simplest implementation
+      for this step requires keeping all resampled outputs fully in memory at the same time.
 
 Many Level 3 products only include a modest number of input exposures which can be
-processed using less than 32Gb of memory at a time.  However, given the number of
-ways this memory limit can be exceeded, the overall memory model for the outlier detection
-was revised to minimize the memory usage at the expense of file I/O with limited control
-over this through the ``in_memory`` parameter when set to `False`.
+processed using less than 32Gb of memory at a time.  However, there are a number of
+ways this memory limit can be exceeded.  This has been addressed by implementing an
+overall memory model for the outlier detection that includes options to minimize the
+memory usage at the expense of file I/O.  The control over this memory model happens
+with the use of the ``in_memory`` parameter.  The full impact of this parameter
+during processing includes:
 
     * The ``save_open`` parameter gets set to `False`
       when opening the input :py:class:`~jwst.datamodels.ModelContainer` object.

--- a/docs/jwst/outlier_detection/outlier_detection.rst
+++ b/docs/jwst/outlier_detection/outlier_detection.rst
@@ -50,6 +50,55 @@ Specifically, this routine performs the following operations:
 * Perform statistical comparison between blotted image and original image to identify outliers.
 * Update input data model DQ arrays with mask of detected outliers.
 
+Memory Model for Outlier Detection Algorithm
+---------------------------------------------
+The outlier detection algorithm can end up using massive amounts of memory
+depending on the number of inputs, the size of each input, and the size of the
+final output product.  Specifically,
+
+* The input :py:class:`~jwst.datamodels.ModelContainer` or
+  :py:class:`~jwst.datamodels.CubeModel`
+  for IFU data, by default, all input exposures would have been kept open in memory to make
+  processing more efficient.
+
+* The initial resample step creates an output product for EACH input that is the
+  same size as the final
+  output product, which for imaging modes can span all chips in the detector while
+  also accounting for all dithers.  For some Level 3 products, each resampled image can
+  be on the order of 2Gb or more.
+
+* The median combination step then needs to have all pixels at the same position on
+  the sky in memory in order to perform the median computation.  The simplest implmentation
+  for this step would require keeping all resampled outputs in memory at the same time.
+
+Many Level 3 products only include a modest number of input exposures which can be
+processed using less than 32Gb of memory at a time.  However, given the number of
+ways this memory limit can be exceeded, the overall memory model for the outlier detection
+was revised to minimize the memory usage at the expense of file I/O with limited control
+over this through the ``in_memory`` parameter when set to `False`.
+
+* The ``save_open`` parameter gets set to `False`
+  when opening the input :py:class:`~jwst.datamodels.ModelContainer` object.
+  This forces all input models in the input :py:class:`~jwst.datamodels.ModelContainer` or
+  :py:class:`~jwst.datamodels.CubeModel` to get written out to disk.  The ModelContainer
+  then uses the filename of the input model during subsequent processing.
+
+* The ``in_memory`` parameter gets passed to the :py:class:`~jwst.resample.ResampleStep`
+  to set whether or not to keep the resampled images in memory or not.  By default,
+  the outlier detection processing sets this parameter to `False` so that each resampled
+  image gets written out to disk.
+
+* Computing the median image works section-by-section by only keeping 1Mb of each input
+  in memory at a time.  As a result, only the final output product array for the final
+  median image along with a stack of 1Mb image sections are kept in memory.
+
+* The final resampling step also avoids keeping all inputs in memory by only reading
+  each input into memory 1 at a time as it gets resampled onto the final output product.
+
+These changes result in a minimum amount of memory usage during processing at the obvious
+expense of reading and writing the products from disk.
+
+
 Outlier Detection for TSO data
 -------------------------------
 Time-series observations (TSO) result in input data stored as a 3D CubeModel

--- a/docs/jwst/outlier_detection/outlier_detection.rst
+++ b/docs/jwst/outlier_detection/outlier_detection.rst
@@ -56,20 +56,20 @@ The outlier detection algorithm can end up using massive amounts of memory
 depending on the number of inputs, the size of each input, and the size of the
 final output product.  Specifically,
 
-* The input :py:class:`~jwst.datamodels.ModelContainer` or
-  :py:class:`~jwst.datamodels.CubeModel`
-  for IFU data, by default, all input exposures would have been kept open in memory to make
-  processing more efficient.
+    * The input :py:class:`~jwst.datamodels.ModelContainer` or
+      :py:class:`~jwst.datamodels.CubeModel`
+      for IFU data, by default, all input exposures would have been kept open in memory to make
+      processing more efficient.
 
-* The initial resample step creates an output product for EACH input that is the
-  same size as the final
-  output product, which for imaging modes can span all chips in the detector while
-  also accounting for all dithers.  For some Level 3 products, each resampled image can
-  be on the order of 2Gb or more.
+    * The initial resample step creates an output product for EACH input that is the
+      same size as the final
+      output product, which for imaging modes can span all chips in the detector while
+      also accounting for all dithers.  For some Level 3 products, each resampled image can
+      be on the order of 2Gb or more.
 
-* The median combination step then needs to have all pixels at the same position on
-  the sky in memory in order to perform the median computation.  The simplest implmentation
-  for this step would require keeping all resampled outputs in memory at the same time.
+    * The median combination step then needs to have all pixels at the same position on
+      the sky in memory in order to perform the median computation.  The simplest implmentation
+      for this step would require keeping all resampled outputs in memory at the same time.
 
 Many Level 3 products only include a modest number of input exposures which can be
 processed using less than 32Gb of memory at a time.  However, given the number of
@@ -77,23 +77,23 @@ ways this memory limit can be exceeded, the overall memory model for the outlier
 was revised to minimize the memory usage at the expense of file I/O with limited control
 over this through the ``in_memory`` parameter when set to `False`.
 
-* The ``save_open`` parameter gets set to `False`
-  when opening the input :py:class:`~jwst.datamodels.ModelContainer` object.
-  This forces all input models in the input :py:class:`~jwst.datamodels.ModelContainer` or
-  :py:class:`~jwst.datamodels.CubeModel` to get written out to disk.  The ModelContainer
-  then uses the filename of the input model during subsequent processing.
+    * The ``save_open`` parameter gets set to `False`
+      when opening the input :py:class:`~jwst.datamodels.ModelContainer` object.
+      This forces all input models in the input :py:class:`~jwst.datamodels.ModelContainer` or
+      :py:class:`~jwst.datamodels.CubeModel` to get written out to disk.  The ModelContainer
+      then uses the filename of the input model during subsequent processing.
 
-* The ``in_memory`` parameter gets passed to the :py:class:`~jwst.resample.ResampleStep`
-  to set whether or not to keep the resampled images in memory or not.  By default,
-  the outlier detection processing sets this parameter to `False` so that each resampled
-  image gets written out to disk.
+    * The ``in_memory`` parameter gets passed to the :py:class:`~jwst.resample.ResampleStep`
+      to set whether or not to keep the resampled images in memory or not.  By default,
+      the outlier detection processing sets this parameter to `False` so that each resampled
+      image gets written out to disk.
 
-* Computing the median image works section-by-section by only keeping 1Mb of each input
-  in memory at a time.  As a result, only the final output product array for the final
-  median image along with a stack of 1Mb image sections are kept in memory.
+    * Computing the median image works section-by-section by only keeping 1Mb of each input
+      in memory at a time.  As a result, only the final output product array for the final
+      median image along with a stack of 1Mb image sections are kept in memory.
 
-* The final resampling step also avoids keeping all inputs in memory by only reading
-  each input into memory 1 at a time as it gets resampled onto the final output product.
+    * The final resampling step also avoids keeping all inputs in memory by only reading
+      each input into memory 1 at a time as it gets resampled onto the final output product.
 
 These changes result in a minimum amount of memory usage during processing at the obvious
 expense of reading and writing the products from disk.

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -83,13 +83,14 @@ class ModelContainer(JwstDataModel, Sequence):
         to control how the DataModels are used by the ModelContainer.
         If ``save_open`` is set to `False`,
         each input DataModel instance in ``init`` will be written out to disk and closed,
-         then only the filename for the
+        then only the filename for the
         DataModel will be used to initialize the ModelContainer object.  Subsequent
         access of each member will then open the DataModel file to work with it.  If
         ``return_open`` is also `False`, then the DataModel will be closed when
         access to the DataModel is completed.  The use of these parameters can
         minimize the amount of memory used by this object during processing, with
         these parameters being used by :py:class:`~jwst.outlier_detection.OutlierDetectionStep`.
+
 
     """
     schema_url = None

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -76,6 +76,21 @@ class ModelContainer(JwstDataModel, Sequence):
     >>> c = ModelContainer()
     >>> m = datamodels.open('myfile.fits')
     >>> c.append(m)
+
+    Notes
+    -----
+        The optional paramters ``save_open`` and ``return_open`` can be provided
+        to control how the DataModels are used by the ModelContainer.
+        If ``save_open`` is set to `False`,
+        each input DataModel instance in ``init`` will be written out to disk and closed,
+         then only the filename for the
+        DataModel will be used to initialize the ModelContainer object.  Subsequent
+        access of each member will then open the DataModel file to work with it.  If
+        ``return_open`` is also `False`, then the DataModel will be closed when
+        access to the DataModel is completed.  The use of these parameters can
+        minimize the amount of memory used by this object during processing, with
+        these parameters being used by :py:class:`~jwst.outlier_detection.OutlierDetectionStep`.
+
     """
     schema_url = None
 

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -70,7 +70,8 @@ class OutlierDetectionStep(Step):
     def process(self, input_data):
         """Perform outlier detection processing on input data."""
 
-        with datamodels.open(input_data, save_open=False) as input_models:
+        # interpret how memory should be used
+        with datamodels.open(input_data, save_open=self.in_memory) as input_models:
             self.input_models = input_models
             if not isinstance(self.input_models, datamodels.ModelContainer):
                 self.input_container = False

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -55,6 +55,13 @@ class ResampleData:
 
             .. note::
                 ``output_shape`` is in the ``x, y`` order.
+
+            .. note::
+                ``in_memory`` controls whether or not the resampled
+                array from ``resample_many_to_many()``
+                should be kept in memory or written out to disk and
+                deleted from memory. Default value is `True` to keep
+                all products in memory.
         """
         self.input_models = input_models
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2816](https://jira.stsci.edu/browse/JP-2816)
Resolves [JP-2820](https://jira.stsci.edu/browse/JP-2820)

<!-- describe the changes comprising this PR here -->
This PR updates the documentation related to the memory model implemented under #6904 for [JP-2527](https://jira.stsci.edu/browse/JP-2527).  The changes include:
  - Adding a section to the outlier_detection algorithm discussion on the overall memory model. 
  - Updated the ModelContainer docstring to add Notes describing the optional parameters defined and used for the outlier_detection memory improvements
  - Added a Note to the ResampleStep docstring to describe the new ``in_memory`` parameter.
  - Updates initialization of the ModelContainter based on ``in_memory`` parameter. [JP-2820]

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
