### PR TITLE
JP-2980 Documentation improvement for multiprocessing: a script which spawns processes on import will cause system failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ documentation
 - Added docs for the NIRSpec MSA metadata file to the data products area of RTD.
   [#8399]
 
+- Added docs for multipreocessing. [#8408]
+
 pipeline
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ documentation
 - Added docs for the NIRSpec MSA metadata file to the data products area of RTD.
   [#8399]
 
-- Added docs for multipreocessing. [#8408]
+- Added documentation for multiprocessing. [#8408]
 
 pipeline
 --------

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -537,9 +537,9 @@ Multiprocessing
 ===============
 
 Multiprocessing is supported to speed up certain computationally-intensive steps
-in the pipeline, including :ref:`jump_step <jump_step>`,
-:ref:`ramp_fitting_step <ramp_fitting_step>`, and
-:ref:`wfss_contam_step <wfss_contam_step>`. The examples below show how
+in the pipeline, including the :ref:`jump detection <jump_step>`,
+:ref:`ramp fitting <ramp_fitting_step>`, and
+:ref:`WFSS contamination correction <wfss_contam_step>` steps. The examples below show how
 multiprocessing can be enabled for these steps, as well as how to set up
 multiprocessing to simultaneously run the entire pipeline on multiple observations.
 

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -571,8 +571,8 @@ for the ``ramp_fitting`` and ``wfss_contam`` steps. These parameters can be
 set to `quarter`, `half`, `all`, or `none`, which is the default value.
 
 The following example turns on a step's multiprocessing option. Notice only
-one of the steps has multiprocessing turned on. We do not recommend to
-simultaneously enable both steps to do multiprocessing, as this may likely
+one of the steps has multiprocessing turned on. We do not recommend
+simultaneously enabling both steps to do multiprocessing, as this may likely
 lead to running out of system memory.
 
 

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -566,7 +566,7 @@ The following example turns on the step multiprocessing while setting up a log
 file for each run of the pipeline and a text file with the full traceback in case
 there is a crash. Notice only one of the steps has multiprocessing turned on. We
 do not recommend to simultaneously enable both steps to do multiprocessing, as
-this may likely incur in the system running out of memory.
+this may likely lead to running out of system memory.
 
 
 
@@ -631,7 +631,7 @@ this may likely incur in the system running out of memory.
 option setting up a log file for each run of the pipeline and a text file with
 the full traceback in case there is a crash. Notice that the ``import`` statement
 of the pipeline is within the multiprocessing block that gets called by every
-worker. This is to avoid a known memory leackage issue.
+worker. This is to avoid a known memory leak.
 
 
 ::

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -543,9 +543,9 @@ in the pipeline, including the :ref:`jump detection <jump_step>`,
 multiprocessing can be enabled for these steps, as well as how to set up
 multiprocessing to simultaneously run the entire pipeline on multiple observations.
 
-Since the pipeline uses multiprocessing it is critical that any code using the pipeline adhere to the guidelines
-described in the `python multiprocessing documentation 
-<https://docs.python.org/3/library/multiprocessing.html#multiprocessing-programming>`_.
+Since the pipeline uses multiprocessing it is critical that any code using the pipeline adhere
+to the guidelines described in the
+`python multiprocessing documentation <https://docs.python.org/3/library/multiprocessing.html#multiprocessing-programming>`_.
 The pipeline uses the `forkserver` start method internally and it is recommended that any
 multiprocessing scripts that use the pipline use the same start. As detailed in the
 `python documentation <https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods>`_

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -570,7 +570,7 @@ optional parameters are `max_cores` for the ``jump`` step, and `maximum_cores`
 for the ``ramp_fitting`` and ``wfss_contam`` steps. These parameters can be
 set to `quarter`, `half`, `all`, or `none`, which is the default value.
 
-The following example script turns on the step multiprocessing. Notice only
+The following example turns on a step's multiprocessing option. Notice only
 one of the steps has multiprocessing turned on. We do not recommend to
 simultaneously enable both steps to do multiprocessing, as this may likely
 lead to running out of system memory.
@@ -684,11 +684,11 @@ worker. This is to avoid a known memory leak.
 
 
 .. warning::
-    Allthough it is technically possible to call the pipeline with
-    multiprocessing as well as turning on a step multiprocessing parameter, we
+    Although it is technically possible to call the pipeline with
+    multiprocessing while also enabling this option in a step, we
     strongly recommend not to do this. This scenario would be the same as
     `SampleScript2` except with adding and calling the parameter dictionary
-    `parameter_dict` in `SampleScript1`. However, this scenario will likely
-    crash if both multiprocessing options are set to use all the cores or less.
-    We recommend not enabling step multiprocessing for parallel pipeline runs
-    to avoid potentially running out of memory.
+    `parameter_dict` in `SampleScript1`. However, it will likely
+    crash if both multiprocessing options are set to use all the cores or even
+    less. We recommend not enabling step multiprocessing for parallel pipeline
+    runs to avoid potentially running out of memory.

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -543,21 +543,12 @@ in the pipeline, including the :ref:`jump detection <jump_step>`,
 multiprocessing can be enabled for these steps, as well as how to set up
 multiprocessing to simultaneously run the entire pipeline on multiple observations.
 
-Python's multiprocessing module explicitly imports and executes a script's
-`__main__` with each and every worker. If `__main__` is not present the behavior is
-undefined. Hence, Python will crash unless the multiprocess code in enclosed in a
-`__main__` block like this:
-
+Since the pipeline uses multiprocessing it is critical that any code using the pipeline adhere to the guidelines described in the `python multiprocessing documentation <https://docs.python.org/3/library/multiprocessing.html#multiprocessing-programming>`_. The pipeline uses the `forkserver` start method internally and it is recommended that any multiprocessing scripts that use the pipline use the same start. As detailed in the `python documentation <https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods>`_ this will require that code be "protected" with a ``if __name__ == '__main__':`` check as follows
 
 ::
 
-    import sys
-
-    def main():
-        [code used in multiprocessing]
-
     if __name__ = '__main__':
-        sys.exit(main())
+        [code used in multiprocessing]
 
 
 There are a couple of scenarios to use multiprocessing with the pipeline:

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -563,9 +563,9 @@ undefined. Hence, Python will crash unless the multiprocess code in enclosed in 
 There are a couple of scenarios to use multiprocessing with the pipeline:
 
 1.  Multiprocessing within a pipeline step. At the moment, the steps that
-support this are the :ref:`jump_step <jump_step>`,
-:ref:`ramp_fitting_step <ramp_fitting_step>`,
-and :ref:`wfss_contam_step <wfss_contam_step>`. To enable multiprocessing the
+support this are the :ref:`jump <jump_step>`,
+:ref:`ramp_fitting <ramp_fitting_step>`,
+and :ref:`wfss_contam <wfss_contam_step>` steps. To enable multiprocessing, the
 optional parameters are `max_cores` for the ``jump`` step, and `maximum_cores`
 for the ``ramp_fitting`` and ``wfss_contam`` steps. These parameters can be
 set to `quarter`, `half`, `all`, or `none`, which is the default value.

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -566,9 +566,10 @@ There are a couple of scenarios to use multiprocessing with the pipeline:
 support this are the :ref:`jump <jump_step>`,
 :ref:`ramp_fitting <ramp_fitting_step>`,
 and :ref:`wfss_contam <wfss_contam_step>` steps. To enable multiprocessing, the
-optional parameters are `max_cores` for the ``jump`` step, and `maximum_cores`
-for the ``ramp_fitting`` and ``wfss_contam`` steps. These parameters can be
-set to `quarter`, `half`, `all`, or `none`, which is the default value.
+optional parameter is `maximum_cores` for the ``jump``, ``ramp_fitting``, and
+``wfss_contam`` steps. This parameter can be set to a numerical value given
+as a string or it can be set to the words `quarter`, `half`, `all`,
+or `none`, which is the default value.
 
 The following example turns on a step's multiprocessing option. Notice only
 one of the steps has multiprocessing turned on. We do not recommend
@@ -607,7 +608,7 @@ worker. This is to avoid a known memory leak.
 
     # SampleScript2
 
-    import os
+    import os, sys
     import traceback
     import configparser
     import multiprocessing
@@ -672,15 +673,13 @@ worker. This is to avoid a known memory leak.
         print('* Using ', cores2use, ' cores for multiprocessing.')
 
         # set the pool and run multiprocess
-        p = multiprocessing.Pool(cores2use)
-        p.starmap(run_det1, zip(files_to_run, outptd))
-        p.close()
-        p.join()
+        with multiprocessing.Pool(cores2use) as pool:
+            pool.starmap(run_det1, zip(files_to_run, outptd))
+
+        print('\n * Finished multiprocessing! \n')
 
     if __name__ == '__main__':
-        multiprocessing.freeze_support()
-        main()
-        print('\n * Finished multiprocessing! \n')
+        sys.exit(main())
 
 
 .. warning::
@@ -688,7 +687,8 @@ worker. This is to avoid a known memory leak.
     multiprocessing while also enabling this option in a step, we
     strongly recommend not to do this. This scenario would be the same as
     `SampleScript2` except with adding and calling the parameter dictionary
-    `parameter_dict` in `SampleScript1`. However, it will likely
-    crash if both multiprocessing options are set to use all the cores or even
-    less. We recommend not enabling step multiprocessing for parallel pipeline
+    `parameter_dict` in `SampleScript1`. However, Python will crash
+    if both multiprocessing options are set to use all the cores or even
+    less, because it is not permitted that a worker has children processes.
+    We recommend not enabling step multiprocessing for parallel pipeline
     runs to avoid potentially running out of memory.

--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -543,7 +543,13 @@ in the pipeline, including the :ref:`jump detection <jump_step>`,
 multiprocessing can be enabled for these steps, as well as how to set up
 multiprocessing to simultaneously run the entire pipeline on multiple observations.
 
-Since the pipeline uses multiprocessing it is critical that any code using the pipeline adhere to the guidelines described in the `python multiprocessing documentation <https://docs.python.org/3/library/multiprocessing.html#multiprocessing-programming>`_. The pipeline uses the `forkserver` start method internally and it is recommended that any multiprocessing scripts that use the pipline use the same start. As detailed in the `python documentation <https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods>`_ this will require that code be "protected" with a ``if __name__ == '__main__':`` check as follows
+Since the pipeline uses multiprocessing it is critical that any code using the pipeline adhere to the guidelines
+described in the `python multiprocessing documentation 
+<https://docs.python.org/3/library/multiprocessing.html#multiprocessing-programming>`_.
+The pipeline uses the `forkserver` start method internally and it is recommended that any
+multiprocessing scripts that use the pipline use the same start. As detailed in the
+`python documentation <https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods>`_
+this will require that code be "protected" with a ``if __name__ == '__main__':`` check as follows
 
 ::
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2980](https://jira.stsci.edu/browse/JP-2980)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7308 

<!-- describe the changes comprising this PR here -->
This PR addresses needed documentation requested in several help desk tickets. This is connected to GitHub issues:
https://github.com/spacetelescope/jwst/issues/8404
https://github.com/spacetelescope/jwst/issues/8306 


**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
