### PR TITLE
JP-3426: Check WFSS background mask against input dq array

### DIFF
--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -295,7 +295,9 @@ def subtract_wfss_bkg(input_model, bkg_filename, wl_range_name, mmag_extract=Non
     # i.e. in regions we can use as background.
     if got_catalog:
         bkg_mask = mask_from_source_cat(input_model, wl_range_name, mmag_extract)
-        if bkg_mask.sum() < 100:
+        # Ensure mask has 100 pixels and that those pixels correspond to valid
+        # pixels using model DQ array
+        if bkg_mask.sum() < 100 or sum(input_model.dq[bkg_mask] % 2 ^ 1) < 100:
             log.warning("Not enough background pixels to work with.")
             log.warning("Step will be SKIPPED.")
             return None


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3426](https://jira.stsci.edu/browse/JP-3426)

<!-- describe the changes comprising this PR here -->
This PR addresses errors seen in operations processing of a WFSS program - the background subtraction step generates a mask by excluding pixels deemed to have source flux using bounding boxes. In the case of the problematic dataset, the only pixels remaining after source exclusion is the 4-pixel wide boundary corresponding to reference pixels. This PR adds an additional check by masking the input model DQ array and ensuring the remaining pixels do not have DO_NOT_USE flagged.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
