### PR TITLE
[SCSB-146] prevent extra test jobs from uploading and overwriting environment files in `jwst-pipeline-results/`

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -105,11 +105,13 @@ bc1.test_configs = []
 
 bc2 = utils.copy(bc0)
 bc2.pip_reqs_files = ['requirements-dev-st.txt']
+bc2.test_configs = []
 
 bc3 = utils.copy(bc0)
 bc3.conda_packages = [
     "python=3.12",
 ]
+bc3.test_configs = []
 
 utils.run([jobconfig, bc0, bc1, bc2, bc3])
 }  // withCredentials


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [SCSB-146](https://jira.stsci.edu/browse/SCSB-146)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR attempts to address the build delivery issue where the extra Jenkins test jobs (i.e. the Python 3.12 tests) overwrite the existing environment files previously uploaded by the Python 3.11 job to `jwst-pipeline-results/`. I assume the `data_config` uploads results files, but I'm not sure which attributes I should change to prevent `bc2` and `bc3` from uploading the actual environment files

**Checklist for maintainers**
- [x] ~added entry in `CHANGES.rst` within the relevant release section~
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
