### PR TITLE
Apply code style rules to source_catalog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,6 @@ repos:
             jwst/saturation/.* |
             jwst/scripts/.* |
             jwst/skymatch/.* |
-            jwst/source_catalog/.* |
             jwst/spectral_leak/.* |
             jwst/srctype/.* |
             jwst/stpipe/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -76,7 +76,7 @@ exclude = [
     "jwst/saturation/**.py",
     "jwst/scripts/**.py",
     "jwst/skymatch/**.py",
-    "jwst/source_catalog/**.py",
+    # "jwst/source_catalog/**.py",
     "jwst/spectral_leak/**.py",
     "jwst/srctype/**.py",
     "jwst/stpipe/**.py",
@@ -206,7 +206,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/saturation/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/scripts/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/skymatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/source_catalog/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/source_catalog/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/spectral_leak/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/srctype/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/stpipe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/source_catalog/__init__.py
+++ b/jwst/source_catalog/__init__.py
@@ -1,3 +1,5 @@
+"""Build a catalog of sources detected in an image with photometry."""
+
 from .source_catalog_step import SourceCatalogStep
 
-__all__ = ['SourceCatalogStep']
+__all__ = ["SourceCatalogStep"]

--- a/jwst/source_catalog/_wcs_helpers.py
+++ b/jwst/source_catalog/_wcs_helpers.py
@@ -1,8 +1,4 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-# (taken from photutils: should probably migrate into astropy.wcs)
-"""
-This module provides WCS helper tools.
-"""
+"""Provide WCS helper tools to source_catalog."""
 
 import astropy.units as u
 import numpy as np
@@ -10,8 +6,7 @@ import numpy as np
 
 def pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1 * u.arcsec):
     """
-    Calculate the pixel coordinate and scale and WCS rotation angle at
-    the position of a SkyCoord coordinate.
+    Calculate the pixel coordinate, scale, and WCS rotation angle at a SkyCoord coordinate.
 
     Parameters
     ----------

--- a/jwst/source_catalog/detection.py
+++ b/jwst/source_catalog/detection.py
@@ -1,6 +1,4 @@
-"""
-Module to detect sources using image segmentation.
-"""
+"""Module to detect sources using image segmentation."""
 
 import logging
 import warnings
@@ -19,38 +17,30 @@ log.setLevel(logging.DEBUG)
 
 
 class JWSTBackground:
-    """
-    Class to estimate a 2D background and background RMS noise in an
-    image.
-
-    Parameters
-    ----------
-    data : 2D `~numpy.ndarray`
-        The input 2D array.
-
-    box_size : int or array_like (int)
-        The box size along each axis.  If ``box_size`` is a scalar then
-        a square box of size ``box_size`` will be used.  If ``box_size``
-        has two elements, they should be in ``(ny, nx)`` order.
-
-    coverage_mask : array_like (bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-        Masked data are excluded from calculations. ``coverage_mask``
-        should be `True` where there is no coverage (i.e., no data) for
-        a given pixel (e.g., blank areas in a mosaic image). It should
-        not be used for bad pixels.
-
-    Attributes
-    ----------
-    background : 2D `~numpy.ndimage`
-        The estimated 2D background image.
-
-    background_rms : 2D `~numpy.ndimage`
-        The estimated 2D background RMS image.
-    """
+    """Class to estimate a 2D background and background RMS noise in an image."""
 
     def __init__(self, data, box_size=100, coverage_mask=None):
+        """
+        Initialize the class.
+
+        Parameters
+        ----------
+        data : `~numpy.ndarray`
+            The input 2D image for which to estimate the background.
+
+        box_size : int or array_like (int)
+            The box size along each axis.  If ``box_size`` is a scalar then
+            a square box of size ``box_size`` will be used.  If ``box_size``
+            has two elements, they should be in ``(ny, nx)`` order.
+
+        coverage_mask : array_like (bool), optional
+            A boolean mask, with the same shape as ``data``, where a `True`
+            value indicates the corresponding element of ``data`` is masked.
+            Masked data are excluded from calculations. ``coverage_mask``
+            should be `True` where there is no coverage (i.e., no data) for
+            a given pixel (e.g., blank areas in a mosaic image). It should
+            not be used for bad pixels.
+        """
         self.data = data
         self.box_size = np.asarray(box_size).astype(int)  # must be integer
         self.coverage_mask = coverage_mask
@@ -66,7 +56,7 @@ class JWSTBackground:
             A Background2D object containing the 2D background and
             background RMS noise estimates.
         """
-        sigma_clip = SigmaClip(sigma=3.)
+        sigma_clip = SigmaClip(sigma=3.0)
         bkg_estimator = MedianBackground()
         filter_size = (3, 3)
 
@@ -74,45 +64,63 @@ class JWSTBackground:
         with warnings.catch_warnings():
             warnings.filterwarnings(action="ignore", category=AstropyUserWarning)
             try:
-                bkg = Background2D(self.data, self.box_size,
-                                   filter_size=filter_size,
-                                   coverage_mask=self.coverage_mask,
-                                   sigma_clip=sigma_clip,
-                                   bkg_estimator=bkg_estimator)
+                bkg = Background2D(
+                    self.data,
+                    self.box_size,
+                    filter_size=filter_size,
+                    coverage_mask=self.coverage_mask,
+                    sigma_clip=sigma_clip,
+                    bkg_estimator=bkg_estimator,
+                )
             except ValueError:
                 # use the entire unmasked array
-                bkg = Background2D(self.data, self.data.shape,
-                                   filter_size=filter_size,
-                                   coverage_mask=self.coverage_mask,
-                                   sigma_clip=sigma_clip,
-                                   bkg_estimator=bkg_estimator,
-                                   exclude_percentile=100.)
-                log.info('Background could not be estimated in meshes. '
-                         'Using the entire unmasked array for background '
-                         f'estimation: bkg_boxsize={self.data.shape}.')
+                bkg = Background2D(
+                    self.data,
+                    self.data.shape,
+                    filter_size=filter_size,
+                    coverage_mask=self.coverage_mask,
+                    sigma_clip=sigma_clip,
+                    bkg_estimator=bkg_estimator,
+                    exclude_percentile=100.0,
+                )
+                log.info(
+                    "Background could not be estimated in meshes. "
+                    "Using the entire unmasked array for background "
+                    f"estimation: bkg_boxsize={self.data.shape}."
+                )
 
         return bkg
 
     @lazyproperty
     def background(self):
         """
-        The 2D background image.
+        Compute the 2-D background if it has not been computed yet, then return it.
+
+        Returns
+        -------
+        background : `~numpy.ndarray`
+            The 2D background image.
         """
         return self._background2d.background
 
     @lazyproperty
     def background_rms(self):
         """
-        The 2D background RMS image.
+        Compute the 2-D background RMS image if it has not been computed yet, then return it.
+
+        Returns
+        -------
+        background_rms : `~numpy.ndarray`
+            The 2D background RMS image.
         """
         return self._background2d.background_rms
 
 
 def make_kernel(kernel_fwhm):
     """
-    Make a 2D Gaussian smoothing kernel that is used to filter the image
-    before thresholding.
+    Make a 2D Gaussian smoothing kernel.
 
+    The kernel is used to filter the image before thresholding.
     Filtering the image will smooth the noise and maximize detectability
     of objects with a shape similar to the kernel.
 
@@ -131,7 +139,7 @@ def make_kernel(kernel_fwhm):
     """
     sigma = kernel_fwhm * gaussian_fwhm_to_sigma
     kernel = Gaussian2DKernel(sigma)
-    kernel.normalize(mode='integral')
+    kernel.normalize(mode="integral")
     return kernel
 
 
@@ -143,13 +151,16 @@ def convolve_data(data, kernel_fwhm, mask=None):
     ----------
     data : `~numpy.ndarray`
         The 2D array to convolve.
-
     kernel_fwhm : float
         The full-width at half-maximum (FWHM) of the 2D Gaussian kernel.
-
     mask : array_like, bool, optional
         A boolean mask with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
+
+    Returns
+    -------
+    convolved_data : `~numpy.ndarray`
+        The convolved 2D array.
     """
     kernel = make_kernel(kernel_fwhm)
 
@@ -160,36 +171,36 @@ def convolve_data(data, kernel_fwhm, mask=None):
 
 
 class JWSTSourceFinder:
-    """
-    Class to detect sources, including deblending, using image
-    segmentation.
-
-    Parameters
-    ----------
-    threshold : float
-        The data value to be used as the per-pixel detection threshold.
-
-    npixels : int
-        The number of connected pixels, each greater than the threshold,
-        that an object must have to be detected. ``npixels`` must be a
-        positive integer.
-
-    deblend : bool, optional
-        Whether to deblend overlapping sources. Source deblending
-        requires scikit-image.
-    """
+    """Detect sources, including deblending, using image segmentation."""
 
     def __init__(self, threshold, npixels, deblend=False):
+        """
+        Initialize the class.
+
+        Parameters
+        ----------
+        threshold : float
+            The data value to be used as the per-pixel detection threshold.
+        npixels : int
+            The number of connected pixels, each greater than the threshold,
+            that an object must have to be detected. ``npixels`` must be a
+            positive integer.
+        deblend : bool, optional
+            Whether to deblend overlapping sources. Source deblending
+            requires scikit-image.
+        """
         self.threshold = threshold
         self.npixels = npixels
         self.deblend = deblend
         self.connectivity = 8
         self.nlevels = 32
         self.contrast = 0.001
-        self.mode = 'exponential'
+        self.mode = "exponential"
 
     def __call__(self, convolved_data, mask=None):
         """
+        Run the source detection and deblending.
+
         Parameters
         ----------
         convolved_data : 2D `numpy.ndarray`
@@ -211,31 +222,36 @@ class JWSTSourceFinder:
         """
         if mask is not None:
             if mask.all():
-                log.error('There are no valid pixels in the image to detect '
-                          'sources.')
+                log.error("There are no valid pixels in the image to detect sources.")
                 return None
 
         with warnings.catch_warnings():
             # suppress NoDetectionsWarning from photutils
-            warnings.filterwarnings('ignore', category=NoDetectionsWarning)
+            warnings.filterwarnings("ignore", category=NoDetectionsWarning)
 
-            segment_img = detect_sources(convolved_data, self.threshold,
-                                         self.npixels, mask=mask,
-                                         connectivity=self.connectivity)
+            segment_img = detect_sources(
+                convolved_data,
+                self.threshold,
+                self.npixels,
+                mask=mask,
+                connectivity=self.connectivity,
+            )
             if segment_img is None:
-                log.warning('No sources were found. Source catalog will not '
-                            'be created.')
+                log.warning("No sources were found. Source catalog will not be created.")
                 return None
 
             # source deblending requires scikit-image
             if self.deblend:
-                segment_img = deblend_sources(convolved_data, segment_img,
-                                              npixels=self.npixels,
-                                              nlevels=self.nlevels,
-                                              contrast=self.contrast,
-                                              mode=self.mode,
-                                              connectivity=self.connectivity,
-                                              relabel=True)
+                segment_img = deblend_sources(
+                    convolved_data,
+                    segment_img,
+                    npixels=self.npixels,
+                    nlevels=self.nlevels,
+                    contrast=self.contrast,
+                    mode=self.mode,
+                    connectivity=self.connectivity,
+                    relabel=True,
+                )
 
-        log.info(f'Detected {segment_img.nlabels} sources')
+        log.info(f"Detected {segment_img.nlabels} sources")
         return segment_img

--- a/jwst/source_catalog/reference_data.py
+++ b/jwst/source_catalog/reference_data.py
@@ -1,6 +1,4 @@
-"""
-Module for parsing APCORR and ABVEGAOFFSET reference file data.
-"""
+"""Module for parsing APCORR and ABVEGAOFFSET reference file data."""
 
 import logging
 
@@ -15,39 +13,27 @@ log.setLevel(logging.DEBUG)
 
 
 class ReferenceData:
-    """
-    Class for APCORR and ABVEGAOFFSET reference file data needed by
-    `SourceCatalogStep`.
-
-    Parameters
-    ----------
-    model : `ImageModel`
-        An `ImageModel` of drizzled image.
-
-    reffile_paths : list of 2 str
-        The full path filename of the APCORR and ABVEGAOFFSET reference
-        files.
-
-    aperture_ee : tuple of 3 int
-        The aperture encircled energies to be used for aperture
-        photometry.  The values must be 3 strictly-increasing integers.
-        Valid values are defined in the APCORR reference files (20, 30,
-        40, 50, 60, 70, or 80).
-
-    Attributes
-    ----------
-    aperture_params : `dict`
-        A dictionary containing the aperture parameters (radii, aperture
-        corrections, and background annulus inner and outer radii).
-
-    abvega_offset : float
-        Offset to convert from AB to Vega magnitudes.  The value
-        represents m_AB - m_Vega.
-    """
+    """Manipulate APCORR and ABVEGAOFFSET reference file data needed by `SourceCatalogStep`."""
 
     def __init__(self, model, reffile_paths, aperture_ee):
+        """
+        Initialize the class.
+
+        Parameters
+        ----------
+        model : `ImageModel`
+            An `ImageModel` of drizzled image.
+        reffile_paths : list of 2 str
+            The full path filename of the APCORR and ABVEGAOFFSET reference
+            files.
+        aperture_ee : tuple of 3 int
+            The aperture encircled energies to be used for aperture
+            photometry.  The values must be 3 strictly-increasing integers.
+            Valid values are defined in the APCORR reference files (20, 30,
+            40, 50, 60, 70, or 80).
+        """
         if not isinstance(model, ImageModel):
-            raise ValueError('The input model must be a ImageModel.')
+            raise TypeError("The input model must be a ImageModel.")
         self.model = model
 
         self.aperture_ee = self._validate_aperture_ee(aperture_ee)
@@ -60,95 +46,117 @@ class ReferenceData:
         self.pupil = model.meta.instrument.pupil
         self.subarray = self.model.meta.subarray.name
 
-        log.info(f'Instrument: {self.instrument}')
+        log.info(f"Instrument: {self.instrument}")
         if self.detector is not None:
-            log.info(f'Detector: {self.detector}')
+            log.info(f"Detector: {self.detector}")
         if self.filtername is not None:
-            log.info(f'Filter: {self.filtername}')
+            log.info(f"Filter: {self.filtername}")
         if self.pupil is not None:
-            log.info(f'Pupil: {self.pupil}')
+            log.info(f"Pupil: {self.pupil}")
         if self.subarray is not None:
-            log.info(f'Subarray: {self.subarray}')
+            log.info(f"Subarray: {self.subarray}")
 
     @staticmethod
     def _validate_aperture_ee(aperture_ee):
-        """
-        Validate the input ``aperture_ee``.
-        """
         aperture_ee = np.array(aperture_ee).astype(int)
         if not np.all(aperture_ee[1:] > aperture_ee[:-1]):
-            raise ValueError('aperture_ee values must be strictly '
-                             'increasing')
+            raise ValueError("aperture_ee values must be strictly increasing")
         if len(aperture_ee) != 3:
-            raise ValueError('aperture_ee must contain only 3 values')
+            raise ValueError("aperture_ee must contain only 3 values")
         if np.any(np.logical_or(aperture_ee <= 0, aperture_ee >= 100)):
-            raise ValueError('aperture_ee values must be between 0 and 100')
+            raise ValueError("aperture_ee values must be between 0 and 100")
         return aperture_ee
 
     @lazyproperty
     def _aperture_ee_table(self):
         """
-        Get the encircled energy table for the given instrument
-        configuration.
+        Get the encircled energy table for the given instrument configuration.
+
+        Returns
+        -------
+        ee_table : `astropy.table.Table`
+            The encircled energy table.
         """
-        if self.instrument in ('NIRCAM', 'NIRISS'):
-            selector = {'filter': self.filtername, 'pupil': self.pupil}
-        elif self.instrument == 'MIRI':
-            selector = {'filter': self.filtername, 'subarray': self.subarray}
-        elif self.instrument == 'FGS':
+        if self.instrument in ("NIRCAM", "NIRISS"):
+            selector = {"filter": self.filtername, "pupil": self.pupil}
+        elif self.instrument == "MIRI":
+            selector = {"filter": self.filtername, "subarray": self.subarray}
+        elif self.instrument == "FGS":
             selector = None
         else:
-            raise RuntimeError(f'{self.instrument} is not a valid instrument')
+            raise RuntimeError(f"{self.instrument} is not a valid instrument")
 
         apcorr_model = datamodels.open(self.apcorr_filename)
         apcorr = apcorr_model.apcorr_table
         if selector is None:  # FGS
             ee_table = apcorr
         else:
-            mask_idx = [apcorr[key] == value
-                        for key, value in selector.items()]
+            mask_idx = [apcorr[key] == value for key, value in selector.items()]
             ee_table = apcorr[np.logical_and.reduce(mask_idx)]
 
         if len(ee_table) == 0:
-            raise RuntimeError('APCORR reference file data is missing for '
-                               f'{selector}.')
+            raise RuntimeError(f"APCORR reference file data is missing for {selector}.")
 
         return ee_table
 
     def _get_ee_table_row(self, aperture_ee):
         """
         Get the encircled energy row for the input ``aperture_ee``.
+
+        Parameters
+        ----------
+        aperture_ee : int
+            The aperture encircled energy value. Must exactly match the value
+            in a row of the APCORR reference file.
+
+        Returns
+        -------
+        ee_row : `astropy.io.fits.FITS_rec`
+            The row of the APCORR reference file that matches the input
         """
-        ee_percent = np.round(self._aperture_ee_table['eefraction'] * 100)
-        row_mask = (ee_percent == aperture_ee)
+        ee_percent = np.round(self._aperture_ee_table["eefraction"] * 100)
+        row_mask = ee_percent == aperture_ee
         ee_row = self._aperture_ee_table[row_mask]
         if len(ee_row) == 0:
-            raise RuntimeError('Aperture encircled energy value of '
-                               f'{aperture_ee} appears to be invalid. No '
-                               'matching row was found in the APCORR '
-                               'reference file {self.apcorr_filename}')
+            raise RuntimeError(
+                "Aperture encircled energy value of "
+                f"{aperture_ee} appears to be invalid. No "
+                "matching row was found in the APCORR "
+                "reference file {self.apcorr_filename}"
+            )
         if len(ee_row) > 1:
-            raise RuntimeError('More than one matching row was found in '
-                               'the APCORR reference file '
-                               f'{self.apcorr_filename}')
+            raise RuntimeError(
+                "More than one matching row was found in "
+                "the APCORR reference file "
+                f"{self.apcorr_filename}"
+            )
         return ee_row
 
     @lazyproperty
     def aperture_params(self):
         """
-        A dictionary containing the aperture parameters (radii, aperture
-        corrections, and background annulus inner and outer radii).
+        Build the aperture parameters dictionary.
+
+        Returns
+        -------
+        params : dict
+            A dictionary containing the aperture parameters (radii, aperture
+            corrections, and background annulus inner and outer radii).
         """
         if self.apcorr_filename is None:
-            log.warning('APCorrModel reference file was not input. Using '
-                        'fallback aperture sizes without any aperture '
-                        'corrections.')
+            log.warning(
+                "APCorrModel reference file was not input. Using "
+                "fallback aperture sizes without any aperture "
+                "corrections."
+            )
 
-            params = {'aperture_radii': np.array((1.0, 2.0, 3.0)),
-                      'aperture_corrections': np.array((1.0, 1.0, 1.0)),
-                      'aperture_ee': np.array((1, 2, 3)),
-                      'bkg_aperture_inner_radius': 5.0,
-                      'bkg_aperture_outer_radius': 10.0}
+            params = {
+                "aperture_radii": np.array((1.0, 2.0, 3.0)),
+                "aperture_corrections": np.array((1.0, 1.0, 1.0)),
+                "aperture_ee": np.array((1, 2, 3)),
+                "bkg_aperture_inner_radius": 5.0,
+                "bkg_aperture_outer_radius": 10.0,
+            }
             return params
 
         params = {}
@@ -158,33 +166,37 @@ class ReferenceData:
         skyouts = []
         for aper_ee in self.aperture_ee:
             row = self._get_ee_table_row(aper_ee)
-            radii.append(row['radius'][0])
-            apcorrs.append(row['apcorr'][0])
-            skyins.append(row['skyin'][0])
-            skyouts.append(row['skyout'][0])
+            radii.append(row["radius"][0])
+            apcorrs.append(row["apcorr"][0])
+            skyins.append(row["skyin"][0])
+            skyouts.append(row["skyout"][0])
 
         if self.model.meta.resample.pixel_scale_ratio is not None:
             # pixel_scale_ratio is the ratio of the resampled to the native
             # pixel scale (values < 1 have smaller resampled pixels)
             pixel_scale_ratio = self.model.meta.resample.pixel_scale_ratio
         else:
-            log.warning('model.meta.resample.pixel_scale_ratio was not '
-                        'found. Assuming the native detector pixel scale '
-                        '(i.e., pixel_scale_ratio = 1)')
+            log.warning(
+                "model.meta.resample.pixel_scale_ratio was not "
+                "found. Assuming the native detector pixel scale "
+                "(i.e., pixel_scale_ratio = 1)"
+            )
             pixel_scale_ratio = 1.0
 
-        params['aperture_ee'] = self.aperture_ee
-        params['aperture_radii'] = np.array(radii) / pixel_scale_ratio
-        params['aperture_corrections'] = np.array(apcorrs)
+        params["aperture_ee"] = self.aperture_ee
+        params["aperture_radii"] = np.array(radii) / pixel_scale_ratio
+        params["aperture_corrections"] = np.array(apcorrs)
 
         skyins = np.unique(skyins)
         skyouts = np.unique(skyouts)
         if len(skyins) != 1 or len(skyouts) != 1:
-            raise RuntimeError('Expected to find only one value for skyin '
-                               'and skyout in the APCORR reference file for '
-                               'a given selector.')
-        params['bkg_aperture_inner_radius'] = skyins[0] / pixel_scale_ratio
-        params['bkg_aperture_outer_radius'] = skyouts[0] / pixel_scale_ratio
+            raise RuntimeError(
+                "Expected to find only one value for skyin "
+                "and skyout in the APCORR reference file for "
+                "a given selector."
+            )
+        params["bkg_aperture_inner_radius"] = skyins[0] / pixel_scale_ratio
+        params["bkg_aperture_outer_radius"] = skyouts[0] / pixel_scale_ratio
 
         return params
 
@@ -193,43 +205,52 @@ class ReferenceData:
         """
         Offset to convert from AB to Vega magnitudes.
 
-        The value represents m_AB - m_Vega.
+        Returns
+        -------
+        abvega_offset : float
+            The value m_AB - m_Vega.
         """
         if self.abvegaoffset_filename is None:
-            log.warning('ABVEGAOFFSET reference file was not input. '
-                        'Catalog Vega magnitudes are not correct.')
+            log.warning(
+                "ABVEGAOFFSET reference file was not input. "
+                "Catalog Vega magnitudes are not correct."
+            )
             return 0.0
 
-        if self.instrument in ('NIRCAM', 'NIRISS'):
-            selector = {'filter': self.filtername, 'pupil': self.pupil}
-        elif self.instrument == 'MIRI':
-            selector = {'filter': self.filtername}
-        elif self.instrument == 'FGS':
-            selector = {'detector': self.detector}
+        if self.instrument in ("NIRCAM", "NIRISS"):
+            selector = {"filter": self.filtername, "pupil": self.pupil}
+        elif self.instrument == "MIRI":
+            selector = {"filter": self.filtername}
+        elif self.instrument == "FGS":
+            selector = {"detector": self.detector}
         else:
-            raise RuntimeError(f'{self.instrument} is not a valid instrument')
+            raise RuntimeError(f"{self.instrument} is not a valid instrument")
 
         abvegaoffset_model = ABVegaOffsetModel(self.abvegaoffset_filename)
         offsets_table = abvegaoffset_model.abvega_offset
 
         try:
-            mask_idx = [offsets_table[key] == value
-                        for key, value in selector.items()]
+            mask_idx = [offsets_table[key] == value for key, value in selector.items()]
         except KeyError as badkey:
-            raise KeyError(f'{badkey} not found in ABVEGAOFFSET reference '
-                           f'file {self.abvegaoffset_filename}')
+            raise KeyError(
+                f"{badkey} not found in ABVEGAOFFSET reference file {self.abvegaoffset_filename}"
+            ) from None
 
         row = offsets_table[np.logical_and.reduce(mask_idx)]
 
         if len(row) == 0:
-            raise RuntimeError('Did not find matching row in ABVEGAOFFSET '
-                               f'reference file {self.abvegaoffset_filename}')
+            raise RuntimeError(
+                "Did not find matching row in ABVEGAOFFSET "
+                f"reference file {self.abvegaoffset_filename}"
+            )
         if len(row) > 1:
-            raise RuntimeError('Found more than one matching row in '
-                               'ABVEGAOFFSET reference file '
-                               f'{self.abvegaoffset_filename}')
+            raise RuntimeError(
+                "Found more than one matching row in "
+                "ABVEGAOFFSET reference file "
+                f"{self.abvegaoffset_filename}"
+            )
 
-        abvega_offset = row['abvega_offset'][0]
-        log.info(f'AB to Vega magnitude offset {abvega_offset:.5f}')
+        abvega_offset = row["abvega_offset"][0]
+        log.info(f"AB to Vega magnitude offset {abvega_offset:.5f}")
         abvegaoffset_model.close()
         return abvega_offset

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -146,7 +146,7 @@ class JWSTSourceCatalog:
 
         Parameters
         ----------
-        flux, flux_err : `~astropy.unit.Quantity`
+        flux, flux_err : `~astropy.unit.Quantity` (array-like of floats with units)
             The input flux and error arrays in units of Jy.
 
         Returns
@@ -600,24 +600,24 @@ class JWSTSourceCatalog:
     @lazyproperty
     def aper_bkg_flux(self):
         """
-        Return aperture local background flux (per pixel).
+        Return aperture local background fluxes (per pixel).
 
         Returns
         -------
-        `~astropy.unit.Quantity`
-            The aperture local background flux.
+        `~astropy.unit.Quantity` (array-like of floats with units)
+            The aperture local background fluxes.
         """
         return self._aper_local_background[0]
 
     @lazyproperty
     def aper_bkg_flux_err(self):
         """
-        Return aperture local background flux error (per pixel).
+        Return aperture local background flux errors (per pixel).
 
         Returns
         -------
-        `~astropy.unit.Quantity`
-            The aperture local background flux error.
+        `~astropy.unit.Quantity` (array-like of floats with units)
+            The aperture local background flux errors.
         """
         return self._aper_local_background[1]
 
@@ -1006,8 +1006,8 @@ class JWSTSourceCatalog:
 
         Returns
         -------
-        `~astropy.units.Quantity`
-            The distance in pixels to the nearest neighbor.
+        `~astropy.units.Quantity` (array-like of floats with units)
+            The distances in pixels to the nearest neighbors.
         """
         nn_dist = self._kdtree_query[0]
         if self.n_sources == 1:

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1,6 +1,4 @@
-"""
-Module to calculate the source catalog.
-"""
+"""Module to calculate the source catalog."""
 
 import logging
 import warnings
@@ -17,8 +15,7 @@ from scipy import ndimage
 from scipy.spatial import KDTree
 
 from photutils.segmentation import SourceCatalog
-from photutils.aperture import (CircularAperture, CircularAnnulus,
-                                aperture_photometry)
+from photutils.aperture import CircularAperture, CircularAnnulus, aperture_photometry
 
 from stdatamodels.jwst.datamodels import ImageModel
 
@@ -34,44 +31,6 @@ class JWSTSourceCatalog:
     """
     Class for the JWST source catalog.
 
-    Parameters
-    ----------
-    model : `ImageModel`
-        The input `ImageModel`.  The data is assumed to be
-        background subtracted.
-
-    segment_image : `~photutils.segmentation.SegmentationImage`
-        A 2D segmentation image, with the same shape as the input data,
-        where sources are marked by different positive integer values.
-        A value of zero is reserved for the background.
-
-    convolved_data : data : 2D `~numpy.ndarray`
-        The 2D array used to calculate the source centroid and
-        morphological properties.
-
-    kernel_fwhm : float
-        The full-width at half-maximum (FWHM) of the 2D Gaussian kernel.
-        This is needed to calculate the DAOFind sharpness and roundness
-        properties (DAOFind uses a special kernel that sums to zero).
-
-    aperture_params : `dict`
-        A dictionary containing the aperture parameters (radii, aperture
-        corrections, and background annulus inner and outer radii).
-
-    abvega_offset : float
-        Offset to convert from AB to Vega magnitudes.  The value
-        represents m_AB - m_Vega.
-
-    ci_star_thresholds : array-like of 2 floats
-        The concentration index thresholds for determining whether
-        a source is a star. The first threshold corresponds to the
-        concentration index calculated from the smallest and middle
-        aperture radii (see ``aperture_params``). The second threshold
-        corresponds to the concentration index calculated from the
-        middle and largest aperture radii. An object is considered
-        extended if both concentration indices are greater than the
-        corresponding thresholds, otherwise it is considered a star.
-
     Notes
     -----
     ``model.err`` is assumed to be the total error array corresponding
@@ -80,11 +39,52 @@ class JWSTSourceCatalog:
     and have the same shape and units as the science data array.
     """
 
-    def __init__(self, model, segment_img, convolved_data, kernel_fwhm,
-                 aperture_params, abvega_offset, ci_star_thresholds):
+    def __init__(
+        self,
+        model,
+        segment_img,
+        convolved_data,
+        kernel_fwhm,
+        aperture_params,
+        abvega_offset,
+        ci_star_thresholds,
+    ):
+        """
+        Initialize the class.
 
+        Parameters
+        ----------
+        model : `ImageModel`
+            The input `ImageModel`. The data is assumed to be background-subtracted.
+        segment_img : `~photutils.segmentation.SegmentationImage`
+            A 2D segmentation image, with the same shape as the input data,
+            where sources are marked by different positive integer values.
+            A value of zero is reserved for the background.
+        convolved_data : data : 2D `~numpy.ndarray`
+            The 2D array used to calculate the source centroid and
+            morphological properties.
+        kernel_fwhm : float
+            The full-width at half-maximum (FWHM) of the 2D Gaussian kernel.
+            This is needed to calculate the DAOFind sharpness and roundness
+            properties (DAOFind uses a special kernel that sums to zero).
+        aperture_params : dict
+            A dictionary containing the aperture parameters (radii, aperture
+            corrections, and background annulus inner and outer radii).
+        abvega_offset : float
+            Offset to convert from AB to Vega magnitudes.  The value
+            represents m_AB - m_Vega.
+        ci_star_thresholds : array-like of 2 floats
+            The concentration index thresholds for determining whether
+            a source is a star. The first threshold corresponds to the
+            concentration index calculated from the smallest and middle
+            aperture radii (see ``aperture_params``). The second threshold
+            corresponds to the concentration index calculated from the
+            middle and largest aperture radii. An object is considered
+            extended if both concentration indices are greater than the
+            corresponding thresholds, otherwise it is considered a star.
+        """
         if not isinstance(model, ImageModel):
-            raise ValueError('The input model must be a ImageModel.')
+            raise TypeError("The input model must be a ImageModel.")
         self.model = model  # background was previously subtracted
 
         self.segment_img = segment_img
@@ -94,11 +94,11 @@ class JWSTSourceCatalog:
         self.abvega_offset = abvega_offset
 
         if len(ci_star_thresholds) != 2:
-            raise ValueError('ci_star_thresholds must contain only 2 items')
+            raise ValueError("ci_star_thresholds must contain only 2 items")
         self.ci_star_thresholds = ci_star_thresholds
 
         self.n_sources = len(self.segment_img.labels)
-        self.aperture_ee = self.aperture_params['aperture_ee']
+        self.aperture_ee = self.aperture_params["aperture_ee"]
         self.n_aper = len(self.aperture_ee)
         self.wcs = self.model.meta.wcs
         self.column_desc = {}
@@ -107,21 +107,16 @@ class JWSTSourceCatalog:
         self.meta = {}
 
     def convert_to_jy(self):
-        """
-        Convert the data and errors from MJy/sr to Jy and convert to
-        `~astropy.unit.Quantity` objects.
-        """
-        in_unit = 'MJy/sr'
-        if (self.model.meta.bunit_data != in_unit or
-                self.model.meta.bunit_err != in_unit):
-            raise ValueError('data and err are expected to be in units of '
-                             'MJy/sr')
+        """Convert data and errors from MJy/sr to Jy, and into `~astropy.unit.Quantity` objects."""
+        in_unit = "MJy/sr"
+        if self.model.meta.bunit_data != in_unit or self.model.meta.bunit_err != in_unit:
+            raise ValueError("data and err are expected to be in units of MJy/sr")
 
         unit = u.Jy
         if self.model.meta.photometry.pixelarea_steradians is None:
             log.warning("Pixel area is None. Can't convert to Jy.")
         else:
-            to_jy = 1.e6 * self.model.meta.photometry.pixelarea_steradians
+            to_jy = 1.0e6 * self.model.meta.photometry.pixelarea_steradians
             self.model.data *= to_jy
             self.model.err *= to_jy
             self.model.data <<= unit
@@ -130,23 +125,19 @@ class JWSTSourceCatalog:
             self.model.meta.bunit_err = unit.name
 
     def convert_from_jy(self):
-        """
-        Convert the data and errors from Jy to MJy/sr and change from
-        `~astropy.unit.Quantity` objects to `~numpy.ndarray`.
-        """
-
+        """Convert data and errors from Jy to MJy/sr, and from `Quantity` to `~np.ndarray`."""
         if self.model.meta.photometry.pixelarea_steradians is None:
             log.warning("Pixel area is None. Can't convert from Jy.")
         else:
-            to_mjy_sr = 1.e6 * self.model.meta.photometry.pixelarea_steradians
+            to_mjy_sr = 1.0e6 * self.model.meta.photometry.pixelarea_steradians
             self.model.data /= to_mjy_sr
             self.model.err /= to_mjy_sr
 
             self.model.data = self.model.data.value  # remove units
             self.model.err = self.model.err.value  # remove units
 
-            self.model.meta.bunit_data = 'MJy/sr'
-            self.model.meta.bunit_err = 'MJy/sr'
+            self.model.meta.bunit_data = "MJy/sr"
+            self.model.meta.bunit_err = "MJy/sr"
 
     @staticmethod
     def convert_flux_to_abmag(flux, flux_err):
@@ -160,12 +151,12 @@ class JWSTSourceCatalog:
 
         Returns
         -------
-        abmag, abmag_err : `~astropy.ndarray`
+        abmag, abmag_err : `~np.ndarray`
             The output AB magnitude and error arrays.
         """
         # ignore RunTimeWarning if flux or flux_err contains NaNs
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
+            warnings.simplefilter("ignore", category=RuntimeWarning)
 
             abmag = -2.5 * np.log10(flux.value) + 8.9
             abmag_err = 2.5 * np.log10(1.0 + (flux_err.value / flux.value))
@@ -180,44 +171,58 @@ class JWSTSourceCatalog:
     @lazyproperty
     def segment_colnames(self):
         """
-        A dictionary of the output table column names and descriptions
-        for the segment catalog.
+        Update the column_desc dictionary to include column names and descriptions.
+
+        Returns
+        -------
+        colnames : list of str
+            A list of the column names that were updated by this function.
         """
         desc = {}
-        desc['label'] = 'Unique source identification label number'
-        desc['xcentroid'] = 'X pixel value of the source centroid (0 indexed)'
-        desc['ycentroid'] = 'Y pixel value of the source centroid (0 indexed)'
-        desc['sky_centroid'] = 'ICRS Sky coordinate of the source centroid'
-        desc['isophotal_flux'] = 'Isophotal flux'
-        desc['isophotal_flux_err'] = 'Isophotal flux error'
-        desc['isophotal_abmag'] = 'Isophotal AB magnitude'
-        desc['isophotal_abmag_err'] = 'Isophotal AB magnitude error'
-        desc['isophotal_vegamag'] = 'Isophotal Vega magnitude'
-        desc['isophotal_vegamag_err'] = 'Isophotal Vega magnitude error'
-        desc['isophotal_area'] = 'Isophotal area'
-        desc['semimajor_sigma'] = ('1-sigma standard deviation along the '
-                                   'semimajor axis of the 2D Gaussian '
-                                   'function that has the same second-order '
-                                   'central moments as the source')
-        desc['semiminor_sigma'] = ('1-sigma standard deviation along the '
-                                   'semiminor axis of the 2D Gaussian '
-                                   'function that has the same second-order '
-                                   'central moments as the source')
-        desc['ellipticity'] = ('1 minus the ratio of the 1-sigma lengths of '
-                               'the semimajor and semiminor axes')
-        desc['orientation'] = ('The angle (degrees) between the positive X '
-                               'axis and the major axis (increases '
-                               'counter-clockwise)')
-        desc['sky_orientation'] = ('The position angle (degrees) from North '
-                                   'of the major axis')
-        desc['sky_bbox_ll'] = ('Sky coordinate of the lower-left vertex of '
-                               'the minimal bounding box of the source')
-        desc['sky_bbox_ul'] = ('Sky coordinate of the upper-left vertex of '
-                               'the minimal bounding box of the source')
-        desc['sky_bbox_lr'] = ('Sky coordinate of the lower-right vertex of '
-                               'the minimal bounding box of the source')
-        desc['sky_bbox_ur'] = ('Sky coordinate of the upper-right vertex of '
-                               'the minimal bounding box of the source')
+        desc["label"] = "Unique source identification label number"
+        desc["xcentroid"] = "X pixel value of the source centroid (0 indexed)"
+        desc["ycentroid"] = "Y pixel value of the source centroid (0 indexed)"
+        desc["sky_centroid"] = "ICRS Sky coordinate of the source centroid"
+        desc["isophotal_flux"] = "Isophotal flux"
+        desc["isophotal_flux_err"] = "Isophotal flux error"
+        desc["isophotal_abmag"] = "Isophotal AB magnitude"
+        desc["isophotal_abmag_err"] = "Isophotal AB magnitude error"
+        desc["isophotal_vegamag"] = "Isophotal Vega magnitude"
+        desc["isophotal_vegamag_err"] = "Isophotal Vega magnitude error"
+        desc["isophotal_area"] = "Isophotal area"
+        desc["semimajor_sigma"] = (
+            "1-sigma standard deviation along the "
+            "semimajor axis of the 2D Gaussian "
+            "function that has the same second-order "
+            "central moments as the source"
+        )
+        desc["semiminor_sigma"] = (
+            "1-sigma standard deviation along the "
+            "semiminor axis of the 2D Gaussian "
+            "function that has the same second-order "
+            "central moments as the source"
+        )
+        desc["ellipticity"] = (
+            "1 minus the ratio of the 1-sigma lengths of the semimajor and semiminor axes"
+        )
+        desc["orientation"] = (
+            "The angle (degrees) between the positive X "
+            "axis and the major axis (increases "
+            "counter-clockwise)"
+        )
+        desc["sky_orientation"] = "The position angle (degrees) from North of the major axis"
+        desc["sky_bbox_ll"] = (
+            "Sky coordinate of the lower-left vertex of the minimal bounding box of the source"
+        )
+        desc["sky_bbox_ul"] = (
+            "Sky coordinate of the upper-left vertex of the minimal bounding box of the source"
+        )
+        desc["sky_bbox_lr"] = (
+            "Sky coordinate of the lower-right vertex of the minimal bounding box of the source"
+        )
+        desc["sky_bbox_ur"] = (
+            "Sky coordinate of the upper-right vertex of the minimal bounding box of the source"
+        )
 
         self.column_desc.update(desc)
 
@@ -229,9 +234,13 @@ class JWSTSourceCatalog:
 
         The values are set as dynamic attributes.
         """
-        segm_cat = SourceCatalog(self.model.data, self.segment_img,
-                                 convolved_data=self.convolved_data << u.Jy,
-                                 error=self.model.err, wcs=self.wcs)
+        segm_cat = SourceCatalog(
+            self.model.data,
+            self.segment_img,
+            convolved_data=self.convolved_data << u.Jy,
+            error=self.model.err,
+            wcs=self.wcs,
+        )
         self._xpeak = segm_cat.maxval_xindex
         self._ypeak = segm_cat.maxval_yindex
 
@@ -239,9 +248,9 @@ class JWSTSourceCatalog:
 
         # rename some columns in the output catalog
         prop_names = {}
-        prop_names['isophotal_flux'] = 'segment_flux'
-        prop_names['isophotal_flux_err'] = 'segment_fluxerr'
-        prop_names['isophotal_area'] = 'area'
+        prop_names["isophotal_flux"] = "segment_flux"
+        prop_names["isophotal_flux_err"] = "segment_fluxerr"
+        prop_names["isophotal_area"] = "area"
 
         for column in self.segment_colnames:
             # define the property name
@@ -255,78 +264,120 @@ class JWSTSourceCatalog:
     @lazyproperty
     def xypos(self):
         """
-        The (x, y) source positions, defined from the segmentation
-        image.
+        Return the (x, y) source centroids defined from the segmentation image.
+
+        Returns
+        -------
+        xypos : `~numpy.ndarray`
+            A 2D array of the (x, y) source positions.
         """
         return np.transpose((self.xcentroid, self.ycentroid))
 
     @lazyproperty
     def _xypos_finite(self):
         """
-        The (x, y) source positions, where non-finite positions are
-        set to a large negative value.
+        Set non-finite source positions to a large negative value.
 
-        At this position the aperture will not overlap the data, thus
-        returning NaN fluxes and errors.
+        At these unrealistic positions, the aperture will not overlap the data,
+        causing the fluxes and errors from the source finder to be NaN.
+
+        Returns
+        -------
+        xypos : `~numpy.ndarray`
+            A 2D array of the (x, y) source positions.
         """
         xypos = self.xypos.copy()
         nanmask = ~np.isfinite(xypos)
-        xypos[nanmask] = -1000.
+        xypos[nanmask] = -1000.0
         return xypos
 
     @lazyproperty
     def _xypos_nonfinite_mask(self):
         """
-        A 1D boolean mask where `True` values denote sources where
-        either the xcentroid or the ycentroid is not finite.
+        Mask sources with non-finite positions.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            A 1D boolean mask where `True` values denote sources where
+            either the xcentroid or the ycentroid is not finite.
         """
         return ~np.isfinite(self.xypos).all(axis=1)
 
     @lazyproperty
     def _isophotal_abmag(self):
         """
-        The isophotal AB magnitude and error.
+        Compute the isophotal AB magnitudes and errors if not yet computed.
+
+        Returns
+        -------
+        (isophotal_abmag, isophotal_abmag_err) : tuple of `np.ndarray`
+            The isophotal AB magnitudes and errors.
         """
-        return self.convert_flux_to_abmag(self.isophotal_flux,
-                                          self.isophotal_flux_err)
+        return self.convert_flux_to_abmag(self.isophotal_flux, self.isophotal_flux_err)
 
     @lazyproperty
     def isophotal_abmag(self):
         """
-        The isophotal AB magnitude.
+        Return the isophotal AB magnitudes.
+
+        Returns
+        -------
+        `np.ndarray`
+            The isophotal AB magnitudes.
         """
         return self._isophotal_abmag[0]
 
     @lazyproperty
     def isophotal_abmag_err(self):
         """
-        The isophotal AB magnitude error.
+        Return the isophotal AB magnitude errors.
+
+        Returns
+        -------
+        `np.ndarray`
+            The isophotal AB magnitudes.
         """
         return self._isophotal_abmag[1]
 
     @lazyproperty
     def isophotal_vegamag(self):
         """
-        The isophotal Vega magnitude.
+        Return the isophotal Vega magnitudes.
+
+        Returns
+        -------
+        `np.ndarray`
+            The isophotal Vega magnitudes.
         """
         return self.isophotal_abmag - self.abvega_offset
 
     @lazyproperty
     def isophotal_vegamag_err(self):
         """
-        The isophotal Vega magnitude error.
+        Return the isophotal Vega magnitude errors.
+
+        Returns
+        -------
+        `np.ndarray`
+            The isophotal Vega magnitude errors.
         """
         return self.isophotal_abmag_err
 
     @lazyproperty
     def sky_orientation(self):
         """
-        The orientation of the source major axis as the position angle
-        in degrees measured East of North.
+        Compute the orientation of the source major axis.
+
+        Returns
+        -------
+        `~astropy.units.Quantity`
+            The position angle of the source major axis, measured East of North.
         """
         # NOTE: crpix1 and crpix2 are 1-based values
-        skycoord = self.wcs.pixel_to_world(self.model.meta.wcsinfo.crpix1 - 1,
-                                           self.model.meta.wcsinfo.crpix2 - 1)
+        skycoord = self.wcs.pixel_to_world(
+            self.model.meta.wcsinfo.crpix1 - 1, self.model.meta.wcsinfo.crpix2 - 1
+        )
         _, _, angle = pixel_scale_angle_at_skycoord(skycoord, self.wcs)
 
         return (180.0 * u.deg) - angle + self.orientation
@@ -350,10 +401,10 @@ class JWSTSourceCatalog:
         """
         colnames = []
         for aper_ee in self.aperture_ee:
-            basename = f'aper{aper_ee}_{name}'
+            basename = f"aper{aper_ee}_{name}"
             colnames.append(basename)
-            colnames.append(f'{basename}_err')
-        colnames.extend([f'aper_total_{name}', f'aper_total_{name}_err'])
+            colnames.append(f"{basename}_err")
+        colnames.extend([f"aper_total_{name}", f"aper_total_{name}_err"])
 
         return colnames
 
@@ -371,84 +422,123 @@ class JWSTSourceCatalog:
         descriptions : list of str
             A list of the output column descriptions.
         """
-        if name == 'flux':
-            ftype = 'Flux'
-            ftype2 = 'flux'
-        elif name == 'abmag':
-            ftype = ftype2 = 'AB magnitude'
-        elif name == 'vegamag':
-            ftype = ftype2 = 'Vega magnitude'
+        if name == "flux":
+            ftype = "Flux"
+            ftype2 = "flux"
+        elif name == "abmag":
+            ftype = ftype2 = "AB magnitude"
+        elif name == "vegamag":
+            ftype = ftype2 = "Vega magnitude"
 
         desc = []
         for aper_ee in self.aperture_ee:
-            desc.append(f'{ftype} within the {aper_ee}% encircled energy '
-                        'circular aperture')
-            desc.append(f'{ftype} error within the {aper_ee}% encircled '
-                        'energy circular aperture')
+            desc.append(f"{ftype} within the {aper_ee}% encircled energy circular aperture")
+            desc.append(f"{ftype} error within the {aper_ee}% encircled energy circular aperture")
 
-        desc.append(f'Total aperture-corrected {ftype2} based on the '
-                    f'{self.aperture_ee[-1]}% encircled energy circular '
-                    'aperture; should be used only for unresolved sources.')
-        desc.append(f'Total aperture-corrected {ftype2} error based on the '
-                    f'{self.aperture_ee[-1]}% encircled energy circular '
-                    'aperture; should be used only for unresolved sources.')
+        desc.append(
+            f"Total aperture-corrected {ftype2} based on the "
+            f"{self.aperture_ee[-1]}% encircled energy circular "
+            "aperture; should be used only for unresolved sources."
+        )
+        desc.append(
+            f"Total aperture-corrected {ftype2} error based on the "
+            f"{self.aperture_ee[-1]}% encircled energy circular "
+            "aperture; should be used only for unresolved sources."
+        )
 
         return desc
 
     @lazyproperty
     def aperture_flux_colnames(self):
         """
-        The aperture flux column names.
+        Return the aperture flux column names.
+
+        Returns
+        -------
+        list of str
+            The aperture flux column names.
         """
-        return self._make_aperture_colnames('flux')
+        return self._make_aperture_colnames("flux")
 
     @lazyproperty
     def aperture_flux_descriptions(self):
         """
-        The aperture flux column descriptions.
+        Return the aperture flux column descriptions.
+
+        Returns
+        -------
+        list of str
+            The aperture flux column descriptions.
         """
-        return self._make_aperture_descriptions('flux')
+        return self._make_aperture_descriptions("flux")
 
     @lazyproperty
     def aperture_abmag_colnames(self):
         """
-        The aperture AB magnitude column names.
+        Return the aperture AB magnitude column names.
+
+        Returns
+        -------
+        list of str
+            The aperture AB magnitude column names.
         """
-        return self._make_aperture_colnames('abmag')
+        return self._make_aperture_colnames("abmag")
 
     @lazyproperty
     def aperture_abmag_descriptions(self):
         """
-        The aperture AB magnitude column descriptions.
+        Return the aperture AB magnitude column descriptions.
+
+        Returns
+        -------
+        list of str
+            The aperture AB magnitude column descriptions.
         """
-        return self._make_aperture_descriptions('abmag')
+        return self._make_aperture_descriptions("abmag")
 
     @lazyproperty
     def aperture_vegamag_colnames(self):
         """
-        The aperture Vega magnitude column names.
+        Return the aperture Vega magnitude column names.
+
+        Returns
+        -------
+        list of str
+            The aperture Vega magnitude column names.
         """
-        return self._make_aperture_colnames('vegamag')
+        return self._make_aperture_colnames("vegamag")
 
     @lazyproperty
     def aperture_vegamag_descriptions(self):
         """
-        The aperture Vega magnitude column descriptions.
+        Return the aperture Vega magnitude column descriptions.
+
+        Returns
+        -------
+        list of str
+            The aperture Vega magnitude column descriptions.
         """
-        return self._make_aperture_descriptions('vegamag')
+        return self._make_aperture_descriptions("vegamag")
 
     @lazyproperty
     def aperture_colnames(self):
         """
-        A dictionary of the output table column names and descriptions
-        for the aperture catalog.
+        Update the column_desc dictionary to include background flux information.
+
+        Returns
+        -------
+        colnames : list of str
+            A list of the column names that were updated by this function.
         """
         desc = {}
-        desc['aper_bkg_flux'] = ('The local background value calculated as '
-                                 'the sigma-clipped median value in the '
-                                 'background annulus aperture')
-        desc['aper_bkg_flux_err'] = ('The standard error of the '
-                                     'sigma-clipped median background value')
+        desc["aper_bkg_flux"] = (
+            "The local background value calculated as "
+            "the sigma-clipped median value in the "
+            "background annulus aperture"
+        )
+        desc["aper_bkg_flux_err"] = (
+            "The standard error of the sigma-clipped median background value"
+        )
 
         for idx, colname in enumerate(self.aperture_flux_colnames):
             desc[colname] = self.aperture_flux_descriptions[idx]
@@ -464,23 +554,28 @@ class JWSTSourceCatalog:
     @lazyproperty
     def _aper_local_background(self):
         """
-        Estimate the local background and error using a circular annulus
-        aperture.
+        Estimate the local background and error using a circular annulus aperture.
 
         The local background is the sigma-clipped median value in the
         annulus.  The background error is the standard error of the
         median, sqrt(pi / 2N) * std.
+
+        Returns
+        -------
+        bkg_median, bkg_median_err : tuple of `~astropy.unit.Quantity`
+            The local background and error.
         """
         bkg_aper = CircularAnnulus(
             self._xypos_finite,
-            self.aperture_params['bkg_aperture_inner_radius'],
-            self.aperture_params['bkg_aperture_outer_radius'])
-        bkg_aper_masks = bkg_aper.to_mask(method='center')
-        sigclip = SigmaClip(sigma=3.)
+            self.aperture_params["bkg_aperture_inner_radius"],
+            self.aperture_params["bkg_aperture_outer_radius"],
+        )
+        bkg_aper_masks = bkg_aper.to_mask(method="center")
+        sigclip = SigmaClip(sigma=3.0)
 
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-            warnings.simplefilter('ignore', category=AstropyUserWarning)
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            warnings.simplefilter("ignore", category=AstropyUserWarning)
 
             nvalues = []
             bkg_median = []
