### PR TITLE
Add test for duplicate data when resaving model to fits

### DIFF
--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -4,7 +4,8 @@ from numpy.testing import assert_array_equal
 import numpy as np
 import pytest
 
-from jwst.datamodels import JwstDataModel, RampModel
+from jwst import datamodels
+from jwst.datamodels import ImageModel, JwstDataModel, RampModel
 
 
 @pytest.fixture
@@ -68,3 +69,26 @@ def test_casting():
         total = dm.data.sum()
         dm.data = dm.data + 2
         assert dm.data.sum() > total
+
+
+@pytest.mark.skip(reason='fix required for asdf')
+def test_resave_duplication_bug(tmp_path):
+    """
+    An issue in asdf (https://github.com/asdf-format/asdf/issues/1232)
+    resulted in duplication of data when a model was read from and then
+    written to a fits file. A resave results in array data being written to
+    both hdus and as internal blocks within the asdf tree (which is then
+    stored in the asdf hdu).
+    """
+    fn1 = tmp_path / "test1.fits"
+    fn2 = tmp_path / "test2.fits"
+
+    arr = np.zeros((1000, 100), dtype='f4')
+    m = ImageModel(arr)
+    m.save(fn1)
+
+    with datamodels.open(fn1) as m2:
+        m2.save(fn2)
+
+    with fits.open(fn1) as ff1, fits.open(fn2) as ff2:
+        assert ff1['ASDF'].size == ff2['ASDF'].size

--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -71,7 +71,6 @@ def test_casting():
         assert dm.data.sum() > total
 
 
-@pytest.mark.skip(reason='fix required for asdf')
 def test_resave_duplication_bug(tmp_path):
     """
     An issue in asdf (https://github.com/asdf-format/asdf/issues/1232)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf>=2.13.0
+    asdf>=2.14.1
     asdf-transform-schemas>=0.3.0
     astropy>=5.1
     BayesicFitting>=3.0.1


### PR DESCRIPTION
When resaving a model to fits, asdf loses track of array-hdu links and saves arrays in both hdu and as internal blocks in the asdf tree. This can make an asdf tree that is larger than what can be stored in a fits hdu.

See asdf issue: https://github.com/asdf-format/asdf/issues/1232

This test is skipped as it fails with the current asdf version.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
