### PR TITLE
JP-2975 Update MIRI Imager Filteroffset schema 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ cube_build
 
 - Fix a bug in 3d drizzle code for NIRSpec IFU.  [#7306]
 
+datamodels
+----------
+
+- Add subarray keywords in filteroffset schema [#7317]
+
 1.8.2 (2022-10-20)
 ==================
 

--- a/jwst/datamodels/schemas/filteroffset.schema.yaml
+++ b/jwst/datamodels/schemas/filteroffset.schema.yaml
@@ -9,6 +9,8 @@ allOf:
 - $ref: keyword_pfilter.schema
 - $ref: keyword_channel.schema
 - $ref: keyword_module.schema
+- $ref: subarray.schema
+- $ref: keyword_psubarray.schema
 - type: object
   properties:
     meta:
@@ -38,3 +40,5 @@ allOf:
             type: number
           column_offset:
             type: number
+	
+	   

--- a/jwst/datamodels/schemas/filteroffset.schema.yaml
+++ b/jwst/datamodels/schemas/filteroffset.schema.yaml
@@ -40,5 +40,3 @@ allOf:
             type: number
           column_offset:
             type: number
-	
-	   


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2975](https://jira.stsci.edu/browse/JP-2975)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7299 

<!-- describe the changes comprising this PR here -->
This PR adds subarray.schema and keyword_p_subarray.schema to the filter offset file. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
