### PR TITLE
add a table of failing unit tests to the CI workflow summary page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,15 +65,22 @@ jobs:
       envs: |
         - linux: test-oldestdeps-xdist-cov
           python-version: 3.9
+          pytest-results-summary: true
         - linux: test-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - linux: test-sdpdeps-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - linux: test-xdist
           python-version: 3.10
+          pytest-results-summary: true
         - linux: test-xdist
           python-version: 3.11
+          pytest-results-summary: true
         - macos: test-xdist
           python-version: 3.11
+          pytest-results-summary: true
         - linux: test-xdist-cov
           coverage: codecov
+          pytest-results-summary: true

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -45,12 +45,20 @@ jobs:
       envs: |
         - macos: test-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - macos: test-sdpdeps-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - macos: test-xdist
           python-version: 3.10
+          pytest-results-summary: true
         - windows: test-xdist
+          pytest-results-summary: true
         - linux: test-pyargs-xdist
+          pytest-results-summary: true
         - linux: test-devdeps-xdist
+          pytest-results-summary: true
         - macos: test-devdeps-xdist
+          pytest-results-summary: true
         - windows: test-devdeps-xdist
+          pytest-results-summary: true


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR uses the new `pytest-results-summary` keyword in the OpenAstronomy reusable workflow to display test summaries on the job page. Here is an example from https://github.com/spacetelescope/romancal/pull/691:
<img width="973" alt="image" src="https://user-images.githubusercontent.com/16024299/235205377-1ea102cc-6f92-4fa9-a53c-5be381ebe2d3.png">

If tests fail, the [`test-summary` action](https://github.com/marketplace/actions/testforest-dashboard) will create a Markdown table of failures:
<img width="974" alt="image" src="https://user-images.githubusercontent.com/16024299/235216425-4e5f7bad-8430-44be-b46c-1319bac59ba8.png">

**Checklist for maintainers**
- [N/A] ~added entry in `CHANGES.rst` within the relevant release section~
- [x] updated or added relevant tests
- [N/A] ~updated relevant documentation~
- [N/A] ~added relevant milestone~
- [x] added relevant label(s)
- [N/A] ~ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)~
- [N/A] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
