### PR TITLE
fix bug in AmiAverageStep spec that prevents step creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.15.2 (unreleased)
 ===================
 
+ami_average
+-----------
+
+- Fix error in step spec that prevents step creation. [#8677]
+
 assign_wcs
 ----------
 

--- a/jwst/ami/ami_average_step.py
+++ b/jwst/ami/ami_average_step.py
@@ -12,7 +12,7 @@ class AmiAverageStep(Step):
     class_alias = "ami_average"
 
     spec = """
-    skip = True # Do not run this step
+    skip = boolean(default=True) # Do not run this step
     """
 
     def flatten_input(self, input_items):

--- a/jwst/ami/tests/test_ami_average.py
+++ b/jwst/ami/tests/test_ami_average.py
@@ -1,0 +1,10 @@
+from jwst.ami.ami_average_step import AmiAverageStep
+
+
+def test_step_init():
+    """
+    Just a simple smoke test to make sure the step
+    can be created with the default spec.
+    """
+    step = AmiAverageStep()
+    assert step


### PR DESCRIPTION
The step spec for `AmiAverageStep` contains an invalid entry:
https://github.com/spacetelescope/jwst/blob/7d97170f080771ef1f7a6276052f250089adf3bb/jwst/ami/ami_average_step.py#L14-L16
which leads to an error when attempting to construct the step:
```python
ValidationError: Config parameter 'skip': missing
```

This PR fixes the spec and adds a very basic unit test to verify the step can be instantiated.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
