### PR TITLE
JP-3784 Fix Pixel replace and cube_build  output file names

### DIFF
--- a/changes/8979.pixel_replace.rst
+++ b/changes/8979.pixel_replace.rst
@@ -1,0 +1,1 @@
+fix a bug in pixel_replace and cube_build output filenames

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -98,7 +98,6 @@ class DataTypes():
         # Suffixes will be added to this name later, to designate the
         # channel+subchannel (MIRI MRS) or grating+filter (NRS IFU) the output cube covers.
 
-
         if output_file is not None:
             basename, ext = os.path.splitext(os.path.basename(output_file))
             self.output_name = basename

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -563,7 +563,6 @@ class IFUCubeData():
         """
 
         self.output_name = self.define_cubename()
-        print('ifu cube returend output_name', self.output_name)
         total_num = self.naxis1 * self.naxis2 * self.naxis3
 
         self.spaxel_flux = np.zeros(total_num, dtype=np.float64)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -53,7 +53,6 @@ class IFUCubeData():
 
         self.input_models = input_models  # needed when building single mode IFU cubes
         self.output_name_base = output_name_base
-        print('At the start output name base', self.output_name_base)
         
         self.num_files = None
 
@@ -170,9 +169,7 @@ class IFUCubeData():
         """ Define the base output name
         """
         if self.pipeline == 2:
-            print('in define_cubename', self.output_name_base)
-            newname = self.output_name_base + self.suffix + '.fits'
-            print('***********NAME OF CUBE FILE', newname)
+            newname = self.output_name_base + '_' + self.suffix + '.fits'
         else:
             if self.instrument == 'MIRI':
 
@@ -207,7 +204,6 @@ class IFUCubeData():
                     b_name = b_name + subchannels[i]
                 b_name = b_name.lower()
                 newname = self.output_name_base + ch_name + '-' + b_name
-                print('*******************NAME of cube when not pipeline2', newname)
                 if self.coord_system == 'internal_cal':
                     newname = self.output_name_base + ch_name + '-' + b_name + '_internal'
                 if self.output_type == 'single':

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -179,9 +179,10 @@ class IFUCubeData():
                 # that the remaining suffixes created below form the entire
                 # list of optical elements in the final output name.
                 suffix = self.output_name_base[self.output_name_base.rfind('_') + 1:]
+                
                 if suffix in ['clear']:
                     self.output_name_base = self.output_name_base[:self.output_name_base.rfind('_')]
-
+                    
                 # Now compose the appropriate list of optical element suffix names
                 # based on MRS channel and sub-channel
                 channels = []
@@ -562,6 +563,7 @@ class IFUCubeData():
         """
 
         self.output_name = self.define_cubename()
+        print('ifu cube returend output_name', self.output_name)
         total_num = self.naxis1 * self.naxis2 * self.naxis3
 
         self.spaxel_flux = np.zeros(total_num, dtype=np.float64)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -53,6 +53,8 @@ class IFUCubeData():
 
         self.input_models = input_models  # needed when building single mode IFU cubes
         self.output_name_base = output_name_base
+        print('At the start output name base', self.output_name_base)
+        
         self.num_files = None
 
         self.instrument = instrument
@@ -168,7 +170,9 @@ class IFUCubeData():
         """ Define the base output name
         """
         if self.pipeline == 2:
+            print('in define_cubename', self.output_name_base)
             newname = self.output_name_base + self.suffix + '.fits'
+            print('***********NAME OF CUBE FILE', newname)
         else:
             if self.instrument == 'MIRI':
 
@@ -203,6 +207,7 @@ class IFUCubeData():
                     b_name = b_name + subchannels[i]
                 b_name = b_name.lower()
                 newname = self.output_name_base + ch_name + '-' + b_name
