### PR TITLE
JP-2928: Update MIRI coron3 test with flight data

### DIFF
--- a/jwst/regtest/test_miri_coron3.py
+++ b/jwst/regtest/test_miri_coron3.py
@@ -8,7 +8,7 @@ from jwst.stpipe import Step
 def run_pipeline(jail, rtdata_module):
     """Run calwebb_coron3 on MIRI 4QPM coronographic data."""
     rtdata = rtdata_module
-    rtdata.get_asn("miri/coron/miri_1065_coron3_asn.json")
+    rtdata.get_asn("miri/coron/jw01386-c1002_20230109t015044_coron3_00001_asn.json")
 
     # Run the calwebb_coron3 pipeline on the association
     args = [
@@ -20,13 +20,13 @@ def run_pipeline(jail, rtdata_module):
 
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("suffix", ["psfalign", "psfsub"])
-@pytest.mark.parametrize("exposure", ["roll1", "roll2"])
+@pytest.mark.parametrize("suffix", ["crfints", "psfalign", "psfsub"])
+@pytest.mark.parametrize("exposure", ["4", "5"])
 def test_miri_coron3_sci_exp(run_pipeline, suffix, exposure, fitsdiff_default_kwargs):
     """Check intermediate results of calwebb_coron3"""
     rtdata = run_pipeline
 
-    output = "MIRIM_CORON1065-F1065C-" + exposure + "_a3001_" + suffix + ".fits"
+    output = "jw0138600" + exposure + "001_04101_00001_mirimage_c1002_" + suffix + ".fits"
     rtdata.output = output
     rtdata.get_truth("truth/test_miri_coron3/" + output)
 
@@ -41,7 +41,7 @@ def test_miri_coron3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
     """Check final products of calwebb_coron3"""
     rtdata = run_pipeline
 
-    output = "coron1065_" + suffix + ".fits"
+    output = "jw01386-c1002_t001_miri_f1140c-mask1140_" + suffix + ".fits"
     rtdata.output = output
     rtdata.get_truth("truth/test_miri_coron3/" + output)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-2928](https://jira.stsci.edu/browse/JP-2928)


<!-- describe the changes comprising this PR here -->
This PR updates the MIRI coron3 regression test (test_miri_coron3) to use in-flight data. All input and truth files have been uploaded to artifactory and run successfully locally.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
