### PR TITLE
drop `--ignore-installed` flag to force installing minimum dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands_pre =
 # Generate a requirements-min.txt file
     oldestdeps: minimum_dependencies jwst --filename requirements-min.txt
 # Force install everything in that file
-    oldestdeps: pip install --ignore-installed -r requirements-min.txt
+    oldestdeps: pip install -r requirements-min.txt
     pip freeze
 commands =
     pip freeze


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses an issue found when using `minimum_dependencies` on the `stpipe` CI, where the minimum dependencies were sometimes ignored when the `--ignore-installed` flag was used in `pip install -r requirements-min.txt`

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
