### PR TITLE
uncomment MacOS in Jenkins

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -96,13 +96,13 @@ bc0.failedFailureThresh = 0
 // macos-specific buildconfig to cause the creation of counterparts to the linux
 // environment dumps. Packages in a minimal conda environment differ by OS
 // which is why this is needed.
-// bc1 = utils.copy(bc0)
-// bc1.nodetype = 'macos'
-// bc1.name = 'macos-stable-deps'
-// bc1.build_cmds = ["pip install -e ."]
-// bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
-// bc1.test_cmds = []
-// bc1.test_configs = []
+bc1 = utils.copy(bc0)
+bc1.nodetype = 'macos'
+bc1.name = 'macos-stable-deps'
+bc1.build_cmds = ["pip install -e ."]
+bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
+bc1.test_cmds = []
+bc1.test_configs = []
 
-utils.run([jobconfig, bc0])
+utils.run([jobconfig, bc0, bc1])
 }  // withCredentials


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue where MacOS artifacts have not been uploaded since October. The MacOS job was commented out because of an issue where `sed` was not available on `boyle`, which caused the regression tests to hang and fail. The `sed` issue has since been resolved.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
