### PR TITLE
Cube Build JP 3016 allow custom suffix and other improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ cube_build
 
 -  Windows: MSVC: Allocate ``wave_slice_dq`` array using ``mem_alloc_dq()`` [#7491]
 
+- Memory improvements, do not allow MIRI and 'internal_cal', allow user to set suffix. [#7521]
+  
 datamodels
 ----------
 

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -16,7 +16,6 @@ class CubeData():
 
     def __init__(self,
                  input_models,
-                 #input_filenames,
                  par_filename,
                  **pars):
         """ Initialize the high level of information for the ifu cube
@@ -31,15 +30,12 @@ class CubeData():
         Parameters
         ----------
         input_models : list of data models
-        input_files : str
-          list of fits filenames
         par_filename: str
           cube parameter reference filename
         pars : dictionary holding top level cube parameters
         """
 
         self.input_models = input_models
-        #self.input_filenames = input_filenames
         self.par_filename = par_filename
         self.single = pars.get('single')
         self.channel = pars.get('channel')
@@ -49,7 +45,6 @@ class CubeData():
         self.weighting = pars.get('weighting')
         self.output_type = pars.get('output_type')
         self.instrument = None
-        self.in_memory = pars.get('in_memory')
 
         self.all_channel = []
         self.all_subchannel = []
@@ -82,9 +77,8 @@ class CubeData():
 # Read in the input data (association table or single file)
 # Fill in MasterTable   based on Channel/Subchannel  or filter/grating
 # ______________________________________________________________________________
-        master_table = file_table.FileTable(self.in_memory)
+        master_table = file_table.FileTable()
         instrument = master_table.set_file_table(self.input_models)
-                                                 #self.input_filenames)
 # _______________________________________________________________________________
 # find out how many files are in the association table or if it is an single
 # file store the input_filenames and input_models

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -16,7 +16,7 @@ class CubeData():
 
     def __init__(self,
                  input_models,
-                 input_filenames,
+                 #input_filenames,
                  par_filename,
                  **pars):
         """ Initialize the high level of information for the ifu cube
@@ -39,7 +39,7 @@ class CubeData():
         """
 
         self.input_models = input_models
-        self.input_filenames = input_filenames
+        #self.input_filenames = input_filenames
         self.par_filename = par_filename
         self.single = pars.get('single')
         self.channel = pars.get('channel')
@@ -49,6 +49,7 @@ class CubeData():
         self.weighting = pars.get('weighting')
         self.output_type = pars.get('output_type')
         self.instrument = None
+        self.in_memory = pars.get('in_memory')
 
         self.all_channel = []
         self.all_subchannel = []
@@ -81,9 +82,9 @@ class CubeData():
 # Read in the input data (association table or single file)
 # Fill in MasterTable   based on Channel/Subchannel  or filter/grating
 # ______________________________________________________________________________
-        master_table = file_table.FileTable()
-        instrument = master_table.set_file_table(self.input_models,
-                                                 self.input_filenames)
+        master_table = file_table.FileTable(self.in_memory)
+        instrument = master_table.set_file_table(self.input_models)
+                                                 #self.input_filenames)
 # _______________________________________________________________________________
 # find out how many files are in the association table or if it is an single
 # file store the input_filenames and input_models

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -124,6 +124,8 @@ def read_cubepars(par_filename,
                 for tabdata in ptab.ifucubepars_multichannel_driz_wavetable:
                     table_wave = tabdata['WAVELENGTH']
                     instrument_info.SetMultiChannelDrizTable(table_wave)
+            ptab.close()
+            del ptab
 
     # Read in NIRSPEC Values
     elif instrument == 'NIRSPEC':
@@ -231,3 +233,7 @@ def read_cubepars(par_filename,
                     table_scalerad = tabdata['SCALERAD']
                     instrument_info.SetHighEMSMTable(table_wave, table_sroi,
                                                      table_wroi, table_scalerad)
+
+
+            ptab.close()
+            del ptab

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -57,6 +57,7 @@ class CubeBuildStep (Step):
          skip_dqflagging = boolean(default=false) # skip setting the DQ plane of the IFU
          search_output_file = boolean(default=false)
          output_use_model = boolean(default=true) # Use filenames in the output models
+         in_memory = boolean(default=True) # if False then do not hold data in memory, save to disk.         
        """
 
     reference_file_types = ['cubepar']
@@ -72,12 +73,15 @@ class CubeBuildStep (Step):
         """
 
         self.log.info('Starting IFU Cube Building Step')
+
+        print('suffix', self.suffix)
+        
+        t0 = time.time()
 # ________________________________________________________________________________
 # For all parameters convert to a standard format
 # Report read in values to screen
 # ________________________________________________________________________________
         self.subchannel = self.band
-        self.suffix = 's3d'  # override suffix = cube_build
 
         if not self.subchannel.islower():
             self.subchannel = self.subchannel.lower()
@@ -118,7 +122,7 @@ class CubeBuildStep (Step):
 
         self.interpolation = 'pointcloud'  # initialize
 
-        # coord system = internal_cal only option for weighting = area
+        # coord system = internal_cal only option for weighting = area ONLY USED FOR NIRSPEC
         if self.coord_system == 'internal_cal':
             self.interpolation = 'area'
             self.weighting = 'emsm'
@@ -159,7 +163,8 @@ class CubeBuildStep (Step):
         # including values in pars_input that could get updated in cube_build_step.py
         self.pars_input['output_type'] = self.output_type
         self.pars_input['coord_system'] = self.coord_system
-
+        self.pars_input['in_memory'] = self.in_memory
+        
         if self.single:
             self.pars_input['output_type'] = 'single'
             self.log.info('Cube Type: Single cubes')
@@ -178,9 +183,9 @@ class CubeBuildStep (Step):
             if self.weighting == 'emsm':
                 self.interpolation = 'pointcloud'
 
-# read_user_input:
-# see if options channel, band,grating filter are set on the command lines
-# if they are then self.pars_input['output_type'] = 'user' and fill in  par_input with values
+        # read_user_input:
+        # see if options channel, band,grating filter are set on the command lines
+        # if they are then self.pars_input['output_type'] = 'user' and fill in  par_input with values
         self.read_user_input()
 # ________________________________________________________________________________
 # DataTypes: Read in the input data - 4 formats are allowed:
@@ -198,21 +203,18 @@ class CubeBuildStep (Step):
 # ________________________________________________________________________________
         input_table = data_types.DataTypes(input, self.single,
                                            self.output_file,
-                                           self.output_dir)
+                                           self.output_dir,
+                                           self.in_memory)
 
         self.input_models = input_table.input_models
-        self.input_filenames = input_table.filenames
         self.output_name_base = input_table.output_name
-
-        self.pipeline = 3
-        if self.output_type == 'multi' and len(self.input_filenames) == 1:
-            self.pipeline = 2
-
+        print('output name base', self.output_name_base)
 # ________________________________________________________________________________
 # Read in Cube Parameter Reference file
 # identify what reference file has been associated with these input
+
         par_filename = self.get_reference_file(self.input_models[0], 'cubepar')
-# Check for a valid reference file
+        # Check for a valid reference file
         if par_filename == 'N/A':
             self.log.warning('No default cube parameters reference file found')
             return
@@ -226,10 +228,11 @@ class CubeBuildStep (Step):
             'filter': self.pars_input['filter'],
             'weighting': self.weighting,
             'single': self.single,
-            'output_type': self.pars_input['output_type']}
+            'output_type': self.pars_input['output_type'],
+            'in_memory': self.pars_input['in_memory']}
 
-# shove the input parameters in to pars_cube to pull out ifu_cube.py
-# these parameters are related to the building a single ifucube_model
+        # shove the input parameters in to pars_cube to pull out ifu_cube.py
+        # these parameters are related to the building a single ifucube_model
 
         pars_cube = {
             'scale1': self.scale1,
@@ -243,14 +246,14 @@ class CubeBuildStep (Step):
             'roiw': self.roiw,
             'wavemin': self.wavemin,
             'wavemax': self.wavemax,
-            'skip_dqflagging': self.skip_dqflagging}
+            'skip_dqflagging': self.skip_dqflagging,
+            'suffix': self.suffix}
 
 # ________________________________________________________________________________
 # create an instance of class CubeData
 
         cubeinfo = cube_build.CubeData(
             self.input_models,
-            self.input_filenames,
             par_filename,
             **pars)
 # ________________________________________________________________________________
