### PR TITLE
JP-3254: Update extract_2d docs for WFSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ documentation
 - Update references to datamodels in docs to point to stdatamodels which
   now provides datamodels for jwst. [#7672]
 
+- Update the ``extract_2d`` step docs to give better descriptions of how to create
+  and use object lists for WFSS grism image extractions. [#7684]
+
 tweakreg
 --------
 

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -10,7 +10,7 @@ The ``extract_2d`` step extracts 2D arrays from spectral images. The extractions
 are performed within all of the SCI, ERR, and DQ arrays of the input image
 model, as well as any variance arrays that may be present. It also computes an
 array of wavelengths to attach to the extracted data. The extracted arrays
-are stored as one or more ``slit`` objects in an output MultiSlitModel
+are stored as one or more ``slit`` objects in an output ``MultiSlitModel``
 and saved as separate tuples of extensions in the output FITS file.
 
 Assumptions
@@ -19,17 +19,21 @@ This step uses the ``bounding_box`` attribute of the WCS stored in the data mode
 which is populated by the ``assign_wcs`` step. Hence the ``assign_wcs`` step
 must be applied to the science exposure before running this step.
 
-For NIRCam and NIRISS WFSS modes, no ``bounding_box`` has been attached
-to the data model. This is to keep the WCS flexible enough to be used with any
-source catalog that may be associated with the dispersed image. Instead, there
+For NIRCam and NIRISS WFSS modes, no ``bounding_box`` is attached to the data
+model by the ``assign_wcs`` step.
+This is to keep the WCS flexible enough to be used with any
+source catalog or similar list of objects that may be associated with the dispersed image.
+Instead, there
 is a helper method that is used to calculate the bounding boxes that contain
-the dispersed spectra for each object. One box is made for each spectral order of
-each object. The ``extract2d`` step uses the source catalog referenced in the input
+the spectral trace for each object. One box is made for each spectral order of
+each object. In regular, automated processing, the ``extract_2d`` step uses the
+source catalog specified in the input
 model's meta information to create the list of objects and their corresponding
 bounding box. This list is used to make the 2D cutouts from the dispersed image.
 
-NIRCam TSGRISM exposures do not use a source catalog, so instead it relies on the
-assumption that the source of interest is located at the aperture reference point.
+NIRCam TSGRISM exposures do not use a source catalog, so the step instead relies on the
+assumption that the source of interest is located at the aperture reference point
+and centers the extraction there.
 More details are given below.
 
 Algorithm
@@ -37,8 +41,8 @@ Algorithm
 This step is currently applied only to NIRSpec Fixed-Slit, NIRSpec MOS, NIRSpec TSO
 (BrightObj), NIRCam and NIRISS WFSS, and NIRCam TSGRISM observations.
 
-NIRSpec
-+++++++
+NIRSpec Fixed Slit and MOS
+++++++++++++++++++++++++++
 
 If the step parameter ``slit_name`` is left unspecified, the default behavior is
 to extract all slits that project onto the detector. A single slit may be extracted by
@@ -58,7 +62,7 @@ The corner locations of the regions to be extracted are determined from the
 along each axis. The input coordinates are in the image frame, i.e. subarray shifts
 are accounted for.
 
-The output MultiSlit data model will have the meta data associated with each
+The output ``MultiSlitModel`` data model will have the meta data associated with each
 slit region populated with the name and region characteristic for the slits,
 corresponding to the FITS keywords "SLTNAME", "SLTSTRT1", "SLTSIZE1",
 "SLTSTRT2", and "SLTSIZE2."  Keyword "DISPAXIS" (dispersion direction)
@@ -68,10 +72,13 @@ will be copied from the input file to each of the output cutout images.
 NIRCam and NIRISS WFSS
 ++++++++++++++++++++++
 
-If the step parameter ``grism_objects`` is left unspecified, the default behavior
-is to use the source catalog that is specified in the input model's meta information,
-``input_model.meta.source_catalog.filename``. Otherwise, a user can submit a list of
-``GrismObjects`` that contains information about the objects that should be extracted.
+During normal, automated processing of WFSS grism images, the 
+step parameter ``grism_objects`` is left unspecified, in which case the ``extract_2d``
+step uses the source catalog that is specified in the input model's meta information,
+``input_model.meta.source_catalog.filename`` ("SCATFILE" keyword) to define the
+list of objects to be extracted.
+Otherwise, a user can submit a list of ``GrismObjects`` that contains information
+about the objects that they want extracted.
 The ``GrismObject`` list can be created automatically by using the method in
 ``jwst.assign_wcs.utils.create_grism_bbox``. This method also uses the name of the source
 catalog saved in the input model's meta information. If it's better to construct a list
@@ -102,81 +109,128 @@ All remaining objects are then extracted from the grism image.
 
 WFSS Examples
 ^^^^^^^^^^^^^
-Following are examples of how to customize the list of grism objects used in extract_2d.
-The input file must have a WCS assigned to it by running ``assign_wcs``. The default values
-for  wavelength range and the spectral orders are stored in the ``wavelengthrange``
-reference file, which can be retrieved from CRDS. A user may supply a different
-wavelength range by passing `None` to ``reference_files``. In this case the spectral
-orders to be extracted and their corresponding wavelength range will be taken
-from the ``wavelength_range`` parameter, which is a dictionary ``{spectral_order: (lam_min, lam_max)}``.
+The extraction of sources from WFSS grism images is a multi-step process, as outlined above.
+Here we show detailed examples of how to customize the list of WFSS grism objects to be
+extracted, in order to better explain the various steps.
+First, the input file (or data model) must aleady have a WCS object assigned to it by running
+the :ref:`assign_wcs <assign_wcs_step>` step. The default values
+for the wavelength range of each spectral order to be extracted are also required;
+they are stored in the ``wavelengthrange`` reference file, which can be retrieved from CRDS.
+
+Load the grism image, which is assumed to have already been processed through ``assign_wcs``,
+into an `ImageModel` data model (used for all 2-D "images", regardless of whether
+they actually contain imaging data or dispersed spectra):
 
 .. doctest-skip::
 
   >>> from stdatamodels.jwst.datamodels import ImageModel
-  >>> input_model = ImageModel("nircam_wfss_assign_wcs.fits")
+  >>> input_model = ImageModel("jw12345001001_03101_00001_nis_assign_wcs.fits")
 
-Retrieve the wavelengthrange file specific for this mode:
+Load the ``extract_2d`` step and retrieve the ``wavelengthrange`` reference file
+specific for this mode:
 
 .. doctest-skip::
 
   >>> from jwst.extract_2d import Extract2dStep
   >>> step = Extract2dStep()
   >>> refs = {}
-  >>> for ref_type in step.reference_file_types:
-  ...     refs[ref_type] = step.get_reference_file(input_model, ref_type)
+  >>> reftype = 'wavelengthrange'
+  >>> refs[reftype] = step.get_reference_file(input_model, reftype)
   >>> print(refs)
-  {'wavelengthrange': '/crds/references/jwst/niriss/jwst_niriss_wavelengthrange_0002.asdf'}
+  {'wavelengthrange': '/crds/jwst/references/jwst_niriss_wavelengthrange_0002.asdf'}
 
 Create a list of grism objects for a specified spectral order with a limited
-minimum magnitude, and a specified half height of the extraction box in
-cross-dispersion direction. The ``wfss_extract_half_height`` parameter applies only to
-point sources.
+minimum magnitude and a specified half-height of the extraction box in the
+cross-dispersion direction via the ``wfss_extract_half_height`` parameter.
+Note that the half-height parameter only applies to point sources.
 
 .. doctest-skip::
 
   >>> from jwst.assign_wcs.util import create_grism_bbox
-  >>> grism_objects = create_grism_bbox(im, refs, wfss_mmag_extract=17,
+  >>> grism_objects = create_grism_bbox(input_model, refs, mmag_extract=17,
   ... extract_orders=[1], wfss_extract_half_height=10)
   >>> print(len(grism_objects))
   6
   >>> print(grism_objects[0])
-  GrismObject(sid=12, order_bounding={1: ((246, 266), (1367, 1581))}, sky_centroid=<SkyCoord (ICRS): (ra, dec) in deg
-  (85.19582803, -69.53656873)>, partial_order={1: False}, waverange={1: (1.29, 1.71)}, sky_bbox_ll=<SkyCoord (ICRS): (ra, dec) in deg
-  (85.19917182, -69.53721616)>, sky_bbox_lr=<SkyCoord (ICRS): (ra, dec) in deg
-  (85.19270524, -69.53718398)>, sky_bbox_ur=<SkyCoord (ICRS): (ra, dec) in deg
-  (85.19276186, -69.53579839)>, sky_bbox_ul=<SkyCoord (ICRS): (ra, dec) in deg
-  (85.19922801, -69.53583056)>, xcentroid=1574.0825945473498, ycentroid=254.2556654610221)
+  id: 432
+  order_bounding {1: ((array(1113), array(1471)), (array(1389), array(1609)))}
+  sky_centroid: <SkyCoord (ICRS): (ra, dec) in deg
+      (3.59204081, -30.40553435)>
+  sky_bbox_ll: <SkyCoord (ICRS): (ra, dec) in deg
+      (3.59375611, -30.40286617)>
+  sky_bbox_lr: <SkyCoord (ICRS): (ra, dec) in deg
+      (3.59520565, -30.40665425)>
+  sky_bbox_ur: <SkyCoord (ICRS): (ra, dec) in deg
+      (3.58950974, -30.4082754)>
+  sky_bbox_ul:<SkyCoord (ICRS): (ra, dec) in deg
+      (3.5880604, -30.40448726)>
+  xcentroid: 1503.6541213285695
+  ycentroid: 1298.2882813663837
+  partial_order: {1: False}
+  waverange: {1: (0.97, 1.32)}
+  is_extended: True
+  isophotal_abmag: 16.185488680084294
 
 Create a list of grism objects for a specified spectral order and wavelength range.
-Use the source ID, ``sid`` to modify the extraction limits for specific objects.
-The computed extraction limits are in the ``order_bounding`` attribute ordered ``(y, x)``.
+In this case we don't use the default wavelength range limits from the ``wavelengthrange``
+reference file, but instead designate custom limits via the ``wavelength_range`` parameter
+passed to the ``create_grism_bbox`` function, which is a dictionary of the form
+``{spectral_order: (wave_min, wave_max)}``. 
+Use the source ID, ``sid``, to identify the object(s) to be modified.
+The computed extraction limits are stored in the ``order_bounding`` attribute,
+which is ordered ``(y, x)``.
 
 .. doctest-skip::
 
   >>> from jwst.assign_wcs.util import create_grism_bbox
-  >>> grism_objects = create_grism_bbox(im, wfss_mmag_extract=17, wavelength_range={1: (3.01, 4.26)})
+  >>> grism_objects = create_grism_bbox(input_model, mmag_extract=18,
+  ... wavelength_range={1: (3.01, 4.26)})
   >>> print([obj.sid for obj in grism_objects])
-  [12, 26, 31, 37, 57]
+  [12, 26, 31, 37, 104]
   >>> print(grism_objects[-1])
-  id: 57
-  order_bounding {1: ((995, 1114), (-18, 407))}
+  id: 104
+  order_bounding {1: ((array(1165), array(1566)), (array(1458), array(1577)))}
   sky_centroid: <SkyCoord (ICRS): (ra, dec) in deg
-      (85.23831544, -69.52207261)>
+      (3.57958792, -30.40926139)>
   sky_bbox_ll: <SkyCoord (ICRS): (ra, dec) in deg
-      (85.24337262, -69.5231152)>
+      (3.58060118, -30.40800999)>
   sky_bbox_lr: <SkyCoord (ICRS): (ra, dec) in deg
-      (85.2351383, -69.52307624)>
+      (3.58136873, -30.41001654)>
   sky_bbox_ur: <SkyCoord (ICRS): (ra, dec) in deg
-      (85.23522188, -69.5209249)>
+      (3.57866098, -30.4107869)>
   sky_bbox_ul:<SkyCoord (ICRS): (ra, dec) in deg
-      (85.24345537, -69.52096386)>
-  xcentroid: 767.278551509201
-  ycentroid: 1053.7806251513593
-  partial_order: {1: True}
+      (3.57789348, -30.40878033)>
+  xcentroid: 1513.4964315117466
+  ycentroid: 1920.6251490007467
+  partial_order: {1: False}
   waverange: {1: (3.01, 4.26)}
-  >>> grism_object[-1].order_bounding[1] = ((1000, 1110), (0, 450))
+  is_extended: True
+  isophotal_abmag: 17.88278103874113
+  >>> grism_object[-1].order_bounding[1] = ((1200, 1500), (1480, 1520))
   >>> print(grism_object[-1].order_bounding
-  {1: ((1000, 1110), (0, 450))})
+  {1: ((1200, 1500), (1480,1520))}
+
+The ``grism_objects`` list created in the above examples can now be used
+as input to the ``extract_2d`` step in order to extract the particular objects
+defined in that list:
+
+.. doctest-skip::
+
+  >>> result = step.call(input_model, grism_objects=grism_objects)
+
+``result`` is a ``MultiSlitModel`` data model, containing one ``SlitModel``
+instance for each extracted object, which includes meta data that identify
+each object and the actual extracted data arrays, e.g.:
+
+.. doctest-skip::
+
+  >>> print(len(result.slits))
+  8
+  >>> result.slits[0].source_id
+  104
+  >>> result.slits[0].data
+  array([[..., ..., ...]])
+
 
 NIRCam TSGRISM
 ++++++++++++++


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3254](https://jira.stsci.edu/browse/JP-3254)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7654 

<!-- describe the changes comprising this PR here -->
This PR updates the docs for the extract_2d step, in particular the sections that describe the details of how WFSS grism object lists are created, modified, and used to extract sources from a WFSS image. It fixes some inconsistencies in the existing write up and adds some additional descriptions of some of the details, to hopefully make it more clear for users.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
