### PR TITLE
Update NIRSpec IRS2 detector1 test to use flight data

### DIFF
--- a/jwst/regtest/test_nirspec_irs2_detector1.py
+++ b/jwst/regtest/test_nirspec_irs2_detector1.py
@@ -12,7 +12,7 @@ from jwst.stpipe import Step
 def run_detector1pipeline(rtdata_module):
     """Run calwebb_detector1 pipeline on NIRSpec data with IRS2 readout mode."""
     rtdata = rtdata_module
-    rtdata.get_data("nirspec/irs2/jw0010010_11010_nrs1_chimera_uncal.fits")
+    rtdata.get_data("nirspec/irs2/jw01335004001_03101_00002_nrs2_uncal.fits")
 
     Step.from_cmdline([
         "calwebb_detector1",
@@ -33,7 +33,8 @@ def run_detector1pipeline(rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ['dq_init', 'saturation', 'superbias',
-                                    'refpix', 'linearity', 'dark_current', 'jump', '0_ramp_fit', 'gain_scale',
+                                    'refpix', 'linearity', 'dark_current', 'jump',
+                                    '0_ramp_fit', 'gain_scale',
                                     'rate'])
 def test_nirspec_irs2_detector1(run_detector1pipeline, rtdata_module,
                                 fitsdiff_default_kwargs, suffix):
@@ -42,7 +43,7 @@ def test_nirspec_irs2_detector1(run_detector1pipeline, rtdata_module,
     """
     rtdata = rtdata_module
 
-    output_filename = f"jw0010010_11010_nrs1_chimera_{suffix}.fits"
+    output_filename = f"jw01335004001_03101_00002_nrs2_{suffix}.fits"
     rtdata.output = output_filename
     rtdata.get_truth(f"truth/test_nirspec_irs2_detector1/{output_filename}")
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-2928](https://jira.stsci.edu/browse/JP-2928)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
For regression testing #8669, it would be helpful to have an in-flight NIRSpec uncal file to run through detector1.  The existing regression test for NRS IRS2 detector1 uses pre-flight data; this PR replaces it with a NRS IFU file that is also useful for testing 1/f noise correction. 

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] ~added entry in `CHANGES.rst` within the relevant release section~
- [ ] updated or added relevant tests
- [ ] ~updated relevant documentation~
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
