### PR TITLE
Added __main__ to ramp fit class for multiprocessing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ ramp_fitting
   to use uint16 instead of uint8, in order to avoid potential
   overflow/wraparound problems. [#8377]
 
+- Added __main__ to the class to avoid memory leak when running
+  multiprocessing. []
+
 residual_fringe
 ---------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ ramp_fitting
   overflow/wraparound problems. [#8377]
 
 - Added __main__ to the class to avoid memory leak when running
-  multiprocessing. []
+  multiprocessing. [#8421]
 
 residual_fringe
 ---------------

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -526,3 +526,7 @@ class RampFitStep(Step):
             int_model.meta.cal_step.ramp_fit = 'COMPLETE'
 
         return out_model, int_model
+
+
+if __name__ == '__main__':
+    RampFitStep().process()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a memory leak caused by the multiprocessing bit of code not enclosed in a __main__ block.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
