### PR TITLE
JP-2943: add asn_id to outlier_i2d filename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ general
 - Removed deprecated stdatamodels model types ``DrizProductModel``, 
   ``MIRIRampModel``, and ``MultiProductModel``. [#8388]
 
+outlier_detection
+-----------------
+
+- Add association id to ``outlier_i2d`` intermediate filenames. [#8418]
+
 pipeline
 --------
 

--- a/docs/jwst/outlier_detection/outlier_detection.rst
+++ b/docs/jwst/outlier_detection/outlier_detection.rst
@@ -58,8 +58,8 @@ Specifically, this routine performs the following operations:
      should be used when resampling to create the output mosaic.  Any pixel with a
      DQ value not included in this value (or list of values) will be ignored when
      resampling.
-   * Resampled images will be written out to disk with the suffix '_<asn_id>_outlier_i2d.fits'
-     if the input model container has an <asn_id>, otherwise the suffix will be '_outlier_i2d.fits'
+   * Resampled images will be written out to disk with the suffix ``_<asn_id>_outlier_i2d.fits``
+     if the input model container has an <asn_id>, otherwise the suffix will be ``_outlier_i2d.fits``
      by default.
    * **If resampling is turned off** through the use of the ``resample_data`` parameter,
      a copy of the unrectified input images (as a ModelContainer)

--- a/docs/jwst/outlier_detection/outlier_detection.rst
+++ b/docs/jwst/outlier_detection/outlier_detection.rst
@@ -58,7 +58,7 @@ Specifically, this routine performs the following operations:
      should be used when resampling to create the output mosaic.  Any pixel with a
      DQ value not included in this value (or list of values) will be ignored when
      resampling.
-   * Resampled images will be written out to disk as `_outlier_i2d.fits` by default.
+   * Resampled images will be written out to disk as `_<asn_id>_outlier_i2d.fits` by default.
    * **If resampling is turned off** through the use of the ``resample_data`` parameter,
      a copy of the unrectified input images (as a ModelContainer)
      will be used for subsequent processing.

--- a/docs/jwst/outlier_detection/outlier_detection.rst
+++ b/docs/jwst/outlier_detection/outlier_detection.rst
@@ -58,7 +58,9 @@ Specifically, this routine performs the following operations:
      should be used when resampling to create the output mosaic.  Any pixel with a
      DQ value not included in this value (or list of values) will be ignored when
      resampling.
-   * Resampled images will be written out to disk as `_<asn_id>_outlier_i2d.fits` by default.
+   * Resampled images will be written out to disk with the suffix '_<asn_id>_outlier_i2d.fits'
+     if the input model container has an <asn_id>, otherwise the suffix will be '_outlier_i2d.fits'
+     by default.
    * **If resampling is turned off** through the use of the ``resample_data`` parameter,
      a copy of the unrectified input images (as a ModelContainer)
      will be used for subsequent processing.

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -210,11 +210,16 @@ class OutlierDetection:
 
         # Perform median combination on set of drizzled mosaics
         median_model.data = self.create_median(drizzled_models)
-        median_model_output_path = self.make_output_path(
-            basepath=median_model.meta.filename.replace(self.resample_suffix, '.fits'),
-            suffix='median')
-        median_model.save(median_model_output_path)
-        log.info(f"Saved model in {median_model_output_path}")
+        if pars['save_intermediate_results']:
+            if self.outlierpars.get('asn_id', None) is None:
+                suffix_to_remove = self.resample_suffix
+            else:
+                suffix_to_remove = f"_{self.outlierpars['asn_id']}{self.resample_suffix}"
+            median_model_output_path = self.make_output_path(
+                basepath=median_model.meta.filename.replace(suffix_to_remove, '.fits'),
+                suffix='median')
+            median_model.save(median_model_output_path)
+            log.info(f"Saved model in {median_model_output_path}")
 
         if pars['resample_data']:
             # Blot the median image back to recreate each input image specified

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -165,7 +165,7 @@ class OutlierDetectionStep(Step):
             reffiles = {}
 
             # Set up outlier detection, then do detection
-            step = detection_step(self.input_models, reffiles=reffiles, **pars)
+            step = detection_step(self.input_models, reffiles=reffiles, asn_id=asn_id, **pars)
             step.do_detection()
 
             state = 'COMPLETE'
@@ -177,8 +177,11 @@ class OutlierDetectionStep(Step):
                     if not self.save_intermediate_results:
                         #  Remove unwanted files
                         crf_path = self.make_output_path(basepath=model.meta.filename)
-                        suffix = model.meta.filename.split(sep='_')[-1]
-                        outlr_file = model.meta.filename.replace(suffix, 'outlier_i2d.fits')
+                        if asn_id is None:
+                            suffix = model.meta.filename.split(sep='_')[-1]
+                            outlr_file = model.meta.filename.replace(suffix, 'outlier_i2d.fits')
+                        else:
+                            outlr_file = crf_path.replace('crf', 'outlier_i2d')
                         blot_path = crf_path.replace('crf', 'blot')
                         median_path = blot_path.replace('blot', 'median')
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -93,6 +93,8 @@ class ResampleData:
         crval = kwargs.get('crval', None)
         rotation = kwargs.get('rotation', None)
 
+        self.asn_id = kwargs.get('asn_id', None)
+
         if pscale is not None:
             log.info(f'Output pixel scale: {pscale} arcsec.')
             pscale /= 3600.0
@@ -225,7 +227,10 @@ class ResampleData:
             output_type = exposure[0].meta.filename[indx:]
             output_root = '_'.join(exposure[0].meta.filename.replace(
                 output_type, '').split('_')[:-1])
-            output_model.meta.filename = f'{output_root}_outlier_i2d{output_type}'
+            if self.asn_id is not None:
+                output_model.meta.filename = f'{output_root}_{self.asn_id}_outlier_i2d{output_type}'
+            else:
+                output_model.meta.filename = f'{output_root}_outlier_i2d{output_type}'
 
             # Initialize the output with the wcs
             driz = gwcs_drizzle.GWCSDrizzle(output_model, pixfrac=self.pixfrac,

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -80,6 +80,8 @@ class ResampleSpecData(ResampleData):
         self.input_pixscale0 = None  # computed pixel scale of the first image (deg)
         self._recalc_pscale_ratio = pscale is not None
 
+        self.asn_id = kwargs.get('asn_id', None)
+
         # Define output WCS based on all inputs, including a reference WCS
         if output_wcs is None:
             if resample_utils.is_sky_like(


### PR DESCRIPTION
This PR adds the association identifier (if available) to filenames used to store `outlier_i2d` products used during outlier detection.

This should partially address an issue that occurs during operations where multiple parallel runs of pipeline use the same working directory (which is used as the output directory). If the parallel runs process the same input files (when they are present in both associations) it is possible that one run can overwrite or delete `outlier_i2d` files that are in-use by the other run due to the filenames not containing the association identifier.

Regression tests run at: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1390/
show 1 unrelated (common) failure `test_duplicate_names` likely due to lost log messages.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
