### PR TITLE
Pin tweakwcs version to 0.8.1 and update tweakreg unit test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -176,6 +176,10 @@ tweakreg
 - Fix a bug in the logic that handles inputs with a single image group when
   an absolute reference catalog is provided. [#7328]
 
+- Pinned ``tweakwcs`` version to 0.8.1 that fixes a bug in how 2D histogram's
+  bin size is computed. This affects pre-alignment performed before source
+  matching. [#7417]
+
 wfss_contam
 -----------
 

--- a/jwst/tweakreg/tests/test_multichip_jwst.py
+++ b/jwst/tweakreg/tests/test_multichip_jwst.py
@@ -191,7 +191,7 @@ def _make_reference_gwcs_wcs(fits_hdr):
     return gw
 
 
-def _match(x, y):
+def _match(x, y, **kwargs):
     lenx = len(x)
     leny = len(y)
     if lenx == leny:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     stpipe>=0.4.4,<1.0
     stsci.image>=2.3.5
     stsci.imagestats>=1.6.3
-    tweakwcs>=0.8.0
+    tweakwcs>=0.8.1
     asdf-astropy>=0.2.2
     wiimatch>=0.2.1
 


### PR DESCRIPTION
This PR fixes a unit test failure in `tweakreg` step and pins `tweakwcs=0.8.1`.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
     https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/521/
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
