### PR TITLE
return opencv-python to a hard dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,6 @@ jobs:
           - toxenv: test-oldestdeps-xdist-cov
             os: ubuntu-latest
             python-version: '3.8'
-          - toxenv: test-opencv-xdist
-            os: ubuntu-latest
-            python-version: '3.10'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -7,12 +7,7 @@ from stdatamodels.jwst.datamodels import GainModel, ReadnoiseModel, RampModel
 
 from jwst.jump import JumpStep
 
-try:
-    import cv2 as cv # noqa: F401
-
-    OPENCV_INSTALLED = True
-except ImportError:
-    OPENCV_INSTALLED = False
+import cv2 as cv
 
 MAXIMUM_CORES = ['none', 'quarter', 'half', 'all']
 
@@ -311,7 +306,6 @@ def test_three_group_integration(generate_miri_reffiles, setup_inputs):
     assert out_model.meta.cal_step.jump == 'COMPLETE'
 
 
-@pytest.mark.xfail(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
 def test_snowball_flagging_nosat(generate_nircam_reffiles, setup_inputs):
     """Test that snowballs are properly flagged when the `sat_required_snowball`,
     which requires there to be a saturated pixel within the cluster of
@@ -356,7 +350,6 @@ def test_snowball_flagging_nosat(generate_nircam_reffiles, setup_inputs):
         assert (np.floor(expanded_area / initial_area) == (expand_factor**2))
 
 
-@pytest.mark.xfail(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
 def test_snowball_flagging_sat(generate_nircam_reffiles, setup_inputs):
     """Test that snowballs are properly flagged when the `sat_required_snowball`,
     which requires there to be a saturated pixel within the cluster of

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -12,5 +12,5 @@
 #
 #     conda create -n sdp python -y
 #     conda activate sdp
-#     pip install -e .[test,sdp] "opencv-python>=4.6.0.66"
+#     pip install -e .[test,sdp]
 #     pip freeze | grep -v jwst >> requirements-sdp.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     drizzle>=1.13.7
     gwcs>=0.18.3
     numpy>=1.20
+    opencv-python>=4.6.0.66
     photutils>=1.4.0
     psutil>=5.7.2
     poppy>=1.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ commands =
 [testenv]
 description =
     run tests
-    opencv: requiring opencv-python
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     sdpdeps: with the recent STScI DMS release pinned dependencies
@@ -68,7 +67,6 @@ deps =
     xdist: pytest-xdist
     devdeps: -rrequirements-dev.txt
     sdpdeps: -rrequirements-sdp.txt
-    opencv: opencv-python
     oldestdeps: minimum_dependencies
 package =
     !pyargs: editable
@@ -87,7 +85,6 @@ commands =
     regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
     xdist: -n auto \
     pyargs: {toxinidir}/docs --pyargs jwst \
-    opencv: -- jwst/jump/tests/test_jump_step.py \
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Related to [JP-3120](https://jira.stsci.edu/browse/JP-3120)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR adds `opencv-python` back to the hard dependencies in `setup.cfg`. This will prevent installation on platforms that do not have a compiled binary for `opencv-python`, such as MacOS Mojave + Python 3.10.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
