### PR TITLE
JP-3223: Extract_2d 'slit_name' parameter fails for NRS_MSASPEC slits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,13 @@ extract_1d
 - Include zero values in dispersion direction check during
   SOSS ATOCA algorithm [#8038]
 
+extract_2d
+----------
+
+- Fixed crash with slit_name for MOS. Now the argument should
+  be passed as a string, e.g. slit_name='67'. Included this
+  in the corresponding documentation. [#8081]
+
 general
 -------
 

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -49,7 +49,8 @@ to extract all slits that project onto the detector. A single slit may be extrac
 specifying the slit name with the ``slit_name`` argument. In the case of a NIRSpec
 fixed-slit exposure the allowed slit names are: "S1600A1", "S200A1", "S200A2", "S200B1"
 and "S400A1". For NIRSpec MOS exposures, the slit name is the slitlet number from the
-MSA metadata file, corresponding to the value of the "SLTNAME" keyword in FITS products.
+MSA metadata file, corresponding to the value of the "SLTNAME" keyword in FITS products,
+and it has to be provided as a string, e.g. slit_name='60'.
 
 To find out what slits are available for extraction:
 

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -45,15 +45,18 @@ def nrs_extract2d(input_model, slit_name=None):
     # This model keeps open_slits as an attribute.
     open_slits = slit2msa.slits[:]
     if slit_name is not None:
+        new_open_slits = []
         if not isinstance(slit_name, str):
             slit_name = str(slit_name)
-        #open_slits = [sub for sub in open_slits if sub.name == slit_name]
-        open_slits = []
         for sub in open_slits:
             if not isinstance(sub.name, str):
                 str_subnme = str(sub.name)
             if str_subnme == slit_name:
-                open_slits.append(sub.name)
+                new_open_slits.append(sub)
+                break
+        if len(new_open_slits) == 0:
+            raise AttributeError("Slit {} not in open slits.".format(slit_name))
+        open_slits = new_open_slits
 
     # NIRSpec BRIGHTOBJ (S1600A1 TSO) mode
     if exp_type == 'NRS_BRIGHTOBJ':

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -45,7 +45,15 @@ def nrs_extract2d(input_model, slit_name=None):
     # This model keeps open_slits as an attribute.
     open_slits = slit2msa.slits[:]
     if slit_name is not None:
-        open_slits = [sub for sub in open_slits if sub.name == slit_name]
+        if not isinstance(slit_name, str):
+            slit_name = str(slit_name)
+        #open_slits = [sub for sub in open_slits if sub.name == slit_name]
+        open_slits = []
+        for sub in open_slits:
+            if not isinstance(sub.name, str):
+                str_subnme = str(sub.name)
+            if str_subnme == slit_name:
+                open_slits.append(sub.name)
 
     # NIRSpec BRIGHTOBJ (S1600A1 TSO) mode
     if exp_type == 'NRS_BRIGHTOBJ':


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3223](https://jira.stsci.edu/browse/JP-3223)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7865

<!-- describe the changes comprising this PR here -->
This PR addresses a crash of Spec2 when the parameter slit_name was provided as integer for MOS data. The pipeline now expects a string for this value, and the extract_2d code will make the corresponding value type conversions to make sure that both values in the comparison are the same type. 
The documentation was modified to explain that for MOS data the value is expected as a string, e.g. slit_name='67'

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
