### PR TITLE
JP-3636: Fix crash in tweakreg due to MalformedPolygonError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,14 +23,14 @@ master_background
 outlier_detection
 -----------------
 
-- Fixed failures due to a missing ``wcs.array_shape`` attribute when the 
+- Fixed failures due to a missing ``wcs.array_shape`` attribute when the
   ``outlier_detection`` step was run standalone using e.g. ``strun`` [#8645]
 
 stpipe
 ------
 
 - Removed setting of the `self.skip` attribute in the `record_step_status()` function;
-  added a `query_step_status()` function to use as an alternative to checking 
+  added a `query_step_status()` function to use as an alternative to checking
   `self.skip`. [#8600]
 
 tweakreg
@@ -38,6 +38,13 @@ tweakreg
 
 - Removed direct setting of the ``self.skip`` attribute from within the step
   itself. [#8600]
+
+- Updated requirement for ``tweakwcs`` to version ``0.8.8`` which fixes a crash
+  in the ``tweakreg`` step due to a ``MalformedPolygonError`` exception being
+  raised by the ``spherical_geometry`` package for some data sets. For more
+  details, see JP-3636 and
+  https://github.com/spacetelescope/tweakwcs/pull/205. [#8657]
+
 
 1.15.1 (2024-07-08)
 ===================
@@ -182,7 +189,7 @@ extract_1d
 - Add propagation of uncertainty when annular backgrounds are subtracted
   from source spectra during IFU spectral extraction. [#8515]
 
-- Add propagation of background uncertainty when background is subtracted from 
+- Add propagation of background uncertainty when background is subtracted from
   source spectra during non-IFU spectral extraction. [#8532]
 
 - Fix error in application of aperture correction to variance arrays. [#8530]
@@ -190,7 +197,7 @@ extract_1d
 - Fix error in ``_coalesce_bounds`` that returned incorrect spectral or background
   extraction region when one set of pixel limits is entirely contained within
   another [#8586]
-  
+
 - Removed a check for the primary slit for NIRSpec fixed slit mode:
   all slits containing point sources are now handled consistently,
   whether they are marked primary or not. [#8467]
@@ -203,7 +210,7 @@ extract_2d
 - Added support for slit names that have string values instead of integer
   values, necessary for processing combined NIRSpec MOS and fixed slit
   data products. [#8467]
-  
+
 - Assign slit ``source_xpos`` and ``source_ypos`` attributes here instead of
   in ``wavecorr`` for NIRSpec FS data. [#8569]
 
@@ -312,8 +319,8 @@ outlier_detection
 pathloss
 --------
 
-- Updated pathloss calculations for NIRSpec fixed slit mode to use the appropriate 
-  wavelengths for point and uniform sources if the ``wavecorr`` wavelength 
+- Updated pathloss calculations for NIRSpec fixed slit mode to use the appropriate
+  wavelengths for point and uniform sources if the ``wavecorr`` wavelength
   zero-point corrections for point sources have been applied. [#8376]
 
 photom
@@ -354,7 +361,7 @@ pipeline
 
 - Added a hook to skip ``photom`` step when the ``extract_1d`` step was skipped
   for NIRISS SOSS data [#8575].
-  
+
 - Added hook to the ``calwebb_tso3`` pipeline to skip all subsequent steps
   if the ``extract_1d`` step is skipped. [#8583]
 
@@ -424,7 +431,7 @@ residual_fringe
 srctype
 -------
 
-- Reset ``source_xpos`` and ``source_ypos`` values to zero for extended sources 
+- Reset ``source_xpos`` and ``source_ypos`` values to zero for extended sources
   in NIRSpec FS data to enable assigning those attributes in ``extract_2d``. [#8569]
 
 saturation
@@ -470,7 +477,7 @@ wavecorr
 
 - Assign slit ``source_xpos`` and ``source_ypos`` attributes in ``extract_2d``
   instead of in ``wavecorr`` for NIRSpec FS data. [#8569]
-  
+
 wfss_contam
 -----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "stsci.image>=2.3.5",
     "stsci.imagestats>=1.6.3",
     "synphot>=1.2",
-    "tweakwcs>=0.8.6",
+    "tweakwcs>=0.8.8",
     "asdf-astropy>=0.3.0",
     "wiimatch>=0.2.1",
     "packaging>20.0",


### PR DESCRIPTION
Resolves [JP-3636](https://jira.stsci.edu/browse/JP-3636)

Closes #8513

This PR fixes a crash in the `tweakreg` step due to `MalformedPolygonError` in the `spherical_geometry`. The error was fixed via https://github.com/spacetelescope/tweakwcs/pull/205 

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

Regression test was run here: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1608
