### PR TITLE
JP-3005: Pixel replacement for flagged pixels before spectral extraction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -186,6 +186,12 @@ pipeline
   calling the ``resample_spec`` and ``extract_1d`` steps, to avoid issues with the
   input data accidentally getting modified by those steps. [#7451]
 
+pixel_replace
+-------------
+
+- Add ``pixel_replace`` step to pipeline, which uses a weighted interpolation
+  to estimate flux values for pixels flagged as ``DO_NOT_USE``. [#7398]
+
 ramp_fitting
 ------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,7 +189,7 @@ pipeline
 pixel_replace
 -------------
 
-- Add ``pixel_replace`` step to pipeline, which uses a weighted interpolation
+- Add ``pixel_replace`` step to ``Spec2Pipeline``, which uses a weighted interpolation
   to estimate flux values for pixels flagged as ``DO_NOT_USE``. [#7398]
 
 ramp_fitting

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -77,6 +77,8 @@ TSO exposures. The instrument mode abbreviations used in the table are as follow
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
 | :ref:`residual_fringe <residual_fringe_step>` \ :sup:`2` |     |     |     |     |     | |c| |      |      |        |     |
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
+| :ref:`pixel_replace <pixel_replace_step>` \ :sup:`2`     | |c| | |c| |     | |c| | |c| |     |      | |c|  |  |c|   |     |
++----------------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
 | :ref:`resample_spec <resample_step>`                     | |c| | |c| |     | |c| |     |     |      |      |        |     |
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
 | :ref:`cube_build <cube_build_step>`                      |     |     | |c| |     |     | |c| |      |      |        |     |
@@ -90,7 +92,7 @@ For NIRISS and NIRCam WFSS, as well as NIRCam TSO grism exposures, the order is
 flat_field, extract_2d, and srctype (no wavecorr).
 For all other modes the order is extract_2d, srctype, wavecorr, and flat_field.
 
-:sup:`2`\ By default the :ref:`residual_fringe <residual_fringe_step>` is skipped in the ``calwebb_spec2`` pipeline. 
+:sup:`2`\ By default this step is skipped in the ``calwebb_spec2`` pipeline.
 
 Notice that NIRSpec MOS is the only mode to receive master background subtraction
 in the ``calwebb_spec2`` pipeline. All other spectral modes have master background

--- a/docs/jwst/pixel_replace/arguments.rst
+++ b/docs/jwst/pixel_replace/arguments.rst
@@ -1,0 +1,15 @@
+Step Arguments
+==============
+
+The ``pixel_replace`` step has the following step-specific arguments:
+
+``--algorithm`` (str, default='fit_profile')
+  This sets the method used to estimate flux values for bad pixels. Only one
+  option has been implemented so far, using a profile fit to adjacent column values.
+
+``--n_adjacent_cols`` (int, default=3)
+  Number of adjacent columns (on either side of column containing a bad pixel) to use in
+  creation of the source profile, in cross-dispersion direction. The total number of
+  columns used in the profile will be twice this number; on array edges, the total number
+  of columns contributing to the source profile will be less than ``2 * n_adjacent_cols``.
+

--- a/docs/jwst/pixel_replace/index.rst
+++ b/docs/jwst/pixel_replace/index.rst
@@ -1,0 +1,13 @@
+.. _pixel_replace_step:
+
+===============
+Pixel Replacement
+===============
+
+.. toctree::
+   :maxdepth: 2
+
+   main.rst
+   arguments.rst
+
+.. automodapi:: jwst.pixel_replace.pixel_replace_step

--- a/docs/jwst/pixel_replace/index.rst
+++ b/docs/jwst/pixel_replace/index.rst
@@ -9,5 +9,6 @@ Pixel Replacement
 
    main.rst
    arguments.rst
+   reference_files.rst
 
 .. automodapi:: jwst.pixel_replace.pixel_replace_step

--- a/docs/jwst/pixel_replace/main.rst
+++ b/docs/jwst/pixel_replace/main.rst
@@ -1,0 +1,34 @@
+Description
+===========
+
+:Classes: `jwst.pixel_replace.PixelReplaceStep`
+:Alias: pixel_replace
+
+During spectral extraction, pixels flagged as bad are ignored in the summation process.
+If a bad pixel is part of the point-spread function (PSF) at a given wavelength, the
+absence of the signal in the flagged pixel will lead to a divot at that wavelength in
+the extracted spectrum.
+
+To avoid this defect in the 1-D spectrum, this step estimates the flux values of pixels
+flagged as ``DO_NOT_USE`` in 2-D extracted spectra, prior to rectification in the
+``resample_spec`` step. ``pixel_replace`` inserts these estimates into the data array,
+unsets the ``DO_NOT_USE`` flag and sets the ``FLUX_ESTIMATED`` flag for each pixel affected.
+
+Algorithms
+==========
+
+Currently, one algorithm has been tested to estimate the missing fluxes.
+
+Adjacent Profile Approximation
+------------------------------
+
+First, the input 2-d spectral cutout is scanned across the dispersion axis to determine
+which cross-dispersion vectors (column or row, depending on dispersion direction) contain
+at least one flagged pixel. Next, for each affected vector, a median normalized profile is created.
+
+First, the adjacent arrays (the number of which is set by the step argument
+``n_adjacent_cols``) are individually normalized. Next, each pixel in the profile is set to
+the median of the normalized values. This results in a median of normalized values filling the vector.
+
+Finally, this profile is scaled to the vector containing a missing pixel, and the value is
+estimated from the scaled profile.

--- a/docs/jwst/pixel_replace/reference_files.rst
+++ b/docs/jwst/pixel_replace/reference_files.rst
@@ -1,0 +1,4 @@
+Reference File
+==============
+
+This step does not use any reference file.

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -602,7 +602,7 @@ Bit  Value         Name              Description
 4    16            OUTLIER           Flagged by outlier detection
 5    32            PERSISTENCE       High persistence
 6    64            AD_FLOOR          Below A/D floor
-7    128           RESERVED
+7    128           UNDERSAMP         Undersampling correction
 8    256           UNRELIABLE_ERROR  Uncertainty exceeds quoted error
 9    512           NON_SCIENCE       Pixel not on science portion of detector
 10   1024          DEAD              Dead pixel
@@ -623,7 +623,7 @@ Bit  Value         Name              Description
 25   33554432      UNRELIABLE_FLAT   Flat variance large
 26   67108864      OPEN              Open pixel (counts move to adjacent pixels)
 27   134217728     ADJ_OPEN          Adjacent to open pixel
-28   268435456     UNRELIABLE_RESET  Sensitive to reset anomaly
+28   268435456     FLUX_ESTIMATED    Pixel flux estimated due to missing/bad data
 29   536870912     MSA_FAILED_OPEN   Pixel sees light from failed-open shutter
 30   1073741824    OTHER_BAD_PIXEL   A catch-all flag
 31   2147483648    REFERENCE_PIXEL   Pixel is a reference pixel

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -190,6 +190,7 @@ _calculated_suffixes = {
     'wavecorrstep',
     'wfsscontamstep',
     'undersamplingcorrectionstep',
+    'pixelreplacestep',
 }
 
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -276,7 +276,7 @@ class Spec2Pipeline(Pipeline):
         calibrated.meta.asn.table_name = op.basename(asn_file)
         calibrated.meta.filename = self.make_output_path(suffix=suffix)
 
-        # Replace pixels before rectification
+        # Replace bad pixels before rectification
         calibrated = self.pixel_replace(calibrated)
 
         # Produce a resampled product, either via resample_spec for

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -276,6 +276,9 @@ class Spec2Pipeline(Pipeline):
         calibrated.meta.asn.table_name = op.basename(asn_file)
         calibrated.meta.filename = self.make_output_path(suffix=suffix)
 
+        # Replace pixels before rectification
+        calibrated = self.pixel_replace(calibrated)
+
         # Produce a resampled product, either via resample_spec for
         # "regular" spectra or cube_build for IFU data. No resampled
         # product is produced for time-series modes.

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -25,6 +25,7 @@ from ..master_background import master_background_mos_step
 from ..msaflagopen import msaflagopen_step
 from ..pathloss import pathloss_step
 from ..photom import photom_step
+from ..pixel_replace import pixel_replace_step
 from ..resample import resample_spec_step
 from ..srctype import srctype_step
 from ..straylight import straylight_step
@@ -78,6 +79,7 @@ class Spec2Pipeline(Pipeline):
         'barshadow': barshadow_step.BarShadowStep,
         'wfss_contam': wfss_contam_step.WfssContamStep,
         'photom': photom_step.PhotomStep,
+        'pixel_replace': pixel_replace_step.PixelReplaceStep,
         'resample_spec': resample_spec_step.ResampleSpecStep,
         'cube_build': cube_build_step.CubeBuildStep,
         'extract_1d': extract_1d_step.Extract1dStep

--- a/jwst/pixel_replace/__init__.py
+++ b/jwst/pixel_replace/__init__.py
@@ -1,0 +1,3 @@
+from .pixel_replace_step import PixelReplaceStep
+
+__all__ = ["PixelReplaceStep"]

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -161,7 +161,6 @@ class PixelReplacement:
         # dispersion direction by indexing data shape with
         # strange dispaxis argument. Keep indices in full-frame numbering scheme,
         # but only iterate through slices with valid data.
-        log.debug(f"Number of profiles with at least one bad pixel: {len(profiles_to_replace)}")
         for ind in range(*valid_shape[2 - dispaxis]):
             # Exclude regions with no data for dq slice.
             dq_slice = model.dq[self.custom_slice(dispaxis, ind)][profile_cut[0]: profile_cut[1]]
@@ -175,6 +174,8 @@ class PixelReplacement:
             else:
                 log.debug(f"Slice {ind} contains {n_bad} bad pixels.")
                 profiles_to_replace.add(ind)
+
+        log.debug(f"Number of profiles with at least one bad pixel: {len(profiles_to_replace)}")
 
         ## check_output = np.zeros((profile_cut[1]-profile_cut[0], len(valid_profiles)))
         for i, ind in enumerate(profiles_to_replace):

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -254,7 +254,7 @@ class PixelReplacement:
             # Exclude regions with NON_SCIENCE flag
             dq_slice = np.where(
                 dq_slice & self.NON_SCIENCE,
-                512,
+                self.NON_SCIENCE,
                 dq_slice
             )
             # Find bad pixels in region containing valid data.
@@ -270,9 +270,7 @@ class PixelReplacement:
 
         log.debug(f"Number of profiles with at least one bad pixel: {len(profiles_to_replace)}")
 
-        # check_output = np.zeros((profile_cut[1]-profile_cut[0], len(valid_profiles)))
         for i, ind in enumerate(profiles_to_replace):
-            # for i, ind in enumerate(valid_profiles):
 
             # Use sets for convenient finding of neighboring slices to use in profile creation
             adjacent_inds = set(range(ind - self.pars['n_adjacent_cols'], ind + self.pars['n_adjacent_cols'] + 1))
@@ -330,10 +328,6 @@ class PixelReplacement:
 
             model_replaced.data[self.custom_slice(dispaxis, ind)][range(*profile_cut)] = replaced_current
             model_replaced.dq[self.custom_slice(dispaxis, ind)][range(*profile_cut)] = replaced_dq
-
-        # import matplotlib.pyplot as plt
-        # plt.imshow(check_output.T)
-        # plt.show()
 
         return model_replaced
 

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from .. import datamodels
+from stdatamodels.jwst import datamodels
 from scipy.optimize import minimize
 import warnings
 from ..assign_wcs.nirspec import nrs_wcs_set_input
@@ -59,7 +59,7 @@ class PixelReplacement:
 
         except KeyError:
             log.critical(f"Algorithm name {self.pars['algorithm']} provided does "
-                         f"not match an implemented algorithm!")
+                         "not match an implemented algorithm!")
             raise Exception
 
     def replace(self):
@@ -168,10 +168,6 @@ class PixelReplacement:
         # CubeModel inputs are TSO (so far?); only SlitModel seen so far is NRS_BRIGHTOBJ, also requiring
         # a re-packaging of the data into 2D inputs for the algorithm.
         elif isinstance(self.input, (datamodels.CubeModel, datamodels.SlitModel)):
-            if len(self.input.data) != len(self.input.dq):
-                log.critical("Data and DQ arrays are not of equal length - skipping pixel replacement.")
-                return
-
             # Initial attempt looped over model.meta.exposure.nints, but test data had mismatch. Could change this.
             for i in range(len(self.input.data)):
                 dummy_model = datamodels.ImageModel(data=self.input.data[i], dq=self.input.dq[i])
@@ -185,11 +181,10 @@ class PixelReplacement:
                 dummy_replaced.close()
                 dummy_model.close()
 
-
         else:
-            # This should never happen, as these would be caught in the step code.
-            log.critical("How did we get here?")
-            raise Exception
+            # This should never happen, as these should be caught in the step code.
+            log.critical("Pixel replacement code did not filter this input correctly - skipping step.")
+            return
 
     def fit_profile(self, model):
         """

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -1,0 +1,146 @@
+import logging
+import numpy as np
+from .. import datamodels
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+class PixelReplacement:
+    """Main class for performing pixel replacement.
+
+    This class controls loading the input data model, selecting the
+    method for pixel replacement, and executing each step. This class
+    should provide modularization to allow for multiple options and possible
+    future reference files.
+
+    """
+
+    # Shortcuts for DQ Flags
+    DO_NOT_USE = datamodels.dqflags.pixel['DO_NOT_USE']
+    REPLACED = datamodels.dqflags.pixel['RESERVED_4']
+
+    # Shortcuts for dispersion direction for ease of reading
+    HORIZONTAL = 1
+    VERTICAL = 2
+
+    default_suffix = 'pixrep'
+
+    def __init__(self, input_model, **pars):
+        """
+        Initialize the class with input data model.
+
+        Parameters
+        ----------
+        input_model : DataModel, str
+            list of data models as ModelContainer or ASN file,
+            one data model for each input image
+
+        pars : dict, optional
+            Optional parameters to modify how pixel replacement
+            will execute.
+        """
+        self.input = input_model
+        self.pars = dict()
+        self.pars.update(pars)
+
+        self.algorithm_dict = {
+            'fit_profile': self.fit_profile,
+        }
+
+        self.algorithm = self.algorithm_dict[self.pars['algorithm']]
+
+    def replace(self):
+        """
+        Process the input DataModel, unpack any model that holds
+        more than one 2D spectrum, then apply selected algorithm
+        to each 2D spectrum in input.
+        """
+        # ImageModel inputs (MIR_LRS-FIXEDSLIT)
+        if isinstance(self.input, datamodels.ImageModel):
+            self.output = self.algorithm(self.input)
+
+        # MultiSlitModel inputs (WFSS, NRS_FIXEDSLIT, ?)
+        elif isinstance(self.input, datamodels.MultiSlitModel):
+            for i, slit in enumerate(self.input.slits):
+                slit_model = datamodels.SlitModel(self.input.slits[i].instance)
+                slit_replaced = self.algorithm(slit_model)
+                self.input.slits[i] = slit_replaced
+
+        # Unsure how to deal with IFU data - should this be run
+        # on pre- or post- cube_build products?
+        else:
+            log.critical(f"For input of exposure type {self.input.exposure.type}\n"
+                         f"Algorithm has not yet been implemented.")
+            raise Exception
+
+    def fit_profile(self, model):
+        """
+        Fit a profile to adjacent columns, scale profile to
+        column with missing pixel(s), and find flux estimate
+        from scaled profile.
+
+        Parameters
+        ----------
+        model : DataModel
+            Either the input to the pixel_replace step in the
+            case of DataModels containing only one 2D spectrum,
+            or a single 2D spectrum from the input DataModel
+            containting multiple spectra (i.e. MultiSlitModel).
+            Requires data and dq attributes.
+
+        Returns
+        -------
+        model_replaced : DataModel
+            DataModel with flagged bad pixels now flagged with
+            TO-BE-DETERMINED and holding a flux value estimated
+            from spatial profile, derived from adjacent columns.
+
+        """
+        dispaxis = model.meta.wcsinfo.dispersion_direction
+
+        # Trucate array to region where good pixels exist
+        good_pixels = np.where(~model.dq & 1)
+        x_range = [np.min(good_pixels[0]), np.max(good_pixels[0]) + 1]
+        y_range = [np.min(good_pixels[1]), np.max(good_pixels[1]) + 1]
+
+        # Loop over axis of data array corresponding to cross-
+        # dispersion direction by indexing data shape with
+        # strange dispaxis argument.
+        log.critical(f"Number of profiles: {model.data.shape[2 - dispaxis]}")
+        for ind in range(model.data.shape[2 - dispaxis]):
+            dq_slice = model.dq[self.custom_slice(dispaxis, ind)]
+            n_bad = np.count_nonzero(dq_slice & self.DO_NOT_USE)
+            if n_bad == len(dq_slice):
+                log.debug(f"Slice {ind} contains no good pixels. Skipping replacement.")
+            else:
+                log.debug(f"Slice {ind} contains {len(dq_slice) - n_bad} good pixels.")
+
+
+
+    def custom_slice(self, dispaxis, index):
+        """
+        Construct slice for ease of use with varying
+        dispersion axis.
+
+        Parameters
+        ----------
+        dispaxis : int
+            Using module-defined HORIZONTAL=1,
+            VERTICAL=2
+
+        index : int or slice
+            Index or indices of cross-dispersion
+            vectors to slice
+
+        Returns
+        -------
+        Tuple
+            Slice constructed using np.s_
+        """
+        if dispaxis == self.HORIZONTAL:
+            return np.s_[:, index]
+        elif dispaxis == self.VERTICAL:
+            return np.s_[index, :]
+        else:
+            raise Exception

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -21,7 +21,7 @@ class PixelReplacement:
 
     # Shortcuts for DQ Flags
     DO_NOT_USE = datamodels.dqflags.pixel['DO_NOT_USE']
-    REPLACED = datamodels.dqflags.pixel['RESERVED_4']
+    REPLACED = datamodels.dqflags.pixel['LOW_QE']
     NON_SCIENCE = datamodels.dqflags.pixel['NON_SCIENCE']
 
     # Shortcuts for dispersion direction for ease of reading

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -55,9 +55,9 @@ class PixelReplacement:
         try:
             self.algorithm = self.algorithm_dict[self.pars['algorithm']]
 
-        except:
-            log.critical(f"Algorithm name provided does not match an"
-                         f"implemented algorithm!")
+        except KeyError:
+            log.critical(f"Algorithm name {self.pars['algorithm']} provided does "
+                         f"not match an implemented algorithm!")
             raise Exception
 
     def replace(self):
@@ -67,10 +67,10 @@ class PixelReplacement:
         to each 2D spectrum in input.
         """
         # ImageModel inputs (MIR_LRS-FIXEDSLIT)
-        if isinstance(self.input, datamodels.ImageModel):
+        if isinstance(self.input, (datamodels.ImageModel, datamodels.IFUImageModel)):
             self.output = self.algorithm(self.input)
             n_replaced = np.sum(self.output.dq & self.REPLACED)
-            log.info(f"Input ImageModel had {n_replaced} pixels replaced.")
+            log.info(f"Input model had {n_replaced} pixels replaced.")
 
         # MultiSlitModel inputs (WFSS, NRS_FIXEDSLIT, ?)
         elif isinstance(self.input, datamodels.MultiSlitModel):
@@ -86,7 +86,7 @@ class PixelReplacement:
 
         else:
             # This should never happen, as these would be caught in the step code.
-            log.critical(f"How did we get here?")
+            log.critical("How did we get here?")
             raise Exception
 
     def fit_profile(self, model):
@@ -124,8 +124,8 @@ class PixelReplacement:
         # Truncate array to region where good pixels exist
         good_pixels = np.where(~model.dq & 1)
         if np.any(0 in np.shape(good_pixels)):
-            log.warning(f"No good pixels in at least one dimension of "
-                        f"data array - skipping pixel replacement.")
+            log.warning("No good pixels in at least one dimension of "
+                        "data array - skipping pixel replacement.")
             return model
         x_range = [np.min(good_pixels[0]), np.max(good_pixels[0]) + 1]
         y_range = [np.min(good_pixels[1]), np.max(good_pixels[1]) + 1]

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from .. import datamodels
+from jwst import datamodels
 from scipy.optimize import minimize
 import warnings
 

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -84,8 +84,9 @@ class PixelReplacement:
 
                 self.output.slits[i] = slit_replaced
 
-        # CubeModel inputs are TSO (so far?)
-        elif isinstance(self.input, datamodels.CubeModel):
+        # CubeModel inputs are TSO (so far?); only SlitModel seen so far is NRS_BRIGHTOBJ, also requiring
+        # a re-packaging of the data into 2D inputs for the algorithm.
+        elif isinstance(self.input, (datamodels.CubeModel, datamodels.SlitModel)):
             if len(self.input.data) != len(self.input.dq):
                 log.critical("Data and DQ arrays are not of equal length - skipping pixel replacement.")
                 return

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -86,7 +86,12 @@ class PixelReplacement:
 
         # CubeModel inputs are TSO (so far?)
         elif isinstance(self.input, datamodels.CubeModel):
-            for i in range(self.input.meta.exposure.nints):
+            if len(self.input.data) != len(self.input.dq):
+                log.critical("Data and DQ arrays are not of equal length - skipping pixel replacement.")
+                return
+
+            # Initial attempt looped over model.meta.exposure.nints, but test data had mismatch. Could change this.
+            for i in range(len(self.input.data)):
                 dummy_model = datamodels.ImageModel(data=self.input.data[i], dq=self.input.dq[i])
                 dummy_model.update(self.input)
                 dummy_replaced = self.algorithm(dummy_model)

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from jwst import datamodels
+from .. import datamodels
 from scipy.optimize import minimize
 import warnings
 

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -125,7 +125,7 @@ class PixelReplacement:
         # dispersion direction by indexing data shape with
         # strange dispaxis argument. Keep indices in full-frame numbering scheme,
         # but only iterate through slices with valid data.
-        log.info(f"Number of profiles: {len(valid_profiles)}")
+        log.debug(f"Number of profiles with at least one bad pixel: {len(profiles_to_replace)}")
         for ind in range(*valid_shape[2 - dispaxis]):
             # Exclude regions with no data for dq slice.
             dq_slice = model.dq[self.custom_slice(dispaxis, ind)][profile_cut[0]: profile_cut[1]]

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -21,7 +21,7 @@ class PixelReplacement:
 
     # Shortcuts for DQ Flags
     DO_NOT_USE = datamodels.dqflags.pixel['DO_NOT_USE']
-    REPLACED = datamodels.dqflags.pixel['LOW_QE']
+    FLUX_ESTIMATED = datamodels.dqflags.pixel['FLUX_ESTIMATED']
     NON_SCIENCE = datamodels.dqflags.pixel['NON_SCIENCE']
 
     # Shortcuts for dispersion direction for ease of reading
@@ -71,7 +71,7 @@ class PixelReplacement:
         # ImageModel inputs (MIR_LRS-FIXEDSLIT)
         if isinstance(self.input, datamodels.ImageModel):
             self.output = self.algorithm(self.input)
-            n_replaced = np.count_nonzero(self.output.dq & self.REPLACED)
+            n_replaced = np.count_nonzero(self.output.dq & self.FLUX_ESTIMATED)
             log.info(f"Input model had {n_replaced} pixels replaced.")
         elif isinstance(self.input, datamodels.IFUImageModel):
                 # Attempt to run pixel replacement on each throw of the IFU slicer
@@ -107,12 +107,12 @@ class PixelReplacement:
                             self.output.dq
                         )
 
-                        n_replaced = np.count_nonzero(trace_model.dq & self.REPLACED)
+                        n_replaced = np.count_nonzero(trace_model.dq & self.FLUX_ESTIMATED)
                         log.info(f"Input MRS frame had {n_replaced} pixels replaced in IFU slice {i+1}.")
 
                         trace_model.close()
 
-                    n_replaced = np.count_nonzero(self.output.dq & self.REPLACED)
+                    n_replaced = np.count_nonzero(self.output.dq & self.FLUX_ESTIMATED)
                     log.info(f"Input MRS frame had {n_replaced} total pixels replaced.")
                 else:
                     # NRS_IFU method - Fixed number of IFU slices to iterate over
@@ -145,12 +145,12 @@ class PixelReplacement:
                             self.output.dq
                         )
 
