### PR TITLE
JP-3009: Add cleanups for files left behind while running tests

### DIFF
--- a/jwst/associations/tests/test_level3_wfscmb.py
+++ b/jwst/associations/tests/test_level3_wfscmb.py
@@ -80,14 +80,14 @@ def jitter_present(jitter, associations):
     return False
 
 
-def test_level3_wfscmb_jitter_suppression():
+def test_level3_wfscmb_jitter_suppression(tmp_path):
     """
     Make sure no candidate from the pool with DMS_NOTE equal to
     WFSC_LOS_JITTER is in any association.
     """
     pfile = "data/pool_033_wfs_jitter.csv"
     with mkstemp_pool_file(t_path(pfile)) as pool_path:
-        cmd_args = [pool_path]
+        cmd_args = [pool_path, f"--path={tmp_path}"]
         generated = Main(cmd_args)
         jitter = get_jitter_not_jitter(pool_path)
 

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -251,7 +251,7 @@ def test_outlier_step_square_source_no_outliers(we_three_sci, _jail):
 
 
 @pytest.mark.parametrize("exptype", IMAGE_MODES)
-def test_outlier_step_image_weak_CR_dither(exptype):
+def test_outlier_step_image_weak_CR_dither(exptype, _jail):
     """Test whole step with an outlier for imaging modes"""
     bkg = 1.5
     sig = 0.02
@@ -278,7 +278,7 @@ def test_outlier_step_image_weak_CR_dither(exptype):
 
 
 @pytest.mark.parametrize("exptype, tsovisit", exptypes_tso + exptypes_coron)
-def test_outlier_step_image_weak_CR_nodither(exptype, tsovisit):
+def test_outlier_step_image_weak_CR_nodither(exptype, tsovisit, _jail):
     """Test whole step with an outlier for TSO & coronagraphic modes"""
     bkg = 1.5
     sig = 0.02


### PR DESCRIPTION
Resolves [JP-3009](https://jira.stsci.edu/browse/JP-3009)

<!-- describe the changes comprising this PR here -->
This PR adds fixtures to a few tests so that those tests do not leave files generated and saved while running the tests behind. The unit tests for JWST should not leave behind "artifacts" after running as this could interfere with re-running tests and/or lead to those files accidentally being picked up by git.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
