### PR TITLE
Apply code style rules to badpix_selfcal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,6 @@ repos:
             jwst/assign_wcs/.* |
             jwst/associations/.* |
             jwst/background/.* |
-            jwst/badpix_selfcal/.* |
             jwst/barshadow/.* |
             jwst/charge_migration/.* |
             jwst/combine_1d/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -27,7 +27,7 @@ exclude = [
     "jwst/assign_wcs/**.py",
     "jwst/associations/**.py",
     "jwst/background/**.py",
-    "jwst/badpix_selfcal/**.py",
+    # "jwst/badpix_selfcal/**.py",
     "jwst/barshadow/**.py",
     "jwst/charge_migration/**.py",
     # "jwst/clean_flicker_noise/**.py",
@@ -157,7 +157,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/assign_wcs/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/associations/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/background/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/badpix_selfcal/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/badpix_selfcal/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/barshadow/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/charge_migration/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 # "jwst/clean_flicker_noise/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/badpix_selfcal/__init__.py
+++ b/jwst/badpix_selfcal/__init__.py
@@ -1,4 +1,6 @@
+"""Self-calibration of bad pixels in JWST data."""
+
 from .badpix_selfcal_step import BadpixSelfcalStep
 
 
-__all__ = ['BadpixSelfcalStep']
+__all__ = ["BadpixSelfcalStep"]

--- a/jwst/badpix_selfcal/badpix_selfcal.py
+++ b/jwst/badpix_selfcal/badpix_selfcal.py
@@ -8,13 +8,15 @@ from stcal.outlier_detection.utils import medfilt
 from stdatamodels.jwst.datamodels.dqflags import pixel
 
 
-def badpix_selfcal(minimg: np.ndarray,
-                   flagfrac_lower: float = 0.001,
-                   flagfrac_upper: float = 0.001,
-                   kernel_size: int = 15,
-                   dispaxis=None) -> np.ndarray:
+def badpix_selfcal(
+    minimg: np.ndarray,
+    flagfrac_lower: float = 0.001,
+    flagfrac_upper: float = 0.001,
+    kernel_size: int = 15,
+    dispaxis=None,
+) -> np.ndarray:
     """
-    Flag residual artifacts as bad pixels in the DQ array of a JWST exposure
+    Flag residual artifacts as bad pixels in the DQ array of a JWST exposure.
 
     Parameters
     ----------
@@ -56,7 +58,9 @@ def badpix_selfcal(minimg: np.ndarray,
     minimg_hpf = minimg - smoothed
 
     # Flag outliers using percentile cutoff
-    flag_low, flag_high = np.nanpercentile(minimg_hpf, [flagfrac_lower * 100, (1 - flagfrac_upper) * 100])
+    flag_low, flag_high = np.nanpercentile(
+        minimg_hpf, [flagfrac_lower * 100, (1 - flagfrac_upper) * 100]
+    )
     bad = (minimg_hpf > flag_high) | (minimg_hpf < flag_low)
     flagged_indices = np.where(bad)
     return flagged_indices
@@ -64,7 +68,9 @@ def badpix_selfcal(minimg: np.ndarray,
 
 def apply_flags(input_model: IFUImageModel, flagged_indices: np.ndarray) -> IFUImageModel:
     """
-    Apply the flagged indices to the input model. Sets the flagged pixels to NaN
+    Apply the flagged indices to the input model.
+
+    Sets the flagged pixels to NaN
     and the DQ flag to DO_NOT_USE + OTHER_BAD_PIXEL
 
     Parameters
@@ -80,7 +86,6 @@ def apply_flags(input_model: IFUImageModel, flagged_indices: np.ndarray) -> IFUI
     output_model : IFUImageModel
         Flagged data model
     """
-
     input_model.dq[flagged_indices] |= pixel["DO_NOT_USE"] + pixel["OTHER_BAD_PIXEL"]
 
     input_model.data[flagged_indices] = np.nan

--- a/jwst/badpix_selfcal/badpix_selfcal_step.py
+++ b/jwst/badpix_selfcal/badpix_selfcal_step.py
@@ -11,15 +11,15 @@ __all__ = ["BadpixSelfcalStep"]
 PEDESTAL_INDX_MIRIFULONG = (50, 974, 474, 507)
 PEDESTAL_INDX_MIRIFUSHORT = (50, 974, 503, 516)
 
+
 class BadpixSelfcalStep(Step):
     """
-    BadpixSelfcalStep: Flags residual artifacts as bad pixels in the DQ array
-    of a JWST exposure using a median filter and percentile cutoffs.
+    Flag residual artifacts as bad pixels using a median filter and percentile cutoffs.
 
     All input exposures in the association file (or manually-provided bkg_list) are combined
     into a single background model using a MIN operation. The bad pixels are then identified
     using a median filter and percentile cutoffs, and applied to the science data by setting
-    the flagged pixels, errors, and variances to NaN
+    the flagged pixels, errors, and variances to NaN,
     and the DQ flag to DO_NOT_USE + OTHER_BAD_PIXEL.
     """
 
@@ -32,40 +32,62 @@ class BadpixSelfcalStep(Step):
     force_single = boolean(default=False)  # force single input exposure
     save_flagged_bkg = boolean(default=False)  # save flagged background exposures to file
     skip = boolean(default=True)
-    """
+    """  # noqa: E501
 
     def save_model(self, model, *args, **kwargs):
-        """Override save_model to suppress index 0 when save_model is True"""
+        """
+        Override save_model to suppress index 0 when save_model is True.
+
+        Parameters
+        ----------
+        model : JWST data model
+            Data model to save
+        *args : tuple
+            Additional arguments to pass to Step.save_model
+        **kwargs : dict
+            Additional keyword arguments to pass to Step.save_model
+
+        Returns
+        -------
+        list[str]
+            List of output paths for the saved models
+        """
         kwargs["idx"] = None
         return Step.save_model(self, model, *args, **kwargs)
 
     def save_bkg(self, bkg_list, suffix="badpix_selfcal_bkg"):
-        """Save the background exposures to file with correct indexing
+        """
+        Save the background exposures to file with correct indexing.
+
+        Parameters
+        ----------
+        bkg_list : list of ImageModels
+            Background exposures to save
+        suffix : str
+            Suffix to append to the filename
         """
         for i, bkg_model in enumerate(bkg_list):
             self.save_model(bkg_model, suffix=suffix + f"_{str(i)}")
 
-    def process(self, input, selfcal_list=None, bkg_list=None):
+    def process(self, input_data, selfcal_list=None, bkg_list=None):
         """
-        Flag residual artifacts as bad pixels in the DQ array of a JWST exposure
+        Flag residual artifacts as bad pixels in the DQ array of a JWST exposure.
 
         Parameters
         ----------
-        input : JWST data model or association
-            input science data to be corrected, or tuple of (sci, bkg, selfcal)
-
+        input_data : JWST data model or association
+            Input science data to be corrected, or tuple of (sci, bkg, selfcal)
         selfcal_list : list of ImageModels or filenames, default None
-            exposures to include as part of median background model used to find bad pixels,
-            but that are not flagged and returned as background exposures
-
+            Exposures to include as part of median background model used to find bad pixels,
+            but that are not flagged and returned as background exposures.
         bkg_list : list of ImageModels or filenames, default None
-            exposures to include as part of median background model used to find bad pixels,
-            and that are flagged and returned as background exposures
+            Exposures to include as part of median background model used to find bad pixels,
+            and that are flagged and returned as background exposures.
 
         Returns
         -------
         output : JWST data model or association
-            data model with CRs flagged
+            Data model with CRs flagged
 
         Notes
         -----
@@ -80,24 +102,29 @@ class BadpixSelfcalStep(Step):
         In that case, the input exposure will be used as the sole background exposure,
         i.e., true self-calibration.
         """
-        input_sci, selfcal_list, bkg_list = _parse_inputs(input, selfcal_list, bkg_list)
+        input_sci, selfcal_list, bkg_list = _parse_inputs(input_data, selfcal_list, bkg_list)
 
         # ensure that there are background exposures to use, otherwise skip the step
         # unless forced
         if (len(selfcal_list + bkg_list) == 0) and (not self.force_single):
-            self.log.warning("No selfcal or background exposures provided for self-calibration. "
-                        "Skipping step.")
-            self.log.info("If you want to force self-calibration with the science "
-                        "exposure alone (generally not recommended), set force_single=True.")
-            input_sci.meta.cal_step.badpix_selfcal = 'SKIPPED'
+            self.log.warning(
+                "No selfcal or background exposures provided for self-calibration. Skipping step."
+            )
+            self.log.info(
+                "If you want to force self-calibration with the science "
+                "exposure alone (generally not recommended), set force_single=True."
+            )
+            input_sci.meta.cal_step.badpix_selfcal = "SKIPPED"
             return input_sci, bkg_list
 
         # get the dispersion axis
         try:
             dispaxis = input_sci.meta.wcsinfo.dispersion_direction
         except AttributeError:
-            self.log.warning("Dispersion axis not found in input science image metadata. "
-                        "Kernel for self-calibration will be two-dimensional.")
+            self.log.warning(
+                "Dispersion axis not found in input science image metadata. "
+                "Kernel for self-calibration will be two-dimensional."
+            )
             dispaxis = None
 
         # collapse all selfcal exposures into a single background model
@@ -105,25 +132,38 @@ class BadpixSelfcalStep(Step):
         # all exposures are combined into a single background model using a MIN operation.
         selfcal_list = [input_sci] + selfcal_list
         selfcal_3d = []
-        for i, selfcal_model in enumerate(selfcal_list):
+        for selfcal_model in selfcal_list:
             # If working with MIRI MRS data, subtract any pedestal residual dark
             # using the median of count rates from between the channels
-            if (input_sci.meta.instrument.detector.upper() == 'MIRIFUSHORT'):
-                selfcal_3d.append(selfcal_model.data - np.nanmedian(
-                    selfcal_model.data[PEDESTAL_INDX_MIRIFUSHORT[0]:PEDESTAL_INDX_MIRIFUSHORT[1],
-                    PEDESTAL_INDX_MIRIFUSHORT[2]:PEDESTAL_INDX_MIRIFUSHORT[3]]))
-            elif (input_sci.meta.instrument.detector.upper() == 'MIRIFULONG'):
-                selfcal_3d.append(selfcal_model.data - np.nanmedian(
-                    selfcal_model.data[PEDESTAL_INDX_MIRIFULONG[0]:PEDESTAL_INDX_MIRIFULONG[1],
-                    PEDESTAL_INDX_MIRIFULONG[2]:PEDESTAL_INDX_MIRIFULONG[3]]))
+            if input_sci.meta.instrument.detector.upper() == "MIRIFUSHORT":
+                selfcal_3d.append(
+                    selfcal_model.data
+                    - np.nanmedian(
+                        selfcal_model.data[
+                            PEDESTAL_INDX_MIRIFUSHORT[0] : PEDESTAL_INDX_MIRIFUSHORT[1],
+                            PEDESTAL_INDX_MIRIFUSHORT[2] : PEDESTAL_INDX_MIRIFUSHORT[3],
+                        ]
+                    )
+                )
+            elif input_sci.meta.instrument.detector.upper() == "MIRIFULONG":
+                selfcal_3d.append(
+                    selfcal_model.data
+                    - np.nanmedian(
+                        selfcal_model.data[
+                            PEDESTAL_INDX_MIRIFULONG[0] : PEDESTAL_INDX_MIRIFULONG[1],
+                            PEDESTAL_INDX_MIRIFULONG[2] : PEDESTAL_INDX_MIRIFULONG[3],
+                        ]
+                    )
+                )
             else:
                 selfcal_3d.append(selfcal_model.data)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=RuntimeWarning, message="All-NaN")
             minimg = np.nanmin(np.asarray(selfcal_3d), axis=0)
