### PR TITLE
Remove configuration for non-existant schema tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,9 +223,6 @@ norecursedirs = [
     "build",
     "venv",
 ]
-asdf_schema_tests_enabled = true
-asdf_schema_validate_default = false
-asdf_schema_root = "jwst/transforms/resources/schemas jwst/datamodels/schemas"
 junit_family = "xunit2"
 inputs_root = "jwst-pipeline"
 results_root = "jwst-pipeline-results"


### PR DESCRIPTION
The current `pyproject.toml` enables asdf schema tests for 2 directories that do not exist:
https://github.com/spacetelescope/jwst/blob/77c4966a836e03f34939d3de6ba805bc0934a7d6/pyproject.toml#L226-L228
As the directories do not exist, no tests are run.

These could have been disabled in: https://github.com/spacetelescope/jwst/pull/7439 which moved the schemas to `stdatamodels` (where they are [tested](https://github.com/spacetelescope/stdatamodels/blob/60d8dc7749708363a49648a8d393cd8740ab76a0/pyproject.toml#L143))

This PR removes the configuration in `pyproject.toml` that enables the asdf schema tests.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
