### PR TITLE
JP-3047 Change how NIRSpec wavelengths are set in ifucube

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,13 @@
 1.10.3 (unreleased)
 ===================
 
+
 datamodels
 ----------
 
 - Removed use of deprecated ``stdatamodels.jwst.datamodels.DataModel`` class from
   all steps and replaced it with ``stdatamodels.jwst.datamodels.JwstDataModel``. [#7571]
+
 
 documentation
 -------------
@@ -25,6 +27,13 @@ flat_field
 ----------
 
 - Refactored NIRSpec 1D flat interpolation for improved performance. [#7550]
+
+
+cube_build
+----------
+- Wavelength range of NIRSpec IFU cubes are set by cubepars reference file and
+  a new cubepars reference file with wavelength arrays for drizzle implemented. [#7559]
+  
 
 other
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ flat_field
 cube_build
 ----------
 - Wavelength range of NIRSpec IFU cubes are set by cubepars reference file and
-  a new cubepars reference file with wavelength arrays for drizzle implemented. [#7559]
+  a new cubepars reference file with wavelength arrays for drizzle is implemented. [#7559]
   
 
 other

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -131,7 +131,6 @@ def read_cubepars(par_filename,
     elif instrument == 'NIRSPEC':
         with datamodels.NirspecIFUCubeParsModel(par_filename) as ptab:
             number_gratings = len(all_grating)
-
             for i in range(number_gratings):
                 this_gwa = all_grating[i]
                 this_filter = all_filter[i]
@@ -142,13 +141,11 @@ def read_cubepars(par_filename,
                     table_spectralstep = tabdata['SPECTRALSTEP']
                     table_wavemin = tabdata['WAVEMIN']
                     table_wavemax = tabdata['WAVEMAX']
-
                     if this_gwa == table_grating and this_filter == table_filter:
                         instrument_info.SetSpatialSize(table_spaxelsize, this_gwa, this_filter)
                         instrument_info.SetSpectralStep(table_spectralstep, this_gwa, this_filter)
                         instrument_info.SetWaveMin(table_wavemin, this_gwa, this_filter)
                         instrument_info.SetWaveMax(table_wavemax, this_gwa, this_filter)
-
                 #  modified Shepard method 1/r weighting
                 if weighting == 'msm':
                     for tabdata in ptab.ifucubepars_msm_table:
@@ -234,6 +231,19 @@ def read_cubepars(par_filename,
                     instrument_info.SetHighEMSMTable(table_wave, table_sroi,
                                                      table_wroi, table_scalerad)
 
+            elif weighting == 'drizzle':
+                # TODO when we get a new cubepars reference file with wavelength
+                # arrays for Drizzle replace the table used with the one for drizzling
+                # For now just reuse the emsm wavetable
+                for tabdata in ptab.ifucubepars_prism_emsm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
+                    instrument_info.SetPrismDrizTable(table_wave)
+                for tabdata in ptab.ifucubepars_med_emsm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
+                    instrument_info.SetMedDrizTable(table_wave)
+                for tabdata in ptab.ifucubepars_high_emsm_wavetable:
+                    table_wave = tabdata['WAVELENGTH']
+                    instrument_info.SetHighDrizTable(table_wave)
 
             ptab.close()
             del ptab

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -242,6 +242,5 @@ def read_cubepars(par_filename,
                 for tabdata in ptab.ifucubepars_high_driz_wavetable:
                     table_wave = tabdata['WAVELENGTH']
                     instrument_info.SetHighDrizTable(table_wave)
-
             ptab.close()
             del ptab

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -130,7 +130,6 @@ def read_cubepars(par_filename,
     # Read in NIRSPEC Values
     elif instrument == 'NIRSPEC':
         with datamodels.NirspecIFUCubeParsModel(par_filename) as ptab:
-            print(par_filename)
             number_gratings = len(all_grating)
             for i in range(number_gratings):
                 this_gwa = all_grating[i]

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -130,6 +130,7 @@ def read_cubepars(par_filename,
     # Read in NIRSPEC Values
     elif instrument == 'NIRSPEC':
         with datamodels.NirspecIFUCubeParsModel(par_filename) as ptab:
+            print(par_filename)
             number_gratings = len(all_grating)
             for i in range(number_gratings):
                 this_gwa = all_grating[i]
@@ -232,16 +233,13 @@ def read_cubepars(par_filename,
                                                      table_wroi, table_scalerad)
 
             elif weighting == 'drizzle':
-                # TODO when we get a new cubepars reference file with wavelength
-                # arrays for Drizzle replace the table used with the one for drizzling
-                # For now just reuse the emsm wavetable
-                for tabdata in ptab.ifucubepars_prism_emsm_wavetable:
+                for tabdata in ptab.ifucubepars_prism_driz_wavetable:
                     table_wave = tabdata['WAVELENGTH']
                     instrument_info.SetPrismDrizTable(table_wave)
-                for tabdata in ptab.ifucubepars_med_emsm_wavetable:
+                for tabdata in ptab.ifucubepars_med_driz_wavetable:
                     table_wave = tabdata['WAVELENGTH']
                     instrument_info.SetMedDrizTable(table_wave)
-                for tabdata in ptab.ifucubepars_high_emsm_wavetable:
+                for tabdata in ptab.ifucubepars_high_driz_wavetable:
                     table_wave = tabdata['WAVELENGTH']
                     instrument_info.SetHighDrizTable(table_wave)
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1340,12 +1340,14 @@ class IFUCubeData():
         final_b_max = max(corner_b)
 
         log.debug(f'final a and b:{final_a_min, final_b_min, final_a_max, final_b_max}')
-        log.debug(f'final wave using data:   {min(lambda_min), max(lambda_max)}')
+        log.debug(f' min and max wavelengths:   {min(lambda_min), max(lambda_max)}')
         # ______________________________________________________________________
         # the wavelength limits of cube are determined from 1. User or 2. cubepars
         # reference file (in the priority)
         final_lambda_min = self.wavemin
         final_lambda_max = self.wavemax
+
+        log.debug(f' final min and max used in IFUcube:   {final_lambda_min), final_lambda_max)}')
 
         if self.instrument == 'MIRI' and self.coord_system == 'internal_cal':
             #  we have a 1 to 1 mapping in y across slice  dimension

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1347,7 +1347,7 @@ class IFUCubeData():
         final_lambda_min = self.wavemin
         final_lambda_max = self.wavemax
 
-        log.debug(f' final min and max used in IFUcube:   {final_lambda_min), final_lambda_max)}')
+        log.debug(f' final min and max used in IFUcube:   {final_lambda_min, final_lambda_max}')
 
         if self.instrument == 'MIRI' and self.coord_system == 'internal_cal':
             #  we have a 1 to 1 mapping in y across slice  dimension

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -941,6 +941,7 @@ class IFUCubeData():
 
             a_scale, b_scale, w_scale = self.instrument_info.GetScale(par1,
                                                                       par2)
+
             spaxelsize[i] = a_scale
             spectralsize[i] = w_scale
             minwave[i] = self.instrument_info.GetWaveMin(par1, par2)
@@ -1339,23 +1340,13 @@ class IFUCubeData():
         final_b_max = max(corner_b)
 
         log.debug(f'final a and b:{final_a_min, final_b_min, final_a_max, final_b_max}')
-        log.debug(f'final wave:   {min(lambda_min), max(lambda_max)}')
-
-        # for MIRI wavelength range read in from cube pars reference file
-        if self.instrument == 'MIRI':
-            final_lambda_min = self.wavemin
-            final_lambda_max = self.wavemax
-
-        # for NIRSPec wavelength range determined from the data
-        if self.instrument == 'NIRSPEC':
-            final_lambda_min = min(lambda_min)
-            final_lambda_max = max(lambda_max)
-            if self.wavemin_user:
-                final_lambda_min = self.wavemin
-
-            if self.wavemax_user:
-                final_lambda_max = self.wavemax
+        log.debug(f'final wave using data:   {min(lambda_min), max(lambda_max)}')
         # ______________________________________________________________________
+        # the wavelength limits of cube are determined from 1. User or 2. cubepars
+        # reference file (in the priority)
+        final_lambda_min = self.wavemin
+        final_lambda_max = self.wavemax
+
         if self.instrument == 'MIRI' and self.coord_system == 'internal_cal':
             #  we have a 1 to 1 mapping in y across slice  dimension
             nslice = self.instrument_info.GetNSlice(parameter1[0])

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -766,6 +766,30 @@ class InstrumentInfo():
         self.high_softrad.append(None)
         self.high_power.append(None)
 
+    def SetPrismDrizTable(self, wave):
+        self.prism_wavelength.append(wave)
+        self.prism_sroi.append(None)
+        self.prism_wroi.append(None)
+        self.prism_scalerad.append(None)
+        self.prism_power.append(None)
+        self.prism_softrad.append(None)
+
+    def SetMedDrizTable(self, wave):
+        self.med_wavelength.append(wave)
+        self.med_sroi.append(None)
+        self.med_wroi.append(None)
+        self.med_scalerad.append(None)
+        self.med_power.append(None)
+        self.med_softrad.append(None)
+
+    def SetHighDrizTable(self, wave):
+        self.high_wavelength.append(wave)
+        self.high_sroi.append(None)
+        self.high_wroi.append(None)
+        self.high_scalerad.append(None)
+        self.high_power.append(None)
+        self.high_softrad.append(None)
+
     def SetXSliceLimits(self, x1, x2, parameter1):
         self.Info[parameter1]['xstart'] = x1
         self.Info[parameter1]['xend'] = x2


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves  part 2 of [JP-3047](https://jira.stsci.edu/browse/JP-3047) (Homogenize the use of the wavemin/wavemax parameters defining output cubes between MIRI and NIRSpec. ....NIRSpec to use cubepar to define default wavelength ranges.)


<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

NOTE an update to stdatamodels (#162) is required to be merged before this PR is merged. Stdatamodels PR 162 updated the NIRSpec cubepar data model to read in 3 wavelength arrays when the drizzle weighting method is used. In order to use this updated stdatamodels the requirement in the jwst package that stdatamodels could be higher than 1.4.0 was removed from
requirements-max.txt

Also **before this PR can be merged** the new NIRSpec cubepars reference file need to delivered to CRDS.

<!-- describe the changes comprising this PR here -->
This PR modifies cube_build to use data from the cubepars reference file to define the wavelength ranges of the NIRSpec IFU cubes. Before, the wavelength range was determined from the data.   The NIRSpec team has delivered a new cubepar reference file with  a wavelength array for the PRISM, MEDIUM, and HIGH resolution gratings for the weighting method of drizzle. Currently these wavelength arrays are only needed if data from multiple gratings  (of the same resolution) are combined.  NIRSpec associations are by default only made from 1 grating. But the user can make associations contain multiple gratings and adding the wavelength arrays for the drizzle method to cubepars  allows the code to run if in the future the associations are made from multiple gratings.  


**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests - ran unit tests and all passed.
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
