### PR TITLE
JP-2928: Update regression test data for NIRSpec spec2 steps

### DIFF
--- a/jwst/regtest/test_nirspec_mos_spec2_steps.py
+++ b/jwst/regtest/test_nirspec_mos_spec2_steps.py
@@ -13,14 +13,18 @@ from jwst.photom import PhotomStep
 @pytest.mark.bigdata
 def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
     """Test providing a user-supplied flat field to the FlatFieldStep"""
-    data = rtdata.get_data('nirspec/mos/usf_wavecorr.fits')
-    user_supplied_flat = rtdata.get_data('nirspec/mos/usf_flat.fits')
+    basename = 'jw01345066001_05101_00001_nrs1'
+    output_file = f'{basename}_flat_from_user_file.fits'
 
-    data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat)
-    rtdata.output = 'flat_fielded_step_user_supplied.fits'
+    data = rtdata.get_data(f'nirspec/mos/{basename}_wavecorr.fits')
+    user_supplied_flat = rtdata.get_data(f'nirspec/mos/{basename}_interpolatedflat.fits')
+
+    data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat,
+                                           save_results=False)
+    rtdata.output = output_file
     data_flat_fielded.write(rtdata.output)
 
-    rtdata.get_truth('truth/test_nirspec_mos_spec2/flat_fielded_step_user_supplied.fits')
+    rtdata.get_truth(f'truth/test_nirspec_mos_spec2/{output_file}')
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
@@ -28,7 +32,7 @@ def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_ff_inv(rtdata, fitsdiff_default_kwargs):
     """Test flat field inversion"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         flatted = FlatFieldStep.call(data)
         unflatted = FlatFieldStep.call(flatted, inverse=True)
 
@@ -52,7 +56,7 @@ def test_ff_inv(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_pathloss_corrpars(rtdata):
     """Test PathLossStep using correction_pars"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         pls = PathLossStep()
         corrected = pls.run(data)
 
@@ -70,7 +74,7 @@ def test_pathloss_corrpars(rtdata):
 @pytest.mark.bigdata
 def test_pathloss_inverse(rtdata):
     """Test PathLossStep using inversion"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         pls = PathLossStep()
         corrected = pls.run(data)
 
@@ -90,7 +94,7 @@ def test_pathloss_inverse(rtdata):
 @pytest.mark.bigdata
 def test_pathloss_source_type(rtdata):
     """Test PathLossStep forcing source type"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         pls = PathLossStep()
         pls.source_type = 'extended'
         pls.run(data)
@@ -106,7 +110,7 @@ def test_pathloss_source_type(rtdata):
 @pytest.mark.bigdata
 def test_barshadow_corrpars(rtdata):
     """BarShadowStep using correction_pars"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         pls = BarShadowStep()
         corrected = pls.run(data)
 
@@ -124,7 +128,7 @@ def test_barshadow_corrpars(rtdata):
 @pytest.mark.bigdata
 def test_barshadow_inverse(rtdata):
     """BarShadowStep using inversion"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         pls = BarShadowStep()
         corrected = pls.run(data)
 
@@ -144,7 +148,7 @@ def test_barshadow_inverse(rtdata):
 @pytest.mark.bigdata
 def test_barshadow_source_type(rtdata):
     """Test BarShadowStep forcing source type"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         pls = BarShadowStep()
         pls.source_type = 'extended'
         corrected = pls.run(data)
@@ -159,7 +163,7 @@ def test_barshadow_source_type(rtdata):
 @pytest.mark.bigdata
 def test_photom_corrpars(rtdata):
     """Test for photom correction parameters"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         pls = PhotomStep()
         corrected = pls.run(data)
 
@@ -177,7 +181,7 @@ def test_photom_corrpars(rtdata):
 @pytest.mark.bigdata
 def test_photom_inverse(rtdata):
     """PhotomStep using inversion"""
-    with dm.open(rtdata.get_data('nirspec/mos/usf_wavecorr.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits')) as data:
         pls = PhotomStep()
         corrected = pls.run(data)
 

--- a/jwst/regtest/test_nirspec_steps_spec2.py
+++ b/jwst/regtest/test_nirspec_steps_spec2.py
@@ -18,10 +18,11 @@ TRUTH_PATH = 'truth/test_nirspec_ifu'
 @pytest.mark.bigdata
 def test_nirspec_ifu_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
     """Test using predefined interpolated flat"""
-    output_file = 'jw01251004001_03107_00001_nrs1_flat_from_user_model.fits'
-    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_assign_wcs.fits')) as data:
+    basename = 'jw01251004001_03107_00001_nrs1'
+    output_file = f'{basename}_flat_from_user_model.fits'
+    with dm.open(rtdata.get_data(f'nirspec/ifu/{basename}_assign_wcs.fits')) as data:
         with dm.open(rtdata.get_data(
-                'nirspec/ifu/jw01251004001_03107_00001_nrs1_interpolatedflat.fits')) as user_supplied_flat:
+                f'nirspec/ifu/{basename}_interpolatedflat.fits')) as user_supplied_flat:
 
             # Call the flat field function directly with a user flat
             nirspec_ifu(data, None, None, None, None, user_supplied_flat=user_supplied_flat)
