### PR TITLE
Reset 'seen' flag in log watcher after check

### DIFF
--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -43,9 +43,17 @@ class LogWatcher:
     """
     The pytest caplog fixture only works for the root
     logger. We use all sorts of loggers which can lead
-    to random test failures with caplog. This class
-    can be monkeypatched onto a logger method to
-    check for a specific message.
+    to random test failures with caplog.
+
+    This class can be monkeypatched onto a logger method to
+    check for a specific message. When the logger method is
+    called, a `seen` attribute is set in the watcher,
+    if the calling message matches the expected value.
+
+    The `seen` flag can be checked via `assert_seen`. When
+    called, this function will reset the `seen` attribute
+    to False. This allows the same watcher to be reused for
+    multiple function calls.
     """
     def __init__(self, message):
         self.seen = False
@@ -58,6 +66,10 @@ class LogWatcher:
             self.seen = True
 
     def assert_seen(self):
+        """Check if message has been seen.
+
+        After calling, the `seen` attribute is reset to False.
+        """
         assert self.seen, f"{self.message} not in logs"
 
         # reset flag after check

--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -59,3 +59,6 @@ class LogWatcher:
 
     def assert_seen(self):
         assert self.seen, f"{self.message} not in logs"
+
+        # reset flag after check
+        self.seen = False


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Small PR to make LogWatcher reusable for multiple messages.

Using this helper to develop tests for #8669, I found it's convenient to use the same watcher to check for different messages, but the flag needs to be reset between calls.  I can do it manually, but that's failure prone. With this change, I can do something like:

```
log_watcher.message = 'test 1'
function_call()
log_watcher.assert_seen()

log_watcher.message = 'test 2'
function_call()
log_watcher.assert_seen()
```

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] ~added entry in `CHANGES.rst` within the relevant release section~
- [ ] ~updated or added relevant tests~
- [ ] ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ~ran regression tests, post a link to the Jenkins job below.~
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
