### PR TITLE
JP-3584-bugfix: fixed failed save for intermediate (median) files

### DIFF
--- a/jwst/outlier_detection/outlier_detection_tso.py
+++ b/jwst/outlier_detection/outlier_detection_tso.py
@@ -35,6 +35,7 @@ class OutlierDetectionTSO(OutlierDetection):
 
     def do_detection(self):
         """Flag outlier pixels in DQ of input images."""
+        self.build_suffix(**self.outlierpars)
         weighted_cube = self.weight_no_resample()
 
         maskpt = self.outlierpars.get('maskpt', 0.7)
@@ -56,7 +57,7 @@ class OutlierDetectionTSO(OutlierDetection):
         # Save median model if pars['save_intermediate_results'] is True
         # this will be a CubeModel with rolling median values.
         if self.outlierpars['save_intermediate_results']:
-            with dm.open(weighted_cube[0]) as dm0:
+            with dm.open(weighted_cube) as dm0:
                 median_model.update(dm0)
             self.save_median(median_model)
 

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from astropy.io.fits.diff import FITSDiff
 from numpy.testing import assert_allclose
@@ -63,6 +64,7 @@ def run_tso3_pipeline(run_tso_spec2_pipeline, rtdata_module):
         "calwebb_tso3",
         ASN3_FILENAME,
         "--steps.outlier_detection.save_results=true",
+        "--steps.outlier_detection.save_intermediate_results=true"
     ]
     Step.from_cmdline(args)
 
@@ -106,6 +108,9 @@ def test_miri_lrs_slitless_tso3(run_tso3_pipeline, rtdata_module,
                                 fitsdiff_default_kwargs, step_suffix):
     """Compare the output of a MIRI LRS slitless calwebb_tso3 pipeline."""
     rtdata = rtdata_module
+
+    median_filename = f"{DATASET1_ID}_{ASN_ID}_median.fits"
+    assert os.path.isfile(median_filename)
 
     output_filename = f"{DATASET1_ID}_{ASN_ID}_{step_suffix}.fits"
     rtdata.output = output_filename


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3584](https://jira.stsci.edu/browse/JP-3584)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8378

<!-- describe the changes comprising this PR here -->
This PR fixes a bug in implementation of JP-3584 that was causing crashes when save_intermediate_results was set True for TSO data. 

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