@@ -37,14 +38,15 @@ def test_nirspec_ifu_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
     """Test providing a user-supplied flat field to the FlatFieldStep"""
-    output_file = 'jw01251004001_03107_00001_nrs1_flat_from_user_file.fits'
+    basename = 'jw01251004001_03107_00001_nrs1'
+    output_file = f'{basename}_flat_from_user_file.fits'
 
-    data = rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_assign_wcs.fits')
-    user_supplied_flat = rtdata.get_data(
-        'nirspec/ifu/jw01251004001_03107_00001_nrs1_interpolatedflat.fits')
+    data = rtdata.get_data(f'nirspec/ifu/{basename}_assign_wcs.fits')
+    user_supplied_flat = rtdata.get_data(f'nirspec/ifu/{basename}_interpolatedflat.fits')
 
     # Call the step with a user flat
-    data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat)
+    data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat,
+                                           save_results=False)
     rtdata.output = output_file
     data_flat_fielded.write(rtdata.output)
     del data_flat_fielded

--- a/jwst/regtest/test_nirspec_steps_spec2.py
+++ b/jwst/regtest/test_nirspec_steps_spec2.py
@@ -18,13 +18,18 @@ TRUTH_PATH = 'truth/test_nirspec_ifu'
 @pytest.mark.bigdata
 def test_nirspec_ifu_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
     """Test using predefined interpolated flat"""
-    with dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits')) as data:
-        with dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_interpolated_flat.fits')) as user_supplied_flat:
+    output_file = 'jw01251004001_03107_00001_nrs1_flat_from_user_model.fits'
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_assign_wcs.fits')) as data:
+        with dm.open(rtdata.get_data(
+                'nirspec/ifu/jw01251004001_03107_00001_nrs1_interpolatedflat.fits')) as user_supplied_flat:
+
+            # Call the flat field function directly with a user flat
             nirspec_ifu(data, None, None, None, None, user_supplied_flat=user_supplied_flat)
-            rtdata.output = 'ff_using_interpolated.fits'
+
+            rtdata.output = output_file
             data.write(rtdata.output)
 
-    rtdata.get_truth(TRUTH_PATH + '/' + 'ff_using_interpolated.fits')
+    rtdata.get_truth(TRUTH_PATH + '/' + output_file)
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
@@ -32,15 +37,19 @@ def test_nirspec_ifu_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
     """Test providing a user-supplied flat field to the FlatFieldStep"""
-    data = rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits')
-    user_supplied_flat = rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_interpolated_flat.fits')
+    output_file = 'jw01251004001_03107_00001_nrs1_flat_from_user_file.fits'
 
+    data = rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_assign_wcs.fits')
+    user_supplied_flat = rtdata.get_data(
+        'nirspec/ifu/jw01251004001_03107_00001_nrs1_interpolatedflat.fits')
+
+    # Call the step with a user flat
     data_flat_fielded = FlatFieldStep.call(data, user_supplied_flat=user_supplied_flat)
-    rtdata.output = 'flat_fielded_step_user_supplied.fits'
+    rtdata.output = output_file
     data_flat_fielded.write(rtdata.output)
     del data_flat_fielded
 
-    rtdata.get_truth(TRUTH_PATH + '/' + 'flat_fielded_step_user_supplied.fits')
+    rtdata.get_truth(TRUTH_PATH + '/' + output_file)
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
@@ -49,7 +58,7 @@ def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_ff_inv(rtdata, fitsdiff_default_kwargs):
     """Test flat field inversion"""
-    with dm.open(rtdata.get_data('nirspec/ifu/nrs_ifu_nrs1_assign_wcs.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_assign_wcs.fits')) as data:
         flatted = FlatFieldStep.call(data)
         unflatted = FlatFieldStep.call(flatted, inverse=True)
 
@@ -71,7 +80,7 @@ def test_ff_inv(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_pathloss_corrpars(rtdata):
     """Test PathLossStep using correction_pars"""
-    with dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
         pls = PathLossStep()
         corrected = pls.run(data)
 
@@ -85,7 +94,7 @@ def test_pathloss_corrpars(rtdata):
 @pytest.mark.bigdata
 def test_pathloss_inverse(rtdata):
     """Test PathLossStep using correction_pars"""
-    with dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
         pls = PathLossStep()
         corrected = pls.run(data)
 
@@ -100,7 +109,7 @@ def test_pathloss_inverse(rtdata):
 @pytest.mark.bigdata
 def test_pathloss_source_type(rtdata):
     """Test PathLossStep forcing source type"""
-    with dm.open(rtdata.get_data('nirspec/ifu/nrs1_flat_field.fits')) as data:
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
         pls = PathLossStep()
         pls.source_type = 'extended'
         pls.run(data)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-2928](https://jira.stsci.edu/browse/JP-2928)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Use intermediate files generated from in-flight data already in artifactory as input for regression tests that test certain steps individually.  Tests are for NIRSpec spec2, input data is IFU and MOS.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
