### PR TITLE
JP-3862: Clean up guider_cds step for code style and CRDS inconsistencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,6 @@ repos:
             jwst/extract_2d/.* |
             jwst/flatfield/.* |
             jwst/fringe/.* |
-            jwst/guider_cds/.* |
             jwst/ipc/.* |
             jwst/lib/.* |
             jwst/linearity/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -36,7 +36,6 @@ exclude = [
     "jwst/extract_2d/**.py",
     "jwst/flatfield/**.py",
     "jwst/fringe/**.py",
-    "jwst/guider_cds/**.py",
     "jwst/ipc/**.py",
     "jwst/lib/**.py",
     "jwst/linearity/**.py",
@@ -136,7 +135,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/extract_2d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/flatfield/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/fringe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/guider_cds/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/ipc/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/lib/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/linearity/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/changes/9141.guider_cds.rst
+++ b/changes/9141.guider_cds.rst
@@ -1,0 +1,1 @@
+Remove hard-wired reference file information from step and apply style updates for increased readability. 

--- a/jwst/guider_cds/__init__.py
+++ b/jwst/guider_cds/__init__.py
@@ -1,3 +1,5 @@
+"""Countrate calculations for all FGS data."""
+
 from .guider_cds_step import GuiderCdsStep
 
-__all__ = ['GuiderCdsStep']
+__all__ = ["GuiderCdsStep"]

--- a/jwst/guider_cds/guider_cds.py
+++ b/jwst/guider_cds/guider_cds.py
@@ -159,8 +159,8 @@ def get_ref_arr(model, reference_model):
                 if model.data.shape[-2:] != reference_model.data.shape:
                     log.debug(
                         f"The {reference_model.meta.model_type} reference file array does not "
-                        f"match the shape of stacked FGS data;"
-                        f"applying the mean value to the data."
+                        "match the shape of stacked FGS data;"
+                        "applying the mean value to the data."
                     )
                     ref_arr = np.zeros(model.data.shape[-2:], dtype=np.float32) + np.mean(
                         reference_model.data

--- a/jwst/guider_cds/guider_cds.py
+++ b/jwst/guider_cds/guider_cds.py
@@ -144,6 +144,10 @@ def get_ref_arr(model, gain_model, readnoise_model):
     readnoise_arr : ndarray, 2-D, float
         Readnoise values from the ref file
     """
+    # breakpoint()
+    if "STACK" in model.meta.exposure.type:
+        # No reference file matches stacked data shape, so find median and broadcast
+        log.debug("No ga")
     # extract subarray from gain reference file, if necessary
     if reffile_utils.ref_matches_sci(model, gain_model):
         gain_arr = gain_model.data

--- a/jwst/guider_cds/guider_cds.py
+++ b/jwst/guider_cds/guider_cds.py
@@ -1,31 +1,16 @@
-#! /usr/bin/env python
-#
-#  guider_cds.py
-
 import numpy as np
 import logging
 
 from stdatamodels.jwst import datamodels
 
-from ..lib import reffile_utils
+from jwst.lib import reffile_utils
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-# When an appropriate ref file for the gain (read noise) can not be retrieved
-#  for the calculation of the variances, and then the ERR array constant
-#  value equal to the mean of the SCI values in this accessible ref file will
-#  be used:
-DEFAULT_GAIN = 1.9713863
-DEFAULT_READNOISE = 21.0
-DEFAULT_GAIN_FILE = "jwst_fgs_gain_0010.fits"
-DEFAULT_READNOISE_FILE = "jwst_fgs_readnoise_0000.fits"
 
-
-def guider_cds(model, gain_model=None, readnoise_model=None):
+def guider_cds(model, gain_model, readnoise_model):
     """
-    Extended Summary
-    ----------------
     Calculate the count rate for each pixel in all integrations.
 
     For each integration in a given FGS guider dataset whose mode is ACQ1,
@@ -43,38 +28,36 @@ def guider_cds(model, gain_model=None, readnoise_model=None):
     Parameters
     ----------
     model : `datamodels.GuiderRawModel`
-        input data model
-
-    gain_model : `datamodels.GainModel` or None
+        Input data model
+    gain_model : `datamodels.GainModel`
         Gain for all pixels
-
-    readnoise_model : `datamodels.ReadnoiseModel` or None
+    readnoise_model : `datamodels.ReadnoiseModel`
         Readnoise for all pixels
 
     Returns
     -------
     new_model : 'datamodels.GuiderCalModel'
-        output data model
+        Output data model
     """
     # get needed sizes and shapes
-    imshape, n_int, grp_time, exp_type = get_dataset_info(model)
+    grp_time = model.meta.exposure.group_time
+    exp_type = model.meta.exposure.type
+    n_int = model.data.shape[0]
+    imshape = (model.data.shape[2], model.data.shape[3])
 
     # If exp_type is 'FGS_ID', force output to have single slice, and use
     # default GAIN and READNOISE values by setting their ref models to None
-    if exp_type[:6] == 'FGS_ID':
+    if exp_type[:6] == "FGS_ID":
         new_model = datamodels.GuiderCalModel((1,) + imshape)
-        gain_model = None
-        readnoise_model = None
     else:
         new_model = datamodels.GuiderCalModel()
 
     # get gain and readnoise arrays to calculate ERR array
-    gain_arr, readnoise_arr = get_ref_arr(model, imshape, gain_model,
-                                          readnoise_model)
+    gain_arr, readnoise_arr = get_ref_arr(model, gain_model, readnoise_model)
 
     # set up output data arrays
     slope_int_cube = np.zeros((n_int,) + imshape, dtype=np.float32)
-    if exp_type[:6] == 'FGS_ID':
+    if exp_type[:6] == "FGS_ID":
         var_rn = np.zeros((1,) + imshape, dtype=np.float32)
         var_pn = np.zeros((1,) + imshape, dtype=np.float32)
     else:
@@ -85,15 +68,15 @@ def guider_cds(model, gain_model=None, readnoise_model=None):
     # loop over data integrations
     for num_int in range(0, n_int):
         data_sect = model.data[num_int, :, :, :]
-        if exp_type == 'FGS_FINEGUIDE':
+        if exp_type == "FGS_FINEGUIDE":
             first_4 = data_sect[:4, :, :].mean(axis=0)
             last_4 = data_sect[-4:, :, :].mean(axis=0)
             slope_int_cube[num_int, :, :] = last_4 - first_4
 
-            var_rn[num_int, :, :] = 2 * (readnoise_arr / grp_time)**2
+            var_rn[num_int, :, :] = 2 * (readnoise_arr / grp_time) ** 2
             var_pn[num_int, :, :] = slope_int_cube[num_int, :, :] / (gain_arr * grp_time)
 
-        elif exp_type[:6] == 'FGS_ID':
+        elif exp_type[:6] == "FGS_ID":
             grp_last = data_sect[1, :, :]
             grp_first = data_sect[0, :, :]
 
@@ -106,18 +89,18 @@ def guider_cds(model, gain_model=None, readnoise_model=None):
             grp_last = data_sect[1, :, :]
             grp_first = data_sect[0, :, :]
             slope_int_cube[num_int, :, :] = grp_last - grp_first
-            var_rn[num_int, :, :] = 2 * (readnoise_arr / grp_time)**2
+            var_rn[num_int, :, :] = 2 * (readnoise_arr / grp_time) ** 2
             var_pn[num_int, :, :] = slope_int_cube[num_int, :, :] / (gain_arr * grp_time)
 
-    if exp_type[:6] == 'FGS_ID':
+    if exp_type[:6] == "FGS_ID":
         new_model.data[0, :, :] = np.minimum(diff_int1, diff_int0) / grp_time
-        var_rn[0, :, :] = 2 * (readnoise_arr / grp_time)**2
+        var_rn[0, :, :] = 2 * (readnoise_arr / grp_time) ** 2
         var_pn[0, :, :] = np.minimum(diff_int1, diff_int0) / (gain_arr * grp_time)
     else:  # FINEGUIDE, ACQ1, ACQ2, or TRACK
         new_model.data = slope_int_cube / grp_time
 
     # set err to sqrt of sum of variances
-    var_pn[var_pn < 0] = 0.  # ensure variance is non-negative
+    var_pn[var_pn < 0] = 0.0  # ensure variance is non-negative
     new_model.err = (var_rn + var_pn) ** 0.5
 
     # Add all table extensions to be carried over to output
@@ -136,119 +119,47 @@ def guider_cds(model, gain_model=None, readnoise_model=None):
     new_model.update(model)
 
     # Update BUNIT to reflect count rate
-    new_model.meta.bunit_data = 'DN/s'
+    new_model.meta.bunit_data = "DN/s"
 
     return new_model
 
 
-def get_ref_arr(model, imshape, gain_model=None, readnoise_model=None):
+def get_ref_arr(model, gain_model, readnoise_model):
     """
-    Extract gain and readnoise arrays in appropriate shape for the sci data from
-    the reference files
+    Extract gain and readnoise arrays in appropriate shape from the reference files.
 
     Parameters
     ----------
     model : `datamodels.GuiderRawModel`
-        input data model
-
-    imshape: (int, int) tuple
-       shape of 2D image
-
-    gain_model : `datamodels.GainModel` or None
+        Input data model
+    gain_model : `datamodels.GainModel`
         Gain for all pixels
-
-    readnoise_model : `datamodels.ReadnoiseModel` or None
+    readnoise_model : `datamodels.ReadnoiseModel`
         Readnoise for all pixels
 
     Returns
     -------
     gain_arr : ndarray, 2-D, float
-        gain values from the ref file, or default value if ref file unavailable
-
+        Gain values from the ref file
     readnoise_arr : ndarray, 2-D, float
-        readnoise values from the ref file, or default value if ref file
-        unavailable
+        Readnoise values from the ref file
     """
-    # if no gain_model was retrieved, use the default value for all pixels
-    if gain_model is None:
-        gain_arr = np.zeros(imshape, dtype=np.float32) + DEFAULT_GAIN
-
-        log.info('A GAIN reference file could not be retrieved from CRDS.')
-        log.info('The mean of the SCI values in the FGS gain reference file %s', DEFAULT_GAIN_FILE)
-        log.info('will be used to populate the gain array.')
+    # extract subarray from gain reference file, if necessary
+    if reffile_utils.ref_matches_sci(model, gain_model):
+        gain_arr = gain_model.data
     else:
-        # extract subarray from gain reference file, if necessary
-        if reffile_utils.ref_matches_sci(model, gain_model):
-            gain_arr = gain_model.data
-        else:
-            log.info('Extracting reference file subarray to match science data')
-            ref_sub_model = reffile_utils.get_subarray_model(model, gain_model)
-            gain_arr = ref_sub_model.data
-            ref_sub_model.close()
+        log.info("Extracting reference file subarray to match science data")
+        ref_sub_model = reffile_utils.get_subarray_model(model, gain_model)
+        gain_arr = ref_sub_model.data
+        ref_sub_model.close()
 
-    # if no readnoise_model was retrieved, use the default value for all pixels
-    if readnoise_model is None:
-        readnoise_arr = np.zeros(imshape, dtype=np.float32) + DEFAULT_READNOISE
-
-        log.info('A READNOISE reference file could not be retrieved from CRDS.')
-        log.info('The mean of the SCI values in the FGS readnoise reference file %s', DEFAULT_READNOISE_FILE)
-        log.info('will be used to populate the readnoise array.')
+    # extract subarray from readnoise reference file, if necessary
+    if reffile_utils.ref_matches_sci(model, readnoise_model):
+        readnoise_arr = readnoise_model.data
     else:
-        # extract subarray from readnoise reference file, if necessary
-        if reffile_utils.ref_matches_sci(model, readnoise_model):
-            readnoise_arr = readnoise_model.data
-        else:
-            log.info('Extracting readnoise reference file subarray to match science data')
-            ref_sub_model = reffile_utils.get_subarray_model(model, readnoise_model)
-            readnoise_arr = ref_sub_model.data
-            ref_sub_model.close()
+        log.info("Extracting readnoise reference file subarray to match science data")
+        ref_sub_model = reffile_utils.get_subarray_model(model, readnoise_model)
+        readnoise_arr = ref_sub_model.data
+        ref_sub_model.close()
 
     return gain_arr, readnoise_arr
-
-
-def get_dataset_info(model):
-    """
-    Short Summary
-    -------------
-    Extract values for the image shape, the number of integrations,
-    the group time, and the exposure type.
-
-    Parameters
-    ----------
-    model: instance of Data Model
-       DM object for input
-
-    Returns
-    -------
-    imshape: (int, int) tuple
-       shape of 2D image
-
-    n_int: int
-       number of integrations
-
-    grp_time: float
-       group time
-
-    exp_type: string
-        exposure type
-    """
-    instrume = model.meta.instrument.name
-    frame_time = model.meta.exposure.frame_time
-    ngroups = model.meta.exposure.ngroups
-    grp_time = model.meta.exposure.group_time
-    exp_type = model.meta.exposure.type
-
-    n_int = model.data.shape[0]
-    asize2 = model.data.shape[2]
-    asize1 = model.data.shape[3]
-
-    imshape = (asize2, asize1)
-
-    log.info('Instrument: %s' % (instrume))
-    log.info('Exposure type: %s' % (exp_type))
-    log.info('Number of integrations: %d' % (n_int))
-    log.info('Number of groups per integration: %d' % (ngroups))
-    log.info('Group time: %s' % (grp_time))
-    log.info('Frame time: %10.5f' % (frame_time))
-
-    return imshape, n_int, grp_time, exp_type

--- a/jwst/guider_cds/guider_cds_step.py
+++ b/jwst/guider_cds/guider_cds_step.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-from crds.core.exceptions import CrdsLookupError
 
 from stdatamodels.jwst import datamodels
 
@@ -8,44 +7,59 @@ from ..stpipe import Step
 from . import guider_cds
 
 import logging
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 __all__ = ["GuiderCdsStep"]
 
 
-class GuiderCdsStep (Step):
-
-    """
-    This step calculates the countrate for each pixel for FGS modes.
-    """
+class GuiderCdsStep(Step):
+    """Calculate the count rate for each pixel for FGS modes."""
 
     class_alias = "guider_cds"
 
-    def process(self, input):
-        with datamodels.GuiderRawModel(input) as input_model:
+    def process(self, input_data):
+        """
+        Execute the step.
 
+        Parameters
+        ----------
+        input_data : datamodel, str
+            The input GuiderRawModel or filename containing
+            a GuiderRawModel.
+
+        Returns
+        -------
+        JWST GuiderCalModel or GuiderRawModel
+            This will be a GuiderRawModel if the step was skipped; otherwise,
+            it will be a GuiderCalModel containing calibrated count rates.
+        """
+        with datamodels.GuiderRawModel(input_data) as input_model:
             # Get the gain reference file
-            gain_model = None   # will overwrite if file can be retrieved
-            try:
-                gain_filename = self.get_reference_file(input_model, 'gain')
-                gain_model = datamodels.GainModel(gain_filename)
-                self.log.info('Using GAIN reference file: %s', gain_filename)
-            except CrdsLookupError:
-                self.log.warning('Unable to retrieve GAIN ref file.')
+            gain_filename = self.get_reference_file(input_model, "gain")
+            if gain_filename == "N/A":
+                self.log.warning("No GAIN reference file found!")
+                self.log.warning("guider_cds step will be skipped.")
+                input_model.meta.cal_step.guider_cds = "SKIPPED"
+                return input_model
+
+            self.log.info("Using GAIN reference file: %s", gain_filename)
+            gain_model = datamodels.GainModel(gain_filename)
 
             # Get the readnoise reference file
-            readnoise_model = None   # will overwrite if file can be retrieved
-            try:
-                readnoise_filename = self.get_reference_file(input_model, 'readnoise')
-                readnoise_model = datamodels.ReadnoiseModel(readnoise_filename)
-                self.log.info('Using READNOISE reference file: %s',
-                              readnoise_filename)
-            except CrdsLookupError:
-                self.log.warning('Unable to retrieve READNOISE ref file.')
+            readnoise_filename = self.get_reference_file(input_model, "readnoise")
+            if readnoise_filename == "N/A":
+                self.log.warning("No READNOISE reference file found!")
+                self.log.warning("guider_cds step will be skipped.")
+                input_model.meta.cal_step.guider_cds = "SKIPPED"
+                return input_model
+
+            self.log.info("Using READNOISE reference file: %s", readnoise_filename)
+            readnoise_model = datamodels.ReadnoiseModel(readnoise_filename)
 
             out_model = guider_cds.guider_cds(input_model, gain_model, readnoise_model)
 
-        out_model.meta.cal_step.guider_cds = 'COMPLETE'
+        out_model.meta.cal_step.guider_cds = "COMPLETE"
 
         return out_model

--- a/jwst/guider_cds/tests/test_guider_cds.py
+++ b/jwst/guider_cds/tests/test_guider_cds.py
@@ -3,12 +3,12 @@ import pytest
 
 from stdatamodels.jwst import datamodels
 
-from jwst.guider_cds.guider_cds import get_dataset_info, guider_cds
+from jwst.guider_cds.guider_cds import guider_cds
 
 
 @pytest.fixture
 def make_guider_image():
-    """Generate science image"""
+    """Generate science image."""
 
     image = datamodels.GuiderRawModel()
 
@@ -23,21 +23,8 @@ def make_guider_image():
     return image
 
 
-def test_get_dataset_info(make_guider_image):
-    """Make sure information assigned to datamodel is retrieved correctly."""
-
-    model = make_guider_image
-
-    imshape, n_int, grp_time, exp_type = get_dataset_info(model)
-
-    assert imshape == (10, 10)
-    assert n_int == model.data.shape[0]
-    assert grp_time == model.meta.exposure.group_time
-    assert exp_type == model.meta.exposure.type
-
-
 def test_guider_cds_fineguide_mode(make_guider_image):
-    """Test the fine guiding mode"""
+    """Test the fine guiding mode."""
 
     model = make_guider_image
 
@@ -63,7 +50,7 @@ def test_guider_cds_fineguide_mode(make_guider_image):
 
 @pytest.mark.parametrize("exptype", ['FGS_ACQ1', 'FGS_ACQ2', 'FGS_TRACK'])
 def test_guider_cds_acq_track_modes(exptype, make_guider_image):
-    """Test acq and track exptypes"""
+    """Test acq and track exptypes."""
 
     model = make_guider_image
     model.meta.exposure.type = exptype
@@ -89,7 +76,7 @@ def test_guider_cds_acq_track_modes(exptype, make_guider_image):
 
 @pytest.mark.parametrize("exptype", ['FGS_ID-IMAGE', 'FGS_ID-STACK'])
 def test_guider_cds_id_modes(exptype, make_guider_image):
-    """Test fgs id exptypes"""
+    """Test fgs id exptypes."""
 
     model = make_guider_image
     model.meta.exposure.type = exptype
@@ -117,7 +104,7 @@ def test_guider_cds_id_modes(exptype, make_guider_image):
 
 
 def test_unit_assignment(make_guider_image):
-    """Test that correct units are returned"""
+    """Test that correct units are returned."""
 
     model = make_guider_image
 
@@ -127,7 +114,7 @@ def test_unit_assignment(make_guider_image):
 
 
 def test_table_extensions(make_guider_image):
-    """Test that tables are assigned to result of pipeline"""
+    """Test that tables are assigned to result of pipeline."""
 
     model = make_guider_image
 

--- a/jwst/regtest/test_fgs_guider.py
+++ b/jwst/regtest/test_fgs_guider.py
@@ -30,7 +30,6 @@ def run_guider_pipelines(rtdata_module, request):
     return rtdata
 
 
-@pytest.mark.xfail(reason="CRDS-917 needed to create valid readnoise references")
 @pytest.mark.bigdata
 @pytest.mark.parametrize('suffix', GUIDER_SUFFIXES, ids=GUIDER_SUFFIXES)
 def test_fgs_guider(run_guider_pipelines, fitsdiff_default_kwargs, suffix):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3862](https://jira.stsci.edu/browse/JP-3862)
Relates to [CRDS-917](https://jira.stsci.edu/browse/CRDS-917)
Addresses [JP-3878](https://jira.stsci.edu/browse/JP-3878)

<!-- describe the changes comprising this PR here -->
This PR addresses code style issues and some hard-wired reference file information present in the `guider_cds` step.

Unfortunately, we weren't able to completely remove some "workaround" behavior - for `FGS_ID-STACK` data, there is no gain or readnoise reference file matching the data array shape. In conversation with Pierre Chayer of the FGS team, it was confirmed that ID products are used to visually check where guide star and reference stars are located, but are not expected to be fully calibrated products; for stacked data, then, we apply the mean value of the fetched reference file array to the data (matching past behavior, though with a slighly different value).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
