### PR TITLE
JP-3311: OutlierDetectionStep producing extraneous outlier_i2d files

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -69,7 +69,17 @@ class ResampleData:
                 all products in memory.
         """
         self.input_models = input_models
+        self.output_dir = None
         self.output_filename = output
+        if output is not None and '.fits' not in output:
+            self.output_dir = output
+            self.output_filename = None
+        if 'mk_output_list' in kwargs:
+            self.mk_output_list = kwargs['mk_output_list']
+        else:
+            self.mk_output_list = False
+        self.output_list = []  # list of the names of all output files created
+
         self.pscale_ratio = pscale_ratio
         self.single = single
         self.blendheaders = blendheaders
@@ -295,7 +305,11 @@ class ResampleData:
             if not self.in_memory:
                 # Write out model to disk, then return filename
                 output_name = output_model.meta.filename
+                if self.output_dir is not None:
+                    output_name = os.path.join(self.output_dir, output_name)
                 output_model.save(output_name)
+                if self.mk_output_list:
+                    self.output_list.append(output_name)
                 log.info(f"Saved model in {output_name}")
                 self.output_models.append(output_name)
             else:
@@ -303,7 +317,10 @@ class ResampleData:
             output_model.data *= 0.
             output_model.wht *= 0.
 
-        return self.output_models
+        if self.mk_output_list:
+            return self.output_list, self.output_models
+        else:
+            return self.output_models
 
     def resample_many_to_one(self):
         """Resample and coadd many inputs to a single output.

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -63,6 +63,15 @@ class ResampleSpecData(ResampleData):
         self.input_models = input_models
 
         self.output_filename = output
+        self.output_dir = None
+        if output is not None and '.fits' not in output:
+            self.output_dir = output
+            self.output_filename = None
+        if 'mk_output_list' in kwargs:
+            self.mk_output_list = kwargs['mk_output_list']
+        else:
+            self.mk_output_list = False
+        self.output_list = []  # list of the names of all output files created
         self.pscale_ratio = pscale_ratio
         self.pscale = pscale
         self.single = single


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3311](https://jira.stsci.edu/browse/JP-3311)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses intermediate files being left over after step was run. I made a series of modifications to produce an output file list and then clean up these files. In the process of creating such a list, https://jira.stsci.edu/browse/JP-3039 got resolved as well.

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
