### PR TITLE
JP-3088 updated bunit_data for the top multislit model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,8 +31,9 @@ extract_1d
 photom
 ------
 
-- Fixed a bug in multislit data that did not update the bunit_data and
-  bunit_error in the top datamodel, just individual slit models. [#8189]
+- Set the top model of multislit data for bunit_data and
+  bunit_error to None, forcing information on units from come from
+  individual slit models. [#8189]
   
 tweakreg
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,12 @@ extract_1d
 - Fixed a bug in the calling of optional MIRI MRS 1d residual fringe
   correction that could cause defringing to fail in some cases. [#8180]
 
+photom
+------
+
+- Fixed a bug in multislit data that did not update the bunit_data and
+  bunit_error in the top datamodel, just individual slit models. [#8189]
+  
 tweakreg
 --------
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -903,13 +903,13 @@ class DataSet():
                 if unit_is_surface_brightness:
                     slit.meta.bunit_data = 'MJy/sr'
                     slit.meta.bunit_err = 'MJy/sr'
-                    self.input.meta.bunit_data = 'MJy/sr'
-                    self.input.meta.bunit_err = 'MJy/sr'
+                    self.input.meta.bunit_data = None
+                    self.input.meta.bunit_err = None
                 else:
                     slit.meta.bunit_data = 'MJy'
                     slit.meta.bunit_err = 'MJy'
-                    self.input.meta.bunit_data = 'MJy'
-                    self.input.meta.bunit_err = 'MJy'
+                    self.input.meta.bunit_data = None
+                    self.input.meta.bunit_err = None
             else:
                 self.input.meta.bunit_data = 'DN/s'
                 self.input.meta.bunit_err = 'DN/s'

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -903,9 +903,13 @@ class DataSet():
                 if unit_is_surface_brightness:
                     slit.meta.bunit_data = 'MJy/sr'
                     slit.meta.bunit_err = 'MJy/sr'
+                    self.input.meta.bunit_data = 'MJy/sr'
+                    self.input.meta.bunit_err = 'MJy/sr'
                 else:
                     slit.meta.bunit_data = 'MJy'
                     slit.meta.bunit_err = 'MJy'
+                    self.input.meta.bunit_data = 'MJy'
+                    self.input.meta.bunit_err = 'MJy'
             else:
                 self.input.meta.bunit_data = 'DN/s'
                 self.input.meta.bunit_err = 'DN/s'

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -903,11 +903,15 @@ class DataSet():
                 if unit_is_surface_brightness:
                     slit.meta.bunit_data = 'MJy/sr'
                     slit.meta.bunit_err = 'MJy/sr'
+                    # Setting top model to None so they will not be written to FITs File.
+                    # Information on the units should only come from the individual slits.
                     self.input.meta.bunit_data = None
                     self.input.meta.bunit_err = None
                 else:
                     slit.meta.bunit_data = 'MJy'
                     slit.meta.bunit_err = 'MJy'
+                    # Setting top model to None so they will not be written to FITs File.
+                    # Information on the units should only come from the individual slits.
                     self.input.meta.bunit_data = None
                     self.input.meta.bunit_err = None
             else:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3088](https://jira.stsci.edu/browse/JP-3088)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7792 

<!-- describe the changes comprising this PR here -->
This PR was described in JP-3088 as "`exp_to_source` is copying wrong and/or incomplete meta information."  For a multislt data model the model.meta.bunit_data had a different value than model.slit[*].meta.bunit_data. 
This even occurs in the cal file after calspec2.  So I think the issue is related to calspec2.

The multslitmodel is create in extract_2d/nirspec.py:
output_model = datamodels.MultiSlitModel()
output_model.update(input_model)

The slit bunit values are copies of output_model (L95-96) in nirspec.py
# Copy BUNIT values to output slit
            new_model.meta.bunit_data = input_model.meta.bunit_data
            new_model.meta.bunit_err = input_model.meta.bunit_err


In the photom step the slit bunit values are updated (starting L903) but not the upper datamodel. I added to those
line for the PR that. sets the input.meta.bunit values
if not self.inverse:
                if unit_is_surface_brightness:
                    slit.meta.bunit_data = 'MJy/sr'
                    slit.meta.bunit_err = 'MJy/sr'
                else:
                    slit.meta.bunit_data = 'MJy'
                    slit.meta.bunit_err = 'MJy'
                    
**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
