### PR TITLE
JP-2946: Update NOUTPUTS allowed values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.8.1 (unreleased)
 ==================
 
+datamodels
+----------
+
+- Update the definition of the NOUTPUTS keyword to include "5" as an allowed value.
+  [#7062]
 
 
 1.8.0 (2022-10-07)

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -741,7 +741,7 @@ properties:
           noutputs:
             title: Number of detector outputs used
             type: integer
-            enum: [1, 4]
+            enum: [1, 4, 5]
             fits_keyword: NOUTPUTS
             blend_table: True
           nints:

--- a/jwst/datamodels/schemas/keyword_noutputs.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_noutputs.schema.yaml
@@ -13,5 +13,5 @@ properties:
           noutputs:
             title: Number of detector outputs used
             type: integer
-            enum: [1, 4]
+            enum: [1, 4, 5]
             fits_keyword: NOUTPUTS


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2946](https://jira.stsci.edu/browse/JP-2946)

<!-- describe the changes comprising this PR here -->
This PR updates the datamodels schemas that contain the NOUTPUTS keyword definitions to add "5" to the list of allowed values.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
