### PR TITLE
import bytes2human directly from stdatamodels

### DIFF
--- a/jwst/lib/basic_utils.py
+++ b/jwst/lib/basic_utils.py
@@ -1,8 +1,5 @@
 """General utility objects"""
 
-# Moved to stdatamodels, kept here to preserve interface
-from stdatamodels.jwst.library.basic_utils import deprecate_class, bytes2human  # noqa: F401
-
 
 class LoggingContext:
     """Logging context manager

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -6,12 +6,12 @@ from drizzle import cdrizzle
 from spherical_geometry.polygon import SphericalPolygon
 
 from stdatamodels.jwst import datamodels
+from stdatamodels.jwst.library.basic_utils import bytes2human
 
 from jwst.datamodels import ModelContainer
 
 from . import gwcs_drizzle
 from . import resample_utils
-from ..lib.basic_utils import bytes2human
 from ..model_blender import blendmeta
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
`resample` uses `bytes2human` from `jwst.lib.basic_utils` which imports this function from `stdatamodels.jwst.library.basic_utils`.

This PR updates the import to get `bytes2human` from stdatamodels directly and removes `bytes2human` and `deprecate_class` from `basic_utils`. These are internal functions that don't occur in `basic_utils.__all__` or the docs. A follow-up PR will deprecate and eventually remove `deprecate_class` from `stdatamodels`.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
