### PR TITLE
remove requirements-max.txt

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -74,7 +74,7 @@ bc0.conda_ver = '22.11.1'
 bc0.conda_packages = [
     "python=${python_version}",
 ]
-bc0.pip_reqs_files = ['requirements-dev-st.txt', 'requirements-max.txt', 'requirements-sdp.txt']
+bc0.pip_reqs_files = ['requirements-dev-st.txt', 'requirements-sdp.txt']
 bc0.build_cmds = [
     "pip install certifi -U --force-reinstall",
     "pip install -e .[test,sdp] --no-cache-dir",

--- a/requirements-max.txt
+++ b/requirements-max.txt
@@ -1,4 +1,0 @@
-# this requirements file applies upper pins on critical upstream dependencies with incompatible functionality / refactoring that has not yet been implemented in this repository
-
-stcal<1.8.0
-stdatamodels<1.10.0


### PR DESCRIPTION
The `requirements-max.txt` file contains 2 upper pins:
https://github.com/spacetelescope/jwst/blob/380dc5eb082c6c5d4e024a9337999f69cd5b8443/requirements-max.txt#L3-L4

and is used in the main (non-dev) jenkins file:
https://github.com/spacetelescope/jwst/blob/380dc5eb082c6c5d4e024a9337999f69cd5b8443/JenkinsfileRT#L77

This appears to be run after the `pip list` in the job which may mean that our regtests have been using a version of stcal that is lower than our minimum version listed in `pyproject.toml`:
https://github.com/spacetelescope/jwst/blob/380dc5eb082c6c5d4e024a9337999f69cd5b8443/pyproject.toml#L37

As `requirements-max.txt` is not used for the GA regression tests (and at the moment only show differences due to different machines) this PR removes the file (and the use in the jenkins regtests).

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
