### PR TITLE
JP-3221: Fixing Segment Length Computation Needed for Optimal Weighting

### DIFF
--- a/jwst/ramp_fitting/tests/test_ramp_fit_cases.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_cases.py
@@ -343,12 +343,13 @@ def test_pix_8():
         'OLS', 'optimal', 'none', test_dq_flags)
 
     # Set truth values for PRIMARY results:
-    p_true = [1.0101178, JUMP, 0.1848883, 0.00363636, 0.03054732]
+    p_true = [0.98561335, JUMP, 0.1848883, 0.00363636, 0.03054732]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.0101178, 12.385354, 0.00363636, 0.03054732, 16.508228,
-              40.81897, 4.898822, 855.78046]
+    o_true = [0.98561335, 9.920554, 0.00363636, 0.03054732, 16.508228,
+              39.383667, 5.1438665, 855.78046]
 
+    # XXX
     assert_pri(p_true, new_mod, 0)
     assert_opt(o_true, opt_mod, 0)
 


### PR DESCRIPTION
… lengths.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3221](https://jira.stsci.edu/browse/JP-3221)

<!-- describe the changes comprising this PR here -->
This PR addresses the computation of segment lengths for the purposes of optimal weighting.  Originally, this was done by counting the non-zero groups in an integration ramp of the masked data.  The masked data was created by multiplying a boolean array where contiguous `True` values defined the current segment being computed.  This multiplication had the side effect that `np.nan * False = np.nan`, so NaN groups were incorrectly being included in the computation of the number of groups in a segment.

Specifically, a test ramp with the group DQ flags as follows:

GDQ: [0, 0, 0, 4, 0, 0, 0, 0, 2, 2] (where 4 is JUMP_DET and 2 is SATURATED)

resulted in two segments, [0, 2] and [3, 7].  Because groups flagged as SATURATED have SCI data set to NaN, the last two groups are erroneously included in the computation of the length of each group.  Instead of computing two segments of length 3 and 5, the segment lengths were computed as 4 and 7.

The computation of the segment length is now changed to consider only the mask, which, as mentioned, is a boolean array with contiguous `True` values denoting the groups of a segment.

This PR will affect regression tests, since there are pixels with saturated groups in ramps.  JWST regression tests have been run locally using the `-k rate` filter and the tests showing differences in outputted data and the truth table show differences in pixels that have saturated ramps, as expected.

This PR should not be merged before the related STCAL PR https://github.com/spacetelescope/stcal/pull/163

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
