### PR TITLE
Update codestyle for first frame step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,6 @@ repos:
             jwst/exp_to_source/.* |
             jwst/extract_1d/.* |
             jwst/extract_2d/.* |
-            jwst/firstframe/.* |
             jwst/flatfield/.* |
             jwst/fringe/.* |
             jwst/gain_scale/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -43,7 +43,7 @@ exclude = [
     "jwst/exp_to_source/**.py",
     "jwst/extract_1d/**.py",
     "jwst/extract_2d/**.py",
-    "jwst/firstframe/**.py",
+    # "jwst/firstframe/**.py",
     "jwst/flatfield/**.py",
     "jwst/fringe/**.py",
     "jwst/gain_scale/**.py",
@@ -173,7 +173,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/exp_to_source/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/extract_1d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/extract_2d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/firstframe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
+# "jwst/firstframe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/flatfield/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/fringe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/gain_scale/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -43,7 +43,6 @@ exclude = [
     "jwst/exp_to_source/**.py",
     "jwst/extract_1d/**.py",
     "jwst/extract_2d/**.py",
-    # "jwst/firstframe/**.py",
     "jwst/flatfield/**.py",
     "jwst/fringe/**.py",
     "jwst/gain_scale/**.py",
@@ -173,7 +172,6 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "jwst/exp_to_source/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/extract_1d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/extract_2d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-# "jwst/firstframe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/flatfield/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/fringe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/gain_scale/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/firstframe/__init__.py
+++ b/jwst/firstframe/__init__.py
@@ -1,3 +1,5 @@
+"""Set data quality flag of first group in MIRI data."""
+
 from .firstframe_step import FirstFrameStep
 
-__all__ = ['FirstFrameStep']
+__all__ = ["FirstFrameStep"]

--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -8,22 +8,34 @@ __all__ = ["FirstFrameStep"]
 
 class FirstFrameStep(Step):
     """
-    FirstFrameStep: This is a MIRI specific task.  If the number of groups
-    is greater than 3, the DO_NOT_USE group data quality flag is added to
-    first group.
+    Set data quality flags for the first group in MIRI ramps.
+
+    A MIRI specific task.  If the number of groups is > than 3,
+    the DO_NOT_USE group data quality flag is added to first group.
     """
 
     class_alias = "firstframe"
 
     spec = """
         bright_use_group1 = boolean(default=False) # do not flag group1 if group3 is saturated
-    """ # noqa: E501
+    """  # noqa: E501
 
     def process(self, step_input):
+        """
+        For MIRI data with more than 3 groups, set first group dq to DO_NOT_USE.
 
+        Parameters
+        ----------
+        step_input : DataModel
+            Input datamodel to be corrected
+
+        Returns
+        -------
+        output_model : DataModel
+            Firstframe corrected datamodel
+        """
         # Open the input data model
         with datamodels.open(step_input) as input_model:
-
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector.upper()
             if detector[:3] != "MIR":
@@ -36,8 +48,6 @@ class FirstFrameStep(Step):
             result = input_model.copy()
 
             # Do the firstframe correction subtraction
-            result = firstframe_sub.do_correction(
-                result, bright_use_group1=self.bright_use_group1
-            )
+            result = firstframe_sub.do_correction(result, bright_use_group1=self.bright_use_group1)
 
         return result

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -12,26 +12,25 @@ log.setLevel(logging.DEBUG)
 
 def do_correction(output, bright_use_group1=False):
     """
-    Short Summary
-    -------------
-    The sole correction is to add the DO_NOT_USE flat to the GROUP data
-    quality flags for the first group, if the number of groups is greater
-    than 3.
+    Set data quality of the first group in an integration to DO_NOT_USE.
+
+    This correction only works on MIRI data. If the number of groups is > 3,
+    then the GROUP data quality flag of the first group is set to
+    DO_NOT_USE.
 
     Parameters
     ----------
-    output: data model object
-        science data to be corrected
-    bright_use_group1: boolean
-        do not flag group1 for bright pixels = group 3 saturated
+    output : DataModel
+        Science data to be corrected
+    bright_use_group1 : bool
+        If True, setting first group data quality flag to DO_NOT_USE will not be
+        done for pixels that have the saturation flag set for group 3.
 
     Returns
     -------
-    output: data model object
-        firstframe-corrected science data
-
+    output : DataModel
+        Firstframe-corrected science data
     """
-
     # Save some data params for easy use later
     sci_ngroups = output.data.shape[1]
 
@@ -49,7 +48,7 @@ def do_correction(output, bright_use_group1=False):
             )
             output.groupdq[:, 0, :, :] = tvals
             log.info(
-                f"FirstFrame Sub: bright_first_frame set, #{np.sum(svals)} bright pixels group1 not set to DO_NOT_USE"
+                f"Number of bright pixels with first group not set to DO_NOT_USE, #{np.sum(svals)}"
             )
         else:
             output.groupdq[:, 0, :, :] = np.bitwise_or(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3855](https://jira.stsci.edu/browse/JP-3855)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
This PR updates the first frame step to use the new code style rules. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
