### PR TITLE
JP-3083: Fix photom handling of NRS FS source types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,20 @@ pathloss
 - Repeat pathloss correction array into cube, to apply step to
   rateints input for MIRI LRS fixed slit data [#7446]
 
+photom
+------
+
+- Fix bug so that each slit of a NIRSpec fixed-slit dataset gets the proper flux
+  calibration applied, based on the slit-dependent source type (POINT or EXTENDED).
+  [#7451]
+
+pipeline
+--------
+
+- Update the calwebb_spec2 pipeline to make a deep copy of the current results before
+  calling the ``resample_spec`` and ``extract_1d`` steps, to avoid issues with the
+  input data accidentally getting modified by those steps. [#7451]
+
 set_telescope_pointing
 ----------------------
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -853,13 +853,9 @@ class DataSet():
                                                      dqflags.pixel['DO_NOT_USE'])
             if not self.inverse:
                 if unit_is_surface_brightness:
-                    log.debug(' unit_is_surf_bright is True')
-                    log.debug(' in photom_io MultiSlit; set to MJy/sr')
                     slit.meta.bunit_data = 'MJy/sr'
                     slit.meta.bunit_err = 'MJy/sr'
                 else:
-                    log.debug(' unit_is_surf_bright is False')
-                    log.debug(' in photom_io MultiSlit; set to MJy')
                     slit.meta.bunit_data = 'MJy'
                     slit.meta.bunit_err = 'MJy'
             else:

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -134,9 +134,26 @@ class DataSet():
         self.slitnum = -1
         self.specnum = -1
         self.inverse = inverse
-        self.source_type = source_type
-        if self.source_type is None and model.meta.target.source_type is not None:
-            self.source_type = model.meta.target.source_type.upper()
+        self.source_type = None
+
+        # For MultiSlitModels, only set a generic source_type value for the
+        # entire datamodel if the user has set the source_type parameter.
+        # Otherwise leave the generic source_type set to None, which will
+        # force the use of per-slit source_types later in processing.
+        if isinstance(model, datamodels.MultiSlitModel):
+            if source_type is not None:
+                self.source_type = source_type
+
+        # For non-MultiSlitModel inputs, where there's only 1 target and
+        # one source_type, use the user-provided source_type value, if it
+        # exists. Otherwise, use the generic source_type value provided in
+        # the input model (if it exists).
+        else:
+            if source_type is not None:
+                self.source_type = source_type
+            else:
+                if model.meta.target.source_type is not None:
+                    self.source_type = model.meta.target.source_type.upper()
 
         # Create a copy of the input model
         self.input = model.copy()
@@ -691,7 +708,7 @@ class DataSet():
             conversion = tabdata['photmj']              # unit is MJy
             if isinstance(self.input, datamodels.MultiSlitModel):
                 slit = self.input.slits[self.slitnum]
-                if self.exptype == 'NRS_MSASPEC':
+                if self.exptype in ['NRS_MSASPEC', 'NRS_FIXEDSLIT']:
                     srctype = self.source_type if self.source_type else slit.source_type
                 else:
                     srctype = self.source_type
@@ -836,14 +853,19 @@ class DataSet():
                                                      dqflags.pixel['DO_NOT_USE'])
             if not self.inverse:
                 if unit_is_surface_brightness:
+                    log.debug(' unit_is_surf_bright is True')
+                    log.debug(' in photom_io MultiSlit; set to MJy/sr')
                     slit.meta.bunit_data = 'MJy/sr'
                     slit.meta.bunit_err = 'MJy/sr'
                 else:
+                    log.debug(' unit_is_surf_bright is False')
+                    log.debug(' in photom_io MultiSlit; set to MJy')
                     slit.meta.bunit_data = 'MJy'
                     slit.meta.bunit_err = 'MJy'
             else:
                 self.input.meta.bunit_data = 'DN/s'
                 self.input.meta.bunit_err = 'DN/s'
+
         elif isinstance(self.input, datamodels.MultiSpecModel):
             # Does this block need to address SB columns as well, or will
             # they (presumably) never be populated for SOSS?
@@ -869,6 +891,7 @@ class DataSet():
             spec.spec_table.columns['BKGD_VAR_POISSON'].unit = 'Jy^2'
             spec.spec_table.columns['BKGD_VAR_RNOISE'].unit = 'Jy^2'
             spec.spec_table.columns['BKGD_VAR_FLAT'].unit = 'Jy^2'
+
         else:
             if not self.inverse:
                 self.input.data *= conversion
@@ -885,16 +908,16 @@ class DataSet():
                 self.input.dq[..., no_cal] = np.bitwise_or(self.input.dq[..., no_cal],
                                                            dqflags.pixel['DO_NOT_USE'])
 
-        if not self.inverse:
-            if unit_is_surface_brightness:
-                self.input.meta.bunit_data = 'MJy/sr'
-                self.input.meta.bunit_err = 'MJy/sr'
+            if not self.inverse:
+                if unit_is_surface_brightness:
+                    self.input.meta.bunit_data = 'MJy/sr'
+                    self.input.meta.bunit_err = 'MJy/sr'
+                else:
+                    self.input.meta.bunit_data = 'MJy'
+                    self.input.meta.bunit_err = 'MJy'
             else:
-                self.input.meta.bunit_data = 'MJy'
-                self.input.meta.bunit_err = 'MJy'
-        else:
-            self.input.meta.bunit_data = 'DN/s'
-            self.input.meta.bunit_err = 'DN/s'
+                self.input.meta.bunit_data = 'DN/s'
+                self.input.meta.bunit_err = 'DN/s'
 
         return
 

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -218,10 +218,12 @@ def create_input(instrument, detector, exptype,
             wl = mk_wavelength(shape, 1.0, 5.0, dispaxis=1)
             input_model.meta.target.source_type = 'POINT'  # output will be MJy
             slitnames = ['S200A1', 'S200A2', 'S400A1', 'S1600A1', 'S200B1']
+            srctypes = ['EXTENDED', 'POINT', 'EXTENDED', 'POINT', 'EXTENDED']
             for k in range(nslits):
                 slit = datamodels.SlitModel(data=data, dq=dq, err=err,
                                             wavelength=wl)
                 slit.name = slitnames[k]
+                slit.source_type = srctypes[k]
                 slit.var_poisson = var_p
                 slit.var_rnoise = var_r
                 slit.var_flat = var_f
@@ -1078,6 +1080,7 @@ def test_nirspec_fs():
     result = []
     for (k, slit) in enumerate(save_input.slits):
         slitname = slit.name
+        srctype = slit.source_type
         input = slit.data                       # this is from save_input
         output = ds.input.slits[k].data         # ds.input is the output
         rownum = find_row_in_ftab(save_input, ftab, ['filter', 'grating'],
@@ -1093,6 +1096,9 @@ def test_nirspec_fs():
         rel_resp = np.interp(wl, wavelength, relresponse,
                              left=np.nan, right=np.nan)
         compare = photmj * rel_resp
+        if srctype != 'POINT':
+            compare /= slit.meta.photometry.pixelarea_steradians
+
         # Compare the values at the center pixel.
         ratio = output[iy, ix] / input[iy, ix]
         result.append(np.allclose(ratio, compare, rtol=1.e-7))
@@ -1115,10 +1121,14 @@ def test_nirspec_fs():
         ratio_var_f = np.sqrt(ds.input.slits[k].var_flat[iy, ix] /
                               slit.var_flat[iy, ix])
         result.append(np.allclose(ratio_var_f, compare, rtol=1.e-7))
-        # The output units are flux density rather than surface brightness
-        # because this is NIRSpec data for a point source.
-        result.append(ds.input.slits[k].meta.bunit_data == 'MJy')
-        result.append(ds.input.slits[k].meta.bunit_err == 'MJy')
+        # The output units are flux density for point sources and
+        # surface brightness for extended.
+        if srctype == 'POINT':
+            result.append(ds.input.slits[k].meta.bunit_data == 'MJy')
+            result.append(ds.input.slits[k].meta.bunit_err == 'MJy')
+        else:
+            result.append(ds.input.slits[k].meta.bunit_data == 'MJy/sr')
+            result.append(ds.input.slits[k].meta.bunit_err == 'MJy/sr')
 
     assert np.alltrue(result)
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -281,12 +281,14 @@ class Spec2Pipeline(Pipeline):
            and not isinstance(calibrated, datamodels.CubeModel):
 
             # Call the resample_spec step for 2D slit data
-            resampled = self.resample_spec(calibrated)
+            resampled = calibrated.copy()
+            resampled = self.resample_spec(resampled)
 
         elif is_nrs_slit_linelamp(calibrated):
 
             # Call resample_spec for NRS 2D line lamp slit data
-            resampled = self.resample_spec(calibrated)
+            resampled = calibrated.copy()
+            resampled = self.resample_spec(resampled)
 
         elif (exp_type in ['MIR_MRS', 'NRS_IFU']) or is_nrs_ifu_linelamp(calibrated):
 
@@ -294,7 +296,8 @@ class Spec2Pipeline(Pipeline):
             # always create a single cube containing multiple
             # wavelength bands
 
-            resampled = self.cube_build(calibrated)
+            resampled = calibrated.copy()
+            resampled = self.cube_build(resampled)
             if not self.cube_build.skip:
                 self.save_model(resampled[0], 's3d')
         else:
@@ -313,7 +316,8 @@ class Spec2Pipeline(Pipeline):
             else:
                 self.photom.suffix = 'x1d'
             self.extract_1d.save_results = False
-            x1d = self.extract_1d(resampled)
+            x1d = resampled.copy()
+            x1d = self.extract_1d(x1d)
 
             # Possible that no fit was possible - if so, skip photom
             if x1d is not None:
@@ -322,16 +326,15 @@ class Spec2Pipeline(Pipeline):
             else:
                 self.log.warning("Extract_1d did not return a DataModel - skipping photom.")
         else:
-            x1d = self.extract_1d(resampled)
+            x1d = resampled.copy()
+            x1d = self.extract_1d(x1d)
 
         resampled.close()
         if x1d is not None:
             x1d.close()
 
         # That's all folks
-        self.log.info(
-            'Finished processing product {}'.format(exp_product['name'])
-        )
+        self.log.info('Finished processing product {}'.format(exp_product['name']))
 
         return calibrated
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3083](https://jira.stsci.edu/browse/JP-3083)


<!-- describe the changes comprising this PR here -->
This PR fixes the logic in the photom step that handles NIRSpec fixed-slit data, so that it uses the correct source type for each slit, which was assigned up-stream in the srctype step. This is important, because point sources are left in units of MJy, while extended sources are converted to surface brightness (MJy/sr).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
