### PR TITLE
JP-3787: Add regtest for IFU moving target with background spectrum

### DIFF
--- a/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
@@ -1,10 +1,7 @@
 from astropy.io.fits.diff import FITSDiff
 import pytest
-import numpy as np
-from gwcs import wcstools
 
 from jwst.stpipe import Step
-from stdatamodels.jwst import datamodels
 
 
 @pytest.fixture(scope="module")

--- a/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
@@ -1,0 +1,47 @@
+from astropy.io.fits.diff import FITSDiff
+import pytest
+import numpy as np
+from gwcs import wcstools
+
+from jwst.stpipe import Step
+from stdatamodels.jwst import datamodels
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(rtdata_module):
+    """
+    Run the calwebb_spec3 pipeline on a NIRSpec IFU moving target.
+    """
+    rtdata = rtdata_module
+
+    # Get the ASN file and input exposures
+    # Note: ASN contains a background spectrum
+    rtdata.get_asn('nirspec/ifu/jw01252-o001_spec3_00003_asn_with_bg.json')
+
+    # Run the calwebb_spec3 pipeline; save results from intermediate steps
+    args = ["calwebb_spec3", rtdata.input]
+    Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["cal", "o001_crf", "s3d", "x1d"])
+def test_nirspec_ifu_spec3_moving_target(
+        run_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix):
+    """Test spec3 pipeline on a NIRSpec IFU moving target."""
+    rtdata = rtdata_module
+
+    if suffix in {"cal", "o001_crf"}:
+        output = f"jw01252001001_03101_00001_nrs1_{suffix}.fits"
+    else:
+        output = f"jw01252-o001_t004_nirspec_prism-clear_{suffix}.fits"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/test_nirspec_ifu_spec3_moving_target/{output}")
+
+    # Adjust tolerance for machine precision for resampled data
+    if suffix == "s3d":
+        fitsdiff_default_kwargs["rtol"] = 1e-2
+        fitsdiff_default_kwargs["atol"] = 2e-4
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3787](https://jira.stsci.edu/browse/JP-3787)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Add a regression test for a spec3 run on a moving target with a background spectrum specified.

JP-3787 requires a fix in stpipe -- this test will currently error out.  I will leave this PR at draft until there's a fix in stpipe.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
