### PR TITLE
JP-2984: Update ASN rules for NIS_WFSS to keep grisms separate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ associations
 
 - Suppress the use of association candidates for level 3 products marked with WFSC_LOS_JITTER. [#7339]
 
+- Split NIRISS WFSS dual grism (gr150r+gr150c) associations into separate asn's for each grism. [#7351]
+
 cube_build
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ associations
 - Added background association candidates to list of level 3 candidate
   types requiring members from more than one observation [#7329]
 
-- Refactor item reprocessing for efficiency, refactor how background associations are configured [#7332]
+- Refactor item reprocessing for efficiency. Also refactor how background associations are configured [#7332]
 
 - Suppress the use of association candidates for level 3 products marked with WFSC_LOS_JITTER. [#7339]
 
@@ -32,28 +32,27 @@ cube_build
 datamodels
 ----------
 
-- Add subarray keywords in the filteroffset schema [#7317]
+- Add subarray keywords in the ``filteroffset`` schema [#7317]
 
-- Remove duplicates and add comments to core.schema dithering types [#7331]
+- Remove duplicate enum entries for PATTTYPE (dither pattern type) values [#7331]
 
 
 extract_1d
 ----------
 
-- Fix IFU spectral extraction code to not fail on nan fill values
-  now populating empty regions of the data cubes. [#7337]
+- Fix IFU spectral extraction code to not fail on NaN fill values
+  that now populate empty regions of the data cubes. [#7337]
 
 extract_2d
 ----------
 
 - Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
 
-
 flatfield
 ---------
 
-- JP-2993 Update the flat-field ERR computation for FGS guider mode exposures to
-  combine the input ERR and the flat field ERR in quadrature. [#7346]
+- Update the flat-field ERR computation for FGS guider mode exposures to
+  combine the input ERR and the flatfield ERR in quadrature. [#7346]
   
 guider_cds
 ----------
@@ -94,6 +93,7 @@ tweakreg
 
 - Fix a bug in the logic that handles inputs with a single image group when
   an absolute reference catalog is provided. [#7328]
+
 
 1.8.4 (2022-11-15)
 ==================

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -950,7 +950,7 @@ class Asn_Lv3WFSSNIS(AsnMixin_Spectrum):
                 name='opt_elem',
                 sources=['filter'],
                 value='gr150r|gr150c',
-                force_unique=False,
+                force_unique=True,
             ),
             DMSAttrConstraint(
                 name='opt_elem2',

--- a/jwst/associations/tests/test_level3_spectrographic.py
+++ b/jwst/associations/tests/test_level3_spectrographic.py
@@ -33,7 +33,7 @@ class TestLevel3Spec(BasePoolRule):
         ),
         PoolParams(
             path=t_path('data/pool_019_niriss_wfss.csv'),
-            n_asns=2,
+            n_asns=3,
             n_orphaned=0
         ),
     ]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2984](https://jira.stsci.edu/browse/JP-2984)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7315 

<!-- describe the changes comprising this PR here -->
This PR makes a trivial change to the NIRISS WFSS level-3 ASN rule so that unique ASN's and products are created for each of the gr150r and gr150c grisms.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
