### PR TITLE
remove MultilineLogger

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.15.2 (unreleased)
 ===================
 
+associations
+------------
+
+- remove ``MultilineLogger`` and no longer set it as the default logger. [#8694]
+
 align_refs
 ----------
 

--- a/jwst/associations/lib/log_config.py
+++ b/jwst/associations/lib/log_config.py
@@ -5,8 +5,6 @@ import logging
 from logging.config import dictConfig
 from collections import defaultdict
 
-from functools import partialmethod
-
 
 __all__ = ['log_config']
 
@@ -145,28 +143,6 @@ DMS_config = {
         }
     }
 }
-
-
-class MultilineLogger(logging.getLoggerClass()):
-    """Split multilines so that each line is logged separately"""
-
-    def __init__(self, *args, **kwargs):
-        super(MultilineLogger, self).__init__(*args, **kwargs)
-
-    def log(self, level, msg, *args, **kwargs):
-        if self.isEnabledFor(level):
-            for line in msg.split('\n'):
-                self._log(level, line, args, **kwargs)
-
-    debug = partialmethod(log, logging.DEBUG)
-    info = partialmethod(log, logging.INFO)
-    warning = partialmethod(log, logging.WARNING)
-    error = partialmethod(log, logging.ERROR)
-    critical = partialmethod(log, logging.CRITICAL)
-    fatal = critical
-
-
-logging.setLoggerClass(MultilineLogger)
 
 
 def log_config(name=None,


### PR DESCRIPTION
This PR removes [MultilineLogger](https://github.com/spacetelescope/jwst/blob/89f126a035751674f29a9027e2deae11b3e63fca/jwst/associations/lib/log_config.py#L150)

This logger splits log messages containing a newline character into multiple log messages. It also is sometimes registered as the default logger (only when `jwst.associations.lib.log_config` is imported). This produces unexpected changes in the test behavior that sometimes leads to test failures like the following in stcal:
https://github.com/spacetelescope/stcal/actions/runs/10166472093/job/28116723217#step:10:3648
and as reported by external users:
https://github.com/spacetelescope/jwst/issues/6407

The class and the registering of the class as the default logger occurred in the "initial commit" 8 years ago:
https://github.com/spacetelescope/jwst/commit/5915b0e919be1e3393fd0ba74ff9106de77a4a1e

and I suspect contributes to other logging issues.

Regression tests all passed: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1635/

Fixes https://github.com/spacetelescope/jwst/issues/6407

This is an alternative to https://github.com/spacetelescope/jwst/pull/7616

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
