### PR TITLE
JP-3848 Update S_REGION for MIRI LRS fixed slit data 

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -73,11 +73,12 @@ def load_wcs(input_model, reference_files={}, nrs_slit_y_range=None):
 
         if output_model.meta.exposure.type.lower() not in exclude_types:
             imaging_types = IMAGING_TYPES.copy()
-            imaging_lrs_types = ['mir_lrs-fixedslit']
+            imaging_lrs_types = ['mir_lrs-fixedslit'] # keep it separate
             imaging_types.update(['mir_lrs-slitless'])
             if output_model.meta.exposure.type.lower() in imaging_lrs_types:
-                print('*** Going to update the s_region value for lrs fixed slit')    
-                update_s_region_lrs(output_model)
+                # uses slits corners in V2, V3 that are read in from the
+                # lrs specwcs reference file
+                update_s_region_lrs(output_model, reference_files)
             elif output_model.meta.exposure.type.lower() in IMAGING_TYPES:
                 try:
                     update_s_region_imaging(output_model)

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -2,7 +2,8 @@ import logging
 import importlib
 from gwcs.wcs import WCS
 from .util import (update_s_region_spectral, update_s_region_imaging,
-                   update_s_region_nrs_ifu, update_s_region_mrs)
+                   update_s_region_nrs_ifu, update_s_region_mrs,
+                   update_s_region_lrs)
 from ..lib.exposure_types import IMAGING_TYPES, SPEC_TYPES, NRS_LAMP_MODE_SPEC_TYPES
 from ..lib.dispaxis import get_dispersion_direction
 from ..lib.wcs_utils import get_wavelengths
@@ -72,8 +73,12 @@ def load_wcs(input_model, reference_files={}, nrs_slit_y_range=None):
 
         if output_model.meta.exposure.type.lower() not in exclude_types:
             imaging_types = IMAGING_TYPES.copy()
-            imaging_types.update(['mir_lrs-fixedslit', 'mir_lrs-slitless'])
-            if output_model.meta.exposure.type.lower() in imaging_types:
+            imaging_lrs_types = ['mir_lrs-fixedslit']
+            imaging_types.update(['mir_lrs-slitless'])
+            if output_model.meta.exposure.type.lower() in imaging_lrs_types:
+                print('*** Going to update the s_region value for lrs fixed slit')    
+                update_s_region_lrs(output_model)
+            elif output_model.meta.exposure.type.lower() in IMAGING_TYPES:
                 try:
                     update_s_region_imaging(output_model)
                 except Exception as exc:

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -95,6 +95,7 @@ class AssignWcsStep(Step):
                     message = "MSA metadata file (MSAMETFL) is required for NRS_MSASPEC exposures."
                     log.error(message)
                     raise MSAFileError(message)
+                
             slit_y_range = [self.slit_y_low, self.slit_y_high]
             result = load_wcs(input_model, reference_file_names, slit_y_range)
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -277,7 +277,6 @@ def lrs_xytoabl(input_model, reference_files):
     y0 = refmodel.wave_table.y0
     x1 = refmodel.wave_table.x1
     y2 = refmodel.wave_table.y2
-
     refmodel.close()
     # If in fixed slit mode, define the bounding box using the corner locations provided in
     # the CDP reference file.

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -12,7 +12,7 @@ from gwcs import selector
 
 from stdatamodels.jwst.datamodels import (DistortionModel, FilteroffsetModel,
                                           DistortionMRSModel, WavelengthrangeModel,
-                                          RegionsModel, SpecwcsModel, MIRILrsModel)
+                                          RegionsModel, SpecwcsModel, MiriLRSSpecwcsModel)
 from stdatamodels.jwst.transforms.models import (MIRI_AB2Slice, IdealToV2V3)
 
 from . import pointing
@@ -251,7 +251,7 @@ def lrs_xytoabl(input_model, reference_files):
     else:
         subarray_dist = distortion
 
-    refmodel = MIRILrsModel(reference_files['specwcs'])
+    refmodel = MiriLRSSpecwcsModel(reference_files['specwcs'])
     if input_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
         zero_point = refmodel.meta.x_ref - 1, refmodel.meta.y_ref - 1
     elif input_model.meta.exposure.type.lower() == 'mir_lrs-slitless':
