### PR TITLE
update SourceCatalog meta data handling for new photutils changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,11 @@ resample
   results in modified values in the resampled images. New computations
   significantly reduce photometric errors. [#7894]
 
+source_catalog
+--------------
+
+- Update meta data for compatibility with photutils changes [#8014]
+
 tweakreg
 --------
 

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -239,8 +239,7 @@ class JWSTSourceCatalog:
         # so copy over the new 'versions' into 'version' and remove 'versions'
         # to stay consistent with the old behavior that this code expects
         if 'versions' in segm_cat.meta:
-            segm_cat.meta['version'] = segm_cat.meta['versions']
-            del segm_cat.meta['versions']
+            segm_cat.meta['version'] = segm_cat.meta.pop('versions')
 
         self.meta.update(segm_cat.meta)
         for key in ('sklearn', 'matplotlib'):

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -235,6 +235,13 @@ class JWSTSourceCatalog:
         self._xpeak = segm_cat.maxval_xindex
         self._ypeak = segm_cat.maxval_yindex
 
+        # newer versions of photutils use 'versions' instead of 'version'
+        # so copy over the new 'versions' into 'version' and remove 'versions'
+        # to stay consistent with the old behavior that this code expects
+        if 'versions' in segm_cat.meta:
+            segm_cat.meta['version'] = segm_cat.meta['versions']
+            del segm_cat.meta['versions']
+
         self.meta.update(segm_cat.meta)
         for key in ('sklearn', 'matplotlib'):
             self.meta['version'].pop(key)


### PR DESCRIPTION
The development version of photutils updated what is contained in the `SourceCatalog` meta data. One specific change that is impacting jwst is changing `version` to `versions` in the `meta`.
https://github.com/astropy/photutils/pull/1640

This is causing devdeps failures:
https://github.com/spacetelescope/jwst/actions/runs/6562032419/job/17823126866?pr=8010#step:10:339

This PR updates `set_segment_properties` to reproduce `version` from the new `versions` key in the `SourceCatalog` `meta`.

Regression tests (with released version of photutils) running at: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1048/

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
