### PR TITLE
remove global multiprocessing.set_start_method

### DIFF
--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -4,11 +4,8 @@ from stdatamodels.jwst import datamodels
 from ..stpipe import Step
 from .jump import run_detect_jumps
 import time
-import multiprocessing
 
 __all__ = ["JumpStep"]
-
-multiprocessing.set_start_method('forkserver', force=True)
 
 
 class JumpStep(Step):

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -18,12 +18,10 @@ from ..lib import reffile_utils
 import logging
 import copy
 import warnings
-import multiprocessing
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-multiprocessing.set_start_method('forkserver', force=True)
 
 
 __all__ = ["RampFitStep"]

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -1,6 +1,6 @@
 import time
+import multiprocessing
 import numpy as np
-from multiprocessing import Pool
 
 from scipy import sparse
 
@@ -259,7 +259,8 @@ class Observation:
 
         time1 = time.time()
         if self.max_cpu > 1:
-            mypool = Pool(self.max_cpu)  # Create the pool
+            ctx = multiprocessing.get_context("forkserver")
+            mypool = ctx.Pool(self.max_cpu)  # Create the pool
             all_res = mypool.imap_unordered(dispersed_pixel, pars)  # Fill the pool
             mypool.close()  # Drain the pool
         else:


### PR DESCRIPTION
Fixes: https://github.com/spacetelescope/jwst/issues/8306

Without setting a multiprocessing start method (using the default) on linux with python 3.12 results in a `DeprecationWarning`.

Warnings for python 3.12:
```
  jwst/jump/tests/test_detect_jumps.py: 9 warnings
  jwst/jump/tests/test_jump_step.py: 24 warnings
    /opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=2483) is multi-threaded, use of fork() may lead to deadlocks in the child.
      self.pid = os.fork()
  
  jwst/ramp_fitting/tests/test_ramp_fit.py::test_multiprocessing
  jwst/ramp_fitting/tests/test_ramp_fit.py::test_multiprocessing2
  jwst/ramp_fitting/tests/test_ramp_fit_step.py::test_ramp_fit_step[2]
  jwst/ramp_fitting/tests/test_ramp_fit_step.py::test_ramp_fit_step[2]
  jwst/ramp_fitting/tests/test_ramp_fit_step.py::test_ramp_fit_step[half]
  jwst/ramp_fitting/tests/test_ramp_fit_step.py::test_ramp_fit_step[half]
  jwst/ramp_fitting/tests/test_ramp_fit_step.py::test_ramp_fit_step[all]
  jwst/ramp_fitting/tests/test_ramp_fit_step.py::test_ramp_fit_step[all]
    /opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=2486) is multi-threaded, use of fork() may lead to deadlocks in the child.
      self.pid = os.fork()
```
This is due to `fork` being unsafe for applications that use threads. This warning was previously silenced using a global `set_start_method` which can cause issues for other packages (see https://github.com/spacetelescope/jwst/issues/8306).

stcal (which is the primary user of multiprocessing in the pipeline) was updated:
https://github.com/spacetelescope/stcal/pull/249

~This PR temporarily uses stcal main (that can be removed prior to merge or after a stcal release is made) to pick up the changes in the above PR and updates the remaining multiprocessing usage in wfss_contam to only set `forkserver` in a context (to not impact other packages).~ EDIT: stcal 1.7.0 (now the required version) contains the required changes