### PR TITLE
Update NIRSpec IFU spec2 regtest with in-flight data

### DIFF
--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -435,7 +435,7 @@ def extract_ifu(input_model, source_type, extract_params):
     dq = np.zeros(shape[0], dtype=np.uint32)
 
     # This boolean mask will be used to mask any bad voxels in a given plane
-    bmask = np.zeros([shape[1], shape[2]], dtype=np.bool)
+    bmask = np.zeros([shape[1], shape[2]], dtype=bool)
 
     # If the user supplied extraction center coords, use them and
     # ignore all other source type and source position values

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -10,11 +10,11 @@ TRUTH_PATH = 'truth/test_nirspec_ifu'
 
 @pytest.fixture(scope='module')
 def run_spec2(jail, rtdata_module):
-    """Run the Spec2Pipeline on a single exposure"""
+    """Run the Spec2Pipeline on a spec2 ASN containing a single exposure"""
     rtdata = rtdata_module
 
     # Setup the inputs
-    asn_name = 'single_nrs1_ifu_spec2_asn.json'
+    asn_name = 'jw01251-o004_20221105t023552_spec2_031_asn.json'
     asn_path = INPUT_PATH + '/' + asn_name
 
     # Run the pipeline
@@ -22,21 +22,11 @@ def run_spec2(jail, rtdata_module):
         'input_path': asn_path,
         'step': 'calwebb_spec2',
         'args': [
-            '--steps.bkg_subtract.save_results=true',
             '--steps.assign_wcs.save_results=true',
-            '--steps.imprint_subtract.save_results=true',
             '--steps.msa_flagging.save_results=true',
-            '--steps.extract_2d.save_results=true',
-            '--steps.flat_field.save_results=true',
             '--steps.srctype.save_results=true',
-            '--steps.straylight.save_results=true',
-            '--steps.fringe.save_results=true',
+            '--steps.flat_field.save_results=true',
             '--steps.pathloss.save_results=true',
-            '--steps.barshadow.save_results=true',
-            '--steps.photom.save_results=true',
-            '--steps.resample_spec.save_results=true',
-            '--steps.cube_build.save_results=true',
-            '--steps.extract_1d.save_results=true',
         ]
     }
 
@@ -48,37 +38,10 @@ def run_spec2(jail, rtdata_module):
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix',
-    ['assign_wcs', 'cal', 'flat_field', 'imprint_subtract', 'msa_flagging',
-     'pathloss', 'photom', 's3d', 'srctype', 'x1d']
+    ['assign_wcs', 'cal', 'flat_field', 'msa_flagging',
+     'pathloss', 's3d', 'srctype', 'x1d']
 )
 def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test matching output files"""
     rt.is_like_truth(run_spec2, fitsdiff_default_kwargs, suffix,
-                     truth_path=TRUTH_PATH)
-
-
-@pytest.fixture(scope='module')
-def run_photom(jail, rtdata_module):
-    """Run the photom step on an NRS IFU exposure with SRCTYPE=EXTENDED"""
-    rtdata = rtdata_module
-
-    # Setup the inputs
-    rate_name = 'jwdata0010010_11010_0001_NRS1_pathloss.fits'
-    rate_path = INPUT_PATH + '/' + rate_name
-
-    # Run the step
-    step_params = {
-        'input_path': rate_path,
-        'step': 'jwst.photom.PhotomStep',
-        'args': ['--save_results=True', ]
-    }
-
-    rtdata = rt.run_step_from_dict(rtdata, **step_params)
-    return rtdata
-
-
-@pytest.mark.bigdata
-def test_photom(run_photom, fitsdiff_default_kwargs):
-    """Regression test matching output files"""
-    rt.is_like_truth(run_photom, fitsdiff_default_kwargs, 'photom',
                      truth_path=TRUTH_PATH)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- describe the changes comprising this PR here -->
This PR updates the existing test_nirspec_ifu_spec2 regression test to use in-flight data (a single IFU exposure).

It also updates 1 line of the extract_1d/ifu.py module to switch the use of the deprecated `np.bool` to plain `bool` (gets rid of an execution time warning).

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
