### PR TITLE
JP-3777: Select first and last groups in ramp fitting

### DIFF
--- a/changes/9095.ramp_fitting.rst
+++ b/changes/9095.ramp_fitting.rst
@@ -1,0 +1,4 @@
+Add code to enable users to select firstgroup and lastgroup parameters when performing
+ramp fitting. It works by setting the DO_NOT_USE bit in the GROUPDQ extension for groups
+outside the selected range.  Added a unit test and updated the docs.
+

--- a/docs/jwst/ramp_fitting/arguments.rst
+++ b/docs/jwst/ramp_fitting/arguments.rst
@@ -16,6 +16,11 @@ The ramp fitting step has the following optional arguments that can be set by th
 * ``--int_name``: A string that can be used to override the default name
   for the per-integration product.
 
+* ``--firstgroup``, ``--lastgroup``: A pair of integers that can be used to set the first and last groups
+  to be used in the ramp fitting procedure.  These values are zero-indexed.  If the first group is set to <0,
+  or None, or the last group is set to > (#groups - 1) or None, or the first group is set to > last group,
+  the settings are ignored and the full ramp is fit.  Default values for both parameters are None.
+
 * ``--suppress_one_group``: A boolean to suppress computations for saturated ramps
   with only one good (unsaturated) sample.  The default is set to True to suppress these computations,
   which will compute all values for the ramp the same as if the entire ramp were

--- a/docs/jwst/ramp_fitting/description.rst
+++ b/docs/jwst/ramp_fitting/description.rst
@@ -40,6 +40,10 @@ segment of length greater than one.
 Once all segments have been determined, slopes and variances are determined for
 each one.
 
+The range of groups to be fitted can be limited using the ``--firstgroup`` and
+``--lastgroup`` parameters.  This works by setting the DO_NOT_USE DQ bit in the GROUPDQ
+attribute for all groups outside the range selected.
+
 Pixels are processed simultaneously in blocks using the array-based functionality of numpy.
 The size of the block depends on the image size and the number of groups per
 integration.

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -462,7 +462,7 @@ class RampFitStep(Step):
             # and groups after lastgroup
             firstgroup = self.firstgroup
             lastgroup = self.lastgroup
-            
+
             if firstgroup is None:
                 firstgroup = 0
             if lastgroup is None:

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -562,7 +562,7 @@ class RampFitStep(Step):
 def set_groupdq(firstgroup, lastgroup, ngroups, groupdq, groupdqflags):
     """
     Set the groupdq flags based on the values of firstgroup, lastgroup
-    
+
     Parameters:
     -----------
 

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -468,13 +468,13 @@ class RampFitStep(Step):
             if lastgroup is None:
                 lastgroup = ngroups - 1
             if firstgroup < 0:
-                log.warning(f"first group < 0, reset to 0")
+                log.warning("first group < 0, reset to 0")
                 firstgroup = 0
             if lastgroup >= ngroups:
                 log.warning(f"Last group number >= #groups ({ngroups}), reset to {ngroups-1}")
             if firstgroup >= lastgroup:
                 log.warning(f"firstgroup ({firstgroup}) cannot be >= lastgroup ({lastgroup})")
-                log.warning(f"Group selectors ignored")
+                log.warning("Group selectors ignored")
                 firstgroup = 0
                 lastgroup = ngroups - 1
             if firstgroup > 0:

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -391,6 +391,8 @@ class RampFitStep(Step):
         save_opt = boolean(default=False) # Save optional output
         opt_name = string(default='')
         suppress_one_group = boolean(default=True)  # Suppress saturated ramps with good 0th group
+        firstgroup = integer(default=None)   # Ignore groups before this one (zero indexed)
+        lastgroup = integer(default=None)   # Ignore groups after this one (zero indexed)
         maximum_cores = string(default='1')
         # cores for multiprocessing. Can be an integer, 'half', 'quarter', or 'all'
     """
@@ -414,7 +416,7 @@ class RampFitStep(Step):
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
 
-            # Cork on a copy
+            # Work on a copy
             result = input_model.copy()
 
             max_cores = self.maximum_cores
@@ -455,6 +457,30 @@ class RampFitStep(Step):
                 buffsize //= 10
 
             int_times = result.int_times
+
+            # Set the DO_NOT_USE bit in the groupdq values for groups before firstgroup
+            # and groups after lastgroup
+            firstgroup = self.firstgroup
+            lastgroup = self.lastgroup
+            
+            if firstgroup is None:
+                firstgroup = 0
+            if lastgroup is None:
+                lastgroup = ngroups - 1
+            if firstgroup < 0:
+                log.warning(f"first group < 0, reset to 0")
+                firstgroup = 0
+            if lastgroup >= ngroups:
+                log.warning(f"Last group number >= #groups ({ngroups}), reset to {ngroups-1}")
+            if firstgroup >= lastgroup:
+                log.warning(f"firstgroup ({firstgroup}) cannot be >= lastgroup ({lastgroup})")
+                log.warning(f"Group selectors ignored")
+                firstgroup = 0
+                lastgroup = ngroups - 1
+            if firstgroup > 0:
+                result.groupdq[:,:firstgroup] = np.bitwise_or(result.groupdq[:,:firstgroup], dqflags.group['DO_NOT_USE'])
+            if lastgroup < (ngroups - 1):
+                result.groupdq[:,(lastgroup+1):] = np.bitwise_or(result.groupdq[:,(lastgroup+1):], dqflags.group['DO_NOT_USE'])
 
             # Before the ramp_fit() call, copy the input model ("_W" for weighting)
             # for later reconstruction of the fitting array tuples.

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -12,6 +12,7 @@ from stcal.ramp_fitting.utils import LARGE_VARIANCE_THRESHOLD
 from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import dqflags
 
+
 from ..stpipe import Step
 
 from ..lib import reffile_utils
@@ -21,10 +22,6 @@ import warnings
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-
-
-
-__all__ = ["RampFitStep"]
 
 
 def get_reference_file_subarrays(model, readnoise_model, gain_model, nframes):
@@ -462,25 +459,10 @@ class RampFitStep(Step):
             # and groups after lastgroup
             firstgroup = self.firstgroup
             lastgroup = self.lastgroup
+            groupdqflags = dqflags.group
 
-            if firstgroup is None:
-                firstgroup = 0
-            if lastgroup is None:
-                lastgroup = ngroups - 1
-            if firstgroup < 0:
-                log.warning("first group < 0, reset to 0")
-                firstgroup = 0
-            if lastgroup >= ngroups:
-                log.warning(f"Last group number >= #groups ({ngroups}), reset to {ngroups-1}")
-            if firstgroup >= lastgroup:
-                log.warning(f"firstgroup ({firstgroup}) cannot be >= lastgroup ({lastgroup})")
-                log.warning("Group selectors ignored")
-                firstgroup = 0
-                lastgroup = ngroups - 1
-            if firstgroup > 0:
-                result.groupdq[:,:firstgroup] = np.bitwise_or(result.groupdq[:,:firstgroup], dqflags.group['DO_NOT_USE'])
-            if lastgroup < (ngroups - 1):
-                result.groupdq[:,(lastgroup+1):] = np.bitwise_or(result.groupdq[:,(lastgroup+1):], dqflags.group['DO_NOT_USE'])
+            if firstgroup is not None or lastgroup is not None:
+                set_groupdq(firstgroup, lastgroup, ngroups, result.groupdq, groupdqflags)
 
             # Before the ramp_fit() call, copy the input model ("_W" for weighting)
             # for later reconstruction of the fitting array tuples.
@@ -576,3 +558,45 @@ class RampFitStep(Step):
         del result
 
         return out_model, int_model
+
+def set_groupdq(firstgroup, lastgroup, ngroups, groupdq, groupdqflags):
+    """
+    Set the groupdq flags based on the values of firstgroup, lastgroup
+    
+    Parameters:
+    -----------
+
+    firstgroup : int or None
+        The first group to be used in the ramp fitting
+
+    lastgroup : int or None
+        The last group to be used in the ramp fitting
+
+    ngroups : int
+        The number of groups in the ramp
+
+    groupdq : ndarray
+        The groupdq array to be modified in place
+
+    groupdqflags : dict
+        The groupdq flags dict
+
+    """
+    if firstgroup is None:
+        firstgroup = 0
+    if lastgroup is None:
+        lastgroup = ngroups - 1
+    if firstgroup < 0:
+        log.warning("first group < 0, reset to 0")
+        firstgroup = 0
+    if lastgroup >= ngroups:
+        log.warning(f"Last group number >= #groups ({ngroups}), reset to {ngroups-1}")
+    if firstgroup >= lastgroup:
+        log.warning(f"firstgroup ({firstgroup}) cannot be >= lastgroup ({lastgroup})")
+        log.warning("Group selectors ignored")
+        firstgroup = 0
+        lastgroup = ngroups - 1
+    if firstgroup > 0:
+        groupdq[:,:firstgroup] = np.bitwise_or(groupdq[:,:firstgroup], groupdqflags['DO_NOT_USE'])
+    if lastgroup < (ngroups - 1):
+        groupdq[:,(lastgroup+1):] = np.bitwise_or(groupdq[:,(lastgroup+1):], groupdqflags['DO_NOT_USE'])

--- a/jwst/ramp_fitting/tests/test_ramp_fit_step.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_step.py
@@ -258,6 +258,19 @@ def test_int_times2(generate_miri_reffiles, setup_inputs):
 
     assert len(cube_model.int_times) == nints
 
+def test_set_groups(generate_miri_reffiles, setup_inputs):
+    # Test results when using the firstgroup and lastgroup options
+    ngroups = 20
+    rampmodel, gdq, rnmodel, pixdq, err, gain = setup_inputs(ngroups=ngroups)
+    # Set up data array as group# squared
+    # This has the property that the slope=(firstgroup+lastgroup)
+    squares = np.array([k*k for k in range(ngroups)],dtype=np.float32)
+    rampmodel.data[0,:] = squares[:, np.newaxis, np.newaxis]
+    firstgroup = 3
+    lastgroup = 11
+    slopes, cubemodel = RampFitStep.call(rampmodel, override_gain=gain, override_readnoise=rnmodel,
+                                         firstgroup=firstgroup, lastgroup=lastgroup)
+    np.testing.assert_allclose(slopes.data, firstgroup+lastgroup, rtol=1e-7)
 
 def one_group_suppressed(nints, suppress, setup_inputs):
     """


### PR DESCRIPTION


Added a unit test and updated docs

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3777](https://jira.stsci.edu/browse/JP-3777)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8872

<!-- describe the changes comprising this PR here -->
This PR addresses JP-3777.  It enables users to select firstgroup and lastgroup parameters when performing
ramp fitting.  It works by setting the DO_NOT_USE bit in the GROUPDQ extension for groups outside the selected range.
Added a unit test and updated the docs.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?  No
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
