### PR TITLE
JP-2697: Update background subtraction step to accept rateints (3D) input

### DIFF
--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -26,85 +26,168 @@ def background_sub(input_model, bkg_list, sigma, maxiters):
     bkg_list: filename list
         list of background exposure file names
 
+    sigma: float, optional
+        Number of standard deviations to use for both the lower
+        and upper clipping limits.
+
+    maxiters: int or None, optional
+        Maximum number of sigma-clipping iterations to perform
+
     Returns
     -------
     result: JWST data model
         background-subtracted target data model
 
     """
+    # Subtract the average background from the member
+    log.debug(' subtracting avg bkg from {}'.format(input_model.meta.filename))
 
     # Compute the average of the background images associated with
     # the target exposure
-    bkg_model = average_background(bkg_list, sigma, maxiters)
+    if input_model.meta.model_type == "ImageModel":
+        data_dim = 2  # rate
+    elif input_model.meta.model_type == "CubeModel":
+        data_dim = 3  # rateints
+    else:
+        log.error("Input target exposure must be either a CubeModel or an ImageModel.")
+        raise ValueError("Expected either a CubeModel or an ImageModel.")
 
-    # Subtract the average background from the member
-    log.debug(' subtracting avg bkg from {}'.format(input_model.meta.filename))
-    result = subtract_images.subtract(input_model, bkg_model)
+    bkg_model = average_background(bkg_list, sigma, maxiters, data_dim)
+
+    if data_dim == 2:  # rate
+        result = subtract_images.subtract(input_model, bkg_model)
+    elif data_dim == 3:  # rateints
+        result = subtract_images.subtract_ints(input_model, bkg_model)
 
     # We're done. Return the result.
     return bkg_model, result
 
 
-def average_background(bkg_list, sigma, maxiters):
+def average_background(bkg_list, sigma, maxiters, data_dim):
     """
-    Average multiple background exposures into a combined data model
+    Short Summary
+    -------------
+    Average multiple background exposures into a combined data model.
+
+    Long Summary
+    ------------
+    For 2D (rate) background exposures, the average background will be calculated
+    as the mean of the sigma-clipped data in the background expoosures.
+
+    For 3D (rateint) background exposures, each exposure can have an arbitrary
+    number of integrations. First the average (over integrations) of the clipped
+    mean will be calculated for each exposure. Then the mean of these average
+    backgrounds will be calculated as the final average background image. This
+    final average will be subtracted from each integration of the SCI exposure.
 
     Parameters:
     -----------
-
     bkg_list: filename list
         List of background exposure file names
 
+    sigma: float, optional
+        Number of standard deviations to use for both the lower
+        and upper clipping limits.
+
+    maxiters: int or None, optional
+        Maximum number of sigma-clipping iterations to perform
+
+    data_dim: int
+        Dimension of data arrays in input files. For input rate files: 2.
+        For input rateint files: 3,
+
     Returns:
     --------
-
     avg_bkg: data model
         The averaged background exposure
