### PR TITLE
JP-3019: Remove code trimming zero-valued cube planes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,7 @@ cube_build
   from 0 to nan. [#7337]
 
 - Remove code trimming zero-valued planes from cubes, so that cubes of fixed length will always
-  be produced. Move nan-value setting to below spectral tear cleanup. []
+  be produced. Move nan-value setting to below spectral tear cleanup. [#7391]
 
 datamodels
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ cube_build
 - Change fill value for regions of SCI and ERR extensions with no data
   from 0 to nan. [#7337]
 
+- Remove code trimming zero-valued planes from cubes, so that cubes of fixed length will always
+  be produced. Move nan-value setting to below spectral tear cleanup. []
+
 datamodels
 ----------
 

--- a/docs/jwst/cube_build/main.rst
+++ b/docs/jwst/cube_build/main.rst
@@ -175,7 +175,7 @@ contains the number of point cloud elements contained in the region of interest 
 dq flags from previous steps but is defined in the cube build step as: good data (value = 0), non_science (value = 512), do_not_use(value =1), or a combination of non_science and do_not_use (value = 513).  
 
 The SCI and ERR cubes are populated with NaN values for voxels where there is no valid data (e.g., outside
-the IFU cube footprint).
+the IFU cube footprint or for saturated pixels for which no slope could be measured).
 
 Output Product Name
 -------------------


### PR DESCRIPTION
Resolves [JP-3019](https://jira.stsci.edu/browse/JP-3019)

Given other updates in the past couple years this is no longer necessary, and always producing cubes of known size is helpful for both science analyses and MAST.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
