### PR TITLE
JP-3148: Trap source catalog errors in tweakreg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,7 +96,6 @@ ramp_fitting
 - Update ramp fitting to calculate separate readnoise variance for processing
   ``undersampling_correction`` output [#7484]
 
-
 resample
 --------
 
@@ -127,15 +126,16 @@ straylight
 
 - Fix bug with straylight zeroing out NaNs in input rate images, as these
   are now deliberately set as such [#7455]
-- Move ``jwst.datamodels`` out of ``jwst`` into ``stdatamodels.jwst.datamodels``. [#7439]
 
 scripts
 -------
 
 - Added a script ``adjust_wcs.py`` to apply additional user-provided rotations
   and scale corrections to an imaging WCS of a calibrated image. [#7430]
+
 - Update ``minimum_deps`` script to use ``importlib_metadata`` and ``packaging``
   instead of ``pkg_resources``. [#7457]
+
 - Offload ``minimum_deps`` script to ``minimum_dependencies`` package [#7463]
 
 transforms
@@ -155,6 +155,9 @@ tweakreg
 
 - Fixed a bug due to which alignment may be aborted due to corrections
   being "too large" yet compatible with step parameters. [#7494]
+
+- Added a trap for failures in source detection, which now just skips the
+  step. [#7507]
 
 undersampling_correction
 ------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -165,8 +165,8 @@ tweakreg
 - Fixed a bug due to which alignment may be aborted due to corrections
   being "too large" yet compatible with step parameters. [#7494]
 
-- Added a trap for failures in source detection, which now just skips the
-  step. [#7507]
+- Added a trap for failures in source catalog construction, which now returns
+  an empty catalog for the image on which the error occurred. [#7507]
 
 undersampling_correction
 ------------------------

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -1,3 +1,5 @@
+import logging
+
 from astropy.table import Table
 import numpy as np
 from photutils.detection import DAOStarFinder
@@ -5,6 +7,9 @@ from photutils.detection import DAOStarFinder
 from stdatamodels.jwst.datamodels import dqflags, ImageModel
 
 from ..source_catalog.detection import JWSTBackground
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 
 def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
@@ -73,10 +78,17 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
                       dqflags.pixel['DO_NOT_USE']) &
                      model.dq).astype(bool)
 
-    bkg = JWSTBackground(model.data, box_size=bkg_boxsize,
-                         coverage_mask=coverage_mask)
+    columns = ['id', 'xcentroid', 'ycentroid', 'flux']
+    try:
+        bkg = JWSTBackground(model.data, box_size=bkg_boxsize,
+                             coverage_mask=coverage_mask)
+        threshold_img = bkg.background + (snr_threshold * bkg.background_rms)
+    except ValueError as e:
+        log.warning(f"Error determining sky background: {e.args[0]}")
+        # return an empty catalog
+        catalog = Table(names=columns, dtype=(int, float, float, float))
+        return catalog
 
-    threshold_img = bkg.background + (snr_threshold * bkg.background_rms)
     threshold = np.median(threshold_img)  # DAOStarFinder requires float
 
     daofind = DAOStarFinder(fwhm=kernel_fwhm, threshold=threshold,
@@ -85,7 +97,6 @@ def make_tweakreg_catalog(model, kernel_fwhm, snr_threshold, sharplo=0.2,
                             peakmax=peakmax)
     sources = daofind(model.data, mask=coverage_mask)
 
-    columns = ['id', 'xcentroid', 'ycentroid', 'flux']
     if sources:
         catalog = sources[columns]
     else:

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -170,25 +170,14 @@ class TweakRegStep(Step):
 
             else:
                 # source finding
-                try:
-                    catalog = make_tweakreg_catalog(
-                        image_model, self.kernel_fwhm, self.snr_threshold,
-                        sharplo=self.sharplo, sharphi=self.sharphi,
-                        roundlo=self.roundlo, roundhi=self.roundhi,
-                        brightest=self.brightest, peakmax=self.peakmax,
-                        bkg_boxsize=self.bkg_boxsize
-                    )
-                    new_cat = True
-
-                except ValueError as e:
-                    # something went wrong; skip the step
-                    msg = e.args[0]
-                    self.log.warning(msg)
-                    self.log.warning("Nothing to do. Skipping tweakreg step.")
-                    for model in images:
-                        model.meta.cal_step.tweakreg = "SKIPPED"
-                        self.skip = True
-                    return images
+                catalog = make_tweakreg_catalog(
+                    image_model, self.kernel_fwhm, self.snr_threshold,
+                    sharplo=self.sharplo, sharphi=self.sharphi,
+                    roundlo=self.roundlo, roundhi=self.roundhi,
+                    brightest=self.brightest, peakmax=self.peakmax,
+                    bkg_boxsize=self.bkg_boxsize
+                )
+                new_cat = True
 
             for axis in ['x', 'y']:
                 if axis not in catalog.colnames:

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -170,14 +170,25 @@ class TweakRegStep(Step):
 
             else:
                 # source finding
-                catalog = make_tweakreg_catalog(
-                    image_model, self.kernel_fwhm, self.snr_threshold,
-                    sharplo=self.sharplo, sharphi=self.sharphi,
-                    roundlo=self.roundlo, roundhi=self.roundhi,
-                    brightest=self.brightest, peakmax=self.peakmax,
-                    bkg_boxsize=self.bkg_boxsize
-                )
-                new_cat = True
+                try:
+                    catalog = make_tweakreg_catalog(
+                        image_model, self.kernel_fwhm, self.snr_threshold,
+                        sharplo=self.sharplo, sharphi=self.sharphi,
+                        roundlo=self.roundlo, roundhi=self.roundhi,
+                        brightest=self.brightest, peakmax=self.peakmax,
+                        bkg_boxsize=self.bkg_boxsize
+                    )
+                    new_cat = True
+
+                except ValueError as e:
+                    # something went wrong; skip the step
+                    msg = e.args[0]
+                    self.log.warning(msg)
+                    self.log.warning("Nothing to do. Skipping tweakreg step.")
+                    for model in images:
+                        model.meta.cal_step.tweakreg = "SKIPPED"
+                        self.skip = True
+                    return images
 
             for axis in ['x', 'y']:
                 if axis not in catalog.colnames:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3148](https://jira.stsci.edu/browse/JP-3148)

<!-- describe the changes comprising this PR here -->
This PR simply adds a try/except block to the tweakreg step code where it attempts to build source catalogs for each input image. This addresses situations where something goes wrong in the source catalog generation (e.g. all pixels flagged as bad, etc.), preventing it from completing successfully. Instead of aborting with an error, it now emits a warning and just skips the rest of the tweakreg step. The subsequent pipeline steps can proceed without it.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
