### PR TITLE
(JP-2993) Update flat-field ERR computation for FGS guider

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.8.3 (unreleased)
+1.8.4 (unreleased)
 ==================
 
 assign_wcs
@@ -31,12 +31,14 @@ datamodels
 ----------
 
 - Add subarray keywords in the filteroffset schema [#7317]
+
 - Remove duplicates and add comments to core.schema dithering types [#7331]
 
 documentation
 -------------
 
-- CRDS PUB deprecation notice and transition documentation [#7342]
+-  Update deprecation notice with copyedit changes [#7348]
+
 
 extract_1d
 ----------
@@ -49,6 +51,7 @@ extract_2d
 
 - Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
 
+
 flatfield
 ---------
 
@@ -58,7 +61,7 @@ flatfield
 guider_cds
 ----------
 
-- Calculate and output the ERR array based on the gain and readnoise 
+- Calculate and output the ERR array based on the gain and readnoise
   variances, and force the stack mode to use the default gain and readnoise
   pixel values. [#7309]
 
@@ -79,8 +82,12 @@ photom
 resample
 --------
 
-- Enhance spectral output WCS construction to guard against nearly identical
+- Enhanced spectral output WCS construction to guard against nearly identical
   points. [#7321]
+
+- Added a utility function ``decode_context()`` to help identify all input
+  images that have contributed with flux to an output (resampled)
+  pixel. [#7345]
 
 tweakreg
 --------
@@ -91,6 +98,13 @@ tweakreg
 - Fix a bug in the logic that handles inputs with a single image group when
   an absolute reference catalog is provided. [#7328]
 
+1.8.3 (2022-11-11)
+==================
+
+documentation
+-------------
+
+- CRDS PUB deprecation notice and transition documentation [#7342]
 
 1.8.2 (2022-10-20)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,12 @@ extract_2d
 
 - Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
 
+flatfield
+---------
+
+- JP-2993 Update the flat-field ERR computation for FGS guider mode exposures to
+  combine the input ERR and the flat field ERR in quadrature. [#7346]
+  
 guider_cds
 ----------
 

--- a/docs/jwst/error_propagation/main.rst
+++ b/docs/jwst/error_propagation/main.rst
@@ -69,11 +69,17 @@ ERR array.
 flat_field
 ++++++++++
 The SCI array of the exposure being processed is divided by the flat-field reference
-image, and the VAR_POISSON and VAR_RNOISE arrays are divided by the square of the flat.
-A VAR_FLAT array is created, computed from the science data and the flat-field
-reference file ERR array.
-The science data ERR array is then updated to be the square root of the quadratic sum of
-the three variance arrays.
+image.  The VAR_FLAT array is created, computed from the science data and the flat-field
+reference file ERR array. 
+
+For all modes except GUIDER, the VAR_POISSON and VAR_RNOISE arrays are divided by the
+square of the flat. The science data ERR array is then updated to be the square root
+of the sum of the three variance arrays. 
+
+For the GUIDER mode, their are no VAR_POISSON and VAR_RNOISE arrays. The science data
+ERR array is updated to be the square root of the sum of the variance VAR_FLAT and the
+square of the incoming science ERR array. 
+
 For more details see :ref:`flat_field <flatfield_step>`.
 
 fringe 

--- a/docs/jwst/flatfield/main.rst
+++ b/docs/jwst/flatfield/main.rst
@@ -58,6 +58,12 @@ Multi-integration datasets ("_rateints.fits" products), which are common
 for modes like NIRCam Time-Series Grism, NIRISS SOSS, and MIRI LRS Slitless,
 are handled by applying the above equations to each integration.
 
+For guider exposures, the flat is applied in the same manner as given
+in the equations above, except for several differences.  First, the variances
+due to Poisson noise and read noise are not calculated.  Second, the output
+ERR array is the combined input ERR plus the flatfield ERR, summed in
+quadrature.
+
 NIRSpec Spectroscopic Data
 --------------------------
 Flat-fielding of NIRSpec spectrographic data differs from other modes

--- a/docs/jwst/guider_cds/description.rst
+++ b/docs/jwst/guider_cds/description.rst
@@ -21,6 +21,30 @@ the 2 integrations. The minimum difference image is then divided
 by the group time to produce a countrate image. The output
 data array is 3D, with dimensions of (ncols x nrows x 1).
 
+For this mode, the output ERR array has the same dimensions as the
+output data array. The values for the ERR array are calculated for each
+2-group segment in each of the 2 integrations from the two variances of
+the slope of the segment. 
+
+The segment's variance due to read noise is:
+
+.. math::
+   var^R = \frac{2 \ R^2 }{tgroup^2 } \,,
+
+where :math:`R` is the noise (using the default READNOISE pixel value)
+in the difference between the 2 groups and :math:`tgroup` is the group
+time in seconds (from the keyword TGROUP).
+
+The segment's variance due to Poisson noise is: 
+
+.. math::
+   var^P = \frac{ slope }{ tgroup \times gain }  \,,
+
+where :math:`gain` is the gain for the pixel (using the default GAIN
+pixel value), in e/DN. The :math:`slope` is the value of the pixel in
+the minimum difference image.
+
+
 ACQ1, ACQ2, and TRACK modes
 ---------------------------
 These modes use multiple integrations (NINTS>1) with 2 groups
@@ -29,6 +53,18 @@ step computes a countrate image for each integration, by
 subtracting group 1 from group 2 and dividing by the group time.
 The output data array is 3D, with dimensions of
 (ncols x nrows x nints).
+
+For these modes, the values for the variances are calculated
+using the same equations as above for the ID mode, except :
+
+1) :math:`slope` is the slope of the pixel.
+
+2) :math:`R` is the noise from the READNOISE reference file, or
+   the default READNOISE pixel value if the reference file is not accessible.
+
+3) :math:`gain` is the gain from the GAIN reference file, or
+   the default GAIN pixel value if the reference file is not accessible.
+
 
 FineGuide mode
 --------------
@@ -40,33 +76,14 @@ first 4 groups from the average of the last 4 groups and
 dividing by the group time. The output data array is
 3D, with dimensions of (ncols x nrows x nints).
 
-For all modes, the values for the output ERR array are calculated for
-each segment in each integration from the two variances of the slope
-of the segment. The ERR array has the same dimensions as the output
-data array.
+For this mode, the values for the variancesare calculated
+using the same equations as above for the ID mode, except 
+:math:`slope` is the slope of the pixel, averaged over all integrations.
 
-The segment's variance due to read noise is:
-
-.. math::
-   var^R = \frac{2 \ R^2 }{tgroup^2 } \,,
-
-where :math:`R` is the noise (from the READNOISE reference file) in the
-difference between 2 groups (or, for the FineGuide mode, the difference
-between the averages of the
-4 groups at the beginning and the 4 groups at the end of the integration)
-and :math:`tgroup` is the group time in seconds (from the keyword TGROUP).
-
-
-The segment's variance due to Poisson noise is: 
-
-.. math::
-   var^P = \frac{ slope }{ tgroup \times gain }  \,,
-
-where :math:`gain` is the gain for the pixel (from the GAIN reference file),
-in e/DN. The :math:`slope` is the slope of the pixel.
-
-The square-root of the sum of the Poisson variance and read noise variance is
-written to the ERR extension.
+All modes
+---------    
+For all of the above modes, the square-root of the sum of the Poisson
+variance and read noise variance is written to the ERR extension.
 
 After successful completion of the step, the "BUNIT" keyword in
 the output data is updated to "DN/s" and the "S_GUICDS"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2993](https://jira.stsci.edu/browse/JP-2993)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2993

<!-- describe the changes comprising this PR here -->
This PR updates the flat-field step's ERR computation for the FGS guider mode exposures. The recent update in #7309, which added computation of ERR values for guide star exposures in the guider_cds step, necessitates this update in the flatfield step to make use of those ERR values when computing the total ERR for the flat-fielded data.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [X] updated relevant documentation
- [X] added relevant milestone
- [X] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