@@ -270,13 +270,13 @@ def lrs_xytoabl(input_model, reference_files):
     # centroid trace along the detector in pixels relative to nominal location.
     # x0,y0(ul) x1,y1 (ur) x2,y2(lr) x3,y3(ll) define corners of the box within which the distortion
     # and wavelength calibration was derived
-    xcen = refmodel.wave_table.x_center
-    ycen = refmodel.wave_table.y_center
-    wavetab = refmodel.wave_table.wavelength
-    x0 = refmodel.wave_table.x0
-    y0 = refmodel.wave_table.y0
-    x1 = refmodel.wave_table.x1
-    y2 = refmodel.wave_table.y2
+    xcen = refmodel.wavetable.x_center
+    ycen = refmodel.wavetable.y_center
+    wavetab = refmodel.wavetable.wavelength
+    x0 = refmodel.wavetable.x0
+    y0 = refmodel.wavetable.y0
+    x1 = refmodel.wavetable.x1
+    y2 = refmodel.wavetable.y2
     refmodel.close()
     # If in fixed slit mode, define the bounding box using the corner locations provided in
     # the CDP reference file.
@@ -399,7 +399,7 @@ def lrs_abltov2v3l(input_model, reference_files):
     else:
         subarray_dist = distortion
 
-    refmodel = MIRILrsModel(reference_files['specwcs'])
+    refmodel = MiriLRSSpecwcsModel(reference_files['specwcs'])
     if input_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
         zero_point = refmodel.meta.x_ref - 1, refmodel.meta.y_ref - 1
     elif input_model.meta.exposure.type.lower() == 'mir_lrs-slitless':

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -260,6 +260,7 @@ def lrs_xytoabl(input_model, reference_files):
         # Transform to slitless subarray from full array
         zero_point = subarray2full.inverse(zero_point[0], zero_point[1])
 
+
     # Figure out the typical along-slice pixel scale at the center of the slit
     v2_cen, v3_cen = subarray_dist(zero_point[0], zero_point[1])
     v2_off, v3_off = subarray_dist(zero_point[0] + 1, zero_point[1])
@@ -277,6 +278,7 @@ def lrs_xytoabl(input_model, reference_files):
     x1 = refmodel.wave_table.x1
     y2 = refmodel.wave_table.y2
 
+    refmodel.close()
     # If in fixed slit mode, define the bounding box using the corner locations provided in
     # the CDP reference file.
     if input_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
@@ -407,6 +409,7 @@ def lrs_abltov2v3l(input_model, reference_files):
         # Transform to slitless subarray from full array
         zero_point = subarray2full.inverse(zero_point[0], zero_point[1])
 
+    refmodel.close()
     # Figure out the typical along-slice pixel scale at the center of the slit
     v2_cen, v3_cen = subarray_dist(zero_point[0], zero_point[1])
     v2_off, v3_off = subarray_dist(zero_point[0] + 1, zero_point[1])

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -307,9 +307,9 @@ def lrs_xytoabl(input_model, reference_files):
     # This function will give slit dX as a function of Y subarray pixel value
     dxmodel = models.Tabular1D(lookup_table=xshiftref, points=ycen_subarray, name='xshiftref',
                                  bounds_error=False, fill_value=np.nan)
+    #if input_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
+    #    bb_sub = (bb_sub[0], (dxmodel.points[0].min(), dxmodel.points[0].max()))
 
-    if input_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
-        bb_sub = (bb_sub[0], (dxmodel.points[0].min(), dxmodel.points[0].max()))
     # Fit for the wavelength as a function of Y
     # Reverse the vectors so that yinv is increasing (needed for spline fitting function)
     # Spline fit with enforced smoothness

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -307,6 +307,7 @@ def lrs_xytoabl(input_model, reference_files):
     # This function will give slit dX as a function of Y subarray pixel value
     dxmodel = models.Tabular1D(lookup_table=xshiftref, points=ycen_subarray, name='xshiftref',
                                  bounds_error=False, fill_value=np.nan)
+    # remove commented out how after testing
     #if input_model.meta.exposure.type.lower() == 'mir_lrs-fixedslit':
     #    bb_sub = (bb_sub[0], (dxmodel.points[0].min(), dxmodel.points[0].max()))
 

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -19,7 +19,7 @@ from gwcs import utils as gwutils
 from stpipe.exceptions import StpipeExitException
 from stcal.alignment.util import compute_s_region_keyword, compute_s_region_imaging
 
