### PR TITLE
JP-2989: Add 'background' to asn types requiring multiple group contributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ associations
 - Moved text dump of associations to happen when using the '-D' option,
   rather than the '-v' option. [#7068]
 
+- Added background association candidates to list of level three candidate
+  types requiring members from more than one observation [#7329]
+
 cube_build
 ----------
 

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -83,11 +83,8 @@ LEVEL2B_EXPTYPES.extend(IMAGE2_SCIENCE_EXP_TYPES)
 LEVEL2B_EXPTYPES.extend(IMAGE2_NONSCIENCE_EXP_TYPES)
 LEVEL2B_EXPTYPES.extend(SPEC2_SCIENCE_EXP_TYPES)
 
-# Association Candidates that should never make Level3 associations
-INVALID_AC_TYPES = ['background']
-
 # Association Candidates that should have more than one observations
-MULTI_OBS_AC_TYPES = ['group']
+MULTI_OBS_AC_TYPES = ['group', 'background']
 
 
 class DMS_Level3_Base(DMSBaseMixin, Association):
@@ -465,21 +462,6 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
             )
         result = '\n'.join(result_list)
         return result
-
-    def ok_candidate(self, member=None):
-        """Validation test for acceptable candidates
-
-        Parameters
-        ----------
-        member : Member
-            Member being added causing check.
-            Not used
-
-        Returns
-        -------
-        is_valid : bool
-        """
-        return self.acid.type.lower() not in INVALID_AC_TYPES
 
 
 @RegistryMarker.utility


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2989](https://jira.stsci.edu/browse/JP-2989)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a residual c1xxx level 3 association created despite containing members from only one observation. The c1xxx association was of type 'background', while only 'group' types were being subjected to the additional requirement added in #6886. Additionally, a function used to prevent background associations from being generated was turned off ~3 years ago but never removed, so this tidies that up as well.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
