### PR TITLE
RTD: Restore tags for all branches

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: mambaforge-4.10
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+      - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' || true
+      - git fetch --all --tags || true
 
 conda:
   environment: docs/rtd_environment.yaml


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3549](https://jira.stsci.edu/browse/JP-3549)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR fixes the `__version__ `returned by `setuptools_scm` to include the tag associated with the commit. RTD's default checkout behavior creates a shallow clone and removes tag objects from the local repo. This "unshallows" the clone and restores the object associations.

See: https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-git-clone

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
