### PR TITLE
remove `pymssql` dependency from `sdp` to resolve build issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ docs =
     stsci-rtd-theme
 sdp =
     jplephem>=2.9
-    pymssql>=2.1.6
+#    pymssql>=2.1.6 # pymssql has issues building on Jenkins; it is not used by JWST code but is used by DMS
     pysiaf>=0.13.0
 test =
     ci-watson>=0.5.0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR resolves an issue in the regression test build where the build fails upon attempting to build `pymssql`, which is part of the `sdp` dependency extra, as seen here: https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST/detail/JWST/2500/pipeline#step-125-log-371

**Checklist for maintainers**
- [ ] ~added entry in `CHANGES.rst` within the relevant release section~
- [ ] ~updated or added relevant tests~
- [ ] ~updated relevant documentation~
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
