### PR TITLE
Cleanup skymatch code and fix PEP8 issues

### DIFF
--- a/jwst/skymatch/region.py
+++ b/jwst/skymatch/region.py
@@ -14,8 +14,8 @@ Polygon filling algorithm.
 # as well as top-most row of the polygon.
 #
 # NOTE: Algorithm description can be found, e.g., here:
-#    http://www.cs.rit.edu/~icss571/filling/how_to.html
-#    http://www.cs.uic.edu/~jbell/CourseNotes/ComputerGraphics/PolygonFilling.html
+# http://www.cs.rit.edu/~icss571/filling/how_to.html
+# http://www.cs.uic.edu/~jbell/CourseNotes/ComputerGraphics/PolygonFilling.html
 #
 from collections import OrderedDict
 import numpy as np
@@ -178,7 +178,13 @@ class Polygon(Region):
         edges = []
         for i in range(1, len(self._vertices)):
             name = 'E' + str(i - 1)
-            edges.append(Edge(name=name, start=self._vertices[i - 1], stop=self._vertices[i]))
+            edges.append(
+                Edge(
+                    name=name,
+                    start=self._vertices[i - 1],
+                    stop=self._vertices[i]
+                )
+            )
         return edges
 
     def scan(self, data):
@@ -199,16 +205,20 @@ class Polygon(Region):
         - For each scan line:
           1. Add edges from GET to AET for which ymin==y
           2. Remove edges from AET fro which ymax==y
-          3. Compute the intersection of the current scan line with all edges in the AET
+          3. Compute the intersection of the current scan line with all edges
+             in the AET
           4. Sort on X of intersection point
           5. Set elements between pairs of X in the AET to the Edge's ID
 
         """
-        # TODO: 1.This algorithm does not mark pixels in the top row and left most column.
-        # Pad the initial pixel description on top and left with 1 px to prevent this.
-        # 2. Currently it uses intersection of the scan line with edges. If this is
-        # too slow it should use the 1/m increment (replace 3 above) (or the increment
-        # should be removed from the GET entry).
+        # TODO:
+        # 1. This algorithm does not mark pixels in the top row and left
+        #    most column. Pad the initial pixel description on top and left
+        #    with 1 px to prevent this.
+        # 2. Currently it uses intersection of the scan line with edges.
+        #    If this is too slow it should use the 1/m increment
+        #    (replace 3 above) (or the increment should be removed from
+        #    the GET entry).
 
         # see comments in the __init__ function for the reason of introducing
         # polygon shifts (self._shiftx & self._shifty). Here we need to shift
@@ -232,7 +242,10 @@ class Polygon(Region):
 
             scan_line = Edge('scan_line', start=[self._bbox[0], y],
                              stop=[self._bbox[0] + self._bbox[2], y])
-            x = [int(np.ceil(e.compute_AET_entry(scan_line)[1])) for e in AET if e is not None]
+            x = [
+                int(np.ceil(e.compute_AET_entry(scan_line)[1]))
+                for e in AET if e is not None
+            ]
             xnew = np.sort(x)
             ysh = y + self._shifty
 
@@ -276,8 +289,12 @@ class Polygon(Region):
         # maxx = self._vertices[:,0].max()
         # miny = self._vertices[:,1].min()
         # maxy = self._vertices[:,1].max()
-        return px[0] >= self._bbox[0] and px[0] <= self._bbox[0] + self._bbox[2] and \
-            px[1] >= self._bbox[1] and px[1] <= self._bbox[1] + self._bbox[3]
+        return (
+            px[0] >= self._bbox[0] and
+            px[0] <= self._bbox[0] + self._bbox[2] and
+            px[1] >= self._bbox[1] and
+            px[1] <= self._bbox[1] + self._bbox[3]
+        )
 
 
 class Edge():
@@ -349,7 +366,12 @@ class Edge():
             if np.diff(earr[:, 1]).item() == 0:
                 return None
             else:
-                entry = [self._ymax, self._yminx, (np.diff(earr[:, 0]) / np.diff(earr[:, 1])).item(), None]
+                entry = [
+                    self._ymax,
+                    self._yminx,
+                    (np.diff(earr[:, 0]) / np.diff(earr[:, 1])).item(),
+                    None
+                ]
         return entry
 
     def compute_AET_entry(self, edge):

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -35,6 +35,7 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
 
     Parameters
     ----------
+
     images : list of SkyImage or SkyGroup
         A list of of :py:class:`~jwst.skymatch.skyimage.SkyImage` or
         :py:class:`~jwst.skymatch.skyimage.SkyGroup` objects.
@@ -54,8 +55,8 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
         * **'global'** : compute a common sky value for all input images and
           groups of images. With this setting `local` will compute
           sky values for each input image/group, find the minimum sky value,
-          and then it will set (and/or subtract) the sky value of each input image
-          to this minimum value. This method *may* be
+          and then it will set (and/or subtract) the sky value of each input
+          image to this minimum value. This method *may* be
           useful when the input images have been already matched.
 
         * **'match'** : compute differences in sky values between images
@@ -65,7 +66,8 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
           (reported to be) 0. This setting will "equalize" sky values between
           the images in large mosaics. However, this method is not recommended
           when used in conjunction with
-          `astrodrizzle <http://stsdas.stsci.edu/stsci_python_sphinxdocs_2.13/drizzlepac/astrodrizzle.html>`_
+          `astrodrizzle <http://stsdas.stsci.edu/stsci_python_sphinxdocs_2.13/\
+drizzlepac/astrodrizzle.html>`_
           because it computes relative sky values while `astrodrizzle` needs
           "absolute" sky values for median image generation and CR rejection.
 
@@ -107,7 +109,8 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
 
     :py:func:`match` provides new algorithms for sky value computations
     and enhances previously available algorithms used by, e.g.,
-    `astrodrizzle <http://stsdas.stsci.edu/stsci_python_sphinxdocs_2.13/drizzlepac/astrodrizzle.html>`_.
+    `astrodrizzle <http://stsdas.stsci.edu/stsci_python_sphinxdocs_2.13/\
+drizzlepac/astrodrizzle.html>`_.
 
     Two new methods of sky subtraction have been introduced (compared to the
     standard ``'local'``): ``'global'`` and ``'match'``, as well as a
@@ -142,12 +145,12 @@ def match(images, skymethod='global+match', match_down=True, subtract=False):
 
       .. warning::
 
-        The current algorithm is not capable of detecting cases where some subsets
-        of intersecting images (from the input list of images) do not intersect
-        at all with other subsets of intersecting images (except for the simple
-        case when *single* images do not intersect any other images). In these
-        cases the algorithm will find equalizing sky values for each
-        intersecting subset of images and/or groups of images.
+        The current algorithm is not capable of detecting cases where some
+        subsets of intersecting images (from the input list of images) do not
+        intersect at all with other subsets of intersecting images (except for
+        the simple case when *single* images do not intersect any other
+        images). In these cases the algorithm will find equalizing sky values
+        for each intersecting subset of images and/or groups of images.
         However since these subsets of images do not intersect each other,
         sky will be matched only within each subset and the "inter-subset"
         sky mismatch could be significant.
@@ -456,8 +459,14 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
 #     for i in range(ns):
 #         for j in range(i+1, ns):
 #             overlap = images[i].intersection(images[j])
-#             s1, w1, area1 = images[i].calc_sky(overlap=overlap, delta=apply_sky)
-#             s2, w2, area2 = images[j].calc_sky(overlap=overlap, delta=apply_sky)
+#             s1, w1, area1 = images[i].calc_sky(
+#                 overlap=overlap,
+#                 delta=apply_sky
+#             )
+#             s2, w2, area2 = images[j].calc_sky(
+#                 overlap=overlap,
+#                 delta=apply_sky
+#             )
 #             if area1 == 0.0 or area2 == 0.0 or s1 is None or s2 is None:
 #                 continue
 #             A[j,i] = s1

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -35,7 +35,8 @@ __all__ = ['SkyMatchStep']
 
 class SkyMatchStep(Step):
     """
