### PR TITLE
[CI] run `pip list` after installing override requirements in Jenkins

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -83,11 +83,8 @@ bc0.build_cmds = [
     "pip install git+https://github.com/spacetelescope/stdatamodels.git@master git+https://github.com/spacetelescope/stcal.git@main",
     "pip install -r requirements-max.txt",
     "pip install -r requirements-sdp.txt",
-    "pip freeze",
-]
-bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
+] + PipInject(env.OVERRIDE_REQUIREMENTS) + ["pip list"]
 bc0.test_cmds = [
-    "pip list",
     "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -80,11 +80,8 @@ bc0.build_cmds = [
     "pip install -e .[test,sdp] --no-cache-dir",
     "pip install pytest-xdist",
     "pip install -r requirements-dev.txt",
-    "pip freeze",
-]
-bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS) 
+] + PipInject(env.OVERRIDE_REQUIREMENTS) + ["pip list"]
 bc0.test_cmds = [
-    "pip list",
     "pytest -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
analogous to https://github.com/spacetelescope/romancal/pull/711#pullrequestreview-1462883026

> Currently the `pip freeze` happens after the initial dependency install, but before the `OVERRIDE_REQUIREMENTS` option is handled by Jenkins. This makes it difficult to see if Jenkins has successfully installed an overriden requirement for the test run. This PR adds an additional `pip list` (same as `pip freeze` just more nicely formatted as a table) after the `OVERRIDE_REQUIREMENTS` are applied so that one can check in the Jenkins job log to make sure overriden requirements have successfully installed.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
