### PR TITLE
use `ruff` in place of `flake8`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ datamodels
 - Added ``SUB400X256ALWB`` to subarray enum list of allowed NIRCam values. This
   replaces ``SUB320ALWB``, which is retained in the ``obsolete`` enum list.
   [#7361]
-  
+
 extract_1d
 ----------
 
@@ -66,8 +66,10 @@ general
 
 - Reorganize and expand user documentation, update docs landing page. Add install instructions, quickstart guide, and elaborate on running
   pipeline in Python and with strun. [#6919]
-  
+
 - fixed wrong Python version expected in ``__init__.py`` [#7366]
+
+- replace `flake8` with `ruff` [#7054]
 
 guider_cds
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,7 +69,7 @@ general
 
 - fixed wrong Python version expected in ``__init__.py`` [#7366]
 
-- replace `flake8` with `ruff` [#7054]
+- replace ``flake8`` with ``ruff`` [#7054]
 
 guider_cds
 ----------

--- a/jwst/pipeline/tests/helpers.py
+++ b/jwst/pipeline/tests/helpers.py
@@ -8,9 +8,7 @@ import tempfile
 
 # Import from the common helpers module
 # simply to make available from this module.
-from ...tests.helpers import (  # noqa: F401
-    abspath,
-)
+from ...tests.helpers import abspath # noqa: F401
 
 from ...associations import load_asn
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,14 @@ exclude = [
     '.eggs',
     'build',
 ]
-per-file-ignores = [
-    'jwst/ramp_fitting/tests/compare_cr_navg_files.py:E402',
-    'jwst/ramp_fitting/tests/compare_crs.py:E402',
-    'jwst/ramp_fitting/tests/compare_cr_files.py:E402',
-    'jwst/ramp_fitting/tests/create_cube.py:E402',
-    'jwst/ramp_fitting/tests/mc_3d.py:E402',
-]
+
 ignore = [
     'E741', # ambiguous variable name
 ]
+
+[tool.ruff.per-file-ignores]
+'jwst/ramp_fitting/tests/compare_cr_navg_files.py' = ['E402']
+'jwst/ramp_fitting/tests/compare_crs.py' = ['E402']
+'jwst/ramp_fitting/tests/compare_cr_files.py' = ['E402']
+'jwst/ramp_fitting/tests/create_cube.py' = ['E402']
+'jwst/ramp_fitting/tests/mc_3d.py' = ['E402']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,5 @@ per-file-ignores = [
     'jwst/ramp_fitting/tests/mc_3d.py:E402',
 ]
 ignore = [
-    'A001', # Variable is shadowing a python builtin
-    'A002', # Argument is shadowing a python builtin
-    'A003', # class attribute is shadowing a python builtin
     'E741', # ambiguous variable name
-    'SPR001', # Use `super()` instead of `super(__class__, self)`
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,29 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+
+[tool.ruff]
+line-length = 130
+exclude = [
+    'jwst/extern',
+    'docs',
+    'jwst/associations',
+    'jwst/fits_generator',
+    '.tox',
+    '.eggs',
+    'build',
+]
+per-file-ignores = [
+    'jwst/ramp_fitting/tests/compare_cr_navg_files.py:E402',
+    'jwst/ramp_fitting/tests/compare_crs.py:E402',
+    'jwst/ramp_fitting/tests/compare_cr_files.py:E402',
+    'jwst/ramp_fitting/tests/create_cube.py:E402',
+    'jwst/ramp_fitting/tests/mc_3d.py:E402',
+]
+ignore = [
+    'A001', # Variable is shadowing a python builtin
+    'A002', # Argument is shadowing a python builtin
+    'A003', # class attribute is shadowing a python builtin
+    'E741', # ambiguous variable name
+    'SPR001', # Use `super()` instead of `super(__class__, self)`
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ test =
     ci-watson>=0.5.0
     codecov>=1.6.0
     colorama>=0.4.1
-    flake8>=3.6.0
+    ruff
     getch>=1.0.0
     pytest>=6.0.0
     pytest-cov>=2.9.0
@@ -100,30 +100,6 @@ all_files = 1
 [upload_docs]
 upload-dir = docs/_build/html
 show-response = 1
-
-[flake8]
-select = F, W, E, C
-# We should set max line length lower eventually
-max-line-length = 130
-exclude =
-    jwst/extern,
-    docs,
-    jwst/associations,
-    jwst/fits_generator,
-    .tox,
-    .eggs,
-    build
-per-file-ignores =
-    jwst/ramp_fitting/tests/compare_cr_navg_files.py:E
-    jwst/ramp_fitting/tests/compare_crs.py:E
-    jwst/ramp_fitting/tests/compare_cr_files.py:E
-    jwst/ramp_fitting/tests/create_cube.py:E
-    jwst/ramp_fitting/tests/mc_3d.py:E
-ignore = E231,E241,W503,W504
-# E231, # Missing whitespace after ',', ';', or ':'
-# E241, # Multiple spaces after ','
-# W503, # Line break occurred before a binary operator
-# W504, # Line break occurred after a binary operator
 
 [tool:pytest]
 minversion = 6.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,9 @@ isolated_build = true
 description = check code style, e.g. with flake8
 skip_install = true
 deps =
-    flake8
+    ruff
 commands =
-    flake8 . {posargs}
+    ruff . {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
`ruff` is an in-development Python linter written in Rust that aims for parity with combined Flake8 and Black: https://github.com/charliermarsh/ruff

It has several advantages over `flake8`, including significant speedups in linting and support for `pyproject.toml` configuration and PEP517 / PEP621.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
