### PR TITLE
JP-2996: Remove duplicate application of pixel area to NRS_IFU extended data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,10 @@ photom
 
 - Cutout pixel area array to match the subarray of the science data. [#7319]
 
+- Remove duplicated division of pixel area during photometric calibration
+  of NIRSpec IFU data with EXTENDED source type; correct units in pixel area
+  division to sr from square arcseconds [#7336]
+
 resample
 --------
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -309,8 +309,12 @@ class DataSet():
                 # Compute relative sensitivity for each pixel based
                 # on its wavelength
                 sens2d = np.interp(wave2d, waves, relresps)
-                sens2d *= conv_factor  # include the scalar conversion factor
-                sens2d /= area2d  # divide by pixel area
+                sens2d *= tabdata['photmj']  # include the initial scalar conversion factor -> MJ
+                # This line used to be applied to all IFU data, but I think this was an error -
+                # masked by the fact that the initial pixel area maps for IFU data were
+                # arrays of 1-values (in arcsec**2). If srctype==POINT, do not apply.
+                if self.source_type.upper() != 'POINT':
+                    sens2d /= area2d * A2_TO_SR  # divide by pixel area * A2_TO_SR -> MJ/sr
                 # Reset NON_SCIENCE pixels to 1 in sens2d array and flag
                 # them in the science data DQ array
                 where_dq = np.bitwise_and(dqmap, dqflags.pixel['NON_SCIENCE'])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2996](https://jira.stsci.edu/browse/JP-2996)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an issue seen when corrections to the NRS_IFU pixel area reference file were tested. Changes to the pixel area of scale N were seen applied to the data array at scale N**2, indicating that the pixel areas were being divided out twice.

In testing edits to the code, it was noticed that the pixel area was being divided out of all NRS_IFU data, but because the current dummy files are filled with values of 1, it went unnoticed. Additionally, the pixel area division was being done in units of square arcseconds, which required adding a factor of A2_TO_SR to the code where the pixel area is divided out slice-by-slice. 

The duplicate removed was dividing the conversion factor by the mean pixel area across all slices, which was redundant but also imprecise.


**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
