### PR TITLE
JP-3248: MIRI Subarrays 390 Hz EMI bug fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.13.1 (unreleased)
 ===================
 
+emicorr
+-------
+
+- Fix emicorr crashing with readpatt values other than FASTR1 or SLOWR1. [#8147]
+
 other
 -----
 

--- a/docs/jwst/references_general/emi_reffile.inc
+++ b/docs/jwst/references_general/emi_reffile.inc
@@ -33,9 +33,9 @@ Example file contents::
       ├─BRIGHTSKY (dict)
       │ ├─frameclocks (int): 23968
       │ ├─freqs (dict)
-      │ │ ├─FASTR1 (list)
+      │ │ ├─FAST (list)
       │ │ │ └─[0] (str): Hz10
-      │ │ └─SLOWR1 (dict)
+      │ │ └─SLOW (dict)
       │ │   ├─MIRIFULONG (list)
       │ │   │ └─[0] (str): Hz10_slow_MIRIFULONG
       │ │   ├─MIRIFUSHORT (list)
@@ -46,10 +46,10 @@ Example file contents::
       ├─MASK1140 (dict)
       │ ├─frameclocks (int): 23968
       │ ├─freqs (dict)
-      │ │ ├─FASTR1 (list)
+      │ │ ├─FAST (list)
       │ │ │ ├─[0] (str): Hz390
       │ │ │ └─[1] (str): Hz10
-      │ │ └─SLOWR1 (dict)
+      │ │ └─SLOW (dict)
       │ │   ├─MIRIFULONG (list)
       │ │   │ ├─[0] (str): Hz390
       │ │   │ └─[1] (str): Hz10_slow_MIRIFULONG

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -143,7 +143,7 @@ def do_correction(input_model, emicorr_model, save_onthefly_reffile, **pars):
                         save_intermediate_results=save_intermediate_results,
                         user_supplied_reffile=user_supplied_reffile,
                         nints_to_phase=nints_to_phase,
-                        nbins=nbins,
+                        nbins_all=nbins,
                         scale_reference=scale_reference
                         )
 
@@ -152,7 +152,7 @@ def do_correction(input_model, emicorr_model, save_onthefly_reffile, **pars):
 
 def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
         save_intermediate_results=False, user_supplied_reffile=None,
