### PR TITLE
JP-3859: Apply code style rules to wavecorr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,6 @@ repos:
             jwst/superbias/.* |
             jwst/tests/.* |
             jwst/tso_photometry/.* |
-            jwst/wavecorr/.* |
             jwst/wfs_combine/.* |
             jwst/white_light/.* |
             jwst/conftest.py |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -62,7 +62,6 @@ exclude = [
     "jwst/superbias/**.py",
     "jwst/tests/**.py",
     "jwst/tso_photometry/**.py",
-    "jwst/wavecorr/**.py",
     "jwst/wfs_combine/**.py",
     "jwst/white_light/**.py",
 ]
@@ -168,6 +167,5 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/superbias/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/tests/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/tso_photometry/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/wavecorr/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/wfs_combine/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/white_light/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/changes/9128.wavecorr.rst
+++ b/changes/9128.wavecorr.rst
@@ -1,0 +1,1 @@
+Fixed recording cal_step status for wavecorr for NIRSpec BOTS mode.

--- a/jwst/wavecorr/__init__.py
+++ b/jwst/wavecorr/__init__.py
@@ -1,3 +1,5 @@
+"""Apply wavelength corrections to off-center NIRSpec point sources."""
+
 from .wavecorr_step import WavecorrStep
 
 __all__ = ["WavecorrStep"]

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -1,34 +1,31 @@
-import os.path
+from pathlib import Path
+
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
-
 from gwcs import wcstools
-
+from numpy.testing import assert_allclose
 from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.transforms import models
 from stpipe.crds_client import reference_uri_to_cache_path
 
 import jwst
 from jwst.assign_wcs import AssignWcsStep
+from jwst.assign_wcs.tests.test_nirspec import create_nirspec_mos_file, create_nirspec_fs_file
 from jwst.extract_2d import Extract2dStep
 from jwst.srctype import SourceTypeStep
 from jwst.wavecorr import WavecorrStep
 from jwst.wavecorr import wavecorr
 
-from jwst.assign_wcs.tests.test_nirspec import (create_nirspec_mos_file,
-                                                create_nirspec_fs_file)
-
 
 def test_wavecorr():
     hdul = create_nirspec_mos_file()
-    msa_meta = os.path.join(jwst.__path__[0], *['assign_wcs', 'tests', 'data', 'msa_configuration.fits'])
-    hdul[0].header['MSAMETFL'] = msa_meta
-    hdul[0].header['MSAMETID'] = 12
+    msa_meta = Path(jwst.__path__[0]) / "assign_wcs" / "tests" / "data" / "msa_configuration.fits"
+    hdul[0].header["MSAMETFL"] = str(msa_meta)
+    hdul[0].header["MSAMETID"] = 12
     im = datamodels.ImageModel(hdul)
     im_wcs = AssignWcsStep.call(im)
     im_ex2d = Extract2dStep.call(im_wcs)
-    bbox = ((-.5, 1432.5), (-.5, 37.5))
+    bbox = ((-0.5, 1432.5), (-0.5, 37.5))
     im_ex2d.slits[0].meta.wcs.bounding_box = bbox
     x, y = wcstools.grid_from_bounding_box(bbox)
     ra, dec, lam_before = im_ex2d.slits[0].meta.wcs(x, y)
@@ -36,7 +33,7 @@ def test_wavecorr():
     im_src = SourceTypeStep.call(im_ex2d)
 
     # the mock msa source is an extended source, change to point for testing
-    im_src.slits[0].source_type = 'POINT'
+    im_src.slits[0].source_type = "POINT"
     im_wave = WavecorrStep.call(im_src)
 
     # test dispersion is of the correct order
@@ -60,22 +57,26 @@ def test_wavecorr():
     # test the round-tripping on the wavelength correction transform
     ref_name = im_wave.meta.ref_file.wavecorr.name
     freference = datamodels.WaveCorrModel(
-        reference_uri_to_cache_path(ref_name, im.crds_observatory))
+        reference_uri_to_cache_path(ref_name, im.crds_observatory)
+    )
 
     lam_uncorr = lam_before * 1e-6
     wave2wavecorr = wavecorr.calculate_wavelength_correction_transform(
-        lam_uncorr, dispersion, freference, slit.source_xpos, 'MOS')
+        lam_uncorr, dispersion, freference, slit.source_xpos, "MOS"
+    )
     lam_corr = wave2wavecorr(lam_uncorr)
     assert_allclose(lam_uncorr, wave2wavecorr.inverse(lam_corr))
 
     # test on both sides of the shutter