-                        n_replaced = np.count_nonzero(trace_model.dq & self.REPLACED)
+                        n_replaced = np.count_nonzero(trace_model.dq & self.FLUX_ESTIMATED)
                         log.info(f"Input NRS_IFU frame had {n_replaced} pixels replaced in IFU slice {i + 1}.")
 
                         trace_model.close()
 
-                    n_replaced = np.count_nonzero(self.output.dq & self.REPLACED)
+                    n_replaced = np.count_nonzero(self.output.dq & self.FLUX_ESTIMATED)
                     log.info(f"Input NRS_IFU frame had {n_replaced} total pixels replaced.")
 
         # MultiSlitModel inputs (WFSS, NRS_FIXEDSLIT, ?)
@@ -160,7 +160,7 @@ class PixelReplacement:
                 slit_model = datamodels.SlitModel(self.input.slits[i].instance)
                 slit_replaced = self.algorithm(slit_model)
 
-                n_replaced = np.count_nonzero(slit_replaced.dq & self.REPLACED)
+                n_replaced = np.count_nonzero(slit_replaced.dq & self.FLUX_ESTIMATED)
                 log.info(f"Slit {i} had {n_replaced} pixels replaced.")
 
                 self.output.slits[i] = slit_replaced
@@ -177,7 +177,7 @@ class PixelReplacement:
                 dummy_model = datamodels.ImageModel(data=self.input.data[i], dq=self.input.dq[i])
                 dummy_model.update(self.input)
                 dummy_replaced = self.algorithm(dummy_model)
