### PR TITLE
Remove `codecov` dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ other
 - Remove use of deprecated ``pytest-openfiles`` plugin. This has been replaced by
   catching ``ResourceWarning``s. [#7526]
 
+- Remove use of ``codecov`` package. [#7543]
+
 photom
 ------
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -89,7 +89,9 @@ bc0.test_cmds = [
     --env=${artifactoryenv} ${pytest_args}",
     // The following line needs single quotes to avoid insecure interpolation
     // of the codecov_token
-    'codecov --token=${codecov_token} -F nightly',
+    "curl -Os https://uploader.codecov.io/latest/linux/codecov",
+    "chmod +x codecov",
+    './codecov --token=${codecov_token} -F nightly',
 ]
 bc0.test_configs = [data_config]
 bc0.failedFailureThresh = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,6 @@ sdp =
     pysiaf>=0.13.0
 test =
     ci-watson>=0.5.0
-    codecov>=1.6.0
     colorama>=0.4.1
     readchar>=3.0
     ruff


### PR DESCRIPTION
`codecov` was yanked from PyPi the morning of April 12, 2023. This is causing installs for testing `jwst` to fail. This PR is an attempt to fix that.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [N/A] ~updated or added relevant tests~
- [N/A] ~updated relevant documentation~
- [N/A] ~added relevant milestone~
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [N/A] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
