### PR TITLE
JP-3589: fixed deprecated code from numpy 2.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.14.1 (unreleased)
 ===================
 
+ami
+---
+
+- Replaced deprecated ``np.mat()`` with ``np.asmatrix()``. [#8415]
+
 associations
 ------------
 
@@ -15,6 +20,11 @@ documentation
 
 - Added docs for the NIRSpec MSA metadata file to the data products area of RTD.
   [#8399]
+
+extract_1d
+----------
+
+- Replaced deprecated ``np.trapz`` with ``np.trapezoid()``. [#8415]
 
 pipeline
 --------

--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -615,7 +615,7 @@ def matrix_operations(img, model, flux=None, linfit=False, dqm=None):
             from linearfit import linearfit
 
             # dependent variables
-            M = np.mat(flatimg)
+            M = np.asmatrix(flatimg)
 
             # photon noise
             noise = np.sqrt(np.abs(flatimg))
@@ -625,9 +625,9 @@ def matrix_operations(img, model, flux=None, linfit=False, dqm=None):
 
             # uniform weight
             wy = weights
-            S = np.mat(np.diag(wy))
+            S = np.asmatrix(np.diag(wy))
             # matrix of independent variables
-            C = np.mat(flatmodeltransp)
+            C = np.asmatrix(flatmodeltransp)
 
             # initialize object
             result = linearfit.LinearFit(M, S, C)

--- a/jwst/extract_1d/soss_extract/atoca.py
+++ b/jwst/extract_1d/soss_extract/atoca.py
@@ -1485,7 +1485,7 @@ class _BaseOverlap:
 
             # Integrate
             integrand = fct_f_k(x_grid) * x_grid
-            bin_val.append(np.trapz(integrand, x_grid))
+            bin_val.append(np.trapezoid(integrand, x_grid))
 
         # Convert to array and return with the pixel centers.
         return pix_center, np.array(bin_val)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3589](https://jira.stsci.edu/browse/JP-3589)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8400

<!-- describe the changes comprising this PR here -->
This PR addresses a few loose-end code deprecations from the new AMI suite and from the numpy 2.0 update.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
