### PR TITLE
replace check_memory_allocation in resample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,6 +153,8 @@ resample
   ``world_to_pixel_values``) for reproject, which also fixed a bug, and
   removed support for astropy model [#8172]
 
+- Replace use of ``check_memory_allocation``. [#8324]
+
 residual_fringe
 ---------------
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -1,8 +1,10 @@
 import logging
+import os
 
 import numpy as np
 from drizzle import util
 from drizzle import cdrizzle
+import psutil
 from spherical_geometry.polygon import SphericalPolygon
 
 from stdatamodels.jwst import datamodels
@@ -141,9 +143,27 @@ class ResampleData:
         self.pscale = pscale  # in deg
 
         log.debug('Output mosaic size: {}'.format(self.output_wcs.array_shape))
-        can_allocate, required_memory = datamodels.util.check_memory_allocation(
-            self.output_wcs.array_shape, kwargs['allowed_memory'], datamodels.ImageModel
-        )
+
+        allowed_memory = kwargs['allowed_memory']
+        if allowed_memory is None:
+            allowed_memory = os.environ.get('DMODEL_ALLOWED_MEMORY', allowed_memory)
+        if allowed_memory:
+            allowed_memory = float(allowed_memory)
+            # make a small image model to get the dtype
+            dtype = datamodels.ImageModel((1, 1)).data.dtype
+
+            # get the available memory
+            available_memory = psutil.virtual_memory().available + psutil.swap_memory().total
+
+            # compute the output array size
+            required_memory = np.prod(self.output_wcs.array_shape) * dtype.itemsize
+
+            # compare used to available
+            used_fraction = required_memory / available_memory
+            can_allocate = used_fraction <= allowed_memory
+        else:
+            can_allocate = True
+
         if not can_allocate:
             raise OutputTooLargeError(
                 f'Combined ImageModel size {self.output_wcs.array_shape} '


### PR DESCRIPTION
This PR repaces `check_memory_allocation` in `resample`.

The replaced function allocates a large array, then measures the size of the array to determine if it's safe to allocate an array of that size. See https://github.com/spacetelescope/stdatamodels/issues/272 for more details.

The replacement instead allocates a small (1x1) array to get the expected dtype then computes the expected size of the upcoming array allocation.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
