### PR TITLE
Remove multiline logger

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.15.2 (unreleased)
 ===================
 
+associations
+------------
+
+- remove ``MultilineLogger`` and no longer set it as the default logger. [#8694]
+
 align_refs
 ----------
 

--- a/jwst/associations/lib/log_config.py
+++ b/jwst/associations/lib/log_config.py
@@ -5,8 +5,6 @@ import logging
 from logging.config import dictConfig
 from collections import defaultdict
 
-from functools import partialmethod
-
 
 __all__ = ['log_config']
 
@@ -145,28 +143,6 @@ DMS_config = {
         }
     }
 }
-
-
-class MultilineLogger(logging.getLoggerClass()):
-    """Split multilines so that each line is logged separately"""
-
-    def __init__(self, *args, **kwargs):
-        super(MultilineLogger, self).__init__(*args, **kwargs)
-
-    def log(self, level, msg, *args, **kwargs):
-        if self.isEnabledFor(level):
-            for line in msg.split('\n'):
-                self._log(level, line, args, **kwargs)
-
-    debug = partialmethod(log, logging.DEBUG)
-    info = partialmethod(log, logging.INFO)
-    warning = partialmethod(log, logging.WARNING)
-    error = partialmethod(log, logging.ERROR)
-    critical = partialmethod(log, logging.CRITICAL)
-    fatal = critical
-
-
-logging.setLoggerClass(MultilineLogger)
 
 
 def log_config(name=None,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #6407

<!-- describe the changes comprising this PR here -->
This PR is a second attempt to resolve issue #6407 by removing the MultiLineLogger, based on PR #8694.

All log messages containing newlines have been removed, so this default should no longer be needed. Removing it should resolve some technical debt.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API?
  - [ ] add an entry to `CHANGES.rst` within the relevant release section (otherwise add the `no-changelog-entry-needed` label to this PR)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
