### PR TITLE
JP-3730: Re-enable saving of blot models during outlier detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -496,6 +496,8 @@ outlier_detection
 
 - Fix errors in documentation describing arguments. [#8603]
 
+- Re-enabled saving of blot models when `save_intermediate_results` is True. [#8758]
+
 pathloss
 --------
 

--- a/docs/jwst/outlier_detection/outlier_detection_imaging.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_imaging.rst
@@ -75,7 +75,8 @@ Specifically, this routine performs the following operations:
    * The median image is written out to disk as `_<asn_id>_median.fits` by default.
 
 #. By default, the median image is blotted back (inverse of resampling) to
-   match each original input image.
+   match each original input image.  Resampled/blotted images are written out to disk if 
+   the ``save_intermediate_results`` parameter is set to `True`.
 
    * **If resampling is turned off**, the median image is compared directly to
      each input image.

--- a/docs/jwst/outlier_detection/outlier_detection_spec.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_spec.rst
@@ -39,6 +39,8 @@ Specifically, this routine performs the following operations (modified from the
      if the ``save_intermediate_results`` parameter is set to `True`
 #. Blot median image to match each original input image
 
+   - Resampled/blotted images are written out to disk if the ``save_intermediate_results``
+     parameter is set to `True`
    - **If resampling is turned off**, the median image is used for comparison
      with the original input models for detecting outliers
 #. Perform statistical comparison between blotted image and original image to identify outliers

--- a/jwst/outlier_detection/imaging.py
+++ b/jwst/outlier_detection/imaging.py
@@ -127,7 +127,7 @@ def detect_outliers(
     with input_models:
         for image in input_models:
             if resample_data:
-                flag_resampled_model_crs(image, median_data, median_wcs, snr1, snr2, scale1, scale2, backg)
+                flag_resampled_model_crs(image, median_data, median_wcs, snr1, snr2, scale1, scale2, backg, save_blot=save_intermediate_results, make_output_path=make_output_path)
             else:
                 flag_model_crs(image, median_data, snr1)
             input_models.shelve(image, modify=True)

--- a/jwst/outlier_detection/imaging.py
+++ b/jwst/outlier_detection/imaging.py
@@ -127,7 +127,16 @@ def detect_outliers(
     with input_models:
         for image in input_models:
             if resample_data:
-                flag_resampled_model_crs(image, median_data, median_wcs, snr1, snr2, scale1, scale2, backg, save_blot=save_intermediate_results, make_output_path=make_output_path)
+                flag_resampled_model_crs(image,
+                                         median_data,
+                                         median_wcs,
+                                         snr1,
+                                         snr2,
+                                         scale1,
+                                         scale2,
+                                         backg,
+                                         save_blot=save_intermediate_results,
+                                         make_output_path=make_output_path)
             else:
                 flag_model_crs(image, median_data, snr1)
             input_models.shelve(image, modify=True)

--- a/jwst/outlier_detection/spec.py
+++ b/jwst/outlier_detection/spec.py
@@ -130,7 +130,11 @@ def detect_outliers(
             scale1,
             scale2,
             backg,
+            save_blot=save_intermediate_results,
+            make_output_path=make_output_path
         )
     else:
-        flag_crs_in_models(input_models, median_data, snr1)
+        flag_crs_in_models(input_models,
+                           median_data,
+                           snr1)
     return input_models

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -288,11 +288,13 @@ def test_outlier_step_spec(tmp_cwd, tmp_path):
         i2d_files = glob(os.path.join(dirname, '*i2d*.fits'))
         s2d_files = glob(os.path.join(dirname, '*outlier_s2d.fits'))
         median_files = glob(os.path.join(dirname, '*median.fits'))
+        blot_files = glob(os.path.join(dirname, '*blot.fits'))
 
         # intermediate files are removed
         assert len(i2d_files) == 0
         assert len(s2d_files) == 0
         assert len(median_files) == 0
+        assert len(blot_files) == 0
 
         # result files are written to the output directory
         if dirname == output_dir:
@@ -320,25 +322,31 @@ def test_outlier_step_spec(tmp_cwd, tmp_path):
         i2d_files = glob(os.path.join(dirname, '*i2d*.fits'))
         s2d_files = glob(os.path.join(dirname, '*outlier_s2d.fits'))
         median_files = glob(os.path.join(dirname, '*median.fits'))
+        blot_files = glob(os.path.join(dirname, '*blot.fits'))
         if dirname == output_dir:
             # result files are written to the output directory
             assert len(result_files) == len(container)
 
-            # s2d and median files are written to the output directory
+            # s2d, median, and blot files are written to the output directory
             assert len(s2d_files) == len(container)
+            assert len(blot_files) == len(container)
             assert len(median_files) == 1
 
             # i2d files not written
             assert len(i2d_files) == 0
 
             # nothing else was written
-            assert len(all_files) == len(s2d_files) + len(median_files) + len(result_files)
+            assert len(all_files) == len(s2d_files) + \
+                                     len(median_files) + \
+                                     len(result_files) + \
+                                     len(blot_files)
         else:
             # nothing should be written to the current directory
             assert len(result_files) == 0
             assert len(s2d_files) == 0
             assert len(median_files) == 0
             assert len(i2d_files) == 0
+            assert len(blot_files) == 0
             assert len(all_files) == 0
 
     miri_rate.close()

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -405,6 +405,30 @@ def test_outlier_step_on_disk(three_sci_as_asn, tmp_cwd):
         assert zeroth.dq[12, 12] == OUTLIER_DO_NOT_USE
         result.shelve(zeroth, modify=False)
 
+    # Verify intermediate results were written to disk
+    dirname = tmp_cwd
+    all_files = glob(os.path.join(dirname, '*.fits'))
+    input_files = glob(os.path.join(dirname, '*_cal.fits'))
+    result_files = glob(os.path.join(dirname, '*outlierdetectionstep.fits'))
+    i2d_files = glob(os.path.join(dirname, '*i2d*.fits'))
+    s2d_files = glob(os.path.join(dirname, '*outlier_s2d.fits'))
+    median_files = glob(os.path.join(dirname, '*median.fits'))
+    blot_files = glob(os.path.join(dirname, '*blot.fits'))
+
+    assert len(result_files) == len(container)
+
+    # i2d, median, blot files are written to the output directory
+    assert len(i2d_files) == len(container)
+    assert len(blot_files) == len(container)
+    assert len(median_files) == 1
+
+    # s2d files not written
+    assert len(s2d_files) == 0
+
+    # nothing else was written
+    assert len(all_files) == len(input_files) + len(i2d_files) + len(median_files) + len(result_files) + len(blot_files)
+
+
 
 def test_outlier_step_square_source_no_outliers(we_three_sci, tmp_cwd):
     """Test whole step with square source with sharp edges, no outliers"""

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -301,8 +301,6 @@ def flag_model_crs(image, blot, snr):
 
 
 def _make_blot_model(input_model, blot):
-    blot_model = input_model.copy()
+    blot_model = type(input_model)()
     blot_model.data = blot
-    blot_model.dq *= 0
-    blot_model.err *= 0.0
     return blot_model

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -303,4 +303,5 @@ def flag_model_crs(image, blot, snr):
 def _make_blot_model(input_model, blot):
     blot_model = type(input_model)()
     blot_model.data = blot
+    blot_model.update(input_model)
     return blot_model

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -275,7 +275,16 @@ def flag_crs_in_models_with_resampling(
     make_output_path=None,
 ):
     for image in input_models:
-        flag_resampled_model_crs(image, median_data, median_wcs, snr1, snr2, scale1, scale2, backg, save_blot=save_blot, make_output_path=make_output_path)
+        flag_resampled_model_crs(image,
+                                 median_data,
+                                 median_wcs,
+                                 snr1,
+                                 snr2,
+                                 scale1,
+                                 scale2,
+                                 backg,
+                                 save_blot=save_blot,
+                                 make_output_path=make_output_path)
 
 
 def flag_model_crs(image, blot, snr):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3730](https://jira.stsci.edu/browse/JP-3730)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8750

<!-- describe the changes comprising this PR here -->
[Recent work](https://github.com/spacetelescope/jwst/pull/8613) refactoring the memory management within the outlier detection step had disabled the creation of blot files as optional intermediate-stage outputs. This PR reverts this removal, allowing these blot models to be saved when `save_intermediate_results` is True.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [x] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
