### PR TITLE
JP-3095: Fix extract_1d usage of use_source_posn param

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ datamodels
 
 - Move ``jwst.datamodels`` out of ``jwst`` into ``stdatamodels.jwst.datamodels``. [#7439]
 
+extract_1d
+----------
+
+- Fix the logic for handling the ``use_source_posn`` parameter, so that proper
+  precedence is given for command line override, reference file settings, and
+  internal decisions of the appropriate setting (in that order). [#7466]
+
 other
 -----
 
@@ -32,6 +39,13 @@ pipeline
   calling the ``resample_spec`` and ``extract_1d`` steps, to avoid issues with the
   input data accidentally getting modified by those steps. [#7451]
 
+ramp_fitting
+------------
+
+- Changed computations for ramps that have only one good group in the 0th
+  group.  Ramps that have a non-zero groupgap should not use group_time, but
+  (NFrames+1)*TFrame/2, instead.  [#7461, spacetelescope/stcal#142]
+
 resample
 --------
 
@@ -40,13 +54,6 @@ resample
 - Require minimum version of ``drizzle`` to be at least 1.13.7, which fixes
   a bug due to which parts of input images may not be present in the output
   resampled image under certain circumstances. [#7460]
-
-ramp_fitting
-------------
-
-- Changed computations for ramps that have only one good group in the 0th
-  group.  Ramps that have a non-zero groupgap should not use group_time, but
-  (NFrames+1)*TFrame/2, instead.  [#7461, spacetelescope/stcal#142]
 
 scripts
 -------
@@ -70,6 +77,7 @@ transforms
 
 - Fix the NIRISS SOSS transform in the manifest and converter so the correct tag
   is used and no warnings are issued by ASDF. [#7456]
+
 - Move ``jwst.transforms`` out of ``jwst`` into ``stdatamodels.jwst.transforms``. [#7441]
 
 tweakreg

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -8,11 +8,14 @@ The ``extract_1d`` step has the following step-specific arguments.
   image data used to perform background extraction will be smoothed in the
   dispersion direction with a boxcar of this width.  If ``smoothing_length``
   is None (the default), the step will attempt to read the value from the
-  EXTRACT1D reference file.  If a value is specified in the reference file,
+  :ref:`EXTRACT1D <extract1d_reffile>` reference file.
+  If a value is specified in the reference file,
   that value will be used.  Note that by specifying this parameter in the
-  EXTRACT1D reference file a different value can be designated for each slit.
-  If no value is specified either by the user or in the EXTRACT1D reference
-  file, no background smoothing is done.
+  :ref:`EXTRACT1D <extract1d_reffile>` reference file, a different value can
+  be designated for each slit, if desired.
+  If no value is specified either by the user or in the
+  :ref:`EXTRACT1D <extract1d_reffile>` reference file,
+  no background smoothing is done.
 
 ``--bkg_fit``
   The type of fit to perform to the background data in each image column
@@ -24,7 +27,8 @@ The ``extract_1d`` step has the following step-specific arguments.
   row) will be fit with a polynomial of order "bkg_order" (see below).
   Values of "mean" and "median" compute the simple average and median,
   respectively, of the background region values in each column (or row).
-  This parameter can also be specified in the EXTRACT1D reference file. If
+  This parameter can also be specified in the
+  :ref:`EXTRACT1D <extract1d_reffile>` reference file. If
   specified in the reference file and given as an argument to the step by
   the user, the user-supplied value takes precedence.
 
@@ -34,7 +38,8 @@ The ``extract_1d`` step has the following step-specific arguments.
   dispersion is vertical) of the input image, and the fitted curve will be
   subtracted from the target data.  ``bkg_order`` = 0 (the minimum allowed
   value) means to fit a constant.  The user-supplied value (if any)
-  overrides the value in the EXTRACT1D reference file.  If neither is specified, a
+  overrides the value in the
+  :ref:`EXTRACT1D <extract1d_reffile>` reference file.  If neither is specified, a
   value of 0 will be used. If a sufficient number of valid data points is
   unavailable to construct the polynomial fit, the fit will be forced to
   0 for that particular column (or row). If "bkg_fit" is not "poly", this
@@ -59,13 +64,14 @@ The ``extract_1d`` step has the following step-specific arguments.
 
 ``--subtract_background``
   This is a boolean flag to specify whether the background should be
-  subtracted.  If None, the value in the EXTRACT1D reference file (if any)
-  will be used.  If not None, this parameter overrides the value in the
-  reference file.
+  subtracted.  If None, the value in the :ref:`EXTRACT1D <extract1d_reffile>`
+  reference file (if any) will be used.  If not None, this parameter overrides
+  the value in the reference file.
 
 ``--use_source_posn``
   This is a boolean flag to specify whether the target and background extraction
-  region locations specified in the EXTRACT1D reference file should be shifted
+  region locations specified in the :ref:`EXTRACT1D <extract1d_reffile>` reference
+  file should be shifted
   to account for the expected position of the source. If None (the default),
   the step will make the decision of whether to use the source position based
   on the observing mode and the source type. The source position will only be
@@ -75,7 +81,11 @@ The ``extract_1d`` step has the following step-specific arguments.
   Coordinate System (WCS) to compute the x/y source location. For long-slit
   type modes (e.g. MIRI LRS and NIRSpec fixed-slit and MOS), only the position
   in the cross-dispersion direction is used to potentially offset the
-  extraction regions in that direction.
+  extraction regions in that direction. If this parameter is specified in the
+  :ref:`EXTRACT1D <extract1d_reffile>` reference file, the reference file value
+  will override any automatic settings based on exposure and source type.
+  As always, a value given by the user as an argument to the step overrides all
+  settings in the reference file or within the step code.
 
 ``--center_xy``
   A list of two integer values giving the desired x/y location for the center

--- a/docs/jwst/extract_1d/description.rst
+++ b/docs/jwst/extract_1d/description.rst
@@ -29,8 +29,8 @@ optionally including background subtraction using a circular annulus.
 For an extended source, rectangular aperture photometry is used, with
 the entire image being extracted, and no background subtraction, regardless
 of what was specified in the reference file or step arguments.
-For either point or extended sources, the photometry makes use of the Astropy
-affiliated package
+For both point or extended sources, photometric measurements make use of
+the Astropy affiliated package
 `photutils <https://photutils.readthedocs.io/en/latest/>`_ to define an aperture
 object and perform extraction.
 
@@ -53,11 +53,11 @@ for MIRI MRS and NIRSpec IFU. For other modes that are not resampled (e.g. MIRI
 LRS slitless, NIRISS SOSS, NIRSpec BrightObj, and NIRCam and NIRISS WFSS), this will
 be a "cal" product.
 For modes that have multiple slit instances (NIRSpec fixed-slit and MOS, WFSS),
-The SCI extensions should have keyword SLTNAME to specify which slit was extracted,
+the SCI extensions should have the keyword SLTNAME to specify which slit was extracted,
 though if there is only one slit (e.g. MIRI LRS and NIRISS SOSS), the slit name can
 be taken from the EXTRACT1D reference file instead.
 
-Normally the :ref:`photom <photom_step>` step should have been run before running
+Normally the :ref:`photom <photom_step>` step should be applied before running
 ``extract_1d``.  If ``photom`` has not been run, a warning will be logged and the
 output of ``extract_1d`` will be in units of count rate.  The ``photom`` step
 converts data to units of either surface brightness (MegaJanskys per steradian) or,
@@ -72,7 +72,7 @@ have columns WAVELENGTH, FLUX, FLUX_ERROR, FLUX_VAR_POISSON, FLUX_VAR_RNOISE,
 FLUX_VAR_FLAT, SURF_BRIGHT, SB_ERROR, SB_VAR_POISSON, SB_VAR_RNOISE,
 SB_VAR_FLAT, DQ, BACKGROUND, BKGD_ERROR, BKGD_VAR_POISSON, BKGD_VAR_RNOISE,
 BKGD_VAR_FLAT and NPIXELS.
-Some metadata will be written to the table header, mostly copied from the
+Some meta data will be written to the table header, mostly copied from the
 input header.
 
 The output WAVELENGTH data is copied from the wavelength array of the input 2D data,
@@ -143,12 +143,12 @@ If ``extract_width`` is also given, that takes priority over ``ystart`` and
 in the cross-dispersion direction. For point source data, 
 then the ``xstart`` and ``xstop`` values (dispaxis = 2) are shifted to account
 for the expected location of the source. If dispaxis=1, then the ``ystart`` and ``ystop`` values
-are modified. The offset amount is internally calculated. If it is not desired to apply this
+are modified. The offset amount is calculated internally. If it is not desired to apply this
 offset, then set ``use_source_posn`` = False. If the ``use_source_posn`` parameter is None (default),
 the values of ``xstart/xstop`` or ``ystart/ystop`` in the ``extract_1d`` reference file will be used
-to determine the center position of the extraction aperture. If these values are not set in the reference file
-the ``use_source_posn``  will be 
-internally set to True for point source data according to the table given in :ref:`srctype <srctype_table>`.
+to determine the center position of the extraction aperture. If these values are not set in the
+reference file, the ``use_source_posn``  will be set internally to True for point source data
+according to the table given in :ref:`srctype <srctype_table>`.
 Any of the extraction location parameters will be modified internally by the step code if the
 extraction region would extend outside the limits of the input image or outside
 the domain specified by the WCS.

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -25,12 +25,12 @@ EXP_TYPE   model.meta.exposure.type
 
 Reference File Format for non-IFU data
 ++++++++++++++++++++++++++++++++++++++
-EXTRACT1D reference files for non-ifu data are text files, with the information stored in
+EXTRACT1D reference files for non-IFU data are text files, with the information stored in
 JSON format.
 All the information is specified in a list with key ``apertures``.  Each
 element of this list is a dictionary, one for each aperture (e.g. a slit)
 that is supported by the given reference file.  The particular dictionary
-to use is found by matching the slit name in the science data with the
+used by the step is found by matching the slit name in the science data with the
 value of key ``id``.  Key ``spectral_order`` is optional, but if it is
 present, it must match the expected spectral order number.
 
@@ -58,10 +58,10 @@ and background extraction regions.
 * spectral_order: the spectral order number (optional); this can be either
   positive or negative, but it should not be zero (int)
 * dispaxis: dispersion direction, 1 for X, 2 for Y (int)
-* xstart: first pixel in the horizontal direction, X (int)
-* xstop: last pixel in the horizontal direction, X (int)
-* ystart: first pixel in the vertical direction, Y (int)
-* ystop: last pixel in the vertical direction, Y (int)
+* xstart: first pixel in the horizontal direction, X (int) (0-indexed)
+* xstop: last pixel in the horizontal direction, X (int) (0-indexed)
+* ystart: first pixel in the vertical direction, Y (int) (0-indexed)
+* ystop: last pixel in the vertical direction, Y (int) (0-indexed)
 * src_coeff: this takes priority for specifying the source extraction region
   (list of lists of float)
 * bkg_coeff: for specifying background subtraction regions
@@ -72,13 +72,15 @@ and background extraction regions.
 * bkg_fit: the type of background fit or computation (string)
 * bkg_order: order of polynomial fit to background regions (int)
 * extract_width: number of pixels in cross-dispersion direction (int)
+* use_source_posn: adjust the extraction limits based on source RA/Dec (bool)
 
 .. note::
 
    All parameter values that represent pixel indexes, such as ``xstart``,
    ``xstop``, and the ``src_coeff`` and ``bkg_coeff`` coefficients, are always
    in the frame of the image being operated on, which could be a small cutout
-   from a larger original image.
+   from a larger original image. They are also ZERO-indexed and the limits are
+   inclusive (e.g. 11-15 includes 5 pixels).
 
 See :ref:`extract-1d-for-slits` for more details on how these parameters
 are used in the extraction process.

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -378,11 +378,22 @@ def get_extract_parameters(
                         # If the user supplied a value, use that value.
                         extract_params['bkg_order'] = bkg_order
 
-                    if use_source_posn is None:
-                        extract_params['use_source_posn'] = aper.get('use_source_posn', False)
-                    else:
-                        # If the user supplied a value, use that value.
-                        extract_params['use_source_posn'] = use_source_posn
+                    # Set use_source_posn based on hierarchy of priorities:
+                    # parameter value on the command line is highest precedence,
+                    # then parameter value from the extract1d reference file,
+                    # and finally a default setting based on exposure type.
+                    use_source_posn_aper = aper.get('use_source_posn', None)  # value from the extract1d ref file
+                    if use_source_posn is None:  # no value set on command line
+                        if use_source_posn_aper is None:  # no value set in ref file
+                            # Use a suitable default
+                            if meta.exposure.type in ['MIR_LRS-FIXEDSLIT', 'MIR_MRS', 'NRS_FIXEDSLIT', 'NRS_IFU', 'NRS_MSASPEC']:
+                                use_source_posn = True
+                                log.info(f"Turning on source position correction for exp_type = {meta.exposure.type}")
+                            else:
+                                use_source_posn = False
+                        else:  # use the value from the ref file
+                            use_source_posn = use_source_posn_aper
+                    extract_params['use_source_posn'] = use_source_posn
 
                     extract_params['extract_width'] = aper.get('extract_width')
                     extract_params['position_correction'] = 0  # default value
@@ -2783,14 +2794,6 @@ def do_extract1d(
             log.warning(
                 f"Correcting for source position is not supported for exp_type = "
                 f"{meta_source.meta.exposure.type}, so use_source_posn will be set to False",
-            )
-
-    # Turn use_source_posn on for types that should use it by default
-    if use_source_posn is None:
-        if exp_type in ['MIR_LRS-FIXEDSLIT', 'MIR_MRS', 'NRS_FIXEDSLIT', 'NRS_IFU', 'NRS_MSASPEC']:
-            use_source_posn = True
-            log.info(
-                f"Turning on source position correction for exp_type = {exp_type}"
             )
 
     # Handle inputs that contain one or more slit models


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3095](https://jira.stsci.edu/browse/JP-3095)

<!-- describe the changes comprising this PR here -->
This PR updates the logic in the lower-levels of the extract_1d code to properly handle the various ways the "use_source_posn" can be specified, including command line overrides and from within the extract1d reference file. The previous logic was automatically turning the param on for certain exposure types, such as MIRI MRS and LRS fixed-slit, and NIRSpec IFU and slits, too high up in the code, before the information from the extract1d ref file had been loaded, thus overriding any settings in the ref file (if present). These changes move the logic down lower, so that the automatic override is only applied after the ref file params have been loaded and checked. The new logic how honors the appropriate hierarchy of precedence, in that it gives highest precedence to user-supplied values on the command line, then the ref file value (if any), and finally the automatic setting for some exposure types.

This fixes an issue encountered when the MIRI team decided they wanted to turn off the use of "use_source_posn" for LRS fixed-slit data by setting the param in the extract1d ref file and it was being ignored.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
