### PR TITLE
Fix srctype docs

### DIFF
--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -55,7 +55,7 @@ TSO exposures. The instrument mode abbreviations used in the table are as follow
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
 | :ref:`extract_2d <extract_2d_step>`\ :sup:`1`            | |c| | |c| |     |     |     |     |      | |c|  |  |c|   | |c| |
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
-| :ref:`srctype <srctype_step>`\ :sup:`1`                  | |c| | |c| | |c| | |c| | |c| | |c| |  |c| |      |        | |c| |
+| :ref:`srctype <srctype_step>`\ :sup:`1`                  | |c| | |c| | |c| | |c| | |c| | |c| |  |c| | |c|  |  |c|   | |c| |
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
 | :ref:`master_background <master_background_step>`        |     | |c| |     |     |     |     |      |      |        |     |
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+------+------+--------+-----+
@@ -87,7 +87,7 @@ TSO exposures. The instrument mode abbreviations used in the table are as follow
 :sup:`1`\ The exact order of the :ref:`extract_2d <extract_2d_step>`, :ref:`srctype <srctype_step>`,
 and :ref:`flat_field <flatfield_step>` steps depends on the observing mode.
 For NIRISS and NIRCam WFSS, as well as NIRCam TSO grism exposures, the order is
-flat_field followed by extract_2d (no wavecorr or srctype).
+flat_field, extract_2d, and srctype (no wavecorr).
 For all other modes the order is extract_2d, srctype, wavecorr, and flat_field.
 
 :sup:`2`\ By default the :ref:`residual_fringe <residual_fringe_step>` is skipped in the ``calwebb_spec2`` pipeline. 

--- a/docs/jwst/srctype/description.rst
+++ b/docs/jwst/srctype/description.rst
@@ -135,6 +135,6 @@ NIRCam and NIRISS WFSS
 ++++++++++++++++++++++
 It is not possible to specify ahead of time the source types for spectra that
 may show up in a Wide-Field Slitless Spectroscopy exposure. So for these modes
-the ``srctype`` step simply sets the SRCTYPE keyword value to "UNKNOWN" and the
-actual source sizes are derived from the catalog information generated
-from direct images that are obtained as part of a WFSS observation.
+the ``srctype`` step uses the value from the ``is_extended`` column of the
+source catalog generated from the direct imaging taken with WFSS observations
+and uses that to set "POINT" or "EXTENDED" for each extracted source.


### PR DESCRIPTION
This PR fixes the docs for the calwebb_spec2 pipeline and the srctype step to indicate that srctype *is* applied to WFSS exposures (error in docs pointed out by an INS user on Slack).

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