-from stdatamodels.jwst.datamodels import WavelengthrangeModel, MIRILrsModel
+from stdatamodels.jwst.datamodels import WavelengthrangeModel, MiriLRSSpecwcsModel
 from stdatamodels.jwst.transforms.models import GrismObject
 
 from ..lib.catalog_utils import SkyObject
@@ -813,7 +813,7 @@ def update_s_region_lrs(model, reference_files):
     reference file`.
     """
 
-    refmodel = MIRILrsModel(reference_files['specwcs'])
+    refmodel = MiriLRSSpecwcsModel(reference_files['specwcs'])
     
     v2vert1 = refmodel.meta.v2_vert1
     v2vert2 = refmodel.meta.v2_vert2

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -814,7 +814,7 @@ def update_s_region_lrs(model, reference_files):
     """
 
     refmodel = MIRILrsModel(reference_files['specwcs'])
-
+    
     v2vert1 = refmodel.meta.v2_vert1
     v2vert2 = refmodel.meta.v2_vert2
     v2vert3 = refmodel.meta.v2_vert3

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -19,7 +19,7 @@ from gwcs import utils as gwutils
 from stpipe.exceptions import StpipeExitException
 from stcal.alignment.util import compute_s_region_keyword, compute_s_region_imaging
 
-from stdatamodels.jwst.datamodels import WavelengthrangeModel
+from stdatamodels.jwst.datamodels import WavelengthrangeModel, MIRILrsModel
 from stdatamodels.jwst.transforms.models import GrismObject
 
 from ..lib.catalog_utils import SkyObject
@@ -807,80 +807,36 @@ def update_s_region_imaging(model):
         model.meta.wcsinfo.s_region = s_region
 
 
-def update_s_region_lrs(model):
+def update_s_region_lrs(model, reference_files):
     """
     Update the ``S_REGION`` keyword using V2,V3 of the slit corners from reference file`.
     """
-    print('*********In update_s_region_lrs')
-    s_region_org = model.meta.wcsinfo.s_region
-    print('original s region', s_region_org)
-    spatial_box = s_region_org
-    s = spatial_box.split(' ')
-    a1 = float(s[3])
-    b1 = float(s[4])
-    a2 = float(s[5])
-    b2 = float(s[6])
-    a3 = float(s[7])
-    b3 = float(s[8])
-    a4 = float(s[9])
-    b4 = float(s[10])
 
-    #s_region = compute_s_region_imaging(model.meta.wcs, shape=model.data.shape, center=False)
-    #print(s_region)
-    #spatial_box = s_region
-    #s = spatial_box.split(' ')
-    #na1 = float(s[3])
-    #nb1 = float(s[4])
-    #na2 = float(s[5])
-    #nb2 = float(s[6])
-    #na3 = float(s[7])
-    #nb3 = float(s[8])
-    #na4 = float(s[9])
-    #nb4 = float(s[10])
+    refmodel = MIRILrsModel(reference_files['specwcs'])
 
-    #print((a1 - na1)*3600)
-    #print((a2 - na2)*3600)
-    #print((a3 - na3)*3600)
-    #print((a4 - na4)*3600)
-    #print((b1 - nb1)*3600)
-    #print((b2 - nb2)*3600)
-    #print((b3 - nb3)*3600)
-    #print((b4 - nb4)*3600)
-    
-    v2,v3= np.array([-412.54598854, -412.50298855,-417.21103301, -417.25301145]),\
-        np.array([-401.01798362, -400.50498252, -400.11702824, -400.63101748])    
+    v2vert1 = refmodel.meta.v2_vert1
+    v2vert2 = refmodel.meta.v2_vert2
+    v2vert3 = refmodel.meta.v2_vert3
+    v2vert4 = refmodel.meta.v2_vert4
 
-    #lam = 0
-    #s = model.meta.wcs.transform('v2v3', 'world', v2, v3, lam)
-    #print(s)
-    lam = 7.6
-    lam = 0.0
+    v3vert1 = refmodel.meta.v3_vert1
+    v3vert2 = refmodel.meta.v3_vert2
+    v3vert3 = refmodel.meta.v3_vert3
+    v3vert4 = refmodel.meta.v3_vert4
+
+    v2 = [v2vert1, v2vert2, v2vert3, v2vert4]
+    v3 = [v3vert1, v3vert2, v3vert3, v3vert4]
+
+    lam = None # wavelength does not matter for s region
     s = model.meta.wcs.transform('v2v3', 'world', v2, v3, lam)
     a = s[0]
     b = s[1]
-    
-    print(a)
-    print(b)
-    print('Difference of v2,v3 values to original')
-    print( (a1 - a[0])*3600)
-    print( (a2 - a[1])*3600)
-    print( (a3 - a[2])*3600)
-    print( (a4 - a[3])*3600)
-    print((b1 - b[0])*3600)
-    print((b2 - b[1])*3600)
-    print((b3 - b[2])*3600)
-    print((b4 - b[3])*3600)
-
     footprint = np.array([[a[0], b[0]],
                           [a[1], b[1]],
                           [a[2], b[2]],
                           [a[3], b[3]]])
 
     update_s_region_keyword(model, footprint)
-    #print(model.meta.wcsinfo.s_region)
-    #if s_region is not None:
-    #    model.meta.wcsinfo.s_region = s_region
-
 
 def compute_footprint_spectral(model):
     """

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -807,6 +807,81 @@ def update_s_region_imaging(model):
         model.meta.wcsinfo.s_region = s_region
 
 
