### PR TITLE
Add background error propagation to non-IFU spectral extraction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,7 +68,7 @@ extract_1d
 - Fix error in application of aperture correction to variance arrays. [#8530]
 
 - Add propagation of background uncertainty when background is subtracted from 
-  source spectra during non-IFU spectral extraction.
+  source spectra during non-IFU spectral extraction. [#8531]
 
 extract_2d
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,8 @@ extract_1d
 - Add propagation of uncertainty when annular backgrounds are subtracted
   from source spectra during IFU spectral extraction. [#8515]
 
+- Fix error in application of aperture correction to variance arrays. [#8530]
+
 extract_2d
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ extract_1d
 
 - Fix error in application of aperture correction to variance arrays. [#8530]
 
+- Add propagation of background uncertainty when background is subtracted from 
+  source spectra during non-IFU spectral extraction.
+
 extract_2d
 ----------
 

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -154,8 +154,8 @@ class ApCorrBase(abc.ABC):
 
         """
         flux_cols_to_correct = ('flux', 'flux_error', 'surf_bright', 'sb_error')
-        var_cols_to_correct = {'flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
-                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat'}
+        var_cols_to_correct = ('flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
+                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat')
 
         for row in spec_table:
             correction = self.apcorr_func(row['npixels'], row['wavelength'])
@@ -237,8 +237,8 @@ class ApCorrPhase(ApCorrBase):
 
         """
         flux_cols_to_correct = ('flux', 'flux_error', 'surf_bright', 'sb_error')
-        var_cols_to_correct = {'flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
-                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat'}
+        var_cols_to_correct = ('flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
+                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat')
 
         for row in spec_table:
             try:
@@ -298,8 +298,8 @@ class ApCorrRadial(ApCorrBase):
 
         """
         flux_cols_to_correct = ('flux', 'flux_error', 'surf_bright', 'sb_error')
-        var_cols_to_correct = {'flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
-                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat'}
+        var_cols_to_correct = ('flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
+                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat')
 
         for i, row in enumerate(spec_table):
             correction = self.apcorr_correction[i]

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -153,15 +153,17 @@ class ApCorrBase(abc.ABC):
             Table of aperture corrections values from apcorr reference file.
 
         """
-        cols_to_correct = ('flux', 'flux_error', 'flux_var_poisson', 'flux_var_rnoise',
-                           'flux_var_flat', 'surf_bright', 'sb_error', 'sb_var_poisson',
-                           'sb_var_rnoise', 'sb_var_flat')
+        flux_cols_to_correct = ('flux', 'flux_error', 'surf_bright', 'sb_error')
+        var_cols_to_correct = {'flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
+                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat'}
 
         for row in spec_table:
             correction = self.apcorr_func(row['npixels'], row['wavelength'])
 
-            for col in cols_to_correct:
+            for col in flux_cols_to_correct:
                 row[col] *= correction.item()
+            for col in var_cols_to_correct:
+                row[col] *= correction.item() * correction.item()
 
 
 class ApCorrPhase(ApCorrBase):
@@ -234,9 +236,9 @@ class ApCorrPhase(ApCorrBase):
             Table of aperture corrections values from apcorr reference file.
 
         """
-        cols_to_correct = ('flux', 'flux_error', 'flux_var_poisson', 'flux_var_rnoise',
-                           'flux_var_flat', 'surf_bright', 'sb_error', 'sb_var_poisson',
-                           'sb_var_rnoise', 'sb_var_flat')
+        flux_cols_to_correct = ('flux', 'flux_error', 'surf_bright', 'sb_error')
+        var_cols_to_correct = {'flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
+                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat'}
 
         for row in spec_table:
             try:
@@ -244,9 +246,11 @@ class ApCorrPhase(ApCorrBase):
             except ValueError:
                 correction = None  # Some input wavelengths might not be supported (especially at the ends of the range)
 
-            for col in cols_to_correct:
-                if correction:
+            if correction:
+                for col in flux_cols_to_correct:
                     row[col] *= correction.item()
+                for col in var_cols_to_correct:
+                    row[col] *= correction.item() * correction.item()
 
 
 class ApCorrRadial(ApCorrBase):
@@ -293,14 +297,16 @@ class ApCorrRadial(ApCorrBase):
             Table of aperture corrections values from apcorr reference file.
 
         """
-        cols_to_correct = ('flux', 'flux_error', 'flux_var_poisson', 'flux_var_rnoise',
-                           'flux_var_flat', 'surf_bright', 'sb_error', 'sb_var_poisson',
-                           'sb_var_rnoise', 'sb_var_flat')
+        flux_cols_to_correct = ('flux', 'flux_error', 'surf_bright', 'sb_error')
+        var_cols_to_correct = {'flux_var_poisson', 'flux_var_rnoise', 'flux_var_flat', 
+                            'sb_var_poisson', 'sb_var_rnoise', 'sb_var_flat'}
 
         for i, row in enumerate(spec_table):
             correction = self.apcorr_correction[i]
-            for col in cols_to_correct:
+            for col in flux_cols_to_correct:
                 row[col] *= correction
+            for col in var_cols_to_correct:
+                row[col] *= correction * correction
 
     def match_wavelengths(self, wavelength_ifu):
         # given the ifu wavelength value - redefine the apcor func and radius to this wavelength

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -457,6 +457,11 @@ def _extract_src_flux(image, var_poisson, var_rnoise, var_flat, x, j, lam, srcli
     # subtract background per pixel:
     val -= bkg
 
+    # add background variance to variance in source extraction region
+    f_var_poisson += b_var_poisson
+    f_var_rnoise += b_var_rnoise
+    f_var_flat += b_var_flat
+
     # scale per pixel values by pixel area included in extraction
     val *= area
     bkg *= area


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3643](https://jira.stsci.edu/browse/JP-3643)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8522 

<!-- describe the changes comprising this PR here -->
This PR adds error propagation to the extracted source flux when carrying out spectral extraction with background subtraction in non-IFU modes. The individual background variance arrays are added to the corresponding flux variance arrays.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] ~~updated relevant documentation~~
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
