### PR TITLE
Update README to exclude Python 3.12 from supported versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 
 ![STScI Logo](docs/_static/stsci_logo.png)
 
-**JWST requires Python 3.9 or above and a C compiler for dependencies.**
+**JWST requires a C compiler for dependencies and is currently limited to Python 3.9, 3.10 or 3.11.**
+
+**Until Python 3.12 is supported, fresh conda environments will require setting the
+  Python version to one of the three supported versions.**
 
 **Linux and MacOS platforms are tested and supported.  Windows is not currently supported.**
 
@@ -50,13 +53,13 @@ Remember that all conda operations must be done from within a bash/zsh shell.
 
 You can install the latest released version via `pip`.  From a bash/zsh shell:
 
-    conda create -n <env_name> python
+    conda create -n <env_name> python=3.11
     conda activate <env_name>
     pip install jwst
 
 You can also install a specific version:
 
-    conda create -n <env_name> python
+    conda create -n <env_name> python=3.11
     conda activate <env_name>
     pip install jwst==1.9.4
 
@@ -65,7 +68,7 @@ You can also install a specific version:
 You can install the latest development version (not as well tested) from the
 Github master branch:
 
-    conda create -n <env_name> python
+    conda create -n <env_name> python=3.11
     conda activate <env_name>
     pip install git+https://github.com/spacetelescope/jwst
 
@@ -117,7 +120,7 @@ already installed with released versions of the `jwst` package.
 
 As usual, the first two steps are to create and activate an environment:
 
-    conda create -n <env_name> python
+    conda create -n <env_name> python=3.11
     conda activate <env_name>
 
 To install your own copy of the code into that environment, you first need to


### PR DESCRIPTION


<!-- describe the changes comprising this PR here -->
This PR adds caveats back into the README, warning users that they need to create an environment using python < 3.12

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
