### PR TITLE
JP-3304: use error table from f-flat reference files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,13 @@ set_telescope_pointing
 ----------------------
 
 - Extend engineering coverage time for guiding modes. [#7966]
+ 
+flat_field
+----------
+
+- Update ``combine_fast_slow`` to use error values provided by f-flat
+  reference files. [#7972]
+
 
 1.12.0 (2023-09-18)
 ===================

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -1173,7 +1173,7 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
         nelem_col = None
     wl_col = data["wavelength"]
     flat_col = data["data"]
-    flat_err_col = data["err"]
+    flat_err_col = data["error"]
 
     nrows = len(wl_col)
     row = None

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -731,8 +731,7 @@ def fore_optics_flat(wl, f_flat_model, exposure_type, dispaxis,
     else:
         quadrant = slit_nt.quadrant - 1  # convert to zero indexed
 
-    (tab_wl, tab_flat) = read_flat_table(f_flat_model, exposure_type,
-                                         slit_name, quadrant)
+    (tab_wl, tab_flat, tab_flat_err) = read_flat_table(f_flat_model, exposure_type, slit_name, quadrant)
     if tab_wl.max() < MICRONS_100:
         log.warning("Wavelengths in f_flat table appear to be in meters")
 
@@ -778,8 +777,13 @@ def fore_optics_flat(wl, f_flat_model, exposure_type, dispaxis,
 
     # The shape of the output array is obtained from `wl`.
 
-    f_flat, f_flat_dq = combine_fast_slow(wl, flat_2d, f_flat_dq,
-                                          tab_wl, tab_flat, dispaxis)
+    f_flat, f_flat_dq, f_err = combine_fast_slow(wl, flat_2d, f_flat_dq, tab_wl, tab_flat, tab_flat_err, dispaxis)
+
+    # if error values have not already been calculated (as occurs above
+    # for NRS_MSASPEC exposures) use the propogated interpolated error
+    # values from the reference file computed in combine_fast_slow
+    if f_flat_err is None:
+        f_flat_err = f_err
 
     # Find pixels in the flat that have a value of NaN and add to
     # DQ mask, DO_NOT_USE + NO_FLAT_FIELD
@@ -856,7 +860,7 @@ def spectrograph_flat(wl, s_flat_model,
     if xstart >= xstop or ystart >= ystop:
         return 1., None
 
-    (tab_wl, tab_flat) = read_flat_table(s_flat_model, exposure_type,
+    (tab_wl, tab_flat, tab_flat_err) = read_flat_table(s_flat_model, exposure_type,
                                          slit_name, quadrant)
     if tab_wl.max() < MICRONS_100:
         log.warning("Wavelengths in s_flat table appear to be in meters")
@@ -902,8 +906,9 @@ def spectrograph_flat(wl, s_flat_model,
     # correction is made
     flat_2d[np.where(flat_bad)] = 1.0
 
-    s_flat, s_flat_dq = combine_fast_slow(wl, flat_2d, s_flat_dq,
-                                          tab_wl, tab_flat, dispaxis)
+    # do not use error values from s-flat reference files, instead use
+    # the values computed above
+    s_flat, s_flat_dq, _ = combine_fast_slow(wl, flat_2d, s_flat_dq, tab_wl, tab_flat, tab_flat_err, dispaxis)
 
     return s_flat, s_flat_dq, s_flat_err
 
@@ -963,7 +968,7 @@ def detector_flat(wl, d_flat_model,
     if xstart >= xstop or ystart >= ystop:
         return 1., None
 
-    (tab_wl, tab_flat) = read_flat_table(d_flat_model, exposure_type,
+    (tab_wl, tab_flat, tab_flat_err) = read_flat_table(d_flat_model, exposure_type,
                                          slit_name, quadrant)
     if tab_wl.max() < MICRONS_100:
         log.warning("Wavelengths in d_flat table appear to be in meters.")
@@ -1001,8 +1006,9 @@ def detector_flat(wl, d_flat_model,
     # correction is made
     flat_2d[np.where(flat_bad)] = 1.0
 
-    d_flat, d_flat_dq = combine_fast_slow(wl, flat_2d, d_flat_dq,
-                                          tab_wl, tab_flat, dispaxis)
+    # do not use error values from d-flat reference files, instead use
+    # the values computed above
+    d_flat, d_flat_dq, _ = combine_fast_slow(wl, flat_2d, d_flat_dq, tab_wl, tab_flat, tab_flat_err, dispaxis)
     return d_flat, d_flat_dq, d_flat_err
 
 
@@ -1146,6 +1152,10 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
     tab_flat : ndarray, 1-D, float
         The column of flat_field values read from the fast-variation table.
         `tab_wl` and `tab_flat` should be the same length.
+
+    tab_flat_err : ndarray, 1-D
+        The column of flat_field error values read from the fast-variation
+        table.
     """
 
     if quadrant is not None:  # NRS_MSASPEC
@@ -1163,6 +1173,7 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
         nelem_col = None
     wl_col = data["wavelength"]
     flat_col = data["data"]
+    flat_err_col = data["err"]
 
     nrows = len(wl_col)
     row = None
@@ -1188,6 +1199,7 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
         # Table contains arrays; use the row that was found above.
         tab_wl = wl_col[row].copy()
         tab_flat = flat_col[row].copy()
+        tab_flat_err = flat_err_col[row].copy()
         if nelem_col is not None:
             nelem = nelem_col[row]
     else:
@@ -1196,12 +1208,14 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
             # Table contains arrays, but there should be only one row.
             tab_wl = wl_col[0].copy()
             tab_flat = flat_col[0].copy()
+            tab_flat_err = flat_err_col[0].copy()
             if nelem_col is not None:
                 nelem = nelem_col[0]
         else:
             # Table contains scalar columns.
             tab_wl = wl_col.copy()
             tab_flat = flat_col.copy()
+            tab_flat_err = flat_err_col.copy()
             if nelem_col is not None:
                 nelem = nelem_col[0]  # arbitrary choice of row
     if nelem is not None:
@@ -1213,6 +1227,7 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
         else:
             tab_wl = tab_wl[:nelem]
             tab_flat = tab_flat[:nelem]
+            tab_flat_err = tab_flat_err[:nelem]
     else:
         nelem = len(tab_wl)
 
@@ -1227,6 +1242,7 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
                   "%d NaNs; these have been skipped.", nelem - n1)
         tab_wl = tab_wl[filter]
         tab_flat = tab_flat[filter]
+        tab_flat_err = tab_flat_err[filter]
     del filter1, filter2, filter
     # Skip zero or negative wavelengths, and skip zero flat-field values.
     filter1 = (tab_wl > 0.)
@@ -1239,6 +1255,7 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
                   n1 - n2)
         tab_wl = tab_wl[filter]
         tab_flat = tab_flat[filter]
+        tab_flat_err = tab_flat_err[filter]
     del filter1, filter2, filter
 
     # Check that the wavelengths are increasing.  This is a requirement
@@ -1249,10 +1266,10 @@ def read_flat_table(flat_model, exposure_type, slit_name=None, quadrant=None):
             log.warning("Wavelengths in the fast-variation table "
                         "must be strictly increasing.")
 
-    return tab_wl, tab_flat
+    return tab_wl, tab_flat, tab_flat_err
 
 
-def combine_fast_slow(wl, flat_2d, flat_dq, tab_wl, tab_flat, dispaxis):
+def combine_fast_slow(wl, flat_2d, flat_dq, tab_wl, tab_flat, tab_flat_error, dispaxis):
     """Multiply the image by the tabular values.
 
     Parameters
@@ -1279,6 +1296,9 @@ def combine_fast_slow(wl, flat_2d, flat_dq, tab_wl, tab_flat, dispaxis):
         is the "fast" variation of the flat, i.e. fast with respect to
         wavelength.
 
+    tab_flat_err : ndarray, 1-D
+        The flat field error from the table part of the reference file.
+
     dispaxis : int
         1 is horizontal, 2 is vertical.
 
@@ -1294,6 +1314,10 @@ def combine_fast_slow(wl, flat_2d, flat_dq, tab_wl, tab_flat, dispaxis):
         within the range of `tab_wl`, NO_FLAT_FIELD will be used to flag
         this condition, and the fast-variation flat field value at that
         pixel will be set to 1.
+
+    flat_error : ndarray, 1-D
+        The `tab_flat_err` values interpolated to the wavelengths of the
+        science image, i.e. `wl`.
     """
 
     wl_c = clean_wl(wl, dispaxis)
@@ -1328,6 +1352,11 @@ def combine_fast_slow(wl, flat_2d, flat_dq, tab_wl, tab_flat, dispaxis):
         values += weight * np.interp(wavelengths, tab_wl, tab_flat,
                                      left=np.nan, right=np.nan)
 
+    # Interpolate error values from reference file using a simple
+    # linear interpolation as these don't have the required precision
+    # to justify a more complex interpolation
+    error_value = np.interp(wavelengths, tab_wl, tab_flat_error, left=np.nan, right=np.nan)
+
     # Handle bad wavelength values in un-cleaned wavelength array
     bad = (wl <= 0)
     values[bad] = 1.0
@@ -1338,7 +1367,7 @@ def combine_fast_slow(wl, flat_2d, flat_dq, tab_wl, tab_flat, dispaxis):
     combined_dq[missing] |= dqflags.pixel['NO_FLAT_FIELD']
     combined_dq[missing] |= dqflags.pixel['DO_NOT_USE']
 
-    return flat_2d * values, combined_dq
+    return flat_2d * values, combined_dq, error_value
 
 
 def clean_wl(wl, dispaxis):

--- a/jwst/flatfield/tests/test_combine_fast_slow.py
+++ b/jwst/flatfield/tests/test_combine_fast_slow.py
@@ -34,6 +34,7 @@ def test_combine_fast_slow():
              'c5': 2.0e-3}
     poly = polynomial.Polynomial1D(degree=5, **coeff)
     tab_flat = poly(tab_wl)
+    tab_flat_err = np.full(tab_flat.shape, np.nan, dtype=tab_flat.dtype)
 
     wl0 = 7.37
     dwl0 = 2.99
@@ -52,8 +53,7 @@ def test_combine_fast_slow():
     flat_dq = np.zeros((10, 10), dtype=np.uint32)
     dispaxis = 1
 
-    value, new_dq = combine_fast_slow(wl, flat_2d, flat_dq, tab_wl,
-                                      tab_flat, dispaxis)
+    value, new_dq, err = combine_fast_slow(wl, flat_2d, flat_dq, tab_wl, tab_flat, tab_flat_err, dispaxis)
 
     # Column 5 is the expected value
     assert np.allclose(value[:, 5], correct_value, rtol=1.e-8, atol=1.e-8)
@@ -68,3 +68,7 @@ def test_combine_fast_slow():
     bad_value = dqflags.pixel['NO_FLAT_FIELD'] | dqflags.pixel['DO_NOT_USE']
     assert np.all(value[:, (3, 4, 6, 7, 8, 9)] == 1)
     assert np.all(new_dq[:, (3, 4, 6, 7, 8, 9)] == bad_value)
+
+    # as we've only provided nans for tab_flat_err the expected err should be nan
+    assert err.shape == value.shape
+    assert np.all(np.isnan(err))


### PR DESCRIPTION
Partially resolves [JP-3304](https://jira.stsci.edu/browse/JP-3304)
Fully resolving this requires reference files to test the code modified in this PR.

https://github.com/spacetelescope/stdatamodels/pull/183 added support for `error` columns in `NirspecFlatModel` and `NirspecQuadFlatModel` files. This PR modifies `combine_fast_slow` based on suggestions in the above ticket to use the new error columns.

Regression tests running at: https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/972/pipeline/201

Some failures are expected as `f_flat` reference files do not contain `error` columns. https://github.com/spacetelescope/stdatamodels/pull/183 fills in the missing `error` column with `nan` values and the resulting interpolated `error` (with this PR) is `nan`. It appears that on the current main branch (and in the truth files) these `error` values are instead `0`. This should result in many `FITSDiff` errors where the `ERR` hdu contains `nan` instead of `0`.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
