### PR TITLE
Fix miri avg_dark regtest

### DIFF
--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -36,7 +36,7 @@ def run_detector1_with_average_dark_current(rtdata_module):
     estimate of the average dark current for inclusion in ramp_fitting
     poisson variance estimation."""
     rtdata = rtdata_module
-    rtdata.get_data("miri/image/jw01024001001_04101_00002_mirimage_uncal.fits")
+    rtdata.get_data("miri/image/jw01024002001_02101_00001_mirimage_uncal.fits")
 
     # Run detector1 pipeline only on one of the _uncal files
     args = ["jwst.pipeline.Detector1Pipeline", rtdata.input,
@@ -100,8 +100,8 @@ def test_miri_image_detector1_with_avg_dark_current(run_detector1_with_average_d
     """Regression test of detector1 pipeline performed on MIRI imaging data with a specified
     average dark current."""
     rtdata = rtdata_module
-    rtdata.input = "jw01024001001_04101_00002_mirimage_uncal.fits"
-    output = f"jw01024001001_04101_00002_mirimage_{suffix}.fits"
+    rtdata.input = "jw01024002001_02101_00001_mirimage_uncal.fits"
+    output = f"jw01024002001_02101_00001_mirimage_{suffix}.fits"
     rtdata.output = output
 
     rtdata.get_truth(f"truth/test_miri_image_stages/{output}")


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR changes the test of the average_dark capability in the calwebb_detector1 pipeline so that it no longer uses one of the same datasets that's already used in another test in the same regtest module. That causes issues with outputs clobbering one another. All the new input/output files have been loaded to Artifactory and the new regtest passes locally.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
