### PR TITLE
JP-3483: fix atoca failures due to sparse matrix solver

### DIFF
--- a/jwst/extract_1d/soss_extract/atoca.py
+++ b/jwst/extract_1d/soss_extract/atoca.py
@@ -12,8 +12,9 @@ ATOCA: Algorithm to Treat Order ContAmination (English)
 
 # General imports.
 import numpy as np
+import warnings
 from scipy.sparse import issparse, csr_matrix, diags
-from scipy.sparse.linalg import spsolve
+from scipy.sparse.linalg import spsolve, lsqr, MatrixRankWarning
 from scipy.interpolate import interp1d
 
 # Local imports.
@@ -1277,7 +1278,14 @@ class _BaseOverlap:
         # Only solve for valid indices, i.e. wavelengths that are
         # covered by the pixels on the detector.
         # It will be a singular matrix otherwise.
-        sln[idx] = spsolve(matrix[idx, :][:, idx], result[idx])
+        with warnings.catch_warnings(action="error") as w:
+            try:
+                sln[idx] = spsolve(matrix[idx, :][:, idx], result[idx])
+            except MatrixRankWarning:
+                # on rare occasions spsolve's approximation of the matrix is not appropriate
+                # and fails on good input data. revert to different solver
+                log.info(f'ATOCA matrix solve failed with spsolve. Retrying with least-squares.')
+                sln[idx] = lsqr(matrix[idx, :][:, idx], result[idx])[0]
 
         return sln
 

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -1032,6 +1032,8 @@ def run_extract1d(input_model, spectrace_ref_name, wavemap_ref_name,
     transform = soss_kwargs.pop('transform')
     if transform is None:
         transform = [None, None, None]
+    else:
+        transform = [float(val) for val in transform]
     # Save names for logging
     param_name = np.array(['theta', 'x-offset', 'y-offset'])
 

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -124,3 +124,35 @@ def test_niriss_soss_extras(rtdata_module, run_atoca_extras, fitsdiff_default_kw
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+@pytest.fixture(scope='module')
+def run_extract1d_spsolve_failure(jail, rtdata_module):
+    """
+    Test coverage for fix to error thrown when spsolve fails to find
+    a good solution in ATOCA and needs to be replaced with a least-
+    squares solver. Note this failure is architecture-dependent
+    and also only trips for specific values of the transform parameters.
+    Pin tikfac for faster runtime.
+    """
+    rtdata = rtdata_module
+    rtdata.get_data("niriss/soss/jw04098007001_04101_00001-seg003_nis_int01.fits")
+    args = ["extract_1d", rtdata.input,
+            "--soss_tikfac=3.1881637371089252e-15",
+            "--soss_transform=-0.00038201755227297866, -0.24237455427848956, 0.5404013401742825",
+            ]
+    Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+def test_extract1d_null_order2(rtdata_module, run_extract1d_spsolve_failure, fitsdiff_default_kwargs):
+    rtdata = rtdata_module
+
+    output = "jw04098007001_04101_00001-seg003_nis_int01_extract1dstep.fits"
+    rtdata.output = output
+
+    rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3483](https://jira.stsci.edu/browse/JP-3483)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a bug where the ATOCA algorithm's matrix solver would sometimes fail on good data, likely because the approximations in spsolve were inappropriate.  The fix allows the code to try using a least-squares solver instead when these failures occur.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
