### PR TITLE
JP-2858: rework resample_spec for MIRI LRS

### DIFF
--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -106,7 +106,7 @@ def wcsinfo_from_model(input_model):
     """
     defaults = {'CRPIX': 0, 'CRVAL': 0, 'CDELT': 1., 'CTYPE': "", 'CUNIT': u.Unit("")}
     wcsinfo = {}
-    wcsaxes = input_model.meta.wcsinfo.wcsaxes
+    wcsaxes = input_model.meta.wcsinfo.wcsaxes or input_model.meta.wcs.output_frame.naxes
     wcsinfo['WCSAXES'] = wcsaxes
     for key in ['CRPIX', 'CRVAL', 'CDELT', 'CTYPE', 'CUNIT']:
         val = []

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -328,6 +328,8 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
         if sky_axes.any():
             if spec.any():
                 dispaxis = refmodel.meta.wcsinfo.dispersion_direction
+            else:
+                dispaxis = None
             if not pscale:
                 pscale = compute_scale(refmodel.meta.wcs, ref_fiducial,
                                        pscale_ratio=pscale_ratio, disp_axis=dispaxis,

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -17,6 +17,7 @@ from typing import Union, List
 from gwcs import WCS
 from gwcs.wcstools import wcs_from_fiducial, grid_from_bounding_box
 from gwcs import utils as gwutils
+from gwcs import coordinate_frames as cf
 from stpipe.exceptions import StpipeExitException
 
 from stdatamodels.jwst.datamodels import JwstDataModel
@@ -136,7 +137,6 @@ def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray],
         crpix = np.array(wcs.invert(fiducial[0], fiducial[1], wavelength))
     else:
         crpix = np.array(wcs.invert(*fiducial))
-    crpix = np.array(wcs.invert(*fiducial))
 
     delta = np.zeros_like(crpix)
     spatial_idx = np.where(np.array(wcs.output_frame.axes_type) == 'SPATIAL')[0]
@@ -325,7 +325,7 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
         rotation = astmodels.AffineTransformation2D(pc, name='pc_rotation_matrix')
         transform.append(rotation)
 
-        if sky_axes:
+        if sky_axes.any():
             if spec.any():
                 dispaxis = refmodel.meta.wcsinfo.dispersion_direction
             if not pscale:
@@ -338,7 +338,7 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
             transform = functools.reduce(lambda x, y: x | y, transform)
 
     if isinstance(refmodel.meta.wcs.output_frame, cf.CompositeFrame):
-        out_frame.frames[0]
+        out_frame = refmodel.meta.wcs.output_frame.frames[0]
     else:
         out_frame = refmodel.meta.wcs.output_frame
     input_frame = refmodel.meta.wcs.input_frame

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -501,7 +501,8 @@ def extract_ifu(input_model, source_type, extract_params):
         scale_degrees = compute_scale(
             input_model.meta.wcs,
             locn_use,
-            disp_axis=input_model.meta.wcsinfo.dispersion_direction)
+            disp_axis=input_model.meta.wcsinfo.dispersion_direction,
+            wavelength=np.nanmean(wavelength))
 
         scale_arcsec = scale_degrees * 3600.00
         radius_match /= scale_arcsec

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -82,7 +82,7 @@ class ResampleSpecData(ResampleData):
             if resample_utils.is_sky_like(
                 self.input_models[0].meta.wcs.output_frame
             ):
-                if self.input_models[0].metaexposure.type == "MIR_LRS-FIXEDSLIT":
+                if self.input_models[0].meta.exposure.type == "MIR_LRS-FIXEDSLIT":
                     self.output_wcs = self.build_miri_lrs_output()
                 elif self.input_models[0].meta.instrument.name != "NIRSPEC":
                     self.output_wcs = self.build_interpolated_output_wcs()
@@ -315,7 +315,7 @@ class ResampleSpecData(ResampleData):
 
         return y_slit_min, y_slit_max
 
-    def build_miri_lrs_output():
+    def build_miri_lrs_output(self):
         """ Build MIRI LRS FIXEDSLIT output WCS. """
         all_wavelength = []
         all_ra_slit = []


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2858](https://jira.stsci.edu/browse/JP-2858)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR reworks the computation of the spatial component of the output WCS in resample_spec for MIRI LRS. It reuses the function that computes the output WCS for imaging mode and replaces the axis on the detector corresponding to the spectral axis with what is computed by the code specific to wavelength computation, to determine the bounding_box of the new output WCS. The wavelength axis computation is kept the same as before, i.e. a table of wavelengths is constructed and interpolated during evaluation.

I think the main issue solved by this method is taking into account the roll angle of the telescope during the observation. The method computes a point on the detector where the fiducial on the sky is projected using the inverse transform of the WCS. This requires passing a wavelength to the `assign_wcs.util.compute_scale`  method (I used the mean of the wavelengths) and changing the signature of the method to accept a wavelength. This method is used for imaging and spectral observations. For imaging mode it is a transparent change - the new `wavelength` parameter is ignored. When a spectral observation is detected, a `wavelength` parameter is required and this is what the change in `ifu.py` for Nirspec is.

This method is implemented as a new function specific to `MIRI-LRS-FIXEDSLIT` exposure type. If testing proves it works better than the current methods we should consider expanding it to other exposure types.

The regression tests were run in https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/709. They show errors for Nirspec which I think are bugs - essentially calling `interpolate` too strictly, without allowing for extrapolation or providing a `fill_value`. These are caused by the change in `compute_scale` and need to be tracked down.

This method was tested only with the data in the JP-2858 ticket. It needs to be tested with the Spec3Pipeline.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
