### PR TITLE
JP-3532: MRS 1d residual fringe treatment of negative values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,7 +74,7 @@ residual_fringe
 ---------------
 
 - Fix a bug with 1d residual fringe zeroing out negative fluxes instead of
-  ignoring them. []
+  ignoring them. [#8261]
 
 tweakreg
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,12 @@ refpix
   to avoid failures for moderate-brightness sources due to extremely low
   throughput at the long wavelength end of MRS band 4C. [#8199]
 
+residual_fringe
+---------------
+
+- Fix a bug with 1d residual fringe zeroing out negative fluxes instead of
+  ignoring them. []
+
 tweakreg
 --------
 

--- a/jwst/residual_fringe/utils.py
+++ b/jwst/residual_fringe/utils.py
@@ -1094,7 +1094,7 @@ def fit_residual_fringes_1d(flux, wavelength, channel=1, dichroic_only=False, ma
         Modified version of input flux array
     """
 
-    # Restrict to just the non-zero fluxes
+    # Restrict to just the non-zero positive fluxes
     indx = np.where(flux > 0)
     useflux = flux[indx]
     usewave = wavelength[indx]

--- a/jwst/residual_fringe/utils.py
+++ b/jwst/residual_fringe/utils.py
@@ -1095,7 +1095,7 @@ def fit_residual_fringes_1d(flux, wavelength, channel=1, dichroic_only=False, ma
     """
 
     # Restrict to just the non-zero fluxes
-    indx = np.where(flux != 0)
+    indx = np.where(flux > 0)
     useflux = flux[indx]
     usewave = wavelength[indx]
 


### PR DESCRIPTION
Resolves [JP-3532](https://jira.stsci.edu/browse/JP-3532) by properly masking zero or negative-valued spectra instead of only zero-valued spectra.

Closes #8260 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
