### PR TITLE
Fix failing assign_wcs test due to gwcs changes

### DIFF
--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -1,4 +1,6 @@
 import pytest
+from packaging.version import Version
+
 from numpy import zeros
 from numpy.testing import assert_allclose
 from astropy import units as u
@@ -6,6 +8,7 @@ from astropy import wcs
 from astropy.io import fits
 from astropy.modeling.models import RotationSequence3D
 
+import gwcs
 from gwcs.wcstools import grid_from_bounding_box
 from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
 
@@ -189,6 +192,8 @@ def test_create_fitswcs(tmpdir, create_model_3d):
     assert_allclose((ra, dec), (gra, gdec))
 
 
+@pytest.mark.xfail(Version(gwcs.__version__) > Version('0.18.1'),
+                   reason="Changes in fit errors units in gwcs.to_sip_fits")
 def test_sip_approx(tmpdir):
     # some of the wcs info
     true_wcs = {

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -192,8 +192,10 @@ def test_create_fitswcs(tmpdir, create_model_3d):
     assert_allclose((ra, dec), (gra, gdec))
 
 
-@pytest.mark.xfail(Version(gwcs.__version__) > Version('0.18.1'),
-                   reason="Changes in fit errors units in gwcs.to_sip_fits")
+@pytest.mark.xfail(
+    Version('0.18.1') < Version(gwcs.__version__) < Version('0.18.2'),
+    reason="Changes in fit errors units in gwcs.to_sip_fits"
+)
 def test_sip_approx(tmpdir):
     # some of the wcs info
     true_wcs = {


### PR DESCRIPTION
@jdavies-st  reported that pytest jwst/assign_wcs/tests/test_wcs.py::test_sip_approx was failing and my investigation showed that it happened after recent changes in `gwcs` reporting SIP fit errors from arcseconds to pixels (since fit quality is specified in pixels so it was good to be consistent). The only parameter that is different is `sipmxerr` and the test is expected to fail when using master branch of `gwcs`. Once there is a release of `gwcs`, this test will need to be updated.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
