### PR TITLE
Fix bug in emicorr logic for finding matching ref file info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,8 @@ emicorr
   allow the user to run the step for given frequencies with an on-the-fly
   generated reference file. [#8270]
 
+- Fixed bug for finding correction data for subarray FULL. [#8375]
+
 exp_to_source
 -------------
 

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -585,13 +585,14 @@ def get_subarcase(subarray_cases, subarray, readpatt, detector):
     mdl_dict = subarray_cases.to_flat_dict()
     for subname in subarray_cases.subarray_cases:
         subname = subname.split(sep='.')[0]
-        if subarray not in subname:
+        dataconfig = subarray
+        if 'FULL' in dataconfig:
+            dataconfig = subarray + '_' + readpatt.replace('R1', '')
+        if dataconfig != subname:
             continue
         log.debug('Found subarray case {}!'.format(subname))
         for item, val in mdl_dict.items():
             if subname in item:
-                if 'FULL' in item and readpatt not in item:
-                    continue
                 if "rowclocks" in item:
                     rowclocks = val
                 elif "frameclocks" in item:
@@ -601,8 +602,8 @@ def get_subarcase(subarray_cases, subarray, readpatt, detector):
                         frequencies.append(val)
                     elif "FAST" in readpatt  and "FAST" in item:
                         frequencies.append(val)
-        if subname is not None and rowclocks is not None and frameclocks is not None and frequencies is not None:
-            break
+            if subname is not None and rowclocks is not None and frameclocks is not None and frequencies is not None:
+                break
     return subname, rowclocks, frameclocks, frequencies
 
 


### PR DESCRIPTION

<!-- describe the changes comprising this PR here -->
This PR addresses a bug in the emicorr step that was discovered after merging #8270. The bug affected the matching of dataset subarray and readpatt values to ref file entries, which was causing no matching entry to be found and hence the step was skipped.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
