### PR TITLE
Modify `test_flatfield_step_interface` step to not interfere with other tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 1.11.4 (unreleased)
 ===================
 
--
+flat_field
+----------
+
+- Modify test_flatfield_step_interface test to prevent it from causing
+  other tests to fail [#7752]
 
 1.11.3 (2023-07-17)
 ===================

--- a/jwst/flatfield/tests/test_flatfield.py
+++ b/jwst/flatfield/tests/test_flatfield.py
@@ -23,7 +23,6 @@ from jwst.flatfield.flat_field_step import NRS_IMAGING_MODES, NRS_SPEC_MODES
         ("FGS", "FGS_IMAGE"),
     ] + [("NIRSPEC", exptype) for exptype in NRS_IMAGING_MODES]
 )
-#@pytest.mark.skip(reason="modifying reference_file_types caused other tests to fail")
 def test_flatfield_step_interface(instrument, exptype):
     """Test that the basic interface works for data requiring a FLAT reffile"""
 
@@ -50,8 +49,12 @@ def test_flatfield_step_interface(instrument, exptype):
     # override class attribute so only the `flat` type needs to be overridden
     # in the step call.  Otherwise CRDS calls will be made for the other 3
     # types of flat reference file not used in this test.
-    FlatFieldStep.reference_file_types = ["flat"]
-    result = FlatFieldStep.call(data, override_flat=flat)
+    previous_reference_file_types = FlatFieldStep.reference_file_types
+    try:
+        FlatFieldStep.reference_file_types = ["flat"]
+        result = FlatFieldStep.call(data, override_flat=flat)
+    finally:
+        FlatFieldStep.reference_file_types = previous_reference_file_types
 
     assert (result.data == data.data).all()
     assert result.var_flat.shape == shape


### PR DESCRIPTION
The `test_flatfield_step_interface` was unskipped in https://github.com/spacetelescope/jwst/pull/7615 right before the frequent but unpredictable failures for FlatField.

This test modifies `FlatFieldStep.reference_file_types` (and does not undo the modification). Subsequent tests (in the same process) that use `FlatField` may fail (and not consider f/s/dflats) which would explain the errors seen in regression tests following the merge of the above changes.

This minimal regression test run (2 tests in one process) will hopefully help to explain the error:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/799/tests
The order of tests was controlled so that `test_flatfield_step_interface` was called prior to `test_nis_wfss_spec2` (which fails with the expected error).

This PR modifies the test to save, modify then restore `FlatFieldStep.reference_file_types` so that it doesn't interfere with other tests.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
