### PR TITLE
JP-3317: Use same logic for resample limits for SCI, ERR, and VAR* images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,13 @@ master_background
 - Allow the user to write the 2D expanded version of the user-provided 1D background for each
   file in the assocation. [#7714]
 
+resample
+--------
+
+- Use the same logic for computing input range for resample step from input
+  image shape and the bounding box both for ``SCI`` image as well as for the
+  ``ERR`` and ``VARIANCE_*`` images. [#7774]
+
 
 1.11.3 (2023-07-17)
 ===================

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -144,29 +144,29 @@ class GWCSDrizzle:
             Must have the same dimensions as insci. If none is supplied,
             the weighting is set to one.
 
-        xmin : float, optional
+        xmin : int, optional
             This and the following three parameters set a bounding rectangle
-            on the output image. Only pixels on the output image inside this
-            rectangle will have their flux updated. Xmin sets the minimum value
-            of the x dimension. The x dimension is the dimension that varies
-            quickest on the image. If the value is zero or less, no minimum will
-            be set in the x dimension. All four parameters are zero based,
-            counting starts at zero.
+            on the input image. Only pixels on the input image inside this
+            rectangle will have their flux added to the output image. Xmin
+            sets the minimum value of the x dimension. The x dimension is the
+            dimension that varies quickest on the image. All four parameters
+            are zero based, counting starts at zero.
 
-        xmax : float, optional
+        xmax : int, optional
             Sets the maximum value of the x dimension on the bounding box
-            of the output image. If the value is zero or less, no maximum will
-            be set in the x dimension.
+            of the input image. If ``xmax = 0``, no maximum will
+            be set in the x dimension (all pixels in a row of the input image
+            will be resampled).
 
-        ymin : float, optional
+        ymin : int, optional
             Sets the minimum value in the y dimension on the bounding box. The
             y dimension varies less rapidly than the x and represents the line
-            index on the output image. If the value is zero or less, no minimum
-            will be set in the y dimension.
+            index on the input image.
 
-        ymax : float, optional
-            Sets the maximum value in the y dimension. If the value is zero or
-            less, no maximum will be set in the y dimension.
+        ymax : int, optional
+            Sets the maximum value in the y dimension. If ``ymax = 0``,
+            no maximum will be set in the y dimension (all pixels in a column
+            of the input image will be resampled).
 
         expin : float, optional
             The exposure time of the input image, a positive number. The
@@ -279,31 +279,29 @@ def dodrizzle(insci, input_wcs, inwht, output_wcs, outsci, outwht, outcon,
         this function is called and incremented by one on each subsequent
         call.
 
-    xmin : float, optional
+    xmin : int, optional
         This and the following three parameters set a bounding rectangle
         on the input image. Only pixels on the input image inside this
         rectangle will have their flux added to the output image. Xmin
         sets the minimum value of the x dimension. The x dimension is the
-        dimension that varies quickest on the image. If the value is zero,
-        no minimum will be set in the x dimension. All four parameters are
-        zero based, counting starts at zero.
+        dimension that varies quickest on the image. All four parameters
+        are zero based, counting starts at zero.
 
-    xmax : float, optional
+    xmax : int, optional
         Sets the maximum value of the x dimension on the bounding box
-        of the input image. If the value is zero, no maximum will
-        be set in the x dimension, the full x dimension of the output
-        image is the bounding box.
+        of the input image. If ``xmax = 0``, no maximum will
+        be set in the x dimension (all pixels in a row of the input image
+        will be resampled).
 
-    ymin : float, optional
+    ymin : int, optional
         Sets the minimum value in the y dimension on the bounding box. The
         y dimension varies less rapidly than the x and represents the line
-        index on the input image. If the value is zero, no minimum  will be
-        set in the y dimension.
+        index on the input image.
 
-    ymax : float, optional
-        Sets the maximum value in the y dimension. If the value is zero, no
-        maximum will be set in the y dimension,  the full x dimension
-        of the output image is the bounding box.
+    ymax : int, optional
+        Sets the maximum value in the y dimension. If ``ymax = 0``,
+        no maximum will be set in the y dimension (all pixels in a column
+        of the input image will be resampled).
 
     pixfrac : float, optional
         The fraction of a pixel that the pixel flux is confined to. The

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -174,8 +174,11 @@ class ResampleData:
             for img in exposure:
                 img = datamodels.open(img)
                 # TODO: should weight_type=None here?
-                inwht = resample_utils.build_driz_weight(img, weight_type=self.weight_type,
-                                                         good_bits=self.good_bits)
+                inwht = resample_utils.build_driz_weight(
+                    img,
+                    weight_type=self.weight_type,
+                    good_bits=self.good_bits
+                )
 
                 # apply sky subtraction
                 blevel = img.meta.background.level
@@ -184,7 +187,20 @@ class ResampleData:
                 else:
                     data = img.data
 
-                driz.add_image(data, img.meta.wcs, inwht=inwht)
+                xmin, xmax, ymin, ymax = resample_utils._resample_range(
+                    data.shape,
+                    img.meta.wcs.bounding_box
+                )
+
+                driz.add_image(
+                    data,
+                    img.meta.wcs,
+                    inwht=inwht,
+                    xmin=xmin,
+                    xmax=xmax,
+                    ymin=ymin,
+                    ymax=ymax
+                )
                 del data
                 img.close()
 
@@ -230,7 +246,20 @@ class ResampleData:
             else:
                 data = img.data.copy()
 
-            driz.add_image(data, img.meta.wcs, inwht=inwht)
+            xmin, xmax, ymin, ymax = resample_utils._resample_range(
+                data.shape,
+                img.meta.wcs.bounding_box
+            )
+
+            driz.add_image(
+                data,
+                img.meta.wcs,
+                inwht=inwht,
+                xmin=xmin,
+                xmax=xmax,
+                ymin=ymin,
+                ymax=ymax
+            )
             del data, inwht
 
         # Resample variances array in self.input_models to output_model
@@ -292,11 +321,28 @@ class ResampleData:
             outwht = np.zeros_like(output_model.data)
             outcon = np.zeros_like(output_model.con)
 
+            xmin, xmax, ymin, ymax = resample_utils._resample_range(
+                variance.shape,
+                model.meta.wcs.bounding_box
+            )
+
             # Resample the variance array. Fill "unpopulated" pixels with NaNs.
-            self.drizzle_arrays(variance, inwht, model.meta.wcs,
-                                output_wcs, resampled_variance, outwht, outcon,
-                                pixfrac=self.pixfrac, kernel=self.kernel,
-                                fillval=np.nan)
+            self.drizzle_arrays(
+                variance,
+                inwht,
+                model.meta.wcs,
+                output_wcs,
+                resampled_variance,
+                outwht,
+                outcon,
+                pixfrac=self.pixfrac,
+                kernel=self.kernel,
+                fillval=np.nan,
+                xmin=xmin,
+                xmax=xmax,
+                ymin=ymin,
+                ymax=ymax
+            )
 
             # Add the inverse of the resampled variance to a running sum.
             # Update only pixels (in the running sum) with valid new values:
@@ -329,9 +375,10 @@ class ResampleData:
         output_model.meta.resample.product_exposure_time = total_exposure_time
 
     @staticmethod
-    def drizzle_arrays(insci, inwht, input_wcs, output_wcs, outsci, outwht, outcon,
-                       uniqid=1, xmin=None, xmax=None, ymin=None, ymax=None,
-                       pixfrac=1.0, kernel='square', fillval="INDEF", wtscale=1.0):
+    def drizzle_arrays(insci, inwht, input_wcs, output_wcs, outsci, outwht,
+                       outcon, uniqid=1, xmin=0, xmax=0, ymin=0, ymax=0,
+                       pixfrac=1.0, kernel='square', fillval="INDEF",
+                       wtscale=1.0):
         """
         Low level routine for performing 'drizzle' operation on one image.
 
@@ -378,31 +425,29 @@ class ResampleData:
             this function is called and incremented by one on each subsequent
             call.
 
-        xmin : float, optional
+        xmin : int, optional
             This and the following three parameters set a bounding rectangle
             on the input image. Only pixels on the input image inside this
             rectangle will have their flux added to the output image. Xmin
             sets the minimum value of the x dimension. The x dimension is the
-            dimension that varies quickest on the image. If the value is zero,
-            no minimum will be set in the x dimension. All four parameters are
-            zero based, counting starts at zero.
+            dimension that varies quickest on the image. All four parameters
+            are zero based, counting starts at zero.
 
-        xmax : float, optional
+        xmax : int, optional
             Sets the maximum value of the x dimension on the bounding box
-            of the input image. If the value is zero, no maximum will
-            be set in the x dimension, the full x dimension of the output
-            image is the bounding box.
+            of the input image. If ``xmax = 0``, no maximum will
+            be set in the x dimension (all pixels in a row of the input image
+            will be resampled).
 
-        ymin : float, optional
+        ymin : int, optional
             Sets the minimum value in the y dimension on the bounding box. The
             y dimension varies less rapidly than the x and represents the line
-            index on the input image. If the value is zero, no minimum  will be
-            set in the y dimension.
+            index on the input image.
 
-        ymax : float, optional
-            Sets the maximum value in the y dimension. If the value is zero, no
-            maximum will be set in the y dimension,  the full x dimension
-            of the output image is the bounding box.
+        ymax : int, optional
+            Sets the maximum value in the y dimension. If ``ymax = 0``,
+            no maximum will be set in the y dimension (all pixels in a column
+            of the input image will be resampled).
 
         pixfrac : float, optional
             The fraction of a pixel that the pixel flux is confined to. The
@@ -461,14 +506,6 @@ class ResampleData:
         # Alias context image to the requested plane if 3d
         if outcon.ndim == 3:
             outcon = outcon[planeid]
-
-        if xmin is xmax is ymin is ymax is None:
-            bb = input_wcs.bounding_box
-            ((x1, x2), (y1, y2)) = bb
-            xmin = int(min(x1, x2))
-            ymin = int(min(y1, y2))
-            xmax = int(max(x1, x2))
-            ymax = int(max(y1, y2))
 
         # Compute the mapping between the input and output pixel coordinates
         # for use in drizzle.cdrizzle.tdriz

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -303,3 +303,19 @@ def decode_context(context, x, y):
         )
 
     return idx
+
+
+def _resample_range(data_shape, bbox=None):
+    # Find range of input pixels to resample:
+    if bbox is None:
+        xmin = ymin = 0
+        xmax = data_shape[1] - 1
+        ymax = data_shape[0] - 1
+    else:
+        ((x1, x2), (y1, y2)) = bbox
+        xmin = max(0, int(x1 + 0.5))
+        ymin = max(0, int(y1 + 0.5))
+        xmax = min(data_shape[1] - 1, int(x2 + 0.5))
+        ymax = min(data_shape[0] - 1, int(y2 + 0.5))
+
+    return xmin, xmax, ymin, ymax


### PR DESCRIPTION
Resolves [JP-3317](https://jira.stsci.edu/browse/JP-3317)
Closes #7761

Resample step has two branches: one for resampling of the science image (SCI extension in the FITS file) and one for resampling error and variance arrays (ERR, VARIANCE_* extensions). The logic in the branch for processing the science image ignores the bounding box from the input images' WCS while the logic for processing ERR, VAR* arrays does take it into account.

Both science and error images should be processed (resampled) using the same limits for input image pixels.

This PR solves this issue by using the same algorithm for computing resample limits (in input image coordinates) to science, error, and variance arrays from input image shape and input WCS' bounding box.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [Regression test 824](https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/824)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
