### PR TITLE
JP-3466 Remove the CRDS PUB notices througout the documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.12.6 (unreleased)
 ===================
 
+documentation
+-------------
+
+- Remove the CRDS PUB notices througout the documentation [#8075]
+
 extract_1d
 ----------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,12 +8,6 @@
    :width: 400
    :align: center
 
-.. warning::
-
-   As of November 10, 2022, the process of deprecating the CRDS PUB Server will start.
-
-   For details, refer to the :ref:`pub-deprecation` page.
-
 Welcome to the documentation for `jwst`. This package contains the Python
 software suite for the James Webb Space Telescope (JWST) calibration pipeline,
 which processes data from all JWST instruments by applying various corrections to

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,6 @@ desk at `JWST Help Desk <https://jwsthelp.stsci.edu>`_.
 
    jwst/user_documentation/introduction.rst
    jwst/user_documentation/reference_files_crds.rst
-   jwst/user_documentation/pub_deprecation.rst
    jwst/user_documentation/parameters.rst
    jwst/user_documentation/running_pipeline_python.rst
    jwst/user_documentation/running_pipeline_command_line.rst
@@ -48,6 +47,7 @@ desk at `JWST Help Desk <https://jwsthelp.stsci.edu>`_.
    jwst/user_documentation/input_output_file_conventions.rst
    jwst/user_documentation/logging_configuration.rst
    jwst/user_documentation/datamodels.rst
+   jwst/user_documentation/pub_deprecation.rst
 
 .. toctree::
    :maxdepth: 2

--- a/docs/jwst/user_documentation/reference_files_crds.rst
+++ b/docs/jwst/user_documentation/reference_files_crds.rst
@@ -9,12 +9,6 @@ The JWST pipeline uses version-controlled :ref:`reference files <crds_reference_
 and set pipeline/step parameters, respectivley. These files both use the ASDF format,
 and are managed by the Calibration References Data System (:ref:`CRDS <crds>`) system.
 
-.. warning::
-
-   As of November 10, 2022, the process of deprecating the CRDS PUB Server will start.
-
-   For details, refer to the :ref:`pub-deprecation` page.
-
 .. _crds_reference_files:
 
 Reference Files


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3466](https://jira.stsci.edu/browse/JP-3466)

<!-- describe the changes comprising this PR here -->
This PR removes all the in-line notifications about the CRDS PUB server. The server has not been available for over a year; there is no more reason for the in-your-face notifications.

However, for historical and the one potential user that may still have used it, the notification notice itself has been left in the index, though moved to the last position.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- ~updated or added relevant tests~
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