-        nints_to_phase=None, nbins=None, scale_reference=True):
+        nints_to_phase=None, nbins_all=None, scale_reference=True):
     """
     -> NOTE: This is translated from IDL code fix_miri_emi.pro
 
@@ -199,8 +199,9 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
     nints_to_phase : int
         Number of integrations to phase
 
-    nbins : int
-        Number of bins in one phased wave
+    nbins_all : int
+        Number of bins in one phased wave (this number will be used for all
+        frequencies to be corrected)
 
     scale_reference : bool
         If True, the reference wavelength will be scaled to the data's phase amplitude
@@ -378,7 +379,7 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
         # streched to a different dimension later. By default, use period_in_pixels/2.0
 
         # number of bins in one phased wave (e.g. 255, 218, etc)
-        if nbins is None:
+        if nbins_all is None:
             # the IDL code sets nbins as ulong type (ulonglong in python)
             nbins = int(period_in_pixels/2.0)
 

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -27,79 +27,79 @@ default_subarray_cases = {
     "SLITLESSPRISM": {
         "rowclocks": 28,
         "frameclocks": 15904,
-        "freqs":  {"FASTR1": ["Hz390", "Hz10"],
-                   "SLOWR1":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
+        "freqs":  {"FAST": ["Hz390", "Hz10"],
+                   "SLOW":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
                               "MIRIFULONG" : ["Hz390", "Hz10_slow_MIRIFULONG"],
                               "MIRIFUSHORT" : ["Hz390", "Hz10_slow_MIRIFUSHORT"]}}},
 
     "MASKLYOT": {
         "rowclocks": 90,
         "frameclocks": 32400,
-        "freqs":  {"FASTR1": ["Hz390", "Hz10"],
-                   "SLOWR1":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
+        "freqs":  {"FAST": ["Hz390", "Hz10"],
+                   "SLOW":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
                               "MIRIFULONG" : ["Hz390", "Hz10_slow_MIRIFULONG"],
                               "MIRIFUSHORT" : ["Hz390", "Hz10_slow_MIRIFUSHORT"]}}},
 
     "SUB64": {
         "rowclocks": 28,
         "frameclocks": 8512,
-        "freqs":  {"FASTR1": ["Hz390", "Hz10"],
-                   "SLOWR1":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
+        "freqs":  {"FAST": ["Hz390", "Hz10"],
+                   "SLOW":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
                               "MIRIFULONG" : ["Hz390", "Hz10_slow_MIRIFULONG"],
                               "MIRIFUSHORT" : ["Hz390", "Hz10_slow_MIRIFUSHORT"]}}},
 
     "SUB128": {
         "rowclocks": 44,
         "frameclocks": 11904,
-        "freqs":  {"FASTR1": ["Hz390_sub128", "Hz10"],
-                   "SLOWR1":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
+        "freqs":  {"FAST": ["Hz390_sub128", "Hz10"],
+                   "SLOW":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
                               "MIRIFULONG" : ["Hz390", "Hz10_slow_MIRIFULONG"],
                               "MIRIFUSHORT" : ["Hz390", "Hz10_slow_MIRIFUSHORT"]}}},
 
     "MASK1140": {
         "rowclocks": 82,
         "frameclocks": 23968,
-        "freqs":  {"FASTR1": ["Hz390", "Hz10"],
-                   "SLOWR1":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
+        "freqs":  {"FAST": ["Hz390", "Hz10"],
+                   "SLOW":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
                               "MIRIFULONG" : ["Hz390", "Hz10_slow_MIRIFULONG"],
                               "MIRIFUSHORT" : ["Hz390", "Hz10_slow_MIRIFUSHORT"]}}},
 
     "MASK1550": {
         "rowclocks": 82,
         "frameclocks": 23968,
-        "freqs":  {"FASTR1": ["Hz390", "Hz10"],
-                   "SLOWR1":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
+        "freqs":  {"FAST": ["Hz390", "Hz10"],
+                   "SLOW":  {"MIRIMAGE" : ["Hz390", "Hz10_slow_MIRIMAGE"],
                               "MIRIFULONG" : ["Hz390", "Hz10_slow_MIRIFULONG"],
                               "MIRIFUSHORT" : ["Hz390", "Hz10_slow_MIRIFUSHORT"]}}},
 
     # 390Hz already in-phase for these, but may need corr for other
     # frequencies (e.g. 10Hz heater noise)
 
-    "FULL_FASTR1": {
+    "FULL_FAST": {
         "rowclocks": 271,
         "frameclocks": 277504,
-        "freqs": {"FASTR1" : ["Hz10"]}},
+        "freqs": {"FAST" : ["Hz10"]}},
 
-    "FULL_SLOWR1": {
+    "FULL_SLOW": {
         "rowclocks": 2333,
         "frameclocks": 2388992,
-        "freqs": {"SLOWR1":  {"MIRIMAGE" : ["Hz10_slow_MIRIMAGE"],
+        "freqs": {"SLOW":  {"MIRIMAGE" : ["Hz10_slow_MIRIMAGE"],
                               "MIRIFULONG" : ["Hz10_slow_MIRIFULONG"],
                               "MIRIFUSHORT" : ["Hz10_slow_MIRIFUSHORT"]}}},
 
     "BRIGHTSKY": {
         "rowclocks": 162,
         "frameclocks": 86528,
-        "freqs": {"FASTR1" : ["Hz10"],
-                  "SLOWR1": {"MIRIMAGE" : ["Hz10_slow_MIRIMAGE"],
+        "freqs": {"FAST" : ["Hz10"],
+                  "SLOW": {"MIRIMAGE" : ["Hz10_slow_MIRIMAGE"],
                             "MIRIFULONG" : ["Hz10_slow_MIRIFULONG"],
                             "MIRIFUSHORT" : ["Hz10_slow_MIRIFUSHORT"]}}},
 
     "SUB256": {
         "rowclocks": 96,
         "frameclocks": 29952,
-        "freqs": {"FASTR1" : ["Hz10"],
-                  "SLOWR1": {"MIRIMAGE" : ["Hz10_slow_MIRIMAGE"],
+        "freqs": {"FAST" : ["Hz10"],
+                  "SLOW": {"MIRIMAGE" : ["Hz10_slow_MIRIMAGE"],
                             "MIRIFULONG" : ["Hz10_slow_MIRIFULONG"],
                             "MIRIFUSHORT" : ["Hz10_slow_MIRIFUSHORT"]}}},
 }
@@ -234,8 +234,9 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
             freq = get_frequency_info(default_emi_freqs, fnme)
             freqs_numbers.append(freq)
 
-    if rowclocks is None:
-        # no subarray match found, print to log and skip correction
+    log.info('With configuration: Subarray={}, Read_pattern={}, Detector={}'.format(subarray, readpatt, detector))
+    if rowclocks is None or len(freqs_numbers) == 0:
+        # no subarray or read pattern match found, print to log and skip correction
         return subname
 
     # get the number of samples, 10us sample times per pixel (1 for fastmode, 9 for slowmode)
@@ -249,7 +250,6 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
         freq_pa_dict = {'frequencies': {}, 'subarray_cases': {}}
 
     # Loop over the frequencies to correct
-    log.info('With configuration: Subarray={}, Read_pattern={}, Detector={}'.format(subarray, readpatt, detector))
     log.info('Will correct data for the following {} frequencies: '.format(len(freqs2correct)))
     log.info('   {}'.format(freqs2correct))
     for fi, frequency_name in enumerate(freqs2correct):
@@ -463,7 +463,7 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
         output_model.data = corr_data
 
     if save_intermediate_results and save_onthefly_reffile is not None:
-        if readpatt == 'FASTR1':
+        if readpatt == 'FAST':
             freqs_dict = {readpatt: freqs2correct}
         else:
             freqs_dict = {readpatt: {detector: freqs2correct} }
@@ -600,6 +600,17 @@ def get_subarcase(subarray_cases, subarray, readpatt, detector):
         List of frequency names to use
     """
     subname, rowclocks, frameclocks, frequencies = None, None, None, None
