### PR TITLE
JP-3034: Change import for photutils CircularAnnulus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,11 @@ lib
 
 - Fix circular import in ``lib.wcs_utils``. [#7330]
 
+outlier_detection
+-----------------
+
+- Fix deprecated calls to photutils.CircularAnnulus. [#7407]
+
 photom
 ------
 

--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 import numpy as np
 
-from photutils import aperture_photometry, CircularAperture, CircularAnnulus
+from photutils.aperture import (aperture_photometry, CircularAperture, CircularAnnulus)
 import astropy.units as u
 
 from .. import datamodels


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3034](https://jira.stsci.edu/browse/JP-3034)


<!-- describe the changes comprising this PR here -->
This PR changes the import for several photutils routines, to keep up with changes in the photutils pkg.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
