### PR TITLE
JP-2998 Extract1D using custom json files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ extract_1d
 - Fix IFU spectral extraction code to not fail on NaN fill values
   that now populate empty regions of the data cubes. [#7337]
 
+- Re-organized the way extract1d reference files are read in based
+  on type of file and added more checks when reading files. [#7369]
+
 extract_2d
 ----------
 

--- a/docs/jwst/extract_1d/description.rst
+++ b/docs/jwst/extract_1d/description.rst
@@ -261,12 +261,11 @@ direction perpendicular to dispersion.
 
 Extraction for 3D IFU Data
 --------------------------
-For IFU cube data, 1D extraction is controlled by a different set of EXTRACT1D
-reference file parameters. The ``use_source_posn`` parameter is not used when extracting spectra from an IFU cube.
-Instead, for point source data, the extraction aperture is centered at the RA/DEC target location
-indicated by the header. If the target location is undefined in the header, then the extraction
+In IFU cube data, 1D extraction is controlled by a different set of EXTRACT1D
+reference file parameters. For  point source data  the extraction
+aperture is centered at the RA/DEC target location indicated by the header. If the target location is undefined in the header, then the extraction
 region is the  center of the IFU cube. For extended source data, anything specified in the reference file
-or step arguments will be ignored; the entire image will be extracted, and no background subtraction will be done. 
+or step arguments will be ignored; the entire image will be extracted, and no background subtraction will be done.  
 
 For point sources a circular extraction aperture is used, along with an optional
 circular annulus for background extraction and subtraction. The size of the extraction

--- a/docs/jwst/extract_1d/description.rst
+++ b/docs/jwst/extract_1d/description.rst
@@ -265,7 +265,7 @@ In IFU cube data, 1D extraction is controlled by a different set of EXTRACT1D
 reference file parameters. For  point source data  the extraction
 aperture is centered at the RA/DEC target location indicated by the header. If the target location is undefined in the header, then the extraction
 region is the  center of the IFU cube. For extended source data, anything specified in the reference file
-or step arguments will be ignored; the entire image will be extracted, and no background subtraction will be done.  
+or step arguments will be ignored; the entire image will be extracted, and no background subtraction will be done.
 
 For point sources a circular extraction aperture is used, along with an optional
 circular annulus for background extraction and subtraction. The size of the extraction

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -87,9 +87,10 @@ Editing JSON Reference File Format for non-IFU data
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 The default EXTRACT1D reference file is found in CRDS. The user can download this file, modify the contents,
 and use this modified file in ``extract_1d`` by specifying this modified reference file with the ``override`` option
-(:ref:`override in python <override_ref_python>` or :ref:`override in strun <override_ref_strun>`). The format for JSON files has to be exact, for example,
-the format of a floating-point value with a fractional portion must include at least one decimal digit, so "1." is invalid, while "1.0" is valid.
-The best practice after editing a JSON reference file is to run a JSON validator off-line and correct any format errors before using
+(:ref:`override in python <override_ref_python>` or :ref:`override in strun <override_ref_strun>`). The format for
+JSON files has to be exact, for example, the format of a floating-point value with a fractional portion must include
+at least one decimal digit, so "1." is invalid, while "1.0" is valid. The best practice after editing a JSON reference
+file is to run a JSON validator off-line, such as `jsonlint  <https://jsonlint.com>`,  and correct any format errors before using
 the JSON reference file in the pipeline.
 
 

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -90,7 +90,7 @@ and use this modified file in ``extract_1d`` by specifying this modified referen
 (:ref:`override in python <override_ref_python>` or :ref:`override in strun <override_ref_strun>`). The format for
 JSON files has to be exact, for example, the format of a floating-point value with a fractional portion must include
 at least one decimal digit, so "1." is invalid, while "1.0" is valid. The best practice after editing a JSON reference
-file is to run a JSON validator off-line, such as `jsonlint  <https://jsonlint.com>`,  and correct any format errors before using
+file is to run a JSON validator off-line, such as `https://jsonlint.com/`,  and correct any format errors before using
 the JSON reference file in the pipeline.
 
 

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -86,7 +86,7 @@ are used in the extraction process.
 Editing JSON Reference File Format for non-IFU data
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 The default EXTRACT1D reference file is found in CRDS. The user can download this file, modify the contents,
-and use this modified file in ``extract-1d`` by specifying this modified reference file with the ``override`` option
+and use this modified file in ``extract_1d`` by specifying this modified reference file with the ``override`` option
 (:ref:`override in python <override_ref_python>` or :ref:`override in strun <override_ref_strun>`). The format for JSON files has to be exact, for example,
 the format of a floating point with a fractional portion must include at least one decimal digit, so "1." is invalid, while "1.0" is valid.
 The best practice after editing a JSON reference file is to run a JSON validator off-line and correct any format errors before using

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -83,6 +83,16 @@ and background extraction regions.
 See :ref:`extract-1d-for-slits` for more details on how these parameters
 are used in the extraction process.
 
+Editing JSON Reference File Format for non-IFU data
++++++++++++++++++++++++++++++++++++++++++++++++++++
+The default EXTRACT1D reference file is found in CRDS. The user can download this file, modify the contents,
+and use this modified file in ``extract-1d`` by specifying this modified reference file with the ``override`` option
+(:ref:`override in python <override_ref_python>` or :ref:`override in strun <override_ref_strun>`). The format for JSON files has to be exact, for example,
+the format of a floating point with a fractional portion must include at least one decimal digit, so "1." is invalid, while "1.0" is valid.
+The best practice after editing a JSON reference file is to run a JSON validator off-line and correct any format errors before using
+the JSON reference file in the pipeline.
+
+
 Reference File Format IFU data
 ++++++++++++++++++++++++++++++
 For IFU data the reference files are stored as ASDF files. The extraction size

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -88,7 +88,7 @@ Editing JSON Reference File Format for non-IFU data
 The default EXTRACT1D reference file is found in CRDS. The user can download this file, modify the contents,
 and use this modified file in ``extract_1d`` by specifying this modified reference file with the ``override`` option
 (:ref:`override in python <override_ref_python>` or :ref:`override in strun <override_ref_strun>`). The format for JSON files has to be exact, for example,
-the format of a floating point with a fractional portion must include at least one decimal digit, so "1." is invalid, while "1.0" is valid.
+the format of a floating-point value with a fractional portion must include at least one decimal digit, so "1." is invalid, while "1.0" is valid.
 The best practice after editing a JSON reference file is to run a JSON validator off-line and correct any format errors before using
 the JSON reference file in the pipeline.
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -148,7 +148,7 @@ def open_extract1d_ref(refname: str, exptype: str) -> dict:
                 # Input file does not load correctly as json file.
                 # Probably an error in json file
                 fd.close()
-                log.error(f"Extract1d json reference file has an error, run a json validator off line and fix the file")
+                log.error("Extract1d json reference file has an error, run a json validator off line and fix the file")
                 raise RuntimeError("Invalid json extract 1d reference file, run json validator off line and fix file.")
         elif refname_type == 'fits':
             try:
@@ -157,7 +157,7 @@ def open_extract1d_ref(refname: str, exptype: str) -> dict:
                 ref_dict = {'ref_file_type': FILE_TYPE_IMAGE, 'ref_model': extract_model}
                 fd.close()
             except OSError:
-                log.error(f"Extract1d fits reference file has an error")
+                log.error("Extract1d fits reference file has an error")
                 raise RuntimeError("Invalid fits extract 1d reference file- fix reference file.")
 
         elif refname_type == 'asdf':
@@ -166,7 +166,7 @@ def open_extract1d_ref(refname: str, exptype: str) -> dict:
             ref_dict['ref_file_type'] = FILE_TYPE_ASDF
             ref_dict['ref_model'] = extract_model
         else:
-            log.error(f"Invalid Extract 1d reference file, must be json, fits or asdf.")
+            log.error("Invalid Extract 1d reference file, must be json, fits or asdf.")
             raise RuntimeError("Invalid Extract 1d reference file, must be json, fits or asdf.")
 
     return ref_dict
@@ -431,7 +431,7 @@ def get_extract_parameters(
                 extract_params['subtract_background'] = False
 
     else:
-        log.error(f"Reference file type {ref_dict['ref_file_type']} not recognized")
+        log.error("Reference file type {ref_dict['ref_file_type']} not recognized")
 
     return extract_params
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -167,7 +167,7 @@ def open_extract1d_ref(refname: str, exptype: str) -> dict:
             ref_dict['ref_model'] = extract_model
         else:
             log.error(f"Invalid Extract 1d reference file, must be json, fits or asdf.")
-            raise RuntimeError("Invalid Extract 1d reference file, must be json, fits or asd.")
+            raise RuntimeError("Invalid Extract 1d reference file, must be json, fits or asdf.")
 
     return ref_dict
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -148,7 +148,7 @@ def open_extract1d_ref(refname: str, exptype: str) -> dict:
                 # Input file does not load correctly as json file.
                 # Probably an error in json file
                 fd.close()
-                log.error(f"Extract 1d json reference file has an error, run a json validator off line and fix the file")
+                log.error(f"Extract1d json reference file has an error, run a json validator off line and fix the file")
                 raise RuntimeError("Invalid json extract 1d reference file, run json validator off line and fix file.")
         elif refname_type == 'fits':
             try:
@@ -157,7 +157,7 @@ def open_extract1d_ref(refname: str, exptype: str) -> dict:
                 ref_dict = {'ref_file_type': FILE_TYPE_IMAGE, 'ref_model': extract_model}
                 fd.close()
             except OSError:
-                log.error(f"Extract 1d fits reference file has an error")
+                log.error(f"Extract1d fits reference file has an error")
                 raise RuntimeError("Invalid fits extract 1d reference file- fix reference file.")
 
         elif refname_type == 'asdf':

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -133,31 +133,41 @@ def open_extract1d_ref(refname: str, exptype: str) -> dict:
         handle for the jwst.datamodels object for the extract1d file.
     """
 
+    # the extract1d reference file can be 1 of three types:  'json', 'fits', or  'asdf'
+    refname_type = refname[-4:].lower()
     if refname == "N/A":
         ref_dict = None
     else:
-        fd = open(refname)
-        try:
-            ref_dict = json.load(fd)
-            ref_dict['ref_file_type'] = FILE_TYPE_JSON
-            fd.close()
-        except (UnicodeDecodeError, JSONDecodeError):
-            # input file is not JSON so lets try fits and then asdf
-            fd.close()
+        if refname_type == 'json':
+            fd = open(refname)
+            try:
+                ref_dict = json.load(fd)
+                ref_dict['ref_file_type'] = FILE_TYPE_JSON
+                fd.close()
+            except (UnicodeDecodeError, JSONDecodeError):
+                # Input file does not load correctly as json file.
+                # Probably an error in json file
+                fd.close()
+                log.error(f"Extract 1d json reference file has an error, run a json validator off line and fix the file")
+                raise RuntimeError("Invalid json extract 1d reference file, run json validator off line and fix file.")
+        elif refname_type == 'fits':
             try:
                 fd = fits.open(refname)
-                fits_present = 1
-                fd.close()
-            except OSError:
-                fits_present = 0
-            if fits_present:
                 extract_model = datamodels.MultiExtract1dImageModel(refname)
                 ref_dict = {'ref_file_type': FILE_TYPE_IMAGE, 'ref_model': extract_model}
-            else:
-                extract_model = datamodels.Extract1dIFUModel(refname)
-                ref_dict = dict()
-                ref_dict['ref_file_type'] = FILE_TYPE_ASDF
-                ref_dict['ref_model'] = extract_model
+                fd.close()
+            except OSError:
+                log.error(f"Extract 1d fits reference file has an error")
+                raise RuntimeError("Invalid fits extract 1d reference file- fix reference file.")
+
+        elif refname_type == 'asdf':
+            extract_model = datamodels.Extract1dIFUModel(refname)
+            ref_dict = dict()
+            ref_dict['ref_file_type'] = FILE_TYPE_ASDF
+            ref_dict['ref_model'] = extract_model
+        else:
+            log.error(f"Invalid Extract 1d reference file, must be json, fits or asdf.")
+            raise RuntimeError("Invalid Extract 1d reference file, must be json, fits or asd.")
 
     return ref_dict
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2998](https://jira.stsci.edu/browse/JP-2998)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses when a user modifies an extract1d json reference file (which contains format errors) and used this file in  extract1d step. The errors returned were not helpful to understanding that the bug was in the json reference file. The organization of reading in the possible types of extract1d reference file formats (json, fits, asdf) now uses the last 4 characters of the file to assist in reading the file. Checks were put in if an error is encountered in reading the file and possible solutions returned in the log messages. In addition , in the documentation a section was added concerning  modifying the extract1d json files. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/473/
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
