### PR TITLE
Speed up regtests by reorganizing test_nirspec_ifu_spec3

### DIFF
--- a/jwst/regtest/test_nirspec_ifu_spec3.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3.py
@@ -3,11 +3,6 @@ import pytest
 
 from jwst.regtest import regtestdata as rt
 
-# Define artifactory source and truth
-INPUT_PATH = 'nirspec/ifu'
-TRUTH_PATH = 'truth/test_nirspec_ifu'
-TRUTH_PATH_PIXEL_REPLACE = 'truth/test_nirspec_ifu_pixel_replace'
-
 
 @pytest.fixture(scope='module')
 def run_spec3_multi(rtdata_module):
@@ -24,27 +19,6 @@ def run_spec3_multi(rtdata_module):
             '--steps.cube_build.save_results=true',
             '--steps.extract_1d.save_results=true',
             '--steps.combine_1d.save_results=true',
-        }
-    }
-
-    rtdata = rt.run_step_from_dict(rtdata, **step_params)
-    return rtdata
-
-
-@pytest.fixture(scope='module')
-def run_spec3_multi_pixel_replace(rtdata_module):
-    """Run Spec3Pipeline with pixel replacement"""
-    rtdata = rtdata_module
-
-    step_params = {
-        'input_path': 'nirspec/ifu/jw01249-o005_20230622t074431_rp_spec3_00001_asn.json',
-        'step': 'calwebb_spec3',
-        'args': {
-            '--steps.pixel_replace.skip=false',
-            '--steps.pixel_replace.save_results=true',
-            '--steps.pixel_replace.algorithm=mingrad',
-            '--steps.cube_build.save_results=true',
-            '--steps.extract_1d.save_results=true',
         }
     }
 
@@ -73,32 +47,6 @@ def test_spec3_multi(run_spec3_multi, fitsdiff_default_kwargs, output):
     """Regression test matching output files"""
     rt.is_like_truth(
         run_spec3_multi, fitsdiff_default_kwargs, output,
-        truth_path=TRUTH_PATH,
-        is_suffix=False
-    )
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-@pytest.mark.parametrize(
-    'output',
-    [
-        'jw01249005001_03101_00001_nrs1_o005_pixel_replace.fits',
-        'jw01249005001_03101_00001_nrs2_o005_pixel_replace.fits',
-        'jw01249005001_03101_00002_nrs1_o005_pixel_replace.fits',
-        'jw01249005001_03101_00002_nrs2_o005_pixel_replace.fits',
-        'jw01249005001_03101_00003_nrs1_o005_pixel_replace.fits',
-        'jw01249005001_03101_00003_nrs2_o005_pixel_replace.fits',
-        'jw01249005001_03101_00004_nrs1_o005_pixel_replace.fits',
-        'jw01249005001_03101_00004_nrs2_o005_pixel_replace.fits',
-        'jw01249-o005_t001_nirspec_rp_test_g395h-f290lp_s3d.fits',
-        'jw01249-o005_t001_nirspec_rp_test_g395h-f290lp_x1d.fits',
-    ]
-)
-def test_spec3_multi_pixel_replace(run_spec3_multi_pixel_replace, fitsdiff_default_kwargs, output):
-    """Regression test matching output files"""
-    rt.is_like_truth(
-        run_spec3_multi_pixel_replace, fitsdiff_default_kwargs, output,
-        truth_path=TRUTH_PATH_PIXEL_REPLACE,
+        truth_path='truth/test_nirspec_ifu',
         is_suffix=False
     )

--- a/jwst/regtest/test_nirspec_ifu_spec3_pixelreplace.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_pixelreplace.py
@@ -1,0 +1,53 @@
+"""Regression tests for NIRSpec IFU"""
+import pytest
+
+from jwst.regtest import regtestdata as rt
+
+TRUTH_PATH_PIXEL_REPLACE = 'truth/test_nirspec_ifu_pixel_replace'
+
+
+@pytest.fixture(scope='module')
+def run_spec3_multi_pixel_replace(rtdata_module):
+    """Run Spec3Pipeline with pixel replacement"""
+    rtdata = rtdata_module
+
+    step_params = {
+        'input_path': 'nirspec/ifu/jw01249-o005_20230622t074431_rp_spec3_00001_asn.json',
+        'step': 'calwebb_spec3',
+        'args': {
+            '--steps.pixel_replace.skip=false',
+            '--steps.pixel_replace.save_results=true',
+            '--steps.pixel_replace.algorithm=mingrad',
+            '--steps.cube_build.save_results=true',
+            '--steps.extract_1d.save_results=true',
+        }
+    }
+
+    rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    return rtdata
+
+
+@pytest.mark.slow
+@pytest.mark.bigdata
+@pytest.mark.parametrize(
+    'output',
+    [
+        'jw01249005001_03101_00001_nrs1_o005_pixel_replace.fits',
+        'jw01249005001_03101_00001_nrs2_o005_pixel_replace.fits',
+        'jw01249005001_03101_00002_nrs1_o005_pixel_replace.fits',
+        'jw01249005001_03101_00002_nrs2_o005_pixel_replace.fits',
+        'jw01249005001_03101_00003_nrs1_o005_pixel_replace.fits',
+        'jw01249005001_03101_00003_nrs2_o005_pixel_replace.fits',
+        'jw01249005001_03101_00004_nrs1_o005_pixel_replace.fits',
+        'jw01249005001_03101_00004_nrs2_o005_pixel_replace.fits',
+        'jw01249-o005_t001_nirspec_rp_test_g395h-f290lp_s3d.fits',
+        'jw01249-o005_t001_nirspec_rp_test_g395h-f290lp_x1d.fits',
+    ]
+)
+def test_spec3_multi_pixel_replace(run_spec3_multi_pixel_replace, fitsdiff_default_kwargs, output):
+    """Regression test matching output files"""
+    rt.is_like_truth(
+        run_spec3_multi_pixel_replace, fitsdiff_default_kwargs, output,
+        truth_path='truth/test_nirspec_ifu_pixel_replace',
+        is_suffix=False
+    )


### PR DESCRIPTION
This is a minor reorganization of tests in test_nirspec_ifu_spec3 to more efficiently run them in parallel.

This reduces regtests runtime by about 8 minutes.

jwst/regtest/test_nirspec_ifu_spec3.py contains 2 of the [slower](https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1744/testReport/jwst.regtest/test_nirspec_ifu_spec3/) regtests since the regtests run in parallel scoped by module these 2 tests end up in the same scope given to 1 worker. This worker then spends over 2 hours on those 2 tests (run serially). This PR splits jwst/regtest/test_nirspec_ifu_spec3.py putting the 2 slow fixtures in different files/modules so they can be run on different workers.

Ideally we'd start the slowest tests first so they could toil away while other workers run other tests. If we instead start them later in the test run our overall run will likely end up taking as we wait for the slow test to finish. However this is currently not possible with pytest-xdist (see https://github.com/pytest-dev/pytest-xdist/pull/778).

With this PR regtests ran in 1hr 8 minutes: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1745/ (with only unrelated failures).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API?
  - [ ] add an entry to `CHANGES.rst` within the relevant release section (otherwise add the `no-changelog-entry-needed` label to this PR)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
