### PR TITLE
increase conda version in jenkins files

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -70,7 +70,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'stable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '22.11.1'
+bc0.conda_ver = '24.5.0'
 bc0.conda_packages = [
     "python=${python_version}",
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -70,7 +70,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'unstable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '22.11.1'
+bc0.conda_ver = '24.5.0'
 bc0.conda_packages = [
     "python=${python_version}",
 ]


### PR DESCRIPTION
Following the switch to microforge on jenkins the configurations in this repo look to have a conflicting conda version:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/1545/pipeline
that's resulting in run failures after a few minutes (when an attempt is made to install conda).

This updates the conda version listed in the jenkins files in this repo to (try and) work around the conflict.

Regtests made it past the conflict and are now running at (I'll update this description when they finish but feel free to do the same if you see the run finished successfully).
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1548/

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
