### PR TITLE
Fix outlier blot filenames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,11 @@ master_background
 - Allow the user to write the 2D expanded version of the user-provided 1D background for each
   file in the assocation. [#7714]
 
+outlier_detection
+-----------------
+
+- Fix naming and logging of intermediate blot files written to disk for imaging modes. [#7784]
+
 resample
 --------
 

--- a/docs/jwst/outlier_detection/outlier_detection.rst
+++ b/docs/jwst/outlier_detection/outlier_detection.rst
@@ -58,8 +58,7 @@ Specifically, this routine performs the following operations:
      should be used when resampling to create the output mosaic.  Any pixel with a
      DQ value not included in this value (or list of values) will be ignored when
      resampling.
-   * Resampled images will be written out to disk if the
-     ``save_intermediate_results`` parameter is set to `True`
+   * Resampled images will be written out to disk as `_outlier_i2d.fits` by default.
    * **If resampling is turned off** through the use of the ``resample_data`` parameter,
      a copy of the unrectified input images (as a ModelContainer)
      will be used for subsequent processing.
@@ -76,14 +75,12 @@ Specifically, this routine performs the following operations:
    * The ``grow`` parameter sets the width, in pixels, beyond the limit set by
      the rejection algorithm being used, for additional pixels to be rejected in
      an image.
-   * The median image is written out to disk if the ``save_intermediate_results``
-     parameter is set to `True`.
+   * The median image is written out to disk as `_<asn_id>_median.fits` by default.
 
 #. By default, the median image is blotted back (inverse of resampling) to
    match each original input image.
 
-   * Resampled/blotted images are written out to disk if
-     the ``save_intermediate_results`` parameter is set to `True`
+   * Blotted images are written out to disk as `_<asn_id>_blot.fits` by default.
    * **If resampling is turned off**, the median image is compared directly to
      each input image.
 

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -203,12 +203,10 @@ class OutlierDetection:
                     good_bits=pars['good_bits'])
 
         # Initialize intermediate products used in the outlier detection
-        dm0 = datamodel_open(drizzled_models[0])
-        median_model = datamodels.ImageModel(dm0.data.shape)
-        median_model.update(dm0)
-        median_model.meta.wcs = dm0.meta.wcs
-        dm0.close()
-        del dm0
+        with datamodel_open(drizzled_models[0]) as dm0:
+            median_model = datamodels.ImageModel(dm0.data.shape)
+            median_model.update(dm0)
+            median_model.meta.wcs = dm0.meta.wcs
 
         # Perform median combination on set of drizzled mosaics
         median_model.data = self.create_median(drizzled_models)
@@ -216,6 +214,7 @@ class OutlierDetection:
             basepath=median_model.meta.filename,
             suffix='median')
         median_model.save(median_model_output_path)
+        log.info(f"Saved model in {median_model_output_path}")
 
         if pars['resample_data']:
             # Blot the median image back to recreate each input image specified
