### PR TITLE
Remove min_gaia and rename gaia->abs parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,8 +18,8 @@ photom
 straylight
 ----------
 
-- Fix a bug in calibrated MRS slopes from small pedestal rate offsets between exposures by reintroducing zeropoint
-  subtraction using dark regions of MRS detectors. [#7013]
+- Fix a bug in calibrated MRS slopes from small pedestal rate offsets between
+  exposures by reintroducing zeropoint subtraction using dark regions of MRS detectors. [#7013]
 
 tweakreg
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,22 @@ photom
   flux conversion factors get computed correctly for both point-source and
   extended-source data. [#7019]
 
+tweakreg
+--------
+
+- Renamed ``gaia`` suffix to ``abs`` for the absolute astrometry
+  parameters. Specifically, ``gaia_catalog``->``abs_refcat``,
+  ``save_gaia_catalog``->``save_abs_catalog``. [#7023]
+
+- Removed ``align_to_gaia`` boolean step parameter since it now can be
+  indicated via ``abs_refcat`` parameter. When ``abs_refcat`` is None or an
+  empty string, alignment to an absolute astrometric catalog will be turned
+  OFF. When ``abs_refcat`` is a non-empty string, alignment to an absolute
+  astrometric reference catalog will be turned ON.
+
+- Bug fix: removed ``min_gaia`` which should have been removed in the
+  PR 6987. [#2023]
+
 1.7.0 (2022-09-01)
 ==================
 
@@ -167,7 +183,6 @@ tweakreg
   alignment (which needs 2 images) instead of skipping the entire
   step. [#6938]
 
-
 - Added support for user-supplied reference catalog for stage 2 of alignment
   in the ``tweakreg`` step. This catalog, if provided, will be used instead
   of the 'GAIA' catalogs for aligning all input images together as one single
@@ -176,10 +191,11 @@ tweakreg
 - Exposed ``tweakreg_catalog`` parameters in ``tweakreg`` [#7003]
 
 - exposed additional parameters for absolute astrometry:
- ``abs_minobj``, ``abs_searchrad``, ``abs_use2dhist``, ``abs_separation``, ``abs_tolerance``, ``abs_fitgeometry``, ``abs_nclip``,  and ``abs_sigma``. [#6987]
+  ``abs_minobj``, ``abs_searchrad``, ``abs_use2dhist``, ``abs_separation``,
+  ``abs_tolerance``, ``abs_fitgeometry``, ``abs_nclip``,
+  and ``abs_sigma``. [#6987]
 
 - Refactored code to work with changes in ``tweakwcs`` version 0.8.0. [#7006]
-
 
 1.6.2 (2022-07-19)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ tweakreg
   astrometric reference catalog will be turned ON.
 
 - Bug fix: removed ``min_gaia`` which should have been removed in the
-  PR 6987. [#2023]
+  PR 6987. [#7023]
 
 1.7.0 (2022-09-01)
 ==================

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -144,16 +144,16 @@ Parameters used for absolute astrometry using a reference catalog:
 * ``abs_minobj``: A positive `int` indicating minimum number of objects acceptable
   for matching. (Default=15)
 
-* ``abs_searchrad``: A `float` indicating the search radius in arcsec for a match. 
-  It is recommended that a value larger than ``searchrad`` be used for this parameter 
+* ``abs_searchrad``: A `float` indicating the search radius in arcsec for a match.
+  It is recommended that a value larger than ``searchrad`` be used for this parameter
   (e.g. 3 times larger) (Default=6.0)
 
 * ``abs_use2dhist``: A boolean indicating whether to use 2D histogram to find
-  initial offset. It is strongly recommended setting this parameter to `True`. 
+  initial offset. It is strongly recommended setting this parameter to `True`.
   Otherwise the initial guess for the offsets will be set to zero (Default=True)
 
-* ``abs_separation``: Minimum object separation in arcsec. It is recommended that 
-  a value smaller than ``separation`` be used for this parameter 
+* ``abs_separation``: Minimum object separation in arcsec. It is recommended that
+  a value smaller than ``separation`` be used for this parameter
   (e.g. 10 times smaller) (Default=0.1)
 
 * ``abs_tolerance``: Matching tolerance for ``xyxymatch`` in arcsec. (Default=0.7)
@@ -191,7 +191,19 @@ Parameters used for absolute astrometry using a reference catalog:
 * ``sigma``: A positive `float` indicating the clipping limit, in sigma units,
   used when performing fit. (Default=3.0)
 
-Parameters used for absolute astrometry using a reference catalog:
+**Absolute Astrometric fitting parameters:**
+
+Parameters used for absolute astrometry to a reference catalog.
+
+* ``abs_refcat``: String indicating what astrometric catalog should be used.
+  Currently supported options: `None`, '', 'GAIADR2' and 'GAIADR1' or a path
+  to an existing reference catalog. See
+  :py:data:`jwst.tweakreg.tweakreg_step.SINGLE_GROUP_REFCAT`
+  for an up-to-date list of supported built-in reference catalogs.
+
+  When ``abs_refcat`` is `None` or an empty string, alignment to the
+  absolute astrometry catalog will be turned off.
+  (Default='')
 
 * ``abs_fitgeometry``: A `str` value indicating the type of affine transformation
   to be considered when fitting catalogs. Allowed values:
@@ -201,7 +213,7 @@ Parameters used for absolute astrometry using a reference catalog:
   - ``'rscale'``: rotation and scale
   - ``'general'``: shift, rotation, and scale
 
-  The default value is "rshift". Note that the same conditions/restrictions that 
+  The default value is "rshift". Note that the same conditions/restrictions that
   apply to ``fitgeometry`` also apply to ``abs_fitgeometry``.
 
 * ``abs_nclip``: A non-negative integer number of clipping iterations
@@ -210,21 +222,10 @@ Parameters used for absolute astrometry using a reference catalog:
 * ``abs_sigma``: A positive `float` indicating the clipping limit, in sigma units,
   used when performing fit. (Default=3.0)
 
-**Astrometric fitting parameters:**
-
 * ``align_to_gaia``: A boolean indicating whether or not to fit to
   perform the fit to an astrometric catalog. (Default=False)
 
-* ``gaia_catalog``: String indicating what astrometric catalog should be used.
-  Currently supported options: 'GAIADR2' and 'GAIADR1' or a path to an existing
-  reference catalog. See :py:data:`jwst.tweakreg.tweakreg_step.SINGLE_GROUP_REFCAT`
-  for an up-to-date list of supported built-in reference catalogs.
-  (Default='GAIADR2')
-
-* ``min_gaia``: Minimum number of matches to astrometric sources to initiate a fit.
-  (Default=5)
-
-* ``save_gaia_catalog``: A boolean specifying whether or not to write out the
+* ``save_abs_catalog``: A boolean specifying whether or not to write out the
   astrometric catalog used for the fit as a separate product. (Default=False)
 
 

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -141,23 +141,6 @@ The ``tweakreg`` step has the following optional arguments:
 
 Parameters used for absolute astrometry using a reference catalog:
 
-* ``abs_minobj``: A positive `int` indicating minimum number of objects acceptable
-  for matching. (Default=15)
-
-* ``abs_searchrad``: A `float` indicating the search radius in arcsec for a match.
-  It is recommended that a value larger than ``searchrad`` be used for this parameter
-  (e.g. 3 times larger) (Default=6.0)
-
-* ``abs_use2dhist``: A boolean indicating whether to use 2D histogram to find
-  initial offset. It is strongly recommended setting this parameter to `True`.
-  Otherwise the initial guess for the offsets will be set to zero (Default=True)
-
-* ``abs_separation``: Minimum object separation in arcsec. It is recommended that
-  a value smaller than ``separation`` be used for this parameter
-  (e.g. 10 times smaller) (Default=0.1)
-
-* ``abs_tolerance``: Matching tolerance for ``xyxymatch`` in arcsec. (Default=0.7)
-
 **Catalog fitting parameters:**
 
 * ``fitgeometry``: A `str` value indicating the type of affine transformation
@@ -196,8 +179,8 @@ Parameters used for absolute astrometry using a reference catalog:
 Parameters used for absolute astrometry to a reference catalog.
 
 * ``abs_refcat``: String indicating what astrometric catalog should be used.
-  Currently supported options: `None`, '', 'GAIADR2' and 'GAIADR1' or a path
-  to an existing reference catalog. See
+  Currently supported options: 'GAIADR1', 'GAIADR2' a path to an existing
+  reference catalog, `None`, or ''. See
   :py:data:`jwst.tweakreg.tweakreg_step.SINGLE_GROUP_REFCAT`
   for an up-to-date list of supported built-in reference catalogs.
 
@@ -205,22 +188,41 @@ Parameters used for absolute astrometry to a reference catalog.
   absolute astrometry catalog will be turned off.
   (Default='')
 
-* ``abs_fitgeometry``: A `str` value indicating the type of affine transformation
-  to be considered when fitting catalogs. Allowed values:
+* ``abs_minobj``: A positive `int` indicating minimum number of objects
+  acceptable for matching. (Default=15)
+
+* ``abs_searchrad``: A `float` indicating the search radius in arcsec for
+  a match. It is recommended that a value larger than ``searchrad`` be used for
+  this parameter (e.g. 3 times larger) (Default=6.0)
+
+* ``abs_use2dhist``: A boolean indicating whether to use 2D histogram to find
+  initial offset. It is strongly recommended setting this parameter to `True`.
+  Otherwise the initial guess for the offsets will be set to zero
+  (Default=True)
+
+* ``abs_separation``: Minimum object separation in arcsec. It is recommended
+  that a value smaller than ``separation`` be used for this parameter
+  (e.g. 10 times smaller) (Default=0.1)
+
+* ``abs_tolerance``: Matching tolerance for ``xyxymatch`` in arcsec.
+  (Default=0.7)
+
+* ``abs_fitgeometry``: A `str` value indicating the type of affine
+  transformation to be considered when fitting catalogs. Allowed values:
 
   - ``'shift'``: x/y shifts only
   - ``'rshift'``: rotation and shifts
   - ``'rscale'``: rotation and scale
   - ``'general'``: shift, rotation, and scale
 
-  The default value is "rshift". Note that the same conditions/restrictions that
-  apply to ``fitgeometry`` also apply to ``abs_fitgeometry``.
+  The default value is "rshift". Note that the same conditions/restrictions
+  that apply to ``fitgeometry`` also apply to ``abs_fitgeometry``.
 
 * ``abs_nclip``: A non-negative integer number of clipping iterations
   to use in the fit. (Default = 3)
 
-* ``abs_sigma``: A positive `float` indicating the clipping limit, in sigma units,
-  used when performing fit. (Default=3.0)
+* ``abs_sigma``: A positive `float` indicating the clipping limit, in sigma
+  units, used when performing fit. (Default=3.0)
 
 * ``align_to_gaia``: A boolean indicating whether or not to fit to
   perform the fit to an astrometric catalog. (Default=False)


### PR DESCRIPTION
1. This PR fixes a bug from PR #6987 which introduced `abs_minobj` parameter which should have _replaced_ `min_gaia` but it inadvertently left it in the step `spec` and also in the code.2. 

2. This PR renames `gaia`-specific parameters to be in line with the new convention (`abs`) adopted in #6987. This is continuation of the work started in #6946. In particular, @hbushouse see https://github.com/spacetelescope/jwst/pull/6946#discussion_r944534937.

Specifically, this PR renames: ``gaia_catalog``->``abs_refcat`` and ``save_gaia_catalog``->``save_abs_catalog``.

``save_abs_catalog`` is used to save used GAIADR? catalogs to disk (but it will also re-save user-supplied reference catalogs if users choose to do so - hopefully they won't).

This PR also removes `align_to_gaia` boolean step parameter since it now can be
  indicated via `abs_refcat` parameter. When `abs_refcat` is None or an
  empty string, alignment to an absolute astrometric catalog will be turned
  OFF. When `abs_refcat` is a non-empty string, alignment to an absolute
  astrometric reference catalog will be turned ON.

It is not clear to me if there is any mechanism for deprecating step's `spec` attributes. So this might introduce some backward incompatibility... Hopefully a minimal one.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)

Regression Tests: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/415/