### PR TITLE
Remove pytest-openfiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.10.1 (unreleased)
 ===================
 
+- Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
+  catching ``ResourceWarning``s. [#7526]
 
 
 1.10.0 (2023-04-03)

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,6 @@ test =
     pytest>=6.0.0
     pytest-cov>=2.9.0
     pytest-doctestplus>=0.10.0
-    pytest-openfiles>=0.5.0
     requests_mock>=1.0
 
 [options.entry_points]
@@ -163,8 +162,9 @@ results_root = jwst-pipeline-results
 text_file_format = rst
 doctest_plus = enabled
 doctest_rst = enabled
-addopts = --show-capture=no --open-files --report-crds-context
+addopts = --show-capture=no --report-crds-context
 filterwarnings =
+    error::ResourceWarning
     ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning
 
 [coverage:run]


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
`pytest-openfiles` has been deprecated and is interfering with the use of fixtures in our test code (ones that handle files). This PR switches `ResourceWarnings` into errors which will catch almost all cases of files left open. The only cases it does not catch is if an open file handle is assigned to a global variable as the "warning" will not be emitted until python stops running, which occurs after pytest has completed.

Similar to spacetelescope/romancal#666

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
