### PR TITLE
test opencv functionality separately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
           - toxenv: test-oldestdeps-xdist-cov
             os: ubuntu-latest
             python-version: '3.8'
+          - toxenv: test-opencv-xdist
+            os: ubuntu-latest
+            python-version: '3.10'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -310,7 +310,8 @@ def test_three_group_integration(generate_miri_reffiles, setup_inputs):
                               override_readnoise=override_readnoise, maximum_cores='none')
     assert out_model.meta.cal_step.jump == 'COMPLETE'
 
-@pytest.mark.skipif(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
+
+@pytest.mark.xfail(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
 def test_snowball_flagging_nosat(generate_nircam_reffiles, setup_inputs):
     """Test that snowballs are properly flagged when the `sat_required_snowball`,
     which requires there to be a saturated pixel within the cluster of
@@ -355,7 +356,7 @@ def test_snowball_flagging_nosat(generate_nircam_reffiles, setup_inputs):
         assert (np.floor(expanded_area / initial_area) == (expand_factor**2))
 
 
-@pytest.mark.skipif(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
+@pytest.mark.xfail(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
 def test_snowball_flagging_sat(generate_nircam_reffiles, setup_inputs):
     """Test that snowballs are properly flagged when the `sat_required_snowball`,
     which requires there to be a saturated pixel within the cluster of

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,6 @@ test =
     colorama>=0.4.1
     readchar>=3.0
     ruff
-    opencv-python
     pytest>=6.0.0
     pytest-cov>=2.9.0
     pytest-doctestplus>=0.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands =
 [testenv]
 description =
     run tests
+    opencv: requiring opencv-python
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     sdpdeps: with the recent STScI DMS release pinned dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -80,18 +80,20 @@ commands =
     regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
     xdist: -n auto \
     pyargs: {toxinidir}/docs --pyargs jwst \
-    {posargs}
+    {posargs} \
+    opencv: -- jwst/jump/tests/test_jump_step.py
 deps =
     xdist: pytest-xdist
     devdeps: -rrequirements-dev.txt
     sdpdeps: -rrequirements-sdp.txt
+    opencv: opencv-python
 setenv =
     sdpdeps,regtests: CRDS_CONTEXT = jwst-edit
 commands_pre =
     python -m pip install --upgrade pip
-    # Generate a requirements-min.txt file
+# Generate a requirements-min.txt file
     oldestdeps: minimum_deps
-    # Force install everything in that file
+# Force install everything in that file
     oldestdeps: pip install --ignore-installed -r requirements-min.txt
 # Don't treat positional arguments passed to tox as file system paths
 args_are_paths =

--- a/tox.ini
+++ b/tox.ini
@@ -80,8 +80,8 @@ commands =
     regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
     xdist: -n auto \
     pyargs: {toxinidir}/docs --pyargs jwst \
-    {posargs} \
-    opencv: -- jwst/jump/tests/test_jump_step.py
+    opencv: -- jwst/jump/tests/test_jump_step.py \
+    {posargs}
 deps =
     xdist: pytest-xdist
     devdeps: -rrequirements-dev.txt


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Addresses #7409
related to https://github.com/spacetelescope/stcal/pull/136

<!-- describe the changes comprising this PR here -->
This PR runs the tests requiring `opencv` in a separate `toxenv` with `opencv-python` installed, to test whether conditional usage of ellipse construction is handled gracefully.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
