### PR TITLE
re-add quick check for alternative engineering database test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,12 @@ datamodels
 
 - Remove ``jwst.datamodels.schema`` in favor of ``stdatamodels.schema`` [#7660]
 
+engdb_tools
+-----------
+
+- Check alternative host is alive before attempting to run test for
+  access to avoid waiting the full timeout during test runs [#7780]
+
 flat_field
 ----------
 

--- a/jwst/lib/tests/test_engdb_tools.py
+++ b/jwst/lib/tests/test_engdb_tools.py
@@ -62,6 +62,10 @@ def engdb():
         yield engdb
 
 
+@pytest.mark.skipif(
+    not is_alive(ALTERNATE_HOST),
+    reason='Alternate test host not available.'
+)
 def test_environmental(jail_environ):
     os.environ['ENG_BASE_URL'] = ALTERNATE_URL
     try:


### PR DESCRIPTION
The test_environmental test when not run on the vpn will fail to contact the alternative engineering database server. This results in the test taking ~10 minutes waiting for a response before turning into a skip.

This commit adds some lines of code that were removed in PR #3022 which changed the skip from a decorator to a pytest.skip when the exception/timeout occurs. This should allow the test to skip quickly when the host is not accessable (and instead skips in <1 second). The pytest.skip call during the except block is left to deal with cases when the host resolves but the url fails to resolve.

As the alternative host appears unresponsive for github CI runs (which run tests in parallel with 2 workers) this should free up one of the workers that without this PR sits waiting for ~10 minutes. As a comparison, the python 3.9 tests for this recent PR took [~22 minutes](https://github.com/spacetelescope/jwst/actions/runs/5692683750/job/15430193293?pr=7772#step:10:16) whereas similar tests for this PR took [~16 minutes](https://github.com/spacetelescope/jwst/actions/runs/5695453779/job/15438646749?pr=7780#step:10:16).

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