@@ -495,8 +590,7 @@ class JWSTSourceCatalog:
             nvalues = np.array(nvalues)
             bkg_median = np.array(bkg_median)
             # standard error of the median
-            bkg_median_err = (np.sqrt(np.pi / (2. * nvalues))
-                              * np.array(bkg_std))
+            bkg_median_err = np.sqrt(np.pi / (2.0 * nvalues)) * np.array(bkg_std)
 
         bkg_median <<= self.model.data.unit
         bkg_median_err <<= self.model.data.unit
@@ -506,34 +600,41 @@ class JWSTSourceCatalog:
     @lazyproperty
     def aper_bkg_flux(self):
         """
-        The aperture local background flux (per pixel).
+        Return aperture local background flux (per pixel).
+
+        Returns
+        -------
+        `~astropy.unit.Quantity`
+            The aperture local background flux.
         """
         return self._aper_local_background[0]
 
     @lazyproperty
     def aper_bkg_flux_err(self):
         """
-        The aperture local background flux error (per pixel).
+        Return aperture local background flux error (per pixel).
+
+        Returns
+        -------
+        `~astropy.unit.Quantity`
+            The aperture local background flux error.
         """
         return self._aper_local_background[1]
 
     def set_aperture_properties(self):
-        """
-        Calculate the aperture photometry.
-
-        The values are set as dynamic attributes.
-        """
-        apertures = [CircularAperture(self._xypos_finite, radius) for radius in
-                     self.aperture_params['aperture_radii']]
-        aper_phot = aperture_photometry(self.model.data, apertures,
-                                        error=self.model.err)
+        """Calculate the aperture photometry and set the values as dynamic attributes."""
+        apertures = [
+            CircularAperture(self._xypos_finite, radius)
+            for radius in self.aperture_params["aperture_radii"]
+        ]
+        aper_phot = aperture_photometry(self.model.data, apertures, error=self.model.err)
 
         for i, aperture in enumerate(apertures):
