### PR TITLE
JP-2987: Add documentation on WCS corrections due to spacecraft motion

### DIFF
--- a/docs/jwst/assign_wcs/main.rst
+++ b/docs/jwst/assign_wcs/main.rst
@@ -132,3 +132,18 @@ the reference and actual angles.
 - `astropy <http://www.astropy.org/>`__
 
 - `asdf <http://asdf.readthedocs.io/en/latest/>`__
+
+Corrections Due to Spacecraft Motion
+------------------------------------
+
+The WCS transforms contain two corrections due to motion of the observatory.
+
+Absolute velocity aberration is calculated onboard when acquiring the guide star, but
+differential velocity aberration effects are calculated during the ``assign_wcs`` step.
+This introduces corrections in the conversion from sky coordinates to observatory
+V2/V3 coordinates, and is stored in the WCS under the ``v2v3vacorr`` frame.
+
+For spectroscopic data, a relativistic Doppler correction is applied to all wavelengths to place
+observations into the barycentric reference frame. This correction factor is applied to the WCS
+wavelength solution created during the ``assign_wcs`` step, such that extracted spectral products
+will have wavelength arrays in the barycentric frame.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2987](https://jira.stsci.edu/browse/JP-2987)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a missing part of documentation - how we make corrections to the WCS to account for spacecraft motion. Looking for any comments on if what I've written is correct, clear, and sufficiently detailed. Could add references?

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
