### PR TITLE
JP-3081 NIRSpec Imprints improvement - constrain by observation number

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ general
 
 - Pin ``BayesicFitting`` to < 3.1.0 to avoid an import error in that release. [#7435]
 
+imprint
+-------
+Ensure that the observation number of the imprint matches the image observation number the imprint is to be subtracted from. [#7440] 
+
 regtest
 -------
 

--- a/jwst/imprint/imprint_step.py
+++ b/jwst/imprint/imprint_step.py
@@ -55,9 +55,10 @@ class ImprintStep(Step):
 
             # Update the step status and close the imprint model
             result.meta.cal_step.imprint = 'COMPLETE'
-            input_model.close()
             imprint_model.close()
         else:
             self.log.info(f'No imprint image was found for {input}')
             result.meta.cal_step.imprint = 'SKIP'
+
+        input_model.close()
         return result

--- a/jwst/imprint/imprint_step.py
+++ b/jwst/imprint/imprint_step.py
@@ -58,7 +58,7 @@ class ImprintStep(Step):
             imprint_model.close()
         else:
             self.log.info(f'No imprint image was found for {input}')
-            result.meta.cal_step.imprint = 'SKIP'
+            result.meta.cal_step.imprint = 'SKIPPED'
 
         input_model.close()
         return result

--- a/jwst/imprint/imprint_step.py
+++ b/jwst/imprint/imprint_step.py
@@ -19,13 +19,15 @@ class ImprintStep(Step):
     def process(self, input, imprint):
 
         # subtract leakcal (imprint) image
-        # If there is only one imprint image is in the association use for all the data.
-        # If there is more than one imprint image  in the association then select
-        # the imprint  image to subtract based on position number (DataModel.meta.dither.position_number).
+        # If there is only one imprint image is in the association use it  for all the data.
+        # If there is more than one imprint image in the association then select
+        # the imprint  image to subtract based on position number (DataModel.meta.dither.position_number) &
+        # observation number (Datamodel.meta.observation.observation_number)
 
         # Open the input data model and get position number of image
         input_model = datamodels.open(input)
         pos_no = input_model.meta.dither.position_number
+        obs_no = input_model.meta.observation.observation_number
 
         # find imprint that goes with input image - if there is only 1 imprint image - use it.
         num_imprint = len(imprint)
@@ -38,9 +40,9 @@ class ImprintStep(Step):
                 # open imprint images and read in pos_no to find match
                 imprint_model = datamodels.open(imprint[i])
                 imprint_pos_no = imprint_model.meta.dither.position_number
+                imprint_obs_no = imprint_model.meta.observation.observation_number
                 imprint_model.close()
-
-                if pos_no == imprint_pos_no:
+                if pos_no == imprint_pos_no and obs_no == imprint_obs_no:
                     match = i
                 i = i + 1
 
@@ -57,4 +59,5 @@ class ImprintStep(Step):
             imprint_model.close()
         else:
             self.log.info(f'No imprint image was found for {input}')
+            result.meta.cal_step.imprint = 'SKIP'
         return result


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3081](https://jira.stsci.edu/browse/JP-3081)


<!-- describe the changes comprising this PR here -->
This PR ensures that for an imprint to be subtracted from either a background or science image the observation number and dither position number must match.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
