### PR TITLE
JP-3787: Use meta.asn.exptype in ModelLibrary

### DIFF
--- a/changes/8918.datamodels.rst
+++ b/changes/8918.datamodels.rst
@@ -1,0 +1,1 @@
+Update ModelLibrary to use meta.asn.exptype instead of meta.exptype.

--- a/jwst/datamodels/library.py
+++ b/jwst/datamodels/library.py
@@ -20,14 +20,14 @@ class ModelLibrary(AbstractModelLibrary):
     @property
     def crds_observatory(self):
         return "jwst"
-    
+
     @property
     def exptypes(self):
         """
         List of exposure types for all members in the library.
         """
         return [member["exptype"] for member in self._members]
-    
+
     def indices_for_exptype(self, exptype):
         """
         Determine the indices of models corresponding to ``exptype``.
@@ -104,6 +104,9 @@ class ModelLibrary(AbstractModelLibrary):
             msg = f"Cannot find header keyword {e} in {filename}"
             raise NoGroupID(msg) from e
 
+    def _model_to_exptype(self, model):
+        return model.meta.asn.exptype
+
     def _model_to_group_id(self, model):
         """
         Compute a "group_id" from a model using the DataModel interface
@@ -123,7 +126,8 @@ class ModelLibrary(AbstractModelLibrary):
         raise NoGroupID(f"{model} missing group_id")
 
     def _assign_member_to_model(self, model, member):
-        for attr in ("group_id", "tweakreg_catalog", "exptype"):
+        model.meta.asn.exptype = member["exptype"]
+        for attr in ("group_id", "tweakreg_catalog"):
             if attr in member:
                 setattr(model.meta, attr, member[attr])
         if not hasattr(model.meta, "asn"):

--- a/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
@@ -1,10 +1,7 @@
 from astropy.io.fits.diff import FITSDiff
 import pytest
-import numpy as np
-from gwcs import wcstools
 
 from jwst.stpipe import Step
-from stdatamodels.jwst import datamodels
 
 
 @pytest.fixture(scope="module")

--- a/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
@@ -1,0 +1,47 @@
+from astropy.io.fits.diff import FITSDiff
+import pytest
+import numpy as np
+from gwcs import wcstools
+
+from jwst.stpipe import Step
+from stdatamodels.jwst import datamodels
+
+
+@pytest.fixture(scope="module")
+def run_pipeline(rtdata_module):
+    """
+    Run the calwebb_spec3 pipeline on a NIRSpec IFU moving target.
+    """
+    rtdata = rtdata_module
+
+    # Get the ASN file and input exposures
+    # Note: ASN contains a background spectrum
+    rtdata.get_asn('nirspec/ifu/jw01252-o001_spec3_00003_asn_with_bg.json')
+
+    # Run the calwebb_spec3 pipeline; save results from intermediate steps
+    args = ["calwebb_spec3", rtdata.input]
+    Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["cal", "o001_crf", "s3d", "x1d"])
+def test_nirspec_ifu_spec3_moving_target(
+        run_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix):
+    """Test spec3 pipeline on a NIRSpec IFU moving target."""
+    rtdata = rtdata_module
+
+    if suffix in {"cal", "o001_crf"}:
+        output = f"jw01252001001_03101_00001_nrs1_{suffix}.fits"
+    else:
+        output = f"jw01252-o001_t004_nirspec_prism-clear_{suffix}.fits"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/test_nirspec_ifu_spec3_moving_target/{output}")
+
+    # Adjust tolerance for machine precision for resampled data
+    if suffix == "s3d":
+        fitsdiff_default_kwargs["rtol"] = 1e-2
+        fitsdiff_default_kwargs["atol"] = 2e-4
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "spherical-geometry>=1.2.22",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",
-    "stpipe>=0.7.0,<0.8.0",
+    "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",
     "stsci.imagestats>=1.6.3",
     "synphot>=1.2",
     "tweakwcs>=0.8.8",


### PR DESCRIPTION
This PR includes the changes in #8917 to test the fix in this PR and updates the required stpipe version to main.

With these combined changes all regression tests (including the new one) pass:
https://github.com/spacetelescope/RegressionTests/actions/runs/11485771613/job/31967090526

Resolves [JP-3787](https://jira.stsci.edu/browse/JP-3787)

This PR  fixes the bug where ModelLibrary was using `meta.exptype` instead of `meta.asn.exptype`. A small change is needed to stpipe to allow jwst to control the exptypes added to the fake asn when `ModelLibrary` is constructed from a list of models.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
