### PR TITLE
JP-3796: Scale barshadow correction to long slits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
             jwst/associations/.* |
             jwst/background/.* |
             jwst/badpix_selfcal/.* |
-            jwst/barshadow/.* |
             jwst/charge_migration/.* |
             jwst/combine_1d/.* |
             jwst/coron/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -28,7 +28,7 @@ exclude = [
     "jwst/associations/**.py",
     "jwst/background/**.py",
     "jwst/badpix_selfcal/**.py",
-    "jwst/barshadow/**.py",
+    #"jwst/barshadow/**.py",
     "jwst/charge_migration/**.py",
     # "jwst/clean_flicker_noise/**.py",
     "jwst/combine_1d/**.py",
@@ -158,7 +158,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/associations/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/background/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/badpix_selfcal/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/barshadow/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+#"jwst/barshadow/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/charge_migration/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 # "jwst/clean_flicker_noise/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/combine_1d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/changes/9085.assign_wcs.rst
+++ b/changes/9085.assign_wcs.rst
@@ -1,0 +1,1 @@
+Calculate slit scaling factors for open area to full slit pitch for NIRSpec MOS data and store in the slit and spectral datamodels as slit_xscale and slit_yscale.

--- a/changes/9085.barshadow.rst
+++ b/changes/9085.barshadow.rst
@@ -1,1 +1,1 @@
-Update barshadow correction to scale correctly to NIRSpec MOS data in long slit mode.
+Update barshadow correction to scale correctly to NIRSpec MOS data in long slit mode. Also correct the scale factors for error propagation when the correction is inverted.

--- a/changes/9085.barshadow.rst
+++ b/changes/9085.barshadow.rst
@@ -1,0 +1,1 @@
+Update barshadow correction to scale correctly to NIRSpec MOS data in long slit mode.

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -547,7 +547,8 @@ def get_msa_slit_scales(msa_ref_file):
     Returns
     -------
     scales : dict
-        todo: update.
+        Keys are integer quadrant values (one-indexed).  Values
+        are 2-tuples of float values (scale_x, scale_y).
     """
     msa = MSAModel(msa_ref_file)
     scales = {}

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -319,7 +319,8 @@ def test_msa_configuration_normal():
     slitlet_info = nirspec.get_open_msa_slits(prog_id, msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
     ref_slit = trmodels.Slit(55, 9376, 1, 251, 26, -5.6, 1.0, 4, 1, '1111x', '95065_1', '2122',
-                             0.13, -0.31716078999999997, -0.18092266)
+                             0.13, -0.31716078999999997, -0.18092266, 0.0, 0.0,
+                             *nirspec.MSA_SLIT_SCALES)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -365,7 +366,7 @@ def test_msa_configuration_all_background():
     slitlet_info = nirspec.get_open_msa_slits(prog_id, msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
     ref_slit = trmodels.Slit(57, 8281, 1, 251, 23, -2.15, 2.15, 4, 57, '1x1', '1234_BKG57', 'BKG57',
-                             0.0, 0.0, 0.0)
+                             0.0, 0.0, 0.0, 0.0, 0.0, *nirspec.MSA_SLIT_SCALES)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -382,7 +383,8 @@ def test_msa_configuration_row_skipped():
     slitlet_info = nirspec.get_open_msa_slits(prog_id, msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
     ref_slit = trmodels.Slit(58, 8646, 1, 251, 24, -3.3, 5.6, 4, 1, '11x1011', '95065_1', '2122',
-                             0.130, -0.31716078999999997, -0.18092266)
+                             0.130, -0.31716078999999997, -0.18092266,
+                             0.0, 0.0, *nirspec.MSA_SLIT_SCALES)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -398,9 +400,11 @@ def test_msa_configuration_multiple_returns():
     slitlet_info = nirspec.get_open_msa_slits(prog_id, msaconfl, msa_meta_id, dither_position,
                                               slit_y_range=[-.5, .5])
     ref_slit1 = trmodels.Slit(59, 8651, 1, 256, 24, -3.3, 5.6, 4, 1, '11x1011', '95065_1', '2122',
-                              0.13000000000000003, -0.31716078999999997, -0.18092266)
+                              0.13000000000000003, -0.31716078999999997, -0.18092266,
+                              0.0, 0.0, *nirspec.MSA_SLIT_SCALES)
     ref_slit2 = trmodels.Slit(60, 11573, 1, 258, 32, -3.3, 4.45, 4, 2, '11x111', '95065_2', '172',
-                              0.70000000000000007, -0.31716078999999997, -0.18092266)
+                              0.70000000000000007, -0.31716078999999997, -0.18092266,
+                              0.0, 0.0, *nirspec.MSA_SLIT_SCALES)
     _compare_slits(slitlet_info[0], ref_slit1)
     _compare_slits(slitlet_info[1], ref_slit2)
 
@@ -418,12 +422,14 @@ def test_msa_fs_configuration():
 
     # MSA slit: reads in as normal
     ref_slit = trmodels.Slit(55, 9376, 1, 251, 26, -5.6, 1.0, 4, 1, '1111x', '95065_1', '2122',
-                             0.13, -0.31716078999999997, -0.18092266)
+                             0.13, -0.31716078999999997, -0.18092266,
+                             0.0, 0.0, *nirspec.MSA_SLIT_SCALES)
     _compare_slits(slitlet_info[0], ref_slit)
 
     # FS primary: S200A1, shutter id 0, quadrant 5
     ref_slit = trmodels.Slit('S200A1', 0, 1, 0, 0, -0.5, 0.5, 5, 3, 'x', '95065_3', '3',
-                             1.0, -0.161, -0.229, 53.139904, -27.805002)
+                             1.0, -0.161, -0.229, 53.139904, -27.805002,
+                             *nirspec.MSA_SLIT_SCALES)
     _compare_slits(slitlet_info[1], ref_slit)
 
     # The remaining fixed slits may be in the MSA file but not primary:
@@ -487,13 +493,15 @@ def test_msa_missing_source(tmp_path):
     # MSA slit: virtual source name assigned
     ref_slit = trmodels.Slit(55, 9376, 1, 251, 26, -5.6, 1.0, 4, 1, '1111x',
                              '1234_VRT55', 'VRT55', 0.0,
-                             -0.31716078999999997, -0.18092266, 0.0, 0.0)
+                             -0.31716078999999997, -0.18092266, 0.0, 0.0,
+                             *nirspec.MSA_SLIT_SCALES)
     _compare_slits(slitlet_info[0], ref_slit)
 
     # FS primary: S200A1, virtual source name assigned
     ref_slit = trmodels.Slit('S200A1', 0, 1, 0, 0, -0.5, 0.5, 5, 3, 'x',
                              '1234_VRTS200A1', 'VRTS200A1', 0.0,
-                             -0.161, -0.229, 0.0, 0.0)
+                             -0.161, -0.229, 0.0, 0.0,
+                             *nirspec.MSA_SLIT_SCALES)
     _compare_slits(slitlet_info[1], ref_slit)
 
 
@@ -525,7 +533,9 @@ def test_msa_nan_source_posn(tmp_path):
                              ymin=-0.5, ymax=0.5, quadrant=5, source_id=3, shutter_state='x',
                              source_name='95065_3', source_alias='3', stellarity=1.0,
                              source_xpos=0.0, source_ypos=-0.2290000021457672,
-                             source_ra=53.139904, source_dec=-27.805002)
+                             source_ra=53.139904, source_dec=-27.805002,
+                             slit_xscale=nirspec.MSA_SLIT_SCALES[0],
+                             slit_yscale=nirspec.MSA_SLIT_SCALES[1])
     _compare_slits(slitlet_info[1], ref_slit)
 
 

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -39,7 +39,8 @@ wcs_kw = {'wcsaxes': 2, 'ra_ref': 165, 'dec_ref': 54,
 
 slit_fields_num = ["shutter_id", "dither_position", "xcen", "ycen",
                    "ymin", "ymax", "quadrant", "source_id",
-                   "stellarity", "source_xpos", "source_ypos"]
+                   "stellarity", "source_xpos", "source_ypos",
+                   "slit_xscale", "slit_yscale"]
 
 
 slit_fields_str = ["name", "shutter_state", "source_name", "source_alias"]
@@ -319,6 +320,21 @@ def test_msa_configuration_normal():
                                               slit_y_range=[-.5, .5])
     ref_slit = trmodels.Slit(55, 9376, 1, 251, 26, -5.6, 1.0, 4, 1, '1111x', '95065_1', '2122',
                              0.13, -0.31716078999999997, -0.18092266)
+    _compare_slits(slitlet_info[0], ref_slit)
+
+
+def test_msa_configuration_slit_scales():
+    prog_id = '1234'
+    msa_meta_id = 12
+    msaconfl = get_file_path('msa_configuration.fits')
+    dither_position = 1
+
+    # mock slit scale for quadrant 4
+    slit_scales = {4: (2.0, 3.0)}
+    slitlet_info = nirspec.get_open_msa_slits(prog_id, msaconfl, msa_meta_id, dither_position,
+                                              slit_y_range=[-.5, .5], slit_scales=slit_scales)
+    ref_slit = trmodels.Slit(55, 9376, 1, 251, 26, -5.6, 1.0, 4, 1, '1111x', '95065_1', '2122',
+                             0.13, -0.31716078999999997, -0.18092266, 0.0, 0.0, 2.0, 3.0)
     _compare_slits(slitlet_info[0], ref_slit)
 
 

--- a/jwst/barshadow/__init__.py
+++ b/jwst/barshadow/__init__.py
@@ -1,3 +1,5 @@
+"""Correct NIRSpec MOS data for barshadow effects."""
+
 from .barshadow_step import BarShadowStep
 
 __all__ = ["BarShadowStep"]

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -1,34 +1,36 @@
-#
-#  Module for calculating bar shadow correction for science data sets
-#
+"""Calculate bar shadow correction for science data sets."""
 
 import numpy as np
 import logging
 from gwcs import wcstools
-
+from scipy import ndimage
 from stdatamodels.jwst import datamodels
+
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def do_correction(input_model, barshadow_model=None, inverse=False, source_type=None, correction_pars=None):
-    """Do the Bar Shadow Correction
+def do_correction(
+    input_model,
+    barshadow_model=None,
+    inverse=False,
+    source_type=None,
+    correction_pars=None,
+):
+    """
+    Correct MSA data for bar shadows.
 
     Parameters
     ----------
     input_model : `~jwst.datamodels.MultiSlitModel`
-        science data model to be corrected
-
+        Science data model to be corrected.
     barshadow_model : `~jwst.datamodels.BarshadowModel`
-        bar shadow data model from reference file
-
-    inverse : boolean
+        Bar shadow data model from reference file.
+    inverse : bool
         Invert the math operations used to apply the flat field.
-
     source_type : str or None
         Force processing using the specified source type.
-
     correction_pars : dict or None
         Correction parameters to use instead of recalculation.
 
@@ -38,7 +40,6 @@ def do_correction(input_model, barshadow_model=None, inverse=False, source_type=
         Science data model with correction applied and barshadow extensions added,
         and a model of the correction arrays.
     """
-
     # Input is a MultiSlitModel science data model.
     # A MultislitModel has a member ".slits" that behaves like
     # a list of Slits, each of which has several data arrays and
@@ -52,7 +53,7 @@ def do_correction(input_model, barshadow_model=None, inverse=False, source_type=
     # -1 to 1 in their Y value WCS.
 
     exp_type = input_model.meta.exposure.type
-    log.debug(f'EXP_TYPE = {exp_type}')
+    log.debug(f"EXP_TYPE = {exp_type}")
 
     # Create output as a copy of the input science data model
     output_model = input_model.copy()
@@ -61,7 +62,7 @@ def do_correction(input_model, barshadow_model=None, inverse=False, source_type=
     corrections = datamodels.MultiSlitModel()
     for slit_idx, slitlet in enumerate(output_model.slits):
         slitlet_number = slitlet.slitlet_id
-        log.info('Working on slitlet %d' % slitlet_number)
+        log.info(f"Working on slitlet {slitlet_number}")
 
         if correction_pars:
             correction = correction_pars.slits[slit_idx]
@@ -87,7 +88,8 @@ def do_correction(input_model, barshadow_model=None, inverse=False, source_type=
 
 
 def _calc_correction(slitlet, barshadow_model, source_type):
-    """Calculate the barshadow correction for a slitlet
+    """
+    Calculate the barshadow correction for a slitlet.
 
     Parameters
     ----------
@@ -95,7 +97,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
         The slitlet to calculate for.
 
     barshadow_model : `~jwst.datamodels.BarshadowModel`
-        bar shadow data model from reference file
+        Bar shadow data model from reference file.
 
     source_type : str or None
         Force processing using the specified source type.
@@ -103,15 +105,17 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     Returns
     -------
     correction : jwst.datamodels.SlitModel
-        The correction to be applied
+        The correction to be applied.
     """
     slitlet_number = slitlet.slitlet_id
 
     # Correction only applies to extended/uniform sources
     correction = datamodels.SlitModel(data=np.ones(slitlet.data.shape))
     if not has_uniform_source(slitlet, source_type):
-        log.info("Bar shadow correction skipped for "
-                 f"slitlet {slitlet_number} (source not uniform)")
+        log.info(
+            "Bar shadow correction skipped for "
+            f"slitlet {slitlet_number} (source not uniform)"
+        )
         return correction
 
     # No correction for zero length slitlets
@@ -134,7 +138,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     x, y = wcstools.grid_from_bounding_box(slitlet.meta.wcs.bounding_box, step=(1, 1))
 
     # Create the transformation from slit_frame to detector
-    det2slit = slitlet.meta.wcs.get_transform('detector', 'slit_frame')
+    det2slit = slitlet.meta.wcs.get_transform("detector", "slit_frame")
 
     # Use this transformation to calculate x, y, and wavelength
     xslit, yslit, wavelength = det2slit(x, y)
@@ -146,7 +150,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     yslit = yslit / slitlet.slit_yscale
 
     # Find the fiducial shutter to align the constructed shadow with the real array
-    src_loc = shutter_status.find('x')
+    src_loc = shutter_status.find("x")
     index_of_fiducial = len(shutter_status) - src_loc
 
     # The shutters go downwards, i.e. the first shutter in shutter_status corresponds to
@@ -158,14 +162,18 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     wcol = (wavelength - w0) / wave_increment
 
     # Interpolate the bar shadow correction for non-Nan pixels
-    correction.data = interpolate(yrow, wcol, shadow)
+    correction.data = ndimage.map_coordinates(
+        shadow, [yrow, wcol], cval=np.nan, order=1
+    )
 
     return correction
 
 
 def create_shutter_elements(barshadow_model):
-    """Create the pieces that will be put together to make the barshadow
-    array for the slitlets.  The pieces are:
+    """
+    Create half-shutter pieces for assembling a full barshadow array.
+
+    The pieces are:
 
         1. shutter_elements['first']
            Goes from the bottom edge of the array (at 1 shutter width from
@@ -186,183 +194,89 @@ def create_shutter_elements(barshadow_model):
             Goes from the center of the last open shutter to the top edge of the shutter
             array (1 shutter width from the center of the last open shutter)
 
-       Parameters:
+    Parameters
+    ----------
+    barshadow_model : BarshadowModel
+        The barshadow model used to construct these pieces.
 
-       barshadow_model: BarshadowModel object
-           The barshadow model used to construct these pieces
-
-       Returns:
-
-       shutter_elements: dict
-           Dictionary (specified above) with the pieces
+    Returns
+    -------
+    shutter_elements : dict
+        Dictionary (specified above) with the pieces.
     """
     shadow1x1 = barshadow_model.data1x1
     shadow1x3 = barshadow_model.data1x3
-    shutter_elements = {}
-    shutter_elements['first'] = create_first(shadow1x1)
-    shutter_elements['open_open'] = create_open_open(shadow1x3)
-    shutter_elements['open_closed'] = create_open_closed(shadow1x1)
-    shutter_elements['closed_open'] = create_closed_open(shadow1x1)
-    shutter_elements['closed_closed'] = create_closed_closed()
-    shutter_elements['last'] = create_last(shadow1x1)
+
+    # Each shutter is assumed to be 1000 pixels tall, so
+    # center elements are at row 500.
+    # 1 pixel overlap is used at the boundaries, for averaging
+    # corrections between adjoining sections
+    # NOTE: the closed-closed element should not happen often, if ever:
+    # it is rare to have two adjacent shutters closed within a slitlet
+    shutter_elements = {
+        "first": shadow1x1[:501, :],
+        "open_open": shadow1x3[:501, :],
+        "open_closed": shadow1x1[500:, :],
+        "closed_open": shadow1x1[:501, :],
+        "closed_closed": np.nanmin(shadow1x1) * np.ones((501, 101)),
+        "last": shadow1x1[501:, :],
+    }
 
     return shutter_elements
 
 
-def create_first(shadow1x1):
-    """Create the first half shutter in the bar shadow array.
-    Use rows 1-501 in the shadow1x1 array
-
-    Parameters:
-
-    shadow1x1: nddata array
-        The 1x1 shadow array from the barshadow model
-
-    Returns:
-
-    The array to use as shutter_elements['first']
-    """
-    return shadow1x1[:501, :]
-
-
-def create_open_open(shadow1x3):
-    """Create the two half shutters obtained from two open shutters
-    Use rows 1-501 in the shadow1x3 array
-
-    Parameters:
-
-    shadow1x3: nddata array
-        The 1x3 shadow array from the barshadow model
-
-    Returns:
-
-    The array to use as shutter_elements['open_open']
-    """
-    return shadow1x3[:501, :]
-
-
-def create_open_closed(shadow1x1):
-    """Create the two half shutters obtained from one open and
-    one closed shutter
-    Use rows 501-1001 in the shadow1x1 array
-
-    Parameters:
-
-    shadow1x1: nddata array
-        The 1x1 shadow array from the barshadow model
-
-    Returns:
-
-    The array to use as shutter_elements['open_closed']
-    """
-    return shadow1x1[500:, :]
-
-
-def create_closed_open(shadow1x1):
-    """Create the two half shutters obtained from one closed and
-    one open shutter
-    Use rows 1-501 in the shadow1x1 array
-
-    Parameters:
-
-    shadow1x1: nddata array
-        The 1x1 shadow array from the barshadow model
-
-    Returns:
-
-    The array to use as shutter_elements['closed_open']
-    """
-    return shadow1x1[:501, :]
-
-
-def create_closed_closed():
-    """Create the two half shutters obtained from two closed shutters
-    Uses 0.01 somewhat arbitrarily, although this case shouldn't occur
-    very often, only when there are 2 or more consecutive closed shutters
-    in a slitlet
-
-    Parameters:
-
-    None
-
-    Returns:
-
-    The array to use as shutter_elements['closed_closed']
-    """
-    return 0.01 * np.ones((501, 101))
-
-
-def create_last(shadow1x1):
-    """Create the last half shutter in the bar shadow array.
-    Use rows 501-1001 in the shadow1x1 array
-
-    Parameters:
-
-    shadow1x1: nddata array
-        The 1x1 shadow array from the barshadow model
-
-    Returns:
-
-    The array to use as shutter_elements['last']
-    """
-    return shadow1x1[501:, :]
-
-
 def create_shadow(shutter_elements, shutter_status):
-    """Create a bar shadow reference array on the fly from the shutter
-    elements dictionary.
+    """
+    Create a bar shadow reference array from the shutter elements.
 
-    Parameters:
-
-    shutter_elements: dict
-        The shutter elements dictionary
-
-    shutter_status: string
+    Parameters
+    ----------
+    shutter_elements : dict
+        The shutter elements dictionary.
+    shutter_status : str
         String describing the shutter status:
            0:  Closed
            1:  Open
            x:  Contains source
 
-    Returns:
-
-    shadow_array: nddata array
-        The constructed bar shadow array
-
+    Returns
+    -------
+    shadow_array : ndarray of float
+        The constructed bar shadow array.
     """
     nshutters = len(shutter_status)
     shadow = create_empty_shadow_array(nshutters)
     first_row = 0
-    shadow = add_first_half_shutter(shadow, shutter_elements['first'])
-    first_row = first_row + shutter_elements['first'].shape[0] - 1
-    last_shutter = 'open'
+    shadow = add_first_half_shutter(shadow, shutter_elements["first"])
+    first_row = first_row + shutter_elements["first"].shape[0] - 1
+    last_shutter = "open"
     for this_status in shutter_status[1:]:
-        if this_status == '0':
-            this_shutter = 'closed'
+        if this_status == "0":
+            this_shutter = "closed"
         else:
-            this_shutter = 'open'
-        shutter_pair = '_'.join((last_shutter, this_shutter))
+            this_shutter = "open"
+        shutter_pair = "_".join((last_shutter, this_shutter))
         shadow = add_next_shutter(shadow, shutter_elements[shutter_pair], first_row)
         first_row = first_row + shutter_elements[shutter_pair].shape[0] - 1
         last_shutter = this_shutter
-    shadow = add_last_half_shutter(shadow, shutter_elements['last'], first_row)
+    shadow = add_last_half_shutter(shadow, shutter_elements["last"], first_row)
     return shadow
 
 
 def create_empty_shadow_array(nshutters):
-    """Create the empty bar shadow array.
-
-    Parameters:
-
-    nshutters: int
-        The length of the slit in shutters
-
-    Returns:
-
-    empty_shadow: nddata_array
-        The empty shadow array
-
     """
-    #
+    Create the empty bar shadow array.
+
+    Parameters
+    ----------
+    nshutters : int
+        The length of the slit in shutters.
+
+    Returns
+    -------
+    empty_shadow : ndarray
+        The empty shadow array.
+    """
     # Assume the reference files have a shape of 1001 rows by 101 columns
     # and go from -1 to +1 in Y
     nrows = nshutters * 500 + 500
@@ -372,47 +286,44 @@ def create_empty_shadow_array(nshutters):
 
 
 def add_first_half_shutter(shadow, shadow_element):
-    """Add the first half shutter to the shadow array
+    """
+    Add the first half shutter to the shadow array.
 
-    Parameters:
-
-    shadow: nddata array
+    Parameters
+    ----------
+    shadow : ndarray
         The bar shadow array.
+    shadow_element : ndarray
+        The shutter_elements['first'] array.  Should be 501 rows (Y)
+        by 101 columns (wavelength).
 
-    shadow_element: nddata array
-        the shutter_elements['first'] array.  Should be 501 rows (Y) by 101 columns (wavelength)
-
-    Returns:
-
-    shadow: nddata array
-        The bar shadow array with the first half shutter inserted
-
+    Returns
+    -------
+    shadow : ndarray
+        The bar shadow array with the first half shutter inserted.
     """
     shadow[0:501, :] = shadow_element[:, :]
     return shadow
 
 
 def add_next_shutter(shadow, shadow_element, first_row):
-    """Add a single internal shutter and advance the last row by 501
-
-    Parameters:
-
-    shadow: nddata array
-        The bar shadow array.
-
-    shadow_element: nddata array
-        the internal shutter element data array.
-
-    first_row: int
-        The first row to place the shutter element
-
-    Returns:
-
-    shadow: nddata array
-        The bar shadow array with the double internal shutter inserted
-
     """
-    #
+    Add a single internal shutter and advance the last row by 501.
+
+    Parameters
+    ----------
+    shadow : ndarray
+        The bar shadow array.
+    shadow_element : ndarray
+        The internal shutter element data array.
+    first_row : int
+        The first row to place the shutter element.
+
+    Returns
+    -------
+    shadow: ndarray
+        The bar shadow array with the double internal shutter inserted.
+    """
     # Average the last row in the current bar shadow array with the first row of
     # the single internal shutter array
     shadow[first_row, :] = 0.5 * (shadow[first_row, :] + shadow_element[0, :])
@@ -423,25 +334,24 @@ def add_next_shutter(shadow, shadow_element, first_row):
 
 
 def add_last_half_shutter(shadow, shadow_element, first_row):
-    """Add the last half shutter from the 1x1 array.  The last half shutter
-    is rows 501-1001.
+    """
+    Add the last half shutter from the 1x1 array.
 
-    Parameters:
+    The last half shutter is rows 501-1001.
 
-    shadow: nddata array
+    Parameters
+    ----------
+    shadow : nddata array
         The bar shadow array.
+    shadow_element : nddata array
+        The shadow_element array.
+    first_row : int
+        The first row to place the shadow element.
 
-    shadow_element: nddata array
-        the shadow_element array.
-
-    first_row: int
-        The first row to place the shadow element
-
-    Returns:
-
-    shadow: nddata array
-        The bar shadow array with the last half shutter inserted
-
+    Returns
+    -------
+    shadow: ndarray
+        The bar shadow array with the last half shutter inserted.
     """
     #
     # Average the last row in the current bar shadow array with the first row of
@@ -453,92 +363,33 @@ def add_last_half_shutter(shadow, shadow_element, first_row):
     return shadow
 
 
-def interpolate(rows, columns, array, default=np.nan):
-    """Interpolate row and column vectors in array
-
-    Parameters:
-
-    row: nddata array
-        array of row indices
-
-    column: nddata array
-        array of column indices
-
-    array: nddata array
-        array to be interpolated
-
-    default: number
-        value to use in output array when input index is nan (default np.nan)
-
-    Returns:
-
-    correction: nddata array
-        array of correction factors, or default when not calculated
-    """
-    nrows, ncolumns = rows.shape
-    correction = np.ones((nrows, ncolumns))
-    correction.fill(default)
-    nrows_out, ncols_out = array.shape
-    #
-    # Extend the boundary of array by 1 row and column to handle end cases
-    augmented_array = np.ones((nrows_out + 1, ncols_out + 1))
-    augmented_array[:nrows_out, :ncols_out] = array
-    augmented_array[nrows_out, :ncols_out] = array[nrows_out - 1, :]
-    augmented_array[:nrows_out, ncols_out] = array[:, ncols_out - 1]
-    augmented_array[nrows_out, ncols_out] = array[nrows_out - 1, ncols_out - 1]
-    for row in range(nrows):
-        for column in range(ncolumns):
-            if ~np.isnan(rows[row, column]) and ~np.isnan(columns[row, column]):
-                array_row = rows[row, column]
-                array_column = columns[row, column]
-                #
-                # Deal with out-of-bounds pixels
-                if array_row >= nrows_out:
-                    array_row = nrows_out - 1
-                if array_column >= ncols_out:
-                    array_column = ncols_out - 1
-                if array_row < 0:
-                    array_row = 0
-                if array_column < 0:
-                    array_column = 0
-                ix = int(array_column)
-                iy = int(array_row)
-                a11 = augmented_array[iy, ix]
-                a12 = augmented_array[iy, ix + 1]
-                a21 = augmented_array[iy + 1, ix]
-                a22 = augmented_array[iy + 1, ix + 1]
-                dx = array_column - ix
-                dy = array_row - iy
-                correction[row, column] = a11 * (1.0 - dx) * (1.0 - dy) + a12 * dx * (1.0 - dy) + \
-                    a21 * (1.0 - dx) * dy + a22 * dx * dy
-    return correction
-
-
 def has_uniform_source(slitlet, force_type=None):
-    """Determine whether the slitlet contains a uniform source
+    """
+    Determine whether the slitlet contains a uniform source.
 
-    Parameters:
-
-    slitlet: slitlet object
-        The slitlet being interrogated
-
-    force_type : string or None
+    Parameters
+    ----------
+    slitlet : SlitModel
+        The slitlet being interrogated.
+    force_type : str or None
         Source type to force to and decide upon.
 
-    Returns:
-
-    answer: boolean
-        True if the slitlet contains a uniform source
+    Returns
+    -------
+    answer: bool
+        True if the slitlet contains a uniform source.
     """
     source_type = force_type if force_type else slitlet.source_type
 
     if source_type:
         # Assume extended, unless explicitly set to POINT
-        if source_type.upper() == 'POINT':
+        if source_type.upper() == "POINT":
             return False
         else:
             return True
     else:
         # If there's no source type info, default to EXTENDED
-        log.info('SRCTYPE not set for slitlet %d; assuming EXTENDED' % slitlet.slitlet_id)
+        log.info(
+            f"SRCTYPE not set for slitlet {slitlet.slitlet_id}; assuming EXTENDED."
+        )
         return True

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -86,13 +86,6 @@ def do_correction(input_model, barshadow_model=None, inverse=False, source_type=
     return output_model, corrections
 
 
-def _slit_ratio(quadrant):
-    # Should be calculated by quadrant, from the MSA reference file
-    # Current approximations for Q1-4 are:
-    slit_scale = [1.14392, 1.1500415, 1.1503992, 1.1435773]
-    return slit_scale[quadrant - 1]
-
-
 def _calc_correction(slitlet, barshadow_model, source_type):
     """Calculate the barshadow correction for a slitlet
 
@@ -150,7 +143,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     # (i.e. a slit goes from -0.5 to 0.5).  The barshadow array is scaled
     # so that the separation between the slit centers is 1,
     # i.e. slit height + interslit bar
-    yslit = yslit / _slit_ratio(slitlet.quadrant)
+    yslit = yslit / slitlet.slit_yscale
 
     # Find the fiducial shutter to align the constructed shadow with the real array
     src_loc = shutter_status.find('x')

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -115,10 +115,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     # Correction only applies to extended/uniform sources
     correction = datamodels.SlitModel(data=np.ones(slitlet.data.shape))
     if not has_uniform_source(slitlet, source_type):
-        log.info(
-            "Bar shadow correction skipped for "
-            f"slitlet {slitlet_number} (source not uniform)"
-        )
+        log.info(f"Bar shadow correction skipped for slitlet {slitlet_number} (source not uniform)")
         return correction
 
     # No correction for zero length slitlets
@@ -151,9 +148,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     # so that the separation between the slit centers is 1,
     # i.e. slit height + interslit bar
     if slitlet.slit_yscale is None:
-        log.warning(
-            f"Slit height scale factor not found. Using default value {SLITRATIO}."
-        )
+        log.warning(f"Slit height scale factor not found. Using default value {SLITRATIO}.")
         yslit = yslit / SLITRATIO
     else:
         yslit = yslit / slitlet.slit_yscale
@@ -171,9 +166,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     wcol = (wavelength - w0) / wave_increment
 
     # Interpolate the bar shadow correction for non-Nan pixels
-    correction.data = ndimage.map_coordinates(
-        shadow, [yrow, wcol], cval=np.nan, order=1
-    )
+    correction.data = ndimage.map_coordinates(shadow, [yrow, wcol], cval=np.nan, order=1)
 
     return correction
 
@@ -398,7 +391,5 @@ def has_uniform_source(slitlet, force_type=None):
             return True
     else:
         # If there's no source type info, default to EXTENDED
-        log.info(
-            f"SRCTYPE not set for slitlet {slitlet.slitlet_id}; assuming EXTENDED."
-        )
+        log.info(f"SRCTYPE not set for slitlet {slitlet.slitlet_id}; assuming EXTENDED.")
         return True

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -93,8 +93,8 @@ def _calc_correction(slitlet, barshadow_model, source_type):
 
     Parameters
     ----------
-    slitlet : jwst.datamodels.SlitModel
-        The slitlet to calculate for.
+    slitlet : `~jwst.datamodels.SlitModel`
+        The slitlet to calculate the correction for.
 
     barshadow_model : `~jwst.datamodels.BarshadowModel`
         Bar shadow data model from reference file.
@@ -104,7 +104,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
 
     Returns
     -------
-    correction : jwst.datamodels.SlitModel
+    correction : `~jwst.datamodels.SlitModel`
         The correction to be applied.
     """
     slitlet_number = slitlet.slitlet_id
@@ -369,7 +369,7 @@ def has_uniform_source(slitlet, force_type=None):
 
     Parameters
     ----------
-    slitlet : SlitModel
+    slitlet : `~jwst.datamodels.SlitModel`
         The slitlet being interrogated.
     force_type : str or None
         Source type to force to and decide upon.

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -78,13 +78,18 @@ def do_correction(
         #     because they're variance, while err is standard deviation
         if not inverse:
             slitlet.data /= correction.data
+            slitlet.err /= correction.data
+            slitlet.var_poisson /= correction.data**2
+            slitlet.var_rnoise /= correction.data**2
+            if slitlet.var_flat is not None and np.size(slitlet.var_flat) > 0:
+                slitlet.var_flat /= correction.data**2
         else:
             slitlet.data *= correction.data
-        slitlet.err /= correction.data
-        slitlet.var_poisson /= correction.data**2
-        slitlet.var_rnoise /= correction.data**2
-        if slitlet.var_flat is not None and np.size(slitlet.var_flat) > 0:
-            slitlet.var_flat /= correction.data**2
+            slitlet.err *= correction.data
+            slitlet.var_poisson *= correction.data**2
+            slitlet.var_rnoise *= correction.data**2
+            if slitlet.var_flat is not None and np.size(slitlet.var_flat) > 0:
+                slitlet.var_flat *= correction.data**2
         slitlet.barshadow = correction.data
 
     return output_model, corrections

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -10,6 +10,9 @@ from stdatamodels.jwst import datamodels
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+# Fallback value for ratio of slit spacing to slit height
+SLITRATIO = 1.15
+
 
 def do_correction(
     input_model,
@@ -147,7 +150,12 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     # (i.e. a slit goes from -0.5 to 0.5).  The barshadow array is scaled
     # so that the separation between the slit centers is 1,
     # i.e. slit height + interslit bar
-    yslit = yslit / slitlet.slit_yscale
+    if slitlet.slit_yscale is None:
+        log.warning(f'Slit height scale factor not found. '
+                    f'Using default value {SLITRATIO}.')
+        yslit = yslit / SLITRATIO
+    else:
+        yslit = yslit / slitlet.slit_yscale
 
     # Find the fiducial shutter to align the constructed shadow with the real array
     src_loc = shutter_status.find("x")

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -151,8 +151,9 @@ def _calc_correction(slitlet, barshadow_model, source_type):
     # so that the separation between the slit centers is 1,
     # i.e. slit height + interslit bar
     if slitlet.slit_yscale is None:
-        log.warning(f'Slit height scale factor not found. '
-                    f'Using default value {SLITRATIO}.')
+        log.warning(
+            f"Slit height scale factor not found. Using default value {SLITRATIO}."
+        )
         yslit = yslit / SLITRATIO
     else:
         yslit = yslit / slitlet.slit_yscale

--- a/jwst/barshadow/barshadow_step.py
+++ b/jwst/barshadow/barshadow_step.py
@@ -23,7 +23,7 @@ class BarShadowStep(Step):
     spec = """
         inverse = boolean(default=False)    # Invert the operation
         source_type = string(default=None)  # Process as specified source type.
-    """ # noqa: E501
+    """  # noqa: E501
 
     reference_file_types = ["barshadow"]
 

--- a/jwst/barshadow/barshadow_step.py
+++ b/jwst/barshadow/barshadow_step.py
@@ -54,12 +54,8 @@ class BarShadowStep(Step):
                     correction_pars = None
 
                     # Get the name of the bar shadow reference file to use
-                    self.barshadow_name = self.get_reference_file(
-                        input_model, "barshadow"
-                    )
-                    self.log.info(
-                        f"Using BARSHADOW reference file {self.barshadow_name}"
-                    )
+                    self.barshadow_name = self.get_reference_file(input_model, "barshadow")
+                    self.log.info(f"Using BARSHADOW reference file {self.barshadow_name}")
 
                     # Check for a valid reference file
                     if self.barshadow_name == "N/A":

--- a/jwst/barshadow/barshadow_step.py
+++ b/jwst/barshadow/barshadow_step.py
@@ -1,3 +1,5 @@
+"""Barshadow correction step."""
+
 from stdatamodels.jwst import datamodels
 
 from ..stpipe import Step
@@ -9,13 +11,11 @@ __all__ = ["BarShadowStep"]
 
 class BarShadowStep(Step):
     """
-    BarShadowStep: Inserts the bar shadow and wavelength arrays
-    into the data.
+    Correct NIRSpec MOS data for barshadow effects.
 
     Bar shadow correction depends on the position of a pixel along the slit
     and the wavelength. It is only applied to uniform sources and only for
     NRS MSA data.
-
     """
 
     class_alias = "barshadow"
@@ -25,27 +25,27 @@ class BarShadowStep(Step):
         source_type = string(default=None)  # Process as specified source type.
     """ # noqa: E501
 
-    reference_file_types = ['barshadow']
+    reference_file_types = ["barshadow"]
 
-    def process(self, input):
-        """Perform the barshadow correction step
+    def process(self, input_data):
+        """
+        Perform the barshadow correction step.
 
         Parameters
         ----------
-        input : JWST datamodel
-            input JWST datamodel object
+        input_data : DataModel
+            Input JWST datamodel object.
 
         Returns
         -------
-        result : jwst datamodel
-            JWST datamodel object with barshadow extension(s) added
+        result : DataModel
+            JWST datamodel object with corrected science data and barshadow
+            extension(s) added.
         """
-
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.open(input_data) as input_model:
             exp_type = input_model.meta.exposure.type
-            if exp_type == 'NRS_MSASPEC':
-
+            if exp_type == "NRS_MSASPEC":
                 if self.use_correction_pars:
                     correction_pars = self.correction_pars
                     barshadow_model = None
@@ -54,17 +54,19 @@ class BarShadowStep(Step):
                     correction_pars = None
 
                     # Get the name of the bar shadow reference file to use
-                    self.barshadow_name = self.get_reference_file(input_model,
-                                                                  'barshadow')
-                    self.log.info('Using BARSHADOW reference file %s',
-                                  self.barshadow_name)
+                    self.barshadow_name = self.get_reference_file(
+                        input_model, "barshadow"
+                    )
+                    self.log.info(
+                        f"Using BARSHADOW reference file {self.barshadow_name}"
+                    )
 
                     # Check for a valid reference file
-                    if self.barshadow_name == 'N/A':
-                        self.log.warning('No BARSHADOW reference file found')
-                        self.log.warning('Bar shadow step will be skipped')
+                    if self.barshadow_name == "N/A":
+                        self.log.warning("No BARSHADOW reference file found")
+                        self.log.warning("Bar shadow step will be skipped")
                         result = input_model.copy()
-                        result.meta.cal_step.barshadow = 'SKIPPED'
+                        result.meta.cal_step.barshadow = "SKIPPED"
                         return result
 
                     # Open the barshadow ref file data model
@@ -72,15 +74,17 @@ class BarShadowStep(Step):
 
                 # Do the bar shadow correction
                 result, self.correction_pars = bar_shadow.do_correction(
-                    input_model, barshadow_model,
-                    inverse=self.inverse, source_type=self.source_type,
-                    correction_pars=correction_pars
+                    input_model,
+                    barshadow_model,
+                    inverse=self.inverse,
+                    source_type=self.source_type,
+                    correction_pars=correction_pars,
                 )
 
                 if barshadow_model:
                     barshadow_model.close()
-                result.meta.cal_step.barshadow = 'COMPLETE'
+                result.meta.cal_step.barshadow = "COMPLETE"
             else:
-                input_model.meta.cal_step.barshadow = 'SKIPPED'
+                input_model.meta.cal_step.barshadow = "SKIPPED"
                 result = input_model
         return result

--- a/jwst/barshadow/tests/test_barshadow.py
+++ b/jwst/barshadow/tests/test_barshadow.py
@@ -13,17 +13,16 @@ def test_create_shutter_elements():
     barshadow_model = datamodels.BarshadowModel(data1x1=d1x1, data1x3=d1x3)
     shutter_elements = bar.create_shutter_elements(barshadow_model)
 
-    assert np.allclose(shutter_elements['first'], d1x1[:501, :], atol=1.e-10)
-    assert np.allclose(shutter_elements['open_open'], d1x3[:501, :],
-                       atol=1.e-10)
-    assert np.allclose(shutter_elements['open_closed'], d1x1[500:, :],
-                       atol=1.e-10)
-    assert np.allclose(shutter_elements['closed_open'], d1x1[:501, :],
-                       atol=1.e-10)
-    assert np.allclose(shutter_elements['closed_closed'],
-                       min_closed * np.ones((501, 101), dtype=np.float64),
-                       atol=1.e-10)
-    assert np.allclose(shutter_elements['last'], d1x1[501:, :], atol=1.e-10)
+    assert np.allclose(shutter_elements["first"], d1x1[:501, :], atol=1.0e-10)
+    assert np.allclose(shutter_elements["open_open"], d1x3[:501, :], atol=1.0e-10)
+    assert np.allclose(shutter_elements["open_closed"], d1x1[500:, :], atol=1.0e-10)
+    assert np.allclose(shutter_elements["closed_open"], d1x1[:501, :], atol=1.0e-10)
+    assert np.allclose(
+        shutter_elements["closed_closed"],
+        min_closed * np.ones((501, 101), dtype=np.float64),
+        atol=1.0e-10,
+    )
+    assert np.allclose(shutter_elements["last"], d1x1[501:, :], atol=1.0e-10)
 
 
 def test_create_shadow():
@@ -39,23 +38,23 @@ def test_create_shadow():
     shadow = bar.create_shadow(shutter_elements, shutter_status)
 
     # first
-    assert np.allclose(shadow[0:500, :], d1x1[0:500, :], atol=1.e-10)
+    assert np.allclose(shadow[0:500, :], d1x1[0:500, :], atol=1.0e-10)
     # open_open
-    assert np.allclose(shadow[501:1000, :], d1x3[1:500, :], atol=1.e-10)
+    assert np.allclose(shadow[501:1000, :], d1x3[1:500, :], atol=1.0e-10)
     # open_closed
-    assert np.allclose(shadow[1001:1500, :], d1x1[501:1000, :], atol=1.e-10)
+    assert np.allclose(shadow[1001:1500, :], d1x1[501:1000, :], atol=1.0e-10)
     # closed_closed
-    assert np.allclose(shadow[1501:2000, :], min_closed, atol=1.e-10)
+    assert np.allclose(shadow[1501:2000, :], min_closed, atol=1.0e-10)
     # closed_open
-    assert np.allclose(shadow[2001:2500, :], d1x1[1:500, :], atol=1.e-10)
+    assert np.allclose(shadow[2001:2500, :], d1x1[1:500, :], atol=1.0e-10)
     # open_open
-    assert np.allclose(shadow[2501:3000, :], d1x3[1:500, :], atol=1.e-10)
+    assert np.allclose(shadow[2501:3000, :], d1x3[1:500, :], atol=1.0e-10)
     # open_open
-    assert np.allclose(shadow[3001:3500, :], d1x3[1:500, :], atol=1.e-10)
+    assert np.allclose(shadow[3001:3500, :], d1x3[1:500, :], atol=1.0e-10)
     # open_open
-    assert np.allclose(shadow[3501:4000, :], d1x3[1:500, :], atol=1.e-10)
+    assert np.allclose(shadow[3501:4000, :], d1x3[1:500, :], atol=1.0e-10)
     # last
-    assert np.allclose(shadow[4001:4500, :], d1x1[502:1001, :], atol=1.e-10)
+    assert np.allclose(shadow[4001:4500, :], d1x1[502:1001, :], atol=1.0e-10)
 
 
 def test_create_empty_shadow_array():
@@ -63,8 +62,8 @@ def test_create_empty_shadow_array():
     shadow = bar.create_empty_shadow_array(nshutters)
 
     assert shadow.shape == (2000, 101)
-    assert shadow.min() == 0.
-    assert shadow.max() == 0.
+    assert shadow.min() == 0.0
+    assert shadow.max() == 0.0
 
 
 def test_add_first_half_shutter():
@@ -75,7 +74,7 @@ def test_add_first_half_shutter():
     shadow_element = rng.random((501, 101))
     shadow = bar.add_first_half_shutter(shadow, shadow_element)
 
-    assert np.allclose(shadow[0:501, :], shadow_element, atol=1.e-10)
+    assert np.allclose(shadow[0:501, :], shadow_element, atol=1.0e-10)
 
 
 def test_add_next_shutter():
@@ -90,20 +89,21 @@ def test_add_next_shutter():
     shadow[:, :] = dummy_value
     shadow = bar.add_next_shutter(shadow, shadow_element, first_row)
 
-    assert np.allclose(shadow[0:first_row, :], dummy_value, atol=1.e-10)
+    assert np.allclose(shadow[0:first_row, :], dummy_value, atol=1.0e-10)
 
     # This column is the average of 1.7 and shadow_element[0, :].
-    assert np.allclose(shadow[first_row, :],
-                       (dummy_value + shadow_element[0, :]) / 2.,
-                       atol=1.e-9)
+    assert np.allclose(
+        shadow[first_row, :], (dummy_value + shadow_element[0, :]) / 2.0, atol=1.0e-9
+    )
 
     first_row += 1
     last_row = first_row + 500
 
-    assert np.allclose(shadow[first_row:last_row, :], shadow_element[1:, :],
-                       atol=1.e-10)
+    assert np.allclose(
+        shadow[first_row:last_row, :], shadow_element[1:, :], atol=1.0e-10
+    )
 
-    assert np.allclose(shadow[last_row:, :], dummy_value, atol=1.e-10)
+    assert np.allclose(shadow[last_row:, :], dummy_value, atol=1.0e-10)
 
 
 def test_add_last_half_shutter():
@@ -119,40 +119,43 @@ def test_add_last_half_shutter():
     shadow[:, :] = dummy_value
     shadow = bar.add_last_half_shutter(shadow, shadow_element, first_row)
 
-    assert np.allclose(shadow[0:first_row, :], dummy_value, atol=1.e-10)
+    assert np.allclose(shadow[0:first_row, :], dummy_value, atol=1.0e-10)
 
     # This column is the average of 1.3 and shadow_element[0, :].
-    assert np.allclose(shadow[first_row, :],
-                       (dummy_value + shadow_element[0, :]) / 2.,
-                       atol=1.e-9)
+    assert np.allclose(
+        shadow[first_row, :], (dummy_value + shadow_element[0, :]) / 2.0, atol=1.0e-9
+    )
 
     first_row += 1
     last_row = first_row + 500
 
-    assert np.allclose(shadow[first_row:last_row, :], shadow_element[1:, :],
-                       atol=1.e-10)
+    assert np.allclose(
+        shadow[first_row:last_row, :], shadow_element[1:, :], atol=1.0e-10
+    )
 
 
 def test_interpolate():
-    """Test barshadow interpolation.
+    """
+    Test barshadow interpolation.
 
     This was originally a test for a local implementation of a bilinear
     interpolation scheme (`bar_shadow.interpolate`).  The local
     implementation is now replaced by scipy.ndimage.map_coordinates,
-    but this test is retained to verify that the drop-in replacement is valid.
+    but this test is retained to verify that the drop-in replacement is
+    equivalent.
     """
-    d1x1 = np.arange(101 * 1001, dtype=np.float64) / (101. * 1001. - 1.)
+    d1x1 = np.arange(101 * 1001, dtype=np.float64) / (101.0 * 1001.0 - 1.0)
     d1x1 = d1x1.reshape(1001, 101)
     d1x3 = d1x1.copy()
     barshadow_model = datamodels.BarshadowModel(data1x1=d1x1, data1x3=d1x3)
     shutter_elements = bar.create_shutter_elements(barshadow_model)
 
-    shutter_status = "11x101"                   # 6 shutters
+    shutter_status = "11x101"  # 6 shutters
     # shadow will have shape (7 * 500, 101)     # 7 = len(shutter_status) + 1
     shadow = bar.create_shadow(shutter_elements, shutter_status)
 
-    rows = np.arange(0, 3400 * 100 + 1, 10000, dtype=np.float64) / 100.
-    columns = np.arange(0, 3400 * 100 + 1, 10000, dtype=np.float64) / 3400.
+    rows = np.arange(0, 3400 * 100 + 1, 10000, dtype=np.float64) / 100.0
+    columns = np.arange(0, 3400 * 100 + 1, 10000, dtype=np.float64) / 3400.0
     rows = rows.reshape(5, 7)
     columns = columns.reshape(5, 7)
 
@@ -181,10 +184,10 @@ def test_has_uniform_source():
     # assume that the source is extended.
     assert bar.has_uniform_source(slitlet)
 
-    slitlet.source_type = 'POINT'
-    assert not bar.has_uniform_source(slitlet)          # not extended
+    slitlet.source_type = "POINT"
+    assert not bar.has_uniform_source(slitlet)  # not extended
 
-    slitlet.source_type = 'UNKNOWN'
+    slitlet.source_type = "UNKNOWN"
     # Since source_type is not 'POINT', the step will assume that the
     # source is extended.
     assert bar.has_uniform_source(slitlet)

--- a/jwst/barshadow/tests/test_barshadow_step.py
+++ b/jwst/barshadow/tests/test_barshadow_step.py
@@ -1,0 +1,165 @@
+import logging
+import os
+
+import numpy as np
+import pytest
+from stdatamodels.jwst import datamodels
+
+import jwst
+from jwst.assign_wcs import AssignWcsStep
+from jwst.barshadow import BarShadowStep
+from jwst.extract_2d import Extract2dStep
+from jwst.tests.helpers import LogWatcher
+from jwst.assign_wcs.tests.test_nirspec import create_nirspec_mos_file
+
+
+@pytest.fixture
+def log_watcher(monkeypatch):
+    # Set a log watcher to check for a log message at any level
+    # in the barshadow module
+    watcher = LogWatcher("")
+    logger = logging.getLogger("jwst.barshadow.bar_shadow")
+    for level in ["debug", "info", "warning", "error"]:
+        monkeypatch.setattr(logger, level, watcher)
+    return watcher
+
+
+@pytest.fixture(scope="module")
+def nirspec_mos_model():
+    hdul = create_nirspec_mos_file()
+    msa_meta = os.path.join(
+        jwst.__path__[0], *["assign_wcs", "tests", "data", "msa_configuration.fits"]
+    )
+    hdul[0].header["MSAMETFL"] = msa_meta
+    hdul[0].header["MSAMETID"] = 12
+    im = datamodels.ImageModel(hdul)
+    im.data = np.full((2048, 2048), 1.0)
+    im_wcs = AssignWcsStep.call(im)
+    im_ex2d = Extract2dStep.call(im_wcs)
+
+    # add error/variance arrays
+    im_ex2d.slits[0].err = im_ex2d.slits[0].data * 0.1
+    im_ex2d.slits[0].var_rnoise = im_ex2d.slits[0].data * 0.01
+    im_ex2d.slits[0].var_poisson = im_ex2d.slits[0].data * 0.01
+    im_ex2d.slits[0].var_flat = im_ex2d.slits[0].data * 0.01
+
+    yield im_ex2d
+    im_ex2d.close()
+    im_wcs.close()
+    im.close()
+    hdul.close()
+
+
+def test_barshadow_step(nirspec_mos_model):
+    model = nirspec_mos_model.copy()
+    result = BarShadowStep.call(model)
+    assert result.meta.cal_step.barshadow == "COMPLETE"
+
+    # 5 shutter slitlet, correction should not be uniform
+    shadow = result.slits[0].barshadow
+    assert not np.all(shadow == 1)
+
+    # maximum correction value should be 1.0, minimum should be above zero
+    assert np.nanmax(shadow) <= 1.0
+    assert np.nanmin(shadow) > 0.0
+
+    # data should have been divided by barshadow
+    nnan = ~np.isnan(result.slits[0].data)
+    assert np.allclose(
+        result.slits[0].data[nnan] * shadow[nnan], model.slits[0].data[nnan]
+    )
+    assert np.allclose(
+        result.slits[0].err[nnan] * shadow[nnan], model.slits[0].err[nnan]
+    )
+    assert np.allclose(
+        result.slits[0].var_rnoise[nnan] * shadow[nnan] ** 2,
+        model.slits[0].var_rnoise[nnan],
+    )
+    assert np.allclose(
+        result.slits[0].var_poisson[nnan] * shadow[nnan] ** 2,
+        model.slits[0].var_poisson[nnan],
+    )
+    assert np.allclose(
+        result.slits[0].var_flat[nnan] * shadow[nnan] ** 2,
+        model.slits[0].var_flat[nnan],
+    )
+
+    result.close()
+
+
+def test_barshadow_step_zero_length(nirspec_mos_model, log_watcher):
+    model = nirspec_mos_model.copy()
+    model.slits[0].shutter_state = ""
+
+    log_watcher.message = "has zero length, correction skipped"
+    result = BarShadowStep.call(model)
+    log_watcher.assert_seen()
+
+    # correction ran, but is all 1s
+    assert result.meta.cal_step.barshadow == "COMPLETE"
+    assert np.all(result.slits[0].barshadow == 1)
+    result.close()
+
+
+def test_barshadow_step_not_uniform(nirspec_mos_model, log_watcher):
+    model = nirspec_mos_model.copy()
+    model.slits[0].source_type = "POINT"
+
+    log_watcher.message = "source not uniform"
+    result = BarShadowStep.call(model)
+    log_watcher.assert_seen()
+
+    # correction ran, but is all 1s
+    assert result.meta.cal_step.barshadow == "COMPLETE"
+    assert np.all(result.slits[0].barshadow == 1)
+    result.close()
+
+
+def test_barshadow_no_reffile(monkeypatch, nirspec_mos_model):
+    model = nirspec_mos_model.copy()
+    monkeypatch.setattr(
+        BarShadowStep, "get_reference_file", lambda *args, **kwargs: "N/A"
+    )
+
+    result = BarShadowStep.call(model)
+
+    # correction did not run
+    assert result.meta.cal_step.barshadow == "SKIPPED"
+    assert result.slits[0].barshadow.size == 0
+    result.close()
+
+
+def test_barshadow_wrong_exptype():
+    model = datamodels.MultiSlitModel()
+    model.meta.exposure.type = "ANY"
+    model.slits.append(datamodels.SlitModel())
+    result = BarShadowStep.call(model)
+
+    # correction did not run
+    assert result.meta.cal_step.barshadow == "SKIPPED"
+    assert result.slits[0].barshadow.size == 0
+
+    result.close()
+
+
+def test_barshadow_correction_pars(nirspec_mos_model):
+    model = nirspec_mos_model.copy()
+    step = BarShadowStep()
+    result = step.run(model)
+
+    # output data is not the same
+    nnan = ~np.isnan(model.slits[0].data) & ~np.isnan(result.slits[0].data)
+    assert not np.allclose(result.slits[0].data[nnan], model.slits[0].data[nnan])
+
+    # use the computed correction and invert
+    new_step = BarShadowStep()
+    new_step.use_correction_pars = True
+    new_step.correction_pars = step.correction_pars
+    new_step.inverse = True
+    inverse_result = new_step.run(result)
+
+    # output data is the same as input, except that NaNs do not invert
+    assert np.allclose(inverse_result.slits[0].data[nnan], model.slits[0].data[nnan])
+
+    result.close()
+    inverse_result.close()

--- a/jwst/barshadow/tests/test_barshadow_step.py
+++ b/jwst/barshadow/tests/test_barshadow_step.py
@@ -160,6 +160,10 @@ def test_barshadow_correction_pars(nirspec_mos_model):
 
     # output data is the same as input, except that NaNs do not invert
     assert np.allclose(inverse_result.slits[0].data[nnan], model.slits[0].data[nnan])
+    assert np.allclose(inverse_result.slits[0].err[nnan], model.slits[0].err[nnan])
+    assert np.allclose(inverse_result.slits[0].var_rnoise[nnan], model.slits[0].var_rnoise[nnan])
+    assert np.allclose(inverse_result.slits[0].var_poisson[nnan], model.slits[0].var_poisson[nnan])
+    assert np.allclose(inverse_result.slits[0].var_flat[nnan], model.slits[0].var_flat[nnan])
 
     result.close()
     inverse_result.close()

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -679,9 +679,10 @@ def copy_keyword_info(slit, slitname, spec):
         if hasattr(slit, key):
             setattr(spec, key, getattr(slit, key))
 
-    # copy over some attributes only if they are present and not None
+    # Copy over some attributes only if they are present and not None
     copy_populated_attributes = ["source_name", "source_alias",
-                                 "source_type", "stellarity"]
+                                 "source_type", "stellarity",
+                                 "quadrant", "slit_xscale", "slit_yscale"]
     for key in copy_populated_attributes:
         if getattr(slit, key, None) is not None:
             setattr(spec, key, getattr(slit, key))

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -199,6 +199,8 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
         output_model.dither_position = int(slit.dither_position)
         output_model.source_ra = float(slit.source_ra)
         output_model.source_dec = float(slit.source_dec)
+        output_model.slit_xscale = float(slit.slit_xscale)
+        output_model.slit_yscale = float(slit.slit_yscale)
         # for pathloss correction
         output_model.shutter_state = slit.shutter_state
     log.info('set slit_attributes completed')


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3796](https://jira.stsci.edu/browse/JP-3796)
Partially resolves [JP-1341](https://jira.stsci.edu/browse/JP-1341)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
There are two approximations being made in the barshadow correction that are not scaling well to the very long "slitlet" in MOS data taken in longslit mode.

The first is related to [JP-1341](https://jira.stsci.edu/browse/JP-1341): there are two different definitions of slit height. The barshadow correction needs the full bar-to-bar height, but the slit coordinates in the WCS use the open area height. The barshadow code currently hard-codes the ratio between the full and open heights as 1.15, but the value actually varies a bit by quadrant. I'm proposing that we use the equation in [JP-1341](https://jira.stsci.edu/browse/JP-1341) to calculate and store the scale factors in the slit datamodel and use the slit.slit_yscale attribute in the barshadow correction in place of the hard-coded value.  This requires an stdatamodels PR: https://github.com/spacetelescope/stdatamodels/pull/379.  With this change, the bars are much closer to where they need to be for long slit data.

The second approximation is that the barshadow code shifts the slit y-coordinates by the mean value for the bounding box in order to put the center of the constructed shadow at the center of the slit. This is correct if the center of the bounding box is also the center of the middle shutter, but may be a little offset if not. For the long slit test case, it introduced a shift of ~1 pixel. Changing the code to shift the constructed shadow to the fiducial shutter instead of the center of the bounding box fixes this offset as well.

This PR also includes some maintenance and minor refactoring for the barshadow step, to clean up documentation and add unit tests.  I also replaced a local implementation of a bilinear interpolation algorithm with scipy.ndimage.map_coordinates: this was a simple, drop-in replacement that performs identically except that map_coordinates preserves NaNs at the edges of the arrays where there are no valid coordinates.  The old interpolator extended the barshadow correction all the way to the edge of the data array in the dispersion direction.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