-            flux_col = f'aperture_sum_{i}'
-            flux_err_col = f'aperture_sum_err_{i}'
+            flux_col = f"aperture_sum_{i}"
+            flux_err_col = f"aperture_sum_err_{i}"
 
             # subtract the local background measured in the annulus
-            aper_phot[flux_col] -= (self.aper_bkg_flux * aperture.area)
+            aper_phot[flux_col] -= self.aper_bkg_flux * aperture.area
 
             flux = aper_phot[flux_col]
             flux_err = aper_phot[flux_err_col]
@@ -553,18 +654,22 @@ class JWSTSourceCatalog:
     @lazyproperty
     def extras_colnames(self):
         """
-        A dictionary of the output table column names and descriptions
-        for the additional catalog values.
+        Update the column_desc dictionary to include DAO starfinder computed quantities.
+
+        Returns
+        -------
+        colnames : list of str
+            A list of the column names that were updated by this function.
         """
         desc = {}
         for idx, colname in enumerate(self.ci_colnames):
             desc[colname] = self.ci_colname_descriptions[idx]
 
-        desc['is_extended'] = 'Flag indicating whether the source is extended'
-        desc['sharpness'] = 'The DAOFind source sharpness statistic'
-        desc['roundness'] = 'The DAOFind source roundness statistic'
-        desc['nn_label'] = 'The label number of the nearest neighbor'
-        desc['nn_dist'] = 'The distance in pixels to the nearest neighbor'
+        desc["is_extended"] = "Flag indicating whether the source is extended"
+        desc["sharpness"] = "The DAOFind source sharpness statistic"
+        desc["roundness"] = "The DAOFind source roundness statistic"
+        desc["nn_label"] = "The label number of the nearest neighbor"
+        desc["nn_dist"] = "The distance in pixels to the nearest neighbor"
         self.column_desc.update(desc)
 
         return list(desc.keys())
