### PR TITLE
JP-3632: Change the Spec of Ramp Fitting to Select Algorithm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,11 @@ ramp_fitting
   to use uint16 instead of uint8, in order to avoid potential
   overflow/wraparound problems. [#8377]
 
+- Changed the spec for ramp fitting that allows for selecting
+  the algorithm "OLS" to use the python implementation of ramp
+  fitting or "OLS_C" to use the C extension implementation of
+  ramp fitting. [#8503]
+
 resample
 --------
 

--- a/docs/jwst/ramp_fitting/arguments.rst
+++ b/docs/jwst/ramp_fitting/arguments.rst
@@ -2,6 +2,11 @@ Arguments
 =========
 The ramp fitting step has the following optional arguments that can be set by the user:
 
+* ``--algorithm``: A string to select the desired algorithm.  The available
+  values are "OLS" to select the python implementation of ramp fitting and
+  "OLS_C" to select the C extension implementation of ramp fitting.  The
+  algorithm defaults to "OLS".
+
 * ``--save_opt``: A True/False value that specifies whether to write
   the optional output product. Default is False.
 

--- a/docs/jwst/ramp_fitting/arguments.rst
+++ b/docs/jwst/ramp_fitting/arguments.rst
@@ -3,9 +3,9 @@ Arguments
 The ramp fitting step has the following optional arguments that can be set by the user:
 
 * ``--algorithm``: A string to select the desired algorithm.  The available
-  values are "OLS" to select the python implementation of ramp fitting and
-  "OLS_C" to select the C extension implementation of ramp fitting.  The
-  algorithm defaults to "OLS".
+  values are "OLS" to select the python implementation of the Ordinary
+  Least Squares algorithm and  "OLS_C" to select the C extension
+  implementation of OLS.  The algorithm defaults to "OLS".
 
 * ``--save_opt``: A True/False value that specifies whether to write
   the optional output product. Default is False.

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -385,7 +385,7 @@ class RampFitStep(Step):
     class_alias = "ramp_fit"
 
     spec = """
-        algorithm = string(default='OLS')
+        algorithm = string(default='OLS') # Can be 'OLS_C' to select the C extension
         int_name = string(default='')
         save_opt = boolean(default=False) # Save optional output
         opt_name = string(default='')

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -385,7 +385,7 @@ class RampFitStep(Step):
     class_alias = "ramp_fit"
 
     spec = """
-        algorithm = string(default='OLS') # Can be 'OLS_C' to select the C extension
+        algorithm = option('OLS', 'OLS_C', default='OLS') # Can be 'OLS_C' to select the C extension
         int_name = string(default='')
         save_opt = boolean(default=False) # Save optional output
         opt_name = string(default='')

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -385,6 +385,7 @@ class RampFitStep(Step):
     class_alias = "ramp_fit"
 
     spec = """
+        algorithm = string(default='OLS')
         int_name = string(default='')
         save_opt = boolean(default=False) # Save optional output
         opt_name = string(default='')
@@ -399,8 +400,8 @@ class RampFitStep(Step):
     # As of 04/26/17, the only allowed algorithm is 'ols', and the
     #      only allowed weighting is 'optimal'.
 
-    algorithm = 'ols'      # Only algorithm allowed for Build 7.1
-#    algorithm = 'gls'       # 032520
+    # algorithm = 'ols'      # Only algorithm allowed for Build 7.1
+    # algorithm = 'gls'       # 032520
 
     weighting = 'optimal'  # Only weighting allowed for Build 7.1
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3632](https://jira.stsci.edu/browse/JP-3632)

Closes #8501 

<!-- describe the changes comprising this PR here -->
This PR addresses the ability to select the C extension implementation of ramp fitting or the python implementation.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
