### PR TITLE
Silence resample test warning by using non-zero data

### DIFF
--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -222,6 +222,12 @@ def nircam_rate():
 
 def test_nirspec_wcs_roundtrip(nirspec_rate):
     im = AssignWcsStep.call(nirspec_rate)
+
+    # Since the ra_targ, and dec_targ are flux-weighted, we need non-zero
+    # flux values.  Add random values.
+    rng = np.random.default_rng(1234)
+    im.data += rng.random(im.data.shape)
+
     im = Extract2dStep.call(im)
     for slit in im.slits:
         _set_photom_kwd(slit)


### PR DESCRIPTION
Currently there's a warning when running one of the resample unit tests.

```
$ pytest jwst/resample/tests/test_resample_step.py::test_nirspec_wcs_roundtrip
========================================================== test session starts ===========================================================
platform darwin -- Python 3.12.0, pytest-7.4.4, pluggy-1.3.0
crds_context: jwst_1188.pmap
rootdir: /Users/jdavies/dev/jwst
configfile: pyproject.toml
plugins: ci_watson-0.6.2, asdf-3.0.1, cov-4.1.0, jwst-1.13.4.dev36+g5a0835817, doctestplus-1.1.0, requests-mock-1.11.0, xdist-3.5.0
collected 1 item                                                                                                                         

jwst/resample/tests/test_resample_step.py .                                                                                        [100%]

============================================================ warnings summary ============================================================
jwst/resample/tests/test_resample_step.py::test_nirspec_wcs_roundtrip
  /Users/jdavies/dev/jwst/jwst/resample/resample_spec.py:144: RuntimeWarning: invalid value encountered in scalar divide
    wmean_s = np.sum(sd[good_s]) / total

jwst/resample/tests/test_resample_step.py::test_nirspec_wcs_roundtrip
  /Users/jdavies/dev/jwst/jwst/resample/resample_spec.py:145: RuntimeWarning: invalid value encountered in scalar divide
    wmean_l = np.sum(ld[good_s]) / total

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 1 passed, 2 warnings in 2.72s ======================================================
```

To find out what's causing it, we convert warnings to errors and print the local values of the variables (pruning the output here for readability).

```
$ pytest jwst/resample/tests/test_resample_step.py::test_nirspec_wcs_roundtrip -l -W error
========================================================== test session starts ===========================================================
platform darwin -- Python 3.12.0, pytest-7.4.4, pluggy-1.3.0
crds_context: jwst_1188.pmap
rootdir: /Users/jdavies/dev/jwst
configfile: pyproject.toml
plugins: ci_watson-0.6.2, asdf-3.0.1, cov-4.1.0, jwst-1.13.4.dev36+g5a0835817, doctestplus-1.1.0, requests-mock-1.11.0, xdist-3.5.0
collected 1 item                                                                                                                         

jwst/resample/tests/test_resample_step.py F                                                                                        [100%]

================================================================ FAILURES ================================================================
_______________________________________________________ test_nirspec_wcs_roundtrip _______________________________________________________

    def test_nirspec_wcs_roundtrip(nirspec_rate):
        im = AssignWcsStep.call(nirspec_rate)
        im = Extract2dStep.call(im)
        for slit in im.slits:
            _set_photom_kwd(slit)
>       im = ResampleSpecStep.call(im)

jwst/resample/tests/test_resample_step.py:228: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../miniconda3/envs/jwst-dev/lib/python3.12/site-packages/stpipe/step.py:653: in call
../../miniconda3/envs/jwst-dev/lib/python3.12/site-packages/stpipe/step.py:479: in run
jwst/resample/resample_spec_step.py:98: in process
jwst/resample/resample_spec_step.py:134: in _process_multislit
jwst/resample/resample_spec.py:91: in __init__
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def build_nirspec_output_wcs(self, refmodel=None):
        """
        Create a spatial/spectral WCS covering footprint of the input
        """
        all_wcs = [m.meta.wcs for m in self.input_models if m is not refmodel]
        if refmodel:
            all_wcs.insert(0, refmodel.meta.wcs)
        else:
            refmodel = self.input_models[0]
    
        # make a copy of the data array for internal manipulation
        refmodel_data = refmodel.data.copy()
        # renormalize to the minimum value, for best results when
        # computing the weighted mean below
        refmodel_data -= np.nanmin(refmodel_data)
    
        # save the wcs of the reference model
        refwcs = refmodel.meta.wcs
    
        # setup the transforms that are needed
        s2d = refwcs.get_transform('slit_frame', 'detector')
        d2s = refwcs.get_transform('detector', 'slit_frame')
        s2w = refwcs.get_transform('slit_frame', 'world')
    
        # estimate position of the target without relying on the meta.target:
        # compute the mean spatial and wavelength coords weighted
        # by the spectral intensity
        bbox = refwcs.bounding_box
        grid = wcstools.grid_from_bounding_box(bbox)
        _, s, lam = np.array(d2s(*grid))
        sd = s * refmodel_data
        ld = lam * refmodel_data
        good_s = np.isfinite(sd)
        if np.any(good_s):
            total = np.sum(refmodel_data[good_s])
>           wmean_s = np.sum(sd[good_s]) / total
E           RuntimeWarning: invalid value encountered in scalar divide
...
good_s     = array([[False, False, False, ..., False, False, False],
       [False, False, False, ..., False, False, False],
      ...True],
       [ True,  True,  True, ...,  True,  True,  True],
       [False, False, False, ..., False, False, False]])
...
refmodel_data = array([[0., 0., 0., ..., 0., 0., 0.],
       [0., 0., 0., ..., 0., 0., 0.],
       [0., 0., 0., ..., 0., 0., 0.],
    ..., 0., 0., ..., 0., 0., 0.],
       [0., 0., 0., ..., 0., 0., 0.],
       [0., 0., 0., ..., 0., 0., 0.]], dtype=float32)
...
sd         = array([[nan, nan, nan, ..., nan, nan, nan],
       [nan, nan, nan, ..., nan, nan, nan],
       [nan, nan, nan, ..., na...-0., -0., ..., -0., -0., -0.],
       [-0., -0., -0., ..., -0., -0., -0.],
       [nan, nan, nan, ..., nan, nan, nan]])
...
total      = 0.0

jwst/resample/resample_spec.py:144: RuntimeWarning
======================================================== short test summary info =========================================================
FAILED jwst/resample/tests/test_resample_step.py::test_nirspec_wcs_roundtrip - RuntimeWarning: invalid value encountered in scalar divide
=========================================================== 1 failed in 2.73s ============================================================
```

So it's a divide-by-zero warning because the sum `total` of the flux in the slit is zero.  This is the part of the code where the mean spatial location of the spectrum is found by flux-weighting the spatial WCS.  But in the test, the flux was all zeros.

This PR fixes the input data to the test to be non-zero.

One could probably handle this exceedingly unlikely case in the runtime code as well, i.e. check for `total == 0`, but this is probably not realistic for any real data.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
