### PR TITLE
JP-3671: make OLS_C the default algorithm for ramp fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -323,6 +323,8 @@ ramp_fitting
   fitting or "OLS_C" to use the C extension implementation of
   ramp fitting. [#8503]
 
+- Made "OLS_C" the default algorithm for ramp fitting. [#8607]
+
 refpix
 ------
 

--- a/docs/jwst/ramp_fitting/arguments.rst
+++ b/docs/jwst/ramp_fitting/arguments.rst
@@ -5,7 +5,7 @@ The ramp fitting step has the following optional arguments that can be set by th
 * ``--algorithm``: A string to select the desired algorithm.  The available
   values are "OLS" to select the python implementation of the Ordinary
   Least Squares algorithm and  "OLS_C" to select the C extension
-  implementation of OLS.  The algorithm defaults to "OLS".
+  implementation of OLS.  The algorithm defaults to "OLS_C".
 
 * ``--save_opt``: A True/False value that specifies whether to write
   the optional output product. Default is False.

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -385,7 +385,7 @@ class RampFitStep(Step):
     class_alias = "ramp_fit"
 
     spec = """
-        algorithm = option('OLS', 'OLS_C', default='OLS') # Can be 'OLS_C' to select the C extension
+        algorithm = option('OLS', 'OLS_C', default='OLS_C') # 'OLS' and 'OLS_C' use the same underlying algorithm, but OLS_C is implemented in C
         int_name = string(default='')
         save_opt = boolean(default=False) # Save optional output
         opt_name = string(default='')


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3671](https://jira.stsci.edu/browse/JP-3671)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8605 

<!-- describe the changes comprising this PR here -->
This PR changes the default ramp fitting algorithm to Ken's new C implementation of the ordinary least-squares algorithm.  The original Python implementation is still selectable, but no longer the default.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
