### PR TITLE
JP-3111: Add MIRI segmented dark subtraction test

### DIFF
--- a/jwst/regtest/test_miri_dark.py
+++ b/jwst/regtest/test_miri_dark.py
@@ -10,6 +10,7 @@ from jwst.stpipe import Step
     ['jw00001001001_01101_00001_mirimage', 'jw02201001001_01101_00001_MIRIMAGE']
 )
 def test_miri_dark_pipeline(exposure, _jail, rtdata, fitsdiff_default_kwargs):
+    """Test the DarkPipeline on MIRI dark exposures"""
     rtdata.get_data(f"miri/image/{exposure}_uncal.fits")
 
     args = ["jwst.pipeline.DarkPipeline", rtdata.input]
@@ -17,6 +18,25 @@ def test_miri_dark_pipeline(exposure, _jail, rtdata, fitsdiff_default_kwargs):
     rtdata.output = f"{exposure}_dark.fits"
 
     rtdata.get_truth(f"truth/test_miri_dark_pipeline/{exposure}_dark.fits")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize(
+    'exposure',
+    ['jw01033005001_04103_00001-seg003_mirimage']
+)
+def test_miri_segmented_dark(exposure, _jail, rtdata, fitsdiff_default_kwargs):
+    """Test the dark_current step on MIRI segmented exposures"""
+    rtdata.get_data(f"miri/image/{exposure}_linearity.fits")
+
+    args = ["jwst.dark_current.DarkCurrentStep", rtdata.input]
+    Step.from_cmdline(args)
+    rtdata.output = f"{exposure}_darkcurrentstep.fits"
+
+    rtdata.get_truth(f"truth/test_miri_segmented_dark/{exposure}_darkcurrentstep.fits")
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Supports the resolution of [JP-3111](https://jira.stsci.edu/browse/JP-3111)  The actual code updates that resolves JP-3111 are in https://github.com/spacetelescope/stcal/pull/165

<!-- describe the changes comprising this PR here -->
This PR adds a regression test that runs the dark_current step on a MIRI segmented exposure, to verify that the proper integration-dependent dark frames are applied to the science data. The example segmented exposure is the 3rd segment in a larger series and hence tests whether the last available integration from the dark reference file is applied to all integrations in the science segment.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
