### PR TITLE
Do not skip tweakreg when input model container has only one group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,12 @@ resample
 - Enhance spectral output WCS construction to guard against nearly identical
   points. [#7321]
 
+tweakreg
+--------
+
+- Do not skip tweakreg step in ``Image3Pipeline`` when ``ModelContainer``
+  has only one group group. This is a continuation of PR #6938. [#7326]
+
 
 1.8.2 (2022-10-20)
 ==================

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -75,7 +75,7 @@ class Image3Pipeline(Pipeline):
 
             # Check if input is single or multiple exposures
             try:
-                has_groups = len(input_models.group_names) > 1
+                has_groups = len(input_models.group_names) >= 1
             except (AttributeError, TypeError, KeyError):
                 has_groups = False
 


### PR DESCRIPTION
Title says it all. This is a continuation of https://github.com/spacetelescope/jwst/pull/6938.
I missed that there was another check for the number of groups in the ``Image3Pipeline``,

Resolves [JP-2687](https://jira.stsci.edu/browse/JP-2687)

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
