### PR TITLE
Fix a bug in tweakreg when using user catalogs with ASN file name inputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,12 @@ ramp_fitting
   of groups in a segment are computed when applying optimal weighting to line
   fit segments. [#7560, spacetelescope/stcal#163]
 
+tweakreg
+--------
+
+- Fixed a bug in the ``tweakreg`` step that resulted in an exception when
+  using custom catalogs with ASN file name input. [#7578]
+
 
 1.10.2 (2023-04-14)
 ===================
@@ -75,7 +81,7 @@ jump
   in the STCAL jump code but not in JWST. This allows the parameter to be changed.
   Also, scaled two input parameters that are listed as radius to be a factor of two
   higher to match the opencv code that uses diameter. [#7545]
-  
+
 other
 -----
 
@@ -127,7 +133,7 @@ cube_build
 - Windows: MSVC: Allocate ``wave_slice_dq`` array using ``mem_alloc_dq()`` [#7491]
 
 - Memory improvements, do not allow MIRI and 'internal_cal', allow user to set suffix. [#7521]
-  
+
 datamodels
 ----------
 

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -124,7 +124,7 @@ class TweakRegStep(Step):
                         elif 'tweakreg_catalog' in member:
                             del member['tweakreg_catalog']
 
-                    images.from_asn(input)
+                    images.from_asn(asn_data)
 
                 elif is_association(input):
                     images.from_asn(input)


### PR DESCRIPTION
Closes #7577

This PR fixes a bug in the `tweakreg` step that would result in a `TypeError` when user enables custom catalogs and uses ASN file name as input.

Thanks @dkmagee for reporting the bug and proposing a solution which is implemented in this PR!

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
