### PR TITLE
JP-3350: Set all DO_NOT_USE pixels to NaN after flat field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ charge_migration
 - Added tests to see if the data array is changed after runnung the step and
   setting signal_threshold to 25000. [#7895]
 
+flat_field
+----------
+
+- For NIRSpec flat fields, set new DO_NOT_USE pixels to NaN after
+  correction. [#7979]
+
 1.12.1 (2023-09-26)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,6 @@ straylight
 - Adjust MIRI MRS straylight routine to ensure cross-artifact correction does not
   get applied to pedestal dark signal. [#7980]
 
->>>>>>> master
 
 1.12.1 (2023-09-26)
 ===================

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -440,9 +440,9 @@ def nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model, dispa
         # Combine the science and flat DQ arrays
         slit.dq |= slit_flat.dq
 
-        # Make sure any new DO_NOT_USE pixels are NaN
-        dnu = np.bitwise_and(slit.dq, dqflags.pixel['DO_NOT_USE'])
-        slit.data[np.where(dnu)] = np.nan
+        # Make sure all DO_NOT_USE pixels are set to NaN,
+        # including those flagged by this step
+        slit.data[np.where(slit.dq & dqflags.pixel['DO_NOT_USE'])] = np.nan
 
         any_updated = True
 
@@ -519,9 +519,9 @@ def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model, di
         output_model.var_poisson + output_model.var_rnoise + output_model.var_flat
     )
 
-    # Make sure any new DO_NOT_USE pixels are NaN
-    dnu = np.bitwise_and(output_model.dq, dqflags.pixel['DO_NOT_USE'])
-    output_model.data[np.where(dnu)] = np.nan
+    # Make sure all DO_NOT_USE pixels are set to NaN,
+    # including those flagged by this step
+    output_model.data[np.where(output_model.dq & dqflags.pixel['DO_NOT_USE'])] = np.nan
 
     output_model.meta.cal_step.flat_field = 'COMPLETE'
 
@@ -589,9 +589,9 @@ def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis
             output_model.var_poisson + output_model.var_rnoise + output_model.var_flat
         )
 
-        # Make sure any new DO_NOT_USE pixels are NaN
-        dnu = np.bitwise_and(output_model.dq, dqflags.pixel['DO_NOT_USE'])
-        output_model.data[np.where(dnu)] = np.nan
+        # Make sure all DO_NOT_USE pixels are set to NaN,
+        # including those flagged by this step
+        output_model.data[np.where(output_model.dq & dqflags.pixel['DO_NOT_USE'])] = np.nan
 
         output_model.meta.cal_step.flat_field = 'COMPLETE'
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -440,6 +440,10 @@ def nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model, dispa
         # Combine the science and flat DQ arrays
         slit.dq |= slit_flat.dq
 
+        # Make sure any new DO_NOT_USE pixels are NaN
+        dnu = np.bitwise_and(slit.dq, dqflags.pixel['DO_NOT_USE'])
+        slit.data[np.where(dnu)] = np.nan
+
         any_updated = True
 
     if any_updated:
@@ -515,6 +519,10 @@ def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model, di
         output_model.var_poisson + output_model.var_rnoise + output_model.var_flat
     )
 
+    # Make sure any new DO_NOT_USE pixels are NaN
+    dnu = np.bitwise_and(output_model.dq, dqflags.pixel['DO_NOT_USE'])
+    output_model.data[np.where(dnu)] = np.nan
+
     output_model.meta.cal_step.flat_field = 'COMPLETE'
 
     return interpolated_flat
@@ -580,6 +588,10 @@ def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis
         output_model.err = np.sqrt(
             output_model.var_poisson + output_model.var_rnoise + output_model.var_flat
         )
+
+        # Make sure any new DO_NOT_USE pixels are NaN
+        dnu = np.bitwise_and(output_model.dq, dqflags.pixel['DO_NOT_USE'])
+        output_model.data[np.where(dnu)] = np.nan
 
         output_model.meta.cal_step.flat_field = 'COMPLETE'
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3350](https://jira.stsci.edu/browse/JP-3350)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7834 

<!-- describe the changes comprising this PR here -->
For NIRSpec data, any new DO_NOT_USE pixels generated during the flat field process are set to NaN. This addresses a cosmetic issue, where data that has not been flat-fielded is many orders of magnitude higher than data that has been corrected.  The pixels are already ignored in further processing, but can be confusing to look at in intermediate data products.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
