### PR TITLE
expand extraction box indices by 1 to conform with behaviour of `slice()`

### DIFF
--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -447,8 +447,8 @@ def extract_grism_objects(input_model,
                                                  ycenter_model &
                                                  order_model) | tr
                 from gwcs.utils import _toindex
-                y_slice = slice(_toindex(ymin), _toindex(ymax))
-                x_slice = slice(_toindex(xmin), _toindex(xmax))
+                y_slice = slice(_toindex(ymin), _toindex(ymax) + 1)
+                x_slice = slice(_toindex(xmin), _toindex(xmax) + 1)
                 ext_data = input_model.data[y_slice, x_slice].copy()
                 ext_err = input_model.err[y_slice, x_slice].copy()
                 ext_dq = input_model.dq[y_slice, x_slice].copy()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue brought up in https://github.com/spacetelescope/jwst/pull/6803?notification_referrer_id=NT_kwDOAPSC67MzNDgzOTc1MjI5OjE2MDI0Mjk5#discussion_r1006112868 by @hbushouse 

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
