### PR TITLE
JP-3234: Mask NaN values for background subtraction of "robust mean"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ associations
   contains the target as coron, while treating the others as regular imaging. Also
   create an image3 ASN that contains data from all 4 detectors. [#7556]
 
+background
+----------
+
+- Mask out NaN pixels before removing outlier values and calculating mean in
+  ``robust_mean`` function. [#7587]
+
 datamodels
 ----------
 

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -307,8 +307,11 @@ def robust_mean(x, lowlim=25., highlim=75.):
         percentile limits.
     """
 
-    limits = np.percentile(x, (lowlim, highlim))
-    mask = np.logical_and(x >= limits[0], x <= limits[1])
-    mean_value = x[mask].mean(dtype=float)
+    nan_mask = np.isnan(x)
+    cleaned_x = x[~nan_mask]
+    limits = np.percentile(cleaned_x, (lowlim, highlim))
+    mask = np.logical_and(cleaned_x >= limits[0], cleaned_x <= limits[1])
+
+    mean_value = np.mean(cleaned_x[mask], dtype=float)
 
     return mean_value


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3234](https://jira.stsci.edu/browse/JP-3234)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a bug in the calculation of the mean background value when NaN values are present.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
