### PR TITLE
JP-3028 Do not clobber reprocessing lists when Level 2 rules are operating on 'c' type candidates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ associations
 
 - Fix NIRSpec IFU NOD background subtract and include leakcal in the Level2 associations. [#7405]
 
+- Do not clobber reprocessing lists when Level 2 rules are operating on 'c' type candidates [#7410]
+
 combine_1d
 ----------
 

--- a/jwst/associations/generate.py
+++ b/jwst/associations/generate.py
@@ -18,7 +18,7 @@ logger.addHandler(logging.NullHandler())
 __all__ = ['generate']
 
 
-def generate(pool, rules, version_id=None):
+def generate(pool, rules, version_id=None, finalize=True):
     """Generate associations in the pool according to the rules.
 
     Parameters
@@ -34,6 +34,9 @@ def generate(pool, rules, version_id=None):
         If None, no tagging occurs.
         If True, use a timestamp
         If a string, the string.
+
+    finalize : bool
+        Run all rule methods marked as 'finalized'.
 
     Returns
     -------
@@ -98,10 +101,13 @@ def generate(pool, rules, version_id=None):
 
     # Finalize found associations
     logger.debug('# associations before finalization: %d', len(associations))
-    try:
-        finalized_asns = rules.callback.reduce('finalize', associations)
-    except KeyError:
-        finalized_asns = associations
+    finalized_asns = associations
+    if finalize:
+        logger.debug('Performing association finalization.')
+        try:
+            finalized_asns = rules.callback.reduce('finalize', associations)
+        except KeyError as exception:
+            logger.debug('Finalization failed for reason: %s', exception)
 
     return finalized_asns
 

--- a/jwst/associations/generate.py
+++ b/jwst/associations/generate.py
@@ -97,6 +97,7 @@ def generate(pool, rules, version_id=None, finalize=True):
         logger.debug('New process lists: %d', total_reprocess)
         logger.debug('Updated process queue: %s', process_queue)
         logger.debug('# associations: %d', len(associations))
+        logger.debug('Associations: %s', [type(_association) for _association in associations])
         logger.debug('Seconds to process: %.2f\n', timer() - time_start)
 
     # Finalize found associations

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -115,19 +115,6 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         if 'asn_pool' not in self.data:
             self.data['asn_pool'] = 'none'
 
-    def check_and_set_constraints(self, item):
-        """Override of Association method
-
-        An addition check is made on candidate type.
-        Level 2 associations can only be created by
-        OBSERVATION and BACKGROUND candidates.
-        """
-        match, reprocess = super(DMSLevel2bBase, self).check_and_set_constraints(item)
-        if match and not self.acid.type in ['observation', 'background']:
-            return False, []
-        else:
-            return match, reprocess
-
     def members_by_type(self, member_type):
         """Get list of members by their exposure type"""
         member_type = member_type.lower()

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -173,6 +173,11 @@ class Main():
             help='Version of the generator.'
         )
         parser.add_argument(
+            '--no-finalize',
+            action='store_true',
+            help='Do not run the finalization methods on the interim associations'
+        )
+        parser.add_argument(
             '--merge', action='store_true',
             help='Merge associations into single associations with multiple products'
         )
@@ -248,7 +253,7 @@ class Main():
 
         logger.info('Generating associations.')
         self.associations = generate(
-            self.pool, self.rules, version_id=parsed.version_id
+            self.pool, self.rules, version_id=parsed.version_id, finalize=not parsed.no_finalize
         )
 
         if parsed.discover:

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -52,6 +52,11 @@ SPECIAL_POOLS = {
         'xfail': 'JSOCINT-TDB: WFSC ROUTINE VISIT issue',
         'slow': False,
     },
+    'jw00663_20221218t111937_pool': {
+        'args': ['-i', 'o004', 'c1000'],
+        'xfail': None,
+        'slow': False,
+    },
     'jw00676_20210403t114320_pool': {
         'args': [],
         'xfail': None,
@@ -66,6 +71,11 @@ SPECIAL_POOLS = {
         'args': [],
         'xfail': None,
         'slow': True,
+    },
+    'jw00839_20221220t025418_pool': {
+        'args': ['-i', 'o002', 'c1000'],
+        'xfail': None,
+        'slow': False,
     },
     'jw80600_20171108T041522_pool': {
         'args': [],


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3028](https://jira.stsci.edu/browse/JP-3028)
<!-- describe the changes comprising this PR here -->
This PR addresses an issue found in pre-integration testing by SDP. When the `asn_generate` command is run on both 'o'-level and 'c'-level candidates, often the observation candidates did not get created when they should have been. The issue was a redundant method that was meant to remove Level 2 'c'-level candidates when those candidates are not BACKGROUND candidates. The reprocessing list from those associations were deleted along with the associations. These reprocessing lists contained the necessary info to produce the 'o'-level associations.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
