### PR TITLE
Fix recently updated regression test

### DIFF
--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -47,10 +47,9 @@ def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
                      truth_path=TRUTH_PATH)
 
 
-@pytest.fixture(scope='module')
-def run_photom(jail, rtdata_module):
+@pytest.fixture()
+def run_photom(jail, rtdata):
     """Run the photom step on an NRS IFU exposure with SRCTYPE=POINT"""
-    rtdata = rtdata_module
 
     # Setup the inputs
     rate_name = 'jw01251004001_03107_00002_nrs1_pathloss.fits'
@@ -74,10 +73,9 @@ def test_photom(run_photom, fitsdiff_default_kwargs):
                      truth_path=TRUTH_PATH)
 
 
-@pytest.fixture(scope='module')
-def run_extract1d(jail, rtdata_module):
+@pytest.fixture()
+def run_extract1d(jail, rtdata):
     """Run the extract_1d step on an NRS IFU cube with SRCTYPE=POINT"""
-    rtdata = rtdata_module
 
     # Setup the inputs
     cube_name = 'jw01251004001_03107_00002_nrs1_s3d.fits'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- describe the changes comprising this PR here -->
This PR fixes the regression test that was updated in #7349. When running in the Jenkins tests the individual photom and extract_1d tests were searching for truth files of the wrong name. @stscieisenhamer suggested this was due to scope being set to the module level, so the multiple tests were clobbering the contents of `rtdata_module`, leading to incorrect file names being used in the `is_like_truth` convenience function. This change removes the module-level scope to (hopefully) fix the problems.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
