### PR TITLE
Add ability to perform PSF extraction for MIRI LRS 

### DIFF
--- a/jwst/extract_1d/psf_extract.py
+++ b/jwst/extract_1d/psf_extract.py
@@ -1,0 +1,222 @@
+import abc
+import logging
+import copy
+import json
+import math
+import numpy as np
+
+from typing import Union, Tuple, NamedTuple, List
+from astropy.modeling import polynomial
+from scipy.interpolate import CubicSpline
+from scipy import interpolate
+from scipy import ndimage
+from astropy.io import fits
+from gwcs import WCS
+
+from stdatamodels.properties import ObjectNode
+from stdatamodels.jwst import datamodels
+from stdatamodels import DataModel
+from stdatamodels.jwst.datamodels import dqflags, SlitModel, SpecModel,SpecwcsModel, PsfModel
+from jwst.datamodels import SourceModelContainer
+
+from ..assign_wcs.util import wcs_bbox_from_shape
+from ..lib import pipe_utils
+from ..lib.wcs_utils import get_wavelengths
+from . import extract1d
+from . import ifu
+from . import spec_wcs
+from . import utils
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+
+HORIZONTAL = 1
+VERTICAL = 2
+"""Dispersion direction, predominantly horizontal or vertical."""
+
+# This is intended to be larger than any possible distance (in pixels) between the target and any point in the image;
+# used by locn_from_wcs().
+HUGE_DIST = 1.e20
+
+def open_specwcs(specwcs_ref_name: str, exp_type):
+    print('in open specwcs', exp_type)
+    if exp_type == 'MIR_LRS-FIXEDSLIT':
+        # use fits to read file (the datamodel does not have all that is needed) 
+        ref = fits.open(specwcs_ref_name)
+        print(' Number of rows in the table', ref[1].data.shape)
+
+        with ref:
+            lrsdata = np.array([d for d in ref[1].data])
+            # Get the zero point from the reference data.
+            # The zero_point is X, Y  (which should be COLUMN, ROW)
+            # These are 1-indexed in CDP-7 (i.e., SIAF convention) so must be converted to 0-indexed
+            # for lrs_fixedslit
+            zero_point = ref[0].header['imx'] - 1, ref[0].header['imy'] - 1
+            print('zero point', zero_point) 
+    
+        # In the lrsdata reference table, X_center,Y_center, wavelength  relative to zero_point
+        # x0,y0(ul) x1,y1 (ur) x2,y2(lr) x3,y3(ll) define corners of the box within which the distortion
+        # and wavelength calibration was derived
+        xcen = lrsdata[:, 0]
+        ycen = lrsdata[:, 1]
+        wavetab = lrsdata[:, 2]
+        trace = xcen + zero_point[0]
+        wave_trace = ycen + zero_point[1]
+    return trace, wave_trace, wavetab
+    
+
+def open_psf(psf_refname: str, exp_type):
+
+    psf_model = None
+    if exp_type == 'MIR_LRS-FIXEDSLIT':
+        psf_model = PsfModel(psf_refname)
+        print(psf_model.meta.psf.center_col)
+        print(psf_model.meta.psf.subpix)
+        print(psf_model.data)
+        print(psf_model.wave) 
+    return psf_model 
+
+    
+
+class PSFExtractData():
+    """ Class for PSF extraction for each source"""
+    
+    def __init__(self,
+                 input_model: DataModel,
+                 slit: Union[DataModel, None] = None,
+                 dispaxis: int = HORIZONTAL,
+                 use_source_posn: Union[bool, None] = None):
+
+
+        """
+        Parameters
+        ----------
+        input_model : data model
+            The input science data.
+
+        slit : an input slit, or None if not used
+            For MultiSlit, `slit` is one slit from
+            a list of slits in the input.  For other types of data, `slit`
+            will not be used.
+
+        dispaxis : int
+            Dispersion direction:  1 is horizontal, 2 is vertical.
+        """
+  
+        self.exp_type = input_model.meta.exposure.type        
+        self.dispaxis = dispaxis
+        self.wcs = None
+
+
+        if slit is None:
+            if hasattr(input_model.meta, 'wcs'):
+                self.wcs = input_model.meta.wcs
+        elif hasattr(slit, 'meta') and hasattr(slit.meta, 'wcs'):
+            self.wcs = slit.meta.wcs
+
+        if self.wcs is None:
+            log.warning("WCS function not found in input.")
+
+
+
+            
+            
+def psf_extraction(input_model, psf_ref_name, specwcs_ref_name):
+
+    exp_type = input_model.meta.exposure.type
+    trace, wave_trace, wavetab = open_specwcs(specwcs_ref_name, exp_type)
+    psf_model = open_psf(psf_ref_name, exp_type)
+    # Input data 
+    # 1. Must bePoint Source (for now PSF extraction is only working with Point Source data)
+    # 2. Can have multiple sources in one input_model
+    # 3. Keep track of mode to help decide how to find the sources and use WCS
+    
+    # We want to organize the data by source. The input can be a source ModelContainer or a single model.
+    # The type of the individual models can be: ImageModel (LRS), SlitModel (NIRSpec Slit), MultiSlitModel (MOS)
+    # of IFUCubeModel
+    # For now store all the data  as a list of input models. We will loop over each input mode, find the sources
+    # determine the spatial profile, and call extract1d. 
+    
+    input_models = []
+    if isinstance(input_model, SourceModelContainer):
+        input_models = input_model
+    else:
+        input_models.append(input_model)
+        
+    for model in input_models:
+
+        # currently for LRS-FIXEDSLIT data it is assume there is 1 source and the source is located
+        # at the dither_position
+        
+        if exp_type == 'MIR_LRS-FIXEDSLIT': # assume we can use the WCS to find source location
+            dispaxis = 2
+            wcs  = model.meta.wcs
+
+            # assuming 1 source
+            # Set up the profiles that are to be determined
+            nsource = 1
+            profile_2d = []
+            profile_bg = []  # Currently not sure if this is needed
+                             # Calwebb_spec2 subtracts the other nod position automatically 
+
+            # Only one source 
+            middle, locn_w, locn_x = utils.locn_from_wcs(
+                dispaxis,
+                wcs, 
+                model,
+                None, None, None)
+
+            # Match the  reference trace and corresponding wavelength to the data
+            # The wavelength for the reference trace does not exactly line up exactly with the data
+            
+            cs = CubicSpline(wavetab, trace)
+            cen_shift = cs(locn_w)
+            shift = locn_x - cen_shift
+
+            print('Location of source in observed spectrum', locn_x, ' at wavelength', locn_w)
+            print('In the reference trace the location is ', cen_shift)
+            print('Shift to apply to ref trace', shift)
+            
+            # For LRS-Fix data  we want to cut out the slit from the full array
+            slit = []
+            bbox = wcs.bounding_box
+            x0, x1 = bbox[0]
+            y0, y1 = bbox[1]
+            cutout = model.data[int(np.ceil(y0)):int(np.ceil(y1)), int(np.round(x0)):int(np.round(x1))]
+            slit.append(cutout)
+            
+            # adjust the trace to for slit region 
+            trace_cutout = trace - bbox[0][0]
+            wtrace_cutout = wave_trace - bbox[1][0]
+            trace_shift = trace_cutout + xshift
+   
+            # xtrace_shift - for each wavelength in the PSF this is the shift in x to apply to the PSF image to shift it
+            #                 to fall on the source.
+            # wavetab : is the wavelengh cooresponding the the trace. This wavelength may not match exactly to the the PSF.wave
+
+            # determine what the shifts per row are for the the wavelengths given by the model PSF 
+
+            PSFinterp = interpolate.interp1d(wavetab, xtrace_shift,fill_value="extrapolate")
+            psf_shift = PSFinterp(psf_model.wave)
+            psf_shift =  psf_model.meta.center_col - (psf_shift * psf_subpix)
+
+            # if the PSF is an ePSF
+            _x, _y = np.meshgrid(np.arange(cutout.shape[1]), np.arange(cutout.shape[0]))
+            _x = _x*psf_subpix + psf_shift[:, np.newaxis]
+            sprofile = ndimage.map_coordinates(psf, [_y, _x], order=1)
+            profile_2d.append(sprofile)
+            
+            print(sprofile)
+
+            # set up the data to be passed to extract1d
+            result = util.setup_data(model)
+            data, dq, var_poisson, var_rnoise, weights = result
+            
+
+
+
+
+
+

