### PR TITLE
adjust test tolerances for scipy 1.13.0 on arm64

### DIFF
--- a/jwst/coron/tests/test_coron.py
+++ b/jwst/coron/tests/test_coron.py
@@ -141,8 +141,8 @@ def test_align_array():
         ]
     )
 
-    npt.assert_allclose(aligned, truth_aligned, atol=1e-6)
-    npt.assert_allclose(shifts, truth_shifts, atol=1e-6)
+    npt.assert_allclose(aligned, truth_aligned, atol=1e-6, rtol=1e-4)
+    npt.assert_allclose(shifts, truth_shifts, atol=1e-6, rtol=1e-3)
 
 
 def test_align_models():


### PR DESCRIPTION
This PR adjusts tolerances in a test that is currently failing for scipy 1.13.0 on arm64. The root appears to be different results for leastsq (used in align_arrays).

If these tolerances don't look acceptable pinning to <1.13.0 would be an alternative fix. It's possible that the next version of scipy would fix this issue:
https://github.com/scipy/scipy/issues/20531
The PR that fixed the issue mentions backporting but is currently milestoned for 1.14.0:
https://github.com/scipy/scipy/pull/20569

If we decide to pin to <1.13.0 we will likely need to regenerate regression test truth files (as was done when those tests picked up 1.13.0).

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
