### PR TITLE
RTD: Clear the dirty git index flag

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,6 +25,8 @@ build:
       - git fetch --unshallow || true
       - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' || true
       - git fetch --all --tags || true
+    pre_install:
+      - git update-index --assume-unchanged environment.yml docs/conf.py
 
 conda:
   environment: docs/rtd_environment.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,7 +26,7 @@ build:
       - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' || true
       - git fetch --all --tags || true
     pre_install:
-      - git update-index --assume-unchanged environment.yml docs/conf.py
+      - git update-index --assume-unchanged docs/rtd_environment.yaml docs/conf.py
 
 conda:
   environment: docs/rtd_environment.yaml


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->

The last build (#8642) produced:
```
Version: 1.15.2.dev10+g2d15511ca.d20240712
```

RTD modifies indexed files in the repository prior to building the documentation. This change should prevent `setuptools_scm` from returning a dirty version (`.dXXXXXXXX` suffix).

See: https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
