### PR TITLE
Fix incorrect deallocation attempts of unallocated memory in cube builder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,10 @@ cube_build
 - Remove code trimming zero-valued planes from cubes, so that cubes of fixed length will always
   be produced. Move nan-value setting to below spectral tear cleanup. [#7391]
 
+- Fix several bugs in memory management in the C code for cube build which
+  would result in attempts to deallocate memory that was never allocated
+  resulting in core dump. [#7408]
+
 datamodels
 ----------
 

--- a/jwst/cube_build/src/cube_match_internal.c
+++ b/jwst/cube_build/src/cube_match_internal.c
@@ -6,12 +6,12 @@ each slice are assumed to not overlap on the output plane with pixels from other
 breaks the 3-D representation of the pixel's coordinates in the output plane to 2D. Standard
 drizzling type routines are used to calculate the percentage of each pixel's overlap with
 the output spaxels. The percentage of the pixel area  overlapped onto an output
-spaxel is used to weight the pixel flux for determining the spaxel flux. 
+spaxel is used to weight the pixel flux for determining the spaxel flux.
 
- 
+
 Main function for Python: cube_wrapper_internal
 
-Python signature: 
+Python signature:
     result = cube_wrapper_internal(instrument_no, naxis1, naxis2,
                                    crval_along, cdelt_along, crval3, cdelt3,
                                    a1, a2, a3, a4, lam1, lam2, lam3, lam4,
@@ -19,14 +19,14 @@ Python signature:
                                    pixel_flux, pixel_err)
 provide more details
 
-The output of this function is a tuple of 5 arrays:(spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq) 
-example output 
+The output of this function is a tuple of 5 arrays:(spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq)
+example output
 
 Parameters
 ----------
 instrument: int
     0 = MIRI, 1 = NIRSPEC. Used for set the dq plane
-naxis1 : int 
+naxis1 : int
    axis 1 of IFU cube
 nasix2 : int
   axis 2 of IFU cube
@@ -38,18 +38,18 @@ crval3 : double
    wavelength reference value in IFU cube
 cdetl3 : double
    wavelength sampling in IFU cube
-a1, a2, a3, a4: double array 
+a1, a2, a3, a4: double array
     array of corners of pixels holding along slice coordinates
-    a1 holds corner 1 
-    a2 holds corner 2 
-    a3 holds corner 3 
-    a4 holds corner 4 
+    a1 holds corner 1
+    a2 holds corner 2
+    a3 holds corner 3
+    a4 holds corner 4
 lam1, lam2, lam3, lam4: double array
     array of corners of pixels holding wavelength coordinates
-    lam1 holds corner 1 
-    lam2 holds corner 2 
-    lam3 holds corner 3 
-    lam4 holds corner 4 
+    lam1 holds corner 1
+    lam2 holds corner 2
+    lam3 holds corner 3
+    lam4 holds corner 4
 acoord : double array
    Array holds along slice coordinates in IFU cube
 zcoord : double array
@@ -85,7 +85,7 @@ spaxel_dq : array
 
 
 // routines used from cube_utils.c
-extern double sh_find_overlap(const double xcenter, const double ycenter, 
+extern double sh_find_overlap(const double xcenter, const double ycenter,
 		      const double xlength, const double ylength,
 			      double xPixelCorner[],double yPixelCorner[]);
 
@@ -109,12 +109,12 @@ int match_detector_cube(int instrument, int naxis1, int naxis2, int nz, int npt,
 			double *pixel_flux, double *pixel_err,
 			double **spaxel_flux, double **spaxel_weight, double **spaxel_var,double **spaxel_iflux){
 
-  double *fluxv, *weightv, *varv, *ifluxv ;  // vectors for spaxel 
+  double *fluxv=NULL, *weightv=NULL, *varv=NULL, *ifluxv=NULL;  // vectors for spaxel
   double along_corner[4], wave_corner[4], along_min, wave_min, along_max, wave_max, Area, MinW, MaxW, zcenter, acenter, area_overlap,
     AreaRatio, err;
   int ipixel, ia1, ia2, iz1, iz2, nplane, zz, istart, aa, j, cube_index;
 
-  // allocate memory to hold output 
+  // allocate memory to hold output
   if (alloc_flux_arrays(ncube, &fluxv, &weightv, &varv, &ifluxv)) return 1;
 
 
@@ -190,7 +190,7 @@ int match_detector_cube(int instrument, int naxis1, int naxis2, int nz, int npt,
 	}
       }
     }
-    
+
   }
 
   *spaxel_flux = fluxv;
@@ -222,7 +222,7 @@ PyArrayObject * ensure_array(PyObject *obj, int *is_copy) {
 
 
 static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
-  
+
   PyObject *result = NULL, *a1o, *a2o, *a3o, *a4o, *lam1o, *lam2o, *lam3o, *lam4o,
     *fluxo, *erro, *acoordo, *zcoordo;
 
@@ -230,28 +230,27 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
   int  nz, na, npt, naxis1, naxis2, ncube;
   int ss;
   int instrument;
-  
+
   double *spaxel_flux=NULL, *spaxel_weight=NULL, *spaxel_var=NULL;
   double *spaxel_iflux=NULL;
 
   int free_a1=0, free_a2=0, free_a3=0, free_a4 =0, free_lam1=0, free_lam2 =0, free_lam3=0, free_lam4=0;
   int free_acoord=0, free_zcoord=0, status=0;
-  int free_flux=0, free_err=0; 
+  int free_flux=0, free_err=0;
 
   int n1, n2;
-  PyArrayObject *a1, *a2, *a3, *a4, *lam1, *lam2, *lam3, *lam4, *flux, *err, *acoord, *zcoord;
+  PyArrayObject *a1=NULL, *a2=NULL, *a3=NULL, *a4=NULL, *lam1=NULL, *lam2=NULL;
+  PyArrayObject *lam3=NULL, *lam4=NULL, *flux=NULL, *err=NULL, *acoord=NULL, *zcoord=NULL;
 
   PyArrayObject *spaxel_flux_arr=NULL, *spaxel_weight_arr=NULL, *spaxel_var_arr=NULL;
   PyArrayObject *spaxel_iflux_arr=NULL;
   npy_intp npy_ncube = 0;
 
-
   if (!PyArg_ParseTuple(args, "iiiddddOOOOOOOOOOiOO:cube_wrapper_internal",
 			&instrument, &naxis1, &naxis2, &crval_along, &cdelt_along,
 			&crval3, &cdelt3,
 			&a1o, &a2o, &a3o, &a4o,&lam1o, &lam2o, &lam3o, &lam4o,
-			&acoordo, &zcoordo, &ss,  &fluxo, &erro)){
-
+			&acoordo, &zcoordo, &ss,  &fluxo, &erro)) {
     return NULL;
   }
 
@@ -275,11 +274,8 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
       (!(acoord = ensure_array(acoordo, &free_acoord))) ||
       (!(zcoord = ensure_array(zcoordo, &free_zcoord))) ||
       (!(flux = ensure_array(fluxo, &free_flux))) ||
-      (!(err = ensure_array(erro, &free_err))) )
-
-    {
+      (!(err = ensure_array(erro, &free_err))) ) {
       goto cleanup;
-
     }
 
   npt = (int) PyArray_Size((PyObject *) flux);
