### PR TITLE
JP-3156: Fix SOSS-specific spec_table unit labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,12 @@ other
 - Remove use of deprecated ``pytest-openfiles`` plugin. This has been replaced by
   catching ``ResourceWarning``s. [#7526]
 
+photom
+------
+
+- Label spectral data units for NIRISS SOSS as MJy, to be consistent with
+  ``PHOTMJ`` scalar conversion factor and other point-source spectral data [#7538]
+
 resample_spec
 -------------
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -879,16 +879,16 @@ class DataSet():
             spec.spec_table.BKGD_VAR_POISSON *= conversion ** 2.
             spec.spec_table.BKGD_VAR_RNOISE *= conversion ** 2.
             spec.spec_table.BKGD_VAR_FLAT *= conversion ** 2.
-            spec.spec_table.columns['FLUX'].unit = 'Jy'
-            spec.spec_table.columns['FLUX_ERROR'].unit = 'Jy'
-            spec.spec_table.columns['FLUX_VAR_POISSON'].unit = 'Jy^2'
-            spec.spec_table.columns['FLUX_VAR_RNOISE'].unit = 'Jy^2'
-            spec.spec_table.columns['FLUX_VAR_FLAT'].unit = 'Jy^2'
-            spec.spec_table.columns['BACKGROUND'].unit = 'Jy'
-            spec.spec_table.columns['BKGD_ERROR'].unit = 'Jy'
-            spec.spec_table.columns['BKGD_VAR_POISSON'].unit = 'Jy^2'
-            spec.spec_table.columns['BKGD_VAR_RNOISE'].unit = 'Jy^2'
-            spec.spec_table.columns['BKGD_VAR_FLAT'].unit = 'Jy^2'
+            spec.spec_table.columns['FLUX'].unit = 'MJy'
+            spec.spec_table.columns['FLUX_ERROR'].unit = 'MJy'
+            spec.spec_table.columns['FLUX_VAR_POISSON'].unit = 'MJy^2'
+            spec.spec_table.columns['FLUX_VAR_RNOISE'].unit = 'MJy^2'
+            spec.spec_table.columns['FLUX_VAR_FLAT'].unit = 'MJy^2'
+            spec.spec_table.columns['BACKGROUND'].unit = 'MJy'
+            spec.spec_table.columns['BKGD_ERROR'].unit = 'MJy'
+            spec.spec_table.columns['BKGD_VAR_POISSON'].unit = 'MJy^2'
+            spec.spec_table.columns['BKGD_VAR_RNOISE'].unit = 'MJy^2'
+            spec.spec_table.columns['BKGD_VAR_FLAT'].unit = 'MJy^2'
 
         else:
             if not self.inverse:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3156](https://jira.stsci.edu/browse/JP-3156)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an inconsistency noted between PHOTMJ photom scalar conversion units and the unit labels in the spec_table output for NIRISS SOSS data. To keep the units consistent across exposure types, the correction applied here is to the labels, to consistently store spectral point-source data in units of MJy rather than Jy.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
