### PR TITLE
JP-3679: Separate resample_spec parameters from resample step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ align_refs
 ----------
 
 - Compute alignment shifts from the first integration of the science exposure only. [#8643]
+
 ami_average
 -----------
 
@@ -64,6 +65,10 @@ resample_spec
 
 - Fixed a bug resulting in incorrect output slit coordinates for NIRSpec moving
   targets in the ``calwebb_spec3`` pipeline. [#8596]
+
+- Separate ``resample_spec`` step parameters from ``resample`` step parameters
+  so that the spectral resampling step only exposes parameters that are appropriate
+  for spectral data. [#8622]
 
 scripts
 -------

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -368,7 +368,8 @@ which has the same structure and content as the calints_ product described above
 
 Resampled 2-D data: ``i2d`` and ``s2d``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Images and spectra that have been resampled by the :ref:`resample <resample_step>` step use a
+Images and spectra that have been resampled by the :ref:`resample <resample_step>`
+or :ref:`resample_spec <resample_spec_step>` steps use a
 different set of data arrays than other science products. Resampled 2-D images are stored in
 ``i2d`` products and resampled 2-D spectra are stored in ``s2d`` products.
 The FITS file structure for ``i2d`` and ``s2d`` products is as follows:

--- a/docs/jwst/master_background/description.rst
+++ b/docs/jwst/master_background/description.rst
@@ -376,7 +376,7 @@ as follows:
    extended sources (appropriate for background signal), and saving the extended
    source correction arrays for each slit in an internal copy of the data model
 #. If a user-supplied master background spectrum is **not** given, the
-   :ref:`resample_spec <resample_step>` and :ref:`extract_1d <extract_1d_step>`
+   :ref:`resample_spec <resample_spec_step>` and :ref:`extract_1d <extract_1d_step>`
    steps are applied to the calibrated background slits, resulting
    in extracted 1D background spectra
 #. The 1D background spectra are combined, using the

--- a/docs/jwst/outlier_detection/outlier_detection_coron.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_coron.rst
@@ -26,7 +26,7 @@ Specifically, this routine performs the following operations:
 
    The core detection algorithm uses the following to generate an outlier mask
 
-   .. math:: | image\_input - image\_median | > SNR*input_\err
+   .. math:: | image\_input - image\_median | > SNR*input\_err
 
 #. Update input data model DQ arrays with mask of detected outliers.
 

--- a/docs/jwst/outlier_detection/outlier_detection_imaging.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_imaging.rst
@@ -86,7 +86,7 @@ Specifically, this routine performs the following operations:
      will be ignored and instead the outlier mask will be computed using the following
      formula:
 
-       .. math:: | image\_input - image\_median | > SNR*input_err
+       .. math:: | image\_input - image\_median | > SNR * input\_err
 
    * When resampling is enabled, the comparison uses the original input images, the blotted
      median image, and the derivative of the blotted image to

--- a/docs/jwst/package_index.rst
+++ b/docs/jwst/package_index.rst
@@ -54,6 +54,7 @@ Package Index
    references_general/index.rst
    refpix/index.rst
    resample/index.rst
+   resample_spec/index.rst
    reset/index.rst
    residual_fringe/index.rst
    rscd/index.rst

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -83,7 +83,7 @@ TSO exposures. The instrument mode abbreviations used in the table are as follow
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+-----------------+------+--------+-----+
 | :ref:`pixel_replace <pixel_replace_step>` \ :sup:`2`     | |c| | |c| | |c| | |c| | |c| |     |                 | |c|  |  |c|   |     |
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+-----------------+------+--------+-----+
-| :ref:`resample_spec <resample_step>`                     | |c| | |c| |     | |c| |     |     |                 |      |        |     |
+| :ref:`resample_spec <resample_spec_step>`                | |c| | |c| |     | |c| |     |     |                 |      |        |     |
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+-----------------+------+--------+-----+
 | :ref:`cube_build <cube_build_step>`                      |     |     | |c| |     |     | |c| |                 |      |        |     |
 +----------------------------------------------------------+-----+-----+-----+-----+-----+-----+-----------------+------+--------+-----+
@@ -109,8 +109,8 @@ Notice that NIRSpec MOS is the only mode to receive master background subtractio
 in the ``calwebb_spec2`` pipeline. All other spectral modes have master background
 subtraction applied in the :ref:`calwebb_spec3 <calwebb_spec3>` pipeline.
 
-The :ref:`resample_spec <resample_step>` step produces a resampled/rectified product for
-non-IFU modes of some spectroscopic exposures. If the :ref:`resample_spec <resample_step>` step
+The :ref:`resample_spec <resample_spec_step>` step produces a resampled/rectified product for
+non-IFU modes of some spectroscopic exposures. If the :ref:`resample_spec <resample_spec_step>` step
 is not applied to a given exposure, the :ref:`extract_1d <extract_1d_step>` operation will be
 performed on the original (unresampled) data. The :ref:`cube_build <cube_build_step>` step produces
 a resampled/rectified cube for IFU exposures, which is then used as input to
@@ -148,7 +148,7 @@ The detailed processing flow is as follows:
   steps are saved, they will have an additional "_fs" suffix appended to
   their file names.
 - MOS and FS slits are recombined and processed together through the
-  :ref:`resample_spec <resample_step>` step.
+  :ref:`resample_spec <resample_spec_step>` step.
 - MOS slits are processed through the :ref:`extract_1d <extract_1d_step>` step,
   then FS slits are processed through the same step.  The extracted spectra are
   recombined into a final data product.
@@ -220,49 +220,49 @@ abbreviations used in the table are as follows:
 - NIRSpec MOS = Multi-Object Spectroscopy
 - NIRSpec IFU = Integral Field Unit
 
-+---------------------------------------+------------+--------------+-----------------+--------------+
-|    Pipeline Step                      |         NRS_LAMP          |  NRS_AUTOWAVE   | NRS_AUTOFLAT |
-+---------------------------------------+------------+--------------+-----------------+              +
-|                                       |   LINE     |     FLAT     |                 |  (MOS only)  |
-+=======================================+============+==============+=================+==============+
-| :ref:`assign_wcs <assign_wcs_step>`   |   ALL      |     ALL      |       ALL       |       ALL    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`msaflagopen <msaflagopen_step>` |  MOS, IFU  |   MOS, IFU   |    MOS, IFU     |       MOS    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`nsclean <nsclean_step>`         |  NONE      |    NONE      |      NONE       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`imprint <imprint_step>`         |  NONE      |     IFU      |      NONE       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`background <background_step>`   |  NONE      |    NONE      |      NONE       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`extract_2d <extract_2d_step>`   |  MOS, FS   |   MOS, FS    |    MOS, FS      |       MOS    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`srctype <srctype_step>`         |  NONE      |    NONE      |      NONE       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`wavecorr <wavecorr_step>`       |   ALL      |     ALL      |       ALL       |       ALL    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`flat_field <flatfield_step>`    |            |              |                 |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-|              - D-FLAT                 |   ALL      |     ALL      |       ALL       |              |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-|              - S-FLAT                 |   ALL      |    NONE      |       ALL       |              |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-|              - F-FLAT                 |  NONE      |    NONE      |      NONE       |              |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`pathloss <pathloss_step>`       |  NONE      |    NONE      |      NONE       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`barshadow <barshadow_step>`     |  NONE      |    NONE      |      NONE       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`photom <photom_step>`           |  NONE      |    NONE      |      NONE       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`resample_spec <resample_step>`  |  MOS, FS   |    NONE      |    MOS, FS      |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`cube_build <cube_build_step>`   |   IFU      |    NONE      |       IFU       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
-| :ref:`extract_1d <extract_1d_step>`   |   ALL      |    NONE      |       ALL       |      NONE    |
-+---------------------------------------+------------+--------------+-----------------+--------------+
++--------------------------------------------+------------+--------------+-----------------+--------------+
+|    Pipeline Step                           |         NRS_LAMP          |  NRS_AUTOWAVE   | NRS_AUTOFLAT |
++--------------------------------------------+------------+--------------+-----------------+              +
+|                                            |   LINE     |     FLAT     |                 |  (MOS only)  |
++============================================+============+==============+=================+==============+
+| :ref:`assign_wcs <assign_wcs_step>`        |   ALL      |     ALL      |       ALL       |       ALL    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`msaflagopen <msaflagopen_step>`      |  MOS, IFU  |   MOS, IFU   |    MOS, IFU     |       MOS    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`nsclean <nsclean_step>`              |  NONE      |    NONE      |      NONE       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`imprint <imprint_step>`              |  NONE      |     IFU      |      NONE       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`background <background_step>`        |  NONE      |    NONE      |      NONE       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`extract_2d <extract_2d_step>`        |  MOS, FS   |   MOS, FS    |    MOS, FS      |       MOS    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`srctype <srctype_step>`              |  NONE      |    NONE      |      NONE       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`wavecorr <wavecorr_step>`            |   ALL      |     ALL      |       ALL       |       ALL    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`flat_field <flatfield_step>`         |            |              |                 |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+|              - D-FLAT                      |   ALL      |     ALL      |       ALL       |              |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+|              - S-FLAT                      |   ALL      |    NONE      |       ALL       |              |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+|              - F-FLAT                      |  NONE      |    NONE      |      NONE       |              |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`pathloss <pathloss_step>`            |  NONE      |    NONE      |      NONE       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`barshadow <barshadow_step>`          |  NONE      |    NONE      |      NONE       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`photom <photom_step>`                |  NONE      |    NONE      |      NONE       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`resample_spec <resample_spec_step>`  |  MOS, FS   |    NONE      |    MOS, FS      |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`cube_build <cube_build_step>`        |   IFU      |    NONE      |       IFU       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
+| :ref:`extract_1d <extract_1d_step>`        |   ALL      |    NONE      |       ALL       |      NONE    |
++--------------------------------------------+------------+--------------+-----------------+--------------+
 
-In the :ref:`resample_spec <resample_step>` and :ref:`cube_build <cube_build_step>` steps, the spectra are
+In the :ref:`resample_spec <resample_spec_step>` and :ref:`cube_build <cube_build_step>` steps, the spectra are
 transformed to a space of (wavelength, offset along the slit) without applying a tangent plane projection.
 
 Arguments
@@ -304,7 +304,7 @@ in the association.
 If "_rateints" products are used as input, for modes other than NIRSpec Fixed Slit,
 each step applies its algorithm to each integration in the exposure, where appropriate.
 For the NIRSpec Fixed Slit mode the ``calwebb_spec2`` pipeline will currently
-skip both the :ref:`resample_spec <resample_step>` step and the
+skip both the :ref:`resample_spec <resample_spec_step>` step and the
 :ref:`extract_1d <extract_1d_step>` step, because neither step supports
 multiple integration input products for this mode.
 
@@ -348,7 +348,7 @@ The output is a fully calibrated, but unrectified, exposure, using the product
 type suffix "_cal" or "_calints", depending on the type of input,
 e.g. "jw80600012001_02101_00003_mirimage_cal.fits." This is the output of the
 :ref:`photom <photom_step>` step, or whichever step is performed last before applying
-either :ref:`resample_spec <resample_step>`, :ref:`cube_build <cube_build_step>`, or
+either :ref:`resample_spec <resample_spec_step>`, :ref:`cube_build <cube_build_step>`, or
 :ref:`extract_1d <extract_1d_step>`.
 
 The output data model type can be any of the 4 listed above and is completely
@@ -376,12 +376,12 @@ extracted slits/sources.
 :File suffix: _s2d
 
 If the input is a 2D exposure type that gets resampled/rectified by the
-:ref:`resample_spec <resample_step>` step, the rectified 2D spectral product is saved as a
-"_s2d" file. This image is intended for use as a quick-look product only and is
-not used in subsequent processing. The 2D unresampled, calibrated ("_cal")
+:ref:`resample_spec <resample_spec_step>` step, the rectified 2D spectral product
+is saved as a "_s2d" file. This image is intended for use as a quick-look product only
+and is not used in subsequent processing. The 2D unresampled, calibrated ("_cal")
 products are passed along as input to subsequent Stage 3 processing.
 
-If the input to the :ref:`resample_spec <resample_step>` step is a `~jwst.datamodels.MultiSlitModel`,
+If the input to the :ref:`resample_spec <resample_spec_step>` step is a `~jwst.datamodels.MultiSlitModel`,
 then the resampled output will be in the form of a
 `~jwst.datamodels.MultiSlitModel`, which contains an array of individual models,
 one per slit. Otherwise the output will be a single `~jwst.datamodels.SlitModel`.

--- a/docs/jwst/pipeline/calwebb_spec3.rst
+++ b/docs/jwst/pipeline/calwebb_spec3.rst
@@ -34,7 +34,7 @@ processed using the :ref:`calwebb_tso3 <calwebb_tso3>` pipeline.
 +-------------------------------------------------------------+-----+-----+-----+-----+-----+------+------+--------+
 | :ref:`pixel_replace <pixel_replace_step>`                   | |c| | |c| | |c| | |c| | |c| |      |  |c| |   |c|  |
 +-------------------------------------------------------------+-----+-----+-----+-----+-----+------+------+--------+
-| :ref:`resample_spec <resample_step>`                        | |c| | |c| |     | |c| |     |      |      |        |
+| :ref:`resample_spec <resample_spec_step>`                   | |c| | |c| |     | |c| |     |      |      |        |
 +-------------------------------------------------------------+-----+-----+-----+-----+-----+------+------+--------+
 | :ref:`cube_build <cube_build_step>`                         |     |     | |c| |     | |c| |      |      |        |
 +-------------------------------------------------------------+-----+-----+-----+-----+-----+------+------+--------+
@@ -157,7 +157,8 @@ new field in the original product root name, e.g.
 
 When processing non-IFU modes, a resampled/rectified 2D product of type
 "_s2d" is created containing the rectified and combined data for a given
-slit/source, which is the output of the :ref:`resample_spec <resample_step>` step.
+slit/source, which is the output of the :ref:`resample_spec <resample_spec_step>`
+step.
 
 3D resampled and combined spectral data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/jwst/pixel_replace/main.rst
+++ b/docs/jwst/pixel_replace/main.rst
@@ -12,7 +12,7 @@ the extracted spectrum.
 
 To avoid this defect in the 1-D spectrum, this step estimates the flux values of pixels
 flagged as ``DO_NOT_USE`` in 2-D extracted spectra using interpolation methods,
-prior to rectification in the :ref:`resample_spec <resample_step>` step.
+prior to rectification in the :ref:`resample_spec <resample_spec_step>` step.
 ``pixel_replace`` inserts these estimates into the 2-D data array,
 unsets the ``DO_NOT_USE`` flag, and sets the ``FLUX_ESTIMATED`` flag for each affected pixel.
 Error values and variance components for the replaced pixels are similarly updated with

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -48,7 +48,7 @@ image.
 
 ``--output_shape`` (tuple of int, default=None)
     Shape of the image (data array) using "standard" ``nx`` first and ``ny``
-    second (as opposite to the ``numpy.ndarray`` convention - ``ny`` first and
+    second (opposite to the ``numpy.ndarray`` convention - ``ny`` first and
     ``nx`` second). This value will be assigned to
     ``pixel_shape`` and ``array_shape`` properties of the returned
     WCS object. When supplied from command line, it should be a comma-separated
@@ -59,7 +59,7 @@ image.
         ``output_wcs`` does not have ``bounding_box`` property set.
 
 ``--output_wcs`` (str, default='')
-    File name of a ``ASDF`` file with a GWCS stored under the ``"wcs"`` key
+    File name of an ``ASDF`` file with a GWCS stored under the ``"wcs"`` key
     under the root of the file. The output image size is determined from the
     bounding box of the WCS (if any). Argument ``output_shape`` overrides
     computed image size and it is required when output WCS does not have

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -15,51 +15,15 @@ image.
     image.  Available kernels are `square`, `gaussian`, `point`,
     `turbo`, `lanczos2`, and `lanczos3`.
 
-    For spectral data, only the `square` and `point` kernels should be used.
-    The other kernels do not conserve spectral flux.
-
 ``--pixel_scale_ratio`` (float, default=1.0)
     Ratio of input to output pixel scale.
-
     For imaging data, a value of 0.5 means the output
     image would have 4 pixels sampling each input pixel.
-
-    For spectral data, values greater than 1 indicate that the input
-    pixels have a larger spatial scale, so more output pixels will
-    sample the same input pixel.  For example, a value of 2.0
-    means the output image would have 2 pixels sampling each input
-    spatial pixel. If the input data has units of flux density (MJy/pixel),
-    the output flux per pixel will be half the input flux per pixel.
-    If the input data has units of surface brightness (MJy/sr), the output
-    flux per pixel is not scaled.
-
-    Note that this parameter is only applied in the cross-dispersion
-    direction for spectral data: sampling wavelengths are not affected.
-
     Ignored when ``pixel_scale`` or ``output_wcs`` are provided.
-
-    .. note::
-        If this parameter is modified for spectral data, the extraction
-        aperture for the :ref:`extract_1d <extract_1d_step>` step must
-        also be modified, since it is specified in pixels.
 
 ``--pixel_scale`` (float, default=None)
     Absolute pixel scale in ``arcsec``. When provided, overrides
     ``pixel_scale_ratio``. Ignored when ``output_wcs`` is provided.
-
-    For spectral data, if the input data has units of flux density
-    (MJy/pixel), the output flux per pixel will be scaled by the ratio
-    of the selected output pixel scale to an average input pixel scale.
-    If the input data has units of surface brightness (MJy/sr),
-    the output flux per pixel is not scaled.
-
-    Note that this parameter is only applied in the cross-dispersion
-    direction for spectral data: sampling wavelengths are not affected.
-
-    .. note::
-        If this parameter is modified for spectral data, the extraction
-        aperture for the :ref:`extract_1d <extract_1d_step>` step must
-        also be modified, since it is specified in pixels.
 
 ``--rotation`` (float, default=None)
     Position angle of output image’s Y-axis relative to North.
@@ -68,20 +32,19 @@ image.
     but will instead be resampled in the default orientation for the camera
     with the x and y axes of the resampled image corresponding
     approximately to the detector axes. Ignored when ``pixel_scale``
-    or ``output_wcs`` are provided.  Also ignored for all spectral data.
+    or ``output_wcs`` are provided.
 
 ``--crpix`` (tuple of float, default=None)
     Position of the reference pixel in the image array in the ``x, y`` order.
     If ``crpix`` is not specified, it will be set to the center of the bounding
     box of the returned WCS object. When supplied from command line, it should
     be a comma-separated list of floats. Ignored when ``output_wcs``
-    is provided. Also ignored for all spectral data.
+    is provided.
 
 ``--crval`` (tuple of float, default=None)
     Right ascension and declination of the reference pixel. Automatically
     computed if not provided. When supplied from command line, it should be a
     comma-separated list of floats. Ignored when ``output_wcs`` is provided.
-    Also ignored for all spectral data.
 
 ``--output_shape`` (tuple of int, default=None)
     Shape of the image (data array) using "standard" ``nx`` first and ``ny``
@@ -140,7 +103,7 @@ image.
 ``--single`` (bool, default=False)
     If set to `True`, resample each input image into a separate output.  If
     `False` (the default), each input is resampled additively (with weights) to
-    a common output
+    a common output.
 
 ``--blendheaders`` (bool, default=True)
     Blend metadata from all input images into the resampled output image.
@@ -154,8 +117,6 @@ image.
 
     For example, if set to ``0.5``, only resampled images that use less than
     half the available memory can be created.
-
-    This parameter is ignored for spectral data.
 
 ``--in_memory`` (boolean, default=True)
   Specifies whether or not to load and create all images that are used during

--- a/docs/jwst/resample/index.rst
+++ b/docs/jwst/resample/index.rst
@@ -1,8 +1,8 @@
 .. _resample_step:
 
-==========
-Resampling
-==========
+=======================
+Resampling Imaging Data
+=======================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/jwst/resample/main.rst
+++ b/docs/jwst/resample/main.rst
@@ -1,8 +1,8 @@
 Description
 ===========
 
-:Classes: `jwst.resample.ResampleStep`, `jwst.resample.ResampleSpecStep`
-:Alias: resample, resample_spec
+:Classes: `jwst.resample.ResampleStep`
+:Alias: resample
 
 This routine will resample each input 2D image based on the WCS and
 distortion information, and will combine multiple resampled images
@@ -144,16 +144,6 @@ context array ``con``, one can do something like this:
 
 For convenience, this functionality was implemented in the
 :py:func:`~jwst.resample.resample_utils.decode_context` function.
-
-
-Spectroscopic Data
-------------------
-
-Use the ``resample_spec`` step for spectroscopic data.  The dispersion
-direction is needed for this case, and this is obtained from the
-DISPAXIS keyword.  For the NIRSpec Fixed Slit mode, the ``resample_spec``
-step will be skipped if the input is a rateints product, as 3D input for
-the mode is not supported.
 
 
 References

--- a/docs/jwst/resample/resample.rst
+++ b/docs/jwst/resample/resample.rst
@@ -1,7 +1,6 @@
 .. resample_:
 
-Python Interface to Drizzle: ResampleData() and ResampleSpecData()
-==================================================================
+Python Interface to Drizzle: ResampleData()
+===========================================
 
 .. automodapi:: jwst.resample.resample
-.. automodapi:: jwst.resample.resample_spec

--- a/docs/jwst/resample/resample_step.rst
+++ b/docs/jwst/resample/resample_step.rst
@@ -1,7 +1,6 @@
 .. resample_step_:
 
-Python Step Interface: ResampleStep() and ResampleSpecStep()
-============================================================
+Python Step Interface: ResampleStep()
+=====================================
 
 .. automodapi:: jwst.resample.resample_step
-.. automodapi:: jwst.resample.resample_spec_step

--- a/docs/jwst/resample_spec/arguments.rst
+++ b/docs/jwst/resample_spec/arguments.rst
@@ -19,10 +19,9 @@ image.
 ``--pixel_scale_ratio`` (float, default=1.0)
     Ratio of input to output spatial pixel scale.
 
-    For spectral data, values greater than 1 indicate that the input
-    pixels have a larger spatial scale, so more output pixels will
-    sample the same input pixel.  For example, a value of 2.0
-    means the output image would have 2 pixels sampling each input
+    Values greater than 1 indicate that the input pixels have a larger spatial
+    scale, so more output pixels will sample the same input pixel.  For example,
+    a value of 2.0 means the output image would have 2 pixels sampling each input
     spatial pixel. If the input data has units of flux density (MJy/pixel),
     the output flux per pixel will be half the input flux per pixel.
     If the input data has units of surface brightness (MJy/sr), the output
@@ -42,9 +41,9 @@ image.
     Absolute pixel scale in ``arcsec``. When provided, overrides
     ``pixel_scale_ratio``. Ignored when ``output_wcs`` is provided.
 
-    For spectral data, if the input data has units of flux density
-    (MJy/pixel), the output flux per pixel will be scaled by the ratio
-    of the selected output pixel scale to an average input pixel scale.
+    If the input data has units of flux density (MJy/pixel), the output flux per
+    pixel will be scaled by the ratio of the selected output pixel scale to an average
+    input pixel scale.
     If the input data has units of surface brightness (MJy/sr),
     the output flux per pixel is not scaled.
 
@@ -58,7 +57,7 @@ image.
 
 ``--output_shape`` (tuple of int, default=None)
     Shape of the image (data array) using "standard" ``nx`` first and ``ny``
-    second (as opposite to the ``numpy.ndarray`` convention - ``ny`` first and
+    second (opposite to the ``numpy.ndarray`` convention - ``ny`` first and
     ``nx`` second). This value will be assigned to
     ``pixel_shape`` and ``array_shape`` properties of the returned
     WCS object. When supplied from command line, it should be a comma-separated
@@ -69,7 +68,7 @@ image.
         ``output_wcs`` does not have ``bounding_box`` property set.
 
 ``--output_wcs`` (str, default='')
-    File name of a ``ASDF`` file with a GWCS stored under the ``"wcs"`` key
+    File name of an ``ASDF`` file with a GWCS stored under the ``"wcs"`` key
     under the root of the file. The output image size is determined from the
     bounding box of the WCS (if any). Argument ``output_shape`` overrides
     computed image size and it is required when output WCS does not have

--- a/docs/jwst/resample_spec/arguments.rst
+++ b/docs/jwst/resample_spec/arguments.rst
@@ -12,21 +12,49 @@ image.
 
 ``--kernel`` (str, default='square')
     The form of the kernel function used to distribute flux onto the output
-    image.  Available kernels are `square` and `point`.
+    image.  Available kernels for spectral data are `square` and `point`.
+    Other drizzle kernels, available for imaging data, do not conserve
+    spectral flux.
 
 ``--pixel_scale_ratio`` (float, default=1.0)
-    Ratio of input to output spatial pixel scale.  Values greater than 1
-    indicate that the input pixels have a larger spatial scale, so more output
-    pixels will sample the same input pixel.  For example, a value of 2.0
-    means the output image would have 4 pixels sampling each input pixel.
-    This parameter is only applied in the cross-dispersion
+    Ratio of input to output spatial pixel scale.
+
+    For spectral data, values greater than 1 indicate that the input
+    pixels have a larger spatial scale, so more output pixels will
+    sample the same input pixel.  For example, a value of 2.0
+    means the output image would have 2 pixels sampling each input
+    spatial pixel. If the input data has units of flux density (MJy/pixel),
+    the output flux per pixel will be half the input flux per pixel.
+    If the input data has units of surface brightness (MJy/sr), the output
+    flux per pixel is not scaled.
+
+    Note that this parameter is only applied in the cross-dispersion
     direction: sampling wavelengths are not affected.
+
     Ignored when ``pixel_scale`` or ``output_wcs`` are provided.
 
+    .. note::
+        If this parameter is modified from the default value, the extraction
+        aperture for the :ref:`extract_1d <extract_1d_step>` step must
+        also be modified, since it is specified in pixels.
+
 ``--pixel_scale`` (float, default=None)
-    Absolute pixel scale in ``arcsec``. This parameter is only applied in
-    the cross-dispersion direction. When provided, overrides
+    Absolute pixel scale in ``arcsec``. When provided, overrides
     ``pixel_scale_ratio``. Ignored when ``output_wcs`` is provided.
+
+    For spectral data, if the input data has units of flux density
+    (MJy/pixel), the output flux per pixel will be scaled by the ratio
+    of the selected output pixel scale to an average input pixel scale.
+    If the input data has units of surface brightness (MJy/sr),
+    the output flux per pixel is not scaled.
+
+    Note that this parameter is only applied in the cross-dispersion
+    direction: sampling wavelengths are not affected.
+
+    .. note::
+        If this parameter is modified from the default value, the extraction
+        aperture for the :ref:`extract_1d <extract_1d_step>` step must
+        also be modified, since it is specified in pixels.
 
 ``--output_shape`` (tuple of int, default=None)
     Shape of the image (data array) using "standard" ``nx`` first and ``ny``
@@ -84,7 +112,7 @@ image.
 ``--single`` (bool, default=False)
     If set to `True`, resample each input image into a separate output.  If
     `False` (the default), each input is resampled additively (with weights) to
-    a common output
+    a common output.
 
 ``--blendheaders`` (bool, default=True)
     Blend metadata from all input images into the resampled output image.

--- a/docs/jwst/resample_spec/arguments.rst
+++ b/docs/jwst/resample_spec/arguments.rst
@@ -1,0 +1,95 @@
+.. _resample_spec_step_args:
+
+Step Arguments
+==============
+The `resample_spec` step has the following optional arguments that control
+the behavior of the processing and the characteristics of the resampled
+image.
+
+``--pixfrac`` (float, default=1.0)
+    The fraction by which input pixels are "shrunk" before being drizzled
+    onto the output image grid, given as a real number between 0 and 1.
+
+``--kernel`` (str, default='square')
+    The form of the kernel function used to distribute flux onto the output
+    image.  Available kernels are `square` and `point`.
+
+``--pixel_scale_ratio`` (float, default=1.0)
+    Ratio of input to output spatial pixel scale.  Values greater than 1
+    indicate that the input pixels have a larger spatial scale, so more output
+    pixels will sample the same input pixel.  For example, a value of 2.0
+    means the output image would have 4 pixels sampling each input pixel.
+    This parameter is only applied in the cross-dispersion
+    direction: sampling wavelengths are not affected.
+    Ignored when ``pixel_scale`` or ``output_wcs`` are provided.
+
+``--pixel_scale`` (float, default=None)
+    Absolute pixel scale in ``arcsec``. This parameter is only applied in
+    the cross-dispersion direction. When provided, overrides
+    ``pixel_scale_ratio``. Ignored when ``output_wcs`` is provided.
+
+``--output_shape`` (tuple of int, default=None)
+    Shape of the image (data array) using "standard" ``nx`` first and ``ny``
+    second (as opposite to the ``numpy.ndarray`` convention - ``ny`` first and
+    ``nx`` second). This value will be assigned to
+    ``pixel_shape`` and ``array_shape`` properties of the returned
+    WCS object. When supplied from command line, it should be a comma-separated
+    list of integers ``nx, ny``.
+
+    .. note::
+        Specifying ``output_shape`` *is required* when the WCS in
+        ``output_wcs`` does not have ``bounding_box`` property set.
+
+``--output_wcs`` (str, default='')
+    File name of a ``ASDF`` file with a GWCS stored under the ``"wcs"`` key
+    under the root of the file. The output image size is determined from the
+    bounding box of the WCS (if any). Argument ``output_shape`` overrides
+    computed image size and it is required when output WCS does not have
+    ``bounding_box`` property set or if ``pixel_shape`` or ``array_shape`` keys
+    (see below) are not provided.
+
+    Additional information may be stored under
+    other keys under the root of the file. Currently, the following keys are
+    recognized:
+
+    - ``pixel_area``: Indicates average pixel area of the output WCS in
+      units of steradians. When provided, this value will be used for updating
+      photometric quantities  ``PIXAR_SR`` and ``PIXAR_A2`` of the output image.
+      If ``pixel_area`` is not provided, the code will attempt to estimate
+      this value from the WCS.
+
+    - ``pixel_shape``: dimensions of the output image in the order (nx, ny).
+      Overrides the value of ``array_shape`` if provided.
+
+    - ``array_shape``: shape of the output image in ``numpy`` order: (ny, nx).
+
+    .. note::
+        When ``output_wcs`` is specified, WCS-related arguments
+        ``pixel_scale_ratio`` and ``pixel_scale`` will be ignored.
+
+``--fillval`` (str, default='NAN')
+    The value to assign to output pixels that have zero weight or do not
+    receive any flux from any input pixels during drizzling.
+
+``--weight_type`` (str, default='ivm')
+    The weighting type for each input image.
+    If `weight_type=ivm` (the default), the scaling value
+    will be determined per-pixel using the inverse of the read noise
+    (VAR_RNOISE) array stored in each input image. If the VAR_RNOISE array does
+    not exist, the variance is set to 1 for all pixels (equal weighting).
+    If `weight_type=exptime`, the scaling value will be set equal to the
+    measurement time (TMEASURE) found in the image header if available;
+    if unavailable, the scaling will be set equal to the exposure time (EFFEXPTM).
+
+``--single`` (bool, default=False)
+    If set to `True`, resample each input image into a separate output.  If
+    `False` (the default), each input is resampled additively (with weights) to
+    a common output
+
+``--blendheaders`` (bool, default=True)
+    Blend metadata from all input images into the resampled output image.
+
+``--in_memory`` (boolean, default=True)
+  Specifies whether or not to load and create all images that are used during
+  processing into memory. If ``False``, input files are loaded from disk when
+  needed and all intermediate files are stored on disk, rather than in memory.

--- a/docs/jwst/resample_spec/index.rst
+++ b/docs/jwst/resample_spec/index.rst
@@ -1,0 +1,17 @@
+.. _resample_spec_step:
+
+========================
+Resampling Spectral Data
+========================
+
+.. toctree::
+   :maxdepth: 2
+
+   main.rst
+   arguments.rst
+   reference_files.rst
+   resample_spec_step.rst
+   resample_spec.rst
+
+See the :ref:`resample step <resample_step>` for full API documentation
+for the the `resample` module.

--- a/docs/jwst/resample_spec/main.rst
+++ b/docs/jwst/resample_spec/main.rst
@@ -1,0 +1,32 @@
+Description
+===========
+
+:Classes: `jwst.resample.ResampleSpecStep`
+:Alias: resample_spec
+
+This routine will resample each input 2D spectral image based on the WCS and
+distortion information, and will combine multiple resampled images
+into a single rectified product.  The distortion information should have
+been incorporated into the image using the
+:ref:`assign_wcs <assign_wcs_step>` step.
+
+The ``resample`` step can take as input either:
+
+#. a single 2D input image
+#. an association table (in json format)
+
+The underlying resampling algorithm is the same as is used in the
+:ref:`resample step<resample_step>`: 2D spectral images are resampled into
+a rectified spatial/spectral output WCS via the drizzle algorithm.  See
+the documentation for that step for more information on error propagation
+and output extensions, as well as further references for the drizzle
+algorithm.
+
+The output WCS is created from a combination of the WCS information of
+all input images.  The first input image is taken as the reference
+for the output WCS and expanded to include the spatial and spectral
+range of all inputs.
+
+The parameters for the drizzle operation are provided via ``resample_spec``
+step parameters, which may be overridden by a step parameter reference
+file from CRDS.

--- a/docs/jwst/resample_spec/reference_files.rst
+++ b/docs/jwst/resample_spec/reference_files.rst
@@ -1,0 +1,3 @@
+Reference File
+==============
+The ``resample_spec`` step does not use any reference files.

--- a/docs/jwst/resample_spec/resample_spec.rst
+++ b/docs/jwst/resample_spec/resample_spec.rst
@@ -1,0 +1,6 @@
+.. resample_spec_:
+
+Python Interface to Drizzle: ResampleSpecData()
+===============================================
+
+.. automodapi:: jwst.resample.resample_spec

--- a/docs/jwst/resample_spec/resample_spec_step.rst
+++ b/docs/jwst/resample_spec/resample_spec_step.rst
@@ -1,0 +1,6 @@
+.. resample_spec_step_:
+
+Python Step Interface: ResampleSpecStep()
+=========================================
+
+.. automodapi:: jwst.resample.resample_spec_step

--- a/jwst/regtest/test_miri_lrs_slit_spec3.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec3.py
@@ -11,67 +11,20 @@ from jwst.stpipe import Step
 from jwst import datamodels
 
 
-@pytest.fixture(
-    scope="module",
-    params=["default_wcs", "user_wcs", "user_wcs+shape", "user_wcs+shape1"]
-)
+@pytest.fixture(scope='module')
 def run_pipeline(rtdata_module, request):
     """
     Run the calwebb_spec3 pipeline on an ASN of nodded MIRI LRS
-    fixed-slit exposures using different options for the WCS and output
-    image shape for the resample step.
-
-    The first iteration ("default_wcs") creates an output WCS for the combined
-    product based on the built-in WCS's in the inputs.
-
-    The second iteration ("user_wcs") creates a user-supplied WCS input file
-    using the WCS from the default product, just to prove that you get the
-    identical result when using a user-supplied WCS.
-
-    The third iteration ("user_wcs+shape") uses the same user-supplied WCS and also
-    specifies the output 2D file shape, using a shape that is identical to the
-    default. Hence all of the first 3 iterations should produce identical results
-    and therefore are compared to a single set of truth files.
-
-    The fourth iteration ("user_wcs+shape1") uses the same user-specified WCS and
-    specifies an output 2D file shape that is 1 pixel larger than the default in
-    both axes. Hence the resulting s2d product needs a separate (larger) truth file.
-    Meanwhile, the x1d product from this iteration should still be identical to
-    the first 3, because the extra row and column of the 2D data file are ignored
-    during extraction.
+    fixed-slit exposures.
     """
     rtdata = rtdata_module
 
     # Get the spec3 ASN and its members
     rtdata.get_asn("miri/lrs/jw01530-o005_20221202t204827_spec3_00001_asn.json")
-    root_file = "jw01530-o005_t004_miri_p750l_"
-
     args = [
         "calwebb_spec3",
         rtdata.input
     ]
-
-    rtdata.custom_wcs_mode = request.param
-
-    if request.param != "default_wcs":
-        # Get the s2d product that was just created using "default_wcs"
-        default_s2d = root_file + "s2d.fits"
-        dm = datamodels.open(default_s2d)
-        # Create a user-supplied WCS file that is identical to the default WCS
-        af = asdf.AsdfFile({"wcs": dm.meta.wcs})
-        wcs_file = default_s2d[:-8] + 'wcs.asdf'
-        af.write_to(wcs_file)
-        args.append(f"--steps.resample_spec.output_wcs={wcs_file}")
-
-    if request.param == "user_wcs+shape":
-        output_shape = ','.join(map(str, dm.data.shape[::-1]))
-        args.append(f"--steps.resample_spec.output_shape={output_shape}")
-
-    elif request.param == "user_wcs+shape1":
-        output_shape = ','.join(map(str, (d + 1 for d in dm.data.shape[::-1])))
-        args.append(f"--steps.resample_spec.output_shape={output_shape}")
-        output_file = root_file + 'shape1.fits'
-        args.append(f"--steps.resample_spec.output_file={output_file}")
 
     # Run the calwebb_spec3 pipeline; save results from intermediate steps
     Step.from_cmdline(args)
@@ -87,10 +40,7 @@ def test_miri_lrs_slit_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwarg
     # Run the pipeline and retrieve outputs
     rtdata = rtdata_module
 
-    if rtdata.custom_wcs_mode == 'user_wcs+shape1' and suffix == "s2d":
-        output = f"jw01530-o005_t004_miri_p750l_shape1_{suffix}.fits"
-    else:
-        output = f"jw01530-o005_t004_miri_p750l_{suffix}.fits"
+    output = f"jw01530-o005_t004_miri_p750l_{suffix}.fits"
     rtdata.output = output
 
     # Get the truth files
@@ -108,11 +58,11 @@ def test_miri_lrs_slit_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwarg
         if isinstance(dmt, datamodels.MultiSlitModel):
             names = [s.name for s in dmt.slits]
             for name in names:
-                st_idx = [(s.wcs, s.wavelength) for s in dmt.slits if s.name==name]
+                st_idx = [(s.wcs, s.wavelength) for s in dmt.slits if s.name == name]
                 w = dmt.slits[st_idx].meta.wcs
                 x, y = wcstools.grid_from_bounding_box(w.bounding_box, step=(1, 1), center=True)
                 _, _, wave = w(x, y)
-                sr_idx = [(s.wcs, s.wavelength) for s in dmr.slits if s.name==name]
+                sr_idx = [(s.wcs, s.wavelength) for s in dmr.slits if s.name == name]
                 wlr = dmr.slits[sr_idx].wavelength
                 assert np.all(np.isclose(wave, wlr, atol=tolerance))
         else:
@@ -121,4 +71,3 @@ def test_miri_lrs_slit_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwarg
             _, _, wave = w(x, y)
             wlr = dmr.wavelength
             assert np.all(np.isclose(wave, wlr, atol=tolerance))
-

--- a/jwst/regtest/test_miri_lrs_slit_spec3.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec3.py
@@ -4,7 +4,6 @@ import pytest
 import numpy as np
 from gwcs import wcstools
 
-import asdf
 from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step

--- a/jwst/regtest/test_miri_lrs_slit_spec3.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec3.py
@@ -4,26 +4,74 @@ import pytest
 import numpy as np
 from gwcs import wcstools
 
+import asdf
 from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
 from jwst import datamodels
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(
+    scope="module",
+    params=["default_wcs", "user_wcs", "user_wcs+shape", "user_wcs+shape1"]
+)
 def run_pipeline(rtdata_module, request):
     """
     Run the calwebb_spec3 pipeline on an ASN of nodded MIRI LRS
-    fixed-slit exposures.
+    fixed-slit exposures using different options for the WCS and output
+    image shape for the resample step.
+
+    The first iteration ("default_wcs") creates an output WCS for the combined
+    product based on the built-in WCS's in the inputs.
+
+    The second iteration ("user_wcs") creates a user-supplied WCS input file
+    using the WCS from the default product, just to prove that you get the
+    identical result when using a user-supplied WCS.
+
+    The third iteration ("user_wcs+shape") uses the same user-supplied WCS and also
+    specifies the output 2D file shape, using a shape that is identical to the
+    default. Hence all of the first 3 iterations should produce identical results
+    and therefore are compared to a single set of truth files.
+
+    The fourth iteration ("user_wcs+shape1") uses the same user-specified WCS and
+    specifies an output 2D file shape that is 1 pixel larger than the default in
+    both axes. Hence the resulting s2d product needs a separate (larger) truth file.
+    Meanwhile, the x1d product from this iteration should still be identical to
+    the first 3, because the extra row and column of the 2D data file are ignored
+    during extraction.
     """
     rtdata = rtdata_module
 
     # Get the spec3 ASN and its members
     rtdata.get_asn("miri/lrs/jw01530-o005_20221202t204827_spec3_00001_asn.json")
+    root_file = "jw01530-o005_t004_miri_p750l_"
+
     args = [
         "calwebb_spec3",
         rtdata.input
     ]
+
+    rtdata.custom_wcs_mode = request.param
+
+    if request.param != "default_wcs":
+        # Get the s2d product that was just created using "default_wcs"
+        default_s2d = root_file + "s2d.fits"
+        dm = datamodels.open(default_s2d)
+        # Create a user-supplied WCS file that is identical to the default WCS
+        af = asdf.AsdfFile({"wcs": dm.meta.wcs})
+        wcs_file = default_s2d[:-8] + 'wcs.asdf'
+        af.write_to(wcs_file)
+        args.append(f"--steps.resample_spec.output_wcs={wcs_file}")
+
+    if request.param == "user_wcs+shape":
+        output_shape = ','.join(map(str, dm.data.shape[::-1]))
+        args.append(f"--steps.resample_spec.output_shape={output_shape}")
+
+    elif request.param == "user_wcs+shape1":
+        output_shape = ','.join(map(str, (d + 1 for d in dm.data.shape[::-1])))
+        args.append(f"--steps.resample_spec.output_shape={output_shape}")
+        output_file = root_file + 'shape1.fits'
+        args.append(f"--steps.resample_spec.output_file={output_file}")
 
     # Run the calwebb_spec3 pipeline; save results from intermediate steps
     Step.from_cmdline(args)
@@ -39,7 +87,10 @@ def test_miri_lrs_slit_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwarg
     # Run the pipeline and retrieve outputs
     rtdata = rtdata_module
 
-    output = f"jw01530-o005_t004_miri_p750l_{suffix}.fits"
+    if rtdata.custom_wcs_mode == 'user_wcs+shape1' and suffix == "s2d":
+        output = f"jw01530-o005_t004_miri_p750l_shape1_{suffix}.fits"
+    else:
+        output = f"jw01530-o005_t004_miri_p750l_{suffix}.fits"
     rtdata.output = output
 
     # Get the truth files
@@ -57,11 +108,11 @@ def test_miri_lrs_slit_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwarg
         if isinstance(dmt, datamodels.MultiSlitModel):
             names = [s.name for s in dmt.slits]
             for name in names:
-                st_idx = [(s.wcs, s.wavelength) for s in dmt.slits if s.name == name]
+                st_idx = [(s.wcs, s.wavelength) for s in dmt.slits if s.name==name]
                 w = dmt.slits[st_idx].meta.wcs
                 x, y = wcstools.grid_from_bounding_box(w.bounding_box, step=(1, 1), center=True)
                 _, _, wave = w(x, y)
-                sr_idx = [(s.wcs, s.wavelength) for s in dmr.slits if s.name == name]
+                sr_idx = [(s.wcs, s.wavelength) for s in dmr.slits if s.name==name]
                 wlr = dmr.slits[sr_idx].wavelength
                 assert np.all(np.isclose(wave, wlr, atol=tolerance))
         else:
@@ -70,3 +121,4 @@ def test_miri_lrs_slit_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwarg
             _, _, wave = w(x, y)
             wlr = dmr.wavelength
             assert np.all(np.isclose(wave, wlr, atol=tolerance))
+

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -3,7 +3,7 @@ __all__ = ["ResampleSpecStep"]
 from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import MultiSlitModel, ImageModel
 
-from . import resample_spec, resample_utils
+from . import resample_spec, ResampleStep
 from ..exp_to_source import multislit_to_container
 from ..assign_wcs.util import update_s_region_spectral
 from ..stpipe import Step
@@ -33,6 +33,7 @@ class ResampleSpecStep(Step):
         kernel = option('square', 'point', default='square')  # Flux distribution kernel
         fillval = string(default='NAN')  # Output value for pixels with no weight or flux
         weight_type = option('ivm', 'exptime', None, default='ivm')  # Input image weighting type
+        output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         pixel_scale_ratio = float(default=1.0)  # Ratio of input to output spatial pixel scale
         pixel_scale = float(default=None)  # Spatial pixel scale in arcsec
         output_wcs = string(default='')  # Custom output WCS
@@ -171,7 +172,13 @@ class ResampleSpecStep(Step):
         )
 
         # Custom output WCS parameters
-        kwargs['output_wcs'] = resample_utils.load_custom_wcs(self.output_wcs)
+        kwargs['output_shape'] = ResampleStep.check_list_pars(
+            self.output_shape,
+            'output_shape',
+            min_vals=[1, 1]
+        )
+        kwargs['output_wcs'] = ResampleStep.load_custom_wcs(
+            self.output_wcs, kwargs['output_shape'])
         kwargs['pscale'] = self.pixel_scale
         kwargs['pscale_ratio'] = self.pixel_scale_ratio
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -30,7 +30,7 @@ class ResampleSpecStep(Step):
 
     spec = """
         pixfrac = float(min=0.0, max=1.0, default=1.0)  # Pixel shrinkage factor
-        kernel = option('square','gaussian','point','turbo','lanczos2','lanczos3',default='square')  # Flux distribution kernel
+        kernel = option('square', 'point', default='square')  # Flux distribution kernel
         fillval = string(default='NAN')  # Output value for pixels with no weight or flux
         weight_type = option('ivm', 'exptime', None, default='ivm')  # Input image weighting type
         pixel_scale_ratio = float(default=1.0)  # Ratio of input to output spatial pixel scale

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -1,8 +1,5 @@
 import logging
 import re
-from copy import deepcopy
-
-import asdf
 
 from stdatamodels.jwst import datamodels
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -3,9 +3,8 @@ import logging
 import warnings
 
 import numpy as np
-import asdf
-import gwcs
 from astropy import units as u
+import gwcs
 
 from stdatamodels.dqflags import interpret_bit_flags
 from stdatamodels.jwst.datamodels.dqflags import pixel
@@ -353,52 +352,3 @@ def check_for_tmeasure(model):
             return 0
     except AttributeError:
         return 0
-
-
-def load_custom_wcs(asdf_wcs_file, output_shape=None):
-    """
-    Load a custom output WCS from an ASDF file.
-
-    Parameters
-    ----------
-    asdf_wcs_file : str
-        Path to an ASDF file containing a GWCS structure.
-    output_shape : tuple of int, optional
-        Array shape for the output data.  If not provided,
-        the custom WCS must specify one of: pixel_shape,
-        array_shape, or bounding_box.
-
-    Returns
-    -------
-    wcs : WCS
-        The output WCS to resample into.
-    """
-    if not asdf_wcs_file:
-        return None
-
-    with asdf.open(asdf_wcs_file) as af:
-        wcs = deepcopy(af.tree["wcs"])
-        wcs.pixel_area = af.tree.get("pixel_area", None)
-        wcs.array_shape = af.tree.get("pixel_shape", None)
-        wcs.array_shape = af.tree.get("array_shape", None)
-
-    if output_shape is not None:
-        wcs.array_shape = output_shape[::-1]
-        wcs.pixel_shape = output_shape
-    elif wcs.pixel_shape is not None:
-        wcs.array_shape = wcs.pixel_shape[::-1]
-    elif wcs.array_shape is not None:
-        wcs.pixel_shape = wcs.array_shape[::-1]
-    elif wcs.bounding_box is not None:
-        wcs.array_shape = tuple(
-            int(axs[1] + 0.5)
-            for axs in wcs.bounding_box.bounding_box(order="C")
-        )
-    else:
-        raise ValueError(
-            "Step argument 'output_shape' is required when custom WCS "
-            "does not have neither of 'array_shape', 'pixel_shape', or "
-            "'bounding_box' attributes set."
-        )
-
-    return wcs

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -3,8 +3,9 @@ import logging
 import warnings
 
 import numpy as np
-from astropy import units as u
+import asdf
 import gwcs
+from astropy import units as u
 
 from stdatamodels.dqflags import interpret_bit_flags
 from stdatamodels.jwst.datamodels.dqflags import pixel
@@ -352,3 +353,52 @@ def check_for_tmeasure(model):
             return 0
     except AttributeError:
         return 0
+
+
+def load_custom_wcs(asdf_wcs_file, output_shape=None):
+    """
+    Load a custom output WCS from an ASDF file.
+
+    Parameters
+    ----------
+    asdf_wcs_file : str
+        Path to an ASDF file containing a GWCS structure.
+    output_shape : tuple of int, optional
+        Array shape for the output data.  If not provided,
+        the custom WCS must specify one of: pixel_shape,
+        array_shape, or bounding_box.
+
+    Returns
+    -------
+    wcs : WCS
+        The output WCS to resample into.
+    """
+    if not asdf_wcs_file:
+        return None
+
+    with asdf.open(asdf_wcs_file) as af:
+        wcs = deepcopy(af.tree["wcs"])
+        wcs.pixel_area = af.tree.get("pixel_area", None)
+        wcs.array_shape = af.tree.get("pixel_shape", None)
+        wcs.array_shape = af.tree.get("array_shape", None)
+
+    if output_shape is not None:
+        wcs.array_shape = output_shape[::-1]
+        wcs.pixel_shape = output_shape
+    elif wcs.pixel_shape is not None:
+        wcs.array_shape = wcs.pixel_shape[::-1]
+    elif wcs.array_shape is not None:
+        wcs.pixel_shape = wcs.array_shape[::-1]
+    elif wcs.bounding_box is not None:
+        wcs.array_shape = tuple(
+            int(axs[1] + 0.5)
+            for axs in wcs.bounding_box.bounding_box(order="C")
+        )
+    else:
+        raise ValueError(
+            "Step argument 'output_shape' is required when custom WCS "
+            "does not have neither of 'array_shape', 'pixel_shape', or "
+            "'bounding_box' attributes set."
+        )
+
+    return wcs


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3679](https://jira.stsci.edu/browse/JP-3679)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8621 

<!-- describe the changes comprising this PR here -->
Remove inheritance link between ResampleSpecStep and ResampleStep, so that the resample_spec step can have a different step parameter spec.
Remove parameters and options from the new spec for resample_spec that are only appropriate for imaging data.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] ~updated or added relevant tests~
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
