### PR TITLE
Make meta data flexible for photutils changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,11 @@ resample
 - Improved compatibility with upcoming ``numpy 2.0`` that was affecting
   decoding of context images and creation of masks. [#8059]
 
+source_catalog
+--------------
+
+- Made meta data flexible for photutils changes. [#8066]
+
 tweakreg
 --------
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR makes the source catalog meta data flexible for planned changes of the version key name in `photutils`.  Note that I reverted the key name change in `photutils` (https://github.com/astropy/photutils/pull/1652) so that it does not affect the pipeline.  However, I will re-apply it for the the 1.11.0 release.

I did not add a changelog entry because this is not a user-facing change.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
