### PR TITLE
(JP-3029) Update to calculate separate RN variance

### DIFF
--- a/docs/jwst/ramp_fitting/appendix.rst
+++ b/docs/jwst/ramp_fitting/appendix.rst
@@ -1,7 +1,7 @@
 Appendix
 ========
 
-The derivation of the segment-specific readnoise variance (:math:`{ var^R_{s}  }`) is shown here.  This derivation follows the standard procedure to fitting data to a straight line, such as in chapter 15 of Numerical Recipes.  The segment-specific variance from read noise corresponds to :math:`{\sigma_b^2}` in section 15.2. 
+The derivation of the segment-specific readnoise variance (:math:`{ var^R_{s}  }`) is shown here. This pertains to both the 'conventional' and 'weighted` readnoise variances - the only difference being the number of groups in the segment.  This derivation follows the standard procedure to fitting data to a straight line, such as in chapter 15 of Numerical Recipes.  The segment-specific variance from read noise corresponds to :math:`{\sigma_b^2}` in section 15.2. 
 
 For read noise R, weight w = :math:`{1 / R^2}`, which is a constant. 
   

--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -317,3 +317,26 @@ Poisson noise, :math:`var^P_{o}`, is stored in the VAR_POISSON extension, the va
 due to read noise, :math:`var^R_{o}`, is stored in the VAR_RNOISE extension, and the
 square-root of the combined variance, :math:`var^C_{o}`, is stored in the ERR
 extension.
+
+
+
+Weighted Readnoise Variance
++++++++++++++++++++++++++++
+If the :ref:`undersampline correction <undersampling_correction_step>`
+step has been performed prior to ramp fitting, any group whose value exceeds the
+`signal_threshold` parameter will have been flagged with the UNDERSAMP and DO_NOT_USE
+data quality flags. Due to the DO_NOT_USE flags, such groups will be excluded
+from the slope calculations.
+
+However, it is desired to have a readnoise variance that is similar to pixels
+unaffected by charge migration, so an additional type of variance will
+be calculated, in which the excluded groups mentioned above will be included.
+This additional, 'weighted', readnoise variance is used for weighting in the
+:ref:`resample_spec <resample_step>` step later in the pipeline. The 'weighted'
+readnoise variance is written to the VAR_RNOISE extension of each of the 3
+output products.
+
+The original ('conventional') type of readnoise variance described earlier is still used
+internally in other variance calculations but, as mentioned above, is no longer written
+to the separate variance extension.
+

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -13,7 +13,6 @@ from jwst.datamodels import dqflags
 from ..lib import reffile_utils
 
 import logging
-
 import copy
 
 log = logging.getLogger(__name__)
@@ -178,6 +177,203 @@ def create_optional_results_model(input_model, opt_info):
     return opt_model
 
 
