### PR TITLE
add fix for JQuery for documentation search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,7 @@ if sys.version_info[0] == 2:
 # ones.
 extensions = [
     'numfig',
+    'sphinxcontrib.jquery',
     'pytest_doctestplus.sphinx.doctestplus',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR attempts to resolve the issue with the documentation search not working - see https://github.com/readthedocs/sphinx_rtd_theme/issues/1452

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
