### PR TITLE
JP-2803: Propagate asn keywords to resample output products for level 2 processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,7 +78,7 @@ resample
   pixels. [#6954]
 
 - Propagate ``asn.pool_name`` and ``asn.table_name`` through step ModelContainer
-  for level 2 processing of single input datamodels
+  for level 2 processing of single input datamodels [#6989]
 
 skymatch
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,9 @@ resample
   resampled error map contained an excessive number of zero-valued
   pixels. [#6954]
 
+- Propagate ``asn.pool_name`` and ``asn.table_name`` through step ModelContainer
+  for level 2 processing of single input datamodels
+
 skymatch
 --------
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -84,6 +84,7 @@ class ResampleSpecStep(ResampleStep):
 
         # Update ASNTABLE in output
         result.meta.asn.table_name = input_models[0].meta.asn.table_name
+        result.meta.asn.pool_name = input_models[0].meta.asn.pool_name
 
         return result
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -66,6 +66,8 @@ class ResampleStep(Step):
                 output = None
         else:
             input_models = datamodels.ModelContainer([input])
+            input_models.asn_pool_name = input.meta.asn.pool_name
+            input_models.asn_table_name = input.meta.asn.table_name
             output = input.meta.filename
             self.blendheaders = False
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2803](https://jira.stsci.edu/browse/JP-2803)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds assignment of `model.meta.asn.pool_name` and `{...}.table_name` to level 2b i2d products - this required propagating these keywords through an intermediate ModelContainer in the resample step.

There was discussion in the JIRA ticket of propagating values from the first contained model if any ModelContainer was found have no assigned values, but I felt that this covers the issue more cleanly - if there is a need for other behavior, please let me know.

NB: If a user runs e.g. `strun calwebb_image2 some_rate.fits`, the i2d output will have values of 'singleton' for both of these keywords. If using a MAST-provided level2 asn, the values propagate as expected.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
