### PR TITLE
Remove unnecessary test after pastasoss inclusion

### DIFF
--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -127,24 +127,6 @@ def test_niriss_soss_extras(rtdata_module, run_atoca_extras, fitsdiff_default_kw
 
 
 @pytest.fixture(scope='module')
-def run_extract1d_spsolve_failure(rtdata_module):
-    """
-    Test coverage for fix to error thrown when spsolve fails to find
-    a good solution in ATOCA and needs to be replaced with a least-
-    squares solver. Note this failure is architecture-dependent
-    and also only trips for specific values of the transform parameters.
-    Pin tikfac for faster runtime.
-    """
-    rtdata = rtdata_module
-    rtdata.get_data("niriss/soss/jw04098007001_04101_00001-seg003_nis_int01.fits")
-    args = ["extract_1d", rtdata.input,
-            "--soss_tikfac=3.1881637371089252e-15",
-            "--soss_transform=-0.00038201755227297866, -0.24237455427848956, 0.5404013401742825",
-            ]
-    Step.from_cmdline(args)
-
-
-@pytest.fixture(scope='module')
 def run_extract1d_null_order2(rtdata_module):
     """
     Test coverage for fix to error thrown when all of the pixels
@@ -156,23 +138,8 @@ def run_extract1d_null_order2(rtdata_module):
     rtdata.get_data("niriss/soss/jw01201008001_04101_00001-seg003_nis_int72.fits")
     args = ["extract_1d", rtdata.input,
             "--soss_tikfac=4.290665733550672e-17",
-            "--soss_transform=0.0794900761418923, -1.3197790951056494, -0.796875809148081",
             ]
     Step.from_cmdline(args)
-
-
-@pytest.mark.bigdata
-def test_extract1d_spsolve_failure(rtdata_module, run_extract1d_spsolve_failure, fitsdiff_default_kwargs):
-
-    rtdata = rtdata_module
-
-    output = "jw04098007001_04101_00001-seg003_nis_int01_extract1dstep.fits"
-    rtdata.output = output
-
-    rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
-
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()
 
 
 @pytest.mark.bigdata


### PR DESCRIPTION
This PR addresses a failure in regression testing after our 1.16.0 release, coupled with the migration of `pastasoss` reference files to CRDS OPS. This test was introduced to ensure the prior algorithm could navigate an internal failure of the transform solver - that solver algorithm is now gone, and the new algorithm is robust to the previous issue (i.e. it does not care what pixel values exist). It is no longer relevant and can be removed.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
    - ``changes/<PR#>.docs.rst``
    - ``changes/<PR#>.stpipe.rst``
    - ``changes/<PR#>.datamodels.rst``
    - ``changes/<PR#>.scripts.rst``
    - ``changes/<PR#>.fits_generator.rst``
    - ``changes/<PR#>.set_telescope_pointing.rst``

    ## stage 1
    - ``changes/<PR#>.group_scale.rst``
    - ``changes/<PR#>.dq_init.rst``
    - ``changes/<PR#>.emicorr.rst``
    - ``changes/<PR#>.saturation.rst``
    - ``changes/<PR#>.ipc.rst``
    - ``changes/<PR#>.firstframe.rst``
    - ``changes/<PR#>.lastframe.rst``
    - ``changes/<PR#>.reset.rst``
    - ``changes/<PR#>.superbias.rst``
    - ``changes/<PR#>.refpix.rst``
    - ``changes/<PR#>.linearity.rst``
    - ``changes/<PR#>.rscd.rst``
    - ``changes/<PR#>.persistence.rst``
    - ``changes/<PR#>.dark_current.rst``
    - ``changes/<PR#>.charge_migration.rst``
    - ``changes/<PR#>.jump.rst``
    - ``changes/<PR#>.ramp_fitting.rst``
    - ``changes/<PR#>.gain_scale.rst``

    ## stage 2
    - ``changes/<PR#>.assign_wcs.rst``
    - ``changes/<PR#>.msaflagopen.rst``
    - ``changes/<PR#>.nsclean.rst``
    - ``changes/<PR#>.imprint.rst``
    - ``changes/<PR#>.background.rst``
    - ``changes/<PR#>.extract_2d.rst``
    - ``changes/<PR#>.master_background.rst``
    - ``changes/<PR#>.wavecorr.rst``
    - ``changes/<PR#>.srctype.rst``
    - ``changes/<PR#>.straylight.rst``
    - ``changes/<PR#>.wfss_contam.rst``
    - ``changes/<PR#>.flatfield.rst``
    - ``changes/<PR#>.fringe.rst``
    - ``changes/<PR#>.pathloss.rst``
    - ``changes/<PR#>.barshadow.rst``
    - ``changes/<PR#>.photom.rst``
    - ``changes/<PR#>.pixel_replace.rst``
    - ``changes/<PR#>.resample_spec.rst``
    - ``changes/<PR#>.residual_fringe.rst``
    - ``changes/<PR#>.cube_build.rst``
    - ``changes/<PR#>.extract_1d.rst``
    - ``changes/<PR#>.resample.rst``

    ## stage 3
    - ``changes/<PR#>.assign_mtwcs.rst``
    - ``changes/<PR#>.mrs_imatch.rst``
    - ``changes/<PR#>.tweakreg.rst``
    - ``changes/<PR#>.skymatch.rst``
    - ``changes/<PR#>.exp_to_source.rst``
    - ``changes/<PR#>.outlier_detection.rst``
    - ``changes/<PR#>.tso_photometry.rst``
    - ``changes/<PR#>.stack_refs.rst``
    - ``changes/<PR#>.align_refs.rst``
    - ``changes/<PR#>.klip.rst``
    - ``changes/<PR#>.spectral_leak.rst``
    - ``changes/<PR#>.source_catalog.rst``
    - ``changes/<PR#>.combine_1d.rst``
    - ``changes/<PR#>.ami.rst``

    ## other
    - ``changes/<PR#>.wfs_combine.rst``
    - ``changes/<PR#>.white_light.rst``
    - ``changes/<PR#>.cube_skymatch.rst``
    - ``changes/<PR#>.engdb_tools.rst``
    - ``changes/<PR#>.guider_cds.rst``
</details>
