### PR TITLE
remove CRDS PUB server from test

### DIFF
--- a/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/jwst/datamodels/tests/test_schema_against_crds.py
@@ -165,7 +165,7 @@ ref_to_datamodel_dict = {
 @pytest.mark.parametrize('instrument', ['fgs', 'miri', 'nircam', 'niriss', 'nirspec'])
 def test_crds_selectors_vs_datamodel(jail_environ, instrument):
 
-    os.environ["CRDS_SERVER_URL"] = 'https://jwst-crds-pub.stsci.edu'
+    os.environ["CRDS_SERVER_URL"] = 'https://jwst-crds.stsci.edu'
 
     log.info(f"CRDS_PATH: {os.environ['CRDS_PATH']}")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,11 +119,11 @@ per-file-ignores =
     jwst/ramp_fitting/tests/compare_cr_files.py:E
     jwst/ramp_fitting/tests/create_cube.py:E
     jwst/ramp_fitting/tests/mc_3d.py:E
-ignore =
-    E231, # Missing whitespace after ',', ';', or ':'
-    E241, # Multiple spaces after ','
-    W503, # Line break occurred before a binary operator
-    W504, # Line break occurred after a binary operator
+ignore = E231,E241,W503,W504
+# E231, # Missing whitespace after ',', ';', or ':'
+# E241, # Multiple spaces after ','
+# W503, # Line break occurred before a binary operator
+# W504, # Line break occurred after a binary operator
 
 [tool:pytest]
 minversion = 6.0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Is it time to replace the CRDS PUB server from a datamodels test with the OPS server? Noticed because of an issue with the JWST-devdeps job.


**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
