### PR TITLE
update regtest conftest for pytest 8

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -24,12 +24,22 @@ conf.use_memmap = False
 @pytest.fixture(scope="session")
 def artifactory_repos(pytestconfig):
     """Provides Artifactory inputs_root and results_root"""
-    try:
-        inputs_root = pytestconfig.getini('inputs_root')[0]
-        results_root = pytestconfig.getini('results_root')[0]
-    except IndexError:
+    inputs_root = pytestconfig.getini('inputs_root')
+    # in pytest 8 inputs_root will be None
+    # in pytest <8 inputs_root will be []
+    # see: https://github.com/pytest-dev/pytest/pull/11594
+    # using "not inputs_root" will handle both cases
+    if not inputs_root:
         inputs_root = "jwst-pipeline"
+    else:
+        inputs_root = inputs_root[0]
+
+    results_root = pytestconfig.getini('results_root')
+    # see not above about inputs_root
+    if not results_root:
         results_root = "jwst-pipeline-results"
+    else:
+        results_root = results_root[0]
     return inputs_root, results_root
 
 


### PR DESCRIPTION
pytest 8.0 (the current version) includes a fix:
https://github.com/pytest-dev/pytest/pull/11594
for issue:
https://github.com/pytest-dev/pytest/issues/11282

the `conftest.py` in `jwst/regtest` relied on the above bug:
https://github.com/spacetelescope/jwst/blob/bddb39c6efb2ec949a36398d21819de2abd2118b/jwst/regtest/conftest.py#L27-L30
and with pytest 8 test runs which don't use the options defined in the jwst `pyproject.toml` file result in failures:
```
 >           inputs_root = pytestconfig.getini('inputs_root')[0]
E           TypeError: 'NoneType' object is not subscriptable
```
see the full log in stdatamodels: https://github.com/spacetelescope/stdatamodels/actions/runs/7701806178/job/20988725161?pr=253#step:10:172

Although a `pyargs` tox factor is defined for jwst it appears to be unused in the CI. I opened a test PR for stdatamodels (which runs jwst tests with `pyargs`) that uses the changes in this PR to show that the included changes fix the above issue:
https://github.com/spacetelescope/stdatamodels/actions/runs/7711328119/job/21016495791?pr=254

regression tests run with no errors: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1178/

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
