### PR TITLE
JP-3012: Add note for install issue on Mojave

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 
 **Linux and MacOS platforms are tested and supported.  Windows is not currently supported.**
 
-
+**If installing on MacOS Mojave 10.14, you must install 
+  into an environment with python 3.8 or 3.9. Installation will fail on python 3.10 due
+  to lack of a stable build for dependency ``opencv-python``.**
 ## Installation
 
 The easiest way to install the latest `jwst` release into a fresh virtualenv or conda environment is

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -36,6 +36,11 @@ including tagged releases, DMS builds used in operations, and development
 versions. Remember that all conda operations must be done from within a bash/zsh
 shell.
 
+.. warning::
+
+    Users on MacOS Mojave (10.14) should limit their environment python to 3.9 -
+    there is a package dependency which currently fails to build on Mojave with
+    python>=3.10.
 
 Installing Latest Release
 -------------------------


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3012](https://jira.stsci.edu/browse/JP-3012)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an installation issue found by some help desk users on MacOS Mojave in a python 3.10 environment. The dependency ``opencv-python`` has no stable build and will prevent successful installation.

**Checklist for maintainers**
~~- [ ] added entry in `CHANGES.rst` within the relevant release section~~
~~- [ ] updated or added relevant tests~~
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
