### PR TITLE
JP-3585: remove deprecated datamodel types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ documentation
 - Added docs for the NIRSpec MSA metadata file to the data products area of RTD.
   [#8399]
 
+general
+-------
+
+- Removed deprecated stdatamodels model types ``DrizProductModel``, 
+  ``MIRIRampModel``, and ``MultiProductModel``. [#8388]
+
 pipeline
 --------
 

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -29,10 +29,10 @@ _jwst_modules = ["container", "source_container"]
 _jwst_models = ["ModelContainer", "SourceModelContainer"]
 
 # Deprecated modules in stdatamodels
-_deprecated_modules = ['drizproduct', 'multiprod', 'schema']
+_deprecated_modules = ['schema']
 
 # Deprecated models in stdatamodels
-_deprecated_models = ['DrizProductModel', 'MultiProductModel', 'MIRIRampModel']
+_deprecated_models = []
 
 # Import all submodules from stdatamodels.jwst.datamodels
 for attr in dir(stdatamodels.jwst.datamodels):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3585](https://jira.stsci.edu/browse/JP-3585)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8382 

<!-- describe the changes comprising this PR here -->
This PR enforces removal of the deprecated stdatamodels model types DrizProductModel, MIRIRampModel, and MultiProductModel.  Most of the changes are in stdatamodels; [see PR here](https://github.com/spacetelescope/stdatamodels/pull/171).  On the jwst side, the only change is to remove the model types from the deprecated list.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
