### PR TITLE
JP-2971 Make the GWCSDrizzle.outcon attribute a property with setter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,11 @@ datamodels
 
 - Fix handling of ASN directory path by the ``ModelContainer``. [#7071]
 
+resample
+--------
+
+- Make the GWCSDrizzle.outcon attribute a property with setter [#7295]
+
 set_telescope_pointing
 ----------------------
 

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -373,33 +373,33 @@ different set of data arrays than other science products. Resampled 2-D images a
 ``i2d`` products and resampled 2-D spectra are stored in ``s2d`` products.
 The FITS file structure for ``i2d`` and ``s2d`` products is as follows:
 
-+-----+-------------+----------+-----------+---------------+
-| HDU | EXTNAME     | HDU Type | Data Type | Dimensions    |
-+=====+=============+==========+===========+===============+
-|  0  | N/A         | primary  | N/A       | N/A           |
-+-----+-------------+----------+-----------+---------------+
-|  1  | SCI         | IMAGE    | float32   | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|  2  | ERR         | IMAGE    | float32   | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|  3  | CON         | IMAGE    | int32     | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|  4  | WHT         | IMAGE    | float32   | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|  5  | VAR_POISSON | IMAGE    | float32   | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|  6  | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|  7  | VAR_FLAT    | IMAGE    | float32   | ncols x nrows |
-+-----+-------------+----------+-----------+---------------+
-|     | HDRTAB*     | BINTABLE | N/A       | variable      |
-+-----+-------------+----------+-----------+---------------+
-|     | ASDF        | BINTABLE | N/A       | variable      |
-+-----+-------------+----------+-----------+---------------+
++-----+-------------+----------+-----------+-------------------------+
+| HDU | EXTNAME     | HDU Type | Data Type | Dimensions              |
++=====+=============+==========+===========+=========================+
+|  0  | N/A         | primary  | N/A       | N/A                     |
++-----+-------------+----------+-----------+-------------------------+
+|  1  | SCI         | IMAGE    | float32   | ncols x nrows           |
++-----+-------------+----------+-----------+-------------------------+
+|  2  | ERR         | IMAGE    | float32   | ncols x nrows           |
++-----+-------------+----------+-----------+-------------------------+
+|  3  | CON         | IMAGE    | int32     | ncols x nrows x nplanes |
++-----+-------------+----------+-----------+-------------------------+
+|  4  | WHT         | IMAGE    | float32   | ncols x nrows           |
++-----+-------------+----------+-----------+-------------------------+
+|  5  | VAR_POISSON | IMAGE    | float32   | ncols x nrows           |
++-----+-------------+----------+-----------+-------------------------+
+|  6  | VAR_RNOISE  | IMAGE    | float32   | ncols x nrows           |
++-----+-------------+----------+-----------+-------------------------+
+|  7  | VAR_FLAT    | IMAGE    | float32   | ncols x nrows           |
++-----+-------------+----------+-----------+-------------------------+
+|     | HDRTAB*     | BINTABLE | N/A       | variable                |
++-----+-------------+----------+-----------+-------------------------+
+|     | ASDF        | BINTABLE | N/A       | variable                |
++-----+-------------+----------+-----------+-------------------------+
 
  - SCI: 2-D data array containing the pixel values, in units of surface brightness
  - ERR: 2-D data array containing resampled uncertainty estimates, given as standard deviation
- - CON: 2-D context image, which encodes information about which input images contribute
+ - CON: 3-D context image, which encodes information about which input images contribute
    to a specific output pixel
  - WHT: 2-D weight image giving the relative weight of the output pixels
  - VAR_POISSON: 2-D resampled Poisson variance estimates for each pixel
@@ -408,12 +408,16 @@ The FITS file structure for ``i2d`` and ``s2d`` products is as follows:
  - HDRTAB: A table containing meta data (FITS keyword values) for all of the input images
    that were combined to produce the output image. Only appears when multiple inputs are used.
  - ADSF: The data model meta data.
- 
+
 For spectroscopic exposure-based products that contain spectra for more than one source or slit
 (e.g. NIRSpec MOS) there will be multiple tuples of the SCI, ERR, CON, WHT, and variance
 extensions, one set for each source or slit. FITS "EXTVER" keywords are used in each
 extension header to segregate the multiple instances of each extension type by
 source.
+
+For the context array, CON, though the schema represents it as an ``int32``,
+users should interpret and recast the array as ``uint32`` post-processing. This
+inconsistency will be dealt with in a later release.
 
 .. _s3d:
 

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -57,6 +57,7 @@ class GWCSDrizzle:
         """
 
         # Initialize the object fields
+        self._product = product
         self.outsci = None
         self.outwht = None
         self.outcon = None
@@ -105,6 +106,18 @@ class GWCSDrizzle:
             np.divide(self.outsci, self.outexptime, self.outsci)
         elif out_units != "cps":
             raise ValueError("Illegal value for out_units: %s" % out_units)
+
+    # Since the context array is dynamic, it must be re-assigned
+    # back to the product's `con` attribute.
+    @property
+    def outcon(self):
+        """Return the context array"""
+        return self._product.con
+
+    @outcon.setter
+    def outcon(self, value):
+        """Set new context array"""
+        self._product.con = value
 
     def add_image(self, insci, inwcs, inwht=None, xmin=0, xmax=0, ymin=0, ymax=0,
                   expin=1.0, in_units="cps", wt_scl=1.0):

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -22,7 +22,7 @@ class GWCSDrizzle:
         Parameters
         ----------
 
-        product : str, optional
+        product : DataModel
             A data model containing results from a previous run. The three
             extensions SCI, WHT, and CTX contain the combined image, total counts
             and image id bitmap, respectively. The WCS of the combined image is


### PR DESCRIPTION
This forces the context array to be in sync with the products `con` attribute.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2971](https://jira.stsci.edu/browse/JP-2971)

<!-- describe the changes comprising this PR here -->
This PR addresses an issue found in by a user where the output of `calwebb_image3` had a context array that made no sense. The issue was that the context array was being calculated but not attached to the output model.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
