### PR TITLE
use parallel processes to check dependencies

### DIFF
--- a/scripts/verify_install_requires
+++ b/scripts/verify_install_requires
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import argparse
 import pkgutil
+from concurrent.futures import ProcessPoolExecutor
 from importlib import import_module
-import os
 
 import jwst
 
@@ -29,9 +29,14 @@ def main():
 
     no_check = ["test", "time"]
 
-    for importer, module_name, ispkg in pkgutil.walk_packages(package.__path__, prefix=prefix):
-        if not any(True for word in no_check if word in module_name):
-            module = import_module(module_name)
+    modules = [
+        module_name
+        for _, module_name, _ in pkgutil.walk_packages(package.__path__, prefix=prefix)
+        if not any(word in module_name for word in no_check)
+    ]
+
+    with ProcessPoolExecutor() as process_pool:
+        process_pool.map(import_module, modules)
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
 
 [testenv:check-dependencies]
 description = verify that install_requires in setup.cfg has correct dependencies
+usedevelop = true
 commands =
     verify_install_requires
 

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,8 @@ description =
     cov: with coverage
     xdist: using parallel processing
 # The following indicates which extras_require from setup.cfg will be installed
-extras = test
+extras =
+    !check: test
 # Pass through the following environment variables which may be needed for the CI
 passenv =
     TOXENV


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR attempts to speed up `verify_install_requires` in the `check-dependencies` toxenv

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
