### PR TITLE
separate tox testenvs to cache CRDS reference files retrieved by initial test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install tox crds
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+      - run: pip install tox
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
@@ -116,12 +111,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install tox crds
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+      - run: pip install tox
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        toxenv: [ check-style, check-security, check-install ]
+        python-version: [ '3.9' ]
+        os: [ ubuntu-latest ]
         include:
           - name: Code style check
-            os: ubuntu-latest
-            python-version: 3.9
             toxenv: check-style
           - name: Security audit
-            os: ubuntu-latest
-            python-version: 3.9
             toxenv: check-security
           - name: Verify install_requires in setup.py
-            os: ubuntu-latest
-            python-version: 3.9
             toxenv: check-install
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        toxenv: [ test ]
+        toxenv: [ test-xdist ]
         python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
     steps:
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        toxenv: [ test-pyargs ]
+        toxenv: [ test-pyargs-xdist ]
         python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
           - name: Verify install_requires in setup.py
             toxenv: check-install
     steps:
-      - run: echo ${{ format('{0}/{1}', env.CRDS_PATH, 'references') }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -65,7 +64,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
       - run: tox -e ${{ matrix.toxenv }}
   test:
     name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -88,7 +87,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -116,7 +115,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
     name: build distribution (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         toxenv: [ check-style, check-security, check-install ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
         include:
           - name: Code style check
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         toxenv: [ test ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
     strategy:
       matrix:
         toxenv: [ test-pyargs ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         toxenv: [ build-twine ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(join([env.CRDS_PATH, 'references'], '/')) }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
       - run: tox -e ${{ matrix.toxenv }}
   test:
     name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(join([env.CRDS_PATH, 'references'], '/')) }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(join([env.CRDS_PATH, 'references'], '/')) }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
     name: build distribution (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
 jobs:
-  checks:
+  check:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -47,13 +47,14 @@ jobs:
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
-    name: test Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }}
-    needs: [ checks ]
+    name: ${{ matrix.name }}
+    needs: [ check ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - python-version: '3.10'
+          - name: Python 3.10 tests
+            python-version: '3.10'
             os: ubuntu-latest
             toxenv: test
     steps:
@@ -67,37 +68,11 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/reference') }}
+          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/references') }}
       - run: tox -e ${{ matrix.toxenv }}
   test:
-    name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
-    needs: [ quick_test ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            python-version: 3.9
-            toxenv: test
-          - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: test-pyargs
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: pip install tox
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/reference') }}
-      - run: tox -e ${{ matrix.toxenv }}
-  test_dependencies:
     name: ${{ matrix.name }}
-    needs: [ test ]
+    needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -114,6 +89,14 @@ jobs:
             os: ubuntu-latest
             python-version: 3.9
             toxenv: test-sdpdeps
+          - name: Installed package with --pyargs
+            os: ubuntu-latest
+            python-version: 3.9
+            toxenv: test-pyargs
+          - name: MacOS
+            os: macos-latest
+            python-version: 3.9
+            toxenv: test
     steps:
       - uses: actions/checkout@v3
         with:
@@ -125,30 +108,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/reference') }}
-      - run: tox -e ${{ matrix.toxenv }}
-  test_with_coverage:
-    name: test with coverage (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
-    needs: [ test ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: 3.10
-            toxenv: test-cov
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: pip install tox
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/reference') }}
+          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/references') }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -158,7 +118,7 @@ jobs:
           fail_ci_if_error: true
   build:
     name: build distribution (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
-    needs: [ quick_test ]
+    needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toxenv: [ test-cov test-oldestdeps-cov, test-sdpdeps ]
+        toxenv: [ test-cov, test-oldestdeps-cov, test-sdpdeps ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toxenv: [ test-cov, test-oldestdeps-cov, test-sdpdeps ]
+        toxenv: [ test-xdist, test-oldestdeps, test-sdpdeps-xdist ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
@@ -99,15 +99,9 @@ jobs:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
-      - if: ${{ contains(matrix.toxenv,'-cov') }}
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
-          flags: unit
-          fail_ci_if_error: true
   test_pyargs:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    needs: [ quick_test ]
+    needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -131,6 +125,39 @@ jobs:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
+  test_with_coverage:
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [ test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv: [ test-cov ]
+        python-version: [ '3.x' ]
+        os: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/download-artifact@v3
+        with:
+          name: reference_files_hash
+      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - run: tox -e ${{ matrix.toxenv }}
+      - if: ${{ contains(matrix.toxenv,'-cov') }}
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          flags: unit
+          fail_ci_if_error: true
   build:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ test ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,16 +47,14 @@ jobs:
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
-    name: ${{ matrix.name }}
+    name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
     needs: [ check ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - name: Python 3.10 tests
-            python-version: '3.10'
-            os: ubuntu-latest
-            toxenv: test
+        python-version: [ '3.10' ]
+        toxenv: [ test ]
+        os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -76,8 +74,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
-        toxenv: [ test-pyargs, test-cov test-oldestdeps-cov, test-sdpdeps ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        toxenv: [ test-cov test-oldestdeps-cov, test-sdpdeps ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -98,6 +96,28 @@ jobs:
           file: ./coverage.xml
           flags: unit
           fail_ci_if_error: true
+  test_pyargs:
+    name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
+    needs: [ quick_test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [ '3.10' ]
+        toxenv: [ test-pyargs ]
+        os: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/references') }}
+      - run: tox -e ${{ matrix.toxenv }}
   build:
     name: build distribution (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
     needs: [ test ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,15 @@ jobs:
           - name: Code style check
             os: ubuntu-latest
             python-version: 3.9
-            toxenv: style
+            toxenv: check-style
           - name: Security audit
             os: ubuntu-latest
             python-version: 3.9
-            toxenv: security
+            toxenv: check-security
           - name: Verify install_requires in setup.py
             os: ubuntu-latest
             python-version: 3.9
-            toxenv: verify-install-requires
+            toxenv: check-install
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,7 +55,7 @@ jobs:
         include:
           - python-version: '3.10'
             os: ubuntu-latest
-            toxenv: py310
+            toxenv: test
     steps:
       - uses: actions/checkout@v3
         with:
@@ -78,10 +78,10 @@ jobs:
         include:
           - os: macos-latest
             python-version: 3.9
-            toxenv: py39
+            toxenv: test
           - os: ubuntu-latest
             python-version: 3.9
-            toxenv: pyargs
+            toxenv: test-pyargs
     steps:
       - uses: actions/checkout@v3
         with:
@@ -105,15 +105,15 @@ jobs:
           - name: Latest dependency versions w/coverage
             os: ubuntu-latest
             python-version: 3.9
-            toxenv: py39-cov
+            toxenv: test-cov
           - name: Oldest dependency versions w/coverage
             os: ubuntu-latest
             python-version: 3.8
-            toxenv: py38-oldestdeps-cov
+            toxenv: test-oldestdeps-cov
           - name: SDP dependencies in requirements-sdp.txt
             os: ubuntu-latest
             python-version: 3.9
-            toxenv: sdpdeps
+            toxenv: test-sdpdeps
     steps:
       - uses: actions/checkout@v3
         with:
@@ -136,7 +136,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: 3.10
-            toxenv: py310-cov
+            toxenv: test-cov
     steps:
       - uses: actions/checkout@v3
         with:
@@ -162,9 +162,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'ubuntu-latest', 'macos-latest' ]
+        os: [ ubuntu-latest, macos-latest ]
         python-version: [ '3.9', '3.10', '3.11' ]
-        toxenv: [ 'twine' ]
+        toxenv: [ build-twine ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-  CRDS_PATH: $HOME/crds_cache/
+  CRDS_PATH: $HOME/crds_cache
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(env.CRDS_PATH + 'references') }}
+          key: crds-reference-files-${{ hashFiles(join([env.CRDS_PATH, 'references'], '/')) }}
       - run: tox -e ${{ matrix.toxenv }}
   test:
     name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(env.CRDS_PATH + 'references') }}
+          key: crds-reference-files-${{ hashFiles(join([env.CRDS_PATH, 'references'], '/')) }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(env.CRDS_PATH + 'references') }}
+          key: crds-reference-files-${{ hashFiles(join([env.CRDS_PATH, 'references'], '/')) }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
     name: build distribution (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - run: echo $HOME
+      - run: echo ${{ env.CRDS_PATH }}
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,13 @@ jobs:
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
-    name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
+    name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ check ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.10' ]
         toxenv: [ test ]
+        python-version: [ '3.10' ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -70,14 +70,14 @@ jobs:
           key: crds-reference-files-${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
       - run: tox -e ${{ matrix.toxenv }}
   test:
-    name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
+    name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         toxenv: [ test-cov test-oldestdeps-cov, test-sdpdeps ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -99,13 +99,13 @@ jobs:
           flags: unit
           fail_ci_if_error: true
   test_pyargs:
-    name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
+    name: test installed package with `--pyargs` (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.10' ]
         toxenv: [ test-pyargs ]
+        python-version: [ '3.10' ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -121,14 +121,14 @@ jobs:
           key: crds-reference-files-${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
-    name: build distribution (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
+    name: build distribution (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        python-version: [ '3.9', '3.10', '3.11' ]
         toxenv: [ build-twine ]
+        python-version: [ '3.9', '3.10', '3.11' ]
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -61,6 +65,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
       - run: echo "REFERENCE_FILES_HASH=${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}" >> $GITHUB_ENV
       - uses: actions/cache@v3
@@ -98,6 +106,10 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_pyargs:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -124,6 +136,10 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_with_coverage:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -151,6 +167,10 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -175,4 +195,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -65,10 +61,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
       - run: echo "REFERENCE_FILES_HASH=${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}" >> $GITHUB_ENV
       - uses: actions/cache@v3
@@ -106,10 +98,6 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_pyargs:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -136,10 +124,6 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_with_coverage:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -167,10 +151,6 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -195,8 +175,4 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
             os: ubuntu-latest
             python-version: 3.9
             toxenv: verify-install-requires
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}
   quick_test:
     name: test Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }}
     needs: [ checks ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ on:
   schedule:
     # Weekly Monday 9AM build
     - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      crds_context:
+        type: string
+        description: CRDS context(s) to use with tests (defaults to operational context)
+        required: false
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu
@@ -61,6 +67,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
@@ -84,6 +95,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
@@ -112,6 +128,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,32 +71,14 @@ jobs:
           key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/references') }}
       - run: tox -e ${{ matrix.toxenv }}
   test:
-    name: ${{ matrix.name }}
+    name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
     needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - name: Latest dependency versions w/coverage
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: test-cov
-          - name: Oldest dependency versions w/coverage
-            os: ubuntu-latest
-            python-version: 3.8
-            toxenv: test-oldestdeps-cov
-          - name: SDP dependencies in requirements-sdp.txt
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: test-sdpdeps
-          - name: Installed package with --pyargs
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: test-pyargs
-          - name: MacOS
-            os: macos-latest
-            python-version: 3.9
-            toxenv: test
+        python-version: [ '3.8', '3.9', '3.10' ]
+        toxenv: [ test-pyargs, test-cov test-oldestdeps-cov, test-sdpdeps ]
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       - run: pip install tox
       - run: echo $HOME
       - run: echo ${{ env.CRDS_PATH }}
+      - run: echo ${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+      - run: echo '${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}' > reference_files_hash.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: reference_files_hash
+          path: reference_files_hash.txt
   test:
     name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ quick_test ]
@@ -84,10 +89,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/download-artifact@v3
+        with:
+          name: reference_files_hash
+      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -112,10 +121,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/download-artifact@v3
+        with:
+          name: reference_files_hash
+      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
     name: build distribution (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         toxenv: [ check-style, check-security, check-install ]
-        python-version: [ '3.9' ]
+        python-version: [ '3.10' ]
         os: [ ubuntu-latest ]
         include:
           - name: Code style check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,86 +19,139 @@ env:
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
 jobs:
-  tox:
+  checks:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         include:
-          - name: Python 3.10 Tests
-            python-version: '3.10'
-            os: ubuntu-latest
-            toxenv: py310
-
-          - name: Latest dependency versions w/coverage
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-cov
-
-          - name: Oldest dependency versions
-            os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-oldestdeps-cov
-
-          - name: SDP dependencies in requirements-sdp.txt
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: sdpdeps
-
-          - name: Installed package with --pyargs
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: pyargs
-
-          - name: Verify install_requires in setup.py
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: verify-install-requires
-
-          - name: Build distribution
-            os: ubuntu-latest
-            python-version: 3.9
-            toxenv: twine
-
           - name: Code style check
             os: ubuntu-latest
             python-version: 3.9
             toxenv: style
-
           - name: Security audit
             os: ubuntu-latest
             python-version: 3.9
             toxenv: security
-
-          # MacOS job is flaky on Github actions and fails routinely.
-          # Re-enable when things get more reliable.
-          # - name: macOS
-          #   os: macos-latest
-          #   python-version: 3.9
-          #   toxenv: py39
+          - name: Verify install_requires in setup.py
+            os: ubuntu-latest
+            python-version: 3.9
+            toxenv: verify-install-requires
+  quick_test:
+    name: test Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }}
+    needs: [ checks ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - python-version: '3.10'
+            os: ubuntu-latest
+            toxenv: py310
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install tox
-        run: |
-          pip install tox
-
-      - name: Run tests
-        run: tox -e ${{ matrix.toxenv }}
-
-      - name: Upload coverage to codecov
-        if: ${{ contains(matrix.toxenv,'-cov') }}
+      - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/reference') }}
+      - run: tox -e ${{ matrix.toxenv }}
+  test:
+    name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
+    needs: [ quick_test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            python-version: 3.9
+            toxenv: py39
+          - os: ubuntu-latest
+            python-version: 3.9
+            toxenv: pyargs
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/reference') }}
+      - run: tox -e ${{ matrix.toxenv }}
+  test_dependencies:
+    name: ${{ matrix.name }}
+    needs: [ test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Latest dependency versions w/coverage
+            os: ubuntu-latest
+            python-version: 3.9
+            toxenv: py39-cov
+          - name: Oldest dependency versions w/coverage
+            os: ubuntu-latest
+            python-version: 3.8
+            toxenv: py38-oldestdeps-cov
+          - name: SDP dependencies in requirements-sdp.txt
+            os: ubuntu-latest
+            python-version: 3.9
+            toxenv: sdpdeps
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/reference') }}
+      - run: tox -e ${{ matrix.toxenv }}
+  test_with_coverage:
+    name: test with coverage (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
+    needs: [ test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: 3.10
+            toxenv: py310-cov
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/reference') }}
+      - run: tox -e ${{ matrix.toxenv }}
+      - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: unit
           fail_ci_if_error: true
+  build:
+    name: build distribution (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
+    needs: [ quick_test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
+        toxenv: [ 'twine' ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-  CRDS_PATH: $HOME/crds_cache
+  CRDS_PATH: $HOME/crds_cache/
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
@@ -23,6 +23,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: Code style check
@@ -66,13 +67,14 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/references') }}
+          key: crds-reference-files-${{ hashFiles(env.CRDS_PATH + 'references') }}
       - run: tox -e ${{ matrix.toxenv }}
   test:
     name: test (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})
     needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         toxenv: [ test-cov test-oldestdeps-cov, test-sdpdeps ]
@@ -88,7 +90,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/references') }}
+          key: crds-reference-files-${{ hashFiles(env.CRDS_PATH + 'references') }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -116,7 +118,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles('${{ env.CRDS_PATH }}/references') }}
+          key: crds-reference-files-${{ hashFiles(env.CRDS_PATH + 'references') }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
     name: build distribution (Python ${{ matrix.python-version }}, tox testenv ${{ matrix.toxenv }}, ${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
-    name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ check ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -73,7 +73,7 @@ jobs:
           name: reference_files_hash
           path: reference_files_hash.txt
   test:
-    name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -106,7 +106,7 @@ jobs:
           flags: unit
           fail_ci_if_error: true
   test_pyargs:
-    name: test installed package with `--pyargs` (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -132,7 +132,7 @@ jobs:
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
-    name: build distribution (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
             toxenv: verify-install-requires
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -56,6 +58,8 @@ jobs:
             toxenv: py310
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -80,6 +84,8 @@ jobs:
             toxenv: pyargs
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -110,6 +116,8 @@ jobs:
             toxenv: sdpdeps
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -131,6 +139,8 @@ jobs:
             toxenv: py310-cov
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -157,6 +167,8 @@ jobs:
         toxenv: [ 'twine' ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install tox
+      - run: pip install tox crds
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: github.event.inputs.crds_context == ''
       - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install tox
+      - run: pip install tox crds
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: github.event.inputs.crds_context == ''
       - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install tox
+      - run: pip install tox crds
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: github.event.inputs.crds_context == ''
       - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           - name: Verify install_requires in setup.py
             toxenv: check-install
     steps:
+      - run: echo ${{ format('{0}/{1}', env.CRDS_PATH, 'references') }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -61,9 +62,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - run: echo $HOME
-      - run: echo ${{ env.CRDS_PATH }}
-      - run: echo ${{ hashFiles(format('{0}/{1}', env.CRDS_PATH, 'references')) }}
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
+      - run: echo "REFERENCE_FILES_HASH=${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
-      - run: echo '${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}' > reference_files_hash.txt
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - run: echo ${{ env.REFERENCE_FILES_HASH }} > reference_files_hash.txt
       - uses: actions/upload-artifact@v3
         with:
           name: reference_files_hash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,6 @@ on:
   schedule:
     # Weekly Monday 9AM build
     - cron: "0 9 * * 1"
-  workflow_dispatch:
-    inputs:
-      crds_context:
-        type: string
-        description: CRDS context(s) to use with tests (defaults to operational context)
-        required: false
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu
@@ -66,17 +60,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install tox crds
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
-      - run: tox -e ${{ matrix.toxenv }}
   test:
     name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ quick_test ]

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-  CRDS_PATH: ~/crds_cache
+  CRDS_PATH: $HOME/crds_cache
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
@@ -25,32 +25,9 @@ jobs:
             python-version: 3.9
             toxenv: devdeps
     steps:
-      - name: Install system packages
-        if: ${{ contains(matrix.toxenv,'docs') }}
-        run: |
-          sudo apt-get install graphviz texlive-latex-extra dvipng
-
-      - name: Checkout the code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install tox
-        run: |
-          pip install tox
-
-      - name: Run tests
-        run: tox -e ${{ matrix.toxenv }}
-
-      - name: Upload coverage to codecov
-        if: ${{ contains(matrix.toxenv,'-cov') }}
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
-          flags: unit
-          fail_ci_if_error: true
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -30,4 +30,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
       - run: tox -e ${{ matrix.toxenv }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,11 @@ extract_2d
 
 - Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
 
+general
+-------
+
+- refactor ``tox`` environment factors and set dependent CI jobs [#7323]
+
 lib
 ---
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,6 +134,8 @@ norecursedirs =
     jwst/associations/tests/data
     scripts
     .tox
+    .eggs
+    build
 asdf_schema_tests_enabled = true
 asdf_schema_validate_default = false
 asdf_schema_root = jwst/transforms/resources/schemas jwst/datamodels/schemas

--- a/tox.ini
+++ b/tox.ini
@@ -58,9 +58,9 @@ args_are_paths = false
 description = check code style, e.g. with flake8
 skip_install = true
 deps =
-    flake8 .
+    flake8
 commands =
-    flake8 {posargs}
+    flake8 . {posargs}
 
 [testenv:security]
 description = run bandit to check security compliance

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
-    style
-    security
-    py{38,39,310,311}{,-oldestdeps,-devdeps,-sdpdeps}{,-pyargs}{,-cov}
+    check-{style,security,install}
+    test{,-oldestdeps,-devdeps,-sdpdeps}{,-pyargs,-warnings,-regtests,-cov}
+    build-{twine,docs}
 isolated_build = true
 
-[testenv]
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
 # will only take effect if that factor is included in the environment name. To
@@ -14,12 +13,37 @@ isolated_build = true
 #
 #     tox -l -v
 #
+
+[testenv:check-style]
+description = check code style, e.g. with flake8
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8 . {posargs}
+
+[testenv:check-security]
+description = run bandit to check security compliance
+deps =
+    bandit>=1.7
+commands =
+    bandit -r -ll -x jwst/*test*,jwst/**/*test*,jwst/fits_generator jwst scripts
+
+[testenv:check-install]
+description = verify that install_requires in setup.cfg is correct
+extras =
+commands =
+    verify_install_requires
+
+[testenv]
 description =
     run tests
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     sdpdeps: with the recent STScI DMS release pinned dependencies
     pyargs: with --pyargs on installed package
+    warnings: treating warnings as errors
+    regtests: with --bigdata and --slow flags
     cov: with coverage
 # The following indicates which extras_require from setup.cfg will be installed
 extras = test
@@ -37,8 +61,11 @@ passenv =
 usedevelop = true
 commands =
     pip freeze
-    !cov: pytest -n auto {posargs}
-    cov: pytest -n auto --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml {posargs}
+    pytest -n auto \
+    cov: --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml \
+    warnings: -W error \
+    regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
+    {posargs}
 deps =
     pytest-xdist
     devdeps: -rrequirements-dev.txt
@@ -54,26 +81,7 @@ commands_pre =
 # Don't treat positional arguments passed to tox as file system paths
 args_are_paths = false
 
-[testenv:style]
-description = check code style, e.g. with flake8
-skip_install = true
-deps =
-    flake8
-commands =
-    flake8 . {posargs}
 
-[testenv:security]
-description = run bandit to check security compliance
-deps =
-    bandit>=1.7
-commands =
-    bandit -r -ll -x jwst/*test*,jwst/**/*test*,jwst/fits_generator jwst scripts
-
-[testenv:verify-install-requires]
-description = verify that install_requires in setup.cfg is correct
-extras =
-commands =
-    verify_install_requires
 
 [testenv:pyargs]
 changedir = {homedir}
@@ -81,16 +89,7 @@ usedevelop = false
 commands =
     pyargs: pytest -n auto {toxinidir}/docs --pyargs {posargs:jwst}
 
-[testenv:warnings]
-commands =
-    pytest -W error {posargs}
-
-[testenv:regtests]
-description = run tests with --bigdata and --slow flags
-commands =
-    pytest -n auto --bigdata --slow --basetemp={homedir}/test_outputs {posargs}
-
-[testenv:twine]
+[testenv:build-twine]
 description = check that the package builds sdist/wheel and that twine uploads
 deps =
     twine>=3.3
@@ -100,7 +99,7 @@ commands =
     python -m pep517.check .
     twine check --strict {distdir}/*
 
-[testenv:docs]
+[testenv:build-docs]
 description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -61,10 +61,10 @@ passenv =
 usedevelop = true
 commands =
     pip freeze
-    pytest -n auto \
+    pytest \
     cov: --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml \
     warnings: -W error \
-    regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
+    regtests: -n auto --bigdata --slow --basetemp={homedir}/test_outputs \
     {posargs}
 deps =
     pytest-xdist
@@ -87,7 +87,7 @@ args_are_paths = false
 changedir = {homedir}
 usedevelop = false
 commands =
-    pyargs: pytest -n auto {toxinidir}/docs --pyargs {posargs:jwst}
+    pyargs: pytest {toxinidir}/docs --pyargs {posargs:jwst}
 
 [testenv:build-twine]
 description = check that the package builds sdist/wheel and that twine uploads

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ description =
     warnings: treating warnings as errors
     regtests: with --bigdata and --slow flags
     cov: with coverage
+    xdist: using parallel processing
 # The following indicates which extras_require from setup.cfg will be installed
 extras = test
 # Pass through the following environment variables which may be needed for the CI
@@ -64,10 +65,11 @@ commands =
     pytest \
     cov: --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml \
     warnings: -W error \
-    regtests: -n auto --bigdata --slow --basetemp={homedir}/test_outputs \
+    regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
+    xdist: -n auto \
     {posargs}
 deps =
-    pytest-xdist
+    xdist: pytest-xdist
     devdeps: -rrequirements-dev.txt
     sdpdeps: -rrequirements-sdp.txt
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310}{,-oldestdeps,-devdeps,-sdpdeps}{,-pyargs}{,-cov}
     style
     security
+    py{38,39,310,311}{,-oldestdeps,-devdeps,-sdpdeps}{,-pyargs}{,-cov}
 isolated_build = true
 
 [testenv]
@@ -20,11 +20,9 @@ description =
     oldestdeps: with the oldest supported version of key dependencies
     sdpdeps: with the recent STScI DMS release pinned dependencies
     pyargs: with --pyargs on installed package
-    cov: and test coverage
-
+    cov: with coverage
 # The following indicates which extras_require from setup.cfg will be installed
 extras = test
-
 # Pass through the following environment variables which may be needed for the CI
 passenv =
     TOXENV
@@ -36,38 +34,56 @@ passenv =
     PASS_INVALID_VALUES
     VALIDATE_ON_ASSIGNMENT
     TEST_BIGDATA
-
 usedevelop = true
-
 commands =
+    pip freeze
     !cov: pytest -n auto {posargs}
-    cov: pytest -n auto --cov-report=xml --cov=. --cov-config=setup.cfg {posargs}
-
+    cov: pytest -n auto --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml {posargs}
 deps =
     pytest-xdist
     devdeps: -rrequirements-dev.txt
     sdpdeps: -rrequirements-sdp.txt
-
-    py310: git+https://github.com/pytest-dev/pytest
-
 setenv =
     sdpdeps,regtests: CRDS_CONTEXT = jwst-edit
-
 commands_pre =
     python -m pip install --upgrade pip
-    # Generate a requirements-min.txt file
+# Generate a requirements-min.txt file
     oldestdeps: minimum_deps
-    # Force install everything in that file
+# Force install everything in that file
     oldestdeps: pip install --ignore-installed -r requirements-min.txt
-
 # Don't treat positional arguments passed to tox as file system paths
 args_are_paths = false
+
+[testenv:style]
+description = check code style, e.g. with flake8
+skip_install = true
+deps =
+    flake8 .
+commands =
+    flake8 {posargs}
+
+[testenv:security]
+description = run bandit to check security compliance
+deps =
+    bandit>=1.7
+commands =
+    bandit -r -ll -x jwst/*test*,jwst/**/*test*,jwst/fits_generator jwst scripts
+
+[testenv:verify-install-requires]
+description = verify that install_requires in setup.cfg is correct
+extras =
+commands =
+    verify_install_requires
 
 [testenv:pyargs]
 changedir = {homedir}
 usedevelop = false
 commands =
     pyargs: pytest -n auto {toxinidir}/docs --pyargs {posargs:jwst}
+
+[testenv:warnings]
+commands =
+    pytest -W error {posargs}
 
 [testenv:regtests]
 description = run tests with --bigdata and --slow flags
@@ -83,31 +99,6 @@ usedevelop = false
 commands =
     python -m pep517.check .
     twine check --strict {distdir}/*
-
-[testenv:style]
-description = check code style, e.g. with flake8
-skip_install = true
-deps =
-    flake8
-commands =
-    flake8 {posargs}
-
-[testenv:verify-install-requires]
-description = verify that install_requires in setup.cfg is correct
-extras =
-commands =
-    verify_install_requires
-
-[testenv:warnings]
-commands =
-    pytest -W error {posargs}
-
-[testenv:security]
-description = run bandit to check security compliance
-deps =
-    bandit>=1.7
-commands =
-    bandit -r -ll -x jwst/*test*,jwst/**/*test*,jwst/fits_generator jwst scripts
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR sets up dependent CI jobs and attempts to cache CRDS reference files, succeeding https://github.com/spacetelescope/jwst/pull/6867 with suggestions from https://github.com/spacetelescope/jwst/pull/6867#pullrequestreview-1159731951.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
