### PR TITLE
Update min version of tweakwcs to 0.8.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "stpipe>=0.5.0,<0.6.0",
     "stsci.image>=2.3.5",
     "stsci.imagestats>=1.6.3",
-    "tweakwcs>=0.8.3",
+    "tweakwcs>=0.8.6",
     "asdf-astropy>=0.3.0",
     "wiimatch>=0.2.1",
     "packaging>20.0",


### PR DESCRIPTION
Related to [JP-3468](https://jira.stsci.edu/browse/JP-3468)

<!-- describe the changes comprising this PR here -->
This PR updates the minimum required version of tweakwcs, in order to take advantage of recent bug fixes, in particular the one described in JP-3468.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
