### PR TITLE
JP-3288 use DQ plane in residual_fringe code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.14.1 (unreleased)
 ===================
 
+
 associations
 ------------
 
@@ -10,11 +11,12 @@ associations
 - Match NIRSpec imprint observations to science exposures on mosaic tile location
   and dither pointing, ``MOSTILNO`` and ``DITHPTIN``. [#8410]
 
+
 documentation
 -------------
-
 - Added docs for the NIRSpec MSA metadata file to the data products area of RTD.
   [#8399]
+  
 
 pipeline
 --------
@@ -28,6 +30,12 @@ ramp_fitting
 - Changed the data type for several variables in ramp_fitting
   to use uint16 instead of uint8, in order to avoid potential
   overflow/wraparound problems. [#8377]
+
+  
+ residual_fringe
+---------------
+- Using DQ plane and exclude pixels marked as DO_NOT_USE in correction. [#8381]
+
 
 tweakreg
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.14.1 (unreleased)
 ===================
 
+<<<<<<< HEAD
 
 associations
 ------------
@@ -16,6 +17,11 @@ documentation
 -------------
 - Added docs for the NIRSpec MSA metadata file to the data products area of RTD.
   [#8399]
+=======
+residual_fringe
+---------------
+- Use DQ plane to exclude pixels marked as DO_NOT_USE in correction. [#8381]
+>>>>>>> 922e2c50c (updates after review)
   
 
 pipeline

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ associations
 
 documentation
 -------------
+
 - Added docs for the NIRSpec MSA metadata file to the data products area of RTD.
   [#8399]
 
@@ -34,7 +35,8 @@ ramp_fitting
   
  residual_fringe
 ---------------
-- Using DQ plane and exclude pixels marked as DO_NOT_USE in correction. [#8381]
+
+- Use DQ plane to exclude pixels marked as DO_NOT_USE in correction. [#8381]
 
 
 tweakreg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,6 @@
 1.14.1 (unreleased)
 ===================
 
-<<<<<<< HEAD
 
 associations
 ------------
@@ -17,12 +16,7 @@ documentation
 -------------
 - Added docs for the NIRSpec MSA metadata file to the data products area of RTD.
   [#8399]
-=======
-residual_fringe
----------------
-- Use DQ plane to exclude pixels marked as DO_NOT_USE in correction. [#8381]
->>>>>>> 922e2c50c (updates after review)
-  
+
 
 pipeline
 --------

--- a/jwst/regtest/test_miri_residual_fringe.py
+++ b/jwst/regtest/test_miri_residual_fringe.py
@@ -10,7 +10,7 @@ from jwst.stpipe import Step
 def test_residual_fringe_cal(rtdata, fitsdiff_default_kwargs):
     """Run residual fringe correction on MIRI IFUShort """
 
-    input_file = 'MIRM108-SHORT-6021192005_1_495_MIRIFUSHORT_cal.fits'
+    input_file = 'jw01523001001_03101_00001_mirifushort_cal.fits'
     rtdata.get_data(f"miri/mrs/{input_file}")
 
     args = [

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -83,13 +83,12 @@ class ResidualFringeCorrection():
             raise ErrorNoFringeFlat("The fringe flat step has not been run on file %s",
                                     self.input_model.meta.filename)
 
-        # Remove any NaN values adn bad pixels from the data prior to processing
+        # Remove any NaN values and flagged DO_NOT_USE pixels from the data prior to processing
         # Set them to 0 for the residual fringe routine
         # They will be re-added at the end
         output_data = self.model.data.copy()
-        dq = self.model.dq.copy()
         DO_NOT_USE = datamodels.dqflags.pixel["DO_NOT_USE"]
-        nanval_indx = np.where(np.logical_and(np.bitwise_and(dq, DO_NOT_USE).astype(bool),
+        nanval_indx = np.where(np.logical_and(np.bitwise_and(self.model.dq, DO_NOT_USE).astype(bool),
                                               ~np.isfinite(output_data)))
         output_data[nanval_indx] = 0
 

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -83,11 +83,14 @@ class ResidualFringeCorrection():
             raise ErrorNoFringeFlat("The fringe flat step has not been run on file %s",
                                     self.input_model.meta.filename)
 
-        # Remove any NaN values from the data prior to processing
+        # Remove any NaN values adn bad pixels from the data prior to processing
         # Set them to 0 for the residual fringe routine
         # They will be re-added at the end
         output_data = self.model.data.copy()
-        nanval_indx = np.where(~np.isfinite(output_data))
+        dq = self.model.dq.copy()
+        DO_NOT_USE = datamodels.dqflags.pixel["DO_NOT_USE"]
+        nanval_indx = np.where(np.logical_and(np.bitwise_and(dq, DO_NOT_USE).astype(bool),
+                                              ~np.isfinite(output_data)))
         output_data[nanval_indx] = 0
 
         # normalise the output_data to remove units

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -88,7 +88,7 @@ class ResidualFringeCorrection():
         # They will be re-added at the end
         output_data = self.model.data.copy()
         DO_NOT_USE = datamodels.dqflags.pixel["DO_NOT_USE"]
-        nanval_indx = np.where(np.logical_and(np.bitwise_and(self.model.dq, DO_NOT_USE).astype(bool),
+        nanval_indx = np.where(np.logical_or(np.bitwise_and(self.model.dq, DO_NOT_USE).astype(bool),
                                               ~np.isfinite(output_data)))
         output_data[nanval_indx] = 0
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3288](https://jira.stsci.edu/browse/JP-3288)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #3937 

<!-- describe the changes comprising this PR here -->
This PR adds a check on the DQ array in the residual fringe correction. If the pixel has a value of DO_NOT_USE it is not used in the correction. 
 

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)

https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1366/

- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