@@ -572,34 +677,50 @@ class JWSTSourceCatalog:
     @lazyproperty
     def _ci_ee_indices(self):
         """
-        The EE indices for the concentration indices.
+        Return the EE indices for the concentration indices; always in increasing order.
+
+        Returns
+        -------
+        tuple of tuples
+            The EE indices for the concentration indices.
         """
-        # NOTE: the EE values are always in increasing order
         return (0, 1), (1, 2), (0, 2)
 
     @lazyproperty
     def ci_colnames(self):
         """
-        The column names of the three concentration indices.
+        Return the column names of the three concentration indices.
+
+        Returns
+        -------
+        list of str
+            The concentration indices column names.
         """
-        return [f'CI_{self.aperture_ee[j]}_{self.aperture_ee[i]}'
-                for (i, j) in self._ci_ee_indices]
+        return [f"CI_{self.aperture_ee[j]}_{self.aperture_ee[i]}" for (i, j) in self._ci_ee_indices]
 
     @lazyproperty
     def ci_colname_descriptions(self):
         """
-        The concentration indices column descriptions.
+        Return the concentration indices column descriptions.
+
+        Returns
+        -------
+        list of str
+            The concentration indices column descriptions.
         """
-        return ['Concentration index calculated as '
-                f'({self.aperture_flux_colnames[2*j]} / '
-                f'{self.aperture_flux_colnames[2*i]})' for (i, j) in
-                self._ci_ee_indices]
+        return [
+            "Concentration index calculated as "
+            f"({self.aperture_flux_colnames[2 * j]} / "
+            f"{self.aperture_flux_colnames[2 * i]})"
+            for (i, j) in self._ci_ee_indices
+        ]
 
     @lazyproperty
     def concentration_indices(self):
         """
-        A list of concentration indices, calculated as the flux
-        ratios of:
+        Determine the concentration indices.
+
+        These are calculated as the flux ratios of:
 
             * the middle / smallest aperture radii/EE,
               e.g., CI_50_30 = aper50_flux / aper30_flux
@@ -607,24 +728,32 @@ class JWSTSourceCatalog:
               e.g., CI_70_50 = aper70_flux / aper50_flux
             * the largest / smallest aperture radii/EE,
               e.g., CI_70_30 = aper70_flux / aper30_flux
+
+        Returns
+        -------
+        list of float
+            The concentration indices.
         """
