### PR TITLE
JP-3649 Fix cube build error when called from mrs_imatch and add deprecated warning for mrs_imatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ cube_build
 
 - Removed direct setting of the ``self.skip`` attribute from within the step
   itself. [#8600]
+- Fixed a bug when cube_build was called from the mrs_imatch step. [#8728]
 
 documentation
 -------------
@@ -54,6 +55,11 @@ master_background
 
 - Either of ``"background"`` or ``"bkg"`` in slit name now defines the slit
   as a background slit, instead of ``"bkg"`` only. [#8600]
+
+mrs_imatch
+----------
+
+- Added a deprecation warning and set the default to skip=True for the step. [#8728] 
 
 outlier_detection
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ cube_build
 
 - Removed direct setting of the ``self.skip`` attribute from within the step
   itself. [#8600]
-- Fixed a bug when cube_build was called from the mrs_imatch step. [#8728]
+- Fixed a bug when ``cube_build`` was called from the ``mrs_imatch`` step. [#8728]
 
 documentation
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ cube_build
 
 - Removed direct setting of the ``self.skip`` attribute from within the step
   itself. [#8600]
+  
 - Fixed a bug when ``cube_build`` was called from the ``mrs_imatch`` step. [#8728]
 
 documentation

--- a/docs/jwst/mrs_imatch/description.rst
+++ b/docs/jwst/mrs_imatch/description.rst
@@ -8,6 +8,10 @@ Description
 
 Overview
 --------
+
+This step has been deprecated in JWST calibration pipeline version 11.1.
+The mrs_imatch step is skipped in the default running of the calwebb_spec3 pipeline.
+
 The ``mrs_imatch`` step "matches" image intensities of several input
 2D MIRI MRS images by fitting polynomials to cube intensities (cubes built
 from the input 2D images), in such a way as to minimize - in the least squares

--- a/docs/jwst/mrs_imatch/description.rst
+++ b/docs/jwst/mrs_imatch/description.rst
@@ -10,7 +10,7 @@ Overview
 --------
 
 This step has been deprecated in JWST calibration pipeline version 11.1.
-The mrs_imatch step is skipped in the default running of the calwebb_spec3 pipeline.
+The ``mrs_imatch`` step is skipped by default in the calwebb_spec3 pipeline.
 
 The ``mrs_imatch`` step "matches" image intensities of several input
 2D MIRI MRS images by fitting polynomials to cube intensities (cubes built

--- a/docs/jwst/mrs_imatch/description.rst
+++ b/docs/jwst/mrs_imatch/description.rst
@@ -9,8 +9,8 @@ Description
 Overview
 --------
 
-This step has been deprecated in JWST calibration pipeline version 11.1.
-The ``mrs_imatch`` step is skipped by default in the calwebb_spec3 pipeline.
+This step has been deprecated  and will be
+skipped by default in the calwebb_spec3 pipeline.
 
 The ``mrs_imatch`` step "matches" image intensities of several input
 2D MIRI MRS images by fitting polynomials to cube intensities (cubes built

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -826,7 +826,7 @@ class IFUCubeData():
 
                 coord1, coord2, corner_coord, wave, dwave, flux, err, slice_no, \
                     rois_pixel, roiw_pixel, weight_pixel, \
-                    softrad_pixel, scalerad_pixel = pixelresult
+                    softrad_pixel, scalerad_pixel, _, _ = pixelresult
 
                 build_cube = True
                 if wave is None:  # there is no valid data on the detector. Pixels are flagged as DO_NOT_USE.
@@ -870,6 +870,9 @@ class IFUCubeData():
                     linear = 0
                     if self.linear_wavelength:
                         linear = 1
+                        x_det = None
+                        y_det = None
+                        debug_cube = -1
                     result = cube_wrapper_driz(instrument, flag_dq_plane,
                                                start_region, end_region,
                                                self.overlap_partial, self.overlap_full,
@@ -878,7 +881,8 @@ class IFUCubeData():
                                                xi1, eta1, xi2, eta2, xi3, eta3, xi4, eta4,
                                                dwave,
                                                self.cdelt3_normal,
-                                               self.cdelt1, self.cdelt2, cdelt3_mean, linear)
+                                               self.cdelt1, self.cdelt2, cdelt3_mean, linear,
+                                               x_det, y_det, debug_cube)
 
                     spaxel_flux, spaxel_weight, spaxel_var, spaxel_iflux, _ = result
                     self.spaxel_flux = self.spaxel_flux + np.asarray(spaxel_flux, np.float64)

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -9,7 +9,6 @@ JWST pipeline step for image intensity matching for MIRI images.
 import numpy as np
 
 from jwst.datamodels import ModelContainer
-import warnings
 from .. stpipe import Step
 from wiimatch.match import match_lsq
 from astropy.stats import sigma_clipped_stats as sigclip

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -38,7 +38,7 @@ class MRSIMatchStep(Step):
 
         # Provide warning to user this code is deprecated
         self.log.warning('mrs_imatch is deprecated')
-        
+
         chm = {}
         all_models2d = ModelContainer(images)
         for m in all_models2d:

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -37,8 +37,8 @@ class MRSIMatchStep(Step):
     def process(self, images):
 
         # Provide warning to user this code is deprecated
-        warnings.warn("mrs_imatch deprecated", RuntimeWarning)
-
+        self.log.warning('mrs_imatch is deprecated')
+        
         chm = {}
         all_models2d = ModelContainer(images)
         for m in all_models2d:

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -9,7 +9,7 @@ JWST pipeline step for image intensity matching for MIRI images.
 import numpy as np
 
 from jwst.datamodels import ModelContainer
-
+import warnings
 from .. stpipe import Step
 from wiimatch.match import match_lsq
 from astropy.stats import sigma_clipped_stats as sigclip
@@ -29,16 +29,18 @@ class MRSIMatchStep(Step):
         # General sky matching parameters:
         bkg_degree = integer(min=0, default=1) # Degree of the polynomial for background fitting
         subtract = boolean(default=False) # subtract computed sky from 'images' cube data?
-
+        skip = boolean(default=True) # Step must be turned on by parameter reference or user
     """
 
     reference_file_types = []
 
     def process(self, images):
-        all_models2d = ModelContainer(images)
+
+        # Provide warning to user this code is deprecated
+        warnings.warn("mrs_imatch deprecated", RuntimeWarning)
 
         chm = {}
-
+        all_models2d = ModelContainer(images)
         for m in all_models2d:
             ch = m.meta.instrument.channel
             if ch not in chm:

--- a/jwst/mrs_imatch/tests/test_configuration.py
+++ b/jwst/mrs_imatch/tests/test_configuration.py
@@ -70,9 +70,22 @@ def test_imatch_background_subtracted(tmp_cwd, miri_dither_ch12):
     # test if background subtracted - raise error
     with pytest.raises(ValueError):
         step = MRSIMatchStep()
-        step.run(new_container)
+        step.call(new_container, skip=False)
 
 
+def test_imatch_default_run(tmp_cwd, miri_dither_ch12):
+    """ Test mrs_imatch test is skipped by default """
+
+    all_models = ModelContainer(miri_dither_ch12)
+
+    # test if default running results in skipping step
+    step = MRSIMatchStep()
+    results = step.call(all_models)
+    n = len(all_models)
+    for i  in range(n):
+        assert results[i].meta.cal_step.mrs_imatch =='SKIPPED'
+
+    
 def test_imatch_background_reset(tmp_cwd, miri_dither_ch12):
     """ Test if background polynomial is already determined - reset it"""
 


### PR DESCRIPTION
<!--](url) If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3649](https://jira.stsci.edu/browse/JP-3649)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8538 

<!-- describe the changes comprising this PR here -->
This PR addresses a bug in cube_build when it was called from  mrs_imatch. Mrs_imatch  is not used in standard processing. A deprecation warning has been added if mrs_imatch is called and the step has been set to default=True in spec. This will prevent the step from being called when the .run method is used for spec3. 

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
      Running regression tests:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1681/


- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
