### PR TITLE
limit rotation test to 10x the angular repeatability

### DIFF
--- a/jwst/assign_wcs/tests/test_niriss.py
+++ b/jwst/assign_wcs/tests/test_niriss.py
@@ -131,7 +131,8 @@ def test_traverse_wfss_grisms():
         traverse_wfss_trace(f)
 
 
-def test_filter_rotation(theta=[-0.1, 0, 0.5, 20]):
+# 1.585 is 10x the angular repeatability of the niriss pupil wheel
+def test_filter_rotation(theta=[-0.1, 0, 0.5, 1.585]):
     """Make sure that the filter rotation is reversable."""
     for f in niriss_grisms:
         wcsobj = create_wfss_wcs(f)


### PR DESCRIPTION
The `jwst/assign_wcs/tests/test_niriss.py::test_filter_rotation` test is failing on main with the new CRDS context (1228).

The new context contains updated `specwcs` reference files which are leading to the test failure when a 20 degree "rotation" is tested. This appears to be the rotation of the filter (relative to the reference position). A 20 degree rotation seems unlikely given the wheel has a quoted repeatability of 0.1585 degrees (taken from: https://jwst-docs.stsci.edu/jwst-near-infrared-imager-and-slitless-spectrograph/niriss-instrumentation/niriss-pupil-and-filter-wheels#gsc.tab=0).

The test was updated to instead test a rotation that is 10x the quoted repeatability.

However, this test failure may point to other issues with the niriss wcs transforms (which I am not familiar with). @nden does this test update look reasonable to you?

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
