### PR TITLE
Update changelog and README to reflect patch release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ resample_spec
 -------------
 
 - Update NIRSpec spectral resampling to add a missing correction factor in resampled
-  WCS tangent plane transformation. [#8933]
+  WCS tangent plane transformation. [#8908]
 
 1.16.0 (2024-09-20)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ resample_spec
 -------------
 
 - Update NIRSpec spectral resampling to add a missing correction factor in resampled
-  WCS tangent plane transformation.
+  WCS tangent plane transformation. [#8933]
 
 1.16.0 (2024-09-20)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.16.1 (2024-10-30)
+===================
+
+resample_spec
+-------------
+
+- Update NIRSpec spectral resampling to add a missing correction factor in resampled
+  WCS tangent plane transformation.
+
 1.16.0 (2024-09-20)
 ===================
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ the specified context and less than the context for the next release.
 
 | jwst tag            | DMS build | SDP_VER  | CRDS_CONTEXT | Released   | Ops Install | Notes                                         |
 |---------------------|-----------|----------|--------------|------------|-------------|-----------------------------------------------|
-| 1.16.1              | B11.1rc2  | TBD      | 1298         | 2024-10-30 | TBD         | Final release candidate for B11.1             |
+| 1.16.1              | B11.1rc2  | TBD      | 1298         | 2024-11-12 | TBD         | Final release candidate for B11.1             |
 | 1.16.0              | B11.1rc1  | TBD      | 1298         | 2024-09-20 | TBD         | First release candidate for B11.1             |
 | 1.15.1              | B11.0     | 2024.2.2 | 1242         | 2024-07-08 | 2024-09-12  | Final release candidate for B11.0             |
 | 1.15.0              | B11.0rc1  |          | 1241         | 2024-06-26 |             | First release candidate for B11.0             |

--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ the specified context and less than the context for the next release.
 |---------------------|-----------|----------|--------------|------------|-------------|-----------------------------------------------|
 | 1.16.1              | B11.1.1   | 2024.3.1 | 1298         | 2024-11-13 | TBD         | Final release candidate for B11.1             |
 | 1.16.0              | B11.1     | 2024.3.0 | 1298         | 2024-09-20 | TBD         | First release candidate for B11.1             |
-| 1.15.1              | B11.0     | 2024.2.2 | 1242         | 2024-07-08 | 2024-09-12  | Final release candidate for B11.0             |
-| 1.15.0              | B11.0rc1  |          | 1241         | 2024-06-26 |             | First release candidate for B11.0             |
-| 1.14.1              |           |          | 1238         | 2024-06-27 |             | PyPI-only release for external users          |
-| 1.14.0              | B10.2.1   | 2024.1.1 | 1238         | 2024-03-29 | 2024-06-12  | Final release candidate for B10.2.1           |
-| 1.13.4              |           |          | 1185         | 2024-01-25 |             | PyPI-only release for external users          |
+| 1.15.1              | B11.0     | 2024.2.2 | 1293         | 2024-07-08 | 2024-09-12  | Final release candidate for B11.0             |
+| 1.15.0              | B11.0rc1  |          | 1274         | 2024-06-26 |             | First release candidate for B11.0             |
+| 1.14.1              |           |          | 1240         | 2024-06-27 |             | PyPI-only release for external users          |
+| 1.14.0              | B10.2.1   | 2024.1.1 | 1240         | 2024-03-29 | 2024-06-12  | Final release candidate for B10.2.1           |
+| 1.13.4              |           |          | 1210         | 2024-01-25 |             | PyPI-only release for external users          |
 | 1.13.3              | B10.1     | 2023.4.0 | 1181         | 2024-01-05 |             | Final release candidate for B10.1             |
 | 1.13.2              | B10.1rc3  | 2023.4.0 | 1181         | 2023-12-21 |             | Third release candidate for B10.1             |
 | 1.13.1              | B10.1rc2  | 2023.4.0 | 1181         | 2023-12-19 |             | Second release candidate for B10.1            |

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ the specified context and less than the context for the next release.
 
 | jwst tag            | DMS build | SDP_VER  | CRDS_CONTEXT | Released   | Ops Install | Notes                                         |
 |---------------------|-----------|----------|--------------|------------|-------------|-----------------------------------------------|
-| 1.16.0              | B11.1rc1  | TBD      | 1281         | 2024-09-20 | TBD         | First release candidate for B11.1             |
+| 1.16.1              | B11.1rc2  | TBD      | 1298         | 2024-10-30 | TBD         | Final release candidate for B11.1             |
+| 1.16.0              | B11.1rc1  | TBD      | 1298         | 2024-09-20 | TBD         | First release candidate for B11.1             |
 | 1.15.1              | B11.0     | 2024.2.2 | 1242         | 2024-07-08 | 2024-09-12  | Final release candidate for B11.0             |
 | 1.15.0              | B11.0rc1  |          | 1241         | 2024-06-26 |             | First release candidate for B11.0             |
 | 1.14.1              |           |          | 1238         | 2024-06-27 |             | PyPI-only release for external users          |

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ the specified context and less than the context for the next release.
 
 | jwst tag            | DMS build | SDP_VER  | CRDS_CONTEXT | Released   | Ops Install | Notes                                         |
 |---------------------|-----------|----------|--------------|------------|-------------|-----------------------------------------------|
-| 1.16.1              | B11.1rc2  | TBD      | 1298         | 2024-11-12 | TBD         | Final release candidate for B11.1             |
-| 1.16.0              | B11.1rc1  | TBD      | 1298         | 2024-09-20 | TBD         | First release candidate for B11.1             |
+| 1.16.1              | B11.1.1   | 2024.3.1 | 1298         | 2024-11-13 | TBD         | Final release candidate for B11.1             |
+| 1.16.0              | B11.1     | 2024.3.0 | 1298         | 2024-09-20 | TBD         | First release candidate for B11.1             |
 | 1.15.1              | B11.0     | 2024.2.2 | 1242         | 2024-07-08 | 2024-09-12  | Final release candidate for B11.0             |
 | 1.15.0              | B11.0rc1  |          | 1241         | 2024-06-26 |             | First release candidate for B11.0             |
 | 1.14.1              |           |          | 1238         | 2024-06-27 |             | PyPI-only release for external users          |

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -377,6 +377,7 @@ class ResampleSpecData(ResampleData):
 
         pix_to_ytan.intercept = zero_value_y - slope_sign_y * offset_y
         pix_to_xtan.intercept = zero_value_x - slope_sign_x * offset_x
+
         # Now set up the final transforms
 
         # For wavelengths, extrapolate 1/2 pixel at the edges and

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -362,8 +362,8 @@ class ResampleSpecData(ResampleData):
         # Correct the intercept for the new minimum value.
         # Also account for integer pixel size to make sure the
         # data is centered in the array.
-        offset_y  = ny/2 * pix_to_tan_slope_y - diff_y/2
-        offset_x  = ny/2 * pix_to_tan_slope_x - diff_x/2
+        offset_y = ny / 2 * pix_to_tan_slope_y - diff_y / 2
+        offset_x = ny / 2 * pix_to_tan_slope_x - diff_x / 2
 
         if slope_sign_y > 0:
             zero_value_y = min_tan_y
@@ -375,10 +375,8 @@ class ResampleSpecData(ResampleData):
         else:
             zero_value_x = max_tan_x
 
-
         pix_to_ytan.intercept = zero_value_y - slope_sign_y * offset_y
         pix_to_xtan.intercept = zero_value_x - slope_sign_x * offset_x
-
         # Now set up the final transforms
 
         # For wavelengths, extrapolate 1/2 pixel at the edges and


### PR DESCRIPTION
Update the changelog and README to reflect the recent patch release.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
