### PR TITLE
JP-3323: Fix pathloss bilinear interpolation coefficients

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,11 @@ outlier_detection
 
 - Fix naming and logging of intermediate blot files written to disk for imaging modes. [#7784]
 
+pathloss
+--------
+
+- Fix interpolation error for point source corrections. [#7799]
+
 resample
 --------
 

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -187,8 +187,8 @@ def calculate_pathloss_vector(pathloss_refdata,
             a22 = dx2 * dy2
             j, i = int(object_colindex), int(object_rowindex)
             pathloss_vector = (a22 * pathloss_refdata[:, i, j]
-                               + a12 * pathloss_refdata[:, i + 1, j]
-                               + a21 * pathloss_refdata[:, i, j + 1]
+                               + a21 * pathloss_refdata[:, i + 1, j]
+                               + a12 * pathloss_refdata[:, i, j + 1]
                                + a11 * pathloss_refdata[:, i + 1, j + 1])
 
         return wavelength, pathloss_vector, is_inside_slitlet


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3323](https://jira.stsci.edu/browse/JP-3323)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7781 

<!-- describe the changes comprising this PR here -->
This PR fixes an error in the interpolation method for point source pathloss corrections.  The bilinear weights for the pixels to the top and right of the base pixel were accidentally swapped.  This PR brings the bilinear interpolation into agreement with other implementations (e.g. scipy.interpolate.griddata).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
