### PR TITLE
JP-3541: fixed tweakreg step KeyError due to empty gaia catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -206,6 +206,9 @@ tweakreg
 - Suppress warnings from ``photutils.background.Background2D`` regarding
   NaNs in the input data. [#8308]
 
+- Fixed a bug that caused failures instead of warnings when no GAIA sources
+  were found within the bounding box of the input image. [#8334]
+
 
 1.13.4 (2024-01-25)
 ===================

--- a/jwst/tweakreg/astrometric_utils.py
+++ b/jwst/tweakreg/astrometric_utils.py
@@ -96,8 +96,10 @@ def create_astrometric_catalog(input_models, catalog="GAIADR3", output="ref_cat.
         else Time(input_models[0].meta.observation.date).decimalyear
     )
     ref_dict = get_catalog(fiducial[0], fiducial[1], epoch=epoch, sr=radius, catalog=catalog)
+    if len(ref_dict) == 0:
+        return ref_dict
+    
     colnames = ('ra', 'dec', 'mag', 'objID', 'epoch')
-
     ref_table = ref_dict[colnames]
 
     # Add catalog name as meta data

--- a/jwst/tweakreg/tests/test_amutils.py
+++ b/jwst/tweakreg/tests/test_amutils.py
@@ -54,3 +54,22 @@ def test_create_catalog(wcsobj):
     )
     # check that we got expected number of sources
     assert len(gcat) == EXPECTED_NUM_SOURCES
+
+
+def test_create_catalog_graceful_failure(wcsobj):
+    '''
+    Ensure catalog retuns zero sources instead of failing outright
+    when the bounding box is too small to find any sources
+    '''
+    wcsobj.bounding_box = ((0, 0.5), (0, 0.5))
+
+    # Create catalog
+    gcat = amutils.create_astrometric_catalog(
+        None,
+        existing_wcs=wcsobj,
+        catalog=TEST_CATALOG,
+        output=None,
+        epoch='2016.0',
+    )
+    # check that we got expected number of sources
+    assert len(gcat) == 0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3541](https://jira.stsci.edu/browse/JP-3541)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8286 

<!-- describe the changes comprising this PR here -->
This PR addresses a bug that caused tweakreg to fail when the bounding box of the input image was too small to find any sources in the GAIA catalog.  This PR ensures that the appropriate warning (Not enough sources (0) in the reference catalog...), which was already implemented, is hit instead, and the step completes successfully.

[Regression test run here](https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1271/).

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
