### PR TITLE
JP-3347: Improve spectral outlier detection

### DIFF
--- a/changes/8828.outlier_detection.rst
+++ b/changes/8828.outlier_detection.rst
@@ -1,0 +1,1 @@
+For slit spectra, threshold outliers with a median error across exposures instead of input error from the exposure itself.

--- a/docs/jwst/outlier_detection/arguments.rst
+++ b/docs/jwst/outlier_detection/arguments.rst
@@ -23,7 +23,7 @@ that control the behavior of the processing:
   The value to assign to resampled image pixels that have zero weight or
   do not receive any flux from any input pixels during drizzling.
   Any floating-point value, given as a string, is valid.
-  A value of 'INDEF' will use the last zero weight flux.
+  The default value of 'NAN' sets NaN values.
 
 ``--maskpt``
   The percent of maximum weight to use as lower-limit for valid data;

--- a/docs/jwst/outlier_detection/outlier_detection_spec.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_spec.rst
@@ -22,22 +22,23 @@ Specifically, this routine performs the following operations (modified from the
    - A :py:class:`~jwst.datamodels.ModelContainer` serves as the basic format 
      for all processing performed by
      this step, as each entry will be treated as an element of a stack of images
-     to be processed to identify bad pixels, cosmic-rays and other artifacts.
+     to be processed to identify bad pixels, cosmic rays and other artifacts.
 
 #. If the ``resample_data`` parameter is set to True, resample all input images
    using :py:class:`~jwst.resample.resample_spec.ResampleSpecData`.
 
-   - Error images are resampled alongside the science data, to create
+   - Error images are resampled alongside the science data to create
      approximate error arrays for each resampled exposure.
    - The resampled data are written out to disk with suffix "outlier_s2d"
      if the ``save_intermediate_results`` parameter is set to `True`.
 
 #. Create a median image from the resampled exposures, or directly from
-   the input exposures, if ``resample_data`` is set to False.
+   the input exposures if ``resample_data`` is set to False.
 
    - The error images for each exposure are also median-combined.
-   - The median data are written out to disk with suffix "median"
-     if the ``save_intermediate_results`` parameter is set to `True`.
+   - The median datamodel, with ``data`` and ``err`` extensions, is
+     written to disk with suffix "median" if the ``save_intermediate_results``
+     parameter is set to `True`.
 
 #. If ``resample_data`` is set to True, blot the median image to match
    each original input image.

--- a/docs/jwst/outlier_detection/outlier_detection_spec.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_spec.rst
@@ -13,38 +13,49 @@ Specifically, this routine performs the following operations (modified from the
 
 #. Extract parameter settings from input model and merge them with any user-provided values
 
-   - the same set of parameters available to:
+   - The same set of parameters available to:
      ref:`Default Outlier Detection Algorithm <outlier-detection-imaging>`
-     also applies to this code
+     also applies to this code.
+
 #. Convert input data, as needed, to make sure it is in a format that can be processed
 
    - A :py:class:`~jwst.datamodels.ModelContainer` serves as the basic format 
      for all processing performed by
      this step, as each entry will be treated as an element of a stack of images
-     to be processed to identify bad pixels, cosmic-rays and other artifacts
-   - If the input data is a :py:class:`~jwst.datamodels.CubeModel`, convert it into a 
-     :py:class:`~jwst.datamodels.ModelContainer`.
-     This allows each plane of the cube to be treated as a separate 2D image
-     for resampling (if done) and for combining into a median image.
-#. Resample all input images into a :py:class:`~jwst.datamodels.ModelContainer` using
-   :py:class:`~jwst.resample.resample_spec.ResampleSpecData`
+     to be processed to identify bad pixels, cosmic-rays and other artifacts.
 
-   - Resampled images are written out to disk with suffix "outlier_s2d"
+#. If the ``resample_data`` parameter is set to True, resample all input images
+   using :py:class:`~jwst.resample.resample_spec.ResampleSpecData`.
+
+   - Error images are resampled alongside the science data, to create
+     approximate error arrays for each resampled exposure.
+   - The resampled data are written out to disk with suffix "outlier_s2d"
      if the ``save_intermediate_results`` parameter is set to `True`.
-   - **If resampling is turned off**, the original unrectified inputs are used to create
-     the median image for cosmic-ray detection.
-#. Create a median image from (possibly) resampled :py:class:`~jwst.datamodels.ModelContainer`
 
-   - The median image is written out to disk with suffix "median"
-     if the ``save_intermediate_results`` parameter is set to `True`
-#. Blot median image to match each original input image
+#. Create a median image from the resampled exposures, or directly from
+   the input exposures, if ``resample_data`` is set to False.
 
+   - The error images for each exposure are also median-combined.
+   - The median data are written out to disk with suffix "median"
+     if the ``save_intermediate_results`` parameter is set to `True`.
+
+#. If ``resample_data`` is set to True, blot the median image to match
+   each original input image.
+
+   - The median error image is also blotted to match the input.
    - Resampled/blotted images are written out to disk if the ``save_intermediate_results``
-     parameter is set to `True`
-   - **If resampling is turned off**, the median image is used for comparison
-     with the original input models for detecting outliers
-#. Perform statistical comparison between blotted image and original image to identify outliers
-#. Update input data model DQ arrays with mask of detected outliers
+     parameter is set to `True`.
+
+#. Perform statistical comparison between the median image and the original image
+   to identify outliers.
+
+   - Signal-to-noise thresholding uses the median error image, rather than the
+     input error image, in order to better identify outliers that have both
+     high data values and high error values in the input exposures.
+
+#. Update input data model DQ arrays with mask of detected outliers.
+   Update the SCI, ERR, and VAR arrays with NaN values at the outlier
+   locations.
 
 
 .. automodapi:: jwst.outlier_detection.spec

--- a/jwst/outlier_detection/_fileio.py
+++ b/jwst/outlier_detection/_fileio.py
@@ -21,14 +21,16 @@ def save_drizzled(drizzled_model, make_output_path):
     _save_intermediate_output(drizzled_model, suffix, make_output_path)
 
 
-def save_blot(input_model, blot, make_output_path):
-    blot_model = _make_blot_model(input_model, blot)
+def save_blot(input_model, blot, blot_err, make_output_path):
+    blot_model = _make_blot_model(input_model, blot, blot_err)
     _save_intermediate_output(blot_model, "blot", make_output_path)
 
 
-def _make_blot_model(input_model, blot):
+def _make_blot_model(input_model, blot, blot_err):
     blot_model = type(input_model)()
     blot_model.data = blot
+    if blot_err is not None:
+        blot_model.err = blot_err
     blot_model.update(input_model)
     return blot_model
 

--- a/jwst/outlier_detection/_fileio.py
+++ b/jwst/outlier_detection/_fileio.py
@@ -4,29 +4,91 @@ log.setLevel(logging.DEBUG)
 
 
 def save_median(median_model, make_output_path):
-    '''
-    Save median if requested by user
+    """Save a median model.
+
+    Output suffix is 'median'.
 
     Parameters
     ----------
     median_model : ~jwst.datamodels.ImageModel
         The median ImageModel or CubeModel to save
-    '''
+
+    make_output_path : function
+        A function to be used to create an output path from
+        an input path and an optional suffix.
+
+    """
     _save_intermediate_output(median_model, "median", make_output_path)
 
 
 def save_drizzled(drizzled_model, make_output_path):
+    """Save a drizzled model.
+
+    Input model is expected to have a filename that ends with
+    either 'outlier_i2d.fits' or 'outlier_s2d.fits'.
+
+    Parameters
+    ----------
+    drizzled_model : ~jwst.datamodels.ImageModel
+        The median ImageModel or CubeModel to save.
+
+    make_output_path : function
+        A function to be used to create an output path from
+        an input path and an optional suffix.
+
+    """
     expected_tail = "outlier_?2d.fits"
     suffix = drizzled_model.meta.filename[-len(expected_tail):-5]
     _save_intermediate_output(drizzled_model, suffix, make_output_path)
 
 
 def save_blot(input_model, blot, blot_err, make_output_path):
+    """Save a blotted model.
+
+    Output suffix is 'blot'.
+
+    Parameters
+    ----------
+    input_model : ~jwst.datamodels.ImageModel
+        An input model corresponding to the blotted data,
+        containing metadata to copy.
+
+    blot : array-like
+        The blotted science data.
+
+    blot_err : array-like or None
+        The blotted error data, if available.
+
+    make_output_path : function
+        A function to be used to create an output path from
+        an input path and an optional suffix.
+
+    """
     blot_model = _make_blot_model(input_model, blot, blot_err)
     _save_intermediate_output(blot_model, "blot", make_output_path)
 
 
 def _make_blot_model(input_model, blot, blot_err):
+    """Assemble a blot model.
+
+    Parameters
+    ----------
+    input_model : ~jwst.datamodels.ImageModel
+        An input model corresponding to the blotted data,
+        containing metadata to copy.
+
+    blot : array-like
+        The blotted science data.
+
+    blot_err : array-like or None
+        The blotted error data, if available.
+
+    Returns
+    -------
+    blot_model : ~jwst.datamodels.ImageModel
+        An image model containing the blotted data.
+
+    """
     blot_model = type(input_model)()
     blot_model.data = blot
     if blot_err is not None:
@@ -36,15 +98,29 @@ def _make_blot_model(input_model, blot, blot_err):
 
 
 def _save_intermediate_output(model, suffix, make_output_path):
-    """
-    Ensure all intermediate outputs from OutlierDetectionStep have consistent file naming conventions
-    
+    """Save an intermediate output from outlier detection.
+
+    Ensure all intermediate outputs from OutlierDetectionStep have
+    consistent file naming conventions.
+
+    Parameters
+    ----------
+    model : ~jwst.datamodels.ImageModel
+        The intermediate datamodel to save.
+
+    suffix : str
+        A suffix to add to the output file name.
+
+    make_output_path : function
+        A function to be used to create an output path from
+        an input path and an optional suffix.
+
     Notes
     -----
     self.make_output_path() is updated globally for the step in the main pipeline
     to include the asn_id in the output path, so no need to handle it here.
-    """
 
+    """
     # outlier_?2d is not a known suffix, and make_output_path cannot handle an
     # underscore in an unknown suffix, so do a manual string replacement
     input_path = model.meta.filename.replace("_outlier_", "_")

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -43,7 +43,7 @@ class OutlierDetectionStep(Step):
         weight_type = option('ivm','exptime',default='ivm')
         pixfrac = float(default=1.0)
         kernel = string(default='square') # drizzle kernel
-        fillval = string(default='INDEF')
+        fillval = string(default='NAN')
         maskpt = float(default=0.7)
         snr = string(default='5.0 4.0')
         scale = string(default='1.2 0.7')

--- a/jwst/outlier_detection/spec.py
+++ b/jwst/outlier_detection/spec.py
@@ -1,6 +1,5 @@
-"""
-Submodule for performing outlier detection on spectra.
-"""
+"""Perform outlier detection on spectra."""
+
 from jwst.datamodels import ModelContainer, ModelLibrary
 from jwst.stpipe.utilities import record_step_status
 
@@ -36,8 +35,7 @@ def detect_outliers(
     in_memory,
     make_output_path,
 ):
-    """
-    Flag outliers in spec data.
+    """Flag outliers in spec data.
 
     See `OutlierDetectionStep.spec` for documentation of these arguments.
     """

--- a/jwst/outlier_detection/spec.py
+++ b/jwst/outlier_detection/spec.py
@@ -68,20 +68,22 @@ def detect_outliers(
             good_bits=good_bits,
         )
 
-        median_data, median_wcs = median_with_resampling(
+        median_data, median_wcs, median_err = median_with_resampling(
             library,
             resamp,
             maskpt,
             save_intermediate_results=save_intermediate_results,
-            make_output_path=make_output_path,)
+            make_output_path=make_output_path,
+            return_error=True)
     else:
-        median_data, median_wcs = median_without_resampling(
+        median_data, median_wcs, median_err = median_without_resampling(
             library,
             maskpt,
             weight_type,
             good_bits,
             save_intermediate_results=save_intermediate_results,
             make_output_path=make_output_path,
+            return_error=True
         )
 
     # Perform outlier detection using statistical comparisons between
@@ -96,11 +98,13 @@ def detect_outliers(
             scale1,
             scale2,
             backg,
+            median_err=median_err,
             save_blot=save_intermediate_results,
             make_output_path=make_output_path
         )
     else:
         flag_crs_in_models(input_models,
                            median_data,
-                           snr1)
+                           snr1,
+                           median_err=median_err)
     return input_models

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -83,6 +83,7 @@ def test_flag_cr(sci_blot_image_pair):
     _flag_resampled_model_crs(
         sci,
         blot.data,
+        None,
         5.0,
         4.0,
         1.2,

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -89,7 +89,7 @@ def median_without_resampling(input_models,
         library has its on_disk attribute set to False.
 
     return_error : bool, optional
-        If set, an approximate median error is computed alongside the
+        If True, an approximate median error is computed alongside the
         median science image.
 
     Returns
@@ -160,11 +160,8 @@ def median_with_resampling(input_models,
                            return_error=False):
     """Compute a median image with resampling.
 
-    The median is performed across exposures, for both imaging
+    The median is performed across resampled groups, for both imaging
     and spectral modes.
-
-    Shared code between imaging and spec modes for resampling and
-    median computation.
 
     Parameters
     ----------
@@ -190,7 +187,7 @@ def median_with_resampling(input_models,
         library has its on_disk attribute set to False.
 
     return_error : bool, optional
-        If set, an approximate median error is computed alongside the
+        If True, an approximate median error is computed alongside the
         median science image.
 
     Returns

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -85,6 +85,7 @@ def median_without_resampling(input_models,
 
             drizzled_model = input_models.borrow(i)
             drizzled_data = drizzled_model.data.copy()
+            drizzled_err = drizzled_model.err.copy()
             weight = build_driz_weight(drizzled_model,
                                        weight_type=weight_type,
                                        good_bits=good_bits)
@@ -97,7 +98,9 @@ def median_without_resampling(input_models,
 
             weight_threshold = compute_weight_threshold(weight, maskpt)
             drizzled_data[weight < weight_threshold] = np.nan
+            drizzled_err[weight < weight_threshold] = np.nan
             computer.append(drizzled_data, i)
+            err_computer.append(drizzled_err, i)
 
             input_models.shelve(drizzled_model, i, modify=False)
 

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -34,7 +34,7 @@ def create_cube_median(cube_model, maskpt):
     Returns
     -------
     np.ndarray
-        The median over the first axis of the input cube.
+        The median over the zeroth axis of the input cube.
 
     """
     log.info("Computing median")

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -244,10 +244,10 @@ def flag_resampled_model_crs(
         pix_ratio = 1.0
 
     blot = gwcs_blot(median_data, median_wcs, input_model.data.shape,
-                     input_model.meta.wcs, pix_ratio) #, fillval=np.nan)
+                     input_model.meta.wcs, pix_ratio, fillval=np.nan)
     if median_err is not None:
         blot_err = gwcs_blot(median_err, median_wcs, input_model.data.shape,
-                             input_model.meta.wcs, pix_ratio) #, fillval=np.nan)
+                             input_model.meta.wcs, pix_ratio, fillval=np.nan)
     else:
         blot_err = None
     if save_blot:

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -108,6 +108,8 @@ def median_without_resampling(input_models,
     if save_intermediate_results:
         # Save median model to fits
         median_model = datamodels.ImageModel(median_data)
+        if return_error:
+            median_model.err = median_err
         median_model.update(drizzled_model)
         median_model.meta.wcs = median_wcs
         _fileio.save_median(median_model, make_output_path)

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -262,7 +262,7 @@ class ResampleData:
         indices : list
 
         compute_error : bool, optional
-            If set, an approximate error image will be resampled
+            If True, an approximate error image will be resampled
             alongside the science image.
         """
         output_model = self.blank_output.copy()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3347](https://jira.stsci.edu/browse/JP-3347)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

Modify outlier detection for spectral data, in order to threshold outliers for an exposure against an error value computed across exposures, instead of the input error for the exposure itself. This is intended to help address extreme outliers that have both very high data values and very high error values in the input exposure.

The process for resampled data is:
- drizzle the error array the same way as the science, to approximate a resampled error for each exposure
- median combine the drizzled error arrays across exposures, in the same way the drizzled science arrays are median combined
- blot the median error back to the input data coordinates, in the same way the median science image is handled
- compare (input data - blotted median) to blotted median error for thresholding purposes.

For outlier detection on spectra without resampling (not commonly used), the median error is directly computed across the input exposures and used for thresholding.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
