### PR TITLE
JP-3355 added parameter to extract 1d to override srctype and  use point source extraction 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 1.12.1 (unreleased)
 ===================
 
-- 
+extract_1d
+----------
+
+- For IFU data allow the user to set the src_type. For MIRI MRS data allow
+  the user to scale the extraction radius between 0.5 to 3.0 FWHM [#7883]
+ 
 
 1.12.0 (2023-09-18)
 ===================
@@ -111,6 +116,7 @@ extract_1d
 
 - Use ``source_{x/y}pos`` metadata to center extraction region for NIRSpec
   (non-IFU) data; use dithered pointing info for MIRI LRS fixed slit data. [#7796]
+
 
 extract_2d
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 extract_1d
 ----------
 
-- For IFU data allow the user to set the src_type. For MIRI MRS data allow
+- For MIRS MRS IFU data allow the user to set the src_type and allow 
   the user to scale the extraction radius between 0.5 to 3.0 FWHM [#7883]
  
 

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -115,9 +115,9 @@ The ``extract_1d`` step has the following step-specific arguments.
   not changed, instead the extraction method used is based on this parameter setting. This is
   only allowed for IFU data. 
 
-``ifu_rscale``
+``--ifu_rscale``
    A float designating the number of PSF FWHMs to use for the extraction radius. This
-   is  MIRI MRS only paramenter. Values accepted are between 0.5 to 3.0. The default extraction
+   is a MIRI MRS only paramenter. Values accepted are between 0.5 to 3.0. The default extraction
    size is set to 2 * FWHM. Values below 2 will result in a smaller
    radius, a value of 2 results in no change to radius and a value above 2 results in a larger
    extraction radius.  

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -109,6 +109,19 @@ The ``extract_1d`` step has the following step-specific arguments.
   Switch to select whether or not to run 1d residual fringe correction on the
   extracted 1d spectrum (MIRI MRS only). Default is ``False``.
 
+``--ifu_set_srctype``
+  A string that can be used to override the extraction method for the source_type
+  given by the SRCTYPE keyword. The allowed values are POINT and EXTENDED. The SRCTYPE keyword is
+  not changed, instead the extraction method used is based on this parameter setting. This is
+  only allowed for IFU data. 
+
+``ifu_rscale``
+   A float designating the number of PSF FWHMs to use for the extraction radius. This
+   is  MIRI MRS only paramenter. Values accepted are between 0.5 to 3.0. The default extraction
+   size is set to 2 * FWHM. Values below 2 will result in a smaller
+   radius, a value of 2 results in no change to radius and a value above 2 results in a larger
+   extraction radius.  
+   
 ``--soss_atoca``
   This is a NIRISS-SOSS algorithm-specific parameter; if True, use the ATOCA
   algorithm to treat order contamination. Default is ``True``.

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -113,7 +113,7 @@ The ``extract_1d`` step has the following step-specific arguments.
   A string that can be used to override the extraction method for the source_type
   given by the SRCTYPE keyword. The allowed values are POINT and EXTENDED. The SRCTYPE keyword is
   not changed, instead the extraction method used is based on this parameter setting. This is
-  only allowed for IFU data. 
+  only allowed for MIRI MRS IFU data. 
 
 ``--ifu_rscale``
    A float designating the number of PSF FWHMs to use for the extraction radius. This

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2804,7 +2804,7 @@ def do_extract1d(
         for MIRI MRS IFU spectra.  Default is False.
 
     ifu_set_srctype : str
-        For IFU data override srctype and set it to either POINT or EXTENDED.
+        For MIRI MRS IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
         For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2547,7 +2547,7 @@ def run_extract1d(
         center_xy: Union[float, None],
         ifu_autocen: Union[bool, None],
         ifu_rfcorr: Union[bool, None],
-        ifu_set_point_source: Union[bool, None],
+        ifu_set_srctype: str,
         ifu_rscale: float,
         was_source_model: bool = False,
 ) -> DataModel:
@@ -2609,9 +2609,8 @@ def run_extract1d(
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
-    ifu_set_point_source : bool
-        Override srctype and set POINT source extraction for IFU spectra.
-        Default is False.
+    ifu_set_srctype : str
+        For IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
         For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
@@ -2668,7 +2667,7 @@ def run_extract1d(
         center_xy,
         ifu_autocen,
         ifu_rfcorr,
-        ifu_set_point_source,
+        ifu_set_srctype,
         ifu_rscale,
         was_source_model,
     )
@@ -2732,7 +2731,7 @@ def do_extract1d(
         center_xy: Union[int, None] = None,
         ifu_autocen: Union[bool, None] = None,
         ifu_rfcorr: Union[bool, None] = None,
-        ifu_set_point_source: Union[bool, None] = None,
+        ifu_set_srctype: str = None,
         ifu_rscale: float = None,
         was_source_model: bool = False
 ) -> DataModel:
@@ -2804,9 +2803,8 @@ def do_extract1d(
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
-    ifu_set_point_source : bool
-        Override srctype and perform POINT source extraction for IFU spectra.
-        Default is False.
+    ifu_set_srctype : src
+        For IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
         For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
@@ -3022,8 +3020,8 @@ def do_extract1d(
             if source_type is None:
                 source_type = "UNKNOWN"
 
-            if ifu_set_point_source:
-                source_type = "POINT"
+            if ifu_set_srctype is not None:
+                source_type = ifu_set_srctype
                 log.info('Overriding source type and setting it to POINT')
             output_model = ifu.ifu_extract1d(
                 input_model, extract_ref_dict, source_type, subtract_background,

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2610,7 +2610,7 @@ def run_extract1d(
         for MIRI MRS IFU spectra.  Default is False.
 
     ifu_set_srctype : str
-        For IFU data override srctype and set it to either POINT or EXTENDED.
+        For MIRI MRS IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
         For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF
@@ -2803,7 +2803,7 @@ def do_extract1d(
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
-    ifu_set_srctype : src
+    ifu_set_srctype : str
         For IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
@@ -3020,7 +3020,7 @@ def do_extract1d(
             if source_type is None:
                 source_type = "UNKNOWN"
 
-            if ifu_set_srctype is not None:
+            if ifu_set_srctype is not None and input_model.meta.exposure.type == 'MIR_MRS':
                 source_type = ifu_set_srctype
                 log.info(f"Overriding source type and setting it to = {ifu_set_srctype}")
             output_model = ifu.ifu_extract1d(

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2548,6 +2548,7 @@ def run_extract1d(
         ifu_autocen: Union[bool, None],
         ifu_rfcorr: Union[bool, None],
         ifu_set_point_source: Union[bool, None],
+        ifu_rscale: float,
         was_source_model: bool = False,
 ) -> DataModel:
     """Extract 1-D spectra.
@@ -2612,6 +2613,13 @@ def run_extract1d(
         Override srctype and set POINT source extraction for IFU spectra.
         Default is False.
 
+    ifu_rscale: float
+        For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
+        FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
+        default extraction size is set to 2 * FWHM. Values below 2 will results in a smaller
+        radi, a value of 2 results in no change to radi and a value above 2 results in a larger
+        extraction radi.
+
     was_source_model : bool
         True if and only if `input_model` is actually one SlitModel
         obtained by iterating over a SourceModelContainer.  The default
@@ -2661,6 +2669,7 @@ def run_extract1d(
         ifu_autocen,
         ifu_rfcorr,
         ifu_set_point_source,
+        ifu_rscale,
         was_source_model,
     )
 
@@ -2724,6 +2733,7 @@ def do_extract1d(
         ifu_autocen: Union[bool, None] = None,
         ifu_rfcorr: Union[bool, None] = None,
         ifu_set_point_source: Union[bool, None] = None,
+        ifu_rscale: float = None,
         was_source_model: bool = False
 ) -> DataModel:
     """Extract 1-D spectra.
@@ -2797,6 +2807,13 @@ def do_extract1d(
     ifu_set_point_source : bool
         Override srctype and perform POINT source extraction for IFU spectra.
         Default is False.
+
+    ifu_rscale: float
+        For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
+        FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
+        default extraction size is set to 2 * FWHM. Values below 2 will results in a smaller
+        radi, a value of 2 results in no change to radi and a value above 2 results in a larger
+        extraction radi.
 
     was_source_model : bool
         True if and only if `input_model` is actually one SlitModel
@@ -3010,7 +3027,7 @@ def do_extract1d(
                 log.info('Overriding source type and setting it to POINT')
             output_model = ifu.ifu_extract1d(
                 input_model, extract_ref_dict, source_type, subtract_background,
-                bkg_sigma_clip, apcorr_ref_model, center_xy, ifu_autocen, ifu_rfcorr
+                bkg_sigma_clip, apcorr_ref_model, center_xy, ifu_autocen, ifu_rfcorr, ifu_rscale
             )
 
         else:

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -3022,7 +3022,7 @@ def do_extract1d(
 
             if ifu_set_srctype is not None:
                 source_type = ifu_set_srctype
-                log.info('Overriding source type and setting it to POINT')
+                log.info(f"Overriding source type and setting it to = {ifu_set_srctype}")
             output_model = ifu.ifu_extract1d(
                 input_model, extract_ref_dict, source_type, subtract_background,
                 bkg_sigma_clip, apcorr_ref_model, center_xy, ifu_autocen, ifu_rfcorr, ifu_rscale

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2613,11 +2613,11 @@ def run_extract1d(
         For IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
-        For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
+        For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF
         FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
-        default extraction size is set to 2 * FWHM. Values below 2 will results in a smaller
-        radi, a value of 2 results in no change to radi and a value above 2 results in a larger
-        extraction radi.
+        default extraction size is set to 2 * FWHM. Values below 2 will result in a smaller
+        radius, a value of 2 results in no change to the radius and a value above 2 results in a larger
+        extraction radius.
 
     was_source_model : bool
         True if and only if `input_model` is actually one SlitModel
@@ -2807,11 +2807,11 @@ def do_extract1d(
         For IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
-        For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
+        For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF
         FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
-        default extraction size is set to 2 * FWHM. Values below 2 will results in a smaller
-        radi, a value of 2 results in no change to radi and a value above 2 results in a larger
-        extraction radi.
+        default extraction size is set to 2 * FWHM. Values below 2 will result in a smaller
+        radius, a value of 2 results in no change to the radius and a value above 2 results in a larger
+        extraction radius.
 
     was_source_model : bool
         True if and only if `input_model` is actually one SlitModel

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -2547,6 +2547,7 @@ def run_extract1d(
         center_xy: Union[float, None],
         ifu_autocen: Union[bool, None],
         ifu_rfcorr: Union[bool, None],
+        ifu_set_point_source: Union[bool, None],
         was_source_model: bool = False,
 ) -> DataModel:
     """Extract 1-D spectra.
@@ -2607,6 +2608,10 @@ def run_extract1d(
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
+    ifu_set_point_source : bool
+        Override srctype and set POINT source extraction for IFU spectra.
+        Default is False.
+
     was_source_model : bool
         True if and only if `input_model` is actually one SlitModel
         obtained by iterating over a SourceModelContainer.  The default
@@ -2655,6 +2660,7 @@ def run_extract1d(
         center_xy,
         ifu_autocen,
         ifu_rfcorr,
+        ifu_set_point_source,
         was_source_model,
     )
 
@@ -2717,6 +2723,7 @@ def do_extract1d(
         center_xy: Union[int, None] = None,
         ifu_autocen: Union[bool, None] = None,
         ifu_rfcorr: Union[bool, None] = None,
+        ifu_set_point_source: Union[bool, None] = None,
         was_source_model: bool = False
 ) -> DataModel:
     """Extract 1-D spectra.
@@ -2786,6 +2793,10 @@ def do_extract1d(
     ifu_rfcorr : bool
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
+
+    ifu_set_point_source : bool
+        Override srctype and perform POINT source extraction for IFU spectra.
+        Default is False.
 
     was_source_model : bool
         True if and only if `input_model` is actually one SlitModel
@@ -2994,6 +3005,9 @@ def do_extract1d(
             if source_type is None:
                 source_type = "UNKNOWN"
 
+            if ifu_set_point_source:
+                source_type = "POINT"
+                log.info('Overriding source type and setting it to POINT')
             output_model = ifu.ifu_extract1d(
                 input_model, extract_ref_dict, source_type, subtract_background,
                 bkg_sigma_clip, apcorr_ref_model, center_xy, ifu_autocen, ifu_rfcorr

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -81,7 +81,7 @@ class Extract1dStep(Step):
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
-    ifu_set_srctype: src
+    ifu_set_srctype: str
         For IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -81,6 +81,9 @@ class Extract1dStep(Step):
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
+    ifu_set_point_source: bool
+        For IFU data ignore the srctype value and perform a point source extraction.
+
     soss_atoca : bool, default=False
         Switch to toggle extraction of SOSS data with the ATOCA algorithm.
         WARNING: ATOCA results not fully validated, and require the photom step
@@ -149,6 +152,7 @@ class Extract1dStep(Step):
     apply_apcorr = boolean(default=True)  # apply aperture corrections?
     ifu_autocen = boolean(default=False) # Auto source centering for IFU point source data.
     ifu_rfcorr = boolean(default=False) # Apply 1d residual fringe correction
+    ifu_set_point_source = boolean(default=False) # Override srctype and perform point source extraction
     soss_atoca = boolean(default=True)  # use ATOCA algorithm
     soss_threshold = float(default=1e-2)  # TODO: threshold could be removed from inputs. Its use is too specific now.
     soss_n_os = integer(default=2)  # minimum oversampling factor of the underlying wavelength grid used when modeling trace.
@@ -260,6 +264,7 @@ class Extract1dStep(Step):
                         self.center_xy,
                         self.ifu_autocen,
                         self.ifu_rfcorr,
+                        self.ifu_set_point_source,
                         was_source_model=was_source_model
                     )
                     # Set the step flag to complete
@@ -296,6 +301,7 @@ class Extract1dStep(Step):
                             self.center_xy,
                             self.ifu_autocen,
                             self.ifu_rfcorr,
+                            self.ifu_set_point_source,
                             was_source_model=was_source_model,
                         )
                         # Set the step flag to complete in each MultiSpecModel
@@ -335,6 +341,7 @@ class Extract1dStep(Step):
                     self.center_xy,
                     self.ifu_autocen,
                     self.ifu_rfcorr,
+                    self.ifu_set_point_source,
                     was_source_model=was_source_model,
                 )
 
@@ -476,6 +483,7 @@ class Extract1dStep(Step):
                     self.center_xy,
                     self.ifu_autocen,
                     self.ifu_rfcorr,
+                    self.ifu_set_point_source,
                     was_source_model=False,
                 )
 

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -232,17 +232,17 @@ class Extract1dStep(Step):
         if self.ifu_rfcorr:
             if input_model.meta.exposure.type != "MIR_MRS":
                 self.log.warning("The option to apply a residual refringe correction is"
-                                 f"not supported for {input_model.meta.exposure.type} data")
+                                 f" not supported for {input_model.meta.exposure.type} data.")
 
         if self.ifu_rscale is not None:
             if input_model.meta.exposure.type != "MIR_MRS":
                 self.log.warning("The option to change the extraction radius is"
-                                 f"not supported for {input_model.meta.exposure.type} data")
+                                 f" not supported for {input_model.meta.exposure.type} data.")
 
         if self.ifu_set_srctype is not None:
             if input_model.meta.exposure.type != "MIR_MRS":
                 self.log.warning("The option to change the source type is"
-                                 f"not supported for {input_model.meta.exposure.type} data")
+                                 f" not supported for {input_model.meta.exposure.type} data.")
 
         # ______________________________________________________________________
         # Do the extraction for ModelContainer - this might only be WFSS data

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -82,7 +82,7 @@ class Extract1dStep(Step):
         for MIRI MRS IFU spectra.  Default is False.
 
     ifu_set_srctype: str
-        For IFU data override srctype and set it to either POINT or EXTENDED.
+        For MIRI MRS IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
         For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF
@@ -160,7 +160,7 @@ class Extract1dStep(Step):
     ifu_autocen = boolean(default=False) # Auto source centering for IFU point source data.
     ifu_rfcorr = boolean(default=False) # Apply 1d residual fringe correction
     ifu_set_srctype = option("POINT", "EXTENDED", None, default=None) # user-supplied source type
-    ifu_rscale = float(default=None, min=0.5, max=3) Radius in terms of PSF FWHM to scale extraction radii
+    ifu_rscale = float(default=None, min=0.5, max=3) # Radius in terms of PSF FWHM to scale extraction radii
     soss_atoca = boolean(default=True)  # use ATOCA algorithm
     soss_threshold = float(default=1e-2)  # TODO: threshold could be removed from inputs. Its use is too specific now.
     soss_n_os = integer(default=2)  # minimum oversampling factor of the underlying wavelength grid used when modeling trace.
@@ -228,6 +228,21 @@ class Extract1dStep(Step):
             self.log.error('extract_1d will be skipped.')
             input_model.meta.cal_step.extract_1d = 'SKIPPED'
             return input_model
+
+        if self.ifu_rfcorr:
+            if input_model.meta.exposure.type != "MIR_MRS":
+                self.log.warning("The option to apply a residual refringe correction is"
+                                 f"not supported for {input_model.meta.exposure.type} data")
+
+        if self.ifu_rscale:
+            if input_model.meta.exposure.type != "MIR_MRS":
+                self.log.warning("The option to change the extraction radius is"
+                                 f"not supported for {input_model.meta.exposure.type} data")
+
+        if self.ifu_set_srctype:
+            if input_model.meta.exposure.type != "MIR_MRS":
+                self.log.warning("The option to change the source type is"
+                                 f"not supported for {input_model.meta.exposure.type} data")
 
         # ______________________________________________________________________
         # Do the extraction for ModelContainer - this might only be WFSS data

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -84,6 +84,13 @@ class Extract1dStep(Step):
     ifu_set_point_source: bool
         For IFU data ignore the srctype value and perform a point source extraction.
 
+    ifu_rscale: float
+        For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
+        FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
+        default extraction size is set to 2 * FWHM. Values below 2 will results in a smaller
+        radi, a value of 2 results in no change to radi and a value above 2 results in a larger
+        extraction radi.
+
     soss_atoca : bool, default=False
         Switch to toggle extraction of SOSS data with the ATOCA algorithm.
         WARNING: ATOCA results not fully validated, and require the photom step
@@ -153,6 +160,7 @@ class Extract1dStep(Step):
     ifu_autocen = boolean(default=False) # Auto source centering for IFU point source data.
     ifu_rfcorr = boolean(default=False) # Apply 1d residual fringe correction
     ifu_set_point_source = boolean(default=False) # Override srctype and perform point source extraction
+    ifu_rscale = float(default=None, min=0.5, max=3) Radius in terms of PSF FWHM to scale extraction radii
     soss_atoca = boolean(default=True)  # use ATOCA algorithm
     soss_threshold = float(default=1e-2)  # TODO: threshold could be removed from inputs. Its use is too specific now.
     soss_n_os = integer(default=2)  # minimum oversampling factor of the underlying wavelength grid used when modeling trace.
@@ -265,6 +273,7 @@ class Extract1dStep(Step):
                         self.ifu_autocen,
                         self.ifu_rfcorr,
                         self.ifu_set_point_source,
+                        self.ifu_rscsale,
                         was_source_model=was_source_model
                     )
                     # Set the step flag to complete
@@ -302,6 +311,7 @@ class Extract1dStep(Step):
                             self.ifu_autocen,
                             self.ifu_rfcorr,
                             self.ifu_set_point_source,
+                            self.ifu_rscale,
                             was_source_model=was_source_model,
                         )
                         # Set the step flag to complete in each MultiSpecModel
@@ -342,6 +352,7 @@ class Extract1dStep(Step):
                     self.ifu_autocen,
                     self.ifu_rfcorr,
                     self.ifu_set_point_source,
+                    self.ifu_rscale,
                     was_source_model=was_source_model,
                 )
 
@@ -484,6 +495,7 @@ class Extract1dStep(Step):
                     self.ifu_autocen,
                     self.ifu_rfcorr,
                     self.ifu_set_point_source,
+                    self.ifu_rscale,
                     was_source_model=False,
                 )
 

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -81,8 +81,8 @@ class Extract1dStep(Step):
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
-    ifu_set_point_source: bool
-        For IFU data ignore the srctype value and perform a point source extraction.
+    ifu_set_srctype: src
+        For IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
         For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
@@ -159,7 +159,7 @@ class Extract1dStep(Step):
     apply_apcorr = boolean(default=True)  # apply aperture corrections?
     ifu_autocen = boolean(default=False) # Auto source centering for IFU point source data.
     ifu_rfcorr = boolean(default=False) # Apply 1d residual fringe correction
-    ifu_set_point_source = boolean(default=False) # Override srctype and perform point source extraction
+    ifu_set_srctype = option("POINT", "EXTENDED", None, default=None) # user-supplied source type
     ifu_rscale = float(default=None, min=0.5, max=3) Radius in terms of PSF FWHM to scale extraction radii
     soss_atoca = boolean(default=True)  # use ATOCA algorithm
     soss_threshold = float(default=1e-2)  # TODO: threshold could be removed from inputs. Its use is too specific now.
@@ -272,7 +272,7 @@ class Extract1dStep(Step):
                         self.center_xy,
                         self.ifu_autocen,
                         self.ifu_rfcorr,
-                        self.ifu_set_point_source,
+                        self.ifu_set_srctype,
                         self.ifu_rscsale,
                         was_source_model=was_source_model
                     )
@@ -310,7 +310,7 @@ class Extract1dStep(Step):
                             self.center_xy,
                             self.ifu_autocen,
                             self.ifu_rfcorr,
-                            self.ifu_set_point_source,
+                            self.ifu_set_srctype,
                             self.ifu_rscale,
                             was_source_model=was_source_model,
                         )
@@ -351,7 +351,7 @@ class Extract1dStep(Step):
                     self.center_xy,
                     self.ifu_autocen,
                     self.ifu_rfcorr,
-                    self.ifu_set_point_source,
+                    self.ifu_set_srctype,
                     self.ifu_rscale,
                     was_source_model=was_source_model,
                 )
@@ -494,7 +494,7 @@ class Extract1dStep(Step):
                     self.center_xy,
                     self.ifu_autocen,
                     self.ifu_rfcorr,
-                    self.ifu_set_point_source,
+                    self.ifu_set_srctype,
                     self.ifu_rscale,
                     was_source_model=False,
                 )

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -288,7 +288,7 @@ class Extract1dStep(Step):
                         self.ifu_autocen,
                         self.ifu_rfcorr,
                         self.ifu_set_srctype,
-                        self.ifu_rscsale,
+                        self.ifu_rscale,
                         was_source_model=was_source_model
                     )
                     # Set the step flag to complete

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -85,11 +85,11 @@ class Extract1dStep(Step):
         For IFU data override srctype and set it to either POINT or EXTENDED.
 
     ifu_rscale: float
-        For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
+        For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF
         FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
-        default extraction size is set to 2 * FWHM. Values below 2 will results in a smaller
-        radi, a value of 2 results in no change to radi and a value above 2 results in a larger
-        extraction radi.
+        default extraction size is set to 2 * FWHM. Values below 2 will result in a smaller
+        radius, a value of 2 results in no change to the radius and a value above 2 results in a larger
+        extraction radius.
 
     soss_atoca : bool, default=False
         Switch to toggle extraction of SOSS data with the ATOCA algorithm.

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -234,12 +234,12 @@ class Extract1dStep(Step):
                 self.log.warning("The option to apply a residual refringe correction is"
                                  f"not supported for {input_model.meta.exposure.type} data")
 
-        if self.ifu_rscale:
+        if self.ifu_rscale is not None:
             if input_model.meta.exposure.type != "MIR_MRS":
                 self.log.warning("The option to change the extraction radius is"
                                  f"not supported for {input_model.meta.exposure.type} data")
 
-        if self.ifu_set_srctype:
+        if self.ifu_set_srctype is not None:
             if input_model.meta.exposure.type != "MIR_MRS":
                 self.log.warning("The option to change the source type is"
                                  f"not supported for {input_model.meta.exposure.type} data")

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -81,15 +81,15 @@ class Extract1dStep(Step):
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
-    ifu_set_srctype: str
+    ifu_set_srctype : str
         For MIRI MRS IFU data override srctype and set it to either POINT or EXTENDED.
 
-    ifu_rscale: float
-        For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF
-        FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
-        default extraction size is set to 2 * FWHM. Values below 2 will result in a smaller
-        radius, a value of 2 results in no change to the radius and a value above 2 results in a larger
-        extraction radius.
+    ifu_rscale : float
+        For MRS IFU data a value for changing the extraction radius. The value provided is
+        the number of PSF FWHMs to use for the extraction radius. Values accepted are between
+        0.5 to 3.0. The default extraction size is set to 2 * FWHM. Values below 2 will result
+        in a smaller radius, a value of 2 results in no change to the radius and a value above
+        2 results in a larger extraction radius.
 
     soss_atoca : bool, default=False
         Switch to toggle extraction of SOSS data with the ATOCA algorithm.

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -78,11 +78,11 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
         for MIRI MRS IFU spectra.  Default is False.
 
     ifu_rscale: float
-        For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
+        For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF
         FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
-        default extraction size is set to 2 * FWHM. Values below 2 will results in a smaller
-        radi, a value of 2 results in no change to radi and a value above 2 results in a larger
-        extraction radi.
+        default extraction size is set to 2 * FWHM. Values below 2 will resuls in a smaller
+        radius, a value of 2 results in no change to radius and a value above 2 results in a larger
+        extraction radius.
 
     Returns
     -------
@@ -527,7 +527,7 @@ def extract_ifu(input_model, source_type, extract_params):
 
         if ((input_model.meta.instrument.name == 'MIRI') & (extract_params['ifu_rscale'] is not None)):
             radius = radius * extract_params['ifu_rscale']/2.0
-            log.info("Scaling radius by factor =  %g", extract_params['ifu_rscale'] / 2.0 )
+            log.info("Scaling radius by factor =  %g", extract_params['ifu_rscale'] / 2.0)
 
         frad = interp1d(wave_extract, radius, bounds_error=False, fill_value="extrapolate")
         radius_match = frad(wavelength)

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -527,7 +527,7 @@ def extract_ifu(input_model, source_type, extract_params):
 
         if ((input_model.meta.instrument.name == 'MIRI') & (extract_params['ifu_rscale'] is not None)):
             radius = radius * extract_params['ifu_rscale']/2.0
-            log.info("Scaling radius by factor =  %g",extract_params['ifu_rscale']/2.0 )
+            log.info("Scaling radius by factor =  %g", extract_params['ifu_rscale'] / 2.0 )
 
         frad = interp1d(wave_extract, radius, bounds_error=False, fill_value="extrapolate")
         radius_match = frad(wavelength)

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -525,7 +525,7 @@ def extract_ifu(input_model, source_type, extract_params):
         outer_bkg = extract_params['outer_bkg'].flatten()
         radius = extract_params['radius'].flatten()
 
-        if ((input_model.meta.instrument.name == 'MIRI') & (extract_params['ifu_rfcorr'] is not None)):
+        if ((input_model.meta.instrument.name == 'MIRI') & (extract_params['ifu_rscale'] is not None)):
             radius = radius * extract_params['ifu_rscale']/2.0
             log.info("Scaling radius by factor =  %g",extract_params['ifu_rscale']/2.0 )
 

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -37,7 +37,7 @@ HUGE_DIST = 1.e10
 
 def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
                   bkg_sigma_clip, apcorr_ref_model=None, center_xy=None,
-                  ifu_autocen=False, ifu_rfcorr=False):
+                  ifu_autocen=False, ifu_rfcorr=False, ifu_rscale=None):
     """Extract a 1-D spectrum from an IFU cube.
 
     Parameters
@@ -77,6 +77,13 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
 
+    ifu_rscale: float
+        For MRS IFU data a value for changing the extraction radi. The value provided is the number of PSF
+        FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
+        default extraction size is set to 2 * FWHM. Values below 2 will results in a smaller
+        radi, a value of 2 results in no change to radi and a value above 2 results in a larger
+        extraction radi.
+
     Returns
     -------
     output_model : MultiSpecModel
@@ -108,14 +115,17 @@ def ifu_extract1d(input_model, ref_dict, source_type, subtract_background,
 
     extract_params = get_extract_parameters(ref_dict, bkg_sigma_clip, slitname)
 
-    # Add info about IFU auto-centroiding and residual fringe correction to extract_params for use later
+    # Add info about IFU auto-centroiding, residual fringe correction and extraction radius scale
+    # to extract_params for use later
     extract_params['ifu_autocen'] = ifu_autocen
     extract_params['ifu_rfcorr'] = ifu_rfcorr
+    extract_params['ifu_rscale'] = ifu_rscale
 
     # If the user supplied extraction center coords,
     # load them into extract_params for use later.
     extract_params['x_center'] = None
     extract_params['y_center'] = None
+
     if center_xy is not None:
         if len(center_xy) == 2:
             extract_params['x_center'] = float(center_xy[0])
@@ -492,6 +502,7 @@ def extract_ifu(input_model, source_type, extract_params):
     method = extract_params['method']
     subpixels = extract_params['subpixels']
     subtract_background = extract_params['subtract_background']
+    ifu_rscale = extract_params['ifu_rscale']
 
     radius = None
     inner_bkg = None
@@ -514,6 +525,10 @@ def extract_ifu(input_model, source_type, extract_params):
         inner_bkg = extract_params['inner_bkg'].flatten()
         outer_bkg = extract_params['outer_bkg'].flatten()
         radius = extract_params['radius'].flatten()
+
+        if ifu_rscale is not None:
+            radius = radius * ifu_rscale/2.0
+            log.info("Scaling radius by factor = %g", ifu_rscale / 2.0)
 
         frad = interp1d(wave_extract, radius, bounds_error=False, fill_value="extrapolate")
         radius_match = frad(wavelength)
@@ -741,14 +756,14 @@ def extract_ifu(input_model, source_type, extract_params):
         # Determine which MRS channel the spectrum is from
         thischannel = input_model.meta.instrument.channel
         # Valid single-channel values
-        validch=['1','2','3','4']
+        validch = ['1', '2', '3', '4']
         # Embed all calls to residual fringe code in a try/except loop as the default behavior
         # if problems are encountered should be to not apply this optional step
         try:
             # If a valid single channel, specify it in call to residual fringe code
             if (thischannel in validch):
                 temp_flux = rfutils.fit_residual_fringes_1d(temp_flux, wavelength, channel=thischannel,
-                                              dichroic_only=False, max_amp=None)
+                                                            dichroic_only=False, max_amp=None)
             # Otherwise leave channel blank
             else:
                 temp_flux = rfutils.fit_residual_fringes_1d(temp_flux, wavelength,

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -502,7 +502,6 @@ def extract_ifu(input_model, source_type, extract_params):
     method = extract_params['method']
     subpixels = extract_params['subpixels']
     subtract_background = extract_params['subtract_background']
-    ifu_rscale = extract_params['ifu_rscale']
 
     radius = None
     inner_bkg = None
@@ -526,9 +525,9 @@ def extract_ifu(input_model, source_type, extract_params):
         outer_bkg = extract_params['outer_bkg'].flatten()
         radius = extract_params['radius'].flatten()
 
-        if ifu_rscale is not None:
-            radius = radius * ifu_rscale/2.0
-            log.info("Scaling radius by factor = %g", ifu_rscale / 2.0)
+        if ((input_model.meta.instrument.name == 'MIRI') & (extract_params['ifu_rfcorr'] is not None)):
+            radius = radius * extract_params['ifu_rscale']/2.0
+            log.info("Scaling radius by factor =  %g",extract_params['ifu_rscale']/2.0 )
 
         frad = interp1d(wave_extract, radius, bounds_error=False, fill_value="extrapolate")
         radius_match = frad(wavelength)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3355](https://jira.stsci.edu/browse/JP-3355) and Resolves [JP-3340](https://jira.stsci.edu/browse/JP-3340)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7846 and #7815

<!-- describe the changes comprising this PR here -->
This PR allows the user to override the srctype and perform POINT source extraction for IFU data. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/962/
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
