### PR TITLE
limit regression test result search to jwst files

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -61,7 +61,7 @@ pytest_basetemp = "test_outputs"
 // Configure artifactory ingest
 data_config = new DataConfig()
 data_config.server_id = 'bytesalad'
-data_config.root = '${PYTEST_BASETEMP}'
+data_config.root = 'clone/${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
 

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -61,7 +61,7 @@ pytest_basetemp = "test_outputs"
 // Configure artifactory ingest
 data_config = new DataConfig()
 data_config.server_id = 'bytesalad'
-data_config.root = '${PYTEST_BASETEMP}'
+data_config.root = 'clone/${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
 


### PR DESCRIPTION
This PR updates the jenkins configuration files to limit what files are considered for uploading during the `Upload artifacts` step. The changes here are the same as those applied in this romancal PR:
https://github.com/spacetelescope/romancal/pull/950

If/when jwst adds `astroquery` (or `webbpsf` which depends on `astroquery`) the jenkins runs will fail on the `Upload artifacts` step due to searching files beyond those that are generated when attempting to upload test results to artifactory. This search will fail due to finding the [mission_results.json](https://github.com/astropy/astroquery/blob/5add2e3b0ff5b56630840a0f57196c19054f5c01/astroquery/mast/tests/data/mission_results.json#L5) file in the astroquery package.

This PR limits the files searched to those generated during the pytest run in the jenkins workflow.

Regression tests passed with no errors: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1015/

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
