### PR TITLE
JP-3129: Fix WCS correction validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,9 @@ tweakreg
   additional user-provided rotations and scale corrections to an imaging
   WCS of a calibrated image. [#7430]
 
+- Fixed a bug due to which alignment may be aborted due to corrections
+  being "too large" yet compatible with step parameters. [#7494]
+
 undersampling_correction
 ------------------------
 

--- a/jwst/tweakreg/tests/test_multichip_jwst.py
+++ b/jwst/tweakreg/tests/test_multichip_jwst.py
@@ -392,14 +392,16 @@ def test_multichip_alignment_step(monkeypatch):
     step = tweakreg_step.TweakRegStep()
     step.fitgeometry = 'general'
     step.nclip = 0
-    # Increase matching tolerance to pass 'fit_quality_is_good' test.
+    # Increase matching tolerance to pass '_is_wcs_correction_small' test.
     # This test would detect large corrections and therefore
     # would flag the quality of the fit as "bad" and therefore, it will not
-    # apply computed corrections ('fit_quality_is_good' test was designed by
+    # apply computed corrections ('_is_wcs_correction_small' test was designed by
     # Warren for evaluating "quality of fit" for HAP).
-    step.tolerance = 2
-    # Alternatively, disable this 'fit_quality_is_good' test:
-    # step.fit_quality_is_good = lambda x, y: True
+    step.tolerance = 0.1
+    step.use2dhist = True
+    step.searchrad = 20
+    # Alternatively, disable this '_is_wcs_correction_small' test:
+    # step._is_wcs_correction_small = lambda x, y: True
 
     mr, m1, m2 = step.process(mc)
 

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -491,7 +491,11 @@ class TweakRegStep(Step):
 
     def _is_wcs_correction_small(self, wcs, twcs):
         """Check that the newly tweaked wcs hasn't gone off the rails"""
-        tolerance = 10.0 * self.tolerance * u.arcsec
+        if self.use2dhist:
+            max_corr = 2 * (self.searchrad + self.tolerance) * u.arcsec
+        else:
+            max_corr = 2 * (max(abs(self.xoffset), abs(self.yoffset)) +
+                            self.tolerance) * u.arcsec
 
         ra, dec = wcs.footprint(axis_type="spatial").T
         tra, tdec = twcs.footprint(axis_type="spatial").T
@@ -500,7 +504,7 @@ class TweakRegStep(Step):
 
         separation = skycoord.separation(tskycoord)
 
-        return (separation < tolerance).all()
+        return (separation < max_corr).all()
 
     def _imodel2wcsim(self, image_model):
         # make sure that we have a catalog:


### PR DESCRIPTION
Resolves [JP-3129](https://jira.stsci.edu/browse/JP-3129)

`tweakreg_step` has code that "validates" the fit by checking that corrections (as measured by the change of the positions of image boundary vertices before and after WCS corrections) are smaller than `10*tolerance`. This is wrong check since valid corrections can be larger than `10*tolerance` since usually the magnitude of corrections is dependent on `searchrad` parameter as well and usually `searchrad >> tolerance`. Any correction smaller than `searchrad` but larger than `10*tolerance` is a valid correction when `use2dhist=True`. Alternatively, `xoffset` and `yoffset` can determine the magnitude of corrections. magnitude of corrections. The origin of the factor `10` in `10*tolerance` is unexplained too.

This PR combines the two quantities - `searchrad` (or `xoffset` and `yoffset`) and `tolerance` - to make this code work for a larger set of step parameters.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression tests: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/599/