--- a/jwst/extract_1d/psf_extract.py
+++ b/jwst/extract_1d/psf_extract.py
@@ -16,7 +16,7 @@ from gwcs import WCS
 from stdatamodels.properties import ObjectNode
 from stdatamodels.jwst import datamodels
 from stdatamodels import DataModel
-from stdatamodels.jwst.datamodels import dqflags, SlitModel, SpecModel,SpecwcsModel, PsfModel
+from stdatamodels.jwst.datamodels import dqflags, SlitModel, SpecModel,SpecwcsModel, MiriLrsPsfModel
 from jwst.datamodels import SourceModelContainer
 
 from ..assign_wcs.util import wcs_bbox_from_shape
@@ -25,27 +25,38 @@ from ..lib.wcs_utils import get_wavelengths
 from . import extract1d
 from . import ifu
 from . import spec_wcs
-from . import utils
+from . import utils   # these are routines taken from extract.py and pulled out of the class definition. 
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-
 
 
 HORIZONTAL = 1
 VERTICAL = 2
 """Dispersion direction, predominantly horizontal or vertical."""
 
-# This is intended to be larger than any possible distance (in pixels) between the target and any point in the image;
-# used by locn_from_wcs().
-HUGE_DIST = 1.e20
 
-def open_specwcs(specwcs_ref_name: str, exp_type):
-    print('in open specwcs', exp_type)
+def open_specwcs(specwcs_ref_name: str, exp_type: str):
+    """Open the specwcs reference file.
+
+    Parameters
+    ----------
+    specwcs_ref_name : str
+        The name of the specwcs reference file. This file contains information of the trace location.
+        For the MIRI LRS FIED-SlIT it is a fits file containing the x,y center of the trace. 
+    ext_type : str
+        The exposure type of the data
+
+    Returns
+    -------
+        Currently only works on MIRI LRS-FIXEDSLIT exposures. 
+        Return the center of the trace in x and y for a given wavelength
+
+    """
+    
     if exp_type == 'MIR_LRS-FIXEDSLIT':
         # use fits to read file (the datamodel does not have all that is needed) 
         ref = fits.open(specwcs_ref_name)
