### PR TITLE
Update wfss_contam test data for new transforms + temporary xfail

### DIFF
--- a/jwst/regtest/test_nircam_wfss_contam.py
+++ b/jwst/regtest/test_nircam_wfss_contam.py
@@ -10,9 +10,10 @@ def run_wfss_contam(jail, rtdata_module):
     rtdata = rtdata_module
 
     # Get input data files
-    rtdata.get_data('nircam/wfss/jw01076_nircam_f322w2_i2d.fits')
-    rtdata.get_data('nircam/wfss/jw01076_nircam_f322w2_segm.fits')
-    rtdata.get_data('nircam/wfss/jw01076003001_01101_00001_nrca5_srctype.fits')
+    rtdata.get_data('nircam/wfss/jw01076-o107_t001_nircam_clear-f322w2_i2d.fits')
+    rtdata.get_data('nircam/wfss/jw01076-o107_t001_nircam_clear-f322w2_segm.fits')
+    rtdata.get_data('nircam/wfss/jw01076-o107_t001_nircam_clear-f322w2_cat.ecsv')
+    rtdata.get_data('nircam/wfss/jw01076107001_02101_00002_nrcalong_srctype.fits')
 
     # Run the step
     step_params = {
@@ -26,7 +27,7 @@ def run_wfss_contam(jail, rtdata_module):
     rtdata = rt.run_step_from_dict(rtdata, **step_params)
     return rtdata
 
-
+@pytest.mark.xfail(reason='Test too slow until stdatamodels PR#165 merged')
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Related to  [JP-2113](https://jira.stsci.edu/browse/JP-2113)

<!-- describe the changes comprising this PR here -->
This PR addresses regression test failures in wfss_contam due to bad loading of old transforms stored in the existing datamodel in Artifactory. This PR updates the input datamodel, but also contains an xfail - to remain until https://github.com/spacetelescope/stdatamodels/pull/165 is merged to improve speeds.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
