### PR TITLE
Bugfix for SIRS reference pixel subtraction

### DIFF
--- a/changes/9037.refpix.rst
+++ b/changes/9037.refpix.rst
@@ -1,0 +1,1 @@
+Bugfix for the new SIRS reference pixel subtraction.

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -105,7 +105,7 @@ class RefPixStep(Step):
                         else:
                             self.log.info('Using SIRS reference file: {}'.format(sirs_ref_filename))
                             sirs_kernel_model = datamodels.SIRSKernelModel(sirs_ref_filename)
-                            conv_kernel_params['refpix_algorithm'] = sirs_kernel_model
+                            conv_kernel_params['sirs_kernel_model'] = sirs_kernel_model
                     elif input_model.meta.instrument.name == 'MIRI':
                         self.log.info('Simple Improved Reference Subtraction (SIRS) not applied for MIRI data.')
                     elif 'FULL' not in input_model.meta.subarray.name:

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -38,11 +38,11 @@ def run_detector1pipeline_with_sirs(rtdata_module):
     SIRS is the convolution kernel algorithm - Simple Improved Reference Subtraction.
     """
     rtdata = rtdata_module
-    rtdata.get_data("nircam/image/jw01538046001_03105_00001_nrcalong_uncal.fits")
+    rtdata.get_data("nircam/image/jw01345001001_10201_00001_nrca3_uncal.fits")
 
     # Run detector1 pipeline only on one of the _uncal files
     args = ["calwebb_detector1", rtdata.input,
-            "--output_file=jw01538046001_03105_00001_nrcalong_sirs",
+            "--output_file=jw01345001001_10201_00001_nrca3_sirs",
             "--steps.refpix.refpix_algorithm=sirs",
             "--steps.refpix.save_results=True",
             ]
@@ -112,10 +112,10 @@ def run_image3pipeline(run_image2pipeline, rtdata_module):
 def test_nircam_image_sirs(run_detector1pipeline_with_sirs, rtdata_module, fitsdiff_default_kwargs):
     """Regression test of detector1 and image2 pipelines performed on NIRCam data."""
     rtdata = rtdata_module
-    rtdata.input = "jw01538046001_03105_00001_nrcalong_uncal.fits"
-    output = "jw01538046001_03105_00001_nrcalong_sirs_refpix.fits"
+    rtdata.input = "jw01345001001_10201_00001_nrca3_uncal.fits"
+    output = "jw01345001001_10201_00001_nrca3_sirs_refpix.fits"
     rtdata.output = output
-    rtdata.get_truth("truth/test_nircam_image_stages/jw01538046001_03105_00001_nrcalong_sirs_refpix.fits")
+    rtdata.get_truth("truth/test_nircam_image_stages/jw01345001001_10201_00001_nrca3_sirs_refpix.fits")
 
     fitsdiff_default_kwargs["rtol"] = 5e-5
     fitsdiff_default_kwargs["atol"] = 1e-4


### PR DESCRIPTION
This PR fixes a bug with the SIRS reference pixel subtraction introduced in https://github.com/spacetelescope/jwst/pull/8726

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
