### PR TITLE
Add a warning message in Log  to cube_build if not valid data is found on detector

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ associations
   sub-pixel dithers, so that only exposures from other nod positions
   are used as background members in "spec2" associations. [#8184]
 
+cube_build
+----------
+
+- Add a warning message to log if no valid data is found on the detector. [#8220]
+
 documentation
 -------------
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1575,7 +1575,7 @@ class IFUCubeData():
 
         num_good = len(good_data[0])
         if num_good == 0:  # This can occcur if all the pixels on the detector are marked DO_NOT_USE.
-
+            log.warning(f'No valid pixels found on detector {input_model.meta.filename}')
             return coord1, coord2, corner_coord, wave, dwave, flux, err, \
                 slice_no, rois_det, roiw_det, weight_det, \
                 softrad_det, scalerad_det, x_det, y_det


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Helps alert users to cases found in [JP-3517](https://jira.stsci.edu/browse/JP-3517). But it does not resolve [JP-3517]

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses adds a warning message to log is not valid data is on the detector. This indicates that something is wrong with the processing and the user should be warned about  this event. 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