-    source_xpos1 = -.2
-    source_xpos2 = .2
+    source_xpos1 = -0.2
+    source_xpos2 = 0.2
 
     wave_transform1 = wavecorr.calculate_wavelength_correction_transform(
-        lam_uncorr, dispersion, freference, source_xpos1, 'MOS')
+        lam_uncorr, dispersion, freference, source_xpos1, "MOS"
+    )
     wave_transform2 = wavecorr.calculate_wavelength_correction_transform(
-        lam_uncorr, dispersion, freference, source_xpos2, 'MOS')
+        lam_uncorr, dispersion, freference, source_xpos2, "MOS"
+    )
 
     zero_point1 = wave_transform1(lam_uncorr)
     zero_point2 = wave_transform2(lam_uncorr)
@@ -96,25 +97,24 @@ def test_ideal_to_v23_fs():
 
 
 def test_skipped():
-    """ Test all conditions that lead to skipping wavecorr."""
-
+    """Test all conditions that lead to skipping wavecorr."""
     hdul = create_nirspec_fs_file(grating="G140H", filter="F100LP")
     im = datamodels.ImageModel(hdul)
 
     # test a non-valid exp_type2transform
-    im.meta.exposure.type = 'NRS_IMAGE'
+    im.meta.exposure.type = "NRS_IMAGE"
     out = WavecorrStep.call(im)
     assert out.meta.cal_step.wavecorr == "SKIPPED"
 
     # Test an error is raised if assign_wcs or extract_2d were not run.
-    im.meta.exposure.type = 'NRS_FIXEDSLIT'
-    with pytest.raises(ValueError):
+    im.meta.exposure.type = "NRS_FIXEDSLIT"
+    with pytest.raises(TypeError):
         WavecorrStep.call(im)
 
     outa = AssignWcsStep.call(im)
 
     # wcs and other metadata necessary for a good (not skipped) result
-    dither = {'x_offset': 0.0, 'y_offset': 0.0}
+    dither = {"x_offset": 0.0, "y_offset": 0.0}
     outa.meta.dither = dither
     outa.meta.wcsinfo.v3yangle = 138.78
     outa.meta.wcsinfo.vparity = -1
@@ -126,24 +126,24 @@ def test_skipped():
     oute = Extract2dStep.call(outa)
 
     # ensure the source position is set as expected by extract2d
-    ind = np.nonzero([s.name == 'S400A1' for s in oute.slits])[0].item()
+    ind = np.nonzero([s.name == "S400A1" for s in oute.slits])[0].item()
     source_pos = (0.004938526981283373, -0.02795306204991911)
-    assert_allclose((oute.slits[ind].source_xpos, oute.slits[ind].source_ypos),source_pos)
+    assert_allclose((oute.slits[ind].source_xpos, oute.slits[ind].source_ypos), source_pos)
 
     outs = SourceTypeStep.call(oute)
 
     # primary slit is found by source type step to be EXTENDED
     # which means its source position is reset to (0, 0)
     # hack it here to be a point source with the same offset as before here
-    outs.slits[ind].source_type = 'POINT'
+    outs.slits[ind].source_type = "POINT"
     outs.slits[ind].source_xpos = source_pos[0]
     outs.slits[ind].source_ypos = source_pos[1]
 
     # Test step is skipped if no coverage in CRDS
-    outs.meta.observation.date = '2001-08-03'
+    outs.meta.observation.date = "2001-08-03"
     outw = WavecorrStep.call(outs)
     assert outw.meta.cal_step.wavecorr == "SKIPPED"
-    outs.meta.observation.date = '2017-08-03'
+    outs.meta.observation.date = "2017-08-03"
 
     # Run the step for real
     outw = WavecorrStep.call(outs)
@@ -154,31 +154,30 @@ def test_skipped():
     # transform is returned (a skip criterion) with simple case
     # of flipped wavelength solutions, which produces a monotonically
     # decreasing wavelengths
-    lam = np.tile(np.flip(np.arange(0.6, 5.5, 0.01)*1e-6), (22, 1))
-    disp = np.tile(np.full(lam.shape[-1], -0.01)*1e-6, (22, 1))
+    lam = np.tile(np.flip(np.arange(0.6, 5.5, 0.01) * 1e-6), (22, 1))
+    disp = np.tile(np.full(lam.shape[-1], -0.01) * 1e-6, (22, 1))
 
     ref_name = outw.meta.ref_file.wavecorr.name
-    reffile = datamodels.WaveCorrModel(
-        reference_uri_to_cache_path(ref_name, im.crds_observatory))
+    reffile = datamodels.WaveCorrModel(reference_uri_to_cache_path(ref_name, im.crds_observatory))
     source_xpos = 0.1