+                print('*******************NAME of cube when not pipeline2', newname)
                 if self.coord_system == 'internal_cal':
                     newname = self.output_name_base + ch_name + '-' + b_name + '_internal'
                 if self.output_type == 'single':

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from collections import defaultdict
-from functools import wraps
 import os.path as op
 
 from stdatamodels.jwst import datamodels

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -7,7 +7,7 @@ from stdatamodels.jwst import datamodels
 
 from jwst.datamodels import SourceModelContainer
 from jwst.stpipe import query_step_status
-
+from jwst.stpipe.utilities import invariant_filename
 from ..associations.lib.rules_level3_base import format_product
 from ..exp_to_source import multislit_to_container
 from ..master_background.master_background_step import split_container
@@ -350,25 +350,3 @@ class Spec3Pipeline(Pipeline):
             srcid = f's{str(source_id):>09s}'
 
         return srcid
-
-# #########
-# Utilities
-# #########
-def invariant_filename(save_model_func):
-    """Restore meta.filename after save_model"""
-
-    @wraps(save_model_func)
-    def save_model(model, **kwargs):
-        try:
-            filename = model.meta.filename
-        except AttributeError:
-            filename = None
-
-        result = save_model_func(model, **kwargs)
-
-        if filename:
-            model.meta.filename = filename
-
-        return result
-
-    return save_model

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -29,8 +29,6 @@ class PixelReplacement:
     VERTICAL = 2
     LOG_SLICE = ['column', 'row']
 
-    #default_suffix = 'pixrep'
-
     def __init__(self, input_model, **pars):
         """
         Initialize the class with input data model.

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -29,7 +29,7 @@ class PixelReplacement:
     VERTICAL = 2
     LOG_SLICE = ['column', 'row']
 
-    default_suffix = 'pixrep'
+    #default_suffix = 'pixrep'
 
     def __init__(self, input_model, **pars):
         """

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -4,7 +4,8 @@ from functools import partial
 from ..stpipe import Step
 from jwst.stpipe import record_step_status
 from jwst import datamodels
-from .pixel_replace import PixelReplacement#from functools import wraps
+from .pixel_replace import PixelReplacement
+from functools import wraps
 #from jwst.pipeline.calwebb_spec3 import invariant_filename
 
 __all__ = ["PixelReplaceStep"]

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -78,7 +78,7 @@ class PixelReplaceStep(Step):
             # calewbb_spec3 case / ModelContainer
             # __________________________________
             if isinstance(input_model, datamodels.ModelContainer):
-                output_model = input_model
+                output_model = input_model.copy()
                 # Setup output path naming if associations are involved.
                 asn_id = None
                 try:
@@ -103,7 +103,7 @@ class PixelReplaceStep(Step):
                     )
 
                 # Check models to confirm they are the correct type
-                for i, model in enumerate(output_model):
+                for model in output_model:
                     run_pixel_replace = True
                     if model.meta.model_type in ['MultiSlitModel', 'SlitModel',
                                                  'ImageModel', 'IFUImageModel', 'CubeModel']:
@@ -119,8 +119,8 @@ class PixelReplaceStep(Step):
                     if run_pixel_replace:
                         replacement = PixelReplacement(model, **pars)
                         replacement.replace()
-                        output_model[i] = replacement.output
-                        record_step_status(output_model[i], 'pixel_replace', success=True)
+                        model = replacement.output
+                        record_step_status(model, 'pixel_replace', success=True)
                 return output_model
             # ________________________________________
             # calewbb_spec2 case - single input model

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -78,8 +78,10 @@ class PixelReplaceStep(Step):
             # calewbb_spec3 case / ModelContainer
             # __________________________________
             if isinstance(input_model, datamodels.ModelContainer):
-                output_model = input_model.copy()
                 # Setup output path naming if associations are involved.
+                # if input is ModelContainer do not copy the input_model
+                # because assocation information is not copied.
+                # Instead update input_modelin place. 
                 asn_id = None
                 try:
                     asn_id = input_model.asn_table["asn_id"]
@@ -103,7 +105,7 @@ class PixelReplaceStep(Step):
                     )
 
                 # Check models to confirm they are the correct type
