### PR TITLE
JP-3625: Switch to IRAF starfinder default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -152,6 +152,9 @@ tweakreg
 
 - Improve error handling in the absolute alignment. [#8450, #8477]
 
+- Change code default to use IRAF StarFinder instead of
+  DAO StarFinder [#8487]
+
 wfss_contam
 -----------
 

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -218,7 +218,7 @@ The ``tweakreg`` step has the following optional arguments:
   in pixels. (Default=400)
 
 * ``starfinder``: A `str` indicating the source detection algorithm to use.
-  Allowed values: `'iraf'`, `'dao'`, `'segmentation'`. (Default= `'dao'`)
+  Allowed values: `'iraf'`, `'dao'`, `'segmentation'`. (Default= `'iraf'`)
 
 * ``snr_threshold``: A `float` value indicating SNR threshold above the
   background. Required for all star finders. (Default=10.0)

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -148,7 +148,7 @@ def _DaoStarFinderWrapper(data, threshold, mask=None, **kwargs):
     return sources
 
 
-def make_tweakreg_catalog(model, snr_threshold, bkg_boxsize=400, starfinder='dao', starfinder_kwargs={}):
+def make_tweakreg_catalog(model, snr_threshold, bkg_boxsize=400, starfinder='iraf', starfinder_kwargs={}):
     """
     Create a catalog of point-line sources to be used for image
     alignment in tweakreg.

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -56,7 +56,7 @@ class TweakRegStep(Step):
         use_custom_catalogs = boolean(default=False) # Use custom user-provided catalogs?
         catalog_format = string(default='ecsv') # Catalog output file format
         catfile = string(default='') # Name of the file with a list of custom user-provided catalogs
-        starfinder = option('dao', 'iraf', 'segmentation', default='dao') # Star finder to use.
+        starfinder = option('dao', 'iraf', 'segmentation', default='iraf') # Star finder to use.
         snr_threshold = float(default=10.0) # SNR threshold above the bkg for star finder
         # kwargs for DAOStarFinder and IRAFStarFinder, only used if starfinder is 'dao' or 'iraf'
         kernel_fwhm = float(default=2.5) # Gaussian kernel FWHM in pixels


### PR DESCRIPTION
Resolves [JP-3625](https://jira.stsci.edu/browse/JP-3625) by switching the code default starfinder for use in tweakreg to IRAF starfinder instead of DAO starfinder.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
