### PR TITLE
Remove testing statement to ignore import failure

### DIFF
--- a/jwst/lib/tests/test_siafdb.py
+++ b/jwst/lib/tests/test_siafdb.py
@@ -3,10 +3,10 @@ from contextlib import nullcontext as does_not_raise
 import os
 from pathlib import Path
 import pytest
+import pysiaf
 
 from jwst.lib import siafdb
 
-import pysiaf
 
 # Database paths
 DATA_PATH = Path(__file__).parent / 'data'
@@ -53,19 +53,23 @@ def test_create(source, prd, xml_path, exception, jail_environ):
         ('FGS1_FULL_OSS', False,
          siafdb.SIAF(v2_ref=206.407, v3_ref=-697.765, v3yangle=-1.24120427, vparity=1,
                      crpix1=1024.5, crpix2=1024.5, cdelt1=0.06839158, cdelt2=0.06993081,
-                     vertices_idl=(-68.8543, 70.1233, 71.5697, -70.2482, 72.1764, 68.8086, -75.5918, -70.7457))),
+                     vertices_idl=(-68.8543, 70.1233, 71.5697, -70.2482, 72.1764, 68.8086,
+                                   -75.5918, -70.7457))),
         ('FGS2_FULL_OSS', False,
          siafdb.SIAF(v2_ref=22.865, v3_ref=-699.28, v3yangle=0.2914828, vparity=1,
                      crpix1=1024.5, crpix2=1024.5, cdelt1=0.06787747, cdelt2=0.06976441,
-                     vertices_idl=(-70.7843, 69.9807, 68.6042, -69.4153, -74.3558, -71.5516, 71.3065, 69.3639))),
+                     vertices_idl=(-70.7843, 69.9807, 68.6042, -69.4153, -74.3558, -71.5516,
+                                   71.3065, 69.3639))),
         ('MIRIM_TAMRS', False,
          siafdb.SIAF(v2_ref=-481.987342, v3_ref=-318.206242, v3yangle=4.83544897, vparity=-1,
                      crpix1=24.5, crpix2=24.5, cdelt1=0.10986808, cdelt2=0.10996394,
-                     vertices_idl=(-2.6187, 2.6558, 2.6186, -2.6535, -2.6097, -2.6715, 2.6068, 2.6683))),
+                     vertices_idl=(-2.6187, 2.6558, 2.6186, -2.6535, -2.6097, -2.6715,
+                                   2.6068, 2.6683))),
         ('MIRIM_TAMRS', True,
          siafdb.SIAF(v2_ref=-481.987342, v3_ref=-318.206242, v3yangle=4.83544897, vparity=-1,
                      crpix1=997.5, crpix2=993.5, cdelt1=0.10986808, cdelt2=0.10996394,
-                     vertices_idl=(-2.6187, 2.6558, 2.6186, -2.6535, -2.6097, -2.6715, 2.6068, 2.6683))),
+                     vertices_idl=(-2.6187, 2.6558, 2.6186, -2.6535, -2.6097, -2.6715,
+                                   2.6068, 2.6683))),
     ]
 )
 def test_get_wcs(aperture, to_detector, expected):

--- a/jwst/lib/tests/test_siafdb.py
+++ b/jwst/lib/tests/test_siafdb.py
@@ -6,7 +6,7 @@ import pytest
 
 from jwst.lib import siafdb
 
-import pysiaf  # type: ignore[import-not-found]  # noqa: E402
+import pysiaf
 
 # Database paths
 DATA_PATH = Path(__file__).parent / 'data'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "requests>=2.22",
     "scikit-image>=0.19",
     "scipy>=1.9.3",
-    "setuptools>=75.0.0; python_version >= '3.12'",
     "spherical-geometry>=1.2.22",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "requests>=2.22",
     "scikit-image>=0.19",
     "scipy>=1.9.3",
+    "setuptools>=75.0.0; python_version >= '3.12'",
     "spherical-geometry>=1.2.22",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses CI failures with py312-xdist caused by a tox testing method of ignoring the tests if an import fails. The import of pysiaf should work as expected with its inclusion in the test dependencies, so we can safely delete the failure catch.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
