### PR TITLE
allow ami_analyze step to run on cal files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ ami
 
 - Replaced deprecated ``np.mat()`` with ``np.asmatrix()``. [#8415]
 
+- Allow ``ami_analyze`` to run on ``cal`` files. [#8451]
+
 assign_wcs
 ----------
 

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -3,6 +3,8 @@ import logging
 import numpy as np
 import copy
 
+from jwst.datamodels import CubeModel, ImageModel
+
 from .find_affine2d_parameters import find_rotation
 from . import instrument_data
 from . import nrm_core
@@ -73,6 +75,8 @@ def apply_LG_plus(
     # If the input image is 2D, expand all relevant extensions to be 3D
     # Incl. those not currently used?
     if len(input_model.data.shape) == 2:
+        if isinstance(input_copy, ImageModel):
+            input_copy = CubeModel(input_copy)
         input_copy.data = np.expand_dims(input_copy.data, axis=0)
         input_copy.dq = np.expand_dims(input_copy.dq, axis=0)
         # input_copy.err = np.expand_dims(input_copy.err, axis=0)


### PR DESCRIPTION
This allows `ami_analyze` to run on cal files. A regression test is added (input and truth files will be added and a run started when the files are approved).

This is an alternative to https://github.com/spacetelescope/jwst/pull/8448 and instead of using the generic `DataModel` converts the input `ImageModel` to a `CubeModel` before the dimension expansion.

Regression tests run at:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1411/
Showed 1 unrelated error in `[stable-deps] test_filter_rotation – jwst.assign_wcs.tests.test_niriss` which is also failing on main:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST/2869/testReport/junit/jwst.assign_wcs.tests/test_niriss/_stable_deps__test_filter_rotation/
The regtest added in this PR passed.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
