### PR TITLE
restructure test_miri_mrs_badpix_selfcal_bkg to allow it to be okified

### DIFF
--- a/jwst/regtest/test_miri_mrs_badpix_selfcal.py
+++ b/jwst/regtest/test_miri_mrs_badpix_selfcal.py
@@ -72,6 +72,6 @@ def test_miri_mrs_badpix_selfcal_bkg(basename, run_pipeline_background, fitsdiff
     rtdata.output = basename
     rtdata.get_truth(f"truth/test_miri_mrs_badpix_selfcal/{basename}")
 
-    # Compare the results and heck the bkg files in the background case, but not in the selfcal case
+    # Compare the results and check the bkg files in the background case, but not in the selfcal case
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_miri_mrs_badpix_selfcal.py
+++ b/jwst/regtest/test_miri_mrs_badpix_selfcal.py
@@ -59,22 +59,19 @@ def test_miri_mrs_badpix_selfcal(run_pipeline_selfcal, fitsdiff_default_kwargs):
         assert not os.path.isfile(fname)
 
 
+@pytest.mark.parametrize("basename", (
+    [f"{OUTSTEM_BKG}_badpix_selfcal.fits",] + 
+    [f"{OUTSTEM_BKG}_badpix_selfcal_bkg_{idx}.fits" for idx in range(4)]))
 @pytest.mark.bigdata
-def test_miri_mrs_badpix_selfcal_bkg(run_pipeline_background, fitsdiff_default_kwargs):
+def test_miri_mrs_badpix_selfcal_bkg(basename, run_pipeline_background, fitsdiff_default_kwargs):
     """Run a test for MIRI MRS data with dedicated background exposures."""
 
     rtdata = run_pipeline_background
 
     # Get the truth file
-    rtdata.get_truth(f"truth/test_miri_mrs_badpix_selfcal/{OUTSTEM_BKG}_badpix_selfcal.fits")
+    rtdata.output = basename
+    rtdata.get_truth(f"truth/test_miri_mrs_badpix_selfcal/{basename}")
 
-    # Compare the results
+    # Compare the results and heck the bkg files in the background case, but not in the selfcal case
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
-
-    # check the bkg files in the background case, but not in the selfcal case
-    for idx in range(4):
-        fname = f"{OUTSTEM_BKG}_badpix_selfcal_bkg_{idx}.fits"
-        truth = rtdata.get_truth(f"truth/test_miri_mrs_badpix_selfcal/{fname}")
-        diff = FITSDiff(fname, truth, **fitsdiff_default_kwargs)
-        assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/jwst/issues/8968

This PR makes 2 changes to test_miri_mrs_badpix_selfcal_bkg to allow it's results to be okified.

1) The multiple comparisons are split into different tests using parametrization
2) The background comparisons set `rtdata.output` which is required to allow `okify_regtests` to know what files to replace

To provide some more details on 2 above. Currently this test is failing due to expected header comment differences:
```
   a: result_bkgasn_badpix_selfcal_bkg_0.fits
   b: /runner/_work/_temp/pytest_basetemp/popen-gw0/test_miri_mrs_badpix_selfcal_rtdata_module0/truth/result_bkgasn_badpix_selfcal_bkg_0.fits
   HDU(s) not to be compared:
...
     Headers contain differences:
       Keyword DRPFRMS1 has different comments:
          a> Number of frames dropped prior to first integra
           ? ^^^^^^^^^^^
          b> Frames dropped prior to first integration
           ? ^                                    ++++
```
see: https://github.com/spacetelescope/RegressionTests/actions/runs/11937489373
Note that the failed comparison is for `result_bkgasn_badpix_selfcal_bkg_0.fits`. If I run okify_regtests on this run I see the following:
```
OK: jwst-pipeline-results/2024-11-20_GITHUB_CI_Linux-X64-py3.12-1009/2553_test_miri_mrs_badpix_selfcal_bkg/result_bkgasn_badpix_selfcal.fits
--> jwst-pipeline/dev/truth/test_miri_mrs_badpix_selfcal/result_bkgasn_badpix_selfcal_bkg_0.fits
```
As okify regtests is incorrectly attempting to overwrite the truth `result_bkgasn_badpix_selfcal_bkg_0.fits` file with `result_bkgasn_badpix_selfcal.fits` due to the test not setting `rtdata.output` prior to the call to `FITSDIFF`.

Regtest run with just this regtest: https://github.com/spacetelescope/RegressionTests/actions/runs/11938033481
show the expected 4 failures due to header keyword comment differences introduced in https://github.com/spacetelescope/stdatamodels/pull/354
If I run okify_regtests I see 4 failures to okify and the reported moves are now correct with this PR. For example:
```
OK: jwst-pipeline-results/2024-11-20_GITHUB_CI_Linux-X64-py3.12-1013/2554_test_miri_mrs_badpix_selfcal_bkg/result_bkgasn_badpix_selfcal_bkg_0.fits
--> jwst-pipeline/dev/truth/test_miri_mrs_badpix_selfcal/result_bkgasn_badpix_selfcal_bkg_0.fits
```

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
