### PR TITLE
JP-3128: Fix memory leaks in C code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,8 +24,11 @@ other
 
 - Update ``minimum_deps`` script to use ``importlib_metadata`` and ``packaging``
   instead of ``pkg_resources``. [#7457]
+
 - Switch ``stcal.dqflags`` imports to ``stdatamodels.dqflags``. [#7475]
 
+- Fix memory leaks in packages that use C code: ``cube_build``,
+  ``wfss_contam``, and ``straylight``. [#7493]
 
 outlier_detection
 -----------------
@@ -54,7 +57,7 @@ pipeline
 
 - Update the calwebb_spec2 pipeline to move the MIRI MRS straylight step to before
   the flat-fielding step. [#7486]
-  
+
 - Update the calwebb_spec2 pipeline to make a deep copy of the current results before
   calling the ``resample_spec`` and ``extract_1d`` steps, to avoid issues with the
   input data accidentally getting modified by those steps. [#7451]

--- a/jwst/cube_build/src/cube_match_internal.c
+++ b/jwst/cube_build/src/cube_match_internal.c
@@ -306,7 +306,7 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
     spaxel_iflux_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_DOUBLE, 0);
     if (!spaxel_iflux_arr) goto fail;
 
-    result = Py_BuildValue("(OOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
+    result = Py_BuildValue("(NNNN)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr);
 
     goto cleanup;
@@ -360,7 +360,7 @@ static PyObject *cube_wrapper_internal(PyObject *module, PyObject *args) {
     PyArray_ENABLEFLAGS(spaxel_var_arr, NPY_ARRAY_OWNDATA);
     PyArray_ENABLEFLAGS(spaxel_iflux_arr, NPY_ARRAY_OWNDATA);
 
-    result = Py_BuildValue("(OOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
+    result = Py_BuildValue("(NNNN)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr);
 
     goto cleanup;

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -420,7 +420,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     spaxel_dq_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_INT, 0);
     if (!spaxel_dq_arr) goto fail;
 
-    result = Py_BuildValue("(OOOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
+    result = Py_BuildValue("(NNNNN)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr, spaxel_dq_arr);
 
     goto cleanup;
@@ -521,7 +521,7 @@ static PyObject *cube_wrapper_driz(PyObject *module, PyObject *args) {
     PyArray_ENABLEFLAGS(spaxel_var_arr, NPY_ARRAY_OWNDATA);
     PyArray_ENABLEFLAGS(spaxel_iflux_arr, NPY_ARRAY_OWNDATA);
     PyArray_ENABLEFLAGS(spaxel_dq_arr, NPY_ARRAY_OWNDATA);
-    result = Py_BuildValue("(OOOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
+    result = Py_BuildValue("(NNNNN)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr, spaxel_dq_arr);
 
     goto cleanup;

--- a/jwst/cube_build/src/cube_match_sky_pointcloud.c
+++ b/jwst/cube_build/src/cube_match_sky_pointcloud.c
@@ -559,7 +559,7 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
     spaxel_dq_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_ncube, NPY_INT, 0);
     if (!spaxel_dq_arr) goto fail;
 
-    result = Py_BuildValue("(OOOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
+    result = Py_BuildValue("(NNNNN)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr, spaxel_dq_arr);
 
     goto cleanup;
@@ -673,7 +673,7 @@ static PyObject *cube_wrapper(PyObject *module, PyObject *args) {
     PyArray_ENABLEFLAGS(spaxel_var_arr, NPY_ARRAY_OWNDATA);
     PyArray_ENABLEFLAGS(spaxel_iflux_arr, NPY_ARRAY_OWNDATA);
     PyArray_ENABLEFLAGS(spaxel_dq_arr, NPY_ARRAY_OWNDATA);
-    result = Py_BuildValue("(OOOOO)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
+    result = Py_BuildValue("(NNNNN)", spaxel_flux_arr, spaxel_weight_arr, spaxel_var_arr,
 			   spaxel_iflux_arr, spaxel_dq_arr);
 
     goto cleanup;

--- a/jwst/lib/src/winclip.c
+++ b/jwst/lib/src/winclip.c
@@ -404,7 +404,7 @@ static PyObject * get_clipped_pixels(PyObject *module, PyObject *args) {
         idx_arr = (PyArrayObject*) PyArray_EMPTY(1, &npy_npix, NPY_INT, 0);
         if (!idx_arr) goto fail;
 
-        result = Py_BuildValue("(OOOO)", x_arr, y_arr, areas_arr, idx_arr);
+        result = Py_BuildValue("(NNNN)", x_arr, y_arr, areas_arr, idx_arr);
         goto cleanup;
     }
 
@@ -447,7 +447,7 @@ static PyObject * get_clipped_pixels(PyObject *module, PyObject *args) {
         PyArray_ENABLEFLAGS(areas_arr, NPY_ARRAY_OWNDATA);
         PyArray_ENABLEFLAGS(idx_arr, NPY_ARRAY_OWNDATA);
 
-        result = Py_BuildValue("(OOOO)", x_arr, y_arr, areas_arr, idx_arr);
+        result = Py_BuildValue("(NNNN)", x_arr, y_arr, areas_arr, idx_arr);
         goto cleanup;
     }
 

--- a/jwst/straylight/src/calc_xart.c
+++ b/jwst/straylight/src/calc_xart.c
@@ -1,8 +1,8 @@
 /*
- 
+
 Main function for Python: xart_wrapper
 
-Python signature: 
+Python signature:
             result = xart_wrapper(imin, imax, xsize, ysize,
                  xvec, fimg, gamma, lor_amp, g_std, g_dx, g1_amp, g2_amp)
 
@@ -84,7 +84,7 @@ int alloc_xart_arrays(int nelem, double **fluxv) {
 
  failed_mem_alloc:
     free(*fluxv);
-   
+
 }
 
 // Do the computation of the cross-artifact values.
@@ -101,7 +101,7 @@ int xart_model(int imin, int imax, int xsize_det, int ysize_det,
   // This is how big the output vector needs to be
   int npt = xsize_det * ysize_det;
 
-  // allocate memory to hold output 
+  // allocate memory to hold output
   if (alloc_xart_arrays(npt, &fluxv)) return 1;
 
   for (j = 0; j < ysize_det; j++) {
@@ -120,7 +120,7 @@ int xart_model(int imin, int imax, int xsize_det, int ysize_det,
       }
     }
   }
-    
+
   // assign output values:
   *xart_flux = fluxv;
 
@@ -185,7 +185,7 @@ static PyObject *xart_wrapper(PyObject *module, PyObject *args) {
     xart_flux_arr = (PyArrayObject*) PyArray_EMPTY(1, &npt, NPY_DOUBLE, 0);
     if (!xart_flux_arr) goto fail;
 
-    result = Py_BuildValue("(O)", xart_flux_arr);
+    result = Py_BuildValue("(N)", xart_flux_arr);
 
     goto cleanup;
   }
@@ -212,7 +212,7 @@ static PyObject *xart_wrapper(PyObject *module, PyObject *args) {
 
     PyArray_ENABLEFLAGS(xart_flux_arr, NPY_ARRAY_OWNDATA);
 
-    result = Py_BuildValue("(O)", xart_flux_arr);
+    result = Py_BuildValue("(N)", xart_flux_arr);
     goto cleanup;
   }
 


### PR DESCRIPTION
Resolves [JP-3086](https://jira.stsci.edu/browse/JP-3086)
Resolves [JP-3128](https://jira.stsci.edu/browse/JP-3128)

This PR fixes memory leaks in C code due to incorrect reference count of returned arrays. This PR addresses a part of #7483 (other improvements in that PR should be merged after that PR is re-based after this PR is merged). Affected packages are: ``cube_build``, ``wfss_contam``, and ``straylight``.

This PR implements the recommendation from https://numpy.org/doc/stable/user/c-info.how-to-extend.html:

> The [Py_BuildValue](https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue) (format_string, c_variables…) function makes it easy to build tuples of Python objects from C variables. **Pay special attention to the difference between ‘N’ and ‘O’ in the format string or you can easily create memory leaks.** The ‘O’ format string increments the reference count of the [PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject) C-variable it corresponds to, while **the ‘N’ format string steals a reference to the corresponding [PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject) C-variable. You should use ‘N’ if you have already created a reference for the object and just want to give that reference to the tuple.** You should use ‘O’ if you only have a borrowed reference to an object and need to create one to provide for the tuple.


**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression test: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/598/