### PR TITLE
remove name_format usage in wfs_combine

### DIFF
--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -25,11 +25,14 @@ class WfsCombineStep(Step):
         suffix = string(default="wfscmb")
     """
 
+    def make_output_path(self, basepath, *args, **kwargs):
+        # bypass all stpipe filename formatting
+        return basepath
+
     def process(self, input_table):
 
         self.suffix = 'wfscmb'
         self.output_use_model = True
-        self.name_format = False
 
         # Load the input ASN table
         asn_table = self.load_as_level3_asn(input_table)
@@ -69,7 +72,8 @@ class WfsCombineStep(Step):
             output_model.meta.cal_step.wfs_combine = 'COMPLETE'
             output_model.meta.asn.pool_name = asn_table['asn_pool']
             output_model.meta.asn.table_name = os.path.basename(input_table)
-            output_model.meta.filename = which_set['name']
+            # format the filename here
+            output_model.meta.filename = which_set['name'].format(suffix=self.suffix) + self.output_ext
 
             output_container.append(output_model)
 


### PR DESCRIPTION
This PR replaces usage of [name_format](https://github.com/spacetelescope/jwst/blob/f2c9e93e873e9cce64588075183379f53d6c2f35/jwst/wfs_combine/wfs_combine_step.py#L32) in wfs_combine with make_output_path. The resulting filenames saved by the step are the same (as is tested in the [test_nircam_wfs_image](https://github.com/spacetelescope/jwst/blob/f2c9e93e873e9cce64588075183379f53d6c2f35/jwst/regtest/test_nircam_wfs.py#L59) regression test). This PR removes the only use of name_format to allow its removal in stpipe to work towards simplifying the file naming code.

Regression tests show only unrelated errors and no failures of `test_nircam_wfs_image`.
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1502/

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