-                n_replaced = np.count_nonzero(dummy_replaced.dq & self.REPLACED)
+                n_replaced = np.count_nonzero(dummy_replaced.dq & self.FLUX_ESTIMATED)
                 log.info(f"Input TSO integration {i} had {n_replaced} pixels replaced.")
 
                 self.output.data[i] = dummy_replaced.data
@@ -322,7 +322,7 @@ class PixelReplacement:
             replaced_dq = np.where(
                 (current_dq & self.DO_NOT_USE ^ current_dq & self.NON_SCIENCE == 1) &
                 ~(np.isnan(replaced_current)),
-                current_dq ^ self.DO_NOT_USE ^ self.REPLACED,
+                current_dq ^ self.DO_NOT_USE ^ self.FLUX_ESTIMATED,
                 current_dq
             )
 

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -101,8 +101,8 @@ class PixelReplacement:
                     self.output.dq = np.where(
                         # Where trace is located, set replaced values
                         trace_mask,
-                        trace_output.data,
-                        self.output.data
+                        trace_output.dq,
+                        self.output.dq
                     )
 
                     n_replaced = np.count_nonzero(trace_output.dq & self.REPLACED)

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -84,6 +84,6 @@ class PixelReplaceStep(Step):
             replacement = PixelReplacement(result, **pars)
             replacement.replace()
 
