### PR TITLE
Fix for 2 shutter uniform correction 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,10 @@ pathloss
 
 - Updated code to handle NIRSpec MOS slitlets that aren't 1X1 or 1X3. [#8106]
 
+- Fixed an issue from #8106 where the 2-shutter algorithm for uniform sources was
+  incorrectly being applied to larger slits with only 1 open shutter adjacent to
+  the fiducial [#8126]
+
 photom
 ------
 

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -94,7 +94,7 @@ For uniform sources, there is no dependence of the pathloss correction on positi
 so the correction arrays are just 1-d arrays of correction and wavelength.  The
 correction depends only on the number of shutters in the slit:
 
-If there is 1 shutters, the 1x1 entry is used
+If there is 1 shutter, the 1x1 entry is used
 
 If there are 3 or more shutters, the 1x3 entry is used
 

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -91,15 +91,14 @@ array, since each pixel has a different wavelength, and the correction is applie
 to the science pixel array.
 
 For uniform sources, there is no dependence of the pathloss correction on position,
-so the correction arrays are just 1-d arrays of correction and wavelength.  Once
-again, the shutter_state attribute of each slit is used to determine the correction
-entry used:
+so the correction arrays are just 1-d arrays of correction and wavelength.  The
+correction depends only on the number of shutters in the slit:
 
-If both shutters adjacent to the fiducial are closed, the 1x1 entry is used
+If there is 1 shutters, the 1x1 entry is used
 
-If both shutters adjacent to the fiducial are open, the 1x3 entry is used
+If there are 3 or more shutters, the 1x3 entry is used
 
-If one is closed and one is open, the correction used is the average of the 1x1
+If there are 2 shutters, the correction used is the average of the 1x1
 and 1x3 entries.
 
 Like for the point source case, the 1-d arrays of pathloss correction and wavelength

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -276,7 +276,7 @@ def calculate_two_shutter_uniform_pathloss(pathloss_model):
         The wavelength and pathloss 1-d arrays
 
     """
-    # This routine will run if the fiducial shutter has 1 adjacent open shutter
+    # This routine will run if the slit has exactly 2 shutters
     n_apertures = len(pathloss_model.apertures)
     if n_apertures != 2:
         log.warning(f"Expected 2 apertures in pathloss reference file, found {n_apertures}")
@@ -312,6 +312,7 @@ def calculate_two_shutter_uniform_pathloss(pathloss_model):
     for i in np.arange(wavesize):
         wavelength[i] = crval1 + (float(i + 1) - crpix1) * cdelt1
     average_pathloss = 0.5 * (pathloss1x1 + pathloss1x3)
+    log.info("2 shutter slit: Uniform correction averages corrections for 1x1 and 1x3 apertures")
     return (wavelength, average_pathloss)
 
 
@@ -834,14 +835,14 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
         aperture = get_aperture_from_model(pathloss, slit.shutter_state)
         log.info(f"Shutter state = {slit.shutter_state}, using {aperture.name} entry in ref file")
         two_shutters = False
+        if slitlength == 2:
+            two_shutters = True
         if shutter_below_is_closed(slit.shutter_state) and not shutter_above_is_closed(slit.shutter_state):
             ycenter = ycenter - 1.0
             log.info('Shutter below fiducial is closed, using lower region of pathloss array')
-            two_shutters = True
         if not shutter_below_is_closed(slit.shutter_state) and shutter_above_is_closed(slit.shutter_state):
             ycenter = ycenter + 1.0
             log.info('Shutter above fiducial is closed, using upper region of pathloss array')
-            two_shutters = True
         if aperture is not None:
             (wavelength_pointsource,
              pathloss_pointsource_vector,


### PR DESCRIPTION
- only for slits with exactly 2 shutters

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3357](https://jira.stsci.edu/browse/JP-3357)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an issue found in testing the original fix in #8106 - the average of 1x1 and 1x3 uniform corrections is only to be done for slits that have exactly 2 shutters, not for slits that have only 1 open shutter adjacent to the fiducial (like for point sources).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
