### PR TITLE
Update NIRISS WFSS regtest with in-flight data

### DIFF
--- a/jwst/regtest/test_niriss_wfss.py
+++ b/jwst/regtest/test_niriss_wfss.py
@@ -2,37 +2,46 @@
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
-from jwst.regtest import regtestdata as rt
+from jwst.stpipe import Step
 
 
 @pytest.fixture(scope='module')
 def run_nis_wfss_spec2(jail, rtdata_module):
-    """Run the calwebb_spec2 pipeline"""
-    step_params = {
-        'input_path': 'niriss/wfss/nir_wfss_spec2_asn.json',
-        'step': 'calwebb_spec2',
-        'args': [
+    """Run the calwebb_spec2 pipeline on NIRISS WFSS exposures"""
+    rtdata = rtdata_module
+
+    # These are the 4 WFSS exposures we'll be processing
+    spec2_asns = [
+        "niriss/wfss/jw01324-o001_20220629t171902_spec2_001_asn.json",
+        "niriss/wfss/jw01324-o001_20220629t171902_spec2_002_asn.json",
+        "niriss/wfss/jw01324-o001_20220629t171902_spec2_005_asn.json",
+        "niriss/wfss/jw01324-o001_20220629t171902_spec2_007_asn.json",
+    ]
+
+    # Only the first exposure will be used to do comparisons
+    rtdata.get_asn(spec2_asns[0])
+    args = ["calwebb_spec2", rtdata.input,
             '--steps.assign_wcs.save_results=true',
             '--steps.bkg_subtract.save_results=true',
-            '--steps.imprint_subtract.save_results=true',
-            '--steps.msa_flagging.save_results=true',
             '--steps.flat_field.save_results=true',
             '--steps.extract_2d.save_results=true',
             '--steps.srctype.save_results=true',
-            '--steps.straylight.save_results=true',
-            '--steps.fringe.save_results=true',
             '--steps.pathloss.save_results=true',
-            '--steps.barshadow.save_results=true',
-            '--steps.wfss_contam.save_results=true',
             '--steps.photom.save_results=true',
-            '--steps.resample_spec.save_results=true',
-            '--steps.cube_build.save_results=true',
             '--steps.extract_1d.save_results=true',
             '--save_wfss_esec=true',
-        ]
-    }
+            '--steps.extract_2d.wfss_nbright=10',
+    ]
+    Step.from_cmdline(args)
 
-    return rt.run_step_from_dict(rtdata_module, **step_params)
+    # Run the remaining exposures without doing comparisons, just so that
+    # fresh results are available for level-3 processing
+    for asn in spec2_asns[1:]:
+        rtdata.get_asn(asn)
+        args = ["calwebb_spec2", rtdata.input,
+                "--steps.extract_2d.wfss_nbright=10"
+        ]
+        Step.from_cmdline(args)
 
 
 @pytest.mark.bigdata
@@ -40,41 +49,41 @@ def run_nis_wfss_spec2(jail, rtdata_module):
     'suffix',
     ['assign_wcs', 'bsub', 'cal', 'esec', 'extract_2d', 'flat_field', 'photom', 'srctype', 'x1d']
 )
-def test_nis_wfss_spec2(run_nis_wfss_spec2, fitsdiff_default_kwargs, suffix):
+def test_nis_wfss_spec2(run_nis_wfss_spec2, rtdata_module, fitsdiff_default_kwargs, suffix):
     """Regression test for calwebb_spec2 applied to NIRISS WFSS data"""
-    rt.is_like_truth(
-        run_nis_wfss_spec2, fitsdiff_default_kwargs, suffix, 'truth/test_niriss_wfss'
-    )
+    rtdata = rtdata_module
+    rtdata.input = "jw01324001001_03101_00001_nis_rate.fits"
+    output = "jw01324001001_03101_00001_nis_" + suffix + ".fits"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/test_niriss_wfss/{output}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
 
 
 @pytest.fixture(scope='module')
-def run_nis_wfss_spec3(jail, rtdata_module):
+def run_nis_wfss_spec3(run_nis_wfss_spec2, rtdata_module, jail):
     """Run the calwebb_spec3 pipeline"""
