### PR TITLE
Control whether to use absolute or relative values in skymatch overlaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ htmlcov
 requirements-min.txt
 .tox/
 .tmp/
+.idea/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -166,7 +166,8 @@ skymatch
 --------
 
 - Added an ``apply_sky`` parameter, to switch between using relative or absolute
-  sky values in match overlaps. [#7473]
+  sky values in match overlaps. Also changes how bounding box is calculated for
+  SkyImage, to avoid large empty areas in MIRI observations [#7473]
 
 straylight
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,12 @@ scripts
 
 - Offload ``minimum_deps`` script to ``minimum_dependencies`` package [#7463]
 
+skymatch
+--------
+
+- Added an ``apply_sky`` parameter, to switch between using relative or absolute
+  sky values in match overlaps.
+
 transforms
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,6 +162,12 @@ set_telescope_pointing
 - Fill values of ``TARG_RA`` and ``TARG_DEC`` with ``RA_REF`` and ``DEC_REF``
   if target location is not provided, e.g. for pure parallel observations [#7512]
 
+skymatch
+--------
+
+- Added an ``apply_sky`` parameter, to switch between using relative or absolute
+  sky values in match overlaps. [#7473]
+
 straylight
 ----------
 
@@ -178,12 +184,6 @@ scripts
   instead of ``pkg_resources``. [#7457]
 
 - Offload ``minimum_deps`` script to ``minimum_dependencies`` package [#7463]
-
-skymatch
---------
-
-- Added an ``apply_sky`` parameter, to switch between using relative or absolute
-  sky values in match overlaps.
 
 transforms
 ----------

--- a/docs/jwst/skymatch/arguments.rst
+++ b/docs/jwst/skymatch/arguments.rst
@@ -29,13 +29,6 @@ The ``skymatch`` step uses the following optional arguments:
   'sky' value. Otherwise, will use the absolute values of the overlaps.
   Defaults to the opposite of ``subtract``
 
-**Image bounding polygon parameters:**
-
-``stepsize`` (int, default=None)
-  Spacing between vertices of the images bounding polygon. The default value of
-  `None` creates bounding polygons with four vertices corresponding to the corners
-  of the image.
-
 **Sky statistics parameters:**
 
 ``skystat`` (str, default='mode')

--- a/docs/jwst/skymatch/arguments.rst
+++ b/docs/jwst/skymatch/arguments.rst
@@ -23,6 +23,12 @@ The ``skymatch`` step uses the following optional arguments:
   the images. The BKGSUB keyword (boolean) will be set in each output image to
   record whether or not the background was subtracted.
 
+``apply_sky`` (boolean, default=None)
+  Only used for `match` skymethods. If `True`, will use the relative
+  difference between the calculated overlap value and the calculated
+  'sky' value. Otherwise, will use the absolute values of the overlaps.
+  Defaults to the opposite of ``subtract``
+
 **Image bounding polygon parameters:**
 
 ``stepsize`` (int, default=None)

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def match(images, skymethod='global+match', match_down=True, subtract=False):
+def match(images, skymethod='global+match', match_down=True, subtract=False, apply_sky=True,):
     """
     A function to compute and/or "equalize" sky background in input images.
 
@@ -91,6 +91,11 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
 
     subtract : bool (Default = False)
         Subtract computed sky value from image data.
+
+    apply_sky : bool (Default = True)
+        Only used for 'match' skymethods. If True, will use the relative
+        difference between the calculated overlap value and the calculated
+        'sky' value. Otherwise, will use the absolute values of the overlaps.
 
 
     Raises
@@ -302,7 +307,7 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
                  "overlapping regions.")
 
         # find "optimum" sky changes:
-        sky_deltas = _find_optimum_sky_deltas(images, apply_sky=not subtract)
+        sky_deltas = _find_optimum_sky_deltas(images, apply_sky=apply_sky)
         sky_good = np.isfinite(sky_deltas)
 
         if np.any(sky_good):
@@ -318,7 +323,7 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
             float(skd) if np.isfinite(skd) else None for skd in sky_deltas
         ]
 
-        _apply_sky(images, sky_deltas, False, subtract, show_old)
+        _apply_sky(images, sky_deltas, False, not apply_sky, show_old)
         show_old = True
 
     # 2. Method: "local". Compute the minimum sky background

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -47,9 +47,6 @@ class SkyMatchStep(Step):
         subtract = boolean(default=False) # subtract computed sky from image data?
         apply_sky = boolean(default=None) # use relative or absolute sky values in overlaps? Defaults to not subtract
 
-        # Image's bounding polygon parameters:
-        stepsize = integer(default=None) # Max vertex separation
-
         # Sky statistics parameters:
         skystat = option('median', 'midpt', 'mean', 'mode', default='mode') # sky statistics
         dqbits = string(default='~DO_NOT_USE+NON_SCIENCE') # "good" DQ bits
@@ -197,7 +194,6 @@ class SkyMatchStep(Step):
             mask=dqmask,
             id=image_model.meta.filename,  # file name?
             skystat=self._skystat,
-            stepsize=self.stepsize,
             reduce_memory_usage=self._is_asn,
             meta={'image_model': input_image_model}
         )

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -45,6 +45,7 @@ class SkyMatchStep(Step):
         skymethod = option('local', 'global', 'match', 'global+match', default='match') # sky computation method
         match_down = boolean(default=True) # adjust sky to lowest measured value?
         subtract = boolean(default=False) # subtract computed sky from image data?
+        apply_sky = boolean(default=None) # use relative or absolute sky values in overlaps? Defaults to not subtract
 
         # Image's bounding polygon parameters:
         stepsize = integer(default=None) # Max vertex separation
@@ -109,9 +110,12 @@ class SkyMatchStep(Step):
             else:
                 raise AssertionError("Logical error in the pipeline code.")
 
+        if self.apply_sky is None:
+            self.apply_sky = not self.subtract
+
         # match/compute sky values:
         match(images, skymethod=self.skymethod, match_down=self.match_down,
-              subtract=self.subtract)
+              subtract=self.subtract, apply_sky=self.apply_sky)
 
         # set sky background value in each image's meta:
         for im in images:


### PR DESCRIPTION
Closes #7472 (I misunderstood what the code was doing, but this PR fixes the issue we have)

This PR adds a new parameter to the skymatch step, `apply_sky`, to decouple the `subtract` parameter from absolute/relative comparisons in the overlap regions of `match`. This is vital for observations where emission fills the tiles, and is not consistent across them. I've used `apply_sky` to be consistent with the parameter name passed to the `_find_optimum_sky_deltas` call in `skymatch.py`.

For backwards compatibility, this defaults to None, which will then set apply_sky = not subtract, the old behaviour.

To illustrate, here's the F770W image for NGC1087, all with 'global+match'. The difference is the left has subtract=True, middle has subtract=False, and right has subtract=True and apply_sky=True. These are all locked to the same scale. The steps between tiles are super apparent in the left and middle, but are much reduced in the right.

<img width="1800" alt="Screenshot 2023-03-01 at 11 24 54" src="https://user-images.githubusercontent.com/32936518/222126759-8df12eb9-13c5-4004-910d-42dc638bde61.png">

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
