### PR TITLE
Update log messages containing newlines

### DIFF
--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -542,7 +542,8 @@ def matrix_operations(img, model, flux=None, linfit=False, dqm=None):
     flatimg = img.reshape(np.shape(img)[0] * np.shape(img)[1])
     flatdqm = dqm.reshape(np.shape(img)[0] * np.shape(img)[1])
     log.info("fringefitting.leastsqnrm.matrix_operations(): ")
-    log.info(f"\timg {img.shape:} \n\tdqm {dqm.shape:}")
+    log.info(f"\timg {img.shape:}")
+    log.info(f"\tdqm {dqm.shape:}")
     log.info(
         f"\tL x W = {img.shape[0]:d} x {img.shape[1]:d} = {img.shape[0] * img.shape[1]:d}",
     )
@@ -550,7 +551,8 @@ def matrix_operations(img, model, flux=None, linfit=False, dqm=None):
     log.info(f"\tflatdqm {flatdqm.shape:}")
 
 
-    log.info("\n\ttype(dqm) %s", type(dqm))
+    log.info("")
+    log.info("\ttype(dqm) %s", type(dqm))
     if dqm is not None:
         nanlist = np.where(flatdqm)  # where DO_NOT_USE up.
     else:

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -118,7 +118,8 @@ class AssignWcsStep(Step):
 
             except (ValueError, RuntimeError) as e:
                 log.warning("Failed to update 'meta.wcsinfo' with FITS SIP "
-                            f'approximation. Reported error is:\n"{e.args[0]}"')
+                            "approximation. Reported error is:")
+                log.warning(f'"{e.args[0]}"')
         else:  # WFSS modes
             try:
                 # A bounding_box is needed for the imaging WCS
@@ -137,6 +138,7 @@ class AssignWcsStep(Step):
                                  )
             except (ValueError, RuntimeError) as e:
                 log.warning("Failed to update 'meta.wcsinfo' with FITS SIP "
-                            f'approximation. Reported error is:\n"{e.args[0]}"')
+                            "approximation. Reported error is:")
+                log.warning(f'"{e.args[0]}"')
 
         return result

--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -198,7 +198,8 @@ class Association(MutableMapping):
         try:
             jsonschema.validate(asn_data, asn_schema)
         except (AttributeError, jsonschema.ValidationError) as err:
-            logger.debug('Validation failed:\n%s', err)
+            logger.debug('Validation failed:')
+            logger.debug(str(err))
             raise AssociationNotValidError('Validation failed') from err
 
         # Validate no path data for expnames

--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -100,8 +100,8 @@ class DarkCurrentStep(Step):
             if np.sum(dark_model.average_dark_current) == 0.0:
                 input_model.average_dark_current[:, :] = dark_model.meta.exposure.average_dark_current
             elif np.shape(input_model.average_dark_current) != np.shape(dark_model.average_dark_current):
