### PR TITLE
Update code to use tweakwcs 0.8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,7 @@ cube_build
 - Remove trailing dash from IFU cube filenames built from all subchannels.
   Also sort subchannels present by inverse alphabetical order to ensure
   consistent filename creation across processing runs. [#6959]
-  
+
 - Re-wrote c code for NIRSpec dq flagging.[#6981]
 
 - For moving target data removed using  s_region values in cal files to
@@ -143,6 +143,8 @@ tweakreg
   in the ``tweakreg`` step. This catalog, if provided, will be used instead
   of the 'GAIA' catalogs for aligning all input images together as one single
   group. [#6946]
+
+- Refactored code to work with changes in ``tweakwcs`` version 0.8.0. [#7006]
 
 
 1.6.2 (2022-07-19)

--- a/jwst/tweakreg/tests/test_multichip_jwst.py
+++ b/jwst/tweakreg/tests/test_multichip_jwst.py
@@ -12,7 +12,7 @@ from astropy.modeling.models import (
 from astropy import units as u
 from astropy import coordinates as coord
 
-import tweakwcs
+from tweakwcs.correctors import JWSTWCSCorrector
 from tweakwcs.imalign import align_wcs
 
 from jwst.datamodels import ImageModel, ModelContainer
@@ -226,7 +226,7 @@ def test_multichip_jwst_alignment(monkeypatch):
     monkeypatch.setattr(tweakreg_step, 'make_tweakreg_catalog', _make_tweakreg_catalog)
 
     w1 = _make_gwcs_wcs(os.path.join(data_path, 'wfc3_uvis1.hdr'))
-    imcat1 = tweakwcs.JWSTgWCS(w1, {'v2_ref': 0, 'v3_ref': 0, 'roll_ref': 0})
+    imcat1 = JWSTWCSCorrector(w1, {'v2_ref': 0, 'v3_ref': 0, 'roll_ref': 0})
     data_file = os.path.join(data_path, 'wfc3_uvis1.cat')
     imcat1.meta['catalog'] = table.Table.read(
         data_file,
@@ -240,7 +240,7 @@ def test_multichip_jwst_alignment(monkeypatch):
     imcat1.meta['name'] = 'ext1'
 
     w2 = _make_gwcs_wcs(os.path.join(data_path, 'wfc3_uvis2.hdr'))
-    imcat2 = tweakwcs.JWSTgWCS(w2, {'v2_ref': 0, 'v3_ref': 0, 'roll_ref': 0})
+    imcat2 = JWSTWCSCorrector(w2, {'v2_ref': 0, 'v3_ref': 0, 'roll_ref': 0})
     imcat2.meta['catalog'] = table.Table.read(
         os.path.join(data_path, 'wfc3_uvis2.cat'),
         format='ascii.csv',

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -10,8 +10,8 @@ from astropy.table import Table
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from tweakwcs.imalign import align_wcs
-from tweakwcs.tpwcs import JWSTgWCS
-from tweakwcs.matchutils import TPMatch
+from tweakwcs.correctors import JWSTWCSCorrector
+from tweakwcs.matchutils import XYXYMatch
 
 # LOCAL
 from ..stpipe import Step
@@ -190,7 +190,7 @@ class TweakRegStep(Step):
             self.log.info('')
 
             # align images:
-            tpmatch = TPMatch(
+            xyxymatch = XYXYMatch(
                 searchrad=self.searchrad,
                 separation=self.separation,
                 use2dhist=self.use2dhist,
@@ -206,7 +206,7 @@ class TweakRegStep(Step):
                     enforce_user_order=self.enforce_user_order,
                     expand_refcat=self.expand_refcat,
                     minobj=self.minobj,
-                    match=tpmatch,
+                    match=xyxymatch,
                     fitgeom=self.fitgeometry,
                     nclip=self.nclip,
                     sigma=(self.sigma, 'rmse')
@@ -310,7 +310,7 @@ class TweakRegStep(Step):
                 # Update to separation needed to prevent confusion of sources
                 # from overlapping images where centering is not consistent or
                 # for the possibility that errors still exist in relative overlap.
-                tpmatch_gaia = TPMatch(
+                xyxymatch_gaia = XYXYMatch(
                     searchrad=self.searchrad * 3.0,
                     separation=self.separation / 10.0,
                     use2dhist=self.use2dhist,
@@ -336,7 +336,7 @@ class TweakRegStep(Step):
                     enforce_user_order=True,
                     expand_refcat=False,
                     minobj=self.minobj,
-                    match=tpmatch_gaia,
+                    match=xyxymatch_gaia,
                     fitgeom=self.fitgeometry,
                     nclip=self.nclip,
                     sigma=(self.sigma, 'rmse')
@@ -419,7 +419,7 @@ class TweakRegStep(Step):
 
         # create WCSImageCatalog object:
         refang = image_model.meta.wcsinfo.instance
-        im = JWSTgWCS(
+        im = JWSTWCSCorrector(
             wcs=image_model.meta.wcs,
             wcsinfo={'roll_ref': refang['roll_ref'],
                      'v2_ref': refang['v2_ref'],

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     stpipe>=0.4.1,<1.0
     stsci.image>=2.3.5
     stsci.imagestats>=1.6.3
-    tweakwcs>=0.7.2
+    tweakwcs>=0.8.0
     asdf-astropy>=0.2.1
     wiimatch>=0.2.1
 


### PR DESCRIPTION
This PR updates code that uses `tweakwcs` to use newest classes instead of the deprecated ones. For a full list of changes in `tweakwcs 0.8.0` - see https://github.com/spacetelescope/tweakwcs/releases/tag/0.8.0. Most changes are about changing class and module names to better represent what they actually do.

This PR updates `drizzlepac` code in order to avoid deprecation warnings.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression test link: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/402/
