### PR TITLE
JP- 3778 Allow the RSCD correction to work on segmented TSO data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -362,6 +362,7 @@ rscd
 ----
 
 - Removed unnecessary copies, and created a single copy at step.py level. [#8676]
+- Updated step to work on segmented data. [#8878]
 
 saturation
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -362,7 +362,6 @@ rscd
 ----
 
 - Removed unnecessary copies, and created a single copy at step.py level. [#8676]
-- Updated step to work on segmented data. [#8878]
 
 saturation
 ----------

--- a/changes/8946.rscd.rst
+++ b/changes/8946.rscd.rst
@@ -1,0 +1,1 @@
+Updated RSCD step to work on segmented data

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -10,6 +10,7 @@ from stdatamodels.jwst import datamodels
 
 DATASET1_ID = "jw01536028001_03103_00001-seg001_mirimage"
 DATASET2_ID = "jw01536028001_03103_00001-seg002_mirimage"
+DATASET3_ID = "jw01281001001_04103_00001-seg002_trim_mirimage"
 ASN3_FILENAME = "jw01536-o028_20221202t215749_tso3_00001_asn.json"
 PRODUCT_NAME = "jw01536-o028_t008_miri_p750l-slitlessprism"
 ASN_ID = "o028"
@@ -17,7 +18,7 @@ ASN_ID = "o028"
 
 @pytest.fixture(scope="module")
 def run_tso1_pipeline(rtdata_module):
-    """Run the calwebb_tso1 pipeline on a MIRI LRS slitless exposure."""
+    """Run the calwebb_detector1 pipeline on a MIRI LRS slitless exposure."""
     rtdata = rtdata_module
     rtdata.get_data(f"miri/lrs/{DATASET1_ID}_uncal.fits")
 
@@ -29,6 +30,25 @@ def run_tso1_pipeline(rtdata_module):
         "--steps.lastframe.save_results=True",
         "--steps.reset.save_results=True",
         "--steps.linearity.save_results=True",
+        "--steps.dark_current.save_results=True",
+    ]
+    Step.from_cmdline(args)
+
+
+@pytest.fixture(scope="module")
+def run_detector1_pipeline(rtdata_module):
+    """Run calwebb_detector pipeline on a MIRI LRS slitless exposure for Segment 2 data. 
+       Focusing on the steps that depend on integration # and not covered by run_tso1_pipeline.
+       Also test running RSC step"""
+    rtdata = rtdata_module
+    rtdata.get_data(f"miri/lrs/{DATASET3_ID}_uncal.fits")
+
+    args = [
+        "calwebb_detector1",
+        rtdata.input,
+        "--steps.emicorr.save_results=True",
+        "--steps.rscd.skip=False",
+        "--steps.rscd.save_results=True",
         "--steps.dark_current.save_results=True",
     ]
     Step.from_cmdline(args)
@@ -85,6 +105,25 @@ def test_miri_lrs_slitless_tso1(run_tso1_pipeline, rtdata_module, fitsdiff_defau
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("step_suffix", ['rscd', 'emicorr',
+                                         'dark_current', 'ramp', 'rate', 'rateints'])
+def test_miri_lrs_slitless_detector1(run_detector1_pipeline, rtdata_module,
+                                          fitsdiff_default_kwargs, step_suffix):
+    """
+    Regression test of  detector1 pipeline performed on MIRI LRS slitless TSO data.
+    Testing segment 2 data for RSCD, emicorr and dark_current.
+    """
+    rtdata = rtdata_module
+    output_filename = f"{DATASET3_ID}_{step_suffix}.fits"
+    rtdata.output = output_filename
+
+    rtdata.get_truth(f"truth/test_miri_lrs_slitless_detector1/{output_filename}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+    
 
 @pytest.mark.bigdata
 @pytest.mark.parametrize("step_suffix", ["assign_wcs", "srctype", "flat_field",

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_allclose
 
 from jwst.stpipe import Step
 from gwcs.wcstools import grid_from_bounding_box
-
 from stdatamodels.jwst import datamodels
 
 DATASET1_ID = "jw01536028001_03103_00001-seg001_mirimage"

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -95,7 +95,7 @@ def correction_skip_groups(output, group_skip):
               (sci_nints, sci_ngroups))
     log.debug("The first integration in the data is integration: %d" %
               (sci_int_start))
-    log.info("Number of groups to skip for integrations 2 and higher %d ", group_skip)
+    log.info("Number of groups to skip for integrations 2 and higher: %d " %group_skip)
 
     # If ngroups <= group_skip+3, skip the flagging
     # the +3 is to ensure there is a slope to be fit including the flagging for

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -106,17 +106,20 @@ def correction_skip_groups(output, group_skip):
         output.meta.cal_step.rscd = 'SKIPPED'
         return output
 
-    # If ngroups > group_skip+3, set all of the GROUPDQ  in 0: group_skip to 'DO_NOT_USE'
-    # for integrations 1 and higher. Currently no correction is applied to first integration
-    if sci_int_start == 1:
-        output.groupdq[1:, 0:group_skip, :, :] = \
-            np.bitwise_or(output.groupdq[1:, 0:group_skip, :, :], dqflags.group['DO_NOT_USE'])
-        log.debug(f"RSCD Sub: adding DO_NOT_USE to GROUPDQ for the first {group_skip} groups")
+    # The RSCD correction is applied to integrations 2 and higher.
+    # For segmented data the first integration in the file may not be the first integration in the
+    # exposure. The value in meta.exposure.integration_start holds the value of the first integration
+    # in the file.
+    # If a correction is to be done and if  ngroups > group_skip+3, then  set all of the GROUPDQ
+    # in 0: group_skip to 'DO_NOT_USE'
 
-    else: # we have segmented data 
-        output.groupdq[:, 0:group_skip, :, :] = \
-            np.bitwise_or(output.groupdq[:, 0:group_skip, :, :], dqflags.group['DO_NOT_USE'])
-        log.debug(f"RSCD Sub: adding DO_NOT_USE to GROUPDQ for the first {group_skip} groups")
+    int_start = 1
+    if sci_int_start !=1: # we have segmented data
+        int_start = 0
+        
+    output.groupdq[int_start:, 0:group_skip, :, :] = \
+        np.bitwise_or(output.groupdq[int_start:, 0:group_skip, :, :], dqflags.group['DO_NOT_USE'])
+    log.debug(f"RSCD Sub: adding DO_NOT_USE to GROUPDQ for the first {group_skip} groups")
     output.meta.cal_step.rscd = 'COMPLETE'
 
     return output

--- a/jwst/rscd/tests/test_rscd.py
+++ b/jwst/rscd/tests/test_rscd.py
@@ -12,18 +12,27 @@ def test_rscd_baseline_set_groupdq():
     groupdq flags in the 1st integration
     """
 
+    exposure = {
+        'integration_start' : None,
+        'integration_end':  None,
+        'ngroups' : 10,
+        'nints' : 2
+        }
     # size of integration
-    ngroups = 10
+    ngroups = exposure['ngroups']
+    nints  = exposure['nints']
+    
     xsize = 10
     ysize = 10
 
     # create the data and groupdq arrays
-    csize = (2, ngroups, ysize, xsize)
+    csize = (nints, ngroups, ysize, xsize)
     data = np.full(csize, 1.0, dtype=np.float32)
     groupdq = np.zeros(csize, dtype=np.uint8)
 
     # create a JWST datamodel for MIRI data
     dm_ramp = RampModel(data=data, groupdq=groupdq)
+    dm_ramp.meta.exposure._instance.update(exposure)
 
     # get the number of groups to flag
     nflag = 3
@@ -71,11 +80,22 @@ def test_rscd_baseline_too_few_groups():
     """
 
     # size of exposure
-    nints = 2
-    ngroups = 3
     xsize = 10
     ysize = 10
 
+    exposure = {
+        'integration_start' : None,
+        'integration_end':  None,
+        'ngroups' : 3,
+        'nints' : 2
+        }
+    # size of integration
+    ngroups = exposure['ngroups']
+    nints  = exposure['nints']
+    
+    xsize = 10
+    ysize = 10
+    
     # create the data and groupdq arrays
     csize = (nints, ngroups, ysize, xsize)
     data = np.full(csize, 1.0, dtype=np.float32)
@@ -83,7 +103,8 @@ def test_rscd_baseline_too_few_groups():
 
     # create a JWST datamodel for MIRI data on a copy (the copy is created at the step script)
     dm_ramp = RampModel(data=data, groupdq=groupdq)
-
+    dm_ramp.meta.exposure._instance.update(exposure)
+    
     # get the number of groups to flag
     nflag = 3
 
@@ -99,3 +120,63 @@ def test_rscd_baseline_too_few_groups():
                                   dq_diff,
                                   err_msg='groupdq flags changed when '
                                   + 'not enough groups are present')
+
+
+def test_rscd_tso():
+    """
+    The RSCD correction is generally skipped for TSO data, but some users
+    have been running it on TSO data. So this test was added. 
+    Test for TSO segmented data that the correct groups are flagged as 'DO_NOT_USE'
+    for integration 2 and higher. Set up the segmented data so the segment
+    is for integration 25 to 50. A rscd correction should be applied to all 
+    the data.  
+ 
+    """
+    exposure = {
+        'integration_start' : 25,
+        'integration_end':  50,
+        'ngroups' : 8,
+        'nints' : 50
+        }
+        
+    xsize = 10
+    ysize = 10
+    ngroups = exposure['ngroups']
+    seg_nints = exposure['integration_end'] - exposure['integration_start'] + 1
+    input_model = RampModel((seg_nints, exposure['ngroups'],
+                                        ysize, xsize))
+    
+    input_model.groupdq[:,:,:,:] = 0 # initize to 0 - all good
+    input_model.meta.exposure._instance.update(exposure)
+
+    # get the number of groups to flag
+    nflag = 4
+
+    # run the RSCD baseline correction step on a copy (the copy is created at the step script)
+    ramp_rscd = correction_skip_groups(input_model.copy(), nflag)
+
+
+    # check that the difference in the groupdq flags is equal to
+    #  the 'DO_NOT_USE' flag for the 1st integration in the segment
+    # which is actually the 25th integration
+    dq_diff = (ramp_rscd.groupdq[0, 0:nflag, :, :]
+               - input_model.groupdq[0, 0:nflag, :, :])
+
+    np.testing.assert_array_equal(np.full((nflag, ysize, xsize),
+                                          dqflags.group['DO_NOT_USE'],
+                                          dtype=int),
+                                  dq_diff,
+                                  err_msg='Diff in groupdq flags is not '
+                                  + 'equal to the DO_NOT_USE flag')
+
+    # test that the groupdq flags are not changed for the rest of the groups
+    # in the 1st  integration in the segment
+    dq_diff = (ramp_rscd.groupdq[0, nflag:ngroups, :, :]
+               - input_model.groupdq[0, nflag:ngroups, :, :])
+    np.testing.assert_array_equal(np.full((ngroups - nflag, ysize, xsize),
+                                          0,
+                                          dtype=int),
+                                  dq_diff,
+                                  err_msg='groupdq flags changed after '
+                                  + 'maximum requested')
+


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3778](https://jira.stsci.edu/browse/JP-3778)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8878

<!-- describe the changes comprising this PR here -->
This PR addresses allows the RSCD step to  work on segmented data. In segmented data the first integration in the data may not be the first integration in the full exposure. If this is the case, we want to flag initial groups in the integration as DO_NOT_USE. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions]
  Results: (all tests passed) https://github.com/spacetelescope/RegressionTests/actions/runs/12034294166
  - [ ] (https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
  
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
