### PR TITLE
Move common resample code to stcal

### DIFF
--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -1,0 +1,406 @@
+import numpy as np
+
+from drizzle import cdrizzle
+from . import resample_utils
+
+import logging
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+class GWCSDrizzle:
+    """
+    Combine images using the drizzle algorithm
+    """
+
+    def __init__(self, product, outwcs=None, wt_scl=None,
+                 pixfrac=1.0, kernel="square", fillval="NAN"):
+        """
+        Create a new Drizzle output object and set the drizzle parameters.
+
+        Parameters
+        ----------
+
+        product : DataModel
+            A data model containing results from a previous run. The three
+            extensions SCI, WHT, and CTX contain the combined image, total counts
+            and image id bitmap, respectively. The WCS of the combined image is
+            also read from the SCI extension.
+
+        outwcs : `gwcs.WCS`
+            The world coordinate system (WCS) of the resampled image.  If not
+            provided, the WCS is taken from product.
+
+        wt_scl : str, optional
+            How each input image should be scaled. The choices are `exptime`,
+            which scales each image by its exposure time, or `expsq`, which scales
+            each image by the exposure time squared.  If not set, then each
+            input image is scaled by its own weight map.
+
+        pixfrac : float, optional
+            The fraction of a pixel that the pixel flux is confined to. The
+            default value of 1 has the pixel flux evenly spread across the image.
+            A value of 0.5 confines it to half a pixel in the linear dimension,
+            so the flux is confined to a quarter of the pixel area when the square
+            kernel is used.
+
+        kernel : str, optional
+            The name of the kernel used to combine the inputs. The choice of
+            kernel controls the distribution of flux over the kernel. The kernel
+            names are: "square", "gaussian", "point", "turbo", "lanczos2",
+            and "lanczos3". The square kernel is the default.
+
+        fillval : str, optional
+            The value a pixel is set to in the output if the input image does
+            not overlap it. The default value of NAN sets NaN values.
+        """
+
+        # Initialize the object fields
+        self._product = product
+        self.outsci = None
+        self.outwht = None
+        self.outcon = None
+        self.uniqid = 0
+
+        if wt_scl is None:
+            self.wt_scl = ""
+        else:
+            self.wt_scl = wt_scl
+        self.kernel = kernel
+        self.fillval = fillval
+        self.pixfrac = pixfrac
+
+        self.sciext = "SCI"
+        self.whtext = "WHT"
+        self.conext = "CON"
+
+        out_units = "cps"
+
+        self.outexptime = product.meta.exposure.measurement_time or 0.0
+
+        self.outsci = product.data
+        if outwcs:
+            self.outwcs = outwcs
+        else:
+            self.outwcs = product.meta.wcs
+
+        self.outwht = product.wht
+        self.outcon = product.con
+
+        if self.outcon.ndim == 2:
+            self.outcon = np.reshape(self.outcon, (1,
+                                                   self.outcon.shape[0],
+                                                   self.outcon.shape[1]))
+        elif self.outcon.ndim != 3:
+            raise ValueError("Drizzle context image has wrong dimensions: \
+                {0}".format(product))
+
+        # Check field values
+        if not self.outwcs:
+            raise ValueError("Either an existing file or wcs must be supplied")
+
+        if out_units == "counts":
+            np.divide(self.outsci, self.outexptime, self.outsci)
+        elif out_units != "cps":
+            raise ValueError("Illegal value for out_units: %s" % out_units)
+
+    # Since the context array is dynamic, it must be re-assigned
+    # back to the product's `con` attribute.
+    @property
+    def outcon(self):
+        """Return the context array"""
+        return self._product.con
+
+    @outcon.setter
+    def outcon(self, value):
+        """Set new context array"""
+        self._product.con = value
+
+    def add_image(self, insci, inwcs, inwht=None, xmin=0, xmax=0, ymin=0, ymax=0,
+                  expin=1.0, in_units="cps", wt_scl=1.0, iscale=1.0):
+        """
+        Combine an input image with the output drizzled image.
+
+        Instead of reading the parameters from a fits file, you can set
+        them by calling this lower level method. `Add_fits_file` calls
+        this method after doing its setup.
+
+        Parameters
+        ----------
+
+        insci : array
+            A 2d numpy array containing the input image to be drizzled.
+            it is an error to not supply an image.
+
+        inwcs : wcs
+            The world coordinate system of the input image. This is
+            used to convert the pixels to the output coordinate system.
+
+        inwht : array, optional
+            A 2d numpy array containing the pixel by pixel weighting.
+            Must have the same dimensions as insci. If none is supplied,
+            the weighting is set to one.
+
+        xmin : int, optional
+            This and the following three parameters set a bounding rectangle
+            on the input image. Only pixels on the input image inside this
+            rectangle will have their flux added to the output image. Xmin
+            sets the minimum value of the x dimension. The x dimension is the
+            dimension that varies quickest on the image. All four parameters
+            are zero based, counting starts at zero.
+
+        xmax : int, optional
+            Sets the maximum value of the x dimension on the bounding box
+            of the input image. If ``xmax = 0``, no maximum will
+            be set in the x dimension (all pixels in a row of the input image
+            will be resampled).
+
+        ymin : int, optional
+            Sets the minimum value in the y dimension on the bounding box. The
+            y dimension varies less rapidly than the x and represents the line
+            index on the input image.
+
+        ymax : int, optional
+            Sets the maximum value in the y dimension. If ``ymax = 0``,
+            no maximum will be set in the y dimension (all pixels in a column
+            of the input image will be resampled).
+
+        expin : float, optional
+            The exposure time of the input image, a positive number. The
+            exposure time is used to scale the image if the units are counts and
+            to scale the image weighting if the drizzle was initialized with
+            wt_scl equal to "exptime" or "expsq."
+
+        in_units : str, optional
+            The units of the input image. The units can either be "counts"
+            or "cps" (counts per second.) If the value is counts, before using
+            the input image it is scaled by dividing it by the exposure time.
+
+        wt_scl : float, optional
+            If drizzle was initialized with wt_scl left blank, this value will
+            set a scaling factor for the pixel weighting. If drizzle was
+            initialized with wt_scl set to "exptime" or "expsq", the exposure time
+            will be used to set the weight scaling and the value of this parameter
+            will be ignored.
+
+        iscale : float, optional
+            A scale factor to be applied to pixel intensities of the
+            input image before resampling.
+
+        """
+        if self.wt_scl == "exptime":
+            wt_scl = expin
+        elif self.wt_scl == "expsq":
+            wt_scl = expin * expin
+
+        wt_scl = 1.0  # hard-coded for JWST count-rate data
+        self.increment_id()
+
+        dodrizzle(insci, inwcs, inwht, self.outwcs, self.outsci, self.outwht,
+                  self.outcon, expin, in_units, wt_scl, uniqid=self.uniqid,
+                  xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax,
+                  iscale=iscale, pixfrac=self.pixfrac, kernel=self.kernel,
+                  fillval=self.fillval)
+
+    def increment_id(self):
+        """
+        Increment the id count and add a plane to the context image if needed
+
+        Drizzle tracks which input images contribute to the output image
+        by setting a bit in the corresponding pixel in the context image.
+        The uniqid indicates which bit. So it must be incremented each time
+        a new image is added. Each plane in the context image can hold 32 bits,
+        so after each 32 images, a new plane is added to the context.
+        """
+
+        # Compute what plane of the context image this input would
+        # correspond to:
+        planeid = int(self.uniqid / 32)
+
+        # Add a new plane to the context image if planeid overflows
+
+        if self.outcon.shape[0] == planeid:
+            plane = np.zeros_like(self.outcon[0])
+            plane = plane.reshape((1, plane.shape[0], plane.shape[1]))
+            self.outcon = np.concatenate((self.outcon, plane))
+
+        # Increment the id
+        self.uniqid += 1
+
+
+def dodrizzle(insci, input_wcs, inwht, output_wcs, outsci, outwht, outcon,
+              expin, in_units, wt_scl, uniqid=1, xmin=0, xmax=0, ymin=0, ymax=0,
+              iscale=1.0, pixfrac=1.0, kernel='square', fillval="NAN"):
+    """
+    Low level routine for performing 'drizzle' operation on one image.
+
+    Parameters
+    ----------
+
+    insci : 2d array
+        A 2d numpy array containing the input image to be drizzled.
+
+    input_wcs : gwcs.WCS object
+        The world coordinate system of the input image.
+
+    inwht : 2d array
+        A 2d numpy array containing the pixel by pixel weighting.
+        Must have the same dimensions as insci. If none is supplied,
+        the weighting is set to one.
+
+    output_wcs : gwcs.WCS object
+        The world coordinate system of the output image.
+
+    outsci : 2d array
+        A 2d numpy array containing the output image produced by
+        drizzling. On the first call it should be set to zero.
+        Subsequent calls it will hold the intermediate results
+
+    outwht : 2d array
+        A 2d numpy array containing the output counts. On the first
+        call it should be set to zero. On subsequent calls it will
+        hold the intermediate results.
+
+    outcon : 2d or 3d array, optional
+        A 2d or 3d numpy array holding a bitmap of which image was an input
+        for each output pixel. Should be integer zero on first call.
+        Subsequent calls hold intermediate results.
+
+    expin : float
+        The exposure time of the input image, a positive number. The
+        exposure time is used to scale the image if the units are counts.
+
+    in_units : str
+        The units of the input image. The units can either be "counts"
+        or "cps" (counts per second.)
+
+    wt_scl : float
+        A scaling factor applied to the pixel by pixel weighting.
+
+    uniqid : int, optional
+        The id number of the input image. Should be one the first time
+        this function is called and incremented by one on each subsequent
+        call.
+
+    xmin : int, optional
+        This and the following three parameters set a bounding rectangle
+        on the input image. Only pixels on the input image inside this
+        rectangle will have their flux added to the output image. Xmin
+        sets the minimum value of the x dimension. The x dimension is the
+        dimension that varies quickest on the image. All four parameters
+        are zero based, counting starts at zero.
+
+    xmax : int, optional
+        Sets the maximum value of the x dimension on the bounding box
+        of the input image. If ``xmax = 0``, no maximum will
+        be set in the x dimension (all pixels in a row of the input image
+        will be resampled).
+
+    ymin : int, optional
+        Sets the minimum value in the y dimension on the bounding box. The
+        y dimension varies less rapidly than the x and represents the line
+        index on the input image.
+
+    ymax : int, optional
+        Sets the maximum value in the y dimension. If ``ymax = 0``,
+        no maximum will be set in the y dimension (all pixels in a column
+        of the input image will be resampled).
+
+    iscale : float, optional
+        A scale factor to be applied to pixel intensities of the
+        input image before resampling.
+
+    pixfrac : float, optional
+        The fraction of a pixel that the pixel flux is confined to. The
+        default value of 1 has the pixel flux evenly spread across the image.
+        A value of 0.5 confines it to half a pixel in the linear dimension,
+        so the flux is confined to a quarter of the pixel area when the square
+        kernel is used.
+
+    kernel: str, optional
+        The name of the kernel used to combine the input. The choice of
+        kernel controls the distribution of flux over the kernel. The kernel
+        names are: "square", "gaussian", "point", "turbo", "lanczos2",
+        and "lanczos3". The square kernel is the default.
+
+    fillval: str, optional
+        The value a pixel is set to in the output if the input image does
+        not overlap it. The default value of NAN sets NaN values.
+
+    Returns
+    -------
+    A tuple with three values: a version string, the number of pixels
+    on the input image that do not overlap the output image, and the
+    number of complete lines on the input image that do not overlap the
+    output input image.
+
+    """
+    # Insure that the fillval parameter gets properly interpreted for use with tdriz
+    if resample_utils.is_blank(str(fillval)):
+        fillval = 'NAN'
+    else:
+        fillval = str(fillval)
+
+    if in_units == 'cps':
+        expscale = 1.0
+    else:
+        expscale = expin
+
+    if insci.dtype > np.float32:
+        insci = insci.astype(np.float32)
+
+    # Add input weight image if it was not passed in
+    if inwht is None:
+        inwht = np.ones_like(insci)
+
+    if xmax is None or xmax == xmin:
+        xmax = insci.shape[1]
+    if ymax is None or ymax == ymin:
+        ymax = insci.shape[0]
+
+    # Compute what plane of the context image this input would
+    # correspond to:
+    planeid = int((uniqid - 1) / 32)
+
+    # Check if the context image has this many planes
+    if outcon.ndim == 3:
+        nplanes = outcon.shape[0]
+    elif outcon.ndim == 2:
+        nplanes = 1
+    else:
+        nplanes = 0
+
+    if nplanes <= planeid:
+        raise IndexError("Not enough planes in drizzle context image")
+
+    # Alias context image to the requested plane if 3d
+    if outcon.ndim == 3:
+        outcon = outcon[planeid]
+
+    # Compute the mapping between the input and output pixel coordinates
+    # for use in drizzle.cdrizzle.tdriz
+    pixmap = resample_utils.calc_gwcs_pixmap(input_wcs, output_wcs, insci.shape)
+    # inwht[np.isnan(pixmap[:,:,0])] = 0.
+
+    log.debug(f"Pixmap shape: {pixmap[:,:,0].shape}")
+    log.debug(f"Input Sci shape: {insci.shape}")
+    log.debug(f"Output Sci shape: {outsci.shape}")
+
+    # Call 'drizzle' to perform image combination
+    log.info(f"Drizzling {insci.shape} --> {outsci.shape}")
+
+    _vers, nmiss, nskip = cdrizzle.tdriz(
+        insci.astype(np.float32), inwht.astype(np.float32), pixmap,
+        outsci, outwht, outcon,
+        uniqid=uniqid,
+        xmin=xmin, xmax=xmax,
+        ymin=ymin, ymax=ymax,
+        scale=iscale,
+        pixfrac=pixfrac,
+        kernel=kernel,
+        in_units=in_units,
+        expscale=expscale,
+        wtscale=wt_scl,
+        fillstr=fillval
+    )
+    return _vers, nmiss, nskip

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 import json
 
