### PR TITLE
JP-3696: Ensure EMICORR correction is never NaN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ cube_build
 - Removed direct setting of the ``self.skip`` attribute from within the step
   itself. [#8600]
 
+emicorr
+-------
+
+- Fixed a bug where MIRI EMI correction step would return NaNs when it was unable
+  to compute a correction. [#8675]
+
 master_background
 -----------------
 

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -455,7 +455,7 @@ def apply_emicorr(input_model, emicorr_model,
             noise[:, :, :, noise_x + k] = dd_noise
 
         # Safety catch; anywhere the noise value is not finite, set it to zero
-        noise[np.isfinite(noise) == False] = 0
+        noise[~np.isfinite(noise)] = 0
 
         # Subtract EMI noise from the input data
         log.info('Subtracting EMI noise from data')

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -454,6 +454,9 @@ def apply_emicorr(input_model, emicorr_model,
         for k in range(4):
             noise[:, :, :, noise_x + k] = dd_noise
 
+        # Safety catch; anywhere the noise value is not finite, set it to zero
+        noise[np.isfinite(noise) == False] = 0
+
         # Subtract EMI noise from the input data
         log.info('Subtracting EMI noise from data')
         corr_data = orig_data - noise


### PR DESCRIPTION
This PR addresses a corner case where MIRI EMICORR can sometimes fail to construct a noise model and return NaNs, resulting in data passed out of the step containing NaNs.  EMICORR is now set to first do no harm, and make a zero correction anywhere it was unable to come up with a good model (for any of multiple reasons).

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
