### PR TITLE
JP-3079 Ensure all imprint exposures are include in associations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.9.4 (unreleased)
 ==================
 
+associations
+------------
+
+- Ensure all imprint exposures are include in associations [#7438]
+
 general
 -------
 

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -116,10 +116,16 @@ SPEC2_SCIENCE_EXP_TYPES = [
     'nrs_brightobj',
 ]
 
+# Modifiers from the pool that define the primary use of
+# an exposure.
+#
+# Note: Order is important with the first items taking
+# higher precedence. This depends on Python dicts ordering
+# by order of key addition.
 SPECIAL_EXPOSURE_MODIFIERS = {
-    'background': ['bkgdtarg'],
-    'imprint': ['is_imprt'],
     'psf': ['is_psf'],
+    'imprint': ['is_imprt'],
+    'background': ['bkgdtarg'],
 }
 
 # Exposures that are always TSO

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -1041,10 +1041,10 @@ class AsnMixin_Lv2Special:
             If None, routine will raise LookupError
         Returns
         -------
-        exposure_type : 'science'
-            Always returns as science
+        exposure_type 
+            Always what is defined as `default`
         """
-        return 'science'
+        return default
 
 
 class AsnMixin_Lv2Spectral(DMSLevel2bBase):

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -32,11 +32,12 @@ from jwst.associations.lib.dms_base import (
     SPEC2_SCIENCE_EXP_TYPES,
 )
 from jwst.associations.lib.member import Member
+from jwst.associations.lib.process_list import ListCategory
+from jwst.associations.lib.product_utils import prune_duplicate_products
 from jwst.associations.lib.rules_level3_base import _EMPTY, DMS_Level3_Base
 from jwst.associations.lib.rules_level3_base import Utility as Utility_Level3
-from jwst.lib.suffix import remove_suffix
-from jwst.associations.lib.product_utils import prune_duplicate_products
 from jwst.associations.lib.utilities import getattr_from_list, getattr_from_list_nofail
+from jwst.lib.suffix import remove_suffix
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -54,6 +55,7 @@ __all__ = [
     'Constraint_ExtCal',
     'Constraint_Image_Nonscience',
     'Constraint_Image_Science',
+    'Constraint_Imprint',
     'Constraint_Mode',
     'Constraint_Single_Science',
     'Constraint_Special',
@@ -733,6 +735,26 @@ class Constraint_ExtCal(Constraint):
                 )
             ],
             reduce=Constraint.notany
+        )
+
+
+class Constraint_Imprint(Constraint):
+    """Select on imprint exposures"""
+
+    def __init__(self):
+        super(Constraint_Imprint, self).__init__(
+            [
+                DMSAttrConstraint(
+                    name='imprint',
+                    sources=['is_imprt']
+                ),
+                DMSAttrConstraint(
+                    name='mosaic_tile',
+                    sources=['mostilno'],
+                ),
+            ],
+            reprocess_on_match=True,
+            work_over=ListCategory.EXISTING,
         )
 
 

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -1032,6 +1032,11 @@ class AsnMixin_Lv2Special:
 
     def get_exposure_type(self, item, default='science'):
         """Override to force exposure type to always be science
+
+        The only case where this should not happen is if the association
+        already has its science, and the current item is an imprint. Leave
+        that item as an imprint.
+
         Parameters
         ----------
         item : dict
@@ -1044,6 +1049,9 @@ class AsnMixin_Lv2Special:
         exposure_type 
             Always what is defined as `default`
         """
+        if self.has_science() and super(AsnMixin_Lv2Special, self).get_exposure_type(item, default=default) == 'imprint':
+            return 'imprint'
+
         return default
 
 

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -51,6 +51,7 @@ __all__ = [
     'AsnMixin_Lv2Special',
     'AsnMixin_Lv2Spectral',
     'AsnMixin_Lv2WFSS',
+    'Constraint_Background',
     'Constraint_Base',
     'Constraint_ExtCal',
     'Constraint_Image_Nonscience',
@@ -719,6 +720,19 @@ class Constraint_Base(Constraint):
                 force_unique=True,
             )
         ])
+
+
+class Constraint_Background(SimpleConstraint):
+    """Select backgrounds"""
+
+    def __init__(self, association):
+        super(Constraint_Background, self).__init__(
+            value='background',
+            test=lambda value, item: re.match(value, association.get_exposure_type(item)),
+            force_unique=False,
+            reprocess_on_match=True,
+            work_over=ListCategory.EXISTING,
+        )
 
 
 class Constraint_ExtCal(Constraint):

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -78,13 +78,7 @@ class Asn_Lv2Image(
             ),
             Constraint(
                 [
-                    SimpleConstraint(
-                        value='background',
-                        test=lambda value, item: self.get_exposure_type(item) == value,
-                        force_unique=False,
-                        reprocess_on_match=True,
-                        work_over=ListCategory.EXISTING,
-                    ),
+                    Constraint_Background(self),
                     Constraint_Single_Science(self.has_science),
                 ], reduce=Constraint.any
             ),

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -296,8 +296,14 @@ class Asn_Lv2SpecSpecial(
             Constraint_Base(),
             Constraint_Mode(),
             Constraint_Spectral_Science(),
-            Constraint_Single_Science(self.has_science),
             Constraint_Special(),
+            Constraint(
+                [
+                    Constraint_Imprint(),
+                    Constraint_Single_Science(self.has_science),
+                ],
+                reduce=Constraint.any
+            ),
         ])
 
         # Now check and continue initialization.

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -2,6 +2,7 @@
 """
 from collections import deque
 import logging
+import re
 
 from jwst.associations.exceptions import AssociationNotValidError
 from jwst.associations.lib.rules_level2_base import AsnMixin_Lv2WFSS
@@ -252,15 +253,8 @@ class Asn_Lv2Spec(
             Constraint(
                 [
                     SimpleConstraint(
-                        value='background',
-                        test=lambda value, item: self.get_exposure_type(item) == value,
-                        force_unique=False,
-                        reprocess_on_match=True,
-                        work_over=ListCategory.EXISTING,
-                    ),
-                    SimpleConstraint(
-                        value='imprint',
-                        test=lambda value, item: self.get_exposure_type(item) == value,
+                        value='background|imprint',
+                        test=lambda value, item: re.match(value, self.get_exposure_type(item)),
                         force_unique=False,
                         reprocess_on_match=True,
                         work_over=ListCategory.EXISTING,

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -5,7 +5,7 @@ import logging
 import re
 
 from jwst.associations.exceptions import AssociationNotValidError
-from jwst.associations.lib.rules_level2_base import AsnMixin_Lv2WFSS
+from jwst.associations.lib.rules_level2_base import AsnMixin_Lv2WFSS, Constraint_Imprint_Special
 from jwst.associations.registry import RegistryMarker
 from jwst.associations.lib.constraint import (Constraint, SimpleConstraint)
 from jwst.associations.lib.dms_base import (
@@ -299,7 +299,7 @@ class Asn_Lv2SpecSpecial(
             Constraint_Special(),
             Constraint(
                 [
-                    Constraint_Imprint(),
+                    Constraint_Imprint_Special(self),
                     Constraint_Single_Science(self.has_science),
                 ],
                 reduce=Constraint.any

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -253,12 +253,13 @@ class Asn_Lv2Spec(
             Constraint(
                 [
                     SimpleConstraint(
-                        value='background|imprint',
+                        value='background',
                         test=lambda value, item: re.match(value, self.get_exposure_type(item)),
                         force_unique=False,
                         reprocess_on_match=True,
                         work_over=ListCategory.EXISTING,
                     ),
+                    Constraint_Imprint(),
                     SimpleConstraint(
                         value='science',
                         test=lambda value, item: self.get_exposure_type(item) != value,

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -259,6 +259,13 @@ class Asn_Lv2Spec(
                         work_over=ListCategory.EXISTING,
                     ),
                     SimpleConstraint(
+                        value='imprint',
+                        test=lambda value, item: self.get_exposure_type(item) == value,
+                        force_unique=False,
+                        reprocess_on_match=True,
+                        work_over=ListCategory.EXISTING,
+                    ),
+                    SimpleConstraint(
                         value='science',
                         test=lambda value, item: self.get_exposure_type(item) != value,
                         force_unique=False,

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -263,7 +263,7 @@ class Asn_Lv2Spec(
                     DMSAttrConstraint(
                         name='patttype',
                         sources=['patttype'],
-                        value=['2-point-nod|4-point-nod|along-slit-nod'],
+                        value='2-point-nod|4-point-nod|along-slit-nod',
                     )
                 ],
                 reduce=Constraint.notany
@@ -375,12 +375,12 @@ class Asn_Lv2SpecTSO(
                         DMSAttrConstraint(
                             name='exp_type',
                             sources=['exp_type'],
-                            value=['nrc_tsgrism'],
+                            value='nrc_tsgrism',
                         ),
                         DMSAttrConstraint(
                             name='pupil',
                             sources=['pupil'],
-                            value=['clear'],
+                            value='clear',
                         )],
                     )
                 ],
@@ -427,7 +427,7 @@ class Asn_Lv2MIRLRSFixedSlitNod(
             DMSAttrConstraint(
                 name='patttype',
                 sources=['patttype'],
-                value=['along-slit-nod'],
+                value='along-slit-nod',
             ),
             SimpleConstraint(
                 value=True,
@@ -886,7 +886,7 @@ class Asn_Lv2NRSIFUNod(
             DMSAttrConstraint(
                 name='patttype',
                 sources=['patttype'],
-                value=['2-point-nod|4-point-nod'],
+                value='2-point-nod|4-point-nod',
                 force_unique=True
             ),
             DMSAttrConstraint(
@@ -925,7 +925,7 @@ class Asn_Lv2WFSC(
                     DMSAttrConstraint(
                         name='dms_note',
                         sources=['dms_note'],
-                        value=['wfsc_los_jitter'],
+                        value='wfsc_los_jitter',
                     ),
                     DMSAttrConstraint(
                         name='exp_type',

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -252,13 +252,7 @@ class Asn_Lv2Spec(
             ),
             Constraint(
                 [
-                    SimpleConstraint(
-                        value='background',
-                        test=lambda value, item: re.match(value, self.get_exposure_type(item)),
-                        force_unique=False,
-                        reprocess_on_match=True,
-                        work_over=ListCategory.EXISTING,
-                    ),
+                    Constraint_Background(self),
                     Constraint_Imprint(),
                     SimpleConstraint(
                         value='science',

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -275,6 +275,39 @@ class Asn_Lv2Spec(
 
 
 @RegistryMarker.rule
+class Asn_Lv2SpecImprint(
+        AsnMixin_Lv2Special,
+        AsnMixin_Lv2Spectral,
+        DMSLevel2bBase
+):
+    """Level2b Treat Imprint/Leakcal as science
+
+    Characteristics:
+        - Association type: ``spec2``
+        - Pipeline: ``calwebb_spec2``
+        - Only handles Imprint/Leakcal exposures
+        - Single science exposure
+    """
+
+    def __init__(self, *args, **kwargs):
+
+        # Setup constraints
+        self.constraints = Constraint([
+            Constraint_Base(),
+            Constraint_Mode(),
+            Constraint_Spectral_Science(),
+            Constraint_Single_Science(self.has_science),
+            DMSAttrConstraint(
+                name='imprint',
+                sources=['is_imprt']
+            )
+        ])
+
+        # Now check and continue initialization.
+        super(Asn_Lv2SpecImprint, self).__init__(*args, **kwargs)
+
+
+@RegistryMarker.rule
 class Asn_Lv2SpecSpecial(
         AsnMixin_Lv2Special,
         AsnMixin_Lv2Spectral,

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -226,7 +226,7 @@ class Asn_Lv3Image(AsnMixin_Science):
                 [DMSAttrConstraint(
                 name='bkgdtarg',
                 sources=['bkgdtarg'],
-                value=['T'],
+                value='T',
                 )], reduce=Constraint.notany
             ),
             Constraint(
@@ -273,7 +273,7 @@ class Asn_Lv3ImageBackground(AsnMixin_AuxData, AsnMixin_Science):
                 [DMSAttrConstraint(
                 name='bkgdtarg',
                 sources=['bkgdtarg'],
-                value=['T'],
+                value='T',
                 )],
             ),
             Constraint(
@@ -315,12 +315,12 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_Spectrum):
             DMSAttrConstraint(
                 name='bkgdtarg',
                 sources=['bkgdtarg'],
-                value=['T'],
+                value='T',
             ),
             DMSAttrConstraint(
                 name='allowed_bkgdtarg',
                 sources=['exp_type'],
-                value=['mir_lrs-fixedslit', 'nrs_fixedslit'],
+                value='mir_lrs-fixedslit|nrs_fixedslit',
             ),
             Constraint_Optical_Path(),
         ])
@@ -349,7 +349,7 @@ class Asn_Lv3MIRMRS(AsnMixin_Spectrum):
             DMSAttrConstraint(
                 name='exp_type',
                 sources=['exp_type'],
-                value=('mir_mrs'),
+                value='mir_mrs',
             ),
             Constraint(
                 [
@@ -387,7 +387,7 @@ class Asn_Lv3MIRMRSBackground(AsnMixin_AuxData, AsnMixin_Spectrum):
             DMSAttrConstraint(
                 name='exp_type',
                 sources=['exp_type'],
-                value=('mir_mrs'),
+                value='mir_mrs',
             ),
             Constraint(
                 [
@@ -398,7 +398,7 @@ class Asn_Lv3MIRMRSBackground(AsnMixin_AuxData, AsnMixin_Spectrum):
             DMSAttrConstraint(
                 name='bkgdtarg',
                 sources=['bkgdtarg'],
-                value=['T'],
+                value='T',
             ),
         ])
 
@@ -528,12 +528,12 @@ class Asn_Lv3NRSIFUBackground(AsnMixin_AuxData, AsnMixin_Spectrum):
             DMSAttrConstraint(
                 name='bkgdtarg',
                 sources=['bkgdtarg'],
-                value=['T'],
+                value='T',
             ),
             DMSAttrConstraint(
                 name='allowed_bkgdtarg',
                 sources=['exp_type'],
-                value=['nrs_ifu'],
+                value='nrs_ifu',
             ),
             SimpleConstraint(
                 value=True,
@@ -693,7 +693,7 @@ class Asn_Lv3SpectralTarget(AsnMixin_Spectrum):
                     DMSAttrConstraint(
                         name='patttype_spectarg',
                         sources=['patttype'],
-                        value=['2-point-nod|4-point-nod|along-slit-nod'],
+                        value='2-point-nod|4-point-nod|along-slit-nod',
                     ),
                 ],
                 reduce=Constraint.any

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -730,7 +730,7 @@ class Constraint_MSA(Constraint):
                 DMSAttrConstraint(
                     name='exp_type',
                     sources=['exp_type'],
-                    value=('nrs_msaspec'),
+                    value='nrs_msaspec',
                     force_unique=False
                 ),
                 DMSAttrConstraint(

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -135,7 +135,7 @@ class Main():
         config.DEBUG = (parsed.loglevel != 0) and (parsed.loglevel <= logging.DEBUG)
 
         # Preamble
-        logger.info('Command-line arguments: {}'.format(args))
+        logger.info('Command-line arguments: %s', parsed)
         logger.context.set('asn_candidate_ids', parsed.asn_candidate_ids)
 
         if pool is None:

--- a/jwst/associations/tests/test_main.py
+++ b/jwst/associations/tests/test_main.py
@@ -17,7 +17,7 @@ POOL_PATH = 'pool_018_all_exptypes.csv'
 
 @pytest.mark.parametrize(
     'case', [
-        (None, 59),  # Don't re-run, just compare to the generator fixture results
+        (None, 62),  # Don't re-run, just compare to the generator fixture results
         (['-i', 'o001'], 2),
         (['-i', 'o001', 'o002'], 3),
         (['-i', 'c1001'], 1),

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -77,6 +77,11 @@ SPECIAL_POOLS = {
         'xfail': None,
         'slow': False,
     },
+    'jw01355_20230109t002554_pool': {
+        'args': [],
+        'xfail': None,
+        'slow': True,
+    },
     'jw80600_20171108T041522_pool': {
         'args': [],
         'xfail': 'PR #3450',


### PR DESCRIPTION
Resolves [JP-3079](https://jira.stsci.edu/browse/JP-3079)

This PR addresses the issue that not all imprint exposures that should be associated with science exposures were being associated. The bug was that imprints were not being reprocessed so that they can be matched against associations created after the imprints were processed.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
