### PR TITLE
JP-2857: Update readpatt pattern keyword name to follow other pattern keyword names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,9 @@ datamodels
 
 - Add the ``P_READPA`` keyword to the ``ReadnoiseModel`` schema [#6973]
 
+- Change name of ``P_READPA`` keyword in datamodel metadata to ``p_readpatt``
+  to be consistent with other pattern keyword names [#7001]
+
 
 documentation
 -------------

--- a/jwst/datamodels/schemas/keyword_preadpatt.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_preadpatt.schema.yaml
@@ -10,7 +10,7 @@ properties:
       exposure:
         type: object
         properties:
-          preadpatt:
+          p_readpatt:
             title: Readout pattern
             type: string
             pattern: "\


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2857](https://jira.stsci.edu/browse/JP-2857)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR changes the name of `model.meta.exposure.preadpatt` to `model.meta.exposure.p_readpatt` to follow naming scheme used for all pattern keywords. Documentation states this to be the current name, which was incorrect to this point.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
