### PR TITLE
JP-3164: Fix some xfails that are no longer necessary

### DIFF
--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -417,7 +417,6 @@ def test_open_slits():
     assert len(slits) == 1
 
 
-@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 def test_shutter_size_on_sky():
     """
     Test the size of a MOS shutter on sky is ~ .2 x .4 arcsec.
@@ -454,7 +453,6 @@ def test_shutter_size_on_sky():
     assert sep_y.value < 0.46
 
 
-@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 @pytest.mark.parametrize(('mode'), ['fs', 'msa'])
 def test_functional_fs_msa(mode):
     #     """
@@ -594,7 +592,6 @@ def wcs_ifu_grating():
     return _create_image_model
 
 
-@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 def test_functional_ifu_grating(wcs_ifu_grating):
     """Compare Nirspec instrument model with IDT model for IFU grating."""
 
@@ -751,7 +748,6 @@ def test_functional_ifu_grating(wcs_ifu_grating):
     assert_allclose(v3, ins_tab['yV2V3'])
 
 
-@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 def test_functional_ifu_prism():
     """Compare Nirspec instrument model with IDT model for IFU prism."""
     # setup test
@@ -975,7 +971,6 @@ def ifu_world_coord(wcs_ifu_grating):
     return ra_all, dec_all, lam_all
 
 
-@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 @pytest.mark.parametrize("slice", [1, 17])
 def test_in_slice(slice, wcs_ifu_grating, ifu_world_coord):
     """ Test that the number of valid outputs from a slice forward transform

--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -158,7 +158,7 @@ def make_wfss_datamodel():
         'vparity': -1}
 
     observation = {
-        'date': '2016-09-05',
+        'date': '2023-01-05',
         'time': '8:59:37'}
 
     exposure = {
@@ -245,7 +245,6 @@ def test_nrc_wfss_background(filters, pupils, detectors, make_wfss_datamodel):
         assert np.isclose([pipeline_reference_mean], [test_reference_mean], rtol=1e-1)
 
 
-@pytest.mark.xfail(reason="Needs new reference specawcs reference files in CRDS")
 @pytest.mark.parametrize("filters", ['GR150C', 'GR150R'])
 @pytest.mark.parametrize("pupils", ['F090W', 'F115W', 'F140M', 'F150W', 'F158M', 'F200W'])
 def test_nis_wfss_background(filters, pupils, make_wfss_datamodel):

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -198,7 +198,6 @@ def nircam_rate():
     return im
 
 
-@pytest.mark.xfail(reason="Fails due to updated ref files delivered to CRDS")
 def test_nirspec_wcs_roundtrip(nirspec_rate):
     im = AssignWcsStep.call(nirspec_rate)
     im = Extract2dStep.call(im)

--- a/jwst/residual_fringe/tests/test_configuration.py
+++ b/jwst/residual_fringe/tests/test_configuration.py
@@ -25,7 +25,6 @@ def miri_image():
     return image
 
 
-@pytest.mark.xfail(resason='bug in parsing in parameters')
 def test_call_residual_fringe(_jail,  miri_image):
     """ test defaults of step are set up and user input are defined correctly """
 
@@ -36,6 +35,7 @@ def test_call_residual_fringe(_jail,  miri_image):
     step = ResidualFringeStep()
     step.ignore_region_min = [4.9, 5.7]
     step.ignore_region_max = [5.6, 6.5, 9.0]
+    step.skip = False
 
     # If the number ignore min and max regions is not the same a value error is returned
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3164](https://jira.stsci.edu/browse/JP-3164)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR removes some unnecessary xfails in the unit tests, and fixes one test to run properly.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
