### PR TITLE
JP-3342: add median file to outlier_detection cleanup block

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ extract_1d
 - Bug fix for #7883. The input model type is checked to see if the input is
   a single model or a model container. [#7965]
 
+outlier_detection
+-----------------
+
+- Remove median file output from ``output_dir`` if ``save_intermediate_results``
+  is set to False. [#7961]
+
 set_telescope_pointing
 ----------------------
 

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -211,7 +211,7 @@ class OutlierDetection:
         # Perform median combination on set of drizzled mosaics
         median_model.data = self.create_median(drizzled_models)
         median_model_output_path = self.make_output_path(
-            basepath=median_model.meta.filename,
+            basepath=median_model.meta.filename.replace(self.resample_suffix, '.fits'),
             suffix='median')
         median_model.save(median_model_output_path)
         log.info(f"Saved model in {median_model_output_path}")

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -177,18 +177,20 @@ class OutlierDetectionStep(Step):
                 for model in self.input_models:
                     model.meta.cal_step.outlier_detection = state
                     if not self.save_intermediate_results:
-                        # remove unwanted files
-                        crf_file = self.make_output_path(basepath=model.meta.filename)
-                        outlr_basename = os.path.basename(crf_file)
-                        outlr_file = model.meta.filename.replace('cal', 'outlier_i2d')
-                        outlr_path = crf_file.replace(outlr_basename, outlr_file)
-                        if os.path.isfile(outlr_path):
-                            os.remove(outlr_path)
-                            self.log.debug(f"    {outlr_path}")
-                        blot_file = crf_file.replace('crf', 'blot')
-                        if os.path.isfile(blot_file):
-                            os.remove(blot_file)
-                            self.log.debug(f"    {blot_file}")
+                        # Remove unwanted files
+                        crf_path = self.make_output_path(basepath=model.meta.filename)
+                        crf_file = os.path.basename(crf_path)
+                        outlr_file = crf_file.replace('crf', 'outlier_i2d')
+                        outlr_path = crf_path.replace(crf_file, outlr_file)
+                        blot_path = outlr_path.replace('outlier_i2d', 'blot')
+                        # Need to insert outlier into filename, as median filename is generated from drizzled model
+                        undersplit = outlr_file.split('_')
+                        median_file = '_'.join(undersplit[:-3]) + '_'.join(['_outlier', undersplit[-3], 'median.fits'])
+                        median_path = crf_path.replace(crf_file, median_file)
+                        for fle in [outlr_path, blot_path, median_path]:
+                            if os.path.isfile(fle):
+                                os.remove(fle)
+                                self.log.debug(f"    {fle}")
             else:
                 self.input_models.meta.cal_step.outlier_detection = state
             return self.input_models

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -180,11 +180,13 @@ class OutlierDetectionStep(Step):
                         # Remove unwanted files
                         crf_path = self.make_output_path(basepath=model.meta.filename)
                         crf_file = os.path.basename(crf_path)
-                        outlr_file = crf_file.replace('crf', 'outlier_i2d')
+                        outlr_file = model.meta.filename.replace('cal', 'outlier_i2d')
                         outlr_path = crf_path.replace(crf_file, outlr_file)
-                        blot_path = outlr_path.replace('outlier_i2d', 'blot')
+                        blot_path = crf_path.replace('crf', 'blot')
                         median_path = blot_path.replace('blot', 'median')
-                        for fle in [outlr_path, blot_path, median_path]:
+                        self.log.info(f"{crf_path} {outlr_path} {blot_path} "
+                                      f"{median_path}")
+                        for fle in [outlr_file, blot_path, median_path]:
                             if os.path.isfile(fle):
                                 os.remove(fle)
                                 self.log.debug(f"    {fle}")

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -183,10 +183,13 @@ class OutlierDetectionStep(Step):
                         outlr_file = crf_file.replace('crf', 'outlier_i2d')
                         outlr_path = crf_path.replace(crf_file, outlr_file)
                         blot_path = outlr_path.replace('outlier_i2d', 'blot')
-                        # Need to insert outlier into filename, as median filename is generated from drizzled model
-                        undersplit = outlr_file.split('_')
-                        median_file = '_'.join(undersplit[:-3]) + '_'.join(['_outlier', undersplit[-3], 'median.fits'])
-                        median_path = crf_path.replace(crf_file, median_file)
+                        if pars['resample_data'] is True:
+                            # Need to insert outlier into filename if median filename is generated from drizzled model
+                            undersplit = outlr_file.split('_')
+                            median_file = '_'.join(undersplit[:-3]) + '_'.join(['_outlier', undersplit[-3], 'median.fits'])
+                            median_path = crf_path.replace(crf_file, median_file)
+                        else:
+                            median_path = blot_path.replace('blot', 'median')
                         for fle in [outlr_path, blot_path, median_path]:
                             if os.path.isfile(fle):
                                 os.remove(fle)

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -177,11 +177,12 @@ class OutlierDetectionStep(Step):
                 for model in self.input_models:
                     model.meta.cal_step.outlier_detection = state
                     if not self.save_intermediate_results:
-                        # Remove unwanted files
+                        #  Remove unwanted files
                         crf_path = self.make_output_path(basepath=model.meta.filename)
-                        crf_file = os.path.basename(crf_path)
+                        #  These lines to be used when/if outlier_i2d files follow output_dir
+                        #  crf_file = os.path.basename(crf_path)
+                        #  outlr_path = crf_path.replace(crf_file, outlr_file)
                         outlr_file = model.meta.filename.replace('cal', 'outlier_i2d')
-                        outlr_path = crf_path.replace(crf_file, outlr_file)
                         blot_path = crf_path.replace('crf', 'blot')
                         median_path = blot_path.replace('blot', 'median')
 

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -183,13 +183,7 @@ class OutlierDetectionStep(Step):
                         outlr_file = crf_file.replace('crf', 'outlier_i2d')
                         outlr_path = crf_path.replace(crf_file, outlr_file)
                         blot_path = outlr_path.replace('outlier_i2d', 'blot')
-                        if pars['resample_data'] is True:
-                            # Need to insert outlier into filename if median filename is generated from drizzled model
-                            undersplit = outlr_file.split('_')
-                            median_file = '_'.join(undersplit[:-3]) + '_'.join(['_outlier', undersplit[-3], 'median.fits'])
-                            median_path = crf_path.replace(crf_file, median_file)
-                        else:
-                            median_path = blot_path.replace('blot', 'median')
+                        median_path = blot_path.replace('blot', 'median')
                         for fle in [outlr_path, blot_path, median_path]:
                             if os.path.isfile(fle):
                                 os.remove(fle)

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -184,8 +184,7 @@ class OutlierDetectionStep(Step):
                         outlr_path = crf_path.replace(crf_file, outlr_file)
                         blot_path = crf_path.replace('crf', 'blot')
                         median_path = blot_path.replace('blot', 'median')
-                        self.log.info(f"{crf_path} {outlr_path} {blot_path} "
-                                      f"{median_path}")
+
                         for fle in [outlr_file, blot_path, median_path]:
                             if os.path.isfile(fle):
                                 os.remove(fle)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3422](https://jira.stsci.edu/browse/JP-3422)

Closes #7959 

<!-- describe the changes comprising this PR here -->
This PR addresses another intermediate file not properly cleaned up by `outlier_detection` if `save_intermediate_results` is set to False. The median file has a variable output name, depending on if the step resamples the data or not. If resampling occurs, the name is not constructed from an input model filename but a drizzled model. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
