### PR TITLE
use Python 3.11 in regtests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -43,7 +43,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
-python_version = "3.9"
+python_version = "3.11"
 
 // Define environment variables needed for the regression tests
 env_vars = [


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Related to [DADSJWST-2059](https://jira.stsci.edu/browse/DADSJWST-2059?jql=text%20~%20%22python%203.11%22)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR tells the `RT JWST` job to use Python 3.11

**Checklist for maintainers**
- [x] ~added entry in `CHANGES.rst` within the relevant release section~
- [x] updated or added relevant tests
- [x] ~updated relevant documentation~
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~