### PR TITLE
JP-3116: Do not create observation-only Level 2 associations if part of a background candidate

### DIFF
--- a/changes/9098.associations.rst
+++ b/changes/9098.associations.rst
@@ -1,0 +1,2 @@
+Prevent creation of observation candidate associations when science exposure
+is also part of background association candidate, but only when the DMS flag is enabled.

--- a/jwst/associations/generator/generate_per_candidate.py
+++ b/jwst/associations/generator/generate_per_candidate.py
@@ -187,6 +187,9 @@ def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_de
         for i, row in enumerate(pool_cid):
             if 'background' in row['asn_candidate'] and row['bkgdtarg'] == 'f':
                 skip_rows.append(i)
+        logger.debug(f"Dropping {len(skip_rows)} exposures from pool - observation "
+                     f"candidate type does not allow association generation when a "
+                     f"background candidate is present.")
         pool_cid.remove_rows(skip_rows)
 
     pool_cid['asn_candidate'] = [f"[('{cid}', '{ctype}')]"] * len(pool_cid)

--- a/jwst/associations/generator/generate_per_candidate.py
+++ b/jwst/associations/generator/generate_per_candidate.py
@@ -142,7 +142,7 @@ def generate_per_candidate(pool, rule_defs, candidate_ids=None, all_candidates=T
 
 
 def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_default=False,
-                          DMS_enabled=False):
+                          dms_enabled=False):
     """Generate associations based on a candidate ID
 
     Parameters
@@ -165,7 +165,7 @@ def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_de
     ignore_default : bool
         Ignore the default rules. Use only the user-specified ones.
 
-    DMS_enabled : bool
+    dms_enabled : bool
         Flag for DMS processing, true if command-line argument '--DMS' was used.
 
     Returns
@@ -182,7 +182,7 @@ def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_de
     # DMS processing excludes generation of o-type candidates for science exposures
     # with linked backgrounds, i.e. without the background member present, as it
     # would be for c-type background association candidates.
-    if DMS_enabled and 'observation' in ctype:
+    if dms_enabled and 'observation' in ctype:
         skip_rows = []
         for i, row in enumerate(pool_cid):
             if 'background' in row['asn_candidate'] and row['bkgdtarg'] == 'f':

--- a/jwst/associations/generator/generate_per_candidate.py
+++ b/jwst/associations/generator/generate_per_candidate.py
@@ -14,7 +14,7 @@ logger.addHandler(logging.NullHandler())
 
 def generate_per_candidate(pool, rule_defs, candidate_ids=None, all_candidates=True, discover=False,
                            version_id=None, finalize=True, merge=False, ignore_default=False,
-                           DMS_enabled=False):
+                           dms_enabled=False):
     """Generate associations in the pool according to the rules.
 
     Parameters
@@ -49,7 +49,7 @@ def generate_per_candidate(pool, rule_defs, candidate_ids=None, all_candidates=T
     ignore_default : bool
         Ignore the default rules. Use only the user-specified ones.
 
-    DMS_enabled : bool
+    dms_enabled : bool
         Flag for DMS processing, true if command-line argument '--DMS' was used.
 
     Returns
@@ -91,7 +91,7 @@ def generate_per_candidate(pool, rule_defs, candidate_ids=None, all_candidates=T
             rule_defs,
             version_id=version_id,
             ignore_default=ignore_default,
-            DMS_enabled=DMS_enabled
+            dms_enabled=dms_enabled
         )
 
         # Add to the list

--- a/jwst/associations/generator/generate_per_candidate.py
+++ b/jwst/associations/generator/generate_per_candidate.py
@@ -13,7 +13,8 @@ logger.addHandler(logging.NullHandler())
 
 
 def generate_per_candidate(pool, rule_defs, candidate_ids=None, all_candidates=True, discover=False,
-                           version_id=None, finalize=True, merge=False, ignore_default=False):
+                           version_id=None, finalize=True, merge=False, ignore_default=False,
+                           DMS_enabled=False):
     """Generate associations in the pool according to the rules.
 
     Parameters
@@ -47,6 +48,9 @@ def generate_per_candidate(pool, rule_defs, candidate_ids=None, all_candidates=T
 
     ignore_default : bool
         Ignore the default rules. Use only the user-specified ones.
+
+    DMS_enabled : bool
+        Flag for DMS processing, true if command-line argument '--DMS' was used.
 
     Returns
     -------
@@ -86,7 +90,8 @@ def generate_per_candidate(pool, rule_defs, candidate_ids=None, all_candidates=T
             pool,
             rule_defs,
             version_id=version_id,
-            ignore_default=ignore_default
+            ignore_default=ignore_default,
+            DMS_enabled=DMS_enabled
         )
 
         # Add to the list
@@ -136,7 +141,8 @@ def generate_per_candidate(pool, rule_defs, candidate_ids=None, all_candidates=T
     return finalized_asns
 
 
-def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_default=False):
+def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_default=False,
+                          DMS_enabled=False):
     """Generate associations based on a candidate ID
 
     Parameters
