### PR TITLE
Do not set conda version in Jenkinsfile(s)

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -70,7 +70,6 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'stable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '22.11.1'
 bc0.conda_packages = [
     "python=${python_version}",
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -70,7 +70,6 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'jwst'
 bc0.name = 'unstable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '22.11.1'
 bc0.conda_packages = [
     "python=${python_version}",
 ]


### PR DESCRIPTION
* The version (24.x) installed by miniforge is sufficient. 22.x is too old.

Ref: https://github.com/spacetelescope/jenkins_shared_ci_utils/pull/94