### PR TITLE
Apply basic code style changes to lastframe step 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,6 @@ repos:
             jwst/imprint/.* |
             jwst/ipc/.* |
             jwst/jump/.* |
-            jwst/lastframe/.* |
             jwst/lib/.* |
             jwst/linearity/.* |
             jwst/master_background/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -52,7 +52,7 @@ exclude = [
     "jwst/imprint/**.py",
     "jwst/ipc/**.py",
     "jwst/jump/**.py",
-    "jwst/lastframe/**.py",
+    # "jwst/lastframe/**.py",
     "jwst/lib/**.py",
     "jwst/linearity/**.py",
     "jwst/master_background/**.py",
@@ -182,7 +182,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/imprint/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/ipc/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/jump/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/lastframe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+#"jwst/lastframe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH"#, "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/lib/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/linearity/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/master_background/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/lastframe/__init__.py
+++ b/jwst/lastframe/__init__.py
@@ -1,3 +1,5 @@
+"""Set data quality flag of last group in MIRI data."""
+
 from .lastframe_step import LastFrameStep
 
-__all__ = ['LastFrameStep']
+__all__ = ["LastFrameStep"]

--- a/jwst/lastframe/lastframe_step.py
+++ b/jwst/lastframe/lastframe_step.py
@@ -7,28 +7,40 @@ __all__ = ["LastFrameStep"]
 
 class LastFrameStep(Step):
     """
-    LastFrameStep: This is a MIRI specific task.  If the number of groups
-    is greater than 2, the GROUP data quality flags for the final group will
-    be set to DO_NOT_USE.
+    Set data quality in MIRI data of last group.
+
+    A MIRI specific task.  If the number of groups > 2, the GROUP
+    data quality flag for the  final group will be set to DO_NOT_USE.
     """
 
     class_alias = "lastframe"
 
     spec = """
-    """ # noqa: E501
+    """  # noqa: E501
 
     def process(self, step_input):
+        """
+        For MIRI data with more than 2 groups, set final group dq to DO_NOT_USE.
 
+        Parameters
+        ----------
+        step_input : DataModel
+            Input datamodel to be corrected
+
+        Returns
+        -------
+        output_model : DataModel
+            Lastframe corrected datamodel
+        """
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
-
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector
 
-            if detector[:3] != 'MIR':
-                self.log.warning('Last Frame Correction is only for MIRI data')
-                self.log.warning('Last frame step will be skipped')
-                input_model.meta.cal_step.lastframe = 'SKIPPED'
+            if detector[:3] != "MIR":
+                self.log.warning("Last Frame Correction is only for MIRI data")
+                self.log.warning("Last frame step will be skipped")
+                input_model.meta.cal_step.lastframe = "SKIPPED"
                 return input_model
 
             # Work on a copy

--- a/jwst/lastframe/lastframe_step.py
+++ b/jwst/lastframe/lastframe_step.py
@@ -7,10 +7,10 @@ __all__ = ["LastFrameStep"]
 
 class LastFrameStep(Step):
     """
-    Set data quality in MIRI data of last group.
+    Set data quality flags for the last group in MIRI ramps.
 
     A MIRI specific task.  If the number of groups > 2, the GROUP
-    data quality flag for the  final group will be set to DO_NOT_USE.
+    data quality flag for the final group will be set to DO_NOT_USE.
     """
 
     class_alias = "lastframe"

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -12,36 +12,36 @@ log.setLevel(logging.DEBUG)
 
 def do_correction(output):
     """
-    Short Summary
-    -------------
-    The sole correction is to reset to DO_NOT_USE the GROUP data quality flags
-    for the final group, if the number of groups is greater than 2.
+    MIRI correction to set data quality flag of final group to DO_NOT_USE.
+
+    This correction only works on MIRI data. If the number of groups
+    is greater than 2, then GROUP dq flag of final group is set to
+    DO_NOT_USE.
 
     Parameters
     ----------
-    output: data model object
-        science data to be corrected
+    output : DataModel
+        Science data to be corrected
 
     Returns
     -------
-    output: data model object
-        lastframe-corrected science data
-
+    output : DataModel
+        Lastframe-corrected science data
     """
-
     # Save some data params for easy use later
     sci_ngroups = output.data.shape[1]
 
     # Update the step status, and if ngroups > 2, set all of the GROUPDQ in
     # the final group to 'DO_NOT_USE'
     if sci_ngroups > 2:
-        output.groupdq[:, -1, :, :] = \
-            np.bitwise_or(output.groupdq[:, -1, :, :], dqflags.group['DO_NOT_USE'])
+        output.groupdq[:, -1, :, :] = np.bitwise_or(
+            output.groupdq[:, -1, :, :], dqflags.group["DO_NOT_USE"]
+        )
         log.debug("LastFrame Sub: resetting GROUPDQ in last frame to DO_NOT_USE")
-        output.meta.cal_step.lastframe = 'COMPLETE'
-    else:   # too few groups
+        output.meta.cal_step.lastframe = "COMPLETE"
+    else:  # too few groups
         log.warning("Too few groups to apply correction")
         log.warning("Step will be skipped")
-        output.meta.cal_step.lastframe = 'SKIPPED'
+        output.meta.cal_step.lastframe = "SKIPPED"
 
     return output

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -12,7 +12,7 @@ log.setLevel(logging.DEBUG)
 
 def do_correction(output):
     """
-    MIRI correction to set data quality flag of final group to DO_NOT_USE.
+    Set data quality flag of the final group in an integration to DO_NOT_USE.
 
     This correction only works on MIRI data. If the number of groups
     is greater than 2, then GROUP dq flag of final group is set to


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partilly addresses [JP-3857](https://jira.stsci.edu/browse/JP-3859)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Code style updates for the last frame step.
At this time I have not updated the code in test

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
      -https://github.com/spacetelescope/RegressionTests/actions/runs/13183133505
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
