### PR TITLE
 Fix bug marking background slits as sources in jwst.assign_wcs.nirspec.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ assign_wcs
 - Move the assigned source position for dedicated NIRSpec MOS background slits from the
   lower left corner of the slit to the middle of the slit. [#8461]
 
+- Fixed a bug causing background slits to be marked as sources that were not assigned 
+  to slits but were in the source catalog. These incorrectly marked background slits are 
+  then extracted as targets. [#8494]
+
 associations
 ------------
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -699,11 +699,11 @@ def get_open_msa_slits(msa_file, msa_metadata_id, dither_position,
 
         # subtract 1 because shutter numbers in the MSA reference file are 1-based.
         shutter_id = xcen + (ycen - 1) * 365
-        try:
+        if source_id < max_source_id:
             source_name, source_alias, stellarity, source_ra, source_dec = [
                 (s['source_name'], s['alias'], s['stellarity'], s['ra'], s['dec'])
                 for s in msa_source if s['source_id'] == source_id][0]
-        except IndexError:
+        else:
             # all background shutters
             source_name = "background_{}".format(slitlet_id)
             source_alias = "bkg_{}".format(slitlet_id)


### PR DESCRIPTION
This PR addresses a bug where background slits are incorrectly marked as sources in `jwst.assign_wcs.nirspec.py::get_open_msa_slits`, leading them to be marked as sources that were not assigned to slits but were in the source catalog. These incorrectly marked background slits are then extracted as targets. 

**Full explanation:**
Previously the code in `jwst.assign_wcs.nirspec.py::get_open_msa_slits` can lead to namespace clashes, where the temporary `source_id`s assigned to the background slits are checked against the full source catalog list and incorrectly match to real sources in the full source catalog, instead of failing the try/except Index error in lines 702-712 to return unique source names of `background_{slitlet_id}`.  This leads to incorrect targets marked as being assigned slits in the WCS assignment, and background slits extracted as if they were sources in the full reduction pipeline.

The source catalog (`msa_file[("SOURCE_INFO", 1)].data`) is originally defined in the APT, and often includes many more objects than are assigned slits (`msa_file[('SHUTTER_INFO', 1)]`) in a given MSA configuration. Background slits can therefore be assigned `source_id`s that correspond to actual objects in the source catalog.

The desired behavior, that background slits are re-identified and assigned source information appropriately (lines 707-712), can be achieved with the fix of switching from a try/except IndexError to an explicit check if the object `source_id` is less than the identified `max_source_id`.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
