### PR TITLE
check whether `requirements-sdp.txt` is empty before publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,10 +2,16 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [released]
+    types: [ released ]
 
 jobs:
+  check:
+    name: check that `requirements-sdp.txt` is populated
+    runs-on: ubuntu-latest
+    steps:
+      - run: "[[ -z $(grep -v '^ *#' requirements-sdp.txt) ]] && { echo \"requirements-sdp.txt is empty\" ; exit 1; }"
   publish:
+    needs: [ check ]
     uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
     with:
       test: false


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This change ensures that `requirements-sdp.txt` has requirements in it (non-commented lines) before allowing the PyPI publish to occur. This can hopefully prevent releases without SDP requirements.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
