### PR TITLE
Fix ramp_fit reference in docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,11 @@ datamodels
 
 - updated ``stdatamodels`` pin to ``>=1.8.0`` [#7854]
 
+documentation
+------------
+
+- Fixed a reference to the ``ramp_fitting` module in the user documentation. [#7898]
+
 engdb_tools
 -----------
 

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -48,7 +48,7 @@ Individual pipeline steps can be imported by name from their respective module
 in ``jwst``::
 
 	from jwst.saturation import SaturationStep
-	from jwst.ramp_fit import RampFitStep
+	from jwst.ramp_fitting import RampFitStep
 
 Details of all the available pipeline modules and their names can be found at
 :ref:`pipeline-modules`.


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR fixes an error the docs regarding the name of the ramp_fitting module. Reported by a user via Help Desk ticket INC0193177.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
