### PR TITLE
Fix code style in outlier detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     rev: v2.4.0
     hooks:
     - id: codespell
-      args: ["--write-changes"]
+      args: ["--write-changes", "--summary"]
       additional_dependencies:
         - tomli
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,6 @@ repos:
             jwst/model_blender/.* |
             jwst/mrs_imatch/.* |
             jwst/msaflagopen/.* |
-            jwst/outlier_detection/.* |
             jwst/pathloss/.* |
             jwst/persistence/.* |
             jwst/photom/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -60,7 +60,7 @@ exclude = [
     "jwst/mrs_imatch/**.py",
     "jwst/msaflagopen/**.py",
     #"jwst/nsclean/**.py",
-    "jwst/outlier_detection/**.py",
+    # "jwst/outlier_detection/**.py",
     "jwst/pathloss/**.py",
     "jwst/persistence/**.py",
     "jwst/photom/**.py",
@@ -119,9 +119,11 @@ select = [
 ]
 ignore = [
     "D100", # missing docstring in public module
+    "D105", # missing docstring in magic method
     "E741", # ambiguous variable name (O/0, l/I, etc.)
     "UP008", # use super() instead of super(class, self). no harm being explicit
     "UP015", # unnecessary open(file, "r"). no harm being explicit
+    "UP038",
     "TRY003", # prevents custom exception messages not defined in exception itself.
     "TRY400", # enforces log.exception instead of log.error in except clause.
     "ISC001", # single line implicit string concatenation. formatter recommends ignoring this.
@@ -188,7 +190,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/mrs_imatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/msaflagopen/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 #"jwst/nsclean/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/outlier_detection/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/outlier_detection/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/pathloss/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/persistence/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/photom/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/datamodels/library.py
+++ b/jwst/datamodels/library.py
@@ -28,6 +28,10 @@ class ModelLibrary(AbstractModelLibrary):
         """
         return [member["exptype"] for member in self._members]
 
+    @property
+    def on_disk(self):
+        return self._on_disk
+
     def indices_for_exptype(self, exptype):
         """
         Determine the indices of models corresponding to ``exptype``.

--- a/jwst/outlier_detection/__init__.py
+++ b/jwst/outlier_detection/__init__.py
@@ -1,3 +1,5 @@
+"""Detect outliers and set DQ flags accordingly."""
+
 from .outlier_detection_step import OutlierDetectionStep
 
-__all__ = ['OutlierDetectionStep']
+__all__ = ["OutlierDetectionStep"]

--- a/jwst/outlier_detection/_fileio.py
+++ b/jwst/outlier_detection/_fileio.py
@@ -1,10 +1,12 @@
 import logging
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
 def save_median(median_model, make_output_path):
-    """Save a median model.
+    """
+    Save a median model.
 
     Output suffix is 'median'.
 
@@ -16,13 +18,13 @@ def save_median(median_model, make_output_path):
     make_output_path : function
         A function to be used to create an output path from
         an input path and an optional suffix.
-
     """
     _save_intermediate_output(median_model, "median", make_output_path)
 
 
 def save_drizzled(drizzled_model, make_output_path):
-    """Save a drizzled model.
+    """
+    Save a drizzled model.
 
     Input model is expected to have a filename that ends with
     either 'outlier_i2d.fits' or 'outlier_s2d.fits'.
@@ -35,17 +37,15 @@ def save_drizzled(drizzled_model, make_output_path):
     make_output_path : function
         A function to be used to create an output path from
         an input path and an optional suffix.
-
     """
     expected_tail = "outlier_?2d.fits"
-    suffix = drizzled_model.meta.filename[-len(expected_tail):-5]
+    suffix = drizzled_model.meta.filename[-len(expected_tail) : -5]
     _save_intermediate_output(drizzled_model, suffix, make_output_path)
 
 
 def save_blot(input_model, blot, blot_err, make_output_path):
-    """Save a blotted model.
-
-    Output suffix is 'blot'.
+    """
+    Save a blotted model with output suffix 'blot'.
 
     Parameters
     ----------
@@ -62,14 +62,14 @@ def save_blot(input_model, blot, blot_err, make_output_path):
     make_output_path : function
         A function to be used to create an output path from
         an input path and an optional suffix.
-
     """
     blot_model = _make_blot_model(input_model, blot, blot_err)
     _save_intermediate_output(blot_model, "blot", make_output_path)
 
 
 def _make_blot_model(input_model, blot, blot_err):
-    """Assemble a blot model.
+    """
+    Assemble a blot model.
 
     Parameters
     ----------
@@ -87,7 +87,6 @@ def _make_blot_model(input_model, blot, blot_err):
     -------
     blot_model : ~jwst.datamodels.ImageModel
         An image model containing the blotted data.
-
     """
     blot_model = type(input_model)()
     blot_model.data = blot
@@ -98,7 +97,8 @@ def _make_blot_model(input_model, blot, blot_err):
 
 
 def _save_intermediate_output(model, suffix, make_output_path):
-    """Save an intermediate output from outlier detection.
+    """
+    Save an intermediate output from outlier detection.
 
     Ensure all intermediate outputs from OutlierDetectionStep have
     consistent file naming conventions.
@@ -119,7 +119,6 @@ def _save_intermediate_output(model, suffix, make_output_path):
     -----
     self.make_output_path() is updated globally for the step in the main pipeline
     to include the asn_id in the output path, so no need to handle it here.
-
     """
     # outlier_?2d is not a known suffix, and make_output_path cannot handle an
     # underscore in an unknown suffix, so do a manual string replacement
@@ -127,7 +126,7 @@ def _save_intermediate_output(model, suffix, make_output_path):
 
     # Add a slit name to the output path for MultiSlitModel data if not present
     if hasattr(model, "name") and model.name is not None:
-        if "_"+model.name.lower() not in input_path:
+        if "_" + model.name.lower() not in input_path:
             suffix = f"{model.name.lower()}_{suffix}"
 
     output_path = make_output_path(input_path, suffix=suffix)

--- a/jwst/outlier_detection/coron.py
+++ b/jwst/outlier_detection/coron.py
@@ -1,6 +1,4 @@
-"""
-Submodule for performing outlier detection on coronagraphy data.
-"""
+"""Submodule for performing outlier detection on coronagraphy data."""
 
 import logging
 
@@ -31,7 +29,25 @@ def detect_outliers(
     """
     Flag outliers in coronography data.
 
-    See `OutlierDetectionStep.spec` for documentation of these arguments.
+    Parameters
+    ----------
+    input_model : ~jwst.datamodels.CubeModel
+        The input cube model.
+    save_intermediate_results : bool
+        If True, save the median model.
+    good_bits : int
+        DQ flag bit values indicating good pixels.
+    maskpt : float
+        The percentage of the mean weight to use as a threshold for masking.
+    snr : float
+        The signal-to-noise ratio threshold for flagging outliers.
+    make_output_path : callable
+        A function that generates a path for saving intermediate results.
+
+    Returns
+    -------
+    ~jwst.datamodels.CubeModel
+        The input model with outliers flagged.
     """
     if not isinstance(input_model, datamodels.JwstDataModel):
         input_model = datamodels.open(input_model)

--- a/jwst/outlier_detection/ifu.py
+++ b/jwst/outlier_detection/ifu.py
@@ -55,7 +55,28 @@ def detect_outliers(
     """
     Flag outliers in ifu data.
 
-    See `OutlierDetectionStep.spec` for documentation of these arguments.
+    Parameters
+    ----------
+    input_models : ModelContainer or str
+        A container of data models or an association file readable into a ModelContainer.
+    save_intermediate_results : bool
+        If True, save intermediate results.
+    kernel_size : str
+        The size of the kernel to use to normalize the pixel differences.
+        Must only contain odd values. Valid values are a pair of ints in a single string
+        (for example “7 7”, the step default).
+    ifu_second_check : bool
+        If True, perform a secondary check for outliers. This will set outliers
+        wherever the difference array of adjacent pixels is a NaN.
+    threshold_percent : float
+        The threshold (in percent) of the normalized minimum pixel difference
+        used to identify bad pixels. Pixels with a normalized minimum difference
+        above this percentage are flagged as outliers.
+
+    Returns
+    -------
+    input_models : ModelContainer
+        The input data with DQ flags set for detected outliers.
     """
     if not isinstance(input_models, ModelContainer):
         input_models = ModelContainer(input_models)
@@ -73,48 +94,70 @@ def detect_outliers(
 
     # check if kernel size is an odd value
     if kern_size[0] % 2 == 0:
-        log.info("X kernel size is given as an even number. This value must be an odd number. Increasing number by 1")
+        log.info(
+            "X kernel size is given as an even number. This value must be an odd number. "
+            "Increasing number by 1"
+        )
         kern_size[0] = kern_size[0] + 1
-        log.info("New x kernel size is {}: ".format(kern_size[0]))
+        log.info("New x kernel size is {kern_size[0}: ")
     if kern_size[1] % 2 == 0:
-        log.info("Y kernel size is given as an even number. This value must be an odd number. Increasing number by 1")
+        log.info(
+            "Y kernel size is given as an even number. This value must be an odd number. "
+            "Increasing number by 1"
+        )
         kern_size[1] = kern_size[1] + 1
-        log.info("New y kernel size is {}: ".format(kern_size[1]))
+        log.info(f"New y kernel size is {kern_size[1]}: ")
 
     (diffaxis, ny, nx) = _find_detector_parameters(input_models)
 
     nfiles = len(input_models)
-    detector = np.empty(nfiles, dtype='<U15')
+    detector = np.empty(nfiles, dtype="<U15")
     for i, model in enumerate(input_models):
         detector[i] = model.meta.instrument.detector.lower()
 
     exptype = input_models[0].meta.exposure.type
-    log.info("Performing IFU outlier_detection for exptype {}".format(
-             exptype))
+    log.info(f"Performing IFU outlier_detection for exptype {exptype}")
     # How many unique values of detector?
     uq_det = np.unique(detector)
     ndet = len(uq_det)
     for idet in range(ndet):
         indx = (np.where(detector == uq_det[idet]))[0]
         ndet_files = int(len(indx))
-        flag_outliers(input_models,
-                      idet, uq_det, ndet_files,
-                      diffaxis, nx, ny,
-                      kern_size, threshold_percent,
-                      save_intermediate_results,
-                      ifu_second_check,
-                      make_output_path)
+        flag_outliers(
+            input_models,
+            idet,
+            uq_det,
+            ndet_files,
+            diffaxis,
+            nx,
+            ny,
+            kern_size,
+            threshold_percent,
+            save_intermediate_results,
+            ifu_second_check,
+            make_output_path,
+        )
     return input_models
 
 
-def flag_outliers(input_models, idet, uq_det, ndet_files,
-                  diffaxis, nx, ny,
-                  kern_size, threshold_percent,
-                  save_intermediate_results,
-                  ifu_second_check,
-                  make_output_path):
+def flag_outliers(
+    input_models,
+    idet,
+    uq_det,
+    ndet_files,
+    diffaxis,
+    nx,
+    ny,
+    kern_size,
+    threshold_percent,
+    save_intermediate_results,
+    ifu_second_check,
+    make_output_path,
+):
     """
-    Flag outlier pixels on IFU. In general we are searching for pixels that
+    Flag outlier pixels on IFU.
+
+    In general we are searching for pixels that
     are a form of a bad pixel but not in bad pixel mask, because the bad pixels vary with
     time. This program will flag the DQ of input images as DO_NOT_USE and OUTLIER and set
     the associated science pixel to a Nan. This routine only works on data from one detector.
@@ -123,9 +166,9 @@ def flag_outliers(input_models, idet, uq_det, ndet_files,
     ----------
     idet : int
         Integer indicating which detector we are working with
-    uq_det : string array
+    uq_det : np.array[str]
         Array of (unique) detector names found input data
-    n_det_files : int
+    ndet_files : int
         Number of files for the detector we are working on
     diffaxis : int
         The axis to form the adjacent pixel differences
@@ -140,26 +183,25 @@ def flag_outliers(input_models, idet, uq_det, ndet_files,
         adjacent pixels for all the input data for a detector is above this percentage. The
         percentage is based on using all the pixels except a 4 X 4 row and column region around
         the detector that is often noisy.
-    save_intermediate_results : boolean
+    save_intermediate_results : bool
         If True then save intermediate output data
-    ifu_second_check : boolean
+    ifu_second_check : bool
         If True then perform a secondary check searching for outliers. This will set outliers
         where ever the difference array of adjacent pixels is a Nan.
     make_output_path : function
         The functools.partial instance to pass to save_median. Has no effect if
         save_intermediate_results is False.
     """
-
     # set up array to hold group differences
     diffarr = np.zeros([ndet_files, ny, nx])
     j = 0
-    for i, model in enumerate(input_models):
+    for model in input_models:
         detector = model.meta.instrument.detector.lower()
         # only use data from the same detector
         if detector == uq_det[idet]:
             sci = model.data
             dq = model.dq
-            bad = np.bitwise_and(dq, dqflags.pixel['DO_NOT_USE']).astype(bool)
+            bad = np.bitwise_and(dq, dqflags.pixel["DO_NOT_USE"]).astype(bool)
             # set all science data that have DO_NOT_USE to NAN
             sci[bad] = np.nan
 
@@ -189,12 +231,12 @@ def flag_outliers(input_models, idet, uq_det, ndet_files,
 
     # Normalise the differences to a local median image to deal with ultra-bright sources
     normarr = medfilt(minarr, kern_size)
-    nfloor = np.nanmedian(minarr)/3
+    nfloor = np.nanmedian(minarr) / 3
     normarr[normarr < nfloor] = nfloor  # Ensure we never divide by a tiny number
     minarr_norm = minarr / normarr
     # Percentile cut of the central region (cutting out weird detector edge effects)
-    pctmin = np.nanpercentile(minarr_norm[4:ny-4, 4:nx-4], threshold_percent)
-    log.debug("Flag pixels with values above {} {}: ".format(threshold_percent, pctmin))
+    pctmin = np.nanpercentile(minarr_norm[4 : ny - 4, 4 : nx - 4], threshold_percent)
+    log.debug(f"Flag pixels with values above {threshold_percent} {pctmin}: ")
     # Flag everything above this percentile value. Using np.where here because we count
     # the number of pixels flagged using len(indx[0])
     indx = minarr_norm > pctmin
@@ -202,13 +244,21 @@ def flag_outliers(input_models, idet, uq_det, ndet_files,
 
     if save_intermediate_results:
         detector_name = uq_det[idet]
-        opt_info = (kern_size[0], kern_size[1], threshold_percent,
-                    diffarr, minarr, normarr, minarr_norm)
+        opt_info = (
+            kern_size[0],
+            kern_size[1],
+            threshold_percent,
+            diffarr,
+            minarr,
+            normarr,
+            minarr_norm,
+        )
         opt_model = create_optional_results_model(opt_info)
         opt_model.meta.filename = make_output_path(
             basepath=input_models.meta.asn_table.products[0].name,
-            suffix=detector_name + '_outlier_output')
-        log.info("Writing out intermediate outlier file {}".format(opt_model.meta.filename))
+            suffix=detector_name + "_outlier_output",
+        )
+        log.info("Writing out intermediate outlier file {opt_model.meta.filename}")
         opt_model.save(opt_model.meta.filename)
 
     del diffarr
@@ -221,7 +271,6 @@ def flag_outliers(input_models, idet, uq_det, ndet_files,
 
     # Update DQ flag
     for i in range(len(input_models)):
-
         detector = input_models[i].meta.instrument.detector.lower()
         # only use data from the same detector
         if detector == uq_det[idet]:
@@ -233,34 +282,42 @@ def flag_outliers(input_models, idet, uq_det, ndet_files,
             # but the dq flag of DO_NOT_USE has not been set.
             # This can occur in Non-science regions of the detector.
             check = np.where(
-                np.logical_and(~np.bitwise_and(dq, dqflags.pixel['DO_NOT_USE']).astype(bool),
-                               np.isnan(sci)))
-            log.debug("Number of pixels DQ was not set to DO_NOT_USE and Sci array was Nan{} ".
-                      format(len(check[0])))
+                np.logical_and(
+                    ~np.bitwise_and(dq, dqflags.pixel["DO_NOT_USE"]).astype(bool), np.isnan(sci)
+                )
+            )
+            log.debug(
+                "Number of pixels DQ was not set to DO_NOT_USE "
+                f"and Sci array was Nan{len(check[0])} "
+            )
             # set all pixels with dq = DO_NOT_USE to have sci values of Nan
-            bad = np.bitwise_and(dq, dqflags.pixel['DO_NOT_USE']).astype(bool)
+            bad = np.bitwise_and(dq, dqflags.pixel["DO_NOT_USE"]).astype(bool)
             sci[bad] = np.nan
 
             # Basic setting outliers: flagging those at are found in from Percentage cut
             sci[indx] = np.nan
-            dq[indx] = np.bitwise_or(dq[indx], dqflags.pixel['DO_NOT_USE'])
-            dq[indx] = np.bitwise_or(dq[indx], dqflags.pixel['OUTLIER'])
+            dq[indx] = np.bitwise_or(dq[indx], dqflags.pixel["DO_NOT_USE"])
+            dq[indx] = np.bitwise_or(dq[indx], dqflags.pixel["OUTLIER"])
 
             nadditional = 0
             # Second level of setting outliers: flagging pixels were minarr was a Nan
             # This will also catch pixels that have a sci of Nan but the DQ flags did
             # not have DO_NOT_USE set
             if ifu_second_check:
-                # For counting purposes, count the number of science values that were valid (not Nan)
+                # For counting purposes, count number of science values that were valid (not Nan)
                 # after basic flagging in the nanminarr region that will now  be flagged as a Nan.
                 nadditional = (~np.isnan(sci[nanindx])).sum()
                 sci[nanindx] = np.nan
-                dq[nanindx] = np.bitwise_or(dq[nanindx], dqflags.pixel['DO_NOT_USE'])
-                dq[nanindx] = np.bitwise_or(dq[nanindx], dqflags.pixel['OUTLIER'])
-                log.info("Number of outlier pixels flagged main ifu outlier flagging: {} on detector {} ".format(
-                    len(indx[0]), uq_det[idet]))
-                log.info("Number of outlier pixels flagged in second check: {} on detector {} ".format(
-                    nadditional, uq_det[idet]))
+                dq[nanindx] = np.bitwise_or(dq[nanindx], dqflags.pixel["DO_NOT_USE"])
+                dq[nanindx] = np.bitwise_or(dq[nanindx], dqflags.pixel["OUTLIER"])
+                log.info(
+                    "Number of outlier pixels flagged main ifu outlier flagging: "
+                    f"{len(indx[0])} on detector {uq_det[idet]} "
+                )
+                log.info(
+                    "Number of outlier pixels flagged in second check: "
+                    f"{nadditional} on detector {uq_det[idet]} "
+                )
 
             total_bad = num_above + nadditional
             percent_cr = total_bad / (model.data.shape[0] * model.data.shape[1]) * 100
@@ -275,11 +332,26 @@ def flag_outliers(input_models, idet, uq_det, ndet_files,
 
 
 def _find_detector_parameters(input_models):
-    """Find the size of data and the axis to form the differences (perpendicular to disaxis) """
+    """
+    Find the size of data and the axis to form the differences (perpendicular to dispaxis).
 
-    if input_models[0].meta.instrument.name.upper() == 'MIRI':
+    Parameters
+    ----------
+    input_models : ModelContainer
+        The input data models.
+
+    Returns
+    -------
+    diffaxis : int
+        The axis perpendicular to dispaxis.
+    ny : int
+        The size of the data on the y axis.
+    nx : int
+        The size of the data on the x axis.
+    """
+    if input_models[0].meta.instrument.name.upper() == "MIRI":
         diffaxis = 1
-    elif input_models[0].meta.instrument.name.upper() == 'NIRSPEC':
+    elif input_models[0].meta.instrument.name.upper() == "NIRSPEC":
         diffaxis = 0
     ny, nx = input_models[0].data.shape
     return (diffaxis, ny, nx)
@@ -287,27 +359,22 @@ def _find_detector_parameters(input_models):
 
 def create_optional_results_model(opt_info):
     """
-    Creates an OutlierOutputModel from the computed arrays from outlier detection on IFU data.
+    Create an OutlierOutputModel from the computed arrays from outlier detection on IFU data.
 
-    Parameter
-    ---------
-    input_model: ~stdatamodels.jwst.datamodels.RampModel
+    Parameters
+    ----------
+    opt_info : tuple
+        The output arrays needed for the OutlierOutputModel.
 
-    opt_info: tuple
-    The output arrays needed for the OultierOutputModel.
-
-    Return
-    ---------
+    Returns
+    -------
     opt_model : OutlierIFUOutputModel
         The optional OutlierIFUOutputModel to be returned from the outlier_detection_ifu step.
     """
-    (kernsize_x, kernsize_y, threshold_percent,
-     diffarr, minarr, normarr, minnorm) = opt_info
+    (kernsize_x, kernsize_y, threshold_percent, diffarr, minarr, normarr, minnorm) = opt_info
     opt_model = datamodels.OutlierIFUOutputModel(
-        diffarr=diffarr,
-        minarr=minarr,
-        normarr=normarr,
-        minnorm=minnorm)
+        diffarr=diffarr, minarr=minarr, normarr=normarr, minnorm=minnorm
+    )
     opt_model.meta.kernel_xsize = kernsize_x
     opt_model.meta.kernel_ysize = kernsize_y
     opt_model.meta.threshold_percent = threshold_percent

--- a/jwst/outlier_detection/ifu.py
+++ b/jwst/outlier_detection/ifu.py
@@ -99,7 +99,7 @@ def detect_outliers(
             "Increasing number by 1"
         )
         kern_size[0] = kern_size[0] + 1
-        log.info("New x kernel size is {kern_size[0}: ")
+        log.info(f"New x kernel size is {kern_size[0]}: ")
     if kern_size[1] % 2 == 0:
         log.info(
             "Y kernel size is given as an even number. This value must be an odd number. "
@@ -258,7 +258,7 @@ def flag_outliers(
             basepath=input_models.meta.asn_table.products[0].name,
             suffix=detector_name + "_outlier_output",
         )
-        log.info("Writing out intermediate outlier file {opt_model.meta.filename}")
+        log.info(f"Writing out intermediate outlier file {opt_model.meta.filename}")
         opt_model.save(opt_model.meta.filename)
 
     del diffarr

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -138,7 +138,6 @@ class OutlierDetectionStep(Step):
                 self.pixfrac,
                 self.kernel,
                 self.fillval,
-                self.in_memory,
                 self.make_output_path,
             )
         elif mode == "ifu":

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -150,7 +150,7 @@ class OutlierDetectionStep(Step):
                 self.make_output_path,
             )
         else:
-            self.log.error("Outlier detection failed for unknown/unsupported ", f"mode: {mode}")
+            self.log.error(f"Outlier detection failed for unknown/unsupported mode: {mode}")
             return self._set_status(input_data, False)
 
         return self._set_status(result_models, True)

--- a/jwst/outlier_detection/spec.py
+++ b/jwst/outlier_detection/spec.py
@@ -57,7 +57,7 @@ def detect_outliers(
     scale1 : float
         Scale factor used to scale the absolute derivative of the blot model for the first pass.
     scale2 : float
-        Scal factor used to scale the absolute derivative of the blot model for the second pass.
+        Scale factor used to scale the absolute dervative of the blot model for the second pass.
     backg : float
         Scalar background level to add to the blotted image.
         Ignored if `input_model.meta.background.level` is not None but

--- a/jwst/outlier_detection/spec.py
+++ b/jwst/outlier_detection/spec.py
@@ -4,12 +4,15 @@ from jwst.datamodels import ModelContainer, ModelLibrary
 from jwst.stpipe.utilities import record_step_status
 
 from ..resample import resample_spec
-from .utils import (flag_crs_in_models,
-                    flag_crs_in_models_with_resampling,
-                    median_with_resampling,
-                    median_without_resampling)
+from .utils import (
+    flag_crs_in_models,
+    flag_crs_in_models_with_resampling,
+    median_with_resampling,
+    median_without_resampling,
+)
 
 import logging
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -32,12 +35,52 @@ def detect_outliers(
     pixfrac,
     kernel,
     fillval,
-    in_memory,
     make_output_path,
 ):
-    """Flag outliers in spec data.
+    """
+    Flag outliers in slit-like spectroscopic data.
 
-    See `OutlierDetectionStep.spec` for documentation of these arguments.
+    Parameters
+    ----------
+    input_models : ModelContainer
+        A container of data models.
+    save_intermediate_results : bool
+        If True, save intermediate results.
+    good_bits : int
+        Bit values indicating good pixels.
+    maskpt : float
+        The percentage of the mean weight to use as a threshold for masking.
+    snr1 : float
+        The signal-to-noise ratio threshold for first pass flagging, prior to smoothing.
+    snr2 : float
+        The signal-to-noise ratio threshold for secondary flagging, after smoothing.
+    scale1 : float
+        Scale factor used to scale the absolute derivative of the blot model for the first pass.
+    scale2 : float
+        Scale factor used to scale the absolute derivative of the blot model for the second pass.
+    backg : float
+        Scalar background level to add to the blotted image.
+        Ignored if `input_model.meta.background.level` is not None but
+        `input_model.meta.background.subtracted` is False.
+    resample_data : bool
+        If True, resample the data before detecting outliers.
+    weight_type : str
+        The type of weighting kernel to use when resampling.
+        Options are 'ivm' or 'exptime'.
+    pixfrac : float
+        The pixel shrinkage factor to pass to drizzle.
+    kernel : str
+        The flux distribution kernel function to use when resampling.
+    fillval : str
+        The value to use in the output for pixels with no weight or flux
+    make_output_path : function
+        The functools.partial instance to pass to save_blot. Must be
+        specified if save_blot is True.
+
+    Returns
+    -------
+    ModelContainer
+        The input models with outliers flagged.
     """
     if not isinstance(input_models, ModelContainer):
         input_models = ModelContainer(input_models)
@@ -72,7 +115,8 @@ def detect_outliers(
             maskpt,
             save_intermediate_results=save_intermediate_results,
             make_output_path=make_output_path,
-            return_error=True)
+            return_error=True,
+        )
     else:
         median_data, median_wcs, median_err = median_without_resampling(
             library,
@@ -81,7 +125,7 @@ def detect_outliers(
             good_bits,
             save_intermediate_results=save_intermediate_results,
             make_output_path=make_output_path,
-            return_error=True
+            return_error=True,
         )
 
     # Perform outlier detection using statistical comparisons between
@@ -98,11 +142,8 @@ def detect_outliers(
             backg,
             median_err=median_err,
             save_blot=save_intermediate_results,
-            make_output_path=make_output_path
+            make_output_path=make_output_path,
         )
     else:
-        flag_crs_in_models(input_models,
-                           median_data,
-                           snr1,
-                           median_err=median_err)
+        flag_crs_in_models(input_models, median_data, snr1, median_err=median_err)
     return input_models

--- a/jwst/outlier_detection/spec.py
+++ b/jwst/outlier_detection/spec.py
@@ -57,7 +57,7 @@ def detect_outliers(
     scale1 : float
         Scale factor used to scale the absolute derivative of the blot model for the first pass.
     scale2 : float
-        Scale factor used to scale the absolute derivative of the blot model for the second pass.
+        Scal factor used to scale the absolute derivative of the blot model for the second pass.
     backg : float
         Scalar background level to add to the blotted image.
         Ignored if `input_model.meta.background.level` is not None but

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -7,22 +7,29 @@ import numpy as np
 from jwst.lib.pipe_utils import match_nans_and_flags
 from jwst.resample.resample import compute_image_pixel_area
 from jwst.resample.resample_utils import build_driz_weight
-from stcal.outlier_detection.utils import compute_weight_threshold, gwcs_blot, flag_crs, flag_resampled_crs
+from stcal.outlier_detection.utils import (
+    compute_weight_threshold,
+    gwcs_blot,
+    flag_crs,
+    flag_resampled_crs,
+)
 from stcal.outlier_detection.median import MedianComputer, nanmedian3D
 from stdatamodels.jwst import datamodels
 from . import _fileio
 
 import logging
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-DO_NOT_USE = datamodels.dqflags.pixel['DO_NOT_USE']
-OUTLIER = datamodels.dqflags.pixel['OUTLIER']
+DO_NOT_USE = datamodels.dqflags.pixel["DO_NOT_USE"]
+OUTLIER = datamodels.dqflags.pixel["OUTLIER"]
 
 
 def create_cube_median(cube_model, maskpt):
-    """Compute the median over a cube of data.
+    """
+    Compute the median over a cube of data.
 
     Parameters
     ----------
@@ -35,7 +42,6 @@ def create_cube_median(cube_model, maskpt):
     -------
     np.ndarray
         The median over the zeroth axis of the input cube.
-
     """
     log.info("Computing median")
 
@@ -43,19 +49,25 @@ def create_cube_median(cube_model, maskpt):
 
     # not safe to use overwrite_input=True here because we are operating on model.data directly
     return nanmedian3D(
-        np.ma.masked_array(cube_model.data, np.less(cube_model.wht, weight_threshold), fill_value=np.nan),
-        overwrite_input=False)
+        np.ma.masked_array(
+            cube_model.data, np.less(cube_model.wht, weight_threshold), fill_value=np.nan
+        ),
+        overwrite_input=False,
+    )
 
 
-def median_without_resampling(input_models,
-                              maskpt,
-                              weight_type,
-                              good_bits,
-                              save_intermediate_results=False,
-                              make_output_path=None,
-                              buffer_size=None,
-                              return_error=False):
-    """Compute a median image without resampling.
+def median_without_resampling(
+    input_models,
+    maskpt,
+    weight_type,
+    good_bits,
+    save_intermediate_results=False,
+    make_output_path=None,
+    buffer_size=None,
+    return_error=False,
+):
+    """
+    Compute a median image without resampling.
 
     The median is performed across input exposures, for both
     imaging and spectral modes.
@@ -64,30 +76,23 @@ def median_without_resampling(input_models,
     ----------
     input_models : ModelLibrary
         The input datamodels.
-
     maskpt : float
         The weight threshold for masking out low weight pixels.
-
     weight_type : str
         The type of weighting to use when combining images. Options are:
         'ivm' (inverse variance) or 'exptime' (exposure time).
-
     good_bits : int
         The bit values that are considered good when determining the
         data quality of the input.
-
     save_intermediate_results : bool
-        if True, save the drizzled models and median model to fits.
-
+        If True, save the drizzled models and median model to fits.
     make_output_path : function
         The functools.partial instance to pass to save_median. Must be
         specified if save_intermediate_results is True. Default None.
-
     buffer_size : int
         The size of chunk in bytes that will be read into memory when
         computing the median. This parameter has no effect if the input
         library has its on_disk attribute set to False.
-
     return_error : bool, optional
         If True, an approximate median error is computed alongside the
         median science image.
@@ -96,15 +101,12 @@ def median_without_resampling(input_models,
     -------
     median_data : np.ndarray
         The median data array.
-
     median_wcs : gwcs.WCS
         A WCS corresponding to the median data.
-
     median_error : np.ndarray, optional
         A median error estimate, returned only if `return_error` is True.
-
     """
-    in_memory = not input_models._on_disk
+    in_memory = not input_models.on_disk
     ngroups = len(input_models)
 
     if save_intermediate_results:
@@ -113,16 +115,13 @@ def median_without_resampling(input_models,
 
     with input_models:
         for i in range(len(input_models)):
-
             drizzled_model = input_models.borrow(i)
             drizzled_data = drizzled_model.data.copy()
             if return_error:
                 drizzled_err = drizzled_model.err.copy()
             else:
                 drizzled_err = None
-            weight = build_driz_weight(drizzled_model,
-                                       weight_type=weight_type,
-                                       good_bits=good_bits)
+            weight = build_driz_weight(drizzled_model, weight_type=weight_type, good_bits=good_bits)
             if i == 0:
                 median_wcs = copy.deepcopy(drizzled_model.meta.wcs)
                 input_shape = (ngroups,) + drizzled_data.shape
@@ -167,14 +166,17 @@ def median_without_resampling(input_models,
         return median_data, median_wcs
 
 
-def median_with_resampling(input_models,
-                           resamp,
-                           maskpt,
-                           save_intermediate_results=False,
-                           make_output_path=None,
-                           buffer_size=None,
-                           return_error=False):
-    """Compute a median image with resampling.
+def median_with_resampling(
+    input_models,
+    resamp,
+    maskpt,
+    save_intermediate_results=False,
+    make_output_path=None,
+    buffer_size=None,
+    return_error=False,
+):
+    """
+    Compute a median image with resampling.
 
     The median is performed across resampled groups, for both imaging
     and spectral modes.
@@ -183,25 +185,19 @@ def median_with_resampling(input_models,
     ----------
     input_models : ModelLibrary
         The input datamodels.
-
     resamp : resample.resample.ResampleData object
         The controlling object for the resampling process.
-
     maskpt : float
         The weight threshold for masking out low weight pixels.
-
     save_intermediate_results : bool
-        if True, save the drizzled models and median model to fits.
-
+        If True, save the drizzled models and median model to fits.
     make_output_path : function
         The functools.partial instance to pass to save_median. Must be
         specified if save_intermediate_results is True. Default None.
-
     buffer_size : int
         The size of chunk in bytes that will be read into memory when
         computing the median. This parameter has no effect if the input
         library has its on_disk attribute set to False.
-
     return_error : bool, optional
         If True, an approximate median error is computed alongside the
         median science image.
@@ -210,18 +206,15 @@ def median_with_resampling(input_models,
     -------
     median_data : np.ndarray
         The median data array.
-
     median_wcs : gwcs.WCS
         A WCS corresponding to the median data.
-
     median_error : np.ndarray, optional
         A median error estimate, returned only if `return_error` is True.
-
     """
     if not resamp.single:
         raise ValueError("median_with_resampling should only be used for resample_many_to_many")
 
-    in_memory = not input_models._on_disk
+    in_memory = not input_models.on_disk
     indices_by_group = list(input_models.group_indices.values())
     ngroups = len(indices_by_group)
 
@@ -231,9 +224,9 @@ def median_with_resampling(input_models,
 
     with input_models:
         for i, indices in enumerate(indices_by_group):
-
             drizzled_model = resamp.resample_group(
-                input_models, indices, compute_error=return_error)
+                input_models, indices, compute_error=return_error
+            )
 
             if save_intermediate_results:
                 # write the drizzled model to file
@@ -241,7 +234,7 @@ def median_with_resampling(input_models,
 
             if i == 0:
                 median_wcs = resamp.output_wcs
-                input_shape = (ngroups,)+drizzled_model.data.shape
+                input_shape = (ngroups,) + drizzled_model.data.shape
                 dtype = drizzled_model.data.dtype
                 computer = MedianComputer(input_shape, in_memory, buffer_size, dtype)
                 if return_error:
@@ -283,13 +276,22 @@ def median_with_resampling(input_models,
         return median_data, median_wcs
 
 
-def flag_crs_in_models(
-    input_models,
-    median_data,
-    snr1,
-    median_err=None
-):
-    """Flag outliers in all input models without resampling."""
+def flag_crs_in_models(input_models, median_data, snr1, median_err=None):
+    """
+    Flag outliers in all input models without resampling.
+
+    Parameters
+    ----------
+    input_models : ModelContainer
+        The input datamodels.
+    median_data : np.ndarray
+        The median data array.
+    snr1 : float
+        The signal-to-noise ratio threshold for flagging outliers.
+    median_err : np.ndarray, optional
+        The error array corresponding to the median data. If not provided,
+        the error array stored the input model `err` extension will be used.
+    """
     for image in input_models:
         # dq flags will be updated in-place
         flag_model_crs(image, median_data, snr1, median_err=median_err)
@@ -308,8 +310,39 @@ def flag_resampled_model_crs(
     save_blot=False,
     make_output_path=None,
 ):
-    """Flag outliers in a resampled model."""
-    if 'SPECTRAL' not in input_model.meta.wcs.output_frame.axes_type:
+    """
+    Flag outliers in a resampled model, updating DQ array in place.
+
+    Parameters
+    ----------
+    input_model : ~jwst.datamodels.DataModel
+        The input datamodel.
+    median_data : np.ndarray
+        The median data array.
+    median_wcs : gwcs.WCS
+        A WCS corresponding to the median data.
+    snr1 : float
+        The signal-to-noise ratio threshold for first pass flagging, prior to smoothing.
+    snr2 : float
+        The signal-to-noise ratio threshold for secondary flagging, after smoothing.
+    scale1 : float
+        Scale factor used to scale the absolute derivative of the blot model for the first pass.
+    scale2 : float
+        Scale factor used to scale the absolute derivative of the blot model for the second pass.
+    backg : float
+        Scalar background level to add to the blotted image.
+        Ignored if `input_model.meta.background.level` is not None but
+        `input_model.meta.background.subtracted` is False.
+    median_err : np.ndarray, optional
+        The error array corresponding to the median data. If not provided,
+        the error array stored the input model `err` extension will be used.
+    save_blot : bool
+        If True, save the blotted image to fits.
+    make_output_path : function
+        The functools.partial instance to pass to save_blot. Must be
+        specified if save_blot is True.
+    """
+    if "SPECTRAL" not in input_model.meta.wcs.output_frame.axes_type:
         input_pixflux_area = input_model.meta.photometry.pixelarea_steradians
         # Set array shape, needed to compute image pixel area
         input_model.meta.wcs.array_shape = input_model.shape
@@ -318,11 +351,23 @@ def flag_resampled_model_crs(
     else:
         pix_ratio = 1.0
 
-    blot = gwcs_blot(median_data, median_wcs, input_model.data.shape,
-                     input_model.meta.wcs, pix_ratio, fillval=np.nan)
+    blot = gwcs_blot(
+        median_data,
+        median_wcs,
+        input_model.data.shape,
+        input_model.meta.wcs,
+        pix_ratio,
+        fillval=np.nan,
+    )
     if median_err is not None:
-        blot_err = gwcs_blot(median_err, median_wcs, input_model.data.shape,
-                             input_model.meta.wcs, pix_ratio, fillval=np.nan)
+        blot_err = gwcs_blot(
+            median_err,
+            median_wcs,
+            input_model.data.shape,
+            input_model.meta.wcs,
+            pix_ratio,
+            fillval=np.nan,
+        )
     else:
         blot_err = None
     if save_blot:
@@ -342,14 +387,34 @@ def _flag_resampled_model_crs(
     scale2,
     backg,
 ):
-    """Flag outliers via comparison to a blotted image."""
-    # If the datamodel has a measured background that has not been subtracted
-    # use it instead of the user provided backg.
-    # Get background level of science data if it has not been subtracted, so it
-    # can be added into the level of the blotted data, which has been
-    # background-subtracted
-    if (input_model.meta.background.subtracted is False and
-            input_model.meta.background.level is not None):
+    """
+    Flag outliers via comparison to a blotted image and update the DQ array in place.
+
+    Parameters
+    ----------
+    input_model : ~jwst.datamodels.DataModel
+        The input datamodel.
+    blot : np.ndarray
+        The blotted data array.
+    blot_err : np.ndarray
+        The blotted error array.
+    snr1 : float
+        The signal-to-noise ratio threshold for first pass flagging, prior to smoothing.
+    snr2 : float
+        The signal-to-noise ratio threshold for secondary flagging, after smoothing.
+    scale1 : float
+        Scale factor used to scale the absolute derivative of the blot model for the first pass.
+    scale2 : float
+        Scale factor used to scale the absolute derivative of the blot model for the second pass.
+    backg : float
+        Scalar background level to add to the blotted image.
+        Ignored if `input_model.meta.background.level` is not None but
+        `input_model.meta.background.subtracted` is False.
+    """
+    if (
+        input_model.meta.background.subtracted is False
+        and input_model.meta.background.level is not None
+    ):
         backg = input_model.meta.background.level
         log.debug(f"Adding background level {backg} to blotted image")
 
@@ -357,7 +422,9 @@ def _flag_resampled_model_crs(
         err_to_use = blot_err
     else:
         err_to_use = input_model.err
-    cr_mask = flag_resampled_crs(input_model.data, err_to_use, blot, snr1, snr2, scale1, scale2, backg)
+    cr_mask = flag_resampled_crs(
+        input_model.data, err_to_use, blot, snr1, snr2, scale1, scale2, backg
+    )
 
     # update the dq flags in-place
     input_model.dq |= cr_mask * np.uint32(DO_NOT_USE | OUTLIER)
@@ -381,23 +448,70 @@ def flag_crs_in_models_with_resampling(
     save_blot=False,
     make_output_path=None,
 ):
-    """Flag outliers in all input models, with resampling."""
+    """
+    Flag outliers in all input models, with resampling, modifying DQ array in place.
+
+    Parameters
+    ----------
+    input_models : ~jwst.datamodels.ModelContainer
+        The input datamodels.
+    median_data : np.ndarray
+        The median data array.
+    median_wcs : gwcs.WCS
+        A WCS corresponding to the median data.
+    snr1 : float
+        The signal-to-noise ratio threshold for first pass flagging, prior to smoothing.
+    snr2 : float
+        The signal-to-noise ratio threshold for secondary flagging, after smoothing.
+    scale1 : float
+        Scale factor used to scale the absolute derivative of the blot model for the first pass.
+    scale2 : float
+        Scale factor used to scale the absolute derivative of the blot model for the second pass.
+    backg : float
+        Scalar background level to add to the blotted image.
+        Ignored if `input_model.meta.background.level` is not None but
+        `input_model.meta.background.subtracted` is False.
+    median_err : np.ndarray, optional
+        The error array corresponding to the median data. If not provided,
+        the error array stored the input model `err` extension will be used.
+    save_blot : bool
+        If True, save the blotted image to fits.
+    make_output_path : function
+        The functools.partial instance to pass to save_blot. Must be
+        specified if save_blot is True.
+    """
     for image in input_models:
-        flag_resampled_model_crs(image,
-                                 median_data,
-                                 median_wcs,
-                                 snr1,
-                                 snr2,
-                                 scale1,
-                                 scale2,
-                                 backg,
-                                 median_err=median_err,
-                                 save_blot=save_blot,
-                                 make_output_path=make_output_path)
+        flag_resampled_model_crs(
+            image,
+            median_data,
+            median_wcs,
+            snr1,
+            snr2,
+            scale1,
+            scale2,
+            backg,
+            median_err=median_err,
+            save_blot=save_blot,
+            make_output_path=make_output_path,
+        )
 
 
 def flag_model_crs(image, blot, snr, median_err=None):
-    """Flag outliers in a model."""
+    """
+    Flag outliers in a model.
+
+    Parameters
+    ----------
+    image : ~jwst.datamodels.DataModel
+        The input datamodel.
+    blot : np.ndarray
+        The blotted data array.
+    snr : float
+        The signal-to-noise ratio threshold for flagging outliers.
+    median_err : np.ndarray, optional
+        The error array corresponding to the median data. If not provided,
+        the error array stored the input model `err` extension will be used.
+    """
     if median_err is not None:
         error_to_use = median_err
     else:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially Resolves [JP-3860](https://jira.stsci.edu/browse/JP-3860)

<!-- describe the changes comprising this PR here -->
This PR addresses style issues with the outlier detection submodule.

A singular change has been added outside `outlier_detection`, which is to avoid direct calls to `ModelLibrary._on_disk` by making the non-underscore-protected `on_disk` a property.

This PR also makes the following small updates to the pre-commit configuration:

-  adds the `--summary` option to `codespell` so it shows what changes it made automatically.
-  adds "D105: missing docstring for magic method" to the ruff ignore list.  This rule would require docstrings for `__iter__`, `__len__` and similar, where it's very often obvious what it does and the function itself is a one-liner.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
