### PR TITLE
List pip environment prior to running regression tests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -86,6 +86,7 @@ bc0.build_cmds = [
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc0.test_cmds = [
+    "pip list",
     "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -84,6 +84,7 @@ bc0.build_cmds = [
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS) 
 bc0.test_cmds = [
+    "pip list",
     "pytest -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",


### PR DESCRIPTION
Currently the regression test log shows installs after the `pip freeze`. This makes it so that it is difficult to determine the dependency state for the actual regression tests.

This PR adds a `pip list` to output a nicely formatted pip environment table as part of running the actual tests.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
