### PR TITLE
Fix some minor formatting typos in associations docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ documentation
 - Update the ``extract_2d`` step docs to give better descriptions of how to create
   and use object lists for WFSS grism image extractions. [#7684]
 
+- Fix minor formatting typos in associations docs. [#7694]
+
 tweakreg
 --------
 

--- a/docs/jwst/associations/association_reference.rst
+++ b/docs/jwst/associations/association_reference.rst
@@ -287,7 +287,7 @@ with the ``RegistryMarker.rule`` decorator as follows::
       ...
 
 Then, when the rule file is used to create an ``AssociationRegistry``,
-the class ``MyRule`` will be included as one of the available rules::
+the class ``MyRule`` will be included as one of the available rules:
 
 .. doctest-skip::
    

--- a/docs/jwst/associations/overview.rst
+++ b/docs/jwst/associations/overview.rst
@@ -111,7 +111,7 @@ What exactly is returned depends on what the association is. However,
 for all Stage 2 and Stage 3 associations, a Python ``dict`` is returned,
 whose structure matches that of the JSON or YAML file. Continuing
 from the above example, the following shows how to access the first
-exposure file name of a Stage 3 associations::
+exposure file name of a Stage 3 associations:
 
 .. code-block:: python
 


### PR DESCRIPTION
While looking through the associations docs I found a few minor formatting typos.

overview misconfigured code-block:
- before: https://jwst-pipeline.readthedocs.io/en/latest/jwst/associations/overview.html#usage
- after: https://jwst-pipeline--7694.org.readthedocs.build/en/7694/jwst/associations/overview.html#usage

misconfigured doctest-skip:
- before: https://jwst-pipeline.readthedocs.io/en/latest/jwst/associations/association_reference.html#rule-registration
- after: https://jwst-pipeline--7694.org.readthedocs.build/en/7694/jwst/associations/association_reference.html#rule-registration

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
