### PR TITLE
Fix NIRCam imaging regtest

### DIFF
--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -50,7 +50,6 @@ def run_image3pipeline(run_image2pipeline, rtdata_module, jail):
     # produce fresh _cal files for the image3 pipeline.  We won't check these
     # or look at intermediate products, including the resampled i2d
     rate_files = [
-        "nircam/image/jw01538046001_03105_00001_nrcalong_rate.fits",
         "nircam/image/jw01538046001_03105_00001_nrcblong_rate.fits",
         "nircam/image/jw01538046001_03105_00002_nrcalong_rate.fits",
         "nircam/image/jw01538046001_03105_00002_nrcblong_rate.fits",


### PR DESCRIPTION
This PR fixes a problem in the way the Detector1 and Image2 pipelines were being called back-to-back in the NIRCam imaging mode regtest. The Image2 test was doing a call to `get_data()` on the rate file created by the Detector1 test, so instead of using the output rate file created by Detector1, it was pulling an old version of the rate file from Artifactory. D'oh. The modification no longer call `get_data()` for that file, but just uses the file already sitting in the working directory.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
