### PR TITLE
Fix crashes in assign WCS due to uncaught SIP convergence exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 1.7.2 (unreleased)
 ==================
 
+assign_wcs
+----------
+
+- Fixed a bug in ``assign_wcs`` due to which the step could crash due to
+  uncaught exception when SIP approximation fails to reach desired
+  accuracy. [#7036]
+
 
 1.7.1 (2022-09-07)
 ==================

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -107,10 +107,8 @@ class AssignWcsStep(Step):
                 crpix=None
             )
 
-        except ValueError as e:
+        except (ValueError, RuntimeError) as e:
             log.warning("Failed to update 'meta.wcsinfo' with FITS SIP "
                         f'approximation. Reported error is:\n"{e.args[0]}"')
-
-            pass
 
         return result


### PR DESCRIPTION
Fixes reported crashes in the pipeline during testing. (Reported by @nden)

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
