### PR TITLE
Enable memory saving code in skymatch

### DIFF
--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -18,7 +18,7 @@ from astropy.nddata.bitmask import (
 )
 
 from stdatamodels.jwst.datamodels.dqflags import pixel
-from stdatamodels.jwst.datamodels.util import open as datamodel_open
+from stdatamodels.jwst.datamodels.util import open as datamodel_open, is_association
 
 from jwst.datamodels import ModelContainer
 
@@ -63,14 +63,23 @@ class SkyMatchStep(Step):
 
     reference_file_types = []
 
+    def __init__(self, *args, **kwargs):
+        minimize_memory = kwargs.pop('minimize_memory', False)
+        super().__init__(*args, **kwargs)
+        self.minimize_memory = minimize_memory
+
     def process(self, input):
         self.log.setLevel(logging.DEBUG)
         # for now turn off memory optimization until we have better machinery
         # to handle outputs in a consistent way.
-        self._is_asn = False
-        # self._is_asn = (
-        #     datamodels.util.is_association(input) or isinstance(input, str)
-        # )
+
+        if hasattr(self, 'minimize_memory') and self.minimize_memory:
+            self._is_asn = (
+                is_association(input) or isinstance(input, str)
+            )
+
+        else:
+            self._is_asn = False
 
         img = ModelContainer(
             input,


### PR DESCRIPTION
This PR enables memory saving code in the `skymatch` step first introduced in https://github.com/spacetelescope/jwst/pull/6874. Unfortunately, I do not think that the pipeline allows steps to pass ASN file names as inputs and outputs and so that memory-saving code was disabled in https://github.com/spacetelescope/jwst/pull/6922.

Unfortunately, the way the code was disabled does not allow for the memory-saving code to be covered by unit tests.

This PR allows enabling this code at the time of step object initialization but it is still disabled by default and there is no step argument to enable it. However, this change allows unit testing and experimental usage of this feature for development purpose.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