-    aperture_name = 'S200A1'
+    aperture_name = "S200A1"
 
     transform = wavecorr.calculate_wavelength_correction_transform(
-        lam, disp, reffile, source_xpos, aperture_name)
+        lam, disp, reffile, source_xpos, aperture_name
+    )
     assert transform is None
 
 
 def test_mos_slit_status():
-    """ Test conditions that are skipped for mos slitlets."""
-
+    """Test conditions that are skipped for mos slitlets."""
     hdul = create_nirspec_mos_file()
-    msa_meta = os.path.join(jwst.__path__[0], *['assign_wcs', 'tests', 'data', 'msa_configuration.fits'])
-    hdul[0].header['MSAMETFL'] = msa_meta
-    hdul[0].header['MSAMETID'] = 12
+    msa_meta = Path(jwst.__path__[0]) / "assign_wcs" / "tests" / "data" / "msa_configuration.fits"
+    hdul[0].header["MSAMETFL"] = str(msa_meta)
+    hdul[0].header["MSAMETID"] = 12
     im = datamodels.ImageModel(hdul)
     im_wcs = AssignWcsStep.call(im)
     im_ex2d = Extract2dStep.call(im_wcs)
-    bbox = ((-.5, 1432.5), (-.5, 37.5))
+    bbox = ((-0.5, 1432.5), (-0.5, 37.5))
     im_ex2d.slits[0].meta.wcs.bounding_box = bbox
     x, y = wcstools.grid_from_bounding_box(bbox)
     ra, dec, lam_before = im_ex2d.slits[0].meta.wcs(x, y)
@@ -186,57 +185,59 @@ def test_mos_slit_status():
     im_src = SourceTypeStep.call(im_ex2d)
 
     # test the mock msa source as an extended source
-    im_src.slits[0].source_type = 'EXTENDED'
+    im_src.slits[0].source_type = "EXTENDED"
     im_wave = WavecorrStep.call(im_src)
 
     # check that the step is recorded as skipped,
     # since no slits were corrected
-    assert im_wave.meta.cal_step.wavecorr == 'SKIPPED'
+    assert im_wave.meta.cal_step.wavecorr == "SKIPPED"
 
     # check that the step is listed as skipped for extended mos sources
-    assert im_wave.slits[0].meta.cal_step.wavecorr == 'SKIPPED'
+    assert im_wave.slits[0].meta.cal_step.wavecorr == "SKIPPED"
 
     # test the mock msa source as a point source
-    im_src.slits[0].source_type = 'POINT'
+    im_src.slits[0].source_type = "POINT"
     im_wave = WavecorrStep.call(im_src)
 
     # check that the step is recorded as completed
-    assert im_wave.meta.cal_step.wavecorr == 'COMPLETE'
+    assert im_wave.meta.cal_step.wavecorr == "COMPLETE"
 
     # check that the step is listed as complete for mos point sources
-    assert im_wave.slits[0].meta.cal_step.wavecorr == 'COMPLETE'
+    assert im_wave.slits[0].meta.cal_step.wavecorr == "COMPLETE"
 
 
 def test_wavecorr_fs():
     hdul = create_nirspec_fs_file(grating="PRISM", filter="CLEAR")
     im = datamodels.ImageModel(hdul)
-    dither = {'x_offset': -0.0264, 'y_offset': 1.089798712}
+    dither = {"x_offset": -0.0264, "y_offset": 1.089798712}
 
     im.meta.dither = dither
-    im.meta.instrument.fixed_slit = 'S200A1'
-    im.meta.instrument.lamp_state = 'NONE'
-    im.meta.instrument.lamp_mode = 'FIXEDSLIT'
+    im.meta.instrument.fixed_slit = "S200A1"
+    im.meta.instrument.lamp_state = "NONE"
+    im.meta.instrument.lamp_mode = "FIXEDSLIT"
     im.meta.instrument.gwa_tilt = 698.1256999999999
     im.meta.instrument.gwa_xtilt = 0.334691644
     im.meta.instrument.gwa_ytilt = 0.0349255353
-    im.meta.exposure.type = 'NRS_FIXEDSLIT'
-    im.meta.wcsinfo = {'dec_ref': -70.77497509320972,
-                       'dispersion_direction': 1,
-                       'ra_ref': 90.75414044948525,
-                       'roll_ref': 38.2179067606001,
-                       'specsys': 'BARYCENT',
-                       'spectral_order': 0,
-                       'v2_ref': 332.136078,
-                       'v3_ref': -479.224213,
-                       'v3yangle': 138.7605896,
-                       'velosys': -1398.2,
-                       'vparity': -1,
-                       'waverange_end': 5.3e-06,
-                       'waverange_start': 6e-07}
+    im.meta.exposure.type = "NRS_FIXEDSLIT"
+    im.meta.wcsinfo = {
+        "dec_ref": -70.77497509320972,
+        "dispersion_direction": 1,
+        "ra_ref": 90.75414044948525,
+        "roll_ref": 38.2179067606001,
+        "specsys": "BARYCENT",
+        "spectral_order": 0,
+        "v2_ref": 332.136078,
+        "v3_ref": -479.224213,
+        "v3yangle": 138.7605896,
+        "velosys": -1398.2,
+        "vparity": -1,
+        "waverange_end": 5.3e-06,
+        "waverange_start": 6e-07,
+    }
 
     result = AssignWcsStep.call(im)
     result = Extract2dStep.call(result)
