### PR TITLE
pin `jsonschema` below `4.10.0` to fix issues with unit and regression tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ general
 
 - Made code style changes due to the new 5.0.3 version of flake8, which noted many
   missing white spaces after keywords. [#6958]
+- pin `jsonschema` below `4.10.0` to fix issues with unit and regression tests [#6986]
 
 ami_analyze
 -----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-        Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
 [options]
@@ -34,7 +34,7 @@ install_requires =
     crds>=11.16.5
     drizzle>=1.13.6
     gwcs>=0.18.0
-    jsonschema>=4.0.1
+    jsonschema>=4.0.1,<4.10.0
     numpy>=1.20
     photutils>=1.4.0
     psutil>=5.7.2
@@ -157,7 +157,7 @@ omit =
     jwst/regtest/test*
     jwst/*/tests/*
     docs/*
-    # And list these again for running against installed version
+# And list these again for running against installed version
     */jwst/conftest.py
     */jwst/setup.py
     */jwst/tests/test*


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses a recent issue with unit tests that appears to be causing unit and regression tests to fail. This is possibly related to a new release of `jsonschema` to version `4.10.0`.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
