### PR TITLE
JP-3799: First frame bright

### DIFF
--- a/changes/8952.firstframe.rst
+++ b/changes/8952.firstframe.rst
@@ -1,0 +1,1 @@
+Update firstframe step to optionally not flag when ramp saturations between groups 2 and 3

--- a/changes/8952.firstframe.rst
+++ b/changes/8952.firstframe.rst
@@ -1,1 +1,1 @@
-Update firstframe step to optionally not flag when ramp saturations between groups 2 and 3
+Update the firstframe step to optionally not flag when a ramp saturates between groups 2 and 3

--- a/changes/8952.firstframe.rst
+++ b/changes/8952.firstframe.rst
@@ -1,1 +1,1 @@
-Update the firstframe step to optionally not flag when a ramp saturates between groups 2 and 3
+Update the firstframe step to optionally not flag when a ramp saturates in group 3

--- a/docs/jwst/firstframe/arguments.rst
+++ b/docs/jwst/firstframe/arguments.rst
@@ -5,5 +5,10 @@ The ``firstframe`` step has the following step-specific arguments.
 
 ``--bright_use_group1`` (boolean, default=False)
     If True, setting the group 1 groupdq to DO_NOT_USE will not be done 
-    for pixels that have the saturation flag set for group 3, but not group 2.
-    This will allow a slope to be determined for this pixel.
+    for pixels that have the saturation flag set for group 3.  
+    This will allow a slope to be determined for pixels that saturate
+    between groups 2 and 3.
+    This change in flagging will only impact pixels that saturate in group 3, the behavior
+    for all other pixels will be unchanged.
+    The `bright_use_group1` flag can be set for all data, only data/pixels that saturate 
+    in group 3 will see a difference in behavior.

--- a/docs/jwst/firstframe/arguments.rst
+++ b/docs/jwst/firstframe/arguments.rst
@@ -1,4 +1,8 @@
 Step Arguments
 ==============
 
-The first frame correction has no step-specific arguments.
+The ``firstframe`` step has the following step-specific arguments.
+
+``--bright_use_group1`` (boolean, default=True)
+    If True, for pixels that have the saturation flag set for group 3, 
+    but not group 2 will not have their group 1 groupdq set to DO_NOT_USE.

--- a/docs/jwst/firstframe/arguments.rst
+++ b/docs/jwst/firstframe/arguments.rst
@@ -6,8 +6,7 @@ The ``firstframe`` step has the following step-specific arguments.
 ``--bright_use_group1`` (boolean, default=False)
     If True, setting the group 1 groupdq to DO_NOT_USE will not be done 
     for pixels that have the saturation flag set for group 3.  
-    This will allow a slope to be determined for pixels that saturate
-    between groups 2 and 3.
+    This will allow a slope to be determined for pixels that saturate in group 3.
     This change in flagging will only impact pixels that saturate in group 3, the behavior
     for all other pixels will be unchanged.
     The `bright_use_group1` flag can be set for all data, only data/pixels that saturate 

--- a/docs/jwst/firstframe/arguments.rst
+++ b/docs/jwst/firstframe/arguments.rst
@@ -3,6 +3,7 @@ Step Arguments
 
 The ``firstframe`` step has the following step-specific arguments.
 
-``--bright_use_group1`` (boolean, default=True)
-    If True, for pixels that have the saturation flag set for group 3, 
-    but not group 2 will not have their group 1 groupdq set to DO_NOT_USE.
+``--bright_use_group1`` (boolean, default=False)
+    If True, setting the group 1 groupdq to DO_NOT_USE will not be done 
+    for pixels that have the saturation flag set for group 3, but not group 2.
+    This will allow a slope to be determined for this pixel.

--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -10,8 +10,12 @@ class FirstFrameStep(Step):
     """
     FirstFrameStep: This is a MIRI specific task.  If the number of groups
     is greater than 3, the DO_NOT_USE group data quality flag is added to
-    first group.
+    first group.  
     """
+
+    spec = """
+        bright_use_group1 = boolean(default=False) # do not flag group1 if group2 is not saturated and group3 is saturated   
+    """ 
 
     class_alias = "firstframe"
 
@@ -25,7 +29,10 @@ class FirstFrameStep(Step):
 
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector.upper()
-            if detector[:3] != 'MIR':
+            if detector[:3] == 'MIR':
+                # Do the firstframe correction subtraction
+                result = firstframe_sub.do_correction(input_model, bright_use_group1=self.bright_use_group1)
+            else:
                 self.log.warning('First Frame Correction is only for MIRI data')
                 self.log.warning('First frame step will be skipped')
                 input_model.meta.cal_step.firstframe = 'SKIPPED'

