### PR TITLE
Add missing change log entry for stcal update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -197,6 +197,12 @@ combine_1d
 - Fixed a bug to properly exclude input spectra that have only 1
   wavelength bin. [#7053]
 
+dark_current
+------------
+
+- Bug fix for computation of the total number of frames when science data use
+  on-board frame averaging and/or group gaps. [spacetelescope/stcal#121]
+
 datamodels
 ----------
 
@@ -211,7 +217,7 @@ jump
 ----
 
 - First version of snowball/shower flagging for the jump step
-  JP-#2645. This code will not be actiavated without either a set of
+  JP-2645. This code will not be actiavated without either a set of
   parameter reference files or a command line override. [#7039]
 
 master_background


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR simply adds an entry to the jwst change log to document a bug fix in the dark_current step in the low-level code contained in stcal, which was included in Build 9.0.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
