### PR TITLE
JP-3729: log version and crds context at end of step/pipeline runs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -191,6 +191,8 @@ stpipe
   added a `query_step_status()` function to use as an alternative to checking
   `self.skip`. [#8600]
 
+- Log jwst version and crds context at the end of step/pipeline runs. [#8760]
+
 tso_photometry
 --------------
 

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -80,14 +80,18 @@ class JwstStep(Step):
             result.meta.calibration_software_revision = __version_commit__ or 'RELEASE'
             result.meta.calibration_software_version = __version__
 
+            crds_context = crds_client.get_context_used(result.crds_observatory)
+
             if len(reference_files_used) > 0:
                 for ref_name, filename in reference_files_used:
                     if hasattr(result.meta.ref_file, ref_name):
                         getattr(result.meta.ref_file, ref_name).name = filename
                 result.meta.ref_file.crds.sw_version = crds_client.get_svn_version()
-                result.meta.ref_file.crds.context_used = crds_client.get_context_used(result.crds_observatory)
-                if self.parent is None:
-                    log.info(f"Results used CRDS context: {result.meta.ref_file.crds.context_used}")
+                result.meta.ref_file.crds.context_used = crds_context
+
+            if self.parent is None:
+                log.info(f"Results used CRDS context: {crds_context}")
+                log.info(f"Results used jwst version: {__version__}")
 
 
     def remove_suffix(self, name):
@@ -98,6 +102,4 @@ class JwstStep(Step):
 # be a subclass of JwstStep so that it will pass checks
 # when constructing a pipeline using JwstStep class methods.
 class JwstPipeline(Pipeline, JwstStep):
-    def finalize_result(self, result, reference_files_used):
-        if isinstance(result, JwstDataModel):
-            log.info(f"Results used CRDS context: {crds_client.get_context_used(result.crds_observatory)}")
+    pass

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -76,11 +76,16 @@ class JwstStep(Step):
         return asn
 
     def finalize_result(self, result, reference_files_used):
+        crds_context = crds_client.get_context_used('jwst')
+
+        if self.parent is None:
+            log.info(f"Results used CRDS context: {crds_context}")
+            log.info(f"Results used jwst version: {__version__}")
+
         if isinstance(result, JwstDataModel):
             result.meta.calibration_software_revision = __version_commit__ or 'RELEASE'
             result.meta.calibration_software_version = __version__
 
-            crds_context = crds_client.get_context_used(result.crds_observatory)
 
             if len(reference_files_used) > 0:
                 for ref_name, filename in reference_files_used:
@@ -88,11 +93,6 @@ class JwstStep(Step):
                         getattr(result.meta.ref_file, ref_name).name = filename
                 result.meta.ref_file.crds.sw_version = crds_client.get_svn_version()
                 result.meta.ref_file.crds.context_used = crds_context
-
-            if self.parent is None:
-                log.info(f"Results used CRDS context: {crds_context}")
-                log.info(f"Results used jwst version: {__version__}")
-
 
     def remove_suffix(self, name):
         return remove_suffix(name)

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from os.path import (
     abspath,
@@ -15,8 +16,10 @@ from stpipe.config_parser import ValidationError
 
 from stdatamodels.jwst import datamodels
 
+from jwst import __version__ as jwst_version
 from jwst.white_light import WhiteLightStep
 from jwst.stpipe import Step
+from jwst.tests.helpers import LogWatcher
 
 from jwst.stpipe.tests.steps import (
     EmptyPipeline, MakeListPipeline, MakeListStep,
@@ -38,6 +41,10 @@ WHITELIGHTSTEP_CRDS_MIRI_PARS = {
 
 
 CRDS_ERROR_STRING = 'PARS-WITHDEFAULTSSTEP: No parameters found'
+
+# used in logging tests below to provide a deterministic crds
+# context to look for in the log messages
+FAKE_CRDS_CONTEXT = "0000.pmap"
 
 
 @pytest.fixture(scope='module')
@@ -607,3 +614,22 @@ def test_call_with_config(caplog, tmp_cwd):
     ProperPipeline.call(model, config_file=cfg)
 
     assert "newpar1" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "message", [
+        f"Results used CRDS context: {FAKE_CRDS_CONTEXT}",
+        f"Results used jwst version: {jwst_version}",
+    ])
+def test_finalize_logging(monkeypatch, message):
+    """
+    Check that the jwst version and crds context are logged
+    when a step/pipeline is run.
+    """
+    pipeline = EmptyPipeline()
+    model = datamodels.ImageModel()
+    monkeypatch.setattr(crds_client, 'get_context_used', lambda observatory: FAKE_CRDS_CONTEXT)
+    watcher = LogWatcher(message)
+    monkeypatch.setattr(logging.getLogger("jwst.stpipe.core"), "info", watcher)
+    pipeline.run(model)
+    assert watcher.seen


### PR DESCRIPTION
This PR adds log messages (info level) for the jwst version and crds context at the end of pipeline/step runs (by making logging calls during `finalize_result`). The crds context was previously logged only if reference files were used and is now logged for every run. An example of the log messages is as follows:
```
2024-09-06 13:13:55,491 - stpipe.Image3Pipeline - INFO - Results used CRDS context: jwst_1276.pmap
2024-09-06 13:13:55,491 - stpipe.Image3Pipeline - INFO - Results used jwst version: 1.14.1.dev350+g8efc26fdb
2024-09-06 13:13:55,491 - stpipe.Image3Pipeline - INFO - Step Image3Pipeline done
```

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3729](https://jira.stsci.edu/browse/JP-3729)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8749

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [x] added entry in `CHANGES.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
