### PR TITLE
JP-3733 remove setting pixel_replace.save to True in calwebb_spec3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,6 +181,8 @@ ramp_fitting
 - Moved the read noise variance recalculation for CHARGELOSS flagging to the C
   implementation, when the algorithm is ``OLS_C``. [#8697, spacetelescope/stcal#278]
 
+- Updated `calwebb_spec3` to not save the `pixel_replacement` output by default.[#8765] 
+
 resample
 --------
 

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -106,6 +106,7 @@ class Spec3Pipeline(Pipeline):
         # being modified. This can affect the filenames of subsequent
         # steps.
         self.outlier_detection.save_model = invariant_filename(self.outlier_detection.save_model)
+        self.pixel_replace.save_model = invariant_filename(self.pixel_replace.save_model)
 
         # Retrieve the inputs:
         # could either be done via LoadAsAssociation and then manually
@@ -235,7 +236,6 @@ class Spec3Pipeline(Pipeline):
                 # interpolate pixels that have a NaN value or are flagged
                 # as DO_NOT_USE or NON_SCIENCE.
                 result = self.pixel_replace(result)
-
                 # Resample time. Dependent on whether the data is IFU or not.
                 resample_complete = None
                 if exptype in IFU_EXPTYPES:

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -100,14 +100,12 @@ class Spec3Pipeline(Pipeline):
         self.spectral_leak.save_results = self.save_results
         self.pixel_replace.suffix = 'pixel_replace'
         self.pixel_replace.output_use_model = True
-        self.pixel_replace.save_results = self.save_results
         
         # Overriding the Step.save_model method for the following steps.
         # These steps save intermediate files, resulting in meta.filename
         # being modified. This can affect the filenames of subsequent
         # steps.
         self.outlier_detection.save_model = invariant_filename(self.outlier_detection.save_model)
-        self.pixel_replace.save_model = invariant_filename(self.pixel_replace.save_model)
 
         # Retrieve the inputs:
         # could either be done via LoadAsAssociation and then manually


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3733](https://jira.stsci.edu/browse/JP-3733)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8754

<!-- describe the changes comprising this PR here -->
This PR addresses removes saving the pixel_replace step output by default. The user must set pixel_replace.save_results=True to get the output written to disk. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API?
  - [x] add an entry to `CHANGES.rst` within the relevant release section (otherwise add the `no-changelog-entry-needed` label to this PR)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
  - https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1719/

    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
