### PR TITLE
remove OpenCV from dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,8 @@ general
 
 - Increase minimum required scipy. [#8441]
 
+- remove OpenCV from dependencies [#8544]
+
 master_background_mos
 ---------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "drizzle>=1.15.0",
     "gwcs>=0.21.0,<0.22.0",
     "numpy>=1.22",
-    "opencv-python-headless>=4.6.0.66",
     "photutils>=1.5.0",
     "psutil>=5.7.2",
     "poppy>=1.0.2",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3120](https://jira.stsci.edu/browse/JP-3120)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR removes `opencv-python-headless` in conjunction with the corresponding effort in `stcal` (https://github.com/spacetelescope/stcal/pull/138), which produces ellipses from snowballs with respective functionality from `scikit-image` instead

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
