### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     target-branch: "master"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "zacharyburnett"
 
   # Maintain dependencies for pip
   - package-ecosystem: "pip"
@@ -14,3 +16,6 @@ updates:
     target-branch: "master"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "zacharyburnett"
+


### PR DESCRIPTION
This PR adds a dependabot configuration file which should also enable dependabot to run on this repo.

The configuration file contains sections to keep both github actions versions up-to-date and upper pins for python dependencies (via pip) up-to-date.

I don't have access to the repository settings and I'm not sure if dependabot is enabled there as I found one old PR for jwst from dependabot:
https://github.com/spacetelescope/jwst/pull/6092

However it appears that at least the github actions are not being checked as an older version (3) of the checkout action is in use:
https://github.com/spacetelescope/jwst/blob/5c5b968e3c192b051c431ee8d42702e1c22a80ed/.github/workflows/publish-to-pypi.yml#L12

For an example of what to expect from dependabot PRs, here is the PR for asdf opened by dependabot to update the checkout action in that repository:
https://github.com/asdf-format/asdf/pull/1639

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
