### PR TITLE
JP-3856: Style Updates for Ramp Fitting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,6 @@ repos:
             jwst/persistence/.* |
             jwst/photom/.* |
             jwst/pipeline/.* |
-            jwst/ramp_fitting/.* |
             jwst/refpix/.* |
             jwst/regtest/.* |
             jwst/resample/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -50,7 +50,7 @@ exclude = [
     "jwst/persistence/**.py",
     "jwst/photom/**.py",
     "jwst/pipeline/**.py",
-    "jwst/ramp_fitting/**.py",
+    # "jwst/pixel_replace/**.py",
     "jwst/refpix/**.py",
     "jwst/regtest/**.py",
     "jwst/resample/**.py",
@@ -160,7 +160,7 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/persistence/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/photom/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/pipeline/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/ramp_fitting/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/pixel_replace/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/refpix/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/regtest/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/resample/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/ramp_fitting/__init__.py
+++ b/jwst/ramp_fitting/__init__.py
@@ -1,3 +1,5 @@
+"""Fit ramps creating an ImageModel and CubeModel from RampModel."""
+
 from .ramp_fit_step import RampFitStep
 
 __all__ = ["RampFitStep"]

--- a/jwst/ramp_fitting/__init__.py
+++ b/jwst/ramp_fitting/__init__.py
@@ -1,3 +1,3 @@
 from .ramp_fit_step import RampFitStep
 
-__all__ = ['RampFitStep']
+__all__ = ["RampFitStep"]

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -160,7 +160,7 @@ def create_optional_results_model(input_model, opt_info):
         The optional RampFitOutputModel to be returned from the ramp fit step.
     """
     (slope, sigslope, var_poisson, var_rnoise, yint,
-            sigyint, pedestal, weights, crmag) = opt_info
+                sigyint, pedestal, weights, crmag) = opt_info
     opt_model = datamodels.RampFitOutputModel(
         slope=slope,
         sigslope=sigslope,
@@ -268,7 +268,7 @@ def compute_RN_variances(groupdq, readnoise_2d, gain_2d, group_time):
     # Truncate var_r4 to include only existing segments
     var_r4 = var_r4[:, :max_seg, :, :]
 
-    # Zero out large variances due to reset 
+    # Zero out large variances due to reset
     var_r3[var_r3 > LARGE_VARIANCE_THRESHOLD] = 0.0
     var_r2 = 1 / (s_inv_var_r3.sum(axis=0))
     var_r2[var_r2 > LARGE_VARIANCE_THRESHOLD] = 0.0
@@ -367,7 +367,7 @@ def calc_segs(rn_sect, gdq_sect, group_time):
         warnings.filterwarnings("ignore", ".*invalid value.*", RuntimeWarning)
         warnings.filterwarnings("ignore", ".*divide by zero.*", RuntimeWarning)
         # overwrite where segs>1
-        den = (segs_beg_3[wh_seg_pos] ** 3.0 - segs_beg_3[wh_seg_pos])
+        den = segs_beg_3[wh_seg_pos]**3.0 - segs_beg_3[wh_seg_pos]
         den_r3[wh_seg_pos] = 1.0 / den
 
     # calculate max_seg for this integ and data section
@@ -491,20 +491,18 @@ class RampFitStep(Step):
             if self.algorithm == "OLS":
                 gdq = input_model_W.groupdq.copy()
 
-                dnu = dqflags.group["DO_NOT_USE"])
-                chg = dqflags.group["CHARGELOSS"])
-                sat = dqflags.group["SATURATED"])
+                dnu = dqflags.group["DO_NOT_USE"]
+                chg = dqflags.group["CHARGELOSS"]
+                sat = dqflags.group["SATURATED"]
                 # Locate groups where that are flagged with CHARGELOSS
-                wh_chargeloss = np.where(
-                    np.bitwise_and(gdq.astype(np.uint32), chg)
-                )
+                wh_chargeloss = np.where(np.bitwise_and(gdq.astype(np.uint32), chg))
 
                 if len(wh_chargeloss[0]) > 0:
                     # Unflag groups flagged as both CHARGELOSS and DO_NOT_USE
                     gdq[wh_chargeloss] -= dnu + chg
 
                     # Flag SATURATED groups as DO_NOT_USE for later segment determination
-                    where_sat = np.where(np.bitwise_and(gdq, sat)
+                    where_sat = np.where(np.bitwise_and(gdq, sat))
                     gdq[where_sat] = np.bitwise_or(gdq[where_sat], dnu)
 
                     # Get group_time for readnoise variance calculation
@@ -644,6 +642,4 @@ def set_groupdq(firstgroup, lastgroup, ngroups, groupdq, groupdqflags):
         groupdq[:, :firstgroup] = np.bitwise_or(groupdq[:, :firstgroup], dnu)
 
     if lastgroup < (ngroups - 1):
-        groupdq[:, (lastgroup + 1) :] = np.bitwise_or(
-            groupdq[:, (lastgroup + 1) :], dnu
-        )
+        groupdq[:, (lastgroup + 1) :] = np.bitwise_or(groupdq[:, (lastgroup + 1) :], dnu)

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -325,7 +325,7 @@ def calc_segs(rn_sect, gdq_sect, group_time):
 
     # For a segment, the variance due to readnoise noise
     # = 12 * readnoise**2 /(nreads_seg**3. - nreads_seg)/(tgroup **2.)
-    num_r3 = 12.0 * (rn_sect / group_time)**2.0  # always >0
+    num_r3 = 12.0 * (rn_sect / group_time) ** 2.0  # always >0
 
     # Reshape for every group, every pixel in section
     num_r3 = np.dstack([num_r3] * ngroups)
@@ -392,7 +392,7 @@ class RampFitStep(Step):
 
     def process(self, step_input):
         """
-        Process the ramp fit step.
+        Fit ramps using ramp fitting algorithm.
 
         Parameters
         ----------

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -56,13 +56,13 @@ def get_reference_file_subarrays(model, readnoise_model, gain_model, nframes):
     if reffile_utils.ref_matches_sci(model, gain_model):
         gain_2d = gain_model.data
     else:
-        log.info('Extracting gain subarray to match science data')
+        log.info("Extracting gain subarray to match science data")
         gain_2d = reffile_utils.get_subarray_data(model, gain_model)
 
     if reffile_utils.ref_matches_sci(model, readnoise_model):
         readnoise_2d = readnoise_model.data
     else:
-        log.info('Extracting readnoise subarray to match science data')
+        log.info("Extracting readnoise subarray to match science data")
         readnoise_2d = reffile_utils.get_subarray_data(model, readnoise_model)
 
     return readnoise_2d, gain_2d
@@ -129,7 +129,8 @@ def create_integration_model(input_model, integ_info, int_times):
         dq=np.zeros(data.shape, dtype=np.uint32),
         var_poisson=np.zeros(data.shape, dtype=np.float32),
         var_rnoise=np.zeros(data.shape, dtype=np.float32),
-        err=np.zeros(data.shape, dtype=np.float32))
+        err=np.zeros(data.shape, dtype=np.float32),
+    )
     int_model.update(input_model)  # ... and add all keys from input
 
     int_model.data = data
