### PR TITLE
Fix CI for `3.x` now using python 3.12 and add python 3.12 tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         - linux: py39-sdpdeps-xdist
         - linux: py310-xdist
         - linux: py311-xdist
+        - linux: py312-xdist
         - macos: py311-xdist
           pytest-results-summary: true
         - linux: py311-stdevdeps-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
   check:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
+      default_python: "3.11"
       envs: |
         - linux: check-style
         - linux: check-security


### PR DESCRIPTION
Github actions requesting python `3.x` (which is often the default for reusable workflows) now use python 3.12 instead of python 3.11. This is impacting the `check` jobs:
https://github.com/spacetelescope/jwst/blob/59c853ce59cd4eade004a3aa90cdcc84d4c9e661/.github/workflows/ci.yml#L47-L53

This PR updates the reusable workflow defining a `default_python` of 3.11.

Additionally, this PR adds a python 3.12 run to the CI (which is expected to fail in part because of the current scipy pin):
https://github.com/spacetelescope/jwst/blob/59c853ce59cd4eade004a3aa90cdcc84d4c9e661/setup.cfg#L44
https://github.com/spacetelescope/jwst/pull/8033 is a start at testing if removing the pin is problematic.

As this PR only modifies github actions configuration regression tests were not run.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
