### PR TITLE
JP-3151: Don't make associations for NRS2 IFU if detector not illuminated

### DIFF
--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -320,7 +320,12 @@ class Asn_Lv2Spec(
                     )
                 ],
                 reduce=Constraint.notany
-            )
+            ),
+            SimpleConstraint(
+                value=True,
+                test=lambda value, item: nrsifu_valid_detector(item),
+                force_unique=False
+            ),
         ])
 
         # Now check and continue initialization.

--- a/jwst/associations/mkpool.py
+++ b/jwst/associations/mkpool.py
@@ -106,9 +106,10 @@ def mkpool(data,
 
     params = params.difference(IGNORE_KEYS)
     params = [item.lower() for item in params]
+    # Make sure there's no duplicates
+    params = list(set(params))
     params.sort()
     defaults = {param: 'null' for param in params}
-
     pool = AssociationPool(names=params, dtype=[object] * len(params))
 
     # Set default values for user-settable non-header parameters

--- a/jwst/associations/tests/test_exposerr.py
+++ b/jwst/associations/tests/test_exposerr.py
@@ -21,7 +21,7 @@ def test_exposerr():
         pool=pool
     )
     asns = generated.associations
-    assert len(asns) > 1
+    assert len(asns) == 1
     for asn in asns:
         any_degraded = False
         for product in asn['products']:


### PR DESCRIPTION
Filter dupes in mkpool.
Add requirement that no spec2 associations are made for NRS IFU settings that don't illuminate the NRS2 detector
Fix test that made such an association

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3151](https://jira.stsci.edu/browse/JP-3151)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses remaining issues with this ticket: only data with PATTTYPE with NODs, plus imprint and background exposures was being handled properly, but not all other types.  In this PR, all spec2 associations check whether the nrs2 detector is illuminated before creating an association.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
