### PR TITLE
update test to allow easier deprecation of `ignore_version_mismatch`

### DIFF
--- a/jwst/assign_wcs/tests/test_schemas.py
+++ b/jwst/assign_wcs/tests/test_schemas.py
@@ -2,6 +2,7 @@ import inspect
 import sys
 import warnings
 
+from asdf.exceptions import AsdfDeprecationWarning
 from astropy.modeling import models
 from astropy import units as u
 import pytest
@@ -55,6 +56,14 @@ def test_distortion_schema(distortion_model, tmp_path):
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
+        # filter out the ignore_version_mismatch deprecation as it's
+        # unrelated to this test and will make the deprecation easier
+        # see https://github.com/spacetelescope/stdatamodels/pull/313
+        warnings.filterwarnings(
+            "ignore",
+            message="ignore_version_mismatch is deprecated and has done nothing since asdf 3.0.0",
+            category=AsdfDeprecationWarning,
+        )
         with DistortionModel(path) as dist1:
             assert dist1.meta.instrument.p_pupil == dist.meta.instrument.p_pupil
             assert dist1.meta.instrument.pupil == dist.meta.instrument.pupil


### PR DESCRIPTION
This PR adds a filter to ignore a deprecation warning for an upcoming asdf deprecation:
https://github.com/asdf-format/asdf/pull/1819
`ignore_version_mismatch` has done nothing since asdf 3.0.0. However it is currently set in stdatamodels:
https://github.com/spacetelescope/stdatamodels/pull/313
Deprecating the feature in asdf will cause 1 jwst test to fail which turns all warnings into errors:
https://github.com/spacetelescope/jwst/blob/89f126a035751674f29a9027e2deae11b3e63fca/jwst/assign_wcs/tests/test_schemas.py#L57
This PR ignores the upcoming deprecation warning to allow the test to continue to pass. The trigger for the warning is being addressed in the above stdatamodels PR but would otherwise require a new stdatamodels release (with the above PR). Filtering this warning seems like an easier option.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