@@ -158,8 +159,8 @@ def create_optional_results_model(input_model, opt_info):
     opt_model: RampFitOutputModel
         The optional RampFitOutputModel to be returned from the ramp fit step.
     """
-    (slope, sigslope, var_poisson, var_rnoise,
-        yint, sigyint, pedestal, weights, crmag) = opt_info
+    (slope, sigslope, var_poisson, var_rnoise, yint,
+            sigyint, pedestal, weights, crmag) = opt_info
     opt_model = datamodels.RampFitOutputModel(
         slope=slope,
         sigslope=sigslope,
@@ -169,7 +170,8 @@ def create_optional_results_model(input_model, opt_info):
         sigyint=sigyint,
         pedestal=pedestal,
         weights=weights,
-        crmag=crmag)
+        crmag=crmag,
+    )
 
     opt_model.meta.filename = input_model.meta.filename
     opt_model.update(input_model)  # ... and add all keys from input
@@ -251,25 +253,26 @@ def compute_RN_variances(groupdq, readnoise_2d, gain_2d, group_time):
             del gain_sect
 
         # Zero out entries for non-existing segments in this integration
-        var_r4[num_int, :, :, :] *= (segs_4[num_int, :, :, :] > 0)
+        var_r4[num_int, :, :, :] *= segs_4[num_int, :, :, :] > 0
 
         # Correct for non-positive values to ensure negligible conntribution
-        var_r4[var_r4 <= 0.] = LARGE_VARIANCE
+        var_r4[var_r4 <= 0.0] = LARGE_VARIANCE
 
         # The sums of inverses of the variances are needed for later
         #   variance calculations.
-        s_inv_var_r3[num_int, :, :] = (1. / var_r4[num_int, :, :, :]).sum(axis=0)
-        var_r3[num_int, :, :] = 1. / s_inv_var_r3[num_int, :, :]
+        s_inv_var_r3[num_int, :, :] = (1.0 / var_r4[num_int, :, :, :]).sum(axis=0)
+        var_r3[num_int, :, :] = 1.0 / s_inv_var_r3[num_int, :, :]
 
-    var_r4 *= (segs_4[:, :, :, :] > 0)
+    var_r4 *= segs_4[:, :, :, :] > 0
 
     # Truncate var_r4 to include only existing segments
     var_r4 = var_r4[:, :max_seg, :, :]
 
-    var_r3[var_r3 > LARGE_VARIANCE_THRESHOLD] = 0.  # Zero out large variances due to reset
+    # Zero out large variances due to reset 
+    var_r3[var_r3 > LARGE_VARIANCE_THRESHOLD] = 0.0
     var_r2 = 1 / (s_inv_var_r3.sum(axis=0))
-    var_r2[var_r2 > LARGE_VARIANCE_THRESHOLD] = 0.
-    var_r2[np.isnan(var_r2)] = 0.
+    var_r2[var_r2 > LARGE_VARIANCE_THRESHOLD] = 0.0
+    var_r2[np.isnan(var_r2)] = 0.0
 
     return var_r2, var_r3, var_r4
 
@@ -317,7 +320,7 @@ def calc_segs(rn_sect, gdq_sect, group_time):
     i_read = 0
     while i_read < ngroups:
         gdq_1d = gdq_2d[i_read, :]
-        wh_good = np.where(gdq_1d == dqflags.group['GOOD'])
+        wh_good = np.where(gdq_1d == dqflags.group["GOOD"])
 
         # For good groups, increment those pixels' segments' lengths
         if len(wh_good[0]) > 0:
@@ -325,7 +328,7 @@ def calc_segs(rn_sect, gdq_sect, group_time):
         del wh_good
 
         # Locate any CRs ...
-        wh_cr = np.where(gdq_1d.astype(np.int32) & dqflags.group['JUMP_DET'] > 0)
+        wh_cr = np.where(gdq_1d.astype(np.int32) & dqflags.group["JUMP_DET"] > 0)
         del gdq_1d
 
         # ... (but not on final read): increment the segment number
@@ -342,7 +345,7 @@ def calc_segs(rn_sect, gdq_sect, group_time):
 
     # For a segment, the variance due to readnoise noise
     # = 12 * readnoise**2 /(nreads_seg**3. - nreads_seg)/(tgroup **2.)
-    num_r3 = 12. * (rn_sect / group_time)**2.  # always >0
+    num_r3 = 12.0 * (rn_sect / group_time)**2.0  # always >0
 
     # Reshape for every group, every pixel in section
     num_r3 = np.dstack([num_r3] * ngroups)
@@ -354,7 +357,7 @@ def calc_segs(rn_sect, gdq_sect, group_time):
     #   only one good group at the beginning of the integration, so it will be
     #   be compared to the plane of (near) zeros resulting from the reset. For
     #   longer segments, this value is overwritten below.
-    den_r3 = num_r3.copy() * 0. + 1. / 6
+    den_r3 = num_r3.copy() * 0.0 + 1.0 / 6
 
     wh_seg_pos = np.where(segs_beg_3 > 1)
 
@@ -364,7 +367,8 @@ def calc_segs(rn_sect, gdq_sect, group_time):
         warnings.filterwarnings("ignore", ".*invalid value.*", RuntimeWarning)
         warnings.filterwarnings("ignore", ".*divide by zero.*", RuntimeWarning)
         # overwrite where segs>1
-        den_r3[wh_seg_pos] = 1. / (segs_beg_3[wh_seg_pos] ** 3. - segs_beg_3[wh_seg_pos])
+        den = (segs_beg_3[wh_seg_pos] ** 3.0 - segs_beg_3[wh_seg_pos])
+        den_r3[wh_seg_pos] = 1.0 / den
 
     # calculate max_seg for this integ and data section
     max_seg = (np.count_nonzero(segs_beg_3, axis=0)).max()
@@ -373,7 +377,6 @@ def calc_segs(rn_sect, gdq_sect, group_time):
 
 
 class RampFitStep(Step):
-
     """
     This step fits a straight line to the value of counts vs. time to
     determine the mean count rate for each pixel.
