### PR TITLE
JP-2910: Moving associations dump from info to debug.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.8.3 (unreleased)
 ==================
 
+associations
+------------
+
+- Moved text dump of associations to happen when using the '-D' option,
+  rather than the '-v' option. [#7068]
+
 
 
 1.8.2 (2022-10-20)
@@ -19,9 +25,6 @@ associations
 
 - Expand the sequence field in a file name for association files from
   3 characters to 5 characters. [#7061]
-
-- Moved text dump of associations to happen when using the '-D' option,
-  rather than the '-v' option. [#7068]
 
 
 cube_build

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ associations
 - Expand the sequence field in a file name for association files from
   3 characters to 5 characters. [#7061]
 
+- Moved text dump of associations to happen when using the '-D' option,
+  rather than the '-v' option. [#7068]
+
+
 cube_build
 ----------
 

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -273,7 +273,7 @@ class Main():
             except AttributeError:
                 pass
 
-        logger.info(self.__str__())
+        logger.debug(self.__str__())
 
         if not parsed.dry_run:
             self.save(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2910](https://jira.stsci.edu/browse/JP-2910)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR move printing the association text dump to the screen from "info" to "debug", i.e., the text dump now occurs when using the `-D` option, instead of the `-v` option.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