@@ -264,6 +267,18 @@ class CubeBuildStep (Step):
         instrument = result['instrument']
         instrument_info = result['instrument_info']
         master_table = result['master_table']
+
+        if instrument == 'MIRI' and self.coord_system == 'internal_cal' :
+            self.log.warning('The output coordinate system of internal_cal is not valid for MIRI')
+            self.log.warning('use output_coord = ifualign instead')
+            return
+        filenames = master_table.FileMap['filename']
+
+#        print('master_table save open',master_table.FileMap['MIRI']['1']['short']._save_open)
+
+        self.pipeline = 3
+        if self.output_type == 'multi' and len(filenames) == 1:
+            self.pipeline = 2
 # ________________________________________________________________________________
 # How many and what type of cubes will be made.
 # send self.pars_input['output_type'], all_channel, all_subchannel, all_grating, all_filter
@@ -276,17 +291,15 @@ class CubeBuildStep (Step):
             self.log.info(f'Number of IFU cubes produced by this run = {num_cubes}')
 
         # ModelContainer of ifucubes
-        cube_container = ModelContainer()
-
+        cube_container = ModelContainer(save_open=self.in_memory)
         status_cube = 0
-        t0 = time.time()
+
         for i in range(num_cubes):
             icube = str(i + 1)
             list_par1 = cube_pars[icube]['par1']
             list_par2 = cube_pars[icube]['par2']
             thiscube = ifu_cube.IFUCubeData(
                 self.pipeline,
-                self.input_filenames,
                 self.input_models,
                 self.output_name_base,
                 self.pars_input['output_type'],
@@ -329,30 +342,39 @@ class CubeBuildStep (Step):
 
 # Else standard IFU cube building
             else:
-                cube_result = thiscube.build_ifucube()
-                result, status = cube_result
-                cube_container.append(result)
+                result,status = thiscube.build_ifucube()
+                
+                # check if cube_build failed
+                # **************************
+                if status == 1:
+                    status_cube = 1
 
-            # check if cube_build failed
-            # **************************
-            if status == 1:
-                status_cube = 1
+                # irrelevant WCS keywords we will remove from final product
+                rm_keys = ['v2_ref', 'v3_ref', 'ra_ref', 'dec_ref', 'roll_ref',
+                           'v3yangle', 'vparity']
+                
+                # remove certain WCS keywords that are irrelevant after combine data into IFUCubes
+                for key in rm_keys:
+                    if key in result.meta.wcsinfo.instance:
+                        del result.meta.wcsinfo.instance[key]
+                        
+                footprint = result.meta.wcs.footprint(axis_type="spatial")
+                update_s_region_keyword(result, footprint)
 
+                if self.in_memory:
+                    cube_container.append(result)
+                else:
+                    cube_container.append(result.meta.filename)
+                    self.log.info(f"IFU cube written {result.meta.filename} ")
+                    result.save(result.meta.filename)
+                    result.close()
+
+                del result
+                del thiscube
+                    
         t1 = time.time()
         self.log.debug(f'Time to build all cubes {t1-t0}')
 
-        # irrelevant WCS keywords we will remove from final product
-        rm_keys = ['v2_ref', 'v3_ref', 'ra_ref', 'dec_ref', 'roll_ref',
-                   'v3yangle', 'vparity']
-
-        for cube in cube_container:
-            footprint = cube.meta.wcs.footprint(axis_type="spatial")
-            update_s_region_keyword(cube, footprint)
-
-            # remove certain WCS keywords that are irrelevant after combine data into IFUCubes
-            for key in rm_keys:
-                if key in cube.meta.wcsinfo.instance:
-                    del cube.meta.wcsinfo.instance[key]
         if status_cube == 1:
             self.skip = True
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -334,8 +334,6 @@ class CubeBuildStep (Step):
                 self.log.info("Number of Single IFUCube models returned %i ",
                               len(cube_container))
 
-
-
 # Else standard IFU cube building - the result returned from build_ifucube will be 1 IFU CUBR
             else:
                 result, status = thiscube.build_ifucube()
@@ -349,7 +347,6 @@ class CubeBuildStep (Step):
                 del result
                 
             del thiscube
-
 
         # irrelevant WCS keywords we will remove from final product
         rm_keys = ['v2_ref', 'v3_ref', 'ra_ref', 'dec_ref', 'roll_ref',

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -87,7 +87,6 @@ class DataTypes():
             elif isinstance(input_models, ModelContainer):
                 print('in data_types',input_models._save_open)
                 print('in data types',input_models._models)
-                print(input_models)
                 self.output_name = 'Temp'
                 self.input_models = input_models
                 if not single:  # find the name of the output file from the association

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -33,7 +33,7 @@ class DataTypes():
                 ]
                 }
 
-    def __init__(self, input, single, output_file, output_dir, in_memory):
+    def __init__(self, input, single, output_file, output_dir):
         """ Read in input data and determine what type of input data.
 
         Open the input data using datamodels and determine if data is
@@ -69,13 +69,12 @@ class DataTypes():
 
         self.input_models = []
         self.output_name = None
-        self.in_memory = in_memory
         
         # open the input with datamodels
         # if input is filename or model when it is opened it is a model
         # if input if an association name or ModelContainer then it is opened as a container
 
-        with datamodels.open(input, save_open=self.in_memory) as input_models:
+        with datamodels.open(input) as input_models:
 
             if isinstance(input_models, datamodels.IFUImageModel):
                 # It's a single image that's been passed in as a model
@@ -85,8 +84,6 @@ class DataTypes():
                 self.output_name = self.build_product_name(filename)
 
             elif isinstance(input_models, ModelContainer):
-                print('in data_types',input_models._save_open)
-                print('in data types',input_models._models)
                 self.output_name = 'Temp'
                 self.input_models = input_models
                 if not single:  # find the name of the output file from the association

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -33,7 +33,7 @@ class DataTypes():
                 ]
                 }
 
-    def __init__(self, input, single, output_file, output_dir):
+    def __init__(self, input, single, output_file, output_dir, in_memory):
         """ Read in input data and determine what type of input data.
 
         Open the input data using datamodels and determine if data is