--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -10,12 +10,12 @@ class FirstFrameStep(Step):
     """
     FirstFrameStep: This is a MIRI specific task.  If the number of groups
     is greater than 3, the DO_NOT_USE group data quality flag is added to
-    first group.  
+    first group.
     """
 
     spec = """
         bright_use_group1 = boolean(default=False) # do not flag group1 if group2 is not saturated and group3 is saturated   
-    """ 
+    """
 
     class_alias = "firstframe"
 
@@ -29,13 +29,15 @@ class FirstFrameStep(Step):
 
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector.upper()
-            if detector[:3] == 'MIR':
+            if detector[:3] == "MIR":
                 # Do the firstframe correction subtraction
-                result = firstframe_sub.do_correction(input_model, bright_use_group1=self.bright_use_group1)
+                result = firstframe_sub.do_correction(
+                    input_model, bright_use_group1=self.bright_use_group1
+                )
             else:
-                self.log.warning('First Frame Correction is only for MIRI data')
-                self.log.warning('First frame step will be skipped')
-                input_model.meta.cal_step.firstframe = 'SKIPPED'
+                self.log.warning("First Frame Correction is only for MIRI data")
+                self.log.warning("First frame step will be skipped")
+                input_model.meta.cal_step.firstframe = "SKIPPED"
                 return input_model
 
             # Cork on a copy

--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -19,9 +19,6 @@ class FirstFrameStep(Step):
 
     class_alias = "firstframe"
 
-    spec = """
-    """
-
     def process(self, step_input):
 
         # Open the input data model
@@ -29,10 +26,10 @@ class FirstFrameStep(Step):
 
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector.upper()
-            if detector[:3] != 'MIR':
-                self.log.warning('First Frame Correction is only for MIRI data')
-                self.log.warning('First frame step will be skipped')
-                input_model.meta.cal_step.firstframe = 'SKIPPED'
+            if detector[:3] != "MIR":
+                self.log.warning("First Frame Correction is only for MIRI data")
+                self.log.warning("First frame step will be skipped")
+                input_model.meta.cal_step.firstframe = "SKIPPED"
                 return input_model
 
             # Cork on a copy
@@ -40,7 +37,7 @@ class FirstFrameStep(Step):
 
             # Do the firstframe correction subtraction
             result = firstframe_sub.do_correction(
-                input_model, bright_use_group1=self.bright_use_group1
+                result, bright_use_group1=self.bright_use_group1
             )
 
         return result

--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -29,21 +29,18 @@ class FirstFrameStep(Step):
 
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector.upper()
-            if detector[:3] == "MIR":
-                # Do the firstframe correction subtraction
-                result = firstframe_sub.do_correction(
-                    input_model, bright_use_group1=self.bright_use_group1
-                )
-            else:
-                self.log.warning("First Frame Correction is only for MIRI data")
-                self.log.warning("First frame step will be skipped")
-                input_model.meta.cal_step.firstframe = "SKIPPED"
+            if detector[:3] != 'MIR':
+                self.log.warning('First Frame Correction is only for MIRI data')
+                self.log.warning('First frame step will be skipped')
+                input_model.meta.cal_step.firstframe = 'SKIPPED'
                 return input_model
 
             # Cork on a copy
             result = input_model.copy()
 
             # Do the firstframe correction subtraction
-            result = firstframe_sub.do_correction(result)
+            result = firstframe_sub.do_correction(
+                input_model, bright_use_group1=self.bright_use_group1
+            )
 
         return result

--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -13,11 +13,11 @@ class FirstFrameStep(Step):
     first group.
     """
 
+    class_alias = "firstframe"
+
     spec = """
         bright_use_group1 = boolean(default=False) # do not flag group1 if group2 is not saturated and group3 is saturated   
     """
-
-    class_alias = "firstframe"
 
     def process(self, step_input):
 

--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -16,7 +16,7 @@ class FirstFrameStep(Step):
     class_alias = "firstframe"
 
     spec = """
-        bright_use_group1 = boolean(default=False) # do not flag group1 if group2 is not saturated and group3 is saturated   
+        bright_use_group1 = boolean(default=False) # do not flag group1 if group3 is saturated   
     """
 
     def process(self, step_input):

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -37,6 +37,7 @@ def do_correction(output, bright_use_group1=False):
 
     # Update the step status, and if ngroups > 3, set all GROUPDQ in
     # the first group to 'DO_NOT_USE'
