### PR TITLE
Fix a typo in `load_custom_wcs`

### DIFF
--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -177,7 +177,7 @@ class ResampleStep(Step):
         with asdf.open(asdf_wcs_file) as af:
             wcs = deepcopy(af.tree["wcs"])
             wcs.pixel_area = af.tree.get("pixel_area", None)
-            wcs.array_shape = af.tree.get("pixel_shape", None)
+            wcs.pixel_shape = af.tree.get("pixel_shape", None)
             wcs.array_shape = af.tree.get("array_shape", None)
 
         if output_shape is not None:


### PR DESCRIPTION
This PR fixes a typo in `load_custom_wcs` from `array_shape` to `pixel_shape`.


**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