@@ -292,16 +288,15 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
     PyErr_SetString(PyExc_ValueError,
 		    "Input coordinate arrays of unequal size.");
     goto cleanup;
-
   }
 
-  ncube = naxis1 * naxis2 * nz;  
+  ncube = naxis1 * naxis2 * nz;
 
   if (ncube ==0) {
     // 0-length input arrays. Nothing to clip. Return 0-length arrays
     spaxel_flux_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_DOUBLE, 0);
     if (!spaxel_flux_arr) goto fail;
-    
+
     spaxel_weight_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_DOUBLE, 0);
     if (!spaxel_weight_arr) goto fail;
 
@@ -332,18 +327,18 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
 				 (double *) PyArray_DATA(lam4),
 				 (double *) PyArray_DATA(acoord),
 				 (double *) PyArray_DATA(zcoord),
-				 ss, 
+				 ss,
 				 (double *) PyArray_DATA(flux),
 				 (double *) PyArray_DATA(err),
 				 &spaxel_flux, &spaxel_weight, &spaxel_var, &spaxel_iflux);
-  
+
   if (status ) {
     goto fail;
 
   } else {
     // create return tuple:
     npy_ncube = (npy_intp) ncube;
-    
+
     spaxel_flux_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_flux);
     if (!spaxel_flux_arr) goto fail;
     spaxel_flux = NULL;
@@ -351,11 +346,11 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
     spaxel_weight_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_weight);
     if (!spaxel_weight_arr) goto fail;
     spaxel_weight = NULL;
-    
+
     spaxel_var_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_var);
     if (!spaxel_var_arr) goto fail;
     spaxel_var = NULL;
-    
+
     spaxel_iflux_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_iflux);
     if (!spaxel_iflux_arr) goto fail;
     spaxel_iflux = NULL;
@@ -367,11 +362,11 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
 
     result = Py_BuildValue("(OOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr);
-	
+
     goto cleanup;
   }
 
- fail:
+fail:
   Py_XDECREF(spaxel_flux_arr);
   Py_XDECREF(spaxel_weight_arr);
   Py_XDECREF(spaxel_var_arr);
@@ -381,7 +376,6 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
   free(spaxel_weight);
   free(spaxel_var);
   free(spaxel_iflux);
