### PR TITLE
JP-2913: Fix the coron median replace algorithm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 1.7.3 (unreleased)
 ==================
 
+align_refs
+----------
+
+- Upgrade the median image replacement routine to also replace NaN pixels,
+  in addition to pixels flagged as bad. [#7044]
+
+
 1.7.2 (2022-09-12)
 ==================
 

--- a/jwst/regtest/test_nircam_coron3.py
+++ b/jwst/regtest/test_nircam_coron3.py
@@ -8,14 +8,10 @@ from jwst.stpipe import Step
 def run_pipeline(jail, rtdata_module):
     """Run calwebb_coron3 on coronographic data."""
     rtdata = rtdata_module
-    psfmask = rtdata.get_data("nircam/coron/jwst_nircam_psfmask_somb.fits")
-    rtdata.get_asn("nircam/coron/jw99999-a3001_20170327t121212_coron3_001_asn.json")
+    rtdata.get_asn("nircam/coron/jw01386-c1020_20220909t073458_coron3_002a_asn.json")
 
     # Run the calwebb_coron3 pipeline on the association
-    args = [
-        "calwebb_coron3", rtdata.input,
-        f"--steps.align_refs.override_psfmask={psfmask}"
-    ]
+    args = ["calwebb_coron3", rtdata.input]
     Step.from_cmdline(args)
 
     return rtdata
@@ -23,12 +19,12 @@ def run_pipeline(jail, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["psfalign", "psfsub", "crfints"])
-@pytest.mark.parametrize("exposure", ["00001", "00002"])
-def test_nircam_coron3_sci_exp(run_pipeline, suffix, exposure, fitsdiff_default_kwargs):
+@pytest.mark.parametrize("obs", ["002", "003"])
+def test_nircam_coron3_sci_exp(run_pipeline, suffix, obs, fitsdiff_default_kwargs):
     """Check intermediate results of calwebb_coron3"""
     rtdata = run_pipeline
 
-    output = "jw9999947001_02102_" + exposure + "_nrcb3_a3001_" + suffix + ".fits"
+    output = "jw01386" + obs + "001_03108_00001_nrcalong_c1020_" + suffix + ".fits"
     rtdata.output = output
     rtdata.get_truth("truth/test_nircam_coron3/" + output)
 
@@ -39,12 +35,12 @@ def test_nircam_coron3_sci_exp(run_pipeline, suffix, exposure, fitsdiff_default_
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["crfints"])
-@pytest.mark.parametrize("exposure", ["00003", "00004", "00005"])
+@pytest.mark.parametrize("exposure", ["00001", "00002", "00003", "00004"])
 def test_nircam_coron3_psf_exp(run_pipeline, suffix, exposure, fitsdiff_default_kwargs):
     """Check intermediate results of calwebb_coron3"""
     rtdata = run_pipeline
 
-    output = "jw9999947001_02102_" + exposure + "_nrcb3_a3001_" + suffix + ".fits"
+    output = "jw01386001001_0310a_" + exposure + "_nrcalong_c1020_" + suffix + ".fits"
     rtdata.output = output
     rtdata.get_truth("truth/test_nircam_coron3/" + output)
 
@@ -59,7 +55,7 @@ def test_nircam_coron3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
     """Check final products of calwebb_coron3"""
     rtdata = run_pipeline
 
-    output = "jw99999-a3001_t1_nircam_f140m-maskbar_" + suffix + ".fits"
+    output = "jw01386-c1020_t001_nircam_f410m-maskrnd-sub320a335r_mini_" + suffix + ".fits"
     rtdata.output = output
     rtdata.get_truth("truth/test_nircam_coron3/" + output)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2913](https://jira.stsci.edu/browse/JP-2913)

<!-- describe the changes comprising this PR here -->
This PR updates the median image replacement routine used in the coronagraphic "align_refs" step so that it rejects and replaces pixels that are NaN in addition to pixels that are flagged as bad (some NaNs are not flagged, which is another issue).

The presence of NaN's causes the various FFT routines used for alignment and shifting to return updated images that are all NaN (which is not a good thing).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
