### PR TITLE
JP-3343: Add bounding_box to imaging WCS objects without one

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ assign_wcs
 
 - Use isinstance instead of comparison with a type for lamp_mode inspection [#7801]
 
+- Save bounding box to imaging WCS matching the shape of the data, for datamodels
+  without a defined bounding box. [#7809]
+
 associations
 ------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ assign_wcs
 
 - Use isinstance instead of comparison with a type for lamp_mode inspection [#7801]
 
-- Save bounding box to imaging WCS matching the shape of the data, for datamodels
+- Save bounding box to WCS matching the shape of the data, for datamodels
   without a defined bounding box. [#7809]
 
 associations

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ assign_wcs
 
 - Use isinstance instead of comparison with a type for lamp_mode inspection [#7801]
 
-- Save bounding box to WCS matching the shape of the data, for datamodels
+- Save bounding box to imaging WCS matching the shape of the data, for datamodels
   without a defined bounding box. [#7809]
 
 associations

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -2,8 +2,7 @@ import logging
 import importlib
 from gwcs.wcs import WCS
 from .util import (update_s_region_spectral, update_s_region_imaging,
-                   update_s_region_nrs_ifu, update_s_region_mrs,
-                   wcs_bbox_from_shape)
+                   update_s_region_nrs_ifu, update_s_region_mrs)
 from ..lib.exposure_types import IMAGING_TYPES, SPEC_TYPES, NRS_LAMP_MODE_SPEC_TYPES
 from ..lib.dispaxis import get_dispersion_direction
 from ..lib.wcs_utils import get_wavelengths
@@ -73,33 +72,27 @@ def load_wcs(input_model, reference_files={}, nrs_slit_y_range=None):
         if output_model.meta.exposure.type.lower() not in exclude_types:
             imaging_types = IMAGING_TYPES.copy()
             imaging_types.update(['mir_lrs-fixedslit', 'mir_lrs-slitless'])
-            if output_model.meta.exposure.type.lower() == "nrs_ifu":
-                update_s_region_nrs_ifu(output_model, mod)
-            else:
-                # Generate bounding_box if one does not yet exist,
-                # needed for all modes but NRS_IFU
-                if output_model.meta.wcs.bounding_box is None:
-                    output_model.meta.wcs.bounding_box = wcs_bbox_from_shape(output_model.data.shape)
-
-                if output_model.meta.exposure.type.lower() in imaging_types:
-                    try:
-                        update_s_region_imaging(output_model)
-                    except Exception as exc:
-                        log.error("Unable to update S_REGION for type {}: {}".format(
-                            output_model.meta.exposure.type, exc))
-                    else:
-                        log.info("assign_wcs updated S_REGION to {0}".format(
-                            output_model.meta.wcsinfo.s_region))
-                    if output_model.meta.exposure.type.lower() == 'mir_lrs-slitless':
-                        output_model.wavelength = get_wavelengths(output_model)
-                elif output_model.meta.exposure.type.lower() == 'mir_mrs':
-                    update_s_region_mrs(output_model)
+            if output_model.meta.exposure.type.lower() in imaging_types:
+                try:
+                    update_s_region_imaging(output_model)
+                except Exception as exc:
+                    log.error("Unable to update S_REGION for type {}: {}".format(
+                        output_model.meta.exposure.type, exc))
                 else:
-                    try:
-                        update_s_region_spectral(output_model)
-                    except Exception as exc:
-                        log.info("Unable to update S_REGION for type {}: {}".format(
-                            output_model.meta.exposure.type, exc))
+                    log.info("assign_wcs updated S_REGION to {0}".format(
+                        output_model.meta.wcsinfo.s_region))
+                if output_model.meta.exposure.type.lower() == 'mir_lrs-slitless':
+                    output_model.wavelength = get_wavelengths(output_model)
+            elif output_model.meta.exposure.type.lower() == "nrs_ifu":
+                update_s_region_nrs_ifu(output_model, mod)
+            elif output_model.meta.exposure.type.lower() == 'mir_mrs':
+                update_s_region_mrs(output_model)
+            else:
+                try:
+                    update_s_region_spectral(output_model)
+                except Exception as exc:
+                    log.info("Unable to update S_REGION for type {}: {}".format(
+                        output_model.meta.exposure.type, exc))
 
     log.info("COMPLETED assign_wcs")
     return output_model

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -958,6 +958,7 @@ def update_s_region_imaging(model):
 
     if bbox is None:
         bbox = wcs_bbox_from_shape(model.data.shape)
+        model.meta.wcs.bounding_box = bbox
 
     # footprint is an array of shape (2, 4) as we
     # are interested only in the footprint on the sky

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -956,10 +956,6 @@ def update_s_region_imaging(model):
 
     bbox = model.meta.wcs.bounding_box
 
-    if bbox is None:
-        bbox = wcs_bbox_from_shape(model.data.shape)
-        model.meta.wcs.bounding_box = bbox
-
     # footprint is an array of shape (2, 4) as we
     # are interested only in the footprint on the sky
     footprint = model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T
@@ -986,8 +982,6 @@ def compute_footprint_spectral(model):
     """
     swcs = model.meta.wcs
     bbox = swcs.bounding_box
-    if bbox is None:
-        bbox = wcs_bbox_from_shape(model.data.shape)
 
     x, y = grid_from_bounding_box(bbox)
     ra, dec, lam = swcs(x, y)

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -956,6 +956,10 @@ def update_s_region_imaging(model):
 
     bbox = model.meta.wcs.bounding_box
 
+    if bbox is None:
+        bbox = wcs_bbox_from_shape(model.data.shape)
+        model.meta.wcs.bounding_box = bbox
+
     # footprint is an array of shape (2, 4) as we
     # are interested only in the footprint on the sky
     footprint = model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T
@@ -982,6 +986,8 @@ def compute_footprint_spectral(model):
     """
     swcs = model.meta.wcs
     bbox = swcs.bounding_box
+    if bbox is None:
+        bbox = wcs_bbox_from_shape(model.data.shape)
 
     x, y = grid_from_bounding_box(bbox)
     ra, dec, lam = swcs(x, y)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3343](https://jira.stsci.edu/browse/JP-3343)

Closes #7820 

<!-- describe the changes comprising this PR here -->
This PR addresses a help desk inquiry regarding missing FITS SIP approximations for a NIRSpec TAcq image. These values were not filled during assign_wcs because the bounding_box was never defined. This PR is an experiment to see if saving a bounding box to imaging WCS objects of size {data.shape}, when one does not already exist, will break things.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
