### PR TITLE
JP-2997: Implement nan-filled padding for zero-coverage regions around IFU data cubes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,10 +20,19 @@ cube_build
 
 - Fix a bug in 3d drizzle code for NIRSpec IFU.  [#7306]
 
+- Change fill value for regions of SCI and ERR extensions with no data
+  from 0 to nan. []
+
 datamodels
 ----------
 
 - Add subarray keywords in the filteroffset schema [#7317]
+
+extract_1d
+----------
+
+- Fix IFU spectral extraction code to not fail on nan fill values
+  now populating empty regions of the data cubes. []
 
 extract_2d
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ cube_build
 - Fix a bug in 3d drizzle code for NIRSpec IFU.  [#7306]
 
 - Change fill value for regions of SCI and ERR extensions with no data
-  from 0 to nan. []
+  from 0 to nan. [#7337]
 
 datamodels
 ----------
@@ -32,7 +32,7 @@ extract_1d
 ----------
 
 - Fix IFU spectral extraction code to not fail on nan fill values
-  now populating empty regions of the data cubes. []
+  now populating empty regions of the data cubes. [#7337]
 
 extract_2d
 ----------

--- a/docs/jwst/cube_build/main.rst
+++ b/docs/jwst/cube_build/main.rst
@@ -174,6 +174,9 @@ uncertainty on the SCI values, the DQ image contains the data quality flags for 
 contains the number of point cloud elements contained in the region of interest of the spaxel. The data quality flag does not propagate the
 dq flags from previous steps but is defined in the cube build step as: good data (value = 0), non_science (value = 512), do_not_use(value =1), or a combination of non_science and do_not_use (value = 513).  
 
+The SCI and ERR cubes are populated with NaN values for voxels where there is no valid data (e.g., outside
+the IFU cube footprint).
+
 Output Product Name
 -------------------
 If the input data is passed in as an ImageModel, then the IFU cube will be passed back as an IFUCubeModel. The cube

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -2069,6 +2069,7 @@ class IFUCubeData():
         # loop over the wavelength planes to confirm each plane has some data
         # for initial or final planes that do not have any data - eliminated them
         # from the IFUcube
+
         # Rearrange values from 1d vectors into 3d cubes
 
         flux = self.spaxel_flux.reshape((self.naxis3,
@@ -2080,6 +2081,11 @@ class IFUCubeData():
                                        self.naxis2, self.naxis1))
         dq = self.spaxel_dq.reshape((self.naxis3,
                                      self.naxis2, self.naxis1))
+
+        # Set np.nan values wherever the DO_NOT_USE flag is set
+        dnu = np.where((dq & dqflags.pixel['DO_NOT_USE']) != 0)
+        flux[dnu] = np.nan
+        var[dnu] = np.nan
 
         # For MIRI MRS, apply a quality cut to help fix spectral tearing at the ends of each band.
         # This is largely taken care of by the WCS regions file, but there will still be 1-2 possibly

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -2069,7 +2069,6 @@ class IFUCubeData():
         # loop over the wavelength planes to confirm each plane has some data
         # for initial or final planes that do not have any data - eliminated them
         # from the IFUcube
-
         # Rearrange values from 1d vectors into 3d cubes
 
         flux = self.spaxel_flux.reshape((self.naxis3,

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -434,6 +434,9 @@ def extract_ifu(input_model, source_type, extract_params):
 
     dq = np.zeros(shape[0], dtype=np.uint32)
 
+    # This boolean mask will be used to mask any bad voxels in a given plane
+    bmask = np.zeros([shape[1], shape[2]], dtype=np.bool)
+
     # If the user supplied extraction center coords, use them and
     # ignore all other source type and source position values
     if extract_params['x_center'] is not None:
@@ -570,8 +573,12 @@ def extract_ifu(input_model, source_type, extract_params):
         aperture_area = 0
         annulus_area = 0
 
+        # Make a boolean mask to ignore voxels with no valid data
+        bmask[:]=False
+        bmask[np.where(temp_weightmap == 0)] = True
+
         # aperture_photometry - using weight map
-        phot_table = aperture_photometry(temp_weightmap, aperture,
+        phot_table = aperture_photometry(temp_weightmap, aperture, mask=bmask,
                                          method=method, subpixels=subpixels)
 
         aperture_area = float(phot_table['aperture_sum'][0])
@@ -587,7 +594,7 @@ def extract_ifu(input_model, source_type, extract_params):
 
         if subtract_background and annulus is not None:
             # Compute the area of the annulus.
-            phot_table = aperture_photometry(temp_weightmap, annulus,
+            phot_table = aperture_photometry(temp_weightmap, annulus, mask=bmask,
                                              method=method, subpixels=subpixels)
             annulus_area = float(phot_table['aperture_sum'][0])
 
@@ -608,38 +615,38 @@ def extract_ifu(input_model, source_type, extract_params):
             npixels_bkg[k] = annulus_area
         # aperture_photometry - using data
 
-        phot_table = aperture_photometry(data[k, :, :], aperture,
+        phot_table = aperture_photometry(data[k, :, :], aperture, mask=bmask,
                                          method=method, subpixels=subpixels)
         temp_flux[k] = float(phot_table['aperture_sum'][0])
 
-        var_poisson_table = aperture_photometry(var_poisson[k, :, :], aperture,
+        var_poisson_table = aperture_photometry(var_poisson[k, :, :], aperture, mask=bmask,
                                                 method=method, subpixels=subpixels)
         f_var_poisson[k] = float(var_poisson_table['aperture_sum'][0])
 
-        var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], aperture,
+        var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], aperture, mask=bmask,
                                                method=method, subpixels=subpixels)
         f_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
 
-        var_flat_table = aperture_photometry(var_flat[k, :, :], aperture,
+        var_flat_table = aperture_photometry(var_flat[k, :, :], aperture, mask=bmask,
                                              method=method, subpixels=subpixels)
         f_var_flat[k] = float(var_flat_table['aperture_sum'][0])
 
         # Point source type of data with defined annulus size
         if subtract_background_plane:
-            bkg_table = aperture_photometry(data[k, :, :], annulus,
+            bkg_table = aperture_photometry(data[k, :, :], annulus, mask=bmask,
                                             method=method, subpixels=subpixels)
             background[k] = float(bkg_table['aperture_sum'][0])
             temp_flux[k] = temp_flux[k] - background[k] * normalization
 
-            var_poisson_table = aperture_photometry(var_poisson[k, :, :], annulus,
+            var_poisson_table = aperture_photometry(var_poisson[k, :, :], annulus, mask=bmask,
                                                     method=method, subpixels=subpixels)
             b_var_poisson[k] = float(var_poisson_table['aperture_sum'][0])
 
-            var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], annulus,
+            var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], annulus, mask=bmask,
                                                    method=method, subpixels=subpixels)
             b_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
 
-            var_flat_table = aperture_photometry(var_flat[k, :, :], annulus,
+            var_flat_table = aperture_photometry(var_flat[k, :, :], annulus, mask=bmask,
                                                  method=method, subpixels=subpixels)
             b_var_flat[k] = float(var_flat_table['aperture_sum'][0])
 
@@ -658,7 +665,10 @@ def extract_ifu(input_model, source_type, extract_params):
                 high = bkg_mean + bkg_sigma_clip * bkg_stddev
 
                 # set up the mask to flag data that should not be used in aperture photometry
+                # Reject data outside the sigma-clipped range
                 maskclip = np.logical_or(bkg_data < low, bkg_data > high)
+                # Reject data outside the valid data footprint
+                maskclip = np.logical_or(maskclip, bmask)
 
                 bkg_table = aperture_photometry(bkg_data, aperture, mask=maskclip,
                                                 method=method, subpixels=subpixels)
@@ -964,10 +974,10 @@ def image_extract_ifu(input_model, source_type, extract_params):
     # Extract the data.
     # First add up the values along the x direction, then add up the
     # values along the y direction.
-    gross = (data * mask_target).sum(axis=2, dtype=np.float64).sum(axis=1)
-    f_var_poisson = (var_poisson * mask_target).sum(axis=2, dtype=np.float64).sum(axis=1)
-    f_var_rnoise = (var_rnoise * mask_target).sum(axis=2, dtype=np.float64).sum(axis=1)
-    f_var_flat = (var_flat * mask_target).sum(axis=2, dtype=np.float64).sum(axis=1)
+    gross = np.nansum(np.nansum(data * mask_target, axis=2, dtype=np.float64), axis=1)
+    f_var_poisson = np.nansum(np.nansum(var_poisson * mask_target, axis=2, dtype=np.float64), axis=1)
+    f_var_rnoise = np.nansum(np.nansum(var_rnoise * mask_target, axis=2, dtype=np.float64), axis=1)
+    f_var_flat = np.nansum(np.nansum(var_flat * mask_target, axis=2, dtype=np.float64), axis=1)
 
     # Compute the number of pixels that were added together to get gross.
     normalization = 1.
@@ -975,19 +985,19 @@ def image_extract_ifu(input_model, source_type, extract_params):
     weightmap = input_model.weightmap
     temp_weightmap = weightmap
     temp_weightmap[temp_weightmap > 1] = 1
-    npixels[:] = (temp_weightmap * mask_target).sum(axis=2, dtype=np.float64).sum(axis=1)
+    npixels[:] = np.nansum(np.nansum(temp_weightmap * mask_target, axis=2, dtype=np.float64), axis=1)
     bkg_sigma_clip = extract_params['bkg_sigma_clip']
 
     # Point Source data 1. extract background and subtract 2. do not
     if source_type == 'POINT':
         if subtract_background and mask_bkg is not None:
-            n_bkg[:] = (temp_weightmap * mask_bkg).sum(axis=2, dtype=np.float64).sum(axis=1)
+            n_bkg[:] = np.nansum(np.nansum(temp_weightmap * mask_bkg, axis=2, dtype=np.float64), axis=1)
             n_bkg[:] = np.where(n_bkg <= 0., 1., n_bkg)
             normalization = npixels / n_bkg
-            background = (data * mask_bkg).sum(axis=2, dtype=np.float64).sum(axis=1)
-            b_var_poisson = (var_poisson * mask_bkg).sum(axis=2, dtype=np.float64).sum(axis=1)
-            b_var_rnoise = (var_rnoise * mask_bkg).sum(axis=2, dtype=np.float64).sum(axis=1)
-            b_var_flat = (var_flat * mask_bkg).sum(axis=2, dtype=np.float64).sum(axis=1)
+            background = np.nansum(np.nansum(data * mask_bkg, axis=2, dtype=np.float64), axis=1)
+            b_var_poisson = np.nansum(np.nansum(var_poisson * mask_bkg, axis=2, dtype=np.float64), axis=1)
+            b_var_rnoise = np.nansum(np.nansum(var_rnoise * mask_bkg, axis=2, dtype=np.float64), axis=1)
+            b_var_flat = np.nansum(np.nansum(var_flat * mask_bkg, axis=2, dtype=np.float64), axis=1)
             temp_flux = gross - background * normalization
         else:
             background = np.zeros_like(gross)
@@ -996,7 +1006,7 @@ def image_extract_ifu(input_model, source_type, extract_params):
             b_var_flat = np.zeros_like(gross)
             temp_flux = gross.copy()
     else:
-        temp_flux = (data * mask_target).sum(axis=2, dtype=np.float64).sum(axis=1)
+        temp_flux = np.nansum(np.nansum(data * mask_target, axis=2, dtype=np.float64), axis=1)
 
     # Extended source data, sigma clip outliers of extraction region is performed
     # at each wavelength plane.
@@ -1360,6 +1370,7 @@ def sigma_clip_extended_region(data, var_poisson, var_rnoise, var_flat, mask_tar
 
         # set up the mask to flag data that should not be used
         maskclip = np.logical_or(data_plane < low, data_plane > high)  # flag outliers
+        maskclip = np.logical_or(maskclip, np.isfinite(data_plane) == False)
         extract_region[maskclip] = 0
 
         sigma_clip_region[k] = np.sum(data_plane * extract_region * wmap[k, :, :])

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -574,7 +574,7 @@ def extract_ifu(input_model, source_type, extract_params):
         annulus_area = 0
 
         # Make a boolean mask to ignore voxels with no valid data
-        bmask[:]=False
+        bmask[:] = False
         bmask[np.where(temp_weightmap == 0)] = True
 
         # aperture_photometry - using weight map
@@ -1370,7 +1370,7 @@ def sigma_clip_extended_region(data, var_poisson, var_rnoise, var_flat, mask_tar
 
         # set up the mask to flag data that should not be used
         maskclip = np.logical_or(data_plane < low, data_plane > high)  # flag outliers
-        maskclip = np.logical_or(maskclip, np.isfinite(data_plane) == False)
+        maskclip = np.logical_or(maskclip, ~np.isfinite(data_plane))
         extract_region[maskclip] = 0
 
         sigma_clip_region[k] = np.sum(data_plane * extract_region * wmap[k, :, :])


### PR DESCRIPTION
Resolves [JP-2997](https://jira.stsci.edu/browse/JP-2997), implements switch from zero-fill to nan-fill IFU data cubes.

This PR also fixes multiple parts of the IFU Extract1D code that crash once the s3d data cubes contain nan values, largely because aperture_photometry and the native 'sum' commands do not cleanly handle nans.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
