### PR TITLE
Remove stsci.image dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,11 @@ emicorr
 - Fixed a bug where MIRI EMI correction step would return NaNs when it was unable
   to compute a correction. [#8675]
 
+general
+-------
+
+- Remove the unused ``stsci.image`` dependency. [#8663]
+
 master_background
 -----------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "stcal @ git+https://github.com/spacetelescope/stcal.git",
     "stdatamodels>=2.0.0,<2.1.0",
     "stpipe>=0.6.0,<0.7.0",
-    "stsci.image>=2.3.5",
     "stsci.imagestats>=1.6.3",
     "synphot>=1.2",
     "tweakwcs>=0.8.8",


### PR DESCRIPTION
`stsci.image` is listed as a dependency:
https://github.com/spacetelescope/jwst/blob/de39de07b6f0380860caa86e8485666b4cef35c2/pyproject.toml#L40
but is unused:
https://github.com/search?q=repo%3Aspacetelescope%2Fjwst%20stsci.image&type=code

Regression tests with this PR show that stsci.image is not installed (so it is also not a non-primary dependency): https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/1611/pipeline#step-192-log-94

and all tests passed.

Fixes: #3576

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
