### PR TITLE
JP-2928: Update NIRCam WFS regression test data

### DIFF
--- a/jwst/regtest/test_nircam_wfs.py
+++ b/jwst/regtest/test_nircam_wfs.py
@@ -17,8 +17,8 @@ def run_pipelines(rtdata_module):
 
     # Get the rate files and run the image2 pipeline on each
     rate_files = [
-        "nircam/wavefront/jw02586173001_03104_00001_nrcalong_rate.fits",
-        "nircam/wavefront/jw02586173001_03104_00002_nrcalong_rate.fits"
+        "nircam/wavefront/jw02586173001_03104_00001_nrca3_rate.fits",
+        "nircam/wavefront/jw02586173001_03104_00002_nrca3_rate.fits"
     ]
     for rate_file in rate_files:
         rtdata.get_data(rate_file)
@@ -27,7 +27,7 @@ def run_pipelines(rtdata_module):
 
     # Get the image3 ASN file only, not the members. The members were just
     # produced by the calwebb_image2 pipeline run.
-    rtdata.get_data("nircam/wavefront/jw02586-o173_20240923t165435_wfs-image3_00006_asn.json")
+    rtdata.get_data("nircam/wavefront/jw02586-o173_20240923t165435_wfs-image3_00008_asn.json")
 
     # Run the calwebb_wfs-image3 pipeline with no refinement (default)
     args = ["calwebb_wfs-image3", rtdata.input]
@@ -35,7 +35,7 @@ def run_pipelines(rtdata_module):
 
     # Get the second version of the image3 ASN, which has a unique output
     # product name. Only get the ASN file, not the members.
-    rtdata.get_data("nircam/wavefront/jw02586-o173_20240923t165435_wfs-image3_00006_asn_v2.json")
+    rtdata.get_data("nircam/wavefront/jw02586-o173_20240923t165435_wfs-image3_00008_asn_v2.json")
 
     # Run the calwebb_wfs-image3 pipeline with refinement
     args = ["calwebb_wfs-image3", rtdata.input, "--do_refine=True"]
@@ -54,10 +54,10 @@ def test_nicam_wfsimage_noextras(run_pipelines):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output",[
-    "jw02586173001_03104_00001_nrcalong_cal.fits",
-    "jw02586173001_03104_00002_nrcalong_cal.fits",
-    "jw02586-o173_t035_nircam_clear-f356w-nrcalong_wfscmb-04.fits",
-    "jw02586-o173_t035_nircam_clear-f356w-nrcalong_wfscmb-04_refine.fits"],
+    "jw02586173001_03104_00001_nrca3_cal.fits",
+    "jw02586173001_03104_00002_nrca3_cal.fits",
+    "jw02586-o173_t035_nircam_f212n-wlm8-nrca3_wfscmb-04.fits",
+    "jw02586-o173_t035_nircam_f212n-wlm8-nrca3_wfscmb-04_refine.fits"],
     ids=["cal1", "cal2", "wfscmb1", "wfscmb2"])
 def test_nircam_wfsimage(run_pipelines, fitsdiff_default_kwargs, output):
     """Regression test of the calwebb_wfs-image2 and calwebb_wfs-image3

--- a/jwst/regtest/test_nircam_wfs.py
+++ b/jwst/regtest/test_nircam_wfs.py
@@ -15,16 +15,19 @@ def run_pipelines(rtdata_module):
 
     rtdata = rtdata_module
 
-    # Get the image2 ASN and members
-    rtdata.get_asn("nircam/wavefront/jw00632-o003_20191210t194815_wfs-image2_001_asn.json")
-
-    # Run the calwebb_wfs-image2 pipeline
-    args = ["jwst.pipeline.Image2Pipeline", rtdata.input]
-    Step.from_cmdline(args)
+    # Get the rate files and run the image2 pipeline on each
+    rate_files = [
+        "nircam/wavefront/jw02586173001_03104_00001_nrcalong_rate.fits",
+        "nircam/wavefront/jw02586173001_03104_00002_nrcalong_rate.fits"
+    ]
+    for rate_file in rate_files:
+        rtdata.get_data(rate_file)
+        args = ["calwebb_image2", rtdata.input]
+        Step.from_cmdline(args)
 
     # Get the image3 ASN file only, not the members. The members were just
-    # produced by the calwebb_wfs-image2 pipeline run.
-    rtdata.get_data("nircam/wavefront/jw00632-o003_20191210t194815_wfs-image3_001_asn.json")
+    # produced by the calwebb_image2 pipeline run.
+    rtdata.get_data("nircam/wavefront/jw02586-o173_20240923t165435_wfs-image3_00006_asn.json")
 
     # Run the calwebb_wfs-image3 pipeline with no refinement (default)
     args = ["calwebb_wfs-image3", rtdata.input]
@@ -32,7 +35,7 @@ def run_pipelines(rtdata_module):
 
     # Get the second version of the image3 ASN, which has a unique output
     # product name. Only get the ASN file, not the members.
-    rtdata.get_data("nircam/wavefront/jw00632-o003_20191210t194815_wfs-image3_002_asn.json")
+    rtdata.get_data("nircam/wavefront/jw02586-o173_20240923t165435_wfs-image3_00006_asn_v2.json")
 
     # Run the calwebb_wfs-image3 pipeline with refinement
     args = ["calwebb_wfs-image3", rtdata.input, "--do_refine=True"]
@@ -51,10 +54,10 @@ def test_nicam_wfsimage_noextras(run_pipelines):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output",[
-    "jw00632003002_03105_00001_nrca4_cal.fits",
-    "jw00632003002_03105_00002_nrca4_cal.fits",
-    "jw00632-o003_t001_nircam_f212n-wlp8-nrca4_wfscmb-05.fits",
-    "jw00632-o003_t001_nircam_f212n-wlp8-nrca4_wfscmb-05_refine.fits"],
+    "jw02586173001_03104_00001_nrcalong_cal.fits",
+    "jw02586173001_03104_00002_nrcalong_cal.fits",
+    "jw02586-o173_t035_nircam_clear-f356w-nrcalong_wfscmb-04.fits",
+    "jw02586-o173_t035_nircam_clear-f356w-nrcalong_wfscmb-04_refine.fits"],
     ids=["cal1", "cal2", "wfscmb1", "wfscmb2"])
 def test_nircam_wfsimage(run_pipelines, fitsdiff_default_kwargs, output):
     """Regression test of the calwebb_wfs-image2 and calwebb_wfs-image3
@@ -65,7 +68,7 @@ def test_nircam_wfsimage(run_pipelines, fitsdiff_default_kwargs, output):
     rtdata.output = output
 
     # Get the truth files
-    rtdata.get_truth(os.path.join("truth/nircam/test_wfs-image2and3", output))
+    rtdata.get_truth(os.path.join("truth/test_nircam_wfs", output))
 
     # Compare the results
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-2928](https://jira.stsci.edu/browse/JP-2928)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Update NIRCam WFS regression tests to use in-flight data.

Data used is PID 2586, obs 173 detector nrca3, found via a MAST search for NIRCam imaging public data with PATTYPE = WFSC.

This test had an unusual truth directory location ('truth/nircam/test_wfs-image2and3', where most truth directories are at 'truth/test_*').  I made a new truth directory following the more usual pattern and will delete 'truth/nircam' in artifactory when this is complete.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