-    bbox = ((-.5, 428.5), (-.5, 38.5))
+    bbox = ((-0.5, 428.5), (-0.5, 38.5))
     result.slits[0].meta.wcs.bounding_box = bbox
     x, y = wcstools.grid_from_bounding_box(bbox)
     ra, dec, lam_before = result.slits[0].meta.wcs(x, y)
@@ -249,7 +250,7 @@ def test_wavecorr_fs():
     slit = result.slits[0]
 
     mean_correction = np.abs(src_result.slits[0].wavelength - result.slits[0].wavelength)
-    assert_allclose(np.nanmean(mean_correction), 0.003, atol=.001)
+    assert_allclose(np.nanmean(mean_correction), 0.003, atol=0.001)
 
     dispersion = wavecorr.compute_dispersion(slit.meta.wcs, x, y)
     assert_allclose(dispersion[~np.isnan(dispersion)], 1e-8, atol=1.04e-8)
@@ -260,25 +261,44 @@ def test_wavecorr_fs():
 
     # test the round-tripping on the wavelength correction transform
     ref_name = result.meta.ref_file.wavecorr.name
-    freference = datamodels.WaveCorrModel(reference_uri_to_cache_path(ref_name, im.crds_observatory))
+    freference = datamodels.WaveCorrModel(
+        reference_uri_to_cache_path(ref_name, im.crds_observatory)
+    )
 
     lam_uncorr = lam_before * 1e-6
-    wave2wavecorr = wavecorr.calculate_wavelength_correction_transform(lam_uncorr, dispersion,
-                                                                       freference, slit.source_xpos, 'S200A1')
+    wave2wavecorr = wavecorr.calculate_wavelength_correction_transform(
+        lam_uncorr, dispersion, freference, slit.source_xpos, "S200A1"
+    )
     lam_corr = wave2wavecorr(lam_uncorr)
     assert_allclose(lam_uncorr, wave2wavecorr.inverse(lam_corr))
 
     # test on both sides of the slit center
-    source_xpos1 = -.2
-    source_xpos2 = .2
+    source_xpos1 = -0.2
+    source_xpos2 = 0.2
 
     wave_transform1 = wavecorr.calculate_wavelength_correction_transform(
-        lam_uncorr, dispersion, freference, source_xpos1, 'S200A1')
+        lam_uncorr, dispersion, freference, source_xpos1, "S200A1"
+    )
     wave_transform2 = wavecorr.calculate_wavelength_correction_transform(
-        lam_uncorr, dispersion, freference, source_xpos2, 'S200A1')
+        lam_uncorr, dispersion, freference, source_xpos2, "S200A1"
+    )
 
     zero_point1 = wave_transform1(lam_uncorr)
     zero_point2 = wave_transform2(lam_uncorr)
 
     diff_correction = np.abs(zero_point1 - zero_point2)
     assert_allclose(np.nanmean(diff_correction), 6.3e-9, atol=0.1e-9)
+
+
+def test_assign_wcs_skipped():
+    hdul = create_nirspec_fs_file(grating="G140H", filter="F100LP")
+    im = datamodels.ImageModel(hdul)
+
+    # if assign_wcs was skipped, wavecorr is also skipped
+    im.meta.cal_step.assign_wcs = "SKIPPED"
+    result = WavecorrStep.call(im)
+    assert result.meta.cal_step.wavecorr == "SKIPPED"
+
+    hdul.close()
+    im.close()
+    result.close()

