### PR TITLE
JP-3509: Cut cube collapse for autocentroiding short of 26 microns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ extract_1d
 - Fixed a bug in the calling of optional MIRI MRS 1d residual fringe
   correction that could cause defringing to fail in some cases. [#8180]
 
+- Fixed ifu auto-centroiding to only use wavelengths shortward of 26 microns
+  to avoid failures for moderate-brightness sources due to extremely low
+  throughput at the long wavelength end of MRS band 4C. []
+
 tweakreg
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ extract_1d
 
 - Fixed ifu auto-centroiding to only use wavelengths shortward of 26 microns
   to avoid failures for moderate-brightness sources due to extremely low
-  throughput at the long wavelength end of MRS band 4C. []
+  throughput at the long wavelength end of MRS band 4C. [#8199]
 
 tweakreg
 --------

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -102,7 +102,8 @@ The ``extract_1d`` step has the following step-specific arguments.
 ``--ifu_autocen``
   Switch to select whether or not to enable auto-centroiding of the extraction
   aperture for IFU point sources.  Auto-centroiding works by median collapsing the
-  IFU cube across all wavelengths and using DAOStarFinder to locate the brightest
+  IFU cube across all wavelengths (shortward of 26 microns where the MRS throughput
+  becomes extremely low) and using DAOStarFinder to locate the brightest
   source in the field. Default is ``False``.
 
 ``--ifu_rfcorr``

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -504,7 +504,13 @@ def extract_ifu(input_model, source_type, extract_params):
         # If ifu_autocen is set, try to find the source in the field using DAOphot
         if extract_params['ifu_autocen'] is True:
             log.info('Using auto source detection.')
-            collapse = np.ma.median(np.ma.masked_invalid(data), axis=0)
+
+            # Median collapse across wavelengths, but ignore wavelengths above
+            # 26 microns where MRS throughput is extremely low
+            (_, _, wavetemp) = get_coordinates(input_model, 1, 1)
+            indx = (np.where(wavetemp < 26))[0]
+            collapse = np.ma.median(np.ma.masked_invalid(data[indx, :, :]), axis=0)
+
             # Sigma-clipped stats on collapsed image
             _, clipmed, cliprms = sigclip(collapse)
             # Find source in the collapsed image above 3 sigma


### PR DESCRIPTION
Resolves [JP-3509](https://jira.stsci.edu/browse/JP-3509)

Closes #8193 

This PR addresses JP-3509 by ensuring that only cube wavelengths shortward of 26 microns are used for the IFU autocentroiding.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
