### PR TITLE
JP-3127: Fix bounding box in MRS TSO observations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.9.7 (unreleased)
 ==================
 
+assign_wcs
+----------
+
+- Fix ``WCS.bounding_box`` computation for MIRI MRS TSO observations. [#7492]
+
 datamodels
 ----------
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -18,7 +18,8 @@ from stdatamodels.jwst.transforms import models as jwmodels
 
 from . import pointing
 from .util import (not_implemented_mode, subarray_transform,
-                   velocity_correction, transform_bbox_from_shape, bounding_box_from_subarray)
+                   velocity_correction, transform_bbox_from_shape,
+                   bounding_box_from_subarray)
 
 
 log = logging.getLogger(__name__)
@@ -422,8 +423,7 @@ def ifu(input_model, reference_files):
     tel2sky = pointing.v23tosky(input_model) & models.Identity(1)
 
     # Put the transforms together into a single transform
-    shape = input_model.data.shape
-    det2abl.bounding_box = ((-0.5, shape[0] - 0.5), (-0.5, shape[1] - 0.5))
+    det2abl.bounding_box = transform_bbox_from_shape(input_model.data.shape)
     pipeline = [(detector, det2abl),
                 (miri_focal, abl2v2v3l),
                 (v2v3, va_corr),


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3127](https://jira.stsci.edu/browse/JP-3127)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
This PR fixes a problem with the computation of the bounding box of a MIRI MRS TSO observation. The bounding box is defined by the shape of the data. The code assumed an MRS observation, the input to assign_wcs is always a 2D image and used the shape of the data array in a simplistic way to determine the bounding box. Since TSO observations are cubes this created very small bounding boxes. Fixed by calling the correct function, `transform_bbox_from_shape`, already available in assign_wcs/utils.py

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
