### PR TITLE
JP-3232: Fix NRC coron duplicate product names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ assign_wcs
 
 - Use isinstance instead of comparison with a type for lamp_mode inspection [#7801]
 
+associations
+------------
+
+- Update the Level 3 product name construction for NIRCam coronagraphic data that
+  get processed through both coron3 and image3, to add the suffix "-image3" to the
+  product name for the data processed as imaging, in order to prevent duplicate
+  Level 3 file names from each pipeline. [#7826]
+
 calwebb_spec2
 -------------
 

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -8,7 +8,7 @@ from jwst.associations.lib.dms_base import (nrccoron_valid_detector)
 from jwst.associations.lib.process_list import ListCategory
 from jwst.associations.lib.rules_level3_base import *
 from jwst.associations.lib.rules_level3_base import (
-    dms_product_name_sources, dms_product_name_noopt,
+    dms_product_name_sources, dms_product_name_noopt, dms_product_name_coronimage,
     format_product
 )
 
@@ -473,6 +473,10 @@ class Asn_Lv3NRCCoronImage(AsnMixin_Science):
 
         # Check and continue initialization.
         super(Asn_Lv3NRCCoronImage, self).__init__(*args, **kwargs)
+
+    @property
+    def dms_product_name(self):
+        return dms_product_name_coronimage(self)
 
     def _init_hook(self, item):
         """Post-check and pre-add initialization"""

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -657,6 +657,58 @@ def dms_product_name_sources(asn):
     return product_name.lower()
 
 
+def dms_product_name_coronimage(asn):
+    """Produce image-based product name
+       for coronagraphic data
+
+    Parameters
+    ---------
+    asn : Association
+        The association for which the product
+        name is to be created.
+
+    Returns
+    -------
+    product_name : str
+        The product name
+    """
+
+    target = asn._get_target()
+
+    instrument = asn._get_instrument()
+
+    opt_elem = asn._get_opt_element()
+
+    exposure = asn._get_exposure()
+    if exposure:
+        exposure = '-' + exposure
+
+    subarray = asn._get_subarray()
+    if subarray:
+        subarray = '-' + subarray
+
+    suffix = '-image3'
+
+    product_name = (
+        'jw{program}-{acid}'
+        '_{target}'
+        '_{instrument}'
+        '_{opt_elem}{subarray}{suffix}'
+    )
+    product_name = product_name.format(
+        program=asn.data['program'],
+        acid=asn.acid.id,
+        target=target,
+        instrument=instrument,
+        opt_elem=opt_elem,
+        subarray=subarray,
+        suffix=suffix,
+        exposure=exposure
+    )
+
+    return product_name.lower()
+
+
 # -----------------
 # Basic constraints
 # -----------------


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3232](https://jira.stsci.edu/browse/JP-3232)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7730 

<!-- describe the changes comprising this PR here -->
This PR adds an override for the construction of the level-3 product name for NIRCam coronagraphic associations that are to be processed as regular imaging, i.e. through the image3 pipeline. The data are also processed as a coron3 ASN, which previously resulted in identical "i2d" level-3 product names being created: one from coron3 and one from image3. This update breaks the file name degeneracy by simply adding the additional suffix "-image3" to the optical element field of the product name for the data processed as regular imaging.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
