### PR TITLE
replace utcnow to avoid deprecation warnings in python 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ outlier_detection
 - Remove use of ``scipy.signal.medfilt`` which is undefined for ``nan``
   inputs. [#8033]
 
+- Replace uses of ``datetime.utcnow`` (deprecated in python 3.12) [#8051]
+
 imprint
 -------
 

--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -1,6 +1,6 @@
 from collections.abc import MutableMapping
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import jsonschema
 import logging
@@ -564,7 +564,7 @@ def finalize(asns):
 
 
 def make_timestamp():
-    timestamp = datetime.utcnow().strftime(
+    timestamp = datetime.now(timezone.utc).strftime(
         _TIMESTAMP_TEMPLATE
     )
     return timestamp

--- a/jwst/scripts/migrate_data.py
+++ b/jwst/scripts/migrate_data.py
@@ -4,7 +4,7 @@
 Migrate .fits files whose format has changed between jwst package versions.
 """
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import re
 import traceback
@@ -166,7 +166,8 @@ def migrate_file(filename, args):
             return
 
         migrate_method(hdul)
-        hdul[0].header['HISTORY'] = f'Migrated with jwst {jwst.__version__} migrate_data script {datetime.utcnow().isoformat()}'
+        timestamp = datetime.now(timezone.utc).isoformat()
+        hdul[0].header['HISTORY'] = f'Migrated with jwst {jwst.__version__} migrate_data script {timestamp}'
 
         try:
             getattr(datamodels, model_type)(hdul, strict_validation=True)

--- a/jwst/stpipe/tests/test_config.py
+++ b/jwst/stpipe/tests/test_config.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import asdf
@@ -56,7 +56,8 @@ def test_step_config_to_asdf(config):
     assert asdf_file["parameters"] == config.parameters
     assert asdf_file["steps"] == [s.to_asdf().tree for s in config.steps]
     assert asdf_file["meta"]["author"] == "<SPECIFY>"
-    assert (datetime.utcnow() - datetime.fromisoformat(asdf_file["meta"]["date"])) < timedelta(seconds=10)
+    current_time = datetime.now(timezone.utc).replace(tzinfo=None)
+    assert (current_time - datetime.fromisoformat(asdf_file["meta"]["date"])) < timedelta(seconds=10)
     assert asdf_file["meta"]["description"] == "Parameters for calibration step some.PipelineClass"
     assert asdf_file["meta"]["instrument"]["name"] == "<SPECIFY>"
     assert asdf_file["meta"]["origin"] == "<SPECIFY>"


### PR DESCRIPTION
The PR replaces uses of `utcnow` to avoid `DeprecationWarning` messages seen in python 3.12:
```
   /home/runner/work/jwst/jwst/jwst/associations/association.py:567: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    timestamp = datetime.utcnow().strftime(
```
See this run log for more details:
https://github.com/spacetelescope/jwst/actions/runs/6723984874/job/18275278424?pr=8033

Regression tests running at: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1059/

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
