### PR TITLE
Remove regtest XFAIL for fixed ASN rule

### DIFF
--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -32,11 +32,6 @@ SPECIAL_DEFAULT = {
     'slow': False,
 }
 SPECIAL_POOLS = {
-    'jw00016_20230331t130733_pool': {
-        'args': [],
-        'xfail': None,
-        'slow': False,
-    },
     'jw00623_20190607t021101_pool': {
         'args': [],
         'xfail': None,

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -34,7 +34,7 @@ SPECIAL_DEFAULT = {
 SPECIAL_POOLS = {
     'jw00016_20230331t130733_pool': {
         'args': [],
-        'xfail': 'See issue JP-3230',
+        'xfail': None,
         'slow': False,
     },
     'jw00623_20190607t021101_pool': {


### PR DESCRIPTION
This PR removes the XFAIL setting in the asn regtests for the program jw00016 pool, now that JP-3230 and JP-3232 have been completed. The first regtest run will result in differences, which can then be okified.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
