### PR TITLE
require min version of sphinx_rtd_theme for readthedocs

### DIFF
--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -6,3 +6,4 @@ dependencies:
  - python=3.11
  - pip
  - graphviz
+ - sphinx_rtd_theme>1.2.0


### PR DESCRIPTION
Readthedocs is attempting to build the docs with a version of sphinx_rtd_theme from 2019 (version 0.4.3).
This PR updates the readthedocs environment to require a newer version (>1.2.0).

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
