### PR TITLE
JP-3738: Subtract pedestal dark for MIRI MRS when constructing selfcal minimum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,12 @@ associations
 - Restored slit name to level 3 product names for NIRSpec BOTS and background
   fixed slit targets. [#8699]
 
+badpix_selfcal
+--------------
+
+- Subtract pedestal dark when constructing min array across selfcal exposures
+  for MIRI MRS data. [#8771]
+
 cube_build
 ----------
 

--- a/docs/jwst/badpix_selfcal/description.rst
+++ b/docs/jwst/badpix_selfcal/description.rst
@@ -38,6 +38,9 @@ the spectral axis. The algorithm proceeds as follows:
   If no additional exposures are available, the science data itself is passed in 
   without modification, serving as the "background image" for the rest of the procedure, 
   i.e., true self-calibration.
+* For MIRI MRS, any residual pedestal in the effective dark current is subtracted from
+  each exposure using the unilluminated region of the detector between spectral channels
+  prior to performing the pixelwise minimum combination.
 * The combined background image is median-filtered, ignoring NaNs, along the spectral axis 
   with a user-specified kernel size. The default kernel size is 15 pixels.
 * The difference between the original background image and the median-filtered background image

--- a/jwst/badpix_selfcal/badpix_selfcal_step.py
+++ b/jwst/badpix_selfcal/badpix_selfcal_step.py
@@ -103,7 +103,15 @@ class BadpixSelfcalStep(Step):
         selfcal_list = [input_sci] + selfcal_list
         selfcal_3d = []
         for i, selfcal_model in enumerate(selfcal_list):
-            selfcal_3d.append(selfcal_model.data)
+            # If working with MIRI MRS data, subtract any pedestal residual dark
+            # using the median of count rates from between the channels
+            if (input_sci.meta.instrument.detector.upper() == 'MIRIFUSHORT'):
+                selfcal_3d.append(selfcal_model.data - np.nanmedian(selfcal_model.data[50:1024-50, 503:516]))
+            elif (input_sci.meta.instrument.detector.upper() == 'MIRIFULONG'):
+                selfcal_3d.append(selfcal_model.data - np.nanmedian(selfcal_model.data[50:1024-50, 474:507]))
+            else:
+                selfcal_3d.append(selfcal_model.data)
+
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=RuntimeWarning, message="All-NaN")
             minimg = np.nanmin(np.asarray(selfcal_3d), axis=0)

--- a/jwst/badpix_selfcal/badpix_selfcal_step.py
+++ b/jwst/badpix_selfcal/badpix_selfcal_step.py
@@ -6,6 +6,10 @@ from jwst import datamodels as dm
 
 __all__ = ["BadpixSelfcalStep"]
 
+# Define the regions between MRS channels with which to estimate
+# the pedestal dark.  Format is (Y1, Y2, X1, X2)
+PEDESTAL_INDX_MIRIFULONG = (50, 974, 474, 507)
+PEDESTAL_INDX_MIRIFUSHORT = (50, 974, 503, 516)
 
 class BadpixSelfcalStep(Step):
     """
@@ -106,9 +110,13 @@ class BadpixSelfcalStep(Step):
             # If working with MIRI MRS data, subtract any pedestal residual dark
             # using the median of count rates from between the channels
             if (input_sci.meta.instrument.detector.upper() == 'MIRIFUSHORT'):
-                selfcal_3d.append(selfcal_model.data - np.nanmedian(selfcal_model.data[50:1024-50, 503:516]))
+                selfcal_3d.append(selfcal_model.data - np.nanmedian(
+                    selfcal_model.data[PEDESTAL_INDX_MIRIFUSHORT[0]:PEDESTAL_INDX_MIRIFUSHORT[1],
+                    PEDESTAL_INDX_MIRIFUSHORT[2]:PEDESTAL_INDX_MIRIFUSHORT[3]]))
             elif (input_sci.meta.instrument.detector.upper() == 'MIRIFULONG'):
-                selfcal_3d.append(selfcal_model.data - np.nanmedian(selfcal_model.data[50:1024-50, 474:507]))
+                selfcal_3d.append(selfcal_model.data - np.nanmedian(
+                    selfcal_model.data[PEDESTAL_INDX_MIRIFULONG[0]:PEDESTAL_INDX_MIRIFULONG[1],
+                    PEDESTAL_INDX_MIRIFULONG[2]:PEDESTAL_INDX_MIRIFULONG[3]]))
             else:
                 selfcal_3d.append(selfcal_model.data)
 


### PR DESCRIPTION
This PR addresses [JP-3738](https://jira.stsci.edu/browse/JP-3738) by subtracting off the MRS median pedestal dark when performing bad pixel self calibration combine of multiple input exposures.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API?
  - [x] add an entry to `CHANGES.rst` within the relevant release section (otherwise add the `no-changelog-entry-needed` label to this PR)
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
