### PR TITLE
JP-3469: Replace nanmedian with masked array median in ifu_autocen

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ extract_1d
 - Include zero values in dispersion direction check during
   SOSS ATOCA algorithm [#8038]
 
+- Use masked median instead of nanmedian wavelength collapse during
+  source finding for ifu_autocen [#8080]
+
 general
 -------
 

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -504,7 +504,7 @@ def extract_ifu(input_model, source_type, extract_params):
         # If ifu_autocen is set, try to find the source in the field using DAOphot
         if extract_params['ifu_autocen'] is True:
             log.info('Using auto source detection.')
-            collapse = np.nanmedian(data, axis=0)
+            collapse = np.ma.median(np.ma.masked_invalid(data), axis=0)
             # Sigma-clipped stats on collapsed image
             _, clipmed, cliprms = sigclip(collapse)
             # Find source in the collapsed image above 3 sigma


### PR DESCRIPTION
Resolves [JP-3469](https://jira.stsci.edu/browse/JP-3469) by replacing a nanmedian calculation with a numpy masked median calculation.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
