### PR TITLE
Update test_nirspec_fs_spec3 regtest for new product naming

### DIFF
--- a/jwst/regtest/test_nirspec_fs_spec3.py
+++ b/jwst/regtest/test_nirspec_fs_spec3.py
@@ -24,12 +24,13 @@ def run_pipeline(jail, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d"])
-@pytest.mark.parametrize("source_id", ["s00001", "s00002", "s00003", "s00004", "s00005"])
-def test_nirspec_fs_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix, source_id):
+@pytest.mark.parametrize("source_id,slit_name", [("s00001","s200a2"), ("s00021","s200a1"), ("s00023","s400a1"), ("s00024","s1600a1"), ("s00025","s200b1")])
+def test_nirspec_fs_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix, source_id, slit_name):
     """Test spec3 pipeline on a set of NIRSpec FS exposures."""
     rtdata = rtdata_module
 
-    output = f"jw01309-o022_{source_id}_nirspec_f290lp-g395h-s200a2-allslits_{suffix}.fits"
+    #output = f"jw01309-o022_{source_id}_nirspec_f290lp-g395h-s200a2-allslits_{suffix}.fits"
+    output = f"jw01309-o022_{source_id}_nirspec_f290lp-g395h-{slit_name}-allslits_{suffix}.fits"
     rtdata.output = output
     rtdata.get_truth(f"truth/test_nirspec_fs_spec3/{output}")
 


### PR DESCRIPTION
This PR updates the test_nirspec_fs_spec3 regtest module to account for the fact that FS product names now have varying slit names embedded in them, depending on which slit the data come from. Also the changes in source_id values, all of which are due to JP-3233.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
