### PR TITLE
JP-3285: Allow negative angles in engineering format. Add support for angle units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,16 @@ ramp_fitting
   group, the timing for these ramps is not group time.  These adjusted times
   are now used. [#7612, spacetelescope/stcal#173]
 
+tweakreg
+--------
+
+- Fixed a bug in the ``adjust_wcs`` *script* that was preventing passing
+  negative angular arguments in the engineering format. Exposed ``adjust_wcs``
+  function's docstring to be used in building ``jwst`` documentation. [#7683]
+
+- Added support for units for angular arguments to both ``adjust_wcs`` script
+  and function. [#7683]
+
 
 1.11.0 (2023-06-21)
 ===================
@@ -80,7 +90,7 @@ cube_build
 ----------
 
 - Remove deleting the ``spaxel_dq`` array twice when using a weighting method of either msm or emsm. [#7586]
-  
+
 - Updated to read wavelength range for NIRSpec IFU cubes from the cubepars reference file,
   instead of setting it based on the data. This makes use of new NIRSpec IFU cubepars reference
   files with wavelength arrays for the drizzle method. [#7559]
@@ -131,7 +141,7 @@ flat_field
 ----------
 
 - Added log messages for reporting flat reference file(s) used. [#7606]
-  
+
 other
 -----
 
@@ -213,7 +223,7 @@ tweakreg
   another. It is an analog of the ``tweakback`` task in the
   ``drizzlepac``. [#7573, #7591]
 
-- Added the 'GAIADR3' catalog to the available options for alignment; 
+- Added the 'GAIADR3' catalog to the available options for alignment;
   this has been enabled as the default option [#7611].
 
 


### PR DESCRIPTION
Resolves [JP-3285](https://jira.stsci.edu/browse/JP-3285)

This PR fixes a bug in the `adjust_wcs` _script_ that would prevent setting angles to negative numbers in the engineering format (a limitation of `argparse`). This PR also adds support for units for angles. For example, now the scrpt can be invoked like this:

```
adjust_wcs in_file.fits -f out_file.fits --overwrite -r 1.2 arcsec -d -4.5e-6 -s 1.0001
```
When angle units are not provided (as for the DEC angle correction above), the angles are still assumed to be in degrees.

Finally, this PR adds functions from the `tweakreg.utils` module to the `__all__` variable thus publishing the docstrings of these functions in the `jwst` documentation.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
