### PR TITLE
JP-3834: Update default values for the source finding in tweakreg to match the algorithm

### DIFF
--- a/changes/9036.tweakreg.rst
+++ b/changes/9036.tweakreg.rst
@@ -1,0 +1,3 @@
+Changed the default values for ``sharplo``, ``sharphi``, ``roundlo``, and
+``roundhi`` to the values appropriate for the current default algorith for
+source finding in the ``tweakreg`` step.

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -252,7 +252,7 @@ The ``tweakreg`` step has the following optional arguments:
 * ``peakmax``: A `float` value used to filter out objects with pixel values
   >= ``peakmax``. (Default=None)
 
-.. warn::
+.. warning::
   Different source finding algorithms have different values for the
   ``sharplo``, ``sharphi``, ``roundlo`` and ``roundhi`` parameters. These
   parameters should be adjusted to match the algorithm selected by the

--- a/docs/jwst/tweakreg/README.rst
+++ b/docs/jwst/tweakreg/README.rst
@@ -235,22 +235,30 @@ The ``tweakreg`` step has the following optional arguments:
   Gaussian kernel in units of number of FWHMs. (Default=2.5)
 
 * ``sharplo``: A `float` value indicating The lower bound on sharpness
-  for object detection. (Default=0.2)
+  for object detection. (Default=0.5)
 
 * ``sharphi``: A `float` value indicating the upper bound on sharpness
-  for object detection. (Default=1.0)
+  for object detection. (Default=2.0)
 
 * ``roundlo``: A `float` value indicating the lower bound on roundness
-  for object detection. (Default=-1.0)
+  for object detection. (Default=0.0)
 
 * ``roundhi``: A `float` value indicating the upper bound on roundness
-  for object detection. (Default=1.0)
+  for object detection. (Default=0.2)
 
 * ``brightest``: A positive `int` value indicating the number of brightest
   objects to keep. If None, keep all objects above the threshold. (Default=200)
 
 * ``peakmax``: A `float` value used to filter out objects with pixel values
   >= ``peakmax``. (Default=None)
+
+.. warn::
+  Different source finding algorithms have different values for the
+  ``sharplo``, ``sharphi``, ``roundlo`` and ``roundhi`` parameters. These
+  parameters should be adjusted to match the algorithm selected by the
+  ``starfinder`` parameter. See documentation for
+  [IRAFStarFinder](https://photutils.readthedocs.io/en/stable/api/photutils.detection.IRAFStarFinder.html)
+  and [DAOStarFinder](https://photutils.readthedocs.io/en/stable/api/photutils.detection.DAOStarFinder.html).
 
 **Additional source finding parameters for segmentation:**
 

--- a/jwst/tweakreg/tests/test_tweakreg.py
+++ b/jwst/tweakreg/tests/test_tweakreg.py
@@ -94,6 +94,9 @@ def test_is_wcs_correction_small(offset, is_good):
     twcs.bounding_box = wcs.bounding_box
 
     step = tweakreg_step.TweakRegStep()
+    # TODO: remove 'roundlo' once
+    # https://github.com/astropy/photutils/issues/1977 is fixed
+    step.roundlo=-1.0e-12
 
     class FakeCorrector:
         def __init__(self, wcs, original_skycoord):
@@ -191,6 +194,9 @@ def test_tweakreg_step(example_input, with_shift):
 
     # make the step with default arguments
     step = tweakreg_step.TweakRegStep()
+    # TODO: remove 'roundlo' once
+    # https://github.com/astropy/photutils/issues/1977 is fixed
+    step.roundlo=-1.0e-12
 
     # run the step on the example input modified above
     result = step.run(example_input)
@@ -225,6 +231,9 @@ def test_src_confusion_pars(example_input, alignment_type):
         f"{alignment_type}separation": 1.0,
         f"{alignment_type}tolerance": 1.0,
         "abs_refcat": REFCAT,
+        # TODO: remove 'roundlo' once
+        # https://github.com/astropy/photutils/issues/1977 is fixed
+        "roundlo": -1.0e-12,
     }
     step = tweakreg_step.TweakRegStep(**pars)
     result = step.run(example_input)
@@ -337,7 +346,12 @@ def test_custom_catalog(custom_catalog_path, example_input, catfile, asn, meta, 
             elif asn == "no_cat_in_asn" and meta == "cat_in_meta":
                 n_custom_sources = N_CUSTOM_SOURCES
 
-    kwargs = {'use_custom_catalogs': custom}
+    kwargs = {
+        'use_custom_catalogs': custom,
+        # TODO: remove 'roundlo' once
+        # https://github.com/astropy/photutils/issues/1977 is fixed
+        'roundlo': -1.0e-12,
+    }
     if catfile != "no_catfile":
         kwargs["catfile"] = str(catfile_path)
 
@@ -384,6 +398,9 @@ def test_sip_approx(example_input, with_shift):
     step.sip_max_inv_pix_error = 0.1
     step.sip_inv_degree = 3
     step.sip_npoints = 12
+    # TODO: remove 'roundlo' once
+    # https://github.com/astropy/photutils/issues/1977 is fixed
+    step.roundlo=-1.0e-12
 
     # run the step on the example input modified above
     result = step.run(example_input)

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -63,10 +63,10 @@ class TweakRegStep(Step):
         kernel_fwhm = float(default=2.5) # Gaussian kernel FWHM in pixels
         minsep_fwhm = float(default=0.0) # Minimum separation between detected objects in FWHM
         sigma_radius = float(default=1.5) # Truncation radius of the Gaussian kernel in units of sigma
-        sharplo = float(default=0.2) # The lower bound on sharpness for object detection.
-        sharphi = float(default=1.0) # The upper bound on sharpness for object detection.
-        roundlo = float(default=-1.0) # The lower bound on roundness for object detection.
-        roundhi = float(default=1.0) # The upper bound on roundness for object detection.
+        sharplo = float(default=0.5) # The lower bound on sharpness for object detection.
+        sharphi = float(default=2.0) # The upper bound on sharpness for object detection.
+        roundlo = float(default=0.0) # The lower bound on roundness for object detection.
+        roundhi = float(default=0.2) # The upper bound on roundness for object detection.
         brightest = integer(default=200) # Keep top ``brightest`` objects
         peakmax = float(default=None) # Filter out objects with pixel values >= ``peakmax``
 
@@ -120,7 +120,7 @@ class TweakRegStep(Step):
         sip_max_inv_pix_error = float(default=0.01)  # max err for SIP fit, inverse.
         sip_inv_degree = integer(max=6, default=None)  # degree for inverse SIP fit, None to use best fit.
         sip_npoints = integer(default=12)  #  number of points for SIP
-        
+
         # stpipe general options
         output_use_model = boolean(default=True)  # When saving use `DataModel.meta.filename`
         in_memory = boolean(default=True)  # If False, preserve memory using temporary files at expense of runtime
@@ -311,7 +311,7 @@ class TweakRegStep(Step):
                 finally:
                     del ref_image
 
-        if local_align_failed and not align_to_abs_refcat: 
+        if local_align_failed and not align_to_abs_refcat:
             record_step_status(images, "tweakreg", success=False)
             return images
 


### PR DESCRIPTION
Resolves [JP-3834](https://jira.stsci.edu/browse/JP-3834)

Closes #9035

This PR changes the default value for source finding to match the default algorithm (IRAFStarFind). Current values .exclude the sharpest stars

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/12528517548

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
