### PR TITLE
Add scipy and numpy nightly wheels to dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,12 @@ jobs:
           - toxenv: test-opencv-xdist
             os: ubuntu-latest
             python-version: '3.10'
+          - toxenv: test-devdeps-xdist
+            os: ubuntu-latest
+            python-version: '3.10'
+          - toxenv: test-devdeps-xdist
+            os: macos-latest
+            python-version: '3.10'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,6 @@ jobs:
           - toxenv: test-opencv-xdist
             os: ubuntu-latest
             python-version: '3.10'
-          - toxenv: test-devdeps-xdist
-            os: ubuntu-latest
-            python-version: '3.10'
-          - toxenv: test-devdeps-xdist
-            os: macos-latest
-            python-version: '3.10'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,7 @@ git+https://github.com/spacetelescope/stpipe
 git+https://github.com/spacetelescope/stcal
 git+https://github.com/spacetelescope/tweakwcs
 git+https://github.com/spacetelescope/wiimatch
+
+
+scipy>=0.0.dev0
+numpy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -94,6 +94,7 @@ deps =
     opencv: opencv-python
 setenv =
     sdpdeps,regtests: CRDS_CONTEXT = jwst-edit
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 commands_pre =
     python -m pip install --upgrade pip
 # Generate a requirements-min.txt file


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR adds the scipy and numpy nightly wheels to the dev dependencies, so that we can detect issues like the scipy 1.10.0 release prior to that release.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
