### PR TITLE
allow for slow github mac runners

### DIFF
--- a/jwst/jump/tests/test_detect_jumps.py
+++ b/jwst/jump/tests/test_detect_jumps.py
@@ -7,6 +7,8 @@ from stdatamodels.jwst.datamodels import GainModel, ReadnoiseModel, RampModel, d
 from jwst.jump.jump import run_detect_jumps
 import multiprocessing
 
+import os
+import platform
 import time
 import random
 
@@ -28,13 +30,19 @@ def test_exec_time_0_crs(setup_inputs):
                                        nints=2, readnoise=6.5, gain=5.5,
                                        grouptime=2.775, deltatime=2.775)
 
-    tstart = time.time()
+    tstart = time.monotonic()
     # using dummy variable in next to prevent "F841-variable is assigned to but never used"
     _ = run_detect_jumps(model, gain, rnoise, 4.0, 5.0, 6.0, 'none', 200, 4, True)
-    tstop = time.time()
+    tstop = time.monotonic()
 
     t_elapsed = tstop - tstart
-    MAX_TIME = 10  # takes 1.6 sec on my Mac
+    if platform.system() == 'Darwin' and os.environ.get('CI', False):
+        # github mac runners have known performance issues see:
+        # https://github.com/actions/runner-images/issues/1336
+        # use a longer MAX_TIME when running on github on a mac
+        MAX_TIME = 20
+    else:
+        MAX_TIME = 10  # takes 1.6 sec on my Mac
 
     assert t_elapsed < MAX_TIME
 


### PR DESCRIPTION
As seen in the CI run for a recent PR (and for others at seemingly random times):
https://github.com/spacetelescope/jwst/actions/runs/6562032419/job/17823126182?pr=8010#step:10:182

the `test_exec_time_0_crs` test fails due to a seemingly slow github mac runner:
```
>       assert t_elapsed < MAX_TIME
E       assert 18.11580204963684 < 10
```

This PR updates the test to:
- use [time.monotonic](https://docs.python.org/3/library/time.html#time.monotonic)
- increase the threshold to 60 seconds for mac osx runners on github (which sets the `CI` environment variable)

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
