### PR TITLE
JP-3357: Pathloss: Implement NIRSPEC MSA correction for slits that aren't 1x1 or 1x3

### DIFF
--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -96,20 +96,24 @@ def get_center(exp_type, input, offsets=False):
         log.warning(f'No method to get centering for exp_type {exp_type}')
         log.warning("Using (0.0, 0.0)")
         return 0.0, 0.0
+
+
 def shutter_above_is_closed(shutter_state):
-    reference_location = shutter_state.find('x')
+    ref_loc = shutter_state.find('x')
     nshutters = len(shutter_state)
-    if reference_location == nshutters - 1 or shutter_state[reference_location + 1] == '0':
+    if ref_loc == nshutters - 1 or shutter_state[ref_loc + 1] == '0':
         return True
     else:
         return False
 
+
 def shutter_below_is_closed(shutter_state):
-    reference_location = shutter_state.find('x')
-    if reference_location == 0 or shutter_state[reference_location - 1] == '0':
+    ref_loc = shutter_state.find('x')
+    if ref_loc == 0 or shutter_state[ref_loc - 1] == '0':
         return True
     else:
         return False
+
 
 def get_aperture_from_model(input_model, match):
     """Figure out the correct aperture based on the value of the 'match'
@@ -773,7 +777,6 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
         # for the source position
         # Get the aperture from the reference file that matches the slit
         slitlength = len(slit.shutter_state)
-        openshutters = util.get_num_msa_open_shutters(slit.shutter_state)
         aperture = get_aperture_from_model(pathloss, slit.shutter_state)
         log.info(f"Shutter state = {slit.shutter_state}, using {aperture.name} entry in ref file")
         if shutter_below_is_closed(slit.shutter_state) and not shutter_above_is_closed(slit.shutter_state):

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -260,20 +260,21 @@ def calculate_pathloss_vector(pathloss_refdata,
 
         return wavelength, pathloss_vector, is_inside_slitlet
 
+
 def calculate_two_shutter_uniform_pathloss(pathloss_model):
     """The two shutter MOS case for uniform source calculation requires a custom
      routine since it uses both the 1X1 and 1X3 extensions of the pathloss reference file
-      
+
     Parameters
      ---------
         pathloss_model : pathloss datamodel
 
         The pathloss datamodel
-    
+
     Returns
     -------
         (wavelength, pathloss_vector) : tuple of 2 1-d numpy arrays