-                self.log.warning("DarkModel average_dark_current does not match shape of data.\n"
-                                 "Dark current from reference file cannot be applied.")
+                self.log.warning("DarkModel average_dark_current does not match shape of data.")
+                self.log.warning("Dark current from reference file cannot be applied.")
             else:
                 input_model.average_dark_current = dark_model.average_dark_current
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -805,13 +805,12 @@ def sanity_check_limits(
     """
     if (ap_wcs.xstart >= ap_ref.xstop or ap_wcs.xstop <= ap_ref.xstart or
             ap_wcs.ystart >= ap_ref.ystop or ap_wcs.ystop <= ap_ref.ystart):
-        log.warning(
-            f"The WCS bounding box is outside the aperture:\n\t"
-            f"aperture: {ap_ref.xstart}, {ap_ref.xstop}, {ap_ref.ystart}, {ap_ref.ystop}\n\t"
-            f"wcs: {ap_wcs.xstart}, {ap_wcs.xstop}, {ap_wcs.ystart}, {ap_wcs.ystop}\n"
-            f"so the wcs bounding box will be ignored."
-        )
-
+        log.warning("The WCS bounding box is outside the aperture:")
+        log.warning(f"\taperture: {ap_ref.xstart}, {ap_ref.xstop}, "
+                    f"{ap_ref.ystart}, {ap_ref.ystop}")
+        log.warning(f"\twcs: {ap_wcs.xstart}, {ap_wcs.xstop}, "
+                    f"{ap_wcs.ystart}, {ap_wcs.ystop}")
+        log.warning("so the wcs bounding box will be ignored.")
         flag = False
     else:
         flag = True

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -269,8 +269,8 @@ def extract1d(image, var_poisson, var_rnoise, var_flat, lambdas, disp_range,
             elif len(bkg_model) < bkg_order:
                 log.debug(f"Not enough valid pixels to determine background "
                           f"with the required order for lambda={lam:.6f} "
-                          f"(column {x:d})\n"
-                          f"Lowering background order to {len(bkg_model)}")
+                          f"(column {x:d})")
+                log.debug(f"Lowering background order to {len(bkg_model)}")
 
         # Extract the source, and optionally subtract background using the
         # fit to the background for this column.  Even if

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -603,9 +603,9 @@ def add_wcs(filename, allow_any_file=False, force_level1bmodel=False,
 
     try:
         if type(model) not in EXPECTED_MODELS:
-            logger.warning(f'Input {model} is not of an expected type (uncal, rate, rateints)'
-                           '\n    Updating pointing may have no effect or detrimental effects on the WCS information,'
-                           '\n    especially if the input is the result of Level2b or higher calibration.')
+            logger.warning(f'Input {model} is not of an expected type (uncal, rate, rateints)')
+            logger.warning('    Updating pointing may have no effect or detrimental effects on the WCS information,')
+            logger.warning('    especially if the input is the result of Level2b or higher calibration.')
             if not allow_any_file:
                 raise TypeError(f'Input model {model} is not one of {EXPECTED_MODELS} and `allow_any_file` is `False`.'
                                 '\n\tFailing WCS processing.')
@@ -814,10 +814,10 @@ def update_wcs_from_fgs_guiding(model, t_pars, default_roll_ref=0.0, default_vpa
         model, t_pars, default_roll_ref, default_vparity, default_v3yangle
     )
 
-    logger.info('WCS info:'
-                f'\n\tcrpix1: {crpix1} crpix2: {crpix2}'
-                f'\n\tcrval1: {crval1} crval2: {crval2}'
-                f'\n\tpc_matrix: {pc_matrix}')
+    logger.info('WCS info:')
+    logger.info(f'\tcrpix1: {crpix1} crpix2: {crpix2}')
+    logger.info(f'\tcrval1: {crval1} crval2: {crval2}')
+    logger.info(f'\tpc_matrix: {pc_matrix}')
 
     model.meta.wcsinfo.crpix1 = crpix1
     model.meta.wcsinfo.crpix2 = crpix2
@@ -1242,8 +1242,8 @@ def calc_transforms_track_tr_202111(t_pars: TransformParameters):
     # Check on telemetry for FGS ID. If invalid, use either user-specified or default to 1.
     fgsid = t_pars.pointing.fgsid
     if fgsid not in FGSIDS:
-        logger.warning(f'Method {t_pars.method} requires a valid FGS ID in telementry.'
-                       '\nHowever telemetry reports an invalid id of {fgsid}')
+        logger.warning(f'Method {t_pars.method} requires a valid FGS ID in telementry.')
+        logger.warning('However telemetry reports an invalid id of {fgsid}')
         if t_pars.fgsid in FGSIDS:
             fgsid = t_pars.fgsid
             logger.warning(f'Using user-specified ID of {fgsid}')

--- a/jwst/lib/tests/stp_v1.py
+++ b/jwst/lib/tests/stp_v1.py
@@ -111,12 +111,10 @@ def add_wcs(filename):
         dec = pheader['TARG_DEC']
         roll = 0
 
-        logger.warning(
-            'Cannot retrieve telescope pointing.'
-            '\n{}'
-            '\nUsing TARG_RA={}, TARG_DEC={} and PA_V3=0 '
-            'to set pointing.'.format(exception, ra, dec)
-        )
+        logger.warning('Cannot retrieve telescope pointing.')
+        logger.warning(str(exception))
+        logger.warning(f'Using TARG_RA={ra}, TARG_DEC={dec} and '
+                       f'PA_V3=0 to set pointing.')
 
         local_roll = compute_local_roll(roll, ra, dec, v2ref, v3ref)
         wcsinfo = (ra, dec, local_roll)
@@ -136,10 +134,8 @@ def add_wcs(filename):
         v1_ra_deg, v1_dec_deg, v3_pa_deg = vinfo
         local_roll = compute_local_roll(v3_pa_deg, crval1, crval2, v2ref, v3ref)
 
-        logger.info(
-            'Computed coordinates from quaternions:'
-            '\n\tRA = {} DEC={} PA_V3={}'.format(crval1, crval2, v3_pa_deg)
-        )
+        logger.info('Computed coordinates from quaternions:')
+        logger.info(f'\tRA = {crval1} DEC={crval2} PA_V3={v3_pa_deg}')
 
     pheader['RA_V1'] = v1_ra_deg
     pheader['DEC_V1'] = v1_dec_deg
@@ -339,11 +335,9 @@ def get_pointing(obsstart, obsend, result_type='first'):
     This will need be re-examined when more information is
     available.
     """
-    logger.info(
-        'Determining pointing between observations times (mjd):'
-        '\n\tobsstart = {}'
-        '\n\tobsend = {}'.format(obsstart, obsend)
-    )
+    logger.info('Determining pointing between observations times (mjd):')
+    logger.info(f'\tobsstart = {obsstart}')
+    logger.info(f'\tobsend = {obsend}')
     try:
         engdb = ENGDB_Service()
     except Exception as exception:

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -230,16 +230,18 @@ class Spec2Pipeline(Pipeline):
                 assign_wcs_exception = exception
             if assign_wcs_exception is not None or \
                calibrated.meta.cal_step.assign_wcs != 'COMPLETE':
-                message = (
-                    'Assign_wcs processing was skipped.'
-                    '\nAborting remaining processing for this exposure.'
-                    '\nNo output product will be created.'
+                messages = (
+                    'Assign_wcs processing was skipped.',
+                    'Aborting remaining processing for this exposure.',
+                    'No output product will be created.'
                 )
                 if self.assign_wcs.skip:
-                    self.log.warning(message)
+                    for message in messages:
+                        self.log.warning(message)
                     return
                 else:
-                    self.log.error(message)
+                    for message in messages:
+                        self.log.error(message)
                     if assign_wcs_exception is not None:
                         raise assign_wcs_exception
                     else:

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -59,7 +59,7 @@ class PixelReplaceStep(Step):
                 self.log.debug('Input is a ModelContainer.')
             else:
                 self.log.error(f'Input is of type {str(type(input_model))} for which')
-                self.log.error('pixel_replace does not have an algorithm.\n')
+                self.log.error('pixel_replace does not have an algorithm.')
                 self.log.error('Pixel replacement will be skipped.')
                 input_model.meta.cal_step.pixel_replace = 'SKIPPED'
                 return input_model
@@ -98,7 +98,7 @@ class PixelReplaceStep(Step):
                         self.log.debug('Input is a {model.meta.model_type}.')
                     else:
                         self.log.error(f'Input is of type {model.meta.model_type} for which')
-                        self.log.error('pixel_replace does not have an algorithm.\n')
+                        self.log.error('pixel_replace does not have an algorithm.')
                         self.log.error('Pixel replacement will be skipped.')
                         model.meta.cal_step.pixel_replace = 'SKIPPED'
                         run_pixel_replace = False

--- a/jwst/scripts/adjust_wcs.py
+++ b/jwst/scripts/adjust_wcs.py
@@ -235,8 +235,8 @@ def main():
 
     if wcs_pars == [0.0, 0.0, 0.0, 1.0]:
         logger.info(
-            "All WCS adjustment parameters ('ra_delta', 'dec_delta',"
-            "roll_delta, and scale_factor) have default values"
+            "All WCS adjustment parameters ('ra_delta', 'dec_delta', "
+            "'roll_delta', and 'scale_factor') have default values "
             "(identical transformation)."
         )
         logger.info("Nothing to do. Quitting.")
@@ -265,10 +265,9 @@ def main():
                 npoints=64
             )
         except (ValueError, RuntimeError) as e:
-            logger.warning(
-                "Failed to update 'meta.wcsinfo' with FITS SIP "
-                f'approximation. Reported error is:\n"{e.args[0]}"'
-            )
+            logger.warning("Failed to update 'meta.wcsinfo' with "
+                           "FITS SIP approximation. Reported error is:")
+            logger.warning(f'"{e.args[0]}"')
 
         if options.update:
             data_model.save(fname, overwrite=True)

--- a/jwst/scripts/set_telescope_pointing.py
+++ b/jwst/scripts/set_telescope_pointing.py
@@ -166,7 +166,9 @@ def main():
 
     # Calculate WCS for all inputs.
     for filename in args.exposure:
-        logger.info('\n------' 'Setting pointing for {}'.format(filename))
+        logger.info("")
+        logger.info('------')
+        logger.info('Setting pointing for {}'.format(filename))
 
         # Create path for saving the transforms.
         transform_path = None

--- a/jwst/scripts/v1_calculate.py
+++ b/jwst/scripts/v1_calculate.py
@@ -94,12 +94,11 @@ def main():
             logger.info(f'Retrieving V1 over the time span {obsstart.isot} - {obsend.isot}')
             input_as_files = False
             if args.pointing != 'all':
-                logger.warning(
-                    'V1 pointings have been requested over a time range.'
-                    ' However, the \'pointing\' option is not \'all\'.'
-                    '\nThere will only be a single result returned. Is this what was desired?'
-                    '\nSuggestion: Use \'--pointing=all\''
-                )
+                logger.warning("V1 pointings have been requested over a time range. "
+                               "However, the 'pointing' option is not 'all'.")
+                logger.warning('There will only be a single result returned. '
+                               'Is this what was desired?')
+                logger.warning("Suggestion: Use '--pointing=all'")
     else:
         input_as_files = True
 

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -356,9 +356,9 @@ class TweakRegStep(Step):
                             crpix=None
                         )
                     except (ValueError, RuntimeError) as e:
-                        msg = f"Failed to update 'meta.wcsinfo' with FITS SIP \
-                            approximation. Reported error is: \n {e.args[0]}"
-                        self.log.warning(msg)
+                        self.log.warning("Failed to update 'meta.wcsinfo' with FITS SIP "
+                                         "approximation. Reported error is:")
+                        self.log.warning(f'"{e.args[0]}"')
             record_step_status(image_model, "tweakreg", success=True)
 
         return image_model


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR updates any log messages currently containing newlines, replacing them instead with multiple log messages.  This is a pre-requisite to removing the problematic MultiLineLogger (e.g. #8694), which automatically splits these messages into multiple log messages.

To find these messages, I reviewed every instance of '\n' in the jwst code base and updated code for any that appeared in log messages.  I have tested most of the changes from the command line to make sure they look right, and will run regression tests to make sure they don't break anything.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] ~added entry in `CHANGES.rst` within the relevant release section~
- [ ] ~updated or added relevant tests~
- [ ] ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