@@ -68,41 +68,36 @@ class DataTypes():
         """
 
         self.input_models = []
-        self.filenames = []
         self.output_name = None
-
+        self.in_memory = in_memory
+        
         # open the input with datamodels
         # if input is filename or model when it is opened it is a model
         # if input if an association name or ModelContainer then it is opened as a container
-        # print('***input type***',type(input))
-        input_try = datamodels.open(input)
 
-        if isinstance(input_try, datamodels.IFUImageModel):
-            # print('this is a single file or Model ')
-            # It's a single image that's been passed in as a model
-            # input is a model
-            self.filenames.append(input_try.meta.filename)
-            self.input_models.append(input_try)
-            self.output_name = self.build_product_name(self.filenames[0])
+        with datamodels.open(input, save_open=self.in_memory) as input_models:
 
-        elif isinstance(input_try, ModelContainer):
-            self.output_name = 'Temp'
-            if not single:  # find the name of the output file from the association
-                self.output_name = input_try.meta.asn_table.products[0].name
-            for model in input_try:
-                # check if input data is an IFUImageModel
-                if not isinstance(model, datamodels.IFUImageModel):
-                    raise NotIFUImageModel(
-                        f"Input data is not a IFUImageModel, instead it is {model}")
-                self.filenames.append(model.meta.filename)
-            self.input_models = input_try
+            if isinstance(input_models, datamodels.IFUImageModel):
+                # It's a single image that's been passed in as a model
+                # input is a model
+                filename = input_models.meta.filename
+                self.input_models.append(input_models)
+                self.output_name = self.build_product_name(filename)
 
-        else:
-            raise TypeError("Failed to process file type {}".format(type(input_try)))
+            elif isinstance(input_models, ModelContainer):
+                print('in data_types',input_models._save_open)
+                print('in data types',input_models._models)
+                print(input_models)
+                self.output_name = 'Temp'
+                self.input_models = input_models
+                if not single:  # find the name of the output file from the association
+                    self.output_name = input_models.meta.asn_table.products[0].name
+            else:
+                raise TypeError("Failed to process file type {}".format(type(input_models)))
+            # if the user has set the output name - strip out *.fits
+            # later suffixes will be added to this name to designate the
+            # channel, subchannel or grating,filter the data is covers.
 
-# if the user has set the output name - strip out *.fits
-# later suffixes will be added to this name to designate the
-# channel, subchannel or grating,filter the data is covers.
 
         if output_file is not None:
             basename, ext = os.path.splitext(os.path.basename(output_file))

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -1,8 +1,9 @@
 """ Dictionary holding defaults for cube_build
 """
 from stdatamodels.jwst import datamodels
-
+from jwst.datamodels import ModelContainer
 import logging
+from os import path
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -11,91 +12,92 @@ class FileTable():
     """ Dictionary contains defaults for MIRI and NIRSPEC data
     """
 
-    def __init__(self):
+    def __init__(self, in_memory):
 
+        self.in_memory = in_memory
         self.FileMap = {}
+        self.FileMap['filename'] = []
         self.FileMap['MIRI'] = {}
-
+        
         self.FileMap['MIRI']['1'] = {}
         self.FileMap['MIRI']['1']['short'] = []
-        self.FileMap['MIRI']['1']['medium'] = []
-        self.FileMap['MIRI']['1']['long'] = []
-        self.FileMap['MIRI']['1']['short-medium'] = []
-        self.FileMap['MIRI']['1']['short-long'] = []
-        self.FileMap['MIRI']['1']['medium-short'] = []
-        self.FileMap['MIRI']['1']['medium-long'] = []
-        self.FileMap['MIRI']['1']['long-short'] = []
-        self.FileMap['MIRI']['1']['long-medium'] = []
+        self.FileMap['MIRI']['1']['medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['1']['long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['1']['short-medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['1']['short-long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['1']['medium-short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['1']['medium-long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['1']['long-short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['1']['long-medium'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['MIRI']['2'] = {}
         self.FileMap['MIRI']['2']['short'] = []
-        self.FileMap['MIRI']['2']['medium'] = []
-        self.FileMap['MIRI']['2']['long'] = []
-        self.FileMap['MIRI']['2']['short-medium'] = []
-        self.FileMap['MIRI']['2']['short-long'] = []
-        self.FileMap['MIRI']['2']['medium-short'] = []
-        self.FileMap['MIRI']['2']['medium-long'] = []
-        self.FileMap['MIRI']['2']['long-short'] = []
-        self.FileMap['MIRI']['2']['long-medium'] = []
+        self.FileMap['MIRI']['2']['medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['2']['long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['2']['short-medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['2']['short-long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['2']['medium-short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['2']['medium-long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['2']['long-short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['2']['long-medium'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['MIRI']['3'] = {}
-        self.FileMap['MIRI']['3']['short'] = []
-        self.FileMap['MIRI']['3']['medium'] = []
-        self.FileMap['MIRI']['3']['long'] = []
-        self.FileMap['MIRI']['3']['short-medium'] = []
-        self.FileMap['MIRI']['3']['short-long'] = []
-        self.FileMap['MIRI']['3']['medium-short'] = []
-        self.FileMap['MIRI']['3']['medium-long'] = []
-        self.FileMap['MIRI']['3']['long-short'] = []
-        self.FileMap['MIRI']['3']['long-medium'] = []
+        self.FileMap['MIRI']['3']['short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['short-medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['short-long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['medium-short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['medium-long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['long-short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['long-medium'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['MIRI']['4'] = {}
-        self.FileMap['MIRI']['4']['short'] = []
-        self.FileMap['MIRI']['4']['medium'] = []
-        self.FileMap['MIRI']['4']['long'] = []
-        self.FileMap['MIRI']['4']['short-medium'] = []
-        self.FileMap['MIRI']['4']['short-long'] = []
-        self.FileMap['MIRI']['4']['medium-short'] = []
-        self.FileMap['MIRI']['4']['medium-long'] = []
-        self.FileMap['MIRI']['4']['long-short'] = []
-        self.FileMap['MIRI']['4']['long-medium'] = []
+        self.FileMap['MIRI']['4']['short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['short-medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['short-long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['medium-short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['medium-long'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['long-short'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['long-medium'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['NIRSPEC'] = {}
         self.FileMap['NIRSPEC']['prism'] = {}
-        self.FileMap['NIRSPEC']['prism']['clear'] = []
-        self.FileMap['NIRSPEC']['prism']['opaque'] = []
+        self.FileMap['NIRSPEC']['prism']['clear'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['prism']['opaque'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['NIRSPEC']['g140m'] = {}
-        self.FileMap['NIRSPEC']['g140m']['f070lp'] = []
-        self.FileMap['NIRSPEC']['g140m']['f100lp'] = []
-        self.FileMap['NIRSPEC']['g140m']['opaque'] = []
+        self.FileMap['NIRSPEC']['g140m']['f070lp'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g140m']['f100lp'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g140m']['opaque'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['NIRSPEC']['g140h'] = {}
-        self.FileMap['NIRSPEC']['g140h']['f070lp'] = []
-        self.FileMap['NIRSPEC']['g140h']['f100lp'] = []
-        self.FileMap['NIRSPEC']['g140h']['opaque'] = []
+        self.FileMap['NIRSPEC']['g140h']['f070lp'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g140h']['f100lp'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g140h']['opaque'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['NIRSPEC']['g235m'] = {}
-        self.FileMap['NIRSPEC']['g235m']['f170lp'] = []
-        self.FileMap['NIRSPEC']['g235m']['opaque'] = []
+        self.FileMap['NIRSPEC']['g235m']['f170lp'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g235m']['opaque'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['NIRSPEC']['g235h'] = {}
-        self.FileMap['NIRSPEC']['g235h']['f170lp'] = []
-        self.FileMap['NIRSPEC']['g235h']['opaque'] = []
+        self.FileMap['NIRSPEC']['g235h']['f170lp'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g235h']['opaque'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['NIRSPEC']['g395m'] = {}
-        self.FileMap['NIRSPEC']['g395m']['f290lp'] = []
-        self.FileMap['NIRSPEC']['g395m']['opaque'] = []
+        self.FileMap['NIRSPEC']['g395m']['f290lp'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g395m']['opaque'] = ModelContainer(save_open=self.in_memory)
 
         self.FileMap['NIRSPEC']['g395h'] = {}
-        self.FileMap['NIRSPEC']['g395h']['f290lp'] = []
-        self.FileMap['NIRSPEC']['g395h']['opaque'] = []
+        self.FileMap['NIRSPEC']['g395h']['f290lp'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g395h']['opaque'] = ModelContainer(save_open=self.in_memory)
 
 # ********************************************************************************
 
     def set_file_table(self,
-                       input_models,
-                       input_filenames):
+                       input_models):
         """
         Short Summary
         -------------
