### PR TITLE
JP-2982: Fix extract_2d to skip zero-length cutouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 assign_wcs
 ----------
 
-- Fix computation of bounding box corners for WFSS grism 2D cutouts.
+- Fix computation of bounding box corners for WFSS grism 2D cutouts. [#7312]
 
 associations
 ------------
@@ -25,7 +25,7 @@ datamodels
 extract_2d
 ----------
 
-- Fix slice limits used in extraction of WFSS 2D cutouts.
+- Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
 
 1.8.2 (2022-10-20)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.8.3 (unreleased)
 ==================
 
+assign_wcs
+----------
+
+- Fix computation of bounding box corners for WFSS grism 2D cutouts.
+
 associations
 ------------
 
@@ -16,6 +21,11 @@ datamodels
 ----------
 
 - Add subarray keywords in filteroffset schema [#7317]
+
+extract_2d
+----------
+
+- Fix slice limits used in extraction of WFSS 2D cutouts.
 
 1.8.2 (2022-10-20)
 ==================

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -749,10 +749,10 @@ def _create_grism_bbox(input_model, mmag_extract=None, wfss_extract_half_height=
                     # didn't call this bounding box code. So I think it's safe to leave the subarray
                     # subtraction out, i.e. do not subtract x/ystart.
 
-                    xmin = int(np.nanmin(xstack))
-                    xmax = int(np.nanmax(xstack))
-                    ymin = int(np.nanmin(ystack))
-                    ymax = int(np.nanmax(ystack))
+                    xmin = np.nanmin(xstack)
+                    xmax = np.nanmax(xstack)
+                    ymin = np.nanmin(ystack)
+                    ymax = np.nanmax(ystack)
 
                     if wfss_extract_half_height is not None and not obj.is_extended:
                         if input_model.meta.wcsinfo.dispersion_direction == 2:
@@ -768,14 +768,17 @@ def _create_grism_bbox(input_model, mmag_extract=None, wfss_extract_half_height=
                         else:
                             raise ValueError("Cannot determine dispersion direction.")
 
-                    # don't add objects and orders which are entirely
-                    # off the detector partial_order marks partial
-                    # off-detector objects which are near enough to
-                    # cause spectra to be observed on the detector.
-                    # This is useful because the catalog often is
-                    # created from a resampled direct image that is
-                    # bigger than the detector FOV for a single grism
-                    # exposure.
+                    # Convert floating-point corner values to whole pixel indexes
+                    xmin = gwutils._toindex(xmin)
+                    xmax = gwutils._toindex(xmax)
+                    ymin = gwutils._toindex(ymin)
+                    ymax = gwutils._toindex(ymax)
+
+                    # Don't add objects and orders that are entirely off the detector.
+                    # "partial_order" marks objects that are near enough to the detector
+                    # edge to have some spectrum on the detector.
+                    # This is useful because the catalog often is created from a resampled direct
+                    # image that is bigger than the detector FOV for a single grism exposure.
                     exclude = False
                     ispartial = False
 

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -422,7 +422,7 @@ def extract_grism_objects(input_model,
             # don't extract anything that ended up with zero dimensions in one axis
             # this means that it was identified as a partial order but only on one
             # row or column of the detector
-            if ymax - ymin > 0 and xmax - xmin > 0:
+            if ymax - ymin > 0.5 and xmax - xmin > 0.5:
                 subwcs = copy.deepcopy(inwcs)
                 log.info("Subarray extracted for obj: {} order: {}:".format(obj.sid, order))
                 log.info("Subarray extents are: "

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -422,7 +422,7 @@ def extract_grism_objects(input_model,
             # don't extract anything that ended up with zero dimensions in one axis
             # this means that it was identified as a partial order but only on one
             # row or column of the detector
-            if ymax - ymin > 0.5 and xmax - xmin > 0.5:
+            if ymax - ymin > 0 and xmax - xmin > 0:
                 subwcs = copy.deepcopy(inwcs)
                 log.info("Subarray extracted for obj: {} order: {}:".format(obj.sid, order))
                 log.info("Subarray extents are: "
@@ -447,8 +447,8 @@ def extract_grism_objects(input_model,
                                                  ycenter_model &
                                                  order_model) | tr
                 from gwcs.utils import _toindex
-                y_slice = slice(_toindex(ymin), _toindex(ymax))
-                x_slice = slice(_toindex(xmin), _toindex(xmax))
+                y_slice = slice(_toindex(ymin), _toindex(ymax) + 1)
+                x_slice = slice(_toindex(xmin), _toindex(xmax) + 1)
                 ext_data = input_model.data[y_slice, x_slice].copy()
                 ext_err = input_model.err[y_slice, x_slice].copy()
                 ext_dq = input_model.dq[y_slice, x_slice].copy()

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from astropy.modeling.models import Shift, Const1D, Mapping
 from gwcs.wcstools import grid_from_bounding_box
+from gwcs.utils import _toindex
 
 from .. import datamodels
 from ..assign_wcs import util
@@ -441,14 +442,14 @@ def extract_grism_objects(input_model,
                 order_model.inverse = Const1D(order)
 
                 tr = inwcs.get_transform('grism_detector', 'detector')
-
                 tr = Mapping((0, 1, 0, 0, 0)) | (Shift(xmin) & Shift(ymin) &
                                                  xcenter_model &
                                                  ycenter_model &
                                                  order_model) | tr
-                from gwcs.utils import _toindex
+
                 y_slice = slice(_toindex(ymin), _toindex(ymax) + 1)
                 x_slice = slice(_toindex(xmin), _toindex(xmax) + 1)
+
                 ext_data = input_model.data[y_slice, x_slice].copy()
                 ext_err = input_model.err[y_slice, x_slice].copy()
                 ext_dq = input_model.dq[y_slice, x_slice].copy()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2982](https://jira.stsci.edu/browse/JP-2982)

<!-- describe the changes comprising this PR here -->
This PR updates the extract_2d step so that it skips processing of any 2D cutouts that are defined with a length of <1 pixel in either of their dimensions, as computed from the WCS-related info for the cutout.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
