### PR TITLE
fix fixture for closedfile regtest

### DIFF
--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -170,9 +170,8 @@ def test_nircam_image_stage3_segm(run_image3pipeline, rtdata_module, fitsdiff_de
 
 
 @pytest.fixture()
-def run_image3_closedfile(rtdata_module):
+def run_image3_closedfile(rtdata):
     """Run calwebb_image3 on NIRCam imaging with data that had a closed file issue."""
-    rtdata = rtdata_module
     rtdata.get_asn("nircam/image/fail_short_image3_asn.json")
 
     args = ["calwebb_image3", rtdata.input]


### PR DESCRIPTION
While updating fixtures in https://github.com/spacetelescope/jwst/pull/8327 the `run_image3_closedfile` fixture was changed from:
```
def run_image3_closedfile(rtdata, jail):
```
to
```
def run_image3_closedfile(rtdata_module):
```

The use of `rtdata_module` change the directory where the fixture files are written. The files are written to a directory path ending in `.../test_nircam_image_rtdata_module0`
However `test_image3_closedfile` uses a different directory to check for the files (due to the conflicting `rtdata` fixture):
https://github.com/spacetelescope/jwst/blob/1c054d892777b5271fb5c3664b80e99a6518e6a8/jwst/regtest/test_nircam_image.py#L182-L183
It checks a directory with a path ending in: `.../test_image3_closedfile0`

This PR uses `rtdata` instead to allow the paths to match.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
