### PR TITLE
JP-3423: fixed array shape mismatch in pixel_replace mingrad algorithm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,12 @@ pipeline
 - Updated the ``calwebb_spec2`` pipeline to include NRS_BRIGHTOBJ in
   the list of modes for running the ``nsclean`` step. [#8256]
 
+pixel_replace
+-------------
+
+- Fixed a bug that caused array size mismatches when the ``mingrad`` algorithm
+  was applied to NIRSpec data. [#8312]
+
 refpix
 ------
 

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -402,7 +402,7 @@ class PixelReplacement:
         newdq = model_replaced.dq
 
         # Make an array of x/y values on the detector
-        xsize, ysize = self.input.meta.subarray.xsize, self.input.meta.subarray.ysize
+        (ysize, xsize) = indata.shape
         basex, basey = np.meshgrid(np.arange(xsize), np.arange(ysize))
         pad = 1 # Padding around edge of array to ensure we don't look for neighbors outside array
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3423](https://jira.stsci.edu/browse/JP-3423)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7960

<!-- describe the changes comprising this PR here -->
This PR addresses a bug that would cause crashes when the mingrad algorithm for pixel replacement was applied to NIRSpec data. The error was due to an inappropriate assumption about the input array shape, which was fixed in a single line.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
