### PR TITLE
Fix grism tests after transforms update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,11 @@ engdb_tools
 - Check alternative host is alive before attempting to run test for
   access to avoid waiting the full timeout during test runs [#7780]
 
+extract_2d
+----------
+
+- Updated unit test truth values after NIRCam WFSS transform updates [#7851]
+
 flat_field
 ----------
 

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -219,7 +219,7 @@ def test_create_box_fits():
         assert ids[0].xcentroid > 0
         assert ids[0].ycentroid > 0
         if sid == 19:
-            assert [1, 2] == list(ids[0].order_bounding.keys())
+            assert [1] == list(ids[0].order_bounding.keys())
         if sid == 9:
             assert [1] == list(ids[0].order_bounding.keys())
 
@@ -251,7 +251,7 @@ def test_create_box_gwcs():
         assert ids[0].xcentroid > 0
         assert ids[0].ycentroid > 0
         if sid == 19:
-            assert [1, 2] == list(ids[0].order_bounding.keys())
+            assert [1] == list(ids[0].order_bounding.keys())
         if sid == 9:
             assert [1] == list(ids[0].order_bounding.keys())
 
@@ -392,14 +392,14 @@ def test_extract_wfss_object():
     assert isinstance(outmodel, MultiSlitModel)
     assert len(outmodel.slits) == 3
     ids = [slit.source_id for slit in outmodel.slits]
-    assert ids == [9, 19, 19]
+    assert ids == [9, 19, 25]
 
     # Compare SRCDEC and SRCRA values
     assert np.isclose(outmodel[0].source_dec, -27.80858320887945)
     assert np.isclose(outmodel[0].source_ra, 53.13773660029234)
 
     names = [slit.name for slit in outmodel.slits]
-    assert names == ['9', '19', '19']
+    assert names == ['9', '19', '25']
 
     with pytest.raises(TypeError):
         extract_tso_object(wcsimage, reference_files='myspecwcs.asdf')


### PR DESCRIPTION

<!-- describe the changes comprising this PR here -->
This PR addresses changes to test results after NIRCam WFSS transforms were updated - some source positions have moved on/off detector, altering the expected traces found and extracted during testing.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
