### PR TITLE
don't store empty columns in HDRTAB

### DIFF
--- a/changes/8958.general.rst
+++ b/changes/8958.general.rst
@@ -1,0 +1,1 @@
+When blending metadata don't store columns containing all missing value (nans).

--- a/jwst/model_blender/_tablebuilder.py
+++ b/jwst/model_blender/_tablebuilder.py
@@ -1,6 +1,12 @@
 import numpy as np
 
 
+class _MissingValueType:
+    pass
+
+_MISSING_VALUE = _MissingValueType()
+
+
 def _convert_dtype(value):
     """Convert numarray column dtype into YAML-compatible format description"""
     if 'U' in value:
@@ -99,7 +105,7 @@ class TableBuilder:
 
     def _add_row(self, row):
         for attr, col in self.attr_to_column.items():
-            self.columns[col].append(row[attr] if attr in row else np.nan)
+            self.columns[col].append(row[attr] if attr in row else _MISSING_VALUE)
 
     def build_table(self):
         """
@@ -113,6 +119,8 @@ class TableBuilder:
         arrays = []
         table_dtype = []
         for col, items in self.columns.items():
-            arrays.append(np.array(items))
+            if all((i is _MISSING_VALUE for i in items)):
+                continue
+            arrays.append(np.array([np.nan if i is _MISSING_VALUE else i for i in items]))
             table_dtype.append((col, arrays[-1].dtype))
         return np.rec.fromarrays(arrays, dtype=table_dtype)

--- a/jwst/model_blender/tests/test_blend.py
+++ b/jwst/model_blender/tests/test_blend.py
@@ -200,7 +200,7 @@ def test_blendtab(blend):
     # Ensure all the expected FITS keywords are in the table.
     colnames = set(newtab.dtype.fields)
     assert not fits_expected.difference(colnames)
-    assert not MISSING_COLUMN in colnames
+    assert MISSING_COLUMN not in colnames
     for col in colnames:
         if col in input_values:
             assert newtab[col] == input_values[col]

--- a/jwst/model_blender/tests/test_blend.py
+++ b/jwst/model_blender/tests/test_blend.py
@@ -37,6 +37,11 @@ UNKNOWN_MISSING_FIRSTS = [None, 'fizz', 'buzz']
 # even if the metadata is defined in the schema
 KNOWN_MISSING_FIRSTS = [None, '1', '2']
 
+# None of the below test data defines this attribute.
+# It is expected to be missing from the resulting
+# table (as is checked below).
+MISSING_COLUMN = "TIME-OBS"
+
 
 def _make_data():
     """Create a set of input models to blendmeta
@@ -195,6 +200,7 @@ def test_blendtab(blend):
     # Ensure all the expected FITS keywords are in the table.
     colnames = set(newtab.dtype.fields)
     assert not fits_expected.difference(colnames)
+    assert not MISSING_COLUMN in colnames
     for col in colnames:
         if col in input_values:
             assert newtab[col] == input_values[col]


### PR DESCRIPTION
This PR updates the model blender to skip storing columns full of `nan` for values not defined in any input (blended) model.

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/11824762170

As expected this causes many regression tests differences in the `HDRTAB` extension generated by the model blender like the following:
```
E            Data contains differences:
E              Tables have different number of columns:
E               a: 224
E               b: 417
E              Extra column GSC_VER of format D in b
E              Extra column HGA_STRT of format D in b
E              Extra column HGA_STOP of format D in b
```
To take one example `jwst-pipeline/dev/truth/test_miri_cubebuild/jw01024-o001_t002_miri_ch1-short_s3d.fits` the truth file currently has a HDRTAB with 417 columns. The `GSC_VER` column contains 2 `nan` values (neither of the 2 input files has that value defined). With this PR the `HDRTAB` has 224 columns and does not contain a column for `GSC_VER`.

There are also unrelated failures (that also appear on main) and appear to be due to a crds update:
```
E            Headers contain differences:
E              Keyword R_PTHLOS has different values:
E                 a> crds://jwst_nirspec_pathloss_0007.fits
E                  ?                                 ^
E                 b> crds://jwst_nirspec_pathloss_0004.fits
E                  ?
```

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
