### PR TITLE
Update RTD installation instructions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,11 @@ extract_1d
 - Fixed a bug in the calling of optional MIRI MRS 1d residual fringe
   correction that could cause defringing to fail in some cases. [#8180]
 
+tweakreg
+--------
+
+- Update sregion after WCS corrections are applied. [#8158]
+
 
 1.13.3 (01-05-2024)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ documentation
 - Added additional information for the ``scale`` and ``snr`` parameters
   in the ``outlier_detection`` step docs. [#8177]
 
+- Updated installation instructions to include a warning that Python<=3.11
+  must be used. [#8200]
+
 emicorr
 -------
 

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -68,13 +68,6 @@ You can also install a specific version (from `jwst 0.17.0` onward):
     | >> conda activate <env_name>
     | >> pip install jwst==1.12.5
 
-Installing specific versions before `jwst 0.17.0` need to be installed from Github:
-
-    | >> conda create -n <env_name> python
-    | >> conda activate <env_name>
-    | >> pip install git+https://github.com/spacetelescope/jwst@0.16.2
-
-
 .. _installing_dev:
 
 Installing the Development Version from Github

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -38,8 +38,14 @@ shell.
 
 .. warning::
 
-    Users on MacOS Mojave (10.14) should limit their environment python to 3.9 -
-    there is a package dependency which currently fails to build on Mojave with
+    The jwst package requires a C compiler for dependencies and is currently
+    limited to Python 3.9, 3.10, or 3.11. Until Python 3.12 is supported, fresh
+    conda environments will require setting the Python version to <=3.11.
+
+.. warning::
+
+    Users on MacOS Mojave (10.14) should limit their environment to python 3.9 -
+    there is a package dependency that currently fails to build on Mojave with
     python>=3.10.
 
 Installing Latest Release
@@ -47,7 +53,7 @@ Installing Latest Release
 
 You can install the latest released version via `pip`.  From a bash/zsh shell:
 
-    | >> conda create -n <env_name> python
+    | >> conda create -n <env_name> python=3.11
     | >> conda activate <env_name>
     | >> pip install jwst
 
@@ -58,9 +64,9 @@ Installing Previous Releases
 
 You can also install a specific version (from `jwst 0.17.0` onward):
 
-    | >> conda create -n <env_name> python
+    | >> conda create -n <env_name> python=3.11
     | >> conda activate <env_name>
-    | >> pip install jwst==1.3.3
+    | >> pip install jwst==1.12.5
 
 Installing specific versions before `jwst 0.17.0` need to be installed from Github:
 
@@ -77,7 +83,7 @@ Installing the Development Version from Github
 You can install the latest development version (not as well tested) from the
 Github master branch:
 
-    | >> conda create -n <env_name> python
+    | >> conda create -n <env_name> python=3.11
     | >> conda activate <env_name>
     | >> pip install git+https://github.com/spacetelescope/jwst
 

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -31,9 +31,9 @@ To create a conda environment specifically for the latest stable release of
 
 ::
 
-	conda create --name jwst_latest python=3.10
+	conda create --name jwst_latest python=3.11
 
-This will create a new, (nearly) empty Python 3.10 environment in which you can
+This will create a new, (nearly) empty Python 3.11 environment in which you can
 install the `jwst` package.
 
 **2. Install jwst from PyPi**

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -19,7 +19,7 @@ from jwst.datamodels import ModelContainer
 
 # LOCAL
 from ..stpipe import Step
-from ..assign_wcs.util import update_fits_wcsinfo
+from ..assign_wcs.util import update_fits_wcsinfo, update_s_region_imaging
 from . import astrometric_utils as amutils
 from . tweakreg_catalog import make_tweakreg_catalog
 
@@ -473,6 +473,7 @@ class TweakRegStep(Step):
                     imcat.wcs.name = "FIT-LVL3-{}".format(self.abs_refcat)
 
                 image_model.meta.wcs = imcat.wcs
+                update_s_region_imaging(image_model)
 
                 # Also update FITS representation in input exposures for
                 # subsequent reprocessing by the end-user.


### PR DESCRIPTION
This PR addresses an issue raised in Help Desk ticket [INC0196726](https://stsci.service-now.com/nav_to.do?uri=incident.do%3Fsys_id=d88e80c49733b15023a2fe971153af66%26sysparm_stack=incident_list.do%3Fsysparm_query=active=true) where there was no mention of the fact that we are currently limited to installing jwst with python<=3.11. So I've updated all the places where "conda create" is mentioned.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
