### PR TITLE
Convert tweakreg segmentation connectivity to integer

### DIFF
--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -195,7 +195,7 @@ class TweakRegStep(Step):
                     'peakmax': self.peakmax,
                     'brightest': self.brightest,
                     'npixels': self.npixels,
-                    'connectivity': int(self.connectivity),  # option returns a string, , so cast to int
+                    'connectivity': int(self.connectivity),  # option returns a string, so cast to int
                     'nlevels': self.nlevels,
                     'contrast': self.contrast,
                     'mode': self.multithresh_mode,

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -195,7 +195,7 @@ class TweakRegStep(Step):
                     'peakmax': self.peakmax,
                     'brightest': self.brightest,
                     'npixels': self.npixels,
-                    'connectivity': self.connectivity,
+                    'connectivity': int(self.connectivity),  # option returns a string
                     'nlevels': self.nlevels,
                     'contrast': self.contrast,
                     'mode': self.multithresh_mode,

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -195,7 +195,7 @@ class TweakRegStep(Step):
                     'peakmax': self.peakmax,
                     'brightest': self.brightest,
                     'npixels': self.npixels,
-                    'connectivity': int(self.connectivity),  # option returns a string
+                    'connectivity': int(self.connectivity),  # option returns a string, , so cast to int
                     'nlevels': self.nlevels,
                     'contrast': self.contrast,
                     'mode': self.multithresh_mode,


### PR DESCRIPTION
This PR fixes a bug when using the new `SourceFinder` (via segmentation) starfinder in tweakreg which was added in #8203.  ConfigObj option always returns a string, and that causes problems when one wants options that are ints or floats.  They need to be specifically cast to the correct type.

Another reason to stop using `ConfigObj`.  ;-)

The bug is the following:

```
    TweakRegStep.call(files_to_tweak, save_results=True, suffix="cal",
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/stpipe/step.py", line 653, in call
    return instance.run(*args)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/stpipe/step.py", line 479, in run
    step_result = self.process(*args)
                  ^^^^^^^^^^^^^^^^^^^
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/jwst/tweakreg/tweakreg_step.py", line 208, in process
    catalog = make_tweakreg_catalog(
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/jwst/tweakreg/tweakreg_catalog.py", line 220, in make_tweakreg_catalog
    sources = StarFinder(model.data, threshold, mask=coverage_mask, **starfinder_kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/jwst/tweakreg/tweakreg_catalog.py", line 56, in _SourceFinderWrapper
    segment_map = finder(data, threshold, mask=mask)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/photutils/segmentation/finder.py", line 191, in __call__
    segment_img = detect_sources(data, threshold, self.npixels, mask=mask,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/astropy/utils/decorators.py", line 604, in wrapper
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/photutils/segmentation/detect.py", line 396, in detect_sources
    footprint = _make_binary_structure(data.ndim, connectivity)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdavies/miniconda3/envs/jwst/lib/python3.11/site-packages/photutils/segmentation/utils.py", line 96, in _make_binary_structure
    raise ValueError(f'Invalid connectivity={connectivity}.  '
ValueError: Invalid connectivity=8.  Options are 4 or 8.
```

One may want to update one of the regtests to use `segmentation` as the starfinder.  2 other things for comment:

The current `starfinder` kwarg in spec is fine, but `sourcefinder` would be better, as most sources in JWST images are not stars, but galaxies.  The more general term might be more accurate.

Currently the `segmentation` method doesn't convolve the image first before running detection.  This is done in the standard `photutils` docs and in `SourceCatalogStep`, so perhaps this was an oversight and should be added.  This is needed to boost S/N of detections.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
