### PR TITLE
Update MIRI MRS TSO regtest

### DIFF
--- a/jwst/regtest/test_miri_mrs_tso.py
+++ b/jwst/regtest/test_miri_mrs_tso.py
@@ -25,6 +25,7 @@ def run_spec2(jail, rtdata_module):
             '--steps.srctype.save_results=true',
             '--steps.fringe.save_results=true',
             '--steps.photom.save_results=true',
+            '--steps.photom.mrs_time_correction=false',  # turn on after JP-3359 is fixed
             ]
 
     Step.from_cmdline(args)


### PR DESCRIPTION
Related to [JP-3359](https://jira.stsci.edu/browse/JP-3359)

<!-- describe the changes comprising this PR here -->
This PR updates the MIRI MRS TSO regression test to temporarily skip the MRS time-dependent correction in the photom step of the spec2 pipeline, because that algorithm can't handle 3D MRS data right now. Previously, the test had been working OK, because the DATE-OBS in the input file was pre-flight, such that an old photom ref file was used, which did not contain the time-dependent corrections, so no error occurred. This, however, allowed that error to get through our B9.3 testing and into operations. So I've updated the DATE-OBS in the test input file to use the most recent ref files, which will trigger the error, until it gets fixed by JP-3359.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
