### PR TITLE
JP-3687: fix outlier_detection failures when run outside pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ master_background
 - Either of ``"background"`` or ``"bkg"`` in slit name now defines the slit
   as a background slit, instead of ``"bkg"`` only. [#8600]
 
+outlier_detection
+-----------------
+
+- Fixed failures due to a missing ``wcs.array_shape`` attribute when the 
+  ``outlier_detection`` step was run standalone using e.g. ``strun`` [#8645]
+
 stpipe
 ------
 

--- a/jwst/msaflagopen/tests/test_msa_open.py
+++ b/jwst/msaflagopen/tests/test_msa_open.py
@@ -103,7 +103,7 @@ def test_create_slitlets():
 
     for slit in result:
         # Test the returned data type and fields.
-        assert type(slit) == Slit
+        assert isinstance(slit, Slit)
         assert slit._fields == slit_fields
 
 

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -569,7 +569,8 @@ def gwcs_blot(median_model, blot_img, interp='poly5', sinscl=1.0):
     log.debug("Pixmap shape: {}".format(pixmap[:, :, 0].shape))
     log.debug("Sci shape: {}".format(blot_img.data.shape))
 
-    blot_img.meta.wcs.array_shape = blot_img.shape #needed for compute image pixel area
+    # Set array shape, needed to compute image pixel area
+    blot_img.meta.wcs.array_shape = blot_img.shape
     if 'SPECTRAL' not in blot_img.meta.wcs.output_frame.axes_type:
         input_pixflux_area = blot_img.meta.photometry.pixelarea_steradians
         input_pixel_area = compute_image_pixel_area(blot_img.meta.wcs)

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -569,6 +569,7 @@ def gwcs_blot(median_model, blot_img, interp='poly5', sinscl=1.0):
     log.debug("Pixmap shape: {}".format(pixmap[:, :, 0].shape))
     log.debug("Sci shape: {}".format(blot_img.data.shape))
 
+    blot_img.meta.wcs.array_shape = blot_img.shape #needed for compute image pixel area
     if 'SPECTRAL' not in blot_img.meta.wcs.output_frame.axes_type:
         input_pixflux_area = blot_img.meta.photometry.pixelarea_steradians
         input_pixel_area = compute_image_pixel_area(blot_img.meta.wcs)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3687](https://jira.stsci.edu/browse/JP-3687)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8640

<!-- describe the changes comprising this PR here -->
This PR addresses a bug that occurs when the `outlier_detection` step is run outside the pipeline, i.e., loading the datamodel from file instead of passing it in as a `ModelContainer`.  In that case, the `wcs.array_shape` attribute sometimes does not get saved (saving of this attribute was added to gwcs within the past year, so the behavior is version-dependent). This PR sets the `wcs.array_shape` explicitly.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