@@ -159,6 +165,9 @@ def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_de
     ignore_default : bool
         Ignore the default rules. Use only the user-specified ones.
 
+    DMS_enabled : bool
+        Flag for DMS processing, true if command-line argument '--DMS' was used.
+
     Returns
     -------
     associations : [Association[,...]]
@@ -169,6 +178,17 @@ def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_de
 
     # Get the pool
     pool_cid = pool_from_candidate(pool, cid)
+
+    # DMS processing excludes generation of o-type candidates for science exposures
+    # with linked backgrounds, i.e. without the background member present, as it
+    # would be for c-type background association candidates.
+    if DMS_enabled and 'observation' in ctype:
+        skip_rows = []
+        for i, row in enumerate(pool_cid):
+            if 'background' in row['asn_candidate'] and row['bkgdtarg'] == 'f':
+                skip_rows.append(i)
+        pool_cid.remove_rows(skip_rows)
+
     pool_cid['asn_candidate'] = [f"[('{cid}', '{ctype}')]"] * len(pool_cid)
     logger.info(f'Length of pool for {cid}: {len(pool_cid)}')
 

--- a/jwst/associations/load_as_asn.py
+++ b/jwst/associations/load_as_asn.py
@@ -3,12 +3,13 @@
 from functools import partial
 from os import path as os_path
 
-from ..associations import (
+from jwst.associations import (
     Association,
     AssociationRegistry,
-    libpath,
-    load_asn
+    libpath
 )
+
+from jwst.associations.load_asn import load_asn
 from ..associations.asn_from_list import asn_from_list
 from ..associations.lib.rules_level2_base import DMSLevel2bBase
 

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -184,7 +184,8 @@ class Main():
                 version_id=parsed.version_id,
                 finalize=not parsed.no_finalize,
                 merge=parsed.merge,
-                ignore_default=parsed.ignore_default
+                ignore_default=parsed.ignore_default,
+                DMS_enabled=parsed.DMS_enabled
             )
 
 

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -185,7 +185,7 @@ class Main():
                 finalize=not parsed.no_finalize,
                 merge=parsed.merge,
                 ignore_default=parsed.ignore_default,
-                DMS_enabled=parsed.DMS_enabled
+                dms_enabled=parsed.DMS_enabled
             )
 
 

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -153,6 +153,18 @@ SPECIAL_POOLS = {
         'xfail': None,
         'slow': False,
     },
+    # This pair of pools test the DMS flag usage to prevent o-type asns when
+    # a background c-type candidate is attached to the science exposure.
+    'jw04225_20241213t150701_pool': {
+        'args': ['-i', 'o001', 'o002'],
+        'xfail': None,
+        'slow': False,
+    },
+    'jw04225_20241213t150701DMS_pool': {
+        'args': ['-i', 'o001', 'o002', '--DMS'],
+        'xfail': None,
+        'slow': False,
+    },
     'jw80600_20171108T041522_pool': {
         'args': [],
         'xfail': 'PR #3450',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3116](https://jira.stsci.edu/browse/JP-3116)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #7819 

<!-- describe the changes comprising this PR here -->
This PR adds conditional behavior for association generation for DMS; when generating associations for a observation candidate ("o-type"), any science exposures belonging to a background ("c-type") candidate are dropped from consideration. This PR propagates the `DMS` flag of `asn_generate` down to the appropriate function where the new functionality was added. 

Currently in draft; this PR as currently written also modifies level 3 association behavior, which is not strictly part of the JIRA ticket request.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
