### PR TITLE
JP-3227: Add analog of HST's tweakback tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,14 @@ ramp_fitting
   of groups in a segment are computed when applying optimal weighting to line
   fit segments. [#7560, spacetelescope/stcal#163]
 
+tweakreg
+--------
+
+- Added a tool ``transfer_wcs_correction`` to ``jwst.tweakreg.utils`` that
+  allows transferring alignment corrections from one file/data model to
+  another. It is an analog of the ``tweakback`` task in the
+  ``drizzlepac``. [#7573]
+
 
 1.10.2 (2023-04-14)
 ===================
@@ -75,7 +83,7 @@ jump
   in the STCAL jump code but not in JWST. This allows the parameter to be changed.
   Also, scaled two input parameters that are listed as radius to be a factor of two
   higher to match the opencv code that uses diameter. [#7545]
-  
+
 other
 -----
 
@@ -127,7 +135,7 @@ cube_build
 - Windows: MSVC: Allocate ``wave_slice_dq`` array using ``mem_alloc_dq()`` [#7491]
 
 - Memory improvements, do not allow MIRI and 'internal_cal', allow user to set suffix. [#7521]
-  
+
 datamodels
 ----------
 

--- a/jwst/tweakreg/tests/test_utils.py
+++ b/jwst/tweakreg/tests/test_utils.py
@@ -1,20 +1,135 @@
 from os import path
+from copy import deepcopy
 
+import pytest
 import numpy as np
 import asdf
 from astropy.coordinates import SkyCoord
 from astropy import units as u
+from tweakwcs.correctors import JWSTWCSCorrector
+from tweakwcs.linearfit import build_fit_matrix
 
 from jwst.tweakreg.tests import data
-from jwst.tweakreg.utils import adjust_wcs
+from jwst.datamodels import ImageModel
+from jwst.tweakreg.utils import (
+    adjust_wcs,
+    transfer_wcs_correction,
+    _wcsinfo_from_wcs_transform
+)
 
 
 data_path = path.split(path.abspath(data.__file__))[0]
 
 
+def _get_test_pts(model, npts=5):
+    assert npts >= 5
+    ysize, xsize = model.data.shape
+    x = np.empty(npts, dtype=float)
+    y = np.empty(npts, dtype=float)
+    x[:5] = [-0.499, -0.499, xsize - 0.501, xsize - 0.501, (xsize - 1.0) / 2.0]
+    y[:5] = [-0.499, ysize - 0.501, -0.499, ysize - 0.501, (ysize - 1.0) / 2.0]
+    if npts > 5:
+        npts -= 5
+        np.random.seed(0)
+        x[5:] = xsize * np.random.random(npts) - 0.5
+        y[5:] = ysize * np.random.random(npts) - 0.5
+    return x, y
+
+
+@pytest.fixture
+def nircam_rate():
+    wcs_file = path.join(data_path, 'nrcb1-wcs.asdf')
+    with asdf.open(wcs_file) as af:
+        wcs = deepcopy(af['wcs'])
+
+    xsize = 204
+    ysize = 204
+    shape = (ysize, xsize)
+    im = ImageModel(shape)
+    im.var_rnoise += 0
+
+    wcsinfo = _wcsinfo_from_wcs_transform(wcs)
+    im.meta.wcsinfo = {
+        'ctype1': 'RA---TAN',
+        'ctype2': 'DEC--TAN',
+        'v2_ref': wcsinfo['v2_ref'],
+        'v3_ref': wcsinfo['v3_ref'],
+        'roll_ref': wcsinfo['roll_ref'],
+        'ra_ref': wcsinfo['ra_ref'],
+        'dec_ref': wcsinfo['dec_ref'],
+        'v3yangle': -0.07385127,
+        'vparity': -1,
+        'wcsaxes': 2
+    }
+
+    im.meta.wcs = wcs
+
+    im.meta.instrument = {
+        'channel': 'LONG',
+        'detector': 'NRCALONG',
+        'filter': 'F444W',
+        'lamp_mode': 'NONE',
+        'module': 'A',
+        'name': 'NIRCAM',
+        'pupil': 'CLEAR'
+    }
+    im.meta.subarray = {
+        'fastaxis': -1,
+        'name': 'FULL',
+        'slowaxis': 2,
+        'xsize': xsize,
+        'xstart': 1,
+        'ysize': ysize,
+        'ystart': 1
+    }
+
+    im.meta.observation = {
+        'activity_id': '01',
+        'date': '2021-10-25',
+        'exposure_number': '00001',
+        'obs_id': 'V42424001001P0000000001101',
+        'observation_label': 'nircam_ptsrc_only',
+        'observation_number': '001',
+        'program_number': '42424',
+        'sequence_id': '1',
+        'time': '16:58:27.258',
+        'visit_group': '01',
+        'visit_id': '42424001001',
+        'visit_number': '001'
+    }
+
+    im.meta.exposure = {
+        'duration': 161.05155,
+        'end_time': 59512.70899968495,
+        'exposure_time': 150.31478,
+        'frame_time': 10.73677,
+        'group_time': 21.47354,
+        'groupgap': 1,
+        'integration_time': 150.31478,
+        'mid_time': 59512.70812980775,
+        'nframes': 1,
+        'ngroups': 7,
+        'nints': 1,
+        'nresets_at_start': 1,
+        'nresets_between_ints': 1,
+        'readpatt': 'BRIGHT1',
+        'sample_time': 10,
+        'start_time': 59512.70725993055,
+        'type': 'NRC_IMAGE'
+    }
+
+    im.meta.photometry = {
+        'pixelarea_steradians': 1e-13,
+        'pixelarea_arcsecsq': 4e-3,
+    }
+
+    return im
+
+
 def test_adjust_wcs():
     wcs_file = path.join(data_path, 'nrcb1-wcs.asdf')
-    w0 = asdf.open(wcs_file)['wcs']
+    with asdf.open(wcs_file) as af:
+        w0 = deepcopy(af['wcs'])
 
     crval20, crval10 = w0.pipeline[-2].transform.angles_3.value.tolist()[-2:]
     crval10 = -crval10
@@ -58,4 +173,55 @@ def test_adjust_wcs():
         25.7,
         rtol=1.0e-5,
         atol=0.0
+    )
+
+
+@pytest.mark.parametrize("input_type", ["wcs", "model", "file"])
+def test_transfer_wcs_correction(nircam_rate, tmp_path, input_type):
+    m1 = nircam_rate.copy()
+    m2 = nircam_rate.copy()
+
+    # apply some correction to m2 (from_image)
+    wcsinfo = _wcsinfo_from_wcs_transform(m2.meta.wcs)
+    corr = JWSTWCSCorrector(m2.meta.wcs, wcsinfo)
+    mat = build_fit_matrix(23, 1.0001456)
+    shift = corr.tanp_center_pixel_scale * np.array([3.5, 2.0])
+    corr.set_correction(matrix=mat, shift=shift)
+    m2.meta.wcs = corr.wcs
+
+    if input_type == "file":
+        # write to files:
+        model_file1 = str(tmp_path / 'model1.fits')
+        model_file2 = str(tmp_path / 'model2.fits')
+
+        m1.write(model_file1)
+        m2.write(model_file2)
+        m1 = model_file1
+        m2 = model_file2
+        from_model = model_file2
+
+    elif input_type == "wcs":
+        from_model = m2.meta.wcs
+
+    else:
+        from_model = m2
+
+    # transfer correction to m1:
+    transfer_wcs_correction(m1, from_model)
+
+    # test:
+    if input_type == "file":
+        m1 = ImageModel(m1)
+        m2 = ImageModel(m2)
+
+    x, y = _get_test_pts(m1, 5)
+
+    assert np.allclose(
+        np.linalg.norm(
+            np.subtract(m2.meta.wcs(x, y), m1.meta.wcs(x, y)),
+            axis=0
+        ),
+        0,
+        rtol=0,
+        atol=5e-11
     )

--- a/jwst/tweakreg/utils.py
+++ b/jwst/tweakreg/utils.py
@@ -1,10 +1,56 @@
 from copy import deepcopy
 
+from astropy.modeling.rotations import RotationSequence3D
 from gwcs.wcs import WCS
+import numpy as np
 from tweakwcs.correctors import JWSTWCSCorrector
 from tweakwcs.linearfit import build_fit_matrix
 
+from ..datamodels import ImageModel
+from ..assign_wcs.util import update_fits_wcsinfo
 from ..assign_wcs.pointing import _v23tosky
+
+
+_RAD2ARCSEC = 3600.0 * np.rad2deg(1.0)
+
+
+def _wcsinfo_from_wcs_transform(wcs):
+    frms = wcs.available_frames
+    if 'v2v3' not in frms or 'world' not in frms or frms[-1] != 'world':
+        raise ValueError(
+            "Unsupported WCS structure."
+        )
+
+    # Initially get v2_ref, v3_ref, and roll_ref from
+    # the v2v3 to world transform. Also get ra_ref, dec_ref
+    t = wcs.get_transform(frms[-2], 'world')
+    for m in t:
+        if isinstance(m, RotationSequence3D) and m.parameters.size == 5:
+            v2_ref, nv3_ref, roll_ref, dec_ref, nra_ref = m.angles.value
+            break
+    else:
+        raise ValueError(
+            "Unsupported WCS structure."
+        )
+
+    # overwrite v2_ref, v3_ref, and roll_ref with
+    # values from the tangent plane when available:
+    if 'v2v3corr' in frms:
+        # get v2_ref, v3_ref, and roll_ref from
+        # the v2v3 to v2v3corr transform:
+        frm1 = 'v2v3vacorr' if 'v2v3vacorr' in frms else 'v2v3'
+        tpcorr = wcs.get_transform(frm1, 'v2v3corr')
+        v2_ref, nv3_ref, roll_ref = tpcorr['det_to_optic_axis'].angles.value
+
+    wcsinfo = {
+        'v2_ref': 3600 * v2_ref,
+        'v3_ref': -3600 * nv3_ref,
+        'roll_ref': roll_ref,
+        'ra_ref': -nra_ref,
+        'dec_ref': dec_ref
+    }
+
+    return wcsinfo
 
 
 def adjust_wcs(wcs, delta_ra=0.0, delta_dec=0.0, delta_roll=0.0,
@@ -84,3 +130,145 @@ def adjust_wcs(wcs, delta_ra=0.0, delta_dec=0.0, delta_roll=0.0,
         wcs = corr.wcs
 
     return wcs
+
+
+def transfer_wcs_correction(to_image, from_image, matrix=None, shift=None):
+    """
+    Applies the same WCS correction that was applied to the WCS in the
+    ``from_image`` data model to the WCS of the ``to_image`` data model.
+    In some ways this function is analogous function to the ``tweakback``
+    function for HST available in the
+    `drizzlepac package <https://github.com/spacetelescope/drizzlepac>`_.
+
+    One fundamental difference between this function and ``tweakback``
+    is that JWST data models do not keep a history
+    of data's WCS via alternative WCS as it is done in HST data and so it is
+    impossible to select and apply only one particular WCS correction if
+    there were multiple corrections previously applied to a WCS. The
+    tangent-plane correction in JWST WCS is cumulative/total correction.
+    If you would like to apply a specific/custom correction, you can do that
+    via ``matrix`` and ``shift`` arguments which defined in the
+    reference tangent plane provided by the ``from_image``'s WCS.
+
+    When providing your own corrections via ``matrix`` and ``shift`` arguments,
+    this function is similar to the :py:func:`adjust_wcs` function
+    but provides an alternative way of specifying corrections via affine
+    transformations in a reference tangent plane.
+
+    .. warning::
+        Upon return, if the ``to_image`` argument is an `ImageModel` it will be
+        modified with an updated ``ImageModel.meta.wcs`` WCS model.
+        If ``to_image`` argument is a file name of an ``ImageModel``, that
+        model will be read in, its WCS will be updated, and the updated model
+        will be written out to the same file. BACKUP the file in ``to_image``
+        argument before calling this function.
+
+    Parameters
+    ----------
+
+    to_image : str, ImageModel
+        Image model to which the correction should be applied/transferred to.
+
+        .. warning::
+            If it is a string file name then, upon return, this file
+            will be **overwritten** with a data model with an updated WCS.
+
+    from_image : str, ImageModel, gwcs.wcs.WCS
+        A data model whose WCS was previously corrected.
+        This data model plays two roles: 1) it is the reference WCS which
+        provides a tangent plane in which corrections have been defined, and
+        2) it provides WCS corrections to be applied to ``to_image``'s
+        WCS.
+
+        If the WCS of the ``from_image`` data model does not contain
+        corections, then *both* ``matrix`` *and* ``shift`` arguments *must be
+        supplied*.
+
+    matrix : 2D list, 2D numpy.ndarray, None, optional
+        A 2D matrix part of an affine transformation defined in the tangent
+        plane derived from the ``from_image``'s WCS.
+
+        .. note::
+            When provided, ``shift`` argument *must also be provided* in
+            which case ``matrix`` and ``shift`` arguments override the
+            correction (if present) from the  ``from_file``'s WCS.
+
+    shift : list, numpy.ndarray, None, optional
+        A list of length 2 representing the translational part of an affine
+        transformation (in arcsec) defined in the tangent plane derived
+        from the ``from_image``'s WCS.
+
+        .. note::
+            When provided, ``matrix`` argument *must also be provided* in
+            which case ``matrix`` and ``shift`` arguments override the
+            correction (if present) from the  ``from_file``'s WCS.
+
+    Returns
+    -------
+
+    Upon return, if the ``to_image`` argument is an `ImageModel` it will be
+    modified with an updated ``ImageModel.meta.wcs`` WCS model.
+    If ``to_image`` argument is a file name of an ``ImageModel``, that
+    model will be read in, its WCS will be updated, and the updated model
+    will be written to the same file. BACKUP the file in ``to_image``
+    argument before calling this function.
+
+    """
+    if isinstance(to_image, str):
+        to_file = to_image
+        to_image = ImageModel(to_file)
+    else:
+        to_file = None
+
+    if isinstance(from_image, str):
+        from_image = ImageModel(from_image)
+        refwcs = from_image.meta.wcs
+        ref_wcsinfo = from_image.meta.wcsinfo.instance
+
+    elif isinstance(from_image, WCS):
+        refwcs = from_image
+        ref_wcsinfo = _wcsinfo_from_wcs_transform(refwcs)
+
+    else:  # an ImageModel object
+        refwcs = from_image.meta.wcs
+        ref_wcsinfo = from_image.meta.wcsinfo.instance
+
+    if ((matrix is None and shift is not None) or
+            (matrix is not None and shift is None)):
+        raise ValueError(
+            "Both 'matrix' and 'shift' must be either None or not None."
+        )
+
+    elif matrix is None and shift is None:
+        # use the correction that was applied to the "reference" WCS - the
+        # WCS from the "from_image":
+        if 'v2v3corr' not in refwcs.available_frames:
+            raise ValueError(
+                "The WCS of the 'from_image' data model does not has not been "
+                "previously corrected. A corrected WCS is need in order to "
+                "\"transfer\" it to the 'to_file' when both 'matrix' and "
+                "'shift' are None."
+            )
+
+        t = refwcs.get_transform('v2v3', 'v2v3corr')
+        affine = t['tp_affine']
+        matrix = affine.matrix.value
+        shift = _RAD2ARCSEC * affine.translation.value  # convert to arcsec
+
+    from_corr = JWSTWCSCorrector(
+        refwcs,
+        ref_wcsinfo
+    )
+
+    to_corr = JWSTWCSCorrector(
+        to_image.meta.wcs,
+        to_image.meta.wcsinfo.instance
+    )
+
+    to_corr.set_correction(matrix=matrix, shift=shift, ref_tpwcs=from_corr)
+    to_image.meta.wcs = to_corr.wcs
+
+    update_fits_wcsinfo(to_image)
+
+    if to_file:
+        to_image.write(to_file)

--- a/jwst/tweakreg/utils.py
+++ b/jwst/tweakreg/utils.py
@@ -244,8 +244,8 @@ def transfer_wcs_correction(to_image, from_image, matrix=None, shift=None):
         # WCS from the "from_image":
         if 'v2v3corr' not in refwcs.available_frames:
             raise ValueError(
-                "The WCS of the 'from_image' data model does not has not been "
-                "previously corrected. A corrected WCS is need in order to "
+                "The WCS of the 'from_image' data model has not been "
+                "previously corrected. A corrected WCS is needed in order to "
                 "\"transfer\" it to the 'to_file' when both 'matrix' and "
                 "'shift' are None."
             )

--- a/jwst/tweakreg/utils.py
+++ b/jwst/tweakreg/utils.py
@@ -134,7 +134,7 @@ def adjust_wcs(wcs, delta_ra=0.0, delta_dec=0.0, delta_roll=0.0,
 
 def transfer_wcs_correction(to_image, from_image, matrix=None, shift=None):
     """
-    Applies the same WCS correction that was applied to the WCS in the
+    Applies the same *total* WCS correction that was applied to the WCS in the
     ``from_image`` data model to the WCS of the ``to_image`` data model.
     In some ways this function is analogous function to the ``tweakback``
     function for HST available in the
@@ -147,7 +147,7 @@ def transfer_wcs_correction(to_image, from_image, matrix=None, shift=None):
     there were multiple corrections previously applied to a WCS. The
     tangent-plane correction in JWST WCS is cumulative/total correction.
     If you would like to apply a specific/custom correction, you can do that
-    via ``matrix`` and ``shift`` arguments which defined in the
+    via ``matrix`` and ``shift`` arguments which is defined in the
     reference tangent plane provided by the ``from_image``'s WCS.
 
     When providing your own corrections via ``matrix`` and ``shift`` arguments,


### PR DESCRIPTION
Resolves [JP-3227](https://jira.stsci.edu/browse/JP-3227)

This PR adds functionality similar to HST's `tweakback` task to be able to transfer an alignment solution from a file to another.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. - **no need to run regression tests (new feature)**
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
