### PR TITLE
adjust tolerances for coron registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,11 @@ badpix_selfcal
 - Subtract pedestal dark when constructing min array across selfcal exposures
   for MIRI MRS data. [#8771]
 
+calwebb_coron3
+--------------
+
+- Tighten tolerance of psf alignment. [#8717]
+
 calwebb_detector1
 -----------------
 

--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -40,7 +40,8 @@ def align_fourierLSQ(reference, target, mask=None):
 
     init_pars = [0., 0., 1.]
     results, _ = optimize.leastsq(shift_subtract, init_pars,
-                                  args=(reference, target, mask))
+                                  args=(reference, target, mask),
+                                  xtol=1E-15, ftol=1E-15)
     return results
 
 

--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -41,7 +41,7 @@ def align_fourierLSQ(reference, target, mask=None):
     init_pars = [0., 0., 1.]
     results, _ = optimize.leastsq(shift_subtract, init_pars,
                                   args=(reference, target, mask),
-                                  #xtol=1E-12, ftol=1E-12,
+                                  xtol=1E-15, ftol=1E-15,
                                   )
     return results
 

--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -41,7 +41,8 @@ def align_fourierLSQ(reference, target, mask=None):
     init_pars = [0., 0., 1.]
     results, _ = optimize.leastsq(shift_subtract, init_pars,
                                   args=(reference, target, mask),
-                                  xtol=1E-15, ftol=1E-15)
+                                  #xtol=1E-12, ftol=1E-12,
+                                  )
     return results
 
 
@@ -166,7 +167,7 @@ def align_array(reference, target, mask=None, return_aligned=True):
 
     elif len(target.shape) == 3:
         nslices = target.shape[0]
-        shifts = np.empty((nslices, 3), dtype=float)
+        shifts = np.empty((nslices, 3), dtype=np.float64)
         if return_aligned:
             aligned = np.empty_like(target)
 
@@ -222,19 +223,19 @@ def align_models(reference, target, mask):
     # Compute the shifts of the PSF ("target") images relative to
     # the science ("reference") image in the first integration
     shifts = align_array(
-        reference.data[0].astype(np.float64),
-        target.data.astype(np.float64),
+        reference.data[0],
+        target.data,
         mask=mask.data, return_aligned=False)
 
     # Apply the shifts to the PSF images
     output_model.data = fourier_imshift(
-        target.data.astype(np.float64),
+        target.data,
         -shifts)
 
     # Apply the same shifts to the PSF error arrays, if they exist
     if target.err is not None:
         output_model.err = fourier_imshift(
-            target.err.astype(np.float64),
+            target.err,
             -shifts)
 
     # TODO: in the future we need to add shifts and other info (such as

