### PR TITLE
Don't test specific log formatting for spec

### DIFF
--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -608,4 +608,4 @@ def test_call_with_config(caplog, _jail):
 
     ProperPipeline.call(model, config_file=cfg)
 
-    assert "'par1': 'newpar1'" in caplog.text
+    assert "newpar1" in caplog.text


### PR DESCRIPTION
This PR modifies a single test which expect a specific format for the logging of the step spec.  Since we are changing the format in https://github.com/spacetelescope/stpipe/pull/140, this test will fail.  Instead, we just test for the new parameter being set in spec.  Same test, less fragile.  No runtime code changed.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
