### PR TITLE
JP-2859 Bug fix for cube_build when user changes input spatial scale to use for IFU cube 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ cube_build
 
 - Add a check in the process of building a cube to confirm that there is valid data on the detector. [#6998]
 
+- Fix a bug when user changes the spatial scale [#7002]
+
 datamodels
 ----------
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -309,10 +309,11 @@ class IFUCubeData():
         self.ycoord = np.zeros(self.naxis2)
         ystart = eta_min + self.cdelt2 / 2.0
         self.ycoord = np.arange(start=ystart, stop=ystart + self.naxis2 * self.cdelt2, step=self.cdelt2)
-        # depending on naxis and cdelt the x,ycoord can have more elements (usually just 1) Clean up arrays
+        # depending on the naxis and cdelt values the x,ycoord can have more elements (usually just 1) than naxis.
+        # Clean up arrays dropping extra values at the end.
         self.xcoord = self.xcoord[0:self.naxis1]
         self.ycoord = self.ycoord[0:self.naxis2]
-        
+
         xv,yv = np.meshgrid(self.xcoord, self.ycoord)
         self.xcenters = xv.flatten()
         self.ycenters = yv.flatten()
@@ -336,7 +337,7 @@ class IFUCubeData():
             self.crpix3 = 1.0
             zstart = self.lambda_min + self.cdelt3 / 2.0
             self.zcoord = np.arange(start=zstart, stop=self.lambda_max, step=self.cdelt3)
-
+            self.zcoord = self.zcoord[0:self.naxis3]
         else:
             self.naxis3 = len(self.wavelength_table)
             self.zcoord = np.asarray(self.wavelength_table)
@@ -648,7 +649,6 @@ class IFUCubeData():
                                                    self.cdelt1, self.cdelt2, cdelt3_mean,linear)
 
                         spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq = result
-                        
                         self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)
                         self.spaxel_weight = self.spaxel_weight + np.asarray(spaxel_weight, np.float64)
                         self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -309,7 +309,7 @@ class IFUCubeData():
         self.ycoord = np.zeros(self.naxis2)
         ystart = eta_min + self.cdelt2 / 2.0
         self.ycoord = np.arange(start=ystart, stop=ystart + self.naxis2 * self.cdelt2, step=self.cdelt2)
-        # depending on the naxis and cdelt values the x,ycoord can have more elements (usually just 1) than naxis.
+        # depending on the naxis and cdelt values the x,ycoord can have 1 more element than naxis.
         # Clean up arrays dropping extra values at the end.
         self.xcoord = self.xcoord[0:self.naxis1]
         self.ycoord = self.ycoord[0:self.naxis2]

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -304,13 +304,15 @@ class IFUCubeData():
         # center of spaxels
         self.xcoord = np.zeros(self.naxis1)
         xstart = xi_min + self.cdelt1 / 2.0
-
         self.xcoord = np.arange(start=xstart, stop=xstart + self.naxis1 * self.cdelt1, step=self.cdelt1)
 
         self.ycoord = np.zeros(self.naxis2)
         ystart = eta_min + self.cdelt2 / 2.0
         self.ycoord = np.arange(start=ystart, stop=ystart + self.naxis2 * self.cdelt2, step=self.cdelt2)
-
+        # depending on naxis and cdelt the x,ycoord can have more elements (usually just 1) Clean up arrays
+        self.xcoord = self.xcoord[0:self.naxis1]
+        self.ycoord = self.ycoord[0:self.naxis2]
+        
         xv,yv = np.meshgrid(self.xcoord, self.ycoord)
         self.xcenters = xv.flatten()
         self.ycenters = yv.flatten()
@@ -646,6 +648,7 @@ class IFUCubeData():
                                                    self.cdelt1, self.cdelt2, cdelt3_mean,linear)
 
                         spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq = result
+                        
                         self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)
                         self.spaxel_weight = self.spaxel_weight + np.asarray(spaxel_weight, np.float64)
                         self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -135,8 +135,8 @@ int match_driz(double *xc, double *yc, double *zc,
 
   double *fluxv, *weightv, *varv, *ifluxv;  // vector for spaxel
 
-  int k,j,ix1,ix2,iy1,iy2,iz1,iz2, iw1, iw2;
-  int ii, nxy, ix, iy, iw, index_xy, index_cube;
+  int k,j,ix1,ix2,iy1,iy2, iw1, iw2;
+  int nxy, ix, iy, iw, index_xy, index_cube;
   double wdiff, zreg;
   double w1;
   double weighted_flux, weighted_var;
@@ -389,6 +389,8 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   npt = (long) PyArray_Size((PyObject *) coord1);
   ny = (int) PyArray_Size((PyObject *) coord2);
   nz = (int) PyArray_Size((PyObject *) wave);
+
+
   if (ny != npt || nz != npt ) {
     PyErr_SetString(PyExc_ValueError,
 		    "Input coordinate arrays of unequal size.");
@@ -401,7 +403,6 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   nwave = (int) PyArray_Size((PyObject *) zc);
 
   ncube = nxx * nyy * nwave;
-  
   if (ncube ==0) {
     // 0-length input arrays. Nothing to clip. Return 0-length arrays
     spaxel_flux_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_DOUBLE, 0);


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2859](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR fixes a bug in cube_build when the user provided the spatial scale to use when building the IFU cube. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/399/
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
