### PR TITLE
JP-2013 Fix NIRSpec IFU NOD background subtract and include leakcal in the Level2 associations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ associations
 
 - Fix association registry ListCategory enum bug under Python 3.11 [#7370]
 
+- Fix NIRSpec IFU NOD background subtract and include leakcal in the Level2 associations. [#7405]
+
 combine_1d
 ----------
 

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -835,7 +835,7 @@ class Asn_Lv2NRSIFUNod(
         - Spectral-based NIRSpec IFU multi-object science exposures
         - Single science exposure
         - Handle 2 and 4 point background nodding
-        - Included related imprint exposures
+        - Include related imprint exposures
     """
 
     def __init__(self, *args, **kwargs):

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -864,10 +864,6 @@ class Asn_Lv2NRSIFUNod(
                 name='mosaic_tile',
                 sources=['mostilno'],
             ),
-            DMSAttrConstraint(
-                name='expcount_science',
-                sources=['expcount'],
-            ),
         ])
 
         # Now check and continue initialization.

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -835,6 +835,7 @@ class Asn_Lv2NRSIFUNod(
         - Spectral-based NIRSpec IFU multi-object science exposures
         - Single science exposure
         - Handle 2 and 4 point background nodding
+        - Included related imprint exposures
     """
 
     def __init__(self, *args, **kwargs):
@@ -854,15 +855,19 @@ class Asn_Lv2NRSIFUNod(
                 force_unique=False
             ),
             DMSAttrConstraint(
-                name='expspcin',
-                sources=['expspcin'],
-            ),
-            DMSAttrConstraint(
                 name='patttype',
                 sources=['patttype'],
                 value=['2-point-nod|4-point-nod'],
                 force_unique=True
-            )
+            ),
+            DMSAttrConstraint(
+                name='mosaic_tile',
+                sources=['mostilno'],
+            ),
+            DMSAttrConstraint(
+                name='expcount_science',
+                sources=['expcount'],
+            ),
         ])
 
         # Now check and continue initialization.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
WIP [JP-2013](https://jira.stsci.edu/browse/JP-2013)

<!-- describe the changes comprising this PR here -->
This PR addresses the association creation portion of JP-2013. There were two problems with the rule Asn_Lv2NRSIFUNod:

- Mistakenly other dithers and mosaic tiles were being included in the association
- Leakcals/imprint were not included in assocations

The rule has been modified to

- Include leakcal/imprint exposures
- Limit the science/backgrounds to just the nodded dithers for a particular pointing.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
- [x] Comment related JIRA tickets as appropriate.
