### PR TITLE
JP-2928: Update regression test data for NIRCam subarray

### DIFF
--- a/jwst/regtest/test_nircam_subarray_4amp.py
+++ b/jwst/regtest/test_nircam_subarray_4amp.py
@@ -6,10 +6,9 @@ from astropy.io.fits.diff import FITSDiff
 from jwst.stpipe import Step
 
 """
-jw00617196001_02102_00001_nrca4_uncal.fits       the input (uncal) file
-jw00617196001_02102_00001_nrca4_rate.fits        rate file
-jw00617196001_02102_00001_nrca4_rateints.fits        rateints file
-jw00617196001_02102_00001_nrca4_trapsfilled.fits        trapsfilled file
+jw01409034001_02102_00001_nrca3_uncal.fits       the input (uncal) file
+jw01409034001_02102_00001_nrca3_rate.fits        rate file
+jw01409034001_02102_00001_nrca3_rateints.fits    rateints file
 """
 
 
@@ -17,7 +16,7 @@ jw00617196001_02102_00001_nrca4_trapsfilled.fits        trapsfilled file
 def run_pipeline(rtdata_module):
     """Run calwebb_detector1 pipeline on NIRCAM subarray data."""
     rtdata = rtdata_module
-    rtdata.get_data("nircam/subarray/jw00617196001_02102_00001_nrca4_uncal.fits")
+    rtdata.get_data("nircam/subarray/jw01409034001_02102_00001_nrca3_uncal.fits")
 
     args = ["jwst.pipeline.Detector1Pipeline", rtdata.input]
     Step.from_cmdline(args)
@@ -27,8 +26,8 @@ def run_pipeline(rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output", [
-    'jw00617196001_02102_00001_nrca4_rate.fits',
-    'jw00617196001_02102_00001_nrca4_rateints.fits'],
+    'jw01409034001_02102_00001_nrca3_rate.fits',
+    'jw01409034001_02102_00001_nrca3_rateints.fits'],
     ids=['rate', 'rateints'])
 def test_nircam_detector1_subarray(run_pipeline, fitsdiff_default_kwargs, output):
     """

--- a/jwst/regtest/test_nircam_subarray_4amp.py
+++ b/jwst/regtest/test_nircam_subarray_4amp.py
@@ -6,9 +6,9 @@ from astropy.io.fits.diff import FITSDiff
 from jwst.stpipe import Step
 
 """
-jw01409034001_02102_00001_nrca3_uncal.fits       the input (uncal) file
-jw01409034001_02102_00001_nrca3_rate.fits        rate file
-jw01409034001_02102_00001_nrca3_rateints.fits    rateints file
+jw02459005001_03103_00001-seg001_nrca3_uncal.fits       the input (uncal) file
+jw02459005001_03103_00001-seg001_nrca3_rate.fits        rate file
+jw02459005001_03103_00001-seg001_nrca3_rateints.fits    rateints file
 """
 
 
@@ -16,7 +16,7 @@ jw01409034001_02102_00001_nrca3_rateints.fits    rateints file
 def run_pipeline(rtdata_module):
     """Run calwebb_detector1 pipeline on NIRCAM subarray data."""
     rtdata = rtdata_module
-    rtdata.get_data("nircam/subarray/jw01409034001_02102_00001_nrca3_uncal.fits")
+    rtdata.get_data("nircam/subarray/jw02459005001_03103_00001-seg001_nrca3_uncal.fits")
 
     args = ["jwst.pipeline.Detector1Pipeline", rtdata.input]
     Step.from_cmdline(args)
@@ -26,8 +26,8 @@ def run_pipeline(rtdata_module):
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("output", [
-    'jw01409034001_02102_00001_nrca3_rate.fits',
-    'jw01409034001_02102_00001_nrca3_rateints.fits'],
+    'jw02459005001_03103_00001-seg001_nrca3_rate.fits',
+    'jw02459005001_03103_00001-seg001_nrca3_rateints.fits'],
     ids=['rate', 'rateints'])
 def test_nircam_detector1_subarray(run_pipeline, fitsdiff_default_kwargs, output):
     """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-2928](https://jira.stsci.edu/browse/JP-2928)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Update regression test data for NIRCam subarray, reference pixel correction test. 

~The new data is from PID 1409, obs 34, chosen for its similarity to the original data product (subarray subgrism64, exp_type nrc_tsimage, ngroups 5, nints 1).~

The new data is from PID 2459, obs 5: EXP_TYPE=NRC_TSIMAGE, SUBARRAY=SUBGRISM64, NINTS=4, NGROUPS=5, NOUTPUTS=4.                          


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
