### PR TITLE
remove uses of stdatamodels.jwst.datamodels.schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,17 @@
 1.11.4 (unreleased)
 ===================
 
+datamodels
+----------
+
+- Remove ``jwst.datamodels.schema`` in favor of ``stdatamodels.schema`` [#7660]
+
 flat_field
 ----------
 
 - Modify test_flatfield_step_interface test to prevent it from causing
   other tests to fail [#7752]
+
 
 1.11.3 (2023-07-17)
 ===================
@@ -64,8 +70,6 @@ datamodels
 
 - Added two new header keywords to track the rate of cosmic rays and snowball/showers
   [#7609, spacetelescope/stdatamodels [spacetelescope/stdatamodels#173]
-
-- Remove ``jwst.datamodels.schema`` in favor of ``stdatamodels.schema`` [#7660]
 
 jump
 ----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ datamodels
 - Added two new header keywords to track the rate of cosmic rays and snowball/showers
   [#7609, spacetelescope/stdatamodels [spacetelescope/stdatamodels#173]
 
+- Remove ``jwst.datamodels.schema`` in favor of ``stdatamodels.schema`` [#7660]
+
 jump
 ----
 

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -29,7 +29,7 @@ _jwst_modules = ["container", "source_container"]
 _jwst_models = ["ModelContainer", "SourceModelContainer"]
 
 # Deprecated modules in stdatamodels
-_deprecated_modules = ['drizproduct', 'multiprod']
+_deprecated_modules = ['drizproduct', 'multiprod', 'schema']
 
 # Deprecated models in stdatamodels
 _deprecated_models = ['DrizProductModel', 'MultiProductModel', 'MIRIRampModel']

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -50,6 +50,6 @@ for attr in dir(stdatamodels.jwst.datamodels):
         sys.modules[f"jwst.datamodels.{attr}"] = obj
 
 # Add a few submodules to sys.modules without exposing them locally
-for _submodule_name in ['schema', 'schema_editor', 'validate']:
+for _submodule_name in ['schema_editor', 'validate']:
     _submodule = importlib.import_module(f"stdatamodels.jwst.datamodels.{_submodule_name}")
     sys.modules[f"jwst.datamodels.{_submodule_name}"] = _submodule

--- a/jwst/scripts/move_wcs.py
+++ b/jwst/scripts/move_wcs.py
@@ -6,7 +6,7 @@ from astropy import wcs
 from astropy.io import fits
 from astropy.wcs import InvalidTransformError
 
-from stdatamodels.jwst.datamodels.schema import walk_schema
+from stdatamodels.schema import walk_schema
 from stdatamodels.jwst import datamodels
 
 wcslib_kw_to_remove = ['LONPOLE', 'LATPOLE', 'MJD-OBS', 'DATE-OBS']

--- a/jwst/scripts/schemadoc.py
+++ b/jwst/scripts/schemadoc.py
@@ -32,7 +32,7 @@
 import argparse
 import sys
 
-from stdatamodels.jwst.datamodels.schema import build_docstring
+from stdatamodels.schema import build_docstring
 
 
 def get_docstrings(template, model_names, all=False):


### PR DESCRIPTION
[stdatamodels.jwst.datamodels.schema](https://github.com/spacetelescope/stdatamodels/blob/master/src/stdatamodels/jwst/datamodels/schema.py) is an out-of-date duplicate of [stdatamodels.schema](https://github.com/spacetelescope/stdatamodels/blob/master/src/stdatamodels/schema.py). Uses of the stdatamodels.jwst.datamodels.schema were converted to stdatamodels.schema and the automatic shadowing of stdatamodels.jwst.datamodels.schema to jwst.datamodels.schema was removed.

**This removes jwst.datamodels.schema from the api.**

Regression tests run at: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/794/

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