-        fluxes = [(self.aperture_flux_colnames[2 * j],
-                   self.aperture_flux_colnames[2 * i]) for (i, j) in
-                  self._ci_ee_indices]
-        return [getattr(self, flux1).value / getattr(self, flux2).value
-                for flux1, flux2 in fluxes]
+        fluxes = [
+            (self.aperture_flux_colnames[2 * j], self.aperture_flux_colnames[2 * i])
+            for (i, j) in self._ci_ee_indices
+        ]
+        return [getattr(self, flux1).value / getattr(self, flux2).value for flux1, flux2 in fluxes]
 
     def set_ci_properties(self):
-        """
-        Set the concentration indices as dynamic attributes.
-        """
-        for name, value in zip(self.ci_colnames, self.concentration_indices):
+        """Set the concentration indices as dynamic attributes."""
+        for name, value in zip(self.ci_colnames, self.concentration_indices, strict=False):
             setattr(self, name, value)
 
     @lazyproperty
     def is_extended(self):
         """
-        Boolean indicating whether the source is extended.
+        Return a boolean indicating whether the source is extended.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            A boolean array where `True` values denote extended sources.
         """
         mask1 = self.concentration_indices[0] > self.ci_star_thresholds[0]
         mask2 = self.concentration_indices[1] > self.ci_star_thresholds[1]
