### PR TITLE
JP-3518: Match imprint and science association members by mosaic and dither position

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ associations
 - Ensure NRS IFU exposures don't make a spec2 association for grating/filter combinations 
   where the nrs2 detector isn't illuminated.  Remove dupes in mkpool. [#8395]
 
+- Match NIRSpec imprint observations to science exposures on mosaic tile location
+  and dither pointing, ``MOSTILNO`` and ``DITHPTIN``. [#8410]
+
 documentation
 -------------
 

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -774,11 +774,7 @@ class Constraint_Imprint(Constraint):
                 DMSAttrConstraint(
                     name='imprint',
                     sources=['is_imprt']
-                ),
-                DMSAttrConstraint(
-                    name='mosaic_tile',
-                    sources=['mostilno'],
-                ),
+                )
             ],
             reprocess_on_match=True,
             work_over=ListCategory.EXISTING,

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -304,9 +304,29 @@ class Asn_Lv2Spec(
             ),
             Constraint(
                 [
+                    #  Allow either any background, or ensure imprint and science members
+                    #  match on mosaic tile number and dither pointing position.
                     Constraint_Background(),
-                    Constraint_Imprint(),
-                    Constraint_Single_Science(self.has_science, self.get_exposure_type),
+                    Constraint(
+                        [
+                            Constraint(
+                                [
+                                    Constraint_Imprint(),
+                                    Constraint_Single_Science(self.has_science, self.get_exposure_type),
+                                ],
+                                reduce=Constraint.any
+                            ),
+                            DMSAttrConstraint(
+                                name='mostilno',
+                                sources=['mostilno']
+                            ),
+                            DMSAttrConstraint(
+                                name='dithptin',
+                                sources=['dithptin']
+                            )
+                        ],
+                        reduce=Constraint.all
+                    ),
                 ],
                 reduce=Constraint.any
             ),

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -87,6 +87,11 @@ SPECIAL_POOLS = {
         'xfail': None,
         'slow': True,
     },
+    'jw01192_o008_pool.csv': {
+        'args': ['-i', 'o008'],
+        'xfail': None,
+        'slow': False,
+    },
     'jw01194_20230115t113819_pool': {
         'args': [],
         'xfail': None,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3518](https://jira.stsci.edu/browse/JP-3518)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8215

<!-- describe the changes comprising this PR here -->
This PR addresses mismatches between NIRSpec science and imprint members in level2 spectral associations.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
