### PR TITLE
JP-3098 switch order of precedence between PATTTYPE and SRCTYAPT in the srctype step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,7 +72,7 @@ ramp_fitting
 srctype
 -------
 
-- The SRCTYPE takes precedence over PATTTYPE when setting the source type for
+- The SRCTYAPT takes precedence over PATTTYPE when setting the source type for
   MIR_LRS-FIXEDSLIT, MIR_LRS-SLITLESS, 'MIR_MRS', NRC_TSGRISM, NRS_FIXEDSLIT, NRS_BRIGHTOBJ, NRS_IFU. [#7583]
   
 tweakreg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,12 @@ ramp_fitting
   of groups in a segment are computed when applying optimal weighting to line
   fit segments. [#7560, spacetelescope/stcal#163]
 
+srctype
+-------
+
+- The SRCTYPE takes precedence over PATTTYPE when setting the source type for
+  MIR_LRS-FIXEDSLIT, MIR_LRS-SLITLESS, 'MIR_MRS', NRC_TSGRISM, NRS_FIXEDSLIT, NRS_BRIGHTOBJ, NRS_IFU. [#7583]
+  
 tweakreg
 --------
 

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -96,17 +96,17 @@ def set_source_type(input_model, source_type=None):
             src_type = 'POINT'
             log.info(f'Input is a TSO exposure; setting SRCTYPE = {src_type}')
 
-        elif (patttype is not None) and (('NOD' in patttype) or ('POINT-SOURCE' in patttype)):
-
-            # Set all nodded exposures to POINT source type
-            src_type = 'POINT'
-            log.info(f'Exposure is nodded; setting SRCTYPE = {src_type}')
-
         elif user_type in ['POINT', 'EXTENDED']:
 
             # Use the value supplied by the user
             src_type = user_type
             log.info(f'Using input source type = {src_type}')
+
+        elif (patttype is not None) and (('NOD' in patttype) or ('POINT-SOURCE' in patttype)):
+
+            # Set all nodded exposures to POINT source type
+            src_type = 'POINT'
+            log.info(f'Exposure is nodded; setting SRCTYPE = {src_type}')
 
         else:
 

--- a/jwst/srctype/tests/test_srctype.py
+++ b/jwst/srctype/tests/test_srctype.py
@@ -36,7 +36,7 @@ def test_background_target_unset():
 
     # If BKGDTARG is missing, next test should be based on the
     # value of PATTTYPE, which in this case should return POINT.
-    assert output.meta.target.source_type == 'POINT'
+    assert output.meta.target.source_type == 'EXTENDED'
 
 
 def test_nrsifu_nodded():
@@ -52,7 +52,7 @@ def test_nrsifu_nodded():
     output = srctype.set_source_type(input)
 
     # Result should be POINT regardless of input setting
-    assert output.meta.target.source_type == 'POINT'
+    assert output.meta.target.source_type == 'EXTENDED'
 
 
 def test_mirmrs_nodded():
@@ -69,7 +69,7 @@ def test_mirmrs_nodded():
     output = srctype.set_source_type(input)
 
     # Result should be POINT regardless of input setting
-    assert output.meta.target.source_type == 'POINT'
+    assert output.meta.target.source_type == 'EXTENDED'
 
 
 def test_user_input():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3098](https://jira.stsci.edu/browse/JP-3098)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR changes the order of the precedence of the rules for setting the src_type for 'MIR_LRS-FIXEDSLIT', 'MIR_LRS-SLITLESS', 'MIR_MRS', 'NRC_TSGRISM', 'NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_IFU']. The SRCTYPE has precedence over the PATTTYPE. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
