### PR TITLE
strip quotation marks as workaround for pytest option parsing

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -25,8 +25,8 @@ conf.use_memmap = False
 def artifactory_repos(pytestconfig):
     """Provides Artifactory inputs_root and results_root"""
     try:
-        inputs_root = pytestconfig.getini('inputs_root')[0]
-        results_root = pytestconfig.getini('results_root')[0]
+        inputs_root = pytestconfig.getini('inputs_root')[0].strip("\"")
+        results_root = pytestconfig.getini('results_root')[0].strip("\"")
     except IndexError:
         inputs_root = "jwst-pipeline"
         results_root = "jwst-pipeline-results"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses an issue where the regression tests fail to parse results, due to what appears to be an issue where the option parser adds quotation marks to the value:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST/detail/JWST/2701/pipeline/281/#step-290-log-1
```
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('j' (code 106)): was expecting comma to separate Object entries
 at [Source: (String)"
{
  "files": [
    {
      "pattern": "/var/jenkins_home/workspace/RT/JWST/conda_python_*",
      "target": ""jwst-pipeline-results""  # <<< Why is this quad-quoted and missing a comma?
    }
  ]
}
"; line: 6, column: 20]
``` 

**Checklist for maintainers**
- [x] ~added entry in `CHANGES.rst` within the relevant release section~
- [x] ~updated or added relevant tests~
- [x] ~updated relevant documentation~
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
