### PR TITLE
Suppress warnings about NaNs in input data from TweakRegStep

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,6 +136,12 @@ residual_fringe
 - Fix a bug with 1d residual fringe zeroing out negative fluxes instead of
   ignoring them. [#8261]
 
+source_catalog
+--------------
+
+- Suppress warnings from ``photutils.background.Background2D`` regarding
+  NaNs in the input data. [#8308]
+
 tweakreg
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -141,8 +141,11 @@ tweakreg
 
 - Update ``sregion`` after WCS corrections are applied. [#8158]
 
-- Added option to choose IRAFStarFinder and segmentation.SourceFinder
+- Add option to choose IRAFStarFinder and segmentation.SourceFinder
   instead of DAOStarFinder and exposed star finder parameters. [#8203]
+
+- Suppress warnings from ``photutils.background.Background2D`` regarding
+  NaNs in the input data. [#8308]
 
 
 1.13.4 (2024-01-25)

--- a/jwst/source_catalog/detection.py
+++ b/jwst/source_catalog/detection.py
@@ -70,23 +70,25 @@ class JWSTBackground:
         bkg_estimator = MedianBackground()
         filter_size = (3, 3)
 
-        try:
-            bkg = Background2D(self.data, self.box_size,
-                               filter_size=filter_size,
-                               coverage_mask=self.coverage_mask,
-                               sigma_clip=sigma_clip,
-                               bkg_estimator=bkg_estimator)
-        except ValueError:
-            # use the entire unmasked array
-            bkg = Background2D(self.data, self.data.shape,
-                               filter_size=filter_size,
-                               coverage_mask=self.coverage_mask,
-                               sigma_clip=sigma_clip,
-                               bkg_estimator=bkg_estimator,
-                               exclude_percentile=100.)
-            log.info('Background could not be estimated in meshes. '
-                     'Using the entire unmasked array for background '
-                     f'estimation: bkg_boxsize={self.data.shape}.')
+        # All data has NaNs.  Supress warnings about them.
+        with warnings.catch_warnings(action="ignore", category=AstropyUserWarning):
+            try:
+                bkg = Background2D(self.data, self.box_size,
+                                filter_size=filter_size,
+                                coverage_mask=self.coverage_mask,
+                                sigma_clip=sigma_clip,
+                                bkg_estimator=bkg_estimator)
+            except ValueError:
+                # use the entire unmasked array
+                bkg = Background2D(self.data, self.data.shape,
+                                filter_size=filter_size,
+                                coverage_mask=self.coverage_mask,
+                                sigma_clip=sigma_clip,
+                                bkg_estimator=bkg_estimator,
+                                exclude_percentile=100.)
+                log.info('Background could not be estimated in meshes. '
+                        'Using the entire unmasked array for background '
+                        f'estimation: bkg_boxsize={self.data.shape}.')
 
         return bkg
 
@@ -150,8 +152,8 @@ def convolve_data(data, kernel_fwhm, mask=None):
     """
     kernel = make_kernel(kernel_fwhm)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', AstropyUserWarning)
+    # All data has NaNs.  Supress warnings about them.
+    with warnings.catch_warnings(action="ignore", category=AstropyUserWarning):
         return convolve(data, kernel, mask=mask, normalize_kernel=True)
 
 

--- a/jwst/source_catalog/detection.py
+++ b/jwst/source_catalog/detection.py
@@ -70,26 +70,26 @@ class JWSTBackground:
         bkg_estimator = MedianBackground()
         filter_size = (3, 3)
 
-        # All data has NaNs.  Supress warnings about them.
+        # All data has NaNs.  Suppress warnings about them.
         with warnings.catch_warnings():
             warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
             try:
                 bkg = Background2D(self.data, self.box_size,
-                                filter_size=filter_size,
-                                coverage_mask=self.coverage_mask,
-                                sigma_clip=sigma_clip,
-                                bkg_estimator=bkg_estimator)
+                                   filter_size=filter_size,
+                                   coverage_mask=self.coverage_mask,
+                                   sigma_clip=sigma_clip,
+                                   bkg_estimator=bkg_estimator)
             except ValueError:
                 # use the entire unmasked array
                 bkg = Background2D(self.data, self.data.shape,
-                                filter_size=filter_size,
-                                coverage_mask=self.coverage_mask,
-                                sigma_clip=sigma_clip,
-                                bkg_estimator=bkg_estimator,
-                                exclude_percentile=100.)
+                                   filter_size=filter_size,
+                                   coverage_mask=self.coverage_mask,
+                                   sigma_clip=sigma_clip,
+                                   bkg_estimator=bkg_estimator,
+                                   exclude_percentile=100.)
                 log.info('Background could not be estimated in meshes. '
-                        'Using the entire unmasked array for background '
-                        f'estimation: bkg_boxsize={self.data.shape}.')
+                         'Using the entire unmasked array for background '
+                         f'estimation: bkg_boxsize={self.data.shape}.')
 
         return bkg
 

--- a/jwst/source_catalog/detection.py
+++ b/jwst/source_catalog/detection.py
@@ -71,7 +71,8 @@ class JWSTBackground:
         filter_size = (3, 3)
 
         # All data has NaNs.  Supress warnings about them.
-        with warnings.catch_warnings(action="ignore", category=AstropyUserWarning):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
             try:
                 bkg = Background2D(self.data, self.box_size,
                                 filter_size=filter_size,
@@ -153,7 +154,8 @@ def convolve_data(data, kernel_fwhm, mask=None):
     kernel = make_kernel(kernel_fwhm)
 
     # All data has NaNs.  Supress warnings about them.
-    with warnings.catch_warnings(action="ignore", category=AstropyUserWarning):
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
         return convolve(data, kernel, mask=mask, normalize_kernel=True)
 
 

--- a/jwst/source_catalog/detection.py
+++ b/jwst/source_catalog/detection.py
@@ -70,7 +70,7 @@ class JWSTBackground:
         bkg_estimator = MedianBackground()
         filter_size = (3, 3)
 
-        # All data has NaNs.  Suppress warnings about them.
+        # All data have NaNs.  Suppress warnings about them.
         with warnings.catch_warnings():
             warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
             try:
@@ -153,7 +153,7 @@ def convolve_data(data, kernel_fwhm, mask=None):
     """
     kernel = make_kernel(kernel_fwhm)
 
-    # All data has NaNs.  Supress warnings about them.
+    # All data have NaNs.  Supress warnings about them.
     with warnings.catch_warnings():
         warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
         return convolve(data, kernel, mask=mask, normalize_kernel=True)

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -200,7 +200,7 @@ def make_tweakreg_catalog(model, snr_threshold, bkg_boxsize=400, starfinder='dao
     else:
         raise ValueError(f"Unknown starfinder type: {starfinder}")
 
-    # Mask the non-imaging area (e.g. MIRI)
+    # Mask the non-imaging area, e.g. reference pixels and MIRI non-science area
     coverage_mask = ((dqflags.pixel['NON_SCIENCE'] +
                       dqflags.pixel['DO_NOT_USE']) &
                      model.dq).astype(bool)


### PR DESCRIPTION
Currently `TweakRegStep` logs lots of warnings like the following:

```
2024-02-26 14:09:45,740 - stpipe.tweakreg - WARNING - /Users/jdavies/miniconda3/envs/jwst-dev/lib/python3.11/site-packages/photutils/background/background_2d.py:273: AstropyUserWarning: Input data contains invalid values (NaNs or infs), which were automatically masked.
2024-02-26 14:09:45,740 - stpipe.tweakreg - WARNING -   warnings.warn('Input data contains invalid values (NaNs or '
2024-02-26 14:09:45,740 - stpipe.tweakreg - WARNING - 
2024-02-26 14:09:46,597 - stpipe.tweakreg - INFO - Detected 106 sources in jw01345002001_14201_00002_nrcalong_cal.fits.
2024-02-26 14:09:46,608 - stpipe.tweakreg - WARNING - /Users/jdavies/miniconda3/envs/jwst-dev/lib/python3.11/site-packages/photutils/background/background_2d.py:273: AstropyUserWarning: Input data contains invalid values (NaNs or infs), which were automatically masked.
2024-02-26 14:09:46,608 - stpipe.tweakreg - WARNING -   warnings.warn('Input data contains invalid values (NaNs or '
2024-02-26 14:09:46,608 - stpipe.tweakreg - WARNING - 
2024-02-26 14:09:47,422 - stpipe.tweakreg - INFO - Detected 115 sources in jw01345002001_14201_00003_nrcalong_cal.fits.
2024-02-26 14:09:47,433 - stpipe.tweakreg - WARNING - /Users/jdavies/miniconda3/envs/jwst-dev/lib/python3.11/site-packages/photutils/background/background_2d.py:273: AstropyUserWarning: Input data contains invalid values (NaNs or infs), which were automatically masked.
2024-02-26 14:09:47,433 - stpipe.tweakreg - WARNING -   warnings.warn('Input data contains invalid values (NaNs or '
2024-02-26 14:09:47,433 - stpipe.tweakreg - WARNING - 
2024-02-26 14:09:48,253 - stpipe.tweakreg - INFO - Detected 95 sources in jw01345002001_14201_00001_nrcalong_cal.fits.
2024-02-26 14:09:48,265 - stpipe.tweakreg - WARNING - /Users/jdavies/miniconda3/envs/jwst-dev/lib/python3.11/site-packages/photutils/background/background_2d.py:273: AstropyUserWarning: Input data contains invalid values (NaNs or infs), which were automatically masked.
2024-02-26 14:09:48,266 - stpipe.tweakreg - WARNING -   warnings.warn('Input data contains invalid values (NaNs or '
2024-02-26 14:09:48,266 - stpipe.tweakreg - WARNING - 
2024-02-26 14:09:49,092 - stpipe.tweakreg - INFO - Detected 100 sources in jw01345002001_14201_00001_nrcblong_cal.fits.
2024-02-26 14:09:49,950 - stpipe.tweakreg - WARNING - /Users/jdavies/miniconda3/envs/jwst-dev/lib/python3.11/site-packages/photutils/background/background_2d.py:273: AstropyUserWarning: Input data contains invalid values (NaNs or infs), which were automatically masked.
2024-02-26 14:09:49,950 - stpipe.tweakreg - WARNING -   warnings.warn('Input data contains invalid values (NaNs or '
2024-02-26 14:09:49,950 - stpipe.tweakreg - WARNING - 
2024-02-26 14:09:50,762 - stpipe.tweakreg - INFO - Detected 94 sources in jw01345002001_14201_00002_nrcblong_cal.fits.
2024-02-26 14:09:50,775 - stpipe.tweakreg - WARNING - /Users/jdavies/miniconda3/envs/jwst-dev/lib/python3.11/site-packages/photutils/background/background_2d.py:273: AstropyUserWarning: Input data contains invalid values (NaNs or infs), which were automatically masked.
2024-02-26 14:09:50,775 - stpipe.tweakreg - WARNING -   warnings.warn('Input data contains invalid values (NaNs or '
2024-02-26 14:09:50,775 - stpipe.tweakreg - WARNING - 
2024-02-26 14:09:51,584 - stpipe.tweakreg - INFO - Detected 98 sources in jw01345002001_14201_00003_nrcblong_cal.fits.
```

which is caused by passing `_cal.fits` data with NaNs to `photutils.background.Background2D`:

https://github.com/astropy/photutils/blob/d5e8bc9afebd758087ea47874aff0a1788e22587/photutils/background/background_2d.py#L287-L289

All JWST input data for this step has NaNs, so warning about them is not informative.  This PR suppresses those warnings, so we now get:

```
2024-02-26 14:13:18,475 - stpipe.tweakreg - INFO - Detected 106 sources in jw01345002001_14201_00002_nrcalong_cal.fits.
2024-02-26 14:13:19,287 - stpipe.tweakreg - INFO - Detected 115 sources in jw01345002001_14201_00003_nrcalong_cal.fits.
2024-02-26 14:13:20,097 - stpipe.tweakreg - INFO - Detected 95 sources in jw01345002001_14201_00001_nrcalong_cal.fits.
2024-02-26 14:13:20,903 - stpipe.tweakreg - INFO - Detected 100 sources in jw01345002001_14201_00001_nrcblong_cal.fits.
2024-02-26 14:13:22,522 - stpipe.tweakreg - INFO - Detected 94 sources in jw01345002001_14201_00002_nrcblong_cal.fits.
2024-02-26 14:13:23,345 - stpipe.tweakreg - INFO - Detected 98 sources in jw01345002001_14201_00003_nrcblong_cal.fits.
```

Possible upstream fix for this in astropy/photutils#1712

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
