### PR TITLE
Update NIRSpec MOS regtests with flight data

### DIFF
--- a/jwst/regtest/test_nirspec_masterbackground.py
+++ b/jwst/regtest/test_nirspec_masterbackground.py
@@ -17,8 +17,8 @@ def run_spec2_mbkg(jail, rtdata_module):
     rtdata = rtdata_module
 
     # Get data
-    rtdata.get_data('nirspec/mos/nrs_mos_with_bkgslits_msa.fits')
-    rtdata.get_data('nirspec/mos/nrs_mos_with_bkgslits_rate.fits')
+    rtdata.get_data('nirspec/mos/jw01180025001_01_msa.fits')
+    rtdata.get_data('nirspec/mos/jw01180025001_05101_00001_nrs2_rate.fits')
 
     # Run the pipeline
     step_params = {
@@ -88,7 +88,7 @@ def test_masterbkg_corrpars(rtdata):
 
 @pytest.mark.parametrize(
     'suffix',
-    ['cal', 'masterbg1d', 'masterbg2d']
+    ['masterbg1d', 'masterbg2d', 'cal', 's2d', 'x1d']
 )
 def test_nirspec_mos_mbkg(suffix, run_spec2_mbkg, fitsdiff_default_kwargs):
     """Run spec2 with master background"""

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -12,14 +12,15 @@ def run_pipeline(rtdata_module):
     rtdata = rtdata_module
 
     # Get the MSA metadata file referenced in the input exposure
-    rtdata.get_data("nirspec/mos/jw95065006001_0_short_msa.fits")
+    rtdata.get_data("nirspec/mos/jw01180025001_01_msa.fits")
 
-    # Get the input exposure
-    rtdata.get_data("nirspec/mos/f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod.fits")
+    # Get the input ASN file and exposures
+    rtdata.get_asn("nirspec/mos/jw01180-o025_20221129t204108_spec2_00037_asn.json")
 
     # Run the calwebb_spec2 pipeline; save results from intermediate steps
     args = ["calwebb_spec2", rtdata.input,
             "--steps.assign_wcs.save_results=true",
+            "--steps.bkg_subtract.save_results=true",
             "--steps.msa_flagging.save_results=true",
             "--steps.extract_2d.save_results=true",
             "--steps.srctype.save_results=true",
@@ -34,15 +35,15 @@ def run_pipeline(rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", [
-    "assign_wcs", "msa_flagging", "extract_2d", "wavecorr", "flat_field", "srctype",
-    "pathloss", "barshadow", "cal", "s2d", "x1d"])
+    "assign_wcs", "bsub", "msa_flagging", "extract_2d", "wavecorr", "flat_field",
+    "srctype", "pathloss", "barshadow", "cal", "s2d", "x1d"])
 def test_nirspec_mos_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     """Regression test of the calwebb_spec2 pipeline on a
        NIRSpec MOS exposure."""
 
     # Run the pipeline and retrieve outputs
     rtdata = run_pipeline
-    output = f"f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_{suffix}.fits"
+    output = f"jw01180025001_05101_00001_nrs2_{suffix}.fits"
     rtdata.output = output
 
     # Get the truth files


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR swaps fake data for real in-flight data for a couple of NIRSpec MOS regtests. One is the full calwebb_spec2 pipeline, using a spec2 ASN as input that contains nodded exposures, which allows the background subtraction step to occur. The other processes just a single MOS exposure that has a couple of dedicated bkg slitlets defined and hence is able to exercise the master_background_mos step. All input/truth files have been loaded to Artifactory and have been confirmed to work.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