-        bad_indices = badpix_selfcal.badpix_selfcal(minimg, self.flagfrac_lower, self.flagfrac_upper, self.kernel_size, dispaxis)
-
+        bad_indices = badpix_selfcal.badpix_selfcal(
+            minimg, self.flagfrac_lower, self.flagfrac_upper, self.kernel_size, dispaxis
+        )
 
         # apply the flags to the science data
         input_sci = badpix_selfcal.apply_flags(input_sci, bad_indices)
@@ -137,34 +177,33 @@ class BadpixSelfcalStep(Step):
         if self.save_flagged_bkg:
             self.save_bkg(bkg_list)
 
-        input_sci.meta.cal_step.badpix_selfcal = 'COMPLETE'
+        input_sci.meta.cal_step.badpix_selfcal = "COMPLETE"
         return input_sci, bkg_list
 
 
-def _parse_inputs(input, selfcal_list, bkg_list):
+def _parse_inputs(input_data, selfcal_list, bkg_list):
     """
-    Parse the input to the step. This is a helper function that is used in the
-    command line interface to the step.
+    Parse the input to the step.
 
     Parameters
     ----------
-    input : str
-        input science exposure or association
-
+    input_data : JWSTDataModel, filename, or association
+        Input exposures to be split into science, background, and selfcal lists.
     selfcal_list : list of ImageModels or filenames, default None
-        exposures to include as part of median background model used to find bad pixels,
+        Exposures to include as part of median background model used to find bad pixels,
         but that are not flagged and returned as background exposures
-
     bkg_list : list of ImageModels or filenames, default None
-        exposures to include as part of median background model used to find bad pixels,
+        Exposures to include as part of median background model used to find bad pixels,
         and that are flagged and returned as background exposures
 
     Returns
     -------
-    input : JWST data model or association
-        input science data to be corrected
-
-    selfcal_list : list of ImageModels or filenames to use for selfcal
+    input_sci : JWSTDataModel
+        Input science data to be corrected. Will be a single datamodel regardless of input type.
+    selfcal_list : list[JWSTDataModel]
+        Images to use for self-calibration.
+    bkg_list : list[JWSTDataModel]
+        Images to use as background exposures.
     """
     if selfcal_list is None:
         selfcal_list = []
