### PR TITLE
JP-2595: Update error propagation docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ general
 
 - Made code style changes due to the new 5.0.3 version of flake8, which noted many
   missing white spaces after keywords. [#6958]
+
 - pin `jsonschema` below `4.10.0` to fix issues with unit and regression tests [#6986]
 
 ami_analyze
@@ -48,6 +49,12 @@ datamodels
 - Add the ``P_SUBARR`` keyword to the ``DarkModel`` schema. [#6951]
 
 - Add the ``P_READPA`` keyword to the ``ReadnoiseModel`` schema [#6973]
+
+documentation
+-------------
+
+- Update the Error Propagation section to include info for the ``resample`` step
+  [#6994]
 
 extract_1d
 ----------

--- a/docs/jwst/error_propagation/main.rst
+++ b/docs/jwst/error_propagation/main.rst
@@ -13,9 +13,9 @@ The table below is a summary of which steps create or update variance and error 
 as well as which steps make use of these data. Details of how each step computes or
 uses these data are given in the subsequent sections below.
 
-================= ===== ======================= ====================================== =========
+================= ===== ======================= ====================================== ==========
 Step              Stage Creates arrays          Updates arrays                         Step uses
-================= ===== ======================= ====================================== =========
+================= ===== ======================= ====================================== ==========
 ramp_fitting        1   VAR_POISSON, VAR_RNOISE ERR                                    None
 gain_scale          1   None                    ERR, VAR_POISSON, VAR_RNOISE           None
 flat_field          2   VAR_FLAT                ERR, VAR_POISSON, VAR_RNOISE           None
@@ -24,8 +24,9 @@ barshadow           2   None                    ERR, VAR_POISSON, VAR_RNOISE, VA
 pathloss            2   None                    ERR, VAR_POISSON, VAR_RNOISE, VAR_FLAT None
 photom              2   None                    ERR, VAR_POISSON, VAR_RNOISE, VAR_FLAT None
 outlier_detection   3   None                    None                                   ERR
+resample            3   None                    None                                   VAR_RNOISE
 wfs_combine         3   None                    ERR                                    None
-================= ===== ======================= ====================================== =========
+================= ===== ======================= ====================================== ==========
 
 Stage 1 Pipelines 
 -----------------
@@ -122,6 +123,13 @@ The ``outlier_detection`` step is used in all Stage 3 pipelines.  It uses the ER
 make a local noise model, based on the readnoise and calibration errors of earlier 
 steps in the pipeline. This step does not modify the ERR array or any of the VAR
 arrays.
+
+resample/resample_spec
+++++++++++++++++++++++
+The ``resample`` and ``resample_spec`` steps make use of the VAR_RNOISE array to
+compute weights that are used when combining data with the ``weight_type=ivm``
+option selected. The step also resamples all of the variance and error arrays,
+using the same output WCS frame as the science data.
 
 wfs_combine
 +++++++++++


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2595](https://jira.stsci.edu/browse/JP-2595)

<!-- describe the changes comprising this PR here -->
This PR makes a small update to the Error Propagation section of the docs, adding info about the variance array used by the resample step.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
