### PR TITLE
JP-3440: Revert change clobbering extra pixels near bad reference pixels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ general
 
 - Fix numpy 2.0 deprecation warnings in cube_build, photom and wfs_combine. [#7999]
 
+refpix
+------
+
+- Revert a change introduced in #7745, erroneously setting 2 detector columns near
+  bad reference pixels to zero. [#8005]
 
 1.12.3 (2023-10-03)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,11 @@
 1.12.5 (unreleased)
 ===================
 
-- 
+refpix
+------
 
+- Revert a change introduced in #7745, erroneously setting 2 detector columns near
+  bad reference pixels to zero. [#8005]
 1.12.4 (2023-10-12)
 ===================
 
@@ -18,12 +21,6 @@ general
 
 - Pinned dependencies for several in-development packages below their next versions
   to maintain compatibility. [#8003, #8006]
-
-refpix
-------
-
-- Revert a change introduced in #7745, erroneously setting 2 detector columns near
-  bad reference pixels to zero. [#8005]
 
 
 1.12.3 (2023-10-03)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ refpix
 
 - Revert a change introduced in #7745, erroneously setting 2 detector columns near
   bad reference pixels to zero. [#8005]
+
+
 1.12.4 (2023-10-12)
 ===================
 

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -344,9 +344,9 @@ def clobber_ref(data, output, odd_even, mask, scipix_n=16, refpix_r=4):
         for k in bits:
             ref = (offset + scipix_n // 2 + k * (scipix_n + refpix_r) +
                    2 * (odd_even_row - 1))
-            log.debug("bad interleaved reference at pixels {} through {}"
-                      .format(ref, ref + 4))
-            data[..., ref:ref + 4] = 0.
+            log.debug("bad interleaved reference at pixels {} {}"
+                      .format(ref, ref + 1))
+            data[..., ref:ref + 2] = 0.
 
 
 def decode_mask(output, mask):
@@ -489,7 +489,7 @@ def rm_intermittent_badpix(data, scipix_n, refpix_r, ovr_corr_mitigation_ftr):
         rp2replace.sort()
         rp2replace = np.unique(rp2replace)
         total_rp2replace.extend(rp2replace)
-        log.info('{} supicious bad reference pixels in amplifier {}'.format(len(rp2replace), k))
+        log.info('{} suspicious bad reference pixels in amplifier {}'.format(len(rp2replace), k))
 
         remaining_rp_even, remaining_rp_odd = [], []
         for rp in ref_pix:

--- a/jwst/refpix/tests/test_clobber_ref.py
+++ b/jwst/refpix/tests/test_clobber_ref.py
@@ -21,18 +21,18 @@ def test_clobber_ref():
     clobber_ref(data, output, odd_even, mask)
 
     compare = np.ones((2, 3, 5, 3200))
-    compare[..., 648: 648+4] = 0.
-    compare[..., 668: 668+4] = 0.
-    compare[..., 690: 690+4] = 0.
-    compare[..., 710: 710+4] = 0.
-    compare[..., 1890: 1890+4] = 0.
-    compare[..., 1910: 1910+4] = 0.
-    compare[..., 1808: 1808+4] = 0.
-    compare[..., 1828: 1828+4] = 0.
-    compare[..., 2028: 2028+4] = 0.
-    compare[..., 2068: 2068+4] = 0.
-    compare[..., 2150: 2150+4] = 0.
-    compare[..., 2190: 2190+4] = 0.
+    compare[..., 648: 648+2] = 0.
+    compare[..., 668: 668+2] = 0.
+    compare[..., 690: 690+2] = 0.
+    compare[..., 710: 710+2] = 0.
+    compare[..., 1890: 1890+2] = 0.
+    compare[..., 1910: 1910+2] = 0.
+    compare[..., 1808: 1808+2] = 0.
+    compare[..., 1828: 1828+2] = 0.
+    compare[..., 2028: 2028+2] = 0.
+    compare[..., 2068: 2068+2] = 0.
+    compare[..., 2150: 2150+2] = 0.
+    compare[..., 2190: 2190+2] = 0.
 
     assert np.allclose(data, compare)
 


### PR DESCRIPTION
Resolves [JP-3440](https://jira.stsci.edu/browse/JP-3440)

Closes https://github.com/spacetelescope/jwst/issues/8008

<!-- describe the changes comprising this PR here -->
This PR reverts a change associated with JP-3321, PR 7745, setting two additional detector columns next to bad reference pixels to zero.  Depending on the bad reference pixel location, the additional columns set to zero might have been adjacent interleaved reference pixels, or might have been science data.  If science data, the effect is clear in the rate files: the affected data appear as bad rows with near-zero values.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
