### PR TITLE
JP-3024: Allow MIRI LRS fixed slit rateints data through calwebb_spec2

### DIFF
--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -980,8 +980,19 @@ def _corrections_for_lrs(data, pathloss):
 
         # Save the corrections. The `data` portion is the correction used.
         # The individual ones will be saved in the respective attributes.
-        correction = type(data)(data=pathloss_2d)
-        correction.pathloss_point = pathloss_2d
+        if isinstance(data, datamodels.ImageModel):
+            correction = type(data)(data=pathloss_2d)
+            correction.pathloss_point = pathloss_2d
+        elif isinstance(data, datamodels.CubeModel):
+            pathloss_3d = np.repeat(pathloss_2d[np.newaxis, :, :], len(data.data), axis=0)
+            correction = type(data)(data=pathloss_3d)
+            correction.pathloss_point = pathloss_3d
+        else:
+            errmsg = (f"Pathloss step received unexpected datamodel type {type(data)}, "
+                      f"which it cannot process. Exiting.")
+            log.critical(errmsg)
+            raise RuntimeError(errmsg)
+
         correction.wavelength = wavelength_array
 
     else:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3024](https://jira.stsci.edu/browse/JP-3024)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR fixes an issue preventing by-integration data for MIRI LRS fixed slit exposures from processing through calwebb_spec2 - the pathloss step presumed that the pathloss correction array and the data array were both two dimensional, which is only true when using rate files as input. This PR repeats the pathloss correction across each integration, and it was found to be the only fix necessary to allow for processing to complete.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
