### PR TITLE
re-add latest-commit installs of stdatamodels and stcal

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -79,6 +79,8 @@ bc0.build_cmds = [
     "pip install certifi -U --force-reinstall",
     "pip install -e .[test,sdp] --no-cache-dir",
     "pip install pytest-xdist",
+    // these latest-commit installs are overridden by `requirements-sdp.txt` if it is populated
+    "pip install git+https://github.com/spacetelescope/stdatamodels.git@master git+https://github.com/spacetelescope/stcal.git@main",
     "pip install -r requirements-sdp.txt",
     "pip freeze",
 ]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the discrepancies in truth files from the change in #7544 ; it appears that using an additional call to `pip install -r requirements-sdp.txt` within the build command is a valid workaround for the previously stated issue.

**Checklist for maintainers**
- [N/A] added entry in `CHANGES.rst` within the relevant release section
- [N/A] updated or added relevant tests
- [N/A] updated relevant documentation
- [N/A] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [N/A] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
