### PR TITLE
fix ruff style check

### DIFF
--- a/jwst/lib/engdb_direct.py
+++ b/jwst/lib/engdb_direct.py
@@ -81,7 +81,7 @@ class EngdbDirect(EngdbABC):
         response.raise_for_status()
 
     @property
-    def default_format(self):
+    def default_format(self):  # noqa: F811
         return self._default_format
 
     @default_format.setter

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ skip_install = true
 deps =
     ruff
 commands =
-    ruff . {posargs}
+    ruff check . {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance


### PR DESCRIPTION
Ruff 0.5 removed `ruff <path>` in favor of `ruff check <path>`.
https://astral.sh/blog/ruff-v0.5.0#removed-deprecated-features

This change broke our style check
https://github.com/spacetelescope/jwst/pull/8600#issuecomment-2195456616

This PR fixes the check and adds a `noqa` to jwst/lib/engdb_direct.py for a new F811 failure.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
