### PR TITLE
JP-2927: Fix short spectrum bug in combine1d

### DIFF
--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -341,7 +341,15 @@ def count_input(input_spectra):
 
     # Create an array with all the input wavelengths (i.e. the union
     # of the input wavelengths).
-    wl = np.hstack([in_spec.wavelength for in_spec in input_spectra])
+    wl = None
+    for in_spec in input_spectra:
+        input_wl = in_spec.wavelength
+        # only include spectra that have more than 1 data point
+        if len(input_wl) > 1:
+            if wl is None:
+                wl = input_wl
+            else:
+                wl = np.hstack((input_wl, wl))
     wl.sort()
     nwl = len(wl)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2927](https://jira.stsci.edu/browse/JP-2927)

<!-- describe the changes comprising this PR here -->
This PR fixes a bug in the combine_1d step that gets triggered when one of the input spectra to be combined has only 1 wavelength bin. There was one trap already in place for these so-called "degenerate" spectra, but this particular bug occurs before that trap. The problem was that the union of all wavelength values from all input spectra was being created before the trap for degenerate spectra. So when it came time to count the number of input spectra that contribute to each unionized wavelength point, some were being left with a zero count. So this modification changes the way the union of wavelengths is created, in order to exclude values from degenerate spectra already at that point (so that no zero counts appear later).

I was almost certain that we already had checks in place upstream in steps like `extract_2d` or `extract_1d` to not create spectra with less than 2 data points, but it appears that at least in some cases (this is WFSS data) spectra with only 1 data point are still getting through to this last stage of processing.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