@@ -390,7 +393,7 @@ class RampFitStep(Step):
         firstgroup = integer(default=None)   # Ignore groups before this one (zero indexed)
         lastgroup = integer(default=None)   # Ignore groups after this one (zero indexed)
         maximum_cores = string(default='1') # cores for multiprocessing. Can be an integer, 'half', 'quarter', or 'all'
-    """ # noqa: E501
+    """  # noqa: E501
 
     # Prior to 04/26/17, the following were also in the spec above:
     #      algorithm = option('OLS', 'GLS', default='OLS') # 'OLS' or 'GLS'
@@ -402,36 +405,37 @@ class RampFitStep(Step):
     # algorithm = 'ols'      # Only algorithm allowed for Build 7.1
     # algorithm = 'gls'       # 032520
 
-    weighting = 'optimal'  # Only weighting allowed for Build 7.1
+    weighting = "optimal"  # Only weighting allowed for Build 7.1
 
-    reference_file_types = ['readnoise', 'gain']
+    reference_file_types = ["readnoise", "gain"]
 
     def process(self, step_input):
-
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
-
             # Work on a copy
             result = input_model.copy()
 
             max_cores = self.maximum_cores
-            readnoise_filename = self.get_reference_file(result, 'readnoise')
-            gain_filename = self.get_reference_file(result, 'gain')
+            readnoise_filename = self.get_reference_file(result, "readnoise")
+            gain_filename = self.get_reference_file(result, "gain")
 
             ngroups = input_model.data.shape[1]
             if self.algorithm.upper() == "LIKELY" and ngroups < LIKELY_MIN_NGROUPS:
-                log.info(f"When selecting the LIKELY ramp fitting algorithm the"
-                         f" ngroups needs to be a minimum of {LIKELY_MIN_NGROUPS},"
-                         f" but ngroups = {ngroups}.  Due to this, the ramp fitting algorithm"
-                         f" is being changed to OLS_C")
+                log.info(
+                    f"When selecting the LIKELY ramp fitting algorithm the"
+                    f" ngroups needs to be a minimum of {LIKELY_MIN_NGROUPS},"
+                    f" but ngroups = {ngroups}.  Due to this, the ramp fitting algorithm"
+                    f" is being changed to OLS_C"
+                )
                 self.algorithm = "OLS_C"
 
             log.info(f"Using READNOISE reference file: {readnoise_filename}")
             log.info(f"Using GAIN reference file: {gain_filename}")
 
-            with datamodels.ReadnoiseModel(readnoise_filename) as readnoise_model, \
-                    datamodels.GainModel(gain_filename) as gain_model:
-
+            with (
+                datamodels.ReadnoiseModel(readnoise_filename) as readnoise_model,
+                datamodels.GainModel(gain_filename) as gain_model,
+            ):
                 # Try to retrieve the gain factor from the gain reference file.
                 # If found, store it in the science model meta data, so that it's
                 # available later in the gain_scale step, which avoids having to
@@ -442,7 +446,8 @@ class RampFitStep(Step):
                 # Get gain arrays, subarrays if desired.
                 frames_per_group = result.meta.exposure.nframes
                 readnoise_2d, gain_2d = get_reference_file_subarrays(
-                    result, readnoise_model, gain_model, frames_per_group)
+                    result, readnoise_model, gain_model, frames_per_group
+                )
 
             log.info(f"Using algorithm = {self.algorithm}")
             log.info(f"Using weighting = {self.weighting}")
