### PR TITLE
remove hard-coded reference file that uses grp path

### DIFF
--- a/jwst/regtest/test_nirspec_lamp_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_lamp_ifu_spec2.py
@@ -20,9 +20,7 @@ def run_pipeline(rtdata_module):
     args = ["jwst.pipeline.Spec2Pipeline", rtdata.input,
             "--steps.assign_wcs.save_results=true",
             "--steps.msa_flagging.save_results=true",
-            "--steps.flat_field.save_results=true",
-            # Hardwire extract1d ref file selection until CRDS-525 is implemented
-            "--steps.extract_1d.override_extract1d=/grp/crds/jwst/references/jwst/jwst_nirspec_extract1d_0001.asdf"]
+            "--steps.flat_field.save_results=true"]
     Step.from_cmdline(args)
 
     return rtdata


### PR DESCRIPTION
It's my understanding the `/grp` is not accessible on the runners for the github actions regression tests (@zacharyburnett can you confirm this?).

This is leading to test failures due to a hard-coded path:
```
 E           FileNotFoundError: [Errno 2] No such file or directory: '/grp/crds/jwst/references/jwst/jwst_nirspec_extract1d_0001.asdf'
```

This PR removes the path to allow the test to pick up the latest reference file from crds.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
