### PR TITLE
Refpix bug fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@
 refpix
 ------
 
-- Fixed potential crash due to empty list for NIRSpec IRS2 mode. [#7731]
+- Fixed potential crash due to empty list for NIRSpec IRS2 mode, and
+  incorporated a factor to mitigate overcorrection. [#7731]
 
 
 1.11.2 (2023-07-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 1.11.3 (unreleased)
 ===================
 
-- 
+refpix
+------
+
+- Fixed potential crash due to empty list for NIRSpec IRS2 mode. [#7731]
+
 
 1.11.2 (2023-07-12)
 ===================

--- a/docs/jwst/refpix/arguments.rst
+++ b/docs/jwst/refpix/arguments.rst
@@ -37,3 +37,9 @@ data only when the ``--use_side_ref_pixels`` option is selected.
 If the ``odd_even_rows`` argument is selected, the reference signal is
 calculated and applied separately for even- and odd-numbered rows.  The
 default value is True, and this argument applies to MIR data only.
+
+*  ``--ovr_corr_mitigation_ftr``
+
+This is a factor to avoid overcorrection of intermittently bad reference
+pixels in the IRS2 algorithm. The default value is 1.8, and this argument
+applies only to NIRSpec data taken with IRS2 mode.

--- a/docs/jwst/refpix/description.rst
+++ b/docs/jwst/refpix/description.rst
@@ -200,8 +200,9 @@ reference pixels. This is done by calculating the means and standard
 deviations per reference pixel column, as well as the difference between
 even and odd pairs; then calculates the mean of each of these arrays (the
 mean of the absolute values for the differences array), and flag all
-values greater than the corresponding mean. All suspicious pixels will
-be replaced by their nearest good reference pixel.
+values greater than the corresponding mean times a factor to avoid
+overcorrection. All suspicious pixels will be replaced by their
+nearest good reference pixel.
 
 The next step in this processing is to
 copy the science data and the reference pixel data separately to temporary

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -491,6 +491,8 @@ def rm_intermittent_badpix(data, scipix_n, refpix_r):
                 remaining_rp = remaining_rp_even
             else:
                 remaining_rp = remaining_rp_odd
+            if len(remaining_rp) == 0:   # claims all ref pix are bad, avoid overcorrection and skip
+                continue
             good_idx = (np.abs(remaining_rp - bad_pix)).argmin()
             good_pix = remaining_rp[good_idx]
             data[..., bad_pix] = data[..., good_pix]

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -491,7 +491,7 @@ def rm_intermittent_badpix(data, scipix_n, refpix_r):
                 remaining_rp = remaining_rp_even
             else:
                 remaining_rp = remaining_rp_odd
-            if len(remaining_rp) == 0:   # claims all ref pix are bad, avoid overcorrection and skip
+            if len(remaining_rp) == 0:
                 continue
             good_idx = (np.abs(remaining_rp - bad_pix)).argmin()
             good_pix = remaining_rp[good_idx]

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -8,7 +8,8 @@ log.setLevel(logging.DEBUG)
 
 
 def correct_model(input_model, irs2_model,
-                  scipix_n_default=16, refpix_r_default=4, pad=8):
+                  scipix_n_default=16, refpix_r_default=4, pad=8,
+                  ovr_corr_mitigation_ftr=1.8):
     """Correct an input NIRSpec IRS2 datamodel using reference pixels.
 
     Parameters
@@ -31,6 +32,9 @@ def correct_model(input_model, irs2_model,
         The effective number of pixels sampled during the pause at the end
         of each row (new-row overhead).  The padding is needed to preserve
         the phase of temporally periodic signals.
+
+    ovr_corr_mitigation_ftr: float
+        Factor to avoid overcorrection of intermittently bad reference pixels
 
     Returns
     -------
@@ -136,7 +140,7 @@ def correct_model(input_model, irs2_model,
         # as bad in the DQ extension of the CRDS reference file.
         clobber_ref(data, output, odd_even, mask)
         # Replace intermittently bad pixels
-        rm_intermittent_badpix(data, scipix_n, refpix_r)
+        rm_intermittent_badpix(data, scipix_n, refpix_r, ovr_corr_mitigation_ftr)
     else:
         log.warning("DQ extension not found in reference file")
 
@@ -386,7 +390,7 @@ def decode_mask(output, mask):
     return bits
 
 
-def rm_intermittent_badpix(data, scipix_n, refpix_r):
+def rm_intermittent_badpix(data, scipix_n, refpix_r, ovr_corr_mitigation_ftr):
     """Find pixels that are intermittently bad and replace with nearest
     good value.
 
@@ -404,6 +408,9 @@ def rm_intermittent_badpix(data, scipix_n, refpix_r):
     refpix_r : int
         Number of reference samples before stepping back in to collect
         regular samples.
+
+    ovr_corr_mitigation_ftr: float
+        Factor to avoid overcorrection of bad intermittent reference pixels
 
     Returns
     -------
@@ -457,16 +464,17 @@ def rm_intermittent_badpix(data, scipix_n, refpix_r):
         # order indexes increasing from left to right
         rp2check.sort()
 
-        # find the additional intermittent bad pixels
-        high_diffs = np.where(np.abs(diffs) > diff_m)[0]
+        # find the additional intermittent bad pixels - the factor is to avoid overcorrection
+        log.info('Using overcorrection mitigation factor = {}'.format(ovr_corr_mitigation_ftr))
+        high_diffs = np.where(np.abs(diffs) > ovr_corr_mitigation_ftr * diff_m)[0]
         hd_rp2replace = []
         for j in high_diffs:
             rp2r = rp2check[int(diffs.index(diffs[j]) * 2)]
             # include both even and odd
             hd_rp2replace.append(rp2r)
             hd_rp2replace.append(rp2r+1)
-        high_means_idx = np.where(np.array(rp_means) > mean_mean)[0]
-        high_std_idx = np.where(np.array(rp_stds) > mean_std)[0]
+        high_means_idx = np.where(np.array(rp_means) > ovr_corr_mitigation_ftr * mean_mean)[0]
+        high_std_idx = np.where(np.array(rp_stds) > ovr_corr_mitigation_ftr * mean_std)[0]
         ref_pix = np.array(ref_pix)
         rp2replace = []
         for rp in ref_pix:
@@ -491,7 +499,7 @@ def rm_intermittent_badpix(data, scipix_n, refpix_r):
                 remaining_rp = remaining_rp_even
             else:
                 remaining_rp = remaining_rp_odd
-            if len(remaining_rp) == 0:
+            if len(remaining_rp) == 0:   # claims all ref pix are bad, avoid overcorrection and skip
                 continue
             good_idx = (np.abs(remaining_rp - bad_pix)).argmin()
             good_pix = remaining_rp[good_idx]

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -22,6 +22,7 @@ class RefPixStep(Step):
         side_smoothing_length = integer(default=11)
         side_gain = float(default=1.0)
         odd_even_rows = boolean(default=True)
+        ovr_corr_mitigation_ftr = float(default=1.8)
     """
 
     reference_file_types = ['refpix']
@@ -51,7 +52,8 @@ class RefPixStep(Step):
                 irs2_model = datamodels.IRS2Model(self.irs2_name)
 
                 # Apply the IRS2 correction scheme
-                result = irs2_subtract_reference.correct_model(input_model, irs2_model)
+                result = irs2_subtract_reference.correct_model(input_model, irs2_model,
+                                                               self.ovr_corr_mitigation_ftr)
 
                 if result.meta.cal_step.refpix != 'SKIPPED':
                     result.meta.cal_step.refpix = 'COMPLETE'

--- a/jwst/refpix/tests/test_rm_intermittent_badpix.py
+++ b/jwst/refpix/tests/test_rm_intermittent_badpix.py
@@ -16,7 +16,8 @@ def test_rm_intermittent_badpix():
     data[..., 3128] = 15.
 
     scipix_n, refpix_r = 16, 4
-    rm_intermittent_badpix(data, scipix_n, refpix_r)
+    ovr_corr_mitigation_ftr = 1.8
+    rm_intermittent_badpix(data, scipix_n, refpix_r, ovr_corr_mitigation_ftr)
 
     compare = np.ones((2, 3, 5, 3200), dtype=np.float32)
     compare[..., 688] = 0.


### PR DESCRIPTION
This PR resolves a potential crash due to an empty list. Also added a factor to mitigate the overcorrection due to suspicious intermittently bad reference pixels.


**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
