### PR TITLE
Check input mode type for JP-3355 extract_1d options 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ extract_1d
 ----------
 
 - For MIRS MRS IFU data allow the user to set the src_type and allow 
-  the user to scale the extraction radius between 0.5 to 3.0 FWHM [#7883]
+  the user to scale the extraction radius between 0.5 to 3.0 FWHM. [#7883]
+
+- Bug fix for #7883. The input model type is checked to see if the input is
+  a single model or a model container. [#7965]
  
 
 1.12.0 (2023-09-18)

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -229,18 +229,25 @@ class Extract1dStep(Step):
             input_model.meta.cal_step.extract_1d = 'SKIPPED'
             return input_model
 
+        if isinstance(input_model, datamodels.IFUImageModel):
+            exp_type = input_model.meta.exposure.type
+        elif isinstance(input_model, ModelContainer):
+            exp_type = input_model[0].meta.exposure.type
+        else:
+            exp_type = None
+
         if self.ifu_rfcorr:
-            if input_model.meta.exposure.type != "MIR_MRS":
+            if exp_type != "MIR_MRS":
                 self.log.warning("The option to apply a residual refringe correction is"
                                  f" not supported for {input_model.meta.exposure.type} data.")
 
         if self.ifu_rscale is not None:
-            if input_model.meta.exposure.type != "MIR_MRS":
+            if exp_type != "MIR_MRS":
                 self.log.warning("The option to change the extraction radius is"
                                  f" not supported for {input_model.meta.exposure.type} data.")
 
         if self.ifu_set_srctype is not None:
-            if input_model.meta.exposure.type != "MIR_MRS":
+            if exp_type != "MIR_MRS":
                 self.log.warning("The option to change the source type is"
                                  f" not supported for {input_model.meta.exposure.type} data.")
 

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -229,7 +229,7 @@ class Extract1dStep(Step):
             input_model.meta.cal_step.extract_1d = 'SKIPPED'
             return input_model
 
-        if isinstance(input_model, datamodels.IFUImageModel):
+        if isinstance(input_model, datamodels.IFUCubeModel):
             exp_type = input_model.meta.exposure.type
         elif isinstance(input_model, ModelContainer):
             exp_type = input_model[0].meta.exposure.type

--- a/jwst/regtest/test_miri_mrs_extract1d.py
+++ b/jwst/regtest/test_miri_mrs_extract1d.py
@@ -11,7 +11,7 @@ def test_miri_mrs_extract1d_nominal(rtdata, fitsdiff_default_kwargs):
     """Test running extract_1d on an s3d cube containing a point source"""
     # input s3d are created using the same data that was used in test_miri_mrs_spec3_ifushort:
     # run calwebb_spec3 on miri/mrs/jw01024_ifushort_mediumlong_spec3_00001_asn.json to create
-    # the input data for this test. 
+    # the input data for this test.
 
     rtdata.get_data("miri/mrs/jw01024-c1000_t002_miri_ch2-mediumlong_s3d.fits")
 
@@ -30,7 +30,7 @@ def test_miri_mrs_extract1d_nominal(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_miri_mrs_extract1d_center(rtdata, fitsdiff_default_kwargs):
     """Test running extract_1d on an s3d cube containing a point source with user-supplied center"""
-    # input s3d are created using the same data that was used in run_spec3_ifushort from test_miri_mrs_spec3.py 
+    # input s3d are created using the same data that was used in run_spec3_ifushort from test_miri_mrs_spec3.py
     # This test only uses the ch 2 s3d file.
 
     rtdata.get_data("miri/mrs/jw01024-c1000_t002_miri_ch2-mediumlong_s3d.fits")
@@ -43,6 +43,28 @@ def test_miri_mrs_extract1d_center(rtdata, fitsdiff_default_kwargs):
 
     # Get the truth file
     rtdata.get_truth('truth/test_miri_mrs_extract1d/jw01024-c1000_t002_miri_ch2-mediumlong_center_extract1dstep.fits')
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_miri_mrs_extract1d_radius(rtdata, fitsdiff_default_kwargs):
+    """Test running extract_1d on an s3d cube containing a point source with user-supplied radius"""
+    # input s3d are created using the same data that was used in run_spec3_ifushort from test_miri_mrs_spec3.py
+    # This test only uses the ch 2 s3d file.
+
+    rtdata.get_data("miri/mrs/jw01024-c1000_t002_miri_ch2-mediumlong_s3d.fits")
+
+    args = ['jwst.extract_1d.Extract1dStep', rtdata.input,
+            '--output_file=jw01024-c1000_t002_miri_ch2-mediumlong_radius',
+            '--ifu_rscale=1.0']
+    Step.from_cmdline(args)
+    rtdata.output = "jw01024-c1000_t002_miri_ch2-mediumlong_radius_extract1dstep.fits"
+
+    # Get the truth file
+    rtdata.get_truth('truth/test_miri_mrs_extract1d/jw01024-c1000_t002_miri_ch2-mediumlong_radius_extract1dstep.fits')
 
     # Compare the results
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Fix a bug in JP-3355 that does not check the input model type. 

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses the fact that the Level-3 s3d product passed to extract_1d is actually a modelcontainer of s3d cubes, hence we need to pull out the meta.exposure.type from the first model in the container (all the s3d will be from the same instrument exp type). 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [X] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/968/
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
