### PR TITLE
JP-3429: Flat error propagation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ charge_migration
 - Added tests to see if the data array is changed after runnung the step and
   setting signal_threshold to 25000. [#7895]
 
+flat_field
+----------
+
+- Update ``combine_fast_slow`` to use 1D error values provided by f-flat
+  reference files. [#7978]
+
 1.12.1 (2023-09-26)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,8 @@ charge_migration
 flat_field
 ----------
 
-- Update ``combine_fast_slow`` to use 1D error values provided by f-flat
-  reference files. [#7978]
+- Update the ``combine_fast_slow`` function for NIRSpec spectroscopic flats 
+   to use 1D error values provided by F-flat reference files. [#7978]
 
 1.12.1 (2023-09-26)
 ===================

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -1378,12 +1378,11 @@ def combine_fast_slow(wl, flat_2d, flat_dq, flat_err, tab_wl, tab_flat, tab_flat
     combined_dq[missing] |= dqflags.pixel['NO_FLAT_FIELD']
     combined_dq[missing] |= dqflags.pixel['DO_NOT_USE']
 
-    # Handle NaNs in errors
-    combined_err[np.isnan(combined_err)] = 0.0
-    error_value[np.isnan(error_value)] = 0.0
-
-    # Add new 1D errors and input 2D errors in quadrature
-    combined_err = np.sqrt(combined_err**2 + error_value**2)
+    # Add new 1D errors and input 2D errors in quadrature,
+    # treating NaNs as zeros
+    v1 = error_value**2 * flat_2d**2
+    v2 = combined_err**2 * values**2
+    combined_err = np.sqrt(np.nansum([v1, v2], axis=0))
 
     return flat_2d * values, combined_dq, combined_err
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -434,7 +434,7 @@ def nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model, dispa
         flat_data_squared = slit_flat.data ** 2
         slit.var_poisson /= flat_data_squared
         slit.var_rnoise /= flat_data_squared
-        slit.var_flat = slit.data ** 2 / flat_data_squared * slit_flat.err ** 2
+        slit.var_flat = (slit.data / slit_flat.data * slit_flat.err) ** 2
         slit.err = np.sqrt(slit.var_poisson + slit.var_rnoise + slit.var_flat)
 
         # Combine the science and flat DQ arrays
@@ -510,7 +510,7 @@ def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model, di
     flat_data_squared = interpolated_flat.data ** 2
     output_model.var_poisson /= flat_data_squared
     output_model.var_rnoise /= flat_data_squared
-    output_model.var_flat = output_model.data ** 2 / flat_data_squared * interpolated_flat.err ** 2
+    output_model.var_flat = (output_model.data / interpolated_flat.data * interpolated_flat.err) ** 2
     output_model.err = np.sqrt(
         output_model.var_poisson + output_model.var_rnoise + output_model.var_flat
     )
@@ -576,7 +576,7 @@ def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis
         flat_data_squared = flat ** 2
         output_model.var_poisson /= flat_data_squared
         output_model.var_rnoise /= flat_data_squared
-        output_model.var_flat = output_model.data ** 2 / flat_data_squared * flat_err ** 2
+        output_model.var_flat = (output_model.data / flat * flat_err) ** 2
         output_model.err = np.sqrt(
             output_model.var_poisson + output_model.var_rnoise + output_model.var_flat
         )
@@ -1380,8 +1380,8 @@ def combine_fast_slow(wl, flat_2d, flat_dq, flat_err, tab_wl, tab_flat, tab_flat
 
     # Add new 1D errors and input 2D errors in quadrature,
     # treating NaNs as zeros
-    v1 = error_value**2 * flat_2d**2
-    v2 = combined_err**2 * values**2
+    v1 = np.square(error_value * flat_2d)
+    v2 = np.square(combined_err * values)
     combined_err = np.sqrt(np.nansum([v1, v2], axis=0))
 
     return flat_2d * values, combined_dq, combined_err

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -666,16 +666,17 @@ def create_flat_field(wl, f_flat_model, s_flat_model, d_flat_model,
                          default_shape=flat_2d.shape)
 
     # Combine the uncertainty arrays, excluding the ones that are None
+    # Divide error by flat before squaring to avoid overflow
     sum_var = np.zeros_like(flat_2d)
     if f_flat_err is not None:
         np.place(f_flat, f_flat == 0, 1.)
-        sum_var += f_flat_err ** 2 / f_flat ** 2
+        sum_var += (f_flat_err / f_flat) ** 2
     if s_flat_err is not None:
         np.place(s_flat, s_flat == 0, 1.)
-        sum_var += s_flat_err ** 2 / s_flat ** 2
+        sum_var += (s_flat_err / s_flat) ** 2
     if d_flat_err is not None:
         np.place(d_flat, d_flat == 0, 1.)
-        sum_var += d_flat_err ** 2 / d_flat ** 2
+        sum_var += (d_flat_err / d_flat) ** 2
     flat_err = flat_2d * np.sqrt(sum_var)
 
     mask = np.bitwise_and(flat_dq, dqflags.pixel['DO_NOT_USE'])

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -1319,7 +1319,7 @@ def combine_fast_slow(wl, flat_2d, flat_dq, flat_err, tab_wl, tab_flat, tab_flat
         this condition, and the fast-variation flat field value at that
         pixel will be set to 1.
 
-    flat_error : ndarray, 1-D
+    flat_error : ndarray, 2-D, float32
         The `tab_flat_err` values interpolated to the wavelengths of the
         science image, i.e. `wl`. Missing values are set to 0.
     """

--- a/jwst/flatfield/tests/test_combine_fast_slow.py
+++ b/jwst/flatfield/tests/test_combine_fast_slow.py
@@ -2,6 +2,7 @@
 Test for flat_field.combine_fast_slow
 """
 import numpy as np
+import pytest
 from scipy.integrate import quad
 from astropy.modeling import polynomial
 from stdatamodels.jwst.datamodels import dqflags
@@ -9,7 +10,11 @@ from stdatamodels.jwst.datamodels import dqflags
 from jwst.flatfield.flat_field import combine_fast_slow
 
 
-def test_combine_fast_slow():
+@pytest.mark.parametrize('flat_err_1,flat_err_2,err_result',
+                         [(0.0, None, 0.0), (np.nan, None, 0.0),
+                          (0.0, 0.1, 0.1), (0.1, 0.0, 0.1), (0.1, np.nan, 0.1),
+                          (0.1, None, 0.1), (0.1, 0.1, np.sqrt(0.02))])
+def test_combine_fast_slow(flat_err_1, flat_err_2, err_result):
     """Assign an array of values to tab_wl; these are strictly increasing,
     but they're not uniformly spaced.
     The abscissas and weights in combine_fast_slow are for three-point
@@ -34,6 +39,7 @@ def test_combine_fast_slow():
              'c5': 2.0e-3}
     poly = polynomial.Polynomial1D(degree=5, **coeff)
     tab_flat = poly(tab_wl)
+    tab_flat_err = np.full(tab_flat.shape, flat_err_1, dtype=tab_flat.dtype)
 
     wl0 = 7.37
     dwl0 = 2.99
@@ -50,21 +56,40 @@ def test_combine_fast_slow():
     wl = np.tile(wl_1d, (10, 1))
     flat_2d = np.ones((10, 10), dtype=float)
     flat_dq = np.zeros((10, 10), dtype=np.uint32)
+    if flat_err_2 is None:
+        flat_err = None
+    else:
+        flat_err = np.full((10, 10), flat_err_2)
     dispaxis = 1
 
-    value, new_dq = combine_fast_slow(wl, flat_2d, flat_dq, tab_wl,
-                                      tab_flat, dispaxis)
+    value, new_dq, new_err = combine_fast_slow(wl, flat_2d, flat_dq, flat_err, tab_wl, tab_flat, tab_flat_err, dispaxis)
+
+    # Check output shapes
+    assert value.shape == wl.shape
+    assert new_dq.shape == wl.shape
+    assert new_err.shape == wl.shape
 
     # Column 5 is the expected value
     assert np.allclose(value[:, 5], correct_value, rtol=1.e-8, atol=1.e-8)
     assert np.all(new_dq[:, 5] == 0)
+    assert np.allclose(new_err[:, 5], err_result, rtol=1.e-8, atol=1.e-8,
+                       equal_nan=True)
 
     # Columns 0-2 are bad (negative wavelengths, not marked in DQ)
     assert np.all(value[:, :3] == 1)
     assert np.all(new_dq[:, :3] == 0)
+    if flat_err is None or np.isnan(flat_err_2):
+        assert np.all(new_err[:, :3] == 0)
+    else:
+        assert np.allclose(new_err[:, :3], flat_err[:, :3], equal_nan=True)
 
     # Columns 3, 4, 6-9 are not covered by the tabular data
     # (missing values, marked in DQ)
     bad_value = dqflags.pixel['NO_FLAT_FIELD'] | dqflags.pixel['DO_NOT_USE']
     assert np.all(value[:, (3, 4, 6, 7, 8, 9)] == 1)
     assert np.all(new_dq[:, (3, 4, 6, 7, 8, 9)] == bad_value)
+    if flat_err is None or np.isnan(flat_err_2):
+        assert np.all(new_err[:, (3, 4, 6, 7, 8, 9)] == 0)
+    else:
+        assert np.allclose(new_err[:, (3, 4, 6, 7, 8, 9)],
+                           flat_err[:, (3, 4, 6, 7, 8, 9)], equal_nan=True)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3429](https://jira.stsci.edu/browse/JP-3429)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7973 

<!-- describe the changes comprising this PR here -->
This PR updates flat propagation methods to account for 1D errors from fast variation components. This is needed to support upcoming NIRSpec flats, which will include errors on the 1D F-flats.  Missing errors are handled as zero-error components, so these changes should be backwards-compatible.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