-
 
   if (!PyErr_Occurred()) {
     PyErr_SetString(PyExc_MemoryError,

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -4,7 +4,7 @@ represented by a 3-D regular grid. This module finds the point cloud members con
 in a region centered on the center of the cube spaxel. The size of the spaxel is spatial
 coordinates is cdetl1 and cdelt2, while the wavelength size is cdelt3.
 
- 
+
 Main function for Python: cube_wrapper_driz
 
 Python signature: result = cube_wrapper_driz(instrument, flag_dq_plane,  start_region, end_region,
@@ -16,8 +16,8 @@ Python signature: result = cube_wrapper_driz(instrument, flag_dq_plane,  start_r
                                         roiw_ave, cdelt1, cdelt2)
 provide more details
 
-The output of this function is a tuple of 5 arrays:(spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq) 
-example output 
+The output of this function is a tuple of 5 arrays:(spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq)
+example output
 
 Parameters
 ----------
@@ -29,18 +29,18 @@ flag_dq_plane : int
 
 start_region : int
     starting slice number for detector region used in dq flagging
-end_region: int 
+end_region: int
     ending slice number for detector region used in dq flagging
 overlap_partial : int
     a dq flag indicating that only a portion of the spaxel is overlapped by a mapped detector pixel
 overlap_full : int
     a dq flag indicating that the entire spaxel is overlapped by the mapped detector pixel
 xcoord : double array
-   size of naxis1. This array holds the center x axis values of the ifu cube 
+   size of naxis1. This array holds the center x axis values of the ifu cube
 ycoord : double array
-   size of naxis2. This array holds the center y axis values of the ifu cube 
+   size of naxis2. This array holds the center y axis values of the ifu cube
 zcoord : double array
-   size of naxis3. This array holds the center x axis values of the ifu cube 
+   size of naxis3. This array holds the center x axis values of the ifu cube
 flux : double array
    size: point cloud elements. Flux of each point cloud member
 err : double array
@@ -48,7 +48,7 @@ err : double array
 slice_no: int
    slice number of point cloud member to be in dq flagging
 coord1 : double array
-   size: point cloud elements. Naxis 1 coordinate of point cloud member (xi) 
+   size: point cloud elements. Naxis 1 coordinate of point cloud member (xi)
 coord2 : double array
    size: point cloud elements. Naxis 2 coordinate of point cloud member (eta)
 wave : double array
@@ -66,9 +66,9 @@ Returns
 spaxel_flux : numpy.ndarray
   IFU spaxel cflux
 spaxel_weight : numpy.ndarray
-  IFU spaxel weight 
+  IFU spaxel weight
 spaxel_iflux : numpy.ndarray
-  IFU spaxel weight map (number of overlaps) 
+  IFU spaxel weight map (number of overlaps)
 spaxel_var : numpy.ndarray
   IFU spaxel error
 spaxel_dq : numpy.ndarray
@@ -97,7 +97,7 @@ extern int dq_miri(int start_region, int end_region, int overlap_partial, int ov
 		   double *xc, double *yc, double *zc,
 		   double *coord1, double *coord2, double *wave,
 		   double *sliceno,
-		   long ncube, long npt, 
+		   long ncube, long npt,
 		   int **spaxel_dq);
 
 extern int dq_nirspec(int overlap_partial,
@@ -111,7 +111,7 @@ extern int dq_nirspec(int overlap_partial,
 
 extern int set_dqplane_to_zero(int ncube, int **spaxel_dq);
 
-extern double sh_find_overlap(double xcenter, double ycenter, 
+extern double sh_find_overlap(double xcenter, double ycenter,
                               double xlength, double ylength,
                               double xPixelCorner[],double yPixelCorner[]);
 
@@ -128,12 +128,12 @@ int match_driz(double *xc, double *yc, double *zc,
 	       double *dwave,
 	       double *cdelt3,
 	       double cdelt1, double cdelt2,
-	       int nx, int ny, int nwave, long ncube, long npt, int linear, 
+	       int nx, int ny, int nwave, long ncube, long npt, int linear,
 	       double **spaxel_flux, double **spaxel_weight, double **spaxel_var,
 	       double **spaxel_iflux) {
 
 
-  double *fluxv, *weightv, *varv, *ifluxv;  // vector for spaxel
+  double *fluxv=NULL, *weightv=NULL, *varv=NULL, *ifluxv=NULL;  // vector for spaxel
 
   int k,j,ix1,ix2,iy1,iy2, iw1, iw2;
   int nxy, ix, iy, iw, index_xy, index_cube;
@@ -148,9 +148,9 @@ int match_driz(double *xc, double *yc, double *zc,
   double cdelt1_half, cdelt2_half;
   double xleft, xright, ybot, ytop;
   // double area_quad;
-  // allocate memory to hold output 
+  // allocate memory to hold output
   if (alloc_flux_arrays(ncube, &fluxv, &weightv, &varv, &ifluxv)) return 1;
-    
+
 
   // find max of cdelt3, dwave to be used to estimate which wavelength plane the
   // pixel falls on
@@ -161,7 +161,7 @@ int match_driz(double *xc, double *yc, double *zc,
     if(cdelt3[iw] > max_cdelt3) { max_cdelt3 = cdelt3[iw];}
     if(dwave[iw] > max_dwave){ max_dwave = dwave[iw];}
   }
- 
+
   // loop over each detector pixel and find which spaxels it overlaps with
   nxy = nx * ny;
   for (k = 0; k < npt; k++) {
@@ -195,7 +195,7 @@ int match_driz(double *xc, double *yc, double *zc,
       // area_quad = find_area_quad(xmin, ymin, xpixel, ypixel);
 
       // convert to integer values to get the approximate region to search
-      // cdelt1_half and cdelt2_half - may not be needed. 
+      // cdelt1_half and cdelt2_half - may not be needed.
       ix1 = fabs((xmin - cdelt1_half - xc[0])/cdelt1)-1;
       ix2 = fabs((xmax + cdelt1_half - xc[0])/cdelt1)+1;
 
@@ -242,13 +242,13 @@ int match_driz(double *xc, double *yc, double *zc,
 	  if(z3 < 0) { z3 =0;}
 	  zoverlap = z1 - z2 - z3;
 	  if(zoverlap < 0) { zoverlap = 0;}
-	  
+
 	  // find match in spatial dimension using approximate locations based on
 	  // ix1, ix2, iy1, iy2
 	  for (ix =ix1; ix < ix2; ix++){
 	    for (iy =iy1; iy < iy2; iy++){
-		  
-	      // narrow down the spatial region 
+
+	      // narrow down the spatial region
 	      xleft = xc[ix] - cdelt1*0.5;
 	      xright = xc[ix] + cdelt1*0.5;
 
@@ -256,13 +256,13 @@ int match_driz(double *xc, double *yc, double *zc,
 	      ytop = yc[iy] + cdelt2*0.5;
 
 	      index_xy = iy* nx + ix;
-	
+
 	      if(xleft < xmax && xright > xmin && ybot < ymax && ytop > ymin){
 
 		index_xy = iy* nx + ix;
 		index_cube = iw*nxy + index_xy;
 		// Spatial overlap between detector pixel and cube spaxel
-		area = sh_find_overlap(xc[ix], yc[iy], 
+		area = sh_find_overlap(xc[ix], yc[iy],
 				       cdelt1, cdelt2,
 				       xpixel,ypixel);
 
@@ -276,21 +276,21 @@ int match_driz(double *xc, double *yc, double *zc,
 		  varv[index_cube] = varv[index_cube] + weighted_var;
 		  ifluxv[index_cube] = ifluxv[index_cube] +1.0;
 		}
-	    
+
 	      } // xleft, xright, ybot, ytop
-		  
+
 	    }// end loop over iy
 	  } // end loop over ix
 	} // check of wave
       } // end loop over wave
   } // end loop over detector elements
-    
+
     // assign output values:
   *spaxel_flux = fluxv;
   *spaxel_weight = weightv;
   *spaxel_var = varv;
   *spaxel_iflux = ifluxv;
-  
+
   return 0;
 }
 
@@ -317,7 +317,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   PyObject  *cdelt3o;
   PyObject *xi1o, *eta1o, *xi2o, *eta2o, *xi3o, *eta3o, *xi4o, *eta4o;
   PyObject *dwaveo;
-  
+
   double cdelt1, cdelt2,cdelt3_mean;
   int  nwave, nxx, nyy;
   long npt, ncube;
@@ -332,12 +332,12 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   int free_sliceno=0;
   int free_xi1=0, free_eta1=0,free_xi2=0, free_eta2=0,free_xi3=0, free_eta3=0,free_xi4=0, free_eta4=0;
   int free_dwave=0;
-  
+
   PyArrayObject *xc, *yc, *zc, *flux, *err, *coord1, *coord2, *wave;
   PyArrayObject *xi1, *eta1, *xi2, *eta2, *xi3, *eta3, *xi4, *eta4, *dwave;
   PyArrayObject *cdelt3, *sliceno;
   PyArrayObject *spaxel_flux_arr=NULL, *spaxel_weight_arr=NULL, *spaxel_var_arr=NULL;
-  PyArrayObject *spaxel_iflux_arr=NULL, *spaxel_dq_arr=NULL; 
+  PyArrayObject *spaxel_iflux_arr=NULL, *spaxel_dq_arr=NULL;
   npy_intp npy_ncube = 0;
 
   int  ny,nz;
@@ -407,7 +407,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     // 0-length input arrays. Nothing to clip. Return 0-length arrays
     spaxel_flux_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_DOUBLE, 0);
     if (!spaxel_flux_arr) goto fail;
-    
+
     spaxel_weight_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_DOUBLE, 0);
     if (!spaxel_weight_arr) goto fail;
 
@@ -418,7 +418,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     if (!spaxel_iflux_arr) goto fail;
 
     spaxel_dq_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_INT, 0);
-    if (!spaxel_dq_arr) goto fail;    
+    if (!spaxel_dq_arr) goto fail;
 
     result = Py_BuildValue("(OOOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr, spaxel_dq_arr);
@@ -428,10 +428,10 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   }
 
   //______________________________________________________________________
-  // if flag_dq_plane = 1, Set up the dq plane 
+  // if flag_dq_plane = 1, Set up the dq plane
   //______________________________________________________________________
   int status1 = 0;
-  
+
   if(flag_dq_plane){
     if (instrument == 0){
       status1 = dq_miri(start_region, end_region,overlap_partial, overlap_full,
@@ -463,7 +463,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     }
   } else{ // set dq plane to 0
     status1 = set_dqplane_to_zero(ncube, &spaxel_dq);
-    
+
   }
   //______________________________________________________________________
   // Driz the mapped detector data onto the IFU cube
@@ -471,7 +471,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     status = match_driz((double *) PyArray_DATA(xc),
 			(double *) PyArray_DATA(yc),
 			(double *) PyArray_DATA(zc),
-			(double *) PyArray_DATA(wave),			      
+			(double *) PyArray_DATA(wave),
 			(double *) PyArray_DATA(flux),
 			(double *) PyArray_DATA(err),
 			(double *) PyArray_DATA(xi1),
@@ -495,7 +495,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   } else {
     // create return tuple:
     npy_ncube = (npy_intp) ncube;
-    
+
     spaxel_flux_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_flux);
     if (!spaxel_flux_arr) goto fail;
     spaxel_flux = NULL;
@@ -503,11 +503,11 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     spaxel_weight_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_weight);
     if (!spaxel_weight_arr) goto fail;
     spaxel_weight = NULL;
-    
+
     spaxel_var_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_var);
     if (!spaxel_var_arr) goto fail;
     spaxel_var = NULL;
-    
+
     spaxel_iflux_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_iflux);
     if (!spaxel_iflux_arr) goto fail;
     spaxel_iflux = NULL;
@@ -523,9 +523,9 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     PyArray_ENABLEFLAGS(spaxel_dq_arr, NPY_ARRAY_OWNDATA);
     result = Py_BuildValue("(OOOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr, spaxel_dq_arr);
-	
+
     goto cleanup;
-    
+
   }
 
  fail:
@@ -565,7 +565,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
   if (free_eta2) Py_XDECREF(eta2);
   if (free_eta3) Py_XDECREF(eta3);
   if (free_eta4) Py_XDECREF(eta4);
-  if (free_dwave) Py_XDECREF(dwave);    
+  if (free_dwave) Py_XDECREF(dwave);
   return result;
 }
 

--- a/jwst/cube_build/src/cube_match_sky_pointcloud.c
+++ b/jwst/cube_build/src/cube_match_sky_pointcloud.c
@@ -5,7 +5,7 @@ in a region centered on the center of the cube spaxel. The size of the spaxel is
 coordinates is cdetl1 and cdelt2, while the wavelength size is zcdelt3.
 This module uses the modified shephard weighting method (emsm if weight_type =0 or msm if weight_type =1)
 to determine how to  weight each point cloud member in the spaxel.
- 
+
 Main function for Python: cube_wrapper
 
 Python signature: result = cube_wrapper(instrument, flag_dq_plane, weight_type, start_region, end_region,
@@ -17,8 +17,8 @@ Python signature: result = cube_wrapper(instrument, flag_dq_plane, weight_type, 
                                         roiw_ave, cdelt1, cdelt2)
 provide more details
 
-The output of this function is a tuple of 5 arrays:(spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq) 
-example output 
+The output of this function is a tuple of 5 arrays:(spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq)
+example output
 
 Parameters
 ----------
@@ -32,18 +32,18 @@ weight_type : int
    1: use msm weighting
 start_region : int
     starting slice number for detector region used in dq flagging
-end_region: int 
+end_region: int
     ending slice number for detector region used in dq flagging
 overlap_partial : int
     a dq flag indicating that only a portion of the spaxel is overlapped by a mapped detector pixel
 overlap_full : int
     a dq flag indicating that the entire spaxel is overlapped by the mapped detector pixel
 xcoord : double array
-   size of naxis1. This array holds the center x axis values of the ifu cube 
+   size of naxis1. This array holds the center x axis values of the ifu cube
 ycoord : double array
-   size of naxis2. This array holds the center y axis values of the ifu cube 
+   size of naxis2. This array holds the center y axis values of the ifu cube
 zcoord : double array
-   size of naxis3. This array holds the center x axis values of the ifu cube 
+   size of naxis3. This array holds the center x axis values of the ifu cube
 flux : double array
    size: point cloud elements. Flux of each point cloud member
 err : double array
@@ -51,7 +51,7 @@ err : double array
 slice_no: int
    slice number of point cloud member to be in dq flagging
 coord1 : double array
-   size: point cloud elements. Naxis 1 coordinate of point cloud member (xi) 
+   size: point cloud elements. Naxis 1 coordinate of point cloud member (xi)
 coord2 : double array
    size: point cloud elements. Naxis 2 coordinate of point cloud member (eta)
 wave : double array
@@ -77,9 +77,9 @@ Returns
 spaxel_flux : numpy.ndarray
   IFU spaxel cflux
 spaxel_weight : numpy.ndarray
-  IFU spaxel weight 
+  IFU spaxel weight
 spaxel_iflux : numpy.ndarray
-  IFU spaxel weight map (number of overlaps) 
+  IFU spaxel weight map (number of overlaps)
 spaxel_var : numpy.ndarray
   IFU spaxel error
 spaxel_dq : numpy.ndarray
@@ -108,7 +108,7 @@ extern int dq_miri(int start_region, int end_region, int overlap_partial, int ov
 		   double *xc, double *yc, double *zc,
 		   double *coord1, double *coord2, double *wave,
 		   double *sliceno,
-		   long ncube, int npt, 
+		   long ncube, int npt,
 		   int **spaxel_dq);
 
 extern int dq_nirspec(int overlap_partial,
@@ -138,21 +138,20 @@ int match_point_emsm(double *xc, double *yc, double *zc,
 		     double **spaxel_iflux) {
 
 
-  double *fluxv, *weightv, *varv, *ifluxv;  // vector for spaxel
+  double *fluxv=NULL, *weightv=NULL, *varv=NULL, *ifluxv=NULL;  // vector for spaxel
 
   int k, iwstart, iwend, ixstart,  ixend, iystart, iyend;
   int ii, nxy, ix, iy, iw, index_xy, index_cube;
   int done_search_w, done_search_y, done_search_x;
   double wdiff, ydiff, xdiff, ydist, xdist, radius;
   double d1, d2, dxy, d3, d32, w, wn, ww, weighted_flux, weighted_var;
-  
-  // allocate memory to hold output 
+
+  // allocate memory to hold output
   if (alloc_flux_arrays(ncube, &fluxv, &weightv, &varv, &ifluxv)) return 1;
-  
-    
+
+
     // loop over each point cloud member and find which roi spaxels it is found
 
-  // printf(" number detector elements %i \n" , npt);
   for (k = 0; k < npt; k++) {
     // Search wave and find match
     iwstart = -1;
@@ -184,6 +183,7 @@ int match_point_emsm(double *xc, double *yc, double *zc,
     ixend = -1;
     ii = 0;
     done_search_x = 0;
+
     while (ii < nx && done_search_x == 0) {
       xdiff = fabs(xc[ii] - coord1[k]);
       if(xdiff <= rois_pixel[k]){
@@ -198,12 +198,13 @@ int match_point_emsm(double *xc, double *yc, double *zc,
       }
       ii = ii + 1;
     }
+
     // catch the case of ixstart near nx and becomes = nx before ixend can be set.
     if(ixstart !=-1 && ixend == -1){
       ixend = nx;
       done_search_x = 1;
     }
-  
+
     // Search ycenters and find match
     iystart = -1;
     iyend = -1;
@@ -234,12 +235,14 @@ int match_point_emsm(double *xc, double *yc, double *zc,
     if(done_search_x == 1 && done_search_y ==1 && done_search_w ==1){
       // The search above for x,y  was a crude search - now narrow the search using the distance between
       // the spaxel center and point cloud
+
       for (ix = ixstart; ix< ixend; ix ++){
+
 	for ( iy = iystart; iy < iyend; iy ++){
 	  ydist = fabs(yc[iy] - coord2[k]);
 	  xdist = fabs(xc[ix] - coord1[k]);
 	  radius = sqrt( xdist*xdist + ydist*ydist);
-	  
+
 	  if (radius <= rois_pixel[k]){
 	    // Find the index for this in spatial plane
 	    index_xy = iy* nx + ix;
@@ -254,7 +257,7 @@ int match_point_emsm(double *xc, double *yc, double *zc,
 	      w = d32  +  dxy;
 	      wn = -w/(scalerad_pixel[k]/cdelt1);
 	      ww = exp(wn);
-	      
+
 	      weighted_flux =  flux[k]* ww;
 	      weighted_var = (err[k]* ww) * (err[k]*ww);
 	      fluxv[index_cube] = fluxv[index_cube] + weighted_flux;
@@ -265,10 +268,8 @@ int match_point_emsm(double *xc, double *yc, double *zc,
 	  }
 	} // end loop over iy
       } // end loop over ix
-
     } // end done_search_x, done_search_y, done_search_w
   } // end loop over point cloud
-    
 
   // assign output values:
   *spaxel_flux = fluxv;
@@ -297,19 +298,19 @@ int match_point_msm(double *xc, double *yc, double *zc,
 		    double **spaxel_iflux) {
 
 
-  double *fluxv, *weightv, *varv, *ifluxv;  // vector for spaxel
+  double *fluxv=NULL, *weightv=NULL, *varv=NULL, *ifluxv=NULL;  // vector for spaxel
 
   int k;
   int iwstart, iwend, ixstart, ixend, iystart, iyend;
   int ii, nxy, iw, ix, iy, index_xy, index_cube;
-  int done_search_w, done_search_x, done_search_y; 
+  int done_search_w, done_search_x, done_search_y;
   double wdiff, xdiff, ydiff, radius, ydist, xdist;
   double d1, d2, dxy, d3, d32, w, wn, ww;
   double weighted_flux, weighted_var;
-  
+
   // allocate memory to hold output
   if (alloc_flux_arrays(ncube, &fluxv, &weightv, &varv, &ifluxv)) return 1;
-        
+
   // loop over each point cloud member and find which roi spaxels it is found
 
   for ( k = 0; k < npt; k++) {
@@ -363,7 +364,7 @@ int match_point_msm(double *xc, double *yc, double *zc,
 	ixend = nx;
 	done_search_x = 1;
       }
-      
+
        // Search ycenters and find match
       iystart = -1;
       iyend = -1;
@@ -417,7 +418,7 @@ int match_point_msm(double *xc, double *yc, double *zc,
 		if( wn < softrad_pixel[k]){
 		  wn = softrad_pixel[k];
 		}
-		
+
 		ww = 1.0/wn;
 		weighted_flux =  flux[k]* ww;
 		weighted_var = (err[k]* ww) * (err[k]*ww);
@@ -433,7 +434,7 @@ int match_point_msm(double *xc, double *yc, double *zc,
 
       } // end done_search_x, done_search_y, done_search_w
     } // end loop over point cloud
-    
+
 
     // assign output values:
 
@@ -465,7 +466,7 @@ PyArrayObject * ensure_array(PyObject *obj, int *is_copy) {
 static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
   PyObject *result = NULL, *xco, *yco, *zco, *fluxo, *erro, *coord1o, *coord2o, *waveo, *slicenoo;
   PyObject *rois_pixelo, *roiw_pixelo, *scalerad_pixelo, *zcdelt3o, *softrad_pixelo, *weight_pixelo;
-  
+
   double cdelt1, cdelt2, roiw_ave;
   int  nwave, npt, nxx, nyy, ncube;
 
@@ -477,11 +478,11 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
   int free_xc=0, free_yc=0, free_zc=0, free_coord1=0, free_coord2 =0 , free_wave=0, status=0;
   int free_rois_pixel=0, free_roiw_pixel=0, free_scalerad_pixel=0, free_flux=0, free_err=0, free_zcdelt3=0;
   int free_sliceno=0, free_softrad_pixel, free_weight_pixel=0;
-  
+
   PyArrayObject *xc, *yc, *zc, *flux, *err, *coord1, *coord2, *wave, *rois_pixel, *roiw_pixel, *scalerad_pixel;
   PyArrayObject *zcdelt3, *sliceno, *softrad_pixel, *weight_pixel;
   PyArrayObject *spaxel_flux_arr=NULL, *spaxel_weight_arr=NULL, *spaxel_var_arr=NULL;
-  PyArrayObject *spaxel_iflux_arr=NULL, *spaxel_dq_arr=NULL; 
+  PyArrayObject *spaxel_iflux_arr=NULL, *spaxel_dq_arr=NULL;
   npy_intp npy_ncube = 0;
 
   int  ny,nz;
@@ -540,12 +541,12 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
   nwave = (int) PyArray_Size((PyObject *) zc);
 
   ncube = nxx * nyy * nwave;
-  
+
   if (ncube ==0) {
     // 0-length input arrays. Nothing to clip. Return 0-length arrays
     spaxel_flux_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_DOUBLE, 0);
     if (!spaxel_flux_arr) goto fail;
-    
+
     spaxel_weight_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_DOUBLE, 0);
     if (!spaxel_weight_arr) goto fail;
 
@@ -556,7 +557,7 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
     if (!spaxel_iflux_arr) goto fail;
 
     spaxel_dq_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_INT, 0);
-    if (!spaxel_dq_arr) goto fail;    
+    if (!spaxel_dq_arr) goto fail;
 
     result = Py_BuildValue("(OOOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr, spaxel_dq_arr);
@@ -566,7 +567,7 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
   }
 
   //______________________________________________________________________
-  // if flag_dq_plane = 1, Set up the dq plane 
+  // if flag_dq_plane = 1, Set up the dq plane
   //______________________________________________________________________
   int status1 = 0;
   if(flag_dq_plane){
@@ -600,7 +601,7 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
     }
   } else{ // set dq plane to 0
     status1 = set_dqplane_to_zero(ncube, &spaxel_dq);
-    
+
   }
 
   //______________________________________________________________________
@@ -612,7 +613,7 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
 			      (double *) PyArray_DATA(zc),
 			      (double *) PyArray_DATA(coord1),
 			      (double *) PyArray_DATA(coord2),
-			      (double *) PyArray_DATA(wave),			      
+			      (double *) PyArray_DATA(wave),
 			      (double *) PyArray_DATA(flux),
 			      (double *) PyArray_DATA(err),
 			      (double *) PyArray_DATA(rois_pixel),
@@ -627,7 +628,7 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
 			     (double *) PyArray_DATA(zc),
 			     (double *) PyArray_DATA(coord1),
 			     (double *) PyArray_DATA(coord2),
-			     (double *) PyArray_DATA(wave),			      
+			     (double *) PyArray_DATA(wave),
 			     (double *) PyArray_DATA(flux),
 			     (double *) PyArray_DATA(err),
 			     (double *) PyArray_DATA(rois_pixel),
@@ -646,7 +647,7 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
   } else {
     // create return tuple:
     npy_ncube = (npy_intp) ncube;
-    
+
     spaxel_flux_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_flux);
     if (!spaxel_flux_arr) goto fail;
     spaxel_flux = NULL;
@@ -654,11 +655,11 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
     spaxel_weight_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_weight);
     if (!spaxel_weight_arr) goto fail;
     spaxel_weight = NULL;
-    
+
     spaxel_var_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_var);
     if (!spaxel_var_arr) goto fail;
     spaxel_var = NULL;
-    
+
     spaxel_iflux_arr = (PyArrayObject*) PyArray_SimpleNewFromData(1, &npy_ncube, NPY_DOUBLE, spaxel_iflux);
     if (!spaxel_iflux_arr) goto fail;
     spaxel_iflux = NULL;
@@ -674,9 +675,9 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
     PyArray_ENABLEFLAGS(spaxel_dq_arr, NPY_ARRAY_OWNDATA);
     result = Py_BuildValue("(OOOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr, spaxel_dq_arr);
-	
+
     goto cleanup;
-    
+
   }
 
  fail:

--- a/jwst/cube_build/src/cube_utils.c
+++ b/jwst/cube_build/src/cube_utils.c
@@ -23,46 +23,49 @@ int alloc_flux_arrays(int nelem, double **fluxv, double **weightv, double **varv
     // flux:
     if (!(*fluxv  = (double*)calloc(nelem, sizeof(double)))) {
         PyErr_SetString(PyExc_MemoryError, msg);
-        goto failed_mem_alloc;
+        goto failed_mem_alloc1;
     }
-    
+
     //weight
     if (!(*weightv  = (double*)calloc(nelem, sizeof(double)))) {
       PyErr_SetString(PyExc_MemoryError, msg);
-      goto failed_mem_alloc;
+      goto failed_mem_alloc2;
     }
 
     //variance
     if (!(*varv  = (double*)calloc(nelem, sizeof(double)))) {
       PyErr_SetString(PyExc_MemoryError, msg);
-      goto failed_mem_alloc;
+      goto failed_mem_alloc3;
     }
 
     //iflux
     if (!(*ifluxv  = (double*)calloc(nelem, sizeof(double)))) {
       PyErr_SetString(PyExc_MemoryError, msg);
-      goto failed_mem_alloc;
+      goto failed_mem_alloc4;
     }
-    
+
     return 0;
 
- failed_mem_alloc:
-    free(*fluxv);
-    free(*weightv);
-    free(*varv);
+ failed_mem_alloc4:
     free(*ifluxv);
-    
+ failed_mem_alloc3:
+    free(*varv);
+ failed_mem_alloc2:
+    free(*weightv);
+ failed_mem_alloc1:
+    free(*fluxv);
+    return 1;
 }
 
-// support function for sh_find_overlap 
+// support function for sh_find_overlap
 void addpoint (double x, double y, double xnew[], double ynew[], int *nVertices2){
   xnew[*nVertices2] = x;
   ynew[*nVertices2] = y;
   *nVertices2 = *nVertices2 + 1;
 }
 
-// support function for sh_find_overlap 
-int insideWindow(int edge, double x, double y, 
+// support function for sh_find_overlap
+int insideWindow(int edge, double x, double y,
                  double left,double right, double top, double bottom){
         switch(edge)
         {
@@ -78,8 +81,8 @@ int insideWindow(int edge, double x, double y,
         return 0;
 }
 
-// support function for sh_find_overlap 
-int calcCondition(int edge, double x1, double y1, double x2, double y2, 
+// support function for sh_find_overlap
+int calcCondition(int edge, double x1, double y1, double x2, double y2,
                   double left, double right, double top, double bottom) {
   int stat1 = insideWindow(edge,x1,y1,left,right,top,bottom);
   int stat2 = insideWindow(edge,x2,y2,left,right,top,bottom);
@@ -91,7 +94,7 @@ int calcCondition(int edge, double x1, double y1, double x2, double y2,
 
 }
 
-// support function for sh_find_overlap 
+// support function for sh_find_overlap
 void solveIntersection(int edge ,double x1,double y1,double x2,double y2,
                        double *x,double *y,
                        double left, double right, double top, double bottom){
@@ -142,10 +145,10 @@ double find_area_quad(double MinX, double MinY, double Xcorner[], double Ycorner
     -------
     Area
   */
-  
+
   double PX[5];
   double PY[5];
-  double Area =0; 
+  double Area =0;
 
   PX[0] = Xcorner[0] - MinX;
   PX[1] = Xcorner[1] - MinX;
@@ -162,8 +165,8 @@ double find_area_quad(double MinX, double MinY, double Xcorner[], double Ycorner
   Area = 0.5 * ((PX[0] * PY[1] - PX[1] * PY[0]) +
 		(PX[1] * PY[2] - PX[2] * PY[1]) +
 		(PX[2] * PY[3] - PX[3] * PY[2]) +
-		(PX[3] * PY[4] - PX[4] * PY[3])); 
-    
+		(PX[3] * PY[4] - PX[4] * PY[3]));
+
   return fabs(Area);
 }
 
@@ -172,16 +175,16 @@ double find_area_quad(double MinX, double MinY, double Xcorner[], double Ycorner
 double find_area_poly(int nVertices,double xPixel[],double yPixel[]){
 
   double area = 0;
-  int i; 
+  int i;
   double areaPoly = 0.0;
   double xmin = xPixel[0];
   double ymin = yPixel[0];
 
-  for (i = 1; i < nVertices; i++){ 
+  for (i = 1; i < nVertices; i++){
     if(xPixel[i] < xmin) xmin = xPixel[i];
     if(yPixel[i] < ymin) ymin = yPixel[i];
   }
-  
+
   for (i = 0; i < nVertices-1; i++){
     area = ( xPixel[i]- xmin)*(yPixel[i+1]-ymin) - (xPixel[i+1]-xmin)*(yPixel[i]-ymin);
     areaPoly = areaPoly + area;
@@ -189,10 +192,10 @@ double find_area_poly(int nVertices,double xPixel[],double yPixel[]){
   areaPoly = 0.5* areaPoly;
   return fabs(areaPoly);
 }
-  
+
 
 //________________________________________________________________________________
-double sh_find_overlap(const double xcenter, const double ycenter, 
+double sh_find_overlap(const double xcenter, const double ycenter,
 		      const double xlength, const double ylength,
 		      double xPixelCorner[],double yPixelCorner[])
 {
@@ -214,8 +217,8 @@ double sh_find_overlap(const double xcenter, const double ycenter,
   int MaxVertices = 9;
   double xPixel[9]= {0.0};
   double yPixel[9] = {0.0};
-  double xnew[9]= {0.0}; 
-  double ynew[9]= {0.0}; 
+  double xnew[9]= {0.0};
+  double ynew[9]= {0.0};
 
   // initialize xPixel, yPixel to the detector pixel corners.
   // xPixel,yPixel is become the clipped polygon vertices inside the cube pixel
@@ -246,8 +249,8 @@ double sh_find_overlap(const double xcenter, const double ycenter,
           solveIntersection(i,x1,y1,x2,y2,
                             &x, &y,
                             left,right,top,bottom);
-          
-          
+
+
           addpoint (x, y, xnew, ynew, &nVertices2);
           addpoint (x2, y2, xnew, ynew, &nVertices2);
           break;
@@ -267,7 +270,7 @@ double sh_find_overlap(const double xcenter, const double ycenter,
 
 
    addpoint (xnew[0], ynew[0], xnew, ynew, &nVertices2); // closed polygon
-    
+
    nVertices = nVertices2-1;
 
    for (k = 0; k< nVertices2; k++){
@@ -275,7 +278,7 @@ double sh_find_overlap(const double xcenter, const double ycenter,
      yPixel[k] = ynew[k];
    }
 
-    //update 
+    //update
 
   } // loop over top,bottom,left,right
 
@@ -283,6 +286,6 @@ double sh_find_overlap(const double xcenter, const double ycenter,
   if(nVertices > 0) {
     areaClipped = find_area_poly(nVertices,xPixel,yPixel);
   }
-  
+
   return areaClipped;
 }


### PR DESCRIPTION
This PR addresses fixes several bugs in how C code used by the cube builder may attempt to deallocate unallocated memory resulting in core dump. This happens when memory allocation fails for one array and then code attempts to deallocate several other arrays never allocated before. Due to this bug a memory allocation error is never raised but instead the whole process exits.

This PR also fixes a bug in `alloc_flux_arrays()` due to which 1 is not returned on memory allocation failure resulting in the code not detecting memory allocation failures.

Help desk issue INC0184892.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/511/
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