-            self.record_step_status(result, 'pixel_replacement', success=True)
+            self.record_step_status(result, 'pixel_replace', success=True)
             return replacement.output
 

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -59,6 +59,8 @@ class PixelReplaceStep(Step):
             # MIRI_LRS-FIXEDSLIT comes in ImageModel - any others?
             elif isinstance(input_model, datamodels.ImageModel):
                 self.log.debug(f'Input ImageModel is of exptype: {input_model.meta.exposure.type}')
+            elif isinstance(input_model, datamodels.IFUImageModel):
+                self.log.debug(f'Input is an IFUImageModel.')
                 '''
                 elif isinstance(input_model, datamodels.CubeModel):
                     # It's a 3-D multi-integration model

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -61,17 +61,18 @@ class PixelReplaceStep(Step):
                 self.log.debug(f'Input ImageModel is of exptype: {input_model.meta.exposure.type}')
             elif isinstance(input_model, datamodels.IFUImageModel):
                 self.log.debug(f'Input is an IFUImageModel.')
+
+            elif isinstance(input_model, datamodels.CubeModel):
+                # It's a 3-D multi-integration model
+                self.log.debug('Input is a CubeModel for a multiple integration file')
                 '''
-                elif isinstance(input_model, datamodels.CubeModel):
-                    # It's a 3-D multi-integration model
-                    self.log.debug('Input is a CubeModel for a multiple integ. file')
                 elif isinstance(input_model, datamodels.IFUCubeModel):
                     self.log.debug('Input is an IFUCubeModel')
                 elif isinstance(input_model, datamodels.SlitModel):
                     # NRS_BRIGHTOBJ and MIRI LRS fixed-slit (resampled) modes
                     self.log.debug('Input is a SlitModel')
                 '''
-            # SOSS have CubeModel, along with IFU modes WIP
+            # SOSS & LRS-SLITLESS have CubeModel, along with IFU modes WIP
             else:
                 self.log.error(f'Input is of type {str(type(input_model))} for which')
                 self.log.error('pixel_replace does not have an algorithm.')

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -2,7 +2,7 @@
 
 from ..stpipe import Step
 from .. import datamodels
-from .profile_fitting import pixel_replace_profile_fit
+from .pixel_replace import PixelReplacement
 __all__ = ["PixelReplaceStep"]
 
 
@@ -13,6 +13,10 @@ class PixelReplaceStep(Step):
 
     Attributes
     ----------
+    algorithm : str
+        Method used to estimate flux values for bad pixels. Currently only one option is
+        implemented, using a profile fit to adjacent column values.
+
     n_adjacent_cols : int
         Number of adjacent columns (on either side of column containing a bad pixel) to use in
         creation of source profile, in cross-dispersion direction. The total number of columns
@@ -23,6 +27,7 @@ class PixelReplaceStep(Step):
     class_alias = "pixel_replace"
 
     spec = """
+        algorithm = option("fit_profile", "N/A", default="fit_profile") 
         n_adjacent_cols = integer(default=3)    # Number of adjacent columns to use in creation of profile
     """
 
@@ -31,42 +36,39 @@ class PixelReplaceStep(Step):
 
         Parameters
         ----------
-        input: JWST data model
+        input : JWST DataModel
 
         Returns
         -------
-        JWST data model
-            This will be `input_model` if the step was skipped; otherwise,
+        JWST DataModel
+            This will be `input` if the step was skipped; otherwise,
             it will be a model containing data arrays with estimated fluxes
             for any bad pixels, now flagged as TO-BE-DETERMINED (DQ bit 7?).
         """
 
-        # If more than one method ends up being utilized, may be convenient to
-        # have a selector
-
         with datamodels.open(input) as input_model:
 
+            # Make copy of input to prevent overwriting
             result = input_model.copy()
+
             # If more than one 2d spectrum exists in input, call replacement
             # for each spectrum
             if isinstance(input_model, datamodels.MultiSlitModel):
                 self.log.debug('Input is a MultiSlitModel.')
 
-            # MIRI_LRS-FIXEDSLIT comes in ImageModel
+            # MIRI_LRS-FIXEDSLIT comes in ImageModel - any others?
             elif isinstance(input_model, datamodels.ImageModel):
-                # MIRI LRS mode - any others?
-                self.log.debug('Input is a ImageModel.')
-                result =
-            '''
-            elif isinstance(input_model, datamodels.CubeModel):
-                # It's a 3-D multi-integration model
-                self.log.debug('Input is a CubeModel for a multiple integ. file')
-            elif isinstance(input_model, datamodels.IFUCubeModel):
-                self.log.debug('Input is an IFUCubeModel')
-            elif isinstance(input_model, datamodels.SlitModel):
-                # NRS_BRIGHTOBJ and MIRI LRS fixed-slit (resampled) modes
-                self.log.debug('Input is a SlitModel')
-            '''
+                self.log.debug(f'Input ImageModel is of exptype: {input_model.meta.exposure.type}')
+                '''
+                elif isinstance(input_model, datamodels.CubeModel):
+                    # It's a 3-D multi-integration model
+                    self.log.debug('Input is a CubeModel for a multiple integ. file')
+                elif isinstance(input_model, datamodels.IFUCubeModel):
+                    self.log.debug('Input is an IFUCubeModel')
+                elif isinstance(input_model, datamodels.SlitModel):
+                    # NRS_BRIGHTOBJ and MIRI LRS fixed-slit (resampled) modes
+                    self.log.debug('Input is a SlitModel')
+                '''
             else:
                 self.log.error(f'Input is a {str(type(input_model))}, ')
                 self.log.error('which was not expected for pixel_replace')
@@ -75,5 +77,13 @@ class PixelReplaceStep(Step):
                 #input_model.meta.cal_step.pixel_replace = 'SKIPPED'
                 #return input_model
 
-            self.record_step_status(result, 'master_background', success=False)
+            pars = {
+                'algorithm': self.algorithm,
+                'n_adjacent_cols': self.n_adjacent_cols,
+            }
+
+            replacement = PixelReplacement(result, **pars)
+            replacement.replace()
+
+            self.record_step_status(result, 'pixel_replace', success=True)
 

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -70,8 +70,8 @@ class PixelReplaceStep(Step):
                     self.log.debug('Input is a SlitModel')
                 '''
             else:
