### PR TITLE
JP-3463: Add log message to dark step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ dark_current
 ------------  
 
 - Add log info message when specifying an average_dark_current for noise calculations.
+  [#8425]
 
 documentation
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ associations
 - Match NIRSpec imprint observations to science exposures on mosaic tile location
   and dither pointing, ``MOSTILNO`` and ``DITHPTIN``. [#8410]
 
+dark_current
+------------  
+
+- Add log info message when specifying an average_dark_current for noise calculations.
+
 documentation
 -------------
 

--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -93,6 +93,7 @@ class DarkCurrentStep(Step):
         """
         if self.average_dark_current is not None:
             input_model.average_dark_current[:, :] = self.average_dark_current
+            self.log.info('Using Poisson noise from average dark current %s e-/sec', self.average_dark_current)
         else:
             # First prioritize a 2D average_dark_current, if defined in dark.
             # If not present, apply scalar to datamodel array, if scalar is present.


### PR DESCRIPTION
This PR addresses JP-3463, adding a message to the log.info when users specify a value for average_dark_current to make clear that the value is being used.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
