### PR TITLE
JP-3669: 'OLS' Conditional Read Noise Recalculation for CHARGELOSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,14 +84,8 @@ set_telescope_pointing
 ramp_fitting
 ------------
 
-- The STCAL ramp fitting ``OLS_C`` algorithm has been modified to handle the
-  read noise variance recalculation for CHARGELOSS flagging.  Because of this
-  the JWST ramp fitting step code read noise recalculation should only be run
-  when the ``OLS`` algorithm, which runs the legacy python code for ramp
-  fitting.  Running the step code read noise recalculation when running the
-  ``OLS_C`` algorithm incorrectly runs the recalcuation twice.  Because of this
-  the JWST step code has been modified to account for the change in STCAL.
-  [#8697, spacetelescope/stcal#278]
+- Moved the read noise variance recalculation for CHARGELOSS flagging to the C
+  implementation, when the algorithm is ``OLS_C``. [#8697, spacetelescope/stcal#278]
 
 
 resample_spec
@@ -127,6 +121,14 @@ scripts
 
 - Removed many non-working and out-dated scripts. Including
   many scripts that were replaced by ``strun``. [#8619]
+
+set_telescope_pointing
+----------------------
+
+- replace usage of ``copy_arrays=True`` with ``memmap=False`` [#8660]
+
+- Refactored separate modes into submodules instead of inheriting from a base class.
+  Moved non-JWST-specific code to stcal. [#8613]
 
 stpipe
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -184,9 +184,6 @@ set_telescope_pointing
 
 - replace usage of ``copy_arrays=True`` with ``memmap=False`` [#8660]
 
-- Refactored separate modes into submodules instead of inheriting from a base class.
-  Moved non-JWST-specific code to stcal. [#8613]
-
 skymatch
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,11 +84,14 @@ set_telescope_pointing
 ramp_fitting
 ------------
 
-- Updating the ramp fitting work flow for the read noise variance calculation
-  for ramps containing CHARGELOSS flags.  When running the ``OLS_C`` ramp
-  fitting algorith, this recalculation is being done in the C-extension, so
-  the step code handling this will produce errors.  The step code now runs only
-  when the ``OLS`` algorithm is selected for ramp fitting.[#8697]
+- The STCAL ramp fitting ``OLS_C`` algorithm has been modified to handle the
+  read noise variance recalculation for CHARGELOSS flagging.  Because of this
+  the JWST ramp fitting step code read noise recalculation should only be run
+  when the ``OLS`` algorithm, which runs the legacy python code for ramp
+  fitting.  Running the step code read noise recalculation when running the
+  ``OLS_C`` algorithm incorrectly runs the recalcuation twice.  Because of this
+  the JWST step code has been modified to account for the change in STCAL.
+  [#8697, spacetelescope/stcal#278]
 
 
 resample_spec

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,17 @@ set_telescope_pointing
 
 - replace usage of ``copy_arrays=True`` with ``memmap=False`` [#8660]
 
+
+ramp_fitting
+------------
+
+- Updating the ramp fitting work flow for the read noise variance calculation
+  for ramps containing CHARGELOSS flags.  When running the ``OLS_C`` ramp
+  fitting algorith, this recalculation is being done in the C-extension, so
+  the step code handling this will produce errors.  The step code now runs only
+  when the ``OLS`` algorithm is selected for ramp fitting.[#8697]
+
+
 resample_spec
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -182,7 +182,7 @@ scripts
 set_telescope_pointing
 ----------------------
 
-- replace usage of ``copy_arrays=True`` with ``memmap=False`` [#8660]
+- Replace usage of ``copy_arrays=True`` with ``memmap=False`` [#8660]
 
 skymatch
 --------


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3669](https://jira.stsci.edu/browse/JP-3669)

<!-- describe the changes comprising this PR here -->
This PR updates the code flow for read noise calculation.  For ramps that have CHARGELOSS flagging, when calling the "OLS_C" algorithm, this recalculation is done in the C-extension in the ramp fitting code in STCAL, so the step code calculations defined in the JWST step code no longer needs to be run and will result in errors if it is run.

The step code that handles the recalculation of the read noise for CHARGELOSS flags is now only done when the "OLS" algorithm is used.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
