### PR TITLE
Remove upper pytest pin, switch globals use to fixture in stpipe test

### DIFF
--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -1,6 +1,4 @@
 from os.path import join, dirname, basename
-import shutil
-import tempfile
 
 import pytest
 
@@ -8,19 +6,6 @@ from astropy.io import fits
 
 from jwst.stpipe import Step
 import crds
-
-TMP_DIR = None
-TMP_FITS = None
-
-
-def setup():
-    global TMP_DIR, TMP_FITS
-    TMP_DIR = tempfile.mkdtemp()
-    TMP_FITS = join(TMP_DIR, 'tmp.fits')
-
-
-def teardown():
-    shutil.rmtree(TMP_DIR)
 
 
 class CrdsStep(Step):
@@ -53,7 +38,7 @@ def _run_flat_fetch_on_dataset(dataset_path):
     assert basename(step.ref_filename) == "jwst_nircam_flat_0296.fits"
 
 
-def test_crds_step_override():
+def test_crds_step_override(tmp_path):
     """Run CRDS step with override parameter bypassing CRDS lookup."""
     from stdatamodels.jwst import datamodels
 
@@ -63,9 +48,10 @@ def test_crds_step_override():
     assert step.ref_filename.endswith('data/flat.fits')
     assert result.meta.ref_file.flat.name.endswith('flat.fits')
 
-    result.to_fits(TMP_FITS)
+    fn = tmp_path / 'tmp.fits'
+    result.to_fits(fn)
 
-    with fits.open(TMP_FITS) as hdulist:
+    with fits.open(fn) as hdulist:
         assert hdulist[0].header['R_FLAT'].endswith('flat.fits')
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ test = [
     "colorama>=0.4.1",
     "readchar>=3.0",
     "ruff",
-    "pytest>=6.0.0,<8.1.0",
+    "pytest>=6.0.0",
     "pytest-cov>=2.9.0",
     "pytest-doctestplus>=0.10.0",
     "requests_mock>=1.0",


### PR DESCRIPTION
The pytest pin added in:
https://github.com/spacetelescope/jwst/pull/8328
can be removed as `pytest-doctestplus` now supports `pytest==8.1.1`

The automated PR that attempted this bump:
https://github.com/spacetelescope/jwst/pull/8346
showed a new failure in one unit test:
```
FAILED jwst/stpipe/tests/test_crds.py::test_crds_step_override - ValueError: Empty filename: None
```
This PR  updates the test to use a fixture instead of `global` variables to allow it to pass.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
