### PR TITLE
Use correct bits in resample_variance_array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,6 +130,8 @@ resample
   a bug due to which parts of input images may not be present in the output
   resampled image under certain circumstances. [#7460]
 
+- Carry through good bits correctly for the variance array [#7515]
+
 residual_fringe
 ---------------
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -285,7 +285,7 @@ class ResampleData:
             inwht = resample_utils.build_driz_weight(
                 model,
                 weight_type=None,
-                good_bits="~NON_SCIENCE+REFERENCE_PIXEL"
+                good_bits=self.good_bits
             )
 
             resampled_variance = np.zeros_like(output_model.data)


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7514

<!-- describe the changes comprising this PR here -->
This PR addresses a small bug in the output error arrays, that in MIRI data these will often include the coronagraph observations even if this is not included in the output science array

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
