### PR TITLE
JP-2931: Guard against nearly identical points in nirspec resampled WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ associations
 
 - Moved text dump of associations to happen when using the '-D' option,
   rather than the '-v' option. [#7068]
-  
+
 cube_build
 ----------
 
@@ -26,6 +26,13 @@ extract_2d
 ----------
 
 - Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
+
+resample
+--------
+
+- Enhance spectral output WCS construction to guard against nearly identical
+  points. [#7321]
+
 
 1.8.2 (2022-10-20)
 ==================

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -740,6 +740,9 @@ def _find_nirspec_output_sampling_wavelengths(wcs_list, targ_ra, targ_dec, mode=
                 ref_lam = ref_lam + lam_ar[idx].tolist()
                 lam2 = ref_lam[-1]
 
+    # In the resampled WCS, if two wavelengths are closer to each other
+    # than 1/10 of the minimum difference between two wavelengths,
+    # remove one of the points.
     ediff = np.fabs(np.ediff1d(ref_lam))
     idx = np.flatnonzero(ediff < max(0.1 * min_delta, 1e2 * np.finfo(1.0).eps))
     for i in idx[::-1]:

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -675,7 +675,7 @@ def _find_nirspec_output_sampling_wavelengths(wcs_list, targ_ra, targ_dec, mode=
     ra, dec, lambdas = refwcs(*grid)
 
     if mode == 'median':
-        ref_lam = np.nanmedian(lambdas[:, np.any(np.isfinite(lambdas), axis=0)], axis=0).tolist()
+        ref_lam = sorted(np.nanmedian(lambdas[:, np.any(np.isfinite(lambdas), axis=0)], axis=0))
     else:
         ref_lam, _, _ = _find_nirspec_sampling_wavelengths(
             refwcs,
@@ -687,13 +687,15 @@ def _find_nirspec_output_sampling_wavelengths(wcs_list, targ_ra, targ_dec, mode=
     lam1 = ref_lam[0]
     lam2 = ref_lam[-1]
 
+    min_delta = np.fabs(np.ediff1d(ref_lam).min())
+
     image_lam = []
     for w in wcs_list[1:]:
         bbox = w.bounding_box
         grid = wcstools.grid_from_bounding_box(bbox)
         ra, dec, lambdas = w(*grid)
         if mode == 'median':
-            lam = np.nanmedian(lambdas[:, np.any(np.isfinite(lambdas), axis=0)], axis=0).tolist()
+            lam = sorted(np.nanmedian(lambdas[:, np.any(np.isfinite(lambdas), axis=0)], axis=0))
         else:
             lam, _, _ = _find_nirspec_sampling_wavelengths(
                 w,
@@ -702,6 +704,7 @@ def _find_nirspec_output_sampling_wavelengths(wcs_list, targ_ra, targ_dec, mode=
                 fast=mode == 'fast'
             )
         image_lam.append((lam, np.min(lam), np.max(lam)))
+        min_delta = min(min_delta, np.fabs(np.ediff1d(ref_lam).min()))
 
     # The code below is optimized for the case when wavelength is an increasing
     # function of the pixel index along the X-axis. It will not work correctly
@@ -736,6 +739,11 @@ def _find_nirspec_output_sampling_wavelengths(wcs_list, targ_ra, targ_dec, mode=
                 idx = np.flatnonzero(lam_ar > lam2)
                 ref_lam = ref_lam + lam_ar[idx].tolist()
                 lam2 = ref_lam[-1]
+
+    ediff = np.fabs(np.ediff1d(ref_lam))
+    idx = np.flatnonzero(ediff < max(0.1 * min_delta, 1e2 * np.finfo(1.0).eps))
+    for i in idx[::-1]:
+        del ref_lam[i]
 
     return ref_lam
 


### PR DESCRIPTION
Resolves [JP-2931](https://jira.stsci.edu/browse/JP-2931)

Closes #7293

This PR fixes a crash observed in some datasets caused by the presence of almost the same points in the list of wavelengths in output spectral WCS.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression tests *are still running*: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/450/