--- a/jwst/wavecorr/wavecorr.py
+++ b/jwst/wavecorr/wavecorr.py
@@ -1,32 +1,3 @@
-"""
-Module for applying wavelength corrections to NIRSpec MOS and FS
-slits in which the source is off center. The correction is applied
-only to point sources.
-
-The algorithm uses a reference file which is a look up table of
-wavelength_correction as a function of slit_x_position and wavelength.
-The ``x`` direction is the one parallel to dispersion/wavelength for
-both MOS and FS slits.
-
-The slit_x_position is determined in the following way.
-
-MOS data:
-``slit.source_xpos`` is used. It is read in from the msa_metadata_file
-in the assign_wcs step.
-
-FS data:
-``input_model.meta.dither.x_offset``, populated by SDP, is used. The
-value is in the telescope Ideal frame. To calculate the slit position,
-it is transformed Ideal --> V2, V3 --> slit_frame in the extract_2d step.
-
-The interpolation of the lookup table uses the absolute fractional offset in x.
-This can be computed in two ways. The above transform gives the absolute
-fractional position within the slit directly. The second way is to transform the
-Ideal source_xpos position to the MSA frame and use the metrology data in the
-``msa`` reference file to compute ``(xposabs - xcenter) / (xsize)``.
-Both ways give the same result, the current code uses the first one.
-
-"""
 import logging
 import numpy as np
 from gwcs import wcstools
@@ -42,7 +13,8 @@ log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, wavecorr_file):
-    """ Main wavecorr correction function for NIRSpec MOS and FS.
+    """
+    Perform wavelength correction for NIRSpec MOS and FS point sources.
 
     Parameters
     ----------
@@ -50,48 +22,52 @@ def do_correction(input_model, wavecorr_file):
         Input data model.
     wavecorr_file : str
         Wavecorr reference file name.
-    """
 
-    wavecorr_supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ',
-                                'NRS_AUTOFLAT']
+    Returns
+    -------
+    output_model : `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+        Corrected data model.
+    """
+    wavecorr_supported_modes = ["NRS_FIXEDSLIT", "NRS_MSASPEC", "NRS_BRIGHTOBJ", "NRS_AUTOFLAT"]
 
     # Check for valid exposure type
     exp_type = input_model.meta.exposure.type.upper()
     if exp_type not in wavecorr_supported_modes:
-        log.info(f'Skipping wavecorr correction for EXP_TYPE {exp_type}')
+        log.info(f"Skipping wavecorr correction for EXP_TYPE {exp_type}")
         return input_model
 
     output_model = input_model.copy()
 
     # For BRIGHTOBJ, operate on the single SlitModel
     if isinstance(input_model, datamodels.SlitModel):
-        if _is_point_source(input_model, exp_type):
+        if _is_point_source(input_model):
             apply_zero_point_correction(output_model, wavecorr_file)
     else:
         corrected = False
         for slit in output_model.slits:
-            if _is_point_source(slit, exp_type):
+            if _is_point_source(slit):
                 completed = apply_zero_point_correction(slit, wavecorr_file)
                 if completed:
                     corrected = True
-                    slit.meta.cal_step.wavecorr = 'COMPLETE'
+                    slit.meta.cal_step.wavecorr = "COMPLETE"
                 else:  # pragma: no cover
-                    log.warning(f'Corrections are not invertible for slit {slit.name}')
-                    log.warning('Skipping wavecorr correction')
-                    slit.meta.cal_step.wavecorr = 'SKIPPED'
+                    log.warning(f"Corrections are not invertible for slit {slit.name}")
+                    log.warning("Skipping wavecorr correction")
+                    slit.meta.cal_step.wavecorr = "SKIPPED"
             else:
-                slit.meta.cal_step.wavecorr = 'SKIPPED'
+                slit.meta.cal_step.wavecorr = "SKIPPED"
 
         if corrected:
-            output_model.meta.cal_step.wavecorr = 'COMPLETE'
+            output_model.meta.cal_step.wavecorr = "COMPLETE"
         else:
-            output_model.meta.cal_step.wavecorr = 'SKIPPED'
+            output_model.meta.cal_step.wavecorr = "SKIPPED"
 
     return output_model
 
 
 def apply_zero_point_correction(slit, reffile):
-    """ Apply the NIRSpec wavelength zero-point correction.
+    """
+    Apply the NIRSpec wavelength zero-point correction.
 
     Parameters
     ----------
