### PR TITLE
JP-3308: Prevent creation of level 3 TSO group associations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,11 @@ straylight
 1.12.1 (2023-09-26)
 ===================
 
+associations
+------------
+
+- Prevent group candidates from generating level 3 TSO associations. [#7982]
+
 extract_1d
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ assign_wcs
 
 - Increase margin at edges of NIRSpec MOS slits to reduce edge effects in resampling. [#7976]
 
+associations
+------------
+
+- Prevent group candidates from generating level 3 TSO associations. [#7982]
+
 charge_migration
 ----------------
 
@@ -42,11 +47,6 @@ straylight
 
 1.12.1 (2023-09-26)
 ===================
-
-associations
-------------
-
-- Prevent group candidates from generating level 3 TSO associations. [#7982]
 
 extract_1d
 ----------

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -906,9 +906,9 @@ class Asn_Lv3TSO(AsnMixin_Science):
             )
         ])
 
-        # Only valid if candidate is not a GROUP.
+        # Only valid if candidate type is 'observation'.
         self.validity.update({
-            'is_not_group': {
+            'is_type_observation': {
                 'validated': False,
                 'check': self._validate_candidates
             }
@@ -923,7 +923,7 @@ class Asn_Lv3TSO(AsnMixin_Science):
         super(Asn_Lv3TSO, self)._init_hook(item)
 
     def _validate_candidates(self, member):
-        """Disallow GROUP candidates
+        """Allow only observation-type candidates
 
         Parameters
         ----------
@@ -932,8 +932,8 @@ class Asn_Lv3TSO(AsnMixin_Science):
 
         Returns
         -------
-        False if candidate is GROUP.
-        True otherwise.
+        True if candidate type is observation.
+        False otherwise.
         """
 
         # If a group candidate, reject.

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -937,7 +937,7 @@ class Asn_Lv3TSO(AsnMixin_Science):
         """
 
         # If a group candidate, reject.
-        if self.acid.type.lower() == 'group':
+        if self.acid.type.lower() != 'observation':
             return False
 
         return True

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -906,6 +906,14 @@ class Asn_Lv3TSO(AsnMixin_Science):
             )
         ])
 
+        # Only valid if candidate is not a GROUP.
+        self.validity.update({
+            'is_not_group': {
+                'validated': False,
+                'check': self._validate_candidates
+            }
+        })
+
         super(Asn_Lv3TSO, self).__init__(*args, **kwargs)
 
     def _init_hook(self, item):
@@ -913,6 +921,26 @@ class Asn_Lv3TSO(AsnMixin_Science):
 
         self.data['asn_type'] = 'tso3'
         super(Asn_Lv3TSO, self)._init_hook(item)
+
+    def _validate_candidates(self, member):
+        """Disallow GROUP candidates
+
+        Parameters
+        ----------
+        member : Member
+            Member being added. Ignored.
+
+        Returns
+        -------
+        False if candidate is GROUP.
+        True otherwise.
+        """
+
+        # If a group candidate, reject.
+        if self.acid.type.lower() == 'group':
+            return False
+
+        return True
 
 
 @RegistryMarker.rule

--- a/jwst/associations/tests/test_level3_basics.py
+++ b/jwst/associations/tests/test_level3_basics.py
@@ -31,7 +31,6 @@ def test_meta():
 @pytest.mark.parametrize(
     'pool_file',
     [
-        'data/pool_005_spec_niriss.csv',
         'data/pool_006_spec_nirspec.csv',
         'data/pool_007_spec_miri.csv',
         'data/pool_010_spec_nirspec_lv2bkg.csv',

--- a/jwst/associations/tests/test_level3_spectrographic.py
+++ b/jwst/associations/tests/test_level3_spectrographic.py
@@ -28,7 +28,7 @@ class TestLevel3Spec(BasePoolRule):
         ),
         PoolParams(
             path=t_path('data/pool_007_spec_miri.csv'),
-            n_asns=2,
+            n_asns=1,
             n_orphaned=0
         ),
         PoolParams(

--- a/jwst/associations/tests/test_level3_spectrographic.py
+++ b/jwst/associations/tests/test_level3_spectrographic.py
@@ -18,7 +18,7 @@ class TestLevel3Spec(BasePoolRule):
     pools = [
         PoolParams(
             path=t_path('data/pool_005_spec_niriss.csv'),
-            n_asns=1,
+            n_asns=0,
             n_orphaned=0
         ),
         PoolParams(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3308](https://jira.stsci.edu/browse/JP-3308)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7739 

<!-- describe the changes comprising this PR here -->
This PR addresses a calwebb_tso3 crash when processing a TSO3 association from a group candidate, which attempted to combine two observations. The formation of the int_times table is not currently feasible for observation combinations, leading to failure. This PR prevents the creation of assocations combining TSO observations to avoid the failure.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
