### PR TITLE
JP-3798: Transfer datamodel wcsinfo during Spec2Pipeline MOS+FS processing

### DIFF
--- a/changes/8947.pipeline.rst
+++ b/changes/8947.pipeline.rst
@@ -1,0 +1,1 @@
+Transfer wcsinfo metadata to new MultiSlitModel created during ``calwebb_spec2`` processing of NIRSpec MSA data.

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -608,6 +608,7 @@ class Spec2Pipeline(Pipeline):
 
         # First process MOS slits through all remaining steps
         calib_mos.update(calibrated)
+        calib_mos.meta.wcsinfo = calibrated.meta.wcsinfo.instance
         if len(calib_mos.slits) > 0:
             calib_mos = self.master_background_mos.run(calib_mos)
             calib_mos = self.wavecorr.run(calib_mos)

--- a/jwst/regtest/test_nirspec_mos_movingtarget.py
+++ b/jwst/regtest/test_nirspec_mos_movingtarget.py
@@ -7,7 +7,7 @@ from jwst.stpipe import Step
 
 @pytest.fixture(scope="module")
 def run_spec2_pipeline(rtdata_module):
-    """Run the calwebb_spec2 pipeline on a single NIRSpec MOS/FS exposure."""
+    """Run the calwebb_spec2 pipeline on a single NIRSpec MOS Moving Target exposure."""
 
     rtdata = rtdata_module
 

--- a/jwst/regtest/test_nirspec_mos_movingtarget.py
+++ b/jwst/regtest/test_nirspec_mos_movingtarget.py
@@ -1,0 +1,86 @@
+import pytest
+
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_spec2_pipeline(rtdata_module):
+    """Run the calwebb_spec2 pipeline on a single NIRSpec MOS/FS exposure."""
+
+    rtdata = rtdata_module
+
+    # Get the MSA metadata file referenced in the input exposure
+    rtdata.get_data("nirspec/mos/jw01444003001_01_msa.fits")
+
+    # Get the input ASN file and exposures
+    rtdata.get_data("nirspec/mos/jw01444003001_04102_00001_nrs1_rate.fits")
+
+    # Run the calwebb_spec2 pipeline; save results from intermediate steps
+    args = ["calwebb_spec2", rtdata.input,
+            "--steps.assign_wcs.save_results=true",
+            "--steps.msa_flagging.save_results=true",
+            "--steps.master_background_mos.save_results=true",
+            "--steps.extract_2d.save_results=true",
+            "--steps.srctype.save_results=true",
+            "--steps.wavecorr.save_results=true",
+            "--steps.flat_field.save_results=true",
+            "--steps.pathloss.save_results=true",
+            "--steps.barshadow.save_results=true"]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.fixture(scope="module")
+def run_spec3_pipeline(run_spec2_pipeline, rtdata_module):
+    """Run calwebb_spec3 on NIRSpec MOS data."""
+    rtdata = rtdata_module
+    rtdata.get_data("nirspec/mos/jw01444-o003_20240815t170722_spec3_00001_asn.json")
+
+    # Run the calwebb_spec3 pipeline on the association
+    args = ["calwebb_spec3", rtdata.input]
+    Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", [
+    "assign_wcs", "msa_flagging", "extract_2d", "srctype",
+    "master_background_mos", "wavecorr", "flat_field", "pathloss", "barshadow",
+    "cal", "s2d", "x1d"])
+def test_nirspec_mos_mt_spec2(run_spec2_pipeline, fitsdiff_default_kwargs, suffix):
+    """Regression test for calwebb_spec2 on a NIRSpec MOS Moving Target exposure."""
+
+    # Run the pipeline and retrieve outputs
+    rtdata = run_spec2_pipeline
+    output = f"jw01444003001_04102_00001_nrs1_{suffix}.fits"
+    rtdata.output = output
+
+    # Get the truth files
+    rtdata.get_truth("truth/test_nirspec_mos_movingtarget/" + output)
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d"])
+@pytest.mark.parametrize("source_id", ["v000000001"])
+def test_nirspec_mos_mt_spec3(run_spec3_pipeline, fitsdiff_default_kwargs, suffix, source_id):
+    """Regression test for calwebb_spec3 on a NIRSpec MOS Moving Target exposure."""
+
+    # Run the pipeline and retrieve outputs
+    rtdata = run_spec3_pipeline
+    output = f"jw01444-o003_{source_id}_nirspec_clear-prism_{suffix}.fits"
+    rtdata.output = output
+
+    # Get the truth files
+    rtdata.get_truth("truth/test_nirspec_mos_movingtarget/" + output)
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3798](https://jira.stsci.edu/browse/JP-3798)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an error found during reprocessing of an MSA moving target dataset. 

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/11750586205

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