@@ -105,12 +81,12 @@ def apply_zero_point_correction(slit, reffile):
     completed : bool
         A flag to report whether the zero-point correction was added or skipped.
     """
-    log.info(f'slit name {slit.name}')
+    log.info(f"slit name {slit.name}")
     slit_wcs = slit.meta.wcs
 
     # Retrieve the source position and aperture name from metadata
     source_xpos = slit.source_xpos
-    if slit.meta.exposure.type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
+    if slit.meta.exposure.type in ["NRS_FIXEDSLIT", "NRS_BRIGHTOBJ"]:
         aperture_name = slit.name
     else:
         # For the MSA the aperture name is "MOS"
@@ -120,24 +96,26 @@ def apply_zero_point_correction(slit, reffile):
     dispersion = compute_dispersion(slit.meta.wcs)
 
     wave2wavecorr = calculate_wavelength_correction_transform(
-        lam, dispersion, reffile, source_xpos, aperture_name)
+        lam, dispersion, reffile, source_xpos, aperture_name
+    )
 
     # wave2wavecorr should not be None for real data
-    if wave2wavecorr is None: # pragma: no cover
+    if wave2wavecorr is None:  # pragma: no cover
         completed = False
         return completed
     else:
         # Make a new frame to insert into the slit wcs object
-        slit_spatial = cf.Frame2D(name='slit_spatial', axes_order=(0, 1),
-                                  unit=("", ""), axes_names=('x_slit', 'y_slit'))
-        spec = cf.SpectralFrame(name='spectral', axes_order=(2,), unit=(u.micron,),
-                                axes_names=('wavelength',))
-        wcorr_frame = cf.CompositeFrame(
-            [slit_spatial, spec], name='wavecorr_frame')
+        slit_spatial = cf.Frame2D(
+            name="slit_spatial", axes_order=(0, 1), unit=("", ""), axes_names=("x_slit", "y_slit")
+        )
+        spec = cf.SpectralFrame(
+            name="spectral", axes_order=(2,), unit=(u.micron,), axes_names=("wavelength",)
+        )
+        wcorr_frame = cf.CompositeFrame([slit_spatial, spec], name="wavecorr_frame")
 
         # Insert the new transform into the slit wcs object
         wave2wavecorr = Identity(2) & wave2wavecorr
-        slit_wcs.insert_frame('slit_frame', wave2wavecorr, wcorr_frame)
+        slit_wcs.insert_frame("slit_frame", wave2wavecorr, wcorr_frame)
 
         # Update the stored wavelengths for the slit
         slit.wavelength = compute_wavelength(slit_wcs)
@@ -146,10 +124,11 @@ def apply_zero_point_correction(slit, reffile):
         return completed
 
 
-def calculate_wavelength_correction_transform(lam, dispersion, freference,
-                                              source_xpos, aperture_name):
-    """ Generate a WCS transform for the NIRSpec wavelength zero-point correction
-    and add it to the WCS for each slit.
+def calculate_wavelength_correction_transform(
+    lam, dispersion, freference, source_xpos, aperture_name
+):
+    """
+    Add a transform for wavelength correction to the WCS pipeline for each slit.
 
     Parameters
     ----------
@@ -175,11 +154,11 @@ def calculate_wavelength_correction_transform(lam, dispersion, freference,
     with datamodels.WaveCorrModel(freference) as wavecorr:
         for ap in wavecorr.apertures:
             if ap.aperture_name == aperture_name:
-                log.info(f'Using wavelength zero-point correction for aperture {ap.aperture_name}')
+                log.info(f"Using wavelength zero-point correction for aperture {ap.aperture_name}")
                 offset_model = ap.zero_point_offset.copy()
                 break
         else:
-            log.info(f'No wavelength zero-point correction found for slit {aperture_name}')
+            log.info(f"No wavelength zero-point correction found for slit {aperture_name}")
 
     # Set lookup table to extrapolate at bounds to recover wavelengths
     # beyond model bounds, particularly for the red and blue ends of
@@ -205,11 +184,13 @@ def calculate_wavelength_correction_transform(lam, dispersion, freference,
     if np.all(np.diff(lam_corrected) > 0):
         # monotonically increasing
         # Build a look up table to transform between corrected and uncorrected wavelengths
-        wave2wavecorr = tabular.Tabular1D(points=lam_mean,
-                                          lookup_table=lam_corrected,
-                                          bounds_error=False,
-                                          fill_value=None,
-                                          name='wave2wavecorr')
+        wave2wavecorr = tabular.Tabular1D(
+            points=lam_mean,
+            lookup_table=lam_corrected,
+            bounds_error=False,
+            fill_value=None,
+            name="wave2wavecorr",
+        )
 
         return wave2wavecorr
 
@@ -219,23 +200,25 @@ def calculate_wavelength_correction_transform(lam, dispersion, freference,
 
 
 def compute_dispersion(wcs, xpix=None, ypix=None):
-    """ Compute the pixel dispersion.
+    """
+    Compute the pixel dispersion.
+
+    If `xpix` or `ypix` is not provided, the dispersion is computed on a grid
+    based on ``wcs.bounding_box``.
 
     Parameters
     ----------
     wcs : `~gwcs.wcs.WCS`
         The WCS object for this slit.
     xpix : ndarray, float, optional
+        X pixel coordinates for dispersion elements.
     ypix : ndarray, float, optional
-        Compute the dispersion at the x, y pixels.
-        If not provided the dispersion is computed on a
-        grid based on ``wcs.bounding_box``.
+        Y pixel coordinates for dispersion elements.
 
     Returns
     -------
     dispersion : ndarray
         The pixel dispersion [in m].
-
     """
     if xpix is None or ypix is None:
         xpix, ypix = wcstools.grid_from_bounding_box(wcs.bounding_box, step=(1, 1))
