### PR TITLE
(JP-2991) Require asdf-transform-schemas greater than 0.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.8.4 (unreleased)
+1.8.5 (unreleased)
 ==================
 
 assign_wcs
@@ -34,13 +34,6 @@ datamodels
 
 - Remove duplicates and add comments to core.schema dithering types [#7331]
 
-documentation
--------------
-
-- Update deprecation notice with copyedit changes [#7348]
-
-- Clarify how to manage a local CRDS cache [#7350]
-
 
 extract_1d
 ----------
@@ -59,7 +52,13 @@ flatfield
 
 - JP-2993 Update the flat-field ERR computation for FGS guider mode exposures to
   combine the input ERR and the flat field ERR in quadrature. [#7346]
+
   
+general
+-------
+
+- Add requirement for asdf-transform-schemas >= 0.3.0 [#7352]
+
 guider_cds
 ----------
 
@@ -91,11 +90,6 @@ resample
   images that have contributed with flux to an output (resampled)
   pixel. [#7345]
 
-transforms
-----------
-
-- Require the asdf transform version to be at least 0.3.0 [#7352]
-  
 tweakreg
 --------
 
@@ -104,6 +98,16 @@ tweakreg
 
 - Fix a bug in the logic that handles inputs with a single image group when
   an absolute reference catalog is provided. [#7328]
+
+1.8.4 (2022-11-15)
+==================
+
+documentation
+-------------
+
+- Update deprecation notice with copyedit changes [#7348]
+
+- Clarify how to manage a local CRDS cache [#7350]
 
 1.8.3 (2022-11-11)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,11 @@ resample
   images that have contributed with flux to an output (resampled)
   pixel. [#7345]
 
+transforms
+----------
+
+- Require the asdf transform version to be at least 0.3.0 [#7352]
+  
 tweakreg
 --------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     asdf>=2.13.0
-    asdf-transform>=0.3.0
+    asdf_transform_schemas>=0.3.0
     astropy>=5.1
     BayesicFitting>=3.0.1
     certifi==2022.5.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     asdf>=2.13.0
+    asdf-transform>=0.3.0
     astropy>=5.1
     BayesicFitting>=3.0.1
     certifi==2022.5.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     asdf>=2.13.0
-    asdf_transform_schemas>=0.3.0
+    asdf-transform-schemas>=0.3.0
     astropy>=5.1
     BayesicFitting>=3.0.1
     certifi==2022.5.18.1


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2991](https://jira.stsci.edu/browse/JP-2991)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR requires the asdf transform version to be at least 0.3.0, by updating setup.cfg. This was prompted by a user unable to open files from MAST using the JWST data models .

**Checklist for maintainers**
- [X] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [X] updated relevant documentation
- [X] added relevant milestone
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
