### PR TITLE
JP-3523: Use zero background instead of NaN background where undefined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,6 +189,9 @@ master_background
   Master background correction for MOS mode should be performed
   via ``master_background_mos``, called in ``calwebb_spec2``. [#8467]
 
+- Use zero values for master background outside the background
+  wavelength range instead of NaN to avoid NaN-ing out entire
+  sets of science data when backgrounds are missing. [#8597]
 
 master_background_mos
 ---------------------

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -319,8 +319,6 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
 
     background = input.copy()
     background.data[:, :] = 0.
-    min_wave = np.amin(tab_wavelength)
-    max_wave = np.amax(tab_wavelength)
 
     if input.meta.instrument.name.upper() == "NIRSPEC":
         list_of_wcs = nirspec.nrs_ifu_wcs(input)

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -329,17 +329,9 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
             wl_array = ifu_wcs(x, y)[2]
             wl_array[np.isnan(wl_array)] = -1.
 
-            # mask wavelengths not covered by the master background
-            mask_limit = (wl_array > max_wave) | (wl_array < min_wave)
-            wl_array[mask_limit] = -1
-
-            # mask_limit is indices into each WCS slice grid.  Need them in
-            # full frame coordinates, so we use x and y, which are full-frame
-            full_frame_ind = y[mask_limit].astype(int), x[mask_limit].astype(int)
+            # Anywhere science pixels are beyond the wavelength range of the background, zero
+            # background will be used.
             # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
-            background.dq[full_frame_ind] = np.bitwise_or(background.dq[full_frame_ind],
-                                                          dqflags.pixel['DO_NOT_USE'])
-
             bkg_surf_bright = np.interp(wl_array, tab_wavelength,
                                         tab_background, left=0., right=0.)
             background.data[y.astype(int), x.astype(int)] = bkg_surf_bright.copy()
@@ -356,13 +348,10 @@ def bkg_for_ifu_image(input, tab_wavelength, tab_background):
         # first remove the nans from wl_array and replace with -1
         mask = np.isnan(wl_array)
         wl_array[mask] = -1.
-        # next look at the limits of the wavelength table
-        mask_limit = (wl_array > max_wave) | (wl_array < min_wave)
-        wl_array[mask_limit] = -1
 
+        # Anywhere science pixels are beyond the wavelength range of the background, zero
+        # background will be used.
         # TODO - add another DQ Flag something like NO_BACKGROUND when we have space in dqflags
-        background.dq[mask_limit] = np.bitwise_or(background.dq[mask_limit],
-                                                  dqflags.pixel['DO_NOT_USE'])
         bkg_surf_bright = np.interp(wl_array, tab_wavelength, tab_background,
                                     left=0., right=0.)
         background.data[:, :] = bkg_surf_bright.copy()


### PR DESCRIPTION
Resolves [JP-3523](https://jira.stsci.edu/browse/JP-3523) by having IFU master background default to zero background values beyond the wavelength range of the input backgrounds, instead of automatically NaN-ing out all such wavelength and causing crashes in cube building.

Closes #8244 

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