@@ -243,27 +226,29 @@ def compute_dispersion(wcs, xpix=None, ypix=None):
     xright = xpix + 0.5
     _, _, lamright = wcs(xright, ypix)
     _, _, lamleft = wcs(xleft, ypix)
-    return (lamright - lamleft) * 10 ** -6
+    return (lamright - lamleft) * 10**-6
 
 
 def compute_wavelength(wcs, xpix=None, ypix=None):
-    """ Compute the pixel wavelength.
+    """
+    Compute the pixel wavelength.
+
+    If `xpix` or `ypix` is not provided, the dispersion is computed on a grid
+    based on ``wcs.bounding_box``.
 
     Parameters
     ----------
     wcs : `~gwcs.wcs.WCS`
         The WCS object for this slit.
     xpix : ndarray, float, optional
+        X pixel coordinates for dispersion elements.
     ypix : ndarray, float, optional
-        Compute the wavelength at the x, y pixels.
-        If not provided the dispersion is computed on a
-        grid based on ``wcs.bounding_box``.
+        Y pixel coordinates for dispersion elements.
 
     Returns
     -------
     wavelength : ndarray
         The wavelength [in microns].
-
     """
     if xpix is None or ypix is None:
         xpix, ypix = wcstools.grid_from_bounding_box(wcs.bounding_box, step=(1, 1))
@@ -272,7 +257,7 @@ def compute_wavelength(wcs, xpix=None, ypix=None):
     return lam
 
 
-def _is_point_source(slit, exp_type):
+def _is_point_source(slit):
     """
     Determine if a source is a point source.
 
@@ -280,8 +265,11 @@ def _is_point_source(slit, exp_type):
     ----------
     slit : `~stdatamodels.jwst.transforms.models.Slit`
         A slit object.
-    exp_type : str
-        The exposure type
+
+    Returns
+    -------
+    bool
+        True if point source; False otherwise.
     """
     result = False
 
@@ -293,10 +281,10 @@ def _is_point_source(slit, exp_type):
     else:
         src_type = None
 
-    if src_type is not None and src_type.upper() in ['POINT', 'EXTENDED']:
+    if src_type is not None and src_type.upper() in ["POINT", "EXTENDED"]:
         # Use the supplied value
-        log.info(f'Detected a {src_type} source type in slit {slit.name}')
-        if src_type.strip().upper() == 'POINT':
+        log.info(f"Detected a {src_type} source type in slit {slit.name}")
+        if src_type.strip().upper() == "POINT":
             result = True
         else:
             result = False

--- a/jwst/wavecorr/wavecorr_step.py
+++ b/jwst/wavecorr/wavecorr_step.py
@@ -96,13 +96,7 @@ class WavecorrStep(Step):
 
 
 def _check_slit_metadata_attributes(slit):
-    if not hasattr(slit.meta, "wcs") and slit.meta.wcs is not None:
+    if not (hasattr(slit.meta, "wcs") and slit.meta.wcs is not None):
         raise AttributeError(
             "Input model does not have a WCS object; assign_wcs should be run before wavecorr."
-        )
-
-    if not hasattr(slit, "source_xpos"):
-        raise AttributeError(
-            "Input model does not have source_xpos attribute; "
-            "extract_2d should be run before wavecorr."
         )

--- a/jwst/wavecorr/wavecorr_step.py
+++ b/jwst/wavecorr/wavecorr_step.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 from stdatamodels.jwst import datamodels
 
 from ..stpipe import Step
@@ -9,7 +8,24 @@ __all__ = ["WavecorrStep"]
 
 class WavecorrStep(Step):
     """
-    This step applies wavelength offsets to off-center NIRSpec sources.
+    Apply wavelength offsets to off-center NIRSpec sources.
+
+    Wavelength corrections are applied only to point sources in NIRSpec MOS
+    and FS data.
+
+    The algorithm uses a reference file which is a look-up table of
+    wavelength_correction as a function of slit_x_position and wavelength.
+    The x direction is the one parallel to dispersion/wavelength for
+    both MOS and FS slits.
+
+    The slit_x_position is read from the `source_xpos` attribute in the input
+    slit metadata.  For MOS data, the x position is read from the msa_metadata_file
+    in the assign_wcs step.  For FS data, the x position is calculated from
+    the dither `x_offset` value in the extract_2d step.
+
+    The wavelength value used to look up the wavelength correction at each dispersion
+    element is an average of the wavelength values in the cross-dispersion direction
+    at that element.
     """
 
     class_alias = "wavecorr"
@@ -17,28 +33,41 @@ class WavecorrStep(Step):
     spec = """
     """ # noqa: E501
 
-    reference_file_types = ['wavecorr']
+    reference_file_types = ["wavecorr"]
 
     def process(self, step_input):
+        """
+        Apply the wavelength correction to the input data.
 
