### PR TITLE
remove mistune pin and increase minimum sphinx-asdf version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ documentation
 - Update the ``extract_2d`` step docs to give better descriptions of how to create
   and use object lists for WFSS grism image extractions. [#7684]
 
+- Remove direct mistune dependency (and approximate pin) and increase minimum
+  required sphinx-asdf version [#7696]
+
 tweakreg
 --------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,12 +58,11 @@ install_requires =
 docs =
     matplotlib
     sphinx
-    sphinx-asdf>=0.1.1
+    sphinx-asdf>=0.1.2
     sphinx-astropy
     sphinx-automodapi
     sphinx-rtd-theme
     stsci-rtd-theme
-    mistune~=0.8.4
 sdp =
     jplephem>=2.9
     pymssql>=2.1.6


### PR DESCRIPTION
This PR removes the mistune dependency (and pin).

This pin appears to have been added to deal with sphinx-asdf 0.1.1 not pinning mistune and a new version of mistune being released which broke the docs.
https://github.com/spacetelescope/jwst/pull/6490

The pin was also added to sphinx-asdf 0.1.2 so bumping the minimum version of sphinx-asdf 0.1.2 means the mistune pin is no longer needed in jwst. This PR increases the minimum version of sphinx-asdf to 0.1.2

Removing this pin allows sphinx-asdf 0.2.0 to be installed which removes many of the deprecated call warnings when building the docs.

As can be seen by comparing this docs build log for this PR
https://readthedocs.org/projects/jwst-pipeline/builds/21213123/
to a build log for a PR where sphinx-asdf<0.2.0 is used:
https://readthedocs.org/projects/jwst-pipeline/builds/21211054/

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
