### PR TITLE
update test for numpy 2 compatibility

### DIFF
--- a/jwst/lib/tests/test_engdb_mast.py
+++ b/jwst/lib/tests/test_engdb_mast.py
@@ -67,22 +67,23 @@ def test_get_records(engdb):
     [
         ({}, [-0.7914494276, -0.7914494276, -0.7914494276, -0.791449368]),
         ({'include_obstime': True},
-         [EngDB_Value(obstime=Time('2022-02-02T22:24:58.053', scale='utc', format='isot'), value=-0.7914494276),
-          EngDB_Value(obstime=Time('2022-02-02T22:24:58.309', scale='utc', format='isot'), value=-0.7914494276),
-          EngDB_Value(obstime=Time('2022-02-02T22:24:58.565', scale='utc', format='isot'), value=-0.7914494276),
-          EngDB_Value(obstime=Time('2022-02-02T22:24:58.821', scale='utc', format='isot'), value=-0.791449368)]),
+         [EngDB_Value(obstime=Time(59612.9340052431, format='mjd'), value=-0.7914494276),
+          EngDB_Value(obstime=Time(59612.9340082060, format='mjd'), value=-0.7914494276),
+          EngDB_Value(obstime=Time(59612.9340111690, format='mjd'), value=-0.7914494276),
+          EngDB_Value(obstime=Time(59612.9340141319, format='mjd'), value=-0.791449368)]),
         ({'include_obstime': True, 'zip_results': False}, EngDB_Value(
-            obstime=[Time('2022-02-02T22:24:58.053', scale='utc', format='isot'),
-                     Time('2022-02-02T22:24:58.309', scale='utc', format='isot'),
-                     Time('2022-02-02T22:24:58.565', scale='utc', format='isot'),
-                     Time('2022-02-02T22:24:58.821', scale='utc', format='isot')],
+            obstime=[
+                Time(59612.9340052431, format='mjd'),
+                Time(59612.9340082060, format='mjd'),
+                Time(59612.9340111690, format='mjd'),
+                Time(59612.9340141319, format='mjd')],
             value=[-0.7914494276, -0.7914494276, -0.7914494276, -0.791449368])),
         ({'include_bracket_values': True},
          [-0.791449368, -0.7914494276, -0.7914494276, -0.7914494276, -0.791449368, -0.791449368])
     ])
 def test_get_values(engdb, pars, expected):
     values = engdb.get_values(*QUERY, **pars)
-    assert str(values) == str(expected)
+    assert values == expected
 
 
 def test_negative_aliveness():


### PR DESCRIPTION
This PR updates `test_get_values` in `test_engdb_mast.py` to be compatible with numpy 2.0.

The test is currently failing for numpy 2.0:
https://github.com/spacetelescope/stdatamodels/actions/runs/12012372839/job/33483464825#step:10:345
due to to the change in the string representation of numpy scalars.

This PR updates the test by:
- dropping the string comparison (which was being used to compare numerical results)
- updates the expected values to match the actual values

The updated expected values are taken from:
https://github.com/spacetelescope/jwst/blob/94041ec7f7499f56d455a31a8b4ed13807d5e93d/jwst/lib/tests/test_engdb_mast.py#L16-L22
and allow the test to pass `assert values == expected` due to `engdb.get_values` parsing the `MJD` column to compute the `obstime`:
https://github.com/spacetelescope/jwst/blob/94041ec7f7499f56d455a31a8b4ed13807d5e93d/jwst/lib/engdb_mast.py#L262
There are small numerical differences between the `MJD` and `theTime` columns which mean that if we just change `assert str(values) == str(expected)` to `assert values == expected` the test would fail.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