-                for model in output_model:
+                for i, model in enumerate(input_model):
                     run_pixel_replace = True
                     if model.meta.model_type in ['MultiSlitModel', 'SlitModel',
                                                  'ImageModel', 'IFUImageModel', 'CubeModel']:
@@ -121,7 +123,7 @@ class PixelReplaceStep(Step):
                         replacement.replace()
                         model = replacement.output
                         record_step_status(model, 'pixel_replace', success=True)
-                return output_model
+                return input_model
             # ________________________________________
             # calewbb_spec2 case - single input model
             # ________________________________________

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -6,7 +6,7 @@ from jwst.stpipe import record_step_status
 from jwst import datamodels
 from .pixel_replace import PixelReplacement
 from functools import wraps
-#from jwst.pipeline.calwebb_spec3 import invariant_filename
+from jwst.stpipe.utilities import invariant_filename
 
 __all__ = ["PixelReplaceStep"]
 
@@ -135,23 +135,3 @@ class PixelReplaceStep(Step):
                 record_step_status(replacement.output, 'pixel_replace', success=True)
                 result = replacement.output
                 return result
-            
-
-def invariant_filename(save_model_func):
-    """Restore meta.filename after save_model"""
-
-    @wraps(save_model_func)
-    def save_model(model, **kwargs):
-        try:
-            filename = model.meta.filename
-        except AttributeError:
-            filename = None
-
-        result = save_model_func(model, **kwargs)
-
-        if filename:
-            model.meta.filename = filename
-
-        return result
-
-    return save_model

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -5,7 +5,6 @@ from ..stpipe import Step
 from jwst.stpipe import record_step_status
 from jwst import datamodels
 from .pixel_replace import PixelReplacement
-from functools import wraps
 from jwst.stpipe.utilities import invariant_filename
 
 __all__ = ["PixelReplaceStep"]

