### PR TITLE
JP-3244: Use source_{x,y}pos for NRS_FIXEDSLIT and NRS_MSASPEC

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,12 @@ engdb_tools
 - Check alternative host is alive before attempting to run test for
   access to avoid waiting the full timeout during test runs [#7780]
 
+extract_1d
+----------
+
+- Use ``source_{x/y}pos`` metadata to center extraction region for NIRSpec
+  (non-IFU) data. [#7796]
+
 extract_2d
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ assign_wcs
   slits use a two-digit source_id value that reflects both the primary target in
   use and the secondary slit from which the data are extracted. [#7879]
 
+- Compute sky position of dithered slit center for MIRI LRS fixed slit data, and
+  store in dither metadata under ``dithered_ra`` and ``dithered_dec``. [#7796]
+
 associations
 ------------
 
@@ -94,7 +97,7 @@ extract_1d
 ----------
 
 - Use ``source_{x/y}pos`` metadata to center extraction region for NIRSpec
-  (non-IFU) data. [#7796]
+  (non-IFU) data; use dithered pointing info for MIRI LRS fixed slit data. [#7796]
 
 extract_2d
 ----------

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -40,7 +40,6 @@ withCredentials([string(
 jobconfig = new JobConfig()
 jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
-jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
 python_version = "3.11"

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -42,7 +42,7 @@ jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
 
 // Define python version for conda
-python_version = "3.11"
+python_version = "3.9"
 
 // Define environment variables needed for the regression tests
 env_vars = [

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -79,14 +79,13 @@ The ``extract_1d`` step has the following step-specific arguments.
   off-center due to things like nodding or dithering. If turned on, the position
   of the source is used in conjunction with the World Coordinate System (WCS) to
   compute the x/y source location. For NIRSpec non-IFU modes, the source position
-  is determined from the ``source_xpos/source_ypos`` parameters, while other modes
-  use ``targ_ra/targ_dec``. For long-slit type modes (e.g. MIRI LRS and NIRSpec
-  fixed-slit and MOS), only the position in the cross-dispersion direction is used
-  to potentially offset the extraction regions in that direction. If this parameter
-  is specified in the :ref:`EXTRACT1D <extract1d_reffile>` reference file, the
-  reference file value will override any automatic settings based on exposure and
-  source type. As always, a value given by the user as an argument to the step
-  overrides all settings in the reference file or within the step code.
+  is determined from the ``source_xpos/source_ypos`` parameters. For MIRI LRS fixed slit,
+  the dither offset is applied to the sky pointing location to determine source position.
+  All other modes use ``targ_ra/targ_dec``. If this parameter is specified in the
+  :ref:`EXTRACT1D <extract1d_reffile>` reference file, the reference file value will
+  override any automatic settings based on exposure and source type. As always, a value
+  given by the user as an argument to the step overrides all settings in the reference
+  file or within the step code.
 
 ``--center_xy``
   A list of two integer values giving the desired x/y location for the center

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -76,16 +76,17 @@ The ``extract_1d`` step has the following step-specific arguments.
   the step will make the decision of whether to use the source position based
   on the observing mode and the source type. The source position will only be
   used for point sources and for modes where the source could be located
-  off-center due to things like nodding or dithering. If turned on, the sky
-  (RA/Dec) position of the source is used in conjunction with the World
-  Coordinate System (WCS) to compute the x/y source location. For long-slit
-  type modes (e.g. MIRI LRS and NIRSpec fixed-slit and MOS), only the position
-  in the cross-dispersion direction is used to potentially offset the
-  extraction regions in that direction. If this parameter is specified in the
-  :ref:`EXTRACT1D <extract1d_reffile>` reference file, the reference file value
-  will override any automatic settings based on exposure and source type.
-  As always, a value given by the user as an argument to the step overrides all
-  settings in the reference file or within the step code.
+  off-center due to things like nodding or dithering. If turned on, the position
+  of the source is used in conjunction with the World Coordinate System (WCS) to
+  compute the x/y source location. For NIRSpec non-IFU modes, the source position
+  is determined from the ``source_xpos/source_ypos`` parameters, while other modes
+  use ``targ_ra/targ_dec``. For long-slit type modes (e.g. MIRI LRS and NIRSpec
+  fixed-slit and MOS), only the position in the cross-dispersion direction is used
+  to potentially offset the extraction regions in that direction. If this parameter
+  is specified in the :ref:`EXTRACT1D <extract1d_reffile>` reference file, the
+  reference file value will override any automatic settings based on exposure and
+  source type. As always, a value given by the user as an argument to the step
+  overrides all settings in the reference file or within the step code.
 
 ``--center_xy``
   A list of two integer values giving the desired x/y location for the center

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -6,6 +6,7 @@ from .util import (update_s_region_spectral, update_s_region_imaging,
 from ..lib.exposure_types import IMAGING_TYPES, SPEC_TYPES, NRS_LAMP_MODE_SPEC_TYPES
 from ..lib.dispaxis import get_dispersion_direction
 from ..lib.wcs_utils import get_wavelengths
+from .miri import store_dithered_position
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -93,6 +94,10 @@ def load_wcs(input_model, reference_files={}, nrs_slit_y_range=None):
                 except Exception as exc:
                     log.info("Unable to update S_REGION for type {}: {}".format(
                         output_model.meta.exposure.type, exc))
+
+        # Store position of dithered pointing location in metadata for later spectral extraction
+        if output_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
+            output_model = store_dithered_position(output_model)
 
     log.info("COMPLETED assign_wcs")
     return output_model

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -97,8 +97,8 @@ def load_wcs(input_model, reference_files={}, nrs_slit_y_range=None):
 
         # Store position of dithered pointing location in metadata for later spectral extraction
         if output_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
-            output_model = store_dithered_position(output_model)
+            store_dithered_position(output_model)
             log.debug(f"Storing dithered pointing location information:"
-                     f"{output_model.meta.dither.dithered_ra} {output_model.meta.dither.dithered_dec}")
+                      f"{output_model.meta.dither.dithered_ra} {output_model.meta.dither.dithered_dec}")
     log.info("COMPLETED assign_wcs")
     return output_model

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -98,6 +98,7 @@ def load_wcs(input_model, reference_files={}, nrs_slit_y_range=None):
         # Store position of dithered pointing location in metadata for later spectral extraction
         if output_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
             output_model = store_dithered_position(output_model)
-
+            log.debug(f"Storing dithered pointing location information:"
+                     f"{output_model.meta.dither.dithered_ra} {output_model.meta.dither.dithered_dec}")
     log.info("COMPLETED assign_wcs")
     return output_model

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -9,13 +9,11 @@ from astropy.io import fits
 from scipy.interpolate import UnivariateSpline
 import gwcs.coordinate_frames as cf
 from gwcs import selector
-from gwcs.wcs import WCS
 
 from stdatamodels.jwst.datamodels import (DistortionModel, FilteroffsetModel,
                                           DistortionMRSModel, WavelengthrangeModel,
                                           RegionsModel, SpecwcsModel)
-from stdatamodels.jwst.transforms.models import (MIRI_AB2Slice, V2V3ToIdeal,
-                                                 IdealToV2V3)
+from stdatamodels.jwst.transforms.models import (MIRI_AB2Slice, IdealToV2V3)
 
 from . import pointing
 from .util import (not_implemented_mode, subarray_transform,
@@ -620,11 +618,6 @@ def store_dithered_position(input_model):
     """
     # V2_ref and v3_ref should be in arcsec
     idltov23 = IdealToV2V3(
-        input_model.meta.wcsinfo.v3yangle,
-        input_model.meta.wcsinfo.v2_ref, input_model.meta.wcsinfo.v3_ref,
-        input_model.meta.wcsinfo.vparity
-    )
-    v23toidl = V2V3ToIdeal(
         input_model.meta.wcsinfo.v3yangle,
         input_model.meta.wcsinfo.v2_ref, input_model.meta.wcsinfo.v3_ref,
         input_model.meta.wcsinfo.vparity

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -607,14 +607,12 @@ def get_wavelength_range(input_model, path=None):
 
 def store_dithered_position(input_model):
     """Store the location of the dithered pointing
-    location in the wcsinfo
+    location in the dither metadata
 
     Parameters
     ----------
-    input_model : jwst.datamodels.ImageModel
+    input_model : `jwst.datamodels.ImageModel`
         Data model containing dither offset information
-    pipeline : list
-        List of transforms to create a WCS object
     """
     # V2_ref and v3_ref should be in arcsec
     idltov23 = IdealToV2V3(
@@ -626,9 +624,8 @@ def store_dithered_position(input_model):
     dithered_v2, dithered_v3 = idltov23(input_model.meta.dither.x_offset, input_model.meta.dither.y_offset)
 
     v23toworld = input_model.meta.wcs.get_transform('v2v3', 'world')
-    dithered_ra, dithered_dec, _ = v23toworld(dithered_v2, dithered_v3, 0.0)  # needs a wavelength,
-                                                                              # but does not affect return
+    # v23toworld requires a wavelength along with v2, v3, but value does not affect return
+    dithered_ra, dithered_dec, _ = v23toworld(dithered_v2, dithered_v3, 0.0)
 
     input_model.meta.dither.dithered_ra = dithered_ra
     input_model.meta.dither.dithered_dec = dithered_dec
-    return input_model

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -632,9 +632,13 @@ def store_dithered_position(input_model):
 
     v23toworld = input_model.meta.wcs.get_transform('v2v3', 'world')
 
-    v23dithx, v23dithy = idltov23(input_model.meta.dither.x_offset, input_model.meta.dither.y_offset)
-    dithered_ra, dithered_dec = v23toworld(v23dithx, v23dithy)
+    dithered_v2, dithered_v3 = idltov23(input_model.meta.dither.x_offset, input_model.meta.dither.y_offset)
 
-    input_model.meta.wcsinfo.dithered_ra = dithered_ra
-    input_model.meta.wcsinfo.dithered_dec = dithered_dec
+    log.info(f"Number of expected inputs to transform: {v23toworld.n_inputs}")
+    log.info(f"{dithered_v2} {dithered_v3}")
+    dithered_ra, dithered_dec, _ = v23toworld(dithered_v2, dithered_v3, 0.0)  # needs a wavelength,
+                                                                              # but does not affect return
+
+    input_model.meta.dither.dithered_ra = dithered_ra
+    input_model.meta.dither.dithered_dec = dithered_dec
     return input_model

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -623,12 +623,9 @@ def store_dithered_position(input_model):
         input_model.meta.wcsinfo.vparity
     )
 
-    v23toworld = input_model.meta.wcs.get_transform('v2v3', 'world')
-
     dithered_v2, dithered_v3 = idltov23(input_model.meta.dither.x_offset, input_model.meta.dither.y_offset)
 
-    log.info(f"Number of expected inputs to transform: {v23toworld.n_inputs}")
-    log.info(f"{dithered_v2} {dithered_v3}")
+    v23toworld = input_model.meta.wcs.get_transform('v2v3', 'world')
     dithered_ra, dithered_dec, _ = v23toworld(dithered_v2, dithered_v3, 0.0)  # needs a wavelength,
                                                                               # but does not affect return
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1471,7 +1471,6 @@ class ExtractBase(abc.ABC):
             locn = x_y[1]
         else:
             locn = x_y[0]
-            log.info(f"LOCN: {locn}")
 
         if locn < lower or locn > upper and targ_ra > 340.:
             # Try this as a temporary workaround.

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1450,8 +1450,7 @@ class ExtractBase(abc.ABC):
 
             slit2det = self.wcs.get_transform('slit_frame', 'detector')
             x_y = slit2det(xpos, ypos, middle_wl)
-            log.info(f"Using source_xpos and source_ypos to center extraction "
-                     f"at pixel y={x_y[1]:.2f}.")
+            log.info(f"Using source_xpos and source_ypos to center extraction.")
 
         else:
             try:

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1451,8 +1451,8 @@ class ExtractBase(abc.ABC):
 
             slit2det = self.wcs.get_transform('slit_frame', 'detector')
             x_y = slit2det(xpos, ypos, middle_wl)
-            log.info(f"Using source_xpos and source_ypos to center extraction"
-                     f"at pixel position {x_y[0]:.2f} {x_y[1]:.2f}.")
+            log.info(f"Using source_xpos and source_ypos to center extraction "
+                     f"at pixel y={x_y[1]:.2f}.")
 
         elif input_model.meta.exposure.type in ['MIR_LRS-FIXEDSLIT', 'MIR_LRS-SLITLESS']:
             # V2_ref and v3_ref should be in arcsec

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1439,7 +1439,8 @@ class ExtractBase(abc.ABC):
         fwd_transform = self.wcs(x, y)
         middle_wl = np.nanmean(fwd_transform[2])
 
-        if input_model.meta.exposure.type in ['NRS_FIXEDSLIT', 'NRS_MSASPEC']:
+        if input_model.meta.exposure.type in ['NRS_FIXEDSLIT', 'NRS_MSASPEC',
+                                              'NRS_BRIGHTOBJ']:
             if slit is None:
                 xpos = input_model.source_xpos
                 ypos = input_model.source_ypos

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1454,35 +1454,6 @@ class ExtractBase(abc.ABC):
             log.info(f"Using source_xpos and source_ypos to center extraction "
                      f"at pixel y={x_y[1]:.2f}.")
 
-        elif input_model.meta.exposure.type in ['MIR_LRS-FIXEDSLIT', 'MIR_LRS-SLITLESS']:
-            # V2_ref and v3_ref should be in arcsec
-            idltov23 = IdealToV2V3(
-                input_model.meta.wcsinfo.v3yangle,
-                input_model.meta.wcsinfo.v2_ref, input_model.meta.wcsinfo.v3_ref,
-                input_model.meta.wcsinfo.vparity
-            )
-            v23toidl = V2V3ToIdeal(
-                input_model.meta.wcsinfo.v3yangle,
-                input_model.meta.wcsinfo.v2_ref, input_model.meta.wcsinfo.v3_ref,
-                input_model.meta.wcsinfo.vparity
-            )
-
-            worldtov23 = input_model.meta.wcs.get_transform('world', 'v2v3')
-            v23todet = input_model.meta.wcs.get_transform('v2v3', 'detector')
-
-            v23refx, v23refy = worldtov23(input_model.meta.wcsinfo.ra_ref, input_model.meta.wcsinfo.dec_ref)
-
-            idlrefx, idlrefy = v23toidl(v23refx, v23refy)
-
-            xidl_offset = input_model.meta.dither.x_offset
-            yidl_offset = input_model.meta.dither.y_offset
-
-            v2_off, v3_off = idltov23(idlrefx + xidl_offset, idlrefy + yidl_offset)  # in arcsec
-            x_y = v23todet(v2_off, v3_off)
-
-            log.info(f"Using dither offsets to center extraction"
-                     f"at pixel position {x_y[0]:.2f} {x_y[1]:.2f}.")
-
         else:
             try:
                 x_y = self.wcs.backward_transform(targ_ra, targ_dec, middle_wl)

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -10,7 +10,6 @@ from astropy.modeling import polynomial
 from astropy.io import fits
 from gwcs import WCS
 from stdatamodels import DataModel
-from stdatamodels.jwst.transforms.models import IdealToV2V3, V2V3ToIdeal
 from stdatamodels.properties import ObjectNode
 from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import dqflags, SlitModel, SpecModel

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1450,7 +1450,7 @@ class ExtractBase(abc.ABC):
 
             slit2det = self.wcs.get_transform('slit_frame', 'detector')
             x_y = slit2det(xpos, ypos, middle_wl)
-            log.info(f"Using source_xpos and source_ypos to center extraction.")
+            log.info("Using source_xpos and source_ypos to center extraction.")
 
         else:
             try:

--- a/jwst/master_background/tests/test_master_background.py
+++ b/jwst/master_background/tests/test_master_background.py
@@ -43,6 +43,8 @@ def science_image():
     image.meta.subarray.ystart = 1
     image.meta.wcsinfo.v2_ref = 0
     image.meta.wcsinfo.v3_ref = 0
+    image.meta.wcsinfo.v3yangle = 0
+    image.meta.wcsinfo.vparity = 0
     image.meta.wcsinfo.roll_ref = 0
     image.meta.wcsinfo.ra_ref = 0
     image.meta.wcsinfo.dec_ref = 0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3244](https://jira.stsci.edu/browse/JP-3244)
Resolves [JP-3245](https://jira.stsci.edu/browse/JP-3245)
Closes #7677
Closes #7681 

<!-- describe the changes comprising this PR here -->
This PR addresses extraction region issues for NIRSpec modes by utilizing source_xpos/ypos metadata to center the extraction region.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
