### PR TITLE
don't build for python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,12 @@ jobs:
     with:
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
       targets: |
-        # Linux wheels
-        - cp3*-manylinux_x86_64
-        # MacOS wheels
-        - cp3*-macosx_x86_64
-        # Until we have arm64 runners, we can't automatically test arm64 wheels
-        - cp3*-macosx_arm64
+        # Linux wheels (except python 313)
+        - cp31[!3]-manylinux_x86_64
+        # MacOS wheels (except python 313)
+        - cp31[!3]-macosx_x86_64
+        # MacOS arm64 wheels (except python 313)
+        - cp31[!3]-macosx_arm64
       sdist: true
       test_command: python -c "from jwst.lib import winclip; from jwst.cube_build import cube_match_internal, cube_match_sky_pointcloud, cube_match_sky_driz, blot_median; from jwst.straylight import calc_xart"
     secrets:


### PR DESCRIPTION
cibuildwheel is now (attempting) to build for python 3.13.

However our dependencies (and likely code) is not yet ready.

This is currently leading to build failures due to an attempt to build scipy from source.

This PR restricts the build job to only build for python 3.10, 3.11 and 3.12 (the listed supported versions in [pyproject.toml](https://github.com/spacetelescope/jwst/blob/be80530a4531c0d9cb33d72e294746f48257b6d0/pyproject.toml#L16)).

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8690


**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
