### PR TITLE
JP-2627: Fixes to pixel scale in resample and photometry keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ tweakreg
 - Relaxed FITS WCS SIP fitting parameters for the tweakreg step to make the
   code more robust. [#7038]
 
+resample
+--------
+- Fix calculation of 'pixel_scale_ratio' when 'pixel_scale' parameter is
+  supplied, as well as fix a bug where this value was not being properly passed
+  to ResampleStep, and another where photometry keywords weren't being updated
+  correctly to reflect the correct pixel scale ratio. [#7033]
+
 
 1.7.2 (2022-09-12)
 ==================
@@ -26,6 +33,7 @@ assign_wcs
 
 - Adjust default parameters for FITS SIP approximation to make it more robust
   vis-a-vis MIRI imaging distortions. [#7037]
+
 
 
 1.7.1 (2022-09-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,6 @@ align_refs
 
 - Upgrade the median image replacement routine to also replace NaN pixels,
   in addition to pixels flagged as bad. [#7044]
-  
-tweakreg
---------
-
-- Relaxed FITS WCS SIP fitting parameters for the tweakreg step to make the
-  code more robust. [#7038]
 
 resample
 --------
@@ -19,6 +13,12 @@ resample
   supplied, as well as fix a bug where this value was not being properly passed
   to ResampleStep, and another where photometry keywords weren't being updated
   correctly to reflect the correct pixel scale ratio. [#7033]
+
+tweakreg
+--------
+
+- Relaxed FITS WCS SIP fitting parameters for the tweakreg step to make the
+  code more robust. [#7038]
 
 
 1.7.2 (2022-09-12)
@@ -33,7 +33,6 @@ assign_wcs
 
 - Adjust default parameters for FITS SIP approximation to make it more robust
   vis-a-vis MIRI imaging distortions. [#7037]
-
 
 
 1.7.1 (2022-09-07)

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -64,7 +64,6 @@ class ResampleData:
                 all products in memory.
         """
         self.input_models = input_models
-
         self.output_filename = output
         self.pscale_ratio = pscale_ratio
         self.single = single
@@ -88,7 +87,10 @@ class ResampleData:
         rotation = kwargs.get('rotation', None)
 
         if pscale is not None:
+            log.info(f'Output pixel scale: {pscale} arcsec.')
             pscale /= 3600.0
+        else:
+            log.info(f'Output pixel scale ratio: {pscale_ratio}')
 
         # Define output WCS based on all inputs, including a reference WCS
         self.output_wcs = resample_utils.make_output_wcs(


### PR DESCRIPTION
(This PR is replacing #6999 )

The parameter 'pix_scale_ratio' was not being passed to ResampleData, so the default of 1.0 was always being used - this PR fixes that. Additionally, if 'pixel_scale' is provided, it overrides 'pix_scale_ratio' -  in this case, the header value for `pixel_scale_ratio` was not being recalculated to reflect the absolute pixel scale passed in. The source_catalog step uses this value from the header, so it needed to be accurately calculated. 

Resolves [JP-2627](https://jira.stsci.edu/browse/JP-2627) and [JP-1757](https://jira.stsci.edu/browse/JP-1757)
Closes #5426

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)