### PR TITLE
Reset python back to 3.11 for JenkinsRT

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -87,7 +87,7 @@ bc0.build_cmds = [
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov=./ -r sxf --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml \
-    -n 4 --dist=loadscope \
+    -n 8 --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
     // The following line needs single quotes to avoid insecure interpolation
     // of the codecov_token

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -40,6 +40,7 @@ withCredentials([string(
 jobconfig = new JobConfig()
 jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
+jobconfig.publish_env_filter = "spacetelescope/master"
 
 // Define python version for conda
 python_version = "3.11"

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -42,7 +42,7 @@ jobconfig.enable_env_publication = true
 jobconfig.publish_env_on_success_only = true
 
 // Define python version for conda
-python_version = "3.9"
+python_version = "3.11"
 
 // Define environment variables needed for the regression tests
 env_vars = [

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -84,7 +84,7 @@ bc0.build_cmds = [
 bc0.test_cmds = [
     "pytest -r sxf --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml \
-    -n 4 --dist=loadscope \
+    -n 8 --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
 ]
 bc0.test_configs = [data_config]


### PR DESCRIPTION
In the midst of all the issues with the Jenkins regtest jobs, #7796 set the python version back to 3.9 for RT test runs. This reverts that change, so that python 3.11 is used.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
