### PR TITLE
reduce the parallelism of xdist in the regtests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -84,8 +84,9 @@ bc0.build_cmds = [
     "pip install -r requirements-sdp.txt",
 ] + PipInject(env.OVERRIDE_REQUIREMENTS) + ["pip list"]
 bc0.test_cmds = [
-    "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
-    --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
+    "pytest --cov-report=xml --cov=./ -r sxf --bigdata --slow \
+    --basetemp=${pytest_basetemp} --junit-xml=results.xml \
+    -n 4 --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
     // The following line needs single quotes to avoid insecure interpolation
     // of the codecov_token

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -82,8 +82,9 @@ bc0.build_cmds = [
     "pip install -r requirements-dev.txt",
 ] + PipInject(env.OVERRIDE_REQUIREMENTS) + ["pip list"]
 bc0.test_cmds = [
-    "pytest -r sxf -n auto --bigdata --slow \
-    --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
+    "pytest -r sxf --bigdata --slow \
+    --basetemp=${pytest_basetemp} --junit-xml=results.xml \
+    -n 4 --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
 ]
 bc0.test_configs = [data_config]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR tests setting `pytest -n auto` to `pytest -n 4` in the regtests, to see if that fixes the recent threading / out of memory issues

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
