### PR TITLE
JP-2928: Update NIRISS AMI3 regtest with flight data

### DIFF
--- a/jwst/regtest/test_niriss_ami3.py
+++ b/jwst/regtest/test_niriss_ami3.py
@@ -10,22 +10,7 @@ from jwst.ami import AmiAnalyzeStep
 def run_pipeline(jail, rtdata_module):
     """Run calwebb_ami3 on NIRISS AMI data."""
     rtdata = rtdata_module
-    rtdata.get_asn("niriss/ami/jw00793-c1014_20191210t203450_ami3_001_asn.json")
-
-    # Run the calwebb_ami3 pipeline on the association
-    args = ["calwebb_ami3", rtdata.input,
-            "--steps.ami_analyze.rotation=1.49",
-            ]
-    Step.from_cmdline(args)
-
-    return rtdata
-
-
-@pytest.fixture(scope="module")
-def run_pipeline2(jail, rtdata_module):
-    """Run calwebb_ami3 on NIRISS AMI data."""
-    rtdata = rtdata_module
-    rtdata.get_asn("niriss/ami/jw01093_c1000_short_ami3_asn.json")
+    rtdata.get_asn("niriss/ami/jw01093-c1000_20221110t003218_ami3_002_asn.json")
 
     # Run the calwebb_ami3 pipeline on the association
     args = ["calwebb_ami3", rtdata.input]
@@ -35,13 +20,13 @@ def run_pipeline2(jail, rtdata_module):
 
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("suffix", ["c1014_ami"])
-@pytest.mark.parametrize("exposure", ["022", "025"])
-def test_niriss_ami3_exp(run_pipeline, suffix, exposure, fitsdiff_default_kwargs):
+@pytest.mark.parametrize("obs", ["001", "004", "006"])
+@pytest.mark.parametrize("exp", ["00001", "00002"])
+def test_niriss_ami3_exp(run_pipeline, obs, exp, fitsdiff_default_kwargs):
     """Check exposure-level results of calwebb_ami3"""
     rtdata = run_pipeline
 
-    output = "jw00793" + exposure + "001_03102_00001_nis_" + suffix + ".fits"
+    output = "jw01093" + obs + "001_03106_" + exp + "_nis_c1000_ami.fits"
     rtdata.output = output
     rtdata.get_truth("truth/test_niriss_ami3/" + output)
 
@@ -56,7 +41,7 @@ def test_niriss_ami3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
     """Check final products of calwebb_ami3"""
     rtdata = run_pipeline
 
-    output = "jw00793-c1014_t005_niriss_f480m-nrm-sub80_" + suffix + ".fits"
+    output = "jw01093-c1000_t001_niriss_f380m-nrm-sub80_" + suffix + ".fits"
     rtdata.output = output
     rtdata.get_truth("truth/test_niriss_ami3/" + output)
 
@@ -74,19 +59,5 @@ def test_ami_analyze_with_nans(rtdata, fitsdiff_default_kwargs):
     rtdata.output = 'jw00042004001_01101_00005_nis_withNAN_amianalyzestep.fits'
 
     rtdata.get_truth('truth/test_niriss_ami3/jw00042004001_01101_00005_nis_withNAN_amianalyzestep.fits')
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()
-
-
-@pytest.mark.bigdata
-def test_ami_average_with_sizes(run_pipeline2, fitsdiff_default_kwargs):
-    """Test the AmiAverageStep with inputs of different sizes"""
-    rtdata = run_pipeline2
-
-    output = "jw01093-o007_result_short_amiavg.fits"
-    rtdata.output = output
-    rtdata.get_truth("truth/test_niriss_ami3/" + output)
-
-    fitsdiff_default_kwargs['atol'] = 1e-5
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-2928](https://jira.stsci.edu/browse/JP-2928)

<!-- describe the changes comprising this PR here -->
This PR updates the test_niriss_ami3 regtest module to use recent in-flight data as input. Note that the `test_ami_average_with_sizes` test is no longer needed, because the one main test now also covers the case where dithering of the target and/or psf source(s) leads to outputs of different sizes that need to be averaged. All new input and truth files have been uploaded to artifactory and the new tests pass when run locally.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
