### PR TITLE
Properly fix niriss soss schema not found warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ datamodels
 
 - Move ``jwst.datamodels`` out of ``jwst`` into ``stdatamodels.jwst.datamodels``. [#7439]
 
+transforms
+----------
+
+- Fix the NIRISS SOSS transform in the manifest and converter so the correct tag
+  is used and no warnings are issued by ASDF. [#7456]
+
 1.9.4 (2023-01-27)
 ==================
 

--- a/jwst/transforms/converters/jwst_models.py
+++ b/jwst/transforms/converters/jwst_models.py
@@ -124,7 +124,8 @@ class LogicalConverter(TransformConverterBase):
 
 
 class NirissSOSSConverter(TransformConverterBase):
-    tags = ["tag:stsci.edu:jwst_pipeline/niriss-soss-*"]
+    tags = ["tag:stsci.edu:jwst_pipeline/niriss-soss-*",
+            "tag:stsci.edu:jwst_pipeline/niriss_soss-*"]
     types = ["jwst.transforms.models.NirissSOSSModel"]
 
     def from_yaml_tree_transform(self, node, tag, ctx):

--- a/jwst/transforms/converters/tests/data/niriss_soss.asdf
+++ b/jwst/transforms/converters/tests/data/niriss_soss.asdf
@@ -1,0 +1,95 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.5.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+  name: asdf, version: 2.14.3}
+history:
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension.BuiltinExtension
+    software: !core/software-1.0.0 {name: asdf, version: 2.14.3}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/transform/extensions/transform-1.5.0
+    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.3.0}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://stsci.edu/jwst_pipeline/extensions/jwst_transforms-1.0.0
+    software: !core/software-1.0.0 {name: jwst, version: 1.4.3.dev49+ga4ad6249}
+model: !<tag:stsci.edu:jwst_pipeline/niriss-soss-0.7.0>
+  inputs: [x, y, spectral_order]
+  models:
+  - !transform/concatenate-1.2.0
+    forward:
+    - !transform/concatenate-1.2.0
+      forward:
+      - !transform/constant-1.4.0
+        dimensions: 1
+        inputs: [x]
+        outputs: [y]
+        value: 1.0
+      - !transform/constant-1.4.0
+        dimensions: 1
+        inputs: [x]
+        outputs: [y]
+        value: 2.0
+      inputs: [x0, x1]
+      outputs: [y0, y1]
+    - !transform/constant-1.4.0
+      dimensions: 1
+      inputs: [x]
+      outputs: [y]
+      value: 3.0
+    inputs: [x0, x1, x]
+    outputs: [y0, y1, y]
+  - !transform/concatenate-1.2.0
+    forward:
+    - !transform/concatenate-1.2.0
+      forward:
+      - !transform/constant-1.4.0
+        dimensions: 1
+        inputs: [x]
+        outputs: [y]
+        value: 4.0
+      - !transform/constant-1.4.0
+        dimensions: 1
+        inputs: [x]
+        outputs: [y]
+        value: 5.0
+      inputs: [x0, x1]
+      outputs: [y0, y1]
+    - !transform/constant-1.4.0
+      dimensions: 1
+      inputs: [x]
+      outputs: [y]
+      value: 6.0
+    inputs: [x0, x1, x]
+    outputs: [y0, y1, y]
+  - !transform/concatenate-1.2.0
+    forward:
+    - !transform/concatenate-1.2.0
+      forward:
+      - !transform/constant-1.4.0
+        dimensions: 1
+        inputs: [x]
+        outputs: [y]
+        value: 7.0
+      - !transform/constant-1.4.0
+        dimensions: 1
+        inputs: [x]
+        outputs: [y]
+        value: 8.0
+      inputs: [x0, x1]
+      outputs: [y0, y1]
+    - !transform/constant-1.4.0
+      dimensions: 1
+      inputs: [x]
+      outputs: [y]
+      value: 9.0
+    inputs: [x0, x1, x]
+    outputs: [y0, y1, y]
+  outputs: [ra, dec, lam]
+  spectral_orders: [1, 2, 3]
+...

--- a/jwst/transforms/converters/tests/test_models.py
+++ b/jwst/transforms/converters/tests/test_models.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 import numpy as np
+import os
 import warnings
 from astropy.modeling.models import Shift, Rotation2D, Const1D
 from asdf_astropy.converters.transform.tests.test_transform import (
@@ -69,3 +70,20 @@ def test_niriss_soss(tmpdir):
 
     with asdf.open(path, _force_raw_types=True) as af:
         assert af.tree["model"]._tag == "tag:stsci.edu:jwst_pipeline/niriss_soss-1.0.0"
+
+
+def test_niriss_soss_legacy():
+    data_path = os.path.join(os.path.dirname(__file__), 'data')
+    data = os.path.join(data_path, 'niriss_soss.asdf')
+
+    # confirm that the file contains the legacy tag
+    with asdf.open(data, _force_raw_types=True) as af:
+        assert af.tree["model"]._tag == "tag:stsci.edu:jwst_pipeline/niriss-soss-0.7.0"
+
+    # test that it opens with the legacy tag
+    with asdf.open(data) as af:
+        model = af['model']
+        assert model.spectral_orders == [1, 2, 3]
+        assert (model.models[1].parameters == (1.0, 2.0, 3.0)).all()
+        assert (model.models[2].parameters == (4.0, 5.0, 6.0)).all()
+        assert (model.models[3].parameters == (7.0, 8.0, 9.0)).all()

--- a/jwst/transforms/converters/tests/test_models.py
+++ b/jwst/transforms/converters/tests/test_models.py
@@ -10,6 +10,7 @@ from jwst.transforms.models import (
     NirissSOSSModel, Rotation3DToGWA, Gwa2Slit, Logical, Slit,
     DirCos2Unitless, Unitless2DirCos, Snell, AngleFromGratingEquation,
     WavelengthFromGratingEquation)
+import asdf
 import pytest
 
 
@@ -60,3 +61,11 @@ def test_niriss_soss(tmpdir):
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         assert_model_roundtrip(soss_model, tmpdir)
+
+    # Check tag is the latest version
+    path = str(tmpdir / "test.asdf")
+    with asdf.AsdfFile({"model": soss_model}) as af:
+        af.write_to(path)
+
+    with asdf.open(path, _force_raw_types=True) as af:
+        assert af.tree["model"]._tag == "tag:stsci.edu:jwst_pipeline/niriss_soss-1.0.0"

--- a/jwst/transforms/resources/manifests/jwst_transforms-0.7.0.yaml
+++ b/jwst/transforms/resources/manifests/jwst_transforms-0.7.0.yaml
@@ -44,7 +44,7 @@ tags:
   description: |-
     Implements the Numpy logical operators
 - tag_uri: "tag:stsci.edu:jwst_pipeline/niriss-soss-0.7.0"
-  schema_uri: http://stsci.edu/schemas/jwst_pipeline/niriss-soss-0.7.0
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/niriss_soss-0.7.0
   title: NIRISS SOSS transforms.
   description: |-
     This model is used by the NIRISS SOSS WCS pipeline.


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Fixes #7401

<!-- describe the changes comprising this PR here -->
This PR updates the manifests and the converts so the the niriss soss schema warning issue is resolved. Note that this adds a few tests to ensure the `NirissSOSSModelConverter` is tested outside the regression tests.

This is a follow up to the initially proposed fixes in #7450, which were reverted by #7454.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
