### PR TITLE
JP-3719: Fix names for intermediate spectral outlier detection files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,13 +61,17 @@ outlier_detection
 - Fixed failures due to a missing ``wcs.array_shape`` attribute when the
   ``outlier_detection`` step was run standalone using e.g. ``strun`` [#8645]
 
+- Refactored separate modes into submodules instead of inheriting from a base class.
+  Moved non-JWST-specific code to stcal. [#8613]
+
+- Fixed file names and output directory for intermediate resampled spectral
+  images. Intermediate files now have suffix ``outlier_s2d`` and are saved to
+  the output directory alongside final products. [#8735]
+
 set_telescope_pointing
 ----------------------
 
 - replace usage of ``copy_arrays=True`` with ``memmap=False`` [#8660]
-
-- Refactored separate modes into submodules instead of inheriting from a base class.
-  Moved non-JWST-specific code to stcal. [#8613]
 
 resample_spec
 -------------

--- a/docs/jwst/outlier_detection/outlier_detection_spec.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_spec.rst
@@ -29,14 +29,14 @@ Specifically, this routine performs the following operations (modified from the
 #. Resample all input images into a :py:class:`~jwst.datamodels.ModelContainer` using
    :py:class:`~jwst.resample.resample_spec.ResampleSpecData`
 
-   - Resampled images are written out to disk if the ``save_intermediate_results``
-     parameter is set to `True`
+   - Resampled images are written out to disk with suffix "outlier_s2d"
+     if the ``save_intermediate_results`` parameter is set to `True`.
    - **If resampling is turned off**, the original unrectified inputs are used to create
-     the median image for cosmic-ray detection
+     the median image for cosmic-ray detection.
 #. Create a median image from (possibly) resampled :py:class:`~jwst.datamodels.ModelContainer`
 
-   - The median image is written out to disk if the ``save_intermediate_results``
-     parameter is set to `True`
+   - The median image is written out to disk with suffix "median"
+     if the ``save_intermediate_results`` parameter is set to `True`
 #. Blot median image to match each original input image
 
    - **If resampling is turned off**, the median image is used for comparison

--- a/jwst/outlier_detection/imaging.py
+++ b/jwst/outlier_detection/imaging.py
@@ -60,8 +60,8 @@ def detect_outliers(
     if resample_data:
         # Start by creating resampled/mosaic images for
         # each group of exposures
-        output_path = make_output_path(basepath=input_models[0].meta.filename,
-                        suffix='')
+        output_path = make_output_path(
+            basepath=input_models[0].meta.filename, suffix='')
         output_path = os.path.dirname(output_path)
         resamp = resample.ResampleData(
             input_models,

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -193,7 +193,7 @@ class OutlierDetectionStep(Step):
         if exptype in IFU_SPEC_MODES:
             return 'ifu'
 
-        self.log.error("Outlier detection failed for unknown/unsupported ",
+        self.log.error(f"Outlier detection failed for unknown/unsupported "
                        f"exposure type: {exptype}")
         return None
 

--- a/jwst/outlier_detection/spec.py
+++ b/jwst/outlier_detection/spec.py
@@ -2,6 +2,7 @@
 Submodule for performing outlier detection on spectra.
 """
 import copy
+import os
 
 from stdatamodels.jwst import datamodels
 
@@ -56,8 +57,12 @@ def detect_outliers(
     if resample_data is True:
         # Start by creating resampled/mosaic images for
         #  each group of exposures
+        output_path = make_output_path(
+            basepath=input_models[0].meta.filename, suffix='')
+        output_path = os.path.dirname(output_path)
         resamp = resample_spec.ResampleSpecData(
             input_models,
+            output=output_path,
             single=True,
             blendheaders=False,
             wht_type=weight_type,
@@ -70,14 +75,6 @@ def detect_outliers(
         )
         median_wcs = resamp.output_wcs
         drizzled_models = resamp.do_drizzle(input_models)
-        if save_intermediate_results:
-            for model in drizzled_models:
-                model.meta.filename = make_output_path(
-                    basepath=model.meta.filename,
-                    suffix="_outlier_s2d.fits",
-                )
-                log.info("Writing out resampled spectra...")
-                model.save(model.meta.filename)
     else:
         drizzled_models = input_models
         for i in range(len(input_models)):

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -73,7 +73,7 @@ class ResampleData:
         if output is not None and '.fits' not in str(output):
             self.output_dir = output
             self.output_filename = None
-        self.output_suffix = 'i2d'
+        self.intermediate_suffix = 'outlier_i2d'
 
         self.pscale_ratio = pscale_ratio
         self.single = single
@@ -287,11 +287,11 @@ class ResampleData:
             if self.asn_id is not None:
                 output_model.meta.filename = (
                     f'{output_root}_{self.asn_id}_'
-                    f'outlier_{self.output_suffix}{output_type}')
+                    f'{self.intermediate_suffix}{output_type}')
             else:
                 output_model.meta.filename = (
                     f'{output_root}_'
-                    f'outlier_{self.output_suffix}{output_type}')
+                    f'{self.intermediate_suffix}{output_type}')
 
             # Initialize the output with the wcs
             driz = gwcs_drizzle.GWCSDrizzle(output_model, pixfrac=self.pixfrac,

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -73,6 +73,7 @@ class ResampleData:
         if output is not None and '.fits' not in str(output):
             self.output_dir = output
             self.output_filename = None
+        self.output_suffix = 'i2d'
 
         self.pscale_ratio = pscale_ratio
         self.single = single
@@ -276,6 +277,7 @@ class ResampleData:
         """
         for exposure in input_models.models_grouped:
             output_model = self.blank_output
+
             # Determine output file type from input exposure filenames
             # Use this for defining the output filename
             indx = exposure[0].meta.filename.rfind('.')
@@ -283,9 +285,13 @@ class ResampleData:
             output_root = '_'.join(exposure[0].meta.filename.replace(
                 output_type, '').split('_')[:-1])
             if self.asn_id is not None:
-                output_model.meta.filename = f'{output_root}_{self.asn_id}_outlier_i2d{output_type}'
+                output_model.meta.filename = (
+                    f'{output_root}_{self.asn_id}_'
+                    f'outlier_{self.output_suffix}{output_type}')
             else:
-                output_model.meta.filename = f'{output_root}_outlier_i2d{output_type}'
+                output_model.meta.filename = (
+                    f'{output_root}_'
+                    f'outlier_{self.output_suffix}{output_type}')
 
             # Initialize the output with the wcs
             driz = gwcs_drizzle.GWCSDrizzle(output_model, pixfrac=self.pixfrac,

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -66,6 +66,7 @@ class ResampleSpecData(ResampleData):
         if output is not None and '.fits' not in str(output):
             self.output_dir = output
             self.output_filename = None
+        self.output_suffix = 's2d'
 
         self.pscale_ratio = pscale_ratio
         self.single = single
@@ -78,7 +79,7 @@ class ResampleSpecData(ResampleData):
         self.in_memory = kwargs.get('in_memory', True)
         self._recalc_pscale_ratio = False
 
-        log.info(f"Driz parameter kernal: {self.kernel}")
+        log.info(f"Driz parameter kernel: {self.kernel}")
         log.info(f"Driz parameter pixfrac: {self.pixfrac}")
         log.info(f"Driz parameter fillval: {self.fillval}")
         log.info(f"Driz parameter weight_type: {self.weight_type}")

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -66,7 +66,7 @@ class ResampleSpecData(ResampleData):
         if output is not None and '.fits' not in str(output):
             self.output_dir = output
             self.output_filename = None
-        self.output_suffix = 's2d'
+        self.intermediate_suffix = 'outlier_s2d'
 
         self.pscale_ratio = pscale_ratio
         self.single = single

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -37,8 +37,7 @@ def _set_photom_kwd(im):
         )
 
 
-@pytest.fixture
-def miri_rate():
+def miri_rate_model():
     xsize = 72
     ysize = 416
     shape = (ysize, xsize)
@@ -87,6 +86,11 @@ def miri_rate():
         'start_time': 58119.8333,
         'type': 'MIR_LRS-SLITLESS',
         'zero_frame': False}
+    return im
+
+@pytest.fixture
+def miri_rate():
+    im = miri_rate_model()
     yield im
     im.close()
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3719](https://jira.stsci.edu/browse/JP-3719)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8734 

<!-- describe the changes comprising this PR here -->
For spectral modes with resampling, intermediate files from outlier detection are not being written correctly.  There should be files written to the output directory with suffix 'outlier_s2d'.  Instead, there are currently files written to the **current** directory with suffix 'outlier_**i2d**', and some duplicate files written to the output directory with suffix 'outlier__outlier_s2d.fits'.  

This PR should fix these issues by:
- removing the duplicate file saving mechanism in the spectral outlier detection method, in favor of the native one in the resampler
- modifying the resampling step to store the suffix 'i2d' for imaging and 's2d' for spectral data
- passing the output directory to the resampler in the spectral outlier detection interface.

I also added a unit test for spectral outlier detection, along with some checks for these kinds of regressions in intermediate file saving.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