+def update_s_region_lrs(model):
+    """
+    Update the ``S_REGION`` keyword using V2,V3 of the slit corners from reference file`.
+    """
+    print('*********In update_s_region_lrs')
+    s_region_org = model.meta.wcsinfo.s_region
+    print('original s region', s_region_org)
+    spatial_box = s_region_org
+    s = spatial_box.split(' ')
+    a1 = float(s[3])
+    b1 = float(s[4])
+    a2 = float(s[5])
+    b2 = float(s[6])
+    a3 = float(s[7])
+    b3 = float(s[8])
+    a4 = float(s[9])
+    b4 = float(s[10])
+
+    #s_region = compute_s_region_imaging(model.meta.wcs, shape=model.data.shape, center=False)
+    #print(s_region)
+    #spatial_box = s_region
+    #s = spatial_box.split(' ')
+    #na1 = float(s[3])
+    #nb1 = float(s[4])
+    #na2 = float(s[5])
+    #nb2 = float(s[6])
+    #na3 = float(s[7])
+    #nb3 = float(s[8])
+    #na4 = float(s[9])
+    #nb4 = float(s[10])
+
+    #print((a1 - na1)*3600)
+    #print((a2 - na2)*3600)
+    #print((a3 - na3)*3600)
+    #print((a4 - na4)*3600)
+    #print((b1 - nb1)*3600)
+    #print((b2 - nb2)*3600)
+    #print((b3 - nb3)*3600)
+    #print((b4 - nb4)*3600)
+    
+    v2,v3= np.array([-412.54598854, -412.50298855,-417.21103301, -417.25301145]),\
+        np.array([-401.01798362, -400.50498252, -400.11702824, -400.63101748])    
+
+    #lam = 0
+    #s = model.meta.wcs.transform('v2v3', 'world', v2, v3, lam)
+    #print(s)
+    lam = 7.6
+    lam = 0.0
+    s = model.meta.wcs.transform('v2v3', 'world', v2, v3, lam)
+    a = s[0]
+    b = s[1]
+    
+    print(a)
+    print(b)
+    print('Difference of v2,v3 values to original')
+    print( (a1 - a[0])*3600)
+    print( (a2 - a[1])*3600)
+    print( (a3 - a[2])*3600)
+    print( (a4 - a[3])*3600)
+    print((b1 - b[0])*3600)
+    print((b2 - b[1])*3600)
+    print((b3 - b[2])*3600)
+    print((b4 - b[3])*3600)
+
+    footprint = np.array([[a[0], b[0]],
+                          [a[1], b[1]],
+                          [a[2], b[2]],
+                          [a[3], b[3]]])
+
+    update_s_region_keyword(model, footprint)
+    #print(model.meta.wcsinfo.s_region)
+    #if s_region is not None:
+    #    model.meta.wcsinfo.s_region = s_region
+
+
 def compute_footprint_spectral(model):
     """
     Determine spatial footprint for spectral observations using the instrument model.

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -809,7 +809,8 @@ def update_s_region_imaging(model):
 
 def update_s_region_lrs(model, reference_files):
     """
