### PR TITLE
Pixel Replace - catch profiles with no valid pixel values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,9 @@ pixel_replace
 - Fixed a bug that included ``NON_SCIENCE`` flagged pixels while checking
   for science pixels to be replaced. [#8090]
 
+- Fixed a bug where slices with only unflagged NaN values would cause an error
+  to fit the profile [#8120]
+
 ramp_fitting
 ------------
 

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -27,6 +27,7 @@ class PixelReplacement:
     # Shortcuts for dispersion direction for ease of reading
     HORIZONTAL = 1
     VERTICAL = 2
+    LOG_SLICE = ['column', 'row']
 
     default_suffix = 'pixrep'
 
@@ -316,6 +317,9 @@ class PixelReplacement:
             )[range(*profile_cut)]
 
             replace_mask = np.where(~np.isnan(cleaned_current))[0]
+            if len(replace_mask) == 0:
+                log.info(f"Profile in {self.LOG_SLICE[dispaxis - 1]} {ind} has no valid values - skipping.")
+                continue
             min_median = median_profile[replace_mask]
             min_current = cleaned_current[replace_mask]
             norm_current = min_current / np.max(min_current)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a bug found with recent MIRI LRS reference file deliveries - a row of pixels filled with NaN values but DQ=0 causes a crash. This should catch that issue and pass on replacing pixels from that row.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
