### PR TITLE
CI fixes: Replace type comparison with isinstance and increase lower pin for asdf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.11.4 (unreleased)
 ===================
 
+assign_wcs
+----------
+
+- Use isinstance instead of comparison with a type for lamp_mode
+  inspection [#7801]
+
 calwebb_spec2
 -------------
 
@@ -18,6 +24,11 @@ flat_field
 
 - Modify the test_flatfield_step_interface unit test to prevent it from causing
   other tests to fail [#7752]
+
+general
+-------
+
+- Require minimum asdf version 2.14.4 [#7801]
 
 master_background
 -----------------

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -401,7 +401,7 @@ def get_open_slits(input_model, reference_files=None, slit_y_range=[-.55, .55]):
     """
     exp_type = input_model.meta.exposure.type.lower()
     lamp_mode = input_model.meta.instrument.lamp_mode
-    if type(lamp_mode) == str:
+    if isinstance(lamp_mode, str):
         lamp_mode = lamp_mode.lower()
     else:
         lamp_mode = 'none'
@@ -1825,7 +1825,7 @@ def nrs_lamp(input_model, reference_files, slit_y_range):
         The slit dimensions relative to the center of the slit.
     """
     lamp_mode = input_model.meta.instrument.lamp_mode
-    if type(lamp_mode) == str:
+    if isinstance(lamp_mode, str):
         lamp_mode = lamp_mode.lower()
     else:
         lamp_mode = 'none'

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.9
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf>=2.14.1
+    asdf>=2.14.4
     asdf-transform-schemas>=0.3.0
     astropy>=5.2
     BayesicFitting>=3.0.1


### PR DESCRIPTION
I noticed the CI fail on the main branch due to likely a ruff update (which caused a new E721 rule violation due to a comparison using a type instead of use of `isinstance`) and the oldest deps failing (due to the asdf dependency, jsonschema, updating).

This PR switches the type comparisons to calls to `isinstance` and increases the lower asdf version to 2.14.4.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
