### PR TITLE
JP-3729: report jwst version at end of Step.run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,8 @@ stpipe
   added a `query_step_status()` function to use as an alternative to checking
   `self.skip`. [#8600]
 
+- Log jwst version at end of `Step.run`. [#8769]
+
 tso_photometry
 --------------
 

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -1,6 +1,7 @@
 """
 JWST-specific Step and Pipeline base classes.
 """
+from functools import wraps
 import logging
 
 from stdatamodels.jwst.datamodels import JwstDataModel
@@ -92,6 +93,13 @@ class JwstStep(Step):
 
     def remove_suffix(self, name):
         return remove_suffix(name)
+
+    @wraps(Step.run)
+    def run(self, *args, **kwargs):
+        result = super().run(*args, **kwargs)
+        if not self.parent:
+            log.info(f"Results used jwst version: {__version__}")
+        return result
 
 
 # JwstPipeline needs to inherit from Pipeline, but also


### PR DESCRIPTION
This is a second attempt at logging the jwst version at the end of pipeline/step runs. The first attempt was subject to a stpipe bug which will need to be separately addressed.

This PR wraps `Step.run` to log the version at the end of a run for a step that has no parent. This is similar to the previous attempt https://github.com/spacetelescope/jwst/pull/8760 but does not use `finalize_result` (as that is called incorrectly by stpipe).

Testing with `strun nsclean abcdefg` (to make sure this works around the stpipe bug: https://github.com/spacetelescope/stpipe/issues/188) gives:
```
2024-09-10 14:05:12,152 - stpipe - WARNING - Input dataset is not an instance of AbstractDataModel.
2024-09-10 14:05:12,152 - stpipe - INFO - PARS-NSCLEANSTEP: CRDS parameter reference retrieval disabled.
2024-09-10 14:05:12,154 - stpipe.NSCleanStep - INFO - NSCleanStep instance created.
2024-09-10 14:05:12,198 - stpipe.NSCleanStep - INFO - Step NSCleanStep running with args ('abcdefg',).
2024-09-10 14:05:12,200 - stpipe.NSCleanStep - INFO - Step NSCleanStep parameters are:
  pre_hooks: []
  post_hooks: []
  output_file: None
  output_dir: None
  output_ext: .fits
  output_use_model: False
  output_use_index: True
  save_results: True
  skip: True
  suffix: None
  search_output_file: True
  input_dir: ''
  mask_spectral_regions: True
  n_sigma: 5.0
  save_mask: False
  user_mask: None
2024-09-10 14:05:12,200 - stpipe.NSCleanStep - INFO - Step skipped.
2024-09-10 14:05:12,200 - stpipe - INFO - Results used jwst version: 1.15.2.dev237+gf252448ee
```

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3729](https://jira.stsci.edu/browse/JP-3729)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API?
  - [x] add an entry to `CHANGES.rst` within the relevant release section (otherwise add the `no-changelog-entry-needed` label to this PR)
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