@@ -9,7 +8,9 @@ from drizzle.resample import Drizzle
 from spherical_geometry.polygon import SphericalPolygon
 
 from stdatamodels.jwst import datamodels
-from stdatamodels.jwst.library.basic_utils import bytes2human
+from stcal.resample import ResampleModelIO, ResampleCoAdd, ResampleSingle
+from stcal.resample.utils import get_tmeasure
+from drizzle.resample import Drizzle
 
 from jwst.datamodels import ModelLibrary
 from jwst.associations.asn_from_list import asn_from_list
@@ -20,12 +21,337 @@ from jwst.resample import resample_utils
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-__all__ = ["OutputTooLargeError", "ResampleData"]
+__all__ = [
+    "OutputTooLargeError",
+    "ResampleJWSTModelIO",
+    "ResampleJWSTSingle",
+    "ResampleJWSTCoAdd",
+    "ResampleData",
+]
 
 
 class OutputTooLargeError(RuntimeError):
     """Raised when the output is too large for in-memory instantiation"""
 
+
+class ResampleJWSTModelIO(ResampleModelIO):
+    def open_model(self, file_name):
+        return datamodels.open(file_name)
+
+    def get_model_meta(self, file_name, fields):
+        raise NotImplementedError()
+
+    def close_model(self, model):
+        model.close()
+
+    def save_model(self, model):
+        if model.meta.filename:
+            model.write(model.meta.filename, overwrite=True)
+
+    def write_model(self, model, file_name):
+        model.write(file_name, overwrite=True)
+
+    def new_model(self, image_shape=None, file_name=None):
+        """ Return a new model for the resampled output """
+        model = datamodels.ImageModel(image_shape)
+        model.meta.filename = file_name
+        return model
+
+
+class ResampleJWSTCoAdd(ResampleJWSTModelIO, ResampleCoAdd):
+    # resample_array_names = [
+    #     {'attr': 'data', 'variance', 'exptime']
+    def __init__(self, *args, blendheaders=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._blendheaders = blendheaders
+
+    def _compute_output_wcs(self, **wcs_pars):
+        """
+        returns a distortion-free WCS object and its pixel scale.
+        this code should be moved to stcal
+
+        """
+        # Define output WCS based on all inputs, including a reference WCS:
+        output_shape = wcs_pars.get("output_shape", None)
+        output_wcs = resample_utils.make_output_wcs(
+            self._input_models,
+            ref_wcs=None,
+            pscale_ratio=wcs_pars.get("pixel_scale_ratio", 1.0),
+            pscale=wcs_pars.get("pixel_scale", None),
+            rotation=wcs_pars.get("rotation", 0.0),
+            shape=None if output_shape is None else output_shape[::-1],
+            crpix=wcs_pars.get("crpix", None),
+            crval=wcs_pars.get("crval", None),
+        )
+
+        # Estimate output pixel area in Sr. NOTE: in principle we could
+        # use the same algorithm as for when output_wcs is provided by the
+        # user.
+        tr = output_wcs.pipeline[0].transform
+        output_pix_area = (
+            np.deg2rad(tr['cdelt1'].factor.value) *
+            np.deg2rad(tr['cdelt2'].factor.value)
+        )
+        return output_wcs, output_pix_area
+
+    def _check_var_array(self, data_model, array_name):
+        data = getattr(data_model, array_name, None)
+        if data is None or data.size == 0:
+            log.debug(
+                f"No data for '{array_name}' for model "
+                f"{repr(data_model.meta.filename)}. Skipping ..."
+            )
+            return False
+        elif data.shape != data_model.data.shape:
+            log.warning(
+                f"Data shape mismatch for '{array_name}' for model "
+                f"{repr(data_model.meta.filename)}. Skipping ..."
+            )
+            return False
+        return True
+
+    def extra_pre_resample_setup(self):
+        self._var_rnoise_sum = np.full(self._output_array_shape, np.nan)
+        self._var_poisson_sum = np.full(self._output_array_shape, np.nan)
+        self._var_flat_sum = np.full(self._output_array_shape, np.nan)
+        # self._total_weight_var_rnoise = np.zeros(self._output_array_shape)
+        self._total_weight_var_poisson = np.zeros(self._output_array_shape)
+        self._total_weight_var_flat = np.zeros(self._output_array_shape)
+
+    def post_process_resample_model(self, data_model, driz_init_kwargs, add_image_kwargs):
+        log.info("Resampling variance components")
+
+        # create resample objects for the three variance arrays:
+        driz_init_kwargs = {
+            'kernel': self.kernel,
+            'fillval': np.nan,
+            'out_shape': self._output_array_shape,
+            # 'exptime': 1.0,
+            'no_ctx': True,
+        }
+        driz_rnoise = Drizzle(**driz_init_kwargs)
+        driz_poisson = Drizzle(**driz_init_kwargs)
+        driz_flat = Drizzle(**driz_init_kwargs)
+
+        # Resample read-out noise and compute weight map for variance arrays
+        if self._check_var_array(data_model, 'var_rnoise'):
+            data = np.sqrt(data_model.var_rnoise)
+            driz_rnoise.add_image(data, **add_image_kwargs)
+            var = driz_rnoise.out_img
+            np.square(var, out=var)
+
+            weight_mask = var > 0
+
+            # Set the weight for the image from the weight type
+            if self.weight_type == "ivm":
+                weight_mask = var > 0
+                weight = np.ones(self._output_array_shape)
+                weight[weight_mask] = np.reciprocal(var[weight_mask])
+                weight_mask &= (weight > 0.0)
+                # Add the inverse of the resampled variance to a running sum.
+                # Update only pixels (in the running sum) with valid new values:
+                self._var_rnoise_sum[weight_mask] = np.nansum(
+                    [
+                        self._var_rnoise_sum[weight_mask],
+                        weight[weight_mask]
+                    ],
+                    axis=0
+                )
+            elif self.weight_type == "exptime":
+                weight = np.full(
+                    self._output_array_shape,
+                    get_tmeasure(data_model)[0],
+                )
+                weight_mask = np.ones(self._output_array_shape, dtype=bool)
+                self._var_rnoise_sum = np.nansum(
+                    [self._var_rnoise_sum, weight],
+                    axis=0
+                )
+            else:
+                weight = np.ones(self._output_array_shape)
+                weight_mask = np.ones(self._output_array_shape, dtype=bool)
+                self._var_rnoise_sum = np.nansum(
+                    [self._var_rnoise_sum, weight],
+                    axis=0
+                )
+        else:
+            weight = np.ones(self._output_array_shape)
+            weight_mask = np.ones(self._output_array_shape, dtype=bool)
+
+        if self._check_var_array(data_model, 'var_poisson'):
+            data = np.sqrt(data_model.var_poisson)
+            driz_poisson.add_image(data, **add_image_kwargs)
+            var = driz_poisson.out_img
+            np.square(var, out=var)
+
+            mask = (var > 0) & weight_mask
+
+            # Add the inverse of the resampled variance to a running sum.
+            # Update only pixels (in the running sum) with valid new values:
+            self._var_poisson_sum[mask] = np.nansum(
+                [
+                    self._var_poisson_sum[mask],
+                    var[mask] * weight[mask] * weight[mask]
+                ],
+                axis=0
+            )
+            self._total_weight_var_poisson[mask] += weight[mask]
+
+        if self._check_var_array(data_model, 'var_flat'):
+            data = np.sqrt(data_model.var_flat)
+            driz_flat.add_image(data, **add_image_kwargs)
+            var = driz_flat.out_img
+            np.square(var, out=var)
+
+            mask = (var > 0) & weight_mask
+
+            # Add the inverse of the resampled variance to a running sum.
+            # Update only pixels (in the running sum) with valid new values:
+            self._var_flat_sum[mask] = np.nansum(
+                [
+                    self._var_flat_sum[mask],
+                    var[mask] * weight[mask] * weight[mask]
+                ],
+                axis=0
+            )
+            self._total_weight_var_flat[mask] += weight[mask]
+
+    def finalize_resample(self):
+        # We now have a sum of the weighted resampled variances.
+        # Divide by the total weights, squared, and set in the output model.
+        # Zero weight and missing values are NaN in the output.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "invalid value*", RuntimeWarning)
+            warnings.filterwarnings("ignore", "divide by zero*", RuntimeWarning)
+
+            odt = self._output_model.data.dtype
+
+            # readout noise
+            np.reciprocal(self._var_rnoise_sum, out=self._var_rnoise_sum)
+            self._output_model.var_rnoise = self._var_rnoise_sum.astype(dtype=odt)
+
+            # Poisson noise
+            for _ in range(2):
+                np.divide(
+                    self._var_poisson_sum,
+                    self._total_weight_var_poisson,
+                    out=self._var_poisson_sum
+                )
+            self._output_model.var_poisson = self._var_poisson_sum.astype(dtype=odt)
+
+            # flat's noise
+            for _ in range(2):
+                np.divide(
+                    self._var_flat_sum,
+                    self._total_weight_var_flat,
+                    out=self._var_flat_sum
+                )
+            self._output_model.var_flat = self._var_flat_sum.astype(dtype=odt)
+
+            # compute total error:
+            vars = np.array(
+                [
+                    self._var_rnoise_sum,
+                    self._var_poisson_sum,
+                    self._var_flat_sum,
+                ]
+            )
+            all_nan_mask = np.any(np.isnan(vars), axis=0)
+            self._output_model.err = np.sqrt(np.nansum(vars, axis=0)).astype(dtype=odt)
+            self._output_model.err[all_nan_mask] = np.nan
+
+        del vars
+        del self._var_rnoise_sum
+        del self._var_poisson_sum
+        del self._var_flat_sum
+        # del self._total_weight_var_rnoise
+        del self._total_weight_var_poisson
+        del self._total_weight_var_flat
+
+        # update meta for the output model:
+        self._output_model.meta.cal_step.resample = 'COMPLETE'
+        _update_fits_wcsinfo(self._output_model)
+        util.update_s_region_imaging(self._output_model)
+        self._output_model.meta.asn.pool_name = self._input_models.asn_pool_name
+        self._output_model.meta.asn.table_name = self._input_models.asn_table_name
+        self._output_model.meta.resample.pixel_scale_ratio = self._pixel_scale_ratio
+        self._output_model.meta.resample.pixfrac = self.pixfrac
+
+    # TODO: Not sure about funct. signature and also I don't like it needs
+    # to open input files again. Should we store meta of all inputs?
+    # Should blendmeta.blendmodels be redesigned to blend one meta at a time?
+    def blend_output_metadata(self, output_model):
+        """ Create new output metadata based on blending all input metadata. """
+
+        if not self._blendheaders:
+            return
+
+        ignore_list = [
+            'meta.photometry.pixelarea_steradians',
+            'meta.photometry.pixelarea_arcsecsq',
+        ]
+
+        log.info(f'Blending metadata for {self._output_filename}')
+        blendmeta.blendmodels(
+            output_model,
+            inputs=self._input_models,
+            output=self._output_filename,
+            ignore=ignore_list
+        )
+
+
+class ResampleJWSTSingle(ResampleJWSTModelIO, ResampleSingle):
+    pass
+
+
+def _update_fits_wcsinfo(model):
+    """
+    Update FITS WCS keywords of the resampled image.
+    """
+    # Delete any SIP-related keywords first
+    pattern = r"^(cd[12]_[12]|[ab]p?_\d_\d|[ab]p?_order)$"
+    regex = re.compile(pattern)
+
+    keys = list(model.meta.wcsinfo.instance.keys())
+    for key in keys:
+        if regex.match(key):
+            del model.meta.wcsinfo.instance[key]
+
+    # Write new PC-matrix-based WCS based on GWCS model
+    transform = model.meta.wcs.forward_transform
+    model.meta.wcsinfo.crpix1 = -transform[0].offset.value + 1
+    model.meta.wcsinfo.crpix2 = -transform[1].offset.value + 1
+    model.meta.wcsinfo.cdelt1 = transform[3].factor.value
+    model.meta.wcsinfo.cdelt2 = transform[4].factor.value
+    model.meta.wcsinfo.ra_ref = transform[6].lon.value
+    model.meta.wcsinfo.dec_ref = transform[6].lat.value
+    model.meta.wcsinfo.crval1 = model.meta.wcsinfo.ra_ref
+    model.meta.wcsinfo.crval2 = model.meta.wcsinfo.dec_ref
+    model.meta.wcsinfo.pc1_1 = transform[2].matrix.value[0][0]
+    model.meta.wcsinfo.pc1_2 = transform[2].matrix.value[0][1]
+    model.meta.wcsinfo.pc2_1 = transform[2].matrix.value[1][0]
+    model.meta.wcsinfo.pc2_2 = transform[2].matrix.value[1][1]
+    model.meta.wcsinfo.ctype1 = "RA---TAN"
+    model.meta.wcsinfo.ctype2 = "DEC--TAN"
+
+    # Remove no longer relevant WCS keywords
+    rm_keys = [
+        'v2_ref',
+        'v3_ref',
+        'ra_ref',
+        'dec_ref',
+        'roll_ref',
+        'v3yangle',
+        'vparity',
+    ]
+    for key in rm_keys:
+        if key in model.meta.wcsinfo.instance:
+            del model.meta.wcsinfo.instance[key]
+
+
+####################################################
+#  Code below was left for spectral data for now   #
+####################################################
 
 class ResampleData:
     """

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -351,7 +351,6 @@ class ResampleData:
                 deleted from memory. Default value is `True` to keep
                 all products in memory.
         """
-        assert False
         self.output_dir = None
         self.output_filename = output
         if output is not None and '.fits' not in str(output):

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -42,7 +42,8 @@ class ResampleJWSTModelIO(ResampleModelIO):
         raise NotImplementedError()
 
     def close_model(self, model):
-        model.close()
+        self.save_model(model)
+        # model.close()
 
     def save_model(self, model):
         if model.meta.filename:

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -97,13 +97,14 @@ class ResampleStep(Step):
 
         # Setup drizzle-related parameters
         kwargs = self.get_drizpars()
+        kwargs.pop('blendheaders', None)
 
         # Call the resampling routine
         # resamp = resample.ResampleData(input_models, output=output, **kwargs)
         # result = resamp.do_drizzle(input_models)
 
         if self.single:
-            resamp = resample.ResampleJWSTSingle(input_models, output=output, **kwargs)
+            resamp = resample.ResampleJWSTSingle(input_models, **kwargs)
         else:
             resamp = resample.ResampleJWSTCoAdd(input_models, output=output, **kwargs)
         resamp.run()

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -67,17 +67,18 @@ def make_output_wcs(input_models, ref_wcs=None,
         WCS object, with defined domain, covering entire set of input frames
     """
     if ref_wcs is None:
+        wcslist = []
         with input_models:
-            wcslist = []
-            for i, model in enumerate(input_models):
+            for model in input_models:
                 w = model.meta.wcs
                 if w.bounding_box is None:
                     w.bounding_box = wcs_bbox_from_shape(model.data.shape)
+                if not wcslist:
+                    ref_wcsinfo = model.meta.wcsinfo.instance
+                    ref_wcs = w
+                    naxes = w.output_frame.naxes
                 wcslist.append(w)
-                if i == 0:
-                    example_model = model
                 input_models.shelve(model)
-        naxes = wcslist[0].output_frame.naxes
 
         if naxes != 2:
             msg = ("Output WCS needs 2 spatial axes "
@@ -87,7 +88,7 @@ def make_output_wcs(input_models, ref_wcs=None,
         output_wcs = util.wcs_from_footprints(
             wcslist,
             ref_wcs=wcslist[0],
-            ref_wcsinfo=example_model.meta.wcsinfo.instance,
+            ref_wcsinfo=ref_wcsinfo,
             pscale_ratio=pscale_ratio,
             pscale=pscale,
             rotation=rotation,

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -17,7 +17,13 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-__all__ = ['decode_context']
+__all__ = ['decode_context', 'is_blank']
+
+
+def is_blank(val):
+    """ Determines whether or not a value is considered 'blank'.
+    """
+    return val in [None, '', ' ', 'None', 'INDEF']
 
 
 def make_output_wcs(input_models, ref_wcs=None,


### PR DESCRIPTION
This PR add the common resample code used by both JWST and Roman pipelines to stcal. Also, for the first time, this PR adopts the new `drizzle` API from https://github.com/spacetelescope/drizzle/pull/134 for the resample code used in the pipelines. For now only imaging mode was switched to the new code

This work is related to https://jira.stsci.edu/browse/AL-835

The code in this PR requires the code from https://github.com/spacetelescope/stcal/pull/279 and https://github.com/spacetelescope/drizzle/pull/134 be installed.

At this moment this is a very rough draft for illustration purpose. It should run with default arguments (except input_models and output file name can be specified; everything else is not guaranteed to work). There are no unit/regression tests and documentation may not match the code. Also, for now I kept the old `ResampleData` code to allow resampling of spectral data to work with the old code.

Example:
```python
from stdatamodels.jwst.datamodels import ModelContainer
from jwst.resample import ResampleStep
from jwst import resample as jr
step = ResampleStep(ModelContainer(['jw01536070001_0210l_00001_nis_cal.fits']))
step.call(f, single=False)
```

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