-    Update the ``S_REGION`` keyword using V2,V3 of the slit corners from reference file`.
+    Update the ``S_REGION`` keyword using V2,V3 of the slit corners from 
+    reference file`.
     """
 
     refmodel = MIRILrsModel(reference_files['specwcs'])
@@ -824,10 +825,17 @@ def update_s_region_lrs(model, reference_files):
     v3vert3 = refmodel.meta.v3_vert3
     v3vert4 = refmodel.meta.v3_vert4
 
+    refmodel.close()
     v2 = [v2vert1, v2vert2, v2vert3, v2vert4]
     v3 = [v3vert1, v3vert2, v3vert3, v3vert4]
 
-    lam = None # wavelength does not matter for s region
+    if (any(elem is None for elem in v2) or
+        any(elem is None for elem in v3)):
+        log.info("The V2,V3 coordinates of the MIRI LRS-Fixed slit contains NaN values.")
+        log.info("The s_region will not be updated")      
+    
+    lam = 7.0 # wavelength does not matter for s region assign a value in
+              # wavelength of MIRI LRS
     s = model.meta.wcs.transform('v2v3', 'world', v2, v3, lam)
     a = s[0]
     b = s[1]

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -7,7 +7,7 @@ from stdatamodels.jwst import datamodels
 
 from jwst.stpipe import Step
 from jwst.extract_1d import Extract1dStep
-
+from stcal.alignment import util
 
 @pytest.fixture(scope="module")
 def run_pipeline(rtdata_module):
@@ -87,3 +87,12 @@ def test_miri_lrs_slit_wcs(run_pipeline, rtdata_module, fitsdiff_default_kwargs)
         xtruth, ytruth = im_truth.meta.wcs.backward_transform(ratruth, dectruth, lamtruth)
         assert_allclose(xtest, xtruth)
         assert_allclose(ytest, ytruth)
+
+        # Test the s_region. S_region is formed by footprint which contains
+        # floats rather than a string. Test footprint
+        sregion = im.meta.wcsinfo.s_region
+        sregion_test = im_truth.meta.wcsinfo.s_region
+        footprint=util._sregion_to_footprint(sregion)
+        footprint_test = util._sregion_to_footprint(sregion_test)
+        assert_allclose(footprint, footprint_test)
+        

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -158,14 +158,12 @@ class ResampleSpecData(ResampleData):
             # Any other customizations (crpix, crval, rotation) are ignored.
             if resample_utils.is_sky_like(input_models[0].meta.wcs.output_frame):
                 if input_models[0].meta.instrument.name != "NIRSPEC":
-                    print('**** GOT HERE')
                     self.output_wcs = self.build_interpolated_output_wcs(input_models)
                 else:
                     self.output_wcs = self.build_nirspec_output_wcs(input_models)
             else:
                 self.output_wcs = self.build_nirspec_lamp_output_wcs(input_models)
 
-            print('already called interpolated_output')
             # Use the nominal output pixel area in sr if available,
             # scaling for user-set pixel_scale ratio if needed.
             if nominal_area is not None:
@@ -745,7 +743,6 @@ class ResampleSpecData(ResampleData):
         output_wcs.pixel_shape = output_array_size
         bounding_box = resample_utils.wcs_bbox_from_shape(output_array_size[::-1])
         output_wcs.bounding_box = bounding_box
-        print('bounding box', bounding_box)
         
         return output_wcs
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -158,12 +158,14 @@ class ResampleSpecData(ResampleData):
             # Any other customizations (crpix, crval, rotation) are ignored.
             if resample_utils.is_sky_like(input_models[0].meta.wcs.output_frame):
                 if input_models[0].meta.instrument.name != "NIRSPEC":
+                    print('**** GOT HERE')
                     self.output_wcs = self.build_interpolated_output_wcs(input_models)
                 else:
                     self.output_wcs = self.build_nirspec_output_wcs(input_models)
             else:
                 self.output_wcs = self.build_nirspec_lamp_output_wcs(input_models)
 
+            print('already called interpolated_output')
             # Use the nominal output pixel area in sr if available,
             # scaling for user-set pixel_scale ratio if needed.
             if nominal_area is not None:
@@ -187,6 +189,7 @@ class ResampleSpecData(ResampleData):
         """ Create a new blank model and update it's meta with info from ``ref_input_model``. """
         output_model = datamodels.SlitModel(None)
 
+        print('Going to updated the model')
         # update meta data and wcs
         if ref_input_model is not None:
             output_model.update(ref_input_model)