@@ -470,31 +475,45 @@ class RampFitStep(Step):
             # ramp fitting arrays for the ImageModel, the CubeModel, and the
             # RampFitOutputModel.
             image_info, integ_info, opt_info, gls_opt_model = ramp_fit.ramp_fit(
-                result, buffsize, self.save_opt, readnoise_2d, gain_2d,
-                self.algorithm, self.weighting, max_cores, dqflags.pixel,
-                suppress_one_group=self.suppress_one_group)
+                result,
+                buffsize,
+                self.save_opt,
+                readnoise_2d,
+                gain_2d,
+                self.algorithm,
+                self.weighting,
+                max_cores,
+                dqflags.pixel,
+                suppress_one_group=self.suppress_one_group,
+            )
 
             # Create a gdq to modify if there are charge_migrated groups
             if self.algorithm == "OLS":
                 gdq = input_model_W.groupdq.copy()
 
+                dnu = dqflags.group["DO_NOT_USE"])
+                chg = dqflags.group["CHARGELOSS"])
+                sat = dqflags.group["SATURATED"])
                 # Locate groups where that are flagged with CHARGELOSS
-                wh_chargeloss = np.where(np.bitwise_and(gdq.astype(np.uint32), dqflags.group['CHARGELOSS']))
+                wh_chargeloss = np.where(
+                    np.bitwise_and(gdq.astype(np.uint32), chg)
+                )
 
                 if len(wh_chargeloss[0]) > 0:
                     # Unflag groups flagged as both CHARGELOSS and DO_NOT_USE
-                    gdq[wh_chargeloss] -= (dqflags.group['DO_NOT_USE'] + dqflags.group['CHARGELOSS'])
+                    gdq[wh_chargeloss] -= dnu + chg
 
                     # Flag SATURATED groups as DO_NOT_USE for later segment determination
