### PR TITLE
JP-3084: Separate photometric calibration factors for point vs. uniform use

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ photom
   calibration applied, based on the slit-dependent source type (POINT or EXTENDED).
   [#7451]
 
+- Correct units of ``photom_uniform`` array to MJy/sr for NIRSpec fixed
+  slit data, to allow for expected behavior in ``master_background`` processing. [#7464]
+
 pipeline
 --------
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -826,8 +826,6 @@ class DataSet():
                                                                    self.exptype, conversion,
                                                                    waves, relresps, order)
 
-                    slit.photom_uniform = conversion
-
             elif isinstance(self.input, datamodels.MultiSpecModel):
 
                 # This input does not require a 2d conversion, but a 1d interpolation on the

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -721,6 +721,7 @@ class DataSet():
                                   "to surface brightness")
                         conversion /= slit.meta.photometry.pixelarea_steradians
                 else:
+                    conversion_uniform = conversion / slit.meta.photometry.pixelarea_steradians
                     unit_is_surface_brightness = False
             elif isinstance(self.input, datamodels.MultiSpecModel):
                 # MultiSpecModel output from extract1d should not require this area conversion?
@@ -735,6 +736,7 @@ class DataSet():
                                   "to surface brightness")
                         conversion /= self.input.meta.photometry.pixelarea_steradians
                 else:
+                    conversion_uniform = conversion / slit.meta.photometry.pixelarea_steradians
                     unit_is_surface_brightness = False
 
         # Store the conversion factor in the meta data
@@ -804,26 +806,28 @@ class DataSet():
 
                     # First, compute 2D array of photom correction values using
                     # uncorrected wavelengths, which is appropriate for a uniform source
-                    scalar_conv = conversion
-                    conversion, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
-                                                                   self.exptype, scalar_conv,
+                    conversion_2d_uniform, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
+                                                                   self.exptype, conversion_uniform,
                                                                    waves, relresps, order,
                                                                    use_wavecorr=False)
-                    slit.photom_uniform = conversion  # store the result
+                    slit.photom_uniform = conversion_2d_uniform  # store the result
 
                     # Now repeat the process using corrected wavelength values,
                     # which is appropriate for a point source. This is the version of
                     # the correction that will actually get applied to the data below.
-                    conversion, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
-                                                                   self.exptype, scalar_conv,
+                    conversion_2d_point, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
+                                                                   self.exptype, conversion,
                                                                    waves, relresps, order,
                                                                    use_wavecorr=True)
-                    slit.photom_point = conversion  # store the result
+                    slit.photom_point = conversion_2d_point  # store the result
 
                 else:
-                    conversion, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
+                    conversion_2d, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
                                                                    self.exptype, conversion,
                                                                    waves, relresps, order)
+
+                    slit.photom_uniform = conversion_2d
+
             elif isinstance(self.input, datamodels.MultiSpecModel):
 
                 # This input does not require a 2d conversion, but a 1d interpolation on the

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -815,18 +815,18 @@ class DataSet():
                     # Now repeat the process using corrected wavelength values,
                     # which is appropriate for a point source. This is the version of
                     # the correction that will actually get applied to the data below.
-                    conversion_2d_point, no_cal = self.create_2d_conversion(slit,
+                    conversion, no_cal = self.create_2d_conversion(slit,
                                                                    self.exptype, conversion,
                                                                    waves, relresps, order,
                                                                    use_wavecorr=True)
-                    slit.photom_point = conversion_2d_point  # store the result
+                    slit.photom_point = conversion  # store the result
 
                 else:
-                    conversion_2d, no_cal = self.create_2d_conversion(slit,
+                    conversion, no_cal = self.create_2d_conversion(slit,
                                                                    self.exptype, conversion,
                                                                    waves, relresps, order)
 
-                    slit.photom_uniform = conversion_2d
+                    slit.photom_uniform = conversion
 
             elif isinstance(self.input, datamodels.MultiSpecModel):
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -736,7 +736,7 @@ class DataSet():
                                   "to surface brightness")
                         conversion /= self.input.meta.photometry.pixelarea_steradians
                 else:
-                    conversion_uniform = conversion / slit.meta.photometry.pixelarea_steradians
+                    conversion_uniform = conversion / self.input.meta.photometry.pixelarea_steradians
                     unit_is_surface_brightness = False
 
         # Store the conversion factor in the meta data
@@ -797,16 +797,16 @@ class DataSet():
 
             # Compute a 2-D grid of conversion factors, as a function of wavelength
             if isinstance(self.input, datamodels.MultiSlitModel):
-
+                slit = self.input.slits[self.slitnum]
                 # The NIRSpec fixed-slit primary slit needs special handling if
                 # it contains a point source
                 if self.exptype.upper() == 'NRS_FIXEDSLIT' and \
-                   self.input.slits[self.slitnum].name == self.input.meta.instrument.fixed_slit and \
-                   self.input.slits[self.slitnum].source_type.upper() == 'POINT':
+                   slit.name == self.input.meta.instrument.fixed_slit and \
+                   slit.source_type.upper() == 'POINT':
 
                     # First, compute 2D array of photom correction values using
                     # uncorrected wavelengths, which is appropriate for a uniform source
-                    conversion_2d_uniform, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
+                    conversion_2d_uniform, no_cal = self.create_2d_conversion(slit,
                                                                    self.exptype, conversion_uniform,
                                                                    waves, relresps, order,
                                                                    use_wavecorr=False)
@@ -815,14 +815,14 @@ class DataSet():
                     # Now repeat the process using corrected wavelength values,
                     # which is appropriate for a point source. This is the version of
                     # the correction that will actually get applied to the data below.
-                    conversion_2d_point, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
+                    conversion_2d_point, no_cal = self.create_2d_conversion(slit,
                                                                    self.exptype, conversion,
                                                                    waves, relresps, order,
                                                                    use_wavecorr=True)
                     slit.photom_point = conversion_2d_point  # store the result
 
                 else:
-                    conversion_2d, no_cal = self.create_2d_conversion(self.input.slits[self.slitnum],
+                    conversion_2d, no_cal = self.create_2d_conversion(slit,
                                                                    self.exptype, conversion,
                                                                    waves, relresps, order)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3084](https://jira.stsci.edu/browse/JP-3084)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an inconsistency in how the scalar conversion factor in the `photom` step is passed through various point vs. extended source conditionals, leading to a 2D conversion array stored in `model.slits[i].photom_uniform` not containing a conversion to MJy/sr. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
