### PR TITLE
Wrong Python version expected in __init__.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,7 @@ general
 - Reorganize and expand user documentation, update docs landing page. Add install instructions, quickstart guide, and elaborate on running
   pipeline in Python and with strun. [#6919]
   
-- Wrong Python version expected in __init__.py [#7366]
+- fixed wrong Python version expected in ``__init__.py`` [#7366]
 
 guider_cds
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,8 @@ general
 
 - Reorganize and expand user documentation, update docs landing page. Add install instructions, quickstart guide, and elaborate on running
   pipeline in Python and with strun. [#6919]
+  
+- Wrong Python version expected in __init__.py [#7366]
 
 guider_cds
 ----------

--- a/jwst/__init__.py
+++ b/jwst/__init__.py
@@ -15,5 +15,5 @@ if '+' in __version__:
     if commit:
         __version_commit__ = commit[0]
 
-if sys.version_info < (3, 5):
-    raise ImportError("JWST requires Python 3.5 and above.")
+if sys.version_info < (3, 8):
+    raise ImportError("JWST requires Python 3.8 and above.")


### PR DESCRIPTION
JWST requires Python 3.8 or higher. However, Python 3.5 is specified in __init__.py.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- ~updated or added relevant tests~
- ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
