### PR TITLE
Merge the two update_wcsinfo functions into one

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ assign_wcs
 - Updated the loading of NIRSpec MSA configuration data to assign the source_id
   for each slitlet from the shutter entry that contains the primary/main source. [#7379]
 
-- Added approximated imaging FITS WCS to the grism image headers. [#7373]
+- Added approximated imaging FITS WCS to the grism image headers. [#7373, #7412]
 
 associations
 ------------


### PR DESCRIPTION
This PR merges `fits_wcsinfo` and `update_fits_wcsinfo` functions (`fits_wcsinfo` introduced in https://github.com/spacetelescope/jwst/pull/7373) into a single function, basically expanding capabilities of the original `update_fits_wcsinfo` function. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
