### PR TITLE
JP-2865 Add retries and timeout parameters to engineering access calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.7.1 (unreleased)
 ==================
 
+engdb_tools
+-----------
+
+- Add retries and timeout parameters to engineering access calls [#7025]
+
 photom
 ------
 

--- a/jwst/lib/engdb_direct.py
+++ b/jwst/lib/engdb_direct.py
@@ -27,6 +27,7 @@ ENGDB_METADATA_XML = 'xml/MetaData/TlmMnemonics/'
 
 # HTTP status that should get retries
 FORCE_STATUSES = [500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]
+TIMEOUT = 10 * 60  # 10 minutes
 
 __all__ = [
     'EngdbDirect'
@@ -85,7 +86,7 @@ class EngdbDirect(EngdbABC):
             self.base_url,
             self.default_format,
             ENGDB_METADATA
-        ]))
+        ]), timeout=TIMEOUT)
         response.raise_for_status()
 
     @property
@@ -123,7 +124,7 @@ class EngdbDirect(EngdbABC):
         logger.debug('Query URL="{}"'.format(query))
 
         # Make our request
-        response = self.session.get(query)
+        response = self.session.get(query, timeout=TIMEOUT)
         logger.debug('Response="{}"'.format(response))
         response.raise_for_status()
 
@@ -288,7 +289,7 @@ class EngdbDirect(EngdbABC):
         logger.debug('Query URL="{}"'.format(query))
 
         # Make our request
-        response = self.session.get(query)
+        response = self.session.get(query, timeout=TIMEOUT)
         logger.debug('Response: %s', response)
         logger.debug('Response: %s', response.json())
         response.raise_for_status()

--- a/jwst/lib/engdb_direct.py
+++ b/jwst/lib/engdb_direct.py
@@ -82,7 +82,7 @@ class EngdbDirect(EngdbABC):
         self.set_session()
 
         # Check for aliveness
