### PR TITLE
Move mypy type hint checking into pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
       default_python: "3.12"
       envs: |
         - linux: check-dependencies
-        - linux: check-types
   latest_crds_contexts:
     uses: ./.github/workflows/contexts.yml
   crds_context:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,6 @@ repos:
     rev: v1.6.1  # Use the latest stable version
     hooks:
       - id: mypy
-        args: []
-        language_version: python3.11 # Replace with your Python version
   - repo: https://github.com/numpy/numpydoc
     rev: v1.8.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,12 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1  # Use the latest stable version
+    hooks:
+      - id: mypy
+        args: []
+        language_version: python3.11 # Replace with your Python version
   - repo: https://github.com/numpy/numpydoc
     rev: v1.8.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,14 +427,10 @@ The following three style checks are performed:
     required for contributions. If type hints are used, though, their compliance with 
 	[PEP-484](https://peps.python.org/pep-0484/) standards
     is enforced using [mypy](https://mypy.readthedocs.io/en/stable/index.html).
-    To run these checks locally, first `pip install mypy` then use the command
+    To run these checks locally, use the command
 
-        >> mypy .
+        >> pre-commit run mypy
 
-    from within the `jwst` repository. This check is not run through pre-commit;
-	it's instead handled separately from a different CI workflow. This means that if you are
-	using type hints, you may encounter a situation where `pre-commit` passes locally but
-	the CI checks fail on a pull request.
 
 ---
 **Note:** At time of writing, many submodules in the repository do not yet conform to the style rules;

--- a/jwst/badpix_selfcal/badpix_selfcal.py
+++ b/jwst/badpix_selfcal/badpix_selfcal.py
@@ -12,7 +12,7 @@ def badpix_selfcal(minimg: np.ndarray,
                    flagfrac_lower: float = 0.001,
                    flagfrac_upper: float = 0.001,
                    kernel_size: int = 15,
-                   dispaxis=None) -> tuple:
+                   dispaxis=None) -> np.ndarray:
     """
     Flag residual artifacts as bad pixels in the DQ array of a JWST exposure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,6 +274,7 @@ warn_return_any = true
 warn_unused_configs = true
 disable_error_code = "import-untyped" # do not check imports
 exclude = ["build"]
+python_version = "3.10"
 
 [[tool.mypy.overrides]]
 # don't complain about the installed c parts of this library

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,6 @@ envlist =
 #     tox -l -v
 #
 
-[testenv:check-types]
-description = check type hints, e.g. with mypy
-deps =
-    mypy
-    types-requests
-commands =
-    mypy jwst --config-file pyproject.toml
-
 [testenv:check-dependencies]
 description = verify that install_requires in setup.cfg has correct dependencies
 # `extras` needs to be empty to check modules without additional dependencies


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #9103 

<!-- describe the changes comprising this PR here -->
This PR moves the mypy type check out of the `tox.ini` file and into the `pre-commit-config.yaml` file. This makes it so that all the style checks occur in one place, and makes it so that the mypy checks are part of our pre-commit hook.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
