### PR TITLE
JP-3362: Fix MRS time dependent correction for TSO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,6 +115,12 @@ pathloss
   when the computed target location is outside the slit. Add the parameter 
   "user_slit_loc" to allow specifying the source location to use. [#7806]
 
+photom
+------
+
+- Adapt MRS time dependent correction so that it can run successfully on
+  TSO mode data. [#7869]
+
 pixel_replace
 -------------
 

--- a/jwst/photom/miri_mrs.py
+++ b/jwst/photom/miri_mrs.py
@@ -157,7 +157,7 @@ def time_correction(input, detector, ftab, mid_time):
     timecoeff['right']['ccoeff'] = table_ch[right]['ccoeff']
     timecoeff['right']['x0'] = table_ch[right]['x0']
 
-    ysize, xsize = input.data.shape
+    ysize, xsize = input.data.shape[-2], input.data.shape[-1]
     # the correction is time and wavelength dependent. Pull out the
     # wavelength of the data
     x, y = grid_from_bounding_box(input.meta.wcs.bounding_box)


### PR DESCRIPTION
This PR fixes the issue documented in https://jira.stsci.edu/browse/JP-3359 where the MRS time-dependent correction crashes for TSO mode data.

Resolves [JP-3362](https://jira.stsci.edu/browse/JP-3362)
Closes #7872 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
