### PR TITLE
Revert "[SCSB-145] require Python 3.10"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
       cache-path: /tmp/data/crds_cache
       cache-key: crds-${{ needs.crds_contexts.outputs.jwst }}
       envs: |
-        - linux: py310-oldestdeps-xdist-cov
+        - linux: py39-oldestdeps-xdist-cov
           pytest-results-summary: true
+        - linux: py39-xdist
         - linux: py310-xdist
         - linux: py311-xdist
           pytest-results-summary: true

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -22,6 +22,7 @@ jobs:
       cache-path: /tmp/crds_cache
       cache-key: crds-${{ needs.crds_context.outputs.jwst }}
       envs: |
+        - macos: py39-xdist
         - macos: py310-xdist
         - macos: py312-xdist
         - linux: py311-pyargs-xdist

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -106,10 +106,5 @@ bc1.test_configs = []
 bc2 = utils.copy(bc0)
 bc2.pip_reqs_files = ['requirements-dev-st.txt']
 
-bc3 = utils.copy(bc0)
-bc3.conda_packages = [
-    "python=3.12",
-]
-
-utils.run([jobconfig, bc0, bc1, bc2, bc3])
+utils.run([jobconfig, bc0, bc1, bc2])
 }  // withCredentials

--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@
 
 ![STScI Logo](docs/_static/stsci_logo.png)
 
-> [!IMPORTANT]
-> JWST requires a C compiler for dependencies and is currently limited to Python 3.10, 3.11, or 3.12.
+**JWST requires a C compiler for dependencies and is currently limited to Python 3.9, 3.10 or 3.11.**
 
-> [!NOTE]
-> Linux and MacOS platforms are tested and supported.  Windows is not currently supported.
+**Until Python 3.12 is supported, fresh conda environments will require setting the
+  Python version to one of the three supported versions.**
 
-> [!WARNING]
-> Installation on MacOS Mojave 10.14 will fail due to lack of a stable build for dependency ``opencv-python``.
+**Linux and MacOS platforms are tested and supported.  Windows is not currently supported.**
+
+**If installing on MacOS Mojave 10.14, you must install
+  into an environment with python 3.9. Installation will fail on python 3.10 due
+  to lack of a stable build for dependency ``opencv-python``.**
 
 ## Installation
 

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -38,10 +38,15 @@ shell.
 
 .. warning::
 
-    JWST requires a C compiler for dependencies and is currently limited to Python 3.10, 3.11, or 3.12.
+    The jwst package requires a C compiler for dependencies and is currently
+    limited to Python 3.9, 3.10, or 3.11. Until Python 3.12 is supported, fresh
+    conda environments will require setting the Python version to <=3.11.
 
 .. warning::
-    Installation on MacOS Mojave 10.14 will fail due to lack of a stable build for dependency ``opencv-python``.
+
+    Users on MacOS Mojave (10.14) should limit their environment to python 3.9 -
+    there is a package dependency that currently fails to build on Mojave with
+    python>=3.10.
 
 Installing Latest Release
 -------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jwst"
 description = "Library for calibration of science observations from the James Webb Space Telescope"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 authors = [
     { name = "JWST calibration pipeline developers" },
 ]
@@ -13,6 +13,7 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -32,7 +33,7 @@ dependencies = [
     "pyparsing>=2.2.1",
     "requests>=2.22",
     "scikit-image>=0.19",
-    "scipy>=1.7.2",
+    "scipy>=1.6.0",
     "spherical-geometry>=1.2.22",
     "stcal>=1.7.0,<1.8.0",
     "stdatamodels>=1.10.1,<1.11.0",


### PR DESCRIPTION
Reverts spacetelescope/jwst#8365 due to CRDS container requiring Python 3.9; needed for JWST B10.2rc1

also needs:
- [ ] https://github.com/spacetelescope/stpipe/pull/150
- [ ] https://github.com/spacetelescope/stcal/pull/253/
- [ ] https://github.com/spacetelescope/stdatamodels/pull/294