### PR TITLE
JP-3773: Store logs from calibration pipeline in datamodel

### DIFF
--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -101,8 +101,10 @@ class JwstStep(Step):
 
         if hasattr(result, 'cal_logs'):
             tmpdict = result.cal_logs.instance
-            tmpdict[self.class_alias] = '\n'.join(self._log_records)
-            result.cal_logs = tmpdict
+        else:
+            tmpdict = dict()
+        tmpdict[self.class_alias] = '\n'.join(self._log_records)
+        result.cal_logs = tmpdict
 
     def remove_suffix(self, name):
         return remove_suffix(name)
@@ -138,9 +140,11 @@ class JwstPipeline(Pipeline, JwstStep):
 
             if hasattr(result, 'cal_logs'):
                 tmpdict = result.cal_logs.instance
-                tmpdict[self.class_alias] = '\n'.join(self._log_records)
+            else:
+                tmpdict = dict()
+            tmpdict[self.class_alias] = '\n'.join(self._log_records)
 
-                for _, step in self.step_defs.items():
-                    if step.class_alias in tmpdict.keys():
-                        del tmpdict[step.class_alias]
-                result.cal_logs = tmpdict
+            for _, step in self.step_defs.items():
+                if step.class_alias in tmpdict.keys():
+                    del tmpdict[step.class_alias]
+            result.cal_logs = tmpdict

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -4,15 +4,20 @@ JWST-specific Step and Pipeline base classes.
 from functools import wraps
 import logging
 import warnings
+import time
 
 from stdatamodels.jwst.datamodels import JwstDataModel
 from stdatamodels.jwst import datamodels
-from stpipe import crds_client
-from stpipe import Step
-from stpipe import Pipeline
+from stpipe import crds_client, Step, Pipeline
 
 from .. import __version_commit__, __version__
 from ..lib.suffix import remove_suffix
+
+_LOG_FORMATTER = logging.Formatter(
+    "%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+_LOG_FORMATTER.converter = time.gmtime
 
 
 log = logging.getLogger(__name__)
@@ -24,6 +29,8 @@ class JwstStep(Step):
     spec = """
     output_ext = string(default='.fits')  # Output file type
     """
+
+    _log_records_formatter = _LOG_FORMATTER
 
     @classmethod
     def _datamodels_open(cls, init, **kwargs):
@@ -92,6 +99,10 @@ class JwstStep(Step):
                 if self.parent is None:
                     log.info(f"Results used CRDS context: {result.meta.ref_file.crds.context_used}")
 
+        if hasattr(result, 'cal_logs'):
+            tmpdict = result.cal_logs.instance
+            tmpdict[self.class_alias] = '\n'.join(self._log_records)
+            result.cal_logs = tmpdict
 
     def remove_suffix(self, name):
         return remove_suffix(name)
@@ -124,3 +135,12 @@ class JwstPipeline(Pipeline, JwstStep):
     def finalize_result(self, result, reference_files_used):
         if isinstance(result, JwstDataModel):
             log.info(f"Results used CRDS context: {crds_client.get_context_used(result.crds_observatory)}")
+
+            if hasattr(result, 'cal_logs'):
+                tmpdict = result.cal_logs.instance
+                tmpdict[self.class_alias] = '\n'.join(self._log_records)
+
+                for _, step in self.step_defs.items():
+                    if step.class_alias in tmpdict.keys():
+                        del tmpdict[step.class_alias]
+                result.cal_logs = tmpdict

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -99,12 +99,12 @@ class JwstStep(Step):
                 if self.parent is None:
                     log.info(f"Results used CRDS context: {result.meta.ref_file.crds.context_used}")
 
-        if hasattr(result, 'cal_logs'):
-            tmpdict = result.cal_logs.instance
-        else:
-            tmpdict = dict()
-        tmpdict[self.class_alias] = '\n'.join(self._log_records)
-        result.cal_logs = tmpdict
+            if hasattr(result, 'cal_logs'):
+                tmpdict = result.cal_logs.instance
+            else:
+                tmpdict = dict()
+            tmpdict[self.class_alias] = '\n'.join(self._log_records)
+            result.cal_logs = tmpdict
 
     def remove_suffix(self, name):
         return remove_suffix(name)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3773](https://jira.stsci.edu/browse/JP-3773)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8855

<!-- describe the changes comprising this PR here -->
This PR adds the log records during processing to a datamodel attribute `model.cal_logs`. This attribute is a dictionary, with keys equal to steps and/or pipelines applied to the data, and values associated with those keys equal to the log output.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
