### PR TITLE
JP-2921: Add FITS WCS keywords to WFSS mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ assign_wcs
 - Updated the loading of NIRSpec MSA configuration data to assign the source_id
   for each slitlet from the shutter entry that contains the primary/main source. [#7379]
 
+- Added approximated imaging FITS WCS to the grism image headers. [#7373]
+
 associations
 ------------
 

--- a/docs/jwst/assign_wcs/main.rst
+++ b/docs/jwst/assign_wcs/main.rst
@@ -33,7 +33,7 @@ for display purposes. This step, which occurs for imaging modes early, is perfor
 can be switched off, and parameters controlling the fit can also be adjusted.
 
 
-``jwst.assign_wcs`` is based on `gwcs<https://github.com/spacetelescope/gwcs>`__ and
+``jwst.assign_wcs`` is based on `gwcs <https://gwcs.readthedocs.io/en/latest/>`__ and
 uses `asdf <http://asdf.readthedocs.io/en/latest/>`__.
 
 

--- a/docs/jwst/assign_wcs/main.rst
+++ b/docs/jwst/assign_wcs/main.rst
@@ -30,7 +30,11 @@ For image display with software like DS9 that relies on specific WCS information
 approximation to the WCS is fit. The results are FITS keywords stored in
 ``model.meta.wcsinfo``. This is not an exact fit, but is accurate to ~0.25 pixel and is sufficient
 for display purposes. This step, which occurs for imaging modes early, is performed by default but
-can be switched off, and parameters controlling the fit can also be adjusted. 
+can be switched off, and parameters controlling the fit can also be adjusted.
+
+
+``jwst.assign_wcs`` is based on `gwcs<https://github.com/spacetelescope/gwcs>`__ and
+uses `asdf <http://asdf.readthedocs.io/en/latest/>`__.
 
 
 
@@ -123,15 +127,9 @@ For NIRISS WFSS data the reference files contain a reference value for the filte
 position angle. The trace is rotated about an angle which is the difference between
 the reference and actual angles.
 
-``jwst.assign_wcs`` is based on gwcs and uses the modeling, units and coordinates subpackages in astropy.
-
-- `gwcs <https://github.com/spacetelescope/gwcs>`__
-
-- `numpy <http://www.numpy.org/>`__
-
-- `astropy <http://www.astropy.org/>`__
-
-- `asdf <http://asdf.readthedocs.io/en/latest/>`__
+For WFSS modes (``NIS_WFSS``, ``NRC_WFSS``), an approximation of the GWCS object
+associated with a direct image with the same instrument configuration as the grism image
+is saved as FITS WCS in the headers of grism images.
 
 Corrections Due to Spacecraft Motion
 ------------------------------------

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -93,5 +93,6 @@ def load_wcs(input_model, reference_files={}, nrs_slit_y_range=None):
                 except Exception as exc:
                     log.info("Unable to update S_REGION for type {}: {}".format(
                         output_model.meta.exposure.type, exc))
+
     log.info("COMPLETED assign_wcs")
     return output_model

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -5,12 +5,18 @@ from ..lib.exposure_types import IMAGING_TYPES
 import logging
 from .assign_wcs import load_wcs
 from .util import MSAFileError, update_fits_wcsinfo
+from .util import wfss_imaging_wcs, wcs_bbox_from_shape
+from .nircam import imaging as nircam_imaging
+from .niriss import imaging as niriss_imaging
 
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 __all__ = ["AssignWcsStep"]
+
+
+WFSS_TYPES = set(['nrc_wfss', 'nis_wfss'])
 
 
 class AssignWcsStep(Step):
@@ -92,23 +98,43 @@ class AssignWcsStep(Step):
             slit_y_range = [self.slit_y_low, self.slit_y_high]
             result = load_wcs(input_model, reference_file_names, slit_y_range)
 
-        if not (result.meta.exposure.type.lower() in IMAGING_TYPES and self.sip_approx):
+        if not (result.meta.exposure.type.lower() in (IMAGING_TYPES.union(WFSS_TYPES)) and self.sip_approx):
             return result
 
+        result_exptype = result.meta.exposure.type.lower()
         # fit sip approx., degree is chosen by best fit
-        try:
-            update_fits_wcsinfo(
-                result,
-                max_pix_error=self.sip_max_pix_error,
-                degree=self.sip_degree,
-                max_inv_pix_error=self.sip_max_inv_pix_error,
-                inv_degree=self.sip_inv_degree,
-                npoints=self.sip_npoints,
-                crpix=None
-            )
+        if result_exptype in IMAGING_TYPES:
+            try:
+                log.info(f'HEEY, {result.meta.exposure.type}')
+                update_fits_wcsinfo(
+                    result,
+                    max_pix_error=self.sip_max_pix_error,
+                    degree=self.sip_degree,
+                    max_inv_pix_error=self.sip_max_inv_pix_error,
+                    inv_degree=self.sip_inv_degree,
+                    npoints=self.sip_npoints,
+                    crpix=None
+                )
 
-        except (ValueError, RuntimeError) as e:
-            log.warning("Failed to update 'meta.wcsinfo' with FITS SIP "
-                        f'approximation. Reported error is:\n"{e.args[0]}"')
+            except (ValueError, RuntimeError) as e:
+                log.warning("Failed to update 'meta.wcsinfo' with FITS SIP "
+                            f'approximation. Reported error is:\n"{e.args[0]}"')
+        else:  # WFSS modes
+            try:
+                # A bounding_box is needed for the imaging WCS
+                bbox = wcs_bbox_from_shape(result.data.shape)
+                if result_exptype == 'nis_wfss':
+                    imaging_func = niriss_imaging
+                else:
+                    imaging_func = nircam_imaging
+
+                wfss_imaging_wcs(result, imaging_func, bbox=bbox,
+                                 max_pix_error=self.sip_max_pix_error,
+                                 degree=self.sip_degree,
+                                 npoints=self.sip_npoints,
+                                 )
+            except (ValueError, RuntimeError) as e:
+                log.warning("Failed to update 'meta.wcsinfo' with FITS SIP "
+                            f'approximation. Reported error is:\n"{e.args[0]}"')
 
         return result

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -105,7 +105,6 @@ class AssignWcsStep(Step):
         # fit sip approx., degree is chosen by best fit
         if result_exptype in IMAGING_TYPES:
             try:
-                log.info(f'HEEY, {result.meta.exposure.type}')
                 update_fits_wcsinfo(
                     result,
                     max_pix_error=self.sip_max_pix_error,

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -10,7 +10,7 @@ from gwcs import wcs
 
 from .util import (not_implemented_mode, subarray_transform,
                    velocity_correction, bounding_box_from_subarray,
-                   wcs_bbox_from_shape)
+                   transform_bbox_from_shape)
 from . import pointing
 from ..transforms.models import (NirissSOSSModel,
                                  NIRISSForwardRowGrismDispersion,
@@ -314,7 +314,7 @@ def imaging_distortion(input_model, reference_files):
         else:
             log.debug("No match in fitleroffset file.")
     if bbox is None:
-        distortion.bounding_box = wcs_bbox_from_shape(input_model.data.shape)
+        distortion.bounding_box = transform_bbox_from_shape(input_model.data.shape)
     else:
         distortion.bounding_box = bbox
     return distortion

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -10,7 +10,7 @@ from gwcs import wcs
 
 from .util import (not_implemented_mode, subarray_transform,
                    velocity_correction, bounding_box_from_subarray,
-                   transform_bbox_from_shape)
+                   wcs_bbox_from_shape)
 from . import pointing
 from ..transforms.models import (NirissSOSSModel,
                                  NIRISSForwardRowGrismDispersion,
@@ -314,7 +314,7 @@ def imaging_distortion(input_model, reference_files):
         else:
             log.debug("No match in fitleroffset file.")
     if bbox is None:
-        distortion.bounding_box = transform_bbox_from_shape(input_model.data.shape)
+        distortion.bounding_box = wcs_bbox_from_shape(input_model.data.shape)
     else:
         distortion.bounding_box = bbox
     return distortion

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -19,6 +19,7 @@ from jwst.datamodels.image import ImageModel
 from jwst.datamodels import CubeModel
 from jwst.assign_wcs.assign_wcs_step import AssignWcsStep
 from jwst.assign_wcs import nircam
+from jwst.assign_wcs import util
 
 
 # Allowed settings for nircam
@@ -243,3 +244,15 @@ def test_imaging_distortion():
     assert_allclose(y, wcs_wfss_kw['crpix2'])
     assert_allclose(raout, ra)
     assert_allclose(decout, dec)
+
+
+def test_wfss_sip():
+    hdul = create_hdul(filtername='F444W', pupil='GRISMR', exptype='NRC_WFSS')
+    wfss_model = ImageModel(hdul)
+    ref = get_reference_files(wfss_model)
+    pipeline = nircam.create_pipeline(wfss_model, ref)
+    wcsobj = wcs.WCS(pipeline)
+    wfss_model.meta.wcs = wcsobj
+    util.wfss_imaging_wcs(wfss_model, nircam.imaging, bbox=((1, 1024), (1, 1024)))
+    for key in ['a_order', 'b_order', 'crpix1', 'crpix2', 'crval1', 'crval2', 'cd1_1']:
+        assert key in wfss_model.meta.wcsinfo.instance

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -203,6 +203,8 @@ def test_create_box_fits():
     source_catalog = get_file_path('step_SourceCatalogStep_cat.ecsv')
     hdul = create_hdul(exptype='NRC_WFSS', pupil='GRISMR', wcskeys=wcs_wfss_kw)
     im = ImageModel(hdul)
+    # Add fake data to pass a shape to wfss_imaging_wcs
+    im.data = np.zeros((512, 512))
     aswcs = AssignWcsStep()
     imwcs = aswcs(im)
     imwcs.meta.source_catalog = source_catalog
@@ -233,6 +235,9 @@ def test_create_box_gwcs():
     source_catalog = get_file_path('step_SourceCatalogStep_cat.ecsv')
     hdul = create_hdul(exptype='NRC_WFSS', pupil='GRISMR', wcskeys=wcs_wfss_kw)
     im = ImageModel(hdul)
+    # Add fake data to pass a shape to wfss_imaging_wcs
+    # The data array is not relevant
+    im.data = np.zeros((512, 512))
     aswcs = AssignWcsStep()
     imwcs = aswcs(im)
     imwcs.meta.source_catalog = source_catalog
@@ -256,6 +261,8 @@ def setup_image_cat():
     source_catalog = get_file_path('step_SourceCatalogStep_cat.ecsv')
     hdul = create_hdul(exptype='NRC_WFSS', pupil='GRISMR', wcskeys=wcs_wfss_kw)
     im = ImageModel(hdul)
+    # Add fake data to pass a shape to wfss_imaging_wcs
+    im.data = np.zeros((512, 512))
     im.meta.source_catalog = source_catalog
     aswcs = AssignWcsStep()
     imwcs = aswcs(im)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-2921](https://jira.stsci.edu/browse/JP-2921)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7286 

<!-- describe the changes comprising this PR here -->
This PR adds the approximated FITS WCS keywords to WFSS files. The WCS is associated with a corresponding direct image and is NOT the spectral WCS associated with the grism image which is stored, as usual, in the GWCS object.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression tests - failures are expected or inherited.

https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/515/