### PR TITLE
clarify checklist in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,7 @@ Closes #
 <!-- describe the changes comprising this PR here -->
 This PR addresses ...
 
-**Checklist for PR authors**
-Please check off the items in this list as they are completed. Please
-skip or [strikethrough](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) any irrelevant items.
+**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
 - [ ] added entry in `CHANGES.rst` within the relevant release section
 - [ ] updated or added relevant tests
 - [ ] updated relevant documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@ Closes #
 This PR addresses ...
 
 **Checklist for PR authors**
+Please check off the items in this list as they are completed. Please
+skip or [strikethrough](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) any irrelevant items.
 - [ ] added entry in `CHANGES.rst` within the relevant release section
 - [ ] updated or added relevant tests
 - [ ] updated relevant documentation
@@ -16,5 +18,5 @@ This PR addresses ...
 - [ ] added relevant label(s)
 - [ ] ran regression tests, post a link to the Jenkins job below.
       [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
-- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
 - [ ] All comments are resolved
+- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,4 @@ This PR addresses ...
 - [ ] ran regression tests, post a link to the Jenkins job below.
       [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
 - [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
+- [ ] All comments are resolved

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Closes #
 <!-- describe the changes comprising this PR here -->
 This PR addresses ...
 
-**Checklist for maintainers**
+**Checklist for PR authors**
 - [ ] added entry in `CHANGES.rst` within the relevant release section
 - [ ] updated or added relevant tests
 - [ ] updated relevant documentation


### PR DESCRIPTION
This PR changes `maintainers` to `PR authors` in the PR template to clarify who should fill out the checklist. I never thought it was me :)

This PR also adds a new item to the checklist:
- [ ] All comments are resolved

**Checklist for maintainers**
- ~[ ] added entry in `CHANGES.rst` within the relevant release section~
- ~[ ] updated or added relevant tests~
- ~[ ] updated relevant documentation~
- [ ] added relevant milestone
- [x] added relevant label(s)
- ~[ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)~
- ~[ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
