### PR TITLE
JP-2906: Fix wcs attribute names in wfss_contam step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ photom
   flux conversion factors get computed correctly for both point-source and
   extended-source data. [#7019]
 
+wfss_contam
+-----------
+
+- Update WCS transform attribute names for 2D source cutout offsets,
+  to stay in synch with newer wcs models. [#7028]
+
 1.7.0 (2022-09-01)
 ==================
 

--- a/jwst/wfss_contam/disperse.py
+++ b/jwst/wfss_contam/disperse.py
@@ -84,8 +84,12 @@ def dispersed_pixel(x0, y0, width, height, lams, flxs, order, wmin, wmax,
     # The WCS comes from the first 2D cutout in the grism image, which has
     # the offset from the full-frame origin to the cutout origin in it.
     # We'll use these values later to get back to full-frame coords.
-    offset_x = -imgxy_to_grismxy.offset_1
-    offset_y = -imgxy_to_grismxy.offset_2
+    try:
+        offset_x = -imgxy_to_grismxy.offset_1
+        offset_y = -imgxy_to_grismxy.offset_2
+    except:
+        offset_x = -imgxy_to_grismxy.offset_6
+        offset_y = -imgxy_to_grismxy.offset_7
 
     # Setup function for retrieving flux values at each dispersed wavelength
     if len(lams) > 1:

--- a/jwst/wfss_contam/disperse.py
+++ b/jwst/wfss_contam/disperse.py
@@ -87,7 +87,7 @@ def dispersed_pixel(x0, y0, width, height, lams, flxs, order, wmin, wmax,
     try:
         offset_x = -imgxy_to_grismxy.offset_1
         offset_y = -imgxy_to_grismxy.offset_2
-    except:
+    except AttributeError:
         offset_x = -imgxy_to_grismxy.offset_6
         offset_y = -imgxy_to_grismxy.offset_7
 

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -170,7 +170,7 @@ class Observation:
             self.cached_object = {}
 
         # Initialize the simulated dispersed image
-        self.simulated_image = np.zeros(self.dims, np.float)
+        self.simulated_image = np.zeros(self.dims, float)
 
         # Loop over all source ID's from segmentation map
         for i in range(len(self.IDs)):
@@ -265,7 +265,7 @@ class Observation:
                 all_res.append(dispersed_pixel(*pars[i]))
 
         # Initialize blank image for this source
-        this_object = np.zeros(self.dims, np.float)
+        this_object = np.zeros(self.dims, float)
 
         nres = 0
         for pp in all_res:
@@ -309,7 +309,7 @@ class Observation:
         if not self.cache:
             return
 
-        self.simulated_image = np.zeros(self.dims, np.float)
+        self.simulated_image = np.zeros(self.dims, float)
 
         for i in range(len(self.IDs)):
             this_object = self.disperse_chunk_from_cache(i, trans=trans)
@@ -325,7 +325,7 @@ class Observation:
         time1 = time.time()
 
         # Initialize blank image for this object
-        this_object = np.zeros(self.dims, np.float)
+        this_object = np.zeros(self.dims, float)
 
         if trans is not None:
             log.debug("Applying a transmission function...")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2906](https://jira.stsci.edu/browse/JP-2906)

<!-- describe the changes comprising this PR here -->
This PR updates the attribute names for the subarray corner offsets in the WCS transform used in the `wfss_contam` step for grism images, as described in JP-2906. It should be backwards compatible, by first trying to use the old attribute names and then using the new ones if that fails.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