-
     """
-
     num_bkg = len(bkg_list)
     avg_bkg = None
-    cdata = None
 
-    # Loop over the images to be used as background
-    for i, bkg_file in enumerate(bkg_list):
-        log.info(f'Accumulate bkg from {bkg_file}')
-        bkg_model = datamodels.ImageModel(bkg_file)
+    if data_dim == 2:  # background rate input
+        cdata = None
+        # Loop over the images to be used as background
+        for i, bkg_file in enumerate(bkg_list):
+            log.info(f'Accumulate bkg from {bkg_file}')
+            bkg_model = datamodels.ImageModel(bkg_file)
 
-        # Initialize the avg_bkg model, if necessary
-        if avg_bkg is None:
-            avg_bkg = datamodels.ImageModel(bkg_model.shape)
+            # Initialize the avg_bkg model, if necessary
+            if avg_bkg is None:
+                avg_bkg = datamodels.ImageModel(bkg_model.shape)
 
-        if cdata is None:
-            cdata = np.zeros(((num_bkg,) + bkg_model.shape))
-            cerr = cdata.copy()
+            if cdata is None:
+                cdata = np.zeros(((num_bkg,) + bkg_model.shape))
+                cerr = cdata.copy()
 
-        # Accumulate the data from this background image
-        cdata[i] = bkg_model.data
-        cerr[i] = bkg_model.err * bkg_model.err
-        avg_bkg.dq = np.bitwise_or(avg_bkg.dq, bkg_model.dq)
+            # Accumulate the data from this background image
+            cdata[i] = bkg_model.data
+            cerr[i] = bkg_model.err * bkg_model.err
 
-        bkg_model.close()
+            avg_bkg.dq = np.bitwise_or(avg_bkg.dq, bkg_model.dq)
 
-    # Clip the background data
-    log.debug('clip with sigma={} maxiters={}'.format(sigma, maxiters))
-    mdata = sigma_clip(cdata, sigma=sigma, maxiters=maxiters, axis=0)
+            bkg_model.close()
 
-    # Compute the mean of the non-clipped values
-    avg_bkg.data = mdata.mean(axis=0).data
+        # Clip the background data
+        log.debug('clip with sigma={} maxiters={}'.format(sigma, maxiters))
+        mdata = sigma_clip(cdata, sigma=sigma, maxiters=maxiters, axis=0)
 
-    # Mask the ERR values using the data mask
-    merr = np.ma.masked_array(cerr, mask=mdata.mask)
+        # Compute the mean of the non-clipped values
+        avg_bkg.data = mdata.mean(axis=0).data
 
-    # Compute the combined ERR as the uncertainty in the mean
-    avg_bkg.err = (np.sqrt(merr.sum(axis=0)) / (num_bkg - merr.mask.sum(axis=0))).data
+        # Mask the ERR values using the data mask
+        merr = np.ma.masked_array(cerr, mask=mdata.mask)
 
-    return avg_bkg
+        # Compute the combined ERR as the uncertainty in the mean
+        avg_bkg.err = (np.sqrt(merr.sum(axis=0)) / (num_bkg - merr.mask.sum(axis=0))).data
+
+        return avg_bkg
+
+    else:  # data_dim = 3; background rateints input
+        temp_avg_bkg = None  # accumulating Cube model; file is along axis 0
+
+        # Loop over the images to be used as background
+        for i, bkg_file in enumerate(bkg_list):
+            log.info(f'Accumulate bkg from {bkg_file}')
+            bkg_model = datamodels.CubeModel(bkg_file)  # axis=0 is for integrations
+
+            # Initialize a bunch of stuff if necessary
+            if temp_avg_bkg is None:
+                image_shape = bkg_model.data.shape[1:]
+                avg_bkg = datamodels.ImageModel(image_shape)
+                accum_dq_arr = np.zeros((image_shape), dtype=np.int32)
+                temp_avg_bkg = datamodels.CubeModel((num_bkg,) + image_shape)
+
+            # Sigma clip the bkg model's data along the integration axis
+            sc_bkg_data = sigma_clip(bkg_model.data, sigma=sigma, maxiters=maxiters, axis=0)
+
+            # Accumulate the integ-averaged clipped data in the temp Cubemodel for file
+            temp_avg_bkg.data[i, :, :] = sc_bkg_data.mean(axis=0)
+
+            # Collapse the DQ by doing a bitwise_OR over all integrations in the file
+            for i_nint in range(bkg_model.dq.shape[0]):
+                accum_dq_arr = np.bitwise_or(bkg_model.dq[i_nint, :, :], accum_dq_arr)
+
+            # Accumulate the collapsed DQ in the temp Cubemodel for file
+            temp_avg_bkg.dq[i, :, :] = accum_dq_arr
+
+        # Average data averages over all files
+        avg_bkg.data = temp_avg_bkg.data.mean(axis=0)  # mean along file axis
+
+        # Do bitwise_OR over all of the files to give 2D dq array
+        temp_dq_arr = temp_avg_bkg.dq[0, :, :]
+        for i in range(num_bkg):
+            temp_dq_arr = np.bitwise_or(temp_avg_bkg.dq[i, :, :], temp_dq_arr)
+
+        avg_bkg.dq = temp_dq_arr
+
+        return avg_bkg
 
 
 def subtract_wfss_bkg(input_model, bkg_filename, wl_range_name, mmag_extract=None):
-    """Scale and subtract a background reference image from WFSS/GRISM data.
+    """
+    Short Summary
+    -------------
+    Scale and subtract a background reference image from WFSS/GRISM data.
 
     Parameters
     ----------
@@ -178,7 +261,10 @@ def subtract_wfss_bkg(input_model, bkg_filename, wl_range_name, mmag_extract=Non
 
 
 def no_NaN(model, fill_value=0.):
-    """Replace NaNs with a harmless value.
+    """
+    Short Summary
+    -------------
+    Replace NaNs with a harmless value.
 
     Parameters
     ----------
@@ -204,7 +290,10 @@ def no_NaN(model, fill_value=0.):
 
 
 def mask_from_source_cat(input_model, wl_range_name, mmag_extract=None):
-    """Create a mask that is False within bounding boxes of sources.
+    """
+    Short Summary
+    -------------
+    Create a mask that is False within bounding boxes of sources.
 
     Parameters
     ----------
@@ -249,7 +338,10 @@ def mask_from_source_cat(input_model, wl_range_name, mmag_extract=None):
 
 
 def robust_mean(x, lowlim=25., highlim=75.):
-    """Compute a mean value, excluding outliers.
+    """
+    Short Summary
+    -------------
+    Compute a mean value, excluding outliers.
 
     Parameters
     ----------

--- a/jwst/background/subtract_images.py
+++ b/jwst/background/subtract_images.py
@@ -9,7 +9,8 @@ def subtract(model1, model2):
     """
     Short Summary
     -------------