--- a/jwst/pixel_replace/tests/test_pixel_replace.py
+++ b/jwst/pixel_replace/tests/test_pixel_replace.py
@@ -291,3 +291,37 @@ def test_pixel_replace_nirspec_ifu_container_names(tmp_cwd, tmp_path, input_mode
     
     result.close()
     input_model.close()
+
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('input_model_function',
+                         [nirspec_ifu])
+@pytest.mark.parametrize('algorithm', ['fit_profile', 'mingrad'])
+def test_pixel_replace_nirspec_ifu_name(tmp_cwd, tmp_path, input_model_function, algorithm):
+    """
+    Test pixel replacement for NIRSpec IFU using a single file
+
+    Larger data and more WCS operations required for testing make
+    this test take more than a minute, so marking this test 'slow'.
+
+    The test is otherwise the same as for other modes.
+    """
+    output_dir = tmp_path / 'output'
+    output_dir.mkdir(exist_ok=True)
+    output_dir = str(output_dir)
+    
+    input_model, bad_idx = input_model_function()
+    input_model.meta.filename = 'jwst_nirspec_cal.fits'
+    expected_name = 'jwst_nirspec_pixelreplacestep.fits'
+
+    # for this simple case, the results from either algorithm should
+    # be the same
+    result = PixelReplaceStep.call(input_model, skip=False, algorithm=algorithm,save_results=True)
+    
+    assert expected_name == result.meta.filename
+
+    
+    result.close()
+    input_model.close()
+    

--- a/jwst/pixel_replace/tests/test_pixel_replace.py
+++ b/jwst/pixel_replace/tests/test_pixel_replace.py
@@ -219,7 +219,8 @@ def test_pixel_replace_nirspec_ifu(input_model_function, algorithm):
 
     # for this simple case, the results from either algorithm should
     # be the same
-    result = PixelReplaceStep.call(input_model, skip=False, algorithm=algorithm,save_results=True)
+    result = PixelReplaceStep.call(input_model, skip=False,
+                                   algorithm=algorithm, save_results=True)
 
     assert result.meta.filename == 'jwst_nirspec_pixelreplacestep.fits'
     
@@ -279,12 +280,12 @@ def test_pixel_replace_nirspec_ifu_container_names(tmp_cwd, tmp_path, input_mode
     return_files = []
     # for this simple case, the results from either algorithm should
     # be the same
-    result = PixelReplaceStep.call(container, skip=False, algorithm=algorithm,save_results=True)
-    for dirname in [output_dir, tmp_cwd]:
-        result_files = glob(os.path.join(dirname, '*pixelreplacestep.fits'))
-        for file in result_files:
-            basename = os.path.basename(file)
-            return_files.append(basename)
+    result = PixelReplaceStep.call(container, skip=False, algorithm=algorithm,
+                                   save_results=True)
+    result_files = glob(os.path.join(tmp_cwd, '*pixelreplacestep.fits'))
+    for file in result_files:
+        basename = os.path.basename(file)
+        return_files.append(basename)
     
     assert expected_name[0] == return_files[0]
     assert expected_name[1] == return_files[1]
@@ -321,7 +322,6 @@ def test_pixel_replace_nirspec_ifu_name(tmp_cwd, tmp_path, input_model_function,
     
     assert expected_name == result.meta.filename
 
-    
     result.close()
     input_model.close()
     

--- a/jwst/pixel_replace/tests/test_pixel_replace.py
+++ b/jwst/pixel_replace/tests/test_pixel_replace.py
@@ -286,8 +286,8 @@ def test_pixel_replace_nirspec_ifu_container_names(tmp_cwd, tmp_path, input_mode
             basename = os.path.basename(file)
             return_files.append(basename)
     
-    assert expected_name[0] == basename[0][0]
-    assert expected_name[1] == basename[1][0]
+    assert expected_name[0] == return_files[0]
+    assert expected_name[1] == return_files[1]
     
     result.close()
     input_model.close()

--- a/jwst/pixel_replace/tests/test_pixel_replace.py
+++ b/jwst/pixel_replace/tests/test_pixel_replace.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from stdatamodels.jwst import datamodels
+from jwst.datamodels import ModelContainer
 from stdatamodels.jwst.datamodels.dqflags import pixel as flags
 
 from jwst.assign_wcs import AssignWcsStep
@@ -99,6 +100,7 @@ def nirspec_ifu():
     model.var_poisson = test_data.var_poisson
     model.var_rnoise = test_data.var_rnoise
     model.var_flat = test_data.var_flat
+
     test_data.close()
 
     return model, bad_idx
@@ -212,11 +214,14 @@ def test_pixel_replace_nirspec_ifu(input_model_function, algorithm):
     The test is otherwise the same as for other modes.
     """
     input_model, bad_idx = input_model_function()
+    input_model.meta.filename = 'jwst_nirspec_cal.fits'
 
     # for this simple case, the results from either algorithm should
     # be the same
-    result = PixelReplaceStep.call(input_model, skip=False, algorithm=algorithm)
+    result = PixelReplaceStep.call(input_model, skip=False, algorithm=algorithm,save_results=True)
 
+    assert result.meta.filename == 'jwst_nirspec_pixelreplacestep.fits'
+    
     for ext in ['data', 'err', 'var_poisson', 'var_rnoise', 'var_flat']:
         # non-science edges are uncorrected
         assert np.all(np.isnan(getattr(result, ext)[..., :, 1]))
@@ -236,5 +241,40 @@ def test_pixel_replace_nirspec_ifu(input_model_function, algorithm):
     assert np.all(result.dq[..., 1, :]
                   == flags['DO_NOT_USE'] + flags['NON_SCIENCE'])
 
+    result.close()
+    input_model.close()
+
+
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('input_model_function',
+                         [nirspec_ifu])
+@pytest.mark.parametrize('algorithm', ['fit_profile', 'mingrad'])
+def test_pixel_replace_nirspec_ifu_container_names(input_model_function, algorithm):
+    """
+    Test pixel replacement for NIRSpec IFU using a container
+
+    Larger data and more WCS operations required for testing make
+    this test take more than a minute, so marking this test 'slow'.
+
+    The test is otherwise the same as for other modes.
+    """
+    input_model, bad_idx = input_model_function()
+    input_model.meta.filename = 'jwst_nirspec_1_cal.fits'
+    input_model2, bad_idx2 = input_model_function()
+    input_model2.meta.filename = 'jwst_nirspec_2_cal.fits'
+    cfiles = [input_model, input_model2]
+    container = ModelContainer(cfiles) 
+
+    # for this simple case, the results from either algorithm should
+    # be the same
+    result = PixelReplaceStep.call(container, skip=False, algorithm=algorithm,save_results=True)
+
+    print(result[0].meta.filename, result[1].meta.filename)
+    
+    assert result[0].meta.filename == 'jwst_nirspec_1_pixelreplacestep.fits'
+    assert result[1].meta.filename == 'jwst_nirspec_2_pixelreplacestep.fits'
+    
     result.close()
     input_model.close()

--- a/jwst/stpipe/tests/test_utilities.py
+++ b/jwst/stpipe/tests/test_utilities.py
@@ -5,6 +5,10 @@ from jwst.stpipe import record_step_status, query_step_status
 from jwst.stpipe.utilities import all_steps, NOT_SET
 import jwst.pipeline
 import jwst.step
+import pytest
+from stdatamodels.jwst import datamodels
+from jwst.stpipe.utilities import invariant_filename
+
 from jwst import datamodels as dm
 
 
@@ -54,3 +58,32 @@ def test_record_query_step_status():
     # test query not set
     model3 = dm.MultiSpecModel()
     assert query_step_status(model3, 'test_step') == NOT_SET
+
+# make up a datamodel for testing filename
+@pytest.fixture(scope='function')
+def miri_ifushort():
+    """ Generate input model IFU image """
+
+
+    mirifushort_short = {
+        'detector': 'MIRIFUSHORT',
+        'channel': '12',
+        'band': 'SHORT',
+        'name': 'MIRI'
+    
+    }
+    input_model = datamodels.IFUImageModel()
+    input_model.meta.exposure.type = 'MIR_MRS'
+    input_model.meta.instrument._instance.update(mirifushort_short)
+    input_model.meta.filename = 'test1.fits'
+    return input_model
+    
+
+def change_name_func(model):
+    model.meta.filename = "changed"
+    return model
+
+def test_invariant_filename(miri_ifushort):
+    invariant_save_func = invariant_filename(change_name_func)
+    output_model = invariant_save_func(miri_ifushort)
+    assert output_model.meta.filename == "test1.fits"

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -30,6 +30,7 @@
 Utilities
 """
 import importlib.util
+from functools import wraps
 from importlib import import_module
 import inspect
 import logging
@@ -211,3 +212,23 @@ def query_step_status(datamodel, cal_step):
         return getattr(datamodel[0].meta.cal_step, cal_step, NOT_SET)
     else:
         return getattr(datamodel.meta.cal_step, cal_step, NOT_SET)
+
+
+def invariant_filename(save_model_func):
+    """Restore meta.filename after save_model"""
+
+    @wraps(save_model_func)
+    def save_model(model, **kwargs):
+        try:
+            filename = model.meta.filename
+        except AttributeError:
+            filename = None
+
+        result = save_model_func(model, **kwargs)
+
+        if filename:
+            model.meta.filename = filename
+
+        return result
+
+    return save_model


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3784](https://jira.stsci.edu/browse/JP-3784)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8904

<!-- describe the changes comprising this PR here -->
This PR addresses fixes the names of the output from pixel_replacement when called using a ModelContainer.  In addition, it fixes the output names of cube_build when a single file is input to cube_build. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
  https://github.com/spacetelescope/RegressionTests/actions/runs/12359349881
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
