### PR TITLE
Add NIRSpec WCS fix to patch branch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.16.1 (2024-10-30)
+===================
+
+resample_spec
+-------------
+
+- Update NIRSpec spectral resampling to add a missing correction factor in resampled
+  WCS tangent plane transformation.
+
 1.16.0 (2024-09-20)
 ===================
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ the specified context and less than the context for the next release.
 
 | jwst tag            | DMS build | SDP_VER  | CRDS_CONTEXT | Released   | Ops Install | Notes                                         |
 |---------------------|-----------|----------|--------------|------------|-------------|-----------------------------------------------|
-| 1.16.0              | B11.1rc1  | TBD      | 1281         | 2024-09-20 | TBD         | First release candidate for B11.1             |
+| 1.16.1              | B11.1rc2  | TBD      | 1298         | 2024-10-30 | TBD         | Final release candidate for B11.1             |
+| 1.16.0              | B11.1rc1  | TBD      | 1298         | 2024-09-20 | TBD         | First release candidate for B11.1             |
 | 1.15.1              | B11.0     | 2024.2.2 | 1242         | 2024-07-08 | 2024-09-12  | Final release candidate for B11.0             |
 | 1.15.0              | B11.0rc1  |          | 1241         | 2024-06-26 |             | First release candidate for B11.0             |
 | 1.14.1              |           |          | 1238         | 2024-06-27 |             | PyPI-only release for external users          |

--- a/changes/9000.resample_spec.rst
+++ b/changes/9000.resample_spec.rst
@@ -1,1 +1,0 @@
-Update NIRSpec spectral resampling to add a missing correction factor in resampled WCS tangent plane transformation.

--- a/changes/9000.resample_spec.rst
+++ b/changes/9000.resample_spec.rst
@@ -1,0 +1,1 @@
+Update NIRSpec spectral resampling to add a missing correction factor in resampled WCS tangent plane transformation.

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -335,33 +335,42 @@ class ResampleSpecData(ResampleData):
             raise ValueError("Not enough data to construct output WCS.")
 
         # Find the spatial extent in x/y tangent
-        min_tan, max_tan = self._max_spatial_extent(all_wcs, undist2sky.inverse, swap_xy)
-        diff = np.abs(max_tan - min_tan)
-        if swap_xy:
-            pix_to_tan_slope = np.abs(pix_to_ytan.slope)
-            slope_sign = np.sign(pix_to_ytan.slope)
-        else:
-            pix_to_tan_slope = np.abs(pix_to_xtan.slope)
-            slope_sign = np.sign(pix_to_xtan.slope)
+        min_tan_x, max_tan_x, min_tan_y, max_tan_y = self._max_spatial_extent(
+            all_wcs, undist2sky.inverse)
+        diff_y = np.abs(max_tan_y - min_tan_y)
+        diff_x = np.abs(max_tan_x - min_tan_x)
+
+        pix_to_tan_slope_y = np.abs(pix_to_ytan.slope)
+        slope_sign_y = np.sign(pix_to_ytan.slope)
+        pix_to_tan_slope_x = np.abs(pix_to_xtan.slope)
+        slope_sign_x = np.sign(pix_to_xtan.slope)
 
         # Image size in spatial dimension from the maximum slope
         # and tangent offset span, plus one pixel to make sure
         # we catch all the data
-        ny = int(np.ceil(diff / pix_to_tan_slope)) + 1
+        if swap_xy:
+            ny = int(np.ceil(diff_y / pix_to_tan_slope_y)) + 1
+        else:
+            ny = int(np.ceil(diff_x / pix_to_tan_slope_x)) + 1
 
         # Correct the intercept for the new minimum value.
         # Also account for integer pixel size to make sure the
         # data is centered in the array.
-        offset = ny/2 * pix_to_tan_slope - diff/2
-        if slope_sign > 0:
-            zero_value = min_tan
-        else:
-            zero_value = max_tan
-        if swap_xy:
-            pix_to_ytan.intercept = zero_value - slope_sign * offset
-        else:
-            pix_to_xtan.intercept = zero_value - slope_sign * offset
+        offset_y = ny / 2 * pix_to_tan_slope_y - diff_y / 2
+        offset_x = ny / 2 * pix_to_tan_slope_x - diff_x / 2
 
+        if slope_sign_y > 0:
+            zero_value_y = min_tan_y
+        else:
+            zero_value_y = max_tan_y
+
+        if slope_sign_x > 0:
+            zero_value_x = min_tan_x
+        else:
+            zero_value_x = max_tan_x
+
+        pix_to_ytan.intercept = zero_value_y - slope_sign_y * offset_y
+        pix_to_xtan.intercept = zero_value_x - slope_sign_x * offset_x
         # Now set up the final transforms
 
         # For wavelengths, extrapolate 1/2 pixel at the edges and
@@ -447,12 +456,12 @@ class ResampleSpecData(ResampleData):
 
         return output_wcs
 
-    def _max_spatial_extent(self, wcs_list, transform, swap_xy):
+    def _max_spatial_extent(self, wcs_list, transform):
         """
-        Compute min & max spatial coordinates for all nods in the "virtual"
-        slit frame.
+        Compute spatial coordinate limits for all nods in the tangent plane.
         """
-        min_tan_all, max_tan_all = np.inf, -np.inf
+        limits_x = [np.inf, -np.inf]
+        limits_y = [np.inf, -np.inf]
         for wcs in wcs_list:
             x, y = wcstools.grid_from_bounding_box(wcs.bounding_box)
             ra, dec, _ = wcs(x, y)
@@ -462,20 +471,15 @@ class ResampleSpecData(ResampleData):
             dec = dec[good]
 
             xtan, ytan = transform(ra, dec)
-            if swap_xy:
-                tan_all = ytan
-            else:
-                tan_all = xtan
+            for tan_all, limits in zip([xtan, ytan], [limits_x, limits_y]):
+                min_tan = np.min(tan_all)
+                max_tan = np.max(tan_all)
+                if min_tan < limits[0]:
+                    limits[0] = min_tan
+                if max_tan > limits[1]:
+                    limits[1] = max_tan
 
-            min_tan = np.min(tan_all)
-            max_tan = np.max(tan_all)
-
-            if min_tan < min_tan_all:
-                min_tan_all = min_tan
-            if max_tan > max_tan_all:
-                max_tan_all = max_tan
-
-        return min_tan_all, max_tan_all
+        return *limits_x, *limits_y
 
     def build_interpolated_output_wcs(self, input_models):
         """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3785](https://jira.stsci.edu/browse/JP-3785)

<!-- describe the changes comprising this PR here -->
This PR adds the NIRSpec spectral resampling fix to the patch release branch.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
