### PR TITLE
JP-3151: Don't make Lv2 ASNs for empty NRS2 exposures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ associations
   product name for the data processed as imaging, in order to prevent duplicate
   Level 3 file names from each pipeline. [#7826]
 
+- Update the Level 2 spectroscopic ASN rules to exclude any NIRSpec IFU exposures that
+  use filter/grating combinations known to produce no data on the NRS2 detector.
+  [#7833]
+
 calwebb_spec2
 -------------
 

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -204,6 +204,25 @@ NRS_FSS_VALID_LAMP_OPTICAL_PATHS = (
     ('g140m', 'flat4', 'nrs2'),
 )
 
+# Define the valid optical paths vs detector for NIRSpect IFU Science
+# Tuples are (GRATING, FILTER, DETECTOR)
+# The only combinations that result in data on the NRS2 detector are
+# g140h/f100lp, g235h/f170lp, and g395h/f290lp.
+NRS_IFU_VALID_OPTICAL_PATHS = (
+    ('prism', 'clear',  'nrs1'),
+    ('g140m', 'f070lp', 'nrs1'),
+    ('g140m', 'f100lp', 'nrs1'),
+    ('g235m', 'f170lp', 'nrs1'),
+    ('g395m', 'f290lp', 'nrs1'),
+    ('g140h', 'f070lp', 'nrs1'),
+    ('g140h', 'f100lp', 'nrs1'),
+    ('g140h', 'f100lp', 'nrs2'),
+    ('g235h', 'f170lp', 'nrs1'),
+    ('g235h', 'f170lp', 'nrs2'),
+    ('g395h', 'f290lp', 'nrs1'),
+    ('g395h', 'f290lp', 'nrs2'),
+)
+
 # Key that uniquely identifies members.
 MEMBER_KEY = 'expname'
 
@@ -997,7 +1016,7 @@ def item_getattr(item, attributes, association=None):
 
 
 def nrsfss_valid_detector(item):
-    """Check that a grating/filter combo can appear on the detector"""
+    """Check that a slit/grating/filter combo can appear on the detector"""
     try:
         _, detector = item_getattr(item, ['detector'])
         _, filter = item_getattr(item, ['filter'])
@@ -1015,6 +1034,10 @@ def nrsfss_valid_detector(item):
 
 def nrsifu_valid_detector(item):
     """Check that a grating/filter combo can appear on the detector"""
+    _, exp_type = item_getattr(item, ['exp_type'])
+    if exp_type != 'nrs_ifu':
+        return True
+
     try:
         _, detector = item_getattr(item, ['detector'])
         _, filter = item_getattr(item, ['filter'])
@@ -1022,21 +1045,7 @@ def nrsifu_valid_detector(item):
     except KeyError:
         return False
 
-    # Just a checklist of paths:
-    if grating in ['g395h', 'g235h']:
-        return True
-    elif grating in ['g395m', 'g235m', 'g140m'] and detector == 'nrs1':
-        return True
-    elif grating == 'prism' and filter == 'clear' and detector == 'nrs1':
-        return True
-    elif grating == 'g140h':
-        if filter == 'f100lp':
-            return True
-        elif filter == 'f070lp' and detector == 'nrs1':
-            return True
-
-    # Nothing has matched. Not valid.
-    return False
+    return (grating, filter, detector) in NRS_IFU_VALID_OPTICAL_PATHS
 
 
 def nrslamp_valid_detector(item):

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -198,7 +198,7 @@ class Asn_Lv2ImageSpecial(
             Constraint_Mode(),
             Constraint_Image_Science(),
             Constraint_Single_Science(self.has_science, self.get_exposure_type),
-            Constraint_Special(),
+            Constraint_Special(),  # background and ref_psf exposures
         ])
 
         # Now check and continue initialization.
@@ -350,6 +350,11 @@ class Asn_Lv2SpecImprint(
             Constraint_Mode(),
             Constraint_Spectral_Science(),
             Constraint_Single_Science(self.has_science, self.get_exposure_type),
+            SimpleConstraint(
+                value=True,
+                test=lambda value, item: nrsifu_valid_detector(item),
+                force_unique=False
+            ),
             DMSAttrConstraint(
                 name='imprint',
                 sources=['is_imprt']
@@ -382,7 +387,12 @@ class Asn_Lv2SpecSpecial(
             Constraint_Base(),
             Constraint_Mode(),
             Constraint_Spectral_Science(),
-            Constraint_Special(),
+            Constraint_Special(),  # background and ref_psf exposures
+            SimpleConstraint(
+                value=True,
+                test=lambda value, item: nrsifu_valid_detector(item),
+                force_unique=False
+            ),
             Constraint(
                 [
                     Constraint_Imprint_Special(self),


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3151](https://jira.stsci.edu/browse/JP-3151)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7775 

<!-- describe the changes comprising this PR here -->
This PR updates the spectroscopic level-2 ASN rules used for NIRSpec IFU exposures to exclude exposures using filter/grating combos that are known to produce no data on the NRS2 detector, so that they don't get any level-2b processing.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
