### PR TITLE
JP-3223: Extract_2d 'slit_name' parameter fails for NRS_MSASPEC slits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,7 +47,7 @@ extract_2d
 ----------
 
 - Fixed crash when user provides slit_name, and value is a string. This
-  change had been done in PR8108 but it got undone by another PR. []
+  change had been done in PR8108 but it got undone by another PR. [#8272]
 
 outlier_detection
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,8 +46,9 @@ extract_1d
 extract_2d
 ----------
 
-- Fixed crash when user provides slit_name, and value is a string. This
-  change had been done in PR8108 but it got undone by another PR. [#8272]
+- Fixed crash when user provides an integer value for the `slit_name` argument,
+  by converting to a string. This change had been done in #8108, but it got undone
+  by another PR. [#8272]
 
 outlier_detection
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,13 @@ extract_1d
 
 - Added a hook to bypass the ``extract_1d`` step for NIRISS SOSS data in 
   the FULL subarray with warning. [#8225]
-  
+
+extract_2d
+----------
+
+- Fixed crash when user provides slit_name, and value is a string. This
+  change had been done in PR8108 but it got undone by another PR. []
+
 outlier_detection
 -----------------
 
@@ -202,9 +208,6 @@ extract_2d
 - Fixed crash with slit_name for MOS. Now the argument should
   be passed as a string, e.g. slit_name='67'. Included this
   in the corresponding documentation. [#8081]
-
-- Fixed potential future crash if MSA slitlet name is not an
-  integer. [#8108]
 
 general
 -------

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -46,12 +46,9 @@ def nrs_extract2d(input_model, slit_name=None):
     open_slits = slit2msa.slits[:]
     if slit_name is not None:
         new_open_slits = []
-        if not isinstance(slit_name, str):
-            slit_name = str(slit_name)
+        slit_name = str(slit_name)
         for sub in open_slits:
-            if not isinstance(sub.name, str):
-                str_subnme = str(sub.name)
-            if str_subnme == slit_name:
+            if str(sub.name) == slit_name:
                 new_open_slits.append(sub)
                 break
         if len(new_open_slits) == 0:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3223](https://jira.stsci.edu/browse/JP-3223)  (again)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a crash of extract_2d when user provides slit_name, and value is a string. This change had been done and merged in #8108 , but it accidentally got undone by a later PR. So note that the original fix was NOT included in DMS B10.1 as we'd assumed. It will now be included in B10.2.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
