### PR TITLE
Revert "remove unused nlow nhigh parameters from outlier detection"

### DIFF
--- a/docs/jwst/outlier_detection/arguments.rst
+++ b/docs/jwst/outlier_detection/arguments.rst
@@ -24,6 +24,14 @@ that control the behavior of the processing:
   Any floating-point value, given as a string, is valid.
   A value of 'INDEF' will use the last zero weight flux.
 
+``--nlow`` (integer, default=0)
+  The number of low values in each pixel stack to ignore
+  when computing the median value.
+
+``--nhigh`` (integer, default=0)
+  The number of high values in each pixel stack to ignore
+  when computing the median value.
+
 ``--maskpt`` (float, default=0.7)
   The percent of maximum weight to use as lower-limit for valid data;
   valid values go from 0.0 to 1.0.

--- a/docs/jwst/outlier_detection/outlier_detection_imaging.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_imaging.rst
@@ -69,6 +69,8 @@ Specifically, this routine performs the following operations:
 
    * The median image is created by combining all grouped mosaic images or
      non-resampled input data (as planes in a ModelContainer) pixel-by-pixel.
+   * The ``nlow`` and ``nhigh`` parameters specify how many low and high values
+     to ignore when computing the median for any given pixel.
    * The ``maskpt`` parameter sets the percentage of the weight image values to
      use, and any pixel with a weight below this value gets flagged as "bad" and
      ignored when resampled.

--- a/docs/jwst/outlier_detection/outlier_detection_tso.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_tso.rst
@@ -21,6 +21,8 @@ a few variations to accomodate the nature of these 3D data.
    * The ``rolling_window_width`` parameter specifies the number of integrations over
      which to compute the median. The default is 25. If the number of integrations
      is less than or equal to ``rolling_window_width``, a simple median is used instead.
+   * The ``nlow`` and ``nhigh`` parameters specify how many low and high values
+     to ignore when computing the median for any given pixel.
    * The ``maskpt`` parameter sets the percentage of the weight image values to
      use, and any pixel with a weight below this value gets flagged as "bad" and
      ignored when the median is taken.

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -55,6 +55,8 @@ class OutlierDetectionStep(Step):
         pixfrac = float(default=1.0)
         kernel = string(default='square') # drizzle kernel
         fillval = string(default='INDEF')
+        nlow = integer(default=0)
+        nhigh = integer(default=0)
         maskpt = float(default=0.7)
         snr = string(default='5.0 4.0')
         scale = string(default='1.2 0.7')
@@ -105,6 +107,8 @@ class OutlierDetectionStep(Step):
                 'pixfrac': self.pixfrac,
                 'kernel': self.kernel,
                 'fillval': self.fillval,
+                'nlow': self.nlow,
+                'nhigh': self.nhigh,
                 'maskpt': self.maskpt,
                 'snr': self.snr,
                 'scale': self.scale,


### PR DESCRIPTION
Reverts spacetelescope/jwst#8595

See
https://github.com/spacetelescope/jwst/pull/8595#issuecomment-2191513545

Although these parameters are unused by the step they are unfortunately defined in the parameter reference files:
https://jwst-crds.stsci.edu/browse/jwst_miri_pars-outlierdetectionstep_0054.asdf

This PR just reverts #8595 a follow-up PR will mark these as deprecated.
