### PR TITLE
JP-2928: Update FGS guider test data, add image3 test

### DIFF
--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -1,16 +1,19 @@
 """Regression tests for FGS Guidestar in ID and FINEGUIDE modes"""
 import pytest
 
-from jwst.resample.resample import OutputTooLargeError
+from jwst.regtest import regtestdata as rt
 from jwst.stpipe import Step
 
-from jwst.regtest import regtestdata as rt
+
+EXP_TYPES = ['fgs_acq1', 'fgs_fineguide', 'fgs_id-image', 'fgs_id-stack']
+FILE_ROOTS = ['jw01029001001_gs-acq1_2022142180746',
+              'jw01029001001_gs-fg_2022142181502',
+              'jw01029001001_gs-id_1_image',
+              'jw01029001001_gs-id_1_stacked']
+GUIDER_SUFFIXES = ['cal', 'dq_init', 'guider_cds']
 
 
-file_roots = ['exptype_fgs_acq1', 'exptype_fgs_fineguide', 'exptype_fgs_id_image', 'exptype_fgs_id_stack']
-
-
-@pytest.fixture(scope='module', params=file_roots, ids=file_roots)
+@pytest.fixture(scope='module', params=FILE_ROOTS, ids=FILE_ROOTS)
 def run_guider_pipelines(rtdata_module, request):
     """Run pipeline for guider data"""
     rtdata = rtdata_module
@@ -27,26 +30,9 @@ def run_guider_pipelines(rtdata_module, request):
     return rtdata
 
 
-guider_suffixes = ['cal', 'dq_init', 'guider_cds']
-
-
 @pytest.mark.bigdata
-@pytest.mark.parametrize('suffix', guider_suffixes, ids=guider_suffixes)
+@pytest.mark.parametrize('suffix', GUIDER_SUFFIXES, ids=GUIDER_SUFFIXES)
 def test_fgs_guider(run_guider_pipelines, fitsdiff_default_kwargs, suffix):
     """Regression for FGS Guider data"""
     rt.is_like_truth(run_guider_pipelines, fitsdiff_default_kwargs, suffix,
-                     'truth/fgs/test_fgs_guider', is_suffix=True)
-
-
-@pytest.mark.bigdata
-def test_fgs_toobig(rtdata, fitsdiff_default_kwargs, caplog, monkeypatch):
-    """Test for the situation where the combined mosaic is too large"""
-
-    # Set the environment to not allow the resultant too-large image.
-    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', "0.9")
-
-    rtdata.get_asn('fgs/image3/image3_asn.json')
-
-    args = ['calwebb_image3', rtdata.input]
-    with pytest.raises(OutputTooLargeError):
-        Step.from_cmdline(args)
+                     'truth/test_fgs_guider', is_suffix=True)

--- a/jwst/regtest/test_fgs_image3.py
+++ b/jwst/regtest/test_fgs_image3.py
@@ -21,13 +21,7 @@ def test_fgs_image3(run_fgs_image3, rtdata_module, fitsdiff_default_kwargs, suff
     rtdata = rtdata_module
     output = f"jw01029-o001_t009_fgs_clear_{suffix}.fits"
     rtdata.output = output
-
     rtdata.get_truth(f"truth/test_fgs_image3/{output}")
-
-    # Adjust tolerance for machine precision with float32 drizzle code
-    if suffix == "i2d":
-        fitsdiff_default_kwargs["rtol"] = 3e-3
-        fitsdiff_default_kwargs["atol"] = 2e-2
 
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_fgs_image3.py
+++ b/jwst/regtest/test_fgs_image3.py
@@ -1,0 +1,62 @@
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.resample.resample import OutputTooLargeError
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_fgs_image3(rtdata_module):
+    rtdata = rtdata_module
+    rtdata.get_asn('fgs/image3/jw01029-o001_20240716t172128_image3_00001_asn.json')
+
+    args = ["calwebb_image3", rtdata.input]
+    Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ['i2d', 'segm'])
+def test_fgs_image3(run_fgs_image3, rtdata_module, fitsdiff_default_kwargs, suffix):
+    """Regression test for FGS data in the image3 pipeline"""
+    rtdata = rtdata_module
+    output = f"jw01029-o001_t009_fgs_clear_{suffix}.fits"
+    rtdata.output = output
+
+    rtdata.get_truth(f"truth/test_fgs_image3/{output}")
+
+    # Adjust tolerance for machine precision with float32 drizzle code
+    if suffix == "i2d":
+        fitsdiff_default_kwargs["rtol"] = 3e-3
+        fitsdiff_default_kwargs["atol"] = 2e-2
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_fgs_image3_catalog(run_fgs_image3, rtdata_module, diff_astropy_tables):
+    rtdata = rtdata_module
+    rtdata.output = "jw01029-o001_t009_fgs_clear_cat.ecsv"
+    rtdata.get_truth("truth/test_fgs_image3/jw01029-o001_t009_fgs_clear_cat.ecsv")
+
+    assert diff_astropy_tables(rtdata.output, rtdata.truth, rtol=1e-3, atol=1e-4)
+
+
+@pytest.mark.bigdata
+def test_fgs_toobig(rtdata, fitsdiff_default_kwargs, caplog, monkeypatch):
+    """Test for the situation where the combined mosaic is too large"""
+
+    # Set the environment to not allow the resultant too-large image.
+    # Note: this test was originally run on two pre-flight images
+    # with WCSs from very different parts of the sky.
+    # This condition should hopefully never be encountered in reductions
+    # of in-flight data.  To test the software failsafe, we now use real data
+    # that makes a reasonable sized mosaic, but set the allowed memory to a
+    # small value.
+    monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', "0.0001")
+
+    rtdata.get_asn('fgs/image3/jw01029-o001_20240716t172128_image3_00001_asn.json')
+
+    args = ['jwst.resample.ResampleStep', rtdata.input]
+    with pytest.raises(OutputTooLargeError):
+        Step.from_cmdline(args)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-2928](https://jira.stsci.edu/browse/JP-2928)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Update test data for FGS guider regression tests to in-flight examples.  Data is from PID 1029 obs 1, the same program as is used in the image2 test.  The EXP_TYPEs tested are FGS_ACQ1, FGS_FINEGUIDE, FGS_ID-IMAGE, FGS_ID-STACK.

There was also an image3 test on non-guider data in the `test_fgs_guider` module that checked the resample step with input data that makes too large a mosaic.  I moved this test to a new file (`test_fgs_image3.py`) and added a new test for image3 on FGS image data.  I used cal files for PID 1029 obs 1 for both tests.  To simulate the failure case on data that should succeed, I set the allowed memory environment variable to a small value.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
