### PR TITLE
refactor msa fail/nofail and association duplicate tests to not use caplog

### DIFF
--- a/jwst/associations/tests/test_level3_duplicate.py
+++ b/jwst/associations/tests/test_level3_duplicate.py
@@ -11,9 +11,10 @@ from jwst.associations.tests.helpers import (
 from jwst.associations import (AssociationPool, generate)
 from jwst.associations.main import Main
 from jwst.associations.lib.utilities import constrain_on_candidates
+from jwst.tests.helpers import LogWatcher
 
 
-def test_duplicate_names(caplog):
+def test_duplicate_names(monkeypatch):
     """
     For Level 3 association, there should be no association
     with the same product name.
@@ -22,18 +23,15 @@ def test_duplicate_names(caplog):
     constrain_all_candidates = constrain_on_candidates(None)
     rules = registry_level3_only(global_constraints=constrain_all_candidates)
 
-    caplog.clear()
-    logger = logging.getLogger('jwst.associations')
-    propagate = logger.propagate
-    logger.propagate = True
-    try:
-        with caplog.at_level(logging.WARNING):
-            asns = generate(pool, rules)
-    finally:
-        logger.propagate = propagate
+    # watch for an error log message, we don't use caplog here because
+    # something in the test suite messes up the logging during some runs
+    # (probably stpipe or the association generator) and causes caplog
+    # to sometimes miss the message
+    watcher = LogWatcher("Following associations have the same product name but significant differences")
+    monkeypatch.setattr(logging.getLogger('jwst.associations.lib.prune'), "warning", watcher)
+    asns = generate(pool, rules)
 
-    # There should only be one association left.
-    assert "Following associations have the same product name but significant differences" in caplog.text
+    watcher.assert_seen()
 
 
 def test_duplicate_generate():

--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -37,3 +37,25 @@ def word_precision_check(str1, str2, length=5):
     else:
         return True
     return False
+
+
+class LogWatcher:
+    """
+    The pytest caplog fixture only works for the root
+    logger. We use all sorts of loggers which can lead
+    to random test failures with caplog. This class
+    can be monkeypatched onto a logger method to
+    check for a specific message.
+    """
+    def __init__(self, message):
+        self.seen = False
+        self.message = message
+
+    def __call__(self, *args, **kwargs):
+        if not args or not isinstance(args[0], str):
+            return
+        if self.message in args[0]:
+            self.seen = True
+
+    def assert_seen(self):
+        assert self.seen, f"{self.message} not in logs"


### PR DESCRIPTION
The tests updated in this PR randomly fail (likely due to our complex logging and the pytest `caplog` fixture only using the root logger).

This PR removes the caplog fixture (from only these tests) and replaces it with a monkeypatch of the logger that emits the checked message.

Regression tests running (with jwst_1242.pmap since the new context is causing spec2 failures):
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1581/
show 0 failures.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
