### PR TITLE
Update deprecation notice to name the CRDS_PATH variable appropriately

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,11 @@ datamodels
   replaces ``SUB320ALWB``, which is retained in the ``obsolete`` enum list.
   [#7361]
 
+documentation
+-------------
+
+- Update deprecation notice to name the CRDS_PATH variable appropriately. [#7392]
+
 extract_1d
 ----------
 

--- a/docs/jwst/user_documentation/pub_deprecation.rst
+++ b/docs/jwst/user_documentation/pub_deprecation.rst
@@ -62,11 +62,11 @@ home folder, using Linux, the command is:
 
    $ mkdir $HOME/crds_cache
 
-Then set CRDS_CACHE to point to this new, empty folder:
+Then set CRDS_PATH to point to this new, empty folder:
 
 ::
 
-   $ export CRDS_CACHE=$HOME/crds_cache
+   $ export CRDS_PATH=$HOME/crds_cache
 
 The important point is that whatever folder is to be used to hold the CRDS cache
 should initially be empty; no other content should be present in the folder.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves user incident report INC0184702

<!-- describe the changes comprising this PR here -->
This PR addresses yet another typo in the naming of the CRDS_PATH environment variable.

Developer cannot be trusted to write documentation...

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] ~updated or added relevant tests~
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ~ran regression tests, post a link to the Jenkins job below.~
- [ ] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
