### PR TITLE
JP-3250: Exclude entire var if any NaN present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ documentation
 
 - Fix minor formatting typos in associations docs. [#7694]
 
+extract_1d
+----------
+
+- Prevent propagation of NaNs in variance arrays to error array by excluding entire
+  variance array if at least one NaN is present. [#7711]
+
 tweakreg
 --------
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3250](https://jira.stsci.edu/browse/JP-3250)
Closes #7647 

<!-- describe the changes comprising this PR here -->
This PR addresses an issue found when a variance array contains NaN values - the sum with the other variance arrays leads to NaN values in the error arrays. The current behavior will propagate any NaNs in a variance array to the final error array.

The approach in this PR is to fully exclude a variance array if at least one NaN is present - this is to prevent the error array from having a variable number of contributions. Alternatively, one could let the error array exclude the NaN values from summation for individual variance entries, leading to the error having 0-3 variance contributions depending on the number of NaNs present.


**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