@@ -174,29 +213,30 @@ def _parse_inputs(input, selfcal_list, bkg_list):
     bkg_list = [dm.open(bkg) for bkg in bkg_list]
     selfcal_list = selfcal_list + bkg_list
 
-    with dm.open(input) as input_data:
-
+    with dm.open(input_data) as input_dm:
         # find science and background exposures in association file
-        if isinstance(input_data, dm.ModelContainer):
-
+        if isinstance(input_dm, dm.ModelContainer):
             sci_models, bkg_list_asn, selfcal_list_asn = split_container_by_asn_exptype(
-                input_data, exptypes=['science', 'background', 'selfcal'])
+                input_dm, exptypes=["science", "background", "selfcal"]
+            )
 
             selfcal_list = selfcal_list + list(bkg_list_asn) + list(selfcal_list_asn)
             bkg_list += list(bkg_list_asn)
 
             if len(sci_models) > 1:
-                raise ValueError("Input data contains multiple science exposures. "
-                                 "This is not supported in calwebb_spec2 steps.")
+                raise ValueError(
+                    "Input data contains multiple science exposures. "
+                    "This is not supported in calwebb_spec2 steps."
+                )
             input_sci = sci_models[0]
 
-        elif isinstance(input_data, dm.IFUImageModel) or isinstance(input_data, dm.ImageModel):
-
-            input_sci = input_data
+        elif isinstance(input_dm, dm.IFUImageModel) or isinstance(input_dm, dm.ImageModel):
+            input_sci = input_dm
 
         else:
