### PR TITLE
JP-3465: Use TMEASURE in resample step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,7 +114,7 @@ outlier_detection
 resample
 --------
 - Updated exposure time weighting to use the measurement time 
-  when available [#8212]
+  (TMEASURE) when available [#8212]
 
 photom
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,11 @@ outlier_detection
   original input files to accidentally get deleted instead of just the intermediate
   files. [#8263]
 
+resample
+--------
+- Updated exposure time weighting to use the measurement time 
+  when available [#8212]
+
 photom
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,7 +114,10 @@ outlier_detection
 resample
 --------
 - Updated exposure time weighting to use the measurement time 
-  (TMEASURE) when available [#8212]
+  (TMEASURE) when available. [#8212]
+
+- Removed product exposure time (``TEXPTIME``) from all computations
+  in the resample step. [#8212]
 
 photom
 ------

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -96,7 +96,8 @@ image.
     (VAR_RNOISE) array stored in each input image. If the VAR_RNOISE array does
     not exist, the variance is set to 1 for all pixels (equal weighting).
     If `weight_type=exptime`, the scaling value will be set equal to the
-    exposure time found in the image header.
+    measurement time (TMEASURE) found in the image header if available; 
+    if unavailable, the scaling will be set equal to the exposure time (EFFEXPTM).
 
 ``--single`` (bool, default=False)
     If set to `True`, resample each input image into a separate output.  If

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -79,7 +79,7 @@ class GWCSDrizzle:
 
         out_units = "cps"
 
-        self.outexptime = product.meta.resample.product_exposure_time or 0.0
+        self.outexptime = product.meta.exposure.effective_exposure_time or 0.0
 
         self.outsci = product.data
         if outwcs:

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -61,8 +61,6 @@ class GWCSDrizzle:
         self.outsci = None
         self.outwht = None
         self.outcon = None
-
-        self.outexptime = 0.0
         self.uniqid = 0
 
         if wt_scl is None:
@@ -79,7 +77,7 @@ class GWCSDrizzle:
 
         out_units = "cps"
 
-        self.outexptime = product.meta.exposure.effective_exposure_time or 0.0
+        self.outexptime = product.meta.exposure.measurement_time or 0.0
 
         self.outsci = product.data
         if outwcs:

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -477,16 +477,22 @@ class ResampleData:
         exposure_times = {'start': [], 'end': []}
         duration = 0.0
         total_measurement_time = 0.0
+        measurement_time_failures = []
         for exposure in self.input_models.models_grouped:
             total_exposure_time += exposure[0].meta.exposure.exposure_time
-            total_measurement_time += exposure[0].meta.exposure.measurement_time
+            if exposure[0].meta.exposure.measurement_time is None:
+                measurement_time_failures.append(1)
+            else:
+                total_measurement_time += exposure[0].meta.exposure.measurement_time
+                measurement_time_failures.append(0)
             exposure_times['start'].append(exposure[0].meta.exposure.start_time)
             exposure_times['end'].append(exposure[0].meta.exposure.end_time)
             duration += exposure[0].meta.exposure.duration
 
         # Update some basic exposure time values based on output_model
         output_model.meta.exposure.exposure_time = total_exposure_time
-        output_model.meta.exposure.measurement_time = total_measurement_time
+        if not any(measurement_time_failures):
+            output_model.meta.exposure.measurement_time = total_measurement_time
         output_model.meta.exposure.start_time = min(exposure_times['start'])
         output_model.meta.exposure.end_time = max(exposure_times['end'])
         output_model.meta.resample.product_exposure_time = total_exposure_time

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -495,7 +495,6 @@ class ResampleData:
             output_model.meta.exposure.measurement_time = total_measurement_time
         output_model.meta.exposure.start_time = min(exposure_times['start'])
         output_model.meta.exposure.end_time = max(exposure_times['end'])
-        output_model.meta.resample.product_exposure_time = total_exposure_time
 
         # Update other exposure time keywords:
         # XPOSURE (identical to the total effective exposure time, EFFEXPTM)

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -480,7 +480,7 @@ class ResampleData:
         measurement_time_failures = []
         for exposure in self.input_models.models_grouped:
             total_exposure_time += exposure[0].meta.exposure.exposure_time
-            if exposure[0].meta.exposure.measurement_time is None:
+            if not resample_utils._check_for_tmeasure(exposure[0]):
                 measurement_time_failures.append(1)
             else:
                 total_measurement_time += exposure[0].meta.exposure.measurement_time

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -476,14 +476,17 @@ class ResampleData:
         total_exposure_time = 0.
         exposure_times = {'start': [], 'end': []}
         duration = 0.0
+        total_measurement_time = 0.0
         for exposure in self.input_models.models_grouped:
             total_exposure_time += exposure[0].meta.exposure.exposure_time
+            total_measurement_time += exposure[0].meta.exposure.measurement_time
             exposure_times['start'].append(exposure[0].meta.exposure.start_time)
             exposure_times['end'].append(exposure[0].meta.exposure.end_time)
             duration += exposure[0].meta.exposure.duration
 
         # Update some basic exposure time values based on output_model
         output_model.meta.exposure.exposure_time = total_exposure_time
+        output_model.meta.exposure.measurement_time = total_measurement_time
         output_model.meta.exposure.start_time = min(exposure_times['start'])
         output_model.meta.exposure.end_time = max(exposure_times['end'])
         output_model.meta.resample.product_exposure_time = total_exposure_time

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -46,7 +46,7 @@ class ResampleStep(Step):
         pixfrac = float(default=1.0) # change back to None when drizpar reference files are updated
         kernel = string(default='square') # change back to None when drizpar reference files are updated
         fillval = string(default='INDEF' ) # change back to None when drizpar reference files are updated
-        weight_type = option('ivm', 'exptime', 'tmeasure', None, default='ivm')  # change back to None when drizpar ref update
+        weight_type = option('ivm', 'exptime', None, default='ivm')  # change back to None when drizpar ref update
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)
@@ -199,7 +199,6 @@ class ResampleStep(Step):
             )
 
         return wcs
-
 
     def get_drizpars(self, ref_filename, input_models):
         """

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -46,7 +46,7 @@ class ResampleStep(Step):
         pixfrac = float(default=1.0) # change back to None when drizpar reference files are updated
         kernel = string(default='square') # change back to None when drizpar reference files are updated
         fillval = string(default='INDEF' ) # change back to None when drizpar reference files are updated
-        weight_type = option('ivm', 'exptime', None, default='ivm')  # change back to None when drizpar ref update
+        weight_type = option('ivm', 'exptime', 'tmeasure', None, default='ivm')  # change back to None when drizpar ref update
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)
         crval = float_list(min=2, max=2, default=None)

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -182,10 +182,10 @@ def build_driz_weight(model, weight_type=None, good_bits=None):
             inv_variance = 1.0
         result = inv_variance * dqmask
     elif weight_type == 'exptime':
-        exptime = model.meta.exposure.exposure_time
-        result = exptime * dqmask
-    elif weight_type == 'tmeasure':
-        exptime = model.meta.exposure.measurement_time
+        if model.meta.exposure.measurement_time is not None:
+            exptime = model.meta.exposure.measurement_time
+        else:
+            exptime = model.meta.exposure.exposure_time
         result = exptime * dqmask
     else:
         result = np.ones(model.data.shape, dtype=model.data.dtype) * dqmask

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -182,7 +182,7 @@ def build_driz_weight(model, weight_type=None, good_bits=None):
             inv_variance = 1.0
         result = inv_variance * dqmask
     elif weight_type == 'exptime':
-        if model.meta.exposure.measurement_time is not None:
+        if _check_for_tmeasure(model):
             exptime = model.meta.exposure.measurement_time
         else:
             exptime = model.meta.exposure.exposure_time
@@ -309,3 +309,18 @@ def _resample_range(data_shape, bbox=None):
         ymax = min(data_shape[0] - 1, int(y2 + 0.5))
 
     return xmin, xmax, ymin, ymax
+
+
+def _check_for_tmeasure(model):
+    '''
+    Check if the measurement_time keyword is present in the datamodel
+    for use in exptime weighting. If not, revert to using exposure_time.
+    '''
+    try:
+        tmeasure = model.meta.exposure.measurement_time
+        if tmeasure is not None:
+            return 1
+        else:
+            return 0
+    except AttributeError:
+        return 0

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -184,6 +184,9 @@ def build_driz_weight(model, weight_type=None, good_bits=None):
     elif weight_type == 'exptime':
         exptime = model.meta.exposure.exposure_time
         result = exptime * dqmask
+    elif weight_type == 'tmeasure':
+        exptime = model.meta.exposure.measurement_time
+        result = exptime * dqmask
     else:
         result = np.ones(model.data.shape, dtype=model.data.dtype) * dqmask
 

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -322,12 +322,18 @@ def test_weight_type(nircam_rate, _jail):
     result2 = ResampleStep.call(c, weight_type="exptime", blendheaders=False)
 
     assert_allclose(result2.data[100:105, 100:105], 6.667, rtol=1e-2)
-    assert_allclose(result2.wht[100:105, 100:105], 450.9, rtol=1e-1)
+    expectation_value = 407.
+    assert_allclose(result2.wht[100:105, 100:105], expectation_value, rtol=1e-2)
 
-    result3 = ResampleStep.call(c, weight_type="tmeasure", blendheaders=False)
+    # remove measurement time to force use of exposure time
+    # this also implicitly shows that measurement time was indeed used above
+    expected_ratio = im1.meta.exposure.exposure_time / im1.meta.exposure.measurement_time
+    for im in c:
+        del im.meta.exposure.measurement_time
 
+    result3 = ResampleStep.call(c, weight_type="exptime", blendheaders=False)
     assert_allclose(result3.data[100:105, 100:105], 6.667, rtol=1e-2)
-    assert_allclose(result2.wht[100:105, 100:105], 407., rtol=1e-1)
+    assert_allclose(result3.wht[100:105, 100:105], expectation_value * expected_ratio, rtol=1e-2)
 
 
 def test_sip_coeffs_do_not_propagate(nircam_rate):

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -76,6 +76,7 @@ def nirspec_rate():
         'duration': 11.805952,
         'end_time': 58119.85416,
         'exposure_time': 11.776,
+        'measurement_time': 11.65824,
         'frame_time': 0.11776,
         'group_time': 0.11776,
         'groupgap': 0,
@@ -129,6 +130,7 @@ def miri_rate():
         'duration': 11.805952,
         'end_time': 58119.85416,
         'exposure_time': 11.776,
+        'measurement_time': 11.65824,
         'frame_time': 0.11776,
         'group_time': 0.11776,
         'groupgap': 0,
@@ -198,6 +200,7 @@ def nircam_rate():
         'duration': 161.05155,
         'end_time': 59512.70899968495,
         'exposure_time': 150.31478,
+        'measurement_time': 139.57801,
         'frame_time': 10.73677,
         'group_time': 21.47354,
         'groupgap': 1,
@@ -320,6 +323,11 @@ def test_weight_type(nircam_rate, _jail):
 
     assert_allclose(result2.data[100:105, 100:105], 6.667, rtol=1e-2)
     assert_allclose(result2.wht[100:105, 100:105], 450.9, rtol=1e-1)
+
+    result3 = ResampleStep.call(c, weight_type="tmeasure", blendheaders=False)
+
+    assert_allclose(result3.data[100:105, 100:105], 6.667, rtol=1e-2)
+    assert_allclose(result2.wht[100:105, 100:105], 407., rtol=1e-1)
 
 
 def test_sip_coeffs_do_not_propagate(nircam_rate):

--- a/jwst/resample/tests/test_utils.py
+++ b/jwst/resample/tests/test_utils.py
@@ -113,12 +113,12 @@ def test_build_mask(dq, bitvalues, expected):
     assert_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("weight_type", ["ivm", "exptime", "tmeasure"])
+@pytest.mark.parametrize("weight_type", ["ivm", "exptime"])
 def test_build_driz_weight(weight_type):
     """Check that correct weight map is returned of different weight types"""
     model = ImageModel((10, 10))
     model.dq[0] = DO_NOT_USE
-    model.meta.exposure.exposure_time = 10.0
+    # model.meta.exposure.exposure_time = 10.0
     model.meta.exposure.measurement_time = 10.0
     model.var_rnoise += 0.1
 

--- a/jwst/resample/tests/test_utils.py
+++ b/jwst/resample/tests/test_utils.py
@@ -113,12 +113,13 @@ def test_build_mask(dq, bitvalues, expected):
     assert_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("weight_type", ["ivm", "exptime"])
+@pytest.mark.parametrize("weight_type", ["ivm", "exptime", "tmeasure"])
 def test_build_driz_weight(weight_type):
     """Check that correct weight map is returned of different weight types"""
     model = ImageModel((10, 10))
     model.dq[0] = DO_NOT_USE
     model.meta.exposure.exposure_time = 10.0
+    model.meta.exposure.measurement_time = 10.0
     model.var_rnoise += 0.1
 
     weight_map = build_driz_weight(model, weight_type=weight_type, good_bits="GOOD")

--- a/jwst/resample/tests/test_utils.py
+++ b/jwst/resample/tests/test_utils.py
@@ -118,7 +118,6 @@ def test_build_driz_weight(weight_type):
     """Check that correct weight map is returned of different weight types"""
     model = ImageModel((10, 10))
     model.dq[0] = DO_NOT_USE
-    # model.meta.exposure.exposure_time = 10.0
     model.meta.exposure.measurement_time = 10.0
     model.var_rnoise += 0.1
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3465](https://jira.stsci.edu/browse/JP-3465)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8073 

<!-- describe the changes comprising this PR here -->
This PR adjusts the way exposure time weighting is computed in the resample step to use the new measurement_time keyword from [JP-3449](https://jira.stsci.edu/browse/JP-3449) instead of the exposure time.

[Jenkins job](https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1185/)

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)