### PR TITLE
fix deprecation warnings introduced by Pytest `7.2`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,8 @@ general
 
 - replace ``flake8`` with ``ruff`` [#7054]
 
+- Fix deprecation warnings introduced by ``pytest`` ``7.2`` ahead of ``8.0`` [#7325]
+
 guider_cds
 ----------
 

--- a/jwst/associations/tests/helpers.py
+++ b/jwst/associations/tests/helpers.py
@@ -64,12 +64,6 @@ class BasePoolRule():
     # Each entry is the class name of the rule.
     valid_rules = []
 
-    def setup_method(self):
-        """You set me up...."""
-
-    def tearDown(self):
-        """You tear me down..."""
-
     def test_rules_exist(self):
         rules = registry_level3_only()
         assert len(rules) >= len(self.valid_rules)

--- a/jwst/associations/tests/helpers.py
+++ b/jwst/associations/tests/helpers.py
@@ -64,7 +64,7 @@ class BasePoolRule():
     # Each entry is the class name of the rule.
     valid_rules = []
 
-    def setup(self):
+    def setup_method(self):
         """You set me up...."""
 
     def tearDown(self):

--- a/jwst/conftest.py
+++ b/jwst/conftest.py
@@ -87,7 +87,7 @@ def jail(request, tmpdir_factory):
     os.chdir(old_dir)
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config):
     terminal_reporter = config.pluginmanager.getplugin('terminalreporter')
     config.pluginmanager.register(TestDescriptionPlugin(terminal_reporter), 'testdescription')


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
resolves [SCSB-53](https://jira.stsci.edu/browse/SCSB-53)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the Pytest deprecations introduced in 7.2 ahead of the 8.0 release.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