-        print(' Number of rows in the table', ref[1].data.shape)
 
         with ref:
             lrsdata = np.array([d for d in ref[1].data])
@@ -54,11 +65,9 @@ def open_specwcs(specwcs_ref_name: str, exp_type):
             # These are 1-indexed in CDP-7 (i.e., SIAF convention) so must be converted to 0-indexed
             # for lrs_fixedslit
             zero_point = ref[0].header['imx'] - 1, ref[0].header['imy'] - 1
-            print('zero point', zero_point) 
     
         # In the lrsdata reference table, X_center,Y_center, wavelength  relative to zero_point
-        # x0,y0(ul) x1,y1 (ur) x2,y2(lr) x3,y3(ll) define corners of the box within which the distortion
-        # and wavelength calibration was derived
+
         xcen = lrsdata[:, 0]
         ycen = lrsdata[:, 1]
         wavetab = lrsdata[:, 2]
@@ -67,28 +76,43 @@ def open_specwcs(specwcs_ref_name: str, exp_type):
     return trace, wave_trace, wavetab
     
 
-def open_psf(psf_refname: str, exp_type):
+def open_psf(psf_refname: str, exp_type: str):
+    """Open the PSF reference file.
 
+    Parameters
+    ----------
+    psf_ref_name : str
+        The name of the psf reference file. 
+    ext_type : str
+        The exposure type of the data
+
+    Returns
+    -------
+        Currenly only works on MIRI LRS-FIXEDSLIT exposures. 
+        Returns the EPSF model.
+
+    """
+    
     psf_model = None
     if exp_type == 'MIR_LRS-FIXEDSLIT':
-        psf_model = PsfModel(psf_refname)
-        print(psf_model.meta.psf.center_col)
-        print(psf_model.meta.psf.subpix)
-        print(psf_model.data)
-        print(psf_model.wave) 
+        psf_model = MiriLrsPsfModel(psf_refname)
+        # The information we read in from PSF file is:
+        # center_col: psf_model.meta.psf.center_col
+        # super sample factor: psf_model.meta.psf.subpix)
+        # psf : psf_model.data (2d)
+        # wavelength of PSF planes: psf_model.wave 
     return psf_model 
 
     
 
+# TODO JEM  THIS CLASS IS NOT BEING USED YET. JUST HOOKS FOR LATER
 class PSFExtractData():
     """ Class for PSF extraction for each source"""
     
     def __init__(self,
                  input_model: DataModel,
                  slit: Union[DataModel, None] = None,
-                 dispaxis: int = HORIZONTAL,
-                 use_source_posn: Union[bool, None] = None):
-
+                 dispaxis: int = HORIZONTAL):
 
         """
         Parameters
@@ -109,7 +133,6 @@ class PSFExtractData():
         self.dispaxis = dispaxis
         self.wcs = None
 
-
         if slit is None:
             if hasattr(input_model.meta, 'wcs'):
                 self.wcs = input_model.meta.wcs
@@ -120,11 +143,28 @@ class PSFExtractData():
             log.warning("WCS function not found in input.")
 
 
+def psf_extraction(input_model, psf_ref_name, specwcs_ref_name, save_spatial_profile):
+    """Open the PSF reference file.
 
