### PR TITLE
(JP-3138) Add regtest for calwebb_detector1 for undersampling correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ calwebb_detector1
   pipeline. [#7501]
 
 - Added regression test for ``calwebb_detector1`` pipeline which now
-  includes ``undersampling_correction``. [#XXXX]
+  includes ``undersampling_correction``. [#7509]
   
 
 datamodels

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ calwebb_detector1
 - Added the call to the undersampling_correction step to the ``calwebb_detector1``
   pipeline. [#7501]
 
+- Added regression test for ``calwebb_detector1`` pipeline which now
+  includes ``undersampling_correction``. [#XXXX]
+  
+
 datamodels
 ----------
 

--- a/jwst/regtest/test_niriss_image.py
+++ b/jwst/regtest/test_niriss_image.py
@@ -1,0 +1,52 @@
+""" Test for the detector1 pipeline using NIRISS image mode, starting with
+    an uncal file. The undersampling_correction and ramp fitting output
+    products are saved for comparisons for those two steps.
+"""
+
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_detector1(rtdata_module):
+    """Run calwebb_detector1 pipeline on NIRISS imaging data."""
+    rtdata = rtdata_module
+
+    rtdata.get_data("niriss/jw01094001002_02107_00001_nis_uncal.fits")
+
+    # Run detector1 pipeline on an _uncal files
+    args = ["calwebb_detector1", rtdata.input,
+            "--steps.undersampling_correction.skip=False",
+            "--steps.undersampling_correction.save_results=True",
+            "--steps.ramp_fit.save_results=True",
+            "--steps.persistence.save_trapsfilled=False",
+            ]
+
+    Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["undersampling_correction", "rate", "rateints"])
+def test_niriss_image_detector1(run_detector1, rtdata_module, fitsdiff_default_kwargs, suffix):
+    """Regression test of detector1 pipeline performed on NIRISS imaging data.
+    """
+    _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix)
+
+
+def _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix):
+    """Assertion helper for the above tests"""
+    rtdata = rtdata_module
+    rtdata.input = "jw01094001002_02107_00001_nis_uncal.fits"
+    output = f"jw01094001002_02107_00001_nis_{suffix}.fits"
+    rtdata.output = output
+
+    rtdata.get_truth(f"truth/test_niriss_image/{output}")
+
+    # Set tolerances so the crf, rscd and rateints file comparisons work across
+    # architectures
+    fitsdiff_default_kwargs["rtol"] = 1e-4
+    fitsdiff_default_kwargs["atol"] = 1e-4
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3138](https://jira.stsci.edu/browse/JP-3138)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds a regression test for niriss image calwebb_detector1 for testing the undersampling_correction  output, and testing the rampfitting output (which contains ramps flagged by the undersampling_correction step ). Documentation for the calwebb_detector1 pipeline will be updated in a separate ticket.
**Checklist for maintainers**
- [X] added entry in `CHANGES.rst` within the relevant release section
- [X] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant milestone
- [X] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
