### PR TITLE
JP-3592: Improve runtime for MIRI emicorr step

### DIFF
--- a/docs/jwst/emicorr/arguments.rst
+++ b/docs/jwst/emicorr/arguments.rst
@@ -25,3 +25,6 @@ The ``emicorr`` step has the following step-specific arguments.
     This is to tell the code to do correction for the frequencies in
     the list with a reference file created on-the-fly instead of CRDS.
 
+``--nints_to_phase`` (integer, default=None)
+    Use N cycles to calculate the phase, to use all integrations set to None.
+

--- a/jwst/emicorr/emicorr_step.py
+++ b/jwst/emicorr/emicorr_step.py
@@ -4,6 +4,7 @@
 from stdatamodels.jwst import datamodels
 from ..stpipe import Step
 from . import emicorr
+from jwst.lib.basic_utils import use_datamodel
 
 
 __all__ = ["EmiCorrStep"]
@@ -24,76 +25,80 @@ class EmiCorrStep(Step):
         scale_reference = boolean(default=True)  # If True, the reference wavelength will be scaled to the data's phase amplitude
         skip = boolean(default=True)  # Skip the step
         onthefly_corr_freq = float_list(default=None)  # Frequencies to use for correction
+        use_n_cycles = integer(default=3)  # Use N cycles to calculate the phase, to use all integrations set to None
     """
 
     reference_file_types = ['emicorr']
 
     def process(self, input):
-        with datamodels.open(input) as input_model:
+        # Open the input data model
+        input_model = use_datamodel(input)
 
-            # Catch the cases to skip
-            instrument = input_model.meta.instrument.name
-            if instrument != 'MIRI':
-                self.log.warning('EMI correction not implemented for instrument: {}'.format(instrument))
+        # Catch the cases to skip
+        instrument = input_model.meta.instrument.name
+        if instrument != 'MIRI':
+            self.log.warning('EMI correction not implemented for instrument: {}'.format(instrument))
+            input_model.meta.cal_step.emicorr = 'SKIPPED'
+            return input_model
+
+        readpatt = input_model.meta.exposure.readpatt
+        allowed_readpatts = ['FAST', 'FASTR1', 'SLOW', 'SLOWR1']
+        if readpatt.upper() not in allowed_readpatts:
+            self.log.warning('EMI correction not implemented for read pattern: {}'.format(readpatt))
+            input_model.meta.cal_step.emicorr = 'SKIPPED'
+            return input_model
+
+        # Setup parameters
+        pars = {
+            'save_intermediate_results': self.save_intermediate_results,
+            'user_supplied_reffile': self.user_supplied_reffile,
+            'nints_to_phase': self.nints_to_phase,
+            'nbins': self.nbins,
+            'scale_reference': self.scale_reference,
+            'onthefly_corr_freq': self.onthefly_corr_freq,
+            'use_n_cycles': self.use_n_cycles
+        }
+
+        # Get the reference file
+        save_onthefly_reffile, emicorr_ref_filename, emicorr_model = None, None, None
+        if self.onthefly_corr_freq is not None:
+            emicorr_ref_filename = None
+            self.log.info('Correcting with reference file created on-the-fly.')
+
+        elif self.user_supplied_reffile is None:
+            emicorr_ref_filename = self.get_reference_file(input_model, 'emicorr')
+            # Skip the spep if no reference file is found
+            if emicorr_ref_filename == 'N/A':
+                self.log.warning('No reference file found.')
+                self.log.warning('EMICORR step will be skipped')
                 input_model.meta.cal_step.emicorr = 'SKIPPED'
                 return input_model
-
-            readpatt = input_model.meta.exposure.readpatt
-            allowed_readpatts = ['FAST', 'FASTR1', 'SLOW', 'SLOWR1']
-            if readpatt.upper() not in allowed_readpatts:
-                self.log.warning('EMI correction not implemented for read pattern: {}'.format(readpatt))
-                input_model.meta.cal_step.emicorr = 'SKIPPED'
-                return input_model
-
-            # Setup parameters
-            pars = {
-                'save_intermediate_results': self.save_intermediate_results,
-                'user_supplied_reffile': self.user_supplied_reffile,
-                'nints_to_phase': self.nints_to_phase,
-                'nbins': self.nbins,
-                'scale_reference': self.scale_reference,
-                'onthefly_corr_freq': self.onthefly_corr_freq
-            }
-
-            # Get the reference file
-            save_onthefly_reffile, emicorr_ref_filename, emicorr_model = None, None, None
-            if self.onthefly_corr_freq is not None:
-                emicorr_ref_filename = None
-                self.log.info('Correcting with reference file created on-the-fly.')
-
-            elif self.user_supplied_reffile is None:
-                emicorr_ref_filename = self.get_reference_file(input_model, 'emicorr')
-                # Skip the spep if no reference file is found
-                if emicorr_ref_filename == 'N/A':
-                    self.log.warning('No reference file found.')
-                    self.log.warning('EMICORR step will be skipped')
-                    input_model.meta.cal_step.emicorr = 'SKIPPED'
-                    return input_model
-                else:
-                    self.log.info('Using CRDS reference file: {}'.format(emicorr_ref_filename))
-                    emicorr_model = datamodels.EmiModel(emicorr_ref_filename)
-
             else:
-                self.log.info('Using user-supplied reference file: {}'.format(self.user_supplied_reffile))
-                emicorr_model = datamodels.EmiModel(self.user_supplied_reffile)
+                self.log.info('Using CRDS reference file: {}'.format(emicorr_ref_filename))
+                emicorr_model = datamodels.EmiModel(emicorr_ref_filename)
 
-            # Do the correction
-            if self.save_intermediate_results:
-                if emicorr_ref_filename is None and self.user_supplied_reffile is None:
-                    # get the same full path as input file to save the on-the-fly reference file
-                    emicorr_ref_filename = Step._make_output_path(self, suffix='emi_ref_waves')
-                    save_onthefly_reffile = emicorr_ref_filename
-                else:
-                    save_onthefly_reffile = None
-            output_model = emicorr.do_correction(input_model, emicorr_model, save_onthefly_reffile, **pars)
-            if isinstance(output_model, str) or output_model is None:
-                # in this case output_model=subarray_readpatt configuration
-                self.log.warning('No correction match for this configuration')
-                self.log.warning('Step skipped')
-                input_model.meta.cal_step.emicorr = 'SKIPPED'
-                return input_model
+        else:
+            self.log.info('Using user-supplied reference file: {}'.format(self.user_supplied_reffile))
+            emicorr_model = datamodels.EmiModel(self.user_supplied_reffile)
 
-            # close and remove the reference file created on-the-fly
-            output_model.meta.cal_step.emicorr = 'COMPLETE'
+        # Do the correction
+        if self.save_intermediate_results:
+            if emicorr_ref_filename is None and self.user_supplied_reffile is None:
+                # get the same full path as input file to save the on-the-fly reference file
+                emicorr_ref_filename = Step._make_output_path(self, suffix='emi_ref_waves')
+                save_onthefly_reffile = emicorr_ref_filename
+            else:
+                save_onthefly_reffile = None
+        output_model = emicorr.do_correction(input_model, emicorr_model, save_onthefly_reffile, **pars)
+        if isinstance(output_model, str) or output_model is None:
+            # in this case output_model=subarray_readpatt configuration
+            self.log.warning('No correction match for this configuration')
+            self.log.warning('Step skipped')
+            input_model.meta.cal_step.emicorr = 'SKIPPED'
+            return input_model
+
+        # close and remove the reference file created on-the-fly
+        output_model.meta.cal_step.emicorr = 'COMPLETE'
+        input_model.close()
 
         return output_model


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3592](https://jira.stsci.edu/browse/JP-3592)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR improves the running time of emicorr by introducing a new parameter, use_n_cycles, that can be modified by the user and has a default of 3. Now the user can either provide the number of integrations to phase or the number of cycles to calculate the number of integrations necessary to phase.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
