### PR TITLE
SCSB-63 inject dependency overrides after build

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -84,7 +84,7 @@ bc0.build_cmds = [
     "pip install -r requirements-sdp.txt",
     "pip freeze",
 ]
-bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
+bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -82,7 +82,7 @@ bc0.build_cmds = [
     "pip install -r requirements-dev.txt",
     "pip freeze",
 ]
-bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
+bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS) 
 bc0.test_cmds = [
     "pytest -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [SCSB-63](https://jira.stsci.edu/browse/SCSB-63)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue where override requirements were overridden themselves during the Jenkins regression test build.

**Checklist for maintainers**
- [N/A] ~added entry in `CHANGES.rst` within the relevant release section~
- [N/A] ~updated or added relevant tests~
- [N/A] ~updated relevant documentation~
- [N/A] ~added relevant milestone~
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [N/A] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
