### PR TITLE
JP-3539: replace all instances of deprecated scipy interp2d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,9 @@ extract_1d
   pixels in the 2nd-order spectrum are flagged and would cause the step
   to fail. [#8265]
 
+- Replaced instances of deprecated interp2d with 
+  RectBivariateSpline in ``apply_apcorr``. [#8291]
+
 extract_2d
 ----------
 

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -212,8 +212,12 @@ class ApCorrPhase(ApCorrBase):
             size_wl = size_wl_func(wavelength)
 
             # by default RectBivariateSpline is 3rd order, fails for size_wl=3 as in e.g. the test data
-            pixphase_size_func = RectBivariateSpline(self.reference['wavelength'], size_wl, apcorr_pixphase.T, ky=2, kx=2)
+            wl_sortidx = np.argsort(self.reference['wavelength'])
+            apcorr_pixphase = apcorr_pixphase[:, wl_sortidx]
+            wl_ref = self.reference['wavelength'][wl_sortidx]
+            pixphase_size_func = RectBivariateSpline(wl_ref, size_wl, apcorr_pixphase.T, ky=1, kx=1)
             size_func = pixphase_size_func(wavelength, size).T
+
             return size_func
 
         return _approx_func
@@ -352,7 +356,11 @@ class ApCorr(ApCorrBase):
         apcorr = self.reference['apcorr'][:self.reference['nelem_wl'], :self.reference['nelem_size']]
 
         # by default RectBivariateSpline is 3rd order, fails for size_wl=3 as in e.g. the test data
-        return RectBivariateSpline(size, wavelength, apcorr.T, ky=2, kx=2)
+        wl_sortidx = np.argsort(wavelength)
+        apcorr = apcorr[wl_sortidx, :]
+        wavelength = wavelength[wl_sortidx]
+
+        return RectBivariateSpline(size, wavelength, apcorr.T, ky=1, kx=1)
 
 
 def select_apcorr(input_model: DataModel) -> Union[Type[ApCorr], Type[ApCorrPhase], Type[ApCorrRadial]]:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3539](https://jira.stsci.edu/browse/JP-3539)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8282

<!-- describe the changes comprising this PR here -->
This PR replaces the deprecated interp2d function with RectBivariateSpline in extract_1d.  This turns out to be the only instance of interp2d in the code base.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

[Jenkins run here](https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1223/)