### PR TITLE
JP-3160: Fix a crash on absolute catalog alignment failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ calwebb_detector1
 
 - Added regression test for ``calwebb_detector1`` pipeline which now
   includes ``undersampling_correction``. [#7509]
-  
+
 
 datamodels
 ----------
@@ -35,7 +35,7 @@ documentation
 
 - Update documentation for ``calwebb_detector1`` to include the undersampling_correction
   step. [#7510]
-  
+
 dq_init
 -------
 
@@ -169,6 +169,10 @@ tweakreg
 
 - Added a trap for failures in source catalog construction, which now returns
   an empty catalog for the image on which the error occurred. [#7507]
+
+- Fixed a crash occuring when alignment of a single image to an absolute
+  astrometric catalog (i.e., Gaia) fails due to not enough sources in the
+  catalog. [#7513]
 
 undersampling_correction
 ------------------------

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -406,7 +406,6 @@ class TweakRegStep(Step):
             # Check that there are enough GAIA sources for a reliable/valid fit
             num_ref = len(ref_cat)
             if num_ref < self.abs_minobj:
-                # Raise Exception here to avoid rest of code in this try block
                 self.log.warning(
                     f"Not enough sources ({num_ref}) in the reference catalog "
                     "for the single-group alignment step to perform a fit. "
@@ -456,7 +455,8 @@ class TweakRegStep(Step):
             image_model.meta.cal_step.tweakreg = 'COMPLETE'
 
             # retrieve fit status and update wcs if fit is successful:
-            if 'SUCCESS' in imcat.meta.get('fit_info')['status']:
+            if ('fit_info' in imcat.meta and
+                    'SUCCESS' in imcat.meta['fit_info']['status']):
 
                 # Update/create the WCS .name attribute with information
                 # on this astrometric fit as the only record that it was


### PR DESCRIPTION
Fixes a crash in the tweakreg step when aligning a single image (due to which relative alignment is skipped) and the attempt to align to Gaia fails due to not having enough sources in the Gaia catalog overlapping with the input image.

Resolves [JP-3160](https://jira.stsci.edu/browse/JP-3160)

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
