### PR TITLE
Undo change that prevents cal files from being used by AmiAnalyze step

### DIFF
--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -73,7 +73,7 @@ class AmiAnalyzeStep(Step):
             raise ValueError("Oversample value must be an odd integer.")
 
         # Open the input data model. Can be 2D or 3D image
-        with datamodels.open(input) as input_model:
+        with datamodels.DataModel(input) as input_model:
             # Get the name of the filter throughput reference file to use
             throughput_reffile = self.get_reference_file(input_model, 'throughput')
             self.log.info(f'Using filter throughput reference file {throughput_reffile}')


### PR DESCRIPTION
This PR addresses a small issue introduced by merging #7862 which prevented cal.fits files from being used as input by the AmiAnalyze step. While the default input will be calints files, we still want to have the option of processing cal files. Changing the way the file is opened as a datamodel fixes this (opening as a generic datamodel rather than allowing datamodels to figure out what kind of model to use). 

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
