### PR TITLE
JP-3505: Update ASN rules for NRS MOS compromise dither patterns

### DIFF
--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -445,7 +445,7 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
 
                 for other_science in science_exps:
                     if other_science['expname'] != science_exp['expname']:
-                        if science_exp.item['exp_type'] == 'nrs_fixedslit':
+                        if science_exp.item['exp_type'] in ['nrs_fixedslit', 'nrs_msaspec']:
                             try:
                                 sci_prim_dithpt = (int(science_exp.item['patt_num']) - 1) // \
                                                   int(science_exp.item['subpxpts'])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3505](https://jira.stsci.edu/browse/JP-3505)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8183 

<!-- describe the changes comprising this PR here -->
This PR updates the level-2 ASN rules to accommodate NIRSpec MOS dither patterns that include sub-pixel dithering, so that only exposures from other nod positions get designated as "background" members in spec2 ASN files. This mechanism was already in place for NIRSpec fixed-slit (FS) observations that use both primary nods and sub-pixel dithers, so it just needed to be extended to also include MSA observations.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
