### PR TITLE
Update CRDS cache workflow usage to reduce random failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         - linux: check-types
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1f43251dde69da8613ea8e11144f05cdea41d5  # v1.15.0
+    needs: [ crds_context ]
     with:
       setenv: |
         CRDS_PATH: /tmp/data/crds_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ on:
         type: string
         required: false
         default: ''
-      crds_server_url:
-        description: CRDS server URL
+      crds_server:
+        description: CRDS server
         type: string
         required: false
         default: https://jwst-crds.stsci.edu
@@ -46,18 +46,28 @@ jobs:
       envs: |
         - linux: check-dependencies
         - linux: check-types
+  latest_crds_contexts:
+    uses: ./.github/workflows/contexts.yml
+  crds_context:
+    needs: [ latest_crds_contexts ]
+    runs-on: ubuntu-latest
+    steps:
+      - id: context
+        run: echo context=${{ github.event_name == 'workflow_dispatch' && (inputs.crds_context != '' && inputs.crds_context || needs.latest_crds_contexts.outputs.jwst) || needs.latest_crds_contexts.outputs.jwst }} >> $GITHUB_OUTPUT
+    outputs:
+      context: ${{ steps.context.outputs.context }}
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1f43251dde69da8613ea8e11144f05cdea41d5  # v1.15.0
     needs: [ crds_context ]
     with:
       setenv: |
         CRDS_PATH: /tmp/data/crds_cache
