### PR TITLE
Use log instead of print in tweakreg

### DIFF
--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -133,7 +133,7 @@ class TweakRegStep(Step):
                         filename = im.meta.filename
                         if filename in catdict:
                             self.log.info(
-                                f"setting {filename}' tweakreg_catalog = {repr(catdict[filename])}"
+                                f"setting meta.tweakreg_catalog of '{filename}' to {repr(catdict[filename])}"
                             )
                             im.meta.tweakreg_catalog = catdict[filename]
 

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -132,7 +132,9 @@ class TweakRegStep(Step):
                     for im in images:
                         filename = im.meta.filename
                         if filename in catdict:
-                            print(f"setting {filename}.tweakreg_catalog = {repr(catdict[filename])}")
+                            self.log.info(
+                                f"setting {filename}' tweakreg_catalog = {repr(catdict[filename])}"
+                            )
                             im.meta.tweakreg_catalog = catdict[filename]
 
             else:


### PR DESCRIPTION
This is a simple PR to replace a print statement in the tweakreg step with a `log.info()`. IMO no changelog is need but let me know if you want me to update the change log.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
