### PR TITLE
JP-3455: Updated MIRI imager photom step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,7 +60,7 @@ imprint
 photom
 --------
 
-- Added time-dependent correction for MIRI Imager data [#, spacetelescope/stdatamodels#235]
+- Added time-dependent correction for MIRI Imager data [#8096, spacetelescope/stdatamodels#235]
 
 ramp_fitting
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,11 @@ imprint
 - Updated the logging to report which imprint image is being subtracted from the
   science image. [#8041]
 
+photom
+--------
+
+- Added time-dependent correction for MIRI Imager data [#, spacetelescope/stdatamodels#235]
+
 ramp_fitting
 ------------
 

--- a/jwst/photom/miri_imager.py
+++ b/jwst/photom/miri_imager.py
@@ -1,0 +1,34 @@
+import logging
+import numpy as np
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+# Routine to find a time-dependent correction to the PHOTOM value.
+
+def time_corr_photom(param, t):
+    """
+    Short Summary
+    --------------
+    Time dependent PHOTOM function.
+
+    The model parameters are amplitude, tau, t0. t0 is the reference day 
+    from which the time-dependent parameters were derived. This function will return 
+    a correction to apply to the PHOTOM value at a given MJD.
+
+    Parameters
+    ----------
+    param : numpy array
+            Set of parameters for the PHOTOM value
+    t : int
+        Modified Julian Day (MJD) of the observation
+
+    Returns
+    -------
+    The time-dependent correction to the photmjsr term.
+    """
+    
+    amplitude, tau, t0 = param["amplitude"], param["tau"], param["t0"]
+    corr = amplitude * np.exp(-(t - t0)/tau)
+
+    return corr

--- a/jwst/photom/miri_imager.py
+++ b/jwst/photom/miri_imager.py
@@ -19,13 +19,14 @@ def time_corr_photom(param, t):
     Parameters
     ----------
     param : numpy array
-            Set of parameters for the PHOTOM value
+        Set of parameters for the PHOTOM value
     t : int
         Modified Julian Day (MJD) of the observation
 
     Returns
     -------
-    The time-dependent correction to the photmjsr term.
+    corr: float
+        The time-dependent correction to the photmjsr term.
     """
     
     amplitude, tau, t0 = param["amplitude"], param["tau"], param["t0"]

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -11,7 +11,6 @@ from stdatamodels.jwst.datamodels import dqflags
 from .. lib.wcs_utils import get_wavelengths
 from . import miri_mrs
 from . import miri_imager
-from jwst.datamodels import MirImgPhotomModel
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -489,7 +488,7 @@ class DataSet():
                         ("uncertainty", "<f4")
                         ],
                 )
-                fftab = MirImgPhotomModel(phot_table=data)
+                fftab = datamodels.MirImgPhotomModel(phot_table=data)
                 self.photom_io(fftab.phot_table[0])
             except AttributeError:
                 # No time-dependent correction is applied

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -491,7 +491,7 @@ class DataSet():
                 )
                 fftab = MirImgPhotomModel(phot_table=data)
                 self.photom_io(fftab.phot_table[0])
-            except:
+            except AttributeError:
                 # No time-dependent correction is applied
                 log.info(" Skipping MIRI imager time correction. Extension not found in the reference file.")
                 self.photom_io(ftab.phot_table[row])


### PR DESCRIPTION
Resolves [JP-3455](https://jira.stsci.edu/browse/JP-3455)

Closes #8048 

This PR is related to proposed changes to the PHOTOM step for the MIRI Imager (and coronographs). We add a time-dependent correction to the PHOTOM value.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