-                self.log.error(f'Input is a {str(type(input_model))}, ')
-                self.log.error('which was not expected for pixel_replace')
+                self.log.error(f'Input is of type {str(type(input_model))} for which')
+                self.log.error('pixel_replace does not have an algorithm.')
                 raise Exception
                 #self.log.error('pixel_replace will be skipped.')
                 #input_model.meta.cal_step.pixel_replace = 'SKIPPED'
@@ -86,4 +86,5 @@ class PixelReplaceStep(Step):
             replacement.replace()
 
             self.record_step_status(result, 'pixel_replace', success=True)
+            return replacement.output
 

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -52,7 +52,7 @@ class PixelReplaceStep(Step):
             result = input_model.copy()
 
             # If more than one 2d spectrum exists in input, call replacement
-            # for each spectrum
+            # for each spectrum - NRS_FIXEDSLIT, WFSS
             if isinstance(input_model, datamodels.MultiSlitModel):
                 self.log.debug('Input is a MultiSlitModel.')
 
@@ -69,6 +69,7 @@ class PixelReplaceStep(Step):
                     # NRS_BRIGHTOBJ and MIRI LRS fixed-slit (resampled) modes
                     self.log.debug('Input is a SlitModel')
                 '''
+            # SOSS have CubeModel, along with IFU modes WIP
             else:
                 self.log.error(f'Input is of type {str(type(input_model))} for which')
                 self.log.error('pixel_replace does not have an algorithm.')

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -56,7 +56,9 @@ class PixelReplaceStep(Step):
             # for each spectrum - NRS_FIXEDSLIT, WFSS
             if isinstance(input_model, datamodels.MultiSlitModel):
                 self.log.debug('Input is a MultiSlitModel.')
-
+            # NRS_BRIGHTOBJ provides a SlitModel
+            elif isinstance(input_model, datamodels.SlitModel):
+                self.log.debug('Input is a SlitModel.')
             # MIRI_LRS-FIXEDSLIT comes in ImageModel - any others?
             elif isinstance(input_model, datamodels.ImageModel):
                 self.log.debug(f'Input ImageModel is of exptype: {input_model.meta.exposure.type}')

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -30,6 +30,7 @@ class PixelReplaceStep(Step):
     spec = """
         algorithm = option("fit_profile", "N/A", default="fit_profile") 
         n_adjacent_cols = integer(default=3)    # Number of adjacent columns to use in creation of profile
+        skip = boolean(default=True) # Step must be turned on by parameter reference or user
     """
 
     def process(self, input):
@@ -61,28 +62,19 @@ class PixelReplaceStep(Step):
                 self.log.debug('Input is a SlitModel.')
             # MIRI_LRS-FIXEDSLIT comes in ImageModel - any others?
             elif isinstance(input_model, datamodels.ImageModel):
-                self.log.debug(f'Input ImageModel is of exptype: {input_model.meta.exposure.type}')
+                self.log.debug('Input is an ImageModel.')
             elif isinstance(input_model, datamodels.IFUImageModel):
-                self.log.debug(f'Input is an IFUImageModel.')
-
+                self.log.debug('Input is an IFUImageModel.')
+            # SOSS & LRS-SLITLESS have CubeModel, along with IFU modes WIP
             elif isinstance(input_model, datamodels.CubeModel):
                 # It's a 3-D multi-integration model
-                self.log.debug('Input is a CubeModel for a multiple integration file')
-                '''
-                elif isinstance(input_model, datamodels.IFUCubeModel):
-                    self.log.debug('Input is an IFUCubeModel')
-                elif isinstance(input_model, datamodels.SlitModel):
-                    # NRS_BRIGHTOBJ and MIRI LRS fixed-slit (resampled) modes
-                    self.log.debug('Input is a SlitModel')
-                '''
-            # SOSS & LRS-SLITLESS have CubeModel, along with IFU modes WIP
+                self.log.debug('Input is a CubeModel for a multiple integration file.')
             else:
                 self.log.error(f'Input is of type {str(type(input_model))} for which')
-                self.log.error('pixel_replace does not have an algorithm.')
-                raise Exception
-                #self.log.error('pixel_replace will be skipped.')
-                #input_model.meta.cal_step.pixel_replace = 'SKIPPED'
-                #return input_model
+                self.log.error('pixel_replace does not have an algorithm.\n')
+                self.log.error('Pixel replacement will be skipped.')
+                input_model.meta.cal_step.pixel_replace = 'SKIPPED'
+                return input_model
 
             pars = {
                 'algorithm': self.algorithm,

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -84,6 +84,6 @@ class PixelReplaceStep(Step):
             replacement = PixelReplacement(result, **pars)
             replacement.replace()
 
-            self.record_step_status(result, 'pixel_replace', success=True)
+            self.record_step_status(result, 'pixel_replacement', success=True)
             return replacement.output
 

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -2,7 +2,7 @@
 
 from jwst.stpipe import Step
 from jwst import datamodels
-from .pixel_replace import PixelReplacement
+from jwst.pixel_replace.pixel_replace import PixelReplacement
 
 __all__ = ["PixelReplaceStep"]
 

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python
+
+from ..stpipe import Step
+from .. import datamodels
+from .profile_fitting import pixel_replace_profile_fit
+__all__ = ["PixelReplaceStep"]
+
+
+class PixelReplaceStep(Step):
+    """
+    PixelReplaceStep: Module for replacing flagged bad pixels with an estimate
+    of their flux, prior to spectral extraction.
+
+    Attributes
+    ----------
+    n_adjacent_cols : int
+        Number of adjacent columns (on either side of column containing a bad pixel) to use in
+        creation of source profile, in cross-dispersion direction. The total number of columns
+        used in the profile will be twice this number; on array edges, take adjacent columns until
+        this number is reached.
+    """
+
+    class_alias = "pixel_replace"
+
+    spec = """
+        n_adjacent_cols = integer(default=3)    # Number of adjacent columns to use in creation of profile
+    """
+
+    def process(self, input):
+        """Execute the step.
+
+        Parameters
+        ----------
+        input: JWST data model
+
+        Returns
+        -------
+        JWST data model
+            This will be `input_model` if the step was skipped; otherwise,
+            it will be a model containing data arrays with estimated fluxes
+            for any bad pixels, now flagged as TO-BE-DETERMINED (DQ bit 7?).
+        """
+
+        # If more than one method ends up being utilized, may be convenient to
+        # have a selector
+
+        with datamodels.open(input) as input_model:
+
+            result = input_model.copy()
+            # If more than one 2d spectrum exists in input, call replacement
+            # for each spectrum
+            if isinstance(input_model, datamodels.MultiSlitModel):
+                self.log.debug('Input is a MultiSlitModel.')
+
+            # MIRI_LRS-FIXEDSLIT comes in ImageModel
+            elif isinstance(input_model, datamodels.ImageModel):
+                # MIRI LRS mode - any others?
+                self.log.debug('Input is a ImageModel.')
+                result =
+            '''
+            elif isinstance(input_model, datamodels.CubeModel):
+                # It's a 3-D multi-integration model
+                self.log.debug('Input is a CubeModel for a multiple integ. file')
+            elif isinstance(input_model, datamodels.IFUCubeModel):
+                self.log.debug('Input is an IFUCubeModel')
+            elif isinstance(input_model, datamodels.SlitModel):
+                # NRS_BRIGHTOBJ and MIRI LRS fixed-slit (resampled) modes
+                self.log.debug('Input is a SlitModel')
+            '''
+            else:
+                self.log.error(f'Input is a {str(type(input_model))}, ')
+                self.log.error('which was not expected for pixel_replace')
+                raise Exception
+                #self.log.error('pixel_replace will be skipped.')
+                #input_model.meta.cal_step.pixel_replace = 'SKIPPED'
+                #return input_model
+
+            self.record_step_status(result, 'master_background', success=False)
+

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 
-from jwst.stpipe import Step
-from jwst import datamodels
-from jwst.pixel_replace.pixel_replace import PixelReplacement
+from ..stpipe import Step
+from .. import datamodels
+from .pixel_replace import PixelReplacement
 
 __all__ = ["PixelReplaceStep"]
 

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -1,8 +1,9 @@
 #! /usr/bin/env python
 
-from ..stpipe import Step
-from .. import datamodels
+from jwst.stpipe import Step
+from jwst import datamodels
 from .pixel_replace import PixelReplacement
+
 __all__ = ["PixelReplaceStep"]
 
 

--- a/jwst/pixel_replace/profile_fitting.py
+++ b/jwst/pixel_replace/profile_fitting.py
@@ -1,2 +1,0 @@
-def pixel_replace_profile_fit():
-    pass

--- a/jwst/pixel_replace/profile_fitting.py
+++ b/jwst/pixel_replace/profile_fitting.py
@@ -1,0 +1,2 @@
+def pixel_replace_profile_fit():
+    pass

--- a/jwst/reset/tests/test_reset_sub.py
+++ b/jwst/reset/tests/test_reset_sub.py
@@ -110,20 +110,20 @@ def test_dq_combine(make_rampmodel, make_resetmodel):
     jump_det = dqflags.pixel['JUMP_DET']
     saturated = dqflags.pixel['SATURATED']
     do_not_use = dqflags.pixel['DO_NOT_USE']
-    unreliable_reset = dqflags.pixel['UNRELIABLE_RESET']
+    nonlinear = dqflags.pixel['NONLINEAR']
 
     # populate dq flags of sci pixeldq and reference dq
     dm_ramp.pixeldq[50, 50] = jump_det
     dm_ramp.pixeldq[50, 51] = saturated
 
-    reset.dq[50, 50] = np.bitwise_or(do_not_use, unreliable_reset)
-    reset.dq[50, 51] = unreliable_reset
+    reset.dq[50, 50] = np.bitwise_or(do_not_use, nonlinear)
+    reset.dq[50, 51] = nonlinear
 
     # run correction step
     outfile = resetcorr(dm_ramp, reset)
 
-    t50_50 = jump_det | do_not_use | unreliable_reset
-    t50_51 = saturated | unreliable_reset
+    t50_50 = jump_det | do_not_use | nonlinear
+    t50_51 = saturated | nonlinear
     # check that dq flags were correctly added
     assert outfile.pixeldq[50, 50] == t50_50
     assert outfile.pixeldq[50, 51] == t50_51

--- a/jwst/step.py
+++ b/jwst/step.py
@@ -37,6 +37,7 @@ from .outlier_detection.outlier_detection_stack_step import OutlierDetectionStac
 from .pathloss.pathloss_step import PathLossStep
 from .persistence.persistence_step import PersistenceStep
 from .photom.photom_step import PhotomStep
+from .pixel_replace.pixel_replace_step import PixelReplaceStep
 from .ramp_fitting.ramp_fit_step import RampFitStep
 from .refpix.refpix_step import RefPixStep
 from .resample.resample_step import ResampleStep
@@ -99,6 +100,7 @@ __all__ = [
     "PathLossStep",
     "PersistenceStep",
     "PhotomStep",
+    "PixelReplaceStep",
     "RampFitStep",
     "RefPixStep",
     "ResampleStep",

--- a/jwst/stpipe/integration.py
+++ b/jwst/stpipe/integration.py
@@ -70,6 +70,7 @@ def get_steps():
         ("jwst.step.PathLossStep", 'pathloss', False),
         ("jwst.step.PersistenceStep", 'persistence', False),
         ("jwst.step.PhotomStep", 'photom', False),
+        ("jwst.step.PixelReplaceStep", 'pixel_replace', False),
         ("jwst.step.RampFitStep", 'ramp_fit', False),
         ("jwst.step.RefPixStep", 'refpix', False),
         ("jwst.step.ResampleStep", 'resample', False),


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3005](https://jira.stsci.edu/browse/JP-3005)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR implements an algorithm to estimate values for flagged DO_NOT_USE pixels before spectral extraction takes place. The algorithm creates a median profile from neighboring slices in the dispersed 2d spectrum, then scales the median profile to slice with a bad pixel to estimate its value.

WORK IN PROGRESS: Currently implemented for ImageModel inputs (LRS-FS, others?), and possibly working for MultiSlitModels as well. Testing and coding in progress.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
