### PR TITLE
JP-3247: Retrieve pixel area from AREA reference file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ photom
   the pipeline put the (variable, calculated per pixel) dispersion back in.  Assumes that
   the dispersion needs to be in Angstroms/pixel to match the required factor of ~10. [#8207]
 
+- Get the values of PIXAR_A2 and PIXAR_SR from area reference file
+  instead of photom reference file to avoid missmatching values. [#8187]
+
 refpix
 ------
 

--- a/docs/jwst/photom/main.rst
+++ b/docs/jwst/photom/main.rst
@@ -125,8 +125,9 @@ The step also populates the keywords PIXAR_SR and PIXAR_A2 in the
 science data product, which give the average pixel area in units of
 steradians and square arcseconds, respectively.
 For most instrument modes, the average pixel area values are copied from the
-primary header of the PHOTOM reference file.
-For NIRSpec, however,  the pixel area values are copied from a binary table
+primary header of the AREA reference file, when this file is available. Otherwise
+the pixel area values are copied from the primary header of the PHOTOM reference
+file. For NIRSpec, however, the pixel area values are copied from a binary table
 extension in the AREA reference file.
 
 NIRSpec IFU

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -1225,13 +1225,13 @@ class DataSet():
 
                 # The area reference file might be older, try the photom reference file
                 except AttributeError or KeyError:
-                    area_ster, area_a2 = pixarea_from_ftab(ftab)
+                    area_ster, area_a2 = self.pixarea_from_ftab(ftab)
 
                 pix_area.close()
 
             # The area reference file might be older, try the photom reference file
             else:
-                area_ster, area_a2 = pixarea_from_ftab(ftab)
+                area_ster, area_a2 = self.pixarea_from_ftab(ftab)
 
             # Copy the pixel area values to the output
             log.debug('PIXAR_SR = %s, PIXAR_A2 = %s', str(area_ster), str(area_a2))

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -1162,7 +1162,7 @@ class DataSet():
             log.warning('The PIXAR_A2 keyword is missing from %s', ftab.meta.filename)
         if area_ster is not None and area_a2 is not None:
             log.info('Values for PIXAR_SR and PIXAR_A2 obtained from PHOTOM reference file.')
-        area_ster, area_a2
+        return area_ster, area_a2
 
     def save_area_info(self, ftab, area_fname):
         """

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -247,6 +247,7 @@ class DataSet():
                 if row is None:
                     continue
                 self.photom_io(ftab.phot_table[row])
+
         # Bright object fixed-slit exposures use a SlitModel
         elif self.exptype == 'NRS_BRIGHTOBJ':
 
@@ -1139,7 +1140,7 @@ class DataSet():
 
         return conversion, no_cal
 
-    def save_area_info(self, ftab, area_fname):
+    def save_area_info(self, area_fname):
         """
         Short Summary
         -------------
@@ -1154,9 +1155,6 @@ class DataSet():
 
         Parameters
         ----------
-        ftab : `~jwst.datamodels.JwstDataModel`
-            A photom reference file data model
-
         area_fname : str
             Pixel area reference file name
         """
@@ -1165,8 +1163,9 @@ class DataSet():
         if area_fname is not None and area_fname != "N/A":
             pix_area = datamodels.open(area_fname)
 
-            # Copy the pixel area data array to the appropriate attribute
-            # of the science data model
+            # Load the average pixel area values from the AREA reference file header
+            # Don't need to do this for NIRSpec, because pixel areas have already
+            # been copied using save_area_nirspec
             if self.instrument != 'NIRSPEC':
                 if isinstance(self.input, datamodels.MultiSlitModel):
                     # Note that this only copied to the first slit.
@@ -1179,37 +1178,32 @@ class DataSet():
                     self.input.area = pix_area.data[ystart: yend,
                                                     xstart: xend]
                 log.info('Pixel area map copied to output.')
+
+                area_ster = pix_area.meta.photometry.pixelarea_steradians
+                if area_ster is None:
+                    log.warning('The PIXAR_SR keyword is missing from %s', area_fname)
+                area_a2 = pix_area.meta.photometry.pixelarea_arcsecsq
+                if area_a2 is None:
+                    log.warning('The PIXAR_A2 keyword is missing from %s', area_fname)
+
+                # Copy the pixel area values to the output
+                log.debug('PIXAR_SR = %s, PIXAR_A2 = %s', str(area_ster), str(area_a2))
+                if area_a2 is not None:
+                    area_a2 = float(area_a2)
+                if area_ster is not None:
+                    area_ster = float(area_ster)
+
+                # For MultiSlitModels, copy to each slit attribute
+                if isinstance(self.input, datamodels.MultiSlitModel):
+                    for slit in self.input.slits:
+                        slit.meta.photometry.pixelarea_arcsecsq = area_a2
+                        slit.meta.photometry.pixelarea_steradians = area_ster
+                else:
+                    self.input.meta.photometry.pixelarea_arcsecsq = area_a2
+                    self.input.meta.photometry.pixelarea_steradians = area_ster
             else:
                 self.save_area_nirspec(pix_area)
-
             pix_area.close()
-
-        # Load the average pixel area values from the photom reference file header
-        # Don't need to do this for NIRSpec, because pixel areas come from
-        # the AREA ref file, which have already been copied using save_area_nirspec
-        if self.instrument != 'NIRSPEC':
-            area_ster = ftab.meta.photometry.pixelarea_steradians
-            if area_ster is None:
-                log.warning('The PIXAR_SR keyword is missing from %s', ftab.meta.filename)
-            area_a2 = ftab.meta.photometry.pixelarea_arcsecsq
-            if area_a2 is None:
-                log.warning('The PIXAR_A2 keyword is missing from %s', ftab.meta.filename)
-
-            # Copy the pixel area values to the output
-            log.debug('PIXAR_SR = %s, PIXAR_A2 = %s', str(area_ster), str(area_a2))
-            if area_a2 is not None:
-                area_a2 = float(area_a2)
-            if area_ster is not None:
-                area_ster = float(area_ster)
-
-            # For MultiSlitModels, copy to each slit attribute
-            if isinstance(self.input, datamodels.MultiSlitModel):
-                for slit in self.input.slits:
-                    slit.meta.photometry.pixelarea_arcsecsq = area_a2
-                    slit.meta.photometry.pixelarea_steradians = area_ster
-            else:
-                self.input.meta.photometry.pixelarea_arcsecsq = area_a2
-                self.input.meta.photometry.pixelarea_steradians = area_ster
 
     def save_area_nirspec(self, pix_area):
         """
@@ -1336,7 +1330,7 @@ class DataSet():
         # SOSS data are in a MultiSpecModel, which will not allow for
         # saving the area info.
         if self.exptype != 'NIS_SOSS':
-            self.save_area_info(ftab, area_fname)
+            self.save_area_info(area_fname)
 
         if self.instrument == 'NIRISS':
             self.calc_niriss(ftab)

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -1187,17 +1187,15 @@ class DataSet():
         """
 
         use_pixarea_rfile =  False
+        area_ster, area_a2 = None, None
         if area_fname is not None and area_fname != "N/A":
             use_pixarea_rfile =  True
+            # Load the pixel area reference file
             pix_area = datamodels.open(area_fname)
 
         if self.instrument != 'NIRSPEC':
 
             if use_pixarea_rfile:
-                # Load the pixel area reference file
-                pix_area = datamodels.open(area_fname)
-
-                area_ster, area_a2 = None, None
                 # Copy the pixel area data array to the appropriate attribute
                 # of the science data model
                 if isinstance(self.input, datamodels.MultiSlitModel):
@@ -1225,11 +1223,11 @@ class DataSet():
                     if area_ster is not None and area_a2 is not None:
                         log.info('Values for PIXAR_SR and PIXAR_A2 obtained from AREA reference file.')
 
-                pix_area.close()
-
                 # The area reference file might be older, try the photom reference file
                 except AttributeError or KeyError:
                     area_ster, area_a2 = pixarea_from_ftab(ftab)
+
+                pix_area.close()
 
             # The area reference file might be older, try the photom reference file
             else:

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -1190,17 +1190,20 @@ class DataSet():
                     area_a2 = pix_area.meta.photometry.pixelarea_arcsecsq
                     if area_a2 is None:
                         log.warning('The PIXAR_A2 keyword is missing from %s', area_fname)
-                    log.info('PIXAR_SR and PIXAR_A2 values obtained from AREA reference file.')
+                    if area_ster is not None and area_a2 is not None:
+                        log.info('Values for PIXAR_SR and PIXAR_A2 obtained from AREA reference file.')
 
-                except AttributeError:
+                except AttributeError or KeyError:
                     # The area reference file might be older, try the photom reference file
                     area_ster = ftab.meta.photometry.pixelarea_steradians
+                    log.info('Attempting to obtain PIXAR_SR and PIXAR_A2 values from PHOTOM reference file.')
                     if area_ster is None:
                         log.warning('The PIXAR_SR keyword is missing from %s', ftab.meta.filename)
                     area_a2 = ftab.meta.photometry.pixelarea_arcsecsq
                     if area_a2 is None:
                         log.warning('The PIXAR_A2 keyword is missing from %s', ftab.meta.filename)
-                    log.info('Values for PIXAR_SR and PIXAR_A2 obtained from PHOTOM reference file.')
+                    if area_ster is not None and area_a2 is not None:
+                        log.info('Values for PIXAR_SR and PIXAR_A2 obtained from PHOTOM reference file.')
 
                 # Copy the pixel area values to the output
                 log.debug('PIXAR_SR = %s, PIXAR_A2 = %s', str(area_ster), str(area_a2))

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -1168,22 +1168,21 @@ class DataSet():
 
             if self.instrument != 'NIRSPEC':
                 area_ster, area_a2 = None, None
+                # Load the average pixel area values from the AREA reference file header
+                # Don't need to do this for NIRSpec, because pixel areas have already
+                # been copied using save_area_nirspec
+                if isinstance(self.input, datamodels.MultiSlitModel):
+                    # Note that this only copied to the first slit.
+                    self.input.slits[0].area = pix_area.data
+                else:
+                    ystart = self.input.meta.subarray.ystart - 1
+                    xstart = self.input.meta.subarray.xstart - 1
+                    yend = ystart + self.input.meta.subarray.ysize
+                    xend = xstart + self.input.meta.subarray.xsize
+                    self.input.area = pix_area.data[ystart: yend,
+                                                    xstart: xend]
+                log.info('Pixel area map copied to output.')
                 try:
-                    # Load the average pixel area values from the AREA reference file header
-                    # Don't need to do this for NIRSpec, because pixel areas have already
-                    # been copied using save_area_nirspec
-                    if isinstance(self.input, datamodels.MultiSlitModel):
-                        # Note that this only copied to the first slit.
-                        self.input.slits[0].area = pix_area.data
-                    else:
-                        ystart = self.input.meta.subarray.ystart - 1
-                        xstart = self.input.meta.subarray.xstart - 1
-                        yend = ystart + self.input.meta.subarray.ysize
-                        xend = xstart + self.input.meta.subarray.xsize
-                        self.input.area = pix_area.data[ystart: yend,
-                                                        xstart: xend]
-                    log.info('Pixel area map copied to output.')
-
                     area_ster = pix_area.meta.photometry.pixelarea_steradians
                     if area_ster is None:
                         log.warning('The PIXAR_SR keyword is missing from %s', area_fname)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3247](https://jira.stsci.edu/browse/JP-3247)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7732 

<!-- describe the changes comprising this PR here -->
This PR addresses retrieving the values of PIXAR_A2 and PIXAR_SR from area reference file
  instead of photom reference file to avoid missmatching values.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
