### PR TITLE
fix more missing links to stdatamodels docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.11.2 (unreleased)
 ===================
 
+documentation
+-------------
+
+- Update references to datamodels in docs to point to stdatamodels which
+  now provides datamodels for jwst. [#7672]
+
 tweakreg
 --------
 

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -12,9 +12,7 @@ the `jwst` package into a `conda` environment, and then to set correct
 environment variables for accessing reference files through CRDS. From there,
 the JWST pipeline can be :ref:`run in a Python session<run_from_python>` or with
 the :ref:`command line interface<run_from_strun>`, and
-.. comment out until stdatamodels is released
-.. ref JWST datamodels<data-models>
-JWST datamodels
+:ref:`JWST datamodels<jwst-data-models>`
 and other pipeline utilities can be imported
 and used in a Python session.
 
@@ -84,6 +82,4 @@ For information on how to run the pipeline using the command line interface, see
 :ref:`Running the JWST pipeline: Command Line Interface<run_from_strun>`.
 
 For information on how to read and write data files with JWST `datamodels`, see
-.. comment out until stdatamodels is released
-.. ref JWST datamodels<data-models>
-JWST datamodels.
+:ref:`JWST datamodels<jwst-data-models>`.

--- a/docs/jwst/associations/overview.rst
+++ b/docs/jwst/associations/overview.rst
@@ -118,13 +118,9 @@ exposure file name of a Stage 3 associations::
    exposure = asn['products'][0]['members'][0]['expname']
 
 Since most JWST data are some form of a 
-.. comment out until stdatamodels is released
-.. ref  JWST Data Model<data-models>
-JWST Data Model
+:ref:`JWST Data Model<jwst-data-models>`
 an association can be opened with
-.. comment out until stdatamodels is released
-.. ref  datamodels.open<datamodels-open>
-``datamodels.open``
+:ref:`datamodels.open<stdatamodels:datamodels-open>`
 which returns a
 :py:class:`~jwst.datamodels.ModelContainer`. All members of the association that can
 be represented as a ``DataModel``, will be available in the ``ModelContainer``

--- a/docs/jwst/model_blender/main.rst
+++ b/docs/jwst/model_blender/main.rst
@@ -42,10 +42,7 @@ more efficient (read that: faster) processing.
 
   The generated output model will be considered to contain a default
   (or perhaps even empty) set of :ref:`metadata` based on some
-  model defined in 
-  .. comment out until stdatamodels is released
-  .. ref DataModels<datamodels>.
-  DataModels.
+  model defined in :ref:`stdatamodels<stdatamodels:data-models>`
   This metadata will be replaced
   **in-place** when running :ref:`blender_api`.
 

--- a/docs/jwst/stpipe/user_step.rst
+++ b/docs/jwst/stpipe/user_step.rst
@@ -219,10 +219,7 @@ signature is::
     Step.call(input, config_file=None, **parameters)
 
 The positional argument ``input`` is the data to be operated on, usually a
-string representing a file path or a
-.. comment out until stdatamodels is released
-.. ref  DataModel<datamodels>.
-DataModel.
+string representing a file path or a :ref:`DataModel<jwst-data-models>`
 The optional
 keyword argument ``config_file`` is used to specify a local parameter file. The
 optional keyword argument ``logcfg`` is used to specify a logging configuration file.
@@ -261,9 +258,7 @@ example is::
 
 `input` in this case can be a fits file containing the appropriate data, or the output
 of a previously run step/pipeline, which is an instance of a particular
-.. comment out until stdatamodels is released
-.. ref  datamodel<datamodels>.
-datamodel.
+:ref:`datamodel<jwst-data-models>`.
 
 Unlike the ``call`` class method, there is no parameter initialization that
 occurs, either by a local parameter file or from a CRDS-retrieved parameter

--- a/docs/jwst/user_documentation/datamodels.rst
+++ b/docs/jwst/user_documentation/datamodels.rst
@@ -1,3 +1,5 @@
+.. _jwst-data-models:
+
 ===============
 JWST Datamodels
 ===============


### PR DESCRIPTION
It appears https://github.com/spacetelescope/jwst/pull/7657 was incomplete as while looking at other docs I found another broken link to and malformed comment about stdatamodels. I believe this PR should fix all the broken links and erroneous comments.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
