### PR TITLE
add jsonschema to setup.cfg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,8 @@ general
 
 - Require minimum asdf version 2.15.1 and numpy 1.22 [#7861]
 
+- Add required jsonschema as a dependency [#7880]
+
 jump
 ____
 

--- a/jwst/associations/lib/lv2_v1_to_v2.py
+++ b/jwst/associations/lib/lv2_v1_to_v2.py
@@ -2,7 +2,6 @@
 import argparse
 from glob import glob
 import json
-import jsonschema
 import logging
 import os.path as path
 import re

--- a/jwst/associations/tests/notebooks/lv2_v1_to_v2.ipynb
+++ b/jwst/associations/tests/notebooks/lv2_v1_to_v2.ipynb
@@ -23,7 +23,6 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "import jsonschema\n",
     "import os.path as path\n",
     "import re"
    ]

--- a/jwst/scripts/make_header.py
+++ b/jwst/scripts/make_header.py
@@ -33,9 +33,9 @@ import argparse
 
 import re
 import inspect
-import jsonschema
 import numpy as np
 from os import path as os_path
+from asdf import ValidationError
 from asdf.tags.core import ndarray
 
 from stdatamodels import validate
@@ -768,7 +768,7 @@ def validate_value(im, name, value):
     if schema:
         try:
             validate._check_value(value, schema, im)
-        except jsonschema.ValidationError:
+        except ValidationError:
             valid = False
     return valid
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     wiimatch>=0.2.1
     packaging>19.0
     importlib-metadata>=4.11.4
+    jsonschema>=4.8
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
jsonschema was previously installed by asdf and stdatamodels. However, jsonschema is used directly for association processing. This commit adds jsonschema as a dependency by listing it in setup.cfg.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
