### PR TITLE
disable MacOS regression tests on Jenkins

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -79,6 +79,7 @@ bc0.build_cmds = [
     "pip install certifi -U --force-reinstall",
     "pip install -e .[test,sdp] --no-cache-dir",
     "pip install pytest-xdist",
+    "pip install -r requirements-sdp.txt",
     "pip freeze",
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -100,19 +100,7 @@ bc0.failedFailureThresh = 0
 bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-stable-deps'
-bc1.build_cmds = [
-    "pip install certifi -U --force-reinstall",
-    "pip install -e .[test,sdp] --no-cache-dir",
-    "pip install git+https://github.com/spacetelescope/stdatamodels.git@master git+https://github.com/spacetelescope/stcal.git@main",
-    "pip install pytest-xdist",
-    "pip freeze",
-]
-bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
-// bc1.test_cmds = [
-    // "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
-    // --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
-    // --env=${artifactoryenv} ${pytest_args}",
-// ]
+bc1.test_cmds = []
 bc1.test_configs = []
 
 utils.run([jobconfig, bc0, bc1])

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -78,7 +78,6 @@ bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
     "pip install certifi -U --force-reinstall",
     "pip install -e .[test,sdp] --no-cache-dir",
-    "pip install git+https://github.com/spacetelescope/stdatamodels.git@master git+https://github.com/spacetelescope/stcal.git@main",
     "pip install pytest-xdist",
     "pip freeze",
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -108,11 +108,11 @@ bc1.build_cmds = [
     "pip freeze",
 ]
 bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
-bc1.test_cmds = [
-    "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
-    --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
-    --env=${artifactoryenv} ${pytest_args}",
-]
+// bc1.test_cmds = [
+    // "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
+    // --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
+    // --env=${artifactoryenv} ${pytest_args}",
+// ]
 bc1.test_configs = []
 
 utils.run([jobconfig, bc0, bc1])

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -103,11 +103,6 @@ bc1.build_cmds = [
     "pip freeze",
 ]
 bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
-bc1.test_cmds = [
-    "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
-    --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
-    --env=${artifactoryenv} ${pytest_args}",
-]
 bc1.test_configs = []
 
 utils.run([jobconfig, bc0, bc1])

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -79,6 +79,7 @@ bc0.build_cmds = [
     "pip install certifi -U --force-reinstall",
     "pip install -e .[test,sdp] --no-cache-dir",
     "pip install pytest-xdist",
+    "pip install -r requirements-dev.txt",
     "pip freeze",
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -95,15 +95,6 @@ bc0.test_configs = [data_config]
 bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-unstable-deps'
-bc1.pip_reqs_files = ['requirements-dev.txt']
-bc1.build_cmds = [
-    "pip install certifi -U --force-reinstall",
-    "pip install -e .[test,sdp] --no-cache-dir",
-    "pip install pytest-xdist",
-    "pip freeze",
-]
-bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
-bc1.test_configs = []
 
 utils.run([jobconfig, bc0, bc1])
 }  // withCredentials


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
MacOS regression tests have numerical differences from the Linux ones; additionally, the Boyle Jenkins machine is currently unstable.

**Checklist for maintainers**
- [N/A] ~added entry in `CHANGES.rst` within the relevant release section~
- [N/A] ~updated or added relevant tests~
- [N/A] ~updated relevant documentation~
- [N/A] ~added relevant milestone~
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [N/A] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