@@ -742,7 +745,8 @@ class ResampleSpecData(ResampleData):
         output_wcs.pixel_shape = output_array_size
         bounding_box = resample_utils.wcs_bbox_from_shape(output_array_size[::-1])
         output_wcs.bounding_box = bounding_box
-
+        print('bounding box', bounding_box)
+        
         return output_wcs
 
     def build_nirspec_lamp_output_wcs(self, input_models):

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -146,7 +146,7 @@ class ResampleSpecStep(Step):
             s_region_list = []
             with drizzled_library:
                 for i, model in enumerate(drizzled_library):
-                    self.update_slit_metadata(model)
+s                    self.update_slit_metadata(model)
                     s_region_list.append(model.meta.s_region)
                     update_s_region_spectral(model)
                     result.slits.append(model)
@@ -233,13 +233,12 @@ class ResampleSpecStep(Step):
             result.meta.resample.pixel_scale_ratio = resamp.pscale_ratio
         result.meta.resample.pixfrac = self.pixfrac
         self.update_slit_metadata(result)
-        print(' Updating the spectral region')
 
         if input_models[0].meta.exposure.type.lower() == 'mir_lrs-fixedslit':
             s_region_list = []
             for model in input_models:
                 s_region_list.append(model.meta.wcsinfo.s_region)
-            
+            # Test code for MIRI LRS - does not work as it is written
             combined_footprint = resample_utils.combine_s_regions_lrs(s_region_list)
             update_s_region_keyword(result, combined_footprint)
         else:

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -146,7 +146,7 @@ class ResampleSpecStep(Step):
             s_region_list = []
             with drizzled_library:
                 for i, model in enumerate(drizzled_library):
-s                    self.update_slit_metadata(model)
+                    self.update_slit_metadata(model)
                     s_region_list.append(model.meta.s_region)
                     update_s_region_spectral(model)
                     result.slits.append(model)

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -10,7 +10,8 @@ from jwst.lib.wcs_utils import get_wavelengths
 from . import resample_spec, ResampleStep
 from jwst.resample import resample_utils
 from ..exp_to_source import multislit_to_container
-from ..assign_wcs.util import update_s_region_spectral, update_s_region_keyword
+from ..assign_wcs.util import update_s_region_spectral, \
+    update_s_region_keyword
 from ..stpipe import Step
 
 
@@ -233,16 +234,7 @@ class ResampleSpecStep(Step):
             result.meta.resample.pixel_scale_ratio = resamp.pscale_ratio
         result.meta.resample.pixfrac = self.pixfrac
         self.update_slit_metadata(result)
-
-        if input_models[0].meta.exposure.type.lower() == 'mir_lrs-fixedslit':
-            s_region_list = []
-            for model in input_models:
-                s_region_list.append(model.meta.wcsinfo.s_region)
-            # Test code for MIRI LRS - does not work as it is written
-            combined_footprint = resample_utils.combine_s_regions_lrs(s_region_list)
-            update_s_region_keyword(result, combined_footprint)
-        else:
-            update_s_region_spectral(result)
+        update_s_region_spectral(result)
 
         return result
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -371,3 +371,54 @@ def check_for_tmeasure(model):
             return 0
     except AttributeError:
         return 0
+
+def combine_s_regions_lrs(s_region_list):
+
+    # hold all the footprints of each slit in a list
+    footprint_list = []
+    for sregion in s_region_list: 
+        footprint=util._sregion_to_footprint(sregion)
+        footprint_list.append(footprint) 
+    print(footprint_list)
+
+    nf = len(footprint_list)
+    print('number of footprints', nf)
+    # footprints are 4, 2 arrays
+    # [ra min, dec min] [ra min dec max] [ra max dec max] [ra max dec min]
+    corner_ra = np.zeros(4)
+    corner_dec = np.zeros(4)
+    # initialize
+    for i in range(4):
+        corner_ra[i] = footprint_list[0][i][0]
+        corner_dec[i] = footprint_list[0][i][1]
+    #print('starting corner_ra', corner_ra)
+    #print('starting corner_dec', corner_dec)
+    
+    for i in range(1, nf):
+        if footprint_list[i][0][0] < corner_ra[0]:
+            corner_ra[0] = footprint_list[i][0][0]
+        if footprint_list[i][0][1] < corner_dec[0]:
+            corner_dec[0] = footprint_list[i][0][1]
+
+        if footprint_list[i][1][0] < corner_ra[1]:
+            corner_ra[1] = footprint_list[i][1][0]
+        if footprint_list[i][1][1] > corner_dec[1]:
+            corner_dec[1] = footprint_list[i][1][1]
+
+        if footprint_list[i][2][0] > corner_ra[2]:
+            corner_ra[2] = footprint_list[i][2][0]
+        if footprint_list[i][2][1] > corner_dec[2]:
+            corner_dec[2] = footprint_list[i][2][1]
+
+        if footprint_list[i][3][0] > corner_ra[3]:
+            corner_ra[3] = footprint_list[i][3][0]
+        if footprint_list[i][3][1] < corner_dec[3]:
+            corner_dec[3] = footprint_list[i][3][1]            
+
+
+    #print(corner_ra)
+    #print(corner_dec)
+
+    footprint = np.array([corner_ra, corner_dec]).T
+    print('Final footprint', footprint)
+    return footprint

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -372,53 +372,16 @@ def check_for_tmeasure(model):
     except AttributeError:
         return 0
 
