### PR TITLE
JP-3765: Update documentation of ramp fitting step arguments

### DIFF
--- a/docs/jwst/ramp_fitting/arguments.rst
+++ b/docs/jwst/ramp_fitting/arguments.rst
@@ -4,8 +4,9 @@ The ramp fitting step has the following optional arguments that can be set by th
 
 * ``--algorithm``: A string to select the desired algorithm.  The available
   values are "OLS" to select the python implementation of the Ordinary
-  Least Squares algorithm and  "OLS_C" to select the C extension
-  implementation of OLS.  The algorithm defaults to "OLS_C".
+  Least Squares algorithm, "OLS_C" to select the C extension
+  implementation of OLS, and "LIKELY" to select a prototype maximum-likelihood based
+  approach.  The algorithm defaults to "OLS_C".
 
 * ``--save_opt``: A True/False value that specifies whether to write
   the optional output product. Default is False.


### PR DESCRIPTION
Related to [JP-3765](https://jira.stsci.edu/browse/JP-3765); this PR simply updates the documentation to indicate that the maximum-likelihood based ramp fitting is an option.