### PR TITLE
JP-3667: Add safeguards for NSClean on background/imprint members

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -188,7 +188,7 @@ pipeline
   in memory or on disk. [#8683]
 
 - Updated ``calwebb_spec2`` to run ``nsclean`` on NIRSpec imprint and background 
-  association members. [#8786]
+  association members. [#8786, #8809]
 
 - Updated `calwebb_spec3` to not save the `pixel_replacement` output by default.[#8765]
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -270,15 +270,26 @@ class Spec2Pipeline(Pipeline):
         calibrated = self.nsclean(calibrated)
         
         # Apply nsclean to NIRSpec imprint and background members
-        for i, imprint_file in enumerate(members_by_type['imprint']):
-            self.nsclean.output_file = os.path.basename(imprint_file)
-            imprint_nsclean = self.nsclean(imprint_file)
-            members_by_type['imprint'][i] = imprint_nsclean
-            
-        for i, bkg_file in enumerate(members_by_type['background']):
-            self.nsclean.output_file = os.path.basename(bkg_file)
-            bkg_nsclean = self.nsclean(bkg_file)
-            members_by_type['background'][i] = bkg_nsclean
+        if not self.nsclean.skip:
+            save_results = self.nsclean.save_results
+
+            for i, imprint_file in enumerate(members_by_type['imprint']):
+                if save_results:
+                    if isinstance(imprint_file, datamodels.JwstDataModel):
+                        self.nsclean.output_file = imprint_file.meta.filename
+                    else:
+                        self.nsclean.output_file = os.path.basename(imprint_file)
+                imprint_nsclean = self.nsclean(imprint_file)
+                members_by_type['imprint'][i] = imprint_nsclean
+
+            for i, bkg_file in enumerate(members_by_type['background']):
+                if save_results:
+                    if isinstance(bkg_file, datamodels.JwstDataModel):
+                        self.nsclean.output_file = bkg_file.meta.filename
+                    else:
+                        self.nsclean.output_file = os.path.basename(bkg_file)
+                bkg_nsclean = self.nsclean(bkg_file)
+                members_by_type['background'][i] = bkg_nsclean
 
         # Leakcal subtraction (imprint)  occurs before background subtraction on a per-exposure basis.
         # If there is only one `imprint` member, this imprint exposure is subtracted from all the


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3667](https://jira.stsci.edu/browse/JP-3667)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Follow up to #8786 to fix some unexpected interactions between badpix_selfcal and nsclean, causing a failure in the badpix_selfcal regression tests.  If badpix_selfcal is run, the background members are datamodels instead of filenames.

I also noticed in testing this that setting the output file for nsclean on the background/imprint members caused them to be saved by default, so I added a check for that as well.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API?
  - [x] add an entry to `CHANGES.rst` within the relevant release section (otherwise add the `no-changelog-entry-needed` label to this PR)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