-    SkyMatchStep: Subtraction or equalization of sky background in science images.
+    SkyMatchStep: Subtraction or equalization of sky background in science
+    images.
     """
 
     class_alias = "skymatch"
@@ -58,7 +59,7 @@ class SkyMatchStep(Step):
         lsigma = float(min=0.0, default=4.0) # Lower clipping limit, in sigma
         usigma = float(min=0.0, default=4.0) # Upper clipping limit, in sigma
         binwidth = float(min=0.0, default=0.1) # Bin width for 'mode' and 'midpt' `skystat`, in sigma
-    """
+    """  # noqa: E501
 
     reference_file_types = []
 
@@ -67,7 +68,9 @@ class SkyMatchStep(Step):
         # for now turn off memory optimization until we have better machinery
         # to handle outputs in a consistent way.
         self._is_asn = False
-        # self._is_asn = datamodels.util.is_association(input) or isinstance(input, str)
+        # self._is_asn = (
+        #     datamodels.util.is_association(input) or isinstance(input, str)
+        # )
 
         img = ModelContainer(
             input,

--- a/jwst/skymatch/skystatistics.py
+++ b/jwst/skymatch/skystatistics.py
@@ -109,15 +109,16 @@ cgi-bin/gethelp.cgi?gstatistics>`_
         Parameters
         -----------
         data : numpy.ndarray
-            A numpy array of values for which the statistics needs to be computed.
+            A numpy array of values for which the statistics needs to be
+            computed.
 
         Returns
         --------
         statistics : tuple
-            A tuple of two values: (`skyvalue`, `npix`), where `skyvalue` is the statistics
-            specified by the `skystat` parameter during the initialization
-            of the `SkyStats` object and `npix` is the number of pixels used
-            in computing the statistics reported in `skyvalue`.
+            A tuple of two values: (`skyvalue`, `npix`), where `skyvalue` is
+            the statistics specified by the `skystat` parameter during the
+            initialization of the `SkyStats` object and `npix` is the number
+            of pixels used in computing the statistics reported in `skyvalue`.
 
         """
         imstat = ImageStats(image=data, fields=self._fields,


### PR DESCRIPTION
This PR simply addresses PEP8 issues and also comments out `_calc_sky_orig` function (I just do not have time at this moment to test whether this code can be safely restored. I will do this later but I want to keep it here for convenience.)

I expect no changes to any tests. Most PEP8 issues were line length.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression test is running here: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/636/
