### PR TITLE
fix definition of pixel ratio

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,10 +20,8 @@ resample
 - Fix calculation of 'pixel_scale_ratio' when 'pixel_scale' parameter is
   supplied, as well as fix a bug where this value was not being properly passed
   to ResampleStep, and another where photometry keywords weren't being updated
-  correctly to reflect the correct pixel scale ratio. [#7033]
+  correctly to reflect the correct pixel scale ratio. [#7033, #7048]
 
-- Changed computation of meta.resample.pixel_scale_ratio to correctly be the
-  ratio of input / output areas [#7048]
 
 tweakreg
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ resample
   to ResampleStep, and another where photometry keywords weren't being updated
   correctly to reflect the correct pixel scale ratio. [#7033]
 
+- Changed computation of meta.resample.pixel_scale_ratio to correctly be the
+  ratio of input / output areas [#7048]
+
 tweakreg
 --------
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -77,6 +77,7 @@ class ResampleStep(Step):
             raise RuntimeError("Input {} is not a 2D image.".format(input_models[0]))
 
         #  Get drizzle parameters reference file, if there is one
+        self.wht_type = self.weight_type
         if 'drizpars' in self.reference_file_types:
             ref_filename = self.get_reference_file(input_models[0], 'drizpars')
         else:  # no drizpars reference file found
@@ -88,8 +89,6 @@ class ResampleStep(Step):
         else:
             self.log.info('Using drizpars reference file: {}'.format(ref_filename))
             kwargs = self.get_drizpars(ref_filename, input_models)
-
-        self.wht_type = self.weight_type
 
         kwargs['allowed_memory'] = self.allowed_memory
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -79,14 +79,15 @@ class ResampleStep(Step):
         #  Get drizzle parameters reference file, if there is one
         if 'drizpars' in self.reference_file_types:
             ref_filename = self.get_reference_file(input_models[0], 'drizpars')
-            self.log.info('Using drizpars reference file: {}'.format(ref_filename))
-            kwargs = self.get_drizpars(ref_filename, input_models)
         else:  # no drizpars reference file found
             ref_filename = 'N/A'
 
         if ref_filename == 'N/A':
             self.log.info('No drizpars reference file found.')
             kwargs = self._set_spec_defaults()
+        else:
+        	self.log.info('Using drizpars reference file: {}'.format(ref_filename))
+            kwargs = self.get_drizpars(ref_filename, input_models)
 
         self.wht_type = self.weight_type
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -125,7 +125,7 @@ class ResampleStep(Step):
             if not self.pixel_scale:
                 model.meta.resample.pixel_scale_ratio = self.pixel_scale_ratio
             else:
-                model.meta.resample.pixel_scale_ratio = (self.pixel_scale ** 2) / model.meta.photometry.pixelarea_arcsecsq
+                model.meta.resample.pixel_scale_ratio = self.pixel_scale / np.sqrt(model.meta.photometry.pixelarea_arcsecsq)
             model.meta.resample.pixfrac = kwargs['pixfrac']
             self.update_phot_keywords(model)
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -86,7 +86,7 @@ class ResampleStep(Step):
             self.log.info('No drizpars reference file found.')
             kwargs = self._set_spec_defaults()
         else:
-        	self.log.info('Using drizpars reference file: {}'.format(ref_filename))
+            self.log.info('Using drizpars reference file: {}'.format(ref_filename))
             kwargs = self.get_drizpars(ref_filename, input_models)
 
         self.wht_type = self.weight_type

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -504,11 +504,11 @@ def test_pixscale(nircam_rate):
 
     # check when both pixel_scale and pixel_scale_ratio are passed in
     res = ResampleStep.call(im, pixel_scale=0.04, pixel_scale_ratio=0.7)
-    assert np.allclose(res.meta.resample.pixel_scale_ratio, 0.04**2 / pixarea)
+    assert np.allclose(res.meta.resample.pixel_scale_ratio, 0.04 / np.sqrt(pixarea))
 
     # just pixel_scale
     res = ResampleStep.call(im, pixel_scale=0.04)
-    assert np.allclose(res.meta.resample.pixel_scale_ratio, 0.04**2 / pixarea)
+    assert np.allclose(res.meta.resample.pixel_scale_ratio, 0.04 / np.sqrt(pixarea))
 
     # just pixel_scale_ratio
     res = ResampleStep.call(im, pixel_scale_ratio=0.7)
@@ -527,6 +527,6 @@ def test_phot_keywords(nircam_rate):
     res = ResampleStep.call(im, pixel_scale=0.04)
     new_psr = res.meta.resample.pixel_scale_ratio
 
-    assert res.meta.resample.pixel_scale_ratio == 0.04**2 / orig_pix_area_arcsec
+    assert res.meta.resample.pixel_scale_ratio == 0.04 / np.sqrt(orig_pix_area_arcsec)
     assert res.meta.photometry.pixelarea_steradians == orig_pix_area_sr * new_psr**2
     assert res.meta.photometry.pixelarea_arcsecsq == orig_pix_area_arcsec * new_psr**2


### PR DESCRIPTION
Fixes an error introduced by #7033 where the pixel scale ratio was incorrectly defined - it is now correctly computed as a ratio of pixel areas. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
