### PR TITLE
increase asdf upper pin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.12.6 (unreleased)
+===================
+
+general
+-------
+
+- Increase asdf maximum version to 4 [#8018]
+
 1.12.5 (2023-10-19)
 ===================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.9
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf>=2.15.1,<3
+    asdf>=2.15.1,<4
     asdf-transform-schemas>=0.3.0
     astropy>=5.3
     BayesicFitting>=3.0.1


### PR DESCRIPTION
asdf 3.0 is compatible with jwst and is released on pypi and conda forge

This PR increases the asdf upper pin to `4` as asdf follows semantic versioning and all `3.x` releases will be backwards compatible.

Regression tests run with no errors: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1014/

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
