### PR TITLE
Jp 3523 masterbackground 

### DIFF
--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -296,75 +296,22 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
             background = correct_nrs_ifu_bkg(background)
 
     elif input.meta.instrument.name.upper() == "MIRI":
-
-        # Check the Left channel and right channel seperately to see min and max fall on a range
-        # of wavelengths in the master background
-        print('Master background wavelength range', min_wave, max_wave)
-        
         shape = input.data.shape
-        print(input.meta.filename)
         grid = np.indices(shape, dtype=np.float64)
         wl_array = input.meta.wcs(grid[1], grid[0])[2]
+        # first remove the nans from wl_array and replace with -1
         mask = np.isnan(wl_array)
-        # It would be nice  to add another DQ Flag something like NO_BACKGROUND but we have
-        # no space left in the current dqflags.
-        background.dq[mask] = np.bitwise_or(background.dq[mask],
-                                            dqflags.pixel['DO_NOT_USE'])
-        # ____________________________________________
-        # Work with the left side of the detector
-        wl_array_left = wl_array[:, 0:512]
-        data_min_left = np.nanmin(wl_array_left)
-        data_max_left = np.nanmax(wl_array_left)
-        print('Data range left ', data_min_left, data_max_left)
+        wl_array[mask] = -1.
+        # next look at the limits of the wavelength table
+        mask_limit = (wl_array > max_wave) | (wl_array < min_wave)
+        wl_array[mask_limit] = -1
 
-        # pull out the wavelength range in the back ground for this band/channel
-        index_left = np.where(np.logical_and(tab_wavelength >= data_min_left,
-                                             tab_wavelength <= data_max_left))
-        nvalues_left = len(index_left[0])
-        print('Values left', nvalues_left)
-        print(index_left) 
-        if nvalues_left > 0:
-            tab_wavelength_left = tab_wavelength[index_left]
-            tab_background_left = tab_background[index_left]
-            # remove the nans from wl_array and replace with -1
-            mask = np.isnan(wl_array_left)
-            wl_array_left[mask] = -1.
-            bkg_surf_bright_left = np.interp(wl_array_left, tab_wavelength_left,
-                                              tab_background_left,left=0., right=0.)
-        else: # there is not background for this channel
-            background.dq[:, 0:512] = np.bitwise_or(background.dq[:,0:512],
-                                                    dqflags.pixel['DO_NOT_USE'])            
-        # ____________________________________________
-        # Now work with the right side of the detector
-        wl_array_right = wl_array[:,512:] 
-
-        data_min_right = np.nanmin(wl_array_right)
-        data_max_right = np.nanmax(wl_array_right)
-        print('Data range right ', data_min_right, data_max_right)
-
-        # pull out the wavelength range in the back ground for this band/channel
-        index_right = np.where(np.logical_and(tab_wavelength >= data_min_right,
-                                              tab_wavelength <= data_max_right))
-        nvalues_right = len(index_right[0])
-        if nvalues_right > 0:
-            print('Values right', nvalues_right)
-            tab_wavelength_right = tab_wavelength[index_right]
-            tab_background_right = tab_background[index_right]
-
-            # remove the nans from wl_array and replace with -1
-            mask = np.isnan(wl_array_right)
-            wl_array_right[mask] = -1.
-            bkg_surf_bright_right = np.interp(wl_array_right, tab_wavelength_right,
-                                              tab_background_right,left=0., right=0.)
-        else: # there is not background for this channel
-            background.dq[:,512:] = np.bitwise_or(background.dq[:512:],
-                                                    dqflags.pixel['DO_NOT_USE'])            
-
-        # combine the left and right results
-        if nvalues_left > 0:
-            background.data[:, 0:512] = bkg_surf_bright_left.copy()
-        if nvalues_right > 0:
-            background.data[:, 512:] = bkg_surf_bright_right.copy()
+        # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
+        background.dq[mask_limit] = np.bitwise_or(background.dq[mask_limit],
+                                                  dqflags.pixel['DO_NOT_USE'])
+        bkg_surf_bright = np.interp(wl_array, tab_wavelength, tab_background,
+                                    left=0., right=0.)
+        background.data[:, :] = bkg_surf_bright.copy()
 
     else:
         raise RuntimeError(f'Exposure type {input.meta.exposure.type} is not supported.')

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -139,6 +139,8 @@ class MasterBackgroundStep(Step):
                         exptime_key='exposure_time',
                     )
 
+                    print('************************************************')
+                    print(master_background.spec[0].spec_table['WAVELENGTH'])
                     background_data.close()
 
                     result = ModelContainer()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
This is a draft PR to test the background exposure and if they cover the same bands as the science data. 
This is written with MIRI MRS IFU data but could be expanded to NIRSpec IFU data.

This SHOULD NOT BE MERGED. I have only made a PR to show others in the chartreuse group my plans for the PR. I am going to be gone for an extended time and just wanted to have something to guide others on a possible approach. 

If the background does not cover the full range the master background step is skipped.
For a default pipeline step this seems consistent with how other steps work. 
Originally it was discussed that bands with no background would have 0 values subtracted. This does not
seem desirable. Currently if a background band does not exist and extrapolation over the bands is done. Which
is also not desirable. This solution is straight forward. 

There is test data located at:
grp/jwst/ssb/morrison/Masterbackground_Test_data

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
