### PR TITLE
JP-3430: Fix filteroffset ref file doc

### DIFF
--- a/docs/jwst/references_general/filteroffset_reffile.rst
+++ b/docs/jwst/references_general/filteroffset_reffile.rst
@@ -40,6 +40,6 @@ frame.
 
 :filters:
     :filter: Filter name
-    :pupil: Pupil name (NIRCam only)
+    :pupil: Pupil name (NIRCam and NIRISS only)
     :column_offset: Offset in x (in pixels)
     :row_offset: Offset in y (in pixels)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3430](https://jira.stsci.edu/browse/JP-3430)

This PR fixes one more minor issue with the doc page for the FILTEROFFSET ref file, as noted in JP-3430.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
