### PR TITLE
TST: Use photutils nightly wheel

### DIFF
--- a/requirements-dev-thirdparty.txt
+++ b/requirements-dev-thirdparty.txt
@@ -5,10 +5,12 @@ git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-coordinates-schemas
 git+https://github.com/asdf-format/asdf-wcs-schemas
 
-# Use nightly astropy dev build
+# Use nightly Astropy dev builds
 git+https://github.com/astropy/asdf-astropy
-git+https://github.com/astropy/photutils
---extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
+--extra-index-url https://pypi.anaconda.org/astropy/simple
+pyerfa>=0.0.dev0
+astropy>=0.0.dev0
+photutils>=0.0.dev0
 
 # Use Bi-weekly numpy/scipy dev builds
 --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple


### PR DESCRIPTION
This PR takes advantage of https://github.com/astropy/photutils/pull/1834 . And might as well grab pyerfa-dev from the same place while you are at it?

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] ~added entry in `CHANGES.rst` within the relevant release section~
- [x] updated or added relevant tests
- [x] ~updated relevant documentation~
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [x] ~Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)~
