### PR TITLE
Numpy 2.0 compat: signed/unsigned conversion in context and mask utilities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ resample
   results in modified values in the resampled images. New computations
   significantly reduce photometric errors. [#7894]
 
+- Improved compatibility with upcoming ``numpy 2.0`` that was affecting
+  decoding of context images and creation of masks. [#8059]
+
 tweakreg
 --------
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -295,17 +295,13 @@ def decode_context(context, x, y):
         raise ValueError('Pixel coordinates must be integer values')
 
     nbits = 8 * context.dtype.itemsize
-    utype = np.dtype(context.dtype.str.replace('i', 'u')).type
+    one = np.array(1, context.dtype)
+    flags = np.array([one << i for i in range(nbits)])
 
     idx = []
     for xi, yi in zip(x, y):
         idx.append(
-            np.flatnonzero(
-                [
-                    v & utype(1 << k) for v in context[:, yi, xi]
-                    for k in range(nbits)
-                ]
-            )
+            np.flatnonzero(np.bitwise_and.outer(context[:, yi, xi], flags))
         )
 
     return idx

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -214,6 +214,8 @@ def build_mask(dqarr, bitvalue):
 
     if bitvalue is None:
         return np.ones(dqarr.shape, dtype=np.uint8)
+
+    bitvalue = np.array(bitvalue).astype(dqarr.dtype)
     return np.logical_not(np.bitwise_and(dqarr, ~bitvalue)).astype(np.uint8)
 
 
@@ -293,12 +295,16 @@ def decode_context(context, x, y):
         raise ValueError('Pixel coordinates must be integer values')
 
     nbits = 8 * context.dtype.itemsize
+    utype = np.dtype(context.dtype.str.replace('i', 'u')).type
 
     idx = []
     for xi, yi in zip(x, y):
         idx.append(
             np.flatnonzero(
-                [v & (1 << k) for v in context[:, yi, xi] for k in range(nbits)]
+                [
+                    v & utype(1 << k) for v in context[:, yi, xi]
+                    for k in range(nbits)
+                ]
             )
         )
 


### PR DESCRIPTION
Resolves [JP-3457](https://jira.stsci.edu/browse/JP-3457)

Numpy 2.0 now raises exceptions when values do not fit in the min/max range for the destination type (i.e., converting Python's `-1` `int` to `np.uint32`).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
