### PR TITLE
JP-3856: Style Updates for Group Scale

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,6 @@ repos:
             jwst/flatfield/.* |
             jwst/fringe/.* |
             jwst/gain_scale/.* |
-            jwst/group_scale/.* |
             jwst/guider_cds/.* |
             jwst/imprint/.* |
             jwst/ipc/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -47,7 +47,6 @@ exclude = [
     "jwst/flatfield/**.py",
     "jwst/fringe/**.py",
     "jwst/gain_scale/**.py",
-    "jwst/group_scale/**.py",
     "jwst/guider_cds/**.py",
     "jwst/imprint/**.py",
     "jwst/ipc/**.py",
@@ -177,7 +176,6 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/flatfield/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/fringe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/gain_scale/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/group_scale/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/guider_cds/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/imprint/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/ipc/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/group_scale/__init__.py
+++ b/jwst/group_scale/__init__.py
@@ -1,3 +1,5 @@
+"""Perform the group scale step."""
+
 from .group_scale_step import GroupScaleStep
 
 __all__ = ["GroupScaleStep"]

--- a/jwst/group_scale/__init__.py
+++ b/jwst/group_scale/__init__.py
@@ -1,3 +1,3 @@
 from .group_scale_step import GroupScaleStep
 
-__all__ = ['GroupScaleStep']
+__all__ = ["GroupScaleStep"]

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -11,8 +11,8 @@ log.setLevel(logging.DEBUG)
 
 def do_correction(model):
     """
-    Short Summary
-    -------------
+    Rescale all groups in an exposure by FRMDIVSR/NFRAMES.
+
     Rescales all groups in an exposure by FRMDIVSR/NFRAMES, to
     account for incorrect scaling when on-board frame averaging
     is done using a value of NFRAMES that is not a power of 2.
@@ -22,8 +22,8 @@ def do_correction(model):
 
     Parameters
     ----------
-    model: data model object
-        science data to be corrected. Model is modified in place.
+    model : data model object
+        Science data to be corrected. Model is modified in place.
     """
     # Get the meta data values that we need
     nframes = model.meta.exposure.nframes

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -25,24 +25,23 @@ def do_correction(model):
     model: data model object
         science data to be corrected. Model is modified in place.
     """
-
     # Get the meta data values that we need
     nframes = model.meta.exposure.nframes
     frame_divisor = model.meta.exposure.frame_divisor
     if nframes is None or frame_divisor is None:
-        log.warning('Necessary meta data not found')
-        log.warning('Step will be skipped')
-        model.meta.cal_step.group_scale = 'SKIPPED'
+        log.warning("Necessary meta data not found")
+        log.warning("Step will be skipped")
+        model.meta.cal_step.group_scale = "SKIPPED"
         return
 
-    log.info('NFRAMES={}, FRMDIVSR={}'.format(nframes, frame_divisor))
-    log.info('Rescaling all groups by {}/{}'.format(frame_divisor, nframes))
+    log.info(f"NFRAMES={nframes}, FRMDIVSR={frame_divisor}")
+    log.info(f"Rescaling all groups by {frame_divisor}/{nframes}")
 
     # Apply the rescaling to the entire data array
     scale = float(frame_divisor) / nframes
     if not isinstance(type(model.data), float):
         model.data = (model.data).astype(float)
     model.data *= scale
-    model.meta.cal_step.group_scale = 'COMPLETE'
+    model.meta.cal_step.group_scale = "COMPLETE"
 
     return

--- a/jwst/group_scale/group_scale_step.py
+++ b/jwst/group_scale/group_scale_step.py
@@ -8,6 +8,8 @@ __all__ = ["GroupScaleStep"]
 
 class GroupScaleStep(Step):
     """
+    Rescale group data to account for on-board frame averaging.
+
     GroupScaleStep: Rescales group data to account for on-board
     frame averaging that did not use FRMDIVSR = NFRAMES.
     All groups in the exposure are rescaled by FRMDIVSR/NFRAMES.
@@ -19,6 +21,19 @@ class GroupScaleStep(Step):
     """  # noqa: E501
 
     def process(self, step_input):
+        """
+        Perform group scale step.
+
+        Parameters
+        ----------
+        step_input : datamodel
+            Input data model on which to perform group scale step.
+
+        Returns
+        -------
+        result : datamodel
+            Output data model on which the group scale step has been performed.
+        """
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
             # Try to get values of NFRAMES and FRMDIVSR to see

--- a/jwst/group_scale/group_scale_step.py
+++ b/jwst/group_scale/group_scale_step.py
@@ -16,13 +16,11 @@ class GroupScaleStep(Step):
     class_alias = "group_scale"
 
     spec = """
-    """ # noqa: E501
+    """  # noqa: E501
 
     def process(self, step_input):
-
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
-
             # Try to get values of NFRAMES and FRMDIVSR to see
             # if we need to do any rescaling
             nframes = input_model.meta.exposure.nframes
@@ -31,26 +29,26 @@ class GroupScaleStep(Step):
             # If we didn't find NFRAMES, we don't have enough info
             # to continue. Skip the step.
             if nframes is None:
-                self.log.warning('NFRAMES value not found')
-                self.log.warning('Step will be skipped')
-                input_model.meta.cal_step.group_scale = 'SKIPPED'
+                self.log.warning("NFRAMES value not found")
+                self.log.warning("Step will be skipped")
+                input_model.meta.cal_step.group_scale = "SKIPPED"
                 return input_model
 
             # If we didn't find FRMDIVSR, then check to see if NFRAMES
             # is a power of 2. If it is, rescaling isn't needed.
             if frame_divisor is None:
-                if (nframes & (nframes - 1) == 0):
-                    self.log.info('NFRAMES={} is a power of 2; correction not needed'.format(nframes))
-                    self.log.info('Step will be skipped')
-                    input_model.meta.cal_step.group_scale = 'SKIPPED'
+                if nframes & (nframes - 1) == 0:
+                    self.log.info(f"NFRAMES={nframes} is a power of 2; correction not needed")
+                    self.log.info("Step will be skipped")
+                    input_model.meta.cal_step.group_scale = "SKIPPED"
                     return input_model
 
             # Compare NFRAMES and FRMDIVSR. If they're equal,
             # rescaling isn't needed.
             elif nframes == frame_divisor:
-                self.log.info('NFRAMES and FRMDIVSR are equal; correction not needed')
-                self.log.info('Step will be skipped')
-                input_model.meta.cal_step.group_scale = 'SKIPPED'
+                self.log.info("NFRAMES and FRMDIVSR are equal; correction not needed")
+                self.log.info("Step will be skipped")
+                input_model.meta.cal_step.group_scale = "SKIPPED"
                 return input_model
 
             # Work on a copy


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3855](https://jira.stsci.edu/browse/JP-3855)
Resolves [JP-3856](https://jira.stsci.edu/browse/JP-3856)

<!-- describe the changes comprising this PR here -->
This PR addresses code style changes for the group scale step.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
