### PR TITLE
JP-3424 Extend engineering coverage time for guiding modes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,11 @@ extract_1d
 
 - Bug fix for #7883. The input model type is checked to see if the input is
   a single model or a model container. [#7965]
- 
+
+set_telescope_pointing
+----------------------
+
+- Extend engineering coverage time for guiding modes. [#7966]
 
 1.12.0 (2023-09-18)
 ===================

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -2838,7 +2838,9 @@ def gs_position_acq(mnemonics_to_read, mnemonics, exp_type='fgs_acq1'):
     logger.debug('%s', ordered)
     valid = ordered[ordered['IFGS_ACQ_XPOSG'] != 0.0]
     if len(valid) < FGS_ACQ_MINVALUES[exp_type]:
-        raise ValueError(f'exp_type {exp_type} IFGS_ACQ_XPOSG only has {len(valid)} locations. Requires {FGS_ACQ_MINVALUES[exp_type]}')
+        raise ValueError(
+            f'exp_type {exp_type} IFGS_ACQ_XPOSG only has {len(valid)} locations. Requires {FGS_ACQ_MINVALUES[exp_type]}'
+        )
 
     # Setup parameters depending on ACQ1 vs ACQ2
     if exp_type == 'fgs_acq1':
@@ -2892,7 +2894,7 @@ def gs_position_fgtrack(mnemonics_to_read, mnemonics):
     valid_flags = (ordered['IFGS_TFGGS_X'] != 0.0) | (ordered['IFGS_TFGGS_Y'] != 0.0)
     valid = ordered[valid_flags]
     if len(valid) < 1:
-        raise ValueError(f'Fine guide track mode, no valid engineering is found.')
+        raise ValueError('Fine guide track mode, no valid engineering is found.')
 
     # Get the positions
     position = (np.average(valid['IFGS_TFGGS_X']),
@@ -2938,7 +2940,7 @@ def gs_position_id(mnemonics_to_read, mnemonics):
     valid_flags = (ordered['IFGS_ID_XPOSG'] != 0.0) | (ordered['IFGS_ID_YPOSG'] != 0.0)
     valid = ordered[valid_flags]
     if len(valid) < 1:
-        raise ValueError(f'Guide Star ID mode, no valid engineering is found.')
+        raise ValueError('Guide Star ID mode, no valid engineering is found.')
 
     # Get the positions
     position = (valid['IFGS_ID_XPOSG'][0], valid['IFGS_ID_YPOSG'][0])

--- a/jwst/lib/tests/data/test_from_models_mast.ecsv
+++ b/jwst/lib/tests/data/test_from_models_mast.ecsv
@@ -11,10 +11,10 @@
 #   jwst_velocity: None, method: '<Methods.COARSE_TR_202111: ''coarse_tr_202111''>', obsend: None, obsstart: None, override_transforms: None,
 #   pcs_mode: None, pointing: "Pointing(q=array([-0.30521413, -0.79144945, -0.25000546,  0.46685048]), j2fgs_matrix=array([-8.73067300e-04,\
 #     \  3.60334320e-03,  9.99993132e-01,  9.99757625e-01,\n       -2.19949530e-02,  9.52115800e-04,  2.19982331e-02,  9.99751584e-01,\n\
-#     \       -3.58325960e-03]), fsmcorr=array([-0.15910795, -0.00529688]), obstime=<Time object: scale='utc' format='unix' value=1643840741.0208645>,\
+#     \       -3.58325960e-03]), fsmcorr=array([-0.1592274 , -0.00642305]), obstime=<Time object: scale='utc' format='unix' value=1643840741.6157956>,\
 #     \ gs_commanded=array([0., 0.]), fgsid=0, gs_position=array([0., 0.]))", reduce_func: None, siaf: 'SIAF(v2_ref=0.0, v3_ref=0.0, v3yangle=0.0,
 #     vparity=1.0, crpix1=0, crpix2=0, cdelt1=3600, cdelt2=3600, vertices_idl=(0, 1, 1, 0, 0, 0, 1, 1))', siaf_db: <jwst.lib.siafdb.SiafDb
-#     object at 0x7f97d8f7d270>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
+#     object at 0x164da3890>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
 # schema: astropy-2.0
 source obstime ra dec pa_v3
-<ImageModel> 2022-02-02T22:25:41.021 146.5503941066434 63.08387154277842 194.1482993002141
+<ImageModel> 2022-02-02T22:25:41.616 146.5503945670982 63.08387151112689 194.14829980981426

--- a/jwst/lib/tests/data/test_over_time_mast.ecsv
+++ b/jwst/lib/tests/data/test_over_time_mast.ecsv
@@ -11,10 +11,10 @@
 #   jwst_velocity: None, method: '<Methods.COARSE_TR_202111: ''coarse_tr_202111''>', obsend: None, obsstart: None, override_transforms: None,
 #   pcs_mode: None, pointing: "Pointing(q=array([-0.30521413, -0.79144945, -0.25000546,  0.46685048]), j2fgs_matrix=array([-8.73067300e-04,\
 #     \  3.60334320e-03,  9.99993132e-01,  9.99757625e-01,\n       -2.19949530e-02,  9.52115800e-04,  2.19982331e-02,  9.99751584e-01,\n\
-#     \       -3.58325960e-03]), fsmcorr=array([-0.15910795, -0.00529688]), obstime=<Time object: scale='utc' format='unix' value=1643840741.0208645>,\
+#     \       -3.58325960e-03]), fsmcorr=array([-0.1592274 , -0.00642305]), obstime=<Time object: scale='utc' format='unix' value=1643840741.6157956>,\
 #     \ gs_commanded=array([0., 0.]), fgsid=0, gs_position=array([0., 0.]))", reduce_func: None, siaf: 'SIAF(v2_ref=0.0, v3_ref=0.0, v3yangle=0.0,
 #     vparity=1.0, crpix1=0, crpix2=0, cdelt1=3600, cdelt2=3600, vertices_idl=(0, 1, 1, 0, 0, 0, 1, 1))', siaf_db: <jwst.lib.siafdb.SiafDb
-#     object at 0x7f97d9324c10>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
+#     object at 0x1646e5750>, tolerance: '60.0', useafter: None, v3pa_at_gs: None}
 # schema: astropy-2.0
 source obstime ra dec pa_v3
-"time range" 2022-02-02T22:25:41.021 146.5503941066434 63.08387154277842 194.1482993002141
+"time range" 2022-02-02T22:25:41.616 146.5503945670982 63.08387151112689 194.14829980981426

--- a/jwst/lib/tests/test_engdb_mock.py
+++ b/jwst/lib/tests/test_engdb_mock.py
@@ -91,7 +91,7 @@ def test_cache_partial_data(db_cache, engdb):
     Test read of some data.
     """
     data = db_cache.fetch_data(GOOD_MNEMONIC, GOOD_STARTTIME, GOOD_ENDTIME)
-    assert data['Count'] > 300  # Just to make sure we have some data
+    assert data['Count'] > 1  # Just to make sure we have some data
     endtime = Time(
         engdb_direct.extract_db_time(data['Data'][1]['ObsTime']) / 1000.,
         format='unix'
@@ -115,7 +115,7 @@ def test_cache_end_data(db_cache, engdb):
     Test read of some data.
     """
     data = db_cache.fetch_data(GOOD_MNEMONIC, GOOD_STARTTIME, GOOD_ENDTIME)
-    assert data['Count'] > 300  # Just to make sure we have some data
+    assert data['Count'] > 1  # Just to make sure we have some data
 
     # First test pre-data.
     data_short = db_cache.fetch_data(

--- a/jwst/lib/tests/test_engdb_mock.py
+++ b/jwst/lib/tests/test_engdb_mock.py
@@ -15,10 +15,9 @@ from jwst.lib import engdb_direct, engdb_tools
 # For mocking, just use localhost
 ENGDB_MOCK_URL = 'http://localhost/'
 
-# Midpoint is about 2022-01-26T02:32:26.205
-# When checking against an actual engineering DB, use the production one.
-GOOD_STARTTIME = '2022-01-26 02:29:02.188'
-GOOD_ENDTIME = '2022-01-26 02:35:50.185'
+# Midpoint is about 2021-01-26T02:32:26.205
+GOOD_STARTTIME = '2021-01-26 02:29:02.188'
+GOOD_ENDTIME = '2021-01-26 02:35:50.185'
 GOOD_MNEMONIC = 'inrsi_gwa_y_tilt_avged'
 EARLY_STARTTIME = '2014-01-01'
 EARLY_ENDTIME = '2014-01-02'
@@ -91,7 +90,7 @@ def test_cache_partial_data(db_cache, engdb):
     Test read of some data.
     """
     data = db_cache.fetch_data(GOOD_MNEMONIC, GOOD_STARTTIME, GOOD_ENDTIME)
-    assert data['Count'] > 1  # Just to make sure we have some data
+    assert data['Count'] > 4  # Just to make sure we have some data
     endtime = Time(
         engdb_direct.extract_db_time(data['Data'][1]['ObsTime']) / 1000.,
         format='unix'
@@ -115,7 +114,7 @@ def test_cache_end_data(db_cache, engdb):
     Test read of some data.
     """
     data = db_cache.fetch_data(GOOD_MNEMONIC, GOOD_STARTTIME, GOOD_ENDTIME)
-    assert data['Count'] > 1  # Just to make sure we have some data
+    assert data['Count'] > 4  # Just to make sure we have some data
 
     # First test pre-data.
     data_short = db_cache.fetch_data(

--- a/jwst/lib/tests/test_engdb_mock.py
+++ b/jwst/lib/tests/test_engdb_mock.py
@@ -15,9 +15,10 @@ from jwst.lib import engdb_direct, engdb_tools
 # For mocking, just use localhost
 ENGDB_MOCK_URL = 'http://localhost/'
 
-# Midpoint is about 2021-01-26T02:32:26.205
-GOOD_STARTTIME = '2021-01-26 02:29:02.188'
-GOOD_ENDTIME = '2021-01-26 02:35:50.185'
+# Midpoint is about 2022-01-26T02:32:26.205
+# When checking against an actual engineering DB, use the production one.
+GOOD_STARTTIME = '2022-01-26 02:29:02.188'
+GOOD_ENDTIME = '2022-01-26 02:35:50.185'
 GOOD_MNEMONIC = 'inrsi_gwa_y_tilt_avged'
 EARLY_STARTTIME = '2014-01-01'
 EARLY_ENDTIME = '2014-01-02'
@@ -90,7 +91,7 @@ def test_cache_partial_data(db_cache, engdb):
     Test read of some data.
     """
     data = db_cache.fetch_data(GOOD_MNEMONIC, GOOD_STARTTIME, GOOD_ENDTIME)
-    assert data['Count'] > 4  # Just to make sure we have some data
+    assert data['Count'] > 300  # Just to make sure we have some data
     endtime = Time(
         engdb_direct.extract_db_time(data['Data'][1]['ObsTime']) / 1000.,
         format='unix'
@@ -114,7 +115,7 @@ def test_cache_end_data(db_cache, engdb):
     Test read of some data.
     """
     data = db_cache.fetch_data(GOOD_MNEMONIC, GOOD_STARTTIME, GOOD_ENDTIME)
-    assert data['Count'] > 4  # Just to make sure we have some data
+    assert data['Count'] > 300  # Just to make sure we have some data
 
     # First test pre-data.
     data_short = db_cache.fetch_data(

--- a/jwst/lib/tests/test_v1_calculate.py
+++ b/jwst/lib/tests/test_v1_calculate.py
@@ -32,13 +32,6 @@ MOCK_GOOD_STARTTIME = Time('59240.10349754328', format='mjd')
 MOCK_GOOD_ENDTIME = Time('59240.1082197338', format='mjd')
 
 
-@pytest.fixture
-def engdb_service():
-    """Setup the service to operate through the mock service"""
-    with EngDB_Mocker():
-        yield engdb_tools.ENGDB_Service(base_url='http://localhost')
-
-
 def test_from_models(engdb_service, tmp_path):
     """Test v1_calculate_from_models for basic running"""
     model = ImageModel()
@@ -110,6 +103,16 @@ def test_over_time_mast(tmp_path):
     errors = v1_compare_simplified_tables(v1_formatted, truth)
     errors_str = '\n'.join(errors)
     assert len(errors) == 0, f'V1 tables are different: {errors_str}'
+
+
+# ######################
+# Fixtures and utilities
+# ######################
+@pytest.fixture
+def engdb_service():
+    """Setup the service to operate through the mock service"""
+    with EngDB_Mocker():
+        yield engdb_tools.ENGDB_Service(base_url='http://localhost')
 
 
 def v1_compare_simplified_tables(a, b, rtol=1e-05):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3424](https://jira.stsci.edu/browse/JP-3424)

Closes #7963 

<!-- describe the changes comprising this PR here -->
This PR addresses an issue discovered during Build 10.0 integration with WCS determination in set_telescope_pointing. A new algorithm for the various guider products has been implemented, which require more engineering coverage than science exposures. Turns out that not enough leeway being given. This PR extends the coverage time to use when retrieving engineering data.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
