### PR TITLE
Remove uses and references to deprecated `jwst.datamodels.DataModel`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ background
 - Mask out NaN pixels in WFSS images before removing outlier values and calculating mean in
   ``robust_mean`` function. [#7587]
 
+blendmeta
+---------
+
+- Use ``JwstDataModel`` instead of deprecated ``DataModel`` [#7607]
+
 cube_build
 ----------
 
@@ -44,6 +49,8 @@ documentation
 
 - Update ``calwebb_spec2`` docs to reflect the fact that the MIRI MRS ``straylight``
   step now comes before the ``flatfield`` step. [#7593]
+
+- Remove references to deprecated ``jwst.datamodels.DataModels`` [#7607]
 
 extract_1d
 ----------

--- a/docs/jwst/stpipe/devel_io_design.rst
+++ b/docs/jwst/stpipe/devel_io_design.rst
@@ -132,7 +132,7 @@ is expected to accept other object types as well.
 
 A `Step`'s primary argument is expected to be either a string containing
 the file path to a data file, or a JWST
-:class:`~jwst.datamodels.DataModel` object. The method
+:class:`~jwst.datamodels.JwstDataModel` object. The method
 :meth:`~jwst.stpipe.step.Step.open_model` handles either type of
 input, returning a `DataModel` from the specified file or a shallow
 copy of the `DataModel` that was originally passed to it. A typical
@@ -324,7 +324,7 @@ Save That Model: Step.save_model
 
 If a `Step` needs to save a `DataModel` before the step completes, use
 of :meth:`Step.save_model <jwst.stpipe.step.Step.save_model>` is the recommended over
-directly calling :meth:`DataModel.save <jwst.datamodels.DataModel.save>`.
+directly calling :meth:`DataModel.save <jwst.datamodels.JwstDataModel.save>`.
 `Step.save_model` uses the `Step` framework and hence will honor the
 following:
 

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -19,7 +19,7 @@ def load_wcs(input_model, reference_files={}, nrs_slit_y_range=None):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The exposure.
     reference_files : dict
         A dict {reftype: reference_file_name} containing all

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -26,7 +26,7 @@ def create_pipeline(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The data model.
     reference_files : dict
         {reftype: file_name} mapping.
@@ -48,7 +48,7 @@ def imaging(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The data model.
     reference_files : dict
         {reftype: file_name} mapping.

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -31,7 +31,7 @@ def create_pipeline(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodel.DataModel`
+    input_model : `~jwst.datamodel.JwstDataModel`
         Input datamodel for processing
     reference_files : dict {reftype: reference file name}
         The dictionary of reference file names and their associated files.
@@ -56,7 +56,7 @@ def imaging(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodel.DataModel`
+    input_model : `~jwst.datamodel.JwstDataModel`
         Input datamodel for processing
     reference_files : dict
         The dictionary of reference file names and their associated files
@@ -107,7 +107,7 @@ def imaging_distortion(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodel.DataModel`
+    input_model : `~jwst.datamodel.JwstDataModel`
         Input datamodel for processing
     reference_files : dict
         The dictionary of reference file names and their associated files.

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -31,7 +31,7 @@ def create_pipeline(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodel.DataModel`
+    input_model : `~jwst.datamodel.JwstDataModel`
         Input datamodel for processing
     reference_files : dict
         The dictionary of reference file names and their associated files
@@ -117,7 +117,7 @@ def niriss_soss(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodel.DataModel`
+    input_model : `~jwst.datamodel.JwstDataModel`
         Input datamodel for processing
     reference_files : dict
         The dictionary of reference file names and their associated files
@@ -216,7 +216,7 @@ def imaging(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodel.DataModel`
+    input_model : `~jwst.datamodel.JwstDataModel`
         Input datamodel for processing
     reference_files : dict
         The dictionary of reference file names and their associated files
@@ -268,7 +268,7 @@ def imaging_distortion(input_model, reference_files):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodel.DataModel`
+    input_model : `~jwst.datamodel.JwstDataModel`
         Input datamodel for processing
     reference_files : dict
         The dictionary of reference file names and their associated files.

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -171,7 +171,7 @@ def ifu(input_model, reference_files, slit_y_range=[-.55, .55]):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The input data model.
     reference_files : dict
         The reference files used for this mode.
@@ -294,7 +294,7 @@ def slits_wcs(input_model, reference_files, slit_y_range):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The input data model.
     reference_files : dict
         The reference files used for this mode.
@@ -748,7 +748,7 @@ def get_spectral_order_wrange(input_model, wavelengthrange_file):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The input data model.
     wavelengthrange_file : str
         Reference file of type "wavelengthrange".
@@ -1331,7 +1331,7 @@ def get_disperser(input_model, disperserfile):
 
     Parameters
     ----------
-    input_model : `jwst.datamodels.DataModel`
+    input_model : `jwst.datamodels.JwstDataModel`
         The input data model - either an ImageModel or a CubeModel.
     disperserfile : str
         The name of the disperser reference file.
@@ -1598,7 +1598,7 @@ def _nrs_wcs_set_input(input_model, slit_name):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         A WCS object for the all open slitlets in an observation.
     slit_name : int or str
         Slit.name of an open slit.
@@ -1634,7 +1634,7 @@ def nrs_wcs_set_input(input_model, slit_name, wavelength_range=None,
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         A WCS object for the all open slitlets in an observation.
     slit_name : int or str
         Slit.name of an open slit.
@@ -1680,7 +1680,7 @@ def validate_open_slits(input_model, open_slits, reference_files):
 
     Parameters
     ----------
-    input_model : jwst.datamodels.DataModel
+    input_model : jwst.datamodels.JwstDataModel
         Input data model
 
     Returns
@@ -1748,7 +1748,7 @@ def spectral_order_wrange_from_model(input_model):
 
     Parameters
     ----------
-    input_model : jwst.datamodels.DataModel
+    input_model : jwst.datamodels.JwstDataModel
         The data model. Must have been through the assign_wcs step.
 
     """
@@ -1763,7 +1763,7 @@ def nrs_ifu_wcs(input_model):
 
     Parameters
     ----------
-    input_model : jwst.datamodels.DataModel
+    input_model : jwst.datamodels.JwstDataModel
         The data model. Must have been through the assign_wcs step.
     """
     _, wrange = spectral_order_wrange_from_model(input_model)
@@ -1817,7 +1817,7 @@ def nrs_lamp(input_model, reference_files, slit_y_range):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The input data model.
     reference_files : dict
         The reference files used for this mode.

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -217,9 +217,9 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
 
     Parameters
     ----------
-    dmodels : list of `~jwst.datamodels.DataModel`
+    dmodels : list of `~jwst.datamodels.JwstDataModel`
         A list of data models.
-    refmodel : `~jwst.datamodels.DataModel`, optional
+    refmodel : `~jwst.datamodels.JwstDataModel`, optional
         This model's WCS is used as a reference.
         WCS. The output coordinate frame, the projection and a
         scaling and rotation transform is created from it. If not supplied

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -36,7 +36,7 @@ def do_correction(input_model, barshadow_model=None, inverse=False, source_type=
 
     Returns
     -------
-    output_model, corrections : `~jwst.datamodels.MultiSlitModel`, jwst.datamodels.DataModel
+    output_model, corrections : `~jwst.datamodels.MultiSlitModel`, jwst.datamodels.JwstDataModel
         Science data model with correction applied and barshadow extensions added,
         and a model of the correction arrays.
     """

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -38,10 +38,10 @@ class InputSpectrumModel:
 
         Parameters
         ----------
-        ms : `~jwst.datamodels.DataModel`, MultiSpecModel or SpecModel
+        ms : `~jwst.datamodels.JwstDataModel`, MultiSpecModel or SpecModel
             This is used to get the integration time.
 
-        spec : `~jwst.datamodels.DataModel`, SpecModel table
+        spec : `~jwst.datamodels.JwstDataModel`, SpecModel table
             The table containing columns "wavelength" and "flux".
             The `ms` object may contain more than one spectrum, but `spec`
             should be just one of those.
@@ -272,7 +272,7 @@ class OutputSpectrumModel:
 
         Returns
         -------
-        output_model : `~jwst.datamodels.DataModel`, CombinedSpecModel object
+        output_model : `~jwst.datamodels.JwstDataModel`, CombinedSpecModel object
             A table of combined spectral data.
         """
 
@@ -557,7 +557,7 @@ def combine_1d_spectra(input_model, exptime_key):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         The input spectra.  This will likely be a ModelContainer object.
 
     exptime_key : str
@@ -568,7 +568,7 @@ def combine_1d_spectra(input_model, exptime_key):
 
     Returns
     -------
-    output_model : `~jwst.datamodels.DataModel`
+    output_model : `~jwst.datamodels.JwstDataModel`
         A datamodels.CombinedSpecModel object.
     """
 

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -15,7 +15,7 @@ class ApCorrBase(abc.ABC):
 
     Parameters
     ----------
-    input_model : `~/jwst.datamodels.DataModel`
+    input_model : `~/jwst.datamodels.JwstDataModel`
         Input data model used to determine matching parameters.
     apcorr_table : `~/astropy.io.fits.FITS_rec`
         Aperture correction table data from APCORR reference file.
@@ -358,7 +358,7 @@ def select_apcorr(input_model: DataModel) -> Union[Type[ApCorr], Type[ApCorrPhas
 
     Parameters
     ----------
-    input_model : `~/jwst.datamodels.DataModel`
+    input_model : `~/jwst.datamodels.JwstDataModel`
         Input data on which the aperture correction is to be applied.
 
     Returns

--- a/jwst/extract_1d/tests/test_apply_apcorr_nonifu.py
+++ b/jwst/extract_1d/tests/test_apply_apcorr_nonifu.py
@@ -5,7 +5,7 @@ import os
 from astropy.io import fits
 from astropy.table import Table
 
-from stdatamodels.jwst.datamodels import DataModel
+from stdatamodels.jwst.datamodels import JwstDataModel
 
 from jwst.extract_1d.apply_apcorr import ApCorr, ApCorrPhase, select_apcorr
 
@@ -34,7 +34,7 @@ def inputs(request):
 
     instrument, exptype = request.param
 
-    dm = DataModel()
+    dm = JwstDataModel()
     dm.meta.instrument.name = instrument
     dm.meta.exposure.type = exptype
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -52,7 +52,7 @@ def do_correction(input_model,
     dflat : ~jwst.datamodels.NirspecFlatModel or None
         Flat field for the detector.  Used only for NIRSpec data.
 
-    user_supplied_flat : ~jwst.datamodels.DataModel
+    user_supplied_flat : ~jwst.datamodels.JwstDataModel
         If supplied, all other reference flats and flat creation are
         ignored in favor of the specified flat.
 
@@ -262,7 +262,7 @@ def do_nirspec_flat_field(output_model, f_flat_model, s_flat_model, d_flat_model
     d_flat_model : ~jwst.datamodels.NirspecFlatModel or None
         Flat field for the detector.
 
-    user_supplied_flat : ~jwst.datamodels.DataModel or None
+    user_supplied_flat : ~jwst.datamodels.JwstDataModel or None
         If provided, override all other calculated or reference-file-retrieved
         flat information and use this data.
 
@@ -341,7 +341,7 @@ def nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model, dispa
     dispaxis : int
         1 means horizontal dispersion, 2 means vertical dispersion.
 
-    user_supplied_flat : ~jwst.datamodels.DataModel or None
+    user_supplied_flat : ~jwst.datamodels.JwstDataModel or None
         If provided, override all other calculated or reference-file-retrieved
         flat information and use this data.
 

--- a/jwst/gain_scale/gain_scale.py
+++ b/jwst/gain_scale/gain_scale.py
@@ -15,12 +15,12 @@ def do_correction(input_model, gain_factor):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         Input datamodel to be corrected
 
     Returns
     -------
-    output_model : `~jwst.datamodels.DataModel`
+    output_model : `~jwst.datamodels.JwstDataModel`
         Output datamodel with rescaled data
 
     """

--- a/jwst/lib/pipe_utils.py
+++ b/jwst/lib/pipe_utils.py
@@ -10,7 +10,7 @@ def is_tso(model):
 
     Parameters
     ----------
-    model : `~jwst.datamodels.DataModel`
+    model : `~jwst.datamodels.JwstDataModel`
         Data to check
 
     Returns
@@ -51,7 +51,7 @@ def is_irs2(model):
 
     Parameters
     ----------
-    model : `~jwst.datamodels.DataModel` or ndarray
+    model : `~jwst.datamodels.JwstDataModel` or ndarray
         Data to check
 
     Returns

--- a/jwst/lib/pointing_summary.py
+++ b/jwst/lib/pointing_summary.py
@@ -53,7 +53,7 @@ def calc_pointing_deltas(model):
 
     Parameters
     ----------
-    model : jwst.datamodel.DataModel
+    model : jwst.datamodels.JwstDataModel
         The model to check pointing information in.
 
     Returns
@@ -90,7 +90,7 @@ def calc_deltas(exposures, extra_meta=None):
     Parameters
     ----------
     exposures : [file-like[,...]] or [DataModel[,...]]
-        List of file-like objects or `jwst.datamodels.DataModel` to retrieve
+        List of file-like objects or `jwst.datamodels.JwstDataModel` to retrieve
         pointing information from.
 
     extra_meta: [str[,...]] or None

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -401,9 +401,9 @@ class TransformParameters:
     #: If no telemetry can be found during the observation,
     #: the time, in seconds, beyond the observation time to search for telemetry.
     tolerance: float = 60.
-    #: The date of observation (`jwst.datamodel.DataModel.meta.date`)
+    #: The date of observation (`jwst.datamodels.JwstDataModel.meta.date`)
     useafter: str = None
-    #: V3 position angle at Guide Star (`jwst.datamodel.DataModel.meta.guide_star.gs_v3_pa_science`)
+    #: V3 position angle at Guide Star (`jwst.datamodels.JwstDataModel.meta.guide_star.gs_v3_pa_science`)
     v3pa_at_gs: float = None
 
     def as_reprdict(self):
@@ -620,7 +620,7 @@ def update_wcs(model, default_pa_v3=0., default_roll_ref=0., siaf_path=None, prd
                reduce_func=None, **transform_kwargs):
     """Update WCS pointing information
 
-    Given a `jwst.datamodels.DataModel`, determine the simple WCS parameters
+    Given a `jwst.datamodels.JwstDataModel`, determine the simple WCS parameters
     from the SIAF keywords in the model and the engineering parameters
     that contain information about the telescope pointing.
 
@@ -628,7 +628,7 @@ def update_wcs(model, default_pa_v3=0., default_roll_ref=0., siaf_path=None, prd
 
     Parameters
     ----------
-    model : `~jwst.datamodels.DataModel`
+    model : `~jwst.datamodels.JwstDataModel`
         The model to update.
 
     default_roll_ref : float
@@ -723,7 +723,7 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
 
     Parameters
     ----------
-    model : `~jwst.datamodels.DataModel`
+    model : `~jwst.datamodels.JwstDataModel`
         The model to update.
 
     default_pa_v3 : float
@@ -776,7 +776,7 @@ def update_wcs_from_fgs_guiding(model, default_roll_ref=0.0, default_vparity=1, 
 def update_wcs_from_telem(model, t_pars: TransformParameters):
     """Update WCS pointing information
 
-    Given a `jwst.datamodels.DataModel`, determine the simple WCS parameters
+    Given a `jwst.datamodels.JwstDataModel`, determine the simple WCS parameters
     from the SIAF keywords in the model and the engineering parameters
     that contain information about the telescope pointing.
 
@@ -784,7 +784,7 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
 
     Parameters
     ----------
-    model : `~jwst.datamodels.DataModel`
+    model : `~jwst.datamodels.JwstDataModel`
         The model to update. The update is done in-place.
 
     t_pars : `TransformParameters`
@@ -899,7 +899,7 @@ def update_s_region(model, siaf):
 
     Parameters
     ----------
-    model : `~jwst.datamodels.DataModel`
+    model : `~jwst.datamodels.JwstDataModel`
         The model to update in-place.
     siaf : namedtuple
         The ``SIAF`` tuple with values populated from the PRD database.

--- a/jwst/lib/v1_calculate.py
+++ b/jwst/lib/v1_calculate.py
@@ -22,7 +22,7 @@ def v1_calculate_from_models(sources, siaf_path=None, **calc_wcs_from_time_kwarg
     Returns a table of V1 pointings for all input models.
     The table has the following columns:
 
-        - source (jwst.datamodel.DataModel): The model
+        - source (jwst.datamodels.JwstDataModel): The model
         - obstime (astropy.time.Time): The observation time
         - v1 (float, float, float): 3-tuple or ra, dec, and position angle
 

--- a/jwst/lib/wcs_utils.py
+++ b/jwst/lib/wcs_utils.py
@@ -9,7 +9,7 @@ def get_wavelengths(model, exp_type="", order=None, use_wavecorr=None):
 
     Parameters
     ----------
-    model : `~jwst.datamodels.DataModel`
+    model : `~jwst.datamodels.JwstDataModel`
         The input science data, or a slit from a
         `~jwst.datamodels.MultiSlitModel`.
 

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -23,16 +23,16 @@ def expand_to_2d(input, m_bkg_spec):
 
     Parameters
     ----------
-    input : `~jwst.datamodels.DataModel`
+    input : `~jwst.datamodels.JwstDataModel`
         The input science data.
 
-    m_bkg_spec : str or `~jwst.datamodels.DataModel`
+    m_bkg_spec : str or `~jwst.datamodels.JwstDataModel`
         Either the name of a file containing a 1-D background spectrum,
         or a data model containing such a spectrum.
 
     Returns
     -------
-    background : `~jwst.datamodels.DataModel`
+    background : `~jwst.datamodels.JwstDataModel`
         A copy of `input` but with the data replaced by the background,
         "expanded" from 1-D to 2-D.
     """
@@ -98,7 +98,7 @@ def create_bkg(input, tab_wavelength, tab_background):
 
     Parameters
     ----------
-    input : `~jwst.datamodels.DataModel`
+    input : `~jwst.datamodels.JwstDataModel`
         The input science data.
 
     tab_wavelength : 1-D ndarray
@@ -109,7 +109,7 @@ def create_bkg(input, tab_wavelength, tab_background):
 
     Returns
     -------
-    background : `~jwst.datamodels.DataModel`
+    background : `~jwst.datamodels.JwstDataModel`
         A copy of `input` but with the data replaced by the background,
         "expanded" from 1-D to 2-D.
     """

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -259,17 +259,17 @@ def subtract_2d_background(source, background):
 
     Parameters
     ----------
-    source : `~jwst.datamodels.DataModel` or `~jwst.datamodels.ModelContainer`
+    source : `~jwst.datamodels.JwstDataModel` or `~jwst.datamodels.ModelContainer`
         The input science data.
 
-    background : `~jwst.datamodels.DataModel`
+    background : `~jwst.datamodels.JwstDataModel`
         The input background data.  Must be the same datamodel type as `source`.
         For a `~jwst.datamodels.ModelContainer`, the source and background
         models in the input containers must match one-to-one.
 
     Returns
     -------
-    `~jwst.datamodels.DataModel`
+    `~jwst.datamodels.JwstDataModel`
         Background subtracted from source.
     """
 

--- a/jwst/model_blender/blendmeta.py
+++ b/jwst/model_blender/blendmeta.py
@@ -94,7 +94,7 @@ def blendmodels(product, inputs=None, output=None, verbose=False):
         input_filenames = extract_filenames_from_product(product)
         inputs = [datamodels.open(i) for i in inputs]  # return datamodels
     else:
-        if isinstance(inputs, datamodels.DataModel):
+        if isinstance(inputs, datamodels.JwstDataModel):
             input_filenames = [i.meta.filename for i in inputs]
         else:
             input_filenames = inputs  # assume list of filenames as input
@@ -162,7 +162,7 @@ def get_blended_metadata(input_models, verbose=False):
     ----------
     input_models : list
         Either a single list of filenames from which to extract the metadata to
-        be blended, or a list of `datamodels.DataModel` objects to be blended.
+        be blended, or a list of `datamodels.JwstDataModel` objects to be blended.
         The input models are assumed to have the blending rules defined as
         an integral part of the schema definition for the model.
 

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -219,7 +219,7 @@ def do_correction(input_model, pathloss_model=None, inverse=False, source_type=N
 
     Returns
     -------
-    output_model, corrections : jwst.datamodel.DataModel, jwst.datamodel.datamodel
+    output_model, corrections : jwst.datamodel.JwstDataModel, jwst.datamodel.datamodel
         2-tuple of the corrected science data with pathloss extensions added, and a
         model of the correction arrays.
 
@@ -368,7 +368,7 @@ def do_correction_mos(data, pathloss, inverse=False, source_type=None, correctio
 
     Parameters
     ----------
-    data : jwst.datamodel.DataModel
+    data : jwst.datamodel.JwstDataModel
         The NIRSpec MOS data to be corrected.
 
     pathloss : jwst.datamodel.PathlossModel or None
@@ -431,10 +431,10 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, cor
 
     Parameters
     ----------
-    data : jwst.datamodel.DataModel
+    data : jwst.datamodel.JwstDataModel
         The NIRSpec fixed-slit data to be corrected.
 
-    pathloss : jwst.datamodel.DataModel
+    pathloss : jwst.datamodel.JwstDataModel
         The pathloss reference data.
 
     inverse : boolean
@@ -494,10 +494,10 @@ def do_correction_ifu(data, pathloss, inverse=False, source_type=None, correctio
 
     Parameters
     ----------
-    data : jwst.datamodel.DataModel
+    data : jwst.datamodel.JwstDataModel
         The NIRSpec IFU data to be corrected.
 
-    pathloss : jwst.datamodel.DataModel
+    pathloss : jwst.datamodel.JwstDataModel
         The pathloss reference data.
 
     inverse : boolean
@@ -506,12 +506,12 @@ def do_correction_ifu(data, pathloss, inverse=False, source_type=None, correctio
     source_type : str or None
         Force processing using the specified source type.
 
-    correction_pars : jwst.datamodels.DataModel or None
+    correction_pars : jwst.datamodels.JwstDataModel or None
         The precomputed pathloss to apply instead of recalculation.
 
     Returns
     -------
-    corrections : jwst.datamodel.DataModel
+    corrections : jwst.datamodel.JwstDataModel
         The pathloss corrections applied.
     """
     if correction_pars:
@@ -547,10 +547,10 @@ def do_correction_lrs(data, pathloss):
 
     Parameters
     ----------
-    data : jwst.datamodel.DataModel
+    data : jwst.datamodel.JwstDataModel
         The MIRI LRS fixed-slit data to be corrected.
 
-    pathloss : jwst.datamodel.DataModel
+    pathloss : jwst.datamodel.JwstDataModel
         The pathloss reference data.
     """
     correction = _corrections_for_lrs(data, pathloss)
@@ -591,10 +591,10 @@ def do_correction_soss(data, pathloss):
 
     Parameters
     ----------
-    data : jwst.datamodel.DataModel
+    data : jwst.datamodel.JwstDataModel
         The NIRISS SOSS data to be corrected.
 
-    pathloss : jwst.datamodel.DataModel
+    pathloss : jwst.datamodel.JwstDataModel
         The pathloss reference data.
     """
     # Omit correction if this is a TSO observation
@@ -675,7 +675,7 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
     slit : jwst.datamodels.SlitModel
         The slit being operated on.
 
-    pathloss : jwst.datamodels.DataModel
+    pathloss : jwst.datamodels.JwstDataModel
         The pathloss reference data
 
     exp_type : str
@@ -764,7 +764,7 @@ def _corrections_for_fixedslit(slit, pathloss, exp_type, source_type):
     slit : jwst.datamodels.SlitModel
         The slit being operated on.
 
-    pathloss : jwst.datamodels.DataModel
+    pathloss : jwst.datamodels.JwstDataModel
         The pathloss reference data
 
     exp_type : str
@@ -850,7 +850,7 @@ def _corrections_for_ifu(data, pathloss, source_type):
     data : jwst.datamodels.SlitModel
         The data being operated on.
 
-    pathloss : jwst.datamodels.DataModel
+    pathloss : jwst.datamodels.JwstDataModel
         The pathloss reference data
 
     source_type : str or None
@@ -928,7 +928,7 @@ def _corrections_for_lrs(data, pathloss):
 
     Parameters
     ----------
-    data : jwst.datamodels.DataModel
+    data : jwst.datamodels.JwstDataModel
         The LRS data being operated on.
 
     pathloss : jwst.datamodels.MirLrsPathlossModel
@@ -936,7 +936,7 @@ def _corrections_for_lrs(data, pathloss):
 
     Returns
     -------
-    correction : jwst.datamodels.DataModel
+    correction : jwst.datamodels.JwstDataModel
         The correction arrays
     """
     correction = None

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -87,7 +87,7 @@ class DataSet():
 
         Parameters
         ----------
-        model : `~jwst.datamodels.DataModel`
+        model : `~jwst.datamodels.JwstDataModel`
             input Data Model object
 
         inverse : boolean
@@ -921,7 +921,7 @@ class DataSet():
 
         Parameters
         ----------
-        model : `~jwst.datamodels.DataModel`
+        model : `~jwst.datamodels.JwstDataModel`
             Input data model containing the necessary wavelength information
         exptype : str
             Exposure type of the input
@@ -968,7 +968,7 @@ class DataSet():
 
         Parameters
         ----------
-        model : `~jwst.datamodels.DataModel`
+        model : `~jwst.datamodels.JwstDataModel`
             Input data model containing the necessary wavelength information
         conversion : float
             Initial scalar photometric conversion value
@@ -1034,7 +1034,7 @@ class DataSet():
 
         Parameters
         ----------
-        ftab : `~jwst.datamodels.DataModel`
+        ftab : `~jwst.datamodels.JwstDataModel`
             A photom reference file data model
 
         area_fname : str
@@ -1106,7 +1106,7 @@ class DataSet():
 
         Parameters
         ----------
-        pix_area : `~jwst.datamodels.DataModel`
+        pix_area : `~jwst.datamodels.JwstDataModel`
             Pixel area reference file data model
         """
 
@@ -1208,7 +1208,7 @@ class DataSet():
 
         Returns
         -------
-        output_model : ~jwst.datamodels.DataModel
+        output_model : ~jwst.datamodels.JwstDataModel
             output data model with the flux calibrations applied
 
         """

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -163,7 +163,7 @@ def create_input(instrument, detector, exptype,
 
     Returns
     -------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         An open data model object of the appropriate type.
     """
 
@@ -397,7 +397,7 @@ def create_photom_nrs_fs(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a NIRSpec fixed-slit photom reference file.
     """
 
@@ -469,7 +469,7 @@ def create_photom_nrs_msa(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a NIRSpec MSA photom reference file.
     """
 
@@ -527,7 +527,7 @@ def create_photom_niriss_wfss(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a NIRISS WFSS photom reference file.
     """
 
@@ -583,7 +583,7 @@ def create_photom_niriss_soss(min_r=8.0, max_r=9.0):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a NIRISS SOSS photom reference file.
     """
 
@@ -637,7 +637,7 @@ def create_photom_niriss_image(min_r=8.0, max_r=9.0):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a NIRISS image photom reference file.
     """
 
@@ -681,7 +681,7 @@ def create_photom_miri_mrs(shape, value, pixel_area, photmjsr):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a MIRI MRS photom reference file.
     """
 
@@ -716,7 +716,7 @@ def create_photom_miri_lrs(min_wl=5.0, max_wl=10.0, min_r=8.0, max_r=9.0):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a MIRI LRS photom reference file.
     """
 
@@ -775,7 +775,7 @@ def create_photom_miri_image(min_wl=16.5, max_wl=19.5,
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a MIRI image photom reference file.
     """
 
@@ -812,7 +812,7 @@ def create_photom_nircam_image(min_r=8.0, max_r=9.0):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a NIRCam image photom reference file.
     """
 
@@ -856,7 +856,7 @@ def create_photom_nircam_wfss(min_wl=2.4, max_wl=5.0, min_r=8.0, max_r=9.0):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a NIRCam WFSS photom reference file.
     """
 
@@ -907,7 +907,7 @@ def create_photom_fgs_image(value):
 
     Returns
     -------
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         An open data model for a NIRSpec fixed-slit photom reference file.
     """
 
@@ -939,7 +939,7 @@ def create_pixel_area_ref(shape, area_ster, area_a2):
 
     Returns
     -------
-    area_ref : `~jwst.datamodels.DataModel`
+    area_ref : `~jwst.datamodels.JwstDataModel`
         An open data model for a pixel area reference file.
     """
 
@@ -970,7 +970,7 @@ def create_msa_pixel_area_ref(quadrant, shutter_x, shutter_y, pixarea):
 
     Returns
     -------
-    area_ref : `~jwst.datamodels.DataModel`
+    area_ref : `~jwst.datamodels.JwstDataModel`
         An open data model for a pixel area reference file.
     """
 
@@ -990,10 +990,10 @@ def find_row_in_ftab(input_model, ftab, select, slitname=None, order=None):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.DataModel`
+    input_model : `~jwst.datamodels.JwstDataModel`
         input Data Model object
 
-    ftab : `~jwst.datamodels.DataModel`
+    ftab : `~jwst.datamodels.JwstDataModel`
         This has a `phot_table` attribute, which is a table containing
         photometric information.  This can be any of several data models
         functionally equivalent to _photom_xxxx.fits files in CRDS.

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -79,7 +79,7 @@ class Coron3Pipeline(Pipeline):
 
         Parameters
         ----------
-        user_input : str, Level3 Association, or ~jwst.datamodels.DataModel
+        user_input : str, Level3 Association, or ~jwst.datamodels.JwstDataModel
             The exposure or association of exposures to process
         """
         self.log.info('Starting calwebb_coron3 ...')

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -91,7 +91,7 @@ class Spec2Pipeline(Pipeline):
 
         Parameters
         ----------
-        input: str, Level2 Association, or ~jwst.datamodels.DataModel
+        input: str, Level2 Association, or ~jwst.datamodels.JwstDataModel
             The exposure or association of exposures to process
         """
         self.log.info('Starting calwebb_spec2 ...')

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -73,7 +73,7 @@ class Spec3Pipeline(Pipeline):
 
         Parameters
         ----------
-        input: str, Level3 Association, or ~jwst.datamodels.DataModel
+        input: str, Level3 Association, or ~jwst.datamodels.JwstDataModel
             The exposure or association of exposures to process
         """
         self.log.info('Starting calwebb_spec3 ...')

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -36,7 +36,7 @@ class ResampleStep(Step):
 
     Parameters
     -----------
-    input :  ~jwst.datamodels.DataModel or ~jwst.associations.Association
+    input :  ~jwst.datamodels.JwstDataModel or ~jwst.associations.Association
         Single filename for either a single image or an association table.
     """
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -27,7 +27,7 @@ def make_output_wcs(input_models, ref_wcs=None,
     """ Generate output WCS here based on footprints of all input WCS objects
     Parameters
     ----------
-    input_models : list of `~jwst.datamodel.DataModel`
+    input_models : list of `~jwst.datamodel.JwstDataModel`
         Each datamodel must have a ~gwcs.WCS object.
 
     pscale_ratio : float, optional

--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -31,7 +31,7 @@ class CrdsStep(Step):
 
         with datamodels.open(input_file) as dm:
             self.ref_filename = self.get_reference_file(dm, 'flat')
-        return datamodels.DataModel()
+        return datamodels.JwstDataModel()
 
 
 def test_crds_step():


### PR DESCRIPTION
Closes #7574 
This PR removes use of the deprecated and soon to be removed `jwst.datamodels.DataModel` from:
- a few tests: https://github.com/spacetelescope/jwst/commit/5153670aceaa4a310f0066f12be35d825c4ddec3
- a check in blendmeta: https://github.com/spacetelescope/jwst/commit/c266d1e60c1076556b9955bf8152f080edf02a23
- many docstrings
- some documentation pages (there are many remaining references to `DataModel` which appear to either not reference a page or reference a broken page).

Removing the uses here (and in crds: https://github.com/spacetelescope/crds/pull/938) should allow us to remove the model from stdatamodels: https://github.com/spacetelescope/stdatamodels/pull/171

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
