### PR TITLE
JP-3090: Jump parameters missing from documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,9 @@ ____
 
 - Updated documentation for the step parameters [#7778]
 
+- Added argument description for three_group_rejection_threshold and
+  four_group_rejection_threshold [#7839].
+
 master_background
 -----------------
 

--- a/docs/jwst/jump/arguments.rst
+++ b/docs/jwst/jump/arguments.rst
@@ -14,6 +14,14 @@ The ``jump`` step has 30 optional arguments that can be set by the user:
   rejection threshold will yield 6200 false positives for every million pixels, if the noise
   model is correct.
 
+* ``--three_group_rejection_threshold``: Cosmic ray sigma rejection threshold for ramps
+  having 3 groups. This is a floating-point value with default value of 6.0, and minimum
+  of 0.0.
+
+* ``--four_group_rejection_threshold``: Cosmic ray sigma rejection threshold for ramps
+  having 4 groups. This is a floating-point value with default value of 5.0, and minimum
+  of 0.0.
+
 * ``--maximum_cores``: The fraction of available cores that will be
   used for multi-processing in this step. The default value is 'none', which does not use
   multi-processing. The other options are 'quarter', 'half', and 'all'. Note that these


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3090](https://jira.stsci.edu/browse/JP-3090)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7840 

<!-- describe the changes comprising this PR here -->
This PR addresses the missing argument descriptions in the documentation of the jump step.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