@@ -633,69 +762,93 @@ class JWSTSourceCatalog:
     @lazyproperty
     def _kernel_size(self):
         """
-        The DAOFind kernel size (in both x and y dimensions).
+        Return the DAOFind kernel size (in both x and y dimensions), always odd.
+
+        Returns
+        -------
+        int
+            The DAOFind kernel size.
         """
-        # always odd
         return 2 * int(max(2.0, 1.5 * self.kernel_sigma)) + 1
 
     @lazyproperty
     def _kernel_center(self):
         """
-        The DAOFind kernel x/y center.
+        Return the DAOFind kernel x/y center.
+
+        Returns
+        -------
+        int
+            The DAOFind kernel center.
         """
         return (self._kernel_size - 1) // 2
 
     @lazyproperty
     def _kernel_mask(self):
         """
-        The DAOFind kernel circular mask.
-        NOTE: 1=good pixels, 0=masked pixels
+        Make the DAOFind kernel circular mask.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            A 2D array containing the DAOFind kernel mask, where 1=good pixels and 0=masked pixels.
         """
-        yy, xx = np.mgrid[0:self._kernel_size, 0:self._kernel_size]
-        radius = np.sqrt((xx - self._kernel_center) ** 2
-                         + (yy - self._kernel_center) ** 2)
+        yy, xx = np.mgrid[0 : self._kernel_size, 0 : self._kernel_size]
+        radius = np.sqrt((xx - self._kernel_center) ** 2 + (yy - self._kernel_center) ** 2)
         return (radius <= max(2.0, 1.5 * self.kernel_sigma)).astype(int)
 
     @lazyproperty
     def _daofind_kernel(self):
         """
-        The DAOFind kernel, a 2D circular Gaussian normalized to have
-        zero sum.
+        Compute the DAOFind kernel, a 2D circular Gaussian normalized to have zero sum.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The DAOFind kernel.
         """
         size = self._kernel_size
-        kernel = Gaussian2DKernel(self.kernel_sigma, x_size=size,
-                                  y_size=size).array
+        kernel = Gaussian2DKernel(self.kernel_sigma, x_size=size, y_size=size).array
         kernel /= np.max(kernel)
         kernel *= self._kernel_mask
 
         # normalize the kernel to zero sum
         npixels = self._kernel_mask.sum()
