### PR TITLE
Remove the use of `pkg_resources`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ htmlcov
 requirements-min.txt
 .tox/
 .tmp/
+jwst/_version.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ general
 
 - Remove upper version limit for scipy. [#8033]
 
+- Remove the use of ``pkg_resources`` by ``jwst``. [#8095]
+
 outlier_detection
 -----------------
 

--- a/jwst/__init__.py
+++ b/jwst/__init__.py
@@ -1,19 +1,12 @@
 import re
-import sys
-from pkg_resources import get_distribution, DistributionNotFound
 
-__version_commit__ = ''
-_regex_git_hash = re.compile(r'.*\+g(\w+)')
+from importlib.metadata import version
 
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    __version__ = 'dev'
+__version__ = version(__name__)
 
-if '+' in __version__:
+_regex_git_hash = re.compile(r".*\+g(\w+)")
+__version__commit__ = ""
+if "+" in __version__:
     commit = _regex_git_hash.match(__version__).groups()
     if commit:
         __version_commit__ = commit[0]
-
-if sys.version_info < (3, 9):
-    raise ImportError("JWST requires Python 3.9 and above.")

--- a/jwst/associations/pool.py
+++ b/jwst/associations/pool.py
@@ -1,9 +1,6 @@
 """
 Association Pools
 """
-
-from pkg_resources import parse_version, get_distribution
-
 from collections import UserDict
 
 from astropy.io.ascii import convert_numpy
@@ -134,15 +131,4 @@ def _convert_to_str():
     return [(convert_func, type_)]
 
 
-class _ConvertToStr(dict):
-    def __getitem__(self, k):
-        return _convert_to_str()
-
-    def get(self, k, default=None):
-        return self.__getitem__(k)
-
-
-if parse_version(get_distribution('astropy').version) >= parse_version('5.0.dev'):
-    convert_to_str = {'*': _convert_to_str()}
-else:
-    convert_to_str = _ConvertToStr()
+convert_to_str = {'*': _convert_to_str()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+write_to = "jwst/_version.py"
 
 [tool.ruff]
 line-length = 130


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Currently, JWST makes use of the long deprecated (since python 3.3) module `pkg_resources`. This module was officially removed for Python 3.12+ by python/cpython#98040. This PR removes all remaining uses of `pkg_resources` from JWST, replacing the version generation with `setuptools_scm` generating a hidden python file during install, which is the standard practice for using a git tag/commit versioned python project now.
 
**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
