### PR TITLE
Fix inheritance of data models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.10.3 (unreleased)
 ===================
 
+datamodels
+----------
+
+- Removed use of deprecated ``stdatamodels.jwst.datamodels.DataModel`` class and
+  replaced it with ``stdatamodels.jwst.datamodels.JwstDataModel``. [#7571]
+
 documentation
 -------------
 

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -9,7 +9,7 @@ from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
 
-from stdatamodels import DataModel
+from stdatamodels.jwst.datamodels import JwstDataModel
 
 
 __all__ = ["compute_roll_ref", "frame_from_model", "fitswcs_transform_from_model",
@@ -100,7 +100,7 @@ def wcsinfo_from_model(input_model):
 
     Parameters
     ----------
-    input_model : `~stdatamodels.DataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The input data model
 
     """
@@ -172,7 +172,7 @@ def frame_from_model(wcsinfo):
 
     Parameters
     ----------
-    wcsinfo : `~stdatamodels.DataModel` or dict
+    wcsinfo : `~stdatamodels.jwst.datamodels.JwstDataModel` or dict
         Either one of the JWST data models or a dict with model.meta.wcsinfo.
 
     Returns
@@ -180,7 +180,7 @@ def frame_from_model(wcsinfo):
     frame : `~coordinate_frames.CoordinateFrame`
 
     """
-    if isinstance(wcsinfo, DataModel):
+    if isinstance(wcsinfo, JwstDataModel):
         wcsinfo = wcsinfo_from_model(wcsinfo)
 
     wcsaxes = wcsinfo['WCSAXES']
@@ -215,7 +215,7 @@ def frame_from_model(wcsinfo):
 
 
 def create_fitswcs(inp, input_frame=None):
-    if isinstance(inp, DataModel):
+    if isinstance(inp, JwstDataModel):
         wcsinfo = wcsinfo_from_model(inp)
         wavetable = None
         spatial_axes, spectral_axes, unknown = gwutils.get_axes(wcsinfo)
@@ -226,7 +226,7 @@ def create_fitswcs(inp, input_frame=None):
         transform = fitswcs_transform_from_model(wcsinfo, wavetable=wavetable)
         output_frame = frame_from_model(wcsinfo)
     else:
-        raise TypeError("Input is expected to be a DataModel instance or a FITS file.")
+        raise TypeError("Input is expected to be a JwstDataModel instance or a FITS file.")
 
     if input_frame is None:
         wcsaxes = wcsinfo['WCSAXES']

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -270,7 +270,7 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
     if refmodel is None:
         refmodel = dmodels[0]
     else:
-        if not isinstance(refmodel, DataModel):
+        if not isinstance(refmodel, JwstDataModel):
             raise TypeError("Expected refmodel to be an instance of DataModel.")
 
     fiducial = compute_fiducial(wcslist, bb)

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -19,7 +19,7 @@ from gwcs.wcstools import wcs_from_fiducial, grid_from_bounding_box
 from gwcs import utils as gwutils
 from stpipe.exceptions import StpipeExitException
 
-from stdatamodels import DataModel
+from stdatamodels.jwst.datamodels import JwstDataModel
 from stdatamodels.jwst.datamodels import WavelengthrangeModel
 from stdatamodels.jwst.transforms.models import GrismObject
 
@@ -455,7 +455,7 @@ def subarray_transform(input_model):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         Data model.
 
     Returns
@@ -927,7 +927,7 @@ def bounding_box_from_subarray(input_model):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The data model.
 
     Returns

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from asdf import AsdfFile
 from astropy.io import fits
-from stdatamodels import DataModel, properties
+from stdatamodels import properties
 
 from stdatamodels.jwst.datamodels.model_base import JwstDataModel
 from stdatamodels.jwst.datamodels.util import open as datamodel_open
@@ -81,14 +81,14 @@ class ModelContainer(JwstDataModel, Sequence):
     Notes
     -----
         The optional paramters ``save_open`` and ``return_open`` can be
-        provided to control how the `DataModel` are used by the
+        provided to control how the `JwstDataModel` are used by the
         :py:class:`ModelContainer`. If ``save_open`` is set to `False`, each input
-        `DataModel` instance in ``init`` will be written out to disk and
-        closed, then only the filename for the `DataModel` will be used to
+        `JwstDataModel` instance in ``init`` will be written out to disk and
+        closed, then only the filename for the `JwstDataModel` will be used to
         initialize the :py:class:`ModelContainer` object.
-        Subsequent access of each member will then open the `DataModel` file to
-        work with it. If ``return_open`` is also `False`, then the `DataModel`
-        will be closed when access to the `DataModel` is completed. The use of
+        Subsequent access of each member will then open the `JwstDataModel` file to
+        work with it. If ``return_open`` is also `False`, then the `JwstDataModel`
+        will be closed when access to the `JwstDataModel` is completed. The use of
         these parameters can minimize the amount of memory used by this object
         during processing, with these parameters being used
         by :py:class:`~jwst.outlier_detection.OutlierDetectionStep`.
@@ -155,7 +155,7 @@ to supply custom catalogs.
                 init.close()
             self._models.append(model)
         elif isinstance(init, list):
-            if all(isinstance(x, (str, fits.HDUList, DataModel)) for x in init):
+            if all(isinstance(x, (str, fits.HDUList, JwstDataModel)) for x in init):
                 if self._save_open:
                     init = [datamodel_open(m, memmap=self._memmap) for m in init]
             else:
@@ -177,7 +177,7 @@ to supply custom catalogs.
             init_from_asn = self.read_asn(init)
             self.from_asn(init_from_asn, asn_file_path=init)
         else:
-            raise TypeError('Input {0!r} is not a list of DataModels or '
+            raise TypeError('Input {0!r} is not a list of JwstDataModels or '
                             'an ASN file'.format(init))
 
     def __len__(self):
@@ -185,7 +185,7 @@ to supply custom catalogs.
 
     def __getitem__(self, index):
         m = self._models[index]
-        if not isinstance(m, DataModel) and self._return_open:
+        if not isinstance(m, JwstDataModel) and self._return_open:
             m = datamodel_open(m, memmap=self._memmap)
         return m
 
@@ -197,7 +197,7 @@ to supply custom catalogs.
 
     def __iter__(self):
         for model in self._models:
-            if not isinstance(model, DataModel) and self._return_open:
+            if not isinstance(model, JwstDataModel) and self._return_open:
                 model = datamodel_open(model, memmap=self._memmap)
             yield model
 
@@ -227,7 +227,7 @@ to supply custom catalogs.
         result._schema = self._schema
         result._ctx = result
         for m in self._models:
-            if isinstance(m, DataModel):
+            if isinstance(m, JwstDataModel):
                 result.append(m.copy())
             else:
                 result.append(m)
@@ -456,7 +456,7 @@ to supply custom catalogs.
     @property
     def group_names(self):
         """
-        Return list of names for the DataModel groups by exposure.
+        Return list of names for the JwstDataModel groups by exposure.
         """
         result = []
         for group in self.models_grouped:
@@ -467,7 +467,7 @@ to supply custom catalogs.
         """Close all datamodels."""
         if not self._iscopy:
             for model in self._models:
-                if isinstance(model, DataModel):
+                if isinstance(model, JwstDataModel):
                     model.close()
 
     @property
@@ -503,7 +503,7 @@ to supply custom catalogs.
 
         Returns
         -------
-        stdatamodels.DataModel
+        stdatamodels.JwstDataModel
         """
         for exposure in self.meta.asn_table.products[0].members:
             if exposure.exptype.upper() == "SCIENCE":

--- a/jwst/model_blender/blender.py
+++ b/jwst/model_blender/blender.py
@@ -30,7 +30,7 @@
 import numpy as np
 from numpy import ma
 
-from stdatamodels import DataModel
+from stdatamodels.jwst.datamodels import JwstDataModel
 from stdatamodels.jwst import datamodels
 
 
@@ -86,7 +86,7 @@ def metablender(input_models, spec):
 
     - *input_models* is a sequence where each element is either:
 
-      - a `datamodels.DataModel` instance or sub-class
+      - a `datamodels.JwstDataModel` instance or sub-class
 
       - a string giving the *filename* for the input_model
 
@@ -176,11 +176,11 @@ def metablender(input_models, spec):
 
     # Read in data
     for model in input_models:
-        if not isinstance(model, DataModel):
+        if not isinstance(model, JwstDataModel):
             if not isinstance(model, str):
                 raise TypeError(
                     "Each entry in the headers list must be either a " +
-                    "datamodels.DataModel instance or a filename (str)")
+                    "datamodels.JwstDataModel instance or a filename (str)")
             model = datamodels.open(model)
         header = model.to_flat_dict()
         filename = header['meta.filename']

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -506,7 +506,7 @@ def gwcs_blot(median_model, blot_img, interp='poly5', sinscl=1.0):
 
     Parameters
     ----------
-    median_model : ~jwst.datamodels.DataModel
+    median_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
 
     blot_img : datamodel
         Datamodel containing header and WCS to define the 'blotted' image

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -56,7 +56,7 @@ class OutlierDetectionIFU(OutlierDetection):
         drizzled_models : list of objects
             ModelContainer containing drizzled grouped input images
 
-        reffiles : dict of ~jwst.datamodels.DataModel
+        reffiles : dict of `~stdatamodels.jwst.datamodels.jwstDataModel`
             Dictionary of datamodels.  Keys are reffile_types.
 
 

--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -56,7 +56,7 @@ class OutlierDetectionIFU(OutlierDetection):
         drizzled_models : list of objects
             ModelContainer containing drizzled grouped input images
 
-        reffiles : dict of `~stdatamodels.jwst.datamodels.jwstDataModel`
+        reffiles : dict of `~stdatamodels.jwst.datamodels.JwstDataModel`
             Dictionary of datamodels.  Keys are reffile_types.
 
 

--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -50,7 +50,7 @@ class OutlierDetectionScaled(OutlierDetection):
             list of data models as ModelContainer or ASN file,
             one data model for each input image
 
-        reffiles : dict of `jwst.datamodels.DataModel`
+        reffiles : dict of `stdatamodels.jwst.datamodels.JwstDataModel`
             Dictionary of datamodels.  Keys are reffile_types.
 
         """

--- a/jwst/outlier_detection/outlier_detection_spec.py
+++ b/jwst/outlier_detection/outlier_detection_spec.py
@@ -50,7 +50,7 @@ class OutlierDetectionSpec(OutlierDetection):
             list of data models as ModelContainer or ASN file,
             one data model for each input image
 
-        reffiles : dict of `jwst.datamodels.DataModel`
+        reffiles : dict of `stdatamodels.jwst.datamodels.JwstDataModel`
             Dictionary of datamodels.  Keys are reffile_types.
 
         pars : dict, optional

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -123,7 +123,7 @@ class Image2Pipeline(Pipeline):
         science = science[0]
 
         self.log.info('Working on input %s ...', science)
-        if isinstance(science, datamodels.DataModel):
+        if isinstance(science, datamodels.JwstDataModel):
             input = science
         else:
             input = datamodels.open(science)

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -323,7 +323,7 @@ class ResampleSpecData(ResampleData):
 
         Parameters
         ----------
-        refmodel : `~jwst.datamodels.DataModel`
+        refmodel : `~jwst.datamodels.JwstDataModel`
             The reference input image from which the fiducial WCS is created.
             If not specified, the first image in self.input_models is used.
 

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -2,7 +2,7 @@
 JWST-specific Step and Pipeline base classes.
 """
 from collections.abc import Sequence
-from stdatamodels import DataModel
+from stdatamodels.jwst.datamodels import JwstDataModel
 from stdatamodels.jwst import datamodels
 
 from .. import __version_commit__, __version__
@@ -76,7 +76,7 @@ class JwstStep(Step):
         return asn
 
     def finalize_result(self, result, reference_files_used):
-        if isinstance(result, DataModel):
+        if isinstance(result, JwstDataModel):
             result.meta.calibration_software_revision = __version_commit__ or 'RELEASE'
             result.meta.calibration_software_version = __version__
 
@@ -126,5 +126,5 @@ class JwstStep(Step):
 # when constructing a pipeline using JwstStep class methods.
 class JwstPipeline(Pipeline, JwstStep):
     def finalize_result(self, result, reference_files_used):
-        if isinstance(result, DataModel):
+        if isinstance(result, JwstDataModel):
             log.info(f"Results used CRDS context: {crds_client.get_context_used(result.crds_observatory)}")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an issue with data model inheritance. Models inheriting from `stdatamodels.jwst.DataModel` do not register as instances of `DataModel`. For example `isinstance(SlitModel(), stdatamodels.jwst.datamodels.DataModel` returns `False`. Since `stdatamodels.jwst.datamodels.DataModel` is deprecated n favor of `stdatamodels.jwst.datamodels.JwstDataModel` I've replaced any occurrence of `DatModel` with `JwstDataModel`. 


**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

regression tests: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/695/