### PR TITLE
Set DQ of ref pixels to DO_NOT_USE after refpix correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -577,6 +577,11 @@ ramp_fitting
   removing NaNs from the rateints product and setting appropriate DQ
   flags. [#6949]
 
+refpix
+------
+
+- Set DQ of ref pixels to DO_NOT_USE after `refpix` correction [#7017]
+
 resample
 --------
 

--- a/docs/jwst/refpix/description.rst
+++ b/docs/jwst/refpix/description.rst
@@ -77,6 +77,8 @@ NIR Detector Data
        subtracted from the full group on a row-by-row basis.  Note that the ``odd_even_rows``
        parameter is ignored for NIR data when the side reference pixels are processed.
     #. Transform the data back to the JWST focal plane, or DMS, frame.
+    #. Flag reference pixel locations in DQ array as DO_NOT_USE now that the correction is
+       complete, so that they are not used in ramp fitting or any other downstream steps.
 
 MIR Detector Data
 +++++++++++++++++

--- a/jwst/refpix/tests/test_refpix.py
+++ b/jwst/refpix/tests/test_refpix.py
@@ -6,6 +6,10 @@ from jwst.refpix import RefPixStep
 from jwst.refpix.reference_pixels import Dataset, NIRDataset, correct_model, create_dataset
 
 
+REFERENCE_PIXEL = dqflags.pixel["REFERENCE_PIXEL"]
+DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
+
+
 def test_refpix_subarray():
     '''Check that the correction is skipped for MIR subarray data '''
 
@@ -59,8 +63,8 @@ def test_each_amp():
     im.data[:, 1:, :, 1031] = 4.0
 
     # set reference pixels to 'REFERENCE_PIXEL'
-    im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
-    im.pixeldq[:, 1028:] = dqflags.pixel['REFERENCE_PIXEL']
+    im.pixeldq[:, :4] = REFERENCE_PIXEL
+    im.pixeldq[:, 1028:] = REFERENCE_PIXEL
 
     # run the step
     out = RefPixStep.call(im)
@@ -103,8 +107,8 @@ def test_firstframe_sub():
     im.data[:, :, :, 1031] = 4.0
 
     # set reference pixels to 'REFERENCE_PIXEL'
-    im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
-    im.pixeldq[:, 1028:] = dqflags.pixel['REFERENCE_PIXEL']
+    im.pixeldq[:, :4] = REFERENCE_PIXEL
+    im.pixeldq[:, 1028:] = REFERENCE_PIXEL
 
     # run the step
     outim = RefPixStep.call(im)
@@ -148,8 +152,8 @@ def test_odd_even():
     im.data[:, 1:, 0:ysize - 1:2, 1031] = 8.0
 
     # set reference pixels to 'REFERENCE_PIXEL'
-    im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
-    im.pixeldq[:, 1028:] = dqflags.pixel['REFERENCE_PIXEL']
+    im.pixeldq[:, :4] = REFERENCE_PIXEL
+    im.pixeldq[:, 1028:] = REFERENCE_PIXEL
 
     # run the step
     out = RefPixStep.call(im)
@@ -164,6 +168,11 @@ def test_odd_even():
     assert out.data[0, 5, 101, 5] == 48.0
     assert out.data[0, 5, 101, 6] == 47.0
     assert out.data[0, 5, 101, 7] == 46.0
+
+    # Make sure reference pixel DQs are set to DO_NOT_USE
+    mask1 = out.pixeldq & REFERENCE_PIXEL == REFERENCE_PIXEL
+    mask2 = out.pixeldq & DO_NOT_USE == DO_NOT_USE
+    np.testing.assert_array_equal(mask1, mask1 & mask2)
 
 
 def test_no_odd_even():
@@ -200,8 +209,8 @@ def test_no_odd_even():
     im.data[:, 1:, 0:ysize - 1:2, 1031] = 8.0
 
     # set reference pixels to 'REFERENCE_PIXEL'
-    im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
-    im.pixeldq[:, 1028:] = dqflags.pixel['REFERENCE_PIXEL']
+    im.pixeldq[:, :4] = REFERENCE_PIXEL
+    im.pixeldq[:, 1028:] = REFERENCE_PIXEL
 
     # run the step
     out = RefPixStep.call(im, odd_even_rows=False)
@@ -240,8 +249,8 @@ def test_side_averaging():
     im.data[:, 1:, :, 1028:] = 2.0
 
     # set reference pixels to 'REFERENCE_PIXEL'
-    im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
-    im.pixeldq[:, 1028:] = dqflags.pixel['REFERENCE_PIXEL']
+    im.pixeldq[:, :4] = REFERENCE_PIXEL
+    im.pixeldq[:, 1028:] = REFERENCE_PIXEL
 
     # run the step
     out = RefPixStep.call(im)
@@ -271,8 +280,8 @@ def test_above_sigma():
     im.data[0, 3, 50, 3] = 35.0
 
     # set reference pixels to 'REFERENCE_PIXEL'
-    im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
-    im.pixeldq[:, 1028:] = dqflags.pixel['REFERENCE_PIXEL']
+    im.pixeldq[:, :4] = REFERENCE_PIXEL
+    im.pixeldq[:, 1028:] = REFERENCE_PIXEL
 
     # run the step
     out = RefPixStep.call(im)
@@ -305,9 +314,9 @@ def test_nan_refpix():
     im.data[0, 3, 50, 3] = np.nan
 
     # set reference pixels to 'REFERENCE_PIXEL'
-    im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
-    im.pixeldq[:, 1028:] = dqflags.pixel['REFERENCE_PIXEL']
-    im.pixeldq[50, 3] = dqflags.pixel['DO_NOT_USE']
+    im.pixeldq[:, :4] = REFERENCE_PIXEL
+    im.pixeldq[:, 1028:] = REFERENCE_PIXEL
+    im.pixeldq[50, 3] = DO_NOT_USE
 
     # run the step
     out = RefPixStep.call(im)
@@ -341,8 +350,8 @@ def test_do_corrections_subarray_no_oddEven(setup_subarray_cube):
     input_model.data[0, 0, :, :] = dataval
     input_model.data[0, 0, :4, :] = bottom_rpix
     input_model.data[0, 0, :, :4] = left_rpix
-    input_model.pixeldq[:4, :] = dqflags.pixel['REFERENCE_PIXEL']
-    input_model.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
+    input_model.pixeldq[:4, :] = REFERENCE_PIXEL
+    input_model.pixeldq[:, :4] = REFERENCE_PIXEL
 
     init_dataset = create_dataset(input_model,
                                   odd_even_columns,
@@ -383,8 +392,8 @@ def test_do_corrections_subarray(setup_subarray_cube):
     input_model.data[0, 0, :, :] = dataval
     input_model.data[0, 0, :4, :] = bottom_rpix
     input_model.data[0, 0, :, :4] = left_rpix
-    input_model.pixeldq[:4, :] = dqflags.pixel['REFERENCE_PIXEL']
-    input_model.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
+    input_model.pixeldq[:4, :] = REFERENCE_PIXEL
+    input_model.pixeldq[:, :4] = REFERENCE_PIXEL
 
     init_dataset = create_dataset(input_model,
                                   odd_even_columns,
@@ -453,9 +462,9 @@ def test_do_corrections_subarray_4amp(setup_subarray_cube):
     input_model.data[0, 0, :, 1:4:2] = left_rpix + bottom_rpix_a_even
     input_model.data[0, 0, :, -4::2] = right_rpix + bottom_rpix_d_odd
     input_model.data[0, 0, :, -3::2] = right_rpix + bottom_rpix_d_even
-    input_model.pixeldq[:4, :] = dqflags.pixel['REFERENCE_PIXEL']
-    input_model.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
-    input_model.pixeldq[:, -4:] = dqflags.pixel['REFERENCE_PIXEL']
+    input_model.pixeldq[:4, :] = REFERENCE_PIXEL
+    input_model.pixeldq[:, :4] = REFERENCE_PIXEL
+    input_model.pixeldq[:, -4:] = REFERENCE_PIXEL
 
     init_dataset = create_dataset(input_model,
                                   odd_even_columns,
@@ -752,6 +761,12 @@ def test_correct_model(setup_cube, instr, det):
     input_model.data[0, 0, :, :] = rpix
     input_model.data[0, 0, 4:-4, 4:-4] = dataval
 
+    # Populate DQ array with REFERENCE_PIXEL where appropriate
+    input_model.pixeldq[:4,:] = REFERENCE_PIXEL
+    input_model.pixeldq[-4:,:] = REFERENCE_PIXEL
+    input_model.pixeldq[:,:4] = REFERENCE_PIXEL
+    input_model.pixeldq[:,-4:] = REFERENCE_PIXEL
+
     correct_model(input_model,
                   odd_even_columns,
                   use_side_ref_pixels,
@@ -761,6 +776,11 @@ def test_correct_model(setup_cube, instr, det):
 
     np.testing.assert_almost_equal(np.mean(input_model.data[0, 0, :4, 4:-4]), 0, decimal=0)
     np.testing.assert_almost_equal(np.mean(input_model.data[0, 0, 4:-4, 4:-4]), dataval - rpix, decimal=0)
+
+    # Make sure reference pixel DQs are set to DO_NOT_USE
+    mask1 = input_model.pixeldq & REFERENCE_PIXEL == REFERENCE_PIXEL
+    mask2 = input_model.pixeldq & DO_NOT_USE == DO_NOT_USE
+    np.testing.assert_array_equal(mask1, mask1 & mask2)
 
 
 def test_zero_frame(setup_cube):


### PR DESCRIPTION
Closes #7015 

<!-- describe the changes comprising this PR here -->
This PR addresses the current fragility of how reference pixels are set to DO_NOT_USE in `calwebb_detector1`.  Currently they rely on the GAIN reference file having zeros in the reference pixel locations, and then `ramp_fitting` sets those pixels to DO_NOT_USE in the science data DQ.

This PR sets the DQ of reference pixels to DO_NOT_USE at the end of the `refpix` step.  It does require that `DQInitStep` label these properly as REFERENCE_PIXELS, but this seems to be the case currently for the currently selected MASK reference files for all instruments.

Is this the best way to do this?  Thoughts?

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
