### PR TITLE
JP-3451: Include zero-valued pixels in difference calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.12.6 (unreleased)
 ===================
 
+extract_1d
+----------
+
+- Include zero values in dispersion direction check during
+  SOSS ATOCA algorithm [#8038]
+
 general
 -------
 

--- a/jwst/extract_1d/soss_extract/atoca_utils.py
+++ b/jwst/extract_1d/soss_extract/atoca_utils.py
@@ -228,7 +228,7 @@ def get_wv_map_bounds(wave_map, dispersion_axis=1):
 
         # Compute the change in wavelength for valid cols
         idx_valid = np.isfinite(wave_col)
-        idx_valid &= (wave_col > 0)
+        idx_valid &= (wave_col >= 0)
         wv_col_valid = wave_col[idx_valid]
         delta_wave = np.diff(wv_col_valid)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3451](https://jira.stsci.edu/browse/JP-3451)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8037 

<!-- describe the changes comprising this PR here -->
This PR addresses regression test errors for NIRISS SOSS after a recent delivery of updated reference files. This fix allows the difference calculation inside the bad dispersion direction method to see zero-valued pixels, which will allow it to overwrite them before throwing an error.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
