### PR TITLE
Changes to the PHOTOM step for the MIRI imager/coronograph

### DIFF
--- a/jwst/photom/miri_imager.py
+++ b/jwst/photom/miri_imager.py
@@ -1,0 +1,34 @@
+import logging
+import numpy as np
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+# Routine to find a time-dependent correction to the PHOTOM value.
+
+def time_corr_photom(param, t):
+    """
+    Short Summary
+    --------------
+    Time dependent PHOTOM function.
+
+    The model parameters are amplitude, tau, t0. t0 is the reference day 
+    from which the time-dependent parameters were derived. This function will return 
+    a correction to apply to the PHOTOM value at a given MJD.
+
+    Parameters
+    ----------
+    param : numpy array
+            Set of parameters for the PHOTOM value
+    t : int
+        Modified Julian Day (MJD) of the observation
+
+    Returns
+    -------
+    The time-dependent correction to the photmjsr term.
+    """
+    
+    amplitude, tau, t0 = param["amplitude"], param["tau"], param["t0"]
+    corr = amplitude * np.exp(-(t - t0)/tau)
+
+    return corr


### PR DESCRIPTION
Related to [JP-3455](https://jira.stsci.edu/browse/JP-3455)

This PR is related to proposed changes to the PHOTOM step for the MIRI Imager (and coronographs). We add a time-dependent correction to the PHOTOM value.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
