### PR TITLE
(JP-3007) Add keywords for source RA and Dec for WFSS extractions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ datamodels
 - Added ``SUB400X256ALWB`` to subarray enum list of allowed NIRCam values. This
   replaces ``SUB320ALWB``, which is retained in the ``obsolete`` enum list.
   [#7361]
-  
+
 extract_1d
 ----------
 
@@ -53,14 +53,14 @@ extract_2d
 
 - Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
 
-- JP-3007 Add keywords for source RA and Dec for WFSS extractions [#7372]
+- Add keywords for source RA and Dec for WFSS extractions [#7372]
   
 flatfield
 ---------
 
 - JP-2993 Update the flat-field ERR computation for FGS guider mode exposures to
   combine the input ERR and the flat field ERR in quadrature. [#7346]
-  
+
 general
 -------
 
@@ -68,8 +68,10 @@ general
 
 - Reorganize and expand user documentation, update docs landing page. Add install instructions, quickstart guide, and elaborate on running
   pipeline in Python and with strun. [#6919]
-  
+
 - fixed wrong Python version expected in ``__init__.py`` [#7366]
+
+- replace ``flake8`` with ``ruff`` [#7054]
 
 guider_cds
 ----------
@@ -102,6 +104,8 @@ resample
   images that have contributed with flux to an output (resampled)
   pixel. [#7345]
 
+- Fixed a bug in the definition of the output WCS for NIRSpec. [#7359]
+
 tweakreg
 --------
 
@@ -110,7 +114,7 @@ tweakreg
 
 - Fix a bug in the logic that handles inputs with a single image group when
   an absolute reference catalog is provided. [#7328]
-  
+
 1.8.4 (2022-11-15)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,8 @@ extract_2d
 
 - Fix slice limits used in extraction of WFSS 2D cutouts. [#7312]
 
+- JP-3007 Add keywords for source RA and Dec for WFSS extractions [#7372]
+  
 flatfield
 ---------
 

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -481,6 +481,7 @@ def extract_grism_objects(input_model,
                 new_slit.meta.wcsinfo.specsys = input_model.meta.wcsinfo.specsys
                 new_slit.meta.coordinates = input_model.meta.coordinates
                 new_slit.meta.wcs = subwcs
+
                 if compute_wavelength:
                     log.debug("Computing wavelengths")
                     new_slit.wavelength = compute_wavelength_array(new_slit)
@@ -497,6 +498,8 @@ def extract_grism_objects(input_model,
                 new_slit.source_xpos = float(obj.xcentroid)
                 new_slit.source_ypos = float(obj.ycentroid)
                 new_slit.source_id = obj.sid
+                new_slit.source_dec = obj.sky_centroid.dec.value
+                new_slit.source_ra = obj.sky_centroid.ra.value
                 new_slit.bunit_data = input_model.meta.bunit_data
                 new_slit.bunit_err = input_model.meta.bunit_err
                 slits.append(new_slit)

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -387,6 +387,10 @@ def test_extract_wfss_object():
     ids = [slit.source_id for slit in outmodel.slits]
     assert ids == [9, 19, 19]
 
+    # Compare SRCDEC and SRCRA values
+    assert np.isclose(outmodel[0].source_dec, -27.80858320887945)
+    assert np.isclose(outmodel[0].source_ra, 53.13773660029234)
+
     names = [slit.name for slit in outmodel.slits]
     assert names == ['9', '19', '19']
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3007](https://jira.stsci.edu/browse/JP-3007)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #3007

<!-- describe the changes comprising this PR here -->
This PR populates the slit-specifc keywords "SRCRA, SRCDEC" (whose meta attributes "source_ra, source_dec") for WFSS extractions.

**Checklist for maintainers**
- [X] added entry in `CHANGES.rst` within the relevant release section
- [X] updated or added relevant tests
- [X] updated relevant documentation
- [X] added relevant milestone
- [X] added relevant label(s)
- [X] ran regression tests, post a link to the Jenkins job below.
      (https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/474/#showFailuresLink)

(https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
