### PR TITLE
Run pixel_replace before finalizing cal output in calwebb_spec2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 1.11.4 (unreleased)
 ===================
 
+calwebb_spec2
+-------------
+
+- Run ``pixel_replace`` before setting metadata and suffix of datamodel
+  that is returned by the pipeline to ensure a file is created with the
+  expected ``_cal`` suffix. [#7772]
+
 datamodels
 ----------
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -271,13 +271,13 @@ class Spec2Pipeline(Pipeline):
         else:
             calibrated = self._process_common(calibrated)
 
+        # Replace bad pixels before rectification
+        calibrated = self.pixel_replace(calibrated)
+
         # Record ASN pool and table names in output
         calibrated.meta.asn.pool_name = pool_name
         calibrated.meta.asn.table_name = op.basename(asn_file)
         calibrated.meta.filename = self.make_output_path(suffix=suffix)
-
-        # Replace bad pixels before rectification
-        calibrated = self.pixel_replace(calibrated)
 
         # Produce a resampled product, either via resample_spec for
         # "regular" spectra or cube_build for IFU data. No resampled

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -271,9 +271,6 @@ class Spec2Pipeline(Pipeline):
         else:
             calibrated = self._process_common(calibrated)
 
-        # Replace bad pixels before rectification
-        calibrated = self.pixel_replace(calibrated)
-
         # Record ASN pool and table names in output
         calibrated.meta.asn.pool_name = pool_name
         calibrated.meta.asn.table_name = op.basename(asn_file)
@@ -480,6 +477,7 @@ class Spec2Pipeline(Pipeline):
         calibrated = self.barshadow(calibrated)
         calibrated = self.wfss_contam(calibrated)
         calibrated = self.photom(calibrated)
+        calibrated = self.pixel_replace(calibrated)
 
         return calibrated
 
@@ -497,6 +495,7 @@ class Spec2Pipeline(Pipeline):
         calibrated = self.pathloss(calibrated)
         calibrated = self.barshadow(calibrated)
         calibrated = self.photom(calibrated)
+        calibrated = self.pixel_replace(calibrated)
 
         return calibrated
 
@@ -512,6 +511,7 @@ class Spec2Pipeline(Pipeline):
         calibrated = self.fringe(calibrated)
         calibrated = self.pathloss(calibrated)
         calibrated = self.barshadow(calibrated)
+        calibrated = self.pixel_replace(calibrated)
 
         return calibrated
 
@@ -525,5 +525,6 @@ class Spec2Pipeline(Pipeline):
         calibrated = self.barshadow(calibrated)
         calibrated = self.photom(calibrated)
         calibrated = self.residual_fringe(calibrated)  # only run on MIRI_MRS data
+        calibrated = self.pixel_replace(calibrated)
 
         return calibrated


### PR DESCRIPTION
Resolves [JP-3320](https://jira.stsci.edu/browse/JP-3320)

This PR addresses a bug reported by users setting pixel_replace to run and save results - this caused the default file_cal.fits output to go missing, as a result of incorrect ordering inside calwebb_spec2. This fixes the issue by running pixel_replace before setting metadata and suffix name for the datamodel that the pipeline returns.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
