### PR TITLE
JP-3852 and JP-3853: Fix imprint associations for NRS IFU

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,9 +60,7 @@ repos:
             jwst/flatfield/.* |
             jwst/fringe/.* |
             jwst/guider_cds/.* |
-            jwst/imprint/.* |
             jwst/ipc/.* |
-            jwst/lastframe/.* |
             jwst/lib/.* |
             jwst/linearity/.* |
             jwst/mrs_imatch/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -37,7 +37,6 @@ exclude = [
     "jwst/flatfield/**.py",
     "jwst/fringe/**.py",
     "jwst/guider_cds/**.py",
-    "jwst/imprint/**.py",
     "jwst/ipc/**.py",
     "jwst/lib/**.py",
     "jwst/linearity/**.py",
@@ -140,7 +139,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/flatfield/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/fringe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/guider_cds/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/imprint/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/ipc/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/lib/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/linearity/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/changes/9190.associations.rst
+++ b/changes/9190.associations.rst
@@ -1,0 +1,2 @@
+Remove strict constraint on dither position for imprint images in Level 2 spectral associations.
+Instead, prune extra imprint images intended for other targets or dither positions when the association is finalized.

--- a/changes/9190.imprint.rst
+++ b/changes/9190.imprint.rst
@@ -1,0 +1,1 @@
+Handle imprint matching separately for science and dedicated background targets.

--- a/changes/9190.pipeline.rst
+++ b/changes/9190.pipeline.rst
@@ -1,0 +1,1 @@
+Make unique intermediate output filenames for imprint-subtracted background observations to stop overwriting the imprint-subtracted science observation.

--- a/docs/jwst/imprint/description.rst
+++ b/docs/jwst/imprint/description.rst
@@ -15,8 +15,9 @@ or JWST data models.
 
 In the event that multiple imprint images are provided, the step uses the
 meta data of the target and imprint exposures to find the imprint exposure
-that matches the observation number (keyword "OBSERVTN") and dither pattern
-position number (keyword "PATT_NUM") of the target exposure. The matching
+that matches the observation number (keyword "OBSERVTN"), dither pattern
+position number (keyword "PATT_NUM"), and background target flag
+(keyword "BKGDTARG") of the input exposure. The matching
 imprint image is then subtracted from the target image. If no matching imprint
 image is found, the step will be skipped, returning the input target image
 unaltered.

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -1028,7 +1028,13 @@ class AsnMixin_Lv2Imprint:
         imprints_matching_target = []
         imprints_not_matching_target = []
         for imprint_exp in imprints_to_check:
-            if str(imprint_exp.item['targetid']) in science_targets:
+            try:
+                target = imprint_exp.item['targetid']
+            except KeyError:
+                # Imprint does not match target if it is missing a target ID
+                imprints_not_matching_target.append(imprint_exp)
+                continue
+            if str(target) in science_targets:
                 imprints_matching_target.append(imprint_exp)
             else:
                 imprints_not_matching_target.append(imprint_exp)
@@ -1042,7 +1048,11 @@ class AsnMixin_Lv2Imprint:
         if 1 <= len(science) < len(imprints_to_check):
             imprint_to_keep = set()
             for science_exp in science:
+                if 'dithptin' not in science_exp.item:
+                    continue
                 for imprint_exp in imprints_to_check:
+                    if 'dithptin' not in imprint_exp.item:
+                        continue
                     if imprint_exp.item['dithptin'] == science_exp.item['dithptin']:
                         imprint_to_keep.add(imprint_exp['expname'])
 

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -967,9 +967,33 @@ class AsnMixin_Lv2Image:
 
 
 class AsnMixin_Lv2Imprint:
-    """Level 2 imprint association handling."""
+    """Level 2 association handling for matching imprint images."""
 
     def prune_imprints(self):
+        """
+        Prune extra imprint exposures from the association members.
+
+        First, check for imprints that match the background flag
+        for the "science" member.  Any included imprints that do
+        not match the background flag are left in the association
+        without further checks.
+
+        Among these imprints, check to see if any have target IDs that
+        match the science member. If not, use all imprints for further
+        matches.  If so, use only the matching ones for further checks;
+        remove the non-matching imprints.
+
+        If there are more imprints than science members remaining, and
+        if any of the remaining imprints match the science dither position
+        index, discard any imprints that do not match the dither position.
+
+        Returns
+        -------
+        list of associations
+            The input association with members modified as needed.
+            For this mode, the input association is also the output
+            association, so the return value is always `[self]`.
+        """
         # Only one product for Lv2 associations
         members = self['products'][0]['members']
 
@@ -1029,6 +1053,21 @@ class AsnMixin_Lv2Imprint:
         return [self]
 
     def finalize(self):
+        """
+        Finalize the association.
+
+        For some spectrographic modes, imprint images are taken alongside
+        the science data, the background data, or both.  If there are
+        extra imprints in the association, we should keep only the best
+        matches to the science data.
+
+        Returns
+        -------
+        associations: [association[, ...]] or None
+            List of fully-qualified associations that this association
+            represents.
+            `None` if a complete association cannot be produced.
+        """
         if self.is_valid:
             return self.prune_imprints()
         else:

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -335,6 +335,7 @@ class Asn_Lv2Spec(
                                 name='mostilno',
                                 sources=['mostilno']
                             ),
+                            Constraint_Target(),
                         ],
                         reduce=Constraint.all
                     ),

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -20,6 +20,7 @@ from jwst.associations.lib.rules_level2_base import (
     AsnMixin_Lv2Image,
     AsnMixin_Lv2Spectral,
     AsnMixin_Lv2Nod,
+    AsnMixin_Lv2Imprint,
     AsnMixin_Lv2Special,
     DMSLevel2bBase,
     DMSAttrConstraint,
@@ -293,6 +294,7 @@ class Asn_Lv2FGS(
 @RegistryMarker.rule
 class Asn_Lv2Spec(
         AsnMixin_Lv2Spectral,
+        AsnMixin_Lv2Imprint,
         DMSLevel2bBase
 ):
     """Level2b Science Spectral Association
@@ -318,7 +320,7 @@ class Asn_Lv2Spec(
             Constraint(
                 [
                     #  Allow either any background, or ensure imprint and science members
-                    #  match on mosaic tile number and dither pointing position.
+                    #  match on mosaic tile number
                     Constraint_Background(),
                     Constraint(
                         [
@@ -333,10 +335,6 @@ class Asn_Lv2Spec(
                                 name='mostilno',
                                 sources=['mostilno']
                             ),
-                            DMSAttrConstraint(
-                                name='dithptin',
-                                sources=['dithptin']
-                            )
                         ],
                         reduce=Constraint.all
                     ),
@@ -407,6 +405,7 @@ class Asn_Lv2SpecImprint(
 class Asn_Lv2SpecSpecial(
         AsnMixin_Lv2Special,
         AsnMixin_Lv2Spectral,
+        AsnMixin_Lv2Imprint,
         DMSLevel2bBase
 ):
     """Level2b Auxiliary Science Spectral Association

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -988,6 +988,7 @@ class Asn_Lv2NRSFSS(
 
 @RegistryMarker.rule
 class Asn_Lv2NRSIFUNod(
+        AsnMixin_Lv2Imprint,
         AsnMixin_Lv2Nod,
         AsnMixin_Lv2Spectral,
         DMSLevel2bBase

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -335,7 +335,6 @@ class Asn_Lv2Spec(
                                 name='mostilno',
                                 sources=['mostilno']
                             ),
-                            Constraint_Target(),
                         ],
                         reduce=Constraint.all
                     ),

--- a/jwst/imprint/__init__.py
+++ b/jwst/imprint/__init__.py
@@ -1,3 +1,5 @@
+"""Remove NIRSpec MSA imprint structure from an exposure."""
+
 from .imprint_step import ImprintStep
 
-__all__ = ['ImprintStep']
+__all__ = ["ImprintStep"]

--- a/jwst/imprint/imprint_step.py
+++ b/jwst/imprint/imprint_step.py
@@ -23,43 +23,56 @@ class ImprintStep(Step):
         input_model = datamodels.open(input)
         pos_no = input_model.meta.dither.position_number
         obs_no = input_model.meta.observation.observation_number
+        is_bkgd = input_model.meta.observation.bkgdtarg
 
-        # If there is only one imprint image listed in the association,
-        # use it for all science images.
-        # If there is more than one imprint image in the association,
-        # then select the imprint image to be used by matching the dither pattern position
-        # number and observation number to the science image.
-        num_imprint = len(imprint)
-        if num_imprint == 1:
-            match = 0  # use the first, and only, imprint image
-        else:
-            match = None
-            for i in range(num_imprint):
-                # open imprint image and read in pos_no to find match
-                imprint_model = datamodels.open(imprint[i])
-                imprint_pos_no = imprint_model.meta.dither.position_number
-                imprint_obs_no = imprint_model.meta.observation.observation_number
+        # Check all the imprints to see if there is a direct match for the input
+        imprint_models = []
+        match_model = None
+        for imprint_exp in imprint:
+            imprint_model = datamodels.open(imprint_exp)
+            imprint_pos_no = imprint_model.meta.dither.position_number
+            imprint_obs_no = imprint_model.meta.observation.observation_number
+            imprint_bkg = imprint_model.meta.observation.bkgdtarg
+
+            if is_bkgd != imprint_bkg:
+                # Imprint does not match input's background status.
+                # Don't consider it further.
                 imprint_model.close()
+            else:
+                # Keep the open model for further checks
+                imprint_models.append(imprint_model)
+
+                # Check if there is a direct match to the current
+                # observation and dither position.
                 if pos_no == imprint_pos_no and obs_no == imprint_obs_no:
-                    match = i
+                    match_model = imprint_model
                     break
 
-        # Copy the input image to the output (just in case no matching imprint image was found)
+        if match_model is None and len(imprint_models) == 1:
+            # No direct match found.
+            # Check for a single imprint intended for use with all dither positions.
+            match_model = imprint_models[0]
+
+        # Copy the input image to the output
         result = input_model.copy()
 
-        if match is not None:
+        if match_model is not None:
             # Subtract the matching imprint image
-            imprint_model = datamodels.open(imprint[match])
-            self.log.info(f"Subtracting imprint image {imprint_model.meta.filename}")
-            result = subtract_images.subtract(input_model, imprint_model)
+            self.log.info(f"Subtracting imprint image {match_model.meta.filename} "
+                          f"from {input_model.meta.filename}")
+            result = subtract_images.subtract(input_model, match_model)
 
             # Update the step status and close the imprint model
             result.meta.cal_step.imprint = 'COMPLETE'
-            imprint_model.close()
         else:
             self.log.warning(f'No matching imprint image was found for {input}')
             self.log.warning('Step will be skipped')
             result.meta.cal_step.imprint = 'SKIPPED'
 
+        # Close any open imprint models
+        for model in imprint_models:
+            model.close()
+
+        # Close the input model
         input_model.close()
         return result

--- a/jwst/imprint/imprint_step.py
+++ b/jwst/imprint/imprint_step.py
@@ -104,7 +104,7 @@ class ImprintStep(Step):
             # Update the step status and close the imprint model
             result.meta.cal_step.imprint = "COMPLETE"
         else:
-            self.log.warning(f"No matching imprint image was found for {input}")
+            self.log.warning(f"No matching imprint image found for {input_model.meta.filename}")
             self.log.warning("Step will be skipped")
             result.meta.cal_step.imprint = "SKIPPED"
 

--- a/jwst/imprint/imprint_step.py
+++ b/jwst/imprint/imprint_step.py
@@ -8,19 +8,52 @@ __all__ = ["ImprintStep"]
 
 class ImprintStep(Step):
     """
-    ImprintStep: Removes NIRSpec MSA imprint structure from an exposure
-    by subtracting an imprint (a.k.a. leakcal) exposure.
+    Remove NIRSpec MSA imprint structure from an exposure.
+
+    The imprint structure is removed by subtracting a separate
+    imprint (a.k.a. leakcal) exposure.
     """
 
     class_alias = "imprint"
 
     spec = """
-    """ # noqa: E501
+    """  # noqa: E501
 
-    def process(self, input, imprint):
+    def process(self, input_data, imprint):
+        """
+        Subtract an imprint image from the input data.
 
+        If a single imprint image is provided, it is directly subtracted
+        without further checks.
+
+        If multiple imprint images are provided, the background target
+        flag (`meta.dither.observation.bkgdtarg`) is checked for a match to
+        the input data.  If there is a single imprint image matching the
+        input data's background flag, then it is directly subtracted without
+        further checks.
+
+        If there are multiple imprint images that match the input data's
+        background flag, then the imprint is checked for an
+        observation ID (`meta.observation.observation_number`) and
+        dither position index (`meta.dither.position_number`).  If there is
+        a match, then the matching imprint image is subtracted from the
+        input data.  If there is no match, then the step is skipped for the
+        input data.
+
+        Parameters
+        ----------
+        input_data : DataModel or str
+            Input exposure to be corrected.
+        imprint : list of str or DataModel
+            Imprint exposures associated with the input.
+
+        Returns
+        -------
+        DataModel
+            The imprint subtracted exposure.
+        """
         # Open the input science image and get its dither pattern position number
-        input_model = datamodels.open(input)
+        input_model = datamodels.open(input_data)
         pos_no = input_model.meta.dither.position_number
         obs_no = input_model.meta.observation.observation_number
         is_bkgd = input_model.meta.observation.bkgdtarg
@@ -34,9 +67,13 @@ class ImprintStep(Step):
             imprint_obs_no = imprint_model.meta.observation.observation_number
             imprint_bkg = imprint_model.meta.observation.bkgdtarg
 
-            if is_bkgd != imprint_bkg:
-                # Imprint does not match input's background status.
-                # Don't consider it further.
+            if len(imprint) == 1:
+                # Exactly one imprint provided: use it.
+                match_model = datamodels.open(imprint[0])
+                imprint_models.append(match_model)
+            elif is_bkgd != imprint_bkg:
+                # More than one imprint and imprint does not match input's
+                # background status. Don't consider it further.
                 imprint_model.close()
             else:
                 # Keep the open model for further checks
@@ -48,9 +85,9 @@ class ImprintStep(Step):
                     match_model = imprint_model
                     break
 
+        # Check for a single imprint intended for use with all dither positions.
         if match_model is None and len(imprint_models) == 1:
-            # No direct match found.
-            # Check for a single imprint intended for use with all dither positions.
+            # No direct match found - use the only one available.
             match_model = imprint_models[0]
 
         # Copy the input image to the output
@@ -58,16 +95,18 @@ class ImprintStep(Step):
 
         if match_model is not None:
             # Subtract the matching imprint image
-            self.log.info(f"Subtracting imprint image {match_model.meta.filename} "
-                          f"from {input_model.meta.filename}")
+            self.log.info(
+                f"Subtracting imprint image {match_model.meta.filename} "
+                f"from {input_model.meta.filename}"
+            )
             result = subtract_images.subtract(input_model, match_model)
 
             # Update the step status and close the imprint model
-            result.meta.cal_step.imprint = 'COMPLETE'
+            result.meta.cal_step.imprint = "COMPLETE"
         else:
-            self.log.warning(f'No matching imprint image was found for {input}')
-            self.log.warning('Step will be skipped')
-            result.meta.cal_step.imprint = 'SKIPPED'
+            self.log.warning(f"No matching imprint image was found for {input}")
+            self.log.warning("Step will be skipped")
+            result.meta.cal_step.imprint = "SKIPPED"
 
         # Close any open imprint models
         for model in imprint_models:

--- a/jwst/imprint/tests/test_imprint.py
+++ b/jwst/imprint/tests/test_imprint.py
@@ -1,34 +1,114 @@
-"""
-Unit tests for imprint correction
-"""
+"""Unit tests for imprint correction."""
 
 from stdatamodels.jwst.datamodels import ImageModel
 
 from jwst.imprint import ImprintStep
 import numpy as np
-import pytest
 
 
-def test_step(make_imagemodel):
-    """Assert that the results should be all zeros.
-    """
+def make_imagemodel(ysize, xsize, value=None):
+    """Make an image model for testing."""
+    im = ImageModel()
+    if value is None:
+        rng = np.random.default_rng(seed=42)
+        im.data = rng.random((ysize, xsize))
+    else:
+        im.data = np.full((ysize, xsize), value)
+    return im
+
+
+def test_step():
+    """Test that the results are all zeros when subtracting an image from itself."""
     im = make_imagemodel(10, 10)
-    imprint = []
-    imprint.append(im)
+    imprint = [im]
     result = ImprintStep.call(im, imprint)
 
-    assert result.meta.cal_step.imprint == 'COMPLETE'
+    assert result.meta.cal_step.imprint == "COMPLETE"
     assert result.data.sum() == 0
 
 
-@pytest.fixture(scope='function')
-def make_imagemodel():
-    '''Image model for testing'''
-    def _im(ysize, xsize):
-        # create the data arrays
-        im = ImageModel((ysize, xsize))
-        im.data = np.random.rand(ysize, xsize)
+def test_step_single_imprint():
+    # Make science and imprint with mismatched background flags
+    science = make_imagemodel(10, 10)
+    science.meta.observation.bkgdtarg = False
+    imprint = make_imagemodel(10, 10)
+    imprint.meta.observation.bkgdtarg = True
 
-        return im
+    result = ImprintStep.call(science, [imprint])
 
-    return _im
+    # for a single imprint, it's used anyway
+    assert result.meta.cal_step.imprint == "COMPLETE"
+    assert result.data.sum() == 0
+
+
+def test_step_match_dither():
+    # Make imprints with a range of dither positions
+    science = make_imagemodel(10, 10, value=3.0)
+    science.meta.dither.position_number = 2
+
+    imprints = []
+    for i in range(4):
+        imprint = make_imagemodel(10, 10, value=i)
+        imprint.meta.dither.position_number = i + 1
+        imprints.append(imprint)
+
+    result = ImprintStep.call(science, imprints)
+
+    # The matching imprint is used (i=1, value=1.0)
+    assert result.meta.cal_step.imprint == "COMPLETE"
+    assert np.all(result.data == 2.0)
+
+
+def test_step_match_background():
+    # Make science and imprint with mismatched background flags
+    science = make_imagemodel(10, 10, value=3.0)
+    science.meta.observation.bkgdtarg = False
+    imprint_bg = make_imagemodel(10, 10, value=2.0)
+    imprint_bg.meta.observation.bkgdtarg = True
+    imprint_sci = make_imagemodel(10, 10, value=1.0)
+    imprint_sci.meta.observation.bkgdtarg = False
+
+    result = ImprintStep.call(science, [imprint_bg, imprint_sci])
+
+    # The matching imprint is used
+    assert result.meta.cal_step.imprint == "COMPLETE"
+    assert np.all(result.data == 2.0)
+
+
+def test_step_match_background_mismatched_dither():
+    # Make science and imprint with mismatched background flags
+    # and dither positions
+    science = make_imagemodel(10, 10, value=3.0)
+    science.meta.observation.bkgdtarg = False
+    science.meta.dither.position_number = 2
+    imprint_bg = make_imagemodel(10, 10, value=2.0)
+    imprint_bg.meta.observation.bkgdtarg = True
+    imprint_bg.meta.dither.position_number = 1
+    imprint_sci = make_imagemodel(10, 10, value=1.0)
+    imprint_sci.meta.observation.bkgdtarg = False
+    imprint_sci.meta.dither.position_number = 1
+
+    result = ImprintStep.call(science, [imprint_bg, imprint_sci])
+
+    # The matching imprint is used
+    assert result.meta.cal_step.imprint == "COMPLETE"
+    assert np.all(result.data == 2.0)
+
+
+def test_step_no_match():
+    science = make_imagemodel(10, 10, value=3.0)
+    science.meta.dither.position_number = 5
+
+    # Make imprints with a range of dither positions,
+    # none of which match the science
+    imprints = []
+    for i in range(4):
+        imprint = make_imagemodel(10, 10, value=i)
+        imprint.meta.dither.position_number = i + 1
+        imprints.append(imprint)
+
+    result = ImprintStep.call(science, imprints)
+
+    # No match is found
+    assert result.meta.cal_step.imprint == "SKIPPED"
+    assert np.all(result.data == 3.0)

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -322,7 +322,13 @@ class Spec2Pipeline(Pipeline):
         calibrated = self.imprint_subtract.run(calibrated, members_by_type["imprint"])
 
         # for each background image subtract an associated leak cal
+        save_results = self.imprint_subtract.save_results
         for i, bkg_file in enumerate(members_by_type["background"]):
+            if save_results:
+                if isinstance(bkg_file, datamodels.JwstDataModel):
+                    self.imprint_subtract.output_file = bkg_file.meta.filename
+                else:
+                    self.imprint_subtract.output_file = Path(bkg_file).name
             bkg_imprint_sub = self.imprint_subtract.run(bkg_file, members_by_type["imprint"])
             members_by_type["background"][i] = bkg_imprint_sub
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3852](https://jira.stsci.edu/browse/JP-3852)
Resolves [JP-3853](https://jira.stsci.edu/browse/JP-3853)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Several related issues are fixed here:
1. Imprints were missing from level 2 associations in the case where there was a single imprint taken, intending to match all science dithers.  This was introduced when dither position was added as a required constraint in #8410.
2. Extra imprints were added to level 2 associations in the case where there were multiple imprints taken in an observation, intending to match separately to different targets.
3. Separate imprints intended for science and dedicated background targets were not handled separately in the imprint subtraction step, so the match to targets was inaccurate.

To fix the association issues, I removed the dither position constraint and added a new mix-in class for level 2 associations that handle imprint images.  This adds a `finalize` function that checks for extra imprints in the association and removes them from the members if necessary.  This will:
- remove extra imprints in the case where an imprint was taken at each dither position (formerly handled via the dither position constraint)
- remove extra imprints in the case where an imprint was taken for separate targets in the observation (not formerly handled)

The check is only for imprints that have the same background flag as the "science" member in the association: if dedicated "background" members are present, all their imprints are passed through.

If the new mix-in (`AsnMixin_Lv2Imprint`) is also used with the nod mix-in (`AsnMixin_Lv2Nod`), it should appear first in the inheritance list (see the update for `Asn_Lv2NRSIFUNod`, for example).  That way, imprint pruning will happen first on the association super-set, then the nod `finalize` function is called to separate out the associations into science and background sets.

To fix the handling in the imprint subtraction, I added a check for the `meta.observation.bkgdtarg` flag in the input and imprint.  If there is more than one imprint provided, then only imprints with matching background flags are considered.  This should now appropriately match background and science imprints provided in the same association.

In addition, I added a few improvements for the imprint step here:
- Fixed output filenames for the imprint_subtract step in calwebb_spec2. if background members were present, their intermediate files were overwriting the science member intermediate file.
- Cleaned up code style.
- Added unit test coverage.

I added two new pools to the association regtests:
- jw02162_20241213t063547_pool: contains a dedicated background observation with separate imprints, but only one each to apply to all dither positions.
- jw01554_20241213t060033_pool: contains separate imprints for separate targets in the same observation.

Truth files for these associations are from a run on the main branch, so regtests against this PR should show diffs for these pools. The pool added to check the changes in JP-3815 (jw01192_o008_pool.csv) should show no changes: the new pruning method should produce the same association as the old constraint in this case.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