-                    where_sat = np.where(np.bitwise_and(gdq, dqflags.group['SATURATED']))
-                    gdq[where_sat] = np.bitwise_or(gdq[where_sat], dqflags.group['DO_NOT_USE'])
+                    where_sat = np.where(np.bitwise_and(gdq, sat)
+                    gdq[where_sat] = np.bitwise_or(gdq[where_sat], dnu)
 
                     # Get group_time for readnoise variance calculation
                     group_time = result.meta.exposure.group_time
 
                     # Using the modified GROUPDQ array, create new readnoise variance arrays
-                    image_var_RN, integ_var_RN, opt_var_RN = \
-                        compute_RN_variances(gdq, readnoise_2d, gain_2d, group_time)
+                    image_var_RN, integ_var_RN, opt_var_RN = compute_RN_variances(
+                        gdq, readnoise_2d, gain_2d, group_time
+                    )
 
                     # Create new ramp fitting array tuples, by inserting the new
                     # readnoise variances into copies of the original ramp fitting
@@ -504,66 +523,87 @@ class RampFitStep(Step):
                     if image_info is not None and image_var_RN is not None:
                         rnoise = image_info[3]
                         rnoise[ch_row, ch_col] = image_var_RN[ch_row, ch_col]
-                        image_info_new = (image_info[0], image_info[1], image_info[2], rnoise, image_info[4])
+                        image_info_new = (
+                            image_info[0],
+                            image_info[1],
+                            image_info[2],
+                            rnoise,
+                            image_info[4],
+                        )
 
                     if integ_info is not None and integ_var_RN is not None:
                         rnoise = integ_info[3]
                         rnoise[ch_int, ch_row, ch_col] = integ_var_RN[ch_int, ch_row, ch_col]
-                        integ_info_new = (integ_info[0], integ_info[1], integ_info[2], rnoise, integ_info[4])
+                        integ_info_new = (
+                            integ_info[0],
+                            integ_info[1],
+                            integ_info[2],
+                            rnoise,
+                            integ_info[4],
+                        )
 
                     image_info = image_info_new
                     integ_info = integ_info_new
 
                     opt_info_new = None
                     if opt_info is not None and opt_var_RN is not None:
-                        opt_info_new = (opt_info[0], opt_info[1], opt_info[2], opt_var_RN,
-                                        opt_info[4], opt_info[5], opt_info[6], opt_info[7], opt_info[8])
+                        opt_info_new = (
+                            opt_info[0],
+                            opt_info[1],
+                            opt_info[2],
+                            opt_var_RN,
+                            opt_info[4],
+                            opt_info[5],
+                            opt_info[6],
+                            opt_info[7],
+                            opt_info[8],
+                        )
 
                     opt_info = opt_info_new
 
         # Save the OLS optional fit product, if it exists.
         if opt_info is not None:
             opt_model = create_optional_results_model(result, opt_info)
-            self.save_model(opt_model, 'fitopt', output_file=self.opt_name)
-        '''
+            self.save_model(opt_model, "fitopt", output_file=self.opt_name)
+        """
         # GLS removed from code, since it's not implemented right now.
         # Save the GLS optional fit product, if it exists
         if gls_opt_model is not None:
             self.save_model(
                 gls_opt_model, 'fitoptgls', output_file=self.opt_name
             )
-        '''
+        """
 
         out_model, int_model = None, None
         # Create models from possibly updated info
         if image_info is not None and integ_info is not None:
             out_model = create_image_model(result, image_info)
-            out_model.meta.bunit_data = 'DN/s'
-            out_model.meta.bunit_err = 'DN/s'
-            out_model.meta.cal_step.ramp_fit = 'COMPLETE'
-            if ((result.meta.exposure.type in ['NRS_IFU', 'MIR_MRS']) or
-                    (result.meta.exposure.type in ['NRS_AUTOWAVE', 'NRS_LAMP'] and
-                     result.meta.instrument.lamp_mode == 'IFU')):
-
+            out_model.meta.bunit_data = "DN/s"
+            out_model.meta.bunit_err = "DN/s"
+            out_model.meta.cal_step.ramp_fit = "COMPLETE"
+            if (result.meta.exposure.type in ["NRS_IFU", "MIR_MRS"]) or (
+                result.meta.exposure.type in ["NRS_AUTOWAVE", "NRS_LAMP"]
+                and result.meta.instrument.lamp_mode == "IFU"
+            ):
                 out_model = datamodels.IFUImageModel(out_model)
 
             int_model = create_integration_model(result, integ_info, int_times)
-            int_model.meta.bunit_data = 'DN/s'
-            int_model.meta.bunit_err = 'DN/s'
-            int_model.meta.cal_step.ramp_fit = 'COMPLETE'
+            int_model.meta.bunit_data = "DN/s"
+            int_model.meta.bunit_err = "DN/s"
+            int_model.meta.cal_step.ramp_fit = "COMPLETE"
 
         # Cleanup
         del result
 
         return out_model, int_model
 
+
 def set_groupdq(firstgroup, lastgroup, ngroups, groupdq, groupdqflags):
     """
     Set the groupdq flags based on the values of firstgroup, lastgroup
 
-    Parameters:
-    -----------
-
+    Parameters
+    ----------
     firstgroup : int or None
         The first group to be used in the ramp fitting
 
@@ -580,21 +620,30 @@ def set_groupdq(firstgroup, lastgroup, ngroups, groupdq, groupdqflags):
         The groupdq flags dict
 
     """
+    dnu = groupdqflags["DO_NOT_USE"]
     if firstgroup is None:
         firstgroup = 0
+
     if lastgroup is None:
         lastgroup = ngroups - 1
+
     if firstgroup < 0:
         log.warning("first group < 0, reset to 0")
         firstgroup = 0
+
     if lastgroup >= ngroups:
-        log.warning(f"Last group number >= #groups ({ngroups}), reset to {ngroups-1}")
+        log.warning(f"Last group number >= #groups ({ngroups}), reset to {ngroups - 1}")
+
     if firstgroup >= lastgroup:
         log.warning(f"firstgroup ({firstgroup}) cannot be >= lastgroup ({lastgroup})")
         log.warning("Group selectors ignored")
         firstgroup = 0
         lastgroup = ngroups - 1
+
     if firstgroup > 0:
-        groupdq[:,:firstgroup] = np.bitwise_or(groupdq[:,:firstgroup], groupdqflags['DO_NOT_USE'])
+        groupdq[:, :firstgroup] = np.bitwise_or(groupdq[:, :firstgroup], dnu)
+
     if lastgroup < (ngroups - 1):
-        groupdq[:,(lastgroup+1):] = np.bitwise_or(groupdq[:,(lastgroup+1):], groupdqflags['DO_NOT_USE'])
+        groupdq[:, (lastgroup + 1) :] = np.bitwise_or(
+            groupdq[:, (lastgroup + 1) :], dnu
+        )

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -357,16 +357,7 @@ def calc_segs(rn_sect, gdq_sect, group_time):
 
 
 class RampFitStep(Step):
-    """
-    Fits a line determining the value of mean rate counts vs. time, using least squares.
-
-    The ramp fitting step determines the mean count rate for each pixel using
-    ordinary least squares.  The two OLS selections are:
-    1. OLS_C - the default C implementation of ramp fitting using OLS.
-    2. OLS - the old python implementation of ramp fitting using OLS (not
-       recommended for use).
-    3. LIKELY - a likelihood implementation of GLS based on group differences.
-    """
+    """Fit line to determine the value of mean rate counts vs. time."""
 
     class_alias = "ramp_fit"
 

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -26,6 +26,8 @@ log.setLevel(logging.DEBUG)
 
 def get_reference_file_subarrays(model, readnoise_model, gain_model, nframes):
     """
+    Get read noise and gain reference arrays.
+
     Get readnoise array for calculation of variance of noiseless ramps, and
     the gain array in case optimal weighting is to be done. The returned
     readnoise has been multiplied by the gain.
@@ -33,25 +35,25 @@ def get_reference_file_subarrays(model, readnoise_model, gain_model, nframes):
     Parameters
     ----------
     model : data model
-        input data model, assumed to be of type RampModel
+        Input data model, assumed to be of type RampModel.
 
     readnoise_model : instance of data Model
-        readnoise for all pixels
+        Readnoise for all pixels.
 
     gain_model : instance of gain Model
-        gain for all pixels
+        Gain for all pixels.
 
     nframes : int
-        number of frames averaged per group; from the NFRAMES keyword. Does
+        Number of frames averaged per group; from the NFRAMES keyword. Does
         not contain the groupgap.
 
     Returns
     -------
     readnoise_2d : float, 2D array
-        readnoise subarray
+        Readnoise subarray
 
     gain_2d : float, 2D array
-        gain subarray
+        Gain subarray
     """
     if reffile_utils.ref_matches_sci(model, gain_model):
         gain_2d = gain_model.data
@@ -70,18 +72,18 @@ def get_reference_file_subarrays(model, readnoise_model, gain_model, nframes):
 
 def create_image_model(input_model, image_info):
     """
-    Creates an ImageModel from the computed arrays from ramp_fit.
+    Create an ImageModel from the computed arrays from ramp_fit.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     input_model: RampModel
         Input RampModel for which the output ImageModel is created.
 
     image_info: tuple
         The ramp fitting arrays needed for the ImageModel.
 
-    Return
-    ---------
+    Returns
+    -------
     out_model: ImageModel
         The output ImageModel to be returned from the ramp fit step.
     """
@@ -105,10 +107,10 @@ def create_image_model(input_model, image_info):
 
 def create_integration_model(input_model, integ_info, int_times):
     """
-    Creates an ImageModel from the computed arrays from ramp_fit.
+    Create an ImageModel from the computed arrays from ramp_fit.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     input_model : RampModel
         Input RampModel for which the output CubeModel is created.
 
@@ -118,8 +120,8 @@ def create_integration_model(input_model, integ_info, int_times):
     int_times : astropy.io.fits.fitsrec.FITS_rec or None
         Integration times.
 
-    Return
-    ---------
+    Returns
+    -------
     int_model : CubeModel
         The output CubeModel to be returned from the ramp fit step.
     """
@@ -145,22 +147,21 @@ def create_integration_model(input_model, integ_info, int_times):
 
 def create_optional_results_model(input_model, opt_info):
     """
-    Creates an ImageModel from the computed arrays from ramp_fit.
+    Create an ImageModel from the computed arrays from ramp_fit.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     input_model: ~jwst.datamodels.RampModel
 
     opt_info: tuple
         The ramp fitting arrays needed for the RampFitOutputModel.
 
-    Return
-    ---------
+    Returns
+    -------
     opt_model: RampFitOutputModel
         The optional RampFitOutputModel to be returned from the ramp fit step.
     """
-    (slope, sigslope, var_poisson, var_rnoise, yint,
-                sigyint, pedestal, weights, crmag) = opt_info
+    (slope, sigslope, var_poisson, var_rnoise, yint, sigyint, pedestal, weights, crmag) = opt_info
     opt_model = datamodels.RampFitOutputModel(
         slope=slope,
         sigslope=sigslope,
@@ -179,7 +180,7 @@ def create_optional_results_model(input_model, opt_info):
     return opt_model
 
 
-def compute_RN_variances(groupdq, readnoise_2d, gain_2d, group_time):
+def compute_rn_variances(groupdq, readnoise_2d, gain_2d, group_time):
     """
     Compute the variances due to the readnoise for all integrations.
 
@@ -279,8 +280,7 @@ def compute_RN_variances(groupdq, readnoise_2d, gain_2d, group_time):
 
 def calc_segs(rn_sect, gdq_sect, group_time):
     """
-    Calculate several quantities needed for the readnoise variance, in the
-    data section.
+    Calculate quantities needed for the readnoise variance.
 
     Parameters
     ----------
@@ -367,7 +367,7 @@ def calc_segs(rn_sect, gdq_sect, group_time):
         warnings.filterwarnings("ignore", ".*invalid value.*", RuntimeWarning)
         warnings.filterwarnings("ignore", ".*divide by zero.*", RuntimeWarning)
         # overwrite where segs>1
-        den = segs_beg_3[wh_seg_pos]**3.0 - segs_beg_3[wh_seg_pos]
+        den = segs_beg_3[wh_seg_pos] ** 3.0 - segs_beg_3[wh_seg_pos]
         den_r3[wh_seg_pos] = 1.0 / den
 
     # calculate max_seg for this integ and data section
@@ -378,8 +378,9 @@ def calc_segs(rn_sect, gdq_sect, group_time):
 
 class RampFitStep(Step):
     """
-    This step fits a straight line to the value of counts vs. time to
-    determine the mean count rate for each pixel.
+    Step fits a straight line to the value of counts vs. time.
+
+    The ramp fitting step determines the mean count rate for each pixel.
     """
 
     class_alias = "ramp_fit"
@@ -410,6 +411,7 @@ class RampFitStep(Step):
     reference_file_types = ["readnoise", "gain"]
 
     def process(self, step_input):
+        """Process the ramp fit step."""
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
             # Work on a copy
@@ -469,7 +471,7 @@ class RampFitStep(Step):
 
             # Before the ramp_fit() call, copy the input model ("_W" for weighting)
             # for later reconstruction of the fitting array tuples.
-            input_model_W = result.copy()
+            input_model_w = result.copy()
 
             # Run ramp_fit(), ignoring all DO_NOT_USE groups, and return the
             # ramp fitting arrays for the ImageModel, the CubeModel, and the
@@ -489,7 +491,7 @@ class RampFitStep(Step):
 
             # Create a gdq to modify if there are charge_migrated groups
             if self.algorithm == "OLS":
-                gdq = input_model_W.groupdq.copy()
+                gdq = input_model_w.groupdq.copy()
 
                 dnu = dqflags.group["DO_NOT_USE"]
                 chg = dqflags.group["CHARGELOSS"]
@@ -509,7 +511,7 @@ class RampFitStep(Step):
                     group_time = result.meta.exposure.group_time
 
                     # Using the modified GROUPDQ array, create new readnoise variance arrays
-                    image_var_RN, integ_var_RN, opt_var_RN = compute_RN_variances(
+                    image_var_rn, integ_var_rn, opt_var_rn = compute_rn_variances(
                         gdq, readnoise_2d, gain_2d, group_time
                     )
 
@@ -518,9 +520,9 @@ class RampFitStep(Step):
                     # tuples.
                     image_info_new, integ_info_new = None, None
                     ch_int, ch_grp, ch_row, ch_col = wh_chargeloss
-                    if image_info is not None and image_var_RN is not None:
+                    if image_info is not None and image_var_rn is not None:
                         rnoise = image_info[3]
-                        rnoise[ch_row, ch_col] = image_var_RN[ch_row, ch_col]
+                        rnoise[ch_row, ch_col] = image_var_rn[ch_row, ch_col]
                         image_info_new = (
                             image_info[0],
                             image_info[1],
@@ -529,9 +531,9 @@ class RampFitStep(Step):
                             image_info[4],
                         )
 
-                    if integ_info is not None and integ_var_RN is not None:
+                    if integ_info is not None and integ_var_rn is not None:
                         rnoise = integ_info[3]
-                        rnoise[ch_int, ch_row, ch_col] = integ_var_RN[ch_int, ch_row, ch_col]
+                        rnoise[ch_int, ch_row, ch_col] = integ_var_rn[ch_int, ch_row, ch_col]
                         integ_info_new = (
                             integ_info[0],
                             integ_info[1],
@@ -544,12 +546,12 @@ class RampFitStep(Step):
                     integ_info = integ_info_new
 
                     opt_info_new = None
-                    if opt_info is not None and opt_var_RN is not None:
+                    if opt_info is not None and opt_var_rn is not None:
                         opt_info_new = (
                             opt_info[0],
                             opt_info[1],
                             opt_info[2],
-                            opt_var_RN,
+                            opt_var_rn,
                             opt_info[4],
                             opt_info[5],
                             opt_info[6],
@@ -598,7 +600,7 @@ class RampFitStep(Step):
 
 def set_groupdq(firstgroup, lastgroup, ngroups, groupdq, groupdqflags):
     """
-    Set the groupdq flags based on the values of firstgroup, lastgroup
+    Set the groupdq flags based on the values of firstgroup, lastgroup.
 
     Parameters
     ----------

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -358,9 +358,14 @@ def calc_segs(rn_sect, gdq_sect, group_time):
 
 class RampFitStep(Step):
     """
-    Step fits a straight line to the value of counts vs. time.
+    Fits a line determining the value of mean rate counts vs. time, using least squares.
 
-    The ramp fitting step determines the mean count rate for each pixel.
+    The ramp fitting step determines the mean count rate for each pixel using
+    ordinary least squares.  The two OLS selections are:
+    1. OLS_C - the default C implementation of ramp fitting using OLS.
+    2. OLS - the old python implementation of ramp fitting using OLS (not
+       recommended for use).
+    3. LIKELY - a likelihood implementation of GLS based on group differences.
     """
 
     class_alias = "ramp_fit"
@@ -392,7 +397,7 @@ class RampFitStep(Step):
 
     def process(self, step_input):
         """
-        Fit ramps using ramp fitting algorithm.
+        Fit ramps using the specified ramp fitting algorithm.
 
         Parameters
         ----------

--- a/jwst/ramp_fitting/tests/check_gls_stats.py
+++ b/jwst/ramp_fitting/tests/check_gls_stats.py
@@ -8,12 +8,22 @@ from stdatamodels.jwst.datamodels import dqflags, RampModel, GainModel, Readnois
 from stcal.ramp_fitting import ramp_fit
 
 import logging
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.WARNING)
 
 
-def setup_inputs(ngroups=10, readnoise=10, nints=1,
-                 nrows=1032, ncols=1024, nframes=1, grouptime=1.0, gain=1, deltatime=1):
+def setup_inputs(
+    ngroups=10,
+    readnoise=10,
+    nints=1,
+    nrows=1032,
+    ncols=1024,
+    nframes=1,
+    grouptime=1.0,
+    gain=1,
+    deltatime=1,
+):
     times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
     gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
     err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
@@ -22,13 +32,13 @@ def setup_inputs(ngroups=10, readnoise=10, nints=1,
     read_noise = np.full((nrows, ncols), readnoise, dtype=np.float64)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
     model1 = RampModel(data=data, err=err, pixeldq=pixdq, groupdq=gdq, times=times)
-    model1.meta.instrument.name = 'MIRI'
-    model1.meta.instrument.detector = 'MIRIMAGE'
-    model1.meta.instrument.filter = 'F480M'
-    model1.meta.observation.date = '2015-10-13'
-    model1.meta.exposure.type = 'MIR_IMAGE'
+    model1.meta.instrument.name = "MIRI"
+    model1.meta.instrument.detector = "MIRIMAGE"
+    model1.meta.instrument.filter = "F480M"
+    model1.meta.observation.date = "2015-10-13"
+    model1.meta.exposure.type = "MIR_IMAGE"
     model1.meta.exposure.group_time = deltatime
-    model1.meta.subarray.name = 'FULL'
+    model1.meta.subarray.name = "FULL"
     model1.meta.subarray.xstart = 1
     model1.meta.subarray.ystart = 1
     model1.meta.subarray.xsize = 1024
@@ -39,13 +49,13 @@ def setup_inputs(ngroups=10, readnoise=10, nints=1,
     model1.meta.exposure.nframes = 1
     model1.meta.exposure.groupgap = 0
     gain = GainModel(data=gain)
-    gain.meta.instrument.name = 'MIRI'
+    gain.meta.instrument.name = "MIRI"
     gain.meta.subarray.xstart = 1
     gain.meta.subarray.ystart = 1
     gain.meta.subarray.xsize = 1024
     gain.meta.subarray.ysize = 1032
     rnModel = ReadnoiseModel(data=read_noise)
-    rnModel.meta.instrument.name = 'MIRI'
+    rnModel.meta.instrument.name = "MIRI"
     rnModel.meta.subarray.xstart = 1
     rnModel.meta.subarray.ystart = 1
     rnModel.meta.subarray.xsize = 1024
@@ -53,33 +63,29 @@ def setup_inputs(ngroups=10, readnoise=10, nints=1,
     return model1, gdq, rnModel, pixdq, err, gain
 
 
-def simple_ramp(fit_method='OLS', ngroups=10, cr_group=None):
+def simple_ramp(fit_method="OLS", ngroups=10, cr_group=None):
     # Here given a 10 group ramp with an exact slope of 20/group.
     # The output slope should be 20.
-    slope_per_group = 20.
+    slope_per_group = 20.0
     model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups)
     for k in range(ngroups):
         model1.data[0, k, :, :] = 10.0 + k * slope_per_group
 
     if cr_group:
-        model1.groupdq[0, cr_group, :, :] = dqflags.group['JUMP_DET']
+        model1.groupdq[0, cr_group, :, :] = dqflags.group["JUMP_DET"]
 
-    slopes = ramp_fit(model1, 1024 * 1., False, rnModel, gain, fit_method,
-                      'optimal')
+    slopes = ramp_fit(model1, 1024 * 1.0, False, rnModel, gain, fit_method, "optimal")
     return slopes
 
 
-if __name__ == '__main__':
-
-    solve_method = ['GLS', 'OLS']
+if __name__ == "__main__":
+    solve_method = ["GLS", "OLS"]
     ngroups = [10, 20, 40]
     crgroup = [None, 4]
     for cmethod in solve_method:
         for cgroups in ngroups:
             for cur_cr in crgroup:
                 start_time = time.process_time()
-                slopes = simple_ramp(fit_method=cmethod,
-                                     ngroups=cgroups,
-                                     cr_group=cur_cr)
+                slopes = simple_ramp(fit_method=cmethod, ngroups=cgroups, cr_group=cur_cr)
                 end_time = time.process_time()
-                print('timing: ', cmethod, cgroups, cur_cr, end_time - start_time)
+                print("timing: ", cmethod, cgroups, cur_cr, end_time - start_time)

--- a/jwst/ramp_fitting/tests/check_gls_stats.py
+++ b/jwst/ramp_fitting/tests/check_gls_stats.py
@@ -19,11 +19,10 @@ def setup_inputs(
     nints=1,
     nrows=1032,
     ncols=1024,
-    nframes=1,
-    grouptime=1.0,
     gain=1,
     deltatime=1,
 ):
+    """Set up data."""
     times = np.array(list(range(ngroups)), dtype=np.float64) * deltatime
     gain = np.ones(shape=(nrows, ncols), dtype=np.float64) * gain
     err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float64)
@@ -54,27 +53,28 @@ def setup_inputs(
     gain.meta.subarray.ystart = 1
     gain.meta.subarray.xsize = 1024
     gain.meta.subarray.ysize = 1032
-    rnModel = ReadnoiseModel(data=read_noise)
-    rnModel.meta.instrument.name = "MIRI"
-    rnModel.meta.subarray.xstart = 1
-    rnModel.meta.subarray.ystart = 1
-    rnModel.meta.subarray.xsize = 1024
-    rnModel.meta.subarray.ysize = 1032
-    return model1, gdq, rnModel, pixdq, err, gain
+    rnoise = ReadnoiseModel(data=read_noise)
+    rnoise.meta.instrument.name = "MIRI"
+    rnoise.meta.subarray.xstart = 1
+    rnoise.meta.subarray.ystart = 1
+    rnoise.meta.subarray.xsize = 1024
+    rnoise.meta.subarray.ysize = 1032
+    return model1, gdq, rnoise, pixdq, err, gain
 
 
 def simple_ramp(fit_method="OLS", ngroups=10, cr_group=None):
+    """Create a simple ramp."""
     # Here given a 10 group ramp with an exact slope of 20/group.
     # The output slope should be 20.
     slope_per_group = 20.0
-    model1, gdq, rnModel, pixdq, err, gain = setup_inputs(ngroups=ngroups)
+    model1, gdq, rnoise, pixdq, err, gain = setup_inputs(ngroups=ngroups)
     for k in range(ngroups):
         model1.data[0, k, :, :] = 10.0 + k * slope_per_group
 
     if cr_group:
         model1.groupdq[0, cr_group, :, :] = dqflags.group["JUMP_DET"]
 
-    slopes = ramp_fit(model1, 1024 * 1.0, False, rnModel, gain, fit_method, "optimal")
+    slopes = ramp_fit(model1, 1024 * 1.0, False, rnoise, gain, fit_method, "optimal")
     return slopes
 
 
@@ -88,4 +88,4 @@ if __name__ == "__main__":
                 start_time = time.process_time()
                 slopes = simple_ramp(fit_method=cmethod, ngroups=cgroups, cr_group=cur_cr)
                 end_time = time.process_time()
-                print("timing: ", cmethod, cgroups, cur_cr, end_time - start_time)
+                # print("timing: ", cmethod, cgroups, cur_cr, end_time - start_time)

--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -6,7 +6,7 @@ from stcal.ramp_fitting.ols_fit import calc_num_seg
 
 from stdatamodels.jwst.datamodels import dqflags, RampModel, GainModel, ReadnoiseModel
 
-from jwst.ramp_fitting.ramp_fit_step import compute_RN_variances
+from jwst.ramp_fitting.ramp_fit_step import compute_rn_variances
 
 GOOD = dqflags.pixel["GOOD"]
 DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
@@ -73,7 +73,7 @@ def test_readnoise_variance():
     gdq_4d[:, 1:, 0, 2] = SATURATED + DO_NOT_USE + CHARGELOSS
     gdq_4d[:, 0:, 1, 0] = JUMP_DET
 
-    var_r2, var_r3, var_r4 = compute_RN_variances(gdq_4d, readnoise_2d, gain_2d, group_time)
+    var_r2, var_r3, var_r4 = compute_rn_variances(gdq_4d, readnoise_2d, gain_2d, group_time)
 
     # Compare the exposure level RN variances
     true_var_r2 = np.array(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-5856](https://jira.stsci.edu/browse/JP-5856)
Partially resolves [JP-5855](https://jira.stsci.edu/browse/JP-5855)

<!-- describe the changes comprising this PR here -->
This PR addresses the style checkers using `pre-commit`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
