### PR TITLE
add unit test to confirm step and pipeline __all__

### DIFF
--- a/jwst/stpipe/tests/test_integration.py
+++ b/jwst/stpipe/tests/test_integration.py
@@ -2,6 +2,7 @@ from stpipe.utilities import import_class
 
 from jwst.stpipe.integration import get_steps
 from jwst.stpipe import Step, Pipeline
+from jwst.stpipe.utilities import NON_STEPS
 
 import jwst.pipeline
 import jwst.step
@@ -18,3 +19,36 @@ def test_get_steps():
         assert step_class.class_alias == class_alias
         if is_pipeline:
             assert issubclass(step_class, Pipeline)
+
+
+def _get_subclass_names(class_, ignore=None, ignore_tests=True):
+    """
+    Iterate through names of all subclasses (recursively) of a class ignoring
+    all subclasses with names in ignore (and ignoring any subclasses of
+    ignored classes). Also optionally ignore all classes defined in tests modules.
+    """
+    if ignore is None:
+        ignore = set()
+    for subclass in class_.__subclasses__():
+        if subclass.__name__ in ignore:
+            continue
+        if ignore_tests and (subclass.__module__ == 'local' or 'tests' in subclass.__module__.split('.')):
+            continue
+        yield subclass.__name__
+        yield from _get_subclass_names(subclass, ignore, ignore_tests)
+
+
+def test_all_steps_in_step_all():
+    step_names = set(_get_subclass_names(Step, set(['JwstPipeline'])))
+    # MasterBackgroundMosStep is a pipeline that is treated like a step
+    step_names.add('MasterBackgroundMosStep')
+    # also ignore any 'non-steps'
+    step_names -= set(NON_STEPS)
+    assert set(jwst.step.__all__) == step_names
+
+
+def test_all_pipelines_in_pipeline_all():
+    pipeline_names = set(_get_subclass_names(Pipeline))
+    # MasterBackgroundMosStep is a pipeline that is treated like a step
+    pipeline_names.remove('MasterBackgroundMosStep')
+    assert set(jwst.pipeline.__all__) == pipeline_names


### PR DESCRIPTION
As discussed in #8137 (see https://github.com/spacetelescope/jwst/pull/8137#issuecomment-1857973863)

This PR adds 2 unit tests to:
- confirm that all subclasses of `JwstStep` are listed in `jwst.step.__all__` (except for `JwstPipeline` which is a subclass of `JwstStep`)
- confirm that all subclasses of `JwstPipeline` are listed in `jwst.pipeline.__all__`

~This PR is currently not based of main so this PR can be evaluated for it's ability to catch the omission fixed in #8137 Once this is approved the PR can be rebased prior to merge.~ EDIT: today I learned that `actions/checkout` merges the source PR branch into the target so it doesn't matter that this branch is out-of-date, the tests will still run with the changes in #8137 I opened a test PR https://github.com/spacetelescope/jwst/pull/8142 that reverts #8137 and shows a failure in the `Step` checking unit test added with this PR due to a missing `EmiCorrStep`. See: https://github.com/spacetelescope/jwst/actions/runs/7224942055/job/19687349741?pr=8142#step:10:441
```
  FAILED jwst/stpipe/tests/test_integration.py::test_all_steps_in_step_all - AssertionError: assert {'AlignRefsSt...WcsStep', ...} == {'AlignRefsSt...WcsStep', ...}
    Extra items in the right set:
    'EmiCorrStep'
    Full diff:
      {
...
       'DQInitStep',
       'DarkCurrentStep',
    -  'EmiCorrStep',
       'Extract1dStep',
```

`MasterBackgroundMosStep` appears to be a special case of a `Pipeline` being treated as a `Step`
https://github.com/spacetelescope/jwst/blob/2650df797e352331904dab9a70cb486110c77d2b/jwst/master_background/master_background_mos_step.py#L20
It appears this change was introduced in https://github.com/spacetelescope/jwst/pull/5317
The unit test specially handles `MasterBackgroundMosStep` (treating it like a `Step` instead of a `Pipeline`).

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