-        
+
         The wavelength and pathloss 1-d arrays
 
     """
@@ -314,7 +315,7 @@ def calculate_two_shutter_uniform_pathloss(pathloss_model):
         wavelength[i] = crval1 + (float(i + 1) - crpix1) * cdelt1
     average_pathloss = 0.5 * (pathloss1x1 + pathloss1x3)
     return (wavelength, average_pathloss)
-    
+
 
 def do_correction(input_model, pathloss_model=None, inverse=False, source_type=None,
                   correction_pars=None, user_slit_loc=None):
@@ -856,8 +857,8 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
                 (wavelength_uniformsource,
                  pathloss_uniform_vector,
                  dummy) = calculate_pathloss_vector(aperture.uniform_data,
-                                                aperture.uniform_wcs,
-                                                xcenter, ycenter)
+                                                    aperture.uniform_wcs,
+                                                    xcenter, ycenter)
             # This should only happen if the 2 shutter uniform pathloss calculation has an error
             if wavelength_uniformsource is None or pathloss_uniform_vector is None:
                 log.warning("Unable to calculate 2 shutter uniform pathloss, using 3 shutter aperture")

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -260,6 +260,61 @@ def calculate_pathloss_vector(pathloss_refdata,
 
         return wavelength, pathloss_vector, is_inside_slitlet
 
+def calculate_two_shutter_uniform_pathloss(pathloss_model):
+    """The two shutter MOS case for uniform source calculation requires a custom
+     routine since it uses both the 1X1 and 1X3 extensions of the pathloss reference file
+      
+    Parameters
+     ---------
+        pathloss_model : pathloss datamodel
+
+        The pathloss datamodel
+    
+    Returns
+    -------
+        (wavelength, pathloss_vector) : tuple of 2 1-d numpy arrays
+        
+        The wavelength and pathloss 1-d arrays
+
+    """
+    # This routine will run if the fiducial shutter has 1 adjacent open shutter
+    n_apertures = len(pathloss_model.apertures)
+    if n_apertures != 2:
+        log.warning(f"Expected 2 apertures in pathloss reference file, found {n_apertures}")
+        return (None, None)
+    for aperture in pathloss_model.apertures:
+        aperture_name = aperture.name.upper()
+        if aperture_name == 'MOS1X1':
+            aperture1x1 = aperture
+        elif aperture_name == 'MOS1X3':
+            aperture1x3 = aperture
+        if aperture_name not in ['MOS1X1', 'MOS1X3']:
+            log.warning(f"Unexpected aperture name {aperture_name} (Expected 'MOS1X1' or 'MOS1X3')")
+            return (None, None)
+    pathloss1x1 = aperture1x1.uniform_data
+    pathloss1x3 = aperture1x3.uniform_data
+    if len(pathloss1x1) != len(pathloss1x3):
+        log.warning("Pathloss 1x1 and 1x3 arrays have different sizes")
+        return (None, None)
+    if aperture1x1.uniform_wcs.crval1 != aperture1x3.uniform_wcs.crval1:
+        log.warning("1x1 and 1x3 apertures have different WCS CRVAL1")
+        return (None, None)
+    if aperture1x1.uniform_wcs.crpix1 != aperture1x3.uniform_wcs.crpix1:
+        log.warning("1x1 and 1x3 apertures have different WCS CRPIX1")
+        return (None, None)
+    if aperture1x1.uniform_wcs.cdelt1 != aperture1x3.uniform_wcs.cdelt1:
+        log.warning("1x1 and 1x3 apertures have different WCS CDELT1")
+        return (None, None)
+    wavesize = len(pathloss1x1)
+    wavelength = np.zeros(wavesize)
+    crpix1 = aperture1x1.uniform_wcs.crpix1
+    crval1 = aperture1x1.uniform_wcs.crval1
+    cdelt1 = aperture1x1.uniform_wcs.cdelt1
+    for i in np.arange(wavesize):
+        wavelength[i] = crval1 + (float(i + 1) - crpix1) * cdelt1
+    average_pathloss = 0.5 * (pathloss1x1 + pathloss1x3)
+    return (wavelength, average_pathloss)
+    
 
 def do_correction(input_model, pathloss_model=None, inverse=False, source_type=None,
                   correction_pars=None, user_slit_loc=None):
@@ -779,23 +834,38 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
         slitlength = len(slit.shutter_state)
         aperture = get_aperture_from_model(pathloss, slit.shutter_state)
         log.info(f"Shutter state = {slit.shutter_state}, using {aperture.name} entry in ref file")
+        two_shutters = False
         if shutter_below_is_closed(slit.shutter_state) and not shutter_above_is_closed(slit.shutter_state):
             ycenter = ycenter - 1.0
             log.info('Shutter below fiducial is closed, using lower region of pathloss array')
+            two_shutters = True
         if not shutter_below_is_closed(slit.shutter_state) and shutter_above_is_closed(slit.shutter_state):
             ycenter = ycenter + 1.0
             log.info('Shutter above fiducial is closed, using upper region of pathloss array')
+            two_shutters = True
         if aperture is not None:
             (wavelength_pointsource,
              pathloss_pointsource_vector,
              is_inside_slitlet) = calculate_pathloss_vector(aperture.pointsource_data,
                                                             aperture.pointsource_wcs,
                                                             xcenter, ycenter)
-            (wavelength_uniformsource,
-             pathloss_uniform_vector,
-             dummy) = calculate_pathloss_vector(aperture.uniform_data,
+            if two_shutters:
+                (wavelength_uniformsource,
+                 pathloss_uniform_vector) = calculate_two_shutter_uniform_pathloss(pathloss)
+            else:
+                (wavelength_uniformsource,
+                 pathloss_uniform_vector,
+                 dummy) = calculate_pathloss_vector(aperture.uniform_data,
                                                 aperture.uniform_wcs,
                                                 xcenter, ycenter)
+            # This should only happen if the 2 shutter uniform pathloss calculation has an error
+            if wavelength_uniformsource is None or pathloss_uniform_vector is None:
+                log.warning("Unable to calculate 2 shutter uniform pathloss, using 3 shutter aperture")
+                (wavelength_uniformsource,
+                 pathloss_uniform_vector,
+                 dummy) = calculate_pathloss_vector(aperture.uniform_data,
+                                                    aperture.uniform_wcs,
+                                                    xcenter, ycenter)
             if is_inside_slitlet:
 
                 # Wavelengths in the reference file are in meters,

--- a/jwst/pathloss/tests/test_pathloss.py
+++ b/jwst/pathloss/tests/test_pathloss.py
@@ -8,7 +8,9 @@ from jwst.pathloss.pathloss import (calculate_pathloss_vector,
                                     get_aperture_from_model,
                                     get_center,
                                     interpolate_onto_grid,
-                                    is_pointsource)
+                                    is_pointsource,
+                                    shutter_below_is_closed,
+                                    shutter_above_is_closed)
 from jwst.pathloss.pathloss import do_correction
 import numpy as np
 
@@ -84,10 +86,10 @@ def test_get_aper_from_model_msa():
     aperture reference data is returned for MSA mode"""
 
     datmod = PathlossModel()