+    # bright_use_group1 = False
     if sci_ngroups > 3:
         if bright_use_group1:
             # do not set DO_NOT_USE in the case where saturation happens
@@ -56,9 +57,9 @@ def do_correction(output, bright_use_group1=False):
                 f"FirstFrame Sub: bright_first_frame set, #{np.sum(svals)} bright pixels using first frame"
             )
         else:
-            output.groupdq[:, 0, :, :] = np.bitwise_or(
-                output.groupdq[:, 0, :, :], dqflags.group["DO_NOT_USE"]
-            )
+            output.groupdq[:, 0, :, :] = \
+                np.bitwise_or(output.groupdq[:, 0, :, :], dqflags.group['DO_NOT_USE'])
+
         log.debug("FirstFrame Sub: resetting GROUPDQ in first frame to DO_NOT_USE")
         output.meta.cal_step.firstframe = "COMPLETE"
     else:  # too few groups

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -57,8 +57,9 @@ def do_correction(output, bright_use_group1=False):
                 f"FirstFrame Sub: bright_first_frame set, #{np.sum(svals)} bright pixels using first frame"
             )
         else:
-            output.groupdq[:, 0, :, :] = \
-                np.bitwise_or(output.groupdq[:, 0, :, :], dqflags.group['DO_NOT_USE'])
+            output.groupdq[:, 0, :, :] = np.bitwise_or(
+                output.groupdq[:, 0, :, :], dqflags.group["DO_NOT_USE"]
+            )
 
         log.debug("FirstFrame Sub: resetting GROUPDQ in first frame to DO_NOT_USE")
         output.meta.cal_step.firstframe = "COMPLETE"

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -10,8 +10,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def do_correction(output,
-                  bright_use_group1=False):
+def do_correction(output, bright_use_group1=False):
     """
     Short Summary
     -------------
@@ -42,23 +41,29 @@ def do_correction(output,
         if bright_use_group1:
             # do not set DO_NOT_USE in the case where saturation happens
             # after group2 and before group3
-            # in this case, the first frame effect is small compared to the 
+            # in this case, the first frame effect is small compared to the
             # signal in group2-group1
             # input_model.
-            svals = (((output.groupdq[:, 1, :, :] & dqflags.group['SATURATED']) == 0) 
-                     & ((output.groupdq[:, 2, :, :] & dqflags.group['SATURATED']) > 0))
+            svals = ((output.groupdq[:, 1, :, :] & dqflags.group["SATURATED"]) == 0) & (
+                (output.groupdq[:, 2, :, :] & dqflags.group["SATURATED"]) > 0
+            )
             tvals = output.groupdq[:, 0, :, :]
-            tvals[~svals] = np.bitwise_or((output.groupdq[:, 0, :, :])[~svals], dqflags.group['DO_NOT_USE'])
+            tvals[~svals] = np.bitwise_or(
+                (output.groupdq[:, 0, :, :])[~svals], dqflags.group["DO_NOT_USE"]
+            )
             output.groupdq[:, 0, :, :] = tvals
-            log.info(f"FirstFrame Sub: bright_first_frame set, #{np.sum(svals)} bright pixels using first frame")
+            log.info(
+                f"FirstFrame Sub: bright_first_frame set, #{np.sum(svals)} bright pixels using first frame"
+            )
         else:
-            output.groupdq[:, 0, :, :] = \
-                np.bitwise_or(output.groupdq[:, 0, :, :], dqflags.group['DO_NOT_USE'])
+            output.groupdq[:, 0, :, :] = np.bitwise_or(
+                output.groupdq[:, 0, :, :], dqflags.group["DO_NOT_USE"]
+            )
         log.debug("FirstFrame Sub: resetting GROUPDQ in first frame to DO_NOT_USE")
-        output.meta.cal_step.firstframe = 'COMPLETE'
-    else:   # too few groups
+        output.meta.cal_step.firstframe = "COMPLETE"
+    else:  # too few groups
         log.warning("Too few groups to apply correction")
         log.warning("Step will be skipped")
-        output.meta.cal_step.firstframe = 'SKIPPED'
+        output.meta.cal_step.firstframe = "SKIPPED"
 
     return output

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -51,7 +51,7 @@ def do_correction(output, bright_use_group1=False):
             )
             output.groupdq[:, 0, :, :] = tvals
             log.info(
-                f"FirstFrame Sub: bright_first_frame set, #{np.sum(svals)} bright pixels using first frame"
+                f"FirstFrame Sub: bright_first_frame set, #{np.sum(svals)} bright pixels group1 not set to DO_NOT_USE"
             )
         else:
             output.groupdq[:, 0, :, :] = np.bitwise_or(

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -33,7 +33,7 @@ def do_correction(output, bright_use_group1=False):
     """
 
     # Save some data params for easy use later
