### PR TITLE
use scipy directly instead of astropy modeling for residual fringe fit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,12 @@ resample
   image shape and the bounding box both for ``SCI`` image as well as for the
   ``ERR`` and ``VARIANCE_*`` images. [#7774]
 
+residual_fringe
+---------------
+
+- Use scipy.interpolate.BSpline instead of astropy.modeling.Spline1D in
+  residual_fringe fitting utils [#7764]
+
 
 1.11.3 (2023-07-17)
 ===================

--- a/jwst/residual_fringe/fitter.py
+++ b/jwst/residual_fringe/fitter.py
@@ -1,92 +1,53 @@
 import numpy as np
 
-from astropy.modeling.fitting import model_to_fit_params
+import scipy.interpolate
 
 
-class ChiSqOutlierRejectionFitter:
-    """Chi squared statistic for outlier rejection"""
+def _lsq_spline(x, y, weights, knots, degree):
+    return scipy.interpolate.LSQUnivariateSpline(x, y, knots, w=weights, k=degree)
 
-    def __init__(self, fitter, domain=None, tolerance=0.0001):
-        self.fitter = fitter
-        self.tolerance = tolerance
 
-        if domain is None:
-            self.domain = 10
-        else:
-            self.domain = domain
+def spline_fitter(x, y, weights, knots, degree, bounds, reject_outliers=False):
+    # bbox appears to be [None, None] even if bounds are provided
+    # TODO Spline1D and SplineExactKnotsFitter don't appear to use bounds
 
-    @staticmethod
-    def kernel(x, weights=None):
-        """
-        Weighting function dependent only on provided value (usualy a residual)
-        """
+    if not reject_outliers:
+        return _lsq_spline(x, y, weights, knots, degree)
 
-        kernal = (np.where(x**2 <= 1, 1 - x**2, 0.))**2
-        if weights is not None:
-            kernal *= weights
+    # fit with chi sq outlier rejection
+    # domain=10 and tolerance=0.0001 are never changed
+    domain = 10
+    tolerance = 0.0001
+    # weights are always provided
 
-        return kernal
+    # helpers
+    chi_sq = lambda spline, weights: np.nansum((y - spline(x)) ** 2 * weights)
 
-    @staticmethod
-    def _chi(model, x, y, weights=None):
+    # initial fit
+    spline = _lsq_spline(x, y, weights, knots, degree)
+    chi = chi_sq(spline, weights)
 
-        resid = (y - model(x))**2
-        if weights is not None:
-            resid *= weights
+    # astropy code used the model params which pad the knots based on degree
+    nparams = len(knots) + (degree + 1) * 2
+    deg_of_freedom = np.sum(weights) - nparams
 
-        return np.nansum(resid)
+    for _ in range(1000 * nparams):
+        scale = np.sqrt(chi / deg_of_freedom)
 
-    @staticmethod
-    def _params(model):
-        return model_to_fit_params(model)[0]
+        # Calculate new weights
+        resid = (y - spline(x)) / (scale * domain)
+        new_w = (np.where(resid**2 <= 1, 1 - resid**2, 0.))**2 * weights
 
-    @staticmethod
-    def _sum_weights(x, weights=None):
-        if weights is None:
-            return len(x)
-        else:
-            return np.sum(weights)
+        # Fit new model and find chi
+        spline = _lsq_spline(x, y, new_w, knots, degree)
+        new_chi = chi_sq(spline, new_w)
 
-    def _deg_of_freedom(self, model, x, weights=None):
-        nparams = len(self._params(model))
-        sum_weights = self._sum_weights(x, weights)
+        # Check if fit has converged
+        tol = tolerance if new_chi < 1 else tolerance * new_chi
+        if np.abs(chi - new_chi) < tol:
+            break
+        chi = new_chi
+    else:
+        raise RuntimeError("Bad fit, method should have converged")
 
-        return nparams, sum_weights - nparams
-
-    @staticmethod
-    def _scale(chi, deg_of_freedom):
-        return np.sqrt(chi / deg_of_freedom)
-
-    def __call__(self, model, x, y, weights=None, **kwargs):
-        # Assume equal weights if none are provided
-
-        new_model = model.copy()
-
-        # perform the initial fit
-        new_model = self.fitter(new_model, x, y, weights=weights, **kwargs)
-        chi = self._chi(new_model, x, y, weights)
-
-        # calculate degrees of freedom
-        nparams, deg_of_freedom = self._deg_of_freedom(new_model, x, weights)
-
-        # Iteratively adjust the weights until fit converges
-        for _ in range(1000 * nparams):
-            scale = self._scale(chi, deg_of_freedom)
-
-            # Calculate new weights
-            resid = (y - new_model(x)) / (scale * self.domain)
-            new_w = self.kernel(resid, weights)
-
-            # Fit new model and find chi
-            new_model = self.fitter(new_model, x, y, weights=new_w, **kwargs)
-            new_chi = self._chi(new_model, x, y, new_w)
-
-            # Check if fit has converged
-            tol = self.tolerance if new_chi < 1 else self.tolerance * new_chi
-            if np.abs(chi - new_chi) < tol:
-                break
-            chi = new_chi
-        else:
-            raise RuntimeError("Bad fit, method should have converged")
-
-        return new_model
+    return spline

--- a/jwst/residual_fringe/fitter.py
+++ b/jwst/residual_fringe/fitter.py
@@ -7,10 +7,7 @@ def _lsq_spline(x, y, weights, knots, degree):
     return scipy.interpolate.LSQUnivariateSpline(x, y, knots, w=weights, k=degree)
 
 
-def spline_fitter(x, y, weights, knots, degree, bounds, reject_outliers=False):
-    # bbox appears to be [None, None] even if bounds are provided
-    # TODO Spline1D and SplineExactKnotsFitter don't appear to use bounds
-
+def spline_fitter(x, y, weights, knots, degree, reject_outliers=False):
     if not reject_outliers:
         return _lsq_spline(x, y, weights, knots, degree)
 
@@ -20,8 +17,11 @@ def spline_fitter(x, y, weights, knots, degree, bounds, reject_outliers=False):
     tolerance = 0.0001
     # weights are always provided
 
+
     # helpers
-    chi_sq = lambda spline, weights: np.nansum((y - spline(x)) ** 2 * weights)
+    def chi_sq(spline, weights):
+        return np.nansum((y - spline(x)) ** 2 * weights)
+
 
     # initial fit
     spline = _lsq_spline(x, y, weights, knots, degree)

--- a/jwst/residual_fringe/fitter.py
+++ b/jwst/residual_fringe/fitter.py
@@ -7,17 +7,11 @@ def _lsq_spline(x, y, weights, knots, degree):
     return scipy.interpolate.LSQUnivariateSpline(x, y, knots, w=weights, k=degree)
 
 
-def spline_fitter(x, y, weights, knots, degree, reject_outliers=False):
+def spline_fitter(x, y, weights, knots, degree, reject_outliers=False, domain=10, tolerance=0.0001):
     if not reject_outliers:
         return _lsq_spline(x, y, weights, knots, degree)
 
     # fit with chi sq outlier rejection
-    # domain=10 and tolerance=0.0001 are never changed
-    domain = 10
-    tolerance = 0.0001
-    # weights are always provided
-
-
     # helpers
     def chi_sq(spline, weights):
         return np.nansum((y - spline(x)) ** 2 * weights)

--- a/jwst/residual_fringe/utils.py
+++ b/jwst/residual_fringe/utils.py
@@ -10,10 +10,7 @@ from BayesicFitting import RobustShell
 from BayesicFitting import ConstantModel
 from BayesicFitting import Fitter
 
-from astropy.modeling.models import Spline1D
-from astropy.modeling.fitting import SplineExactKnotsFitter
-
-from .fitter import ChiSqOutlierRejectionFitter
+from .fitter import spline_fitter
 
 import logging
 log = logging.getLogger(__name__)
@@ -478,14 +475,9 @@ def fit_1d_background_complex(flux, weights, wavenum, order=2, ffreq=None, chann
     # Fit the spline
     # robust fitting causing problems for fringe 2 in channels 3 and 4, just use the fitter class
     if ffreq > 1.5:
-        spline_model = Spline1D(knots=t, degree=2, bounds=[x[0], x[-1]])
-        fitter = SplineExactKnotsFitter()
-        robust_fitter = ChiSqOutlierRejectionFitter(fitter)
-        bg_model = robust_fitter(spline_model, x, y, weights=w)
+        bg_model = spline_fitter(x, y, w, t, 2, [x[0], x[-1]], reject_outliers=True)
     else:
-        spline_model = Spline1D(knots=t, degree=1, bounds=[x[0], x[-1]])
-        fitter = SplineExactKnotsFitter()
-        bg_model = fitter(spline_model, x, y, weights=w)
+        bg_model = spline_fitter(x, y, w, t, 1, [x[0], x[-1]], reject_outliers=False)
 
     # fit the background
     bg_fit = bg_model(wavenum_scaled)
@@ -936,14 +928,9 @@ def fit_1d_background_complex_1d(flux, weights, wavenum, order=2, ffreq=None, ch
     # Fit the spline
     # TODO: robust fitting causing problems for fringe 2, change to just using fitter there
     if ffreq > 1.5:
-        spline_model = Spline1D(knots=t, degree=2, bounds=[x[0], x[-1]])
-        fitter = SplineExactKnotsFitter()
-        robust_fitter = ChiSqOutlierRejectionFitter(fitter)
-        bg_model = robust_fitter(spline_model, x, y, weights=w)
+        bg_model = spline_fitter(x, y, w, t, 2, [x[0], x[-1]], reject_outliers=True)
     else:
-        spline_model = Spline1D(knots=t, degree=1, bounds=[x[0], x[-1]])
-        fitter = SplineExactKnotsFitter()
-        bg_model = fitter(spline_model, x, y, weights=w)
+        bg_model = spline_fitter(x, y, w, t, 1, [x[0], x[-1]], reject_outliers=False)
 
     # fit the background
     bg_fit = bg_model(wavenum_scaled)

--- a/jwst/residual_fringe/utils.py
+++ b/jwst/residual_fringe/utils.py
@@ -475,9 +475,9 @@ def fit_1d_background_complex(flux, weights, wavenum, order=2, ffreq=None, chann
     # Fit the spline
     # robust fitting causing problems for fringe 2 in channels 3 and 4, just use the fitter class
     if ffreq > 1.5:
-        bg_model = spline_fitter(x, y, w, t, 2, [x[0], x[-1]], reject_outliers=True)
+        bg_model = spline_fitter(x, y, w, t, 2, reject_outliers=True)
     else:
-        bg_model = spline_fitter(x, y, w, t, 1, [x[0], x[-1]], reject_outliers=False)
+        bg_model = spline_fitter(x, y, w, t, 1, reject_outliers=False)
 
     # fit the background
     bg_fit = bg_model(wavenum_scaled)
@@ -928,9 +928,9 @@ def fit_1d_background_complex_1d(flux, weights, wavenum, order=2, ffreq=None, ch
     # Fit the spline
     # TODO: robust fitting causing problems for fringe 2, change to just using fitter there
     if ffreq > 1.5:
-        bg_model = spline_fitter(x, y, w, t, 2, [x[0], x[-1]], reject_outliers=True)
+        bg_model = spline_fitter(x, y, w, t, 2, reject_outliers=True)
     else:
-        bg_model = spline_fitter(x, y, w, t, 1, [x[0], x[-1]], reject_outliers=False)
+        bg_model = spline_fitter(x, y, w, t, 1, reject_outliers=False)
 
     # fit the background
     bg_fit = bg_model(wavenum_scaled)


### PR DESCRIPTION
While looking at the regression tests. I noticed that `test_residual_fringe_cal` is one of the slower tests.

Running just that test took ~2566 seconds:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/817

Profiling the test locally revealed that the majority of the time is spent in 2 functions:
- [new_fit_1d_fringes_bayes_evidence](https://github.com/spacetelescope/jwst/blob/7556988f110205042334d00c1c9d351c4bfb7773/jwst/residual_fringe/utils.py#L572)
- [fit_1d_background_complex](https://github.com/spacetelescope/jwst/blob/7556988f110205042334d00c1c9d351c4bfb7773/jwst/residual_fringe/utils.py#L391C5-L391C30)
<img width="1125" alt="Screen Shot 2023-07-26 at 8 46 27 AM" src="https://github.com/spacetelescope/jwst/assets/114267/fc8b2392-1bcb-403f-afef-02c9fa893b42">

This PR aims to improve the second function `fit_1d_background_complex` by:
- replacing the [ChiSqOutlierRejectionFitter](https://github.com/spacetelescope/jwst/blob/7556988f110205042334d00c1c9d351c4bfb7773/jwst/residual_fringe/fitter.py#L6) class (defined in fitter.py shown in the above plot) with an equivalent function
- replacing the use of splines from astropy modeling with direct use of scipy.interpolate.BSpline

As mentioned in the [astropy Spline1D docs](https://docs.astropy.org/en/stable/api/astropy.modeling.spline.Spline1D.html#astropy.modeling.spline.Spline1D) much of the functionality of `Spline1D` is handled by `scipy.interpolate.BSpline`. The spline fitting here boiled down to:
- a call to `LSQUnivariateSpline` (which astropy wraps with `SplineExactKnotsFitter`)
- repeated fits with outlier rejection using the `ChiSqOutlierRejectionFitter`

The repeated fits are particularly costly with `Spline1D` due in large part to it's calls to `inspect` which are avoided by using `BSpline` directly. Here's a zoomed in portion of the plot showing what occurs during `Spline1D.__init__`:
<img width="1129" alt="Screen Shot 2023-07-26 at 9 04 40 AM" src="https://github.com/spacetelescope/jwst/assets/114267/a66503a4-ce6a-4532-9b58-512ef9dd90f7">

Running `test_residual_fringe_cal` with the changes in this PR took 1562 seconds (~60% the previous time):
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/818

A similar plot shows the relative speed-up of `fit_1d_background_complex` (and the remaining large contribution of `new_fit_1d_fringes_bayes_evidence` to the total runtime):
<img width="1134" alt="Screen Shot 2023-07-26 at 9 07 44 AM" src="https://github.com/spacetelescope/jwst/assets/114267/257e2d03-9d79-4c4a-852b-db8aa8622980">


**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
