### PR TITLE
drop python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
         - linux: py39-sdpdeps-xdist
         - linux: py310-xdist
         - linux: py311-xdist
-        - linux: py312-xdist
         - macos: py311-xdist
           pytest-results-summary: true
         - linux: py311-stdevdeps-xdist

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 general
 -------
 
+- Add lack of python 3.12 support to project metadata [#8042]
+
 - Increase asdf maximum version to 4 [#8018]
 
 1.12.5 (2023-10-19)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,10 +20,12 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 zip_safe = False
-python_requires = >=3.9
+python_requires = >=3.9,<3.12
 setup_requires =
     setuptools_scm
 install_requires =


### PR DESCRIPTION
jwst cannot yet support python 3.12 due to an upper pin on scipy:
https://github.com/spacetelescope/jwst/blob/7f1c5cadabd8890aa535116ba46592a44ea7b662/setup.cfg#L44

This is proving problematic to remove in part due to different output from `scipy.signal.medfilt` (see: https://github.com/spacetelescope/jwst/pull/8033).

This PR removes python 3.12 support and the consistently failing python 3.12 CI job (which fails to install and produces no additional useful output) to make reviewing other changes easier.

A follow-up PR (possibly #8033) will add python 3.12 support. If this PR is approved and merged a tracking issue will be opened for adding python 3.12 support.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
