### PR TITLE
Fix: models_grouped always return opened data models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,11 @@ extract_2d
   by converting to a string. This change had been done in #8108, but it got undone
   by another PR. [#8272]
 
+general
+-------
+
+- Update minimum required photutils version to 1.5.0 [#8211]
+
 outlier_detection
 -----------------
 
@@ -87,6 +92,12 @@ photom
   was bypassed and came before the ``photom`` step, e.g. for NIRISS SOSS
   data in the FULL subarray. [#8225]
 
+pipeline
+--------
+
+- Updated the ``calwebb_spec2`` pipeline to include NRS_BRIGHTOBJ in
+  the list of modes for running the ``nsclean`` step. [#8256]
+
 refpix
 ------
 
@@ -112,19 +123,7 @@ tweakreg
 - Added option to choose IRAFStarFinder and segmentation.SourceFinder
   instead of DAOStarFinder and exposed star finder parameters. [#8203]
 
-general
--------
 
-- Update minimum required photutils version to 1.5.0 [#8211]
-
-pipeline
---------
-
-- Updated the ``calwebb_spec2`` pipeline to include NRS_BRIGHTOBJ to
-  the list of modes to run nsclean when skip is set to False. [#8256]
-
-
-<<<<<<< HEAD
 1.13.4 (2024-01-25)
 ===================
 
@@ -136,9 +135,6 @@ emicorr
 
 
 1.13.3 (2024-01-05)
-=======
-1.13.3 (01-05-2024)
->>>>>>> 114153eb2 (Fix: models_grouped always return opened data models)
 ===================
 
 documentation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ cube_build
 datamodels
 ----------
 
-- Fixed a bug in the ``ModelContiner`` due to which ``models_grouped``
+- Fixed a bug in the ``ModelContainer`` data model, due to which the ``models_grouped``
   property would return opened data models instead of file names. [#8191]
 
 documentation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ cube_build
 
 - Add a warning message to log if no valid data is found on the detector. [#8220]
 
+datamodels
+----------
+
+- Fixed a bug in the ``ModelContiner`` due to which ``models_grouped``
+  property would return opened data models instead of file names. [#8191]
+
 documentation
 -------------
 
@@ -40,7 +46,7 @@ extract_1d
 - Fixed a bug in the calling of optional MIRI MRS 1d residual fringe
   correction that could cause defringing to fail in some cases. [#8180]
 
-- Added a hook to bypass the ``extract_1d`` step for NIRISS SOSS data in 
+- Added a hook to bypass the ``extract_1d`` step for NIRISS SOSS data in
   the FULL subarray with warning. [#8225]
 
 extract_2d
@@ -77,7 +83,7 @@ photom
 - Get the values of PIXAR_A2 and PIXAR_SR from AREA reference file
   instead of PHOTOM reference file to avoid missmatching values. [#8187]
 
-- Added a hook to bypass the ``photom`` step when the ``extract_1d`` step 
+- Added a hook to bypass the ``photom`` step when the ``extract_1d`` step
   was bypassed and came before the ``photom`` step, e.g. for NIRISS SOSS
   data in the FULL subarray. [#8225]
 
@@ -118,6 +124,7 @@ pipeline
   the list of modes to run nsclean when skip is set to False. [#8256]
 
 
+<<<<<<< HEAD
 1.13.4 (2024-01-25)
 ===================
 
@@ -129,6 +136,9 @@ emicorr
 
 
 1.13.3 (2024-01-05)
+=======
+1.13.3 (01-05-2024)
+>>>>>>> 114153eb2 (Fix: models_grouped always return opened data models)
 ===================
 
 documentation
@@ -206,7 +216,7 @@ documentation
   reported typos in ``tweakreg`` documentation. [#8084]
 
 emicorr
-----------
+-------
 
 - Added new step for removing EMI from all MIRI data. [#7857]
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -480,9 +480,10 @@ to supply custom catalogs.
                     model.meta.group_id = 'exposure{0:04d}'.format(i + 1)
 
                 group_id = model.meta.group_id
-                if not self._save_open and not self._return_open:
-                    model.close()
-                    model = self._models[i]
+
+            if not self._save_open and not self._return_open:
+                model.close()
+                model = self._models[i]
 
             if group_id in group_dict:
                 group_dict[group_id].append(model)


### PR DESCRIPTION
`models_grouped` property of a `ModelContainer` should return file names instead of opened models when input are lists of files names under some circumstances. However, due to an incorrect indentation of a `if-block`, `models_grouped` *always* returns a list of opened (loaded in memory) data models.

This PR fixes the above.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