--- a/jwst/regtest/test_miri_coron3.py
+++ b/jwst/regtest/test_miri_coron3.py
@@ -30,7 +30,7 @@ def test_miri_coron3_sci_exp(run_pipeline, suffix, exposure, fitsdiff_default_kw
     rtdata.output = output
     rtdata.get_truth("truth/test_miri_coron3/" + output)
 
-    fitsdiff_default_kwargs["atol"] = 1e-5
+    fitsdiff_default_kwargs["atol"] = 1e-2
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
@@ -45,6 +45,7 @@ def test_miri_coron3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
     rtdata.output = output
     rtdata.get_truth("truth/test_miri_coron3/" + output)
 
-    fitsdiff_default_kwargs['atol'] = 1e-5
+    fitsdiff_default_kwargs['atol'] = 1e-4
+    fitsdiff_default_kwargs['rtol'] = 1e-4
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_nircam_coron3.py
+++ b/jwst/regtest/test_nircam_coron3.py
@@ -32,7 +32,7 @@ def test_nircam_coron3_sci_exp(run_pipeline, suffix, obs, fitsdiff_default_kwarg
     rtdata.output = output
     rtdata.get_truth("truth/test_nircam_coron3/" + output)
 
-    fitsdiff_default_kwargs["atol"] = 1e-5
+    fitsdiff_default_kwargs["atol"] = 1e-2
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
@@ -63,6 +63,7 @@ def test_nircam_coron3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
     rtdata.output = output
     rtdata.get_truth("truth/test_nircam_coron3/" + output)
 
-    fitsdiff_default_kwargs['atol'] = 1e-5
+    fitsdiff_default_kwargs['atol'] = 1e-4
+    fitsdiff_default_kwargs['rtol'] = 1e-4
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()


### PR DESCRIPTION
This PR attempts to reduce the differences for coron3 results when run on different systems.

The changes are:
- remove casts from `float32` to `float64` and back from `float64` to `float32` in image registration
- tighten tolerances for `leastsq` fit in image registration
- relax tolerances for regtest result comparisons

I ran a (limited) jenkins run:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/1666/pipeline
and (limited) github actions run:
https://github.com/spacetelescope/RegressionTests/actions/runs/10511902948/attempts/1

comparisons of the results using the above tolerances pass. However, the regtests will fail comparison against the current truth files. I suggest that we:
- merge this PR (when approved)
- okify the regtest results (the jenkins runs should now pass)
- run the github actions tests

I believe these should pass although it is possible that follow-up changes will be needed as it's difficult to fully test this PR without generating new truth files. If it's preferable I could generate new truth files, put them in a different location on artifactory and run the jenkins and github actions jobs using those new truth files to judge the changes in this PR before the merge.

Full regtests runs for:
- jenkins: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1668/
- github actions: https://github.com/spacetelescope/RegressionTests/actions/runs/10513549517

Ignoring all the `miri_lrs` `mtimage` failures and the `miri_image` failure (which all look unrelated) the coron3 tests that fail on jenkins also fail on github actions:
- test_nircam_coron3_sci_exp[002-psfalign] 18 different pixels found (0.00% different).
- test_nircam_coron3_sci_exp[003-psfalign] 22 different pixels found (0.00% different).
- test_nircam_coron3_product[i2d] 30 different pixels found (0.02% different).
- test_miri_coron3_sci_exp[4-psfalign] 74000 different pixels found (0.76% different).
- test_miri_coron3_sci_exp[4-psfsub] 1813 different pixels found (0.56% different).
- test_miri_coron3_sci_exp[5-psfalign] 151570 different pixels found (1.57% different).
- test_miri_coron3_sci_exp[5-psfsub] 2384 different pixels found (0.74% different).
- test_miri_coron3_product[i2d]40259 different pixels found (46.80% different).

Pulling down these files and comparing them with tolerances matching the ones in this PR show no differences between jenkins and github actions.

Most differences with the truth files are small (<2%) except for coron3_product[i2d] which shows 46.80% different. Looking at the miri i2d file compared to the truth the differences are mostly small
<img width="582" alt="Screenshot 2024-08-22 at 5 48 49 PM" src="https://github.com/user-attachments/assets/62f3ccce-f551-4abc-b314-7a9205321359">
with the largest differences concentrated in the corner of the image (see the few pixels near the upper left):
<img width="581" alt="Screenshot 2024-08-22 at 5 50 21 PM" src="https://github.com/user-attachments/assets/86e18c2c-176e-4046-93f3-f0f486454e20">
which corresponds with extreme values present in both the truth:
<img width="554" alt="Screenshot 2024-08-22 at 5 52 40 PM" src="https://github.com/user-attachments/assets/9f91be99-804f-4806-b260-586feb7a64aa">

 and jenkins results (with this PR).
<img width="546" alt="Screenshot 2024-08-22 at 5 53 08 PM" src="https://github.com/user-attachments/assets/2464d836-f817-43c0-a68e-a978476ed8ed">

Looking at only the central 50-200 x 50-200 pixels the differences are much smaller
<img width="529" alt="Screenshot 2024-08-22 at 5 54 01 PM" src="https://github.com/user-attachments/assets/124ed0b6-8f77-44e7-bdb6-99971f4349d6">

but do show some structure.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
