### PR TITLE
keep cube build input models open to allow reading wcs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 1.12.4 (unreleased)
 ===================
 
-- 
+cube_build
+----------
+
+- Keep data models opened by cube build open until the step completes. [#7998] 
+
 
 1.12.3 (2023-10-03)
 ===================

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -241,6 +241,7 @@ class CubeBuildStep (Step):
         # Check for a valid reference file
         if par_filename == 'N/A':
             self.log.warning('No default cube parameters reference file found')
+            input_table.close()
             return
 # ________________________________________________________________________________
 # shove the input parameters in to pars to pull out in general cube_build.py
@@ -299,6 +300,7 @@ class CubeBuildStep (Step):
         if instrument == 'MIRI' and self.coord_system == 'internal_cal':
             self.log.warning('The output coordinate system of internal_cal is not valid for MIRI')
             self.log.warning('use output_coord = ifualign instead')
+            input_table.close()
             return
         filenames = master_table.FileMap['filename']
 
@@ -402,6 +404,7 @@ class CubeBuildStep (Step):
         if status_cube == 1:
             self.skip = True
 
+        input_table.close()
         return cube_container
 # ******************************************************************************
 

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -94,9 +94,9 @@ class DataTypes():
             # close files opened above
             self.close()
             raise TypeError("Failed to process file type {}".format(type(input_models)))
-        # if the user has set the output name - strip out *.fits
-        # later suffixes will be added to this name to designate the
-        # channel, subchannel or grating,filter the data is covers.
+        # If the user has set the output name, strip off *.fits.
+        # Suffixes will be added to this name later, to designate the
+        # channel+subchannel (MIRI MRS) or grating+filter (NRS IFU) the output cube covers.
 
 
         if output_file is not None:

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -69,30 +69,34 @@ class DataTypes():
 
         self.input_models = []
         self.output_name = None
-        
+
         # open the input with datamodels
         # if input is filename or model when it is opened it is a model
         # if input if an association name or ModelContainer then it is opened as a container
 
-        with datamodels.open(input) as input_models:
+        input_models = datamodels.open(input)
+        # if input is a filename, we will need to close the opened file 
+        self._opened = [input_models]
 
-            if isinstance(input_models, datamodels.IFUImageModel):
-                # It's a single image that's been passed in as a model
-                # input is a model
-                filename = input_models.meta.filename
-                self.input_models.append(input_models)
-                self.output_name = self.build_product_name(filename)
+        if isinstance(input_models, datamodels.IFUImageModel):
+            # It's a single image that's been passed in as a model
+            # input is a model
+            filename = input_models.meta.filename
+            self.input_models.append(input_models)
+            self.output_name = self.build_product_name(filename)
 
-            elif isinstance(input_models, ModelContainer):
-                self.output_name = 'Temp'
-                self.input_models = input_models
-                if not single:  # find the name of the output file from the association
-                    self.output_name = input_models.meta.asn_table.products[0].name
-            else:
-                raise TypeError("Failed to process file type {}".format(type(input_models)))
-            # if the user has set the output name - strip out *.fits
-            # later suffixes will be added to this name to designate the
-            # channel, subchannel or grating,filter the data is covers.
+        elif isinstance(input_models, ModelContainer):
+            self.output_name = 'Temp'
+            self.input_models = input_models
+            if not single:  # find the name of the output file from the association
+                self.output_name = input_models.meta.asn_table.products[0].name
+        else:
+            # close files opened above
+            self.close()
+            raise TypeError("Failed to process file type {}".format(type(input_models)))
+        # if the user has set the output name - strip out *.fits
+        # later suffixes will be added to this name to designate the
+        # channel, subchannel or grating,filter the data is covers.
 
 
         if output_file is not None:
@@ -101,6 +105,12 @@ class DataTypes():
 
         if output_dir is not None:
             self.output_name = output_dir + '/' + self.output_name
+
+    def close(self):
+        """
+        Close any files opened by this instance
+        """
+        [f.close() for f in self._opened]
 
 # _______________________________________________________________________________
     def build_product_name(self, filename):

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -113,7 +113,6 @@ class FileTable():
 # ________________________________________________________________________________
 # Loop over input list of files and assign fill in the MasterTable with filename
 # for the correct (channel-subchannel) or (grating-subchannel)
-
         for model in input_models:
             instrument = model.meta.instrument.name.upper()
             assign_wcs = model.meta.cal_step.assign_wcs
@@ -142,9 +141,6 @@ class FileTable():
             else:
                 log.info('Instrument not valid for cube')
                 pass
-
-            model.close()
-            del model
 
         return instrument
 


### PR DESCRIPTION
asdf previously had a bug where contents from a closed file could be accessed. See:
https://github.com/asdf-format/asdf/issues/1539

The cube build step was relying on this bug, closing models before the wcs was fully read (this is lazy loaded).

This commit prevents the early model closure. A unit test (using fake `nirspec` data) is added that replicates the issue and passes with the changes in this PR.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