-            raise TypeError("Input data is not a ModelContainer, ImageModel, or IFUImageModel. "
-                            "Cannot continue.")
+            raise TypeError(
+                "Input data is not a ModelContainer, ImageModel, or IFUImageModel. Cannot continue."
+            )
 
     return input_sci, selfcal_list, bkg_list
 
@@ -208,19 +248,21 @@ def split_container_by_asn_exptype(container: dm.ModelContainer, exptypes: list)
     Parameters
     ----------
     container : ModelContainer
-        input data
-
-    exptype : str
-        exposure type to split on
+        The input association.
+    exptypes : list[str]
+        List of exposure types to split on.
 
     Returns
     -------
     split_list : list of lists
-        lists of ImageModels
+        Lists of ImageModels, where the outer list is indexed by the input exptypes and the
+        inner list contains the ImageModels of that type.
     """
     split_list = []
     for exptype in exptypes:
-        good_models = [container[j] for j in range(len(container)) if container[j].meta.asn.exptype == exptype]
+        good_models = [
+            container[j] for j in range(len(container)) if container[j].meta.asn.exptype == exptype
+        ]
         split_list.append(good_models)
 
     return split_list


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially Resolves [JP-3860](https://jira.stsci.edu/browse/JP-3860)

<!-- describe the changes comprising this PR here -->
This PR updates the `badpix_selfcal` step to comply with the new code style rules.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
