### PR TITLE
JP-2970 Allow XML_DATA usage to override PRD specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ datamodels
 - Update the definition of the NOUTPUTS keyword to include "5" as an allowed value.
   [#7062]
 
+set_telescope_pointing
+----------------------
+
+- Allow XML_DATA usage to override PRD specification [#7063]
 
 1.8.0 (2022-10-07)
 ==================

--- a/jwst/lib/siafdb.py
+++ b/jwst/lib/siafdb.py
@@ -160,7 +160,9 @@ class SiafDb:
         Parameters
         ----------
         source : None, str, or a file-like object
-            If None, then the latest PRD version in `pysiaf` is used.
+            If None, the environmental XML_DATA is queried.
+            If None and no XML_DATA information, then the PRD version, as defined by `prd`,
+            will be used.
             Otherwise, it should be a string or Path-like object pointing to a folder containing the
             SIAF XML files.
 
@@ -186,17 +188,17 @@ class SiafDb:
             if not xml_path.is_dir():
                 raise ValueError('Source %s: Needs to be a folder for use with pysiaf', xml_path)
 
-        # If a PRD version is defined, attempt to use that.
-        if not xml_path and prd:
-            prd_to_use, xml_path = nearest_prd(self.pysiaf, prd)
-            self.prd_version = prd_to_use
-            logger.info('Using PRD %s for specified PRD %s', prd_to_use, prd)
-
         # If nothing has been specified, see if XML_DATA says what to do.
         if not xml_path:
             xml_path = os.environ.get('XML_DATA', None)
             if xml_path:
                 xml_path = Path(xml_path) / 'SIAFXML'
+
+        # If a PRD version is defined, attempt to use that.
+        if not xml_path and prd:
+            prd_to_use, xml_path = nearest_prd(self.pysiaf, prd)
+            self.prd_version = prd_to_use
+            logger.info('Using PRD %s for specified PRD %s', prd_to_use, prd)
 
         # If nothing else, use the `pysiaf` default.
         if not xml_path:

--- a/jwst/lib/tests/test_siafdb.py
+++ b/jwst/lib/tests/test_siafdb.py
@@ -18,16 +18,6 @@ OLD_PRD = 'PRDOPSSOC-053'
 OLD_PRD_PATH = PYSIAF_PRD_PATH / OLD_PRD / 'SIAFXML' / 'SIAFXML'
 
 
-@pytest.fixture
-def jail_environ():
-    """Lock changes to the environment"""
-    original = os.environ.copy()
-    try:
-        yield
-    finally:
-        os.environ = original
-
-
 @pytest.mark.parametrize('source, prd, xml_path, exception', [
     # Default
     (None, None, pysiaf.JWST_PRD_DATA_ROOT, does_not_raise()),

--- a/jwst/lib/tests/test_siafdb.py
+++ b/jwst/lib/tests/test_siafdb.py
@@ -96,7 +96,7 @@ def test_nearest_prd(prd, expected, exception):
     (None, None, XML_DATA_SIAFXML_PATH / 'SIAFXML'),
     (None, 'PRDOPSSOC-055', XML_DATA_SIAFXML_PATH / 'SIAFXML'),
     (SIAFXML_PATH, None, SIAFXML_PATH)
-    ])
+])
 def test_xml_data_overrides(source, prd, expected, jail_environ):
     """Test cases where XML_DATA should be used and not used."""
     os.environ['XML_DATA'] = str(XML_DATA_SIAFXML_PATH)

--- a/jwst/lib/tests/test_siafdb.py
+++ b/jwst/lib/tests/test_siafdb.py
@@ -90,3 +90,17 @@ def test_nearest_prd(prd, expected, exception):
     with exception:
         prd_to_use, _ = siafdb.nearest_prd(pysiaf, prd)
         assert prd_to_use == expected
+
+
+@pytest.mark.parametrize('source, prd, expected', [
+    (None, None, XML_DATA_SIAFXML_PATH / 'SIAFXML'),
+    (None, 'PRDOPSSOC-055', XML_DATA_SIAFXML_PATH / 'SIAFXML'),
+    (SIAFXML_PATH, None, SIAFXML_PATH)
+    ])
+def test_xml_data_overrides(source, prd, expected, jail_environ):
+    """Test cases where XML_DATA should be used and not used."""
+    os.environ['XML_DATA'] = str(XML_DATA_SIAFXML_PATH)
+
+    siaf_db = siafdb.SiafDb(source=source, prd=prd)
+
+    assert siaf_db.xml_path == expected


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2970](https://jira.stsci.edu/browse/JP-2970)

This PR addresses an issue found in SDP in the logic of how `set_telescope_pointing` was determining the source of the siaf XML files. `set_telescope_pointing` was using the internal, `pysiaf`-delivered, XML files when PRD_VER was found, ignoring the setting of `XML_DATA` environment variable.

This PR fixes this, so that, if `XML_DATA` is defined, that folder will be used as the source of the XML files.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
