### PR TITLE
Fix associations ListCategory enum bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ associations
 
 - Remove defaulting of the is_psf column [#7356]
 
+- Fix association registry ListCategory enum bug under Python 3.11 [#7370]
+
 combine_1d
 ----------
 

--- a/jwst/associations/lib/process_list.py
+++ b/jwst/associations/lib/process_list.py
@@ -3,11 +3,6 @@ from collections import deque
 from enum import Enum
 from functools import reduce
 
-class ListCategory(Enum):
-    RULES      = 0
-    BOTH       = 1
-    EXISTING   = 2
-    NONSCIENCE = 3
 
 __all__ = [
     'ListCategory',
@@ -16,6 +11,13 @@ __all__ = [
     'ProcessQueue',
     'ProcessQueueSorted'
 ]
+
+
+class ListCategory(Enum):
+    RULES      = 0
+    BOTH       = 1
+    EXISTING   = 2
+    NONSCIENCE = 3
 
 
 class ProcessItem:

--- a/jwst/associations/registry.py
+++ b/jwst/associations/registry.py
@@ -1,5 +1,4 @@
 """Association Registry"""
-from importlib import import_module
 import importlib.util
 from inspect import (
     getmembers,
@@ -15,7 +14,7 @@ from os.path import (
     expanduser,
     expandvars,
 )
-import sys
+from enum import EnumMeta
 
 from . import libpath
 from .exceptions import (
@@ -83,7 +82,7 @@ class AssociationRegistry(dict):
                  global_constraints=None,
                  name=None,
                  include_bases=False):
-        super(AssociationRegistry, self).__init__()
+        super().__init__()
 
         # Generate a UUID for this instance. Used to modify rule
         # names.
@@ -320,7 +319,10 @@ class AssociationRegistry(dict):
             rule_name = '_'.join([self.name, name])
         except TypeError:
             rule_name = name
-        rule = type(rule_name, (obj,), {})
+        if type(obj) is EnumMeta:
+            rule = obj(rule_name, {})
+        else:
+            rule = type(rule_name, (obj,), {})
         rule.GLOBAL_CONSTRAINT = global_constraints
         rule.registry = self
         self.__setitem__(rule_name, rule)


### PR DESCRIPTION
This PR addresses a bug in `associations/registry.py` seen in python 3.11 testing and discussed here

https://github.com/spacetelescope/jwst/pull/7333#issuecomment-1322253629

The failure was in unit test `jwst/associations/tests/test_asn_from_list.py::test_level2_from_cmdline`.

It's not clear to me this is the desired fix.  It does fix it, but given that the generated rules produced in the test produce the following rules (produced by adding `print(rule_name, obj)` at line 322 in registry.py):

```
Association <class 'jwst.associations.association.Association'>
RegistryMarker <class 'jwst.associations.registry.RegistryMarker'>
AsnMixin_Lv2Image <class 'jwst.associations.lib.rules_level2_base.AsnMixin_Lv2Image'>
AsnMixin_Lv2Nod <class 'jwst.associations.lib.rules_level2_base.AsnMixin_Lv2Nod'>
AsnMixin_Lv2Special <class 'jwst.associations.lib.rules_level2_base.AsnMixin_Lv2Special'>
AsnMixin_Lv2Spectral <class 'jwst.associations.lib.rules_level2_base.AsnMixin_Lv2Spectral'>
AsnMixin_Lv2WFSS <class 'jwst.associations.lib.rules_level2_base.AsnMixin_Lv2WFSS'>
Asn_Lv2FGS <class 'jwst.associations.lib.rules_level2b.Asn_Lv2FGS'>
Asn_Lv2Image <class 'jwst.associations.lib.rules_level2b.Asn_Lv2Image'>
Asn_Lv2ImageNonScience <class 'jwst.associations.lib.rules_level2b.Asn_Lv2ImageNonScience'>
Asn_Lv2ImageSpecial <class 'jwst.associations.lib.rules_level2b.Asn_Lv2ImageSpecial'>
Asn_Lv2ImageTSO <class 'jwst.associations.lib.rules_level2b.Asn_Lv2ImageTSO'>
Asn_Lv2MIRLRSFixedSlitNod <class 'jwst.associations.lib.rules_level2b.Asn_Lv2MIRLRSFixedSlitNod'>
Asn_Lv2NRSFSS <class 'jwst.associations.lib.rules_level2b.Asn_Lv2NRSFSS'>
Asn_Lv2NRSIFUNod <class 'jwst.associations.lib.rules_level2b.Asn_Lv2NRSIFUNod'>
Asn_Lv2NRSLAMPImage <class 'jwst.associations.lib.rules_level2b.Asn_Lv2NRSLAMPImage'>
Asn_Lv2NRSLAMPSpectral <class 'jwst.associations.lib.rules_level2b.Asn_Lv2NRSLAMPSpectral'>
Asn_Lv2NRSMSA <class 'jwst.associations.lib.rules_level2b.Asn_Lv2NRSMSA'>
Asn_Lv2Spec <class 'jwst.associations.lib.rules_level2b.Asn_Lv2Spec'>
Asn_Lv2SpecSpecial <class 'jwst.associations.lib.rules_level2b.Asn_Lv2SpecSpecial'>
Asn_Lv2SpecTSO <class 'jwst.associations.lib.rules_level2b.Asn_Lv2SpecTSO'>
Asn_Lv2WFSC <class 'jwst.associations.lib.rules_level2b.Asn_Lv2WFSC'>
Asn_Lv2WFSSNIS <class 'jwst.associations.lib.rules_level2b.Asn_Lv2WFSSNIS'>
Asn_Lv2WFSSNRC <class 'jwst.associations.lib.rules_level2b.Asn_Lv2WFSSNRC'>
AssociationNotValidError <class 'jwst.associations.exceptions.AssociationNotValidError'>
Constraint <class 'jwst.associations.lib.constraint.Constraint'>
Constraint_Base <class 'jwst.associations.lib.rules_level2_base.Constraint_Base'>
Constraint_ExtCal <class 'jwst.associations.lib.rules_level2_base.Constraint_ExtCal'>
Constraint_Image_Nonscience <class 'jwst.associations.lib.rules_level2_base.Constraint_Image_Nonscience'>
Constraint_Image_Science <class 'jwst.associations.lib.rules_level2_base.Constraint_Image_Science'>
Constraint_Mode <class 'jwst.associations.lib.rules_level2_base.Constraint_Mode'>
Constraint_Single_Science <class 'jwst.associations.lib.rules_level2_base.Constraint_Single_Science'>
Constraint_Special <class 'jwst.associations.lib.rules_level2_base.Constraint_Special'>
Constraint_Spectral_Science <class 'jwst.associations.lib.rules_level2_base.Constraint_Spectral_Science'>
Constraint_TSO <class 'jwst.associations.lib.dms_base.Constraint_TSO'>
Constraint_Target <class 'jwst.associations.lib.rules_level2_base.Constraint_Target'>
Constraint_WFSC <class 'jwst.associations.lib.dms_base.Constraint_WFSC'>
DMSAttrConstraint <class 'jwst.associations.lib.dms_base.DMSAttrConstraint'>
DMSLevel2bBase <class 'jwst.associations.lib.rules_level2_base.DMSLevel2bBase'>
DMS_Level3_Base <class 'jwst.associations.lib.rules_level3_base.DMS_Level3_Base'>
ListCategory <enum 'ListCategory'>
Member <class 'jwst.associations.lib.member.Member'>
RegistryMarker <class 'jwst.associations.registry.RegistryMarker'>
SimpleConstraint <class 'jwst.associations.lib.constraint.SimpleConstraint'>
Utility <class 'jwst.associations.lib.rules_level2_base.Utility'>
deque <class 'collections.deque'>
AsnMixin_AuxData <class 'jwst.associations.lib.rules_level3_base.AsnMixin_AuxData'>
AsnMixin_Science <class 'jwst.associations.lib.rules_level3_base.AsnMixin_Science'>
AsnMixin_Spectrum <class 'jwst.associations.lib.rules_level3_base.AsnMixin_Spectrum'>
Asn_Lv3ACQ_Reprocess <class 'jwst.associations.lib.rules_level3.Asn_Lv3ACQ_Reprocess'>
Asn_Lv3AMI <class 'jwst.associations.lib.rules_level3.Asn_Lv3AMI'>
Asn_Lv3Coron <class 'jwst.associations.lib.rules_level3.Asn_Lv3Coron'>
Asn_Lv3Image <class 'jwst.associations.lib.rules_level3.Asn_Lv3Image'>
Asn_Lv3ImageBackground <class 'jwst.associations.lib.rules_level3.Asn_Lv3ImageBackground'>
Asn_Lv3MIRMRS <class 'jwst.associations.lib.rules_level3.Asn_Lv3MIRMRS'>
Asn_Lv3MIRMRSBackground <class 'jwst.associations.lib.rules_level3.Asn_Lv3MIRMRSBackground'>
Asn_Lv3NRSFSS <class 'jwst.associations.lib.rules_level3.Asn_Lv3NRSFSS'>
Asn_Lv3NRSIFU <class 'jwst.associations.lib.rules_level3.Asn_Lv3NRSIFU'>
Asn_Lv3NRSIFUBackground <class 'jwst.associations.lib.rules_level3.Asn_Lv3NRSIFUBackground'>
Asn_Lv3SlitlessSpectral <class 'jwst.associations.lib.rules_level3.Asn_Lv3SlitlessSpectral'>
Asn_Lv3SpecAux <class 'jwst.associations.lib.rules_level3.Asn_Lv3SpecAux'>
Asn_Lv3SpectralSource <class 'jwst.associations.lib.rules_level3.Asn_Lv3SpectralSource'>
Asn_Lv3SpectralTarget <class 'jwst.associations.lib.rules_level3.Asn_Lv3SpectralTarget'>
Asn_Lv3TSO <class 'jwst.associations.lib.rules_level3.Asn_Lv3TSO'>
Asn_Lv3WFSCMB <class 'jwst.associations.lib.rules_level3.Asn_Lv3WFSCMB'>
Asn_Lv3WFSSNIS <class 'jwst.associations.lib.rules_level3.Asn_Lv3WFSSNIS'>
Constraint <class 'jwst.associations.lib.constraint.Constraint'>
Constraint_Base <class 'jwst.associations.lib.rules_level3_base.Constraint_Base'>
Constraint_IFU <class 'jwst.associations.lib.rules_level3_base.Constraint_IFU'>
Constraint_Image <class 'jwst.associations.lib.rules_level3_base.Constraint_Image'>
Constraint_MSA <class 'jwst.associations.lib.rules_level3_base.Constraint_MSA'>
Constraint_Obsnum <class 'jwst.associations.lib.rules_level3_base.Constraint_Obsnum'>
Constraint_Optical_Path <class 'jwst.associations.lib.rules_level3_base.Constraint_Optical_Path'>
Constraint_Spectral <class 'jwst.associations.lib.rules_level3_base.Constraint_Spectral'>
Constraint_TSO <class 'jwst.associations.lib.dms_base.Constraint_TSO'>
Constraint_Target <class 'jwst.associations.lib.rules_level3_base.Constraint_Target'>
Constraint_TargetAcq <class 'jwst.associations.lib.dms_base.Constraint_TargetAcq'>
DMSAttrConstraint <class 'jwst.associations.lib.dms_base.DMSAttrConstraint'>
DMS_Level3_Base <class 'jwst.associations.lib.rules_level3_base.DMS_Level3_Base'>
ListCategory <enum 'ListCategory'>
RegistryMarker <class 'jwst.associations.registry.RegistryMarker'>
SimpleConstraint <class 'jwst.associations.lib.constraint.SimpleConstraint'>
Utility <class 'jwst.associations.lib.rules_level3_base.Utility'>
202211291522:WARNING:jwst.associations.association.validate:Cannot validate: <class 'abc.Association'> has no schema. Presuming OK.
```

It might be picking up "rules" that are not actually rules?  Are `Utility` and `ListCategory` actually rules?  I don't follow the way rules are picked up, as I can't follow the `importlib` usage in these modules.

This PR also fixes a test that litters the repo with `jw01439-o002_wfs-image2_*_asn.json`association files by using a `tmp_path` fixture.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