-    sci_ngroups = output.data.shape[1]
+    sci_ngroups = output.meta.exposure.ngroups
 
     # Update the step status, and if ngroups > 3, set all GROUPDQ in
     # the first group to 'DO_NOT_USE'

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -37,14 +37,11 @@ def do_correction(output, bright_use_group1=False):
 
     # Update the step status, and if ngroups > 3, set all GROUPDQ in
     # the first group to 'DO_NOT_USE'
-    # bright_use_group1 = False
     if sci_ngroups > 3:
         if bright_use_group1:
-            # do not set DO_NOT_USE in the case where saturation happens
-            # after group2 and before group3
-            # in this case, the first frame effect is small compared to the
+            # do not set DO_NOT_USE in the case where saturation happens after group2 and
+            # before group3 in this case, the first frame effect is small compared to the
             # signal in group2-group1
-            # input_model.
             svals = ((output.groupdq[:, 1, :, :] & dqflags.group["SATURATED"]) == 0) & (
                 (output.groupdq[:, 2, :, :] & dqflags.group["SATURATED"]) > 0
             )

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -23,7 +23,7 @@ def do_correction(output, bright_use_group1=False):
     output: data model object
         science data to be corrected
     bright_use_group1: boolean
-        do not flag group1 for bright pixels = saturating before group3 and after group2
+        do not flag group1 for bright pixels = group 3 saturated
 
     Returns
     -------

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -39,12 +39,10 @@ def do_correction(output, bright_use_group1=False):
     # the first group to 'DO_NOT_USE'
     if sci_ngroups > 3:
         if bright_use_group1:
-            # do not set DO_NOT_USE in the case where saturation happens after group2 and
-            # before group3 in this case, the first frame effect is small compared to the
+            # do not set DO_NOT_USE in the case where saturation happens in
+            # group3 as in this case the first frame effect is small compared to the
             # signal in group2-group1
