### PR TITLE
move run results upload to subdir of Artifactory repo

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -37,7 +37,7 @@ def artifactory_repos(pytestconfig):
     results_root = pytestconfig.getini('results_root')
     # see not above about inputs_root
     if not results_root:
-        results_root = "jwst-pipeline-results"
+        results_root = "jwst-pipeline-results/regression-tests/runs/"
     else:
         results_root = results_root[0]
     return inputs_root, results_root

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -31,7 +31,7 @@ class RegtestData:
     """Defines data paths on Artifactory and data retrieval methods"""
 
     def __init__(self, env="dev", inputs_root="jwst-pipeline",
-                 results_root="jwst-pipeline-results", docopy=True,
+                 results_root="jwst-pipeline-results/regression-tests/runs/", docopy=True,
                  input=None, input_remote=None, output=None, truth=None,
                  truth_remote=None, remote_results_path=None, test_name=None,
                  traceback=None, okify_op='file_copy', **kwargs):

--- a/jwst/scripts/okify_regtests.py
+++ b/jwst/scripts/okify_regtests.py
@@ -20,7 +20,7 @@ import asdf
 import readchar
 from colorama import Fore
 
-ARTIFACTORY_REPO = 'jwst-pipeline-results'
+ARTIFACTORY_REPO = 'jwst-pipeline-results/regression-tests/runs/'
 SPECFILE_SUFFIX = '_okify.json'
 RTDATA_SUFFIX = '_rtdata.asdf'
 TERMINAL_WIDTH = shutil.get_terminal_size((80, 20)).columns
@@ -103,7 +103,7 @@ def artifactory_get_breadcrumbs(build_number, suffix):
 
     An example search for build 586 would be:
 
-    jfrog rt search jwst-pipeline-results/*_GITHUB_CI_*-586/*_okify.json
+    jfrog rt search jwst-pipeline-results/regression-tests/runs/*_GITHUB_CI_*-586/*_okify.json
     """
 
     # Retrieve all the okify specfiles for failed tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ norecursedirs = [
 ]
 junit_family = "xunit2"
 inputs_root = "jwst-pipeline"
-results_root = "jwst-pipeline-results"
+results_root = "jwst-pipeline-results/regression-tests/runs/"
 text_file_format = "rst"
 doctest_plus = "enabled"
 doctest_rst = "enabled"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
https://github.com/spacetelescope/RegressionTests/pull/155

<!-- describe the changes comprising this PR here -->
The `jwst-pipeline-results/` repositories on Artifactory has lots of auto-generated run directories in the root, which clutters the file structure and makes it unwieldy to scroll through. This PR proposes moving the run directories from the root of the repository (`jwst-pipeline-results/`) to a subdirectory (`jwst-pipeline-results/regression-tests/runs/`):
```diff
- jwst-pipeline-results/2024-09-25_GITHUB_CI_Linux-X64-py3.12-683/
+ jwst-pipeline-results/regression-tests/runs/2024-09-25_GITHUB_CI_Linux-X64-py3.12-683/
```

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
