### PR TITLE
JP-3601: Fix background interval edge case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ extract_1d
 
 - Replaced deprecated ``np.trapz`` with ``np.trapezoid()``. [#8415]
 
+- Fix a crash in ``extract_1d`` for background regions for which both lower
+  and upper limits are outside the valid area for some data range. [#8433]
+
 flat_field
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,8 +44,9 @@ extract_1d
 
 - Replaced deprecated ``np.trapz`` with ``np.trapezoid()``. [#8415]
 
-- Fix a crash in ``extract_1d`` for background regions for which both lower
-  and upper limits are outside the valid area for some data range. [#8433]
+- Fix a crash in ``extract_1d`` encountered when multiple background or source
+  regions are specified and the lower and upper limits for one of them are
+  outside the valid area for some data range. [#8433]
 
 flat_field
 ----------

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -683,7 +683,8 @@ def _extract_colpix(image_data, x, j, limits):
             continue
         maxval = min(ns, int(math.floor(interval[1] + 0.5)))
         minval = max(0, int(math.floor(interval[0] + 0.5)))
-        npts += maxval - minval + 1
+        if maxval - minval + 1 > 0:
+            npts += maxval - minval + 1
     if npts == 0:
         return [], [], []
 

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -676,9 +676,14 @@ def _extract_colpix(image_data, x, j, limits):
     # compute number of data points:
     ns = image_data.shape[0] - 1
     ns12 = ns + 0.5
-
-    npts = sum(map(lambda x: min(ns, int(math.floor(x[1] + 0.5))) -
-                   max(0, int(math.floor(x[0] + 0.5))) + 1, intervals))
+    npts = 0
+    for interval in intervals:
+        if interval[0] == interval[1]:
+            # no data between limits
+            continue
+        maxval = min(ns, int(math.floor(interval[1] + 0.5)))
+        minval = max(0, int(math.floor(interval[0] + 0.5)))
+        npts += maxval - minval + 1
     if npts == 0:
         return [], [], []
 
@@ -690,6 +695,8 @@ def _extract_colpix(image_data, x, j, limits):
     # populate data and weights:
     k = 0
     for i in intervals:
+        if i[0] == i[1]:
+            continue
         i1 = i[0] if i[0] >= -0.5 else -0.5
         i2 = i[1] if i[1] <= ns12 else ns12
 
@@ -698,8 +705,12 @@ def _extract_colpix(image_data, x, j, limits):
         ii2 = min(ns, int(math.floor(i2 + 0.5)))
 
         # special case: ii1 == ii2:
-        # skip the interval, no data in between
+        # take the value at the pixel
         if ii1 == ii2:
+            v = image_data[ii1, x]
+            val[k] = v
+            wht[k] = i2 - i1
+            k += 1
             continue
 
         # bounds in different pixels:

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -679,7 +679,8 @@ def _extract_colpix(image_data, x, j, limits):
 
     npts = sum(map(lambda x: min(ns, int(math.floor(x[1] + 0.5))) -
                    max(0, int(math.floor(x[0] + 0.5))) + 1, intervals))
-    npts = max(npts, 1)
+    if npts == 0:
+        return [], [], []
 
     # pre-allocate data arrays:
     y = np.empty(npts, dtype=np.float64)

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -697,11 +697,8 @@ def _extract_colpix(image_data, x, j, limits):
         ii2 = min(ns, int(math.floor(i2 + 0.5)))
 
         # special case: ii1 == ii2:
+        # skip the interval, no data in between
         if ii1 == ii2:
-            v = image_data[ii1, x]
-            val[k] = v
-            wht[k] = i2 - i1
-            k += 1
             continue
 
         # bounds in different pixels:

--- a/jwst/extract_1d/tests/test_extract_src_flux.py
+++ b/jwst/extract_1d/tests/test_extract_src_flux.py
@@ -4,12 +4,13 @@ Test for extract_1d._extract_src_flux
 import math
 
 import numpy as np
+import pytest
 
 from jwst.extract_1d import extract1d
 
 
-def test_extract_src_flux():
-
+@pytest.fixture
+def inputs_constant():
     shape = (9, 5)
     image = np.arange(shape[0] * shape[1], dtype=np.float32).reshape(shape)
     var_poisson = image.copy()
@@ -23,6 +24,14 @@ def test_extract_src_flux():
     lower = np.zeros(shape[1], dtype=np.float64) + 3.   # middle of pixel 3
     upper = np.zeros(shape[1], dtype=np.float64) + 7.   # middle of pixel 7
     srclim = [[lower, upper]]
+
+    return (image, var_poisson, var_rnoise, var_rflat,
+            x, j, lam, srclim, weights, bkgmodels)
+
+
+def test_extract_src_flux(inputs_constant):
+    (image, var_poisson, var_rnoise, var_rflat,
+     x, j, lam, srclim, weights, bkgmodels) = inputs_constant
 
     (total_flux, f_var_poisson, f_var_rnoise, f_var_flat,
      bkg_flux, b_var_poisson, b_var_rnoise, b_var_flat,
@@ -60,4 +69,49 @@ def test_extract_src_flux():
 
     assert np.isnan(total_flux)
 
+    assert tarea == 0.
+
+
+@pytest.mark.parametrize('test_type', ['all_empty', 'all_equal'])
+def test_extract_src_flux_empty_interval(inputs_constant, test_type):
+    (image, var_poisson, var_rnoise, var_rflat,
+     x, j, lam, srclim, weights, bkgmodels) = inputs_constant
+
+    if test_type == 'all_empty':
+        # no limits provided
+        srclim = []
+    else:
+        # empty extraction range: upper equals lower
+        srclim[0][1] = srclim[0][0].copy()
+
+    (total_flux, f_var_poisson, f_var_rnoise, f_var_flat,
+     bkg_flux, b_var_poisson, b_var_rnoise, b_var_flat,
+     tarea, twht) = extract1d._extract_src_flux(
+        image, var_poisson, var_rnoise, var_rflat,
+        x, j, lam, srclim, weights, bkgmodels)
+
+    # empty interval, so no flux returned
+    assert np.isnan(total_flux)
+    assert bkg_flux == 0.
+    assert tarea == 0.
+
+
+@pytest.mark.parametrize('offset', [-100, 100])
+def test_extract_src_flux_interval_out_of_range(inputs_constant, offset):
+    (image, var_poisson, var_rnoise, var_rflat,
+     x, j, lam, srclim, weights, bkgmodels) = inputs_constant
+
+    # extraction limits out of range
+    srclim[0][0] += offset
+    srclim[0][1] += offset
+
+    (total_flux, f_var_poisson, f_var_rnoise, f_var_flat,
+     bkg_flux, b_var_poisson, b_var_rnoise, b_var_flat,
+     tarea, twht) = extract1d._extract_src_flux(
+        image, var_poisson, var_rnoise, var_rflat,
+        x, j, lam, srclim, weights, bkgmodels)
+
+    # empty interval, so no flux returned
+    assert np.isnan(total_flux)
+    assert bkg_flux == 0.
     assert tarea == 0.

--- a/jwst/extract_1d/tests/test_fit_background_model.py
+++ b/jwst/extract_1d/tests/test_fit_background_model.py
@@ -2,6 +2,8 @@
 Test for extract_1d._fit_background_model
 """
 import math
+from copy import deepcopy
+
 import numpy as np
 import pytest
 
@@ -138,3 +140,89 @@ def test_handles_one_value(inputs_constant):
     assert math.isclose(b_var_flat_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
 
     assert npts == 0
+
+
+@pytest.mark.parametrize('test_type', ['all_empty', 'all_equal'])
+def test_handles_empty_interval(inputs_constant, test_type):
+    image, var_poisson, var_rnoise, var_rflat, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
+
+    if test_type == 'all_empty':
+        # no limits provided
+        bkglim = []
+    else:
+        # empty extraction range: upper equals lower
+        bkglim[0][1] = bkglim[0][0].copy()
+
+    # No data available: background model is 0
+    (bkg_model, b_var_poisson_model, b_var_rnoise_model, b_var_flat_model, npts) = \
+        extract1d._fit_background_model(image, var_poisson, var_rnoise, var_rflat,
+                                        x, j, bkglim, bkg_fit, bkg_order)
+
+    assert math.isclose(bkg_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(bkg_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_poisson_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_poisson_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_rnoise_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_rnoise_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_flat_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_flat_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert npts == 0
+
+
+@pytest.mark.parametrize('offset', [-100, 100])
+def test_handles_interval_out_of_range(inputs_constant, offset):
+    image, var_poisson, var_rnoise, var_rflat, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
+    bkglim[0][0] += offset
+    bkglim[0][1] += offset
+
+    # No data available: background model is 0
+    (bkg_model, b_var_poisson_model, b_var_rnoise_model, b_var_flat_model, npts) = \
+        extract1d._fit_background_model(image, var_poisson, var_rnoise, var_rflat,
+                                        x, j, bkglim, bkg_fit, bkg_order)
+
+    assert math.isclose(bkg_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(bkg_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_poisson_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_poisson_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_rnoise_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_rnoise_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_flat_model(0.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_flat_model(8.), 0.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert npts == 0
+
+
+def test_handles_one_empty_interval(inputs_constant):
+    image, var_poisson, var_rnoise, var_rflat, x, j, bkglim, bkg_fit, bkg_order = inputs_constant
+
+    # add an extra interval that is empty
+    bkglim.append(deepcopy(bkglim[0]))
+    bkglim[1][0] += 2.0
+    bkglim[1][1] = bkglim[1][0].copy()
+    print(bkglim)
+
+    # should ignore the second interval and return a valid answer for the first
+    (bkg_model, b_var_poisson_model, b_var_rnoise_model, b_var_flat_model, npts) = \
+        extract1d._fit_background_model(image, var_poisson, var_rnoise, var_rflat,
+                                        x, j, bkglim, bkg_fit, bkg_order)
+
+    assert math.isclose(bkg_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(bkg_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_poisson_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_poisson_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_rnoise_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_rnoise_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert math.isclose(b_var_flat_model(0.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(b_var_flat_model(8.), 22.0, rel_tol=1.e-8, abs_tol=1.e-8)
+
+    assert npts == 2


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3601](https://jira.stsci.edu/browse/JP-3601)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8431 

<!-- describe the changes comprising this PR here -->
This PR fixes a crash in an extraction background edge case, in which both lower and upper limits for the background region are outside the valid area for some data range.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