@@ -112,45 +114,61 @@ class FileTable():
         MasterTable filled in with files needed
         instrument name
         """
-        num = 0
-        num = len(input_filenames)
 # ________________________________________________________________________________
 # Loop over input list of files and assign fill in the MasterTable with filename
 # for the correct (channel-subchannel) or (grating-subchannel)
-        for i in range(num):
 
-            ifile = input_filenames[i]
-            input = input_models[i]
+        print('in file table',input_models._models)
+        if not self.in_memory:
+            catfile_dir = path.dirname(input_models._models[0])
+            print('catfile_dir',catfile_dir)
+        for model in input_models:
+            instrument = model.meta.instrument.name.upper()
+            assign_wcs = model.meta.cal_step.assign_wcs
+            
+            filename  = model.meta.filename
+            print(filename)
+            self.FileMap['filename'].append(filename)
 
-        # Open the input data model & Fill in the FileMap information
-
-            with datamodels.IFUImageModel(input) as input_model:
-
-                instrument = input_model.meta.instrument.name.upper()
-                assign_wcs = input_model.meta.cal_step.assign_wcs
-
-                if assign_wcs != 'COMPLETE':
-                    raise ErrorNoAssignWCS("Assign WCS has not been run on file %s",
-                                           ifile)
+            if not isinstance(model, datamodels.IFUImageModel):
+                        raise NotIFUImageModel(
+                           f"Input data is not a IFUImageModel, instead it is {model}")    
+            if assign_wcs != 'COMPLETE':
+                raise ErrorNoAssignWCS("Assign WCS has not been run on file %s",
+                                       model.meta.filename)
             # _____________________________________________________________________
             # MIRI instrument
-                if instrument == 'MIRI':
-                    channel = input_model.meta.instrument.channel
-                    subchannel = input_model.meta.instrument.band.lower()
-                    clenf = len(channel)
-                    for k in range(clenf):
-                        self.FileMap['MIRI'][channel[k]][subchannel].append(input_model)
+            
+            if instrument == 'MIRI':
+                channel = model.meta.instrument.channel
+                subchannel = model.meta.instrument.band.lower()
+                clenf = len(channel)
+                for k in range(clenf):
+                    if self.in_memory:
+                        self.FileMap['MIRI'][channel[k]][subchannel].append(model.copy())
+                    else:
+                        self.FileMap['MIRI'][channel[k]][subchannel].append(catfile_dir + '/' + filename)   
             # _____________________________________________________________________
             # NIRSPEC instrument
-                elif instrument == 'NIRSPEC':
-                    fwa = input_model.meta.instrument.filter.lower()
-                    gwa = input_model.meta.instrument.grating.lower()
-                    self.FileMap['NIRSPEC'][gwa][fwa].append(input_model)
-                else:
-                    pass
-#                    log.info('Instrument not valid for cube')
+            elif instrument == 'NIRSPEC':
+                fwa = model.meta.instrument.filter.lower()
+                gwa = model.meta.instrument.grating.lower()
+                self.FileMap['NIRSPEC'][gwa][fwa].append(model.copy())
+            else:
+                log.info('Instrument not valid for cube')
+                pass
+
+
+            model.close()
+            del model
+              
         return instrument
 
 
 class ErrorNoAssignWCS(Exception):
+    pass
+
+class NotIFUImageModel(Exception):
+    """ Raise Exception if data is not of type IFUImageModel
+    """
     pass

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -1,7 +1,6 @@
 """ Dictionary holding defaults for cube_build
 """
 from stdatamodels.jwst import datamodels
-from jwst.datamodels import ModelContainer
 import logging
 from os import path
 log = logging.getLogger(__name__)

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -12,87 +12,85 @@ class FileTable():
     """ Dictionary contains defaults for MIRI and NIRSPEC data
     """
 
-    def __init__(self, in_memory):
+    def __init__(self):
 
-        self.in_memory = in_memory
         self.FileMap = {}
         self.FileMap['filename'] = []
         self.FileMap['MIRI'] = {}
-        
         self.FileMap['MIRI']['1'] = {}
         self.FileMap['MIRI']['1']['short'] = []
-        self.FileMap['MIRI']['1']['medium'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['1']['long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['1']['short-medium'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['1']['short-long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['1']['medium-short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['1']['medium-long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['1']['long-short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['1']['long-medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['1']['medium'] = []
+        self.FileMap['MIRI']['1']['long'] = []
+        self.FileMap['MIRI']['1']['short-medium'] = []
+        self.FileMap['MIRI']['1']['short-long'] = []
+        self.FileMap['MIRI']['1']['medium-short'] = []
+        self.FileMap['MIRI']['1']['medium-long'] = []
+        self.FileMap['MIRI']['1']['long-short'] = []
+        self.FileMap['MIRI']['1']['long-medium'] = []
 
         self.FileMap['MIRI']['2'] = {}
         self.FileMap['MIRI']['2']['short'] = []
-        self.FileMap['MIRI']['2']['medium'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['2']['long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['2']['short-medium'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['2']['short-long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['2']['medium-short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['2']['medium-long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['2']['long-short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['2']['long-medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['2']['medium'] = []
+        self.FileMap['MIRI']['2']['long'] = []
+        self.FileMap['MIRI']['2']['short-medium'] = []
+        self.FileMap['MIRI']['2']['short-long'] = []
+        self.FileMap['MIRI']['2']['medium-short'] = []
+        self.FileMap['MIRI']['2']['medium-long'] = []
+        self.FileMap['MIRI']['2']['long-short'] = []
+        self.FileMap['MIRI']['2']['long-medium'] = []
 
         self.FileMap['MIRI']['3'] = {}
-        self.FileMap['MIRI']['3']['short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['3']['medium'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['3']['long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['3']['short-medium'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['3']['short-long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['3']['medium-short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['3']['medium-long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['3']['long-short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['3']['long-medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['3']['short'] = []
+        self.FileMap['MIRI']['3']['medium'] = []
+        self.FileMap['MIRI']['3']['long'] = []
+        self.FileMap['MIRI']['3']['short-medium'] = []
+        self.FileMap['MIRI']['3']['short-long'] = []
+        self.FileMap['MIRI']['3']['medium-short'] = []
+        self.FileMap['MIRI']['3']['medium-long'] = []
+        self.FileMap['MIRI']['3']['long-short'] = []
+        self.FileMap['MIRI']['3']['long-medium'] = []
 
         self.FileMap['MIRI']['4'] = {}
-        self.FileMap['MIRI']['4']['short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['4']['medium'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['4']['long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['4']['short-medium'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['4']['short-long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['4']['medium-short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['4']['medium-long'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['4']['long-short'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['MIRI']['4']['long-medium'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['MIRI']['4']['short'] = []
+        self.FileMap['MIRI']['4']['medium'] = []
+        self.FileMap['MIRI']['4']['long'] = []
+        self.FileMap['MIRI']['4']['short-medium'] = []
+        self.FileMap['MIRI']['4']['short-long'] = []
+        self.FileMap['MIRI']['4']['medium-short'] = []
+        self.FileMap['MIRI']['4']['medium-long'] = []
+        self.FileMap['MIRI']['4']['long-short'] = []
+        self.FileMap['MIRI']['4']['long-medium'] = []
 
         self.FileMap['NIRSPEC'] = {}
         self.FileMap['NIRSPEC']['prism'] = {}
-        self.FileMap['NIRSPEC']['prism']['clear'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['prism']['opaque'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['prism']['clear'] = []
+        self.FileMap['NIRSPEC']['prism']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g140m'] = {}
-        self.FileMap['NIRSPEC']['g140m']['f070lp'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['g140m']['f100lp'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['g140m']['opaque'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g140m']['f070lp'] = []
+        self.FileMap['NIRSPEC']['g140m']['f100lp'] = []
+        self.FileMap['NIRSPEC']['g140m']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g140h'] = {}
-        self.FileMap['NIRSPEC']['g140h']['f070lp'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['g140h']['f100lp'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['g140h']['opaque'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g140h']['f070lp'] = []
+        self.FileMap['NIRSPEC']['g140h']['f100lp'] = []
+        self.FileMap['NIRSPEC']['g140h']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g235m'] = {}
-        self.FileMap['NIRSPEC']['g235m']['f170lp'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['g235m']['opaque'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g235m']['f170lp'] = []
+        self.FileMap['NIRSPEC']['g235m']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g235h'] = {}
-        self.FileMap['NIRSPEC']['g235h']['f170lp'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['g235h']['opaque'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g235h']['f170lp'] = []
+        self.FileMap['NIRSPEC']['g235h']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g395m'] = {}
-        self.FileMap['NIRSPEC']['g395m']['f290lp'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['g395m']['opaque'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g395m']['f290lp'] = []
+        self.FileMap['NIRSPEC']['g395m']['opaque'] = []
 
         self.FileMap['NIRSPEC']['g395h'] = {}
-        self.FileMap['NIRSPEC']['g395h']['f290lp'] = ModelContainer(save_open=self.in_memory)
-        self.FileMap['NIRSPEC']['g395h']['opaque'] = ModelContainer(save_open=self.in_memory)
+        self.FileMap['NIRSPEC']['g395h']['f290lp'] = []
+        self.FileMap['NIRSPEC']['g395h']['opaque'] = []
 
 # ********************************************************************************
 
@@ -118,55 +116,44 @@ class FileTable():
 # Loop over input list of files and assign fill in the MasterTable with filename
 # for the correct (channel-subchannel) or (grating-subchannel)
 
-        print('in file table',input_models._models)
-        if not self.in_memory:
-            catfile_dir = path.dirname(input_models._models[0])
-            print('catfile_dir',catfile_dir)
         for model in input_models:
             instrument = model.meta.instrument.name.upper()
             assign_wcs = model.meta.cal_step.assign_wcs
-            
-            filename  = model.meta.filename
-            print(filename)
+            filename = model.meta.filename
             self.FileMap['filename'].append(filename)
 
             if not isinstance(model, datamodels.IFUImageModel):
-                        raise NotIFUImageModel(
-                           f"Input data is not a IFUImageModel, instead it is {model}")    
+                raise NotIFUImageModel(f"Input data is not a IFUImageModel, instead it is {model}")
             if assign_wcs != 'COMPLETE':
                 raise ErrorNoAssignWCS("Assign WCS has not been run on file %s",
                                        model.meta.filename)
             # _____________________________________________________________________
             # MIRI instrument
-            
             if instrument == 'MIRI':
                 channel = model.meta.instrument.channel
                 subchannel = model.meta.instrument.band.lower()
                 clenf = len(channel)
                 for k in range(clenf):
-                    if self.in_memory:
-                        self.FileMap['MIRI'][channel[k]][subchannel].append(model.copy())
-                    else:
-                        self.FileMap['MIRI'][channel[k]][subchannel].append(catfile_dir + '/' + filename)   
+                    self.FileMap['MIRI'][channel[k]][subchannel].append(model)
             # _____________________________________________________________________
             # NIRSPEC instrument
             elif instrument == 'NIRSPEC':
                 fwa = model.meta.instrument.filter.lower()
                 gwa = model.meta.instrument.grating.lower()
-                self.FileMap['NIRSPEC'][gwa][fwa].append(model.copy())
+                self.FileMap['NIRSPEC'][gwa][fwa].append(model)
             else:
                 log.info('Instrument not valid for cube')
                 pass
 
-
             model.close()
             del model
-              
+
         return instrument
 
 
 class ErrorNoAssignWCS(Exception):
     pass
+
 
 class NotIFUImageModel(Exception):
     """ Raise Exception if data is not of type IFUImageModel

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -2,7 +2,6 @@
 """
 from stdatamodels.jwst import datamodels
 import logging
-from os import path
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -78,8 +78,6 @@ class IFUCubeData():
         self.weight_power = pars_cube.get('weight_power')
         self.skip_dqflagging = pars_cube.get('skip_dqflagging')
         self.suffix = pars_cube.get('suffix')
-
-        print('suffix in ifu_cube', self.suffix) 
         self.num_bands = 0
         self.output_name = ''
 
@@ -196,14 +194,11 @@ class IFUCubeData():
                 for i in range(number_subchannels):
                     b_name = b_name + subchannels[i]
                 b_name = b_name.lower()
-                newname = self.output_name_base + ch_name + '-' + b_name + \
-                     '_' + self.suffix + '.fits'
+                newname = self.output_name_base + ch_name + '-' + b_name
                 if self.coord_system == 'internal_cal':
-                    newname = self.output_name_base + ch_name + '-' + b_name + \
-                        '_internal_'+ self.suffix +'.fits'
+                    newname = self.output_name_base + ch_name + '-' + b_name + '_internal'
                 if self.output_type == 'single':
-                    newname = self.output_name_base + ch_name + '-' + b_name + \
-                        '_single_'+self.suffix +'.fits'
+                    newname = self.output_name_base + ch_name + '-' + b_name + '_single'
             # ________________________________________________________________________________
             elif self.instrument == 'NIRSPEC':
 
@@ -220,11 +215,11 @@ class IFUCubeData():
                     if i < self.num_bands - 1:
                         fg_name = fg_name + '-'
                 fg_name = fg_name.lower()
-                newname = self.output_name_base + fg_name + '_' + self.suffix + '.fits'
+                newname = self.output_name_base + fg_name
                 if self.output_type == 'single':
-                    newname = self.output_name_base + fg_name + '_single_' + self.suffix +'.fits'
+                    newname = self.output_name_base + fg_name + '_single'
                 if self.coord_system == 'internal_cal':
-                    newname = self.output_name_base + fg_name + '_internal_'+ self.suffix + '.fits'
+                    newname = self.output_name_base + fg_name + '_internal'
         # ______________________________________________________________________________
         if self.output_type != 'single':
             log.info(f'Output Name: {newname}')
@@ -558,18 +553,14 @@ class IFUCubeData():
         # and map the detector pixels to the cube spaxel
 
         number_bands = len(self.list_par1)
-        k = 0 
+        k = 0
         for ib in range(number_bands):
             this_par1 = self.list_par1[ib]
             this_par2 = self.list_par2[ib]
-            #print(self.master_table.FileMap[self.instrument][this_par1][this_par2]._save_open)
-            #print(self.master_table.FileMap[self.instrument][this_par1][this_par2]._models)
-            
             for input in self.master_table.FileMap[self.instrument][this_par1][this_par2]:
-            # ________________________________________________________________________________
-            # loop over the files that cover the spectral range the cube is for
+                # ________________________________________________________________________________
+                # loop over the files that cover the spectral range the cube is for
 
-                print('input model at start of build_ifu',input)
                 input_model = datamodels.open(input)
                 self.input_models_this_cube.append(input_model.copy())
                 # set up input_model to be first file used to copy in basic header info
@@ -639,6 +630,8 @@ class IFUCubeData():
                         spaxel_dq.astype(np.uint)
                         self.spaxel_dq = np.bitwise_or(self.spaxel_dq, spaxel_dq)
                         result = None
+                        del result
+                        del spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq, spaxel_dq
                     if self.weighting == 'drizzle' and build_cube:
                         cdelt3_mean = np.nanmean(self.cdelt3_normal)
                         xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4 = corner_coord
@@ -663,7 +656,8 @@ class IFUCubeData():
                         spaxel_dq.astype(np.uint)
                         self.spaxel_dq = np.bitwise_or(self.spaxel_dq, spaxel_dq)
                         result = None
-
+                        del result
+                        del spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, spaxel_dq
                 # --------------------------------------------------------------------------------
                 #                     # AREA - 2d method only works for single files local slicer plane (internal_cal)
                 # --------------------------------------------------------------------------------
@@ -701,7 +695,7 @@ class IFUCubeData():
                             self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
                             self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
                             result = None
-
+                            del spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, result
                     # --------------------------------------------------------------------------------
                     # NIRSPEC
                     # --------------------------------------------------------------------------------
@@ -732,13 +726,13 @@ class IFUCubeData():
                             self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
                             self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
                             result = None
+                            del spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, result
                 k = k + 1
                 input_model.close()
                 del input_model
             # _______________________________________________________________________
             # done looping over files
 
-            
         self.find_spaxel_flux()
         self.set_final_dq_flags()
 
@@ -822,11 +816,12 @@ class IFUCubeData():
                                           roiw_ave, self.cdelt1, self.cdelt2)
                     spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, _ = result
 
-                    self.spaxel_flux = self.spaxel_flux + np.asarray(result[0], np.float64)
-                    self.spaxel_weight = self.spaxel_weight + np.asarray(result[1], np.float64)
-                    self.spaxel_var = self.spaxel_var + np.asarray(result[2], np.float64)
-                    self.spaxel_iflux = self.spaxel_iflux + np.asarray(result[3], np.float64)
+                    self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)
+                    self.spaxel_weight = self.spaxel_weight + np.asarray(spaxel_weight, np.float64)
+                    self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
+                    self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
                     result = None
+                    del result, spaxel_flux, spaxel_var, spaxel_iflux
 
                 if self.weighting == 'drizzle' and build_cube:
                     cdelt3_mean = np.nanmean(self.cdelt3_normal)
@@ -850,6 +845,7 @@ class IFUCubeData():
                     self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
                     self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
                     result = None
+                    del result, spaxel_flux, spaxel_var, spaxek_iflux
                 # ______________________________________________________________________
                 # shove Flux and iflux in the  final ifucube
                 self.find_spaxel_flux()
@@ -860,6 +856,7 @@ class IFUCubeData():
                 ifucube_model, status = result
 
                 single_ifucube_container.append(ifucube_model)
+                print('Cube build length', len(single_ifucube_container))
                 if status != 0:
                     log.debug("Possible problem with single ifu cube, no valid data in cube")
                 j = j + 1
@@ -1263,7 +1260,6 @@ class IFUCubeData():
                 lmax = 0.0
 
                 input_file = self.master_table.FileMap[self.instrument][this_a][this_b][k]
-                print('input_file',input_file)
                 input_model = datamodels.open(input_file)
 
                 # Find the footprint of the image
@@ -1332,6 +1328,7 @@ class IFUCubeData():
 
                 lambda_min.append(lmin)
                 lambda_max.append(lmax)
+                input_model.close()
         # ________________________________________________________________________________
         # done looping over files determine final size of cube
         corner_a = np.array(corner_a)
@@ -2183,7 +2180,7 @@ class IFUCubeData():
                 self.output_file = None
                 newname = self.define_cubename()
                 ifucube_model.meta.filename = newname
-                # single files
+
                 if self.instrument == 'MIRI':
                     outchannel = self.list_par1[0]
                     outband = self.list_par2[0]

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -845,7 +845,7 @@ class IFUCubeData():
                     self.spaxel_var = self.spaxel_var + np.asarray(spaxel_var, np.float64)
                     self.spaxel_iflux = self.spaxel_iflux + np.asarray(spaxel_iflux, np.float64)
                     result = None
-                    del result, spaxel_flux, spaxel_var, spaxek_iflux
+                    del result, spaxel_flux, spaxel_var, spaxel_iflux
                 # ______________________________________________________________________
                 # shove Flux and iflux in the  final ifucube
                 self.find_spaxel_flux()

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -856,7 +856,6 @@ class IFUCubeData():
                 ifucube_model, status = result
 
                 single_ifucube_container.append(ifucube_model)
-                print('Cube build length', len(single_ifucube_container))
                 if status != 0:
                     log.debug("Possible problem with single ifu cube, no valid data in cube")
                 j = j + 1

--- a/jwst/cube_build/src/cube_dq_utils.c
+++ b/jwst/cube_build/src/cube_dq_utils.c
@@ -548,6 +548,7 @@ int dq_miri(int start_region, int end_region, int overlap_partial, int overlap_f
 
   nxy = nx * ny;
   int *wave_slice_dq;
+
   if (mem_alloc_dq(nxy, &wave_slice_dq)) return 1;
 
   // Loop over the wavelength planes and set DQ plane 
@@ -593,8 +594,8 @@ int dq_miri(int start_region, int end_region, int overlap_partial, int overlap_f
   } // end loop over wavelength
 
   *spaxel_dq = idqv;
-  free(wave_slice_dq);
 
+  free (wave_slice_dq);
   return 0;
 }
 
@@ -662,6 +663,7 @@ int dq_nirspec(int overlap_partial,
 				       match_slice);
 
     int *wave_slice_dq;
+
     if (mem_alloc_dq(nxy, &wave_slice_dq)) return 1;
 
     for (j =0; j< nxy; j++){
@@ -709,7 +711,7 @@ int dq_nirspec(int overlap_partial,
     free(wave_slice_dq);
   } // end of wavelength
   *spaxel_dq = idqv;
-
+  
   return 0;
 }
 

--- a/jwst/cube_build/tests/test_configuration.py
+++ b/jwst/cube_build/tests/test_configuration.py
@@ -262,8 +262,6 @@ def test_calspec3_config_miri(_jail, miri_full_coverage):
     single = False
     par_filename = 'None'
 
-    num_files = len(miri_full_coverage)
-
     pars = {
         'channel': pars_input['channel'],
         'subchannel': pars_input['subchannel'],
@@ -337,8 +335,6 @@ def test_calspec3_config_miri_multi(_jail, miri_full_coverage):
     single = False
     par_filename = 'None'
 
-    num_files = len(miri_full_coverage)
-
     pars = {
         'channel': pars_input['channel'],
         'subchannel': pars_input['subchannel'],
@@ -393,8 +389,6 @@ def test_calspec3_config_nirspec(_jail, nirspec_medium_coverage):
     single = False
     par_filename = 'None'
 
-    num_files = len(nirspec_medium_coverage)
-
     pars = {
         'channel': pars_input['channel'],
         'subchannel': pars_input['subchannel'],
@@ -442,8 +436,6 @@ def test_calspec3_config_nirspec_multi(_jail, nirspec_medium_coverage):
     output_type = 'multi'
     single = False
     par_filename = 'None'
-
-    num_files = len(nirspec_medium_coverage)
 
     pars = {
         'channel': pars_input['channel'],

--- a/jwst/cube_build/tests/test_configuration.py
+++ b/jwst/cube_build/tests/test_configuration.py
@@ -215,9 +215,7 @@ def test_calspec2_config(_jail, miri_ifushort_short):
     single = False
     par_filename = 'None'
 
-    input_file = 'test.fits'
     input_models = []
-    input_filenames = []
     input_models.append(miri_ifushort_short)
 
     pars = {
@@ -264,7 +262,6 @@ def test_calspec3_config_miri(_jail, miri_full_coverage):
     single = False
     par_filename = 'None'
 
-    input_file = 'test.fits'
     num_files = len(miri_full_coverage)
 
     pars = {
@@ -340,7 +337,6 @@ def test_calspec3_config_miri_multi(_jail, miri_full_coverage):
     single = False
     par_filename = 'None'
 
-    input_file = 'test.fits'
     num_files = len(miri_full_coverage)
 
     pars = {
@@ -397,7 +393,6 @@ def test_calspec3_config_nirspec(_jail, nirspec_medium_coverage):
     single = False
     par_filename = 'None'
 
-    input_file = 'test.fits'
     num_files = len(nirspec_medium_coverage)
 
     pars = {
@@ -448,7 +443,6 @@ def test_calspec3_config_nirspec_multi(_jail, nirspec_medium_coverage):
     single = False
     par_filename = 'None'
 
-    input_file = 'test.fits'
     num_files = len(nirspec_medium_coverage)
 
     pars = {

--- a/jwst/cube_build/tests/test_configuration.py
+++ b/jwst/cube_build/tests/test_configuration.py
@@ -219,7 +219,6 @@ def test_calspec2_config(_jail, miri_ifushort_short):
     input_models = []
     input_filenames = []
     input_models.append(miri_ifushort_short)
-    input_filenames.append(input_file)
 
     pars = {
         'channel': pars_input['channel'],
@@ -232,13 +231,12 @@ def test_calspec2_config(_jail, miri_ifushort_short):
 
     cubeinfo = cube_build.CubeData(
         input_models,
-        input_filenames,
         par_filename,
         **pars)
 
     master_table = file_table.FileTable()
     this_instrument = master_table.set_file_table(
-        cubeinfo.input_models, cubeinfo.input_filenames)
+        cubeinfo.input_models)
 
     assert this_instrument == 'MIRI'
 
@@ -268,9 +266,6 @@ def test_calspec3_config_miri(_jail, miri_full_coverage):
 
     input_file = 'test.fits'
     num_files = len(miri_full_coverage)
-    input_filenames = []
-    for i in range(num_files):
-        input_filenames.append(input_file)
 
     pars = {
         'channel': pars_input['channel'],
@@ -283,13 +278,12 @@ def test_calspec3_config_miri(_jail, miri_full_coverage):
 
     cubeinfo = cube_build.CubeData(
         miri_full_coverage,
-        input_filenames,
         par_filename,
         **pars)
 
     master_table = file_table.FileTable()
     this_instrument = master_table.set_file_table(
-        cubeinfo.input_models, cubeinfo.input_filenames)
+        cubeinfo.input_models)
 
     assert this_instrument == 'MIRI'
 
@@ -348,9 +342,6 @@ def test_calspec3_config_miri_multi(_jail, miri_full_coverage):
 
     input_file = 'test.fits'
     num_files = len(miri_full_coverage)
-    input_filenames = []
-    for i in range(num_files):
-        input_filenames.append(input_file)
 
     pars = {
         'channel': pars_input['channel'],
@@ -363,13 +354,12 @@ def test_calspec3_config_miri_multi(_jail, miri_full_coverage):
 
     cubeinfo = cube_build.CubeData(
         miri_full_coverage,
-        input_filenames,
         par_filename,
         **pars)
 
     master_table = file_table.FileTable()
     this_instrument = master_table.set_file_table(
-        cubeinfo.input_models, cubeinfo.input_filenames)
+        cubeinfo.input_models)
 
     assert this_instrument == 'MIRI'
 
@@ -409,9 +399,6 @@ def test_calspec3_config_nirspec(_jail, nirspec_medium_coverage):
 
     input_file = 'test.fits'
     num_files = len(nirspec_medium_coverage)
-    input_filenames = []
-    for i in range(num_files):
-        input_filenames.append(input_file)
 
     pars = {
         'channel': pars_input['channel'],
@@ -424,13 +411,12 @@ def test_calspec3_config_nirspec(_jail, nirspec_medium_coverage):
 
     cubeinfo = cube_build.CubeData(
         nirspec_medium_coverage,
-        input_filenames,
         par_filename,
         **pars)
 
     master_table = file_table.FileTable()
     this_instrument = master_table.set_file_table(
-        cubeinfo.input_models, cubeinfo.input_filenames)
+        cubeinfo.input_models)
 
     assert this_instrument == 'NIRSPEC'
 
@@ -464,9 +450,6 @@ def test_calspec3_config_nirspec_multi(_jail, nirspec_medium_coverage):
 
     input_file = 'test.fits'
     num_files = len(nirspec_medium_coverage)
-    input_filenames = []
-    for i in range(num_files):
-        input_filenames.append(input_file)
 
     pars = {
         'channel': pars_input['channel'],
@@ -479,13 +462,12 @@ def test_calspec3_config_nirspec_multi(_jail, nirspec_medium_coverage):
 
     cubeinfo = cube_build.CubeData(
         nirspec_medium_coverage,
-        input_filenames,
         par_filename,
         **pars)
 
     master_table = file_table.FileTable()
     this_instrument = master_table.set_file_table(
-        cubeinfo.input_models, cubeinfo.input_filenames)
+        cubeinfo.input_models)
 
     assert this_instrument == 'NIRSPEC'
 

--- a/jwst/cube_build/tests/test_miri_cubepars.py
+++ b/jwst/cube_build/tests/test_miri_cubepars.py
@@ -149,7 +149,7 @@ def test_miri_use_cubepars(_jail, miri_cube_pars):
         'spaxel_debug': None}
 
     pipeline = 3
-    filename = None
+
     input_model = None
     output_name_base = None
     output_type = 'band'
@@ -160,7 +160,6 @@ def test_miri_use_cubepars(_jail, miri_cube_pars):
     instrument_info = instrument_info
     this_cube = ifu_cube.IFUCubeData(
         pipeline,
-        filename,
         input_model,
         output_name_base,
         output_type,
@@ -253,7 +252,6 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
         'spaxel_debug': None}
 
     pipeline = 3
-    filename = None
     input_model = None
     output_name_base = None
     output_type = 'band'
@@ -264,7 +262,6 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
     instrument_info = instrument_info
     this_cube = ifu_cube.IFUCubeData(
         pipeline,
-        filename,
         input_model,
         output_name_base,
         output_type,
@@ -320,7 +317,6 @@ def test_miri_cubepars_user_defaults(_jail, miri_cube_pars):
 
     this_cube = ifu_cube.IFUCubeData(
         pipeline,
-        filename,
         input_model,
         output_name_base,
         output_type,
@@ -429,7 +425,6 @@ def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
         'spaxel_debug': None}
 
     pipeline = 3
-    filename = None
     input_model = None
     output_name_base = None
     output_type = 'multi'
@@ -440,7 +435,6 @@ def test_miri_cubepars_multiple_bands(_jail, miri_cube_pars):
     instrument_info = instrument_info
     this_cube = ifu_cube.IFUCubeData(
         pipeline,
-        filename,
         input_model,
         output_name_base,
         output_type,

--- a/jwst/cube_build/tests/test_nirspec_cubepars.py
+++ b/jwst/cube_build/tests/test_nirspec_cubepars.py
@@ -176,7 +176,6 @@ def test_nirspec_cubepars(_jail, nirspec_cube_pars):
         'spaxel_debug': None}
 
     pipeline = 3
-    filename = None
     input_model = None
     output_name_base = None
     output_type = 'band'
@@ -187,7 +186,6 @@ def test_nirspec_cubepars(_jail, nirspec_cube_pars):
     instrument_info = instrument_info
     this_cube = ifu_cube.IFUCubeData(
         pipeline,
-        filename,
         input_model,
         output_name_base,
         output_type,
@@ -244,7 +242,6 @@ def test_nirspec_cubepars(_jail, nirspec_cube_pars):
 
     this_cube = ifu_cube.IFUCubeData(
         pipeline,
-        filename,
         input_model,
         output_name_base,
         output_type,

--- a/jwst/cube_build/tests/test_wcs.py
+++ b/jwst/cube_build/tests/test_wcs.py
@@ -202,7 +202,6 @@ def test_setup_wcs():
         'spaxel_debug': None}
 
     pipeline = 3
-    filename = None
     input_model = None
     output_name_base = None
     output_type = None
@@ -213,7 +212,6 @@ def test_setup_wcs():
     instrument_info = None
     thiscube = ifu_cube.IFUCubeData(
         pipeline,
-        filename,
         input_model,
         output_name_base,
         output_type,

--- a/jwst/regtest/test_miri_cubebuild.py
+++ b/jwst/regtest/test_miri_cubebuild.py
@@ -40,19 +40,19 @@ def test_cube_build_single_output(run_cube_build_single_output, output, fitsdiff
 
 
 @pytest.mark.bigdata
-def test_cube_build_miri_internal_cal(rtdata, fitsdiff_default_kwargs):
-    """Run cube_build on single file using coord system = internal_cal"""
+def test_cube_build_miri_ifualign(rtdata, fitsdiff_default_kwargs):
+    """Run cube_build on single file using coord system = ifu_align"""
     input_file = 'jw01024001001_04101_00001_mirifushort_cal.fits'
     rtdata.get_data(f"miri/mrs/{input_file}")
 
     args = [
         'jwst.cube_build.CubeBuildStep',
         input_file,
-        '--coord_system=internal_cal'
+        '--coord_system=ifualign'
     ]
     Step.from_cmdline(args)
 
-    output = input_file.replace('cal', 'ch1-short_internal_s3d')
+    output = input_file.replace('cal', 'ch1-short_s3d')
     rtdata.output = output
 
     rtdata.get_truth(f"truth/test_miri_cubebuild/{output}")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3016](https://jira.stsci.edu/browse/JP-3016)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7367 

<!-- describe the changes comprising this PR here -->
This PR addresses allowing the user to provide a custom suffix.  Some improvements were made to manage the memory more efficiently. A few arrays that were not being used any longer were removed.  In addition, it removed the option for users with MIRI data to use the coord_system='internal_cal'. 'internal_cal' was designed for NIRSpec and never tested in commissioning. Instead miri users wanting an IFUcube aligned with the ifu plane should use 'coord_system=ifualign'.

A very large effort was made to see if having an option 'in_memory' the way outlier_detection uses such an option was tested. Basically setting in_memory=False would write out out IFU cubes and single IFUCubes if doing outlier detection to disk instead of storing them in memory.  When just build typical IFUCube this did not save much memory. So I have put adding this option to cube_build until we better know how outlier detection for IFU is going to be re-designed. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
