### PR TITLE
JP-2922: Update level-3 spectral product naming

### DIFF
--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -595,7 +595,7 @@ class Utility():
 # Define default product name filling
 format_product = FormatTemplate(
     key_formats={
-        'source_id': ['s{:05d}', 's{:s}'],
+        'source_id': ['{:09d}', '{:9s}'],
         'expspcin': ['{:0>2s}']
 
     }

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -200,11 +200,23 @@ class Spec3Pipeline(Pipeline):
         for source in sources:
 
             # If each source is a SourceModelContainer
-            # the output name needs to be updated with the source name.
+            # the output name needs to be updated with the source ID.
             if isinstance(source, tuple):
                 source_id, result = source
+                if int(source_id) < 0:
+                    # These are virtual slits/sources (no catalog source) and
+                    # are identified by a negative source_id in the MSA
+                    # configuration data.
+                    tmp_src_id = "v{:0>9d}".format(-int(source_id))
+                elif result[0].source_name[:10] == 'background':
+                    # These are dedicated background slits/sources, previously
+                    # updated to have the prefix "background" in their names
+                    tmp_src_id = "b{:0>9d}".format(int(source_id))
+                else:
+                    # Everything else is a regular catalog source
+                    tmp_src_id = "s{:0>9d}".format(int(source_id))
                 self.output_file = format_product(
-                    output_file, source_id=source_id.lower()
+                    output_file, source_id=tmp_src_id.lower()
                 )
             else:
                 result = source


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2922](https://jira.stsci.edu/browse/JP-2922)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7287 

<!-- describe the changes comprising this PR here -->
This PR implements the long-term fix for handling NIRSpec MOS source id's that have negative and very long values. It increases the length of the `source_id` field in level-3 source-based product names from 5 to 9 characters and uses the 3 prefixes "s", "b", and "v" to indicates source slits, background slits, and virtual (no catalog source) slits, respectively.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
