### PR TITLE
remove duplicate enum values from core.schema.yaml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ datamodels
 ----------
 
 - Add subarray keywords in the filteroffset schema [#7317]
+- Remove duplicates and add comments to core.schema dithering types [#7331]
 
 extract_2d
 ----------

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1058,7 +1058,7 @@ properties:
               PFLAT_CORON1065, PFLAT_CORON1140, PFLAT_CORON1550, PFLAT_CORONLYOT,
 
               # MIRI imaging
-              CYCLING, REULEAUX, SPARSE-CYCLING,
+              REULEAUX,
               2-POINT, 4-POINT-SETS,
               2-POINT-MIRI-F770W-WITH-NIRCAM, 3-POINT-MIRI-F770W-WITH-NIRCAM,
               4-POINT-MIRI-F770W-WITH-NIRCAM, 9-POINT-MIRI-F770W-WITH-NIRCAM,
@@ -1103,15 +1103,13 @@ properties:
               7x3-PIXEL-MAP-SLITLESS, 9x3-8x4-SCAN-MAPS-SLITLESS,
 
               # MIRI MRS
-              2-POINT, 4-POINT, SCAN-CALIBRATION,
+              4-POINT, SCAN-CALIBRATION,
 
               # NIRCam
-              FULL, FULLBOX, FULL-TIGHT,
-              INTRAMODULE, INTRAMODULEBOX, INTRAMODULEX, INTRASCA,
-              SUBARRAY-DITHER, WFSC, 1LOS,
+              FULL-TIGHT,
+              SUBARRAY-DITHER, 1LOS,
 
               # NIRISS
-              AMI, IMAGING, MIMF, WFSS,
 
               # NIRISS with NIRCam in parallel
               NIS-NRC-2L, NIS-NRC-2M,
@@ -1135,7 +1133,7 @@ properties:
               3-POINT-WITH-NIRCAM-SIZE1, 3-POINT-WITH-NIRCAM-SIZE2, 3-POINT-WITH-NIRCAM-SIZE3,
 
               # NIRSpec IFU
-              2-POINT-NOD, 4-POINT-NOD, 4-POINT-DITHER, CYCLING, SPARSE-CYCLING,
+              4-POINT-NOD, 4-POINT-DITHER, CYCLING, SPARSE-CYCLING,
 
               # Misc
               N/A, NONE, ANY]

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1049,8 +1049,17 @@ properties:
             type: string
             enum:
               # FGS in parallel with NIRCam and NIRISS
-             [FULL, FULLBOX, INTRAMODULE, INTRAMODULEBOX, INTRAMODULEX,
-              INTRASCA, SUBARRAY_DITHER, WFSC, AMI, IMAGING, MIMF, WFSS,
+              # shared with NIRCam: FULL, FULLBOX, INTRAMODULE, INTRAMODULEBOX,
+              #   INTRAMODULEX, INTRASCA, WFSC,
+              # shared with NIRISS: AMI, IMAGING, MIMF, WFSS,
+             [SUBARRAY_DITHER,
+
+              # common to NIRISS and FGS in parallel with NIRCam and NIRISS
+              AMI, IMAGING, MIMF, WFSS,
+
+              # common to NIRCam and FGS in parallel with NIRCam and NIRISS
+              FULL, FULLBOX, INTRAMODULE, INTRAMODULEBOX, INTRAMODULEX,
+              INTRASCA, WFSC,
 
               # MIRI coron
               5-POINT-SMALL-GRID, 9-POINT-SMALL-GRID, BACKGROUND,
@@ -1058,8 +1067,10 @@ properties:
               PFLAT_CORON1065, PFLAT_CORON1140, PFLAT_CORON1550, PFLAT_CORONLYOT,
 
               # MIRI imaging
+              # shared with NIRSpec IFU: CYCLING, SPARSE-CYCLING
+              # shared with MIRI MRS: 2-POINT
               REULEAUX,
-              2-POINT, 4-POINT-SETS,
+              4-POINT-SETS,
               2-POINT-MIRI-F770W-WITH-NIRCAM, 3-POINT-MIRI-F770W-WITH-NIRCAM,
               4-POINT-MIRI-F770W-WITH-NIRCAM, 9-POINT-MIRI-F770W-WITH-NIRCAM,
               3-POINT-MIRI-F1000W-WITH-NIRCAM, 4-POINT-MIRI-F1000W-WITH-NIRCAM,
@@ -1103,13 +1114,19 @@ properties:
               7x3-PIXEL-MAP-SLITLESS, 9x3-8x4-SCAN-MAPS-SLITLESS,
 
               # MIRI MRS
+              # shared with MIRI imaging: 2-POINT
               4-POINT, SCAN-CALIBRATION,
 
+              # common to MIRI imaging and MIRI MRS
+              2-POINT,
+
               # NIRCam
-              FULL-TIGHT,
-              SUBARRAY-DITHER, 1LOS,
+              # shared with FGS in parallel with NIRCam and NIRISS:
+              #   FULL, FULLBOX, INTRAMODULE, INTRAMODULEBOX, INTRAMODULEX, INTRASCA, WFSC,
+              FULL-TIGHT, SUBARRAY-DITHER, 1LOS,
 
               # NIRISS
+              # shared with FGS in parallel with NIRCam and NIRISS: AMI, IMAGING, MIMF, WFSS,
 
               # NIRISS with NIRCam in parallel
               NIS-NRC-2L, NIS-NRC-2M,
@@ -1128,12 +1145,21 @@ properties:
               NIS-MIR255-2, NIS-MIR255-3, NIS-MIR255-4, NIS-MIR255-9,
 
               # NIRSpec FS and MOS
-              2-POINT-NOD, 3-POINT-NOD, 5-POINT-NOD,
+              # shared with NIRSpec IFU: 2-POINT-NOD
+              3-POINT-NOD, 5-POINT-NOD,
               2-POINT-WITH-NIRCAM-SIZE1, 2-POINT-WITH-NIRCAM-SIZE2, 2-POINT-WITH-NIRCAM-SIZE3,
               3-POINT-WITH-NIRCAM-SIZE1, 3-POINT-WITH-NIRCAM-SIZE2, 3-POINT-WITH-NIRCAM-SIZE3,
 
+              # common to NIRSpec FS and MOS and NIRSpec IFU
+              2-POINT-NOD,
+
               # NIRSpec IFU
-              4-POINT-NOD, 4-POINT-DITHER, CYCLING, SPARSE-CYCLING,
+              # shared with MIRI imaging: CYCLING, SPARSE-CYCLING
+              # shared with NIRSpec FS and MOS: 2-POINT-NOD
+              4-POINT-NOD, 4-POINT-DITHER,
+
+              # common to MIRI imaging and NIRSpec IFU
+              CYCLING, SPARSE-CYCLING,
 
               # Misc
               N/A, NONE, ANY]


### PR DESCRIPTION
jsonschema draft 4 (used by asdf) states that enum values MUST be unique. This was unchecked prior to a recent commit python-jsonschema/jsonschema@2db9c58

[core.schema.yaml](https://github.com/spacetelescope/jwst/blob/master/jwst/datamodels/schemas/core.schema.yaml#L1061) contains duplicate dithering types for the different instruments (for example CYCLING for NIRSpec IFU and MIRI imaging)

This commit removes the duplicates in a way that might impair user readability of the file (as types are no longer logically grouped to instrument).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
