### PR TITLE
use `pip` instead of `conda` to install `certifi`, to solve `pip freeze` issue

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -76,6 +76,7 @@ bc0.conda_packages = [
 ]
 bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
+    "pip install certifi -U --force-reinstall",
     "pip install -e .[test,sdp] --no-cache-dir",
     "pip install pytest-xdist",
     "pip freeze",

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -76,7 +76,8 @@ bc0.conda_packages = [
 ]
 bc0.pip_reqs_files = ['requirements-dev.txt']
 bc0.build_cmds = [
-    "pip install -e .[test,ephem] --no-cache-dir",
+    "pip install certifi -U --force-reinstall",
+    "pip install -e .[test,sdp] --no-cache-dir",
     "pip install pytest-xdist",
     "pip freeze",
 ]

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -13,4 +13,4 @@
 #     conda create -n sdp python -y
 #     conda activate sdp
 #     pip install -e .[test]
-#     pip freeze | grep -v jwst.git >> requirements-sdp.txt
+#     pip freeze | grep -v jwst >> requirements-sdp.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     asdf>=2.13.0
     astropy>=5.1
     BayesicFitting>=3.0.1
-    certifi==2022.5.18.1
     crds>=11.16.14
     drizzle>=1.13.6
     gwcs>=0.18.2


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [SPB-1023](https://jira.stsci.edu/browse/SPB-1023)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
applies changes, suggested by @jdavies-st in https://github.com/spacetelescope/jwst/issues/7334#issuecomment-1317137651, to ensure the latest version of `certifi` is installed without incurring the issue with `pip freeze` and `certifi` in a `conda` environment

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
