### PR TITLE
pin pytest <8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ test = [
     "colorama>=0.4.1",
     "readchar>=3.0",
     "ruff",
-    "pytest>=6.0.0",
+    "pytest>=6.0.0,<8.1.0",
     "pytest-cov>=2.9.0",
     "pytest-doctestplus>=0.10.0",
     "requests_mock>=1.0",


### PR DESCRIPTION
pytest 8.1 broke doctestplus https://github.com/scientific-python/pytest-doctestplus/issues/239

This PR pins pytest to < 8.1 until this (and possibly other plugins: https://github.com/pytest-dev/pytest/issues/12069) can be fixed.

See the recent scheduled run where all jobs fail at pytest plugin registration (and no tests are run):
https://github.com/spacetelescope/jwst/actions/runs/8138291984

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
