### PR TITLE
JP-2918: Fix bad resampled frames for NRS MOS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,13 @@ resample
   to ResampleStep, and another where photometry keywords weren't being updated
   correctly to reflect the correct pixel scale ratio. [#7033, #7048]
 
+resample_spec
+-------------
+
+- Update computation of target RA/Dec for slit spectra to handle data
+  containing negative spectral traces (due to nodded background subtraction)
+  in a most robust way. [#7047]
+
 tweakreg
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ resample_spec
 
 - Update computation of target RA/Dec for slit spectra to handle data
   containing negative spectral traces (due to nodded background subtraction)
-  in a most robust way. [#7047]
+  in a more robust way. [#7047]
 
 tweakreg
 --------

--- a/jwst/regtest/test_migrate_data.py
+++ b/jwst/regtest/test_migrate_data.py
@@ -20,6 +20,7 @@ def strict_validation(monkeypatch):
     yield
 
 
+@pytest.mark.skip(reason="obsolete test with no available old input data")
 @pytest.mark.bigdata
 @pytest.mark.parametrize("truth_path", [
     "truth/test_miri_lrs_slit_spec2/jw00623032001_03102_00001_mirimage_x1d.fits",
@@ -43,6 +44,7 @@ def test_x1d_spec_table(truth_path, rtdata):
         pass
 
 
+@pytest.mark.skip(reason="obsolete test with no available old input data")
 @pytest.mark.bigdata
 @pytest.mark.parametrize("truth_path",
                          ["truth/test_nircam_mtimage/mt_pre_1-2-2_schema_uncal.fits"],


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2918](https://jira.stsci.edu/browse/JP-2918)

<!-- describe the changes comprising this PR here -->
This PR fixes the calculation of resampled output frames for NIRSpec slit data (either fixed-slit or MOS) by making the algorithm less sensitive to the presence of negative spectral traces in the input images (which occurs when nodding is used to do background subtraction).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
