### PR TITLE
Refactor `minimum_deps` script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ transforms
 - Fix the NIRISS SOSS transform in the manifest and converter so the correct tag
   is used and no warnings are issued by ASDF. [#7456]
 
+other
+-----
+
+- Update ``minimum_deps`` script to use ``importlib_metadata`` and ``packaging``
+  instead of ``pkg_resources``. [#7457]
+
 1.9.4 (2023-01-27)
 ==================
 

--- a/jwst/scripts/minimum_deps.py
+++ b/jwst/scripts/minimum_deps.py
@@ -5,29 +5,38 @@ Generate a requirements-min.txt file based on install_requires
 """
 import warnings
 
-import pkg_resources
 import requests
+from contextlib import suppress
+from importlib_metadata import requires
+from packaging.version import parse, InvalidVersion
+from packaging.requirements import Requirement
 
 
 def get_minimum_version(requirement):
     """Return minimum version available on PyPi for a given version specification"""
-    if not requirement.specs:
+    if not requirement.specifier:
         warnings.warn(
             f'No version specifier for {requirement.name} in '
             'install_requires.  Using lowest available version on PyPi.',
             stacklevel=2,
         )
+
     content = requests.get(
         f'https://pypi.python.org/pypi/{requirement.name}/json'
     ).json()
-    versions = sorted(
-        [pkg_resources.parse_version(v) for v in content['releases'].keys()]
-    )
+    versions = []
+    for v in content['releases'].keys():
+        with suppress(InvalidVersion):
+            versions.append(parse(v))
+
+    versions = sorted(versions)
+
     for version in versions:
-        if version in requirement:
+        if version in requirement.specifier:
             # If the requirement does not list any version, the lowest will be
             # returned
             return version
+
     # If the specified version does not exist on PyPi, issue a warning
     # and return the lowest available version
     warnings.warn(
@@ -38,20 +47,24 @@ def get_minimum_version(requirement):
     return versions[0]
 
 
-def write_minimum_requirements_file(filename: str = None):
+def write_minimum_requirements_file(filename: str = None, extras: list = None):
+    """Write out a requirements-min.txt file for minimum package versions"""
     if filename is None:
         filename = 'requirements-min.txt'
 
-    """Write out a requirements-min.txt file for minimum package versions"""
-    dist = pkg_resources.get_distribution('jwst')
+    if extras is None:
+        extras = []
 
     with open(filename, 'w') as fd:
-        for requirement in dist.requires():
-            if requirement.url is None:
-                version = get_minimum_version(requirement)
-                fd.write(f'{requirement.name}=={version}\n')
-            else:
-                fd.write(f'{requirement}\n')
+        for r in requires('jwst'):
+            requirement = Requirement(r)
+
+            if requirement.marker is None or any(requirement.marker.evaluate({'extra': e}) for e in extras):
+                if requirement.url is None:
+                    version = get_minimum_version(requirement)
+                    fd.write(f'{requirement.name}=={version}\n')
+                else:
+                    fd.write(f'{requirement}\n')
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,12 +53,13 @@ install_requires =
     tweakwcs>=0.8.1
     asdf-astropy>=0.3.0
     wiimatch>=0.2.1
+    packaging>19.0
+    importlib-metadata>=4.11.4
 
 [options.extras_require]
 aws =
     stsci-aws-utils>=0.1.2
 docs =
-    packaging
     matplotlib
     sphinx
     sphinx-asdf>=0.1.1


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Currently the `oldestdeps` job is failing, this likely because the `minimum_deps` script is using `pkg_resources` which is no longer supported. This PR refactors `minimum_deps` to use supported packaging functionality

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
