### PR TITLE
Adding version information to the landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,9 @@
    :width: 400
    :align: center
 
+
 **Version**: |release|
+
 
 Welcome to the documentation for `jwst`. This package contains the Python
 software suite for the James Webb Space Telescope (JWST) calibration pipeline,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,8 @@
    :width: 400
    :align: center
 
+**Version**: |release|
+
 Welcome to the documentation for `jwst`. This package contains the Python
 software suite for the James Webb Space Telescope (JWST) calibration pipeline,
 which processes data from all JWST instruments by applying various corrections to


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3549](https://jira.stsci.edu/browse/JP-3549)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
See #8299 #8633 

<!-- describe the changes comprising this PR here -->
Removing the `stable` branch and allowing RTD to build its own stable documentation has one drawback: the release version (visible under the STScI logo) is replaced with "stable". The release information is written to the HTML `<title>...</title>` tag, so it is _technically_ visible to the user, but only barely.

This PR displays the release version on the index page. When the stable documentation is generated it will continue to write "stable" below the logo above the navigation pane, however, the user will not need to hunt through the page's source code to find the actual version the documentation relates to.

Demo: https://jwst-pipeline--8642.org.readthedocs.build/en/8642/

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
