### PR TITLE
Revert "Fix typo in SOSS transform schema (#7450)"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,6 @@
 1.9.5 (unreleased)
 ==================
 
-datamodels
-----------
-
-- Move ``jwst.datamodels`` out of ``jwst`` into ``stdatamodels.jwst.datamodels``. [#7439]
-
 pathloss
 --------
 
@@ -17,11 +12,10 @@ set_telescope_pointing
 
 - Correct WCS determination for aperture MIRIM_TAMRS [#7449]
 
-transforms
+datamodels
 ----------
 
-- Fix typo in NIRISS SOSS transform schema [#7450]
-
+- Move ``jwst.datamodels`` out of ``jwst`` into ``stdatamodels.jwst.datamodels``. [#7439]
 
 1.9.4 (2023-01-27)
 ==================

--- a/jwst/transforms/resources/manifests/jwst_transforms-0.7.0.yaml
+++ b/jwst/transforms/resources/manifests/jwst_transforms-0.7.0.yaml
@@ -43,8 +43,8 @@ tags:
   title: A model performing logical operations on arrays.
   description: |-
     Implements the Numpy logical operators
-- tag_uri: "tag:stsci.edu:jwst_pipeline/niriss_soss-0.7.0"
-  schema_uri: http://stsci.edu/schemas/jwst_pipeline/niriss_soss-0.7.0
+- tag_uri: "tag:stsci.edu:jwst_pipeline/niriss-soss-0.7.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/niriss-soss-0.7.0
   title: NIRISS SOSS transforms.
   description: |-
     This model is used by the NIRISS SOSS WCS pipeline.


### PR DESCRIPTION
This reverts commit bf7d3c9bc9d08b56103a68c37444c0f44a7c9edd.

<!-- describe the changes comprising this PR here -->
This #7450 was incomplete, and needs to be reworked. See https://github.com/spacetelescope/jwst/issues/7401#issuecomment-1416921842 for details.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
