### PR TITLE
Fix a bug in how a image group name is determined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ assign_wcs
 associations
 ------------
 
-- Ensure NRS IFU exposures don't make a spec2 association for grating/filter combinations 
+- Ensure NRS IFU exposures don't make a spec2 association for grating/filter combinations
   where the nrs2 detector isn't illuminated.  Remove dupes in mkpool. [#8395]
 
 - Match NIRSpec imprint observations to science exposures on mosaic tile location
@@ -39,7 +39,7 @@ extract_1d
 general
 -------
 
-- Removed deprecated stdatamodels model types ``DrizProductModel``, 
+- Removed deprecated stdatamodels model types ``DrizProductModel``,
   ``MIRIRampModel``, and ``MultiProductModel``. [#8388]
 
 outlier_detection
@@ -79,6 +79,8 @@ tweakreg
 
 - Output source catalog file now respects ``output_dir`` parameter. [#8386]
 
+- Improved how a image group name is determined. [#8426]
+
 
 1.14.0 (2024-03-29)
 ===================
@@ -94,7 +96,7 @@ ami
 - Additional optional input arguments for greater user processing flexibility.
   See documentation for details. [#7862]
 
-- Bad pixel correction applied to data using new NRM reference file to calculate 
+- Bad pixel correction applied to data using new NRM reference file to calculate
   complex visibility support (M. Ireland method implemented by J. Kammerer). [#7862]
 
 - Make ``AmiAnalyze`` and ``AmiNormalize`` output conform to the OIFITS standard. [#7862]
@@ -129,7 +131,7 @@ charge_migration
   as DO_NOT_USE.  This group, and all subsequent groups, are then flagged as
   CHARGELOSS and DO_NOT_USE.  The four nearest pixel neighbor are then flagged
   in the same group. [#8336]
-  
+
 - Added warning handler for expected NaN and inf clipping in the
   ``sigma_clip`` function. [#8320]
 
@@ -415,7 +417,7 @@ tweakreg
 
 - Fixed a bug that caused failures instead of warnings when no GAIA sources
   were found within the bounding box of the input image. [#8334]
-  
+
 - Suppress AstropyUserWarnings regarding NaNs in the input data. [#8320]
 
 wfs_combine

--- a/jwst/tweakreg/tests/test_tweakreg.py
+++ b/jwst/tweakreg/tests/test_tweakreg.py
@@ -38,54 +38,6 @@ def test_is_wcs_correction_small(offset, is_good):
     assert step._is_wcs_correction_small(wcs, twcs) == is_good
 
 
-@pytest.mark.parametrize(
-    "groups, all_group_names, common_name",
-    [
-        ([['abc1_cal.fits', 'abc2_cal.fits']], {}, ['abc #1']),
-        (
-            [
-                ['abc1_cal.fits', 'abc2_cal.fits'],
-                ['abc1_cal.fits', 'abc2_cal.fits'],
-                ['abc1_cal.fits', 'abc2_cal.fits'],
-                ['def1_cal.fits', 'def2_cal.fits'],
-                ['cba1_cal.fits', 'cba2_cal.fits'],
-            ],
-            {'cba': 1},
-            ["abc #1", "abc #2", "abc #3", "def #1", "cba #2"],
-        ),
-        ([['cba1_cal.fits', 'abc2_cal.fits']], {}, ['Group #1']),
-        ([['cba1_cal.fits', 'abc2_cal.fits']], {'Group': 1}, ['Group #2']),
-        ([['cba1_cal.fits', 'abc2_cal.fits']], None, ['Group #1']),
-    ]
-)
-def test_common_name(groups, all_group_names, common_name):
-    for g, cn_truth in zip(groups, common_name):
-        group = []
-        for fname in g:
-            model = ImageModel()
-            model.meta.filename = fname
-            group.append(model)
-
-        cn = tweakreg_step._common_name(group, all_group_names)
-        assert cn == cn_truth
-
-
-def test_common_name_special():
-    all_group_names = {}
-    group = []
-    cn = tweakreg_step._common_name(group, all_group_names)
-    assert cn == 'Group #1'
-
-    group = []
-    all_group_names = {'abc': 1, 'abc #2': 1}
-    for fname in ['abc1', 'abc2']:
-        model = ImageModel()
-        model.meta.filename = fname
-        group.append(model)
-    cn = tweakreg_step._common_name(group, all_group_names)
-    assert len(cn.rsplit('_', 1)[1]) == 6
-
-
 def test_expected_failure_bad_starfinder():
 
     model = ImageModel()

--- a/jwst/tweakreg/tests/test_tweakreg.py
+++ b/jwst/tweakreg/tests/test_tweakreg.py
@@ -41,20 +41,21 @@ def test_is_wcs_correction_small(offset, is_good):
 @pytest.mark.parametrize(
     "groups, all_group_names, common_name",
     [
-        ([['abc1_cal.fits', 'abc2_cal.fits']], [], ['abc']),
+        ([['abc1_cal.fits', 'abc2_cal.fits']], {}, ['abc #1']),
         (
             [
                 ['abc1_cal.fits', 'abc2_cal.fits'],
                 ['abc1_cal.fits', 'abc2_cal.fits'],
                 ['abc1_cal.fits', 'abc2_cal.fits'],
                 ['def1_cal.fits', 'def2_cal.fits'],
+                ['cba1_cal.fits', 'cba2_cal.fits'],
             ],
-            [],
-            ["abc", "abc1", "abc2", "def"],
+            {'cba': 1},
+            ["abc #1", "abc #2", "abc #3", "def #1", "cba #2"],
         ),
-        ([['cba1_cal.fits', 'abc2_cal.fits']], [], ['Group #1']),
-        ([['cba1_cal.fits', 'abc2_cal.fits']], ['Group #1'], ['Group #2']),
-        ([['cba1_cal.fits', 'abc2_cal.fits']], None, ['Unnamed Group']),
+        ([['cba1_cal.fits', 'abc2_cal.fits']], {}, ['Group #1']),
+        ([['cba1_cal.fits', 'abc2_cal.fits']], {'Group': 1}, ['Group #2']),
+        ([['cba1_cal.fits', 'abc2_cal.fits']], None, ['Group #1']),
     ]
 )
 def test_common_name(groups, all_group_names, common_name):
@@ -67,6 +68,22 @@ def test_common_name(groups, all_group_names, common_name):
 
         cn = tweakreg_step._common_name(group, all_group_names)
         assert cn == cn_truth
+
+
+def test_common_name_special():
+    all_group_names = {}
+    group = []
+    cn = tweakreg_step._common_name(group, all_group_names)
+    assert cn == 'Group #1'
+
+    group = []
+    all_group_names = {'abc': 1, 'abc #2': 1}
+    for fname in ['abc1', 'abc2']:
+        model = ImageModel()
+        model.meta.filename = fname
+        group.append(model)
+    cn = tweakreg_step._common_name(group, all_group_names)
+    assert len(cn.rsplit('_', 1)[1]) == 6
 
 
 def test_expected_failure_bad_starfinder():

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -279,7 +279,6 @@ class TweakRegStep(Step):
             g = grp_img[0]
             if len(g) == 0:
                 raise AssertionError("Logical error in the pipeline code.")
-            group_name = g[0].meta.group_id
             imcats = list(map(self._imodel2wcsim, g))
             # Remove the attached catalogs
             for model in g:

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -5,7 +5,6 @@ JWST pipeline step for image alignment.
 
 """
 from os import path
-import uuid
 
 from astropy.table import Table
 from astropy import units as u
@@ -110,7 +109,6 @@ class TweakRegStep(Step):
     reference_file_types = []
 
     def process(self, input):
-        _common_name.gid = 0
         use_custom_catalogs = self.use_custom_catalogs
 
         if use_custom_catalogs:

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -281,35 +281,34 @@ class TweakRegStep(Step):
             g = grp_img[0]
             if len(g) == 0:
                 raise AssertionError("Logical error in the pipeline code.")
-            group_name = _common_name(g)
+            group_name = g[0].meta.group_id
             imcats = list(map(self._imodel2wcsim, g))
             # Remove the attached catalogs
             for model in g:
                 del model.catalog
-            self.log.info("* Images in GROUP '{}':".format(group_name))
+            self.log.info(f"* Images in GROUP '{group_name}':")
             for im in imcats:
                 im.meta['group_id'] = group_name
-                self.log.info("     {}".format(im.meta['name']))
+                self.log.info(f"     {im.meta['name']}")
 
             self.log.info('')
 
         elif len(grp_img) > 1:
             # create a list of WCS-Catalog-Images Info and/or their Groups:
             imcats = []
-            all_group_names = {}
-            for k, g in enumerate(grp_img):
+            for g in grp_img:
                 if len(g) == 0:
                     raise AssertionError("Logical error in the pipeline code.")
                 else:
-                    group_name = _common_name(g, all_group_names)
+                    group_name = g[0].meta.group_id
                     wcsimlist = list(map(self._imodel2wcsim, g))
                     # Remove the attached catalogs
                     for model in g:
                         del model.catalog
-                    self.log.info("* Images in GROUP '{}':".format(group_name))
+                    self.log.info(f"* Images in GROUP '{group_name}':")
                     for im in wcsimlist:
                         im.meta['group_id'] = group_name
-                        self.log.info("     {}".format(im.meta['name']))
+                        self.log.info(f"     {im.meta['name']}")
                     imcats.extend(wcsimlist)
 
             self.log.info('')
@@ -514,7 +513,6 @@ class TweakRegStep(Step):
 
         return images
 
-
     def _write_catalog(self, image_model, catalog, filename):
         '''
         Determine output filename for catalog based on outfile for step
@@ -561,7 +559,6 @@ class TweakRegStep(Step):
         image_model.meta.tweakreg_catalog = catalog_filename
 
         return image_model
-
 
     def _is_wcs_correction_small(self, wcs, twcs):
         """Check that the newly tweaked wcs hasn't gone off the rails"""
@@ -613,38 +610,6 @@ class TweakRegStep(Step):
         )
 
         return im
-
-
-def _common_name(group, all_group_names=None):
-    file_names = [
-        path.splitext(im.meta.filename)[0].strip('_- ') for im in group
-    ]
-
-    cn = path.commonprefix(file_names)
-
-    if all_group_names is None:
-        if cn:
-            return cn
-        else:
-            _common_name.gid += 1
-            return f"Group #{_common_name.gid}"
-    else:
-        if not cn:
-            cn = "Group"
-
-        grp_no = all_group_names.get(cn, 0) + 1
-        grp_id = f"{cn} #{grp_no}"
-        if grp_id in all_group_names:
-            # just try some shortened uuid until it is unique:
-            while grp_id in all_group_names:
-                grp_id = f"{cn}_{str(uuid.uuid4())[-6:]}"
-            all_group_names[grp_id] = 0
-        else:
-            all_group_names[cn] = grp_no
-        return grp_id
-
-
-_common_name.gid = 0
 
 
 def _parse_catfile(catfile):

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -284,9 +284,8 @@ class TweakRegStep(Step):
             # Remove the attached catalogs
             for model in g:
                 del model.catalog
-            self.log.info(f"* Images in GROUP '{group_name}':")
+            self.log.info(f"* Images in GROUP '{model.meta['group_id']}':")
             for im in imcats:
-                im.meta['group_id'] = group_name
                 self.log.info(f"     {im.meta['name']}")
 
             self.log.info('')
@@ -298,14 +297,12 @@ class TweakRegStep(Step):
                 if len(g) == 0:
                     raise AssertionError("Logical error in the pipeline code.")
                 else:
-                    group_name = g[0].meta.group_id
                     wcsimlist = list(map(self._imodel2wcsim, g))
                     # Remove the attached catalogs
                     for model in g:
                         del model.catalog
-                    self.log.info(f"* Images in GROUP '{group_name}':")
+                    self.log.info(f"* Images in GROUP '{model.meta['group_id']}':")
                     for im in wcsimlist:
-                        im.meta['group_id'] = group_name
                         self.log.info(f"     {im.meta['name']}")
                     imcats.extend(wcsimlist)
 
@@ -603,8 +600,12 @@ class TweakRegStep(Step):
             wcsinfo={'roll_ref': refang['roll_ref'],
                      'v2_ref': refang['v2_ref'],
                      'v3_ref': refang['v3_ref']},
-            meta={'image_model': image_model, 'catalog': catalog,
-                  'name': model_name}
+            meta={
+                'image_model': image_model,
+                'catalog': catalog,
+                'name': model_name,
+                'group_id': image_model.meta.group_id,
+            }
         )
 
         return im

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -283,7 +283,7 @@ class TweakRegStep(Step):
             # Remove the attached catalogs
             for model in g:
                 del model.catalog
-            self.log.info(f"* Images in GROUP '{model.meta['group_id']}':")
+            self.log.info(f"* Images in GROUP '{imcats[0].meta['group_id']}':")
             for im in imcats:
                 self.log.info(f"     {im.meta['name']}")
 
@@ -300,7 +300,7 @@ class TweakRegStep(Step):
                     # Remove the attached catalogs
                     for model in g:
                         del model.catalog
-                    self.log.info(f"* Images in GROUP '{model.meta['group_id']}':")
+                    self.log.info(f"* Images in GROUP '{wcsimlist[0].meta['group_id']}':")
                     for im in wcsimlist:
                         self.log.info(f"     {im.meta['name']}")
                     imcats.extend(wcsimlist)


### PR DESCRIPTION
It has been reported when an user used custom file names with the same common file name in several groups of images (i.e., with different `group_id` in the asn files). The algorithm for computing group names (`_common_name()`) may fail to produce a unique name for some groups resulting in these groups not being aligned.

This is not an issue for pipeline runs on original JWST file names but may affect grouping when user renames input models.

This PR is a further improvement on #8012

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
