### PR TITLE
Temporarily disable bounding_box when computing pixmap

### DIFF
--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -138,11 +138,8 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, shape=None):
 
     grid = gwcs.wcstools.grid_from_bounding_box(bb)
 
-    if hasattr(out_wcs, "bounding_box"):
-        orig_bbox = getattr(out_wcs, "bounding_box", None)
-        out_wcs.bounding_box = None
-    else:
-        orig_bbox = None
+    orig_bbox = out_wcs.bounding_box
+    out_wcs.bounding_box = None
     try:
         pixmap = np.dstack(reproject(in_wcs, out_wcs)(grid[0], grid[1]))
     finally:
@@ -178,12 +175,9 @@ def reproject(wcs1, wcs2):
         # keyword arguments and `with_bounding_box=False` cannot be passsed.
         # We delete the bounding box on a copy of the WCS - yes, inefficient.
         forward_transform = wcs1.pixel_to_world_values
-        wcs_no_bbox = deepcopy(wcs2)
-        wcs_no_bbox.bounding_box = None
-        backward_transform = wcs_no_bbox.world_to_pixel_values
+        backward_transform = wcs2.world_to_pixel_values
     except AttributeError as err:
         raise TypeError("Input should be a WCS") from err
-
 
     def _reproject(x, y):
         sky = forward_transform(x, y)

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -137,7 +137,17 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, shape=None):
         log.debug("Bounding box from WCS: {}".format(in_wcs.bounding_box))
 
     grid = gwcs.wcstools.grid_from_bounding_box(bb)
-    pixmap = np.dstack(reproject(in_wcs, out_wcs)(grid[0], grid[1]))
+
+    if hasattr(out_wcs, "bounding_box"):
+        orig_bbox = getattr(out_wcs, "bounding_box", None)
+        out_wcs.bounding_box = None
+    else:
+        orig_bbox = None
+    try:
+        pixmap = np.dstack(reproject(in_wcs, out_wcs)(grid[0], grid[1]))
+    finally:
+        if orig_bbox is not None:
+            out_wcs.bounding_box = orig_bbox
 
     return pixmap
 

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -169,6 +169,7 @@ class SkyMatchStep(Step):
                                  .format(image_model.meta.filename))
 
         wcs = deepcopy(image_model.meta.wcs)
+        wcs.bounding_box = None
 
         sky_im = SkyImage(
             image=image_model.data,

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -169,7 +169,6 @@ class SkyMatchStep(Step):
                                  .format(image_model.meta.filename))
 
         wcs = deepcopy(image_model.meta.wcs)
-        wcs.bounding_box = None
 
         sky_im = SkyImage(
             image=image_model.data,


### PR DESCRIPTION
This PR fixes some of the failures in the unit tests due to GWCS now applying bounding box when performing the inverse computations (world->image). 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
