### PR TITLE
JP-3534 update to Sky Match docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ documentation
 - Reorganized ``jump`` and ``ramp_fitting`` step docs content that's split between
   the jwst and stcal repos. [#8253]
 
+- Correct the names of parameter options ``usigma`` and ``lsigma`` for ``sky_match``. [#8356]
+
 emicorr
 -------
 

--- a/docs/jwst/skymatch/arguments.rst
+++ b/docs/jwst/skymatch/arguments.rst
@@ -57,10 +57,10 @@ The ``skymatch`` step uses the following optional arguments:
 ``nclip`` (int, default=5)
   The number of clipping iterations to use when computing sky values.
 
-``lsig`` (float, default=4.0)
+``lsigma`` (float, default=4.0)
   Lower clipping limit, in sigma, used when computing the sky value.
 
-``usig`` (float, default=4.0)
+``usigma`` (float, default=4.0)
   Upper clipping limit, in sigma, used when computing the sky value.
 
 ``binwidth`` (float, default=0.1)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3534](https://jira.stsci.edu/browse/JP-3534)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8269 

<!-- describe the changes comprising this PR here -->
This PR addresses corrects the spelling of the parameter options 'usigma' and 'lsigma'.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
