### PR TITLE
JP-3795: Target group association fixes

### DIFF
--- a/changes/8943.associations.rst
+++ b/changes/8943.associations.rst
@@ -1,0 +1,2 @@
+For nodded NIRSpec FS or MOS spec2 associations, exclude background candidates that do not match the science target ID.
+For NIRSpec FS spec3 associations, update the product name to include the target ID.

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -1101,7 +1101,8 @@ class AsnMixin_Lv2Nod:
 
         For NIRSpec fixed slit or MOS data, this returns True if the
         background candidate shares a primary dither point with the
-        science.
+        science or if the target ID does not match between science
+        and background candidate.
 
         In addition, for NIRSpec fixed slit exposures taken with slit
         S1600A1 in a 5-point nod pattern, this returns True when the

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -1121,6 +1121,20 @@ class AsnMixin_Lv2Nod:
         if exptype not in ['nrs_fixedslit', 'nrs_msaspec']:
             return False
 
+        # Check for target ID - if present,
+        # it must match for either FS or MOS
+        try:
+            sci_target_id = str(science_item['targetid']).lower()
+            bkg_target_id = str(background_item['targetid']).lower()
+        except KeyError:
+            sci_target_id = None
+            bkg_target_id = None
+        if sci_target_id != bkg_target_id:
+            # Report overlap - different activities contain
+            # different sources that may overlap, even if not
+            # at the same primary nod position.
+            return True
+
         # Get pattern number values, needed for FS or MOS
         try:
             numdthpt = int(science_item['numdthpt'])

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -682,6 +682,8 @@ def dms_product_name_nrsfs_sources(asn):
     product_name : str
         The product name
     """
+    target = asn._get_target()
+
     instrument = asn._get_instrument()
 
     opt_elem = asn._get_opt_element()
@@ -690,8 +692,10 @@ def dms_product_name_nrsfs_sources(asn):
     if subarray:
         subarray = '-' + subarray
 
+
     product_name_format = (
         'jw{program}-{acid}'
+        '_{target}'
         '_{source_id}'
         '_{instrument}'
         '_{opt_elem}-{slit_name}{subarray}'
@@ -700,6 +704,7 @@ def dms_product_name_nrsfs_sources(asn):
         product_name_format,
         program=asn.data['program'],
         acid=asn.acid.id,
+        target=target,
         instrument=instrument,
         opt_elem=opt_elem,
         subarray=subarray,

--- a/jwst/associations/tests/test_level3_spectrographic.py
+++ b/jwst/associations/tests/test_level3_spectrographic.py
@@ -56,7 +56,7 @@ def nirspec_params_id(fixture_value):
             'o001',
             'spec3',
             r'jw99009-o001_spec3_\d{5}_asn',
-            'jw99009-o001_{source_id}_nirspec_f100lp-g140m-{slit_name}-s200a2',
+            'jw99009-o001_t001_{source_id}_nirspec_f100lp-g140m-{slit_name}-s200a2',
             set(('science', 'target_acquisition', 'autowave'))
         ),
         (


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3795](https://jira.stsci.edu/browse/JP-3795)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
A couple fixes for target group observations:
- Update background member identification for spec2 for NIRSpec FS and MOS nodded spectral data to exclude mismatched target IDs
- Update output file names for NIRSpec FS spec3 to include the target ID

Note that this will change the spec3 filenames -- DMS will need a heads-up.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
