### PR TITLE
add `erfa` and `drizzle` to devdeps tests

### DIFF
--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches:
       - master
+    types:
+      - synchronize
+      - labeled
   schedule:
     # Weekly Monday 9AM build
     - cron: "0 9 * * 1"

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -312,6 +312,7 @@ class OutlierDetection:
                 median_image[row1:row2] = np.nanmedian(resampled_sci, axis=0)
             del resampled_sci, resampled_weight
 
+        breakpoint()
         return median_image
 
     def blot_median(self, median_model):

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -312,7 +312,6 @@ class OutlierDetection:
                 median_image[row1:row2] = np.nanmedian(resampled_sci, axis=0)
             del resampled_sci, resampled_weight
 
-        breakpoint()
         return median_image
 
     def blot_median(self, median_model):

--- a/requirements-dev-st.txt
+++ b/requirements-dev-st.txt
@@ -10,4 +10,4 @@ git+https://github.com/spacetelescope/crds
 git+https://github.com/spacetelescope/gwcs
 git+https://github.com/spacetelescope/tweakwcs
 git+https://github.com/spacetelescope/wiimatch
-git+https://github.com/spacetelescope/drizzle
+git+https://github.com/braingram/drizzle.git@np2

--- a/requirements-dev-st.txt
+++ b/requirements-dev-st.txt
@@ -10,3 +10,4 @@ git+https://github.com/spacetelescope/crds
 git+https://github.com/spacetelescope/gwcs
 git+https://github.com/spacetelescope/tweakwcs
 git+https://github.com/spacetelescope/wiimatch
+git+https://github.com/spacetelescope/drizzle

--- a/requirements-dev-thirdparty.txt
+++ b/requirements-dev-thirdparty.txt
@@ -15,3 +15,5 @@ git+https://github.com/astropy/photutils
 --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 numpy>=0.0.dev0
 scipy>=0.0.dev0
+contourpy>=0.0.dev0
+matplotlib>=0.0.dev0

--- a/requirements-dev-thirdparty.txt
+++ b/requirements-dev-thirdparty.txt
@@ -9,6 +9,7 @@ git+https://github.com/asdf-format/asdf-wcs-schemas
 git+https://github.com/astropy/asdf-astropy
 git+https://github.com/astropy/photutils
 --extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
+--extra-index-url https://pypi.anaconda.org/liberfa/simple erfa --pre
 
 # Use Bi-weekly numpy/scipy dev builds
 --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple

--- a/requirements-dev-thirdparty.txt
+++ b/requirements-dev-thirdparty.txt
@@ -17,3 +17,6 @@ numpy>=0.0.dev0
 scipy>=0.0.dev0
 contourpy>=0.0.dev0
 matplotlib>=0.0.dev0
+
+# add drizzle as well so it gets compiled with numpy 2.0
+git+https://github.com/braingram/drizzle.git@np2

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands_pre =
     sdpdeps: pip install -r requirements-sdp.txt
     pip freeze
 commands =
-    pytest \
+    pytest -v \
     cov: --cov . --cov-report xml --cov-report term-missing \
     warnings: -W error \
     regtests: --bigdata --slow --basetemp={homedir}/test_outputs \


### PR DESCRIPTION
The changes in this PR allowed the devdeps job to run with the dev version of numpy (currently 2.1.0.dev0):
https://github.com/spacetelescope/jwst/actions/runs/8513247164/job/23316561517?pr=8094#step:10:285
However, there are a few failures and the run never finished (it stalled after 6 hours).

I see no mention of `test_outlier_step_no_outliers` in the logs (with pytest run with `-v`) or any test in `test_outlier_detection.py` which might suggest something is up with outlier_detection with dev numpy.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