-        denom = np.sum(kernel**2) - (np.sum(kernel)**2 / npixels)
+        denom = np.sum(kernel**2) - (np.sum(kernel) ** 2 / npixels)
         return ((kernel - (kernel.sum() / npixels)) / denom) * self._kernel_mask
 
     @lazyproperty
     def _daofind_convolved_data(self):
         """
-        The DAOFind convolved data.
+        Convolve the data with the DAOFind kernel.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The convolved data.
         """
-        return ndimage.convolve(self.model.data.value, self._daofind_kernel,
-                                mode='constant', cval=0.0)
+        return ndimage.convolve(
+            self.model.data.value, self._daofind_kernel, mode="constant", cval=0.0
+        )
 
     @lazyproperty
     def _daofind_cutout(self):
         """
-        3D array containing 2D cutouts centered on each source from the
-        input data.
+        Construct cutouts centered on each source from the input data.
 
-        The cutout size always matches the size of the DAOFind kernel,
-        which has odd dimensions.
+        The cutout size always matches the size of the DAOFind kernel, which has odd dimensions.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            A 3D array containing 2D cutouts centered on each source from the input data.
         """
         cutout = []
-        for xcen, ycen in zip(*np.transpose(self._xypos_finite)):
+        for xcen, ycen in zip(*np.transpose(self._xypos_finite), strict=False):
             try:
-                cutout_ = extract_array(self.model.data,
-                                        self._daofind_kernel.shape,
-                                        (ycen, xcen), fill_value=0.0)
+                cutout_ = extract_array(
+                    self.model.data, self._daofind_kernel.shape, (ycen, xcen), fill_value=0.0
+                )
             except NoOverlapError:
                 cutout_ = np.zeros(self._daofind_kernel.shape)
             cutout.append(cutout_)
@@ -705,18 +858,24 @@ class JWSTSourceCatalog:
     @lazyproperty
     def _daofind_cutout_conv(self):
         """
-        3D array containing 2D cutouts centered on each source from the
-        DAOFind convolved data.
+        Construct cutouts centered on each source from the convolved data.
 
-        The cutout size always matches the size of the DAOFind kernel,
-        which has odd dimensions.
+        The cutout size always matches the size of the DAOFind kernel, which has odd dimensions.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            A 3D array containing 2D cutouts centered on each source from the convolved data.
         """
         cutout = []
-        for xcen, ycen in zip(*np.transpose(self._xypos_finite)):
+        for xcen, ycen in zip(*np.transpose(self._xypos_finite), strict=False):
             try:
-                cutout_ = extract_array(self._daofind_convolved_data,
-                                        self._daofind_kernel.shape,
-                                        (ycen, xcen), fill_value=0.0)
+                cutout_ = extract_array(
+                    self._daofind_convolved_data,
+                    self._daofind_kernel.shape,
+                    (ycen, xcen),
+                    fill_value=0.0,
+                )
             except NoOverlapError:
                 cutout_ = np.zeros(self._daofind_kernel.shape)
             cutout.append(cutout_)
@@ -726,7 +885,7 @@ class JWSTSourceCatalog:
     @lazyproperty
     def sharpness(self):
         """
-        The DAOFind source sharpness statistic.
+        Compute the DAOFind source sharpness statistic.
 
         The sharpness statistic measures the ratio of the difference
         between the height of the central pixel and the mean of the
@@ -734,26 +893,28 @@ class JWSTSourceCatalog:
         Gaussian function at that point.
 
         Stars generally have a ``sharpness`` between 0.2 and 1.0.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The DAOFind source sharpness statistic.
         """
         npixels = self._kernel_mask.sum() - 1  # exclude the peak pixel
         data_masked = self._daofind_cutout * self._kernel_mask
-        data_peak = self._daofind_cutout[:, self._kernel_center,
-                                         self._kernel_center]
-        conv_peak = self._daofind_cutout_conv[:, self._kernel_center,
-                                              self._kernel_center]
+        data_peak = self._daofind_cutout[:, self._kernel_center, self._kernel_center]
+        conv_peak = self._daofind_cutout_conv[:, self._kernel_center, self._kernel_center]
 
-        data_mean = ((np.sum(data_masked, axis=(1, 2))
-                      - data_peak) / npixels)
+        data_mean = (np.sum(data_masked, axis=(1, 2)) - data_peak) / npixels
 
         with warnings.catch_warnings():
             # ignore 0 / 0 for non-finite xypos
-            warnings.simplefilter('ignore', category=RuntimeWarning)
+            warnings.simplefilter("ignore", category=RuntimeWarning)
             return (data_peak - data_mean) / conv_peak
 
     @lazyproperty
     def roundness(self):
         """
-        The DAOFind source roundness statistic based on symmetry.
+        Compute the DAOFind source roundness statistic based on symmetry.
 
         The roundness characteristic computes the ratio of a measure of
         the bilateral symmetry of the object to a measure of the
@@ -761,20 +922,29 @@ class JWSTSourceCatalog:
 
         "Round" objects have a ``roundness`` close to 0, generally
         between -1 and 1.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The DAOFind source roundness statistic.
         """
         # set the central (peak) pixel to zero
         cutout = self._daofind_cutout_conv.copy()
         cutout[:, self._kernel_center, self._kernel_center] = 0.0
 
         # calculate the four roundness quadrants
-        quad1 = cutout[:, 0:self._kernel_center + 1, self._kernel_center + 1:]
-        quad2 = cutout[:, 0:self._kernel_center, 0:self._kernel_center + 1]
-        quad3 = cutout[:, self._kernel_center:, 0:self._kernel_center]
-        quad4 = cutout[:, self._kernel_center + 1:, self._kernel_center:]
+        quad1 = cutout[:, 0 : self._kernel_center + 1, self._kernel_center + 1 :]
+        quad2 = cutout[:, 0 : self._kernel_center, 0 : self._kernel_center + 1]
+        quad3 = cutout[:, self._kernel_center :, 0 : self._kernel_center]
+        quad4 = cutout[:, self._kernel_center + 1 :, self._kernel_center :]
 
         axis = (1, 2)
-        sum2 = (-quad1.sum(axis=axis) + quad2.sum(axis=axis)
-                - quad3.sum(axis=axis) + quad4.sum(axis=axis))
+        sum2 = (
+            -quad1.sum(axis=axis)
+            + quad2.sum(axis=axis)
+            - quad3.sum(axis=axis)
+            + quad4.sum(axis=axis)
+        )
         sum2[sum2 == 0] = 0.0
 
         sum4 = np.abs(cutout).sum(axis=axis)
@@ -782,13 +952,20 @@ class JWSTSourceCatalog:
 
         with warnings.catch_warnings():
             # ignore 0 / 0 for non-finite xypos
-            warnings.simplefilter('ignore', category=RuntimeWarning)
+            warnings.simplefilter("ignore", category=RuntimeWarning)
             return 2.0 * sum2 / sum4
 
     @lazyproperty
     def _kdtree_query(self):
         """
-        The distance in pixels to the nearest neighbor and its index.
+        Compute the distance in pixels from a source to its nearest neighbor.
+
+        Returns
+        -------
+        qdist : `~numpy.ndarray`
+            The distance in pixels to the nearest neighbor.
+        qidx : `~numpy.ndarray`
+            The label number of the nearest neighbor.
         """
         if self.n_sources == 1:
             return [np.nan], [np.nan]
@@ -801,10 +978,15 @@ class JWSTSourceCatalog:
     @lazyproperty
     def nn_label(self):
         """
-        The label number of the nearest neighbor.
+        Return the label number of the nearest neighbor for each source.
 
         A label value of -1 is returned if there is only one detected
         source and for sources with a non-finite xcentroid or ycentroid.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The label number of the nearest neighbor.
         """
         if self.n_sources == 1:
             return -1
@@ -818,11 +1000,17 @@ class JWSTSourceCatalog:
     @lazyproperty
     def nn_dist(self):
         """
-        The distance in pixels to the nearest neighbor.
+        Return the distance in pixels to the nearest neighbor for each source.
+
+        Returns NaN if there is only one detected source or for non-finite xypos.
+
+        Returns
+        -------
+        `~astropy.units.Quantity`
+            The distance in pixels to the nearest neighbor.
         """
         nn_dist = self._kdtree_query[0]
         if self.n_sources == 1:
-            # NaN if only one detected source
             return nn_dist * u.pixel
 
         # assign a distance of np.nan for non-finite xypos
@@ -832,83 +1020,108 @@ class JWSTSourceCatalog:
     @lazyproperty
     def aper_total_flux(self):
         """
-        The aperture-corrected total flux for sources, based on the flux
-        in largest aperture.
+        Return the aperture-corrected total flux for sources.
 
-        The aperture-corrected total flux should be used only for
-        unresolved sources.
+        Computed based on the flux in largest aperture.Should be used only for unresolved sources.
+
+        Returns
+        -------
+        `~astropy.unit.Quantity`
+            The aperture-corrected total flux
         """
         idx = self.n_aper - 1  # apcorr for the largest EE (largest radius)
-        flux = (self.aperture_params['aperture_corrections'][idx]
-                * getattr(self, self.aperture_flux_colnames[idx * 2]))
+        flux = self.aperture_params["aperture_corrections"][idx] * getattr(
+            self, self.aperture_flux_colnames[idx * 2]
+        )
         return flux
 
     @lazyproperty
     def aper_total_flux_err(self):
         """
-        The aperture-corrected total flux error for sources,
-        based on the flux in largest aperture.
+        Return the aperture-corrected total flux error for sources.
 
-        The aperture-corrected total flux error should be used only for
-        unresolved sources.
+        Computed based on the flux in largest aperture. Should be used only for unresolved sources.
+
+        Returns
+        -------
+        `~astropy.unit.Quantity`
+            The aperture-corrected total flux error
         """
         idx = self.n_aper - 1  # apcorr for the largest EE (largest radius)
-        flux_err = (self.aperture_params['aperture_corrections'][idx]
-                    * getattr(self, self.aperture_flux_colnames[idx * 2 + 1]))
+        flux_err = self.aperture_params["aperture_corrections"][idx] * getattr(
+            self, self.aperture_flux_colnames[idx * 2 + 1]
+        )
         return flux_err
 
     @lazyproperty
     def _abmag_total(self):