@@ -247,6 +246,8 @@ class OutlierDetection:
         - 'minmed' not implemented as an option
         """
         maskpt = self.outlierpars.get('maskpt', 0.7)
+
+        log.info("Computing median")
 
         # Compute weight means without keeping datamodels for eacn input open
         # Start by insuring that the ModelContainer does NOT open and keep each datamodel
@@ -321,17 +322,9 @@ class OutlierDetection:
         # Initialize container for output blot images
         blot_models = ModelContainer(open_models=False)
 
-        log.info("Blotting median...")
+        log.info("Blotting median")
         for model in self.input_models:
             blotted_median = model.copy()
-            blot_root = '_'.join(model.meta.filename.replace(
-                '.fits', '').split('_')[:-1])
-            model_path = self.make_output_path(
-                basename=blot_root,
-                suffix='blot'
-            )
-
-            blotted_median.meta.filename = model_path
 
             # clean out extra data not related to blot result
             blotted_median.err *= 0.0  # None
@@ -341,10 +334,12 @@ class OutlierDetection:
             blotted_median.data = gwcs_blot(median_model, model, interp=interp,
                                             sinscl=sinscl)
 
+            model_path = self.make_output_path(basepath=model.meta.filename, suffix='blot')
             blotted_median.save(model_path)
+            log.info(f"Saved model in {model_path}")
+
+            # Append model name to the ModelContainer so it is not passed in memory
             blot_models.append(model_path)
-            blotted_median.close()
-            del blotted_median
 
         return blot_models
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -208,7 +208,7 @@ class ResampleData:
                 # Write out model to disk, then return filename
                 output_name = output_model.meta.filename
                 output_model.save(output_name)
-                log.info(f"Exposure {output_name} saved to file")
+                log.info(f"Saved model in {output_name}")
                 self.output_models.append(output_name)
             else:
                 self.output_models.append(output_model.copy())


### PR DESCRIPTION
This PR addresses very long, redundant file names in `outlier_detection` intermediate products which appears to be a bug in the call to `Step.make_output_path()` with the arg `basename` is used instead of `basepath`.  Currently, blot produces files from standard science associations by default with names like:

```
jw02234-o010_20230627t013403_image3_00001_asn_o010_jw02234010001_02101_00001_nrcalong_blot.fits
jw02234-o010_20230627t013403_image3_00001_asn_o010_jw02234010001_02101_00001_nrcblong_blot.fits
jw02234-o010_20230627t013403_image3_00001_asn_o010_jw02234010001_02101_00002_nrcalong_blot.fits
jw02234-o010_20230627t013403_image3_00001_asn_o010_jw02234010001_02101_00002_nrcblong_blot.fits
jw02234-o010_20230627t013403_image3_00001_asn_o010_jw02234010001_02101_00003_nrcalong_blot.fits
jw02234-o010_20230627t013403_image3_00001_asn_o010_jw02234010001_02101_00003_nrcblong_blot.fits
jw02234-o010_20230627t013403_image3_00001_asn_o010_jw02234010001_02101_00004_nrcalong_blot.fits
jw02234-o010_20230627t013403_image3_00001_asn_o010_jw02234010001_02101_00004_nrcblong_blot.fits
```

Not ideal.  Since the blot image in `outlier_detection` is based on an exposure as modified by the rest of the exposures in the association, it should follow the same naming scheme as the `_crf` step results, which are:

```
jw02234010001_02101_00001_nrcalong_o010_crf.fits
jw02234010001_02101_00001_nrcblong_o010_crf.fits
jw02234010001_02101_00002_nrcalong_o010_crf.fits
jw02234010001_02101_00002_nrcblong_o010_crf.fits
jw02234010001_02101_00003_nrcalong_o010_crf.fits
jw02234010001_02101_00003_nrcblong_o010_crf.fits
jw02234010001_02101_00004_nrcalong_o010_crf.fits
jw02234010001_02101_00004_nrcblong_o010_crf.fits
```

This PR changes the default naming of blot intermediate products to be:

```
jw02234010001_02101_00001_nrcalong_o010_blot.fits
jw02234010001_02101_00001_nrcblong_o010_blot.fits
jw02234010001_02101_00002_nrcalong_o010_blot.fits
jw02234010001_02101_00002_nrcblong_o010_blot.fits
jw02234010001_02101_00003_nrcalong_o010_blot.fits
jw02234010001_02101_00003_nrcblong_o010_blot.fits
jw02234010001_02101_00004_nrcalong_o010_blot.fits
jw02234010001_02101_00004_nrcblong_o010_blot.fits
```

This PR also fixes the logging in resample to be consistent with what `Step.save_model()` echos to the log when writing out a file, making the log easier to read.  It also records in the log the intermediate products that are now written out by default in the step.

So it goes from this:

```
2023-07-31 12:21:37,428 - stpipe.Image3Pipeline.outlier_detection - INFO - 2 exposures to drizzle together
2023-07-31 12:21:41,044 - stpipe.Image3Pipeline.outlier_detection - INFO - Drizzling (2048, 2048) --> (2206, 4959)
2023-07-31 12:21:45,872 - stpipe.Image3Pipeline.outlier_detection - INFO - Drizzling (2048, 2048) --> (2206, 4959)
2023-07-31 12:21:47,221 - stpipe.Image3Pipeline.outlier_detection - INFO - Exposure jw02234010001_02101_00001_nrcblong_outlier_i2d.fits saved to file
2023-07-31 12:22:25,246 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting median...
2023-07-31 12:22:28,320 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting (2048, 2048) <-- (2206, 4959)
2023-07-31 12:22:31,561 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting (2048, 2048) <-- (2206, 4959)
```

to this:

```
2023-07-31 13:45:56,211 - stpipe.Image3Pipeline.outlier_detection - INFO - 2 exposures to drizzle together
2023-07-31 13:45:59,879 - stpipe.Image3Pipeline.outlier_detection - INFO - Drizzling (2048, 2048) --> (2206, 4959)
2023-07-31 13:46:04,708 - stpipe.Image3Pipeline.outlier_detection - INFO - Drizzling (2048, 2048) --> (2206, 4959)
2023-07-31 13:46:06,195 - stpipe.Image3Pipeline.outlier_detection - INFO - Saved model in jw02234010001_02101_00001_nrcblong_outlier_i2d.fits
2023-07-31 13:46:06,423 - stpipe.Image3Pipeline.outlier_detection - INFO - Computing median
2023-07-31 13:46:43,810 - stpipe.Image3Pipeline.outlier_detection - INFO - Saved model in jw02234010001_02101_00002_nrcalong_outlier_o010_median.fits
2023-07-31 13:46:43,819 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting median
2023-07-31 13:46:47,008 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting (2048, 2048) <-- (2206, 4959)
2023-07-31 13:46:47,401 - stpipe.Image3Pipeline.outlier_detection - INFO - Saved model in jw02234010001_02101_00002_nrcalong_o010_blot.fits
2023-07-31 13:46:50,467 - stpipe.Image3Pipeline.outlier_detection - INFO - Blotting (2048, 2048) <-- (2206, 4959)
2023-07-31 13:46:50,782 - stpipe.Image3Pipeline.outlier_detection - INFO - Saved model in jw02234010001_02101_00002_nrcblong_o010_blot.fits
```

I updated the docs to indicate what these intermediate products are.  I also note that `save_intermediate_results` no longer controls whether these products are written out, as they are always written out now.  I'm not doing anything about that right now, only updating the docs to indicate what the current pipeline step does.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
