### PR TITLE
remove sphinx-asdf requirement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ associations
 documentation
 -------------
 
+- Remove ``sphinx-asdf`` fix issue where menu does not scroll. [#8196]
+
 - Fixed small typo in ``user_documentation`` docs. [#8178]
 
 - Added additional information for the ``scale`` and ``snr`` parameters

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,6 @@ extensions = [
     'sphinx_automodapi.automodsumm',
     'sphinx_automodapi.autodoc_enhancements',
     'sphinx_automodapi.smart_resolver',
-    'sphinx_asdf',
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,6 @@ report_crds_context = "pytest_crds.plugin"
 docs = [
     "matplotlib",
     "sphinx",
-    "sphinx-asdf>=0.1.2",
     "sphinx-astropy",
     "sphinx-automodapi",
     "sphinx-rtd-theme",


### PR DESCRIPTION
This PR removes `sphinx-asdf` as a requirement. It's primary purpose is to render asdf schemas in the docs. As jwst no longer contains schemas (those were moved to `stdatamodels`) the requirement for `sphinx-asdf` is no longer needed.

This fixes the current issue where the docs are rendered with a side/navigation menu that does not scroll when it overflows.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
