### PR TITLE
Jump step num cores doc update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,9 @@ ____
 - Added argument description for three_group_rejection_threshold and
   four_group_rejection_threshold [#7839].
 
+- Updated argument description and parameter definition to allow
+  integer number of cores to be passed to STCAL jump.py. [#7871]
+
 master_background
 -----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,8 @@ general
 
 - Require minimum asdf version 2.14.4 [#7801]
 
+- Require minimum asdf version 2.15.1 and numpy 1.22 [#7861]
+
 jump
 ____
 

--- a/docs/jwst/jump/arguments.rst
+++ b/docs/jwst/jump/arguments.rst
@@ -22,15 +22,18 @@ The ``jump`` step has 30 optional arguments that can be set by the user:
   having 4 groups. This is a floating-point value with default value of 5.0, and minimum
   of 0.0.
 
-* ``--maximum_cores``: The fraction of available cores that will be
-  used for multi-processing in this step. The default value is 'none', which does not use
-  multi-processing. The other options are 'quarter', 'half', and 'all'. Note that these
-  fractions refer to the total available cores and on most CPUs these include physical
-  and virtual cores. The clock time for the step is reduced
-  almost linearly by the number of physical cores used on all machines. For example, on an Intel CPU with
-  six real cores and 6 virtual cores setting maximum_cores to 'half' results in a
-  decrease of a factor of six in the clock time for the step to run. Depending on the system
+* ``--maximum_cores``: The number of available cores that will be
+  used for multi-processing in this step. The default value is '1', which does not use
+  multi-processing. The other options are either an integer, 'quarter', 'half', or 'all'.
+  Note that these fractions refer to the total available cores and on most CPUs these include
+  physical and virtual cores. The clock time for the step is reduced almost linearly by the
+  number of physical cores used on all machines. For example, on an Intel CPU with
+  six real cores and six virtual cores, setting maximum_cores to 'half' results in a
+  decrease of a factor of six in the clock time for the step to run. Depending on the system,
   the clock time can also decrease even more with maximum_cores is set to 'all'.
+  Setting the number of cores to an integer can be useful when running on machines with a
+  large number of cores where the user is limited in how many cores they can use.
+  Note that, currently, snowball and shower detection does not use multiprocessing.
 
 * ``--flag_4_neighbors``: If set to True (default is True) it will cause the four perpendicular
   neighbors of all detected jumps to also be flagged as a jump. This is needed because of

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -18,7 +18,7 @@ class JumpStep(Step):
         rejection_threshold = float(default=4.0,min=0) # CR sigma rejection threshold
         three_group_rejection_threshold = float(default=6.0,min=0) # CR sigma rejection threshold
         four_group_rejection_threshold = float(default=5.0,min=0) # CR sigma rejection threshold
-        maximum_cores = option('none', 'quarter', 'half', 'all', default='none') # max number of processes to create
+        maximum_cores = string(default='1') # cores for multiprocessing. Can be an integer, 'half', 'quarter', or 'all'
         flag_4_neighbors = boolean(default=True) # flag the four perpendicular neighbors of each CR
         max_jump_to_flag_neighbors = float(default=1000) # maximum jump sigma that will trigger neighbor flagging
         min_jump_to_flag_neighbors = float(default=10) # minimum jump sigma that will trigger neighbor flagging

--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -7,7 +7,7 @@ from stdatamodels.jwst.datamodels import GainModel, ReadnoiseModel, RampModel
 
 from jwst.jump import JumpStep
 
-MAXIMUM_CORES = ['none', 'quarter', 'half', 'all']
+MAXIMUM_CORES = ['2', 'none', 'quarter', 'half', 'all']
 
 
 @pytest.fixture(scope="module")

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,14 +27,14 @@ python_requires = >=3.9
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf>=2.14.4
+    asdf>=2.15.1
     asdf-transform-schemas>=0.3.0
     astropy>=5.2
     BayesicFitting>=3.0.1
     crds>=11.16.19
     drizzle>=1.13.7
     gwcs>=0.18.3
-    numpy>=1.20
+    numpy>=1.22
     opencv-python-headless>=4.6.0.66
     photutils>=1.4.0
     psutil>=5.7.2


### PR DESCRIPTION
This PR allows the new maximum_cores values to be accepted to be able to pass the value to the STCAL jump.py routine. Read_the_docs was updated to match the new options. 


**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
