### PR TITLE
JP-2671 Update slit model to include var_flat

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ datamodels
   replaces ``SUB320ALWB``, which is retained in the ``obsolete`` enum list.
   [#7361]
 
+- Added var_flat to the initialization in slit.py [#7397]
+
 documentation
 -------------
 

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -26,6 +26,9 @@ class SlitDataModel(JwstDataModel):
     var_rnoise : numpy float32 array
          variance due to read noise
 
+    var_flat : numpy float32 array
+         variance due to flat
+
     wavelength : numpy float32 array
          Wavelength array, corrected for zero-point
 
@@ -67,6 +70,8 @@ class SlitDataModel(JwstDataModel):
                 self.var_poisson = init.var_poisson
             if init.hasattr('var_rnoise'):
                 self.var_rnoise = init.var_rnoise
+            if init.hasattr('var_flat'):
+                self.var_flat = init.var_flat
             if init.hasattr('wavelength'):
                 self.wavelength = init.wavelength
             for key in kwargs:
@@ -103,6 +108,9 @@ class SlitModel(JwstDataModel):
 
     var_rnoise : numpy float32 array
          variance due to read noise
+
+    var_flat : numpy float32 array
+         variance due to flat
 
     wavelength : numpy float32 array
          Wavelength array, corrected for zero-point
@@ -148,6 +156,8 @@ class SlitModel(JwstDataModel):
                 self.var_poisson = init.var_poisson
             if init.hasattr('var_rnoise'):
                 self.var_rnoise = init.var_rnoise
+            if init.hasattr('var_flat'):
+                self.var_flat = init.var_flat
             if init.hasattr('wavelength'):
                 self.wavelength = init.wavelength
             if init.hasattr('int_times'):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
JP-2671 has four issues and this PR resolves only first issue:  LRS data does not have a value for var_flat for s2d or x1d. 
Resolves  only part 1 pf [JP-2671](https://jira.stsci.edu/browse/JP-2671)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes a portion of #7223 

<!-- describe the changes comprising this PR here -->
This PR adds var_flat to the slit.py model, which appears to have been unintentionally omitted. The products after the cal files now contain valid var_flat values.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
