### PR TITLE
JP-3604: Fix possible crashes in the alignment to abs catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -142,11 +142,14 @@ tweakreg
 - Changed default settings for ``abs_separation`` parameter for the ``tweakreg``
   step to have a value compatible with the ``abs_tolerance`` parameter. [#8445]
 
+- Improve error handling in the absolute alignment. [#8450]
+
 wfss_contam
 -----------
 
 - Fixed flux scaling issue in model contamination image by adding background
   subtraction and re-scaling fluxes to respect wavelength oversampling. [#8416]
+
 
 1.14.0 (2024-03-29)
 ===================


### PR DESCRIPTION
Resolves [JP-3604](https://jira.stsci.edu/browse/JP-3604)

Closes #8435

This PR improves handling of exceptions in the absolute alignment stage that could result in crashes when image catalogs contain no sources.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression test: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1410/
