### PR TITLE
update load_local_pkg exclude regex with regtest pattern

### DIFF
--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -97,7 +97,7 @@ def load_local_pkg(fpath):
     package_fpath_len = len(package_fpath) + 1
     try:
         for module_fpath in folder_traverse(
-            fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='tests'
+            fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='(tests)|(regtest)'
         ):
             folder_path, fname = os.path.split(module_fpath[package_fpath_len:])
             module_path = folder_path.split('/')


### PR DESCRIPTION
Fixes https://github.com/spacetelescope/jwst/issues/8348

`test_suffix.py` tests that call `jwst.stpipe.utilities.find_suffixes` are skipped in unit test runs due to `importorskip` calls in the regtests (like):
https://github.com/spacetelescope/jwst/blob/bf3b06fcefae0baa54c9d9f62243038a06f4254e/jwst/regtest/test_stp_jw00697013.py#L30
`pysiaf` is not installed for CI unit test runs and the call to `find_suffixes` results in an attempt to import every `.py` file in the `jwst` directory structure that is not in a `test` folder (so `regtest` is included). This results in an attempt to import for example the above referenced file, the importorskip is called and the test (in this case one in `test_suffix`) is skipped.

This PR updates the regex to also exclude the `regtest` directory.

As a comparison here is the latest `py310-xdist` run log on main:
https://github.com/spacetelescope/jwst/actions/runs/8238566482/job/22529809746#step:10:248
showing:
```
==== 2785 passed, 554 skipped, 4 xfailed, 79 warnings in 854.19s (0:14:14) =====
```

With this PR the `py310-xdist` run log:
https://github.com/spacetelescope/jwst/actions/runs/8254717816/job/22579513473?pr=8350
shows 2 tests were unskipped:
```
==== 2787 passed, 552 skipped, 4 xfailed, 79 warnings in 905.68s (0:15:05) =====
```

The 2 tests that now run in the unit tests CI are:
- [test_suffix_existence](https://github.com/spacetelescope/jwst/blob/bf3b06fcefae0baa54c9d9f62243038a06f4254e/jwst/lib/tests/test_suffix.py#L20-L23)
- [test_all_steps](https://github.com/spacetelescope/jwst/blob/bf3b06fcefae0baa54c9d9f62243038a06f4254e/jwst/stpipe/tests/test_utilities.py#L14)

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