-    Subtract one data model from another
+    Subtract one data model from another, and include updated DQ
+    in output.
 
     Parameters
     ----------
@@ -37,6 +38,47 @@ def subtract(model1, model2):
 
     # Combine the DQ flag arrays using bitwise OR
     output.dq = np.bitwise_or(model1.dq, model2.dq)
+
+    # Return the subtracted model
+    return output
+
+
+def subtract_ints(sci_mod, bkg_mod):
+    """
+    Short Summary
+    -------------
+    Subtract averaged bkg model from sci model for rateints input, and
+    include updated DQ in output.
+
+    Parameters
+    ----------
+    sci_mod: JWST Cube data model for rateints (3D) SCI exposure
+        Input data model on which subtraction will be performed. The 0th axis
+        represents the integrations of the exposure.
+
+    bkg_mod: JWST Image data model for the input BKG exposures.
+        This BKG image has already been averaged over all rateint (3D)
+        background exposures and all their integrations.
+
+    Returns
+    -------
+    output: JWST Cube data model
+        subtracted data model
+    """
+    # Create the output model as a copy of the SCI exposure
+    output = sci_mod.copy()
+
+    # Subtract the background average of data from each integration of the SCI arrays
+    output.data = sci_mod.data - bkg_mod.data
+
+    # bitwise_or combine DQ in BKG average with each SCI integration
+    for i_nint in range(sci_mod.dq.shape[0]):
+        output.dq[i_nint, :, :] = np.bitwise_or(output.dq[i_nint, :, :], bkg_mod.dq[:, :])
+
+    # Combine the ERR arrays in quadrature
+    # NOTE: currently stubbed out until ERR handling is decided
+    # output.err = np.sqrt(sci_mod.err**2 + bkg_mod.err**2)
+    # This is the same behavior as currently in code for the rate input
 
     # Return the subtracted model
     return output


### PR DESCRIPTION


<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2697](https://jira.stsci.edu/browse/JP-2697)


<!-- describe the changes comprising this PR here -->
This PR updates the background subtraction step to accept rateints (3D) input BKG exposures. There is no requirement that these multi-integration exposures have the same number of exposures.  The average over all integrations and all files will be subtracted from each integration of the input SCI exposure.  I also embellished existing epydocs.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [X] updated relevant documentation
- [X] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
