### PR TITLE
JP-3731: Update association path warning message.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ associations
 - Restored slit name to level 3 product names for NIRSpec BOTS and background
   fixed slit targets. [#8699]
 
+- Update warning message about use of paths in associations. [#8752]
+
 cube_build
 ----------
 

--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -208,9 +208,9 @@ class Association(MutableMapping):
             for member in members:
                 fpath, fname = os.path.split(member["expname"])
                 if len(fpath) > 0:
-                    err_str = "'expname' contains path, but should only be a filename."
-                    err_str += "  All input files should be in a single directory"
-                    err_str += ", so no path is needed."
+                    err_str = "Input association file contains path information;"
+                    err_str += "  note that this can complicate usage and/or sharing"
+                    err_str += "  of such files."
                     logger.debug(err_str)
                     warnings.warn(err_str, UserWarning)
         return True


### PR DESCRIPTION
This PR addresses JP-3731, updating the log message warning about use of paths within association files.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