+def compute_RN_variances( groupdq, readnoise_2d, gain_2d, group_time):
+    """
+    Compute the variances due to the readnoise for all integrations
+
+    Parameters
+    ----------
+    groupdq : ndarray
+        The group data quality array for the exposure, 4-D flag
+
+    readnoise_2d : ndarray
+        readnoise values for all pixels in the image, 2-D float
+
+    gain_2d : ndarray
+        gain values for all pixels in the image, 2-D float
+
+    group_time : float
+        Time increment between groups, in seconds.
+
+    Returns
+    -------
+    var_r2 : ndarray
+        Image of integration-specific values for the slope variance due to
+        readnoise only, 2-D float
+
+    var_r3 : ndarray
+        Cube of integration-specific values for the slope variance due to
+        readnoise only, 3-D float
+
+    var_r4 : ndarray
+        Hypercube of segment- and integration-specific values for the slope
+        variance due to read noise only, 4-D float
+    """
+    nint = groupdq.shape[0]
+    ngroups = groupdq.shape[1]
+    nrows = groupdq.shape[2]
+    ncols = groupdq.shape[3]
+
+    imshape = (nrows, ncols)
+    cubeshape = (ngroups,) + imshape
+
+    segs_4 = np.zeros((nint,) + (ngroups,) + imshape, dtype=np.uint8)
+    var_r4 = np.zeros((nint,) + (ngroups,) + imshape, dtype=np.float32)
+    var_r3 = np.zeros((nint,) + imshape, dtype=np.float32)
+    s_inv_var_r3 = np.zeros((nint,) + imshape, dtype=np.float32)
+
+    max_seg = 0
+
+    # Loop over data integrations
+    for num_int in range(nint):
+        # Loop over data sections
+        for rlo in range(0, cubeshape[1], nrows):
+            rhi = rlo + nrows
+
+            if rhi > cubeshape[1]:
+                rhi = cubeshape[1]
+
+            gdq_sect = groupdq[num_int, :, rlo:rhi, :]
+            rn_sect = readnoise_2d[rlo:rhi, :]
+            gain_sect = gain_2d[rlo:rhi, :]
+
+            den_r3, num_r3, segs_beg_3, max_seg_t = calc_segs(rn_sect, gdq_sect, group_time, ngroups)
+            max_seg = max(max_seg, max_seg_t)
+
+            segs_4[num_int, :segs_beg_3.shape[0], rlo:rhi, :] = segs_beg_3
+
+            # Find the segment variance due to read noise and convert back to DN
+            var_r4[num_int, :segs_beg_3.shape[0], rlo:rhi, :] = num_r3 * den_r3 / gain_sect**2
+
+            del den_r3, num_r3, segs_beg_3
+            del gain_sect
+            del gdq_sect
+
+        # The next statements zero out entries for non-existing segments, and
+        #   set the variances for segments having negative slopes (the segment
+        #   variance is proportional to the median estimated slope) to
+        #   outrageously large values so that they will have negligible
+        #   contributions.
+        var_r4[num_int, :, :, :] *= (segs_4[num_int, :, :, :] > 0)
+        var_r4[var_r4 <= 0.] = LARGE_VARIANCE
+
+       # The sums of inverses of the variances are needed for later
+       #   variance calculations.
+        s_inv_var_r3[num_int, :, :] = (1. / var_r4[num_int, :, :, :]).sum(axis=0)
+        var_r3[num_int, :, :] = 1. / s_inv_var_r3[num_int, :, :]
+
+    var_r4 *= (segs_4[:, :, :, :] > 0)   # Zero out non-existing segments
+    var_r4 = var_r4[:, :max_seg, :, :]
+
+    var_r2 = 1 / (s_inv_var_r3.sum(axis=0))
+
+    # Some contributions to these vars may be NaN as they are from ramps
+    # having PIXELDQ=DO_NOT_USE
+    var_r2[np.isnan(var_r2)] = 0.
+
+    return var_r2, var_r3, var_r4
+
+
+def calc_segs( rn_sect, gdq_sect, group_time, ngroups ):
+    """
+    Calculate the lengths of all semi-ramps in all pixels in the data section
+
+    Parameters
+    ----------
+    rn_sect : ndarray
+        readnoise values for all pixels in the data section, 2-D float
+
+    gdq_sect : ndarray
+        gain values for all pixels in the data section, 2-D float
+
+    group_time : float
+        Time increment between groups, in seconds.
+
+    ngroups : int
+        Total number of groups in a ramp
+
+    Returns
+    -------
+    den_r3 : ndarray
+        for a given integration, the reciprocal of the denominator of the
+        segment-specific variance of the segment's slope due to read noise, 3-D float
+
+    num_r3 : ndarray
+        numerator of the segment-specific variance of the segment's slope
+        due to read noise, 3-D float
+
+    segs_beg_3 : ndarray
+        lengths of segments for all pixels in the given data section and
+        integration, 3-D
+
+    max_seg : int
+        maximum number of segments in a ramp
+    """ 
+    (nreads, asize2, asize1) = gdq_sect.shape
+    npix = asize1 * asize2
+    imshape = (asize2, asize1)
+    gdq_2d = gdq_sect[:, :, :].reshape((nreads, npix))
+    segs = np.zeros((nreads, npix), dtype = np.int32)
+    sr_index = np.zeros(npix, dtype=np.uint8)
+
+    i_read = 0
+    while i_read < ngroups :
+        gdq_1d = gdq_2d[i_read, : ]
+        wh_good = np.where( gdq_1d == 0)
+
+        # For godd groups, increment those pixels' segment's lengths
+        if len(wh_good[0]) > 0:
+            segs[ sr_index[ wh_good ], wh_good ] += 1
+        del wh_good
+
+        # Locate any CRs ...
+        wh_cr = np.where( gdq_1d.astype(np.int32) & JUMP > 0)
+ 
+        # ... but not on final read:
+        if len(wh_cr[0]) > 0 and (i_read < ngroups - 1):
+            sr_index[wh_cr[0]] += 1
+            segs[sr_index[wh_cr], wh_cr] += 1
+        del wh_cr
+
+        i_read += 1
+
+    segs = segs.astype(np.uint8)
+
+    max_seg = (np.argwhere(segs).max(0))[0] +1
+    segs_beg = segs[:max_seg, :]  # the leading nonzero lengths
+
+    # Create reshaped version [ segs, y, x ] to simplify computation
+    segs_beg_3 = segs_beg.reshape(max_seg, imshape[0], imshape[1])
+
+    # For a segment, the variance due to readnoise noise
+    # = 12 * readnoise**2 /(ngroups_seg**3. - ngroups_seg)/( tgroup **2.)
+    num_r3 = 12. * (rn_sect / group_time)**2.  # always >0
+
+    # Reshape for every group, every pixel in section
+    num_r3 = np.dstack([num_r3] * max_seg)
+    num_r3 = np.transpose(num_r3, (2, 0, 1))
+
+    # Denominator den_r3 = 1./(segs_beg_3 **3.-segs_beg_3). The minimum number
+    #   of allowed groups is 2, which will apply if there is actually only 1
+    #   group; in this case den_r3 = 1/6. This covers the case in which there is
+    #   only one good group at the beginning of the integration, so it will be
+    #   be compared to the plane of (near) zeros resulting from the reset. For
+    #   longer segments, this value is overwritten below.
+    den_r3 = num_r3.copy() * 0. + 1. / 6
+
+    wh_seg_pos = np.where(segs_beg_3 > 1)
+
+    # Suppress, then, re-enable harmless arithmetic warnings, as NaN will be
+    #   checked for and handled later
+    warnings.filterwarnings("ignore", ".*invalid value.*", RuntimeWarning)
+    warnings.filterwarnings("ignore", ".*divide by zero.*", RuntimeWarning)
+    # overwrite where segs>1
+    den_r3[wh_seg_pos] = 1. / (segs_beg_3[wh_seg_pos] ** 3. - segs_beg_3[wh_seg_pos])
+    warnings.resetwarnings()
+
+    return den_r3, num_r3, segs_beg_3, max_seg
+
+
 class RampFitStep(Step):
 
     """
@@ -212,6 +408,7 @@ class RampFitStep(Step):
     def process(self, input):
 
         with datamodels.RampModel(input) as input_model:
+
             max_cores = self.maximum_cores
             readnoise_filename = self.get_reference_file(input_model, 'readnoise')
             gain_filename = self.get_reference_file(input_model, 'gain')
@@ -226,7 +423,7 @@ class RampFitStep(Step):
                 # available later in the gain_scale step, which avoids having to
                 # load the gain ref file again in that step.
                 if gain_model.meta.exposure.gain_factor is not None:
-                    input_model.meta.exposure.gain_ifactor = gain_model.meta.exposure.gain_factor
+                    input_model.meta.exposure.gain_factor = gain_model.meta.exposure.gain_factor
 
                 # Get gain arrays, subarrays if desired.
                 frames_per_group = input_model.meta.exposure.nframes
@@ -262,6 +459,30 @@ class RampFitStep(Step):
 
             # Locate groups where that are flagged with UNDERSAMP
             wh_undersamp = np.where(np.bitwise_and(gdq.astype(np.int32), dqflags.group['UNDERSAMP']))
+
+            if len(wh_undersamp[0]) > 0: # call the standalone routine
+                group_time = input_model.meta.exposure.group_time
+                image_var_RN, integ_var_RN, opt_var_RN = \
+                     compute_RN_variances(groupdq, readnoise_2d, gain_2d, group_time)
+
+                image_info_new, integ_info_new = None, None
+                if image_info is not None and image_var_RN is not None:
+                    image_info_new = (image_info[0], image_info[1], image_info[2], image_var_RN, image_info[4])
+
+                if integ_info is not None and integ_var_RN is not None:
+                    integ_info_new = (integ_info[0], integ_info[1], integ_info[2], integ_var_RN], integ_info[4])
+
+                image_info = image_info_new
+                integ_info = integ_info_new
+
+                opt_info_new = None
+                if opt_info is not None and opt_var_RN is not None:
+                    opt_info_new = (opt_info[0], opt_info[1], opt_info[2], opt_var_RN,
+                                    opt_info[4], opt_info[5], opt_info[6], opt_info[7], opt_info[8])
+
+                opt_info = opt_info_new
+
+            """
             if len(wh_undersamp[0]) > 0:
                 log.info('Processing groups flagged with UNDERSAMP.')
 
