### PR TITLE
Update regtest tolerances for Mac differences

### DIFF
--- a/jwst/regtest/test_miri_coron3.py
+++ b/jwst/regtest/test_miri_coron3.py
@@ -30,7 +30,8 @@ def test_miri_coron3_sci_exp(run_pipeline, suffix, exposure, fitsdiff_default_kw
     rtdata.output = output
     rtdata.get_truth("truth/test_miri_coron3/" + output)
 
-    fitsdiff_default_kwargs["atol"] = 1e-5
+    fitsdiff_default_kwargs["atol"] = 1e-2
+    fitsdiff_default_kwargs["rtol"] = 1e-2
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
@@ -45,6 +46,7 @@ def test_miri_coron3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
     rtdata.output = output
     rtdata.get_truth("truth/test_miri_coron3/" + output)
 
-    fitsdiff_default_kwargs['atol'] = 1e-5
+    fitsdiff_default_kwargs['atol'] = 5e-3
+    fitsdiff_default_kwargs["rtol"] = 1e-3
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_residual_fringe.py
+++ b/jwst/regtest/test_miri_residual_fringe.py
@@ -26,5 +26,6 @@ def test_residual_fringe_cal(rtdata, fitsdiff_default_kwargs):
 
     rtdata.get_truth(f"truth/test_miri_residual_fringe/{output}")
 
+    fitsdiff_default_kwargs["rtol"] = 3e-2
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -186,6 +186,7 @@ def test_image3_closedfile(run_image3_closedfile, rtdata, fitsdiff_default_kwarg
     rtdata.output = 'jw00617-o082_t001_nircam_clear-f090w-sub320_i2d.fits'
     rtdata.get_truth('truth/test_nircam_image/jw00617-o082_t001_nircam_clear-f090w-sub320_i2d.fits')
 
+    fitsdiff_default_kwargs["rtol"] = 5e-3
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 

--- a/jwst/regtest/test_nircam_mtimage.py
+++ b/jwst/regtest/test_nircam_mtimage.py
@@ -16,7 +16,7 @@ def test_nircam_image_moving_target_i2d(rtdata, fitsdiff_default_kwargs):
     Step.from_cmdline(args)
     rtdata.get_truth("truth/test_nircam_mtimage/mt_assoc_i2d.fits")
 
-    fitsdiff_default_kwargs["atol"] = 1e-5
+    fitsdiff_default_kwargs["atol"] = 4e-5
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -122,5 +122,6 @@ def test_niriss_soss_extras(rtdata_module, run_atoca_extras, fitsdiff_default_kw
 
     rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
 
+    fitsdiff_default_kwargs["rtol"] = 1e-3
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -43,6 +43,8 @@ def run_spec2(jail, rtdata_module):
 )
 def test_spec2(run_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test matching output files"""
+    fitsdiff_default_kwargs["rtol"] = 5e-5
+    fitsdiff_default_kwargs["atol"] = 2e-6
     rt.is_like_truth(run_spec2, fitsdiff_default_kwargs, suffix,
                      truth_path=TRUTH_PATH)
 

--- a/jwst/regtest/test_nirspec_ifu_spec3.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3.py
@@ -44,6 +44,7 @@ def run_spec3_multi(jail, rtdata_module):
 )
 def test_spec3_multi(run_spec3_multi, fitsdiff_default_kwargs, output):
     """Regression test matching output files"""
+    fitsdiff_default_kwargs["rtol"] = 2e-3
     rt.is_like_truth(
         run_spec3_multi, fitsdiff_default_kwargs, output,
         truth_path=TRUTH_PATH,

--- a/jwst/regtest/test_nirspec_masterbackground.py
+++ b/jwst/regtest/test_nirspec_masterbackground.py
@@ -94,6 +94,7 @@ def test_masterbkg_corrpars(rtdata):
 def test_nirspec_mos_mbkg(suffix, run_spec2_mbkg, fitsdiff_default_kwargs):
     """Run spec2 with master background"""
     rtdata = run_spec2_mbkg
+    fitsdiff_default_kwargs["rtol"] = 3e-4
     rt.is_like_truth(rtdata, fitsdiff_default_kwargs, suffix, truth_path='truth/test_nirspec_mos_mbkg')
 
 

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -50,5 +50,6 @@ def test_nirspec_mos_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     rtdata.get_truth("truth/test_nirspec_mos_spec2/" + output)
 
     # Compare the results
+    fitsdiff_default_kwargs["rtol"] = 3e-5
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()


### PR DESCRIPTION
This PR updates or adds tolerances to some of the regression tests, in order to allow Mac runs to pass, because we routinely see numerical differences between Linux and Mac runs.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
