### PR TITLE
JP-3147 Treat PSF exposures as science for Level 2 association processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ associations
 
 - Remove extra reprocessing of existing associations. [#7506]
 
+- Treat PSF exposures as science for Level 2 association processing. [#7508]
+
 calwebb_detector1
 -----------------
 

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -1101,12 +1101,10 @@ class AsnMixin_Lv2Special:
         exposure_type
             Always what is defined as `default`
         """
+        self.original_exposure_type = super(AsnMixin_Lv2Special, self).get_exposure_type(item, default=default)
         if self.has_science():
-            if super(AsnMixin_Lv2Special, self).get_exposure_type(item, default=default) == 'imprint':
+            if self.original_exposure_type == 'imprint':
                 return 'imprint'
-        else:
-            self.original_exposure_type = super(AsnMixin_Lv2Special, self).get_exposure_type(item, default=default)
-
         return default
 
 

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -119,6 +119,31 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         if 'asn_pool' not in self.data:
             self.data['asn_pool'] = 'none'
 
+    def get_exposure_type(self, item, default='science'):
+        """General Level 2 override of exposure type definition
+
+        The exposure type definition is overridden from the default
+        for the following cases:
+
+        - 'psf' -> 'science'
+
+        Parameters
+        ----------
+        item : dict
+            The pool entry to determine the exposure type of
+        default : str or None
+            The default exposure type.
+            If None, routine will raise LookupError
+        Returns
+        -------
+        exposure_type
+            Always what is defined as `default`
+        """
+        self.original_exposure_type = super(DMSLevel2bBase, self).get_exposure_type(item, default=default)
+        if self.original_exposure_type == 'psf':
+            return default
+        return self.original_exposure_type
+
     def members_by_type(self, member_type):
         """Get list of members by their exposure type"""
         member_type = member_type.lower()

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -77,6 +77,11 @@ SPECIAL_POOLS = {
         'xfail': None,
         'slow': False,
     },
+    'jw01194_20230115t113819_pool': {
+        'args': [],
+        'xfail': None,
+        'slow': True,
+    },
     'jw01257_20221201t192226_pool': {
         'args': [],
         'xfail': None,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3147](https://jira.stsci.edu/browse/JP-3147)

<!-- describe the changes comprising this PR here -->
This PR addresses and issue with coronographic observations found while investigating JWSTDMS-770 and documented in JP-3147. The issue is that the PSF observations Level 2 associations were not including their linked background observations. Technically, this is because PSF Image 2 associations were being processed by the rule {{Asn_Lv2ImageSpecial}}, which specifically disallows background candidates.

The solution is that, for Level 2 associations, PSF observations can be treated as normal science, which is handled by the rule {{Asn_Lv2Image}}. This is done by changing the exposure type from "psf" to "science".

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
