### PR TITLE
JP-3101: Fill TARG_RA/DEC with RA/DEC_REF if empty at end of set_telescope_pointing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,9 @@ set_telescope_pointing
 
 - Correct WCS determination for aperture MIRIM_TAMRS [#7449]
 
+- Fill values of ``TARG_RA`` and ``TARG_DEC`` with ``RA_REF`` and ``DEC_REF``
+  if target location is not provided, e.g. for pure parallel observations [#7512]
+
 straylight
 ----------
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -882,6 +882,9 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
     # populate with RA_REF/DEC_REF values
     if (model.meta.target.ra == 0.0 and model.meta.target.dec == 0.0) and (
             'PARALLEL' in model.meta.visit.type):
+
+        logger.warning('No target location specified for parallel observation:'
+                       'copying reference point RA/Dec to TARG_RA/TARG_DEC.')
         model.meta.target.ra = model.meta.wcsinfo.ra_ref
         model.meta.target.dec = model.meta.wcsinfo.dec_ref
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -878,6 +878,12 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
         logger.warning('Calculation of S_REGION failed and will be skipped.')
         logger.warning('Exception is %s', e)
 
+    # If TARG_RA/TARG_DEC still 0/0 (e.g. pure parallels with no defined target),
+    # populate with RA_REF/DEC_REF values
+    if model.meta.target.ra == 0.0 and model.meta.target.dec == 0.0:
+        model.meta.target.ra = model.meta.wcsinfo.ra_ref
+        model.meta.target.dec = model.meta.wcsinfo.dec_ref
+
     return transforms
 
 

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -880,7 +880,8 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
 
     # If TARG_RA/TARG_DEC still 0/0 (e.g. pure parallels with no defined target),
     # populate with RA_REF/DEC_REF values
-    if model.meta.target.ra == 0.0 and model.meta.target.dec == 0.0:
+    if (model.meta.target.ra == 0.0 and model.meta.target.dec == 0.0) and (
+            'PARALLEL' in model.meta.visit.type):
         model.meta.target.ra = model.meta.wcsinfo.ra_ref
         model.meta.target.dec = model.meta.wcsinfo.dec_ref
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3101](https://jira.stsci.edu/browse/JP-3101)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses TARG_RA and TARG_DEC values of 0.0 for pure parallel observations without target information, resulting in poor MAST observation placement. This PR fills TARG_{RA/DEC} values with {RA/DEC}_REF values if the target values are 0.0.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
