### PR TITLE
JP-3859: Apply code style to clean_flicker_noise and nsclean

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,6 @@ repos:
             jwst/model_blender/.* |
             jwst/mrs_imatch/.* |
             jwst/msaflagopen/.* |
-            jwst/nsclean/.* |
             jwst/outlier_detection/.* |
             jwst/pathloss/.* |
             jwst/persistence/.* |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
             jwst/badpix_selfcal/.* |
             jwst/barshadow/.* |
             jwst/charge_migration/.* |
-            jwst/clean_flicker_noise/.* |
             jwst/combine_1d/.* |
             jwst/coron/.* |
             jwst/cube_build/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -123,6 +123,7 @@ ignore = [
     "UP008", # use super() instead of super(class, self). no harm being explicit
     "UP015", # unnecessary open(file, "r"). no harm being explicit
     "TRY003", # prevents custom exception messages not defined in exception itself.
+    "TRY400", # enforces log.exception instead of log.error in except clause.
     "ISC001", # single line implicit string concatenation. formatter recommends ignoring this.
 ]
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -59,7 +59,7 @@ exclude = [
     "jwst/model_blender/**.py",
     "jwst/mrs_imatch/**.py",
     "jwst/msaflagopen/**.py",
-    "jwst/nsclean/**.py",
+    #"jwst/nsclean/**.py",
     "jwst/outlier_detection/**.py",
     "jwst/pathloss/**.py",
     "jwst/persistence/**.py",
@@ -186,7 +186,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/model_blender/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/mrs_imatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/msaflagopen/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/nsclean/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+#"jwst/nsclean/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/outlier_detection/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/pathloss/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/persistence/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -30,7 +30,7 @@ exclude = [
     "jwst/badpix_selfcal/**.py",
     "jwst/barshadow/**.py",
     "jwst/charge_migration/**.py",
-    "jwst/clean_flicker_noise/**.py",
+    # "jwst/clean_flicker_noise/**.py",
     "jwst/combine_1d/**.py",
     "jwst/coron/**.py",
     "jwst/cube_build/**.py",
@@ -157,7 +157,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/badpix_selfcal/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/barshadow/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/charge_migration/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/clean_flicker_noise/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/clean_flicker_noise/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/combine_1d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/coron/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_build/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/clean_flicker_noise/__init__.py
+++ b/jwst/clean_flicker_noise/__init__.py
@@ -1,3 +1,5 @@
+"""Correct ramp or rate data for flicker noise."""
+
 from .clean_flicker_noise_step import CleanFlickerNoiseStep
 
-__all__ = ['CleanFlickerNoiseStep']
+__all__ = ["CleanFlickerNoiseStep"]

--- a/jwst/clean_flicker_noise/clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise.py
@@ -365,7 +365,7 @@ def clip_to_background(
                 data_for_stats, bins=2000, range=(center - 4.0 * sigma, center + 4.0 * sigma)
             )
         except ValueError:
-            log.error("Histogram failed; using clip center and sigma.")  # noqa: TRY400
+            log.error("Histogram failed; using clip center and sigma.")
             hist, edges = None, None
 
         param_opt = None
@@ -383,7 +383,7 @@ def clip_to_background(
             try:
                 param_opt, _ = curve_fit(gaussian, values, hist, p0=param_start, bounds=bounds)
             except RuntimeError:
-                log.error("Gaussian fit failed; using clip center and sigma.")  # noqa: TRY400
+                log.error("Gaussian fit failed; using clip center and sigma.")
                 param_opt = None
 
             if verbose:
@@ -619,7 +619,7 @@ def background_level(image, mask, background_method="median", background_box_siz
                     )
                 background = bkg.background
             except ValueError:
-                log.error("Background fit failed, using median value.")  # noqa: TRY400
+                log.error("Background fit failed, using median value.")
                 background = np.nanmedian(image[mask])
         else:
             background = np.nanmedian(image[mask])

--- a/jwst/clean_flicker_noise/clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise.py
@@ -29,7 +29,7 @@ log.setLevel(logging.DEBUG)
 NRS_FS_REGION = [922, 1116]
 
 
-def make_rate(input_model, input_dir='', return_cube=False):
+def make_rate(input_model, input_dir="", return_cube=False):
     """
     Make a rate model from a ramp model.
 
@@ -76,10 +76,11 @@ def make_rate(input_model, input_dir='', return_cube=False):
     return output_model
 
 
-def post_process_rate(input_model, input_dir='', assign_wcs=False,
-                      msaflagopen=False, flat_dq=False):
+def post_process_rate(
+    input_model, input_dir="", assign_wcs=False, msaflagopen=False, flat_dq=False
+):
     """
-    Post-process the input rate model, as needed.
+    Perform additional processing for the input rate model, as needed.
 
     Parameters
     ----------
@@ -111,7 +112,7 @@ def post_process_rate(input_model, input_dir='', assign_wcs=False,
     output_model = input_model
 
     # If needed, assign a WCS
-    if (assign_wcs or msaflagopen) and not hasattr(output_model.meta, 'wcs'):
+    if (assign_wcs or msaflagopen) and not hasattr(output_model.meta, "wcs"):
         log.info("Assigning a WCS for scene masking")
         step = AssignWcsStep()
         step.input_dir = input_dir
@@ -170,16 +171,14 @@ def mask_ifu_slices(input_model, mask):
 
     # Note: 30 in the line below is hardcoded in nirspec.nrs.ifu_wcs, which
     # the line below replaces.
-    wcsobj, tr1, tr2, tr3 = nirspec._get_transforms(input_model, np.arange(30))
+    wcsobj, tr1, tr2, tr3 = nirspec._get_transforms(input_model, np.arange(30))  # noqa: SLF001
 
     # Loop over the IFU slices, finding the valid region for each
     for k in range(len(tr2)):
-        ifu_wcs = nirspec._nrs_wcs_set_input_lite(input_model, wcsobj, k,
-                                                 [tr1, tr2[k], tr3[k]])
+        ifu_wcs = nirspec._nrs_wcs_set_input_lite(input_model, wcsobj, k, [tr1, tr2[k], tr3[k]])  # noqa: SLF001
 
         # Construct array indexes for pixels in this slice
-        x, y = gwcs.wcstools.grid_from_bounding_box(
-            ifu_wcs.bounding_box, step=(1, 1), center=True)
+        x, y = gwcs.wcstools.grid_from_bounding_box(ifu_wcs.bounding_box, step=(1, 1), center=True)
 
         # Get the world coords for all pixels in this slice;
         # all we actually need are wavelengths
@@ -224,23 +223,24 @@ def mask_slits(input_model, mask):
     mask : array-like of bool
         2D output mask with additional flags for slit pixels
     """
-
     log.info("Finding slit/slitlet pixels")
 
     # Get the slit-to-msa frame transform from the WCS object
-    slit2msa = input_model.meta.wcs.get_transform('slit_frame', 'msa_frame')
+    slit2msa = input_model.meta.wcs.get_transform("slit_frame", "msa_frame")
 
     # Loop over the slits, marking all the pixels within each bounding
     # box as False (do not use) in the mask.
     # Note that for 3D masks (TSO mode), all planes will be set to the same value.
 
     slits = [s.name for s in slit2msa.slits]
-    wcsobj, tr1, tr2, tr3, open_slits = nirspec._get_transforms(input_model, slits, return_slits=True)
+    wcsobj, tr1, tr2, tr3, open_slits = nirspec._get_transforms(  # noqa: SLF001
+        input_model, slits, return_slits=True
+    )
 
     for k in range(len(tr2)):
-        slit_wcs = nirspec._nrs_wcs_set_input_lite(input_model, wcsobj, slits[k],
-                                                  [tr1, tr2[k], tr3[k]],
-                                                  open_slits=open_slits)
+        slit_wcs = nirspec._nrs_wcs_set_input_lite(  # noqa: SLF001
+            input_model, wcsobj, slits[k], [tr1, tr2[k], tr3[k]], open_slits=open_slits
+        )
 
         xlo, xhi = _toindex(slit_wcs.bounding_box[0])
         ylo, yhi = _toindex(slit_wcs.bounding_box[1])
@@ -249,9 +249,15 @@ def mask_slits(input_model, mask):
     return mask
 
 
-def clip_to_background(image, mask, sigma_lower=3.0, sigma_upper=2.0,
-                       fit_histogram=False, lower_half_only=False,
-                       verbose=False):
+def clip_to_background(
+    image,
+    mask,
+    sigma_lower=3.0,
+    sigma_upper=2.0,
+    fit_histogram=False,
+    lower_half_only=False,
+    verbose=False,
+):
     """
     Flag signal and bad pixels in the image mask.
 
@@ -318,40 +324,37 @@ def clip_to_background(image, mask, sigma_lower=3.0, sigma_upper=2.0,
 
     # Initial iterative sigma clip
     with warnings.catch_warnings():
-        warnings.filterwarnings(
-            action="ignore", category=AstropyUserWarning)
-        mean, median, sigma = sigma_clipped_stats(
-            image, mask=~mask, sigma=sigma_limit)
+        warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
+        mean, median, sigma = sigma_clipped_stats(image, mask=~mask, sigma=sigma_limit)
     if fit_histogram:
         center = mean
     else:
         center = median
     if verbose:
-        log.debug('From initial sigma clip:')
-        log.debug(f'    center: {center:.5g}')
-        log.debug(f'    sigma: {sigma:.5g}')
+        log.debug("From initial sigma clip:")
+        log.debug(f"    center: {center:.5g}")
+        log.debug(f"    sigma: {sigma:.5g}")
 
     # If desired, use only the lower half of the data distribution
     if lower_half_only:
         lower_half_idx = mask & (image <= center)
-        data_for_stats = np.concatenate(
-            ((image[lower_half_idx] - center),
-             (center - image[lower_half_idx]))) + center
+        data_for_stats = (
+            np.concatenate(((image[lower_half_idx] - center), (center - image[lower_half_idx])))
+            + center
+        )
 
         # Redo stats on lower half of distribution
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                action="ignore", category=AstropyUserWarning)
-            mean, median, sigma = sigma_clipped_stats(
-                data_for_stats, sigma=sigma_limit)
+            warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
+            mean, median, sigma = sigma_clipped_stats(data_for_stats, sigma=sigma_limit)
         if fit_histogram:
             center = mean
         else:
             center = median
         if verbose:
-            log.debug('From lower half distribution:')
-            log.debug(f'    center: {center:.5g}')
-            log.debug(f'    sigma: {sigma:.5g}')
+            log.debug("From lower half distribution:")
+            log.debug(f"    center: {center:.5g}")
+            log.debug(f"    sigma: {sigma:.5g}")
     else:
         data_for_stats = image[mask]
 
@@ -359,15 +362,15 @@ def clip_to_background(image, mask, sigma_lower=3.0, sigma_upper=2.0,
     if fit_histogram:
         try:
             hist, edges = np.histogram(
-                data_for_stats, bins=2000,
-                range=(center - 4. * sigma, center + 4. * sigma))
+                data_for_stats, bins=2000, range=(center - 4.0 * sigma, center + 4.0 * sigma)
+            )
         except ValueError:
-            log.error('Histogram failed; using clip center and sigma.')
+            log.error("Histogram failed; using clip center and sigma.")  # noqa: TRY400
             hist, edges = None, None
 
         param_opt = None
         if hist is not None:
-            values = (edges[1:] + edges[0:-1]) / 2.
+            values = (edges[1:] + edges[0:-1]) / 2.0
             ind = np.argmax(hist)
             mode_estimate = values[ind]
 
@@ -376,31 +379,28 @@ def clip_to_background(image, mask, sigma_lower=3.0, sigma_upper=2.0,
                 return g_amp * np.exp(-0.5 * ((x - g_mean) / g_sigma) ** 2)
 
             param_start = (hist[ind], mode_estimate, sigma)
-            bounds = [(0, values[0], 0),
-                      (np.inf, values[-1], values[-1] - values[0])]
+            bounds = [(0, values[0], 0), (np.inf, values[-1], values[-1] - values[0])]
             try:
-                param_opt, _ = curve_fit(gaussian, values, hist, p0=param_start,
-                                         bounds=bounds)
+                param_opt, _ = curve_fit(gaussian, values, hist, p0=param_start, bounds=bounds)
             except RuntimeError:
-                log.error('Gaussian fit failed; using clip center and sigma.')
+                log.error("Gaussian fit failed; using clip center and sigma.")  # noqa: TRY400
                 param_opt = None
 
             if verbose:
-                log.debug('From histogram:')
-                log.debug(f'    mode estimate: {mode_estimate:.5g}')
-                log.debug(f'    range of values in histogram: '
-                          f'{values[0]:.5g} to {values[-1]:.5g}')
+                log.debug("From histogram:")
+                log.debug(f"    mode estimate: {mode_estimate:.5g}")
+                log.debug(f"    range of values in histogram: {values[0]:.5g} to {values[-1]:.5g}")
 
         if verbose:
-            log.debug('Gaussian fit results:')
+            log.debug("Gaussian fit results:")
         if param_opt is None:
             if verbose:
-                log.debug('    (fit failed)')
+                log.debug("    (fit failed)")
         else:
             if verbose:
-                log.debug(f'    peak: {param_opt[0]:.5g}')
-                log.debug(f'    center: {param_opt[1]:.5g}')
-                log.debug(f'    sigma: {param_opt[2]:.5g}')
+                log.debug(f"    peak: {param_opt[0]:.5g}")
+                log.debug(f"    center: {param_opt[1]:.5g}")
+                log.debug(f"    sigma: {param_opt[2]:.5g}")
             center = param_opt[1]
             sigma = param_opt[2]
 
@@ -408,8 +408,7 @@ def clip_to_background(image, mask, sigma_lower=3.0, sigma_upper=2.0,
     background_lower_limit = center - sigma_lower * sigma
     background_upper_limit = center + sigma_upper * sigma
     if verbose:
-        log.debug(f'Mask limits: {background_lower_limit:.5g} '
-                  f'to {background_upper_limit:.5g}')
+        log.debug(f"Mask limits: {background_lower_limit:.5g} to {background_upper_limit:.5g}")
 
     # Clip bad values
     bad_values = image < background_lower_limit
@@ -420,8 +419,9 @@ def clip_to_background(image, mask, sigma_lower=3.0, sigma_upper=2.0,
     mask[signal] = False
 
 
-def create_mask(input_model, mask_science_regions=False,
-                n_sigma=2.0, fit_histogram=False, single_mask=False):
+def create_mask(
+    input_model, mask_science_regions=False, n_sigma=2.0, fit_histogram=False, single_mask=False
+):
     """
     Create a mask identifying background pixels.
 
@@ -466,23 +466,22 @@ def create_mask(input_model, mask_science_regions=False,
     mask = np.full(input_model.dq.shape, True)
 
     # If IFU, mask all pixels contained in the IFU slices
-    if exptype == 'nrs_ifu' and mask_science_regions:
+    if exptype == "nrs_ifu" and mask_science_regions:
         mask = mask_ifu_slices(input_model, mask)
 
     # If MOS or FS, mask all pixels affected by open slitlets
-    if (exptype in ['nrs_fixedslit', 'nrs_brightobj', 'nrs_msaspec']
-            and mask_science_regions):
+    if exptype in ["nrs_fixedslit", "nrs_brightobj", "nrs_msaspec"] and mask_science_regions:
         mask = mask_slits(input_model, mask)
 
     # If IFU or MOS, mask pixels affected by failed-open shutters
-    if mask_science_regions and exptype in ['nrs_ifu', 'nrs_msaspec']:
-        open_pix = input_model.dq & dqflags.pixel['MSA_FAILED_OPEN']
+    if mask_science_regions and exptype in ["nrs_ifu", "nrs_msaspec"]:
+        open_pix = input_model.dq & dqflags.pixel["MSA_FAILED_OPEN"]
         mask[open_pix > 0] = False
 
     # If MIRI imaging, mask the non-science regions:
     # they contain irrelevant emission
-    if mask_science_regions and exptype in ['mir_image']:
-        non_science = (input_model.dq & dqflags.pixel['DO_NOT_USE']) > 0
+    if mask_science_regions and exptype in ["mir_image"]:
+        non_science = (input_model.dq & dqflags.pixel["DO_NOT_USE"]) > 0
         mask[non_science] = False
 
     # Mask any NaN pixels or exactly zero value pixels
@@ -491,36 +490,42 @@ def create_mask(input_model, mask_science_regions=False,
 
     # If IFU or MOS, mask the fixed-slit area of the image; uses hardwired indexes
     if mask_science_regions:
-        if exptype == 'nrs_ifu':
+        if exptype == "nrs_ifu":
             log.info("Masking the fixed slit region for IFU data.")
-            mask[..., NRS_FS_REGION[0]:NRS_FS_REGION[1], :] = False
-        elif exptype == 'nrs_msaspec':
+            mask[..., NRS_FS_REGION[0] : NRS_FS_REGION[1], :] = False
+        elif exptype == "nrs_msaspec":
             # check for any slits defined in the fixed slit quadrant:
             # if there is nothing there of interest, mask the whole FS region
             try:
-                slit2msa = input_model.meta.wcs.get_transform('slit_frame', 'msa_frame')
+                slit2msa = input_model.meta.wcs.get_transform("slit_frame", "msa_frame")
                 is_fs = [s.quadrant == 5 for s in slit2msa.slits]
             except (AttributeError, ValueError, TypeError):
-                log.warning('Slit to MSA transform not found.')
+                log.warning("Slit to MSA transform not found.")
                 is_fs = [False]
             if not any(is_fs):
                 log.info("Masking the fixed slit region for MOS data.")
-                mask[..., NRS_FS_REGION[0]:NRS_FS_REGION[1], :] = False
+                mask[..., NRS_FS_REGION[0] : NRS_FS_REGION[1], :] = False
             else:
-                log.info("Fixed slits found in MSA definition; "
-                         "not masking the fixed slit region for MOS data.")
+                log.info(
+                    "Fixed slits found in MSA definition; "
+                    "not masking the fixed slit region for MOS data."
+                )
 
     # Mask outliers and signal using sigma clipping stats.
     # For 3D data, loop over each integration separately.
     if input_model.data.ndim == 3:
         for i in range(input_model.data.shape[0]):
             clip_to_background(
-                input_model.data[i], mask[i],
-                sigma_upper=n_sigma, fit_histogram=fit_histogram, verbose=True)
+                input_model.data[i],
+                mask[i],
+                sigma_upper=n_sigma,
+                fit_histogram=fit_histogram,
+                verbose=True,
+            )
     else:
         clip_to_background(
-            input_model.data, mask,
-            sigma_upper=n_sigma, fit_histogram=fit_histogram, verbose=True)
+            input_model.data, mask, sigma_upper=n_sigma, fit_histogram=fit_histogram, verbose=True
+        )
 
     # Reduce the mask to a single plane if needed
     if single_mask and mask.ndim == 3:
@@ -530,8 +535,7 @@ def create_mask(input_model, mask_science_regions=False,
     return mask
 
 
-def background_level(image, mask, background_method='median',
-                     background_box_size=None):
+def background_level(image, mask, background_method="median", background_box_size=None):
     """
     Fit a low-resolution background level.
 
@@ -574,10 +578,10 @@ def background_level(image, mask, background_method='median',
         # Flag more signal in the background subtracted image,
         # with sigma set by the lower half of the distribution only
         clip_to_background(
-            image, mask, sigma_lower=sigma_limit, sigma_upper=sigma_limit,
-            lower_half_only=True)
+            image, mask, sigma_lower=sigma_limit, sigma_upper=sigma_limit, lower_half_only=True
+        )
 
-        if background_method == 'model':
+        if background_method == "model":
             sigma_clip_for_bkg = SigmaClip(sigma=sigma_limit, maxiters=5)
             bkg_estimator = MedianBackground()
 
@@ -587,28 +591,35 @@ def background_level(image, mask, background_method='median',
                 background_box_size = []
                 recommended = np.arange(1, 33)
                 for i_size in image.shape:
-                    divides_evenly = (i_size % recommended == 0)
+                    divides_evenly = i_size % recommended == 0
                     background_box_size.append(int(recommended[divides_evenly][-1]))
-                log.debug(f'Using box size {background_box_size}')
+                log.debug(f"Using box size {background_box_size}")
 
-            box_division_remainder = (image.shape[0] % background_box_size[0],
-                                      image.shape[1] % background_box_size[1])
+            box_division_remainder = (
+                image.shape[0] % background_box_size[0],
+                image.shape[1] % background_box_size[1],
+            )
             if not np.allclose(box_division_remainder, 0):
-                log.warning(f'Background box size {background_box_size} '
-                            f'does not divide evenly into the image '
-                            f'shape {image.shape}.')
+                log.warning(
+                    f"Background box size {background_box_size} "
+                    f"does not divide evenly into the image "
+                    f"shape {image.shape}."
+                )
 
             try:
                 with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        action="ignore", category=AstropyUserWarning)
+                    warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
                     bkg = Background2D(
-                        image, box_size=background_box_size, filter_size=(5, 5),
-                        mask=~mask, sigma_clip=sigma_clip_for_bkg,
-                        bkg_estimator=bkg_estimator)
+                        image,
+                        box_size=background_box_size,
+                        filter_size=(5, 5),
+                        mask=~mask,
+                        sigma_clip=sigma_clip_for_bkg,
+                        bkg_estimator=bkg_estimator,
+                    )
                 background = bkg.background
             except ValueError:
-                log.error('Background fit failed, using median value.')
+                log.error("Background fit failed, using median value.")  # noqa: TRY400
                 background = np.nanmedian(image[mask])
         else:
             background = np.nanmedian(image[mask])
@@ -635,7 +646,6 @@ def fft_clean_full_frame(image, mask, detector):
     cleaned_image : array-like of float
         The cleaned image.
     """
-
     # Instantiate the cleaner
     cleaner = NSClean(detector, mask)
 
@@ -649,9 +659,16 @@ def fft_clean_full_frame(image, mask, detector):
     return cleaned_image
 
 
-def fft_clean_subarray(image, mask, detector, npix_iter=512,
-                       fc=(1061, 1211, 49943, 49957),
-                       exclude_outliers=True, sigrej=4, minfrac=0.05):
+def fft_clean_subarray(
+    image,
+    mask,
+    detector,
+    npix_iter=512,
+    fc=(1061, 1211, 49943, 49957),
+    exclude_outliers=True,
+    sigrej=4,
+    minfrac=0.05,
+):
     """
     Fit and remove background noise in frequency space for a subarray image.
 
@@ -746,14 +763,15 @@ def fft_clean_subarray(image, mask, detector, npix_iter=512,
     di_list = []
     models = []
     while i1 <= imax:
-
         # Want npix_iter available pixels in this section.  If
         # there are fewer than 1.5*npix_iter available pixels in
         # the rest of the image, just go to the end.
         k = 0
         for k in range(i1 + 1, imax + 2):
-            if (sum_mask[k] - sum_mask[i1] > npix_iter
-                    and sum_mask[-1] - sum_mask[i1] > 1.5 * npix_iter):
+            if (
+                sum_mask[k] - sum_mask[i1] > npix_iter
+                and sum_mask[-1] - sum_mask[i1] > 1.5 * npix_iter
+            ):
                 break
 
         di = k - i1
@@ -767,18 +785,21 @@ def fft_clean_subarray(image, mask, detector, npix_iter=512,
         # over the full array to get reliable values for the mean
         # and standard deviation.
 
-        if np.mean(mask[i1:i1 + di]) > minfrac:
-            cleaner = NSCleanSubarray(image[i1:i1 + di], mask[i1:i1 + di],
-                                      fc=fc, exclude_outliers=False)
+        if np.mean(mask[i1 : i1 + di]) > minfrac:
+            cleaner = NSCleanSubarray(
+                image[i1 : i1 + di], mask[i1 : i1 + di], fc=fc, exclude_outliers=False
+            )
             try:
                 models += [cleaner.clean(return_model=True)]
             except np.linalg.LinAlgError:
                 log.warning("Error cleaning image; step will be skipped")
                 return None
         else:
-            log.warning("Insufficient reference pixels for NSClean around "
-                        "row %d; no correction will be made here." % i1)
-            models += [np.zeros(image[i1:i1 + di].shape)]
+            log.warning(
+                "Insufficient reference pixels for NSClean around "
+                f"row {i1}; no correction will be made here."
+            )
+            models += [np.zeros(image[i1 : i1 + di].shape)]
 
         # If we have reached the end of the array, we are finished.
         if k == imax + 1:
@@ -787,7 +808,7 @@ def fft_clean_subarray(image, mask, detector, npix_iter=512,
         # Step forward by half an interval so that we have
         # overlapping fitting regions.
 
-        i1 += max(int(np.round(di/2)), 1)
+        i1 += max(int(np.round(di / 2)), 1)
 
     model = np.zeros(image.shape)
     tot_wgt = np.zeros(image.shape)
@@ -801,8 +822,8 @@ def fft_clean_subarray(image, mask, detector, npix_iter=512,
 
     for i in range(len(models)):
         wgt = 1.001 - np.abs(np.linspace(-1, 1, di_list[i]))[:, np.newaxis]
-        model[i1_vals[i]:i1_vals[i] + di_list[i]] += wgt*models[i]
-        tot_wgt[i1_vals[i]:i1_vals[i] + di_list[i]] += wgt
+        model[i1_vals[i] : i1_vals[i] + di_list[i]] += wgt * models[i]
+        tot_wgt[i1_vals[i] : i1_vals[i] + di_list[i]] += wgt
 
     # don't divide by zero
     tot_wgt[model == 0] = 1
@@ -872,7 +893,7 @@ def median_clean(image, mask, axis_to_correct, fit_by_channel=False):
     # in the channel
     cstart = 0
     cstop = channel_size
-    for channel in range(n_output):
+    for _channel in range(n_output):
         if array_axis == 1:
             channel_image = masked_image[:, cstart:cstop]
         else:
@@ -909,12 +930,12 @@ def _check_input(exp_type, fit_method):
         True if the input is valid.
     """
     message = None
-    miri_allowed = ['MIR_IMAGE']
-    if exp_type.startswith('MIR') and exp_type not in miri_allowed:
+    miri_allowed = ["MIR_IMAGE"]
+    if exp_type.startswith("MIR") and exp_type not in miri_allowed:
         message = f"EXP_TYPE {exp_type} is not supported"
 
-    nsclean_allowed = ['NRS_MSASPEC', 'NRS_IFU', 'NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']
-    if fit_method == 'fft':
+    nsclean_allowed = ["NRS_MSASPEC", "NRS_IFU", "NRS_FIXEDSLIT", "NRS_BRIGHTOBJ"]
+    if fit_method == "fft":
         if exp_type not in nsclean_allowed:
             message = f"Fit method 'fft' cannot be applied to exp_type {exp_type}"
 
@@ -958,8 +979,7 @@ def _make_intermediate_model(input_model, intermediate_data):
     return intermediate_model
 
 
-def _standardize_parameters(
-        exp_type, subarray, slowaxis, background_method, fit_by_channel):
+def _standardize_parameters(exp_type, subarray, slowaxis, background_method, fit_by_channel):
     """
     Standardize input parameters.
 
@@ -994,7 +1014,7 @@ def _standardize_parameters(
         by input subarray.
     """
     # Get axis to correct, by instrument
-    if exp_type.startswith('MIR'):
+    if exp_type.startswith("MIR"):
         # MIRI doesn't have 1/f-noise, but it does have a vertical flickering.
         # Set the axis for median correction to the y-axis.
         axis_to_correct = 1
@@ -1004,11 +1024,11 @@ def _standardize_parameters(
         axis_to_correct = abs(slowaxis)
 
     # Standardize background arguments
-    if str(background_method).lower() == 'none':
+    if str(background_method).lower() == "none":
         background_method = None
 
     # Check for fit_by_channel argument, and use only if data is full frame
-    if fit_by_channel and (subarray != 'FULL' or exp_type.startswith('MIR')):
+    if fit_by_channel and (subarray != "FULL" or exp_type.startswith("MIR")):
         log.warning("Fit by channel can only be used for full-frame NIR data.")
         log.warning("Setting fit_by_channel to False.")
         fit_by_channel = False
@@ -1053,7 +1073,7 @@ def _read_flat_file(input_model, flat_filename):
         return None
 
     # Open the provided flat as FlatModel
-    log.debug('Dividing by flat data prior to fitting')
+    log.debug("Dividing by flat data prior to fitting")
     flat = datamodels.FlatModel(flat_filename)
 
     # Extract subarray from reference data, if necessary
@@ -1069,7 +1089,7 @@ def _read_flat_file(input_model, flat_filename):
     # Set any zeros or non-finite values in the flat data to a smoothed local value
     bad_data = (flat_data == 0) | ~np.isfinite(flat_data)
     if np.any(bad_data):
-        smoothed_flat = background_level(flat_data, ~bad_data, background_method='model')
+        smoothed_flat = background_level(flat_data, ~bad_data, background_method="model")
         try:
             flat_data[bad_data] = smoothed_flat[bad_data]
         except IndexError:
@@ -1080,7 +1100,8 @@ def _read_flat_file(input_model, flat_filename):
 
 
 def _make_processed_rate_image(
-        input_model, single_mask, input_dir, exp_type, mask_science_regions, flat):
+    input_model, single_mask, input_dir, exp_type, mask_science_regions, flat
+):
     """
     Make a draft rate image and postprocess if needed.
 
@@ -1113,22 +1134,24 @@ def _make_processed_rate_image(
         The processed rate image or cube.
     """
     if isinstance(input_model, datamodels.RampModel):
-        image_model = make_rate(input_model, return_cube=(not single_mask),
-                                input_dir=input_dir)
+        image_model = make_rate(input_model, return_cube=(not single_mask), input_dir=input_dir)
     else:
         # input is already a rate file
         image_model = input_model
 
     # If needed, assign a WCS to the rate file,
     # flag open MSA shutters, or retrieve flat DQ flags
-    assign_wcs = exp_type.startswith('NRS')
-    flag_open = (exp_type in ['NRS_IFU', 'NRS_MSASPEC'])
-    flat_dq = (exp_type in ['MIR_IMAGE'])
+    assign_wcs = exp_type.startswith("NRS")
+    flag_open = exp_type in ["NRS_IFU", "NRS_MSASPEC"]
+    flat_dq = exp_type in ["MIR_IMAGE"]
     if mask_science_regions:
         image_model = post_process_rate(
-            image_model, assign_wcs=assign_wcs,
-            msaflagopen=flag_open, flat_dq=flat_dq,
-            input_dir=input_dir)
+            image_model,
+            assign_wcs=assign_wcs,
+            msaflagopen=flag_open,
+            flat_dq=flat_dq,
+            input_dir=input_dir,
+        )
 
     # Divide by the flat if provided
     if flat is not None:
@@ -1141,8 +1164,8 @@ def _make_processed_rate_image(
 
 
 def _make_scene_mask(
-        user_mask, image_model, mask_science_regions,
-        n_sigma, fit_histogram, single_mask, save_mask):
+    user_mask, image_model, mask_science_regions, n_sigma, fit_histogram, single_mask, save_mask
+):
     """
     Make a scene mask from user input or rate image.
 
@@ -1156,7 +1179,7 @@ def _make_scene_mask(
         Path to user-supplied mask image.
     image_model : `~jwst.datamodel.JwstDataModel`
         A rate image or cube, processed as needed.
-    mask_science_regions: bool
+    mask_science_regions : bool
         For NIRSpec, mask regions of the image defined by WCS bounding
         boxes for slits/slices, as well as any regions known to be
         affected by failed-open MSA shutters.  For MIRI imaging, mask
@@ -1199,8 +1222,10 @@ def _make_scene_mask(
         background_mask = create_mask(
             image_model,
             mask_science_regions=mask_science_regions,
-            n_sigma=n_sigma, fit_histogram=fit_histogram,
-            single_mask=single_mask)
+            n_sigma=n_sigma,
+            fit_histogram=fit_histogram,
+            single_mask=single_mask,
+        )
 
     # Store the mask image in a model, if requested
     if save_mask:
@@ -1250,8 +1275,10 @@ def _check_data_shapes(input_model, background_mask):
         # Check for 3D mask
         if background_mask.ndim == 2:
             if nints > 1:
-                log.info("Data has multiple integrations, but mask is 2D: "
-                         "the same mask will be used for all integrations.")
+                log.info(
+                    "Data has multiple integrations, but mask is 2D: "
+                    "the same mask will be used for all integrations."
+                )
         elif background_mask.shape[0] != nints:
             log.warning("Mask does not match data shape. Step will be skipped.")
             return mismatch, ndim, nints, ngroups
@@ -1264,9 +1291,19 @@ def _check_data_shapes(input_model, background_mask):
     return False, ndim, nints, ngroups
 
 
-def _clean_one_image(image, mask, background_method, background_box_size,
-                     n_sigma, fit_method, detector, fc, axis_to_correct,
-                     fit_by_channel, flat):
+def _clean_one_image(
+    image,
+    mask,
+    background_method,
+    background_box_size,
+    n_sigma,
+    fit_method,
+    detector,
+    fc,
+    axis_to_correct,
+    fit_by_channel,
+    flat,
+):
     """
     Clean an image by fitting and removing background noise.
 
@@ -1332,24 +1369,27 @@ def _clean_one_image(image, mask, background_method, background_box_size,
         return None, None, success
 
     # Fit and remove a background level
-    if str(background_method).lower() == 'none':
+    if str(background_method).lower() == "none":
         background = 0.0
         bkg_sub = image
     else:
         background = background_level(
-            image, mask, background_method=background_method,
-            background_box_size=background_box_size)
-        log.debug(f'Background level: {np.nanmedian(background):.5g}')
+            image,
+            mask,
+            background_method=background_method,
+            background_box_size=background_box_size,
+        )
+        log.debug(f"Background level: {np.nanmedian(background):.5g}")
         bkg_sub = image - background
 
         # Flag more signal in the background subtracted image,
         # with sigma set by the lower half of the distribution only
         clip_to_background(
-            bkg_sub, mask, sigma_lower=n_sigma,
-            sigma_upper=n_sigma, lower_half_only=True)
+            bkg_sub, mask, sigma_lower=n_sigma, sigma_upper=n_sigma, lower_half_only=True
+        )
 
     # Clean the noise
-    if fit_method == 'fft':
+    if fit_method == "fft":
         if bkg_sub.shape == (2048, 2048):
             # Clean a full-frame image
             cleaned_image = fft_clean_full_frame(bkg_sub, mask, detector)
@@ -1357,8 +1397,7 @@ def _clean_one_image(image, mask, background_method, background_box_size,
             # Clean a subarray image
             cleaned_image = fft_clean_subarray(bkg_sub, mask, detector, fc=fc)
     else:
-        cleaned_image = median_clean(bkg_sub, mask, axis_to_correct,
-                                     fit_by_channel=fit_by_channel)
+        cleaned_image = median_clean(bkg_sub, mask, axis_to_correct, fit_by_channel=fit_by_channel)
     if cleaned_image is None:
         return None, None, False
 
@@ -1389,19 +1428,29 @@ def _mask_unusable(mask, dq):
     dq : array-like of int
         DQ flag array matching the mask shape.
     """
-    dnu = (dq & dqflags.group['DO_NOT_USE']) > 0
+    dnu = (dq & dqflags.group["DO_NOT_USE"]) > 0
     mask[dnu] = False
-    jump = (dq & dqflags.group['JUMP_DET']) > 0
+    jump = (dq & dqflags.group["JUMP_DET"]) > 0
     mask[jump] = False
 
 
-def do_correction(input_model, input_dir=None, fit_method='median',
-                  fit_by_channel=False, background_method='median',
-                  background_box_size=None,
-                  mask_science_regions=False, flat_filename=None,
-                  n_sigma=2.0, fit_histogram=False,
-                  single_mask=True, user_mask=None, save_mask=False,
-                  save_background=False, save_noise=False):
+def do_correction(
+    input_model,
+    input_dir=None,
+    fit_method="median",
+    fit_by_channel=False,
+    background_method="median",
+    background_box_size=None,
+    mask_science_regions=False,
+    flat_filename=None,
+    n_sigma=2.0,
+    fit_histogram=False,
+    single_mask=True,
+    user_mask=None,
+    save_mask=False,
+    save_background=False,
+    save_noise=False,
+):
     """
     Apply the 1/f noise correction.
 
@@ -1488,13 +1537,13 @@ def do_correction(input_model, input_dir=None, fit_method='median',
         status = 'COMPLETE'.
     """
     # Track the completion status, for various failure conditions
-    status = 'SKIPPED'
+    status = "SKIPPED"
 
     detector = input_model.meta.instrument.detector.upper()
     subarray = input_model.meta.subarray.name.upper()
     exp_type = input_model.meta.exposure.type
     slowaxis = input_model.meta.subarray.slowaxis
-    log.info(f'Input exposure type is {exp_type}, detector={detector}')
+    log.info(f"Input exposure type is {exp_type}, detector={detector}")
 
     # Check for a valid input that we can work on
     if not _check_input(exp_type, fit_method):
@@ -1505,7 +1554,8 @@ def do_correction(input_model, input_dir=None, fit_method='median',
     # Get parameters needed for subsequent corrections, as appropriate
     # to the input data
     axis_to_correct, background_method, fit_by_channel, fc = _standardize_parameters(
-            exp_type, subarray, slowaxis, background_method, fit_by_channel)
+        exp_type, subarray, slowaxis, background_method, fit_by_channel
+    )
 
     # Read the flat file, if provided
     flat = _read_flat_file(input_model, flat_filename)
@@ -1513,20 +1563,20 @@ def do_correction(input_model, input_dir=None, fit_method='median',
     # Make a rate file if needed
     if user_mask is None:
         image_model = _make_processed_rate_image(
-            input_model, single_mask, input_dir, exp_type, mask_science_regions, flat)
+            input_model, single_mask, input_dir, exp_type, mask_science_regions, flat
+        )
     else:
         image_model = input_model
 
     # Make a mask model from the user input or the rate data
     background_mask, mask_model = _make_scene_mask(
-        user_mask, image_model, mask_science_regions,
-        n_sigma, fit_histogram, single_mask, save_mask)
+        user_mask, image_model, mask_science_regions, n_sigma, fit_histogram, single_mask, save_mask
+    )
 
     log.info(f"Cleaning image {input_model.meta.filename}")
 
     # Check data shapes for 2D, 3D, or 4D inputs
-    mismatch, ndim, nints, ngroups = _check_data_shapes(
-        input_model, background_mask)
+    mismatch, ndim, nints, ngroups = _check_data_shapes(input_model, background_mask)
     if mismatch:
         return output_model, None, None, None, status
 
@@ -1561,21 +1611,31 @@ def do_correction(input_model, input_dir=None, fit_method='median',
             else:
                 # Ramp data input:
                 # subtract the current group from the next one
-                image = input_model.data[i, j+1] - input_model.data[i, j]
-                dq = input_model.groupdq[i, j+1]
+                image = input_model.data[i, j + 1] - input_model.data[i, j]
+                dq = input_model.groupdq[i, j + 1]
 
                 # Mask any DNU and JUMP pixels
                 _mask_unusable(mask, dq)
 
             # Clean the image
             cleaned_image, background, success = _clean_one_image(
-                image, mask, background_method, background_box_size, n_sigma,
-                fit_method, detector, fc, axis_to_correct, fit_by_channel, flat)
+                image,
+                mask,
+                background_method,
+                background_box_size,
+                n_sigma,
+                fit_method,
+                detector,
+                fc,
+                axis_to_correct,
+                fit_by_channel,
+                flat,
+            )
 
             if not success:
                 # Cleaning failed for internal reasons - probably the
                 # mask is not a good match to the data.
-                log.error(f'Cleaning failed for integration {i + 1}, group {j + 1}')
+                log.error(f"Cleaning failed for integration {i + 1}, group {j + 1}")
 
                 # Restore input data to make sure any partial changes
                 # are thrown away
@@ -1585,8 +1645,10 @@ def do_correction(input_model, input_dir=None, fit_method='median',
             if cleaned_image is None:
                 # Cleaning did not proceed because the image is bad:
                 # leave it as is but continue correcting the rest
-                log.warning(f'No usable data in integration {i+1}, group {j+1}. '
-                            f'Skipping correction for this image.')
+                log.warning(
+                    f"No usable data in integration {i + 1}, group {j + 1}. "
+                    f"Skipping correction for this image."
+                )
                 continue
 
             # Store the cleaned image in the output model
@@ -1601,9 +1663,9 @@ def do_correction(input_model, input_dir=None, fit_method='median',
             else:
                 # Add the cleaned data diff to the previously cleaned group,
                 # rather than the noisy input group
-                output_model.data[i, j+1] = output_model.data[i, j] + cleaned_image
+                output_model.data[i, j + 1] = output_model.data[i, j] + cleaned_image
                 if save_background:
-                    background_to_save[i, j+1] = background
+                    background_to_save[i, j + 1] = background
 
     # Store the background image in a model, if requested
     if save_background:
@@ -1620,6 +1682,6 @@ def do_correction(input_model, input_dir=None, fit_method='median',
         noise_model = None
 
     # Set completion status
-    status = 'COMPLETE'
+    status = "COMPLETE"
 
     return output_model, mask_model, background_model, noise_model, status

--- a/jwst/clean_flicker_noise/clean_flicker_noise_step.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise_step.py
@@ -8,7 +8,7 @@ __all__ = ["CleanFlickerNoiseStep"]
 
 class CleanFlickerNoiseStep(Step):
     """
-    CleanFlickerNoiseStep: This step performs flicker noise correction ("cleaning").
+    Perform flicker noise correction.
 
     Input data is expected to be a ramp file (RampModel), in between
     jump and ramp fitting steps, or a rate file (ImageModel or CubeModel).
@@ -20,6 +20,57 @@ class CleanFlickerNoiseStep(Step):
         - `median`: Background noise is characterized by a median
           along the detector slow axis. Implementation is based on the
           `image1overf` algorithm, developed by Chris Willott.
+
+    Attributes
+    ----------
+    fit_method : str, optional
+        The noise fitting algorithm to use.  Options are 'fft' and 'median'.
+    fit_by_channel : bool, optional
+        If set, flicker noise is fit independently for each detector channel.
+        Ignored for MIRI, for subarray data, and for `fit_method` = 'fft'
+    background_method : {'median', 'model', None}
+        If 'median', the preliminary background to remove and restore
+        is a simple median of the background data.  If 'model', the
+        background data is fit with a low-resolution model via
+        `~photutils.background.Background2D`.  If None, the background
+        value is 0.0.
+    background_box_size : tuple of int or None, optional
+        Box size for the data grid used by `Background2D` when
+        `background_method` = 'model'. For best results, use a box size
+        that evenly divides the input image shape.  If None, the largest
+        value between 1 and 32 that evenly divides the image dimension
+        is used.
+    mask_science_regions : bool, optional
+        For NIRSpec, mask regions of the image defined by WCS bounding
+        boxes for slits/slices, as well as any regions known to be
+        affected by failed-open MSA shutters.  For MIRI imaging, mask
+        regions of the detector not used for science.
+    apply_flat_field : bool, optional
+        If set, images are flat-corrected prior to fitting background
+        and noise levels.  A full-frame flat field image
+        (reference type FLAT) is required. For modes that do not provide
+        FLAT files via CRDS, including all NIRSpec spectral modes, a manually
+        generated override flat is required to enable this option.
+        Use the `override_flat` parameter to provide an alternate flat image
+        as needed.
+    n_sigma : float, optional
+        Sigma clipping threshold to be used in detecting outliers in the image.
+    fit_histogram : bool, optional
+        If set, the 'sigma' used with `n_sigma` for clipping outliers
+        is derived from a Gaussian fit to a histogram of values.
+        Otherwise, a simple iterative sigma clipping is performed.
+    single_mask : bool, optional
+        If set, a single mask will be created, regardless of
+        the number of input integrations. Otherwise, the mask will
+        be a 3D cube, with one plane for each integration.
+    user_mask : None, str, or `~jwst.datamodels.ImageModel`
+        Optional user-supplied mask image; path to file or opened datamodel.
+    save_mask : bool, optional
+        Save the computed mask image.
+    save_background : bool, optional
+        Save the computed background image.
+    save_noise : bool, optional
+        Save the computed noise image.
     """
 
     class_alias = "clean_flicker_noise"
@@ -27,10 +78,10 @@ class CleanFlickerNoiseStep(Step):
     spec = """
         fit_method = option('fft', 'median', default='median')  # Noise fitting algorithm
         fit_by_channel = boolean(default=False)  # Fit noise separately by amplifier (NIR only)
-        background_method = option('median', 'model', None, default='median') # Background fitting algorithm
-        background_box_size = int_list(min=2, max=2, default=None)  # Background box size for modeled background
+        background_method = option('median', 'model', None, default='median') # Background fit
+        background_box_size = int_list(min=2, max=2, default=None)  # Background box size
         mask_science_regions = boolean(default=False)  # Mask known science regions
-        apply_flat_field = boolean(default=False)  # Apply a flat correction before fitting background and noise
+        apply_flat_field = boolean(default=False)  # Apply a flat correction before fitting
         n_sigma = float(default=2.0)  # Clipping level for non-background signal
         fit_histogram = boolean(default=False)  # Fit a value histogram to derive sigma
         single_mask = boolean(default=True)  # Make a single mask for all integrations
@@ -41,115 +92,60 @@ class CleanFlickerNoiseStep(Step):
         skip = boolean(default=True)  # By default, skip the step
     """
 
-    reference_file_types = ['flat']
+    reference_file_types = ["flat"]
 
-    def process(self, input):
+    def process(self, input_data):
         """
         Fit and subtract 1/f background noise from a ramp data set.
 
         Parameters
         ----------
-        input : DataModel
+        input_data : DataModel
             Input datamodel to be corrected
-
-        fit_method : str, optional
-            The noise fitting algorithm to use.  Options are 'fft' and 'median'.
-
-        fit_by_channel : bool, optional
-            If set, flicker noise is fit independently for each detector channel.
-            Ignored for MIRI, for subarray data, and for `fit_method` = 'fft'
-
-        background_method : {'median', 'model', None}
-            If 'median', the preliminary background to remove and restore
-            is a simple median of the background data.  If 'model', the
-            background data is fit with a low-resolution model via
-            `~photutils.background.Background2D`.  If None, the background
-            value is 0.0.
-
-        background_box_size : tuple of int or None, optional
-            Box size for the data grid used by `Background2D` when
-            `background_method` = 'model'. For best results, use a box size
-            that evenly divides the input image shape.  If None, the largest
-            value between 1 and 32 that evenly divides the image dimension
-            is used.
-
-        mask_science_regions : bool, optional
-            For NIRSpec, mask regions of the image defined by WCS bounding
-            boxes for slits/slices, as well as any regions known to be
-            affected by failed-open MSA shutters.  For MIRI imaging, mask
-            regions of the detector not used for science.
-
-        apply_flat_field : bool, optional
-            If set, images are flat-corrected prior to fitting background
-            and noise levels.  A full-frame flat field image
-            (reference type FLAT) is required. For modes that do not provide
-            FLAT files via CRDS, including all NIRSpec spectral modes, a manually
-            generated override flat is required to enable this option.
-            Use the `override_flat` parameter to provide an alternate flat image
-            as needed.
-
-        n_sigma : float, optional
-            Sigma clipping threshold to be used in detecting outliers in the image.
-
-        fit_histogram : bool, optional
-            If set, the 'sigma' used with `n_sigma` for clipping outliers
-            is derived from a Gaussian fit to a histogram of values.
-            Otherwise, a simple iterative sigma clipping is performed.
-
-        single_mask : bool, optional
-            If set, a single mask will be created, regardless of
-            the number of input integrations. Otherwise, the mask will
-            be a 3D cube, with one plane for each integration.
-
-        user_mask : None, str, or `~jwst.datamodels.ImageModel`
-            Optional user-supplied mask image; path to file or opened datamodel.
-
-        save_mask : bool, optional
-            Save the computed mask image.
-
-        save_background : bool, optional
-            Save the computed background image.
-
-        save_noise : bool, optional
-            Save the computed noise image.
 
         Returns
         -------
         output_model : DataModel
             The flicker noise corrected datamodel
         """
-
         # Open the input data model
-        with datamodels.open(input) as input_model:
-
+        with datamodels.open(input_data) as input_model:
             flat_filename = None
             if self.apply_flat_field:
-                flat_filename = self.get_reference_file(input_model, 'flat')
+                flat_filename = self.get_reference_file(input_model, "flat")
                 exp_type = input_model.meta.exposure.type
-                if flat_filename == 'N/A':
-                    self.log.warning(f"Flat correction is not available for "
-                                     f"exposure type {exp_type} without a user-"
-                                     f"supplied flat.")
+                if flat_filename == "N/A":
+                    self.log.warning(
+                        f"Flat correction is not available for "
+                        f"exposure type {exp_type} without a user-"
+                        f"supplied flat."
+                    )
                     flat_filename = None
                 else:
-                    self.log.info(f'Using FLAT reference file: {flat_filename}')
+                    self.log.info(f"Using FLAT reference file: {flat_filename}")
 
             result = clean_flicker_noise.do_correction(
-                input_model, input_dir=self.input_dir, fit_method=self.fit_method,
+                input_model,
+                input_dir=self.input_dir,
+                fit_method=self.fit_method,
                 fit_by_channel=self.fit_by_channel,
                 background_method=self.background_method,
                 background_box_size=self.background_box_size,
                 mask_science_regions=self.mask_science_regions,
-                flat_filename=flat_filename, n_sigma=self.n_sigma,
-                fit_histogram=self.fit_histogram, single_mask=self.single_mask,
-                user_mask=self.user_mask, save_mask=self.save_mask,
-                save_background=self.save_background, save_noise=self.save_noise)
+                flat_filename=flat_filename,
+                n_sigma=self.n_sigma,
+                fit_histogram=self.fit_histogram,
+                single_mask=self.single_mask,
+                user_mask=self.user_mask,
+                save_mask=self.save_mask,
+                save_background=self.save_background,
+                save_noise=self.save_noise,
+            )
             output_model, mask_model, background_model, noise_model, status = result
 
             # Save the mask, if requested
             if self.save_mask and mask_model is not None:
-                mask_path = self.make_output_path(
-                    basepath=input_model.meta.filename, suffix='mask')
+                mask_path = self.make_output_path(basepath=input_model.meta.filename, suffix="mask")
                 self.log.info(f"Saving mask file {mask_path}")
                 mask_model.save(mask_path)
                 mask_model.close()
@@ -157,7 +153,8 @@ class CleanFlickerNoiseStep(Step):
             # Save the background, if requested
             if self.save_background and background_model is not None:
                 bg_path = self.make_output_path(
-                    basepath=input_model.meta.filename, suffix='flicker_bkg')
+                    basepath=input_model.meta.filename, suffix="flicker_bkg"
+                )
                 self.log.info(f"Saving background file {bg_path}")
                 background_model.save(bg_path)
                 background_model.close()
@@ -165,7 +162,8 @@ class CleanFlickerNoiseStep(Step):
             # Save the noise, if requested
             if self.save_noise and noise_model is not None:
                 noise_path = self.make_output_path(
-                    basepath=input_model.meta.filename, suffix='flicker_noise')
+                    basepath=input_model.meta.filename, suffix="flicker_noise"
+                )
                 self.log.info(f"Saving noise file {noise_path}")
                 noise_model.save(noise_path)
                 noise_model.close()

--- a/jwst/clean_flicker_noise/lib.py
+++ b/jwst/clean_flicker_noise/lib.py
@@ -447,9 +447,9 @@ class NSCleanSubarray:
             )
             self.data[np.isinf(self.data)] = np.nan  # Restore NaNs
 
-            bdpx[np.logical_not(self.mask)] = (
-                0  # We don't need to worry about non-background pixels
-            )
+            # We don't need to worry about non-background pixels
+            bdpx[np.logical_not(self.mask)] = 0
+
             # Also flag 4 nearest neighbors
             bdpx = (
                 bdpx
@@ -536,10 +536,10 @@ class NSCleanSubarray:
 
             # NSClean's weighting requires the Moore-Penrose inverse of A = P*B.
             #     $A^+ = (A^H A)^{-1} A^H$
-            _a = (
-                p_matrix.reshape((-1, 1)) * basis
-            )  # P is diagonal. Hadamard product is most RAM efficient
-            _a_h = np.conjugate(_a.transpose())  # Hermitian transpose of A
+            # P is diagonal. Hadamard product is most RAM efficient
+            _a = p_matrix.reshape((-1, 1)) * basis
+            # Hermitian transpose of A
+            _a_h = np.conjugate(_a.transpose())
             pinv_pb = np.matmul(np.linalg.inv(np.matmul(_a_h, _a)), _a_h)
 
         else:

--- a/jwst/nsclean/__init__.py
+++ b/jwst/nsclean/__init__.py
@@ -1,3 +1,5 @@
+"""Correct NIRSpec rate data for 1/f noise."""
+
 from .nsclean_step import NSCleanStep
 
-__all__ = ['NSCleanStep']
+__all__ = ["NSCleanStep"]

--- a/jwst/nsclean/nsclean_step.py
+++ b/jwst/nsclean/nsclean_step.py
@@ -8,10 +8,51 @@ __all__ = ["NSCleanStep"]
 
 class NSCleanStep(Step):
     """
+    Perform 1/f noise correction.
+
     NSCleanStep: This step performs 1/f noise correction ("cleaning")
     of NIRSpec images, using the "NSClean" method.
 
     NOTE: This step is a deprecated alias to the ``clean_flicker_noise`` step.
+
+    Attributes
+    ----------
+    fit_method : str, optional
+        The background fit algorithm to use.  Options are 'fft' and 'median';
+        'fft' performs the original NSClean implementation.
+    fit_by_channel : bool, optional
+        If set, flicker noise is fit independently for each detector channel.
+        Ignored for subarray data and for `fit_method` = 'fft'.
+    background_method : {'median', 'model', None}
+        If 'median', the preliminary background to remove and restore
+        is a simple median of the background data.  If 'model', the
+        background data is fit with a low-resolution model via
+        `~photutils.background.Background2D`.  If None, the background
+        value is 0.0.
+    background_box_size : tuple of int, optional
+        Box size for the data grid used by `Background2D` when
+        `background_method` = 'model'. For best results, use a box size
+        that evenly divides the input image shape.
+    mask_spectral_regions : bool, optional
+        Mask regions of the image defined by WCS bounding boxes for slits/slices.
+    n_sigma : float, optional
+        Sigma clipping threshold to be used in detecting outliers in the image.
+    fit_histogram : bool, optional
+        If set, the 'sigma' used with `n_sigma` for clipping outliers
+        is derived from a Gaussian fit to a histogram of values.
+        Otherwise, a simple iterative sigma clipping is performed.
+    single_mask : bool, optional
+        If set, a single mask will be created, regardless of
+        the number of input integrations. Otherwise, the mask will
+        be a 3D cube, with one plane for each integration.
+    user_mask : None, str, or `~jwst.datamodels.ImageModel`
+        Optional user-supplied mask image; path to file or opened datamodel.
+    save_mask : bool, optional
+        Save the computed mask image.
+    save_background : bool, optional
+        Save the computed background image.
+    save_noise : bool, optional
+        Save the computed noise image.
     """
 
     class_alias = "nsclean"
@@ -19,8 +60,8 @@ class NSCleanStep(Step):
     spec = """
         fit_method = option('fft', 'median', default='fft')  # Noise fitting algorithm
         fit_by_channel = boolean(default=False)  # Fit noise separately by amplifier
-        background_method = option('median', 'model', None, default=None) # Background fitting algorithm
-        background_box_size = int_list(min=2, max=2, default=None)  # Background box size for modeled background
+        background_method = option('median', 'model', None, default=None) # Background fit
+        background_box_size = int_list(min=2, max=2, default=None)  # Background box size
         mask_spectral_regions = boolean(default=True)  # Mask WCS-defined spectral regions
         n_sigma = float(default=5.0)  # Clipping level for outliers
         fit_histogram = boolean(default=False)  # Fit a value histogram to derive sigma
@@ -32,75 +73,28 @@ class NSCleanStep(Step):
         skip = boolean(default=True)  # By default, skip the step
     """
 
-    def process(self, input):
+    def process(self, input_data):
         """
-        Fit and subtract 1/f background noise from a NIRSpec image
+        Fit and subtract 1/f background noise from a NIRSpec image.
 
         Parameters
         ----------
-        input : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`
+        input_data : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`
             Input datamodel to be corrected.
-
-        fit_method : str, optional
-            The background fit algorithm to use.  Options are 'fft' and 'median';
-            'fft' performs the original NSClean implementation.
-
-        fit_by_channel : bool, optional
-            If set, flicker noise is fit independently for each detector channel.
-            Ignored for subarray data and for `fit_method` = 'fft'.
-
-        background_method : {'median', 'model', None}
-            If 'median', the preliminary background to remove and restore
-            is a simple median of the background data.  If 'model', the
-            background data is fit with a low-resolution model via
-            `~photutils.background.Background2D`.  If None, the background
-            value is 0.0.
-
-        background_box_size : tuple of int, optional
-            Box size for the data grid used by `Background2D` when
-            `background_method` = 'model'. For best results, use a box size
-            that evenly divides the input image shape.
-
-        mask_spectral_regions : bool, optional
-            Mask regions of the image defined by WCS bounding boxes for slits/slices.
-
-        n_sigma : float, optional
-            Sigma clipping threshold to be used in detecting outliers in the image.
-
-        fit_histogram : bool, optional
-            If set, the 'sigma' used with `n_sigma` for clipping outliers
-            is derived from a Gaussian fit to a histogram of values.
-            Otherwise, a simple iterative sigma clipping is performed.
-
-        single_mask : bool, optional
-            If set, a single mask will be created, regardless of
-            the number of input integrations. Otherwise, the mask will
-            be a 3D cube, with one plane for each integration.
-
-        user_mask : None, str, or `~jwst.datamodels.ImageModel`
-            Optional user-supplied mask image; path to file or opened datamodel.
-
-        save_mask : bool, optional
-            Save the computed mask image.
-
-        save_background : bool, optional
-            Save the computed background image.
-
-        save_noise : bool, optional
-            Save the computed noise image.
 
         Returns
         -------
         output_model : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`
             The 1/f corrected datamodel.
         """
-        message = ("The 'nsclean' step is a deprecated alias to 'clean_flicker_noise' "
-                   "and will be removed in future builds.")
+        message = (
+            "The 'nsclean' step is a deprecated alias to 'clean_flicker_noise' "
+            "and will be removed in future builds."
+        )
         self.log.warning(message)
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
-
+        with datamodels.open(input_data) as input_model:
             # clean_flicker_noise allows flat handling, but NIRSpec is
             # not supported via CRDS files, since it does not have a full
             # frame flat.  Since this step is for NIRSpec only, don't allow
@@ -109,21 +103,27 @@ class NSCleanStep(Step):
 
             # Do the NSClean correction
             result = clean_flicker_noise.do_correction(
-                input_model, input_dir=self.input_dir, fit_method=self.fit_method,
+                input_model,
+                input_dir=self.input_dir,
+                fit_method=self.fit_method,
                 fit_by_channel=self.fit_by_channel,
                 background_method=self.background_method,
                 background_box_size=self.background_box_size,
                 mask_science_regions=self.mask_spectral_regions,
-                flat_filename=flat_filename, n_sigma=self.n_sigma,
-                fit_histogram=self.fit_histogram, single_mask=self.single_mask,
-                user_mask=self.user_mask, save_mask=self.save_mask,
-                save_background=self.save_background, save_noise=self.save_noise)
+                flat_filename=flat_filename,
+                n_sigma=self.n_sigma,
+                fit_histogram=self.fit_histogram,
+                single_mask=self.single_mask,
+                user_mask=self.user_mask,
+                save_mask=self.save_mask,
+                save_background=self.save_background,
+                save_noise=self.save_noise,
+            )
             output_model, mask_model, background_model, noise_model, status = result
 
             # Save the mask, if requested
             if self.save_mask and mask_model is not None:
-                mask_path = self.make_output_path(
-                    basepath=input_model.meta.filename, suffix='mask')
+                mask_path = self.make_output_path(basepath=input_model.meta.filename, suffix="mask")
                 self.log.info(f"Saving mask file {mask_path}")
                 mask_model.save(mask_path)
                 mask_model.close()
@@ -131,7 +131,8 @@ class NSCleanStep(Step):
             # Save the background, if requested
             if self.save_background and background_model is not None:
                 bg_path = self.make_output_path(
-                    basepath=input_model.meta.filename, suffix='flicker_bkg')
+                    basepath=input_model.meta.filename, suffix="flicker_bkg"
+                )
                 self.log.info(f"Saving background file {bg_path}")
                 background_model.save(bg_path)
                 background_model.close()
@@ -139,7 +140,8 @@ class NSCleanStep(Step):
             # Save the noise, if requested
             if self.save_noise and noise_model is not None:
                 noise_path = self.make_output_path(
-                    basepath=input_model.meta.filename, suffix='flicker_noise')
+                    basepath=input_model.meta.filename, suffix="flicker_noise"
+                )
                 self.log.info(f"Saving noise file {noise_path}")
                 noise_model.save(noise_path)
                 noise_model.close()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-3859](https://jira.stsci.edu/browse/JP-3859)

Also ignores rule TRY400, which requires log.exception instead of log.error inside an except clause.  No need to enforce tracebacks every time we log an error.

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Code style updates for clean_flicker_noise and nsclean

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
