### PR TITLE
JP-3547: Fix MIRI array sizing for multiple inputs and pixel ratio != 1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,7 +73,7 @@ resample_spec
 
 - Updated handling for the ``pixel_scale_ratio`` parameter to apply only to the
   spatial dimension, to match the sense of the parameter application to the
-  documented intent, and to conserve spectral flux when applied. [#8596]
+  documented intent, and to conserve spectral flux when applied. [#8596, #8727]
 
 - Implemented handling for the ``pixel_scale`` parameter, which was previously
   ignored for spectral resampling. [#8596]

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -509,6 +509,7 @@ class ResampleSpecData(ResampleData):
         all_wavelength = []
         all_ra_slit = []
         all_dec_slit = []
+        xstop = 0
 
         for im, model in enumerate(input_models):
             wcs = model.meta.wcs
@@ -700,10 +701,10 @@ class ResampleSpecData(ResampleData):
         else:
             pix_to_xtan.intercept = -0.5 * (x_size - 1) * pix_to_xtan.slope
 
-        # single model use size of x_tan_array
+        # single model: use size of x_tan_array
         # to be consistent with method before
         if len(input_models) == 1:
-            x_size = len(x_tan_array)
+            x_size = int(np.ceil(xstop))
 
         # define the output wcs
         transform = mapping | (pix_to_xtan & pix_to_ytan | undist2sky) & pix_to_wavelength
@@ -723,7 +724,7 @@ class ResampleSpecData(ResampleData):
         # compute the output array size in WCS axes order, i.e. (x, y)
         output_array_size = [0, 0]
         output_array_size[spectral_axis] = int(np.ceil(len(wavelength_array)))
-        output_array_size[spatial_axis] = int(np.ceil(x_size * self.pscale_ratio))
+        output_array_size[spatial_axis] = x_size
 
         # turn the size into a numpy shape in (y, x) order
         output_wcs.array_shape = output_array_size[::-1]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3547](https://jira.stsci.edu/browse/JP-3547)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Fixes an issue discovered during testing for #8596.

For MIRI, when there are multiple input files and pixel_scale_ratio is set to something other than 1.0, the output array size was being computed incorrectly: the pixel_scale_ratio was applied twice.  This PR fixes that issue and adds a unit test for the multiple input case.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] ~updated relevant documentation~
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