-        CRDS_SERVER_URL: ${{ inputs.crds_server_url || 'https://jwst-crds.stsci.edu' }}
-        CRDS_CONTEXT: ${{ inputs.crds_context || 'jwst-edit' }}
+        CRDS_SERVER_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.crds_server || 'https://jwst-crds.stsci.edu' }}
+        CRDS_CONTEXT: ${{ needs.crds_context.outputs.context }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       cache-path: /tmp/data/crds_cache
-      cache-key: crds-${{ inputs.crds_context || 'jwst-edit' }}
+      cache-key: crds-${{ needs.crds_context.outputs.context }}
       envs: |
         - linux: py310-oldestdeps-xdist-cov
           pytest-results-summary: true

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -25,6 +25,7 @@ jobs:
   test:
     if: (github.repository == 'spacetelescope/jwst' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run scheduled tests')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1f43251dde69da8613ea8e11144f05cdea41d5  # v1.15.0
+    needs: [ crds_context ]
     with:
       setenv: |
         CRDS_PATH: /tmp/crds_cache

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -11,8 +11,8 @@ on:
         type: string
         required: false
         default: ''
-      crds_server_url:
-        description: CRDS server URL
+      crds_server:
+        description: CRDS server
         type: string
         required: false
         default: https://jwst-crds.stsci.edu
@@ -22,6 +22,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  latest_crds_contexts:
+    uses: ./.github/workflows/contexts.yml
+  crds_context:
+    needs: [ latest_crds_contexts ]
+    runs-on: ubuntu-latest
+    steps:
+      - id: context
+        run: echo context=${{ github.event_name == 'workflow_dispatch' && (inputs.crds_context != '' && inputs.crds_context || needs.latest_crds_contexts.outputs.jwst) || needs.latest_crds_contexts.outputs.jwst }} >> $GITHUB_OUTPUT
+    outputs:
+      context: ${{ steps.context.outputs.context }}
   test:
     if: (github.repository == 'spacetelescope/jwst' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run scheduled tests')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1f43251dde69da8613ea8e11144f05cdea41d5  # v1.15.0
@@ -29,8 +39,8 @@ jobs:
     with:
       setenv: |
         CRDS_PATH: /tmp/crds_cache
-        CRDS_SERVER_URL: ${{ inputs.crds_server_url || 'https://jwst-crds.stsci.edu' }}
-        CRDS_CONTEXT: ${{ inputs.crds_context || 'jwst-edit' }}
+        CRDS_SERVER_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.crds_server || 'https://jwst-crds.stsci.edu' }}
+        CRDS_CONTEXT: ${{ needs.crds_context.outputs.context }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       cache-path: /tmp/crds_cache

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -1,0 +1,26 @@
+name: contexts
+
+on:
+  workflow_call:
+    outputs:
+      jwst:
+        value: ${{ jobs.contexts.outputs.jwst }}
+  workflow_dispatch:
+
+jobs:
+  contexts:
+    name: retrieve latest CRDS contexts
+    runs-on: ubuntu-latest
+    outputs:
+      jwst: ${{ steps.jwst_crds_context.outputs.pmap }}
+    steps:
+      - id: jwst_crds_context
+        env:
+          OBSERVATORY: jwst
+          CRDS_SERVER_URL: https://jwst-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", null], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - run: if [[ ! -z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -18,9 +18,7 @@ jobs:
         env:
           OBSERVATORY: jwst
           CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-        run: >
-          echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", null], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
-          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
-          )" >> $GITHUB_OUTPUT
+        run: |
+          pip install crds
+          echo "pmap=$(crds list --resolve-contexts  --contexts jwst-edit)" >> $GITHUB_OUTPUT
       - run: if [[ ! -z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -34,6 +34,7 @@ jobs:
   test:
     if: (github.repository == 'spacetelescope/jwst' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1f43251dde69da8613ea8e11144f05cdea41d5  # v1.15.0
+    needs: [ crds_context ]
     with:
       setenv: |
         CRDS_PATH: /tmp/data/crds_cache

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -20,8 +20,8 @@ on:
         type: string
         required: false
         default: ''
-      crds_server_url:
-        description: CRDS server URL
+      crds_server:
+        description: CRDS server
         type: string
         required: false
         default: https://jwst-crds.stsci.edu
@@ -31,6 +31,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  latest_crds_contexts:
+    uses: ./.github/workflows/contexts.yml
+  crds_context:
+    needs: [ latest_crds_contexts ]
+    runs-on: ubuntu-latest
+    steps:
+      - id: context
+        run: echo context=${{ github.event_name == 'workflow_dispatch' && (inputs.crds_context != '' && inputs.crds_context || needs.latest_crds_contexts.outputs.jwst) || needs.latest_crds_contexts.outputs.jwst }} >> $GITHUB_OUTPUT
+    outputs:
+      context: ${{ steps.context.outputs.context }}
   test:
     if: (github.repository == 'spacetelescope/jwst' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1f43251dde69da8613ea8e11144f05cdea41d5  # v1.15.0
@@ -38,8 +48,8 @@ jobs:
     with:
       setenv: |
         CRDS_PATH: /tmp/data/crds_cache
-        CRDS_SERVER_URL: ${{ inputs.crds_server_url || 'https://jwst-crds.stsci.edu' }}
-        CRDS_CONTEXT: ${{ inputs.crds_context || 'jwst-edit' }}
+        CRDS_SERVER_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.crds_server || 'https://jwst-crds.stsci.edu' }}
+        CRDS_CONTEXT: ${{ needs.crds_context.outputs.context }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       cache-path: /tmp/data/crds_cache


### PR DESCRIPTION
As this is all CI related marking as "no-changelog".

This PR partially reverts #8987 related commits with the following end results:
- retain using `jwst-edit` as the default virtual context
- remove uses of unstable crds jsonrpc call
- restore the `contexts` workflow to resolve the `jwst-edit` virtual context to a valid `pmap`
- cache based on the `pmap` (not the virtual context) (the main bug fix, the other changes are in support of this)

This (partially) addresses the recent CI failures:
- https://github.com/spacetelescope/jwst/actions/runs/12505212660/job/34888218044?pr=9004
- https://github.com/spacetelescope/jwst/actions/runs/12470838495/job/34806708238
- https://github.com/spacetelescope/jwst/actions/runs/12470838495/job/34806707933
- https://github.com/spacetelescope/jwst/actions/runs/12226442380/job/34101719464
- https://github.com/spacetelescope/jwst/actions/runs/12201548782/job/34040236456?pr=8990

At the core I think this is a CRDS issue (or issue in how the pipeline uses CRDS) where simultaneous requests for a single file results in attempts to read partial files. This issue lead to more common (random-ish) failures when #8987 switched the cache key to `crds-jwst-edit`.

This is only a partial fix because the first run for a new context can still lead to the same failure popping up. However the failures will go away (with these changes) after 1 successful run (needed to generate a valid cache for a given pmap).

To provide some details (for future readers and curious reviewers).

CRDS partial files for xdist runs
----
Let's assume a job starts with an empty (or incomplete) crds cache. In this situation the test run will trigger downloading map files (and reference files). As the tests runs using xdist (spawning multiple worker processes that each run tests in parallel) it's possible that worker 1 will be fetching a mapping that worker 2 tries to use. If worker 1 is partially through downloading the file, the mapping file will be on disk but incomplete. Worker 2 will see the file exists, attempt to read it and fail (see the above linked failures).

This only happens for empty (or incomplete) crds caches. For empty caches if the run doesn't happen to have the problem, the run will complete and the cache will be stored (since it was originally a cache miss). No future runs that use this cache should have the problem unless a new mapping is required or a new reference file is needed (those will be incomplete cache runs). For empty caches if the run fails no cache will be stored. For an incomplete cache run even if the run is successful (and the required mapping or references are downloaded) no updated cache will be stored (because the key resulted in a cache hit).

Using a virtual context as a cache key
----
On main currently the default virtual context is `jwst-edit`. This leads to a cache key `crds-jwst-edit`. However since `jwst-edit` is a virtual context the cache will become stale (incomplete) when `jwst-edit` is updated to point to a new pmap. When the associated cache is stale every run will trigger downloading mapping and reference files that weren't in the pmap that was previously pointed to be `jwst-edit` (see above how an incomplete cache can lead to random test failures due to CRDS behavior and pytest-xdist).

Partial fix
----
This PR is only a partial fix because the first time a new pmap is used (either because `jwst-edit` was updated to point to a new pmap or a pmap was manually specified) it's possible the tests will randomly fail due to the "empty" cache behavior discussed above. A more complete fix would be to:
- enable CRDS cache locking. Options exist but none are currently compatible with parallel test runs
- pre-fetch all mappings and reference files to populate the cache before using it. This may require more than the allowed 10G of cache space and will produce a cache much larger than needed.
- stop running tests in parallel. Which would lead to much slower test runs.

With the partial fix in this PR (which seems more useful than any of the available more complete fixes) there is the possibility the issue will reappear when a new context is used. If failures of this type are seen re-running might resolve the issue (especially if a different run succeeded and stored a valid cache) or in the worst case a manual run could be triggered using `-n 1` to run the tests serially. We could update the workflows to run `-n 1` on a cache miss to avoid the failures (at the expense of a slow run for the first run of a new context) but this would require a more extensive refactoring of the workflows which I think would be working around a more fundamental issue with CRDS. If a user were to start 2 pipeline runs that use the same reference files (missing from their local cache) shouldn't CRDS not try to load the partial file if run 2 starts slightly after run 1?
<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
