### PR TITLE
JP-2821 Correct WCS determination for aperture MIRIM_TAMRS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ pathloss
 - Repeat pathloss correction array into cube, to apply step to
   rateints input for MIRI LRS fixed slit data [#7446]
 
+set_telescope_pointing
+----------------------
+
+- Correct WCS determination for aperture MIRIM_TAMRS [#7449]
+
 1.9.4 (2023-01-27)
 ==================
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -2522,7 +2522,14 @@ def t_pars_from_model(model, **t_pars_kwargs):
             useafter = model.meta.observation.date
             if aperture_name != "UNKNOWN":
                 logger.info("Updating WCS for aperture %s", aperture_name)
-                siaf = t_pars.siaf_db.get_wcs(aperture_name, useafter=useafter)
+
+                # Special case. With aperture MIRIM_TAMRS, the siaf definition is
+                # for the subarray of interest. However, the whole detector is
+                # read out. Hence, need to convert pixel coordinates to be detector-based.
+                to_detector = False
+                if aperture_name == 'MIRIM_TAMRS':
+                    to_detector = True
+                siaf = t_pars.siaf_db.get_wcs(aperture_name, to_detector=to_detector, useafter=useafter)
         t_pars.siaf = siaf
         t_pars.useafter = useafter
     logger.debug('SIAF: %s', t_pars.siaf)

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -2522,7 +2522,7 @@ def t_pars_from_model(model, **t_pars_kwargs):
             useafter = model.meta.observation.date
             if aperture_name != "UNKNOWN":
                 logger.info("Updating WCS for aperture %s", aperture_name)
-                siaf = t_pars.siaf_db.get_wcs(aperture_name, useafter)
+                siaf = t_pars.siaf_db.get_wcs(aperture_name, useafter=useafter)
         t_pars.siaf = siaf
         t_pars.useafter = useafter
     logger.debug('SIAF: %s', t_pars.siaf)

--- a/jwst/lib/siafdb.py
+++ b/jwst/lib/siafdb.py
@@ -107,7 +107,7 @@ class SiafDb:
         aperture = siaf[aperture.upper()]
         return aperture
 
-    def get_wcs(self, aperture, useafter=None):
+    def get_wcs(self, aperture, to_detector=False, useafter=None):
         """
         Query the SIAF database file and get WCS values.
 
@@ -122,6 +122,8 @@ class SiafDb:
         ----------
         aperture : str
             The name of the aperture to retrieve.
+        to_detector : bool
+            Convert all the pixel parameters to be relative to the detector.
         useafter : str
             The date of observation (``model.meta.date``)
 
@@ -148,6 +150,9 @@ class SiafDb:
             value = value if value else getattr(default_siaf, SIAF_MAP[key])
             vertices.append(value)
         vertices = tuple(vertices)
+
+        if to_detector:
+            values['crpix1'], values['crpix2'] = aperture.sci_to_det(aperture.XSciRef, aperture.YSciRef)
 
         # Fill out the Siaf
         siaf = SIAF(**values, vertices_idl=vertices)

--- a/jwst/lib/tests/test_set_telescope_pointing.py
+++ b/jwst/lib/tests/test_set_telescope_pointing.py
@@ -549,6 +549,21 @@ def test_tsgrism_siaf_values(eng_db_ngas, data_file_nosiaf):
         assert model.meta.wcsinfo.siaf_yref_sci == 35
 
 
+def test_mirim_tamrs_siaf_values(eng_db_ngas, data_file_nosiaf):
+    """
+    Test that FITS WCS default values were set.
+    """
+    with datamodels.Level1bModel(data_file_nosiaf) as model:
+        model.meta.exposure.start_time = STARTTIME.mjd
+        model.meta.exposure.end_time = ENDTIME.mjd
+        model.meta.aperture.name = 'MIRIM_TAMRS'
+        model.meta.observation.date = '2017-01-01'
+        model.meta.exposure.type = "MIR_TACQ"
+        stp.update_wcs(model, siaf_path=siaf_path, engdb_url='http://localhost')
+        assert model.meta.wcsinfo.crpix1 == 997.5
+        assert model.meta.wcsinfo.crpix2 == 993.5
+
+
 # ######################
 # Utilities and fixtures
 # ######################

--- a/jwst/lib/tests/test_siafdb.py
+++ b/jwst/lib/tests/test_siafdb.py
@@ -60,9 +60,9 @@ def test_create(source, prd, xml_path, exception, jail_environ):
                      crpix1=1024.5, crpix2=1024.5, cdelt1=0.06787747, cdelt2=0.06976441,
                      vertices_idl=(-70.7843, 69.9807, 68.6042, -69.4153, -74.3558, -71.5516, 71.3065, 69.3639))),
         ('MIRIM_TAMRS', False,
-         siafdb.SIAF(v2_ref=206.407, v3_ref=-697.765, v3yangle=-1.24120427, vparity=1,
-                     crpix1=1024.5, crpix2=1024.5, cdelt1=0.06839158, cdelt2=0.06993081,
-                     vertices_idl=(-68.8543, 70.1233, 71.5697, -70.2482, 72.1764, 68.8086, -75.5918, -70.7457))),
+         siafdb.SIAF(v2_ref=-481.987342, v3_ref=-318.206242, v3yangle=4.83544897, vparity=-1,
+                     crpix1=24.5, crpix2=24.5, cdelt1=0.10986808, cdelt2=0.10996394,
+                     vertices_idl=(-2.6187, 2.6558, 2.6186, -2.6535, -2.6097, -2.6715, 2.6068, 2.6683))),
     ]
 )
 def test_get_wcs(aperture, to_detector, expected):

--- a/jwst/lib/tests/test_siafdb.py
+++ b/jwst/lib/tests/test_siafdb.py
@@ -63,6 +63,10 @@ def test_create(source, prd, xml_path, exception, jail_environ):
          siafdb.SIAF(v2_ref=-481.987342, v3_ref=-318.206242, v3yangle=4.83544897, vparity=-1,
                      crpix1=24.5, crpix2=24.5, cdelt1=0.10986808, cdelt2=0.10996394,
                      vertices_idl=(-2.6187, 2.6558, 2.6186, -2.6535, -2.6097, -2.6715, 2.6068, 2.6683))),
+        ('MIRIM_TAMRS', True,
+         siafdb.SIAF(v2_ref=-481.987342, v3_ref=-318.206242, v3yangle=4.83544897, vparity=-1,
+                     crpix1=997.5, crpix2=993.5, cdelt1=0.10986808, cdelt2=0.10996394,
+                     vertices_idl=(-2.6187, 2.6558, 2.6186, -2.6535, -2.6097, -2.6715, 2.6068, 2.6683))),
     ]
 )
 def test_get_wcs(aperture, to_detector, expected):

--- a/jwst/lib/tests/test_siafdb.py
+++ b/jwst/lib/tests/test_siafdb.py
@@ -49,22 +49,26 @@ def test_create(source, prd, xml_path, exception, jail_environ):
 
 
 @pytest.mark.parametrize(
-    'aperture, expected',
+    'aperture, to_detector, expected',
     [
-        ('FGS1_FULL_OSS',
+        ('FGS1_FULL_OSS', False,
          siafdb.SIAF(v2_ref=206.407, v3_ref=-697.765, v3yangle=-1.24120427, vparity=1,
                      crpix1=1024.5, crpix2=1024.5, cdelt1=0.06839158, cdelt2=0.06993081,
                      vertices_idl=(-68.8543, 70.1233, 71.5697, -70.2482, 72.1764, 68.8086, -75.5918, -70.7457))),
-        ('FGS2_FULL_OSS',
+        ('FGS2_FULL_OSS', False,
          siafdb.SIAF(v2_ref=22.835, v3_ref=-699.423, v3yangle=0.2914828, vparity=1,
                      crpix1=1024.5, crpix2=1024.5, cdelt1=0.06787747, cdelt2=0.06976441,
                      vertices_idl=(-70.7843, 69.9807, 68.6042, -69.4153, -74.3558, -71.5516, 71.3065, 69.3639))),
+        ('MIRIM_TAMRS', False,
+         siafdb.SIAF(v2_ref=206.407, v3_ref=-697.765, v3yangle=-1.24120427, vparity=1,
+                     crpix1=1024.5, crpix2=1024.5, cdelt1=0.06839158, cdelt2=0.06993081,
+                     vertices_idl=(-68.8543, 70.1233, 71.5697, -70.2482, 72.1764, 68.8086, -75.5918, -70.7457))),
     ]
 )
-def test_get_wcs(aperture, expected):
+def test_get_wcs(aperture, to_detector, expected):
     """Test retrieval of wcs information."""
     siaf_db = siafdb.SiafDb(SIAFXML_PATH)
-    siaf = siaf_db.get_wcs(aperture)
+    siaf = siaf_db.get_wcs(aperture, to_detector=to_detector)
     assert siaf == expected
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2821](https://jira.stsci.edu/browse/JP-2821)

<!-- describe the changes comprising this PR here -->
This PR addresses an issue where MIRI_TACQ exposures with aperture MIRIM_TAMRS has incorrect CRPIX* calculated. This is because the aperture definition is for a subarray. However, the actual readout includes the full detector, not the subarray. `set_telescope_pointing` is modified to account for this descrepancy. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
