### PR TITLE
JP-3106: Fix input NaNs in residual fringe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,11 @@ resample
   a bug due to which parts of input images may not be present in the output
   resampled image under certain circumstances. [#7460]
 
+residual_fringe
+---------------
+
+- Fix bug in Residual Fringe step handling of NaNs in input []
+
 scripts
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,7 @@ resample
 residual_fringe
 ---------------
 
-- Fix bug in Residual Fringe step handling of NaNs in input []
+- Fix bug in Residual Fringe step handling of NaNs in input [#7471]
 
 scripts
 -------

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -87,7 +87,7 @@ class ResidualFringeCorrection():
         # Set them to 0 for the residual fringe routine
         # They will be re-added at the end
         output_data = self.model.data.copy()
-        nanval_indx = np.where(np.isfinite(output_data) == False)
+        nanval_indx = np.where(~np.isfinite(output_data))
         output_data[nanval_indx] = 0
 
         # normalise the output_data to remove units

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -83,8 +83,14 @@ class ResidualFringeCorrection():
             raise ErrorNoFringeFlat("The fringe flat step has not been run on file %s",
                                     self.input_model.meta.filename)
 
-        # normalise the output_data to remove units
+        # Remove any NaN values from the data prior to processing
+        # Set them to 0 for the residual fringe routine
+        # They will be re-added at the end
         output_data = self.model.data.copy()
+        nanval_indx = np.where(np.isfinite(output_data) == False)
+        output_data[nanval_indx] = 0
+
+        # normalise the output_data to remove units
         pos_data = self.input_model.data[self.input_model.data > 0]
         normalization_factor = np.median(pos_data)
         output_data /= normalization_factor
@@ -457,6 +463,8 @@ class ResidualFringeCorrection():
         # add units back to output data
         log.info(" adding units back to output array")
         output_data *= normalization_factor
+        # Add NaNs back to output data
+        output_data[nanval_indx] = np.nan
         self.model.data = output_data
         del output_data
 

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -526,7 +526,7 @@ class ResidualFringeCorrection():
         weights = np.zeros(self.input_model.data.shape)
         for c in np.arange(weights.shape[1]):
             flux_1d = self.input_model.data[:, c]
-            w = flux_1d / np.mean(flux_1d)
+            w = flux_1d / np.nanmean(flux_1d)
             weights[:, c] = w
 
         # replace infs and nans in weights with 0


### PR DESCRIPTION
Fixes an issue with MRS Residual Fringe crashing on input NaN values (https://jira.stsci.edu/browse/JP-3106) caused by recent merges of https://jira.stsci.edu/browse/JP-3014 and https://jira.stsci.edu/browse/JP-3087

Convert NaN values to zero at the start of this routine, then repopulate as NaN at the end since the Bayesic routines don't handle either NaN or zero well, but there is already infrastructure in place to deal with input zeros.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
