### PR TITLE
move very slow test to it's own module

### DIFF
--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -42,23 +42,6 @@ def run_tso_spec3(rtdata_module, run_tso_spec2):
     Step.from_cmdline(args)
 
 
-@pytest.fixture(scope="module")
-def run_atoca_extras(rtdata_module):
-    """Run stage 2 pipeline on NIRISS SOSS data using enhanced modes via parameter settings."""
-    rtdata = rtdata_module
-
-    # Run spec2 pipeline on the second _rateints file, using wavegrid generated from first segment.
-    rtdata.get_data("niriss/soss/seg001_wavegrid.fits")
-    rtdata.get_data("niriss/soss/atoca_extras_rateints.fits")
-    args = ["calwebb_spec2", rtdata.input,
-            "--steps.extract_1d.soss_modelname=atoca_extras",
-            "--steps.extract_1d.soss_wave_grid_in=seg001_wavegrid.fits",
-            "--steps.extract_1d.soss_bad_pix=model",
-            "--steps.extract_1d.soss_rtol=1.e-3",
-            ]
-    Step.from_cmdline(args)
-
-
 @pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["calints", "flat_field", "srctype", "x1dints"])
 def test_niriss_soss_stage2(rtdata_module, run_tso_spec2, fitsdiff_default_kwargs, suffix):
@@ -111,21 +94,6 @@ def test_niriss_soss_stage3_whtlt(run_tso_spec3, rtdata_module, diff_astropy_tab
     rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
 
     assert diff_astropy_tables(rtdata.output, rtdata.truth)
-
-
-@pytest.mark.bigdata
-@pytest.mark.parametrize("suffix", ["calints", "x1dints", "AtocaSpectra", "SossExtractModel"])
-def test_niriss_soss_extras(rtdata_module, run_atoca_extras, fitsdiff_default_kwargs, suffix):
-    """Regression test of ATOCA enhanced algorithm performed on NIRISS SOSS data."""
-    rtdata = rtdata_module
-
-    output = f"atoca_extras_{suffix}.fits"
-    rtdata.output = output
-
-    rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
-
-    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
-    assert diff.identical, diff.report()
 
 
 @pytest.fixture(scope='module')

--- a/jwst/regtest/test_niriss_soss_extras.py
+++ b/jwst/regtest/test_niriss_soss_extras.py
@@ -1,0 +1,36 @@
+import pytest
+from astropy.io.fits.diff import FITSDiff
+
+from jwst.stpipe import Step
+
+
+@pytest.fixture(scope="module")
+def run_atoca_extras(rtdata_module):
+    """Run stage 2 pipeline on NIRISS SOSS data using enhanced modes via parameter settings."""
+    rtdata = rtdata_module
+
+    # Run spec2 pipeline on the second _rateints file, using wavegrid generated from first segment.
+    rtdata.get_data("niriss/soss/seg001_wavegrid.fits")
+    rtdata.get_data("niriss/soss/atoca_extras_rateints.fits")
+    args = ["calwebb_spec2", rtdata.input,
+            "--steps.extract_1d.soss_modelname=atoca_extras",
+            "--steps.extract_1d.soss_wave_grid_in=seg001_wavegrid.fits",
+            "--steps.extract_1d.soss_bad_pix=model",
+            "--steps.extract_1d.soss_rtol=1.e-3",
+            ]
+    Step.from_cmdline(args)
+
+
+@pytest.mark.bigdata
+@pytest.mark.parametrize("suffix", ["calints", "x1dints", "AtocaSpectra", "SossExtractModel"])
+def test_niriss_soss_extras(rtdata_module, run_atoca_extras, fitsdiff_default_kwargs, suffix):
+    """Regression test of ATOCA enhanced algorithm performed on NIRISS SOSS data."""
+    rtdata = rtdata_module
+
+    output = f"atoca_extras_{suffix}.fits"
+    rtdata.output = output
+
+    rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()


### PR DESCRIPTION
`test_niriss_soss_extras` on it's own takes >3000 seconds to run. Several other tests in the same module are also slow:
- `test_niriss_soss_stage3_crfints` >400 seconds
- `test_extract1d_null_order2` >200 seconds

(which will run serially in the same process). This PR moves `test_niriss_soss_extras` to it's own module to allow it to run in a separate process by `pytest-xdist`.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/13059831279

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
