### PR TITLE
JP-3308: index out of bounds error for NRC_TSGRISM level_3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 1.12.2 (unreleased)
 ===================
 
-- 
+calwebb_tso3
+------------
+
+- Fix index error occurring because the int_times table was being created
+  with nrows=nints of first model. Instead, now the code uses the model with
+  the largest number of integrations. [#7977]
 
 1.12.1 (2023-09-26)
 ===================

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -155,8 +155,10 @@ class Tso3Pipeline(Pipeline):
             # define output for x1d (level 3) products
             x1d_result = datamodels.MultiSpecModel()
             x1d_result.update(input_models[0], only="PRIMARY")
+            nints_per_mdl = [mdl.meta.exposure.nints for mdl in input_models]
+            nrows = max(nints_per_mdl)   # avoid an index error
             x1d_result.int_times = FITS_rec.from_columns(input_models[0].int_times.columns,
-                                                         nrows=input_models[0].meta.exposure.nints)
+                                                         nrows=nrows)
 
             # Remove source_type from the output model, if it exists, to prevent
             # the creation of an empty SCI extension just for that keyword.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3308](https://jira.stsci.edu/browse/JP-3308)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an index error occurring because the int_times table was being created with nrows=nints of first model. Instead, now the code uses the model with the largest number of integrations.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
