### PR TITLE
set individual module CODEOWNERS from wiki page of maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,11 +44,11 @@
 /jwst/lib/					@stscieisenhamer	@nden
 /jwst/linearity/			@kmacdonald-stsci	@WilliamJamieson
 /jwst/master_background/	@jemorrison	 		
-/jwst/model_blender/		@sgoldman	 		
+/jwst/model_blender/		@s-goldman	 		
 /jwst/mrs_imatch/			@mcara				@jemorrison
 /jwst/msaflagopen/			@stscirij			@nden
 /jwst/nsclean/				@penaguerrero	 	
-/jwst/outlier_detection/	@sgoldman			@mcara
+/jwst/outlier_detection/	@s-goldman			@mcara
 /jwst/outlie/outlier-ifu	@jemorrison	 		
 /jwst/pathloss/				@stscirij			@nden
 /jwst/persistence/			@stscirij	 		
@@ -57,14 +57,14 @@
 /jwst/pixel_replace/		@tapastro	 		
 /jwst/ramp_fitting/			@kmacdonald-stsci	@WilliamJamieson
 /jwst/refpix/				@WilliamJamieson	@stscirij
-/jwst/regtest/				@jhunk				@zburnett
-/jwst/resample/				@mcara				@sgoldman,@nden
+/jwst/regtest/				@jhunkeler			@zacharyburnett
+/jwst/resample/				@mcara				@s-goldman			@nden
 /jwst/reset/				@jemorrison	 		
 /jwst/residual_fringe/		@jemorrison			@WilliamJamieson
 /jwst/rscd/			 		@jemorrison	 		
 /jwst/saturation/			@kmacdonald-stsci	 
-/jwst/skymatch/				@mcara				@sgoldman
-/jwst/source_catalog/		@larrybradley		@sgoldman
+/jwst/skymatch/				@mcara				@s-goldman
+/jwst/source_catalog/		@larrybradley		@s-goldman
 /jwst/set_bary_helio/		@perrygreenfield	@stscieisenhamer
 /jwst/set_tel_point/		@perrygreenfield	@stscieisenhamer
 /jwst/spectral_leak/		@jemorrison	 		
@@ -75,7 +75,7 @@
 /jwst/timeconversion/		@stscieisenhamer	 
 /jwst/transforms/			@nden	 			
 /jwst/tso_photometry/		@larrybradley	 	
-/jwst/tweakreg/				@mcara				@sgoldman
+/jwst/tweakreg/				@mcara				@s-goldman
 /jwst/wavecorr/				@nden				@WilliamJamieson
 /jwst/wfs_combine/			@nden				
 # /jwst/wfss_contam/			

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,75 @@
 /changes/** @spacetelescope/jwst-pipeline-developers  # changelogs
 /docs/** @spacetelescope/jwst-pipeline-developers  # docs
 /jwst/regtest/** @spacetelescope/jwst-pipeline-developers  # regtest code
+
+# individual step maintainers
+# /jwst/ami/					
+/jwst/assign_mtwcs/			@nden				@mcara
+/jwst/assign_wcs/			@nden				@mcara
+/jwst/associations/			@stscieisenhamer	 
+/jwst/background/			@tapastro	 		
+/jwst/barshadow/			@stscirij			@nden
+/jwst/charge_migration/		@kmacdonald-stsci	 
+/jwst/combine_1d/			@stscirij			@tapastro
+# /jwst/coron/				
+/jwst/cube_build/			@jemorrison	 		
+/jwst/cube_skymatch/		@mcara				@jemorrison
+/jwst/dark_current/			@kmacdonald-stsci	@WilliamJamieson
+/jwst/datamodels/			@braingram			@tapastro
+/jwst/dq_init/				@stscirij			@kmacdonald-stsci
+/jwst/emicorr/				@penaguerrero	 	
+/jwst/engblog/				@stscieisenhamer	 
+/jwst/exp_to_source/		@stscieisenhamer	 
+/jwst/extract_1d/			@tapastro			@jemorrison
+/jwst/extract_2d/			@nden				@tapastro
+/jwst/firstframe/			@jemorrison	 		
+/jwst/fits_generator/		@stscirij	 		
+/jwst/flatfield/			@jemorrison			@stscirij
+/jwst/fringe/				@jemorrison	 		
+/jwst/gain_scale/			@kmacdonald-stsci	 
+/jwst/group_scale/			@kmacdonald-stsci	 
+/jwst/guider_cds/			@kmacdonald-stsci	 
+# /jwst/imprint/				
+/jwst/ipc/					@stscirij	 		
+/jwst/jump/					@kmacdonald-stsci	@WilliamJamieson
+/jwst/lastframe/			@jemorrison	 		
+/jwst/lib/					@stscieisenhamer	@nden
+/jwst/linearity/			@kmacdonald-stsci	@WilliamJamieson
+/jwst/master_background/	@jemorrison	 		
+/jwst/model_blender/		@sgoldman	 		
+/jwst/mrs_imatch/			@mcara				@jemorrison
+/jwst/msaflagopen/			@stscirij			@nden
+/jwst/nsclean/				@penaguerrero	 	
+/jwst/outlier_detection/	@sgoldman			@mcara
+/jwst/outlie/outlier-ifu	@jemorrison	 		
+/jwst/pathloss/				@stscirij			@nden
+/jwst/persistence/			@stscirij	 		
+/jwst/photom/				@tapastro	 		
+/jwst/pipeline/				@tapastro	 		
+/jwst/pixel_replace/		@tapastro	 		
+/jwst/ramp_fitting/			@kmacdonald-stsci	@WilliamJamieson
+/jwst/refpix/				@WilliamJamieson	@stscirij
+/jwst/regtest/				@jhunk				@zburnett
+/jwst/resample/				@mcara				@sgoldman,@nden
+/jwst/reset/				@jemorrison	 		
+/jwst/residual_fringe/		@jemorrison			@WilliamJamieson
+/jwst/rscd/			 		@jemorrison	 		
+/jwst/saturation/			@kmacdonald-stsci	 
+/jwst/skymatch/				@mcara				@sgoldman
+/jwst/source_catalog/		@larrybradley		@sgoldman
+/jwst/set_bary_helio/		@perrygreenfield	@stscieisenhamer
+/jwst/set_tel_point/		@perrygreenfield	@stscieisenhamer
+/jwst/spectral_leak/		@jemorrison	 		
+/jwst/srctype/				@tapastro			@nden
+/jwst/stpipe/				@WilliamJamieson	@tapastro
+/jwst/straylight/			@jemorrison	 		
+/jwst/superbias/			@kmacdonald-stsci	 
+/jwst/timeconversion/		@stscieisenhamer	 
+/jwst/transforms/			@nden	 			
+/jwst/tso_photometry/		@larrybradley	 	
+/jwst/tweakreg/				@mcara				@sgoldman
+/jwst/wavecorr/				@nden				@WilliamJamieson
+/jwst/wfs_combine/			@nden				
+# /jwst/wfss_contam/			
+/jwst/whitelight/			@penaguerrero		
+/jwst/wiimatch/				@mcara				


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #9188

<!-- describe the changes comprising this PR here -->
these changes will make it so that PRs that change individual step modules will automatically request a review from the specified maintainers by default, unless a reviewer has already been requested

copied maintainer usernames from https://github.com/spacetelescope/jwst/wiki/Maintainers#step-and-subpackage-maintainers 

we'll probably need to update this list before merging

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
