### PR TITLE
Add option to preserve reference pixels after IRS2 processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,10 @@ extract_1d
   pixels in the 2nd-order spectrum are flagged and would cause the step
   to fail. [#8265]
 
+- Fixed ifu auto-centroiding to only use wavelengths shortward of 26 microns
+  to avoid failures for moderate-brightness sources due to extremely low
+  throughput at the long wavelength end of MRS band 4C. [#8199]
+
 extract_2d
 ----------
 
@@ -112,9 +116,8 @@ refpix
   all groups in each integration and robustly replace bad values from their
   nearest neighbors. [#8197, #8214]
 
-- Fixed ifu auto-centroiding to only use wavelengths shortward of 26 microns
-  to avoid failures for moderate-brightness sources due to extremely low
-  throughput at the long wavelength end of MRS band 4C. [#8199]
+- Add option for NIRSpec IRS2 to preserve interleaved reference pixels in the
+  output file, for calibration and diagnostic purposes. [#8255]
 
 resample
 --------

--- a/docs/jwst/refpix/arguments.rst
+++ b/docs/jwst/refpix/arguments.rst
@@ -1,7 +1,7 @@
 Step Arguments
 ==============
 
-The reference pixel correction step has five step-specific arguments:
+The reference pixel correction step has seven step-specific arguments:
 
 *  ``--odd_even_columns``
 
@@ -44,3 +44,11 @@ This is a factor to avoid overcorrection of intermittently bad reference
 pixels in the IRS2 algorithm. This factor is the number of sigmas away
 from the mean. The default value is 3.0, and this argument applies
 only to NIRSpec data taken with IRS2 mode.
+
+*  ``--preserve_irs2_refpix``
+
+If the ``preserve_irs2_refpix`` argument is set, interleaved reference pixels
+in IRS2 mode will be processed along with the normal pixels and preserved
+in the output.  This option is intended for calibration or diagnostic reductions
+only. For normal science operation, this argument should always be False,
+so that interleaved pixels are stripped before continuing processing.

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -10,8 +10,8 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def correct_model(input_model, irs2_model,
-                  scipix_n_default=16, refpix_r_default=4, pad=8):
+def correct_model(input_model, irs2_model, scipix_n_default=16, refpix_r_default=4,
+                  pad=8, preserve_refpix=False):
     """Correct an input NIRSpec IRS2 datamodel using reference pixels.
 
     Parameters
@@ -34,6 +34,11 @@ def correct_model(input_model, irs2_model,
         The effective number of pixels sampled during the pause at the end
         of each row (new-row overhead).  The padding is needed to preserve
         the phase of temporally periodic signals.
+
+    preserve_refpix: bool
+        If True, reference pixels will be preserved in the output.
+        This is not used in the science pipeline, but is necessary to
+        create new bias files for IRS2 mode.
 
     Returns
     -------
@@ -163,12 +168,19 @@ def correct_model(input_model, irs2_model,
         # Y axis.  This is the reason for the slice `nx-ny:` that is used
         # below.  The last axis of output_model.data should be 2048.
         data0 = data[integ, :, :, :]
-        data0 = subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad)
-        data[integ, :, :, nx - ny:] = data0
+        data0 = subtract_reference(data0, alpha, beta, irs2_mask, scipix_n,
+                                   refpix_r, pad, preserve_refpix=preserve_refpix)
+        if not preserve_refpix:
+            data[integ, :, :, nx - ny:] = data0
+        else:
+            data[integ, :, :, :] = data0
 
     # Convert corrected data back to sky orientation
     output_model = input_model.copy()
-    temp_data = data[:, :, :, nx - ny:]
+    if not preserve_refpix:
+        temp_data = data[:, :, :, nx - ny:]
+    else:
+        temp_data = data
     if detector == "NRS1":
         output_model.data = np.swapaxes(temp_data, 2, 3)
     elif detector == "NRS2":
@@ -177,7 +189,8 @@ def correct_model(input_model, irs2_model,
         output_model.data = temp_data
 
     # Strip interleaved ref pixels from the PIXELDQ, GROUPDQ, and ERR extensions.
-    strip_ref_pixels(output_model, irs2_mask)
+    if not preserve_refpix:
+        strip_ref_pixels(output_model, irs2_mask)
 
     return output_model
 
@@ -642,7 +655,8 @@ def flag_bad_refpix(datamodel, n_sigma=3.0, flag_only=False, replace_only=False)
                               | dqflags.pixel['DO_NOT_USE'])
 
 
-def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
+def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n,
+                       refpix_r, pad, preserve_refpix=False):
     """Subtract reference output and pixels for the current integration.
 
     Parameters
@@ -681,6 +695,11 @@ def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
     pad: int
         The effective number of pixels sampled during the pause at the end
         of each row (new-row overhead).
+
+    preserve_refpix: bool
+        If True, reference pixels will be preserved in the output.
+        This is not used in the science pipeline, but is necessary to
+        create new bias files for IRS2 mode.
 
     Returns
     -------
@@ -721,6 +740,8 @@ def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
 
     hnorm1 = ind_n + (refpix_r + 2) * ((ind_n + scipix_n // 2) // scipix_n)
     href1 = ind_ref + (scipix_n + 2) * (ind_ref // refpix_r) + scipix_n // 2 + 1
+
+    unpad = np.sort(np.hstack([hnorm1, href1]))
 
     # Subtract the average over the ramp for each pixel.
     # b_offset is saved so that it can be added back in at the end.
@@ -852,7 +873,9 @@ def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
         # FFT.  This really shouldn't matter.
         normalization = float(shape_d[2] * shape_d[3])
 
-        if beta is not None:
+        # Set up refout if alpha was provided
+        refout0 = None
+        if alpha is not None:
             # IDL:  refout0 = reform(data0[*,*,*,0], sd[1] * sd[2], sd[3])
             refout0 = data0[0, :, :, :].reshape((shape_d[1], shape_d[2] * shape_d[3]))
 
@@ -872,7 +895,7 @@ def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
 
         # IDL:  for k=0,3 do oBridge[k]->Execute,
         #           "for i=0, s3-1 do r0[*,i] += beta * refout0[*,i]"
-        if beta is not None:
+        if alpha is not None:
             r0k_fft += (alpha[k - 1] * refout0)
         del refout0
 
@@ -888,10 +911,16 @@ def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
         # IDL:  r0 = reform(r0, sd[1], sd[2], sd[3], 5, /over)
         r0k = r0k.reshape(shape_d[1], shape_d[2], shape_d[3])
         r0k = r0k.real
-        r0k = r0k[:, :, hnorm1]
+        if not preserve_refpix:
+            r0k = r0k[:, :, hnorm1]
+        else:
+            r0k = r0k[:, :, unpad]
 
         # Subtract the correction from the data in this sector
-        data0[k, :, :, hnorm1] -= np.transpose(r0k, (2, 0, 1))
+        if not preserve_refpix:
+            data0[k, :, :, hnorm1] -= np.transpose(r0k, (2, 0, 1))
+        else:
+            data0[k, :, :, unpad] -= np.transpose(r0k, (2, 0, 1))
         del r0k
 
     # End of loop over 4 sectors
@@ -899,9 +928,14 @@ def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
     # Original data0 array has shape (5, ngroups, 2048, 712). Now that
     # correction has been applied, remove the interleaved reference pixels.
     # This leaves data0 with shape (5, ngroups, 2048, 512).
-    data0 = data0[:, :, :, hnorm1]
+    if not preserve_refpix:
+        data0 = data0[:, :, :, hnorm1]
+    else:
+        data0 = data0[:, :, :, unpad]
 
     # Unflip the data in the sectors that have opposite readout direction
+    if preserve_refpix:
+        data0[0, :, :, :] = data0[0, :, :, ::-1]
     data0[2, :, :, :] = data0[2, :, :, ::-1]
     data0[4, :, :, :] = data0[4, :, :, ::-1]
 
@@ -920,13 +954,23 @@ def subtract_reference(data0, alpha, beta, irs2_mask, scipix_n, refpix_r, pad):
     # the interleaved reference pixels stripped out.
     # IDL:  data0 = reform(data0[*, 1:*, *, *], s[2], s[2], s[3], /over)
     # Note:  ny x ny, not ny x nx.
-    data0 = data0[:, :, 1:, :].reshape((ngroups, ny, ny))
+    if not preserve_refpix:
+        data0 = data0[:, :, 1:, :].reshape((ngroups, ny, ny))
+    else:
+        data0 = data0.reshape((ngroups, ny, nx))
 
     # b_offset is the average over the ramp that we subtracted near the
     # beginning; add it back in.
     # Shape of b_offset is (2048, 3200), but data0 is (ngroups, 2048, 2048),
     # so a mask is applied to b_offset to remove the reference pix locations.
-    data0 += b_offset[..., irs2_mask]
+    if not preserve_refpix:
+        data0 += b_offset[..., irs2_mask]
+    else:
+        # add in only data value -
+        # reference mean should be subtracted if not stripped,
+        # except in reference sector
+        data0[..., irs2_mask] += b_offset[..., irs2_mask]
+        data0[..., :nx // 5] += b_offset[..., :nx // 5]
 
     return data0
 

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -23,6 +23,7 @@ class RefPixStep(Step):
         side_gain = float(default=1.0) # Multiplicative factor for side reference signal before subtracting from rows
         odd_even_rows = boolean(default=True) # Compute reference signal separately for even- and odd-numbered rows
         ovr_corr_mitigation_ftr = float(default=3.0) # Factor to avoid overcorrection of bad reference pixels for IRS2
+        preserve_irs2_refpix = boolean(default=False) # Preserve reference pixels in output
     """
 
     reference_file_types = ['refpix']
@@ -54,7 +55,8 @@ class RefPixStep(Step):
                 irs2_model = datamodels.IRS2Model(self.irs2_name)
 
                 # Apply the IRS2 correction scheme
-                result = irs2_subtract_reference.correct_model(datamodel, irs2_model)
+                result = irs2_subtract_reference.correct_model(
+                    datamodel, irs2_model, preserve_refpix=self.preserve_irs2_refpix)
 
                 if result.meta.cal_step.refpix != 'SKIPPED':
                     result.meta.cal_step.refpix = 'COMPLETE'

--- a/jwst/refpix/tests/test_refpix.py
+++ b/jwst/refpix/tests/test_refpix.py
@@ -4,10 +4,11 @@ import pytest
 from stdatamodels.jwst.datamodels import RampModel, dqflags
 
 from jwst.refpix import RefPixStep
-from jwst.refpix.reference_pixels import Dataset, NIRDataset, correct_model, create_dataset
+from jwst.refpix.reference_pixels import (
+    Dataset, NIRDataset, correct_model, create_dataset, NRS_edgeless_subarrays)
 
 
-def test_refpix_subarray():
+def test_refpix_subarray_miri():
     '''Check that the correction is skipped for MIR subarray data '''
 
     # For MIRI, no reference pixel correction is performed on subarray data
@@ -34,6 +35,41 @@ def test_refpix_subarray():
 
     # test that the science data are not changed
     np.testing.assert_array_equal(im.data, outim.data)
+
+
+@pytest.mark.parametrize('subarray,ysize,xsize',
+                         [('SUB512', 32, 512),
+                          ('SUBS200A1', 64, 2048)])
+def test_refpix_subarray_nirspec(subarray, ysize, xsize):
+    """Check that the correction is performed for NRS subarray data."""
+
+    # For NIRSpec, reference pixel correction is performed for all
+    # subarrays, with and without edges.
+
+    # create input data
+    ngroups = 3
+    im = make_rampmodel(ngroups, ysize, xsize, instrument='NIRSPEC', fill_value=0.0)
+    im.meta.subarray.name = subarray
+    im.meta.subarray.xstart = 1
+    im.meta.subarray.ystart = 1
+
+    # set reference pixel values top and bottom, left and right
+    im.data[:, :, :4, :] = 1.0
+    im.data[:, :, -4:] = 2.0
+    im.data[:, :, :, :4] = 3.0
+    im.data[:, :, :, -4:] = 4.0
+
+    # set reference pixels to 'REFERENCE_PIXEL'
+    if subarray not in NRS_edgeless_subarrays:
+        im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
+        im.pixeldq[:, -4:] = dqflags.pixel['REFERENCE_PIXEL']
+
+    # run the step
+    out = RefPixStep.call(im)
+
+    # value subtracted should be the average of the left and right
+    # reference pixels
+    assert np.allclose(out.data[:, :, 4:-5, 4:-5], -3.5)
 
 
 def test_each_amp():
@@ -113,7 +149,6 @@ def test_firstframe_sub():
     # test that the science data are not changed
     np.testing.assert_array_equal(im.data, outim.data)
 
-
 def test_odd_even():
     '''Check that odd/even rows are applied when flag is set'''
 
@@ -165,6 +200,82 @@ def test_odd_even():
     assert out.data[0, 5, 101, 5] == 48.0
     assert out.data[0, 5, 101, 6] == 47.0
     assert out.data[0, 5, 101, 7] == 46.0
+
+
+@pytest.mark.parametrize('detector,ysize,odd_even',
+                         [('NRS1', 2048, True),
+                          ('NRS1', 2048, False),
+                          ('NRS2', 2048, True),
+                          ('NRS2', 2048, False),])
+def test_odd_even_amp_nirspec(detector, ysize, odd_even):
+    """Check that odd/even columns are applied when flag is set"""
+
+    # Test that odd and even rows are calculated separately
+
+    # create input data
+    # create model of data with 0 value array
+    ngroups = 1
+    xsize = 2048
+
+    # make ramp model
+    im = make_rampmodel(ngroups, ysize, xsize,
+                        instrument='NIRSPEC', fill_value=0.0)
+    im.meta.instrument.detector = detector
+
+    # check for irs2 data
+    if ysize == 3200:
+        n_amp = 5
+        is_irs = True
+    else:
+        n_amp = 4
+        is_irs = False
+    amp_size = ysize // n_amp
+
+    # set reference pixel values left and right side, odd and even rows.
+    rval = []
+    for i in range(n_amp):
+        start_y = i * amp_size
+        end_y = start_y + amp_size
+        amp_val = 10 * i + 1.0
+        im.data[:, :, start_y:end_y:2, :4] = amp_val
+        im.data[:, :, start_y + 1:end_y:2, :4] = amp_val + 1
+        im.data[:, :, start_y:end_y:2, -4:] = amp_val
+        im.data[:, :, start_y + 1:end_y:2, -4:] = amp_val + 1
+
+        rval.append(amp_val)
+
+    # set reference pixels to 'REFERENCE_PIXEL'
+    im.pixeldq[:, :4] = dqflags.pixel['REFERENCE_PIXEL']
+    im.pixeldq[:, -4:] = dqflags.pixel['REFERENCE_PIXEL']
+
+    # run the step
+    out = RefPixStep.call(im, use_side_ref_pixels=False, odd_even_columns=odd_even)
+
+    # values should be different by amp and by odd/even row if specified
+    # pick a random pixel to test
+    # Note: only 4 amps in output, regardless of how many are in input
+    test_row = 256
+    test_col = xsize // 2
+    for i in range(n_amp):
+        if n_amp == 5:
+            # skip ref section: first for nrs1, last for nrs2
+            if i == 0 and detector == 'NRS1':
+                continue
+            elif i == n_amp - 1 and detector == 'NRS2':
+                continue
+        if odd_even:
+            if is_irs:
+                # odd/even is a little different for irs2: values get mixed
+                assert np.isclose(out.data[0, 0, test_row, test_col], -rval[i] - 0.1)
+                assert np.isclose(out.data[0, 0, test_row + 1, test_col], -rval[i] - 0.9)
+            else:
+                assert out.data[0, 0, test_row, test_col] == -rval[i]
+                assert out.data[0, 0, test_row + 1, test_col] == -rval[i] - 1
+        else:
+            assert out.data[0, 0, test_row, test_col] == -rval[i] - 0.5
+            assert out.data[0, 0, test_row + 1, test_col] == -rval[i] - 0.5
+
+        test_row += 2048 // 4
 
 
 def test_no_odd_even():
@@ -637,27 +748,42 @@ def test_do_top_bottom_correction_no_even_odd(setup_cube):
             decimal=1)
 
 
-def make_rampmodel(ngroups, ysize, xsize):
-    '''Make MIRI ramp model for testing'''
+def make_rampmodel(ngroups, ysize, xsize, instrument='MIRI', fill_value=None):
+    '''Make MIRI or NIRSpec ramp model for testing'''
 
     # create the data and groupdq arrays
     csize = (1, ngroups, ysize, xsize)
 
-    # create JWST datamodel and set each frame equal to frame number
+    # create JWST datamodel
     dm_ramp = RampModel(csize)
 
-    for i in range(0, ngroups - 1):
-        dm_ramp.data[0, i, :, :] = i
+    # set each frame equal to frame number if fill value is not provided
+    if fill_value is None:
+        for i in range(0, ngroups - 1):
+            dm_ramp.data[0, i, :, :] = i
+    else:
+        dm_ramp.data[:] = fill_value
 
     # populate header of data model
+    if instrument == 'NIRSPEC':
+        dm_ramp.meta.instrument.name = 'NIRSPEC'
+        dm_ramp.meta.instrument.detector = 'NRS1'
+        dm_ramp.meta.exposure.type = 'NRS_FIXEDSLIT'
+        if ysize > 2048:
+            dm_ramp.meta.exposure.readpatt = 'NRSIRS2'
+            dm_ramp.meta.exposure.nrs_normal = 16
+            dm_ramp.meta.exposure.nrs_reference = 4
+        else:
+            dm_ramp.meta.exposure.readpatt = 'NRS'
+    else:
+        dm_ramp.meta.instrument.name = 'MIRI'
+        dm_ramp.meta.instrument.detector = 'MIRIMAGE'
+        dm_ramp.meta.instrument.filter = 'F560W'
+        dm_ramp.meta.exposure.type = 'MIR_IMAGE'
 
-    dm_ramp.meta.instrument.name = 'MIRI'
-    dm_ramp.meta.instrument.detector = 'MIRIMAGE'
-    dm_ramp.meta.instrument.filter = 'F560W'
     dm_ramp.meta.instrument.band = 'N/A'
     dm_ramp.meta.observation.date = '2016-06-01'
     dm_ramp.meta.observation.time = '00:00:00'
-    dm_ramp.meta.exposure.type = 'MIR_IMAGE'
     dm_ramp.meta.subarray.name = 'FULL'
     dm_ramp.meta.subarray.xstart = 1
     dm_ramp.meta.subarray.xsize = xsize
@@ -814,3 +940,45 @@ def test_zero_frame(setup_cube):
     zeroframe[0, 4:-4, 4:-4] = dataval / 2. - rpix / 2.
     zeroframe[0, 5, 5] = 0.  # Make sure this pixel is zero.
     np.testing.assert_almost_equal(input_model.zeroframe, zeroframe, decimal=5)
+
+
+@pytest.mark.parametrize('detector,irs2,preserve',
+                         [('NRS1', False, False),
+                          ('NRS1', False, True),
+                          ('NRS1', True, True),
+                          ('NRS1', True, False),
+                          ('NRS2', False, False),
+                          ('NRS2', False, True),
+                          ('NRS2', True, True),
+                          ('NRS2', True, False)])
+def test_preserve_refpix(detector, irs2, preserve):
+    # make some nirspec data
+    ngroups = 1
+    xsize = 2048
+    if irs2:
+        ysize = 3200
+    else:
+        ysize = 2048
+
+    # make ramp model
+    im = make_rampmodel(ngroups, ysize, xsize,
+                        instrument='NIRSPEC', fill_value=0.0)
+    im.meta.instrument.detector = detector
+
+    # run the step
+    out = RefPixStep.call(im, preserve_irs2_refpix=preserve)
+    if not irs2:
+        # parameter ignored for non-irs2 data
+        assert out.data.shape == (1, ngroups, ysize, xsize)
+        assert out.err.shape == (1, ngroups, ysize, xsize)
+        assert out.pixeldq.shape == (ysize, xsize)
+    elif preserve:
+        # output data shape is the same
+        assert out.data.shape == (1, ngroups, ysize, xsize)
+        assert out.err.shape == (1, ngroups, ysize, xsize)
+        assert out.pixeldq.shape == (ysize, xsize)
+    else:
+        # output data is trimmed to remove interleaved refpix
+        assert out.data.shape == (1, ngroups, xsize, xsize)
+        assert out.err.shape == (1, ngroups, xsize, xsize)
+        assert out.pixeldq.shape == (xsize, xsize)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3529](https://jira.stsci.edu/browse/JP-3529)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8254 

<!-- describe the changes comprising this PR here -->
This PR allows interleaved reference pixels in NIRSpec IRS2 mode to be preserved in the output from the refpix step.  This is needed for calibration reductions, to produce new bias reference files, but should not be used for science reductions.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
