### PR TITLE
remove calls to Step.closeout in tests

### DIFF
--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -44,7 +44,6 @@ def test_save_step_default(mk_tmp_dirs):
     ]
 
     step = Step.from_cmdline(args)
-    step.closeout()
 
     fname = 'flat_stepwithmodel.fits'
     assert path.isfile(fname)
@@ -63,7 +62,6 @@ def test_save_step_withoutput(mk_tmp_dirs):
     ]
 
     step = Step.from_cmdline(args)
-    step.closeout()
 
     output_path, output_ext = path.splitext(output_file)
     assert path.isfile(output_path + '_stepwithmodel' + output_ext)
@@ -83,7 +81,6 @@ def test_save_step_withoutputsuffix(mk_tmp_dirs):
     ]
 
     step = Step.from_cmdline(args)
-    step.closeout()
 
     assert path.isfile(actual_output_file)
 
@@ -99,7 +96,6 @@ def test_save_step_withdir(mk_tmp_dirs):
     ]
 
     step = Step.from_cmdline(args)
-    step.closeout()
 
     output_fn_path = path.join(
         tmp_data_path,
@@ -121,7 +117,6 @@ def test_save_step_withdir_environment(mk_tmp_dirs):
     ]
 
     step = Step.from_cmdline(args)
-    step.closeout()
 
     output_fn_path = path.join(
         tmp_data_path,
@@ -144,7 +139,6 @@ def test_save_step_withdir_withoutput(mk_tmp_dirs):
     ]
 
     step = Step.from_cmdline(args)
-    step.closeout()
 
     output_path, output_ext = path.splitext(output_file)
     output_fn_path = path.join(
@@ -199,8 +193,6 @@ def test_save_container_withfile(mk_tmp_dirs):
 
     assert path.isfile('tscwf_0_stepwithcontainer.fits')
     assert path.isfile('tscwf_1_stepwithcontainer.fits')
-
-    step.closeout()
 
 
 def test_save_pipeline_default(mk_tmp_dirs):

--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -43,7 +43,7 @@ def test_save_step_default(mk_tmp_dirs):
         data_fn_path
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     fname = 'flat_stepwithmodel.fits'
     assert path.isfile(fname)
@@ -61,7 +61,7 @@ def test_save_step_withoutput(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_file)
     assert path.isfile(output_path + '_stepwithmodel' + output_ext)
@@ -80,7 +80,7 @@ def test_save_step_withoutputsuffix(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     assert path.isfile(actual_output_file)
 
@@ -95,7 +95,7 @@ def test_save_step_withdir(mk_tmp_dirs):
         '--output_dir=' + tmp_data_path
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_fn_path = path.join(
         tmp_data_path,
@@ -116,7 +116,7 @@ def test_save_step_withdir_environment(mk_tmp_dirs):
         '--output_dir=$TSSWE_OUTPATH'
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_fn_path = path.join(
         tmp_data_path,
@@ -138,7 +138,7 @@ def test_save_step_withdir_withoutput(mk_tmp_dirs):
         '--output_file=' + output_file
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output_path, output_ext = path.splitext(output_file)
     output_fn_path = path.join(
@@ -189,7 +189,7 @@ def test_save_container_withfile(mk_tmp_dirs):
         '--output_file=tscwf.fits',
     ]
 
-    step = Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     assert path.isfile('tscwf_0_stepwithcontainer.fits')
     assert path.isfile('tscwf_1_stepwithcontainer.fits')

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -120,8 +120,6 @@ def test_saving_pars(tmp_path):
         config = StepConfig.from_asdf(af)
         assert config.parameters == original_config.parameters
 
-    step.closeout()
-
 
 @pytest.mark.parametrize(
     'step_obj, expected',

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -105,7 +105,7 @@ def test_saving_pars(tmp_path):
     """Save the step parameters from the commandline"""
     cfg_path = t_path(join('steps', 'jwst_generic_pars-makeliststep_0002.asdf'))
     saved_path = os.path.join(tmp_path, 'savepars.asdf')
-    step = Step.from_cmdline([
+    Step.from_cmdline([
         cfg_path,
         '--save-parameters',
         str(saved_path)


### PR DESCRIPTION
Several tests call [Step.closeout](https://github.com/spacetelescope/stpipe/blob/d20b6429cafe0a4ca846fd43af7b6a61241e632c/src/stpipe/step.py#L1160) with no arguments. This results in a single call to `gc.collect` (since both `to_close` and `to_del` were not provided).

This PR removes the calls to `Step.closeout`. These were not replaced with calls to `gc.collect` (as python should manage that itself). Removing the usage in the tests will allow `Step.closeout` to be removed (as it is otherwise unused).

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