-    step_params = {
-        'input_path': 'niriss/wfss/jw00625-o030_20191121t041727_spec3_001_asn.json',
-        'step': 'calwebb_spec3',
-        'args': [
-            '--steps.extract_1d.save_results=true',
-            '--steps.combine_1d.save_results=true',
-        ]
-    }
+    rtdata = rtdata_module
 
-    return rt.run_step_from_dict(rtdata_module, **step_params)
+    # Get the level3 association file and run the spec3 pipeline on it.
+    # We don't need to retrieve any of the cal members of the association,
+    # because they were all just created by the preceding spec2 test.
+    rtdata.get_data("niriss/wfss/jw01324-o001_20220629t171902_spec3_003_asn.json")
+    args = ["calwebb_spec3", rtdata.input]
+    Step.from_cmdline(args)
 
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize('suffix', ['cal', 'x1d', 'c1d'])
-@pytest.mark.parametrize('source_id', ['s00001', 's00002'])
-def test_nis_wfss_spec3(run_nis_wfss_spec3, suffix, source_id, fitsdiff_default_kwargs):
+@pytest.mark.parametrize('source_id', ['s00015', 's00104'])
+def test_nis_wfss_spec3(run_nis_wfss_spec3, rtdata_module, suffix, source_id, fitsdiff_default_kwargs):
     """Regression test of the calwebb_spec3 pipeline applied to NIRISS WFSS data"""
-
-    # Run the pipeline
-    rtdata = run_nis_wfss_spec3
-
-    # Get outputs and truths
-    output = "jw00625-o030_" + source_id + "_niriss_f090w-gr150c-gr150r_" + suffix + ".fits"
+    rtdata = rtdata_module
+    rtdata.input = "jw01324-o001_20220629t171902_spec3_003_asn.json"
+    output = f"jw01324-o001_" + source_id + "_niriss_f115w-gr150c-gr150r_" + suffix + ".fits"
     rtdata.output = output
-    rtdata.get_truth("truth/test_niriss_wfss/" + output)
+    rtdata.get_truth(f"truth/test_niriss_wfss/{output}")
 
     # Compare the results
     fitsdiff_default_kwargs['atol'] = 1e-5

--- a/jwst/regtest/test_niriss_wfss.py
+++ b/jwst/regtest/test_niriss_wfss.py
@@ -30,8 +30,7 @@ def run_nis_wfss_spec2(jail, rtdata_module):
             '--steps.photom.save_results=true',
             '--steps.extract_1d.save_results=true',
             '--save_wfss_esec=true',
-            '--steps.extract_2d.wfss_nbright=10',
-    ]
+            '--steps.extract_2d.wfss_nbright=10']
     Step.from_cmdline(args)
 
     # Run the remaining exposures without doing comparisons, just so that
@@ -39,8 +38,7 @@ def run_nis_wfss_spec2(jail, rtdata_module):
     for asn in spec2_asns[1:]:
         rtdata.get_asn(asn)
         args = ["calwebb_spec2", rtdata.input,
-                "--steps.extract_2d.wfss_nbright=10"
-        ]
+                "--steps.extract_2d.wfss_nbright=10"]
         Step.from_cmdline(args)
 
 
@@ -81,7 +79,7 @@ def test_nis_wfss_spec3(run_nis_wfss_spec3, rtdata_module, suffix, source_id, fi
     """Regression test of the calwebb_spec3 pipeline applied to NIRISS WFSS data"""
     rtdata = rtdata_module
     rtdata.input = "jw01324-o001_20220629t171902_spec3_003_asn.json"
-    output = f"jw01324-o001_" + source_id + "_niriss_f115w-gr150c-gr150r_" + suffix + ".fits"
+    output = "jw01324-o001_" + source_id + "_niriss_f115w-gr150c-gr150r_" + suffix + ".fits"
     rtdata.output = output
     rtdata.get_truth(f"truth/test_niriss_wfss/{output}")
 


### PR DESCRIPTION

<!-- describe the changes comprising this PR here -->
This PR updates the NIRISS WFSS regression test to use recent in-flight data and the latest "specwcs" calibrations as part of the WCS. All input and truth files have been uploaded to artifactory and runs successfully when tested standalone.

Also just restructured the way the test modules themselves are written (cuz I just didn't like the old style!)

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
