### PR TITLE
Windows: MSVC: Allocate wave_slice_dq array using mem_alloc_dq()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ calwebb_detector1
 - Added the call to the undersampling_correction step to the ``calwebb_detector1``
   pipeline. [#7501]
 
+cube_build
+----------
+
+-  Windows: MSVC: Allocate ``wave_slice_dq`` array using ``mem_alloc_dq()`` [#7491]
+
 datamodels
 ----------
 

--- a/jwst/cube_build/src/cube_dq_utils.c
+++ b/jwst/cube_build/src/cube_dq_utils.c
@@ -547,7 +547,9 @@ int dq_miri(int start_region, int end_region, int overlap_partial, int overlap_f
   // corner of the FOV for each wavelength
 
   nxy = nx * ny;
-  int wave_slice_dq[nxy];
+  int *wave_slice_dq;
+  if (mem_alloc_dq(nxy, &wave_slice_dq)) return 1;
+
   // Loop over the wavelength planes and set DQ plane 
   for (w = 0; w  < nz; w++) {
     
@@ -591,6 +593,7 @@ int dq_miri(int start_region, int end_region, int overlap_partial, int overlap_f
   } // end loop over wavelength
 
   *spaxel_dq = idqv;
+  free(wave_slice_dq);
 
   return 0;
 }
@@ -658,7 +661,9 @@ int dq_nirspec(int overlap_partial,
 				       c1_max, c2_max,
 				       match_slice);
 
-    int wave_slice_dq[nxy];
+    int *wave_slice_dq;
+    if (mem_alloc_dq(nxy, &wave_slice_dq)) return 1;
+
     for (j =0; j< nxy; j++){
       wave_slice_dq[j] = 0;
     }
@@ -701,6 +706,7 @@ int dq_nirspec(int overlap_partial,
 	idqv[in] = wave_slice_dq[ii];
       }
     }
+    free(wave_slice_dq);
   } // end of wavelength
   *spaxel_dq = idqv;
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves _N/A_ <!--[JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn) -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #6466, closes #6905

Related: #5578, https://github.com/spacetelescope/crds/issues/790#issuecomment-1261891494

<!-- describe the changes comprising this PR here -->
This replaces two variable length array declarations that are preventing Microsoft CL from succeeding. (Refer to #6466 above.)

I tested locally with:
- Windows 10 Pro
- MSVC 2022
- Mambaforge

```
$ pytest -rsv jwst/cube_build/
============================= test session starts ==============================
platform linux -- Python 3.10.9, pytest-7.2.2, pluggy-1.0.0
crds_context: jwst_1064.pmap
rootdir: /home/jhunk/Downloads/omg/jwst, configfile: setup.cfg
plugins: asdf-2.14.3, requests-mock-1.10.0, openfiles-0.5.0, doctestplus-0.12.1, cov-4.0.0, ci-watson-0.6.1, jwst-1.9.5.dev37+g73135ae5b.d20230313
collected 16 items                                                             

jwst/cube_build/tests/test_configuration.py .....                        [ 31%]
jwst/cube_build/tests/test_cube_build_step.py .                          [ 37%]
jwst/cube_build/tests/test_miri_cubepars.py ...                          [ 56%]
jwst/cube_build/tests/test_nirspec_cubepars.py .                         [ 62%]
jwst/cube_build/tests/test_wcs.py ......                                 [100%]

============================== 16 passed in 3.48s ==============================
```

PS - I also noticed drizzle-1.13.7 fails to build on Windows, however at the time of this writing `drizzle/master` and `drizzle/1.13.7` are the same... yet `pip install git+https://github.com/spacetelescope/drizzle` actually succeeds. Very strange. Maybe the archive is missing something?

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
