### PR TITLE
Revert "JP-3229: <Fix a bug> added the user-supplied flat reference file to the log"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,8 +54,6 @@ flat_field
 
 - Refactored NIRSpec 1D flat interpolation for improved performance. [#7550]
 
-- Added log messages for reporting flat reference file(s) used. [#7592]
-
 cube_build
 ----------
 

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -104,9 +104,9 @@ class FlatFieldStep(Step):
 
             # Record the user-supplied flat as the FLAT reference type for recording
             # in the result header.
-            flat_ref_file = reference_file_models['user_supplied_flat'].meta.filename
-            self._reference_files_used.append(('flat', flat_ref_file))
-            self.log.info('Using flat field reference file: ', flat_ref_file)
+            self._reference_files_used.append(
+                ('flat', reference_file_models['user_supplied_flat'].meta.filename)
+            )
         elif self.use_correction_pars:
             self.log.info(f'Using flat field from correction pars {self.correction_pars["flat"]}')
             reference_file_models = {
@@ -197,9 +197,9 @@ class FlatFieldStep(Step):
         for reftype, reffile in reference_file_names.items():
             if reffile is not None:
                 reference_file_models[reftype] = model_type[reftype](reffile)
-                self.log.info('Using %s reference file: %s', reftype.upper(), reffile)
+                self.log.debug('Using %s reference file: %s', reftype.upper(), reffile)
             else:
-                self.log.info('No reference found for type %s', reftype.upper())
+                self.log.debug('No reference found for type %s', reftype.upper())
                 reference_file_models[reftype] = None
 
         return reference_file_models


### PR DESCRIPTION
Reverts spacetelescope/jwst#7592

Rats! I *knew* we should've run regression tests before merging this, but I assumed that simple changes to logging would be safe. Shame on me!

Line 109 in flat_field_step.py needs to be changed to include a format specifier, i.e.
`self.log.info('Using flat field reference file: %s', flat_ref_file)`
otherwise it results in a crash.