### PR TITLE
Re-enable photom correction in MIRI MRS TSO regtest

### DIFF
--- a/jwst/regtest/test_miri_mrs_tso.py
+++ b/jwst/regtest/test_miri_mrs_tso.py
@@ -25,7 +25,7 @@ def run_spec2(jail, rtdata_module):
             '--steps.srctype.save_results=true',
             '--steps.fringe.save_results=true',
             '--steps.photom.save_results=true',
-            '--steps.photom.mrs_time_correction=false',  # turn on after JP-3359 is fixed
+            '--steps.photom.mrs_time_correction=true',
             ]
 
     Step.from_cmdline(args)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Now that #7869 has been merged, which fixes a bug in the application of the time-dependent flux correction to MIRI MRS data taken in TSO mode, that correction can be turned back on the MRS TSO regression test.

Updated test runs locally without crashing, but of course results in differences in final outputs.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
