### PR TITLE
JP-2802: Fix a bug in the definition of NIRSpec resampled WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,7 +58,7 @@ flatfield
 
 - JP-2993 Update the flat-field ERR computation for FGS guider mode exposures to
   combine the input ERR and the flat field ERR in quadrature. [#7346]
-  
+
 general
 -------
 
@@ -100,6 +100,8 @@ resample
   images that have contributed with flux to an output (resampled)
   pixel. [#7345]
 
+- Fixed a bug in the definition of the output WCS for NIRSpec. [#7359]
+
 tweakreg
 --------
 
@@ -108,7 +110,7 @@ tweakreg
 
 - Fix a bug in the logic that handles inputs with a single image group when
   an absolute reference catalog is provided. [#7328]
-  
+
 1.8.4 (2022-11-15)
 ==================
 


### PR DESCRIPTION
Resolves [JP-2802](https://jira.stsci.edu/browse/JP-2802)
Closes #7265

This PR fixes a bug in the definition of the NIRSpec resampled WCS. Fundamentally, the bug was that for the forward transformation the horizontal position in the slit was incorrect. This PR fixes horizontal position to 0 - center of the slit. I expect regression tests to fail.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression test: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/469/
