### PR TITLE
JP-3372: Fix typo in refpix log statement

### DIFF
--- a/jwst/refpix/reference_pixels.py
+++ b/jwst/refpix/reference_pixels.py
@@ -388,7 +388,7 @@ class Dataset():
                 else:
                     log.info('Single readout amplifier used')
                     if ngoodtopbottom == 0:
-                        log.info('No valid reference pixels.  This step wil have no effect')
+                        log.info('No valid reference pixels.  This step will have no effect.')
                     else:
                         log.info('The following parameter is valid for this mode:')
                         log.info(f'odd_even_columns = {self.odd_even_columns}')


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3372](https://jira.stsci.edu/browse/JP-3372)

<!-- describe the changes comprising this PR here -->
This PR addresses a typo found in a log statement.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
