### PR TITLE
JP-2256: Apply median filter to IVM weight

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1208,6 +1208,10 @@ tweakreg
 - Added the 'GAIADR3' catalog to the available options for alignment;
   this has been enabled as the default option [#7611].
 
+- Apply median filtering to IVM weight array to better handle saturated
+  pixels. Added option of 'ivm-med', 'ivm-smed' (recommended default) to the
+  ``weight_type`` argument of ``ResampleStep``. [#7563]
+
 
 1.10.2 (2023-04-14)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 1.14.1 (unreleased)
 ===================
 
-- 
+resample
+--------
+
+- Apply a median filter to IVM weight array to better handle saturated
+  pixels. [#7563]
+
 
 1.14.0 (2024-03-29)
 ===================
@@ -17,7 +22,7 @@ ami
 - Additional optional input arguments for greater user processing flexibility.
   See documentation for details. [#7862]
 
-- Bad pixel correction applied to data using new NRM reference file to calculate 
+- Bad pixel correction applied to data using new NRM reference file to calculate
   complex visibility support (M. Ireland method implemented by J. Kammerer). [#7862]
 
 - Make ``AmiAnalyze`` and ``AmiNormalize`` output conform to the OIFITS standard. [#7862]
@@ -53,7 +58,7 @@ charge_migration
   as DO_NOT_USE.  This group, and all subsequent groups, are then flagged as
   CHARGELOSS and DO_NOT_USE.  The four nearest pixel neighbor are then flagged
   in the same group. [#8336]
-  
+
 - Added warning handler for expected NaN and inf clipping in the
   ``sigma_clip`` function. [#8320]
 
@@ -340,7 +345,7 @@ tweakreg
 
 - Fixed a bug that caused failures instead of warnings when no GAIA sources
   were found within the bounding box of the input image. [#8334]
-  
+
 - Suppress AstropyUserWarnings regarding NaNs in the input data. [#8320]
 
 wfs_combine
@@ -902,6 +907,7 @@ resample
 
 - Update the following exposure time keywords: XPOSURE (EFFEXPTM),
   DURATION and TELAPSE. [#7793]
+
 
 residual_fringe
 ---------------

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -46,7 +46,7 @@ class ResampleStep(Step):
         pixfrac = float(default=1.0) # change back to None when drizpar reference files are updated
         kernel = string(default='square') # change back to None when drizpar reference files are updated
         fillval = string(default='INDEF' ) # change back to None when drizpar reference files are updated
-        weight_type = option('ivm', 'exptime', None, default='ivm')  # change back to None when drizpar ref update
+        weight_type = option('ivm', 'ivm-med', 'ivm-smed', 'exptime', None, default='ivm-smed')  # change back to None when drizpar ref update
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -58,7 +58,7 @@ class ResampleStep(Step):
         blendheaders = boolean(default=True)
         allowed_memory = float(default=None)  # Fraction of memory to use for the combined image.
         in_memory = boolean(default=True)
-    """
+    """  # noqa: E501
 
     reference_file_types = ['drizpars']
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -2,19 +2,10 @@ from copy import deepcopy
 import logging
 import warnings
 
-import numpy as np
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-from scipy.signal import medfilt2d
-=======
-from scipy.ndimage import median_filter
->>>>>>> 375ca0dd5 (Add selective median filtering of only saturated data)
-from astropy import wcs as fitswcs
-from astropy.modeling import Model
->>>>>>> bb7888e38 (Apply median filter to IVM weight)
-from astropy import units as u
 import gwcs
+import numpy as np
+from scipy.ndimage import median_filter
+from astropy import units as u
 
 from stdatamodels.dqflags import interpret_bit_flags
 from stdatamodels.jwst.datamodels.dqflags import pixel

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -3,6 +3,12 @@ import logging
 import warnings
 
 import numpy as np
+<<<<<<< HEAD
+=======
+from scipy.signal import medfilt2d
+from astropy import wcs as fitswcs
+from astropy.modeling import Model
+>>>>>>> bb7888e38 (Apply median filter to IVM weight)
 from astropy import units as u
 import gwcs
 
@@ -175,7 +181,14 @@ def build_driz_weight(model, weight_type=None, good_bits=None):
                 model.var_rnoise.shape == model.data.shape):
             with np.errstate(divide="ignore", invalid="ignore"):
                 inv_variance = model.var_rnoise**-1
+
             inv_variance[~np.isfinite(inv_variance)] = 1
+
+            # apply a median filter to smooth the weight at saturated
+            # (or high read-out noise) single pixels. keep kernel size
+            # small to still give lower weight to extended CRs, etc.
+            inv_variance = medfilt2d(inv_variance, kernel_size=3)
+
         else:
             warnings.warn("var_rnoise array not available. Setting drizzle weight map to 1",
                           RuntimeWarning)


### PR DESCRIPTION
Resolves [JP-2256](https://jira.stsci.edu/browse/JP-2256)

This PR addresses the issue of lower flux in saturated sources in resampled images when resampling is done using the IVM weighting. By applying median filtering to the weight mask we will be able to replace low weights of saturated pixels with a median value of the weight from neighbors (suggested by @schlafly).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
