### PR TITLE
JP-2928: Update regtests to use flight data (NRS_FS)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 1.9.4 (unreleased)
 ==================
 
--
+regtest
+-------
+
+- Updated NIRSpec fixed slit testing of spec2 and spec3 pipelines
+  to use in-flight data [#7432]
 
 1.9.3 (2023-01-12)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@
 regtest
 -------
 
-- Updated NIRSpec fixed slit testing of spec2 and spec3 pipelines
+- Updated NIRSpec fixed slit testing of spec2 and spec3 pipelines,
+  and bright object time series testing of spec2,
   to use in-flight data [#7432]
 
 1.9.3 (2023-01-12)

--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -19,7 +19,7 @@ def run_tso_spec2_pipeline(jail, rtdata_module, request):
     rtdata = rtdata_module
 
     # Get the input exposure
-    rtdata.get_data('nirspec/tso/jw02420001001_04101_00001-seg001_nrs1_truncated_rateints.fits')
+    rtdata.get_data('nirspec/tso/jw02420001001_04101_00001-seg001_nrs1_rateints.fits')
 
     # Run the calwebb_spec2 pipeline;
     args = ["calwebb_spec2", rtdata.input,

--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -19,7 +19,7 @@ def run_tso_spec2_pipeline(jail, rtdata_module, request):
     rtdata = rtdata_module
 
     # Get the input exposure
-    rtdata.get_data('nirspec/tso/jw84600042001_02101_00001_nrs2_rateints.fits')
+    rtdata.get_data('nirspec/tso/jw02420001001_04101_00001-seg001_nrs1_truncated_rateints.fits')
 
     # Run the calwebb_spec2 pipeline;
     args = ["calwebb_spec2", rtdata.input,

--- a/jwst/regtest/test_nirspec_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_fs_spec2.py
@@ -11,14 +11,28 @@ from jwst.pathloss import PathLossStep
 from jwst.stpipe import Step
 
 file_roots = [
-    'jw00023001001_01101_00001_nrs1_',
-    'jw93045010001_02101_00001_nrs2_',
-    'jwtest1013001_01101_00001_nrs1_'
+    'jw02072-o002_20221206t143745_spec2_00001_asn.json',
+    'jw01245-o002_20230107t223023_spec2_00001_asn.json',
+    'jw01309-o022_20230113t025924_spec2_00001_asn.json'
 ]
-ids = ["fullframe", "S400A1-subarray", "ALLSLITS-subarray"]
+
+asn_memberdict = {
+    'jw01309-o022_20230113t025924_spec2_00001_asn.json':
+        ['jw01309022001_04102_00004_nrs2_rate.fits',
+         'jw01309022001_04102_00002_nrs2_rate.fits',
+         'jw01309022001_04102_00001_nrs2_rate.fits'],
+    'jw01245-o002_20230107t223023_spec2_00001_asn.json':
+        ['jw01245002001_04102_00002_nrs1_rate.fits',
+         'jw01245002001_04102_00001_nrs1_rate.fits'],
+    'jw02072-o002_20221206t143745_spec2_00001_asn.json':
+        ['jw02072002001_05101_00001_nrs1_rate.fits',
+         'jw02072002001_05101_00002_nrs1_rate.fits',
+         'jw02072002001_05101_00003_nrs1_rate.fits']
+}
+# ids = ["fullframe", "S400A1-subarray", "ALLSLITS-subarray"]
 
 
-@pytest.fixture(scope="module", params=file_roots, ids=ids)
+@pytest.fixture(scope="module", params=file_roots)# ids=ids)
 def run_pipeline(jail, rtdata_module, request):
     """Run the calwebb_spec2 pipeline on NIRSpec Fixed-Slit exposures.
        We currently test the following types of inputs:
@@ -28,8 +42,10 @@ def run_pipeline(jail, rtdata_module, request):
 
     rtdata = rtdata_module
 
+    for fle in asn_memberdict[request.param]:
+        rtdata.get_data('nirspec/fs/' + fle)
     # Get the input exposure
-    rtdata.get_data('nirspec/fs/' + request.param + 'rate.fits')
+    rtdata.get_data('nirspec/fs/' + request.param)
 
     # Run the calwebb_spec2 pipeline; save results from intermediate steps
     args = ["calwebb_spec2", rtdata.input,
@@ -55,7 +71,7 @@ def test_nirspec_fs_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     # Run the pipeline and retrieve outputs
     rtdata = run_pipeline
     output = replace_suffix(
-        os.path.splitext(os.path.basename(rtdata.input))[0], suffix) + '.fits'
+        os.path.splitext(asn_memberdict[os.path.basename(rtdata.input)][0])[0], suffix) + '.fits'
     rtdata.output = output
 
     # Get the truth files

--- a/jwst/regtest/test_nirspec_fs_spec3.py
+++ b/jwst/regtest/test_nirspec_fs_spec3.py
@@ -12,7 +12,7 @@ def run_pipeline(jail, rtdata_module):
     rtdata = rtdata_module
 
     # Get the ASN file and input exposures
-    rtdata.get_asn('nirspec/fs/jw93045-o010_20180725t035735_spec3_001_asn.json')
+    rtdata.get_asn('nirspec/fs/jw01309-o022_spec3_regtest_asn.json')
 
     # Run the calwebb_spec3 pipeline; save results from intermediate steps
     args = ["calwebb_spec3", rtdata.input,
@@ -24,11 +24,12 @@ def run_pipeline(jail, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d"])
-def test_nirspec_fs_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix):
+@pytest.mark.parametrize("source_id", ["s00001", "s00002", "s00003", "s00004", "s00005"])
+def test_nirspec_fs_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix, source_id):
     """Test spec3 pipeline on a set of NIRSpec FS exposures."""
     rtdata = rtdata_module
 
-    output = f"jw93045-o010_s00003_nirspec_f290lp-g395h-subs400a1_{suffix}.fits"
+    output = f"jw01309-o022_{source_id}_nirspec_f290lp-g395h-s200a2-allslits_{suffix}.fits"
     rtdata.output = output
     rtdata.get_truth(f"truth/test_nirspec_fs_spec3/{output}")
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-2928](https://jira.stsci.edu/browse/JP-2928)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR updates the NIRSpec fixed slit regression tests for spec2 and spec3 pipelines to use in-flight data.

EDIT: added BOTS regtest update.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
