### PR TITLE
JP-3702: Fix filenames for level3 NIRSpec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ assign_wcs
 - Moved `update_s_region_imaging`, `update_s_region_keyword`, and `wcs_from_footprints`
   into stcal. [#8624]
 
+associations
+------------
+
+- Restored slit name to level 3 product names for NIRSpec BOTS and background
+  fixed slit targets. [#8699]
+
 cube_build
 ----------
 

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -765,7 +765,7 @@ class DMSBaseMixin(ACIDMixin):
             else:
                 values.sort(key=str.lower)
                 value = format_list(values)
-                if value not in _EMPTY:
+                if value not in _EMPTY and value not in slit_names:
                     slit_names.append(value)
 
         # Build the string. Sort the elements in order to
@@ -773,9 +773,7 @@ class DMSBaseMixin(ACIDMixin):
         slit_names.sort(key=str.lower)
         slit_name = '-'.join(slit_names)
 
-        if slit_name == '':
-            slit_name = None
-
+        # Slit name may be empty string
         return slit_name
 
     def _get_subarray(self):

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -666,8 +666,10 @@ def dms_product_name_sources(asn):
 
 
 def dms_product_name_nrsfs_sources(asn):
-    """Produce source-based product names for
-       NIRSpec fixed-slit observations.
+    """Produce source-based product names for NIRSpec fixed-slit observations.
+
+    For this mode, the product names have a placeholder for the
+    slit name, to be filled in later by the pipeline.
 
     Parameters
     ---------

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -158,6 +158,10 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
 
         opt_elem = association._get_opt_element()
 
+        slit_name = association._get_slit_name()
+        if slit_name:
+            slit_name = '-' + slit_name
+
         exposure = association._get_exposure()
         if exposure:
             exposure = '-' + exposure
@@ -170,7 +174,7 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
             'jw{program}-{acid}'
             '_{target}'
             '_{instrument}'
-            '_{opt_elem}{subarray}'
+            '_{opt_elem}{slit_name}{subarray}'
         )
         product_name = product_name.format(
             program=association.data['program'],
@@ -178,6 +182,7 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
             target=target,
             instrument=instrument,
             opt_elem=opt_elem,
+            slit_name=slit_name,
             subarray=subarray,
             exposure=exposure
         )
@@ -673,10 +678,6 @@ def dms_product_name_nrsfs_sources(asn):
     instrument = asn._get_instrument()
 
     opt_elem = asn._get_opt_element()
-
-    slit_name = asn._get_slit_name()
-    if slit_name:
-        slit_name = '-' + slit_name
 
     subarray = asn._get_subarray()
     if subarray:

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -638,6 +638,10 @@ def dms_product_name_sources(asn):
 
     opt_elem = asn._get_opt_element()
 
+    slit_name = asn._get_slit_name()
+    if slit_name:
+        slit_name = '-' + slit_name
+
     subarray = asn._get_subarray()
     if subarray:
         subarray = '-' + subarray
@@ -646,7 +650,7 @@ def dms_product_name_sources(asn):
         'jw{program}-{acid}'
         '_{source_id}'
         '_{instrument}'
-        '_{opt_elem}{subarray}'
+        '_{opt_elem}{slit_name}{subarray}'
     )
     product_name = format_product(
         product_name_format,
@@ -654,6 +658,7 @@ def dms_product_name_sources(asn):
         acid=asn.acid.id,
         instrument=instrument,
         opt_elem=opt_elem,
+        slit_name=slit_name,
         subarray=subarray,
     )
 

--- a/jwst/associations/tests/test_level3_product_names.py
+++ b/jwst/associations/tests/test_level3_product_names.py
@@ -9,7 +9,7 @@ from jwst.associations.tests.helpers import (
     t_path,
 )
 
-from jwst.associations import (AssociationPool, generate)
+from jwst.associations import generate
 from jwst.associations.lib.dms_base import DMSAttrConstraint
 
 

--- a/jwst/associations/tests/test_level3_product_names.py
+++ b/jwst/associations/tests/test_level3_product_names.py
@@ -117,11 +117,27 @@ def test_multiple_optelems(pool_file):
         if asn['asn_rule'] != 'Asn_Lv3MIRMRS':
             m = re.match(LEVEL3_PRODUCT_NAME_REGEX, product_name)
             assert m is not None
-            try:
-                value = '-'.join(asn.constraints['opt_elem2'].found_values)
-            except KeyError:
-                value = None
-            if value in EMPTY:
-                assert '-' not in m.groupdict()['opt_elem']
-            else:
-                assert '-' in m.groupdict()['opt_elem']
+
+            # should always be an opt_elem
+            values = ['-'.join(asn.constraints['opt_elem'].found_values)]
+
+            # may be an opt_elem2, fixed slit or 2, or a subarray
+            for extra in ['opt_elem2', 'fxd_slit', 'fxd_slit2', 'subarray']:
+
+                # special rules for fixed slit for NRS FS:
+                # it gets a format placeholder instead of the value
+                if asn['asn_rule'] == 'Asn_Lv3NRSFSS':
+                    if extra == 'fxd_slit':
+                        values.append('{slit_name}')
+                        continue
+                    elif extra == 'fxd_slit2':
+                        continue
+
+                try:
+                    value = '-'.join(asn.constraints[extra].found_values)
+                except KeyError:
+                    value = ''
+                if value:
+                    values.append(value)
+
+            assert m.groupdict()['opt_elem'] == '-'.join(values)

