### PR TITLE
 JP-2934: Fix circular import causing crash in photom

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,11 @@ extract_2d
 
 - Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
 
+lib
+---
+
+- Fix circular import in ``lib.wcs_utils``. [#7330]
+
 resample
 --------
 

--- a/jwst/lib/wcs_utils.py
+++ b/jwst/lib/wcs_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ..assign_wcs import niriss
+#from ..assign_wcs import niriss
 
 
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
@@ -51,19 +51,20 @@ def get_wavelengths(model, exp_type="", order=None, use_wavecorr=None):
         else:
             got_wavelength = False  # force wl computation below
 
+    # Evaluate the WCS on the grid of pixel indexes, capturing only the
+    # resulting wavelength values
+    shape = model.data.shape
+    grid = np.indices(shape[-2:], dtype=np.float64)
+
     # If no existing wavelength array, compute one
     if hasattr(model.meta, "wcs") and not got_wavelength:
-
         # Set up an appropriate WCS object
         if hasattr(model.meta, "exposure") and model.meta.exposure.type == "NIS_SOSS":
-            wcs = niriss.niriss_soss_set_input(model, order)
-        else:
-            wcs = model.meta.wcs
+            # wcs = niriss.niriss_soss_set_input(model, order)
+            wl_array = wcs(grid[1], grid[0], order)[2]
+            return wl_array
 
-        # Evaluate the WCS on the grid of pixel indexes, capturing only the
-        # resulting wavelength values
-        shape = model.data.shape
-        grid = np.indices(shape[-2:], dtype=np.float64)
+        wcs = model.meta.wcs
 
         if exp_type in WFSS_EXPTYPES:
             # We currently have to loop over pixels for WFSS data.

--- a/jwst/lib/wcs_utils.py
+++ b/jwst/lib/wcs_utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-#from ..assign_wcs import niriss
 
 
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM', 'NRC_TSGRISM']
@@ -60,8 +59,7 @@ def get_wavelengths(model, exp_type="", order=None, use_wavecorr=None):
     if hasattr(model.meta, "wcs") and not got_wavelength:
         # Set up an appropriate WCS object
         if hasattr(model.meta, "exposure") and model.meta.exposure.type == "NIS_SOSS":
-            # wcs = niriss.niriss_soss_set_input(model, order)
-            wl_array = wcs(grid[1], grid[0], order)[2]
+            wl_array = model.meta.wcs(grid[1], grid[0], order)[2]
             return wl_array
 
         wcs = model.meta.wcs


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2934](https://jira.stsci.edu/browse/JP-2934)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7275 

<!-- describe the changes comprising this PR here -->
This PR addresses a crash in `photom` due to circular imports. photom imports `assign_wcs.niriss` and then `lib.wcs_utils`, which in turn imports `assign_wcs.niriss`. The import of `assign_wcs.niriss` in `lib.wcs_utils` is to use a niriss specific funciton which returns a WCS object for a specific order so that it can be evaluated to generate a wavelength array. This function is not needed any more since the WCS object for NIRISS SOSS mode can be directly evaluated using non-coordinate inputs, like order. One simple calls the WCS object as in `WCS(x, y, spectral_order)`.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
