### PR TITLE
JP-3455: Fix bug in new MIRI imager photom correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,7 +64,8 @@ imprint
 photom
 --------
 
-- Added time-dependent correction for MIRI Imager data [#8096, spacetelescope/stdatamodels#235]
+- Added time-dependent correction for MIRI Imager data.
+  [#8096, #8102, spacetelescope/stdatamodels#235]
 
 pixel_replace
 -------------

--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -76,6 +76,14 @@ The step also computes the equivalent conversion factor to units of
 microJy/square-arcsecond (or microjanskys) and stores it in the header
 keyword PHOTUJA2.
 
+MIRI Imaging
+^^^^^^^^^^^^
+For MIRI imaging mode, the reference file can optionally contain a table of
+coefficients that are used to apply time-dependent corrections to the scalar
+conversion factor. If the time-dependent coefficients are present in the
+reference file, the photom step will apply the correction based on the
+observation date of the exposure being processed.
+
 NIRSpec Fixed-Slit Primary Slit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The primary slit in a NIRSpec fixed-slit exposure receives special handling.

--- a/docs/jwst/references_general/photom_reffile.inc
+++ b/docs/jwst/references_general/photom_reffile.inc
@@ -60,6 +60,16 @@ instrument modes, as shown in the tables below.
 |            |       | uncertainty    | float     | scalar     | MJy/steradian/(DN/sec) |
 +------------+-------+----------------+-----------+------------+------------------------+
 
+The MIRI Imager PHOTOM reference file can contain an optional BINTABLE extension
+named "TIMECOEFF", containing coefficients for an time-dependent correction. The format
+of this additional table extension is as follows:
+
+==========  ========  =====  ===========  =========  
+EXTNAME     XTENSION  NAXIS  Dimensions   Data type
+==========  ========  =====  ===========  =========
+TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
+==========  ========  =====  ===========  =========
+
 :Data model: `~jwst.datamodels.MirLrsPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -463,15 +463,15 @@ class DataSet():
                 warnings.simplefilter("ignore")
                 row = find_row(ftab.phot_table, fields_to_match)
             if row is None:
-
+                # Search again using subarray="GENERIC" for old ref files
                 fields_to_match = {'subarray': 'GENERIC',
                                    'filter': self.filter}
                 row = find_row(ftab.phot_table, fields_to_match)
                 if row is None:
                     return
-                self.photom_io(ftab.phot_table[row])
                 
-            # Check if reference file contains the coefficients for the time-dependent correction of the PHOTOM value
+            # Check to see if the reference file contains the coefficients for the
+            # time-dependent correction of the PHOTOM value
             try:
                 ftab.getarray_noinit("timecoeff")
                 log.info("Applying the time-dependent correction to the PHOTOM value.")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Related to [JP-3455](https://jira.stsci.edu/browse/JP-3455)

<!-- describe the changes comprising this PR here -->
This PR fixes a bug introduced in #8096 , where the photom correction for MIRI imaging data was mistakenly applied twice to the data arrays. It was applied first right after finding the matching row of data in the ref file table, and then again after determining whether the time-dependent correction existed or not. This PR eliminates the first application and leaves only the one after the check for time-dep coeffs. It still gets applied exactly once, regardless of whether or not the time-dep coeffs exist.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
