### PR TITLE
JP-3229: update ref file logging in flat_field step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,7 +55,7 @@ extract_1d
 flat_field
 ----------
 
-- Refactored NIRSpec 1D flat interpolation for improved performance. [#7550]
+- Refactored NIRSpec 1D flat interpolation for improved performance. [#7606]
 
 cube_build
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,7 +55,7 @@ extract_1d
 flat_field
 ----------
 
-- Refactored NIRSpec 1D flat interpolation for improved performance. [#7606]
+- Added log messages for reporting flat reference file(s) used. [#7606]
 
 cube_build
 ----------

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -104,9 +104,9 @@ class FlatFieldStep(Step):
 
             # Record the user-supplied flat as the FLAT reference type for recording
             # in the result header.
-            self._reference_files_used.append(
-                ('flat', reference_file_models['user_supplied_flat'].meta.filename)
-            )
+            flat_ref_file = reference_file_models['user_supplied_flat'].meta.filename
+            self._reference_files_used.append(('flat', flat_ref_file))
+            self.log.info('Using flat field reference file: %s', flat_ref_file)
         elif self.use_correction_pars:
             self.log.info(f'Using flat field from correction pars {self.correction_pars["flat"]}')
             reference_file_models = {
@@ -197,9 +197,9 @@ class FlatFieldStep(Step):
         for reftype, reffile in reference_file_names.items():
             if reffile is not None:
                 reference_file_models[reftype] = model_type[reftype](reffile)
-                self.log.debug('Using %s reference file: %s', reftype.upper(), reffile)
+                self.log.info('Using %s reference file: %s', reftype.upper(), reffile)
             else:
-                self.log.debug('No reference found for type %s', reftype.upper())
+                self.log.info('No reference found for type %s', reftype.upper())
                 reference_file_models[reftype] = None
 
         return reference_file_models


### PR DESCRIPTION
Resolves [JP-3229](https://jira.stsci.edu/browse/JP-3229)

This PR updates the handling of log messages for reporting the reference file(s) used by the step. Previously, a user-supplied ref file was not report at all, and CRDS ref files were only reported at the debug level. Now all ref files are reported at info level.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
