### PR TITLE
JP-2969: Fix MOS handling of source IDs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ assign_wcs
 
 - Fix computation of bounding box corners for WFSS grism 2D cutouts. [#7312]
 
+- Updated the loading of NIRSpec MSA configuration data to assign the source_id
+  for each slitlet from the shutter entry that contains the primary/main source. [#7379]
+
 associations
 ------------
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2969](https://jira.stsci.edu/browse/JP-2969)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7227 

<!-- describe the changes comprising this PR here -->
This PR makes a simple update to the function in the assign_wcs step that does all the parsing of info from the MSA metadata file for NIRSpec MOS exposures. There are now instances where the source_id in the meta data is only set to a non-zero value for the one shutter that contains the primary source, rather than having the same source_id entry for all shutters contained in the slitlet. So this changes the code that retrieves the source_id for a given slitlet to use the value from the primary shutter, rather than just taking it from the first shutter in the slitlet (which can now be zero).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
