### PR TITLE
JP-3743: Make outlier detection respect weights for in-memory models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -520,6 +520,9 @@ outlier_detection
 
 - Re-enabled saving of blot models when `save_intermediate_results` is True. [#8758]
 
+- Fixed a bug that caused different results from the median calculation when the
+  `in_memory` parameter was set to `True` vs `False`. [#8777]
+
 pathloss
 --------
 

--- a/jwst/outlier_detection/imaging.py
+++ b/jwst/outlier_detection/imaging.py
@@ -100,14 +100,13 @@ def detect_outliers(
                 input_models.shelve(model, modify=True)
 
     # Perform median combination on set of drizzled mosaics
-    median_data = create_median(drizzled_models, maskpt, on_disk=not in_memory)
+    median_data = create_median(drizzled_models, maskpt)
 
     if save_intermediate_results:
         # make a median model
         with drizzled_models:
             example_model = drizzled_models.borrow(0)
             drizzled_models.shelve(example_model, modify=False)
-            #with datamodels.open(example_model) as dm0:
             median_model = datamodels.ImageModel(median_data)
             median_model.update(example_model)
             median_model.meta.wcs = median_wcs

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -608,8 +608,8 @@ def test_create_median(three_sci_as_asn, tmp_cwd):
                 model.wht[4,9] = 0.5
                 lib.shelve(model, modify=True)
 
-    median_on_disk = create_median(lib_on_disk, 0.7, on_disk=True)
-    median_in_memory = create_median(lib_in_memory, 0.7, on_disk=False)
+    median_on_disk = create_median(lib_on_disk, 0.7)
+    median_in_memory = create_median(lib_in_memory, 0.7)
 
     assert np.isnan(median_in_memory[4,9])
 

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -600,8 +600,18 @@ def test_create_median(three_sci_as_asn, tmp_cwd):
     lib_on_disk = ModelLibrary(three_sci_as_asn, on_disk=True)
     lib_in_memory = ModelLibrary(three_sci_as_asn, on_disk=False)
 
-    median_on_disk = create_median(lib_on_disk, 0.7)
-    median_in_memory = create_median(lib_in_memory, 0.7)
+    # make this test meaningful w.r.t. handling of weights
+    with (lib_on_disk, lib_in_memory):
+        for lib in [lib_on_disk, lib_in_memory]:
+            for model in lib:
+                model.wht = np.ones_like(model.data)
+                model.wht[4,9] = 0.5
+                lib.shelve(model, modify=True)
+
+    median_on_disk = create_median(lib_on_disk, 0.7, on_disk=True)
+    median_in_memory = create_median(lib_in_memory, 0.7, on_disk=False)
+
+    assert np.isnan(median_in_memory[4,9])
 
     # Make sure the median library is the same for on-disk and in-memory
-    assert np.allclose(median_on_disk, median_in_memory)
+    assert np.allclose(median_on_disk, median_in_memory, equal_nan=True)

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -43,20 +43,19 @@ def create_median(resampled_models, maskpt, buffer_size=10.0):
     maskpt : float
         The weight threshold for masking out low weight pixels.
 
-    on_disk : bool
-        If True, the input models are on disk and will be read in chunks.
-
     buffer_size : float
         The size of chunk in MB, per input model, that will be read into memory.
-        This parameter has no effect if on_disk is False.
+        This parameter has no effect if the input library has its on_disk attribute
+        set to False.
 
     Returns
     -------
     median_image : ndarray
         The median image.
     """
-    # Compute the weight threshold for each input model
     on_disk = resampled_models._on_disk
+    
+    # Compute the weight threshold for each input model
     weight_thresholds = []
     model_list = []
     with resampled_models:

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -32,7 +32,7 @@ def create_cube_median(cube_model, maskpt):
     return median
 
 
-def create_median(resampled_models, maskpt, on_disk=True, buffer_size=10.0):
+def create_median(resampled_models, maskpt, buffer_size=10.0):
     """Create a median image from the singly resampled images.
 
     Parameters
@@ -56,6 +56,7 @@ def create_median(resampled_models, maskpt, on_disk=True, buffer_size=10.0):
         The median image.
     """
     # Compute the weight threshold for each input model
+    on_disk = resampled_models._on_disk
     weight_thresholds = []
     model_list = []
     with resampled_models:

--- a/jwst/regtest/test_nircam_mtimage.py
+++ b/jwst/regtest/test_nircam_mtimage.py
@@ -8,11 +8,12 @@ from jwst.stpipe import Step
 
 
 @pytest.mark.bigdata
-def test_nircam_image_moving_target_i2d(rtdata, fitsdiff_default_kwargs):
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_nircam_image_moving_target_i2d(rtdata, fitsdiff_default_kwargs, in_memory):
     """Test resampled i2d of moving target exposures for NIRCam imaging"""
     rtdata.get_asn("nircam/image/mt_asn.json")
     rtdata.output = "mt_assoc_i2d.fits"
-    args = ["calwebb_image3", rtdata.input]
+    args = ["calwebb_image3", rtdata.input, "--in_memory=" + str(in_memory)]
     Step.from_cmdline(args)
     rtdata.get_truth("truth/test_nircam_mtimage/mt_assoc_i2d.fits")
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3743](https://jira.stsci.edu/browse/JP-3743)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8776

<!-- describe the changes comprising this PR here -->
This PR fixes a bug that causes the results of outlier detection to differ between the on-disk and in-memory cases any time there are weights that fall below the threshold value.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API?
  - [x] add an entry to `CHANGES.rst` within the relevant release section (otherwise add the `no-changelog-entry-needed` label to this PR)
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
