### PR TITLE
JP-3159: Update surface brightness unit strings for astropy unit parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ extract_1d
   precedence is given for command line override, reference file settings, and
   internal decisions of the appropriate setting (in that order). [#7466]
 
+- Edit surface brightness unit strings for parsing by ``astropy.units`` [#7511]
+
 other
 -----
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -3602,13 +3602,13 @@ def create_extraction(extract_ref_dict,
         flux_units = 'Jy'
         f_var_units = 'Jy^2'
         sb_units = 'MJy/sr'
-        sb_var_units = '(MJy/sr)^2'
+        sb_var_units = 'MJy^2 / sr^2'
     else:
         photom_has_been_run = False
         flux_units = 'DN/s'
-        f_var_units = '(DN/s)^2'
+        f_var_units = 'DN^2 / s^2'
         sb_units = 'DN/s'
-        sb_var_units = '(DN/s)^2'
+        sb_var_units = 'DN^2 / s^2'
         log.warning("The photom step has not been run.")
 
     # Turn off use_source_posn if the source is not POINT


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3159](https://jira.stsci.edu/browse/JP-3159)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR edits the surface brightness unit strings so that astropy.units can parse them properly.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
