### PR TITLE
use `--props` instead of `--build` in `okify_regtests`

### DIFF
--- a/jwst/scripts/okify_regtests.py
+++ b/jwst/scripts/okify_regtests.py
@@ -116,8 +116,8 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
     # Retrieve all the okify specfiles for failed tests.
     args = list(
         ['jfrog', 'rt', 'dl']
-        + [f'\'{ARTIFACTORY_REPO}/*/*{suffix}\'']
-        + [f'--props="build.number={build_number};build.name={build_name}"']
+        + [f'{ARTIFACTORY_REPO}/*/*{suffix}']
+        + [f'--props=build.number={build_number};build.name={build_name}']
         + ['--flat']
     )
     subprocess.run(args, check=True, capture_output=True)

--- a/jwst/scripts/okify_regtests.py
+++ b/jwst/scripts/okify_regtests.py
@@ -117,7 +117,7 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
     args = list(
         ['jfrog', 'rt', 'dl']
         + [f'{ARTIFACTORY_REPO}/*/*{suffix}']
-        + [f'--props=\'build.number={build_number};build.name={build_name}\'']
+        + [f'--props=build.number={build_number};build.name={build_name}']
         + ['--flat']
     )
     subprocess.run(args, check=True, capture_output=True)

--- a/jwst/scripts/okify_regtests.py
+++ b/jwst/scripts/okify_regtests.py
@@ -116,8 +116,8 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
     # Retrieve all the okify specfiles for failed tests.
     args = list(
         ['jfrog', 'rt', 'dl']
-        + [f'{ARTIFACTORY_REPO}/*/*{suffix}']
-        + [f'--build={build_name}/{build_number}']
+        + [f'\'{ARTIFACTORY_REPO}/*/*{suffix}\'']
+        + [f'--props="build.number={build_number};build.name={build_name}"']
         + ['--flat']
     )
     subprocess.run(args, check=True, capture_output=True)

--- a/jwst/scripts/okify_regtests.py
+++ b/jwst/scripts/okify_regtests.py
@@ -117,7 +117,7 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
     args = list(
         ['jfrog', 'rt', 'dl']
         + [f'{ARTIFACTORY_REPO}/*/*{suffix}']
-        + [f'--props=build.number={build_number};build.name={build_name}']
+        + [f'--props=\'build.number={build_number};build.name={build_name}\'']
         + ['--flat']
     )
     subprocess.run(args, check=True, capture_output=True)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR attempts to address an issue in `okify_regtests` where the Jfrog query crashes the server process with a 500 error.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