-            
-            
-def psf_extraction(input_model, psf_ref_name, specwcs_ref_name):
+    Parameters
+    ----------
+    input_model : data model
+        This can be either the input science file or one SlitModel out of
+        a list of slits.
+    psf_ref_name : str
+        PSF reference filename
+    specwcs_ref_name : str
+        Reference file containing information on trace of spectra
 
+    save_spatial_profile : bool
+        Save the spatial profile. 
+    Returns
+    -------
+        Currenly only works on MIRI LRS-FIXEDSLIT exposures. 
+        spatial profile
+
+    """
+        
     exp_type = input_model.meta.exposure.type
     trace, wave_trace, wavetab = open_specwcs(specwcs_ref_name, exp_type)
     psf_model = open_psf(psf_ref_name, exp_type)
@@ -147,7 +187,7 @@ def psf_extraction(input_model, psf_ref_name, specwcs_ref_name):
         
     for model in input_models:
 
-        # currently for LRS-FIXEDSLIT data it is assume there is 1 source and the source is located
+        # currently for LRS-FIXEDSLIT data it is assumes there is 1 source and the source is located
         # at the dither_position
         
         if exp_type == 'MIR_LRS-FIXEDSLIT': # assume we can use the WCS to find source location
@@ -158,26 +198,27 @@ def psf_extraction(input_model, psf_ref_name, specwcs_ref_name):
             # Set up the profiles that are to be determined
             nsource = 1
             profile_2d = []
-            profile_bg = []  # Currently not sure if this is needed
+            profile_bg = []  # Currently not sure if this is needed (at least for MIRI LRS data) 
                              # Calwebb_spec2 subtracts the other nod position automatically 
 
-            # Only one source 
+            # Only one source determine the location using the WCS
             middle, locn_w, locn_x = utils.locn_from_wcs(
                 dispaxis,
                 wcs, 
                 model,
                 None, None, None)
 
-            # Match the  reference trace and corresponding wavelength to the data
+            # Perform fit of reference trace and corresponding wavelength
             # The wavelength for the reference trace does not exactly line up exactly with the data
             
             cs = CubicSpline(wavetab, trace)
             cen_shift = cs(locn_w)
             shift = locn_x - cen_shift
 
-            print('Location of source in observed spectrum', locn_x, ' at wavelength', locn_w)
-            print('In the reference trace the location is ', cen_shift)
-            print('Shift to apply to ref trace', shift)
+            log.info ('Location of source in observed spectrum %s at wavelength %s', locn_x, locn_w)
+
+            log.info('For this wavelength: %s  the reference trace the location is %s ', locn_w, cen_shift)
+            log.info('Shift to apply to ref trace %s', shift)
             
             # For LRS-Fix data  we want to cut out the slit from the full array
             slit = []
@@ -187,31 +228,58 @@ def psf_extraction(input_model, psf_ref_name, specwcs_ref_name):
             cutout = model.data[int(np.ceil(y0)):int(np.ceil(y1)), int(np.round(x0)):int(np.round(x1))]
             slit.append(cutout)
             
-            # adjust the trace to for slit region 
+            # adjust the trace to the slit region 
             trace_cutout = trace - bbox[0][0]
             wtrace_cutout = wave_trace - bbox[1][0]
-            trace_shift = trace_cutout + xshift
-   
-            # xtrace_shift - for each wavelength in the PSF this is the shift in x to apply to the PSF image to shift it
+            trace_shift = trace_cutout + shift
+            psf_wave = psf_model.wave
+            
+            # trace_shift - for each wavelength in the PSF this is the shift in x to apply to the PSF image to shift it
             #                 to fall on the source.
-            # wavetab : is the wavelengh cooresponding the the trace. This wavelength may not match exactly to the the PSF.wave
-
+            # wavetab : is the wavelengh cooresponding the the trace. This wavelength may not match exactly to the the PSF.
+            # 
             # determine what the shifts per row are for the the wavelengths given by the model PSF 
 
-            PSFinterp = interpolate.interp1d(wavetab, xtrace_shift,fill_value="extrapolate")
-            psf_shift = PSFinterp(psf_model.wave)
-            psf_shift =  psf_model.meta.center_col - (psf_shift * psf_subpix)
+            psf_subpix = psf_model.meta.psf.subpix
+            
+            PSFinterp = interpolate.interp1d(wavetab, trace_shift,fill_value="extrapolate")
+            psf_shift = PSFinterp(psf_wave)
+            psf_shift =  psf_model.meta.psf.center_col - (psf_shift * psf_subpix)
 
             # if the PSF is an ePSF
             _x, _y = np.meshgrid(np.arange(cutout.shape[1]), np.arange(cutout.shape[0]))
-            _x = _x*psf_subpix + psf_shift[:, np.newaxis]
-            sprofile = ndimage.map_coordinates(psf, [_y, _x], order=1)
+
+            # Convert 1D psf to 2 d with second dimension = 1
+            psf2 = psf_shift[:, np.newaxis]
+            _x = _x*psf_subpix + psf2
+
+            sprofile = ndimage.map_coordinates(psf_model.data, [_y, _x], order=1)
             profile_2d.append(sprofile)
-            
-            print(sprofile)
+
+            # TODO JEM - this might be just for testing. If we keep writing spatial profile
+            # we will need a datamodel module for it  rather than using FITS write
+            # Also need to change how we form the name if we keep writing spatial profile
+            if save_spatial_profile:
+                file_out = model.meta.filename.replace('.fits', '_spatial_profile.fits')
+                hdu = fits.PrimaryHDU()
+                hdu.header['SUBPIX'] = psf_model.meta.psf.subpix
+                hdu.header['CENTCOL'] = psf_model.meta.psf.center_col
+                hdu.header['CENTWAVE'] = locn_w
+                hdu.header['CENTLOC'] = locn_x
+                
+                hdu.header['REFSHFT'] = float(cen_shift)
+                hdu.header['TRCSHFT'] = shift
+                hdu1 = fits.ImageHDU(sprofile, name='SPROFILE')
+                hdu_final = fits.HDUList([hdu, hdu1])
+
+                print(file_out) 
+                hdu_final.writeto(file_out, overwrite=True)
 
             # set up the data to be passed to extract1d
-            result = util.setup_data(model)
+            # TODO JEM - setup data - gathers the data that extract1d will need.
+            # we do not have to do this in seperate module and we need to know what
+            # Tim B routine needs - so this will need to be updated. 
+            result = utils.setup_data(model)
             data, dq, var_poisson, var_rnoise, weights = result
             
 

--- a/jwst/extract_1d/utils.py
+++ b/jwst/extract_1d/utils.py
@@ -1,0 +1,404 @@
+import abc
+import logging
+import copy
+import json
+import math
+import numpy as np
+from stdatamodels import DataModel
+from stdatamodels.jwst import datamodels
+from typing import Union, Tuple, NamedTuple, List
+from astropy.modeling import polynomial
+from astropy.io import fits
+from gwcs import WCS
+from ..lib.wcs_utils import get_wavelengths
+
+# Collection of useful routines
+
+HORIZONTAL = 1
+VERTICAL = 2
+"""Dispersion direction, predominantly horizontal or vertical."""
+
+def locn_from_wcs(
+         dispaxis,
+         wcs,
+         input_model: DataModel,
+         slit: Union[DataModel, None],
+         targ_ra: Union[float, None],
+         targ_dec: Union[float, None],) -> Union[Tuple[int, float, float], None]:
+
+    """Get the location of the spectrum, based on the WCS.
+
+    Parameters
+    ----------
+    input_model : data model
+        The input science model.
+
+    slit : one slit from a MultiSlitModel (or similar), or None
+        The WCS and target coordinates will be gotten from `slit`
+        unless `slit` is None, and in that case they will be gotten
+        from `input_model`.
+
+    targ_ra : float or None
+        The right ascension of the target, or None
+
+    targ_dec : float or None
+        The declination of the target, or None
+    Returns
+    -------
+    tuple (middle, middle_wl, locn) or None
+    middle : int
+        Pixel coordinate in the dispersion direction within the 2-D
+        cutout (or the entire input image) at the middle of the WCS
+        bounding box.  This is the point at which to determine the
+        nominal extraction location, in case it varies along the
+        spectrum.  The offset will then be the difference between
+        `locn` (below) and the nominal location.
+
+    middle_wl : float
+        The wavelength at pixel `middle`.
+
+    locn : float
+        Pixel coordinate in the cross-dispersion direction within the
+        2-D cutout (or the entire input image) that has right ascension
+        and declination coordinates corresponding to the target location.
+        The spectral extraction region should be centered here.
+
+    None will be returned if there was not sufficient information
+    available, e.g. if the wavelength attribute or wcs function is not
+    defined.
+    """
+
+    # WFSS data are not currently supported by this function
+    if input_model.meta.exposure.type in ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM']:
+        log.warning("Can't use target coordinates to get location of spectrum "
+                    f"for exp type {input_model.meta.exposure.type}")
+        return
+
+    bb = wcs.bounding_box  # ((x0, x1), (y0, y1))
+    print('****** ',bb)
+    if bb is None:
+        if slit is None:
+            shape = input_model.data.shape
+        else:
+            shape = slit.data.shape
+        bb = wcs_bbox_from_shape(shape)
+
+    print('dispaxis', dispaxis) 
+    if dispaxis == HORIZONTAL:
+        # Width (height) in the cross-dispersion direction, from the start of the 2-D cutout (or of the full image)
+        # to the upper limit of the bounding box.
+        # This may be smaller than the full width of the image, but it's all we need to consider.
+        xd_width = int(round(bb[1][1]))  # must be an int
+        middle = int((bb[0][0] + bb[0][1]) / 2.)  # Middle of the bounding_box in the dispersion direction.
+        x = np.empty(xd_width, dtype=np.float64)
+        x[:] = float(middle)
+        y = np.arange(xd_width, dtype=np.float64)
+        lower = bb[1][0]
+        upper = bb[1][1]
+    else:  # dispaxis = VERTICAL
+        xd_width = int(round(bb[0][1]))  # Cross-dispersion total width of bounding box; must be an int
+        middle = int((bb[1][0] + bb[1][1]) / 2.)  # Mid-point of width along dispersion direction
+        x = np.arange(xd_width, dtype=np.float64)  # 1-D vector of cross-dispersion (x) pixel indices
+        y = np.empty(xd_width, dtype=np.float64)  # 1-D vector all set to middle y index
+        y[:] = float(middle)
+         
+        # lower and upper range in cross-dispersion direction
+        lower = bb[0][0]
+        upper = bb[0][1]
+
+    # We need stuff[2], a 1-D array of wavelengths crossing the spectrum near its middle.
+    fwd_transform = wcs(x, y)
+    middle_wl = np.nanmean(fwd_transform[2])
+
+    print('middle wl', middle_wl)
+    if input_model.meta.exposure.type in ['NRS_FIXEDSLIT', 'NRS_MSASPEC',
+                                              'NRS_BRIGHTOBJ']:
+        if slit is None:
+            xpos = input_model.source_xpos
+            ypos = input_model.source_ypos
+        else:
+            xpos = slit.source_xpos
+            ypos = slit.source_ypos
+        slit2det = wcs.get_transform('slit_frame', 'detector')
+        x_y = slit2det(xpos, ypos, middle_wl)
+        log.info("Using source_xpos and source_ypos to center extraction.")
+
+    elif input_model.meta.exposure.type == 'MIR_LRS-FIXEDSLIT':
+        try:
+            if slit is None:
+                dithra = input_model.meta.dither.dithered_ra
+                dithdec = input_model.meta.dither.dithered_dec
+            else:
+                dithra = slit.meta.dither.dithered_ra
+                dithdec = slit.meta.dither.dithered_dec
+                
+            x_y = wcs.backward_transform(dithra, dithdec, middle_wl)
+        except AttributeError:
+            log.warning("Dithered pointing location not found in wcsinfo. "
+                        "Defaulting to TARG_RA / TARG_DEC for centering.")
+            return
+
+
+    # locn is the XD location of the spectrum:
+    if dispaxis == HORIZONTAL:
+        locn = x_y[1]
+    else:
+        locn = x_y[0]
+
+    if locn < lower or locn > upper and targ_ra > 340.:
+        # Try this as a temporary workaround.
+        x_y = wcs.backward_transform(targ_ra - 360., targ_dec, middle_wl)
+
+        if dispaxis == HORIZONTAL:
+            temp_locn = x_y[1]
+        else:
+            temp_locn = x_y[0]
+
+        if lower <= temp_locn <= upper:
+            # Subtracting 360 from the right ascension worked!
+            locn = temp_locn
+            log.debug(f"targ_ra changed from {targ_ra} to {targ_ra - 360.}")
+
+    # If the target is at the edge of the image or at the edge of the non-NaN area, we can't use the WCS to find the
+    # location of the target spectrum.
+    if locn < lower or locn > upper:
+        log.warning(f"WCS implies the target is at {locn:.2f}, which is outside the bounding box,")
+        log.warning("so we can't get spectrum location using the WCS")
+        locn = None
+
+    return middle, middle_wl, locn
+
+
+
+def get_target_coordinates(
+            input_model: DataModel, slit: Union[DataModel, None]
+    ) -> Tuple[Union[float, None], Union[float, None]]:
+        """Get the right ascension and declination of the target.
+
+        For MultiSlitModel (or similar) data, each slit has the source
+        right ascension and declination as attributes, and this can vary
+        from one slit to another (e.g. for NIRSpec MOS, or for WFSS).  In
+        this case, we want the celestial coordinates from the slit object.
+        For other models, however, the celestial coordinates of the source
+        are in input_model.meta.target.
+
+        Parameters
+        ----------
+        input_model : data model
+            The input science data model.
+
+        slit : SlitModel or None
+            One slit from a MultiSlitModel (or similar), or None if
+            there are no slits.
+
+        Returns
+        -------
+        targ_ra : float or None
+            The right ascension of the target, or None
+
+        targ_dec : float or None
+            The declination of the target, or None
+        """
+        targ_ra = None
+        targ_dec = None
+
+        if slit is not None:
+            # If we've been passed a slit object, get the RA/Dec
+            # from the slit source attributes
+            targ_ra = getattr(slit, 'source_ra', None)
+            targ_dec = getattr(slit, 'source_dec', None)
+        elif isinstance(input_model, datamodels.SlitModel):
+            # If the input model is a single SlitModel, again
+            # get the coords from the slit source attributes
+            targ_ra = getattr(input_model, 'source_ra', None)
+            targ_dec = getattr(input_model, 'source_dec', None)
+
+        if targ_ra is None or targ_dec is None:
+            # Otherwise get it from the generic target coords
+            targ_ra = input_model.meta.target.ra
+            targ_dec = input_model.meta.target.dec
+
+        # Issue a warning if none of the methods succeeded
+        if targ_ra is None or targ_dec is None:
+            log.warning("Target RA and Dec could not be determined")
+            targ_ra = targ_dec = None
+
+        return targ_ra, targ_dec
+
+
+def replace_bad_values(
+        data: np.ndarray,
+        input_dq: Union[np.ndarray, None],
+        wl_array: np.ndarray
+) -> np.ndarray:
+    """Replace values flagged with DO_NOT_USE or that have NaN wavelengths.
+
+    Parameters
+    ----------
+    data : ndarray
+        The science data array.
+
+    input_dq : ndarray or None
+        If not None, this will be checked for flag value DO_NOT_USE.  The
+        science data will be set to NaN for every pixel that is flagged
+        with DO_NOT_USE in `input_dq`.
+
+    wl_array : ndarray, 2-D
+        Wavelengths corresponding to `data`.  For any element of this
+        array that is NaN, the corresponding element in `data` will be
+        set to NaN.
+
+    Returns
+    -------
+    ndarray
+        A possibly modified copy of `data`.  If no change was made, this
+        will be a view rather than a copy.  Values that are set to NaN
+        should not be included when doing the 1-D spectral extraction.
+
+    """
+    mask = np.isnan(wl_array)
+
+    if input_dq is not None:
+        bad_mask = np.bitwise_and(input_dq, dqflags.pixel['DO_NOT_USE']) > 0
+        mask = np.logical_or(mask, bad_mask)
+
+    if np.any(mask):
+        mod_data = data.copy()
+        mod_data[mask] = np.nan
+        return mod_data
+
+    return data
+
+
+def nans_at_endpoints(
+        wavelength: np.ndarray,
+        dq: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, slice]:
+    """Flag NaNs in the wavelength array.
+
+    Extended summary
+    ----------------
+    Both input arrays should be 1-D and have the same shape.
+    If NaNs are present at endpoints of `wavelength`, the arrays will be
+    trimmed to remove the NaNs.  NaNs at interior elements of `wavelength`
+    will be left in place, but they will be flagged with DO_NOT_USE in the
+    `dq` array.
+
+    Parameters
+    ----------
+    wavelength : ndarray
+        Array of wavelengths, possibly containing NaNs.
+
+    dq : ndarray
+        Data quality array.
+
+    Returns
+    -------
+    wavelength, dq : ndarray
+        The returned `dq` array may have NaNs flagged with DO_NOT_USE,
+        and both arrays may have been trimmed at either or both ends.
+
+    slc : slice
+        The slice to be applied to other output arrays to match the modified
+        shape of the wavelength array.
+    """
+    # The input arrays will not be modified in-place.
+    new_wl = wavelength.copy()
+    new_dq = dq.copy()
+    nelem = wavelength.shape[0]
+    slc = slice(nelem)
+
+    nan_mask = np.isnan(wavelength)
+    new_dq[nan_mask] = np.bitwise_or(new_dq[nan_mask], dqflags.pixel['DO_NOT_USE'])
+    not_nan = np.logical_not(nan_mask)
+    flag = np.where(not_nan)
+
+    if len(flag[0]) > 0:
+        n_trimmed = flag[0][0] + nelem - (flag[0][-1] + 1)
+
+        if n_trimmed > 0:
+            log.debug(f"Output arrays have been trimmed by {n_trimmed} elements")
+
+            slc = slice(flag[0][0], flag[0][-1] + 1)
+            new_wl = new_wl[slc]
+            new_dq = new_dq[slc]
+    else:
+        new_dq |= dqflags.pixel['DO_NOT_USE']
+
+    return new_wl, new_dq, slc
+
+
+def setup_data(
+        input_model: DataModel,
+#        integ: int
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray,
+           np.ndarray]:
+    """Pull out the data from the slit to perform extraction
+
+    Parameters
+    ----------
+    input_model : data model
+        The input science model.
+
+    slit : one slit from a MultiSlitModel (or similar), or None
+        If slit is None, the data array is input_model.data; otherwise,
+        the data array is slit.data.
+        In the former case, if `integ` is zero or larger, the spectrum
+        will be extracted from the 2-D slice input_model.data[integ].
+
+    integ : int
+        For the case that input_model is a SlitModel or a CubeModel,
+        `integ` is the integration number.  If the integration number is
+        not relevant (i.e. the data array is 2-D), `integ` should be -1.
+
+
+
+    """
+
+    # hook for lrs_slitless data 
+    #if integ > -1:
+    #    log.info(f"Extracting integration {integ + 1}")
+    #    data = input_model.data[integ]
+    #    var_poisson = input_model.var_poisson[integ]
+    #    var_rnoise = input_model.var_rnoise[integ]
+    #    var_flat = input_model.var_flat[integ]
+    #    input_dq = input_model.dq[integ]
+
+    bbox = input_model.meta,wcs.bounding_box
+    x0, x1 = bbox[0]
+    y0, y1 = bbox[1]
+    i1, i2, j1, j2 = (int(np.ceil(y0)), int(np.ceil(y1)), int(np.round(x0)), int(np.round(x1)))
+    data = model.data[i1:i2, j1:j2]
+    var_poisson = model.var_poisson[i1:i2, j1:j2]
+    var_rnoise = model.var_rnoise[i1:i2, j1:j2]
+    dq = model.dq[i1:i2, j1:j2]
+    
+    #  Ensure variance arrays have been populated. If not, zero fill.
+    if np.shape(var_poisson) != np.shape(data):
+        var_poisson = np.zeros_like(data)
+        var_rnoise = np.zeros_like(data)
+        
+    if np.shape(var_flat) != np.shape(data):
+        var_flat = np.zeros_like(data)
+        
+    if dq.size == 0:
+        dq = None
+
+    # not sure we need the wl_array - might do this differently 
+    wl_array = get_wavelengths(input_model)
+    wl_array = wl_array[i1:i2, j1:j2]
+    data = replace_bad_values(data, dq, wl_array)
+
+    # Use uniform weights for now, setting invalid values to zero.
+    weights = np.ones(data.shape)
+    weights[dq%2 == 1] = 0
+    weights[np.isnan(var_rnoise)] = 0
+
+    var_rnoise[np.isnan(var_rnoise)] = 1e30
+    var_rnoise[var_rnoise <= 0] = 1e30
+
+    var_poisson[np.isnan(var_poisson)] = 1e30
+    var_poisson[var_poisson <= 0] = 1e30
+    data[np.isnan(data)] = 0
+
+    return data, dq, var_poisson, var_rnoise, weights


### PR DESCRIPTION
DRAFT.
This was pushed up to GitHub for Melanie to look at. More work needs to done.  We need to finalize the datamodel for the PSF reference data for MIRI LRS, and figure out how to call extract1d.


We need the datamodels defining the PSF extraction finalized and merged https://github.com/spacetelescope/stdatamodels/pull/336

utils.py is modules taken from extract.py the Extract class and pull out so they could be used for psf_extraction.
I would like to add (if just temporary) the ability to write the spatial profiles to disk. So they can easily be viewed/verified. 

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