-            svals = ((output.groupdq[:, 1, :, :] & dqflags.group["SATURATED"]) == 0) & (
-                (output.groupdq[:, 2, :, :] & dqflags.group["SATURATED"]) > 0
-            )
+            svals = (output.groupdq[:, 2, :, :] & dqflags.group["SATURATED"]) > 0
             tvals = output.groupdq[:, 0, :, :]
             tvals[~svals] = np.bitwise_or(
                 (output.groupdq[:, 0, :, :])[~svals], dqflags.group["DO_NOT_USE"]

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -33,7 +33,7 @@ def do_correction(output, bright_use_group1=False):
     """
 
     # Save some data params for easy use later
-    sci_ngroups = output.meta.exposure.ngroups
+    sci_ngroups = output.data.shape[1]
 
     # Update the step status, and if ngroups > 3, set all GROUPDQ in
     # the first group to 'DO_NOT_USE'

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def do_correction(input_model,
+def do_correction(output,
                   bright_use_group1=False):
     """
     Short Summary
@@ -43,7 +43,7 @@ def do_correction(input_model,
             # do not set DO_NOT_USE in the case where saturation happens
             # after group2 and before group3
             # in this case, the first frame effect is small compared to the 
-            # signal in frame2-frame1
+            # signal in group2-group1
             # input_model.
             svals = (((output.groupdq[:, 1, :, :] & dqflags.group['SATURATED']) == 0) 
                      & ((output.groupdq[:, 2, :, :] & dqflags.group['SATURATED']) > 0))

--- a/jwst/firstframe/tests/test_firstframe.py
+++ b/jwst/firstframe/tests/test_firstframe.py
@@ -223,7 +223,7 @@ def test_firstframe_bright_use_group1():
     Test if the firstframe code when bright_use_group1 is set to True.
     
     The groupdq flag for group 1 should not be set to DO_NOT_USE for the pixels that saturate 
-    between the 2nd and 3rd groups.  Otherwise, all other pixels should have their group1 groupdq 
+    the 3rd group.  Otherwise, all other pixels should have their group1 groupdq 
     flags set to DO_NOT_USE.
     """
 

--- a/jwst/firstframe/tests/test_firstframe.py
+++ b/jwst/firstframe/tests/test_firstframe.py
@@ -240,6 +240,10 @@ def test_firstframe_bright_use_group1():
     # set a fraction of the pixels to saturate in between the 2nd and 3rd groups
     groupdq[0, 2, 0:100, :] = dqflags.group['SATURATED']
 
+    # set a fraction of the pixels to saturate in between the 1st and 2nd groups
+    groupdq[0, 2, 200:300, :] = dqflags.group['SATURATED']
+    groupdq[0, 1, 200:300, :] = dqflags.group['SATURATED']
+
     # create a JWST datamodel for MIRI data
     dm_ramp = RampModel(data=data, groupdq=groupdq)
 
@@ -253,6 +257,7 @@ def test_firstframe_bright_use_group1():
     
     expected_diff = np.full((ysize, xsize), dqflags.group['DO_NOT_USE'], dtype=int)
     expected_diff[0:100, :] = 0
+    expected_diff[200:300, :] = 0
 
     np.testing.assert_array_equal(expected_diff,
                                   dq_diff,

--- a/jwst/firstframe/tests/test_firstframe.py
+++ b/jwst/firstframe/tests/test_firstframe.py
@@ -9,7 +9,7 @@ from jwst.firstframe import FirstFrameStep
 def test_firstframe_set_groupdq():
     """
     Test if the firstframe code set the groupdq flag on the first
-    group to 'do_not_use' for 5 integrations
+    group to 'do_not_use' for 5 groups
     """
 
     # size of integration
@@ -216,3 +216,55 @@ def test_miri():
                                   dq_diff,
                                   err_msg='Diff in groupdq flags is not '
                                           + 'equal to DO_NOT_USE')
+
+
+def test_firstframe_bright_use_group1():
+    """
+    Test if the firstframe code when bright_use_group1 is set to True.
+    
+    The groupdq flag for group 1 should not be set to DO_NOT_USE for the pixels that saturate 
+    between the 2nd and 3rd groups.  Otherwise, all other pixels should have their group1 groupdq 
+    flags set to DO_NOT_USE.
+    """
+
+    # size of integration
+    ngroups = 5
+    xsize = 1032
+    ysize = 1024
+
+    # create the data and groupdq arrays
+    csize = (1, ngroups, ysize, xsize)
+    data = np.full(csize, 1.0)
+    groupdq = np.zeros(csize, dtype=int)
+
+    # set a fraction of the pixels to saturate in between the 2nd and 3rd groups
+    groupdq[0, 2, 0:100, :] = dqflags.group['SATURATED']
+
+    # create a JWST datamodel for MIRI data
+    dm_ramp = RampModel(data=data, groupdq=groupdq)
+
+    # run the first frame correction step on a copy (the detection to make the copy or
+    # not would have happened at _step.py)
+    dm_ramp_firstframe = do_correction(dm_ramp.copy(), bright_use_group1=True)
+
+    # check that the difference in the groupdq flags is equal to
+    #   the 'do_not_use' flag
+    dq_diff = dm_ramp_firstframe.groupdq[0, 0, :, :] - dm_ramp.groupdq[0, 0, :, :]
+    
+    expected_diff = np.full((ysize, xsize), dqflags.group['DO_NOT_USE'], dtype=int)
+    expected_diff[0:100, :] = 0
+
+    np.testing.assert_array_equal(expected_diff,
+                                  dq_diff,
+                                  err_msg='Diff in groupdq flags is not '
+                                  + 'equal to the DO_NOT_USE flag')
+
+    # test that the groupdq flags are not changed for the rest of the groups
+    dq_diff = (dm_ramp_firstframe.groupdq[0, 1:ngroups, :, :]
+               - dm_ramp.groupdq[0, 1:ngroups, :, :])
+    np.testing.assert_array_equal(np.full((ngroups - 1, ysize, xsize),
+                                          0,
+                                          dtype=int),
+                                  dq_diff,
+                                  err_msg='n >= 2 groupdq flags changes '
+                                  + 'and they should not be')


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3799](https://jira.stsci.edu/browse/JP-3799)

<!-- describe the changes comprising this PR here -->
This PR modifies the firstframe step to optionally not flag the 1st group (aka frame) as DO_NOT_USE for pixels that have ramps that saturation between the 2nd and 3rd groups.   In the case of a pixel having a large signal, it has been found that the slope estimated from the 2nd-1st groups and 3rd-2nd groups is equivalent within 1% indicating that the firstframe effect is small compared to the signal in this specific case. This means that for pixels seeing very bright signal (i.e., saturating between the 2nd and 3rd groups), that the slope can be measured from the 1st and 2nd groups. This provides a slope measurement where previously there was none (i.e., a NaN value).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
