### PR TITLE
Split NRS IFU spec3 regtest in two tests

### DIFF
--- a/jwst/regtest/test_nirspec_ifu_spec3.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3.py
@@ -30,26 +30,6 @@ def run_spec3_multi(jail, rtdata_module):
     return rtdata
 
 
-@pytest.fixture(scope='module')
-def run_spec3_multi_emsm(jail, rtdata_module):
-    """Run Spec3Pipeline"""
-    rtdata = rtdata_module
-
-    step_params = {
-        'input_path': 'nirspec/ifu/jw01249-o005_20230622t074431_spec3_00001_asn.json',
-        'step': 'calwebb_spec3',
-        'args': {
-            '--steps.cube_build.save_results=true',
-            '--steps.cube_build.weighting=emsm',
-            '--steps.cube_build.output_file="nirspec_emsm"',
-            '--steps.extract_1d.save_results=true',
-        }
-    }
-
-    rtdata = rt.run_step_from_dict(rtdata, **step_params)
-    return rtdata
-
-
 @pytest.mark.slow
 @pytest.mark.bigdata
 @pytest.mark.parametrize(
@@ -71,24 +51,6 @@ def test_spec3_multi(run_spec3_multi, fitsdiff_default_kwargs, output):
     """Regression test matching output files"""
     rt.is_like_truth(
         run_spec3_multi, fitsdiff_default_kwargs, output,
-        truth_path=TRUTH_PATH,
-        is_suffix=False
-    )
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-@pytest.mark.parametrize(
-    'output',
-    [
-        'nirspec_emsm_g395h-f290lp_s3d.fits',
-        'nirspec_emsm_g395h-f290lp_x1d.fits',
-    ]
-)
-def test_spec3_multi_emsm(run_spec3_multi_emsm, fitsdiff_default_kwargs, output):
-    """Regression test matching output files"""
-    rt.is_like_truth(
-        run_spec3_multi_emsm, fitsdiff_default_kwargs, output,
         truth_path=TRUTH_PATH,
         is_suffix=False
     )

--- a/jwst/regtest/test_nirspec_ifu_spec3_emsm.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_emsm.py
@@ -1,0 +1,46 @@
+"""Regression tests for NIRSpec IFU"""
+import pytest
+
+from jwst.regtest import regtestdata as rt
+
+# Define artifactory source and truth
+INPUT_PATH = 'nirspec/ifu'
+TRUTH_PATH = 'truth/test_nirspec_ifu'
+
+
+@pytest.fixture(scope='module')
+def run_spec3_multi_emsm(jail, rtdata_module):
+    """Run Spec3Pipeline"""
+    rtdata = rtdata_module
+
+    step_params = {
+        'input_path': 'nirspec/ifu/jw01249-o005_20230622t074431_spec3_00001_asn.json',
+        'step': 'calwebb_spec3',
+        'args': {
+            '--steps.cube_build.save_results=true',
+            '--steps.cube_build.weighting=emsm',
+            '--steps.cube_build.output_file="nirspec_emsm"',
+            '--steps.extract_1d.save_results=true',
+        }
+    }
+
+    rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    return rtdata
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+@pytest.mark.parametrize(
+    'output',
+    [
+        'nirspec_emsm_g395h-f290lp_s3d.fits',
+        'nirspec_emsm_g395h-f290lp_x1d.fits',
+    ]
+)
+def test_spec3_multi_emsm(run_spec3_multi_emsm, fitsdiff_default_kwargs, output):
+    """Regression test matching output files"""
+    rt.is_like_truth(
+        run_spec3_multi_emsm, fitsdiff_default_kwargs, output,
+        truth_path=TRUTH_PATH,
+        is_suffix=False
+    )


### PR DESCRIPTION
This PR splits the 2 tests contained in test_nirspec_ifu_spec3 into separate test moduels, so that they can run in parallel. This is the longest running module in the entire regtest fleet (~1hr:50min)

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
