### PR TITLE
JP-3268: Fix pixel_replace step status error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.11.1 (unreleased)
 ===================
 
+pixel_replace
+-------------
+
+- Fixed bug in setting the step completion status at the end of processing. [#7619]
+`
 ramp_fitting
 ------------
 

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -84,6 +84,6 @@ class PixelReplaceStep(Step):
             replacement = PixelReplacement(result, **pars)
             replacement.replace()
 
-            self.record_step_status(result, 'pixel_replace', success=True)
+            self.record_step_status(replacement.output, 'pixel_replace', success=True)
             return replacement.output
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3268](https://jira.stsci.edu/browse/JP-3268)

<!-- describe the changes comprising this PR here -->
This PR fixes the `pixel_replace` step code so that it properly updates the step status keyword on completion. Previously a data model object was being updated that was not the model returned from the step, so the update was lost.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