+
+    # make sure the readpattern is defined as expected
+    readpatt = readpatt.upper()
+    if "SLOW" in readpatt:
+        readpatt = "SLOW"
+    elif "FAST" in readpatt:
+        readpatt = "FAST"
+    else:
+        return subname, rowclocks, frameclocks, frequencies
+
+    # search and return the specific values for the configuration
     if isinstance(subarray_cases, dict):
         for subname in subarray_cases:
             if subarray not in subname:
@@ -608,10 +619,10 @@ def get_subarcase(subarray_cases, subarray, readpatt, detector):
                 subname = subname + '_' + readpatt
             rowclocks = subarray_cases[subname]["rowclocks"]
             frameclocks = subarray_cases[subname]["frameclocks"]
-            if readpatt == "SLOWR1":
-                frequencies = subarray_cases[subname]["freqs"]["SLOWR1"][detector]
+            if readpatt == "SLOW":
+                frequencies = subarray_cases[subname]["freqs"]["SLOW"][detector]
             else:
-                frequencies = subarray_cases[subname]["freqs"]["FASTR1"]
+                frequencies = subarray_cases[subname]["freqs"]["FAST"]
             break
     else:
         frequencies = []
@@ -630,9 +641,9 @@ def get_subarcase(subarray_cases, subarray, readpatt, detector):
                     elif "frameclocks" in item:
                         frameclocks = val
                     else:
-                        if readpatt == "SLOWR1" and "SLOWR1" in item and detector in item:
+                        if readpatt == "SLOW" and "SLOW" in item and detector in item:
                             frequencies.append(val)
