### PR TITLE
JP-2922: Minor fixes for MSA source names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,13 @@ general
 
 - Increase minimum required scipy. [#8441]
 
+master_background_mos
+---------------------
+
+- Updated check for NIRSpec MOS background slits to use new naming convention:
+  ``slit.source_name`` now contains the string "BKG" instead of
+  "background". [#8533]
+
 outlier_detection
 -----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ assign_wcs
 
 - Updated the routines that load NIRSpec MOS slit and source data from the MSA meta
   data file to properly handle background and virtual slits, and assign appropriate
-  meta data to them for use downstream. [#8442]
+  meta data to them for use downstream. [#8442, #8533]
 
 associations
 ------------

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -674,7 +674,13 @@ def get_open_msa_slits(prog_id, msa_file, msa_metadata_id, dither_position,
                     (s['source_name'], s['alias'], s['stellarity'], s['ra'], s['dec'])
                     for s in msa_source if s['source_id'] == source_id][0]
             except IndexError:
-                log.warning("Could not retrieve source info from MSA file")
+                source_name = f"{prog_id}_VRT{slitlet_id}"
+                source_alias = "VRT{}".format(slitlet_id)
+                stellarity = 0.0
+                source_ra = 0.0
+                source_dec = 0.0
+                log.warning(f"Could not retrieve source info from MSA file; "
+                            f"assigning virtual source_name={source_name}")
 
             if source_id < 0:
                 log.info(f'Slitlet {slitlet_id} contains virtual source, with source_id={source_id}')

--- a/jwst/master_background/master_background_mos_step.py
+++ b/jwst/master_background/master_background_mos_step.py
@@ -191,7 +191,7 @@ class MasterBackgroundMosStep(Pipeline):
         # count how many are background vs source.
         num_bkg = num_src = 0
         for slit in data.slits:
-            if "background" in slit.source_name:
+            if nirspec_utils.is_background_msa_slit(slit):
                 num_bkg += 1
             else:
                 num_src += 1

--- a/jwst/master_background/nirspec_utils.py
+++ b/jwst/master_background/nirspec_utils.py
@@ -101,7 +101,7 @@ def create_background_from_multislit(input_model):
     bkg_model.update(input_model)
     slits = []
     for slit in input_model.slits:
-        if "background" in slit.source_name:
+        if is_background_msa_slit(slit):
             log.info(f'Using background slitlet {slit.source_name}')
             slits.append(slit)
 
@@ -242,3 +242,23 @@ def correct_nrs_fs_bkg(input_model, primary_slit):
         input_model.data *= (pl_uniform / pl_point)
 
     return input_model
+
+
+def is_background_msa_slit(slit):
+    """
+    Check if an MSA slitlet is a background source.
+
+    Parameters
+    ----------
+    slit : `~jwst.datamodels.SlitModel`
+        The slit model to check.
+
+    Returns
+    -------
+    bool
+        True if the slit is background; False if it is not.
+    """
+    if "BKG" in str(slit.source_name).upper():
+        return True
+    else:
+        return False

--- a/jwst/master_background/tests/test_nirspec_corrections.py
+++ b/jwst/master_background/tests/test_nirspec_corrections.py
@@ -2,11 +2,12 @@
 Unit tests for master background NIRSpec corrections
 """
 import numpy as np
+import pytest
 
 from stdatamodels.jwst import datamodels
 
 from jwst.master_background.nirspec_utils import (
-    correct_nrs_ifu_bkg, correct_nrs_fs_bkg
+    correct_nrs_ifu_bkg, correct_nrs_fs_bkg, is_background_msa_slit
 )
 
 
@@ -54,3 +55,15 @@ def test_fs_correction():
     result = correct_nrs_fs_bkg(input, primary_slit=True)
 
     assert np.allclose(corrected, result.data, rtol=1.e-7)
+
+
+@pytest.mark.parametrize('name,status',
+                         [('BKG101', True), ('bkg101', True),
+                          ('background_101', False), ('101', False),
+                          (None, False)])
+def test_is_background(name, status):
+    """Test check for background slit."""
+    slit = datamodels.SlitModel()
+    if name is not None:
+        slit.source_name = name
+    assert is_background_msa_slit(slit) == status


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2922](https://jira.stsci.edu/browse/JP-2922)

<!-- describe the changes comprising this PR here -->
This PR addresses two minor issues with PR #8442.

- Add default fallback values for an edge case in NIRSpec MSA handling: when a source is specified in the SHUTTER_INFO table, but not found in the SOURCE_INFO table.  These cases used to be handled as background sources, but background sources now have their own separate handling.  This case is unlikely to be encountered in operations; this handling would mostly only be needed to gracefully handle a hand-edited MSA file.
- Add a function to check whether a slit contains a background source, and update the test from checking for "background" (old-style background source names) to "BKG" (new-style) in the slit.source_name attribute.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