--- a/jwst/associations/tests/test_level3_product_names.py
+++ b/jwst/associations/tests/test_level3_product_names.py
@@ -96,7 +96,7 @@ def test_level3_names(pool_file, global_constraints):
     rules = registry_level3_only(
         global_constraints=global_constraints
     )
-    pool = AssociationPool.read(pool_file)
+    pool = combine_pools(pool_file)
     asns = generate(pool, rules)
     for asn in asns:
         product_name = asn['products'][0]['name']
@@ -110,8 +110,8 @@ def test_level3_names(pool_file, global_constraints):
 
 def test_multiple_optelems(pool_file):
     rules = registry_level3_only()
-    pool = AssociationPool.read(pool_file)
-    asns = generate(pool, rules)
+    pool = combine_pools(pool_file)
+    asns = generate(pool, rules, finalize=False)
     for asn in asns:
         product_name = asn['products'][0]['name']
         if asn['asn_rule'] != 'Asn_Lv3MIRMRS':
@@ -137,7 +137,37 @@ def test_multiple_optelems(pool_file):
                     value = '-'.join(asn.constraints[extra].found_values)
                 except KeyError:
                     value = None
-                if value not in EMPTY:
+
+                # empty values and subarray = full are not recorded
+                if value not in EMPTY and value != 'full':
                     values.append(value)
 
             assert m.groupdict()['opt_elem'] == '-'.join(values)
+
+
+def test_tso3_names():
+    rules = registry_level3_only()
+    tso_pool = t_path('data/pool_021_tso.csv')
+    pool = combine_pools(tso_pool)
+    asns = generate(pool, rules, finalize=False)
+    for asn in asns:
+        product_name = asn['products'][0]['name']
+
+        m = re.match(LEVEL3_PRODUCT_NAME_REGEX, product_name)
+        assert m is not None
+
+        # there should always be an opt_elem
+        values = ['-'.join(asn.constraints['opt_elem'].found_values)]
+
+        # there may also be an opt_elem2, fixed slit or 2, or a subarray
+        for extra in ['opt_elem2', 'fxd_slit', 'fxd_slit2', 'subarray']:
+            try:
+                value = '-'.join(asn.constraints[extra].found_values)
+            except KeyError:
+                value = None
+
+            # empty values and subarray = full are not recorded
+            if value not in EMPTY and value != 'full':
+                values.append(value)
+
+        assert m.groupdict()['opt_elem'] == '-'.join(values)

--- a/jwst/associations/tests/test_level3_product_names.py
+++ b/jwst/associations/tests/test_level3_product_names.py
@@ -118,10 +118,10 @@ def test_multiple_optelems(pool_file):
             m = re.match(LEVEL3_PRODUCT_NAME_REGEX, product_name)
             assert m is not None
 
-            # should always be an opt_elem
+            # there should always be an opt_elem
             values = ['-'.join(asn.constraints['opt_elem'].found_values)]
 
-            # may be an opt_elem2, fixed slit or 2, or a subarray
+            # there may also be an opt_elem2, fixed slit or 2, or a subarray
             for extra in ['opt_elem2', 'fxd_slit', 'fxd_slit2', 'subarray']:
 
                 # special rules for fixed slit for NRS FS:
@@ -136,8 +136,8 @@ def test_multiple_optelems(pool_file):
                 try:
                     value = '-'.join(asn.constraints[extra].found_values)
                 except KeyError:
-                    value = ''
-                if value:
+                    value = None
+                if value not in EMPTY:
                     values.append(value)
 
             assert m.groupdict()['opt_elem'] == '-'.join(values)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3702](https://jira.stsci.edu/browse/JP-3702)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8688

<!-- describe the changes comprising this PR here -->
Restore slit names to level 3 filenames for NIRSpec products that do not get planned as fixed slit reductions.  This primarily impacts BOTS mode, which has a FXD_SLIT defined, but does not get planned for spec3 with Asn_Lv3NRSFSS rules: these data are planned for tso3 with Asn_Lv3TSO rules.  It also impacts background targets for fixed slit, planned with Asn_Lv3SpecAux rules.

In JP-3233 (#7879), association rules were changed for fixed slits to allow S200A1 and S200A2 targets to be reduced together in spec3.  Part of this change removed a check for fixed slit as one of the 'opt_elem' fields in the filename.  This had the unintended effect of removing the fixed slit from the name for BOTS and auxiliary NIRSpec data.

The fix here is to restore the check for FXD_SLIT in all level3 product names that might apply to NIRSpec data and add the value to the filename if present.

It looks like this regression was reported in the regression tests for JP-3233, e.g. the last entry in this report:
[test_against_standard_pool_010_spec_nirspec_lv2bkg](https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/915/testReport/jwst.regtest/test_associations_standards/_stable_deps__test_against_standard_pool_010_spec_nirspec_lv2bkg_/), but it was buried in some other expected changes.  There were also some unit tests for level3 product names, but they were not specific enough to catch this regression.

I have updated the unit tests (test_level3_product_names.py) to catch this case specifically, and verified that it fails on master and passes with this PR branch.  I think the regression tests should be sufficient as is.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
