### PR TITLE
JP- 3163 nirspec for Point Source data saved in surface brightness 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,10 +15,10 @@ documentation
 - Update tutorial usage of ``jump.threshold`` to ``jump.rejection_threshold``. [#7572]
 
 
-extract_1d:
------------
-For NIRSpec IFU point source data remove options assuming data is in flux units. Treat these data
-the same as all other data and convert extracted values from surface brightness to flux. [#7569]
+extract_1d
+----------
+-For NIRSpec IFU point source data remove options assuming data is in flux units. Treat these data
+ the same as all other data and convert extracted values from surface brightness to flux. [#7569]
 
 
 flat_field

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,14 @@ documentation
 
 - Fix bugs in implementation of ``pixel_replace`` documentation. [#7565]
 
+
 - Update tutorial usage of ``jump.threshold`` to ``jump.rejection_threshold``. [#7572]
+
+extract_1d:
+-----------
+For NIRSpec IFU point source data remove options assuming data is in flux units. Treat these data
+the same as all other data and convert extracted values from surface brightness to flux. [#7569]
+
 
 flat_field
 ----------
@@ -34,6 +41,10 @@ pathloss
 
 - Bug fix for NIRSpec fixed-slit data to remove double application of correction
   factors. [#7566]
+
+photom
+------
+- For NIRSpec IFU point source data save data in units of surface brightness [#7569]
 
 ramp_fitting
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@ documentation
 
 - Fix bugs in implementation of ``pixel_replace`` documentation. [#7565]
 
-
 - Update tutorial usage of ``jump.threshold`` to ``jump.rejection_threshold``. [#7572]
+
 
 extract_1d:
 -----------

--- a/docs/jwst/cube_build/main.rst
+++ b/docs/jwst/cube_build/main.rst
@@ -28,11 +28,11 @@ Assumptions
 It is assumed that the ``assign_wcs`` step has been applied to the data, attaching the distortion and pointing
 information to the image(s). It is also assumed that the ``photom`` step has been applied to convert the pixel
 values from units of count rate to surface brightness. This step will only work with MIRI or NIRSpec IFU data.
-The cube_build algorithm is a flux conservation method and requires the input data to be in unit of surface brightness.
-The NIRSpec calibration plan for point source data is designed to produce units of flux from the calwebb_spec2 pipeline.
-For NIRSpec IFU point source data the calwebb_spec2 pipeline divide the flux values by a pixel area map to produce pseudo
+The cube_build algorithm is a flux conserving method and requires the input data to be in units of surface brightness.
+The NIRSpec calibration plan for point source data is designed to produce units of flux density from the calwebb_spec2 pipeline.
+For NIRSpec IFU point source data the calwebb_spec2 pipeline divides the flux values by a pixel area map to produce pseudo
 surface brightness units (MJy/steradian). This allows the cube_build program to conserve flux when it combines and resamples
-the data. True fluxes are produced only at the extract_1d step, in which a 1D spectrum is extracted from the cube using an
+the data. True fluxes are produced only at the :ref:`extract_1d_step <extract_1d_step>`, in which a 1D spectrum is extracted from the cube using an
 appropriate extraction aperture, with resulting units of Jy.
 
 Instrument Information

--- a/docs/jwst/cube_build/main.rst
+++ b/docs/jwst/cube_build/main.rst
@@ -28,6 +28,12 @@ Assumptions
 It is assumed that the ``assign_wcs`` step has been applied to the data, attaching the distortion and pointing
 information to the image(s). It is also assumed that the ``photom`` step has been applied to convert the pixel
 values from units of count rate to surface brightness. This step will only work with MIRI or NIRSpec IFU data.
+The cube_build algorithm is a flux conservation method and requires the input data to be in unit of surface brightness.
+The NIRSpec calibration plan for point source data is designed to produce units of flux from the calwebb_spec2 pipeline.
+For NIRSpec IFU point source data the calwebb_spec2 pipeline divide the flux values by a pixel area map to produce pseudo
+surface brightness units (MJy/steradian). This allows the cube_build program to conserve flux when it combines and resamples
+the data. True fluxes are produced only at the extract_1d step, in which a 1D spectrum is extracted from the cube using an
+appropriate extraction aperture, with resulting units of Jy.
 
 Instrument Information
 ----------------------

--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -134,7 +134,7 @@ It then uses the scalar conversion constant, the 1-D wavelength and relative
 response, and pixel area data to compute a 2-D sensitivity map (pixel-by-pixel)
 for the entire science image. The 2-D SCI and ERR arrays in the science
 exposure are multiplied by the 2D sensitivity map, which converts the science
-pixels from countrate to either flux density or surface brightness.
+pixels from countrate to surface brightness.
 Variance arrays are multiplied by the square of the conversion factors.
 
 MIRI MRS

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -80,10 +80,6 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
     else:
         log.info(f"Source type = {source_type}")
 
-    # The input units will normally be MJy / sr, but for NIRSpec point-source
-    # spectra the units will be MJy.
-    input_units_are_megajanskys = (source_type == 'POINT' and instrument == 'NIRSPEC')
-
     output_model = datamodels.MultiSpecModel()
     output_model.update(input_model, only="PRIMARY")
 
@@ -150,28 +146,12 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
                     "the flux will not be correct.")
         pixel_solid_angle = 1.
 
-    if input_units_are_megajanskys:
-        # Convert flux from MJy to Jy, and convert background to MJy / sr.
-        flux = temp_flux * 1.e6
-        f_var_poisson *= 1.e12  # MJy**2 --> Jy**2
-        f_var_rnoise *= 1.e12  # MJy**2 --> Jy**2
-        f_var_flat *= 1.e12  # MJy**2 --> Jy**2
-        surf_bright[:] = 0.
-        sb_var_poisson[:] = 0.
-        sb_var_rnoise[:] = 0.
-        sb_var_flat[:] = 0.
-        background[:] /= pixel_solid_angle  # MJy / sr
-        b_var_poisson /= pixel_solid_angle
-        b_var_rnoise /= pixel_solid_angle
-        b_var_flat /= pixel_solid_angle
-
-    else:
-        # Convert flux from MJy / steradian to Jy.
-        flux = temp_flux * pixel_solid_angle * 1.e6
-        f_var_poisson *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
-        f_var_rnoise *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
-        f_var_flat *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
-        # surf_bright and background were computed above
+    # Convert flux from MJy / steradian to Jy.
+    flux = temp_flux * pixel_solid_angle * 1.e6
+    f_var_poisson *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
+    f_var_rnoise *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
+    f_var_flat *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
+    # surf_bright and background were computed above
     del temp_flux
     error = np.sqrt(f_var_poisson + f_var_rnoise + f_var_flat)
     sb_error = np.sqrt(sb_var_poisson + sb_var_rnoise + sb_var_flat)

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -324,8 +324,8 @@ class DataSet():
                 # on its wavelength
                 sens2d = np.interp(wave2d, waves, relresps)
                 sens2d *= tabdata['photmj']  # include the initial scalar conversion factor -> MJ
-                # Apply to all data (both point source and extended)
-                sens2d /= area2d * A2_TO_SR  # divide by pixel area * A2_TO_SR -> MJ/sr
+                # convert all data (both point source and extended) to surface brightness
+                sens2d /= area2d * A2_TO_SR  # divide by pixel area * A2_TO_SR -> MJy/sr
 
                 # Reset NON_SCIENCE pixels to 1 in sens2d array and flag
                 # them in the science data DQ array

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -274,23 +274,18 @@ class DataSet():
                 tabdata = ftab.phot_table[row]
 
                 # Get the scalar conversion factor from the PHOTMJ column;
-                # Note that this is the conversion to flux units, which is
-                # appropriate for a POINT source
                 conv_factor = tabdata['photmj']
                 unit_is_surface_brightness = False
 
-                # Figure out if the calibration needs to be converted to surface
-                # brightness units, which is done if the source is extended.
-                if self.source_type is None or self.source_type.upper() != 'POINT':
-                #if self.source_type is None:
-                    if self.input.meta.photometry.pixelarea_steradians is None:
-                        log.warning("Pixel area is None, so can't convert "
-                                    "flux to surface brightness!")
-                    else:
-                        log.debug("Converting conversion factor from flux "
-                                  "to surface brightness")
-                        conv_factor /= self.input.meta.photometry.pixelarea_steradians
-                        unit_is_surface_brightness = True
+                # Convert to surface brightness units for all types of data
+                if self.input.meta.photometry.pixelarea_steradians is None:
+                    log.warning("Pixel area is None, so can't convert "
+                                "flux to surface brightness!")
+                else:
+                    log.debug("Converting conversion factor from flux "
+                              "to surface brightness")
+                    conv_factor /= self.input.meta.photometry.pixelarea_steradians
+                    unit_is_surface_brightness = True
 
                 # Populate the photometry keywords
                 log.info(f'PHOTMJSR value: {conv_factor:.6g}')
@@ -329,11 +324,9 @@ class DataSet():
                 # on its wavelength
                 sens2d = np.interp(wave2d, waves, relresps)
                 sens2d *= tabdata['photmj']  # include the initial scalar conversion factor -> MJ
-                # This line used to be applied to all IFU data, but I think this was an error -
-                # masked by the fact that the initial pixel area maps for IFU data were
-                # arrays of 1-values (in arcsec**2). If srctype==POINT, do not apply.
-                if self.source_type.upper() != 'POINT':
-                    sens2d /= area2d * A2_TO_SR  # divide by pixel area * A2_TO_SR -> MJ/sr
+                # Apply to all data (both point source and extended)
+                sens2d /= area2d * A2_TO_SR  # divide by pixel area * A2_TO_SR -> MJ/sr
+
                 # Reset NON_SCIENCE pixels to 1 in sens2d array and flag
                 # them in the science data DQ array
                 where_dq = np.bitwise_and(dqmap, dqflags.pixel['NON_SCIENCE'])

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -282,6 +282,7 @@ class DataSet():
                 # Figure out if the calibration needs to be converted to surface
                 # brightness units, which is done if the source is extended.
                 if self.source_type is None or self.source_type.upper() != 'POINT':
+                #if self.source_type is None:
                     if self.input.meta.photometry.pixelarea_steradians is None:
                         log.warning("Pixel area is None, so can't convert "
                                     "flux to surface brightness!")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3163](https://jira.stsci.edu/browse/JP-3163)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR changes the photom step for NIRSpec IFU point source data to save it in units of surface brightness (MJy/sr). This change was made because cube_build was designed to work in surface brightness units. The extract_1d step for NIRSpec IFU point source data also had to be updated to convert the extracted data from surface brightness units to flux units.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/704/
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
