### PR TITLE
JP-3141: Add undersampling_correction call to calwebb_detector1 pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ calwebb_detector1
 -----------------
 
 - Added the call to the undersampling_correction step to the ``calwebb_detector1``
-  pipeline. [#???]
+  pipeline. [#7501]
 
 datamodels
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ assign_wcs
 
 - Fix ``WCS.bounding_box`` computation for MIRI MRS TSO observations. [#7492]
 
+calwebb_detector1
+-----------------
+
+- Added the call to the undersampling_correction step to the ``calwebb_detector1``
+  pipeline. [#???]
+
 datamodels
 ----------
 

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -122,6 +122,9 @@ class Detector1Pipeline(Pipeline):
         # apply the jump step
         input = self.jump(input)
 
+        # apply the undersampling_correction step
+        input = self.undersampling_correction(input)
+
         # save the corrected ramp data, if requested
         if self.save_calibrated_ramp:
             self.save_model(input, 'ramp')


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3141](https://jira.stsci.edu/browse/JP-3141)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds a call to the undersampling_correction step to the calwebb_detector1 pipeline.

**Checklist for maintainers**
- [X] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant milestone
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
