### PR TITLE
JP-3856: Style Updates for Charge Migration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
             jwst/assign_wcs/.* |
             jwst/associations/.* |
             jwst/background/.* |
-            jwst/charge_migration/.* |
+            jwst/combine_1d/.* |
             jwst/coron/.* |
             jwst/cube_build/.* |
             jwst/cube_skymatch/.* |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,6 @@ repos:
             jwst/assign_wcs/.* |
             jwst/associations/.* |
             jwst/background/.* |
-            jwst/combine_1d/.* |
             jwst/coron/.* |
             jwst/cube_build/.* |
             jwst/cube_skymatch/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,7 +25,10 @@ exclude = [
     "jwst/assign_wcs/**.py",
     "jwst/associations/**.py",
     "jwst/background/**.py",
-    "jwst/charge_migration/**.py",
+    # "jwst/badpix_selfcal/**.py",
+    # "jwst/barshadow/**.py",
+    # "jwst/clean_flicker_noise/**.py",
+    "jwst/combine_1d/**.py",
     "jwst/coron/**.py",
     "jwst/cube_build/**.py",
     "jwst/cube_skymatch/**.py",
@@ -135,7 +138,10 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/assign_wcs/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/associations/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/background/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/charge_migration/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/badpix_selfcal/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/barshadow/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/clean_flicker_noise/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+"jwst/combine_1d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/coron/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_build/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_skymatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -30,7 +30,6 @@ exclude = [
     "jwst/cube_build/**.py",
     "jwst/cube_skymatch/**.py",
     "jwst/dark_current/**.py",
-    # "jwst/datamodels/**.py",
     "jwst/emicorr/**.py",
     "jwst/engdblog/**.py",
     "jwst/exp_to_source/**.py",
@@ -49,7 +48,6 @@ exclude = [
     "jwst/persistence/**.py",
     "jwst/photom/**.py",
     "jwst/pipeline/**.py",
-    # "jwst/pixel_replace/**.py",
     "jwst/refpix/**.py",
     "jwst/regtest/**.py",
     "jwst/resample/**.py",
@@ -139,7 +137,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/cube_build/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_skymatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/dark_current/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-# "jwst/datamodels/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/emicorr/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/engdblog/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/exp_to_source/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
@@ -158,7 +155,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/persistence/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/photom/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/pipeline/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-# "jwst/pixel_replace/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/refpix/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/regtest/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/resample/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,9 +25,6 @@ exclude = [
     "jwst/assign_wcs/**.py",
     "jwst/associations/**.py",
     "jwst/background/**.py",
-    # "jwst/badpix_selfcal/**.py",
-    # "jwst/barshadow/**.py",
-    # "jwst/clean_flicker_noise/**.py",
     "jwst/combine_1d/**.py",
     "jwst/coron/**.py",
     "jwst/cube_build/**.py",
@@ -45,7 +42,6 @@ exclude = [
     "jwst/guider_cds/**.py",
     "jwst/imprint/**.py",
     "jwst/ipc/**.py",
-    "jwst/lastframe/**.py",
     "jwst/lib/**.py",
     "jwst/linearity/**.py",
     "jwst/mrs_imatch/**.py",
@@ -138,9 +134,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/assign_wcs/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/associations/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/background/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-# "jwst/badpix_selfcal/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-# "jwst/barshadow/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-# "jwst/clean_flicker_noise/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/combine_1d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/coron/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_build/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
@@ -158,7 +151,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/guider_cds/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/imprint/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/ipc/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/lastframe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/lib/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/linearity/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/mrs_imatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,7 +25,6 @@ exclude = [
     "jwst/assign_wcs/**.py",
     "jwst/associations/**.py",
     "jwst/background/**.py",
-    "jwst/combine_1d/**.py",
     "jwst/coron/**.py",
     "jwst/cube_build/**.py",
     "jwst/cube_skymatch/**.py",
@@ -132,7 +131,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/assign_wcs/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/associations/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/background/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/combine_1d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/coron/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_build/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_skymatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/charge_migration/__init__.py
+++ b/jwst/charge_migration/__init__.py
@@ -1,3 +1,3 @@
 from .charge_migration_step import ChargeMigrationStep
 
-__all__ = ['ChargeMigrationStep']
+__all__ = ["ChargeMigrationStep"]

--- a/jwst/charge_migration/__init__.py
+++ b/jwst/charge_migration/__init__.py
@@ -1,3 +1,5 @@
+"""Detect and flag charge migration."""
+
 from .charge_migration_step import ChargeMigrationStep
 
 __all__ = ["ChargeMigrationStep"]

--- a/jwst/charge_migration/charge_migration.py
+++ b/jwst/charge_migration/charge_migration.py
@@ -18,22 +18,20 @@ CHLO_DNU = CHLO + DNU
 
 def charge_migration(output_model, signal_threshold):
     """
-    Correct for chargemigration
+    Correct for charge migration.
 
     Parameters
     ----------
     output_model : `~jwst.datamodels.RampModel`
-        The input science data to be corrected
-
+        The input science data to be corrected.
     signal_threshold : float
-        Science value above which a group will be flagged as CHARGELOSS
+        Science value above which a group will be flagged as CHARGELOSS.
 
     Returns
     -------
     output_model : `~jwst.datamodels.RampModel`
         Data model with charge_migration applied; add CHARGELOSS and
-
-        DO_NOT_USE flags to groups exceeding signal_threshold
+        DO_NOT_USE flags to groups exceeding signal_threshold.
     """
     data = output_model.data
     gdq = output_model.groupdq
@@ -50,24 +48,24 @@ def charge_migration(output_model, signal_threshold):
 
 def flag_pixels(data, gdq, signal_threshold):
     """
-    Flag each group in each ramp that exceeds signal_threshold as CHARGELOSS and DO_NOT_USE,
-    skipping groups already flagged as DO_NOT_USE.
+    Flag each group in each ramp that exceeds signal_threshold.
+
+    Each group in each ramp exceeding the signal threshold as CHARGELOSS and
+    DO_NOT_USE, skipping groups already flagged as DO_NOT_USE.
 
     Parameters
     ----------
     data : float, 4D array
-        science array
-
+        Science array.
     gdq : int, 4D array
-        group dq array
-
+        Group DQ array.
     signal_threshold : float
-        Science value above which a group will be flagged as CHARGELOSS and DO_NOT_USE
+        Science value above which a group will be flagged as CHARGELOSS and DO_NOT_USE.
 
     Returns
     -------
     new_gdq : int, 4D array
-        updated group dq array
+        Updated group DQ array.
     """
     n_ints, n_grps, n_rows, n_cols = gdq.shape
     chargeloss_pix = np.where((data > signal_threshold) & (gdq != DNU))

--- a/jwst/charge_migration/charge_migration.py
+++ b/jwst/charge_migration/charge_migration.py
@@ -50,8 +50,8 @@ def flag_pixels(data, gdq, signal_threshold):
     """
     Flag each group in each ramp that exceeds signal_threshold.
 
-    Each group in each ramp exceeding the signal threshold as CHARGELOSS and
-    DO_NOT_USE, skipping groups already flagged as DO_NOT_USE.
+    Each group in each ramp exceeding the signal threshold is flagged as
+    CHARGELOSS and DO_NOT_USE, skipping groups already flagged as DO_NOT_USE.
 
     Parameters
     ----------

--- a/jwst/charge_migration/charge_migration.py
+++ b/jwst/charge_migration/charge_migration.py
@@ -38,7 +38,7 @@ def charge_migration(output_model, signal_threshold):
     data = output_model.data
     gdq = output_model.groupdq
 
-    log.info('Using signal_threshold: %.2f', signal_threshold)
+    log.info("Using signal_threshold: %.2f", signal_threshold)
 
     gdq_new = flag_pixels(data, gdq, signal_threshold)
 
@@ -81,18 +81,18 @@ def flag_pixels(data, gdq, signal_threshold):
 
         # North
         if row > 0:
-            new_gdq[integ, group:, row-1, col] |= CHLO_DNU
+            new_gdq[integ, group:, row - 1, col] |= CHLO_DNU
 
         # South
-        if row < (n_rows-1):
-            new_gdq[integ, group:, row+1, col] |= CHLO_DNU
+        if row < (n_rows - 1):
+            new_gdq[integ, group:, row + 1, col] |= CHLO_DNU
 
         # East
-        if col < (n_cols-1):
-            new_gdq[integ, group:, row, col+1] |= CHLO_DNU
+        if col < (n_cols - 1):
+            new_gdq[integ, group:, row, col + 1] |= CHLO_DNU
 
         # West
         if col > 0:
-            new_gdq[integ, group:, row, col-1] |= CHLO_DNU
+            new_gdq[integ, group:, row, col - 1] |= CHLO_DNU
 
     return new_gdq

--- a/jwst/charge_migration/charge_migration_step.py
+++ b/jwst/charge_migration/charge_migration_step.py
@@ -17,22 +17,21 @@ class ChargeMigrationStep(Step):
     This Step sets the CHARGELOSS flag for groups exhibiting significant
     charge migration.
     """
+
     class_alias = "charge_migration"
 
     spec = """
         signal_threshold = float(default=25000)
         skip = boolean(default=True)
-    """ # noqa: E501
+    """  # noqa: E501
 
     def process(self, step_input):
-
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
+            if input_model.data.shape[1] < 3:  # skip step if only 1 or 2 groups/integration
+                log.info("Too few groups per integration; skipping charge_migration")
 
-            if (input_model.data.shape[1] < 3):  # skip step if only 1 or 2 groups/integration
-                log.info('Too few groups per integration; skipping charge_migration')
-
-                input_model.meta.cal_step.charge_migration = 'SKIPPED'
+                input_model.meta.cal_step.charge_migration = "SKIPPED"
                 return input_model
 
             # Work on a copy
@@ -42,6 +41,6 @@ class ChargeMigrationStep(Step):
             signal_threshold = self.signal_threshold
 
             result = charge_migration.charge_migration(result, signal_threshold)
-            result.meta.cal_step.charge_migration = 'COMPLETE'
+            result.meta.cal_step.charge_migration = "COMPLETE"
 
         return result

--- a/jwst/charge_migration/charge_migration_step.py
+++ b/jwst/charge_migration/charge_migration_step.py
@@ -13,10 +13,7 @@ __all__ = ["ChargeMigrationStep"]
 
 
 class ChargeMigrationStep(Step):
-    """
-    This Step sets the CHARGELOSS flag for groups exhibiting significant
-    charge migration.
-    """
+    """Set the CHARGELOSS flag for groups exhibiting significant charge migration."""
 
     class_alias = "charge_migration"
 
@@ -26,6 +23,19 @@ class ChargeMigrationStep(Step):
     """  # noqa: E501
 
     def process(self, step_input):
+        """
+        Detect jumps based on signal threshold.
+
+        Parameters
+        ----------
+        step_input : RampModel
+            The ramp model on which to detect jumps.
+
+        Returns
+        -------
+        result : RampModel
+            The flagged ramp model.
+        """
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
             if input_model.data.shape[1] < 3:  # skip step if only 1 or 2 groups/integration


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3855](https://jira.stsci.edu/browse/JP-3855)
Resolves [JP-3856](https://jira.stsci.edu/browse/JP-3856)


<!-- describe the changes comprising this PR here -->
This PR addresses code style changes for the charge migration step.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
