### PR TITLE
Fix output collisions in clean_flicker_noise tests

### DIFF
--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -56,6 +56,7 @@ def run_detector1_with_clean_flicker_noise(rtdata_module):
     # Run optional clean_flicker_noise step,
     # saving extra outputs and masking to science regions
     args = ["jwst.pipeline.Detector1Pipeline", rtdata_module.input,
+            "--output_file=jw01024002001_02101_00001_mirimage_cfn",
             "--save_calibrated_ramp=True",
             "--steps.clean_flicker_noise.skip=False",
             "--steps.clean_flicker_noise.mask_science_regions=True",
@@ -136,9 +137,9 @@ def test_miri_image_detector1_with_avg_dark_current(run_detector1_with_average_d
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix",
-                         ["clean_flicker_noise", "mask",
+                         ["cfn_clean_flicker_noise", "mask",
                           "flicker_bkg", "flicker_noise",
-                          "ramp", "rate", "rateints"])
+                          "cfn_ramp", "cfn_rate", "cfn_rateints"])
 def test_miri_image_detector1_with_clean_flicker_noise(
         run_detector1_with_clean_flicker_noise,
         rtdata_module, fitsdiff_default_kwargs, suffix):

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -38,6 +38,7 @@ def run_detector1_with_clean_flicker_noise(rtdata_module):
     # Run detector1 pipeline only on one of the _uncal files.
     # Run optional clean_flicker_noise step, saving extra outputs
     args = ["jwst.pipeline.Detector1Pipeline", rtdata_module.input,
+            "--output_file=jw01538046001_03105_00001_nrcalong_cfn",
             "--save_calibrated_ramp=True",
             "--steps.clean_flicker_noise.skip=False",
             "--steps.clean_flicker_noise.save_results=True",
@@ -247,9 +248,9 @@ def test_imaging_distortion(rtdata, fitsdiff_default_kwargs):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix",
-                         ["clean_flicker_noise", "mask",
+                         ["cfn_clean_flicker_noise", "mask",
                           "flicker_bkg", "flicker_noise",
-                          "ramp", "rate", "rateints"])
+                          "cfn_ramp", "cfn_rate", "cfn_rateints"])
 def test_nircam_image_detector1_with_clean_flicker_noise(
         run_detector1_with_clean_flicker_noise,
         rtdata_module, fitsdiff_default_kwargs, suffix):

--- a/jwst/regtest/test_niriss_image.py
+++ b/jwst/regtest/test_niriss_image.py
@@ -45,6 +45,7 @@ def run_detector1_with_clean_flicker_noise(rtdata_module):
     # Run optional clean_flicker_noise step,
     # saving extra outputs and masking to science regions
     args = ["jwst.pipeline.Detector1Pipeline", rtdata_module.input,
+            "--output_file=jw01094001002_02107_00001_nis_cfn",
             "--save_calibrated_ramp=True",
             "--steps.clean_flicker_noise.skip=False",
             "--steps.clean_flicker_noise.save_results=True",
@@ -67,9 +68,9 @@ def test_niriss_image_detector1(run_detector1, rtdata_module, fitsdiff_default_k
 
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("suffix", ["clean_flicker_noise", "mask",
+@pytest.mark.parametrize("suffix", ["cfn_clean_flicker_noise", "mask",
                                     "flicker_bkg", "flicker_noise",
-                                    "ramp", "rate", "rateints"])
+                                    "cfn_ramp", "cfn_rate", "cfn_rateints"])
 def test_niriss_image_detector1_with_clean_flicker_noise(
         run_detector1_with_clean_flicker_noise, rtdata_module, fitsdiff_default_kwargs, suffix):
     """Regression test of detector1 pipeline performed on NIRISS imaging data.

--- a/jwst/regtest/test_nirspec_irs2_detector1.py
+++ b/jwst/regtest/test_nirspec_irs2_detector1.py
@@ -39,6 +39,7 @@ def run_detector1_with_clean_flicker_noise(rtdata_module):
     # Run optional clean_flicker_noise step,
     # saving extra outputs and masking to science regions
     args = ["jwst.pipeline.Detector1Pipeline", rtdata_module.input,
+            "--output_file=jw01335004001_03101_00002_nrs2_cfn",
             "--save_calibrated_ramp=True",
             "--steps.clean_flicker_noise.skip=False",
             "--steps.clean_flicker_noise.mask_science_regions=True",
@@ -74,9 +75,9 @@ def test_nirspec_irs2_detector1(run_detector1pipeline, rtdata_module,
 
 
 @pytest.mark.bigdata
-@pytest.mark.parametrize("suffix", ["clean_flicker_noise", "mask",
+@pytest.mark.parametrize("suffix", ["cfn_clean_flicker_noise", "mask",
                                     "flicker_bkg", "flicker_noise",
-                                    "ramp", "rate", "rateints"])
+                                    "cfn_ramp", "cfn_rate", "cfn_rateints"])
 def test_nirspec_irs2_detector1_with_clean_flicker_noise(
         run_detector1_with_clean_flicker_noise, rtdata_module,
         fitsdiff_default_kwargs, suffix):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Modifying the output file names so that products in the clean_flicker_noise run don't overwrite products in the standard run.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API?
  - [ ] add an entry to `CHANGES.rst` within the relevant release section (otherwise add the `no-changelog-entry-needed` label to this PR)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
