### PR TITLE
JP-3855: Style Updates for DQ init

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
             jwst/cube_build/.* |
             jwst/cube_skymatch/.* |
             jwst/dark_current/.* |
-            jwst/dq_init/.* |
             jwst/emicorr/.* |
             jwst/engdblog/.* |
             jwst/exp_to_source/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -30,7 +30,7 @@ exclude = [
     "jwst/cube_build/**.py",
     "jwst/cube_skymatch/**.py",
     "jwst/dark_current/**.py",
-    "jwst/dq_init/**.py",
+    # "jwst/datamodels/**.py",
     "jwst/emicorr/**.py",
     "jwst/engdblog/**.py",
     "jwst/exp_to_source/**.py",
@@ -140,7 +140,7 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/cube_build/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_skymatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/dark_current/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/dq_init/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/datamodels/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/emicorr/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/engdblog/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/exp_to_source/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/dq_init/__init__.py
+++ b/jwst/dq_init/__init__.py
@@ -1,3 +1,5 @@
+"""Initialize the data with data quality information."""
+
 from .dq_init_step import DQInitStep
 
 __all__ = ["DQInitStep"]

--- a/jwst/dq_init/dq_init_step.py
+++ b/jwst/dq_init/dq_init_step.py
@@ -22,8 +22,8 @@ class DQInitStep(Step):
     class_alias = "dq_init"
 
     spec = """
-    """ # noqa: E501
-    reference_file_types = ['mask']
+    """  # noqa: E501
+    reference_file_types = ["mask"]
 
     def process(self, step_input):
         """Perform the dq_init calibration step
@@ -38,7 +38,6 @@ class DQInitStep(Step):
         output_model : JWST datamodel
             result JWST datamodel
         """
-
         # Try to open the input as a regular RampModel
         try:
             input_model = datamodels.RampModel(step_input)
@@ -62,14 +61,14 @@ class DQInitStep(Step):
             raise
 
         # Retrieve the mask reference file name
-        self.mask_filename = self.get_reference_file(input_model, 'mask')
-        self.log.info('Using MASK reference file %s', self.mask_filename)
+        self.mask_filename = self.get_reference_file(input_model, "mask")
+        self.log.info("Using MASK reference file %s", self.mask_filename)
 
         # Check for a valid reference file
-        if self.mask_filename == 'N/A':
-            self.log.warning('No MASK reference file found')
-            self.log.warning('DQ initialization step will be skipped')
-            input_model.meta.cal_step.dq_init = 'SKIPPED'
+        if self.mask_filename == "N/A":
+            self.log.warning("No MASK reference file found")
+            self.log.warning("DQ initialization step will be skipped")
+            input_model.meta.cal_step.dq_init = "SKIPPED"
             return input_model
 
         # Work on a copy

--- a/jwst/dq_init/dq_init_step.py
+++ b/jwst/dq_init/dq_init_step.py
@@ -9,8 +9,8 @@ __all__ = ["DQInitStep"]
 
 
 class DQInitStep(Step):
-    """Initialize the Data Quality extension from the
-    mask reference file.
+    """
+    Initialize the Data Quality extension from the mask reference file.
 
     The dq_init step initializes the pixeldq attribute of the
     input datamodel using the MASK reference file.  For some
@@ -26,17 +26,18 @@ class DQInitStep(Step):
     reference_file_types = ["mask"]
 
     def process(self, step_input):
-        """Perform the dq_init calibration step
+        """
+        Perform the dq_init calibration step.
 
         Parameters
         ----------
-        input : JWST datamodel
-            input jwst datamodel
+        step_input : JWST datamodel
+            Input jwst datamodel.
 
         Returns
         -------
         output_model : JWST datamodel
-            result JWST datamodel
+            Result JWST datamodel.
         """
         # Try to open the input as a regular RampModel
         try:

--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -12,8 +12,7 @@ log.setLevel(logging.DEBUG)
 
 
 # FGS guide star mode exposure types
-guider_list = ['FGS_ID-IMAGE', 'FGS_ID-STACK', 'FGS_ACQ1', 'FGS_ACQ2',
-               'FGS_TRACK', 'FGS_FINEGUIDE']
+guider_list = ["FGS_ID-IMAGE", "FGS_ID-STACK", "FGS_ACQ1", "FGS_ACQ2", "FGS_TRACK", "FGS_FINEGUIDE"]
 
 
 def correct_model(input_model, mask_model):
@@ -32,7 +31,6 @@ def correct_model(input_model, mask_model):
     output_model : JWST datamodel
         The corrected JWST datamodel
     """
-
     output_model = do_dqinit(input_model, mask_model)
 
     return output_model
@@ -54,7 +52,6 @@ def do_dqinit(output_model, mask_model):
     output_model : JWST datamodel
         The corrected JWST datamodel
     """
-
     # Inflate empty DQ array, if necessary
     check_dimensions(output_model)
 
@@ -62,9 +59,8 @@ def do_dqinit(output_model, mask_model):
     if reffile_utils.ref_matches_sci(output_model, mask_model):
         mask_array = mask_model.dq
     else:
-        log.info('Extracting mask subarray to match science data')
-        mask_sub_model = reffile_utils.get_subarray_model(output_model,
-                                                          mask_model)
+        log.info("Extracting mask subarray to match science data")
+        mask_sub_model = reffile_utils.get_subarray_model(output_model, mask_model)
         mask_array = mask_sub_model.dq.copy()
         mask_sub_model.close()
 
@@ -77,9 +73,11 @@ def do_dqinit(output_model, mask_model):
         output_model.pixeldq = dq
         # Additionally, propagate mask DO_NOT_USE flags to groupdq to
         # ensure no ramps are fit to bad pixels.
-        output_model.groupdq = np.bitwise_or(output_model.groupdq, mask_array & dqflags.group['DO_NOT_USE'])
+        output_model.groupdq = np.bitwise_or(
+            output_model.groupdq, mask_array & dqflags.group["DO_NOT_USE"]
+        )
 
-    output_model.meta.cal_step.dq_init = 'COMPLETE'
+    output_model.meta.cal_step.dq_init = "COMPLETE"
 
     return output_model
 
@@ -100,39 +98,34 @@ def check_dimensions(input_model):
     -------
     None
     """
-
     input_shape = input_model.data.shape
 
     if isinstance(input_model, datamodels.GuiderRawModel):
         if input_model.dq.shape != input_shape[-2:]:
-
             # If the shape is different, then the mask model should have
             # a shape of (0,0).
             # If that's the case, create the array
             if input_model.dq.shape == (0, 0):
-                input_model.dq = np.zeros((input_shape[-2:])).astype('uint32')
+                input_model.dq = np.zeros(input_shape[-2:]).astype("uint32")
             else:
-                log.error("DQ array has the wrong shape: (%d, %d)" %
-                          input_model.dq.shape)
+                log.error("DQ array has the wrong shape: (%d, %d)" % input_model.dq.shape)
 
-    else:   # RampModel
+    else:  # RampModel
         if input_model.pixeldq.shape != input_shape[-2:]:
-
             # If the shape is different, then the mask model should have
             # a shape of (0,0).
             # If that's the case, create the array
             if input_model.pixeldq.shape == (0, 0):
-                input_model.pixeldq = \
-                    np.zeros((input_shape[-2:])).astype('uint32')
+                input_model.pixeldq = np.zeros(input_shape[-2:]).astype("uint32")
             else:
-                log.error("Pixeldq array has the wrong shape: (%d, %d)" %
-                          input_model.pixeldq.shape)
+                log.error("Pixeldq array has the wrong shape: (%d, %d)" % input_model.pixeldq.shape)
 
         # Perform the same check for the input model groupdq array
         if input_model.groupdq.shape != input_shape:
             if input_model.groupdq.shape == (0, 0, 0, 0):
-                input_model.groupdq = np.zeros((input_shape)).astype('uint8')
+                input_model.groupdq = np.zeros(input_shape).astype("uint8")
             else:
-                log.error("Groupdq array has wrong shape: (%d, %d, %d, %d)" %
-                          input_model.groupdq.shape)
+                log.error(
+                    "Groupdq array has wrong shape: (%d, %d, %d, %d)" % input_model.groupdq.shape
+                )
     return

--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -84,7 +84,7 @@ def do_dqinit(output_model, mask_model):
 
 def check_dimensions(input_model):
     """
-    Check that the input model pixeldq dimensions.
+    Check the input model pixeldq dimensions.
 
     The pixeldq attribute should have the same dimensions as
     the image plane of the input model science data
@@ -96,11 +96,6 @@ def check_dimensions(input_model):
     ----------
     input_model : JWST datamodel
         Input datamodel.
-
-    Returns
-    -------
-    None : None
-        Nothing is returned from this function.
     """
     input_shape = input_model.data.shape
 

--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -16,13 +16,13 @@ guider_list = ["FGS_ID-IMAGE", "FGS_ID-STACK", "FGS_ACQ1", "FGS_ACQ2", "FGS_TRAC
 
 
 def correct_model(input_model, mask_model):
-    """Perform the dq_init step on a JWST datamodel
+    """
+    Perform the dq_init step on a JWST datamodel.
 
     Parameters
     ----------
     input_model : input JWST datamodel
         The jwst datamodel to be corrected
-
     mask_model : mask datamodel
         The mask model to use in the correction
 
@@ -37,13 +37,13 @@ def correct_model(input_model, mask_model):
 
 
 def do_dqinit(output_model, mask_model):
-    """Perform the dq_init step on a JWST datamodel
+    """
+    Perform the dq_init step on a JWST datamodel.
 
     Parameters
     ----------
     output_model : input JWST datamodel
         The jwst datamodel to be corrected
-
     mask_model : mask datamodel
         The mask model to use in the correction
 
@@ -83,7 +83,10 @@ def do_dqinit(output_model, mask_model):
 
 
 def check_dimensions(input_model):
-    """Check that the input model pixeldq attribute has the same dimensions as
+    """
+    Check that the input model pixeldq dimensions.
+
+    The pixeldq attribute should have the same dimensions as
     the image plane of the input model science data
     If it has dimensions (0,0), create an array of zeros with the same shape
     as the image plane of the input model. For the FGS modes, the
@@ -92,11 +95,12 @@ def check_dimensions(input_model):
     Parameters
     ----------
     input_model : JWST datamodel
-        input datamodel
+        Input datamodel.
 
     Returns
     -------
-    None
+    None : None
+        Nothing is returned from this function.
     """
     input_shape = input_model.data.shape
 
@@ -108,7 +112,7 @@ def check_dimensions(input_model):
             if input_model.dq.shape == (0, 0):
                 input_model.dq = np.zeros(input_shape[-2:]).astype("uint32")
             else:
-                log.error("DQ array has the wrong shape: (%d, %d)" % input_model.dq.shape)
+                log.error(f"DQ array has the wrong shape: {input_model.dq.shape}")
 
     else:  # RampModel
         if input_model.pixeldq.shape != input_shape[-2:]:
@@ -118,14 +122,12 @@ def check_dimensions(input_model):
             if input_model.pixeldq.shape == (0, 0):
                 input_model.pixeldq = np.zeros(input_shape[-2:]).astype("uint32")
             else:
-                log.error("Pixeldq array has the wrong shape: (%d, %d)" % input_model.pixeldq.shape)
+                log.error(f"Pixeldq array has the wrong shape: {input_model.pixeldq.shape}")
 
         # Perform the same check for the input model groupdq array
         if input_model.groupdq.shape != input_shape:
             if input_model.groupdq.shape == (0, 0, 0, 0):
                 input_model.groupdq = np.zeros(input_shape).astype("uint8")
             else:
-                log.error(
-                    "Groupdq array has wrong shape: (%d, %d, %d, %d)" % input_model.groupdq.shape
-                )
+                log.error(f"Groupdq array has wrong shape: {input_model.groupdq.shape}")
     return


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3856](https://jira.stsci.edu/browse/JP-3856)
Resolves [JP-3855](https://jira.stsci.edu/browse/JP-3855)


<!-- describe the changes comprising this PR here -->
This PR addresses code style changes for the DQ init step.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
