### PR TITLE
JP-3613: Update error arrays to match NaN in data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ flat_field
 - Update the flatfield code for NIRSpec IFU data to ensure that SCI=ERR=NaN and
   DQ has the DO_NOT_USE flag set outside the footprint of the IFU slices [#8385]
 
+- Update NIRSpec flatfield code for all modes to ensure SCI=ERR=NaN wherever the
+  DO_NOT_USE flag is set in the DQ array. [#8463]
+
 general
 -------
 

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -442,7 +442,12 @@ def nirspec_fs_msa(output_model, f_flat_model, s_flat_model, d_flat_model, dispa
 
         # Make sure all DO_NOT_USE pixels are set to NaN,
         # including those flagged by this step
-        slit.data[np.where(slit.dq & dqflags.pixel['DO_NOT_USE'])] = np.nan
+        dnu = np.where(slit.dq & dqflags.pixel['DO_NOT_USE'])
+        slit.data[dnu] = np.nan
+        slit.err[dnu] = np.nan
+        slit.var_poisson[dnu] = np.nan
+        slit.var_rnoise[dnu] = np.nan
+        slit.var_flat[dnu] = np.nan
 
         any_updated = True
 
@@ -521,7 +526,12 @@ def nirspec_brightobj(output_model, f_flat_model, s_flat_model, d_flat_model, di
 
     # Make sure all DO_NOT_USE pixels are set to NaN,
     # including those flagged by this step
-    output_model.data[np.where(output_model.dq & dqflags.pixel['DO_NOT_USE'])] = np.nan
+    dnu = np.where(output_model.dq & dqflags.pixel['DO_NOT_USE'])
+    output_model.data[dnu] = np.nan
+    output_model.err[dnu] = np.nan
+    output_model.var_poisson[dnu] = np.nan
+    output_model.var_rnoise[dnu] = np.nan
+    output_model.var_flat[dnu] = np.nan
 
     output_model.meta.cal_step.flat_field = 'COMPLETE'
 
@@ -591,7 +601,12 @@ def nirspec_ifu(output_model, f_flat_model, s_flat_model, d_flat_model, dispaxis
 
         # Make sure all DO_NOT_USE pixels are set to NaN,
         # including those flagged by this step
-        output_model.data[np.where(output_model.dq & dqflags.pixel['DO_NOT_USE'])] = np.nan
+        dnu = np.where(output_model.dq & dqflags.pixel['DO_NOT_USE'])
+        output_model.data[dnu] = np.nan
+        output_model.err[dnu] = np.nan
+        output_model.var_poisson[dnu] = np.nan
+        output_model.var_rnoise[dnu] = np.nan
+        output_model.var_flat[dnu] = np.nan
 
         output_model.meta.cal_step.flat_field = 'COMPLETE'
 

--- a/jwst/regtest/test_nirspec_steps_spec2.py
+++ b/jwst/regtest/test_nirspec_steps_spec2.py
@@ -60,6 +60,13 @@ def test_ff_inv(rtdata, fitsdiff_default_kwargs):
     # make sure NaNs are only at do_not_use pixels
     assert np.all(unflatted.dq[is_nan] & dm.dqflags.pixel['DO_NOT_USE'])
 
+    # make sure NaNs at science pixels are also NaN in error and var arrays
+    assert np.all(np.isnan(unflatted.err[is_nan]))
+    assert np.all(np.isnan(unflatted.var_poisson[is_nan]))
+    assert np.all(np.isnan(unflatted.var_rnoise[is_nan]))
+    assert np.all(np.isnan(unflatted.var_flat[is_nan]))
+
+
 @pytest.mark.slow
 @pytest.mark.bigdata
 def test_pathloss_corrpars(rtdata):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3613](https://jira.stsci.edu/browse/JP-3613)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8460

<!-- describe the changes comprising this PR here -->
Update the error and variance arrays to NaN whenever science data is set to NaN.  Impacts the flat field step and products up through the cal file, for all NIRSpec modes.

**Checklist for maintainers**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [X] ~~updated relevant documentation~~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