@@ -297,6 +518,7 @@ class RampFitStep(Step):
                                     opt_info[4], opt_info[5], opt_info[6], opt_info[7], opt_info[8])
 
                 opt_info = opt_info_new
+            """
 
         # Save the OLS optional fit product, if it exists.
         if opt_info is not None:

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -9,11 +9,14 @@ from jwst.datamodels import RampModel
 from jwst.datamodels import GainModel
 from jwst.datamodels import ReadnoiseModel
 
+from jwst.ramp_fitting.ramp_fit_step import compute_RN_variances
+
 GOOD = dqflags.pixel["GOOD"]
 DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
 JUMP_DET = dqflags.pixel["JUMP_DET"]
 SATURATED = dqflags.pixel["SATURATED"]
 NO_GAIN = dqflags.pixel["NO_GAIN_VALUE"]
+UNDERSAMP = 128  # replace once PR for 3015 is mergaed
 
 DELIM = "-" * 70
 
@@ -44,6 +47,60 @@ def test_drop_frames1_not_set():
 
     data = slopes[0]
     np.testing.assert_allclose(data[50, 50], 10.0, 1e-6)
+
+
+def test_readnoise_variance():
+    # test RN variance calculations for handling undersample_correction
+
+    group_time= 10.6
+
+    model1, gdq_4d, rnoise, pixdq, err, gain = setup_inputs(ngroups=10, nints=3,
+        nrows=3, ncols=4, nframes=1, gain=1, readnoise=0.7071, grouptime=group_time)
+
+    imshape = (pixdq.shape[0], pixdq.shape[1])
+    readnoise_2d = np.zeros(imshape, dtype=np.float32) + rnoise
+    gain_2d = np.zeros(imshape, dtype=np.float32) + gain
+
+    # Populate ramps with a variety of flags
+    gdq_4d[:,7, 1, 3] = JUMP_DET
+    gdq_4d[:, 6:, 1, 2] = SATURATED
+    gdq_4d[:, 3:, 0, 3] = DO_NOT_USE + UNDERSAMP
+    gdq_4d[:, 7:, 2, 3] = DO_NOT_USE + UNDERSAMP
+    gdq_4d[:, 3, 2, 2] = JUMP_DET
+    gdq_4d[:, 6, 2, 2] = JUMP_DET
+    gdq_4d[:, 8:, 2, 2] = DO_NOT_USE + UNDERSAMP
+    gdq_4d[:, 8, 2, 2] += JUMP_DET
+    gdq_4d[:, 0, 0, 0] = DO_NOT_USE + SATURATED
+    gdq_4d[:, 1:, 0, 0] = SATURATED
+    gdq_4d[:, 0, 0, 2] = SATURATED + DO_NOT_USE
+    gdq_4d[:, 1:, 0, 2] = SATURATED + DO_NOT_USE + UNDERSAMP
+    gdq_4d[:, 0:, 1, 0] = JUMP_DET
+
+    var_r2, var_r3, var_r4 = compute_RN_variances(gdq_4d, readnoise_2d, gain_2d, group_time)
+
+    # Compare the exposure level RN variances
+    true_var_r2 = np.array(
+    [[0.0000000e+00, 1.7979382e-05, 0.0000000e+00, 7.4164942e-04],
+    [2.9665977e-03, 1.7979382e-05, 8.4759937e-05, 4.9443293e-05],
+    [1.7979382e-05, 1.7979382e-05, 3.2962195e-04, 5.2974960e-05]])
+
+    np.testing.assert_allclose(true_var_r2, var_r2, rtol=1e-4)
+
+    # Compare an integration of the integration-specific level RN variances
+    true_var_r3_0 = np.array(
+    [[0.0000000e+00, 5.3938144e-05, 0.0000000e+00, 2.2249483e-03],
+    [8.8997930e-03, 5.3938144e-05, 2.5427982e-04, 1.4832988e-04],
+    [5.3938144e-05, 5.3938144e-05, 9.8886585e-04, 1.5892487e-04]] )
+
+    np.testing.assert_allclose(true_var_r3_0, var_r3[0,:,:], rtol=1e-4)
+
+    # Compare a segment of an integration of the segment level RN variances
+    true_var_r4_0_0 = np.array(
+    [[0.0000000e+00, 5.3938144e-05, 0.0000000e+00, 2.2249483e-03],
+    [0.0000000e+00, 5.3938144e-05, 2.5427982e-04, 1.5892487e-04],
+    [5.3938144e-05, 5.3938144e-05, 2.2249483e-03, 1.5892487e-04]] )
+
+    np.testing.assert_allclose(true_var_r4_0_0, var_r4[0,0,:,:], rtol=1e-4)
 
 
 def test_mixed_crs_and_donotuse():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3029](https://jira.stsci.edu/browse/JP-3029)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR calculates a readnoise variance that can be used by the resampling step, using UNDERSAMP-groups that have been flagged by the undersampling_correction step. This functionality requires that PR# 7396 for JP-3015 be merged

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
