### PR TITLE
Add note about source catalog pixel indexing

### DIFF
--- a/docs/jwst/source_catalog/main.rst
+++ b/docs/jwst/source_catalog/main.rst
@@ -77,9 +77,9 @@ columns (assuming the default encircled energies of 30, 50, and 70):
 +========================+====================================================+
 | label                  | Unique source identification label number          |
 +------------------------+----------------------------------------------------+
-| xcentroid              | X pixel value of the source centroid               |
+| xcentroid              | X pixel value of the source centroid (0 indexed)   |
 +------------------------+----------------------------------------------------+
-| ycentroid              | Y pixel value of the source centroid               |
+| ycentroid              | Y pixel value of the source centroid (0 indexed)   |
 +------------------------+----------------------------------------------------+
 | sky_centroid           | Sky coordinate of the source centroid              |
 +------------------------+----------------------------------------------------+
@@ -231,6 +231,11 @@ columns (assuming the default encircled energies of 30, 50, and 70):
 | sky_bbox_ur            | Sky coordinate of the upper-right vertex of the    |
 |                        | minimal bounding box of the source                 |
 +------------------------+----------------------------------------------------+
+
+Note that pixel coordinates are 0 indexed, matching the Python 0-based
+indexing. That means pixel coordinate ``0`` is the center of the first
+pixel.
+
 
 Segmentation Map
 ^^^^^^^^^^^^^^^^

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -178,9 +178,9 @@ class JWSTSourceCatalog:
         """
         desc = {}
         desc['label'] = 'Unique source identification label number'
-        desc['xcentroid'] = 'X pixel value of the source centroid'
-        desc['ycentroid'] = 'Y pixel value of the source centroid'
-        desc['sky_centroid'] = 'Sky coordinate of the source centroid'
+        desc['xcentroid'] = 'X pixel value of the source centroid (0 indexed)'
+        desc['ycentroid'] = 'Y pixel value of the source centroid (0 indexed)'
+        desc['sky_centroid'] = 'ICRS Sky coordinate of the source centroid'
         desc['isophotal_flux'] = 'Isophotal flux'
         desc['isophotal_flux_err'] = 'Isophotal flux error'
         desc['isophotal_abmag'] = 'Isophotal AB magnitude'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR updates the docs to add a note about the source catalog centroid pixel indexing.  I've also added this to the column descriptions in the output catalog metadata.  A few users (e.g., help desk tickets) have been confused about the pixel indexing.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