-def combine_s_regions_lrs(s_region_list):
+def combine_s_regions_lrs(s_region_list,model):
 
-    # hold all the footprints of each slit in a list
-    footprint_list = []
-    for sregion in s_region_list: 
-        footprint=util._sregion_to_footprint(sregion)
-        footprint_list.append(footprint) 
-    print(footprint_list)
-
-    nf = len(footprint_list)
-    print('number of footprints', nf)
-    # footprints are 4, 2 arrays
-    # [ra min, dec min] [ra min dec max] [ra max dec max] [ra max dec min]
-    corner_ra = np.zeros(4)
-    corner_dec = np.zeros(4)
-    # initialize
-    for i in range(4):
-        corner_ra[i] = footprint_list[0][i][0]
-        corner_dec[i] = footprint_list[0][i][1]
-    #print('starting corner_ra', corner_ra)
-    #print('starting corner_dec', corner_dec)
+    # using the first datamodel find the angle between
+    # LRS slit frame and ra, dec.
     
-    for i in range(1, nf):
-        if footprint_list[i][0][0] < corner_ra[0]:
-            corner_ra[0] = footprint_list[i][0][0]
-        if footprint_list[i][0][1] < corner_dec[0]:
-            corner_dec[0] = footprint_list[i][0][1]
+    wcs = model.meta.wcs
+    s2w = wcs.get_transform('alpha_beta', 'world')
+    d2s = wcs.get_transform('detector','alpha_beta')
+    bbox = wcs.bounding_box
+    grid = wcstools.grid_from_bounding_box(bbox)
+    ra, dec, lam = np.array(wcs(*grid))
+    lam_med = np.nanmedian(lam)
 
-        if footprint_list[i][1][0] < corner_ra[1]:
-            corner_ra[1] = footprint_list[i][1][0]
-        if footprint_list[i][1][1] > corner_dec[1]:
-            corner_dec[1] = footprint_list[i][1][1]
-
-        if footprint_list[i][2][0] > corner_ra[2]:
-            corner_ra[2] = footprint_list[i][2][0]
-        if footprint_list[i][2][1] > corner_dec[2]:
-            corner_dec[2] = footprint_list[i][2][1]
-
-        if footprint_list[i][3][0] > corner_ra[3]:
-            corner_ra[3] = footprint_list[i][3][0]
-        if footprint_list[i][3][1] < corner_dec[3]:
-            corner_dec[3] = footprint_list[i][3][1]            
-
-
-    #print(corner_ra)
-    #print(corner_dec)
-
-    footprint = np.array([corner_ra, corner_dec]).T
-    print('Final footprint', footprint)
-    return footprint


### PR DESCRIPTION
Closing this and replacing it with https://github.com/spacetelescope/jwst/pull/9193

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3848](https://jira.stsci.edu/browse/JP-3848)

This PR needs a new datamodel that defines MIRI LRS specwcs reference files. The stdatamodels for this change is
https://github.com/spacetelescope/stdatamodels/pull/383. The datamodel PR must be merged before this PR can be
merged. 


THIS PR IS NOT READY TO BE MERGED. We still need to make changes to the resample code when it updates the S_REGION for MIRI LRS data. 

This PR is not correct for updating the s-region for spec 3 MIRI LRS data. Still testing code. 

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR correctly updates the s_region set by assign_wcs for MIRI LRS fixed slit data. The change requires using the slit corners in V2,V3 space which were added to the MIRI LRS specwcs reference file. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
