### PR TITLE
JP-3218: Fix pathloss correction for NRS fixed-slit

### DIFF
--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -481,15 +481,6 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, cor
         slit.pathloss_point = correction.pathloss_point
         slit.pathloss_uniform = correction.pathloss_uniform
 
-        slit.data /= correction.data
-        slit.err /= correction.data
-        slit.var_poisson /= correction.data**2
-        slit.var_rnoise /= correction.data**2
-        if slit.var_flat is not None and np.size(slit.var_flat) > 0:
-            slit.var_flat /= correction.data**2
-        slit.pathloss_point = correction.pathloss_point
-        slit.pathloss_uniform = correction.pathloss_uniform
-
     # Set step status to complete
     data.meta.cal_step.pathloss = 'COMPLETE'
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3218](https://jira.stsci.edu/browse/JP-3218)


<!-- describe the changes comprising this PR here -->
This PR removes the double application of the pathloss correction factors for NIRSpec fixed-slit data reported in [JP-3218](https://jira.stsci.edu/browse/JP-3218). Looks like there was just a copy-n-paste error back when the "inverse" capability was added and the original lines of code were never deleted.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