-    datmod.apertures.append({'shutters': 5})
+    datmod.apertures.append({'shutters': 3})
     datmod.meta.exposure.type = 'NRS_MSASPEC'
 
-    result = get_aperture_from_model(datmod, 5)
+    result = get_aperture_from_model(datmod, '11x11')
 
     assert result == datmod.apertures[0]
 
@@ -335,3 +337,20 @@ def test_interpolate_onto_grid():
     result_comparison = np.interp(wavelength_grid, extended_wavelength_vector, extended_pathloss_vector)
 
     np.testing.assert_array_equal(result, result_comparison)
+
+def test_shutter_below_is_closed():
+    shutter_below_closed = ['x111', 'x', '10x11']
+    shutter_below_open = ['11x11', '111x', '11x01']
+    for shutter_state in shutter_below_closed:
+        assert shutter_below_is_closed(shutter_state)
+    for shutter_state in shutter_below_open:
+        assert not shutter_below_is_closed(shutter_state)
+
+def test_shutter_above_is_closed():
+    shutter_above_closed = ['111x', 'x', '1x011']
+    shutter_above_open = ['11x11', 'x111', '110x1']
+    for shutter_state in shutter_above_closed:
+        assert shutter_above_is_closed(shutter_state)
+    for shutter_state in shutter_above_open:
+        assert not shutter_above_is_closed(shutter_state)
+

--- a/jwst/pathloss/tests/test_pathloss.py
+++ b/jwst/pathloss/tests/test_pathloss.py
@@ -338,6 +338,7 @@ def test_interpolate_onto_grid():
 
     np.testing.assert_array_equal(result, result_comparison)
 
+
 def test_shutter_below_is_closed():
     shutter_below_closed = ['x111', 'x', '10x11']
     shutter_below_open = ['11x11', '111x', '11x01']
@@ -346,6 +347,7 @@ def test_shutter_below_is_closed():
     for shutter_state in shutter_below_open:
         assert not shutter_below_is_closed(shutter_state)
 
+
 def test_shutter_above_is_closed():
     shutter_above_closed = ['111x', 'x', '1x011']
     shutter_above_open = ['11x11', 'x111', '110x1']
@@ -353,4 +355,3 @@ def test_shutter_above_is_closed():
         assert shutter_above_is_closed(shutter_state)
     for shutter_state in shutter_above_open:
         assert not shutter_above_is_closed(shutter_state)
-


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3357](https://jira.stsci.edu/browse/JP-3357)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7864

<!-- describe the changes comprising this PR here -->
This PR implements the pathloss correction for NIRSPEC MSA data where the slits are not 1x1 or 1x3

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
