### PR TITLE
JP-3728: Deprecate `Step.__call__`

### DIFF
--- a/changes/8761.stpipe.rst
+++ b/changes/8761.stpipe.rst
@@ -1,0 +1,1 @@
+Add warning that ``Step.__call__`` is deprecated.

--- a/jwst/extract_2d/tests/test_grisms.py
+++ b/jwst/extract_2d/tests/test_grisms.py
@@ -209,7 +209,7 @@ def test_create_box_fits():
     # Add fake data to pass a shape to wfss_imaging_wcs
     im.data = np.zeros((512, 512))
     aswcs = AssignWcsStep()
-    imwcs = aswcs(im)
+    imwcs = aswcs.run(im)
     imwcs.meta.source_catalog = source_catalog
     refs = get_reference_files(im)
     test_boxes = create_grism_bbox(imwcs, refs,
@@ -242,7 +242,7 @@ def test_create_box_gwcs():
     # The data array is not relevant
     im.data = np.zeros((512, 512))
     aswcs = AssignWcsStep()
-    imwcs = aswcs(im)
+    imwcs = aswcs.run(im)
     imwcs.meta.source_catalog = source_catalog
     refs = get_reference_files(im)
     test_boxes = create_grism_bbox(imwcs, refs,
@@ -268,7 +268,7 @@ def setup_image_cat():
     im.data = np.zeros((512, 512))
     im.meta.source_catalog = source_catalog
     aswcs = AssignWcsStep()
-    imwcs = aswcs(im)
+    imwcs = aswcs.run(im)
     refs = get_reference_files(im)
 
     return imwcs, refs

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -3,6 +3,7 @@ JWST-specific Step and Pipeline base classes.
 """
 from functools import wraps
 import logging
+import warnings
 
 from stdatamodels.jwst.datamodels import JwstDataModel
 from stdatamodels.jwst import datamodels
@@ -105,7 +106,10 @@ class JwstStep(Step):
     @wraps(Step.__call__)
     def __call__(self, *args, **kwargs):
         if not self.parent:
-            raise Exception("...")
+            warnings.warn(
+                "Step.__call__ is deprecated use either Step.run or Step.call",
+                UserWarning,
+            )
         return super().__call__(*args, **kwargs)
 
 

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -102,6 +102,12 @@ class JwstStep(Step):
             log.info(f"Results used jwst version: {__version__}")
         return result
 
+    @wraps(Step.__call__)
+    def __call__(self, *args, **kwargs):
+        if not self.parent:
+            raise Exception("...")
+        return super().__call__(*args, **kwargs)
+
 
 # JwstPipeline needs to inherit from Pipeline, but also
 # be a subclass of JwstStep so that it will pass checks

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -107,8 +107,12 @@ class JwstStep(Step):
     def __call__(self, *args, **kwargs):
         if not self.parent:
             warnings.warn(
-                "Step.__call__ is deprecated use either Step.run or Step.call",
-                UserWarning,
+                "Step.__call__ is deprecated. It is equivalent to Step.run "
+                "and is not recommended. See "
+                "https://jwst-pipeline.readthedocs.io/en/latest/jwst/"
+                "user_documentation/running_pipeline_python.html"
+                "#advanced-use-pipeline-run-vs-pipeline-call for more details.",
+                UserWarning
             )
         return super().__call__(*args, **kwargs)
 

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -623,3 +623,9 @@ def test_finalize_logging(monkeypatch):
     monkeypatch.setattr(logging.getLogger("jwst.stpipe.core"), "info", watcher)
     pipeline.run(model)
     assert watcher.seen
+
+
+def test_dunder_call_warning():
+    pipeline = EmptyPipeline()
+    with pytest.warns(UserWarning, match="Step.__call__ is deprecated"):
+        pipeline(None)

--- a/jwst/tweakreg/tests/test_tweakreg.py
+++ b/jwst/tweakreg/tests/test_tweakreg.py
@@ -193,7 +193,7 @@ def test_tweakreg_step(example_input, with_shift):
     step = tweakreg_step.TweakRegStep()
 
     # run the step on the example input modified above
-    result = step(example_input)
+    result = step.run(example_input)
 
     # check that step completed
     with result:
@@ -227,7 +227,7 @@ def test_src_confusion_pars(example_input, alignment_type):
         "abs_refcat": REFCAT,
     }
     step = tweakreg_step.TweakRegStep(**pars)
-    result = step(example_input)
+    result = step.run(example_input)
 
     # check that step was skipped
     with result:
@@ -356,7 +356,7 @@ def test_custom_catalog(custom_catalog_path, example_input, catfile, asn, meta, 
     monkeypatch.setattr(twk, "construct_wcs_corrector", patched_construct_wcs_corrector)
 
     with pytest.raises(ValueError, match="done testing"):
-        step(str(asn_path))
+        step.run(str(asn_path))
 
 
 @pytest.mark.parametrize("with_shift", [True, False])
@@ -384,7 +384,7 @@ def test_sip_approx(example_input, with_shift):
     step.sip_npoints = 12
 
     # run the step on the example input modified above
-    result = step(example_input)
+    result = step.run(example_input)
 
     with result:
         r0 = result.borrow(0)


### PR DESCRIPTION
This PR adds a warning to `Step.__call__` uses to target end-users that might use this expecting the step to use reference files.

Note that `Step.__call__` is used in pipelines so the warning will only appear if `Step.__call__` is used outside a pipeline (it's used on a step that doesn't have a "parent").

If `Step.__call__` is removed, some decision will need to be made about what to do for pipeline uses of `Step.__call__`.

Regression tests show only failures that exist on main:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1694/
and do not show the new warning (so there is no use of `Step.__call__` (outside of a pipeline) in jwst.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3728](https://jira.stsci.edu/browse/JP-3728)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8748

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] All comments are resolved
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