-        wavecorr_supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ',
-                                    'NRS_AUTOFLAT']
+        Parameters
+        ----------
+        step_input : DataModel or str
+            Input data to correct.
+
+        Returns
+        -------
+        DataModel
+            The corrected data.
+        """
+        wavecorr_supported_modes = ["NRS_FIXEDSLIT", "NRS_MSASPEC", "NRS_BRIGHTOBJ", "NRS_AUTOFLAT"]
 
         # Open the input
         with datamodels.open(step_input) as input_model:
-
             # Check for valid exposure type
             exp_type = input_model.meta.exposure.type.upper()
             if exp_type not in wavecorr_supported_modes:
-                self.log.info(f'Skipping wavecorr correction for EXP_TYPE {exp_type}')
+                self.log.info(f"Skipping wavecorr correction for EXP_TYPE {exp_type}")
                 input_model.meta.cal_step.wavecorr = "SKIPPED"
                 return input_model
 
             # Check for prerequisites
-            if hasattr(input_model.meta.cal_step, 'assign_wcs') and input_model.meta.cal_step.assign_wcs == 'SKIPPED':
+            if (
+                hasattr(input_model.meta.cal_step, "assign_wcs")
+                and input_model.meta.cal_step.assign_wcs == "SKIPPED"
+            ):
                 self.log.warning("assign_wcs was skipped")
                 self.log.warning("Wavecorr step will be skipped")
-                input_model.meta.cal_step.wavecorr = 'SKIPPED'
+                input_model.meta.cal_step.wavecorr = "SKIPPED"
                 return input_model
 
             # Check for existence of WCS
@@ -47,15 +76,17 @@ class WavecorrStep(Step):
             elif isinstance(input_model, datamodels.MultiSlitModel):
                 _check_slit_metadata_attributes(input_model.slits[0])
             else:
-                raise ValueError(f"Input model must be a SlitModel or MultiSlitModel, not {type(input_model)}")
+                raise TypeError(
+                    f"Input model must be a SlitModel or MultiSlitModel, not {type(input_model)}"
+                )
 
             # Get the reference file
-            reffile = self.get_reference_file(input_model, 'wavecorr')
-            self.log.info(f'Using WAVECORR reference file {reffile}')
-            if reffile == 'N/A':
-                self.log.warning('No WAVECORR reference file found')
-                self.log.warning('Wavecorr step will be skipped')
-                input_model.meta.cal_step.wavecorr = 'SKIPPED'
+            reffile = self.get_reference_file(input_model, "wavecorr")
+            self.log.info(f"Using WAVECORR reference file {reffile}")
+            if reffile == "N/A":
+                self.log.warning("No WAVECORR reference file found")
+                self.log.warning("Wavecorr step will be skipped")
+                input_model.meta.cal_step.wavecorr = "SKIPPED"
                 return input_model
 
             # Apply the correction
@@ -65,11 +96,13 @@ class WavecorrStep(Step):
 
 
 def _check_slit_metadata_attributes(slit):
+    if not hasattr(slit.meta, "wcs") and slit.meta.wcs is not None:
+        raise AttributeError(
+            "Input model does not have a WCS object; assign_wcs should be run before wavecorr."
+        )
 
-    if not hasattr(slit.meta, 'wcs') and slit.meta.wcs is not None:
-        raise AttributeError("Input model does not have a WCS object; assign_wcs should "
-                             "be run before wavecorr.")
-
-    if not hasattr(slit, 'source_xpos'):
-        raise AttributeError("Input model does not have source_xpos attribute; "
-                             "extract_2d should be run before wavecorr.")
+    if not hasattr(slit, "source_xpos"):
+        raise AttributeError(
+            "Input model does not have source_xpos attribute; "
+            "extract_2d should be run before wavecorr."
+        )

--- a/jwst/wavecorr/wavecorr_step.py
+++ b/jwst/wavecorr/wavecorr_step.py
@@ -31,7 +31,7 @@ class WavecorrStep(Step):
     class_alias = "wavecorr"
 
     spec = """
-    """ # noqa: E501
+    """  # noqa: E501
 
     reference_file_types = ["wavecorr"]
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-3859](https://jira.stsci.edu/browse/JP-3859)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Clean up code style in wavecorr.

Also fixed a few minor logic errors in edge cases and added a few unit tests to complete coverage.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
