### PR TITLE
JP-2928: Update NIRCam tsgrism and tsimg regression test data

### DIFF
--- a/jwst/regtest/test_nircam_tsgrism.py
+++ b/jwst/regtest/test_nircam_tsgrism.py
@@ -2,7 +2,6 @@ import pytest
 from astropy.io.fits.diff import FITSDiff
 from astropy.table import Table, setdiff
 
-from jwst.lib.set_telescope_pointing import add_wcs
 from jwst.stpipe import Step
 
 
@@ -33,7 +32,6 @@ def run_pipelines(rtdata_module):
                 params=["jw01185015001_03104_00001-seg004_nrcalong_rate.fits",
                         "jw01185013001_04103_00001-seg003_nrcalong_rate.fits"])
 def run_pipeline_offsetSR(request, rtdata_module):
-    ''''''
     rtdata = rtdata_module
     rtdata.get_data("nircam/tsgrism/" + request.param)
     args = ["calwebb_spec2", rtdata.input,
@@ -44,12 +42,13 @@ def run_pipeline_offsetSR(request, rtdata_module):
 
 @pytest.mark.bigdata
 def test_nircam_tsgrism_stage2_offsetSR(run_pipeline_offsetSR, fitsdiff_default_kwargs):
-    '''
+    """
     Test coverage for offset special requirement specifying nonzero offset in X.
+
     Test data are two observations of Gliese 436, one with offset specified and one without.
     Quantitatively we just ensure that the outputs are identical to the inputs, but qualitatively
     can check that the spectral lines fall at the same wavelengths in both cases,
-    which is why the zero-offset case is also included here.'''
+    which is why the zero-offset case is also included here."""
     rtdata = run_pipeline_offsetSR
     rtdata.output = rtdata.input.replace("rate", "x1d")
     rtdata.get_truth("truth/test_nircam_tsgrism_stages/" + rtdata.output.split('/')[-1])
@@ -92,33 +91,8 @@ def test_nircam_tsgrism_stage3_whtlt(run_pipelines):
     rtdata.output = "jw01366-o002_t001_nircam_f322w2-grismr-subgrism256_whtlt.ecsv"
     rtdata.get_truth("truth/test_nircam_tsgrism_stages/jw01366-o002_t001_nircam_f322w2-grismr-subgrism256_whtlt.ecsv")
 
-
     table = Table.read(rtdata.output)
     table_truth = Table.read(rtdata.truth)
 
     # setdiff returns a table of length zero if there is no difference
     assert len(setdiff(table, table_truth)) == 0
-
-
-@pytest.mark.bigdata
-def test_nircam_setpointing_tsgrism(rtdata, fitsdiff_default_kwargs):
-    """
-    Regression test of the set_telescope_pointing script on a level-1b NIRCam file.
-    """
-    # Get SIAF PRD database file
-    siaf_path = rtdata.get_data("common/prd.db")
-    rtdata.get_data("nircam/tsgrism/jw00721012001_03103_00001-seg001_nrcalong_uncal.fits")
-    # The add_wcs function overwrites its input
-    rtdata.output = rtdata.input
-
-    # Call the WCS routine, using the ENGDB_Service
-    try:
-        add_wcs(rtdata.input, siaf_path=siaf_path)
-    except ValueError:
-        pytest.skip('Engineering Database not available.')
-
-    rtdata.get_truth("truth/test_nircam_setpointing/jw00721012001_03103_00001-seg001_nrcalong_uncal.fits")
-
-    fitsdiff_default_kwargs['rtol'] = 1e-6
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()

--- a/jwst/regtest/test_nircam_tsgrism.py
+++ b/jwst/regtest/test_nircam_tsgrism.py
@@ -12,7 +12,7 @@ def run_pipelines(rtdata_module):
     rtdata = rtdata_module
 
     # Run tso-spec2 pipeline on the _rateints file, saving intermediate products
-    rtdata.get_data("nircam/tsgrism/jw00721012001_03103_00001-seg001_nrcalong_rateints.fits")
+    rtdata.get_data("nircam/tsgrism/jw01366002001_04103_00001-seg001_nrcalong_rateints.fits")
     args = ["calwebb_spec2", rtdata.input,
             "--steps.flat_field.save_results=True",
             "--steps.extract_2d.save_results=True",
@@ -22,7 +22,7 @@ def run_pipelines(rtdata_module):
 
     # Get the level3 association json file (though not its members) and run
     # the tso3 pipeline on all _calints files listed in association
-    rtdata.get_data("nircam/tsgrism/jw00721-o012_20191119t043909_tso3_001_asn.json")
+    rtdata.get_data("nircam/tsgrism/jw01366-o002_20230107t004627_tso3_00001_asn.json")
     args = ["calwebb_tso3", rtdata.input]
     Step.from_cmdline(args)
 
@@ -60,12 +60,12 @@ def test_nircam_tsgrism_stage2_offsetSR(run_pipeline_offsetSR, fitsdiff_default_
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["calints", "extract_2d", "flat_field",
-                                    "o012_crfints", "srctype", "x1dints"])
+                                    "o002_crfints", "srctype", "x1dints"])
 def test_nircam_tsgrism_stage2(run_pipelines, fitsdiff_default_kwargs, suffix):
     """Regression test of tso-spec2 pipeline performed on NIRCam TSO grism data."""
     rtdata = run_pipelines
-    rtdata.input = "jw00721012001_03103_00001-seg001_nrcalong_rateints.fits"
-    output = "jw00721012001_03103_00001-seg001_nrcalong_" + suffix + ".fits"
+    rtdata.input = "jw01366002001_04103_00001-seg001_nrcalong_rateints.fits"
+    output = "jw01366002001_04103_00001-seg001_nrcalong_" + suffix + ".fits"
     rtdata.output = output
 
     rtdata.get_truth("truth/test_nircam_tsgrism_stages/" + output)
@@ -77,9 +77,9 @@ def test_nircam_tsgrism_stage2(run_pipelines, fitsdiff_default_kwargs, suffix):
 @pytest.mark.bigdata
 def test_nircam_tsgrism_stage3_x1dints(run_pipelines, fitsdiff_default_kwargs):
     rtdata = run_pipelines
-    rtdata.input = "jw00721-o012_20191119t043909_tso3_001_asn.json"
-    rtdata.output = "jw00721-o012_t004_nircam_f444w-grismr-subgrism256_x1dints.fits"
-    rtdata.get_truth("truth/test_nircam_tsgrism_stages/jw00721-o012_t004_nircam_f444w-grismr-subgrism256_x1dints.fits")
+    rtdata.input = "jw01366-o002_20230107t004627_tso3_00001_asn.json"
+    rtdata.output = "jw01366-o002_t001_nircam_f322w2-grismr-subgrism256_x1dints.fits"
+    rtdata.get_truth("truth/test_nircam_tsgrism_stages/jw01366-o002_t001_nircam_f322w2-grismr-subgrism256_x1dints.fits")
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
@@ -88,9 +88,10 @@ def test_nircam_tsgrism_stage3_x1dints(run_pipelines, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_nircam_tsgrism_stage3_whtlt(run_pipelines):
     rtdata = run_pipelines
-    rtdata.input = "jw00721-o012_20191119t043909_tso3_001_asn.json"
-    rtdata.output = "jw00721-o012_t004_nircam_f444w-grismr-subgrism256_whtlt.ecsv"
-    rtdata.get_truth("truth/test_nircam_tsgrism_stages/jw00721-o012_t004_nircam_f444w-grismr-subgrism256_whtlt.ecsv")
+    rtdata.input = "jw01366-o002_20230107t004627_tso3_00001_asn.json"
+    rtdata.output = "jw01366-o002_t001_nircam_f322w2-grismr-subgrism256_whtlt.ecsv"
+    rtdata.get_truth("truth/test_nircam_tsgrism_stages/jw01366-o002_t001_nircam_f322w2-grismr-subgrism256_whtlt.ecsv")
+
 
     table = Table.read(rtdata.output)
     table_truth = Table.read(rtdata.truth)

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -1,6 +1,5 @@
 import pytest
 from astropy.io.fits.diff import FITSDiff
-from astropy.table import Table, setdiff
 
 from jwst.stpipe import Step
 
@@ -45,14 +44,10 @@ def test_nircam_tsimg_stage2(run_pipelines, fitsdiff_default_kwargs, suffix):
 
 
 @pytest.mark.bigdata
-def test_nircam_tsimage_stage3_phot(run_pipelines):
+def test_nircam_tsimage_stage3_phot(run_pipelines, diff_astropy_tables):
     rtdata = run_pipelines
     rtdata.input = "jw01068-o006_20240401t151322_tso3_00002_asn.json"
     rtdata.output = "jw01068-o006_t004_nircam_f150w2-f164n-sub64p_phot.ecsv"
     rtdata.get_truth("truth/test_nircam_tsimg_stage23/jw01068-o006_t004_nircam_f150w2-f164n-sub64p_phot.ecsv")
 
-    table = Table.read(rtdata.output)
-    table_truth = Table.read(rtdata.truth)
-
-    # setdiff returns a table of length zero if there is no difference
-    assert len(setdiff(table, table_truth)) == 0
+    assert diff_astropy_tables(rtdata.output, rtdata.truth)

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -1,12 +1,7 @@
-from pathlib import Path
 import pytest
-
 from astropy.io.fits.diff import FITSDiff
 from astropy.table import Table, setdiff
 
-from jwst.lib import engdb_tools
-from jwst.lib.set_telescope_pointing import add_wcs
-from jwst.lib.tests.engdb_mock import EngDB_Mocker
 from jwst.stpipe import Step
 
 
@@ -18,8 +13,7 @@ def run_pipelines(rtdata_module):
 
     # Run the calwebb_tso-image2 pipeline on each of the 2 inputs
     rate_files = [
-        "nircam/tsimg/jw00312006001_02102_00001-seg001_nrcb1_rateints.fits",
-        "nircam/tsimg/jw00312006001_02102_00001-seg002_nrcb1_rateints.fits"
+        "nircam/tsimg/jw01068006001_03103_00001-seg001_nrcb1_rateints.fits",
     ]
     for rate_file in rate_files:
         rtdata.get_data(rate_file)
@@ -28,7 +22,7 @@ def run_pipelines(rtdata_module):
 
     # Get the level3 association json file (though not its members) and run
     # the tso3 pipeline on all _calints files listed in association
-    rtdata.get_data("nircam/tsimg/jw00312-o006_20191225t115310_tso3_001_asn.json")
+    rtdata.get_data("nircam/tsimg/jw01068-o006_20240401t151322_tso3_00002_asn.json")
     args = ["calwebb_tso3", rtdata.input]
     Step.from_cmdline(args)
 
@@ -40,8 +34,8 @@ def run_pipelines(rtdata_module):
 def test_nircam_tsimg_stage2(run_pipelines, fitsdiff_default_kwargs, suffix):
     """Regression test of tso-image2 pipeline performed on NIRCam TSIMG data."""
     rtdata = run_pipelines
-    rtdata.input = "jw00312006001_02102_00001-seg001_nrcb1_rateints.fits"
-    output = "jw00312006001_02102_00001-seg001_nrcb1_" + suffix + ".fits"
+    rtdata.input = "jw01068006001_03103_00001-seg001_nrcb1_rateints.fits"
+    output = "jw01068006001_03103_00001-seg001_nrcb1_" + suffix + ".fits"
     rtdata.output = output
 
     rtdata.get_truth("truth/test_nircam_tsimg_stage23/" + output)
@@ -53,49 +47,12 @@ def test_nircam_tsimg_stage2(run_pipelines, fitsdiff_default_kwargs, suffix):
 @pytest.mark.bigdata
 def test_nircam_tsimage_stage3_phot(run_pipelines):
     rtdata = run_pipelines
-    rtdata.input = "jw00312-o006_20191225t115310_tso3_001_asn.json"
-    rtdata.output = "jw00312-o006_t001_nircam_f210m-clear-sub64p_phot.ecsv"
-    rtdata.get_truth("truth/test_nircam_tsimg_stage23/jw00312-o006_t001_nircam_f210m-clear-sub64p_phot.ecsv")
+    rtdata.input = "jw01068-o006_20240401t151322_tso3_00002_asn.json"
+    rtdata.output = "jw01068-o006_t004_nircam_f150w2-f164n-sub64p_phot.ecsv"
+    rtdata.get_truth("truth/test_nircam_tsimg_stage23/jw01068-o006_t004_nircam_f150w2-f164n-sub64p_phot.ecsv")
 
     table = Table.read(rtdata.output)
     table_truth = Table.read(rtdata.truth)
 
     # setdiff returns a table of length zero if there is no difference
     assert len(setdiff(table, table_truth)) == 0
-
-
-@pytest.mark.bigdata
-def test_nircam_setpointing_tsimg(rtdata, engdb, fitsdiff_default_kwargs):
-    """
-    Regression test of the set_telescope_pointing script on a level-1b
-    NIRCam TSO imaging file.
-    """
-    # Get SIAF PRD database file
-    siaf_path = rtdata.get_data("common/prd.db")
-    rtdata.get_data("nircam/tsimg/jw00312006001_02102_00001-seg001_nrcb1_uncal.fits")
-    # The add_wcs function overwrites its input, so output = input
-    rtdata.output = rtdata.input
-
-    # Call the WCS routine, using the ENGDB_Service
-    try:
-        add_wcs(rtdata.input, engdb_url='http://localhost', siaf_path=siaf_path)
-    except ValueError:
-        pytest.skip('Engineering Database not available.')
-
-    rtdata.get_truth("truth/test_nircam_setpointing/jw00312006001_02102_00001-seg001_nrcb1_uncal.fits")
-
-    fitsdiff_default_kwargs['rtol'] = 1e-6
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()
-
-
-# ########
-# Fixtures
-# ########
-@pytest.fixture
-def engdb():
-    """Setup the mock engineering database"""
-    db_path = Path(__file__).parents[1] / 'lib' / 'tests' / 'data' / 'engdb'
-    with EngDB_Mocker(db_path=db_path):
-        engdb = engdb_tools.ENGDB_Service(base_url='http://localhost')
-        yield engdb

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -1,6 +1,10 @@
+from pathlib import Path
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
+from jwst.lib import engdb_tools
+from jwst.lib.set_telescope_pointing import add_wcs
+from jwst.lib.tests.engdb_mock import EngDB_Mocker
 from jwst.stpipe import Step
 
 
@@ -51,3 +55,40 @@ def test_nircam_tsimage_stage3_phot(run_pipelines, diff_astropy_tables):
     rtdata.get_truth("truth/test_nircam_tsimg_stage23/jw01068-o006_t004_nircam_f150w2-f164n-sub64p_phot.ecsv")
 
     assert diff_astropy_tables(rtdata.output, rtdata.truth)
+
+
+@pytest.mark.bigdata
+def test_nircam_setpointing_tsimg(rtdata, engdb, fitsdiff_default_kwargs):
+    """
+    Regression test of the set_telescope_pointing script on a level-1b
+    NIRCam TSO imaging file.
+    """
+    # Get SIAF PRD database file
+    siaf_path = rtdata.get_data("common/prd.db")
+    rtdata.get_data("nircam/tsimg/jw00312006001_02102_00001-seg001_nrcb1_uncal.fits")
+    # The add_wcs function overwrites its input, so output = input
+    rtdata.output = rtdata.input
+
+    # Call the WCS routine, using the ENGDB_Service
+    try:
+        add_wcs(rtdata.input, engdb_url='http://localhost', siaf_path=siaf_path)
+    except ValueError:
+        pytest.skip('Engineering Database not available.')
+
+    rtdata.get_truth("truth/test_nircam_setpointing/jw00312006001_02102_00001-seg001_nrcb1_uncal.fits")
+
+    fitsdiff_default_kwargs['rtol'] = 1e-6
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+# ########
+# Fixtures
+# ########
+@pytest.fixture
+def engdb():
+    """Setup the mock engineering database"""
+    db_path = Path(__file__).parents[1] / 'lib' / 'tests' / 'data' / 'engdb'
+    with EngDB_Mocker(db_path=db_path):
+        engdb = engdb_tools.ENGDB_Service(base_url='http://localhost')
+        yield engdb


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-2928](https://jira.stsci.edu/browse/JP-2928)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Update data for NIRCam tsgrism and tsimg regression tests to in-flight data.

The tsgrism data is based on a draft PR in #7738.  The tsimg data looks like the most similar product available in MAST to the pre-flight data.

There are a couple old tests for set_telescope_pointing functionality in these regtests that have been quietly broken since #6993.  I propose we remove them here; if more tests are needed, we can file a ticket to add some with updated data.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