-        """
-        The total AB magnitude and error.
-        """
-        return self.convert_flux_to_abmag(self.aper_total_flux,
-                                          self.aper_total_flux_err)
+        return self.convert_flux_to_abmag(self.aper_total_flux, self.aper_total_flux_err)
 
     @lazyproperty
     def aper_total_abmag(self):
         """
-        The aperture-corrected total AB magnitude.
+        Return the aperture-corrected total AB magnitude.
 
-        The aperture-corrected total magnitude should be used only for
-        unresolved sources.
+        Should be used only for unresolved sources.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The aperture-corrected total AB magnitude.
         """
         return self._abmag_total[0]
 
     @lazyproperty
     def aper_total_abmag_err(self):
         """
-        The aperture-corrected total AB magnitude error.
+        Return the aperture-corrected total AB magnitude error.
 
-        The aperture-corrected total magnitude error should be used only
-        for unresolved sources.
+        Should be used only for unresolved sources.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The aperture-corrected total AB magnitude error.
         """
         return self._abmag_total[1]
 
     @lazyproperty
     def aper_total_vegamag(self):
         """
-        The aperture-corrected total Vega magnitude.
+        Return the aperture-corrected total Vega magnitude.
 
-        The aperture-corrected total magnitude should be used only for
-        unresolved sources.
+        Should be used only for unresolved sources.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The aperture-corrected total Vega magnitude.
         """
         return self.aper_total_abmag - self.abvega_offset
 
     @lazyproperty
     def aper_total_vegamag_err(self):
         """
-        The aperture-corrected total Vega magnitude error.
+        Return the aperture-corrected total Vega magnitude error.
 
-        The aperture-corrected total magnitude error should be used only
-        for unresolved sources.
+        Should be used only for unresolved sources.
+
+        Returns
+        -------
+        `~numpy.ndarray`
+            The aperture-corrected total Vega magnitude error.
         """
         return self.aper_total_abmag_err
 
     @lazyproperty
     def colnames(self):
         """
-        The column name order for the final source catalog.
+        Return the column names in order for the final source catalog.
+
+        Returns
+        -------
+        list of str
+            The column names.
         """
         colnames = self.segment_colnames[0:4]
         colnames.extend(self.aperture_colnames)
@@ -933,23 +1146,36 @@ class JWSTSourceCatalog:
         """
         # output formatting requested by the JPWG (2020.02.05)
         for colname in catalog.colnames:
-            if colname in ('xcentroid', 'ycentroid') or 'CI_' in colname:
-                catalog[colname].info.format = '.4f'
-            if 'flux' in colname:
-                catalog[colname].info.format = '.6e'
-            if ('abmag' in colname or 'vegamag' in colname or
-                    colname in ('nn_dist', 'sharpness', 'roundness')):
-                catalog[colname].info.format = '.6f'
-            if colname in ('semimajor_sigma', 'semiminor_sigma',
-                           'ellipticity', 'orientation', 'sky_orientation'):
-                catalog[colname].info.format = '.6f'
+            if colname in ("xcentroid", "ycentroid") or "CI_" in colname:
+                catalog[colname].info.format = ".4f"
+            if "flux" in colname:
+                catalog[colname].info.format = ".6e"
+            if (
+                "abmag" in colname
+                or "vegamag" in colname
+                or colname in ("nn_dist", "sharpness", "roundness")
+            ):
+                catalog[colname].info.format = ".6f"
+            if colname in (
+                "semimajor_sigma",
+                "semiminor_sigma",
+                "ellipticity",
+                "orientation",
+                "sky_orientation",
+            ):
+                catalog[colname].info.format = ".6f"
 
         return catalog
 
     @lazyproperty
     def catalog(self):
         """
-        The final source catalog.
+        Build the final source catalog.
+
+        Returns
+        -------
+        catalog : `~astropy.table.Table`
+            The final source catalog.
         """
         self.convert_to_jy()
         self.set_segment_properties()
@@ -967,19 +1193,18 @@ class JWSTSourceCatalog:
         # photutils 1.11.0 will change the meta dict key name from
         # version to versions; can remove this check when we require
         # photutils >= 1.11.0
-        verkeys = ('versions', 'version')
+        verkeys = ("versions", "version")
         verkey = set(self.meta.keys()).intersection(verkeys).pop()
         verdict = self.meta.get(verkey, None)
 
         if verdict is not None:
-            verdict['jwst'] = jwst_version
-            packages = ['Python', 'numpy', 'scipy', 'astropy', 'photutils',
-                        'gwcs', 'jwst']
+            verdict["jwst"] = jwst_version
+            packages = ["Python", "numpy", "scipy", "astropy", "photutils", "gwcs", "jwst"]
             verdict = {key: verdict[key] for key in packages if key in verdict}
             self.meta[verkey] = verdict
 
-        self.meta['aperture_params'] = self.aperture_params
-        self.meta['abvega_offset'] = self.abvega_offset
+        self.meta["aperture_params"] = self.aperture_params
+        self.meta["abvega_offset"] = self.abvega_offset
         catalog.meta.update(self.meta)
 
         # reset units on input model back to MJy/sr

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -1,8 +1,6 @@
-"""
-Module for the source catalog step.
-"""
+"""Module for the source catalog step."""
 
-import os
+from pathlib import Path
 
 from crds.core.exceptions import CrdsLookupError
 import numpy as np
@@ -18,14 +16,7 @@ __all__ = ["SourceCatalogStep"]
 
 
 class SourceCatalogStep(Step):
-    """
-    Create a final catalog of source photometry and morphologies.
-
-    Parameters
-    -----------
-    input : str or `ImageModel`
-        A FITS filename or an `ImageModel` of a drizzled image.
-    """
+    """Create a final catalog of source photometry and morphologies."""
 
     class_alias = "source_catalog"
 
@@ -43,17 +34,16 @@ class SourceCatalogStep(Step):
         suffix = string(default='cat')        # Default suffix for output files
     """
 
-    reference_file_types = ['apcorr', 'abvegaoffset']
+    reference_file_types = ["apcorr", "abvegaoffset"]
 
     def _get_reffile_paths(self, model):
         filepaths = []
         for reffile_type in self.reference_file_types:
             try:
                 filepath = self.get_reference_file(model, reffile_type)
-                self.log.info(f'Using {reffile_type.upper()} reference file: '
-                              f'{filepath}')
+                self.log.info(f"Using {reffile_type.upper()} reference file: {filepath}")
             except CrdsLookupError as err:
-                msg = f'{err} Source catalog will not be created.'
+                msg = f"{err} Source catalog will not be created."
                 self.log.warning(msg)
                 return None
 
@@ -61,60 +51,71 @@ class SourceCatalogStep(Step):
         return filepaths
 
     def process(self, input_model):
+        """
+        Create the catalog from the input datamodel.
+
+        Parameters
+        ----------
+        input_model : str or `ImageModel`
+            A FITS filename or an `ImageModel` of a drizzled image.
+
+        Returns
+        -------
+        catalog : `astropy.table.Table` or None
+            The source catalog, or None if no sources were found.
+        """
         with datamodels.open(input_model) as model:
             reffile_paths = self._get_reffile_paths(model)
-            aperture_ee = (self.aperture_ee1, self.aperture_ee2,
-                           self.aperture_ee3)
+            aperture_ee = (self.aperture_ee1, self.aperture_ee2, self.aperture_ee3)
 
             try:
-                refdata = ReferenceData(model, reffile_paths,
-                                        aperture_ee)
+                refdata = ReferenceData(model, reffile_paths, aperture_ee)
                 aperture_params = refdata.aperture_params
                 abvega_offset = refdata.abvega_offset
             except RuntimeError as err:
-                msg = f'{err} Source catalog will not be created.'
+                msg = f"{err} Source catalog will not be created."
                 self.log.warning(msg)
                 return None
 
             coverage_mask = np.isnan(model.err) | (model.wht == 0)
-            bkg = JWSTBackground(model.data, box_size=self.bkg_boxsize,
-                                 coverage_mask=coverage_mask)
+            bkg = JWSTBackground(model.data, box_size=self.bkg_boxsize, coverage_mask=coverage_mask)
             model.data -= bkg.background
 
             threshold = self.snr_threshold * bkg.background_rms
-            finder = JWSTSourceFinder(threshold, self.npixels,
-                                      deblend=self.deblend)
+            finder = JWSTSourceFinder(threshold, self.npixels, deblend=self.deblend)
 
-            convolved_data = convolve_data(model.data, self.kernel_fwhm,
-                                           mask=coverage_mask)
+            convolved_data = convolve_data(model.data, self.kernel_fwhm, mask=coverage_mask)
             segment_img = finder(convolved_data, mask=coverage_mask)
             if segment_img is None:
                 return None
 
-            ci_star_thresholds = (self.ci1_star_threshold,
-                                  self.ci2_star_threshold)
-            catobj = JWSTSourceCatalog(model, segment_img, convolved_data,
-                                       self.kernel_fwhm, aperture_params,
-                                       abvega_offset, ci_star_thresholds)
+            ci_star_thresholds = (self.ci1_star_threshold, self.ci2_star_threshold)
+            catobj = JWSTSourceCatalog(
+                model,
+                segment_img,
+                convolved_data,
+                self.kernel_fwhm,
+                aperture_params,
+                abvega_offset,
+                ci_star_thresholds,
+            )
             catalog = catobj.catalog
 
             # add back background to data so input model is unchanged
             model.data += bkg.background
 
             if self.save_results:
-                cat_filepath = self.make_output_path(ext='.ecsv')
-                catalog.write(cat_filepath, format='ascii.ecsv',
-                              overwrite=True)
-                model.meta.source_catalog = os.path.basename(cat_filepath)
-                self.log.info(f'Wrote source catalog: {cat_filepath}')
+                cat_filepath = self.make_output_path(ext=".ecsv")
+                catalog.write(cat_filepath, format="ascii.ecsv", overwrite=True)
+                model.meta.source_catalog = Path(cat_filepath).name
+                self.log.info(f"Wrote source catalog: {cat_filepath}")
 
                 segm_model = datamodels.SegmentationMapModel(segment_img.data)
                 segm_model.update(model, only="PRIMARY")
                 segm_model.meta.wcs = model.meta.wcs
                 segm_model.meta.wcsinfo = model.meta.wcsinfo
-                self.save_model(segm_model, suffix='segm')
+                self.save_model(segm_model, suffix="segm")
                 model.meta.segmentation_map = segm_model.meta.filename
-                self.log.info('Wrote segmentation map: '
-                              f'{segm_model.meta.filename}')
+                self.log.info(f"Wrote segmentation map: {segm_model.meta.filename}")
 
         return catalog


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially Resolves [JP-3860](https://jira.stsci.edu/browse/JP-3860)

<!-- describe the changes comprising this PR here -->
This PR brings the source_catalog step into compliance with the new code style rules.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
