### PR TITLE
JP-3356 Remove order dependency on association diffing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ associations
   use filter/grating combinations known to produce no data on the NRS2 detector.
   [#7833]
 
+- Remove order dependency on association diffing. [#7853]
+
 calwebb_spec2
 -------------
 

--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -584,13 +584,13 @@ def check_duplicate_products(asns):
             try:
                 compare_product_membership(current_asn['products'][0], asn['products'][0])
             except MultiDiffError as compare_diffs:
-                # Check that the associations differ only in suffix.
-                # If so, the associations are not duplicates
+                # Re-check membership, but allow products that different only in the suffix
+                # of the members. If there are no differences, then the products are not duplicates.
                 try:
-                    compare_nosuffix(current_asn, asn)
+                    compare_product_membership(current_asn['products'][0], asn['products'][0], strict_expname=False)
                 except MultiDiffError:
-                    # Not interested in the diffs from `compare_nosuffix`.
-                    # The diffs from `compare_product_membership` will be more informative.
+                    # Not interested if the second compare generates diffs.
+                    # The initial diffs will be more informative.
                     diffs.extend(compare_diffs)
             else:
                 # Associations are exactly the same. Pure duplicate.

--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -343,57 +343,6 @@ def compare_membership(left, right):
         raise diffs
 
 
-def compare_nosuffix(left, right):
-    """Check if the only difference is in rate vs rateints suffixes
-
-    A valid situation is to have two associations be exactly the same except
-    for the suffix used on all the science inputs. If one association uses
-    "rate" and the other uses "rateints", this is OK.
-
-    If no errors are raised, the two associations are similar except
-    for the suffixes used in the `expname`s, which is valid.
-
-    Otherwise, the following errors can be raised:
-
-    - DifferentProductSetsError
-      Products do not match.
-
-    Parameters
-    ----------
-    left, right : Association, Association
-        The associations to compare.
-
-    Raises
-    ------
-    MultiDiffError
-    """
-    if len(left['products']) != len(right['products']):
-        raise MultiDiffError([DifferentProductSetsError(
-            f'Different products between {left.asn_name}({len(left["products"])}) and {right.asn_name}({len(right["products"])})',
-            asns=[left, right]
-        )])
-
-    diffs = MultiDiffError()
-    for left_product in left['products']:
-        left_members = set(exposure_name(member['expname'])
-                         for member in left_product['members'])
-        for right_product in right['products']:
-            right_members = set(exposure_name(member['expname'])
-                              for member in right_product['members'])
-            if left_members == right_members:
-                break
-        else:
-            # No right product matches the left product.
-            # This is a fail.
-            diffs.append(DifferentProductSetsError(
-                f'Left product {left_product["name"]} has not counterpart in right products',
-                asns=[left, right]
-            ))
-
-    if diffs:
-        raise diffs
-
-
 def compare_product_membership(left, right, strict_expname=True):
     """Compare membership between products
 

--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -176,12 +176,12 @@ def compare_asn_lists(left_asns, right_asns):
     right_product_names, right_duplicates = get_product_names(right_asns)
     if left_duplicates:
         try:
-            check_duplicate_products(left_asns)
+            check_duplicate_products(left_asns, product_names=left_product_names, dup_names=left_duplicates)
         except MultiDiffError as dup_errors:
             diffs.extend(dup_errors)
     if right_duplicates:
         try:
-            check_duplicate_products(right_asns)
+            check_duplicate_products(right_asns, product_names=right_product_names, dup_names=right_duplicates)
         except MultiDiffError as dup_errors:
             diffs.extend(dup_errors)
 

--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -481,7 +481,7 @@ def check_duplicate_members(product):
         )
 
 
-def check_duplicate_products(asns):
+def check_duplicate_products(asns, product_names=None, dup_names=None):
     """Check for duplicate products in a list of associations
 
     Duplicate products are defined as any products that share the same name.
@@ -509,11 +509,20 @@ def check_duplicate_products(asns):
         The associations to compare. Each association should only have one
         product. Use `separate_products` prior to calling if necessary.
 
+    product_names : [str[,...]]
+        Product names in given associations.
+        If None, will be generated internally.
+
+    dup_names : [str[,...]]
+        Duplicate product names in the given associations.
+        If None, will be generated internally.
+
     Raises
     ------
     MultiDiffError
     """
-    product_names, dup_names = get_product_names(asns)
+    if product_names is None or dup_names is None:
+        product_names, dup_names = get_product_names(asns)
     if not dup_names:
         return
 

--- a/jwst/associations/lib/prune.py
+++ b/jwst/associations/lib/prune.py
@@ -144,7 +144,7 @@ def prune_duplicate_products(asns):
                     # If the difference is only in suffix, this is an acceptable duplication of product names.
                     # Trap and do not report.
                     try:
-                        diff.compare_nosuffix(asn, entrant)
+                        diff.compare_product_membership(asn['products'][0], entrant['products'][0], strict_expname=False)
                     except diff.MultiDiffError:
                         # Something is different. Report but do not remove.
                         logger.warning('Following associations have the same product name but significant differences.')

--- a/jwst/associations/lib/tests/test_diff.py
+++ b/jwst/associations/lib/tests/test_diff.py
@@ -227,6 +227,46 @@ asns_subset = {
 }
 
 
+# Test case when comparing groups of associations.
+# There should be no difference because of the `rate/rateints`
+# equivalence. Tests will try different ordering due to a bug
+# which made the comparison order-dependent.
+NODIFF_ASNS = [
+    {
+        "asn_type": "image2",
+        "asn_id": "o006",
+        "products": [
+            {
+                "name": "jw00016006001_04105_00001_nrca4",
+                "members": [
+                    {
+                        "expname": "jw00016006001_04105_00001_nrca4_rate.fits",
+                        "exptype": "science",
+                        "exposerr": "null"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "asn_type": "image2",
+        "asn_id": "o006",
+        "products": [
+            {
+                "name": "jw00016006001_04105_00001_nrca4",
+                "members": [
+                    {
+                        "expname": "jw00016006001_04105_00001_nrca4_rateints.fits",
+                        "exptype": "science",
+                        "exposerr": "null"
+                    }
+                ]
+            }
+        ]
+    },
+]
+
+
 def test_duplicate_members():
     """Test duplicate members"""
     product = badcandidate_asn['products'][0]
@@ -281,6 +321,26 @@ def test_fromfiles():
         json.dump(standard_asn, fh)
 
     asn_diff.compare_asn_files(['test.json'], ['test.json'])
+
+
+@pytest.mark.parametrize(
+    'left_indexes, right_indexes',
+    [
+        ([0, 1], [0, 1]),
+        ([0, 1], [1, 0]),
+        ([1, 0], [0, 1]),
+        ([1, 0], [1, 0]),
+    ]
+)
+def test_nodiff_order(left_indexes, right_indexes):
+    """Associations should have no difference, regardless of order"""
+
+    # Order the associations as specified in the indexes.
+    left_asns = [NODIFF_ASNS[idx] for idx in left_indexes]
+    right_asns = [NODIFF_ASNS[idx] for idx in right_indexes]
+
+    # Execute test. Success will not generate any exceptions.
+    asn_diff.compare_asn_lists(left_asns, right_asns)
 
 
 def test_separate_products():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3356](https://jira.stsci.edu/browse/JP-3356)

<!-- describe the changes comprising this PR here -->
This PR addresses resolves an issue found during regression testing of another PR.

The issue is that the success/failure of an association difference check is dependent on the
order of the associations. This PR resolves that bug while refactoring/removing redundant code.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
