### PR TITLE
Revert "Bump actions/labeler from 4 to 5 (#8107)"

### DIFF
--- a/.github/workflows/label_pull_request.yml
+++ b/.github/workflows/label_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v4
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This reverts commit 6da3c35ddf0f426cef68ad5cb084a4936ca3c8f2.

Based on issues reported by @jemorrison and @penaguerrero there appears to be issues with labeler. See:
https://github.com/spacetelescope/jwst/actions/runs/7144861661/job/19459356277?pr=8039

It appears that upgrading to v5 will require configuration file changes: https://github.com/actions/labeler#breaking-changes-in-v5

This PR reverts the v4 to v5 upgrade until the config file can be updated.

As the labeler workflow runs on `pull_request_target` (which runs from the main branch not the PR branch) it will fail for this PR.

Once this PR is merged I'll open a new issue to track updating the version and configuration file.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
