### PR TITLE
Use current date to fetch current reference files during unit testing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 1.11.4 (unreleased)
 ===================
 
--
+general
+-------
+
+- Use current date instead of a fixed date while creating headers for
+  unit testing to ensure testing against current reference files [#7744]
 
 1.11.3 (2023-07-17)
 ===================

--- a/jwst/assign_wcs/tests/test_miri.py
+++ b/jwst/assign_wcs/tests/test_miri.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.io import fits
 from gwcs import wcs
 from numpy.testing import assert_allclose
+from datetime import datetime
 
 from stdatamodels.jwst.datamodels import ImageModel, CubeModel
 
@@ -41,7 +42,7 @@ def create_hdul(detector, channel, band):
     phdu.header['CHANNEL'] = channel
     phdu.header['BAND'] = band
     phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2017-09-05'
+    phdu.header['date-obs'] = datetime.now().date().strftime('%Y-%m-%d')
     phdu.header['exp_type'] = 'MIR_MRS'
     scihdu = fits.ImageHDU()
     scihdu.header['EXTNAME'] = "SCI"

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -10,7 +10,7 @@ file.
 """
 from numpy.testing import assert_allclose
 import pytest
-
+from datetime import datetime
 
 from astropy.io import fits
 from gwcs import wcs
@@ -69,7 +69,7 @@ def create_hdul(detector='NRCALONG', channel='LONG', module='A',
     phdu.header['PUPIL'] = pupil
     phdu.header['MODULE'] = module
     phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2023-01-01'
+    phdu.header['date-obs'] = datetime.now().date().strftime('%Y-%m-%d')
     phdu.header['exp_type'] = exptype
     scihdu = fits.ImageHDU()
     scihdu.header['EXTNAME'] = "SCI"

--- a/jwst/assign_wcs/tests/test_niriss.py
+++ b/jwst/assign_wcs/tests/test_niriss.py
@@ -12,6 +12,7 @@ file.
 from numpy.testing import assert_allclose
 from astropy.io import fits
 from gwcs import wcs
+from datetime import datetime
 
 from stdatamodels.jwst.datamodels.image import ImageModel
 
@@ -49,7 +50,7 @@ def create_hdul(detector='NIS', filtername='CLEAR',
     phdu.header['FILTER'] = filtername
     phdu.header['PUPIL'] = pupil
     phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2022-09-05'
+    phdu.header['date-obs'] = datetime.now().date().strftime('%Y-%m-%d')
     phdu.header['exp_type'] = exptype
     phdu.header['FWCPOS'] = 354.2111
     scihdu = fits.ImageHDU()

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -16,6 +16,7 @@ import astropy.units as u
 import astropy.coordinates as coords
 from gwcs import wcs
 from gwcs import wcstools
+from datetime import datetime
 
 from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.transforms import models as trmodels
@@ -69,7 +70,7 @@ def create_hdul(detector='NRS1'):
     phdu.header['instrume'] = 'NIRSPEC'
     phdu.header['detector'] = detector
     phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2016-09-05'
+    phdu.header['date-obs'] = datetime.now().date().strftime('%Y-%m-%d')
 
     scihdu = fits.ImageHDU()
     scihdu.header['EXTNAME'] = "SCI"

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from astropy.io import fits
 from gwcs import wcs
+from datetime import datetime
 
 from stdatamodels.jwst.datamodels import ImageModel, CubeModel, SlitModel, MultiSlitModel
 
@@ -90,7 +91,7 @@ def create_hdul(detector='NRCALONG', channel='LONG', module='A',
     phdu.header['PUPIL'] = pupil
     phdu.header['MODULE'] = module
     phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2023-01-05'
+    phdu.header['date-obs'] = datetime.now().date().strftime('%Y-%m-%d')
     phdu.header['exp_type'] = exptype
     phdu.header['SUBARRAY'] = subarray
     phdu.header['SUBSIZE1'] = 2048

--- a/jwst/tso_photometry/tests/test_tso_photometry_step.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry_step.py
@@ -1,7 +1,7 @@
 import pytest
 
 from astropy.io import fits
-
+from datetime import datetime
 from jwst.tso_photometry.tso_photometry_step import TSOPhotometryStep
 
 
@@ -11,7 +11,7 @@ def test_hdu():
     phdu = fits.PrimaryHDU()
     phdu.header['telescop'] = "JWST"
     phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2017-09-05'
+    phdu.header['date-obs'] = datetime.now().date().strftime('%Y-%m-%d')
 
     scihdu = fits.ImageHDU()
     scihdu.header['EXTNAME'] = "SCI"


### PR DESCRIPTION

<!-- describe the changes comprising this PR here -->
This PR addresses some bespoke header generation during unit testing - fixed dates were being provided, which could prevent testing against current reference files due to CRDS USEAFTER dates.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
