### PR TITLE
JP-3078: Add support custom reference WCS for the resample step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ pipeline
   calling the ``resample_spec`` and ``extract_1d`` steps, to avoid issues with the
   input data accidentally getting modified by those steps. [#7451]
 
+resample
+--------
+
+- Added support for custom reference WCS for the resample steps. [#7442]
+
 set_telescope_pointing
 ----------------------
 

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -7,21 +7,22 @@ the behavior of the processing and the characteristics of the resampled
 image.
 
 ``--pixfrac`` (float, default=1.0)
-  The fraction by which input pixels are "shrunk" before being drizzled
-  onto the output image grid, given as a real number between 0 and 1.
+    The fraction by which input pixels are "shrunk" before being drizzled
+    onto the output image grid, given as a real number between 0 and 1.
 
 ``--kernel`` (str, default='square')
-  The form of the kernel function used to distribute flux onto the output
-  image.  Available kernels are `square`, `gaussian`, `point`, `tophat`, `turbo`,
-  `lanczos2`, and `lanczos3`.
+    The form of the kernel function used to distribute flux onto the output
+    image.  Available kernels are `square`, `gaussian`, `point`, `tophat`,
+    `turbo`, `lanczos2`, and `lanczos3`.
 
 ``--pixel_scale_ratio`` (float, default=1.0)
-  Ratio of input to output pixel scale.  A value of 0.5 means the output image
-  would have 4 pixels sampling each input pixel. Ignored when ``pscale`` are provided.
+    Ratio of input to output pixel scale.  A value of 0.5 means the output
+    image would have 4 pixels sampling each input pixel.
+    Ignored when ``pixel_scale`` or ``output_wcs`` are provided.
 
 ``--pixel_scale`` (float, default=None)
     Absolute pixel scale in ``arcsec``. When provided, overrides
-    ``pixel_scale_ratio``.
+    ``pixel_scale_ratio``. Ignored when ``output_wcs`` is provided.
 
 ``--rotation`` (float, default=None)
     Position angle of output image’s Y-axis relative to North.
@@ -29,8 +30,20 @@ image.
     The default of `None` specifies that the images will not be rotated,
     but will instead be resampled in the default orientation for the camera
     with the x and y axes of the resampled image corresponding
-    approximately to the detector axes. Ignored when ``transform`` is
-    provided.
+    approximately to the detector axes. Ignored when ``pixel_scale``
+    or ``output_wcs`` are provided.
+
+``--crpix`` (tuple of float, default=None)
+    Position of the reference pixel in the image array in the ``x, y`` order.
+    If ``crpix`` is not specified, it will be set to the center of the bounding
+    box of the returned WCS object. When supplied from command line, it should
+    be a comma-separated list of floats. Ignored when ``output_wcs``
+    is provided.
+
+``--crval`` (tuple of float, default=None)
+    Right ascension and declination of the reference pixel. Automatically
+    computed if not provided. When supplied from command line, it should be a
+    comma-separated list of floats. Ignored when ``output_wcs`` is provided.
 
 ``--output_shape`` (tuple of int, default=None)
     Shape of the image (data array) using "standard" ``nx`` first and ``ny``
@@ -40,44 +53,53 @@ image.
     WCS object. When supplied from command line, it should be a comma-separated
     list of integers ``nx, ny``.
 
-``--crpix`` (tuple of float, default=None)
-    Position of the reference pixel in the image array in the ``x, y`` order.
-    If ``crpix`` is not specified, it will be set to the center of the bounding
-    box of the returned WCS object. When supplied from command line, it should
-    be a comma-separated list of floats.
+    .. note::
+        Argument ``output_shape``, when provided, overrides output image size
+        computed from the bounding box.
 
-``--crval`` (tuple of float, default=None)
-    Right ascension and declination of the reference pixel. Automatically
-    computed if not provided. When supplied from command line, it should be a
-    comma-separated list of floats.
+    .. note::
+        Specifying ``output_shape`` *is required* when the WCS in
+        ``output_wcs`` does not have ``bounding_box`` property set.
+
+``--output_wcs`` (str, default='')
+    File name of a ``ASDF`` file with a GWCS stored under the ``"wcs"`` key
+    under the root of the file. The output image size is determined from the
+    bounding box of the WCS (if any). Argument ``output_shape`` overrides
+    computed image size and it is required when output WCS does not have
+    ``bounding_box`` property set.
+
+    .. note::
+        When ``output_wcs`` is specified, WCS-related arguments such as
+        ``pixel_scale_ratio``, ``pixel_scale``, ``rotation``, ``crpix``,
+        and ``crval`` will be ignored.
 
 ``--fillval`` (str, default='INDEF')
-  The value to assign to output pixels that have zero weight or do not
-  receive any flux from any input pixels during drizzling.
+    The value to assign to output pixels that have zero weight or do not
+    receive any flux from any input pixels during drizzling.
 
 ``--weight_type`` (str, default='ivm')
-  The weighting type for each input image.
-  If `weight_type=ivm` (the default), the scaling value
-  will be determined per-pixel using the inverse of the read noise
-  (VAR_RNOISE) array stored in each input image. If the VAR_RNOISE array does
-  not exist, the variance is set to 1 for all pixels (equal weighting).
-  If `weight_type=exptime`, the scaling value will be set equal to the exposure
-  time found in the image header.
+    The weighting type for each input image.
+    If `weight_type=ivm` (the default), the scaling value
+    will be determined per-pixel using the inverse of the read noise
+    (VAR_RNOISE) array stored in each input image. If the VAR_RNOISE array does
+    not exist, the variance is set to 1 for all pixels (equal weighting).
+    If `weight_type=exptime`, the scaling value will be set equal to the
+    exposure time found in the image header.
 
 ``--single`` (bool, default=False)
-  If set to `True`, resample each input image into a separate output.  If
-  `False` (the default), each input is resampled additively (with weights) to
-  a common output
+    If set to `True`, resample each input image into a separate output.  If
+    `False` (the default), each input is resampled additively (with weights) to
+    a common output
 
 ``--blendheaders`` (bool, default=True)
-  Blend metadata from all input images into the resampled output image.
+    Blend metadata from all input images into the resampled output image.
 
 ``--allowed_memory`` (float, default=None)
-  Specifies the fractional amount of free memory to allow when creating the
-  resampled image. If ``None``, the environment variable
-  ``DMODEL_ALLOWED_MEMORY`` is used. If not defined, no check is made. If the
-  resampled image would be larger than specified, an ``OutputTooLargeError``
-  exception will be generated.
+    Specifies the fractional amount of free memory to allow when creating the
+    resampled image. If ``None``, the environment variable
+    ``DMODEL_ALLOWED_MEMORY`` is used. If not defined, no check is made. If the
+    resampled image would be larger than specified, an ``OutputTooLargeError``
+    exception will be generated.
 
-  For example, if set to ``0.5``, only resampled images that use less than half
-  the available memory can be created.
+    For example, if set to ``0.5``, only resampled images that use less than
+    half the available memory can be created.

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -54,10 +54,6 @@ image.
     list of integers ``nx, ny``.
 
     .. note::
-        Argument ``output_shape``, when provided, overrides output image size
-        computed from the bounding box.
-
-    .. note::
         Specifying ``output_shape`` *is required* when the WCS in
         ``output_wcs`` does not have ``bounding_box`` property set.
 

--- a/jwst/regtest/test_miri_lrs_slit_spec3.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec3.py
@@ -1,23 +1,53 @@
 """ Test of the spec3 pipeline using MIRI LRS fixed-slit exposures.
     This takes an association and generates the level 3 products."""
 import pytest
+
+import asdf
 from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
+from jwst import datamodels
 
 
-@pytest.fixture(scope="module")
-def run_pipeline(jail, rtdata_module):
-    """Run the calwebb_spec3 pipeline on an ASN of nodded MIRI LRS
-       fixed-slit exposures."""
-
+@pytest.fixture(
+    scope="module",
+    params=["default_wcs", "user_wcs", "user_wcs+shape", "user_wcs+shape1"]
+)
+def run_pipeline(jail, rtdata_module, request):
+    """
+    Run the calwebb_spec3 pipeline on an ASN of nodded MIRI LRS
+    fixed-slit exposures using different options for the WCS and output
+    image shape for the resample step.
+    """
     rtdata = rtdata_module
 
     # Get the spec3 ASN and its members
     rtdata.get_asn("miri/lrs/jw01530-o005_20221202t204827_spec3_00001_asn.json")
+    rtdata.get_truth("truth/test_miri_lrs_slit_spec3/jw01530-o005_t004_miri_p750l_s2d.fits")
+
+    args = [
+        "calwebb_spec3",
+        rtdata.input
+    ]
+
+    rtdata.custom_wcs_mode = request.param
+
+    if request.param != "default_wcs":
+        dm = datamodels.open(rtdata.truth)
+        af = asdf.AsdfFile({"wcs": dm.meta.wcs})
+        wcs_file = rtdata.truth[:-8] + 'wcs.asdf'
+        af.write_to(wcs_file)
+        args.append(f"--steps.resample_spec.output_wcs={wcs_file}")
+
+    if request.param == "user_wcs+shape":
+        output_shape = ','.join(map(str, dm.data.shape[::-1]))
+        args.append(f"--steps.resample_spec.output_shape={output_shape}")
+
+    elif request.param == "user_wcs+shape1":
+        output_shape = ','.join(map(str, (d + 1 for d in dm.data.shape[::-1])))
+        args.append(f"--steps.resample_spec.output_shape={output_shape}")
 
     # Run the calwebb_spec3 pipeline; save results from intermediate steps
-    args = ["calwebb_spec3", rtdata.input]
     Step.from_cmdline(args)
 
 
@@ -38,4 +68,8 @@ def test_miri_lrs_slit_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwarg
 
     # Compare the results
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()
+
+    if rtdata.custom_wcs_mode == 'user_wcs+shape1' and suffix == "s2d":
+        assert not diff.identical
+    else:
+        assert diff.identical, diff.report()

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -82,8 +82,8 @@ class ResampleData:
         log.info(f"Driz parameter fillval: {self.fillval}")
         log.info(f"Driz parameter weight_type: {self.weight_type}")
 
-        ref_wcs = kwargs.get('ref_wcs', None)
-        out_shape = kwargs.get('out_shape', None)
+        output_wcs = kwargs.get('output_wcs', None)
+        output_shape = kwargs.get('output_shape', None)
         crpix = kwargs.get('crpix', None)
         crval = kwargs.get('crval', None)
         rotation = kwargs.get('rotation', None)
@@ -94,17 +94,24 @@ class ResampleData:
         else:
             log.info(f'Output pixel scale ratio: {pscale_ratio}')
 
-        # Define output WCS based on all inputs, including a reference WCS
-        self.output_wcs = resample_utils.make_output_wcs(
-            self.input_models,
-            ref_wcs=ref_wcs,
-            pscale_ratio=self.pscale_ratio,
-            pscale=pscale,
-            rotation=rotation,
-            shape=out_shape if out_shape is None else out_shape[::-1],
-            crpix=crpix,
-            crval=crval
-        )
+        if output_wcs:
+            # Use user-supplied reference WCS for the resampled image:
+            self.output_wcs = output_wcs
+            if output_shape is not None:
+                self.output_wcs.array_shape = output_shape[::-1]
+
+        else:
+            # Define output WCS based on all inputs, including a reference WCS:
+            self.output_wcs = resample_utils.make_output_wcs(
+                self.input_models,
+                ref_wcs=output_wcs,
+                pscale_ratio=self.pscale_ratio,
+                pscale=pscale,
+                rotation=rotation,
+                shape=None if output_shape is None else output_shape[::-1],
+                crpix=crpix,
+                crval=crval
+            )
 
         log.debug('Output mosaic size: {}'.format(self.output_wcs.array_shape))
         can_allocate, required_memory = datamodels.util.check_memory_allocation(

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -74,14 +74,25 @@ class ResampleSpecData(ResampleData):
         self.good_bits = good_bits
         self.in_memory = kwargs.get('in_memory', True)
 
+        output_wcs = kwargs.get('output_wcs', None)
+        output_shape = kwargs.get('output_shape', None)
+
         # Define output WCS based on all inputs, including a reference WCS
-        if resample_utils.is_sky_like(self.input_models[0].meta.wcs.output_frame):
-            if self.input_models[0].meta.instrument.name != "NIRSPEC":
-                self.output_wcs = self.build_interpolated_output_wcs()
+        if output_wcs is None:
+            if resample_utils.is_sky_like(
+                self.input_models[0].meta.wcs.output_frame
+            ):
+                if self.input_models[0].meta.instrument.name != "NIRSPEC":
+                    self.output_wcs = self.build_interpolated_output_wcs()
+                else:
+                    self.output_wcs = self.build_nirspec_output_wcs()
             else:
-                self.output_wcs = self.build_nirspec_output_wcs()
+                self.output_wcs = self.build_nirspec_lamp_output_wcs()
         else:
-            self.output_wcs = self.build_nirspec_lamp_output_wcs()
+            self.output_wcs = output_wcs
+            if output_shape is not None:
+                self.output_wcs.array_shape = output_shape[::-1]
+
         self.blank_output = datamodels.SlitModel(tuple(self.output_wcs.array_shape))
         self.blank_output.update(self.input_models[0])
         self.blank_output.meta.wcs = self.output_wcs

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -63,6 +63,16 @@ class ResampleSpecStep(ResampleStep):
             kwargs = self._set_spec_defaults()
             kwargs['blendheaders'] = self.blendheaders
 
+        kwargs['output_shape'] = self._check_list_pars(
+            self.output_shape,
+            'output_shape',
+            min_vals=[1, 1]
+        )
+        kwargs['output_wcs'] = self._load_custom_wcs(
+            self.output_wcs,
+            kwargs['output_shape']
+        )
+
         kwargs['allowed_memory'] = self.allowed_memory
         kwargs['output'] = output
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -1,8 +1,9 @@
 import logging
 import re
+from copy import deepcopy
 
 import numpy as np
-
+import asdf
 from stpipe.extern.configobj.validate import Validator
 from stpipe.extern.configobj.configobj import ConfigObj
 
@@ -28,6 +29,11 @@ class ResampleStep(Step):
     """
     Resample input data onto a regular grid using the drizzle algorithm.
 
+    .. note::
+        When supplied via ``output_wcs``, a custom WCS overrides other custom
+        WCS parameters such as ``output_shape`` (now computed from by
+        ``output_wcs.bounding_box``), ``crpix``
+
     Parameters
     -----------
     input :  ~jwst.datamodels.DataModel or ~jwst.associations.Association
@@ -47,6 +53,7 @@ class ResampleStep(Step):
         rotation = float(default=None)
         pixel_scale_ratio = float(default=1.0) # Ratio of input to output pixel scale
         pixel_scale = float(default=None) # Absolute pixel scale in arcsec
+        output_wcs = string(default='')  # Custom output WCS.
         single = boolean(default=False)
         blendheaders = boolean(default=True)
         allowed_memory = float(default=None)  # Fraction of memory to use for the combined image.
@@ -103,11 +110,17 @@ class ResampleStep(Step):
 
         # Custom output WCS parameters.
         # Modify get_drizpars if any of these get into reference files:
-        kwargs['ref_wcs'] = None  # TODO: add mechanism of specifying a ref WCS
-        kwargs['out_shape'] = _check_list_pars(self.output_shape, 'output_shape',
-                                               min_vals=[1, 1])
-        kwargs['crpix'] = _check_list_pars(self.crpix, 'crpix')
-        kwargs['crval'] = _check_list_pars(self.crval, 'crval')
+        kwargs['output_shape'] = self._check_list_pars(
+            self.output_shape,
+            'output_shape',
+            min_vals=[1, 1]
+        )
+        kwargs['output_wcs'] = self._load_custom_wcs(
+            self.output_wcs,
+            kwargs['output_shape']
+        )
+        kwargs['crpix'] = self._check_list_pars(self.crpix, 'crpix')
+        kwargs['crval'] = self._check_list_pars(self.crval, 'crval')
         kwargs['rotation'] = self.rotation
         kwargs['pscale'] = self.pixel_scale
         kwargs['pscale_ratio'] = self.pixel_scale_ratio
@@ -139,6 +152,51 @@ class ResampleStep(Step):
 
         input_models.close()
         return result
+
+    @staticmethod
+    def _check_list_pars(vals, name, min_vals=None):
+        if vals is None:
+            return None
+        if len(vals) != 2:
+            raise ValueError(f"List '{name}' must have exactly two elements.")
+        n = sum(x is None for x in vals)
+        if n == 2:
+            return None
+        elif n == 0:
+            if min_vals and sum(x >= y for x, y in zip(vals, min_vals)) != 2:
+                raise ValueError(f"'{name}' values must be larger or equal to {list(min_vals)}")
+            return list(vals)
+        else:
+            raise ValueError(f"Both '{name}' values must be either None or not None.")
+
+    @staticmethod
+    def _load_custom_wcs(asdf_wcs_file, output_shape):
+        if not asdf_wcs_file:
+            return None
+
+        with asdf.open(asdf_wcs_file) as af:
+            wcs = deepcopy(af.tree["wcs"])
+
+        if output_shape is not None or wcs is None:
+            array_shape = output_shape[::-1]
+        elif wcs.array_shape is not None:
+            array_shape = wcs.array_shape
+        elif wcs.pixel_shape is not None:
+            array_shape = wcs.pixel_shape[::-1]
+        elif wcs.bounding_box is not None:
+            array_shape = tuple(
+                int(axs[1] - axs[0] + 0.5)
+                for axs in wcs.bounding_box.bounding_box(order="C")
+            )
+        else:
+            raise ValueError(
+                "Step argument 'output_shape' is required when custom WCS "
+                "does not have neither of 'array_shape', 'pixel_shape', or "
+                "'bounding_box' attributes set."
+            )
+
+        wcs.array_shape = array_shape
+        return wcs
 
     def update_phot_keywords(self, model):
         """Update pixel scale keywords"""
@@ -308,19 +366,3 @@ class ResampleStep(Step):
         for key in rm_keys:
             if key in model.meta.wcsinfo.instance:
                 del model.meta.wcsinfo.instance[key]
-
-
-def _check_list_pars(vals, name, min_vals=None):
-    if vals is None:
-        return None
-    if len(vals) != 2:
-        raise ValueError(f"List '{name}' must have exactly two elements.")
-    n = sum(x is None for x in vals)
-    if n == 2:
-        return None
-    elif n == 0:
-        if min_vals and sum(x >= y for x, y in zip(vals, min_vals)) != 2:
-            raise ValueError(f"'{name}' values must be larger or equal to {list(min_vals)}")
-        return list(vals)
-    else:
-        raise ValueError(f"Both '{name}' values must be either None or not None.")

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -178,24 +178,21 @@ class ResampleStep(Step):
             wcs = deepcopy(af.tree["wcs"])
 
         if output_shape is not None or wcs is None:
-            array_shape = output_shape[::-1]
-        elif wcs.array_shape is not None:
-            array_shape = wcs.array_shape
+            wcs.array_shape = output_shape[::-1]
         elif wcs.pixel_shape is not None:
-            array_shape = wcs.pixel_shape[::-1]
+            wcs.array_shape = wcs.pixel_shape[::-1]
         elif wcs.bounding_box is not None:
-            array_shape = tuple(
+            wcs.array_shape = tuple(
                 int(axs[1] - axs[0] + 0.5)
                 for axs in wcs.bounding_box.bounding_box(order="C")
             )
-        else:
+        elif wcs.array_shape is None:
             raise ValueError(
                 "Step argument 'output_shape' is required when custom WCS "
                 "does not have neither of 'array_shape', 'pixel_shape', or "
                 "'bounding_box' attributes set."
             )
 
-        wcs.array_shape = array_shape
         return wcs
 
     def update_phot_keywords(self, model):

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import logging
 import warnings
 
@@ -66,25 +67,35 @@ def make_output_wcs(input_models, ref_wcs=None,
         WCS object, with defined domain, covering entire set of input frames
 
     """
-    wcslist = [i.meta.wcs for i in input_models]
-    for w, i in zip(wcslist, input_models):
-        if w.bounding_box is None:
-            w.bounding_box = wcs_bbox_from_shape(i.data.shape)
-    naxes = wcslist[0].output_frame.naxes
+    if ref_wcs is None:
+        wcslist = [i.meta.wcs for i in input_models]
+        for w, i in zip(wcslist, input_models):
+            if w.bounding_box is None:
+                w.bounding_box = wcs_bbox_from_shape(i.data.shape)
+        naxes = wcslist[0].output_frame.naxes
 
-    if naxes != 2:
-        raise RuntimeError("Output WCS needs 2 spatial axes. "
-                           f"{wcslist[0]} has {naxes}.")
+        if naxes != 2:
+            raise RuntimeError("Output WCS needs 2 spatial axes. "
+                               f"{wcslist[0]} has {naxes}.")
 
-    output_wcs = wcs_from_footprints(
-        input_models,
-        pscale_ratio=pscale_ratio,
-        pscale=pscale,
-        rotation=rotation,
-        shape=shape,
-        crpix=crpix,
-        crval=crval
-    )
+        output_wcs = wcs_from_footprints(
+            input_models,
+            pscale_ratio=pscale_ratio,
+            pscale=pscale,
+            rotation=rotation,
+            shape=shape,
+            crpix=crpix,
+            crval=crval
+        )
+
+    else:
+        naxes = ref_wcs.output_frame.naxes
+        if naxes != 2:
+            raise RuntimeError("Output WCS needs 2 spatial axes but the "
+                               f"supplied WCS has {naxes} axes.")
+        output_wcs = deepcopy(ref_wcs)
+        if shape is not None:
+            output_wcs.array_shape = shape
 
     # Check that the output data shape has no zero length dimensions
     if not np.product(output_wcs.array_shape):

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -1,7 +1,9 @@
+import pytest
+
 from gwcs.wcstools import grid_from_bounding_box
 from numpy.testing import assert_allclose
 import numpy as np
-import pytest
+import asdf
 
 from stdatamodels.jwst.datamodels import ImageModel
 
@@ -477,6 +479,53 @@ def test_custom_wcs_resample_imaging(nircam_rate, ratio, rotation, crpix, crval,
 
     # test output image shape
     assert result.data.shape == shape[::-1]
+
+
+@pytest.mark.parametrize(
+    'output_shape2, match',
+    [((1205, 1100), True), ((1222, 1111), False), (None, True)]
+)
+def test_custom_refwcs_resample_imaging(nircam_rate, output_shape2, match,
+                                        tmp_path):
+    crpix = (600, 550)
+    crval = (50, 77)
+    rotation = 15
+    ratio = 0.7
+
+    im = AssignWcsStep.call(nircam_rate, sip_approx=False)
+
+    # first pass - create a reference output WCS:
+    im.data[:, :] = np.random.random(im.data.shape)
+    result = ResampleStep.call(
+        im,
+        output_shape=(1205, 1100),
+        crpix=crpix,
+        crval=crval,
+        rotation=rotation,
+        pixel_scale_ratio=ratio
+    )
+
+    data1 = result.data
+
+    refwcs = str(tmp_path / "resample_refwcs.asdf")
+    result.meta.wcs.bounding_box = [(-0.5, 1204.5), (-0.5, 1099.5)]
+    asdf.AsdfFile({"wcs": result.meta.wcs}).write_to(tmp_path / refwcs)
+
+    result = ResampleStep.call(
+        im,
+        output_shape=output_shape2,
+        output_wcs=refwcs
+    )
+
+    data2 = result.data
+
+    if output_shape2 is not None:
+        assert data2.shape == output_shape2[::-1]
+
+    if match:
+        # test output image shape
+        assert data1.shape == data2.shape
+        assert np.allclose(data1, data2)
 
 
 @pytest.mark.parametrize('ratio', [1.3, 1])


### PR DESCRIPTION
Resolves [JP-3078](https://jira.stsci.edu/browse/JP-3078)

This PR adds``output_wcs`` argument to the ``resample_step`` and ``resample_spec_step`` that allows users to provide their own reference GWCS to the resample step. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

#### Regression test(s):

https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/554/
