### PR TITLE
Fix tutorial usage of threshold parameter

### DIFF
--- a/docs/jwst/user_documentation/running_pipeline_command_line.rst
+++ b/docs/jwst/user_documentation/running_pipeline_command_line.rst
@@ -109,22 +109,22 @@ section.
 **Using Command Line Arguments**
 
 When running a pipeline, step-level parameters can be changed by passing in a command
-line argument to that step. For example, to change the ``threshold`` parameter of
+line argument to that step. For example, to change the ``rejection_threshold`` parameter of
 the jump detection step when running the full Detector1Pipeline:
 
 ::
 
     $ strun calwebb_detector1 jw00017001001_01101_00001_nrca1_uncal.fits
-        --steps.jump.threshold=12.0
+        --steps.jump.rejection_threshold=12.0
 
 
 When running a standalone step, command line arguments do not need to be nested within
-``steps``. For example, to change the parameter ``threshold`` for the jump detection
+``steps``. For example, to change the parameter ``rejection_threshold`` for the jump detection
 step when running the step individually:
 
 ::
 
-    $ strun jump jw00017001001_01101_00001_nrca1_uncal.fits --threshold=12.0
+    $ strun jump jw00017001001_01101_00001_nrca1_uncal.fits --rejection_threshold=12.0
 
 
 **Using a Parameter File**
@@ -139,7 +139,7 @@ file to add the following snippet (in this example, to a file named
   - class: jwst.jump.jump_step.JumpStep
     name: jump
     parameters:
-      threshold : 12
+      rejection_threshold : 12
 
 And pass in the modified file to ``strun``:
 

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -122,13 +122,13 @@ will get used if set in multiple locations.
 	# configuring a pipeline and the steps within the pipeline with keyword arguments
 	result = Detector1Pipeline.call('jw00017001001_01101_00001_nrca1_uncal.fits',
 	                                save_results=False,
-	                                steps={'jump': {'threshold': 12.0, 'save_results':True}})
+	                                steps={'jump': {'rejection_threshold': 12.0, 'save_results':True}})
 	# configuring a pipeline step with keyword arguments
 	result = JumpStep.call('jw00017001001_01101_00001_nrca1_uncal.fits',
-	                       save_results=True, 'threshold'=12.0)
+	                       save_results=True, 'rejection_threshold'=12.0)
 
 Both examples above show how to configure the jump detection step with the same
-settings - the ``threshold`` set to 12.0, and ``save_results`` set to True to indicate
+settings - the ``rejection_threshold`` set to 12.0, and ``save_results`` set to True to indicate
 the result from the step should be written to an output file.
 
 The first example shows when the jump step is run inside a pipeline - because a
@@ -175,23 +175,23 @@ but they can be overridden if desired.
 
 As discussed in :ref:`above<configuring_pipeline_python>`, when setting a
 step-level parameter when that step is a substep of a pipeline, it must be passed
-to the `steps` argument dictionary. For exaple, to change the ``threshold``
+to the `steps` argument dictionary. For exaple, to change the ``rejection_threshold``
 parameter of the jump detection step when running the full Detector1Pipeline:
 
 ::
 
 	from jwst.pipeline import Detector1Pipeline
 	result = Detector1Pipeline.call('jw00017001001_01101_00001_nrca1_uncal.fits',
-	                                 steps={'jump': {'threshold':12.0)}})
+	                                 steps={'jump': {'rejection_threshold':12.0)}})
 
 When running a single step, step-level parameters can be passed in directly as
 keyword arguments. For example, to change the parameter
-``threshold`` for the jump detection step when running the step individually:
+``rejection_threshold`` for the jump detection step when running the step individually:
 
 ::
 
 	from jwst.jump import JumpStep
-	result = JumpStep.call('jw00017001001_01101_00001_nrca1_uncal.fits', threshold=12.0)
+	result = JumpStep.call('jw00017001001_01101_00001_nrca1_uncal.fits', rejection_threshold=12.0)
 
 
 **Using a Parameter File**
@@ -205,7 +205,7 @@ file to add the following snippet (in this example, to a file named
   steps:
   - class: jwst.jump.jump_step.JumpStep
     parameters:
-      threshold : 12
+      rejection_threshold : 12
 
 And pass in the modified file to the ``config_file`` argument:
 
@@ -519,7 +519,7 @@ being run directly on the data, attributes can be set directly:
 
 	from jwst.pipeline import Detector1Pipeline
 	pipe = Detector1Pipeline()
-	pipe.jump.threshold = 12
+	pipe.jump.rejection_threshold = 12
 	pipe.ramp_fit.skip = True
 	result = pipe.run('jw00017001001_01101_00001_nrca1_uncal.fits')
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses outdated usage of the jump ``threshold`` parameter, which was renamed to ``rejection_threshold``. 

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
