### PR TITLE
JP-3635: Account for pixel area ratio in outlier detection blotting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,6 +164,9 @@ outlier_detection
   to detect outliers in TSO data, with user-defined
   rolling window width via the ``rolling_window_width`` parameter. [#8473]
 
+- Fixed a bug that led to small total flux offsets between input and blotted
+  images if the nominal and actual wcs-computed pixel areas were different. [#8553]
+
 pathloss
 --------
 

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -569,9 +569,12 @@ def gwcs_blot(median_model, blot_img, interp='poly5', sinscl=1.0):
     log.debug("Pixmap shape: {}".format(pixmap[:, :, 0].shape))
     log.debug("Sci shape: {}".format(blot_img.data.shape))
 
-    input_pixflux_area = blot_img.meta.photometry.pixelarea_steradians
-    input_pixel_area = compute_image_pixel_area(blot_img.meta.wcs)
-    pix_ratio = np.sqrt(input_pixflux_area / input_pixel_area)
+    if 'SPECTRAL' not in blot_img.meta.wcs.output_frame.axes_type:
+        input_pixflux_area = blot_img.meta.photometry.pixelarea_steradians
+        input_pixel_area = compute_image_pixel_area(blot_img.meta.wcs)
+        pix_ratio = np.sqrt(input_pixflux_area / input_pixel_area)
+    else:
+        pix_ratio = 1.0
     log.info('Blotting {} <-- {}'.format(blot_img.data.shape, median_model.data.shape))
 
     outsci = np.zeros(blot_img.shape, dtype=np.float32)

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -568,7 +568,9 @@ def gwcs_blot(median_model, blot_img, interp='poly5', sinscl=1.0):
     log.debug("Pixmap shape: {}".format(pixmap[:, :, 0].shape))
     log.debug("Sci shape: {}".format(blot_img.data.shape))
 
-    pix_ratio = 1
+    pix_ratio = np.sqrt(blot_img.meta.photometry.pixelarea_arcsecsq / \
+                        median_model.meta.photometry.pixelarea_arcsecsq)
+    #log.warning(f"Pixel area ratio: {pix_ratio:.6f}")
     log.info('Blotting {} <-- {}'.format(blot_img.data.shape, median_model.data.shape))
 
     outsci = np.zeros(blot_img.shape, dtype=np.float32)

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -17,7 +17,7 @@ from jwst.datamodels import ModelContainer
 from jwst.resample import resample
 from jwst.resample.resample_utils import build_driz_weight, calc_gwcs_pixmap
 from jwst.stpipe import Step
-from jwst.resample.resample import _compute_image_pixel_area
+from jwst.resample.resample import compute_image_pixel_area
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -570,7 +570,7 @@ def gwcs_blot(median_model, blot_img, interp='poly5', sinscl=1.0):
     log.debug("Sci shape: {}".format(blot_img.data.shape))
 
     input_pixflux_area = blot_img.meta.photometry.pixelarea_steradians
-    input_pixel_area = _compute_image_pixel_area(blot_img.meta.wcs)
+    input_pixel_area = compute_image_pixel_area(blot_img.meta.wcs)
     pix_ratio = np.sqrt(input_pixflux_area / input_pixel_area)
     log.info('Blotting {} <-- {}'.format(blot_img.data.shape, median_model.data.shape))
 

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -17,6 +17,7 @@ from jwst.datamodels import ModelContainer
 from jwst.resample import resample
 from jwst.resample.resample_utils import build_driz_weight, calc_gwcs_pixmap
 from jwst.stpipe import Step
+from jwst.resample.resample import _compute_image_pixel_area
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -568,9 +569,9 @@ def gwcs_blot(median_model, blot_img, interp='poly5', sinscl=1.0):
     log.debug("Pixmap shape: {}".format(pixmap[:, :, 0].shape))
     log.debug("Sci shape: {}".format(blot_img.data.shape))
 
-    pix_ratio = np.sqrt(blot_img.meta.photometry.pixelarea_arcsecsq / \
-                        median_model.meta.photometry.pixelarea_arcsecsq)
-    #log.warning(f"Pixel area ratio: {pix_ratio:.6f}")
+    input_pixflux_area = blot_img.meta.photometry.pixelarea_steradians
+    input_pixel_area = _compute_image_pixel_area(blot_img.meta.wcs)
+    pix_ratio = np.sqrt(input_pixflux_area / input_pixel_area)
     log.info('Blotting {} <-- {}'.format(blot_img.data.shape, median_model.data.shape))
 
     outsci = np.zeros(blot_img.shape, dtype=np.float32)

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -141,6 +141,10 @@ def we_many_sci(
     sci1.var_rnoise = np.zeros(shape) + 1.0
     sci1.meta.filename = "foo1_cal.fits"
 
+    # add pixel areas
+    sci1.meta.photometry.pixelarea_steradians = 1.0
+    sci1.meta.photometry.pixelarea_arcsecsq = 1.0
+
     # Make copies with different noise
     all_sci = [sci1]
     for i in range(numsci - 1):

--- a/jwst/regtest/test_nircam_align_to_gaia.py
+++ b/jwst/regtest/test_nircam_align_to_gaia.py
@@ -13,6 +13,7 @@ def run_image3pipeline(rtdata_module):
     rtdata = rtdata_module
     rtdata.get_asn("nircam/image/level3_F277W_3img_asn.json")
     args = ["calwebb_image3", rtdata.input,
+            "--steps.outlier_detection.save_intermediate_results=True",
             "--steps.tweakreg.abs_refcat=GAIADR2",
             "--steps.tweakreg.save_results=True",
             "--steps.tweakreg.output_use_model=True",
@@ -40,3 +41,36 @@ def test_tweakreg_with_gaia(run_image3pipeline, rtdata_module, root):
 
         assert_allclose(ra, ra_truth)
         assert_allclose(dec, dec_truth)
+
+
+
+
+@pytest.mark.bigdata
+def test_outlier_detection_flux_roundtrip(run_image3pipeline):
+    """
+    Check flux scaling between input and output of OutlierDetectionStep.
+    Covers bugfix for JP-3635. Even after the change, the flux scaling
+    is not perfect, but at least this tolerance fails the test prior 
+    to the fix and passes afterward(?)
+    """
+
+    import os
+    import numpy as np
+    ls = os.listdir(".")
+    for l in ls:
+        print(l)
+
+    stem = "jw01069002004_01101_00013_nrca5"
+
+    calfile = stem+"_cal.fits"
+    blotfile = stem+"_a3001_blot.fits"
+
+    with datamodels.open(calfile) as cal, datamodels.open(blotfile) as blot:
+
+        badcal = (np.isnan(cal.data)) * (np.isinf(cal.data))
+        badblot = (np.isnan(blot.data)) * (np.isinf(blot.data))
+        med_cal = np.nanmedian(cal.data[~badcal])
+        med_blot = np.nanmedian(blot.data[~badblot])
+
+        print(med_cal, med_blot)
+        assert np.isclose(med_cal, med_blot, atol=3e-3)

--- a/jwst/regtest/test_nircam_align_to_gaia.py
+++ b/jwst/regtest/test_nircam_align_to_gaia.py
@@ -13,7 +13,6 @@ def run_image3pipeline(rtdata_module):
     rtdata = rtdata_module
     rtdata.get_asn("nircam/image/level3_F277W_3img_asn.json")
     args = ["calwebb_image3", rtdata.input,
-            "--steps.outlier_detection.save_intermediate_results=True",
             "--steps.tweakreg.abs_refcat=GAIADR2",
             "--steps.tweakreg.save_results=True",
             "--steps.tweakreg.output_use_model=True",
@@ -41,36 +40,3 @@ def test_tweakreg_with_gaia(run_image3pipeline, rtdata_module, root):
 
         assert_allclose(ra, ra_truth)
         assert_allclose(dec, dec_truth)
-
-
-
-
-@pytest.mark.bigdata
-def test_outlier_detection_flux_roundtrip(run_image3pipeline):
-    """
-    Check flux scaling between input and output of OutlierDetectionStep.
-    Covers bugfix for JP-3635. Even after the change, the flux scaling
-    is not perfect, but at least this tolerance fails the test prior 
-    to the fix and passes afterward(?)
-    """
-
-    import os
-    import numpy as np
-    ls = os.listdir(".")
-    for l in ls:
-        print(l)
-
-    stem = "jw01069002004_01101_00013_nrca5"
-
-    calfile = stem+"_cal.fits"
-    blotfile = stem+"_a3001_blot.fits"
-
-    with datamodels.open(calfile) as cal, datamodels.open(blotfile) as blot:
-
-        badcal = (np.isnan(cal.data)) * (np.isinf(cal.data))
-        badblot = (np.isnan(blot.data)) * (np.isinf(blot.data))
-        med_cal = np.nanmedian(cal.data[~badcal])
-        med_blot = np.nanmedian(blot.data[~badblot])
-
-        print(med_cal, med_blot)
-        assert np.isclose(med_cal, med_blot, atol=3e-3)

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -114,7 +114,7 @@ class ResampleData:
                 self.output_wcs.array_shape = output_shape[::-1]
 
             if output_wcs.pixel_area is None:
-                output_pix_area = _compute_image_pixel_area(self.output_wcs)
+                output_pix_area = compute_image_pixel_area(self.output_wcs)
                 if output_pix_area is None:
                     raise ValueError(
                         "Unable to compute output pixel area from 'output_wcs'."
@@ -250,7 +250,7 @@ class ResampleData:
                 if (input_pixflux_area and
                         'SPECTRAL' not in img.meta.wcs.output_frame.axes_type):
                     img.meta.wcs.array_shape = img.data.shape
-                    input_pixel_area = _compute_image_pixel_area(img.meta.wcs)
+                    input_pixel_area = compute_image_pixel_area(img.meta.wcs)
                     if input_pixel_area is None:
                         raise ValueError(
                             "Unable to compute input pixel area from WCS of input "
@@ -336,7 +336,7 @@ class ResampleData:
             if (input_pixflux_area and
                     'SPECTRAL' not in img.meta.wcs.output_frame.axes_type):
                 img.meta.wcs.array_shape = img.data.shape
-                input_pixel_area = _compute_image_pixel_area(img.meta.wcs)
+                input_pixel_area = compute_image_pixel_area(img.meta.wcs)
                 if input_pixel_area is None:
                     raise ValueError(
                         "Unable to compute input pixel area from WCS of input "
@@ -805,7 +805,7 @@ def _get_boundary_points(xmin, xmax, ymin, ymax, dx=None, dy=None, shrink=0):
     return x, y, area, center, b, r, t, l
 
 
-def _compute_image_pixel_area(wcs):
+def compute_image_pixel_area(wcs):
     """ Computes pixel area in steradians.
     """
     if wcs.array_shape is None:

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -12,7 +12,7 @@ from jwst.assign_wcs import AssignWcsStep
 from jwst.assign_wcs.util import compute_fiducial, compute_scale
 from jwst.extract_2d import Extract2dStep
 from jwst.resample import ResampleSpecStep, ResampleStep
-from jwst.resample.resample import _compute_image_pixel_area
+from jwst.resample.resample import compute_image_pixel_area
 from jwst.resample.resample_spec import ResampleSpecData
 
 
@@ -28,7 +28,7 @@ def _set_photom_kwd(im):
         bb = ((xmin - 0.5, xmax - 0.5), (ymin - 0.5, ymax - 0.5))
         im.meta.wcs.bounding_box = bb
 
-    mean_pixel_area = _compute_image_pixel_area(im.meta.wcs)
+    mean_pixel_area = compute_image_pixel_area(im.meta.wcs)
     if mean_pixel_area:
         im.meta.photometry.pixelarea_steradians = mean_pixel_area
         im.meta.photometry.pixelarea_arcsecsq = (


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3635](https://jira.stsci.edu/browse/JP-3635)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8509

<!-- describe the changes comprising this PR here -->
This PR addresses a small bug in outlier detection: resample accounted for the difference between the nominal pixel area in steradians used for the photometric calibration (img.meta.photometry.pixelarea_steradians) and the as-computed pixel area from the WCS when resampling cal files.  That wasn't performed in reverse when blotting median images back to match those individual cal files.  This PR applies that reverse ratio so that the total flux is conserved between input models and blotted models.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
