### PR TITLE
Update regression tests to remove missing files from tests

### DIFF
--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -85,7 +85,7 @@ def run_image3(run_image2, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["dq_init", "saturation", "firstframe", "lastframe", "reset",
-                                    "linearity", "rscd", "dark_current", "refpix", "ramp", "rate",
+                                    "linearity", "rscd", "dark_current", "ramp", "rate",
                                     "rateints"])
 def test_miri_image_detector1(run_detector1, rtdata_module, fitsdiff_default_kwargs, suffix):
     """Regression test of detector1 pipeline performed on MIRI imaging data."""

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -72,7 +72,7 @@ def run_image3pipeline(run_image2pipeline, rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["dq_init", "saturation", "superbias",
-                                    "refpix", "linearity", "trapsfilled",
+                                    "refpix", "linearity",
                                     "dark_current", "jump", "rate",
                                     "flat_field", "cal", "i2d"])
 def test_nircam_image_stages12(run_image2pipeline, rtdata_module, fitsdiff_default_kwargs, suffix):

--- a/jwst/regtest/test_nircam_subarray_4amp.py
+++ b/jwst/regtest/test_nircam_subarray_4amp.py
@@ -28,9 +28,8 @@ def run_pipeline(rtdata_module):
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output", [
     'jw00617196001_02102_00001_nrca4_rate.fits',
-    'jw00617196001_02102_00001_nrca4_rateints.fits',
-    'jw00617196001_02102_00001_nrca4_trapsfilled.fits', ],
-    ids=['rate', 'rateints', 'trapsfilled'])
+    'jw00617196001_02102_00001_nrca4_rateints.fits'],
+    ids=['rate', 'rateints'])
 def test_nircam_detector1_subarray(run_pipeline, fitsdiff_default_kwargs, output):
     """
     Regression test of calwebb_detector1 pipeline performed on NIRSpec data.


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses failing regression tests resulting from updated detector1 parameter reference files delivered by NIRCam and MIRI. The new reference files skip the refpix step for MIRI images and skip the persistence step for NIRCam data, resulting in test errors on missing `{..}_refpix.fits` and `{..}_trapsfilled.fits` files. This PR removes those suffixes/filenames from the test diffs.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