-        response = self.session.get(''.join([
+        response = self._session.get(''.join([
             self.base_url,
             self.default_format,
             ENGDB_METADATA
@@ -124,7 +124,7 @@ class EngdbDirect(EngdbABC):
         logger.debug('Query URL="{}"'.format(query))
 
         # Make our request
-        response = self.session.get(query, timeout=TIMEOUT)
+        response = self._session.get(query, timeout=TIMEOUT)
         logger.debug('Response="{}"'.format(response))
         response.raise_for_status()
 
@@ -216,7 +216,7 @@ class EngdbDirect(EngdbABC):
         retries = Retry(total=10, backoff_factor=1.0, status_forcelist=FORCE_STATUSES, raise_on_status=True)
         s.mount('https://', HTTPAdapter(max_retries=retries))
 
-        self.session = s
+        self._session = s
 
     def _get_records(
             self,
@@ -289,7 +289,7 @@ class EngdbDirect(EngdbABC):
         logger.debug('Query URL="{}"'.format(query))
 
         # Make our request
-        response = self.session.get(query, timeout=TIMEOUT)
+        response = self._session.get(query, timeout=TIMEOUT)
         logger.debug('Response: %s', response)
         logger.debug('Response: %s', response.json())
         response.raise_for_status()

--- a/jwst/lib/engdb_mast.py
+++ b/jwst/lib/engdb_mast.py
@@ -93,9 +93,6 @@ class EngdbMast(EngdbABC):
             raise RuntimeError(f'MAST url: {self.base_url} is not available. Returned HTTPS status {resp.status_code}')
 
         # Basics are covered. Finalize initialization.
-        self._req = requests.Request(method='GET',
-                                     url=self.base_url + API_URI,
-                                     headers={'Authorization': f'token {self.token}'})
         self.set_session()
 
     def cache(self, mnemonics, starttime, endtime, cache_path):
@@ -276,6 +273,10 @@ class EngdbMast(EngdbABC):
 
     def set_session(self):
         """Setup HTTP session"""
+        self._req = requests.Request(method='GET',
+                                     url=self.base_url + API_URI,
+                                     headers={'Authorization': f'token {self.token}'})
+
         s = requests.Session()
         retries = Retry(total=self.retries, backoff_factor=1.0, status_forcelist=FORCE_STATUSES, raise_on_status=True)
         s.mount('https://', HTTPAdapter(max_retries=retries))

--- a/jwst/lib/engdb_mast.py
+++ b/jwst/lib/engdb_mast.py
@@ -168,7 +168,7 @@ class EngdbMast(EngdbABC):
         copy2(metas_path, cache_path / 'meta.json')
 
     def configure(self, base_url=None, token=None):
-        """Configure from parameters and environmentals
+        """Configure from parameters and environment
         Parameters
         ----------
         base_url : str

--- a/jwst/lib/engdb_mast.py
+++ b/jwst/lib/engdb_mast.py
@@ -311,7 +311,7 @@ class EngdbMast(EngdbABC):
         prepped = self._session.prepare_request(self._req)
         settings = self._session.merge_environment_settings(prepped.url, {}, None, None, None)
         logger.debug('Query: %s', prepped.url)
-        self.response = self._session.send(prepped, **settings)
+        self.response = self._session.send(prepped, timeout=TIMEOUT, **settings)
         self.response.raise_for_status()
         logger.debug('Response: %s', self.response)
         logger.debug('Response test: %s', self.response.text)

--- a/jwst/lib/engdb_mast.py
+++ b/jwst/lib/engdb_mast.py
@@ -169,6 +169,7 @@ class EngdbMast(EngdbABC):
 
     def configure(self, base_url=None, token=None):
         """Configure from parameters and environment
+
         Parameters
         ----------
         base_url : str

--- a/jwst/lib/engdb_mast.py
+++ b/jwst/lib/engdb_mast.py
@@ -24,6 +24,7 @@ SERVICE_URI = 'mast:jwstedb/'
 
 # HTTP status that should get retries
 FORCE_STATUSES = [500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]
+RETRIES = 10
 TIMEOUT = 10 * 60  # 10 minutes
 
 # Configure logging
@@ -66,37 +67,35 @@ class EngdbMast(EngdbABC):
     #: The results of the last query.
     response = None
 
+    #: Number of retries to attempt to contact the service
+    retries = RETRIES
+
     #: The start time of the last query.
     starttime = None
+
+    #: Network timeout when communicating with the service
+    timeout = TIMEOUT
+
+    #: MAST Token
+    token = None
 
     def __init__(self, base_url=None, token=None, **service_kwargs):
         logger.debug('kwargs not used by this service: %s', service_kwargs)
 
-        # Determine the database to use
-        if base_url is None:
-            base_url = getenv('ENG_BASE_URL', MAST_BASE_URL)
-        if base_url[-1] != '/':
-            base_url += '/'
-        self.base_url = base_url
-
-        # Get the token
-        if token is None:
-            token = getenv('MAST_API_TOKEN', None)
-        if token is None:
-            raise RuntimeError('No MAST token provided but is required. See https://auth.mast.stsci.edu/ for more information.')
+        self.configure(base_url=base_url, token=token)
 
         # Check for basic aliveness.
         try:
-            resp = requests.get(base_url + 'api/')
+            resp = requests.get(self.base_url + 'api/')
         except requests.exceptions.ConnectionError as exception:
-            raise RuntimeError(f'MAST url: {base_url} is unreachable.') from exception
+            raise RuntimeError(f'MAST url: {self.base_url} is unreachable.') from exception
         if resp.status_code != 200:
-            raise RuntimeError(f'MAST url: {base_url} is not available. Returned HTTPS status {resp.status_code}')
+            raise RuntimeError(f'MAST url: {self.base_url} is not available. Returned HTTPS status {resp.status_code}')
 
         # Basics are covered. Finalize initialization.
         self._req = requests.Request(method='GET',
-                                     url=base_url + API_URI,
-                                     headers={'Authorization': f'token {token}'})
+                                     url=self.base_url + API_URI,
+                                     headers={'Authorization': f'token {self.token}'})
         self.set_session()
 
     def cache(self, mnemonics, starttime, endtime, cache_path):
@@ -170,6 +169,38 @@ class EngdbMast(EngdbABC):
         # A default is saved within the package.
         metas_path = Path(__file__).parent / 'tests/data/meta_for_mock.json'
         copy2(metas_path, cache_path / 'meta.json')
+
+    def configure(self, base_url=None, token=None):
+        """Configure from parameters and environmentals
+        Parameters
+        ----------
+        base_url : str
+            The base url for the engineering RESTful service. If not defined,
+            the environmental variable ENG_BASE_URL is queried. Otherwise
+            the default MAST website is used.
+
+        token : str or None
+            The MAST access token. If not defined, the environmental variable
+            MAST_API_TOKEN is queried. A token is required.
+            For more information, see 'https://auth.mast.stsci.edu/'
+        """
+        # Determine the database to use
+        if base_url is None:
+            base_url = getenv('ENG_BASE_URL', MAST_BASE_URL)
+        if base_url[-1] != '/':
+            base_url += '/'
+        self.base_url = base_url
+
+        # Get the token
+        if token is None:
+            token = getenv('MAST_API_TOKEN', None)
+        if token is None:
+            raise RuntimeError('No MAST token provided but is required. See https://auth.mast.stsci.edu/ for more information.')
+        self.token = token
+
+        # Get various timeout parameters
+        self.retries = getenv('ENG_RETRIES', RETRIES)
+        self.timeout = getenv('ENG_TIMEOUT', TIMEOUT)
 
     def get_meta(self, *kwargs):
         """Get the mnemonics meta info
@@ -246,7 +277,7 @@ class EngdbMast(EngdbABC):
     def set_session(self):
         """Setup HTTP session"""
         s = requests.Session()
-        retries = Retry(total=10, backoff_factor=1.0, status_forcelist=FORCE_STATUSES, raise_on_status=True)
+        retries = Retry(total=self.retries, backoff_factor=1.0, status_forcelist=FORCE_STATUSES, raise_on_status=True)
         s.mount('https://', HTTPAdapter(max_retries=retries))
 
         self._session = s
@@ -311,7 +342,7 @@ class EngdbMast(EngdbABC):
         prepped = self._session.prepare_request(self._req)
         settings = self._session.merge_environment_settings(prepped.url, {}, None, None, None)
         logger.debug('Query: %s', prepped.url)
-        self.response = self._session.send(prepped, timeout=TIMEOUT, **settings)
+        self.response = self._session.send(prepped, timeout=self.timeout, **settings)
         self.response.raise_for_status()
         logger.debug('Response: %s', self.response)
         logger.debug('Response test: %s', self.response.text)

--- a/jwst/lib/engdb_tools.py
+++ b/jwst/lib/engdb_tools.py
@@ -55,6 +55,12 @@ MAST_API_TOKEN
     If no token is provided in code or by command line parameters, this value will be used.
     `~jwst.lib.engdb_mast.EngdbMast` service requires a token to be provided.
     See https://auth.mast.stsci.edu/ for more information.
+
+ENG_RETRIES
+    Number of attempts to make when connecting to the service. Default is 10.
+
+ENG_TIMEOUT
+    Number of seconds before timing out a network connection. Default is 600 seconds (10 minutes)
 """
 import logging
 

--- a/jwst/lib/tests/data/test_from_models_mast.ecsv
+++ b/jwst/lib/tests/data/test_from_models_mast.ecsv
@@ -6,15 +6,15 @@
 # - {name: ra, datatype: float64}
 # - {name: dec, datatype: float64}
 # - {name: pa_v3, datatype: float64}
-# meta: {allow_default: 'False', default_pa_v3: '0.0', dry_run: 'False', engdb_url: '''https://mast.stsci.edu''', fgsid: '1', fsmcorr_units: '''arcsec''',
-#   fsmcorr_version: '''latest''', guide_star_wcs: 'WCSRef(ra=None, dec=None, pa=None)', j2fgs_transpose: 'True', jwst_velocity: None,
-#   method: '<Methods.COARSE_TR_202111: ''coarse_tr_202111''>', obsend: None, obsstart: None, override_transforms: None, pcs_mode: None,
-#   pointing: "Pointing(q=array([-0.30521413, -0.79144945, -0.25000546,  0.46685048]), j2fgs_matrix=array([-8.73067300e-04,  3.60334320e-03,\
-#     \  9.99993132e-01,  9.99757625e-01,\n       -2.19949530e-02,  9.52115800e-04,  2.19982331e-02,  9.99751584e-01,\n       -3.58325960e-03]),\
-#     \ fsmcorr=array([-0.15910795, -0.00529688]), obstime=<Time object: scale='utc' format='unix' value=1643840740.9320743>, gs_commanded=array([0.,\
-#     \ 0.]), fgsid=1, gs_position=array([0., 0.]))", reduce_func: None, siaf: 'SIAF(v2_ref=0.0, v3_ref=0.0, v3yangle=0.0, vparity=1.0,
-#     crpix1=0, crpix2=0, cdelt1=3600, cdelt2=3600, vertices_idl=(0, 1, 1, 0, 0, 0, 1, 1))', siaf_db: <jwst.lib.siafdb.SiafDb object at
-#     0x7fa3fe697730>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
+# meta: {allow_default: 'False', default_pa_v3: '0.0', detector: None, dry_run: 'False', engdb_url: '''https://mast.stsci.edu''', fgsid: '1',
+#   fsmcorr_units: '''arcsec''', fsmcorr_version: '''latest''', guide_star_wcs: 'WCSRef(ra=None, dec=None, pa=None)', j2fgs_transpose: 'True',
+#   jwst_velocity: None, method: '<Methods.COARSE_TR_202111: ''coarse_tr_202111''>', obsend: None, obsstart: None, override_transforms: None,
+#   pcs_mode: None, pointing: "Pointing(q=array([-0.30521413, -0.79144945, -0.25000546,  0.46685048]), j2fgs_matrix=array([-8.73067300e-04,\
+#     \  3.60334320e-03,  9.99993132e-01,  9.99757625e-01,\n       -2.19949530e-02,  9.52115800e-04,  2.19982331e-02,  9.99751584e-01,\n\
+#     \       -3.58325960e-03]), fsmcorr=array([-0.15910795, -0.00529688]), obstime=<Time object: scale='utc' format='unix' value=1643840740.9320743>,\
+#     \ gs_commanded=array([0., 0.]), fgsid=0, gs_position=array([0., 0.]))", reduce_func: None, siaf: 'SIAF(v2_ref=0.0, v3_ref=0.0, v3yangle=0.0,
+#     vparity=1.0, crpix1=0, crpix2=0, cdelt1=3600, cdelt2=3600, vertices_idl=(0, 1, 1, 0, 0, 0, 1, 1))', siaf_db: <jwst.lib.siafdb.SiafDb
+#     object at 0x7fa413873130>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
 # schema: astropy-2.0
 source obstime ra dec pa_v3
-<ImageModel> 2022-02-02T22:25:40.932 146.550322401799 63.08381107913903 194.15784810636973
+<ImageModel> 2022-02-02T22:25:40.932 146.5503941066434 63.08387154277842 194.1482993002141

--- a/jwst/lib/tests/data/test_over_time_mast.ecsv
+++ b/jwst/lib/tests/data/test_over_time_mast.ecsv
@@ -6,15 +6,15 @@
 # - {name: ra, datatype: float64}
 # - {name: dec, datatype: float64}
 # - {name: pa_v3, datatype: float64}
-# meta: {allow_default: 'False', default_pa_v3: '0.0', dry_run: 'False', engdb_url: '''https://mast.stsci.edu''', fgsid: '1', fsmcorr_units: '''arcsec''',
-#   fsmcorr_version: '''latest''', guide_star_wcs: 'WCSRef(ra=None, dec=None, pa=None)', j2fgs_transpose: 'True', jwst_velocity: None,
-#   method: '<Methods.COARSE_TR_202111: ''coarse_tr_202111''>', obsend: None, obsstart: None, override_transforms: None, pcs_mode: None,
-#   pointing: "Pointing(q=array([-0.30521413, -0.79144945, -0.25000546,  0.46685048]), j2fgs_matrix=array([-8.73067300e-04,  3.60334320e-03,\
-#     \  9.99993132e-01,  9.99757625e-01,\n       -2.19949530e-02,  9.52115800e-04,  2.19982331e-02,  9.99751584e-01,\n       -3.58325960e-03]),\
-#     \ fsmcorr=array([-0.15910795, -0.00529688]), obstime=<Time object: scale='utc' format='unix' value=1643840740.9320743>, gs_commanded=array([0.,\
-#     \ 0.]), fgsid=1, gs_position=array([0., 0.]))", reduce_func: None, siaf: 'SIAF(v2_ref=0.0, v3_ref=0.0, v3yangle=0.0, vparity=1.0,
-#     crpix1=0, crpix2=0, cdelt1=3600, cdelt2=3600, vertices_idl=(0, 1, 1, 0, 0, 0, 1, 1))', siaf_db: <jwst.lib.siafdb.SiafDb object at
-#     0x7fa3fe746640>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
+# meta: {allow_default: 'False', default_pa_v3: '0.0', detector: None, dry_run: 'False', engdb_url: '''https://mast.stsci.edu''', fgsid: '1',
+#   fsmcorr_units: '''arcsec''', fsmcorr_version: '''latest''', guide_star_wcs: 'WCSRef(ra=None, dec=None, pa=None)', j2fgs_transpose: 'True',
+#   jwst_velocity: None, method: '<Methods.COARSE_TR_202111: ''coarse_tr_202111''>', obsend: None, obsstart: None, override_transforms: None,
+#   pcs_mode: None, pointing: "Pointing(q=array([-0.30521413, -0.79144945, -0.25000546,  0.46685048]), j2fgs_matrix=array([-8.73067300e-04,\
+#     \  3.60334320e-03,  9.99993132e-01,  9.99757625e-01,\n       -2.19949530e-02,  9.52115800e-04,  2.19982331e-02,  9.99751584e-01,\n\
+#     \       -3.58325960e-03]), fsmcorr=array([-0.15910795, -0.00529688]), obstime=<Time object: scale='utc' format='unix' value=1643840740.9320743>,\
+#     \ gs_commanded=array([0., 0.]), fgsid=0, gs_position=array([0., 0.]))", reduce_func: None, siaf: 'SIAF(v2_ref=0.0, v3_ref=0.0, v3yangle=0.0,
+#     vparity=1.0, crpix1=0, crpix2=0, cdelt1=3600, cdelt2=3600, vertices_idl=(0, 1, 1, 0, 0, 0, 1, 1))', siaf_db: <jwst.lib.siafdb.SiafDb
+#     object at 0x7fa414f061a0>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
 # schema: astropy-2.0
 source obstime ra dec pa_v3
-"time range" 2022-02-02T22:25:40.932 146.550322401799 63.08381107913903 194.15784810636973
+"time range" 2022-02-02T22:25:40.932 146.5503941066434 63.08387154277842 194.1482993002141

--- a/jwst/lib/tests/test_engdb_tools.py
+++ b/jwst/lib/tests/test_engdb_tools.py
@@ -28,7 +28,7 @@ BAD_MNEMONIC = 'No_Such_MNEMONIC'
 NODATA_STARTIME = '2014-01-01'
 NODATA_ENDTIME = '2014-01-02'
 
-ALTERNATE_HOST = 'http://twjwdmsemwebag.stsci.edu'
+ALTERNATE_HOST = 'https://twjwdmsemwebag.stsci.edu'
 ALTERNATE_URL = ALTERNATE_HOST + '/JWDMSEngFqAccSide2/TlmMnemonicDataSrv.svc/'
 
 
@@ -72,7 +72,7 @@ def test_environmental(jail_environ):
 
 
 def test_environmental_bad(jail_environ):
-    alternate = 'http://google.com/'
+    alternate = 'https://google.com/'
     did_except = False
     os.environ['ENG_BASE_URL'] = alternate
     try:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2865](https://jira.stsci.edu/browse/JP-2865)

<!-- describe the changes comprising this PR here -->
This PR addresses an issue discovered in OPS. For unknown reasons, the engineering database service
will fail to provide mnemonics. This causes tasks such as `set_telescope_pointing` to fail.

It has been found that these are transient situations and that adding retry/timeout parameters to the network calls, the above situation would be mitigated. This PR adds these capabilities to the `ENGDB_Service`.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
