### PR TITLE
include `opencv-python` in instructions to generate SDP requirements

### DIFF
--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -12,5 +12,5 @@
 #
 #     conda create -n sdp python -y
 #     conda activate sdp
-#     pip install -e .[test]
+#     pip install -e .[test] "opencv-python>=4.6.0.66"
 #     pip freeze | grep -v jwst >> requirements-sdp.txt


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3109](https://jira.stsci.edu/browse/JP-3109)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
https://github.com/spacetelescope/stcal/pull/126 and https://github.com/spacetelescope/stcal/pull/136 made `opencv-python` an optional dependency (as built binaries are not available on all user platforms). This PR adds `opencv-python` to the instructions for creating `requirements-sdp.txt`, to ensure the environment has `opencv-python` installed.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