-                        elif readpatt == "FASTR1" and "FASTR1" in item:
+                        elif readpatt == "FAST"  and "FAST" in item:
                             frequencies.append(val)
             if subname is not None and rowclocks is not None and frameclocks is not None and frequencies is not None:
                 break

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -382,6 +382,10 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
         if nbins_all is None:
             # the IDL code sets nbins as ulong type (ulonglong in python)
             nbins = int(period_in_pixels/2.0)
+        else:
+            nbins = nbins_all
+        if nbins > 501:
+            nbins = 500
 
         # bin the whole set
         log.info('Calculating the phase amplitude for {} bins'.format(nbins))

--- a/jwst/emicorr/emicorr_step.py
+++ b/jwst/emicorr/emicorr_step.py
@@ -75,7 +75,7 @@ class EmiCorrStep(Step):
             output_model = emicorr.do_correction(input_model, emicorr_model, save_onthefly_reffile, **pars)
             if isinstance(output_model, str) or output_model is None:
                 # in this case output_model=subarray_readpatt configuration
-                self.log.warning('No correction match for this configuration: {}'.format(output_model))
+                self.log.warning('No correction match for this configuration')
                 self.log.warning('Step skipped')
                 input_model.meta.cal_step.emicorr = 'SKIPPED'
                 return input_model

--- a/jwst/emicorr/tests/test_emicorr.py
+++ b/jwst/emicorr/tests/test_emicorr.py
@@ -70,7 +70,7 @@ def test_apply_emicorr():
     emicorr_model, save_onthefly_reffile = None, None
     outmdl = emicorr.apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
                 save_intermediate_results=False, user_supplied_reffile=None,
-                nints_to_phase=None, nbins=None, scale_reference=True)
+                nints_to_phase=None, nbins_all=None, scale_reference=True)
 
     assert outmdl is not None
 

--- a/jwst/emicorr/tests/test_emicorr.py
+++ b/jwst/emicorr/tests/test_emicorr.py
@@ -27,7 +27,7 @@ def mk_data_mdl(data, subarray, readpatt, detector):
 
 def test_EmiCorrStep():
     data = np.ones((1, 5, 20, 20))
-    input_model = mk_data_mdl(data, 'MASK1550', 'FASTR1', 'MIRIMAGE')
+    input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
     expected_outmdl = input_model.copy()
 
     nirmdl = input_model.copy()
@@ -42,7 +42,7 @@ def test_EmiCorrStep():
 
 def test_do_correction():
     data = np.ones((1, 5, 20, 20))
-    input_model = mk_data_mdl(data, 'MASK1550', 'FASTR1', 'MIRIMAGE')
+    input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
     pars = {
         'save_intermediate_results': False,
         'user_supplied_reffile': None,
@@ -66,7 +66,7 @@ def test_do_correction():
 
 def test_apply_emicorr():
     data = np.ones((1, 5, 20, 20))
-    input_model = mk_data_mdl(data, 'MASK1550', 'FASTR1', 'MIRIMAGE')
+    input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
     emicorr_model, save_onthefly_reffile = None, None
     outmdl = emicorr.apply_emicorr(input_model, emicorr_model, save_onthefly_reffile,
                 save_intermediate_results=False, user_supplied_reffile=None,
@@ -76,7 +76,7 @@ def test_apply_emicorr():
 
 
 def test_get_subarcase():
-    subarray, readpatt, detector = 'MASK1550', 'FASTR1', 'MIRIMAGE'
+    subarray, readpatt, detector = 'MASK1550', 'FAST', 'MIRIMAGE'
     subarray_info_r = emicorr.get_subarcase(default_subarray_cases, subarray, readpatt, detector)
     subname_r, rowclocks_r, frameclocks_r, freqs2correct_r = subarray_info_r
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3248](https://jira.stsci.edu/browse/JP-3248)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses emicorr crashing with readpatt values other than FASTR1 or SLOWR1.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
