### PR TITLE
Update MIRI MRS spec3 regtest for new cube defaults

### DIFF
--- a/jwst/regtest/test_miri_mrs_spec3.py
+++ b/jwst/regtest/test_miri_mrs_spec3.py
@@ -100,10 +100,14 @@ def run_spec3_ifushort_extract1d(rtdata_module):
 @pytest.mark.parametrize(
     'output',
     [
-        'jw01024-c1000_t002_miri_ch3-mediumlong_x1d.fits',
-        'jw01024-c1000_t002_miri_ch4-mediumlong_x1d.fits',
-        'jw01024-c1000_t002_miri_ch3-mediumlong_s3d.fits',
-        'jw01024-c1000_t002_miri_ch4-mediumlong_s3d.fits',
+        'jw01024-c1000_t002_miri_ch3-long_x1d.fits',
+        'jw01024-c1000_t002_miri_ch3-medium_x1d.fits',
+        'jw01024-c1000_t002_miri_ch4-long_x1d.fits',
+        'jw01024-c1000_t002_miri_ch4-medium_x1d.fits',
+        'jw01024-c1000_t002_miri_ch3-long_s3d.fits',
+        'jw01024-c1000_t002_miri_ch3-medium_s3d.fits',
+        'jw01024-c1000_t002_miri_ch4-long_s3d.fits',
+        'jw01024-c1000_t002_miri_ch4-medium_s3d.fits',
         ]
 )
 def test_spec3_ifulong(run_spec3_ifulong, fitsdiff_default_kwargs, output):
@@ -122,10 +126,14 @@ def test_spec3_ifulong(run_spec3_ifulong, fitsdiff_default_kwargs, output):
 @pytest.mark.parametrize(
     'output',
     [
-        'jw01024-c1000_t002_miri_ch1-mediumlong_x1d.fits',
-        'jw01024-c1000_t002_miri_ch2-mediumlong_x1d.fits',
-        'jw01024-c1000_t002_miri_ch1-mediumlong_s3d.fits',
-        'jw01024-c1000_t002_miri_ch2-mediumlong_s3d.fits'
+        'jw01024-c1000_t002_miri_ch1-long_x1d.fits',
+        'jw01024-c1000_t002_miri_ch1-medium_x1d.fits',
+        'jw01024-c1000_t002_miri_ch2-long_x1d.fits',
+        'jw01024-c1000_t002_miri_ch2-medium_x1d.fits',
+        'jw01024-c1000_t002_miri_ch1-long_s3d.fits',
+        'jw01024-c1000_t002_miri_ch1-medium_s3d.fits',
+        'jw01024-c1000_t002_miri_ch2-long_s3d.fits',
+        'jw01024-c1000_t002_miri_ch2-medium_s3d.fits'
     ],
 )
 def test_spec3_ifushort(run_spec3_ifushort, fitsdiff_default_kwargs, output):
@@ -145,10 +153,14 @@ def test_spec3_ifushort(run_spec3_ifushort, fitsdiff_default_kwargs, output):
 @pytest.mark.parametrize(
     'output',
     [
-        'miri_mrs_emsm_ch1-mediumlong_x1d.fits',
-        'miri_mrs_emsm_ch2-mediumlong_x1d.fits',
-        'miri_mrs_emsm_ch1-mediumlong_s3d.fits',
-        'miri_mrs_emsm_ch2-mediumlong_s3d.fits'
+        'miri_mrs_emsm_ch1-long_x1d.fits',
+        'miri_mrs_emsm_ch1-medium_x1d.fits',
+        'miri_mrs_emsm_ch2-long_x1d.fits',
+        'miri_mrs_emsm_ch2-medium_x1d.fits',
+        'miri_mrs_emsm_ch1-long_s3d.fits',
+        'miri_mrs_emsm_ch1-medium_s3d.fits',
+        'miri_mrs_emsm_ch2-long_s3d.fits',
+        'miri_mrs_emsm_ch2-medium_s3d.fits'
     ],
 )
 def test_spec3_ifushort_emsm(run_spec3_ifushort_emsm, fitsdiff_default_kwargs, output):
@@ -168,8 +180,10 @@ def test_spec3_ifushort_emsm(run_spec3_ifushort_emsm, fitsdiff_default_kwargs, o
 @pytest.mark.parametrize(
     'output',
     [
-        'jw01024-c1000_t002_extract1dtest_miri_ch1-mediumlong_x1d.fits',
-        'jw01024-c1000_t002_extract1dtest_miri_ch2-mediumlong_x1d.fits'
+        'jw01024-c1000_t002_extract1dtest_miri_ch1-long_x1d.fits',
+        'jw01024-c1000_t002_extract1dtest_miri_ch1-medium_x1d.fits',
+        'jw01024-c1000_t002_extract1dtest_miri_ch2-long_x1d.fits',
+        'jw01024-c1000_t002_extract1dtest_miri_ch2-medium_x1d.fits'
     ],
 )
 def test_spec3_ifushort_extract1d(run_spec3_ifushort_extract1d, fitsdiff_default_kwargs, output):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Update MIRI MRS regtests for new default output cubes.

New locally-generated truth files are uploaded to artifactory.  Old files should be removed after merging.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
