### PR TITLE
Add check for uncalibrated filters for NIRISS SOSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ associations
 
 - Add NIRSpec optical path constraints for TSO associations. [#8537]
 
+- Exclude NIRISS SOSS data taken with uncalibrated filter F277W from spec2 and
+  tso3 associations. [#8549]
+
 combine_1d
 ----------
 

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -136,7 +136,7 @@ TSO_EXP_TYPES = [
     'nrs_brightobj'
 ]
 
-# Define the valid optical paths vs detector for NIRSpect Fixed-slit Science
+# Define the valid optical paths vs detector for NIRSpec Fixed-slit Science
 # Tuples are (SLIT, GRATING, FILTER, DETECTOR)
 # All A-slits are represented by SLIT == 'a'.
 NRS_FSS_VALID_OPTICAL_PATHS = (
@@ -204,7 +204,7 @@ NRS_FSS_VALID_LAMP_OPTICAL_PATHS = (
     ('g140m', 'flat4', 'nrs2'),
 )
 
-# Define the valid optical paths vs detector for NIRSpect IFU Science
+# Define the valid optical paths vs detector for NIRSpec IFU Science
 # Tuples are (GRATING, FILTER, DETECTOR)
 # The only combinations that result in data on the NRS2 detector are
 # g140h/f100lp, g235h/f170lp, and g395h/f290lp.
@@ -222,6 +222,13 @@ NRS_IFU_VALID_OPTICAL_PATHS = (
     ('g395h', 'f290lp', 'nrs1'),
     ('g395h', 'f290lp', 'nrs2'),
 )
+
+
+# Define the uncalibrated filters for NIRISS SOSS
+# Data taken with these filters should not be processed beyond
+# level 2a.
+NIS_SOSS_UNCALIBRATED_FILTERS = ('f277w',)
+
 
 # Key that uniquely identifies members.
 MEMBER_KEY = 'expname'
@@ -1158,3 +1165,17 @@ def nrccoron_valid_detector(item):
             return True
     else:
         return True
+
+
+def nissoss_calibrated_filter(item):
+    """Check that a NIRISS filter is calibrated."""
+    _, exp_type = item_getattr(item, ['exp_type'])
+    if exp_type != 'nis_soss':
+        return True
+
+    try:
+        _, filter = item_getattr(item, ['filter'])
+    except KeyError:
+        return False
+
+    return filter not in NIS_SOSS_UNCALIBRATED_FILTERS

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -13,6 +13,7 @@ from jwst.associations.lib.dms_base import (
     Constraint_WFSC,
     format_list,
     item_getattr,
+    nissoss_calibrated_filter,
     nrccoron_valid_detector,
     nrsfss_valid_detector,
     nrsifu_valid_detector,
@@ -482,11 +483,29 @@ class Asn_Lv2SpecTSO(
                         DMSAttrConstraint(
                             name='exp_type',
                             sources=['exp_type'],
-                            value=('nrs_brightobj')
+                            value='nrs_brightobj'
                         ),
                         SimpleConstraint(
                             value=False,
                             test=lambda value, item: nrsfss_valid_detector(item) == value,
+                            force_unique=False
+                        ),
+                    ]),
+                ],
+                reduce=Constraint.notany
+            ),
+            # Don't allow NIRISS SOSS with uncalibrated filters
+            Constraint(
+                [
+                    Constraint([
+                        DMSAttrConstraint(
+                            name='exp_type',
+                            sources=['exp_type'],
+                            value='nis_soss'
+                        ),
+                        SimpleConstraint(
+                            value=False,
+                            test=lambda value, item: nissoss_calibrated_filter(item) == value,
                             force_unique=False
                         ),
                     ]),

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -3,12 +3,15 @@
 import logging
 
 from jwst.associations.registry import RegistryMarker
-from jwst.associations.lib.dms_base import (Constraint_TargetAcq, Constraint_TSO, nrsfss_valid_detector, nrsifu_valid_detector)
-from jwst.associations.lib.dms_base import (nrccoron_valid_detector)
+from jwst.associations.lib.dms_base import (
+    Constraint_TargetAcq, Constraint_TSO,
+    nissoss_calibrated_filter, nrccoron_valid_detector,
+    nrsfss_valid_detector, nrsifu_valid_detector)
 from jwst.associations.lib.process_list import ListCategory
 from jwst.associations.lib.rules_level3_base import *
 from jwst.associations.lib.rules_level3_base import (
-    dms_product_name_sources, dms_product_name_nrsfs_sources, dms_product_name_noopt, dms_product_name_coronimage,
+    dms_product_name_sources, dms_product_name_nrsfs_sources,
+    dms_product_name_noopt, dms_product_name_coronimage,
     format_product
 )
 
@@ -881,12 +884,12 @@ class Asn_Lv3TSO(AsnMixin_Science):
                         DMSAttrConstraint(
                             name='restricted_grism',
                             sources=['exp_type'],
-                            value=('nrc_tsgrism')
+                            value='nrc_tsgrism'
                         ),
                         DMSAttrConstraint(
                             name='grism_clear',
                             sources=['pupil'],
-                            value=('clear')
+                            value='clear'
                         ),
                     ]),
                     Constraint([
@@ -904,19 +907,31 @@ class Asn_Lv3TSO(AsnMixin_Science):
                 ],
                 reduce=Constraint.notany
             ),
-            # Don't allow NIRISS SOSS with NINTS=1 in tso3
+            # Don't allow NIRISS SOSS with NINTS=1 or uncalibrated filters
             Constraint(
                 [
                     Constraint([
                         DMSAttrConstraint(
                             name='exp_type',
                             sources=['exp_type'],
-                            value=('nis_soss')
+                            value='nis_soss'
                         ),
                         DMSAttrConstraint(
                             name='nints',
                             sources=['nints'],
-                            value=('1')
+                            value='1'
+                        ),
+                    ]),
+                    Constraint([
+                        DMSAttrConstraint(
+                            name='exp_type',
+                            sources=['exp_type'],
+                            value='nis_soss'
+                        ),
+                        SimpleConstraint(
+                            value=False,
+                            test=lambda value, item: nissoss_calibrated_filter(item) == value,
+                            force_unique=False
                         ),
                     ]),
                 ],
@@ -929,7 +944,7 @@ class Asn_Lv3TSO(AsnMixin_Science):
                         DMSAttrConstraint(
                             name='exp_type',
                             sources=['exp_type'],
-                            value=('nrs_brightobj')
+                            value='nrs_brightobj'
                         ),
                         SimpleConstraint(
                             value=False,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3617](https://jira.stsci.edu/browse/JP-3617)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8472 

<!-- describe the changes comprising this PR here -->
Update to TSO stage 2b and 3 association rules to skip processing for an uncalibrated filter for NIRISS SOSS.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
