### PR TITLE
catch `InvalidVersion` error in `minimum_deps`

### DIFF
--- a/jwst/scripts/minimum_deps.py
+++ b/jwst/scripts/minimum_deps.py
@@ -7,6 +7,7 @@ import warnings
 
 import pkg_resources
 import requests
+from packaging.version import InvalidVersion
 
 
 def get_minimum_version(requirement):
@@ -20,9 +21,13 @@ def get_minimum_version(requirement):
     content = requests.get(
         f'https://pypi.python.org/pypi/{requirement.name}/json'
     ).json()
-    versions = sorted(
-        [pkg_resources.parse_version(v) for v in content['releases'].keys()]
-    )
+    versions = []
+    for v in content['releases']:
+        try:
+            versions.append(pkg_resources.parse_version(v))
+        except InvalidVersion:
+            continue
+    versions = sorted(versions)
     for version in versions:
         if version in requirement:
             # If the requirement does not list any version, the lowest will be


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue at https://github.com/spacetelescope/jwst/actions/runs/4116545093/jobs/7106755108, where `pkg_resources` could not parse an old version of `poppy` (`0.3.3.deve8de5627ac0ec66d747e2112f53d414699124be8`)

We could also replace usage of `pkg_resources` with `importlib.metadata` and / or `semantic-version`

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
