### PR TITLE
fix stdatamodels datamodels link in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,7 @@ intersphinx_mapping = {
     'scipy': ('http://scipy.github.io/devdocs', None),
     'matplotlib': ('http://matplotlib.org/', None),
     'gwcs': ('https://gwcs.readthedocs.io/en/stable/', None),
+    'stdatamodels': ('https://stdatamodels.readthedocs.io/en/latest/', None),
 }
 
 if sys.version_info[0] == 2:

--- a/docs/jwst/user_documentation/datamodels.rst
+++ b/docs/jwst/user_documentation/datamodels.rst
@@ -3,16 +3,13 @@ JWST Datamodels
 ===============
 
 The `jwst` package also contains the interface for JWST Datamodels. ``Datamodels``
-are the reccomended way of reading and writing JWST data files (.fits) and
+are the recommended way of reading and writing JWST data files (.fits) and
 reference files (.fits and .asdf). JWST data are encoded in FITS files, and reference
 files consist of a mix of FITS and ASDF - datamodels were designed to
 abstract away these intricacies and provide a simple interface to the data. They
 represent the data in FITS extensions and meta data in FITS headers in a Python object
 with a tree-like structure. The following section gives a brief overview of
-``Datamodels`` as they pertain to the pipeline - see 
-.. comment out until stdatamodels is released
-.. ref  data-models
-data-models
+``Datamodels`` as they pertain to the pipeline - see :ref:`stdatamodels:data-models`
 for more
 detailed documentation on Datamodels.
 


### PR DESCRIPTION
Remove comment that made it's way into the data models docs and link to the now published stdatamodels docs.

Addresses comment: https://github.com/spacetelescope/jwst/issues/7656#issuecomment-1611746940

Fixes: [JP-3280](https://jira.stsci.edu/browse/JP-3280)

Link to updated datamodels docs built with this PR: https://jwst-pipeline--7657.org.readthedocs.build/en/7657/jwst/user_documentation/datamodels.html#jwst-datamodels

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
