### PR TITLE
JP-3838: Update README description of CRDS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,19 +183,30 @@ Guide](https://jwst-crds.stsci.edu/static/users_guide/index.html)
 
 The JWST CRDS server is available at  https://jwst-crds.stsci.edu
 
-It supports the automatic processing pipeline at STScI.
-Inside the STScI network, the same server is used by the pipeline by default with no modifications.
+To run the pipeline inside the STScI network, CRDS must be configured to find the CRDS server
+by setting the environment variable
+
+    export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+
+This server will be used to determine the appropriate CRDS context for a given pipeline
+version, and the pipeline will obtain individual reference files within this context from a local shared disk.
+
 To run the pipeline outside the STScI network, CRDS must be configured by setting
 two environment variables:
 
     export CRDS_PATH=<locally-accessable-path>/crds_cache/jwst_ops
     export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
 
+This server will be used to determine the appropriate CRDS context for a given pipeline
+version, and the pipeline will automatically download individual
+reference files within this context to the local cache specified by CRDS_PATH.
 
 ``<locally-accessable-path>`` can be any the user has permissions to use, such as `$HOME`.
 Expect to use upwards of 200GB of disk space to cache the latest couple of contexts.
 
-To use a specific CRDS context, other than the current default, set the ``CRDS_CONTEXT``
+To use a specific CRDS context other than that 
+[automatically associated](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/crds-migration-to-quarterly-calibration-updates) 
+with a given pipeline version, set the ``CRDS_CONTEXT``
 environment variable:
 
     export CRDS_CONTEXT=jwst_1179.pmap

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -57,18 +57,26 @@ the :ref:`installation` page.
 **3. Set environment variables for Calibration References Data System (CRDS)**
 
 CRDS is the system that manages the reference files needed to run the
-pipeline. Inside the STScI network, the pipeline works with default CRDS
-setup with no modifications. To run the pipeline outside the STScI
+pipeline. Inside the STScI network, CRDS must be configured to find the CRDS server
+by setting the environment variable:
+::
+
+	export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+
+This server will be used to determine the appropriate CRDS context for a given pipeline
+version, and the pipeline will obtain individual reference files within this context from a local shared disk.
+
+To run the pipeline outside the STScI
 network, CRDS must be configured by setting two environment variables:
 ::
 
 	export CRDS_PATH=$HOME/crds_cache
 	export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
 
-The `CRDS_PATH` is the directory on your filesystem that contains your local
-CRDS cache, where reference files are accessed by the pipeline. The
-`CRDS_SERVER_URL` variable specifies from which CRDS server reference files should
-be obtained. For more information, see :ref:`reference_files_crds`.
+This server will be used to determine the appropriate CRDS context for a given pipeline
+version, and the pipeline will automatically download individual
+reference files within this context to the local cache on your filesystem specified by `CRDS_PATH`.
+For more information, see :ref:`reference_files_crds`.
 
 **4. Running the Pipeline**
 

--- a/docs/jwst/user_documentation/reference_files_crds.rst
+++ b/docs/jwst/user_documentation/reference_files_crds.rst
@@ -82,8 +82,8 @@ of reference files if desired.
 
 The CRDS context is usually set by default to always give the 'best' reference files
 associated with a given pipeline version.
-To use a specific CRDS context other than that
-[automatically associated](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/crds-migration-to-quarterly-calibration-updates)
+To use a specific CRDS context other than that `automatically associated
+<https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/crds-migration-to-quarterly-calibration-updates>`
 with a given pipeline version, the environment variable ``CRDS_CONTEXT`` can be used, e.g.
 
 ::

--- a/docs/jwst/user_documentation/reference_files_crds.rst
+++ b/docs/jwst/user_documentation/reference_files_crds.rst
@@ -82,9 +82,9 @@ of reference files if desired.
 
 The CRDS context is usually set by default to always give the 'best' reference files
 associated with a given pipeline version.
-To use a specific CRDS context other than that `automatically associated
-<https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/crds-migration-to-quarterly-calibration-updates>`
-with a given pipeline version, the environment variable ``CRDS_CONTEXT`` can be used, e.g.
+To use a specific CRDS context other than that automatically associated with a given pipeline version
+(see https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/crds-migration-to-quarterly-calibration-updates),
+the environment variable ``CRDS_CONTEXT`` can be used, e.g.
 
 ::
 

--- a/docs/jwst/user_documentation/reference_files_crds.rst
+++ b/docs/jwst/user_documentation/reference_files_crds.rst
@@ -80,17 +80,15 @@ the reference file mapping at any point in time, and revert to any previous set
 of reference files if desired. 
 
 
-The CRDS context is usually set by default to always give access
-to the most recent reference file deliveries and selection rules - i.e the
-'best', most up-to-date set of reference files. On occasion it might be
-necessary or desirable to use one of the non-default mappings in order to, for
-example, run different versions of the pipeline software or use older versions
-of the reference files. This can be accomplished by setting the environment
-variable ``CRDS_CONTEXT`` to the desired project mapping version, e.g.
+The CRDS context is usually set by default to always give the 'best' reference files
+associated with a given pipeline version.
+To use a specific CRDS context other than that
+[automatically associated](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/crds-migration-to-quarterly-calibration-updates)
+with a given pipeline version, the environment variable ``CRDS_CONTEXT`` can be used, e.g.
 
 ::
 
-  $ export CRDS_CONTEXT='jwst_0421.pmap'
+  $ export CRDS_CONTEXT='jwst_1293.pmap'
 
 For all information about CRDS, including context lists, see the JWST CRDS
 website:
@@ -106,20 +104,27 @@ The CRDS server can be found at
 
    https://jwst-crds.stsci.edu
 
-Inside the STScI network, the pipeline defaults are sufficient and no further action is necessary.
+To run the pipeline inside the STScI network, CRDS must be configured to find the CRDS server
+by setting the environment variable
+
+::
+
+    export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+
+This server will be used to determine the appropriate CRDS context for a given pipeline
+version, and the pipeline will obtain individual reference files within this context from a local shared disk.
 
 To run the pipeline outside the STScI network, CRDS must be configured by setting
 two environment variables:
-
-  - CRDS_PATH: Local folder where CRDS content will be cached.
-  - CRDS_SERVER_URL: The server from which to pull reference information
-
-To setup to use the server, use the following settings:
 
 ::
 
     export CRDS_PATH=$HOME/crds_cache/
     export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+
+This server will be used to determine the appropriate CRDS context for a given pipeline
+version, and the pipeline will automatically download individual
+reference files within this context to the local cache specified by ``CRDS_PATH``.
 
 CRDS Cache Configuration for Developers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Resolves [JP-3838](https://jira.stsci.edu/browse/JP-3838)

This PR addresses JP-3838 regarding proper usage of the CRDS_SERVER_URL in both internal and external network configurations.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
