### PR TITLE
JP-3859: Apply code style rules to extract_1d

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,15 +47,6 @@ repos:
             jwst/emicorr/.* |
             jwst/engdblog/.* |
             jwst/exp_to_source/.* |
-            jwst/extract_1d/apply_apcorr.py |
-            jwst/extract_1d/extract.py |
-            jwst/extract_1d/extract1d.py |
-            jwst/extract_1d/extract_1d_step.py |
-            jwst/extract_1d/ifu.py |
-            jwst/extract_1d/psf_profile.py |
-            jwst/extract_1d/source_location.py |
-            jwst/extract_1d/spec_wcs.py |
-            jwst/extract_1d/tests/conftest.py |
             jwst/extract_2d/.* |
             jwst/flatfield/.* |
             jwst/fringe/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -32,7 +32,6 @@ exclude = [
     "jwst/emicorr/**.py",
     "jwst/engdblog/**.py",
     "jwst/exp_to_source/**.py",
-    "jwst/extract_1d/{apply_apcorr.py,extract1d.py,ifu.py,spec_wcs.py,extract.py,extract_1d_step.py,psf_profile.py,source_location.py,tests/conftest.py}",
     "jwst/extract_2d/**.py",
     "jwst/flatfield/**.py",
     "jwst/fringe/**.py",
@@ -135,7 +134,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/emicorr/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/engdblog/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/exp_to_source/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/extract_1d/{apply_apcorr.py,extract1d.py,ifu.py,spec_wcs.py,extract.py,extract_1d_step.py,psf_profile.py,source_location.py,tests/conftest.py}" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/extract_2d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/flatfield/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/fringe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -209,22 +209,23 @@ class ApCorrBase(abc.ABC):
 
 
 class ApCorrPhase(ApCorrBase):
-    """
-    Produce and apply aperture correction for input data with pixel phase.
-
-    Parameters
-    ----------
-    *args : list
-        Input arguments.  See `ApCorrBase` for more.
-    pixphase : float, optional
-        Pixel phase of the input data.
-    **kwargs : dict, optional
-        Optional parameters. See `ApCorrBase` for more.
-    """
+    """Produce and apply aperture correction for input data with pixel phase."""
 
     size_key = "size"
 
     def __init__(self, *args, pixphase=0.5, **kwargs):
+        """
+        Create an aperture correction for data with pixel phase.
+
+        Parameters
+        ----------
+        *args : list
+            Input arguments.  See `ApCorrBase` for more.
+        pixphase : float, optional
+            Pixel phase of the input data.
+        **kwargs : dict, optional
+            Additional parameters. See `ApCorrBase` for more.
+        """
         self.phase = pixphase
 
         super().__init__(*args, **kwargs)
@@ -378,9 +379,9 @@ class ApCorrRadial(ApCorrBase):
         """
         Implement the approximation method.
 
-        Has no effect for this class.
+        Has no effect for this class.  The base class requires that it be implemented,
+        but the equivalent functionality for this class is performed in `find_apcorr_func`.
         """
-        # Base class needs this. For ApCorrRadial, this is done in find_apcorr_func
         pass
 
     def _convert_size_units(self):

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -165,9 +165,8 @@ class ApCorrBase(abc.ABC):
         table = self._reference_table.copy()
 
         for key, value in self.match_pars.items():
-            if isinstance(
-                value, str
-            ):  # Not all files will have the same format as input model metadata values.
+            if isinstance(value, str):
+                # Not all files will have the same format as input model metadata values.
                 table = table[table[key].upper() == value.upper()]
             else:
                 table = table[table[key] == value]

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -604,9 +604,8 @@ def populate_time_keywords(input_model, output_model):
     # Inclusive range of integration numbers in the INT_TIMES table, zero indexed.
     table_range = (int_num[0] - 1, int_num[-1] - 1)
     offset = data_range[0] - table_range[0]
-    if (data_range[0] < table_range[0] or data_range[1] > table_range[1]) or offset > table_range[
-        1
-    ]:
+    data_range_test = data_range[0] < table_range[0] or data_range[1] > table_range[1]
+    if data_range_test or offset > table_range[1]:
         log.warning(
             "Not using the INT_TIMES table because it does not include "
             "rows for all integrations in the data."

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -351,12 +351,13 @@ def get_extract_parameters(
                     # parameter value on the command line is highest precedence,
                     # then parameter value from the extract1d reference file,
                     # and finally a default setting based on exposure type.
-                    use_source_posn_aper = aper.get(
-                        "use_source_posn", None
-                    )  # value from the ref file
-                    if use_source_posn is None:  # no value set on command line
-                        if use_source_posn_aper is None:  # no value set in ref file
-                            # Use a suitable default
+
+                    # value from the ref file
+                    use_source_posn_aper = aper.get("use_source_posn", None)
+                    if use_source_posn is None:
+                        # no value set on command line
+                        if use_source_posn_aper is None:
+                            # no value set in ref file - use a suitable default
                             if meta.exposure.type in SRCPOS_EXPTYPES:
                                 use_source_posn = True
                                 log.info(
@@ -365,7 +366,8 @@ def get_extract_parameters(
                                 )
                             else:
                                 use_source_posn = False
-                        else:  # use the value from the ref file
+                        else:
+                            # use the value from the ref file
                             use_source_posn = use_source_posn_aper
                     extract_params["use_source_posn"] = use_source_posn
                     extract_params["position_offset"] = position_offset
@@ -546,9 +548,8 @@ def populate_time_keywords(input_model, output_model):
         )
         for j in range(num_j):  # for each spectrum or order
             for k in range(num_integ):  # for each integration
-                output_model.spec[(j * num_integ) + k].int_num = (
-                    k + 1
-                )  # set int_num to (k+1) - 1-indexed integration
+                # set int_num to (k+1) - 1-indexed integration
+                output_model.spec[(j * num_integ) + k].int_num = k + 1
         return
 
     # If we have a single plane (e.g. ImageModel or MultiSlitModel),
@@ -597,10 +598,8 @@ def populate_time_keywords(input_model, output_model):
     mid_tdb = input_model.int_times["int_mid_BJD_TDB"]
     end_tdb = input_model.int_times["int_end_BJD_TDB"]
 
-    data_range = (
-        int_start,
-        int_end,
-    )  # Inclusive range of integration numbers in the input data, zero indexed.
+    # Inclusive range of integration numbers in the input data, zero indexed.
+    data_range = (int_start, int_end)
 
     # Inclusive range of integration numbers in the INT_TIMES table, zero indexed.
     table_range = (int_num[0] - 1, int_num[-1] - 1)

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1,13 +1,19 @@
 import logging
 import json
-import numpy as np
 from json.decoder import JSONDecodeError
+from pathlib import Path
 
 from astropy.modeling import polynomial
+import numpy as np
 from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels.apcorr import (
-    MirLrsApcorrModel, MirMrsApcorrModel, NrcWfssApcorrModel, NrsFsApcorrModel,
-    NrsMosApcorrModel, NrsIfuApcorrModel, NisWfssApcorrModel
+    MirLrsApcorrModel,
+    MirMrsApcorrModel,
+    NrcWfssApcorrModel,
+    NrsFsApcorrModel,
+    NrsMosApcorrModel,
+    NrsIfuApcorrModel,
+    NisWfssApcorrModel,
 )
 
 from jwst.datamodels import ModelContainer
@@ -18,19 +24,27 @@ from jwst.extract_1d.apply_apcorr import select_apcorr
 from jwst.extract_1d.psf_profile import psf_profile
 from jwst.extract_1d.source_location import location_from_wcs
 
-__all__ = ['run_extract1d', 'read_extract1d_ref', 'read_apcorr_ref',
-           'get_extract_parameters', 'box_profile', 'aperture_center',
-           'shift_by_offset', 'define_aperture', 'extract_one_slit',
-           'create_extraction']
+__all__ = [
+    "run_extract1d",
+    "read_extract1d_ref",
+    "read_apcorr_ref",
+    "get_extract_parameters",
+    "box_profile",
+    "aperture_center",
+    "shift_by_offset",
+    "define_aperture",
+    "extract_one_slit",
+    "create_extraction",
+]
 
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM']
+WFSS_EXPTYPES = ["NIS_WFSS", "NRC_WFSS", "NRC_GRISM"]
 """Exposure types to be regarded as wide-field slitless spectroscopy."""
 
-SRCPOS_EXPTYPES = ['MIR_LRS-FIXEDSLIT', 'NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ']
+SRCPOS_EXPTYPES = ["MIR_LRS-FIXEDSLIT", "NRS_FIXEDSLIT", "NRS_MSASPEC", "NRS_BRIGHTOBJ"]
 """Exposure types for which source position can be estimated."""
 
 ANY = "ANY"
@@ -62,11 +76,13 @@ EXACT = "exact match"
 
 class ContinueError(Exception):
     """Custom error to pass continue from a function inside a loop."""
+
     pass
 
 
 def read_extract1d_ref(refname):
-    """Read the extract1d reference file.
+    """
+    Read the extract1d reference file.
 
     Parameters
     ----------
@@ -81,14 +97,13 @@ def read_extract1d_ref(refname):
         If the extract1d reference file is specified, ref_dict will be the
         dictionary returned by json.load().
     """
-
     refname_type = refname[-4:].lower()
     if refname == "N/A":
         ref_dict = None
     else:
         # If specified, the extract1d reference file can only be in json format
-        if refname_type == 'json':
-            fd = open(refname)
+        if refname_type == "json":
+            fd = Path(refname).open()
             try:
                 ref_dict = json.load(fd)
                 fd.close()
@@ -96,8 +111,11 @@ def read_extract1d_ref(refname):
                 # Input file does not load correctly as json file.
                 # Probably an error in json file
                 fd.close()
-                log.error("Extract1d JSON reference file has an error. Run a json validator off line and fix the file.")
-                raise RuntimeError("Invalid JSON extract1d reference file.")
+                log.error(
+                    "Extract1d JSON reference file has an error. "
+                    "Run a json validator off line and fix the file."
+                )
+                raise RuntimeError("Invalid JSON extract1d reference file.") from None
         else:
             log.error("Invalid Extract1d reference file: must be JSON.")
             raise RuntimeError("Invalid extract1d reference file: must be JSON.")
@@ -106,7 +124,8 @@ def read_extract1d_ref(refname):
 
 
 def read_apcorr_ref(refname, exptype):
-    """Read the apcorr reference file.
+    """
+    Read the apcorr reference file.
 
     Determine the appropriate DataModel class to use for an APCORR reference file
     and read the file into it.
@@ -115,7 +134,6 @@ def read_apcorr_ref(refname, exptype):
     ----------
     refname : str
         Path to the APCORR reference file.
-
     exptype : str
         EXP_TYPE of the input to the extract_1d step.
 
@@ -123,32 +141,43 @@ def read_apcorr_ref(refname, exptype):
     -------
     DataModel
         A datamodel containing the reference file input.
-
     """
     apcorr_model_map = {
-        'MIR_LRS-FIXEDSLIT': MirLrsApcorrModel,
-        'MIR_LRS-SLITLESS': MirLrsApcorrModel,
-        'MIR_MRS': MirMrsApcorrModel,
-        'NRC_GRISM': NrcWfssApcorrModel,
-        'NRC_WFSS': NrcWfssApcorrModel,
-        'NIS_WFSS': NisWfssApcorrModel,
-        'NRS_BRIGHTOBJ': NrsFsApcorrModel,
-        'NRS_FIXEDSLIT': NrsFsApcorrModel,
-        'NRS_IFU': NrsIfuApcorrModel,
-        'NRS_MSASPEC': NrsMosApcorrModel
+        "MIR_LRS-FIXEDSLIT": MirLrsApcorrModel,
+        "MIR_LRS-SLITLESS": MirLrsApcorrModel,
+        "MIR_MRS": MirMrsApcorrModel,
+        "NRC_GRISM": NrcWfssApcorrModel,
+        "NRC_WFSS": NrcWfssApcorrModel,
+        "NIS_WFSS": NisWfssApcorrModel,
+        "NRS_BRIGHTOBJ": NrsFsApcorrModel,
+        "NRS_FIXEDSLIT": NrsFsApcorrModel,
+        "NRS_IFU": NrsIfuApcorrModel,
+        "NRS_MSASPEC": NrsMosApcorrModel,
     }
 
     apcorr_model = apcorr_model_map[exptype]
     return apcorr_model(refname)
 
 
-def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
-                           smoothing_length=None, bkg_fit=None, bkg_order=None,
-                           subtract_background=None,
-                           use_source_posn=None, position_offset=0.0,
-                           model_nod_pair=False, optimize_psf_location=False,
-                           extraction_type='box', psf_ref_name='N/A'):
-    """Get extraction parameter values.
+def get_extract_parameters(
+    ref_dict,
+    input_model,
+    slitname,
+    sp_order,
+    meta,
+    smoothing_length=None,
+    bkg_fit=None,
+    bkg_order=None,
+    subtract_background=None,
+    use_source_posn=None,
+    position_offset=0.0,
+    model_nod_pair=False,
+    optimize_psf_location=False,
+    extraction_type="box",
+    psf_ref_name="N/A",
+):
+    """
+    Get extraction parameter values.
 
     Parameters
     ----------
@@ -225,42 +254,41 @@ def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
         based on `slitname` and `sp_order`.  Default values will be
         assigned if `ref_dict` is None.
     """
-
-    extract_params = {'match': NO_MATCH}  # initial value
+    extract_params = {"match": NO_MATCH}  # initial value
     if ref_dict is None:
         # There is no extract1d reference file; use "reasonable" default values.
-        extract_params['match'] = EXACT
+        extract_params["match"] = EXACT
         shape = input_model.data.shape
-        extract_params['spectral_order'] = sp_order
-        extract_params['xstart'] = 0  # first pixel in X
-        extract_params['xstop'] = shape[-1] - 1  # last pixel in X
-        extract_params['ystart'] = 0  # first pixel in Y
-        extract_params['ystop'] = shape[-2] - 1  # last pixel in Y
-        extract_params['extract_width'] = None
-        extract_params['src_coeff'] = None
-        extract_params['bkg_coeff'] = None  # no background sub.
-        extract_params['smoothing_length'] = 0  # because no background sub.
-        extract_params['bkg_fit'] = None  # because no background sub.
-        extract_params['bkg_order'] = 0  # because no background sub.
-        extract_params['subtract_background'] = False
-        extract_params['extraction_type'] = 'box'
-        extract_params['use_source_posn'] = False  # no source position correction
-        extract_params['position_offset'] = 0.
-        extract_params['model_nod_pair'] = False
-        extract_params['optimize_psf_location'] = False
-        extract_params['psf'] = 'N/A'
-        extract_params['independent_var'] = 'pixel'
-        extract_params['trace'] = None
+        extract_params["spectral_order"] = sp_order
+        extract_params["xstart"] = 0  # first pixel in X
+        extract_params["xstop"] = shape[-1] - 1  # last pixel in X
+        extract_params["ystart"] = 0  # first pixel in Y
+        extract_params["ystop"] = shape[-2] - 1  # last pixel in Y
+        extract_params["extract_width"] = None
+        extract_params["src_coeff"] = None
+        extract_params["bkg_coeff"] = None  # no background sub.
+        extract_params["smoothing_length"] = 0  # because no background sub.
+        extract_params["bkg_fit"] = None  # because no background sub.
+        extract_params["bkg_order"] = 0  # because no background sub.
+        extract_params["subtract_background"] = False
+        extract_params["extraction_type"] = "box"
+        extract_params["use_source_posn"] = False  # no source position correction
+        extract_params["position_offset"] = 0.0
+        extract_params["model_nod_pair"] = False
+        extract_params["optimize_psf_location"] = False
+        extract_params["psf"] = "N/A"
+        extract_params["independent_var"] = "pixel"
+        extract_params["trace"] = None
         # Note that extract_params['dispaxis'] is not assigned.
         # This will be done later, possibly slit by slit.
 
     else:
-        for aper in ref_dict['apertures']:
-            if ('id' in aper and aper['id'] != "dummy"
-                    and (aper['id'] == slitname
-                         or aper['id'] == ANY
-                         or slitname == ANY)):
-
+        for aper in ref_dict["apertures"]:
+            if (
+                "id" in aper
+                and aper["id"] != "dummy"
+                and (aper["id"] == slitname or aper["id"] == ANY or slitname == ANY)
+            ):
                 # region_type is retained for backward compatibility; it is
                 # not required to be present, but if it is and is not set
                 # to target, then the aperture is not matched.
@@ -268,7 +296,7 @@ def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
                 if region_type != "target":
                     continue
 
-                extract_params['match'] = PARTIAL
+                extract_params["match"] = PARTIAL
 
                 # spectral_order is a secondary selection criterion.  The
                 # default is the expected value, so if the key is not present
@@ -278,114 +306,121 @@ def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
                 spectral_order = aper.get("spectral_order", sp_order)
 
                 if spectral_order == sp_order or spectral_order == ANY:
-                    extract_params['match'] = EXACT
-                    extract_params['spectral_order'] = sp_order
+                    extract_params["match"] = EXACT
+                    extract_params["spectral_order"] = sp_order
                     # Note: extract_params['dispaxis'] is not assigned.
                     # This is done later, possibly slit by slit.
 
                     # Set default start/stop by shape if not specified
                     shape = input_model.data.shape
-                    extract_params['xstart'] = aper.get('xstart', 0)
-                    extract_params['xstop'] = aper.get('xstop', shape[-1] - 1)
-                    extract_params['ystart'] = aper.get('ystart', 0)
-                    extract_params['ystop'] = aper.get('ystop', shape[-2] - 1)
+                    extract_params["xstart"] = aper.get("xstart", 0)
+                    extract_params["xstop"] = aper.get("xstop", shape[-1] - 1)
+                    extract_params["ystart"] = aper.get("ystart", 0)
+                    extract_params["ystop"] = aper.get("ystop", shape[-2] - 1)
 
-                    extract_params['src_coeff'] = aper.get('src_coeff')
-                    extract_params['bkg_coeff'] = aper.get('bkg_coeff')
+                    extract_params["src_coeff"] = aper.get("src_coeff")
+                    extract_params["bkg_coeff"] = aper.get("bkg_coeff")
 
-                    if (extract_params['bkg_coeff'] is not None
-                            and subtract_background is None):
+                    if extract_params["bkg_coeff"] is not None and subtract_background is None:
                         subtract_background = True
 
                     if subtract_background:
-                        extract_params['subtract_background'] = True
+                        extract_params["subtract_background"] = True
                         if bkg_fit is not None:
                             # Mean value for background fitting is equivalent
                             # to a polynomial fit with order 0.
-                            if bkg_fit == 'mean':
-                                bkg_fit = 'poly'
+                            if bkg_fit == "mean":
+                                bkg_fit = "poly"
                                 bkg_order = 0
-                            extract_params['bkg_fit'] = bkg_fit
+                            extract_params["bkg_fit"] = bkg_fit
                         else:
-                            extract_params['bkg_fit'] = aper.get('bkg_fit', 'poly')
+                            extract_params["bkg_fit"] = aper.get("bkg_fit", "poly")
                     else:
-                        extract_params['subtract_background'] = False
-                        extract_params['bkg_fit'] = None
+                        extract_params["subtract_background"] = False
+                        extract_params["bkg_fit"] = None
 
-                    extract_params['independent_var'] = aper.get('independent_var', 'pixel').lower()
+                    extract_params["independent_var"] = aper.get("independent_var", "pixel").lower()
 
                     if bkg_order is None:
-                        extract_params['bkg_order'] = aper.get('bkg_order', 0)
+                        extract_params["bkg_order"] = aper.get("bkg_order", 0)
                     else:
                         # If the user supplied a value, use that value.
-                        extract_params['bkg_order'] = bkg_order
+                        extract_params["bkg_order"] = bkg_order
 
                     # Set use_source_posn based on hierarchy of priorities:
                     # parameter value on the command line is highest precedence,
                     # then parameter value from the extract1d reference file,
                     # and finally a default setting based on exposure type.
-                    use_source_posn_aper = aper.get('use_source_posn', None)  # value from the ref file
+                    use_source_posn_aper = aper.get(
+                        "use_source_posn", None
+                    )  # value from the ref file
                     if use_source_posn is None:  # no value set on command line
                         if use_source_posn_aper is None:  # no value set in ref file
                             # Use a suitable default
                             if meta.exposure.type in SRCPOS_EXPTYPES:
                                 use_source_posn = True
-                                log.info(f"Turning on source position correction "
-                                         f"for exp_type = {meta.exposure.type}")
+                                log.info(
+                                    f"Turning on source position correction "
+                                    f"for exp_type = {meta.exposure.type}"
+                                )
                             else:
                                 use_source_posn = False
                         else:  # use the value from the ref file
                             use_source_posn = use_source_posn_aper
-                    extract_params['use_source_posn'] = use_source_posn
-                    extract_params['position_offset'] = position_offset
-                    extract_params['trace'] = None
+                    extract_params["use_source_posn"] = use_source_posn
+                    extract_params["position_offset"] = position_offset
+                    extract_params["trace"] = None
 
-                    extract_params['extract_width'] = aper.get('extract_width')
+                    extract_params["extract_width"] = aper.get("extract_width")
 
                     if smoothing_length is None:
-                        extract_params['smoothing_length'] = aper.get('smoothing_length', 0)
+                        extract_params["smoothing_length"] = aper.get("smoothing_length", 0)
                     else:
                         # If the user supplied a value, use that value.
-                        extract_params['smoothing_length'] = smoothing_length
+                        extract_params["smoothing_length"] = smoothing_length
 
                     # Check that the smoothing length has a reasonable value
-                    sm_length = extract_params['smoothing_length']
+                    sm_length = extract_params["smoothing_length"]
                     if sm_length != int(sm_length):
                         sm_length = int(np.round(sm_length))
-                        log.warning(f'Smoothing length must be an integer. '
-                                    f'Rounding to {sm_length}')
+                        log.warning(f"Smoothing length must be an integer. Rounding to {sm_length}")
                     if sm_length != 0:
                         if sm_length < 3:
-                            log.warning(f'Smoothing length {sm_length} '
-                                        f'is not allowed. Setting it to 0.')
+                            log.warning(
+                                f"Smoothing length {sm_length} is not allowed. Setting it to 0."
+                            )
                             sm_length = 0
                         elif sm_length % 2 == 0:
                             sm_length -= 1
-                            log.warning('Even smoothing lengths are not supported. '
-                                        'Rounding the smoothing length down to '
-                                        f'{sm_length}.')
-                    extract_params['smoothing_length'] = sm_length
+                            log.warning(
+                                "Even smoothing lengths are not supported. "
+                                "Rounding the smoothing length down to "
+                                f"{sm_length}."
+                            )
+                    extract_params["smoothing_length"] = sm_length
 
-                    extract_params['psf'] = psf_ref_name
-                    extract_params['optimize_psf_location'] = optimize_psf_location
-                    extract_params['model_nod_pair'] = model_nod_pair
+                    extract_params["psf"] = psf_ref_name
+                    extract_params["optimize_psf_location"] = optimize_psf_location
+                    extract_params["model_nod_pair"] = model_nod_pair
 
                     # Check for a valid PSF file
                     extraction_type = str(extraction_type).lower()
-                    if extract_params['psf'] == 'N/A' and extraction_type != 'box':
+                    if extract_params["psf"] == "N/A" and extraction_type != "box":
                         log.warning("No PSF file available. Setting extraction type to 'box'.")
-                        extraction_type = 'box'
+                        extraction_type = "box"
 
                     # Set the extraction type to 'box' or 'optimal'
-                    if extraction_type == 'none':
-                        if extract_params['use_source_posn']:
-                            extract_params['extraction_type'] = 'optimal'
+                    if extraction_type == "none":
+                        if extract_params["use_source_posn"]:
+                            extract_params["extraction_type"] = "optimal"
                         else:
-                            extract_params['extraction_type'] = 'box'
-                        log.info(f"Using extraction type '{extract_params['extraction_type']}' "
-                                 f"for use_source_posn = {extract_params['use_source_posn']}")
+                            extract_params["extraction_type"] = "box"
+                        log.info(
+                            f"Using extraction type '{extract_params['extraction_type']}' "
+                            f"for use_source_posn = {extract_params['use_source_posn']}"
+                        )
                     else:
-                        extract_params['extraction_type'] = extraction_type
+                        extract_params["extraction_type"] = extraction_type
 
                     break
 
@@ -393,7 +428,8 @@ def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
 
 
 def log_initial_parameters(extract_params):
-    """Log the initial extraction parameters.
+    """
+    Log the initial extraction parameters.
 
     Parameters
     ----------
@@ -404,14 +440,15 @@ def log_initial_parameters(extract_params):
         return
 
     log.debug("Extraction parameters:")
-    skip_keys = {'match', 'trace'}
+    skip_keys = {"match", "trace"}
     for key, value in extract_params.items():
         if key not in skip_keys:
             log.debug(f"  {key} = {value}")
 
 
 def create_poly(coeff):
-    """Create a polynomial model from coefficients.
+    """
+    Create a polynomial model from coefficients.
 
     Parameters
     ----------
@@ -428,27 +465,26 @@ def create_poly(coeff):
     if n < 1:
         return None
 
-    coeff_dict = {f'c{i}': coeff[i] for i in range(n)}
+    coeff_dict = {f"c{i}": coeff[i] for i in range(n)}
 
     return polynomial.Polynomial1D(degree=n - 1, **coeff_dict)
 
 
 def populate_time_keywords(input_model, output_model):
-    """Copy the integration times keywords to header keywords.
+    """
+    Copy the integration times keywords to header keywords.
 
     Parameters
     ----------
     input_model : JWSTDataModel
         The input science model.
-
     output_model : JWSTDataModel
         The output science model.  This may be modified in-place.
-
     """
     nints = input_model.meta.exposure.nints
     int_start = input_model.meta.exposure.integration_start
 
-    if hasattr(input_model, 'data'):
+    if hasattr(input_model, "data"):
         shape = input_model.data.shape
 
         if len(shape) == 2:
@@ -470,12 +506,13 @@ def populate_time_keywords(input_model, output_model):
 
     if n_output_spec != num_j * num_integ:  # sanity check
         log.warning(
-            f"populate_time_keywords:  Don't understand n_output_spec = {n_output_spec}, num_j = {num_j}, num_integ = "
-            f"{num_integ}"
+            f"populate_time_keywords:  Don't understand n_output_spec = {n_output_spec}, "
+            f"num_j = {num_j}, num_integ = {num_integ}"
         )
     else:
         log.debug(
-            f"Number of output spectra = {n_output_spec}; number of spectra for each integration = {num_j}; "
+            f"Number of output spectra = {n_output_spec}; "
+            f"number of spectra for each integration = {num_j}; "
             f"number of integrations = {num_integ}"
         )
 
@@ -497,17 +534,21 @@ def populate_time_keywords(input_model, output_model):
     else:
         num_integrations = 1
 
-    if hasattr(input_model, 'int_times') and input_model.int_times is not None:
+    if hasattr(input_model, "int_times") and input_model.int_times is not None:
         nrows = len(input_model.int_times)
     else:
         nrows = 0
 
     if nrows < 1:
-        log.warning("There is no INT_TIMES table in the input file - "
-                    "Making best guess on integration numbers.")
+        log.warning(
+            "There is no INT_TIMES table in the input file - "
+            "Making best guess on integration numbers."
+        )
         for j in range(num_j):  # for each spectrum or order
             for k in range(num_integ):  # for each integration
-                output_model.spec[(j * num_integ) + k].int_num = k + 1  # set int_num to (k+1) - 1-indexed integration
+                output_model.spec[(j * num_integ) + k].int_num = (
+                    k + 1
+                )  # set int_num to (k+1) - 1-indexed integration
         return
 
     # If we have a single plane (e.g. ImageModel or MultiSlitModel),
@@ -521,19 +562,24 @@ def populate_time_keywords(input_model, output_model):
 
     if isinstance(input_model, (datamodels.MultiSlitModel, datamodels.ImageModel)):
         if num_integrations > 1:
-            log.warning("Not using INT_TIMES table because the data have been averaged over integrations.")
+            log.warning(
+                "Not using INT_TIMES table because the data have been averaged over integrations."
+            )
             skip = True
     elif isinstance(input_model, (datamodels.CubeModel, datamodels.SlitModel)):
         shape = input_model.data.shape
 
         if len(shape) == 2 and num_integrations > 1:
-            log.warning("Not using INT_TIMES table because the data have been averaged over integrations.")
+            log.warning(
+                "Not using INT_TIMES table because the data have been averaged over integrations."
+            )
             skip = True
         elif len(shape) != 3 or shape[0] > nrows:
             # Later, we'll check that the integration_number column actually
             # has a row corresponding to every integration in the input.
             log.warning(
-                "Not using INT_TIMES table because the data shape is not consistent with the number of table rows."
+                "Not using INT_TIMES table because the data shape is "
+                "not consistent with the number of table rows."
             )
             skip = True
     elif isinstance(input_model, datamodels.IFUCubeModel):
@@ -543,23 +589,29 @@ def populate_time_keywords(input_model, output_model):
     if skip:
         return
 
-    int_num = input_model.int_times['integration_number']
-    start_time_mjd = input_model.int_times['int_start_MJD_UTC']
-    mid_time_mjd = input_model.int_times['int_mid_MJD_UTC']
-    end_time_mjd = input_model.int_times['int_end_MJD_UTC']
-    start_tdb = input_model.int_times['int_start_BJD_TDB']
-    mid_tdb = input_model.int_times['int_mid_BJD_TDB']
-    end_tdb = input_model.int_times['int_end_BJD_TDB']
+    int_num = input_model.int_times["integration_number"]
+    start_time_mjd = input_model.int_times["int_start_MJD_UTC"]
+    mid_time_mjd = input_model.int_times["int_mid_MJD_UTC"]
+    end_time_mjd = input_model.int_times["int_end_MJD_UTC"]
+    start_tdb = input_model.int_times["int_start_BJD_TDB"]
+    mid_tdb = input_model.int_times["int_mid_BJD_TDB"]
+    end_tdb = input_model.int_times["int_end_BJD_TDB"]
 
-    data_range = (int_start, int_end)  # Inclusive range of integration numbers in the input data, zero indexed.
+    data_range = (
+        int_start,
+        int_end,
+    )  # Inclusive range of integration numbers in the input data, zero indexed.
 
     # Inclusive range of integration numbers in the INT_TIMES table, zero indexed.
     table_range = (int_num[0] - 1, int_num[-1] - 1)
     offset = data_range[0] - table_range[0]
-    if ((data_range[0] < table_range[0] or data_range[1] > table_range[1])
-            or offset > table_range[1]):
-        log.warning("Not using the INT_TIMES table because it does not include "
-                    "rows for all integrations in the data.")
+    if (data_range[0] < table_range[0] or data_range[1] > table_range[1]) or offset > table_range[
+        1
+    ]:
+        log.warning(
+            "Not using the INT_TIMES table because it does not include "
+            "rows for all integrations in the data."
+        )
         return
 
     log.debug("TSO data, so copying times from the INT_TIMES table.")
@@ -567,7 +619,7 @@ def populate_time_keywords(input_model, output_model):
     n = 0  # Counter for spectra in output_model.
 
     for k in range(num_integ):  # for each spectrum or order
-        for j in range(num_j):  # for each integration
+        for _j in range(num_j):  # for each integration
             row = k + offset
             spec = output_model.spec[n]  # n is incremented below
             spec.int_num = int_num[row]
@@ -582,7 +634,8 @@ def populate_time_keywords(input_model, output_model):
 
 
 def get_spectral_order(slit):
-    """Get the spectral order number.
+    """
+    Get the spectral order number.
 
     Parameters
     ----------
@@ -595,7 +648,6 @@ def get_spectral_order(slit):
         Spectral order number for `slit`.  If no information about spectral
         order is available in `wcsinfo`, a default value of 1 will be
         returned.
-
     """
     sp_order = slit.meta.wcsinfo.spectral_order
 
@@ -607,10 +659,9 @@ def get_spectral_order(slit):
 
 
 def is_prism(input_model):
-    """Determine whether the current observing mode used a prism.
+    """
+    Determine whether the current observing mode used a prism.
 
-    Extended summary
-    ----------------
     The reason for this test is so we can skip spectral extraction if the
     spectral order is zero and the exposure was not made using a prism.
     In this context, therefore, a grism is not considered to be a prism.
@@ -624,7 +675,6 @@ def is_prism(input_model):
     -------
     bool
         True if the exposure used a prism; False otherwise.
-
     """
     instrument = input_model.meta.instrument.name
 
@@ -647,49 +697,62 @@ def is_prism(input_model):
 
     prism_mode = False
 
-    if ((instrument == "MIRI" and instrument_filter.find("P750L") >= 0) or
-            (instrument == "NIRSPEC" and grating.find("PRISM") >= 0)):
+    if (instrument == "MIRI" and instrument_filter.find("P750L") >= 0) or (
+        instrument == "NIRSPEC" and grating.find("PRISM") >= 0
+    ):
         prism_mode = True
 
     return prism_mode
 
 
 def copy_keyword_info(slit, slitname, spec):
-    """Copy metadata from the input to the output spectrum.
+    """
+    Copy metadata from the input to the output spectrum.
 
     Parameters
     ----------
     slit : A SlitModel object
         Metadata will be copied from the input `slit` to output `spec`.
-
     slitname : str or None
         The name of the slit.
-
     spec : One element of MultiSpecModel.spec
         Metadata attributes will be updated in-place.
-
     """
     if slitname is not None and slitname != "ANY":
         spec.name = slitname
 
     # Copy over some attributes if present, even if they are None
-    copy_attributes = ["slitlet_id", "source_id", "source_xpos", "source_ypos",
-                       "source_ra", "source_dec", "shutter_state"]
+    copy_attributes = [
+        "slitlet_id",
+        "source_id",
+        "source_xpos",
+        "source_ypos",
+        "source_ra",
+        "source_dec",
+        "shutter_state",
+    ]
     for key in copy_attributes:
         if hasattr(slit, key):
             setattr(spec, key, getattr(slit, key))
 
     # Copy over some attributes only if they are present and not None
-    copy_populated_attributes = ["source_name", "source_alias",
-                                 "source_type", "stellarity",
-                                 "quadrant", "slit_xscale", "slit_yscale"]
+    copy_populated_attributes = [
+        "source_name",
+        "source_alias",
+        "source_type",
+        "stellarity",
+        "quadrant",
+        "slit_xscale",
+        "slit_yscale",
+    ]
     for key in copy_populated_attributes:
         if getattr(slit, key, None) is not None:
             setattr(spec, key, getattr(slit, key))
 
 
 def _set_weight_from_limits(profile, idx, lower_limit, upper_limit, allow_partial=True):
-    """Set profile pixel weighting from a lower and upper limit.
+    """
+    Set profile pixel weighting from a lower and upper limit.
 
     Pixels to be fully included in the aperture are set to 1.0. Pixels partially
     included are set to fractional values.
@@ -715,12 +778,10 @@ def _set_weight_from_limits(profile, idx, lower_limit, upper_limit, allow_partia
         If True, partial pixel weights are set where the pixel index intersects
         the limit values.  If False, only whole integer weights are set.
     """
-
     # Both limits are inclusive
     profile[(idx >= lower_limit) & (idx <= upper_limit)] = 1.0
 
     if allow_partial:
-
         # For each pixel, get the distance from the lower and upper limits,
         # to set partial pixel weights to the fraction of the pixel included.
         # For example, if the lower limit is 1.7, then the weight of pixel 1
@@ -732,17 +793,21 @@ def _set_weight_from_limits(profile, idx, lower_limit, upper_limit, allow_partia
         for partial_pixel_weight in [lower_weight, upper_weight]:
             # Check for overlap values that are between 0 and 1, for which
             # the profile does not already contain a higher weight
-            test = ((partial_pixel_weight > 0)
-                    & (partial_pixel_weight < 1)
-                    & (profile < partial_pixel_weight))
+            test = (
+                (partial_pixel_weight > 0)
+                & (partial_pixel_weight < 1)
+                & (profile < partial_pixel_weight)
+            )
 
             # Set these values to the partial pixel weight
             profile[test] = partial_pixel_weight[test]
 
 
-def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
-                label='aperture', return_limits=False):
-    """Create a spatial profile for box extraction.
+def box_profile(
+    shape, extract_params, wl_array, coefficients="src_coeff", label="aperture", return_limits=False
+):
+    """
+    Create a spatial profile for box extraction.
 
     The output profile is an image matching the input data shape,
     containing weights for each pixel in the image.  Pixels to be fully
@@ -800,24 +865,23 @@ def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
     upper_limit : float, optional
         Average upper limit for the aperture. Returned only if `return_limits`
         is set.
-
     """
     # Get pixel index values for the array
-    yidx, xidx = np.mgrid[:shape[0], :shape[1]]
-    if extract_params['dispaxis'] == HORIZONTAL:
+    yidx, xidx = np.mgrid[: shape[0], : shape[1]]
+    if extract_params["dispaxis"] == HORIZONTAL:
         dval = yidx
     else:
         dval = xidx
 
     # Get start/stop values from parameters if present,
     # or default to data shape
-    xstart = extract_params.get('xstart', 0)
-    xstop = extract_params.get('xstop', shape[1] - 1)
-    ystart = extract_params.get('ystart', 0)
-    ystop = extract_params.get('ystop', shape[0] - 1)
+    xstart = extract_params.get("xstart", 0)
+    xstop = extract_params.get("xstop", shape[1] - 1)
+    ystart = extract_params.get("ystart", 0)
+    ystop = extract_params.get("ystop", shape[0] - 1)
 
     # Check if the profile should contain partial pixel weights
-    if coefficients == 'bkg_coeff' and extract_params['bkg_fit'] == 'median':
+    if coefficients == "bkg_coeff" and extract_params["bkg_fit"] == "median":
         allow_partial = False
     else:
         allow_partial = True
@@ -830,9 +894,9 @@ def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
     profile = np.full(shape, 0.0)
     if extract_params[coefficients] is not None:
         # Limits from source coefficients: ignore ystart/stop/width
-        if extract_params['independent_var'].startswith("wavelength"):
+        if extract_params["independent_var"].startswith("wavelength"):
             ival = wl_array
-        elif extract_params['dispaxis'] == HORIZONTAL:
+        elif extract_params["dispaxis"] == HORIZONTAL:
             ival = xidx.astype(np.float32)
         else:
             ival = yidx.astype(np.float32)
@@ -841,8 +905,9 @@ def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
         # but must contain pairs of lower and upper limits.
         n_src_coeff = len(extract_params[coefficients])
         if n_src_coeff % 2 != 0:
-            raise RuntimeError(f"{coefficients} must contain alternating "
-                               f"lists of lower and upper limits.")
+            raise RuntimeError(
+                f"{coefficients} must contain alternating lists of lower and upper limits."
+            )
 
         lower = None
         lower_limit = None
@@ -864,13 +929,19 @@ def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
                 lower_limit_region = lower(ival) + 0.5
                 upper_limit_region = upper(ival) - 0.5
 
-                _set_weight_from_limits(profile, dval, lower_limit_region,
-                                        upper_limit_region,
-                                        allow_partial=allow_partial)
+                _set_weight_from_limits(
+                    profile,
+                    dval,
+                    lower_limit_region,
+                    upper_limit_region,
+                    allow_partial=allow_partial,
+                )
                 mean_lower = np.mean(lower_limit_region)
                 mean_upper = np.mean(upper_limit_region)
-                log.info(f'Mean {label} start/stop from {coefficients}: '
-                         f'{mean_lower:.2f} -> {mean_upper:.2f} (inclusive)')
+                log.info(
+                    f"Mean {label} start/stop from {coefficients}: "
+                    f"{mean_lower:.2f} -> {mean_upper:.2f} (inclusive)"
+                )
 
                 if lower_limit is None:
                     lower_limit = mean_lower
@@ -881,44 +952,46 @@ def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
                     if mean_upper > upper_limit:
                         upper_limit = mean_upper
 
-    elif extract_params['extract_width'] is not None and extract_params['trace'] is not None:
-        width = extract_params['extract_width']
-        trace = extract_params['trace']
+    elif extract_params["extract_width"] is not None and extract_params["trace"] is not None:
+        width = extract_params["extract_width"]
+        trace = extract_params["trace"]
 
-        if extract_params['dispaxis'] != HORIZONTAL:
+        if extract_params["dispaxis"] != HORIZONTAL:
             trace = np.tile(trace, (shape[1], 1)).T
 
         lower_limit_region = trace - (width - 1.0) / 2.0
         upper_limit_region = lower_limit_region + width - 1
 
-        _set_weight_from_limits(profile, dval, lower_limit_region,
-                                upper_limit_region)
+        _set_weight_from_limits(profile, dval, lower_limit_region, upper_limit_region)
 
         lower_limit = np.nanmean(lower_limit_region)
         upper_limit = np.nanmean(upper_limit_region)
-        log.info(f'Mean {label} start/stop from trace: '
-                 f'{lower_limit:.2f} -> {upper_limit:.2f} (inclusive)')
+        log.info(
+            f"Mean {label} start/stop from trace: "
+            f"{lower_limit:.2f} -> {upper_limit:.2f} (inclusive)"
+        )
 
-    elif extract_params['extract_width'] is not None:
+    elif extract_params["extract_width"] is not None:
         # Limits from extraction width at center of ystart/stop if present,
         # center of array if not
-        if extract_params['dispaxis'] == HORIZONTAL:
+        if extract_params["dispaxis"] == HORIZONTAL:
             nominal_middle = (ystart + ystop) / 2.0
         else:
             nominal_middle = (xstart + xstop) / 2.0
 
-        width = extract_params['extract_width']
+        width = extract_params["extract_width"]
         lower_limit = nominal_middle - (width - 1.0) / 2.0
         upper_limit = lower_limit + width - 1
 
         _set_weight_from_limits(profile, dval, lower_limit, upper_limit)
-        log.info(f'{label.capitalize()} start/stop: '
-                 f'{lower_limit:.2f} -> {upper_limit:.2f} (inclusive)')
+        log.info(
+            f"{label.capitalize()} start/stop: {lower_limit:.2f} -> {upper_limit:.2f} (inclusive)"
+        )
 
     else:
         # Limits from start/stop only, defaulting to the full array
         # if not specified
-        if extract_params['dispaxis'] == HORIZONTAL:
+        if extract_params["dispaxis"] == HORIZONTAL:
             lower_limit = ystart
             upper_limit = ystop
         else:
@@ -926,16 +999,17 @@ def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
             upper_limit = xstop
 
         _set_weight_from_limits(profile, dval, lower_limit, upper_limit)
-        log.info(f'{label.capitalize()} start/stop: '
-                 f'{lower_limit:.2f} -> {upper_limit:.2f} (inclusive)')
+        log.info(
+            f"{label.capitalize()} start/stop: {lower_limit:.2f} -> {upper_limit:.2f} (inclusive)"
+        )
 
     # Set weights to zero outside left and right limits
-    if extract_params['dispaxis'] == HORIZONTAL:
-        profile[:, :int(np.ceil(xstart))] = 0
-        profile[:, int(np.floor(xstop)) + 1:] = 0
+    if extract_params["dispaxis"] == HORIZONTAL:
+        profile[:, : int(np.ceil(xstart))] = 0
+        profile[:, int(np.floor(xstop)) + 1 :] = 0
     else:
-        profile[:int(np.ceil(ystart)), :] = 0
-        profile[int(np.floor(ystop)) + 1:, :] = 0
+        profile[: int(np.ceil(ystart)), :] = 0
+        profile[int(np.floor(ystop)) + 1 :, :] = 0
 
     if return_limits:
         return profile, lower_limit, upper_limit
@@ -943,7 +1017,8 @@ def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
 
 
 def aperture_center(profile, dispaxis=1, middle_pix=None):
-    """Determine the nominal center of an aperture.
+    """
+    Determine the nominal center of an aperture.
 
     The center is determined from a weighted average of the pixel
     coordinates, where the weights are set by the profile image.
@@ -980,7 +1055,7 @@ def aperture_center(profile, dispaxis=1, middle_pix=None):
     weights = profile.copy()
     weights[weights <= 0] = 0.0
 
-    yidx, xidx = np.mgrid[:profile.shape[0], :profile.shape[1]]
+    yidx, xidx = np.mgrid[: profile.shape[0], : profile.shape[1]]
     if dispaxis == HORIZONTAL:
         spec_idx = xidx
         if middle_pix is not None:
@@ -1010,7 +1085,8 @@ def aperture_center(profile, dispaxis=1, middle_pix=None):
 
 
 def shift_by_offset(offset, extract_params, update_trace=True):
-    """Shift the nominal extraction parameters by a pixel offset.
+    """
+    Shift the nominal extraction parameters by a pixel offset.
 
     Start, stop, and polynomial coefficient values for source and
     background are updated in place in the `extract_params` dictionary.
@@ -1026,31 +1102,31 @@ def shift_by_offset(offset, extract_params, update_trace=True):
     update_trace : bool
         If True, the trace in `extract_params['trace']` is also updated
         if present.
-
     """
     # Shift polynomial coefficients
-    coeff_params = ['src_coeff', 'bkg_coeff']
+    coeff_params = ["src_coeff", "bkg_coeff"]
     for params in coeff_params:
         if extract_params[params] is not None:
             for coeff_list in extract_params[params]:
                 coeff_list[0] += offset
 
     # Shift start/stop values
-    if extract_params['dispaxis'] == HORIZONTAL:
-        start_stop_params = ['ystart', 'ystop']
+    if extract_params["dispaxis"] == HORIZONTAL:
+        start_stop_params = ["ystart", "ystop"]
     else:
-        start_stop_params = ['xstart', 'xstop']
+        start_stop_params = ["xstart", "xstop"]
     for params in start_stop_params:
         if extract_params[params] is not None:
             extract_params[params] += offset
 
     # Shift the full trace
-    if update_trace and extract_params['trace'] is not None:
-        extract_params['trace'] += offset
+    if update_trace and extract_params["trace"] is not None:
+        extract_params["trace"] += offset
 
 
 def define_aperture(input_model, slit, extract_params, exp_type):
-    """Define an extraction aperture from input parameters.
+    """
+    Define an extraction aperture from input parameters.
 
     Parameters
     ----------
@@ -1099,7 +1175,6 @@ def define_aperture(input_model, slit, extract_params, exp_type):
         left_limit, right_limit).  Upper/lower limits are along the
         cross-dispersion axis.  Left/right limits are along the dispersion axis.
         All limits are inclusive and start at zero index value.
-
     """
     if slit is None:
         data_model = input_model
@@ -1108,55 +1183,64 @@ def define_aperture(input_model, slit, extract_params, exp_type):
     data_shape = data_model.data.shape[-2:]
 
     # Get a wavelength array for the data
-    wl_array = get_wavelengths(data_model, exp_type, extract_params['spectral_order'])
+    wl_array = get_wavelengths(data_model, exp_type, extract_params["spectral_order"])
 
     # Shift aperture definitions by source position if needed
     # Extract parameters are updated in place
-    if extract_params['use_source_posn']:
+    if extract_params["use_source_posn"]:
         # Source location from WCS
         middle_pix, middle_wl, location, trace = location_from_wcs(input_model, slit)
         if location is not None:
-            log.info(f"Computed source location is {location:.2f}, "
-                     f"at pixel {middle_pix}, wavelength {middle_wl:.2f}")
+            log.info(
+                f"Computed source location is {location:.2f}, "
+                f"at pixel {middle_pix}, wavelength {middle_wl:.2f}"
+            )
 
             # Nominal location from extract params + located middle
-            nominal_profile = box_profile(data_shape, extract_params, wl_array,
-                                          label='nominal aperture')
+            nominal_profile = box_profile(
+                data_shape, extract_params, wl_array, label="nominal aperture"
+            )
             nominal_location, _ = aperture_center(
-                nominal_profile, extract_params['dispaxis'], middle_pix=middle_pix)
+                nominal_profile, extract_params["dispaxis"], middle_pix=middle_pix
+            )
 
             # Offset extract parameters by location - nominal
             offset = location - nominal_location
-            log.info(f"Nominal location is {nominal_location:.2f}, "
-                     f"so offset is {offset:.2f} pixels")
+            log.info(
+                f"Nominal location is {nominal_location:.2f}, so offset is {offset:.2f} pixels"
+            )
             shift_by_offset(offset, extract_params, update_trace=False)
     else:
         middle_pix, middle_wl, location, trace = None, None, None, None
 
     # Store the trace, if computed
-    extract_params['trace'] = trace
+    extract_params["trace"] = trace
 
     # Add an extra position offset if desired, from extract_params['position_offset']
-    offset = extract_params.get('position_offset', 0.0)
+    offset = extract_params.get("position_offset", 0.0)
     if offset != 0.0:
         log.info(f"Applying additional cross-dispersion offset {offset:.2f} pixels")
         shift_by_offset(offset, extract_params, update_trace=True)
 
     # Make a spatial profile, including source shifts if necessary
     nod_profile = None
-    if extract_params['extraction_type'] == 'optimal':
+    if extract_params["extraction_type"] == "optimal":
         profiles, lower_limit, upper_limit = psf_profile(
-            data_model, extract_params['trace'],
-            wl_array, extract_params['psf'],
-            model_nod_pair=extract_params['model_nod_pair'],
-            optimize_shifts=extract_params['optimize_psf_location'])
+            data_model,
+            extract_params["trace"],
+            wl_array,
+            extract_params["psf"],
+            model_nod_pair=extract_params["model_nod_pair"],
+            optimize_shifts=extract_params["optimize_psf_location"],
+        )
         if len(profiles) > 1:
             profile, nod_profile = profiles
         else:
             profile = profiles[0]
     else:
         profile, lower_limit, upper_limit = box_profile(
-            data_shape, extract_params, wl_array, return_limits=True)
+            data_shape, extract_params, wl_array, return_limits=True
+        )
 
     # Make sure profile weights are zero where wavelengths are invalid
     profile[~np.isfinite(wl_array)] = 0.0
@@ -1164,7 +1248,7 @@ def define_aperture(input_model, slit, extract_params, exp_type):
         nod_profile[~np.isfinite(wl_array)] = 0.0
 
     # Get the effective left and right limits from the profile weights
-    nonzero_weight = np.where(np.sum(profile, axis=extract_params['dispaxis'] - 1) > 0)[0]
+    nonzero_weight = np.where(np.sum(profile, axis=extract_params["dispaxis"] - 1) > 0)[0]
     if len(nonzero_weight) > 0:
         left_limit = nonzero_weight[0]
         right_limit = nonzero_weight[-1]
@@ -1174,10 +1258,8 @@ def define_aperture(input_model, slit, extract_params, exp_type):
 
     # Make a background profile if necessary
     # (will also include source shifts)
-    if (extract_params['subtract_background']
-            and extract_params['bkg_coeff'] is not None):
-        bg_profile = box_profile(data_shape, extract_params, wl_array,
-                                 coefficients='bkg_coeff')
+    if extract_params["subtract_background"] and extract_params["bkg_coeff"] is not None:
+        bg_profile = box_profile(data_shape, extract_params, wl_array, coefficients="bkg_coeff")
     else:
         bg_profile = None
 
@@ -1185,7 +1267,7 @@ def define_aperture(input_model, slit, extract_params, exp_type):
     mask = np.isnan(wl_array) | (profile <= 0)
     masked_wl = np.ma.masked_array(wl_array, mask=mask)
     masked_weights = np.ma.masked_array(profile, mask=mask)
-    if extract_params['dispaxis'] == HORIZONTAL:
+    if extract_params["dispaxis"] == HORIZONTAL:
         wavelength = np.average(masked_wl, weights=masked_weights, axis=0).filled(np.nan)
     else:
         wavelength = np.average(masked_wl, weights=masked_weights, axis=1).filled(np.nan)
@@ -1207,9 +1289,9 @@ def define_aperture(input_model, slit, extract_params, exp_type):
     return ra, dec, wavelength, profile, bg_profile, nod_profile, limits
 
 
-def extract_one_slit(data_model, integration, profile, bg_profile,
-                     nod_profile, extract_params):
-    """Extract data for one slit, or spectral order, or integration.
+def extract_one_slit(data_model, integration, profile, bg_profile, nod_profile, extract_params):
+    """
+    Extract data for one slit, or spectral order, or integration.
 
     Parameters
     ----------
@@ -1305,7 +1387,7 @@ def extract_one_slit(data_model, integration, profile, bg_profile,
         var_flat = np.zeros_like(data)
 
     # Transpose data for extraction
-    if extract_params['dispaxis'] == HORIZONTAL:
+    if extract_params["dispaxis"] == HORIZONTAL:
         bg_profile_view = bg_profile
         if nod_profile is not None:
             profiles = [profile, nod_profile]
@@ -1326,13 +1408,19 @@ def extract_one_slit(data_model, integration, profile, bg_profile,
             profiles = [profile.T]
 
     # Extract spectra from the data
-    result = extract1d.extract1d(data, profiles, var_rnoise, var_poisson, var_flat,
-                                 profile_bg=bg_profile_view,
-                                 bg_smooth_length=extract_params['smoothing_length'],
-                                 fit_bkg=extract_params['subtract_background'],
-                                 bkg_fit_type=extract_params['bkg_fit'],
-                                 bkg_order=extract_params['bkg_order'],
-                                 extraction_type=extract_params['extraction_type'])
+    result = extract1d.extract1d(
+        data,
+        profiles,
+        var_rnoise,
+        var_poisson,
+        var_flat,
+        profile_bg=bg_profile_view,
+        bg_smooth_length=extract_params["smoothing_length"],
+        fit_bkg=extract_params["subtract_background"],
+        bkg_fit_type=extract_params["bkg_fit"],
+        bkg_order=extract_params["bkg_order"],
+        extraction_type=extract_params["extraction_type"],
+    )
 
     # Extraction routine can return multiple spectra;
     # here, we just want the first result
@@ -1345,7 +1433,7 @@ def extract_one_slit(data_model, integration, profile, bg_profile,
     # the input data.
     scene_model = result[-1]
     residual = data - scene_model
-    if extract_params['dispaxis'] == HORIZONTAL:
+    if extract_params["dispaxis"] == HORIZONTAL:
         first_result.append(scene_model)
         first_result.append(residual)
     else:
@@ -1354,12 +1442,23 @@ def extract_one_slit(data_model, integration, profile, bg_profile,
     return first_result
 
 
-def create_extraction(input_model, slit, output_model,
-                      extract_ref_dict, slitname, sp_order, exp_type,
-                      apcorr_ref_model=None, log_increment=50,
-                      save_profile=False, save_scene_model=False,
-                      save_residual_image=False, **kwargs):
-    """Extract spectra from an input model and append to an output model.
+def create_extraction(
+    input_model,
+    slit,
+    output_model,
+    extract_ref_dict,
+    slitname,
+    sp_order,
+    exp_type,
+    apcorr_ref_model=None,
+    log_increment=50,
+    save_profile=False,
+    save_scene_model=False,
+    save_residual_image=False,
+    **kwargs,
+):
+    """
+    Extract spectra from an input model and append to an output model.
 
     Input data, specified in the `slit` or `input_model`, should contain data
     with consistent wavelengths, target positions, and spectral image cutouts,
@@ -1435,7 +1534,7 @@ def create_extraction(input_model, slit, output_model,
     save_residual_image : bool, optional
         If True, the residual image (from input minus scene model) will be returned
         as an ImageModel or CubeModel.  If False, the return value is None.
-    kwargs : dict, optional
+    **kwargs : dict, optional
         Additional options to pass to `get_extract_parameters`.
 
     Returns
@@ -1452,7 +1551,6 @@ def create_extraction(input_model, slit, output_model,
         If `save_residual_image` is True, the return value is an ImageModel or CubeModel
         matching the input data, containing the residual image.
     """
-
     if slit is None:
         data_model = input_model
     else:
@@ -1471,18 +1569,18 @@ def create_extraction(input_model, slit, output_model,
     # We need a flag to indicate whether the photom step has been run.
     # If it hasn't, we'll copy the count rate to the flux column.
     s_photom = input_model.meta.cal_step.photom
-    if s_photom is not None and s_photom.upper() == 'COMPLETE':
+    if s_photom is not None and s_photom.upper() == "COMPLETE":
         photom_has_been_run = True
-        flux_units = 'Jy'
-        f_var_units = 'Jy^2'
-        sb_units = 'MJy/sr'
-        sb_var_units = 'MJy^2 / sr^2'
+        flux_units = "Jy"
+        f_var_units = "Jy^2"
+        sb_units = "MJy/sr"
+        sb_var_units = "MJy^2 / sr^2"
     else:
         photom_has_been_run = False
-        flux_units = 'DN/s'
-        f_var_units = 'DN^2 / s^2'
-        sb_units = 'DN/s'
-        sb_var_units = 'DN^2 / s^2'
+        flux_units = "DN/s"
+        f_var_units = "DN^2 / s^2"
+        sb_units = "DN/s"
+        sb_var_units = "DN^2 / s^2"
         log.warning("The photom step has not been run.")
 
     # Get the source type for the data
@@ -1498,39 +1596,43 @@ def create_extraction(input_model, slit, output_model,
             source_type = input_model.meta.target.source_type
 
     # Turn off use_source_posn if the source is not POINT
-    if source_type != 'POINT' or exp_type in WFSS_EXPTYPES:
-        if kwargs.get('use_source_posn') is None:
-            kwargs['use_source_posn'] = False
-            log.info(f"Setting use_source_posn to False for exposure type {exp_type}, "
-                     f"source type {source_type}")
+    if source_type != "POINT" or exp_type in WFSS_EXPTYPES:
+        if kwargs.get("use_source_posn") is None:
+            kwargs["use_source_posn"] = False
+            log.info(
+                f"Setting use_source_posn to False for exposure type {exp_type}, "
+                f"source type {source_type}"
+            )
 
     if photom_has_been_run:
         pixel_solid_angle = data_model.meta.photometry.pixelarea_steradians
         if pixel_solid_angle is None:
-            pixel_solid_angle = 1.
+            pixel_solid_angle = 1.0
             log.warning("Pixel area (solid angle) is not populated; the flux will not be correct.")
     else:
-        pixel_solid_angle = 1.  # not needed
+        pixel_solid_angle = 1.0  # not needed
 
     extract_params = get_extract_parameters(
-        extract_ref_dict, data_model, slitname, sp_order, input_model.meta, **kwargs)
+        extract_ref_dict, data_model, slitname, sp_order, input_model.meta, **kwargs
+    )
 
-    if extract_params['match'] == NO_MATCH:
-        log.critical('Missing extraction parameters.')
-        raise ValueError('Missing extraction parameters.')
-    elif extract_params['match'] == PARTIAL:
-        log.info(f'Spectral order {sp_order} not found, skipping ...')
+    if extract_params["match"] == NO_MATCH:
+        log.critical("Missing extraction parameters.")
+        raise ValueError("Missing extraction parameters.")
+    elif extract_params["match"] == PARTIAL:
+        log.info(f"Spectral order {sp_order} not found, skipping ...")
         raise ContinueError()
 
-    extract_params['dispaxis'] = data_model.meta.wcsinfo.dispersion_direction
-    if extract_params['dispaxis'] is None:
+    extract_params["dispaxis"] = data_model.meta.wcsinfo.dispersion_direction
+    if extract_params["dispaxis"] is None:
         log.warning("The dispersion direction information is missing, so skipping ...")
         raise ContinueError()
 
     # Set up spatial profiles and wavelength array,
     # to be used for every integration
     (ra, dec, wavelength, profile, bg_profile, nod_profile, limits) = define_aperture(
-        input_model, slit, extract_params, exp_type)
+        input_model, slit, extract_params, exp_type
+    )
 
     valid = np.isfinite(wavelength)
     wavelength = wavelength[valid]
@@ -1544,33 +1646,34 @@ def create_extraction(input_model, slit, output_model,
             profile_model = datamodels.ImageModel(profile + nod_profile)
         else:
             profile_model = datamodels.ImageModel(profile)
-        profile_model.update(input_model, only='PRIMARY')
+        profile_model.update(input_model, only="PRIMARY")
         profile_model.name = slitname
     else:
         profile_model = None
 
     # Set up aperture correction, to be used for every integration
     apcorr_available = False
-    if source_type is not None and source_type.upper() == 'POINT' and apcorr_ref_model is not None:
-        log.info('Creating aperture correction.')
+    if source_type is not None and source_type.upper() == "POINT" and apcorr_ref_model is not None:
+        log.info("Creating aperture correction.")
         # NIRSpec needs to use a wavelength in the middle of the
         # range rather than the beginning of the range
         # for calculating the pixel scale since some wavelengths at the
         # edges of the range won't map to the sky
-        if instrument == 'NIRSPEC':
+        if instrument == "NIRSPEC":
             wl = np.median(wavelength)
         else:
             wl = wavelength.min()
 
-        kwargs = {'location': (ra, dec, wl)}
+        kwargs = {"location": (ra, dec, wl)}
         if not isinstance(input_model, datamodels.ImageModel):
-            kwargs['slit_name'] = slitname
-            if exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
-                kwargs['slit'] = slitname
+            kwargs["slit_name"] = slitname
+            if exp_type in ["NRS_FIXEDSLIT", "NRS_BRIGHTOBJ"]:
+                kwargs["slit"] = slitname
 
         apcorr_model = select_apcorr(input_model)
-        apcorr = apcorr_model(input_model, apcorr_ref_model.apcorr_table,
-                              apcorr_ref_model.sizeunit, **kwargs)
+        apcorr = apcorr_model(
+            input_model, apcorr_ref_model.apcorr_table, apcorr_ref_model.sizeunit, **kwargs
+        )
     else:
         apcorr = None
 
@@ -1595,7 +1698,7 @@ def create_extraction(input_model, slit, output_model,
             scene_model = datamodels.CubeModel(shape)
         else:
             scene_model = datamodels.ImageModel()
-        scene_model.update(input_model, only='PRIMARY')
+        scene_model.update(input_model, only="PRIMARY")
         scene_model.name = slitname
     else:
         scene_model = None
@@ -1604,17 +1707,26 @@ def create_extraction(input_model, slit, output_model,
             residual = datamodels.CubeModel(shape)
         else:
             residual = datamodels.ImageModel()
-        residual.update(input_model, only='PRIMARY')
+        residual.update(input_model, only="PRIMARY")
         residual.name = slitname
     else:
         residual = None
 
     # Extract each integration
     for integ in integrations:
-        (sum_flux, f_var_rnoise, f_var_poisson,
-            f_var_flat, background, b_var_rnoise, b_var_poisson,
-            b_var_flat, npixels, scene_model_2d, residual_2d) = extract_one_slit(
-                data_model, integ, profile, bg_profile, nod_profile, extract_params)
+        (
+            sum_flux,
+            f_var_rnoise,
+            f_var_poisson,
+            f_var_flat,
+            background,
+            b_var_rnoise,
+            b_var_poisson,
+            b_var_flat,
+            npixels,
+            scene_model_2d,
+            residual_2d,
+        ) = extract_one_slit(data_model, integ, profile, bg_profile, nod_profile, extract_params)
 
         # Save the scene model and residual
         if save_scene_model:
@@ -1629,9 +1741,9 @@ def create_extraction(input_model, slit, output_model,
                 residual.data = residual_2d
 
         # Convert the sum to an average, for surface brightness.
-        npixels_temp = np.where(npixels > 0., npixels, 1.)
-        npixels_squared = npixels_temp ** 2
-        if extract_params['extraction_type'] == 'optimal':
+        npixels_temp = np.where(npixels > 0.0, npixels, 1.0)
+        npixels_squared = npixels_temp**2
+        if extract_params["extraction_type"] == "optimal":
             # surface brightness makes no sense for an optimal extraction
             surf_bright = np.zeros_like(sum_flux)
             sb_var_poisson = np.zeros_like(sum_flux)
@@ -1653,31 +1765,29 @@ def create_extraction(input_model, slit, output_model,
         # The input units will normally be MJy / sr, but for NIRSpec
         # point-source spectra the units will be MJy.
         input_units_are_megajanskys = (
-            photom_has_been_run
-            and source_type == 'POINT'
-            and instrument == 'NIRSPEC'
+            photom_has_been_run and source_type == "POINT" and instrument == "NIRSPEC"
         )
 
         if photom_has_been_run:
             # for NIRSpec point sources
             if input_units_are_megajanskys:
-                flux = sum_flux * 1.e6  # MJy --> Jy
-                f_var_poisson *= 1.e12  # MJy**2 --> Jy**2
-                f_var_rnoise *= 1.e12  # MJy**2 --> Jy**2
-                f_var_flat *= 1.e12  # MJy**2 --> Jy**2
-                surf_bright[:] = 0.
-                sb_var_poisson[:] = 0.
-                sb_var_rnoise[:] = 0.
-                sb_var_flat[:] = 0.
+                flux = sum_flux * 1.0e6  # MJy --> Jy
+                f_var_poisson *= 1.0e12  # MJy**2 --> Jy**2
+                f_var_rnoise *= 1.0e12  # MJy**2 --> Jy**2
+                f_var_flat *= 1.0e12  # MJy**2 --> Jy**2
+                surf_bright[:] = 0.0
+                sb_var_poisson[:] = 0.0
+                sb_var_rnoise[:] = 0.0
+                sb_var_flat[:] = 0.0
                 background[:] /= pixel_solid_angle  # MJy / sr
-                b_var_poisson = b_var_poisson / pixel_solid_angle ** 2
-                b_var_rnoise = b_var_rnoise / pixel_solid_angle ** 2
-                b_var_flat = b_var_flat / pixel_solid_angle ** 2
+                b_var_poisson = b_var_poisson / pixel_solid_angle**2
+                b_var_rnoise = b_var_rnoise / pixel_solid_angle**2
+                b_var_flat = b_var_flat / pixel_solid_angle**2
             else:
-                flux = sum_flux * pixel_solid_angle * 1.e6  # MJy / steradian --> Jy
-                f_var_poisson *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
-                f_var_rnoise *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
-                f_var_flat *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
+                flux = sum_flux * pixel_solid_angle * 1.0e6  # MJy / steradian --> Jy
+                f_var_poisson *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
+                f_var_rnoise *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
+                f_var_flat *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
         else:
             flux = sum_flux  # count rate
 
@@ -1689,44 +1799,58 @@ def create_extraction(input_model, slit, output_model,
 
         # Set DQ from the flux value
         dq = np.zeros(flux.shape, dtype=np.uint32)
-        dq[np.isnan(flux)] = datamodels.dqflags.pixel['DO_NOT_USE']
+        dq[np.isnan(flux)] = datamodels.dqflags.pixel["DO_NOT_USE"]
 
         # Make a table of the values, trimming to points with valid wavelengths only
         otab = np.array(
             list(
-                zip(wavelength, flux[valid], error[valid],
-                    f_var_poisson[valid], f_var_rnoise[valid], f_var_flat[valid],
-                    surf_bright[valid], sb_error[valid], sb_var_poisson[valid],
-                    sb_var_rnoise[valid], sb_var_flat[valid],
-                    dq[valid], background[valid], berror[valid],
-                    b_var_poisson[valid], b_var_rnoise[valid], b_var_flat[valid],
-                    npixels[valid])
+                zip(
+                    wavelength,
+                    flux[valid],
+                    error[valid],
+                    f_var_poisson[valid],
+                    f_var_rnoise[valid],
+                    f_var_flat[valid],
+                    surf_bright[valid],
+                    sb_error[valid],
+                    sb_var_poisson[valid],
+                    sb_var_rnoise[valid],
+                    sb_var_flat[valid],
+                    dq[valid],
+                    background[valid],
+                    berror[valid],
+                    b_var_poisson[valid],
+                    b_var_rnoise[valid],
+                    b_var_flat[valid],
+                    npixels[valid],
+                    strict=False,
+                )
             ),
-            dtype=datamodels.SpecModel().spec_table.dtype
+            dtype=datamodels.SpecModel().spec_table.dtype,
         )
 
         spec = datamodels.SpecModel(spec_table=otab)
         spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
-        spec.spec_table.columns['wavelength'].unit = 'um'
-        spec.spec_table.columns['flux'].unit = flux_units
-        spec.spec_table.columns['flux_error'].unit = flux_units
-        spec.spec_table.columns['flux_var_poisson'].unit = f_var_units
-        spec.spec_table.columns['flux_var_rnoise'].unit = f_var_units
-        spec.spec_table.columns['flux_var_flat'].unit = f_var_units
-        spec.spec_table.columns['surf_bright'].unit = sb_units
-        spec.spec_table.columns['sb_error'].unit = sb_units
-        spec.spec_table.columns['sb_var_poisson'].unit = sb_var_units
-        spec.spec_table.columns['sb_var_rnoise'].unit = sb_var_units
-        spec.spec_table.columns['sb_var_flat'].unit = sb_var_units
-        spec.spec_table.columns['background'].unit = sb_units
-        spec.spec_table.columns['bkgd_error'].unit = sb_units
-        spec.spec_table.columns['bkgd_var_poisson'].unit = sb_var_units
-        spec.spec_table.columns['bkgd_var_rnoise'].unit = sb_var_units
-        spec.spec_table.columns['bkgd_var_flat'].unit = sb_var_units
+        spec.spec_table.columns["wavelength"].unit = "um"
+        spec.spec_table.columns["flux"].unit = flux_units
+        spec.spec_table.columns["flux_error"].unit = flux_units
+        spec.spec_table.columns["flux_var_poisson"].unit = f_var_units
+        spec.spec_table.columns["flux_var_rnoise"].unit = f_var_units
+        spec.spec_table.columns["flux_var_flat"].unit = f_var_units
+        spec.spec_table.columns["surf_bright"].unit = sb_units
+        spec.spec_table.columns["sb_error"].unit = sb_units
+        spec.spec_table.columns["sb_var_poisson"].unit = sb_var_units
+        spec.spec_table.columns["sb_var_rnoise"].unit = sb_var_units
+        spec.spec_table.columns["sb_var_flat"].unit = sb_var_units
+        spec.spec_table.columns["background"].unit = sb_units
+        spec.spec_table.columns["bkgd_error"].unit = sb_units
+        spec.spec_table.columns["bkgd_var_poisson"].unit = sb_var_units
+        spec.spec_table.columns["bkgd_var_rnoise"].unit = sb_var_units
+        spec.spec_table.columns["bkgd_var_flat"].unit = sb_var_units
         spec.slit_ra = ra
         spec.slit_dec = dec
         spec.spectral_order = sp_order
-        spec.dispersion_direction = extract_params['dispaxis']
+        spec.dispersion_direction = extract_params["dispaxis"]
 
         # Record aperture limits as x/y start/stop values
         lower_limit, upper_limit, left_limit, right_limit = limits
@@ -1744,7 +1868,7 @@ def create_extraction(input_model, slit, output_model,
         copy_keyword_info(data_model, slitname, spec)
 
         if apcorr is not None:
-            if hasattr(apcorr, 'tabulated_correction'):
+            if hasattr(apcorr, "tabulated_correction"):
                 if apcorr.tabulated_correction is not None:
                     apcorr_available = True
 
@@ -1788,15 +1912,27 @@ def create_extraction(input_model, slit, output_model,
     return profile_model, scene_model, residual
 
 
-def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
-                  psf_ref_name="N/A", extraction_type="box",
-                  smoothing_length=None, bkg_fit=None, bkg_order=None,
-                  log_increment=50, subtract_background=None,
-                  use_source_posn=None, position_offset=0.0,
-                  model_nod_pair=False, optimize_psf_location=True,
-                  save_profile=False, save_scene_model=False,
-                  save_residual_image=False):
-    """Extract all 1-D spectra from an input model.
+def run_extract1d(
+    input_model,
+    extract_ref_name="N/A",
+    apcorr_ref_name=None,
+    psf_ref_name="N/A",
+    extraction_type="box",
+    smoothing_length=None,
+    bkg_fit=None,
+    bkg_order=None,
+    log_increment=50,
+    subtract_background=None,
+    use_source_posn=None,
+    position_offset=0.0,
+    model_nod_pair=False,
+    optimize_psf_location=True,
+    save_profile=False,
+    save_scene_model=False,
+    save_residual_image=False,
+):
+    """
+    Extract all 1-D spectra from an input model.
 
     Parameters
     ----------
@@ -1822,7 +1958,7 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
         dispersion is vertical) of background. Only used if `bkg_fit`
         is `poly`.  Allowed values are >= 0.
     log_increment : int
-        if `log_increment` is greater than 0 and the input data are
+        If `log_increment` is greater than 0 and the input data are
         multi-integration, a message will be written to the log every
         `log_increment` integrations.
     subtract_background : bool or None
@@ -1893,16 +2029,16 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
     extract_ref_dict = read_extract1d_ref(extract_ref_name)
 
     # Check for non-null PSF reference file
-    if psf_ref_name == 'N/A':
-        if extraction_type != 'box':
-            log.warning(f'Optimal extraction is not available for EXP_TYPE {exp_type}')
-            log.warning('Defaulting to box extraction.')
-            extraction_type = 'box'
+    if psf_ref_name == "N/A":
+        if extraction_type != "box":
+            log.warning(f"Optimal extraction is not available for EXP_TYPE {exp_type}")
+            log.warning("Defaulting to box extraction.")
+            extraction_type = "box"
 
     # Read in the aperture correction reference file
     apcorr_ref_model = None
-    if apcorr_ref_name is not None and apcorr_ref_name != 'N/A':
-        if extraction_type == 'optimal':
+    if apcorr_ref_name is not None and apcorr_ref_name != "N/A":
+        if extraction_type == "optimal":
             log.warning("Turning off aperture correction for optimal extraction")
         else:
             apcorr_ref_model = read_apcorr_ref(apcorr_ref_name, exp_type)
@@ -1911,7 +2047,7 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
     output_model = datamodels.MultiSpecModel()
     if hasattr(meta_source, "int_times"):
         output_model.int_times = meta_source.int_times.copy()
-    output_model.update(meta_source, only='PRIMARY')
+    output_model.update(meta_source, only="PRIMARY")
 
     # This will be relevant if we're asked to extract a spectrum
     # and the spectral order is zero.
@@ -1941,14 +2077,14 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
             residual = ModelContainer()
 
         for slit in slits:  # Loop over the slits in the input model
-            log.info(f'Working on slit {slit.name}')
-            log.debug(f'Slit is of type {type(slit)}')
+            log.info(f"Working on slit {slit.name}")
+            log.debug(f"Slit is of type {type(slit)}")
 
             slitname = slit.name
             use_source_posn = save_use_source_posn  # restore original value
 
             if np.size(slit.data) <= 0:
-                log.info(f'No data for slit {slit.name}, skipping ...')
+                log.info(f"No data for slit {slit.name}, skipping ...")
                 continue
 
             sp_order = get_spectral_order(slit)
@@ -1957,21 +2093,30 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
                 continue
 
             try:
-               profile, slit_scene_model, slit_residual = create_extraction(
-                   meta_source, slit, output_model,
-                   extract_ref_dict, slitname, sp_order, exp_type,
-                   apcorr_ref_model=apcorr_ref_model, log_increment=log_increment,
-                   save_profile=save_profile, save_scene_model=save_scene_model,
-                   save_residual_image=save_residual_image,
-                   psf_ref_name=psf_ref_name,
-                   extraction_type=extraction_type,
-                   smoothing_length=smoothing_length,
-                   bkg_fit=bkg_fit, bkg_order=bkg_order,
-                   subtract_background=subtract_background,
-                   use_source_posn=use_source_posn,
-                   position_offset=position_offset,
-                   model_nod_pair=model_nod_pair,
-                   optimize_psf_location=optimize_psf_location)
+                profile, slit_scene_model, slit_residual = create_extraction(
+                    meta_source,
+                    slit,
+                    output_model,
+                    extract_ref_dict,
+                    slitname,
+                    sp_order,
+                    exp_type,
+                    apcorr_ref_model=apcorr_ref_model,
+                    log_increment=log_increment,
+                    save_profile=save_profile,
+                    save_scene_model=save_scene_model,
+                    save_residual_image=save_residual_image,
+                    psf_ref_name=psf_ref_name,
+                    extraction_type=extraction_type,
+                    smoothing_length=smoothing_length,
+                    bkg_fit=bkg_fit,
+                    bkg_order=bkg_order,
+                    subtract_background=subtract_background,
+                    use_source_posn=use_source_posn,
+                    position_offset=position_offset,
+                    model_nod_pair=model_nod_pair,
+                    optimize_psf_location=optimize_psf_location,
+                )
             except ContinueError:
                 continue
 
@@ -1996,12 +2141,12 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
 
         elif isinstance(input_model, (datamodels.CubeModel, datamodels.SlitModel)):
             # For NRS_BRIGHTOBJ, the slit name comes from the slit model info
-            if exp_type == 'NRS_BRIGHTOBJ' and hasattr(input_model, "name"):
+            if exp_type == "NRS_BRIGHTOBJ" and hasattr(input_model, "name"):
                 slitname = input_model.name
 
             # For NRS_FIXEDSLIT, the slit name comes from the FXD_SLIT keyword
             # in the model meta if not present in the input model
-            if exp_type == 'NRS_FIXEDSLIT':
+            if exp_type == "NRS_FIXEDSLIT":
                 if hasattr(input_model, "name") and input_model.name is not None:
                     slitname = input_model.name
                 else:
@@ -2009,29 +2154,38 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
 
         else:
             log.error("The input file is not supported for this step.")
-            raise RuntimeError("Can't extract a spectrum from this file.")
+            raise TypeError("Can't extract a spectrum from this file.")
 
         sp_order = get_spectral_order(input_model)
         if sp_order == 0 and not prism_mode:
             log.info("Spectral order 0 is a direct image, skipping ...")
         else:
-            log.info(f'Processing spectral order {sp_order}')
+            log.info(f"Processing spectral order {sp_order}")
             try:
                 profile_model, scene_model, residual = create_extraction(
-                    input_model, slit, output_model,
-                    extract_ref_dict, slitname, sp_order, exp_type,
-                    apcorr_ref_model=apcorr_ref_model, log_increment=log_increment,
-                    save_profile=save_profile, save_scene_model=save_scene_model,
+                    input_model,
+                    slit,
+                    output_model,
+                    extract_ref_dict,
+                    slitname,
+                    sp_order,
+                    exp_type,
+                    apcorr_ref_model=apcorr_ref_model,
+                    log_increment=log_increment,
+                    save_profile=save_profile,
+                    save_scene_model=save_scene_model,
                     save_residual_image=save_residual_image,
                     psf_ref_name=psf_ref_name,
                     extraction_type=extraction_type,
                     smoothing_length=smoothing_length,
-                    bkg_fit=bkg_fit, bkg_order=bkg_order,
+                    bkg_fit=bkg_fit,
+                    bkg_order=bkg_order,
                     subtract_background=subtract_background,
                     use_source_posn=use_source_posn,
                     position_offset=position_offset,
                     model_nod_pair=model_nod_pair,
-                    optimize_psf_location=optimize_psf_location)
+                    optimize_psf_location=optimize_psf_location,
+                )
             except ContinueError:
                 pass
 

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -21,7 +21,7 @@ def build_coef_matrix(image, profiles_2d=None, profile_bg=None, weights=None, or
         to extract.  If set to None, the coefficient matrix values default
         to unity.
     profile_bg : ndarray of bool or None, optional
-        2D rray of the same shape as image, with nonzero elements where the
+        2D array of the same shape as image, with nonzero elements where the
         background is to be estimated.  If not specified, no additional
         pixels are included for background calculations.
     weights : ndarray or None, optional

--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -3,51 +3,44 @@ import warnings
 import numpy as np
 from astropy import convolution
 
-__all__ = ['extract1d']
+__all__ = ["extract1d"]
 
 
-def build_coef_matrix(image, profiles_2d=None, profile_bg=None,
-                      weights=None, order=0):
-    """Build matrices and vectors to enable least-squares fits.
+def build_coef_matrix(image, profiles_2d=None, profile_bg=None, weights=None, order=0):
+    """
+    Build matrices and vectors to enable least-squares fits.
 
-    Parameters:
-    -----------
-    image : 2-D ndarray
-        The array may have been transposed so that the dispersion direction
+    Parameters
+    ----------
+    image : ndarray
+        2D array, transposed if necessary so that the dispersion direction
         is the second index.
-
-    profiles_2d : list of 2-D ndarrays or None, optional
-        These arrays contain the weights for the extraction.  These arrays
+    profiles_2d : list of ndarray or None, optional
+        These 2D arrays contain the weights for the extraction.  These arrays
         should be the same shape as image, with one array for each object
         to extract.  If set to None, the coefficient matrix values default
         to unity.
-
-    profile_bg : boolean 2-D ndarray or None, optional
-        Array of the same shape as image, with nonzero elements where the
+    profile_bg : ndarray of bool or None, optional
+        2D rray of the same shape as image, with nonzero elements where the
         background is to be estimated.  If not specified, no additional
         pixels are included for background calculations.
-
-    weights : 2-D ndarray or None, optional
-        Array of (float) weights for the extraction.  If using inverse
+    weights : ndarray or None, optional
+        2D array of (float) weights for the extraction.  If using inverse
         variance weighting, these should be the square root of the inverse
         variance.  If not supplied, unit weights will be used.
-
     order : int, optional
         Polynomial order for fitting to each column of background.
         Default 0 (uniform background).
 
-    Returns:
-    --------
+    Returns
+    -------
     matrix : ndarray, 3-D, float64
         Design matrix for each pixel, shape (npixels, npar, npar)
-
     vec : ndarray, 2-D, float64
         Target vectors for the design matrix, shape (npixels, npar)
-
     coefmatrix : ndarray, 3-D, float64
         Matrix of coefficients for each parameter for each pixel,
         used to reconstruct the model fit.  Shape (npixels, npixels_y, npar)
-
     """
     if profiles_2d is None:
         profiles_2d = []
@@ -91,17 +84,32 @@ def build_coef_matrix(image, profiles_2d=None, profile_bg=None,
     # Products of the coefficient matrices suitable for passing to
     # linalg.solve.  These are matrices of size (npixels, npar, npar)
     # and (npixels, npar).
-    matrix = np.einsum('lji,ljk->lik', coefmatrix_masked, coefmatrix_masked)
-    vec = np.einsum('lji,lj->li', coefmatrix_masked, targetvector)
+    matrix = np.einsum("lji,ljk->lik", coefmatrix_masked, coefmatrix_masked)  # codespell:ignore
+    vec = np.einsum("lji,lj->li", coefmatrix_masked, targetvector)
 
     return matrix, vec, coefmatrix, coefmatrix_masked
 
 
 def _fit_background_for_box_extraction(
-        image, profiles_2d, variance_rn, variance_phnoise, variance_flat,
-        profile_bg, weights, bg_smooth_length, bkg_fit_type, bkg_order):
-    """Fit a background level for box extraction."""
+    image,
+    profiles_2d,
+    variance_rn,
+    variance_phnoise,
+    variance_flat,
+    profile_bg,
+    weights,
+    bg_smooth_length,
+    bkg_fit_type,
+    bkg_order,
+):
+    """
+    Fit a background level for box extraction.
 
+    Returns
+    -------
+    bkg_2d, var_bkg_rn, var_bkg_phnoise, var_bkg_flat : tuple of ndarray
+        Background and associated variances.
+    """
     # Start by copying the input image
     input_background = image.copy()
 
@@ -112,9 +120,9 @@ def _fit_background_for_box_extraction(
         if not bg_smooth_length % 2 == 1:
             raise ValueError("bg_smooth_length should be an odd integer >= 1.")
         kernel = np.ones((1, bg_smooth_length)) / bg_smooth_length
-        input_background = convolution.convolve(input_background, kernel, boundary='extend')
+        input_background = convolution.convolve(input_background, kernel, boundary="extend")
 
-    if bkg_fit_type == 'median':
+    if bkg_fit_type == "median":
         input_background[profile_bg == 0] = np.nan
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=RuntimeWarning, message="All-NaN")
@@ -134,18 +142,22 @@ def _fit_background_for_box_extraction(
             warnings.filterwarnings("ignore", category=RuntimeWarning, message="invalid value")
             pixwgt = wgt / np.sum(wgt, axis=0)[np.newaxis, :]
 
-        var_bkg_rn = 1.2 ** 2 * bkg_npix ** 2 * np.array([np.nansum(variance_rn * pixwgt ** 2, axis=0)])
-        var_bkg_phnoise = 1.2 ** 2 * bkg_npix ** 2 * np.array([np.nansum(variance_phnoise * pixwgt ** 2, axis=0)])
-        var_bkg_flat = 1.2 ** 2 * bkg_npix ** 2 * np.array([np.nansum(variance_flat * pixwgt ** 2, axis=0)])
+        var_bkg_rn = 1.2**2 * bkg_npix**2 * np.array([np.nansum(variance_rn * pixwgt**2, axis=0)])
+        var_bkg_phnoise = (
+            1.2**2 * bkg_npix**2 * np.array([np.nansum(variance_phnoise * pixwgt**2, axis=0)])
+        )
+        var_bkg_flat = (
+            1.2**2 * bkg_npix**2 * np.array([np.nansum(variance_flat * pixwgt**2, axis=0)])
+        )
 
-    elif bkg_fit_type == 'poly' and bkg_order >= 0:
-
+    elif bkg_fit_type == "poly" and bkg_order >= 0:
         if not bkg_order == int(bkg_order):
             raise ValueError("If bkg_fit_type is 'poly', bkg_order must be an integer >= 0.")
 
         # Build the matrices to fit a polynomial column-by-column.
-        result = build_coef_matrix(input_background, profile_bg=profile_bg,
-                                   weights=weights, order=bkg_order)
+        result = build_coef_matrix(
+            input_background, profile_bg=profile_bg, weights=weights, order=bkg_order
+        )
         matrix, vec, coefmatrix, coefmatrix_masked = result
 
         # Don't try to solve singular matrices.  Background will be
@@ -156,33 +168,53 @@ def _fit_background_for_box_extraction(
 
         # These are the pixel-dependent weights to compute our coefficients.
         # We will use them to propagate errors.
-        pixwgt = weights.T[:, :, np.newaxis] * np.einsum('ijk,ilj->ilk', cov_bg_coefs, coefmatrix_masked)
+        pixwgt = weights.T[:, :, np.newaxis] * np.einsum(
+            "ijk,ilj->ilk", cov_bg_coefs, coefmatrix_masked
+        )
         bkg_mat = np.sum(np.swapaxes(coefmatrix, 0, 1) * profiles_2d[0][:, :, np.newaxis], axis=0)
 
         # Sum of all the contributions to the background at the pixels
         # where we will do the extraction.  Used to propagate errors.
         pixwgt_tot = np.sum(bkg_mat[:, np.newaxis, :] * pixwgt, axis=-1)
 
-        var_bkg_rn = np.array([np.nansum(variance_rn.T * pixwgt_tot ** 2, axis=1)])
-        var_bkg_phnoise = np.array([np.nansum(variance_phnoise.T * pixwgt_tot ** 2, axis=1)])
-        var_bkg_flat = np.array([np.nansum(variance_flat.T * pixwgt_tot ** 2, axis=1)])
+        var_bkg_rn = np.array([np.nansum(variance_rn.T * pixwgt_tot**2, axis=1)])
+        var_bkg_phnoise = np.array([np.nansum(variance_phnoise.T * pixwgt_tot**2, axis=1)])
+        var_bkg_flat = np.array([np.nansum(variance_flat.T * pixwgt_tot**2, axis=1)])
 
-        coefs = np.einsum('ijk,ij->ik', cov_bg_coefs, vec)
+        coefs = np.einsum("ijk,ij->ik", cov_bg_coefs, vec)
 
         # Reconstruct the 2D background.
         bkg_2d = np.sum(coefs[:, np.newaxis, :] * coefmatrix, axis=-1).T
 
     else:
-        raise ValueError("bkg_fit_type should be 'median' or 'poly'. "
-                         "If 'poly', bkg_order must be an integer >= 0.")
+        raise ValueError(
+            "bkg_fit_type should be 'median' or 'poly'. "
+            "If 'poly', bkg_order must be an integer >= 0."
+        )
 
     return bkg_2d, var_bkg_rn, var_bkg_phnoise, var_bkg_flat
 
 
 def _box_extract(
-        image, profiles_2d, variance_rn, variance_phnoise, variance_flat,
-        bkg_2d, var_bkg_rn, var_bkg_phnoise, var_bkg_flat, model):
-    """Perform box extraction."""
+    image,
+    profiles_2d,
+    variance_rn,
+    variance_phnoise,
+    variance_flat,
+    bkg_2d,
+    var_bkg_rn,
+    var_bkg_phnoise,
+    var_bkg_flat,
+    model,
+):
+    """
+    Perform box extraction.
+
+    Returns
+    -------
+    tuple of ndarray
+        Extracted spectrum and associated data.
+    """
     # This only makes sense with a single profile, i.e., pulling out
     # a single spectrum.
     nobjects = 1
@@ -206,9 +238,9 @@ def _box_extract(
 
     # Compute the variance on the sum, same shape as f.
     # Need to decompose this into read noise, photon noise, and flat noise.
-    var_rn = np.array([np.nansum(variance_rn * profile_2d ** 2, axis=0)])
-    var_phnoise = np.array([np.nansum(variance_phnoise * profile_2d ** 2, axis=0)])
-    var_flat = np.array([np.nansum(variance_flat * profile_2d ** 2, axis=0)])
+    var_rn = np.array([np.nansum(variance_rn * profile_2d**2, axis=0)])
+    var_phnoise = np.array([np.nansum(variance_phnoise * profile_2d**2, axis=0)])
+    var_flat = np.array([np.nansum(variance_flat * profile_2d**2, axis=0)])
 
     if bkg_2d is not None:
         var_rn += var_bkg_rn
@@ -219,16 +251,44 @@ def _box_extract(
     else:
         bkg = np.zeros((nobjects, image.shape[1]))
 
-    return (fluxes, var_rn, var_phnoise, var_flat,
-            bkg, var_bkg_rn, var_bkg_phnoise, var_bkg_flat, npixels, model)
+    return (
+        fluxes,
+        var_rn,
+        var_phnoise,
+        var_flat,
+        bkg,
+        var_bkg_rn,
+        var_bkg_phnoise,
+        var_bkg_flat,
+        npixels,
+        model,
+    )
 
 
 def _optimal_extract(
-        image, profiles_2d, variance_rn, variance_phnoise, variance_flat,
-        weights, profile_bg, fit_bkg, bkg_order,
-        bkg_2d, var_bkg_rn, var_bkg_phnoise, var_bkg_flat, model):
-    """Perform optimal extraction."""
+    image,
+    profiles_2d,
+    variance_rn,
+    variance_phnoise,
+    variance_flat,
+    weights,
+    profile_bg,
+    fit_bkg,
+    bkg_order,
+    bkg_2d,
+    var_bkg_rn,
+    var_bkg_phnoise,
+    var_bkg_flat,
+    model,
+):
+    """
+    Perform optimal extraction.
 
+    Returns
+    -------
+    tuple of ndarray
+        Extracted spectrum and associated data.
+    """
     # Background fitting needs to be done simultaneously with the
     # fitting of the spectra in this case.  If we are not fitting a
     # background, pass -1 for the order of the polynomial correction.
@@ -239,8 +299,9 @@ def _optimal_extract(
     else:
         order = -1
 
-    result = build_coef_matrix(image, profiles_2d=profiles_2d, weights=weights,
-                               profile_bg=profile_bg, order=order)
+    result = build_coef_matrix(
+        image, profiles_2d=profiles_2d, weights=weights, profile_bg=profile_bg, order=order
+    )
     matrix, vec, coefmatrix, coefmatrix_masked = result
 
     # Don't try to solve equations with singular matrices.
@@ -256,7 +317,7 @@ def _optimal_extract(
 
     # These are the pixel-dependent weights to compute our coefficients.
     # We will use them to propagate errors.
-    pixwgt = weights.T[:, :, np.newaxis] * np.einsum('ijk,ilj->ilk', covariances, coefmatrix_masked)
+    pixwgt = weights.T[:, :, np.newaxis] * np.einsum("ijk,ilj->ilk", covariances, coefmatrix_masked)
 
     # Don't use NaN pixels in the sum.  These will already be zero in
     # pixwgt.  coefs are the best-fit coefficients of the source and
@@ -267,16 +328,20 @@ def _optimal_extract(
     nobjects = len(profiles_2d)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=RuntimeWarning, message="invalid value")
-        wgt_src_pix = [profiles_2d[i] * (weights > 0) / np.sum(profiles_2d[i] ** 2, axis=0)
-                       for i in range(nobjects)]
+        wgt_src_pix = [
+            profiles_2d[i] * (weights > 0) / np.sum(profiles_2d[i] ** 2, axis=0)
+            for i in range(nobjects)
+        ]
     npixels = np.sum(wgt_src_pix, axis=1)
 
     if order > -1:
-        bkg_2d = np.sum(coefs[:, np.newaxis, :order + 1] * coefmatrix[..., :order + 1], axis=-1).T
+        bkg_2d = np.sum(coefs[:, np.newaxis, : order + 1] * coefmatrix[..., : order + 1], axis=-1).T
 
     # Variances for each object (discard variances for background here)
     var_rn = np.nansum(pixwgt[..., -nobjects:] ** 2 * variance_rn.T[:, :, np.newaxis], axis=1).T
-    var_phnoise = np.nansum(pixwgt[..., -nobjects:] ** 2 * variance_phnoise.T[:, :, np.newaxis], axis=1).T
+    var_phnoise = np.nansum(
+        pixwgt[..., -nobjects:] ** 2 * variance_phnoise.T[:, :, np.newaxis], axis=1
+    ).T
     var_flat = np.nansum(pixwgt[..., -nobjects:] ** 2 * variance_flat.T[:, :, np.newaxis], axis=1).T
 
     # Computing a background contribution to the noise is harder in a joint fit.
@@ -287,22 +352,32 @@ def _optimal_extract(
             warnings.filterwarnings("ignore", category=RuntimeWarning, message="invalid value")
             warnings.filterwarnings("ignore", category=RuntimeWarning, message="divide by zero")
 
-            wgt_nobkg = [profiles_2d[i] * weights
-                         / np.sum(profiles_2d[i] ** 2 * weights, axis=0)
-                         for i in range(nobjects)]
+            wgt_nobkg = [
+                profiles_2d[i] * weights / np.sum(profiles_2d[i] ** 2 * weights, axis=0)
+                for i in range(nobjects)
+            ]
 
             bkg = np.array([np.sum(wgt_nobkg[i] * bkg_2d, axis=0) for i in range(nobjects)])
 
             # Avoid overflow in squaring weights by multiplying by variance first
             var_bkg_rn = np.array(
-                [var_rn[i] - np.sum(variance_rn * wgt_nobkg[i] * wgt_nobkg[i], axis=0)
-                 for i in range(nobjects)])
+                [
+                    var_rn[i] - np.sum(variance_rn * wgt_nobkg[i] * wgt_nobkg[i], axis=0)
+                    for i in range(nobjects)
+                ]
+            )
             var_bkg_phnoise = np.array(
-                [var_phnoise[i] - np.sum(variance_phnoise * wgt_nobkg[i] * wgt_nobkg[i], axis=0)
-                 for i in range(nobjects)])
+                [
+                    var_phnoise[i] - np.sum(variance_phnoise * wgt_nobkg[i] * wgt_nobkg[i], axis=0)
+                    for i in range(nobjects)
+                ]
+            )
             var_bkg_flat = np.array(
-                [var_flat[i] - np.sum(variance_flat * wgt_nobkg[i] * wgt_nobkg[i], axis=0)
-                 for i in range(nobjects)])
+                [
+                    var_flat[i] - np.sum(variance_flat * wgt_nobkg[i] * wgt_nobkg[i], axis=0)
+                    for i in range(nobjects)
+                ]
+            )
 
         # Make sure background values are finite
         bkg[~np.isfinite(bkg)] = 0.0
@@ -319,112 +394,111 @@ def _optimal_extract(
     fluxes = coefs[:, -nobjects:].T
     model += np.sum(coefs[:, np.newaxis, :] * coefmatrix, axis=-1).T
 
-    return (fluxes, var_rn, var_phnoise, var_flat,
-            bkg, var_bkg_rn, var_bkg_phnoise, var_bkg_flat, npixels, model)
+    return (
+        fluxes,
+        var_rn,
+        var_phnoise,
+        var_flat,
+        bkg,
+        var_bkg_rn,
+        var_bkg_phnoise,
+        var_bkg_flat,
+        npixels,
+        model,
+    )
 
 
-def extract1d(image, profiles_2d, variance_rn, variance_phnoise, variance_flat,
-              weights=None, profile_bg=None, extraction_type='box',
-              bg_smooth_length=0, fit_bkg=False, bkg_fit_type='poly', bkg_order=0):
-    """Extract the spectrum, optionally subtracting background.
+def extract1d(
+    image,
+    profiles_2d,
+    variance_rn,
+    variance_phnoise,
+    variance_flat,
+    weights=None,
+    profile_bg=None,
+    extraction_type="box",
+    bg_smooth_length=0,
+    fit_bkg=False,
+    bkg_fit_type="poly",
+    bkg_order=0,
+):
+    """
+    Extract the spectrum, optionally subtracting background.
 
-    Parameters:
-    -----------
-    image : 2-D ndarray
-        The array may have been transposed so that the dispersion direction
+    Parameters
+    ----------
+    image : ndarray
+        2D array, transposed if necessary so that the dispersion direction
         is the second index.
-
-    profiles_2d : list of 2-D ndarray
-        These arrays contain the weights for the extraction.  A box
+    profiles_2d : list of ndarray
+        These 2D arrays contain the weights for the extraction.  A box
         extraction will add up the flux multiplied by these weights; an
         optimal extraction will fit an amplitude to the weight map at each
         column in the dispersion direction.  These arrays should be the
         same shape as image, with one array for each object to extract.
         Box extraction only works if exactly one profile is supplied
         (i.e. this is a one-element list).
-
-    variance_rn : 2-D ndarray
-        Read noise component of the variance.
-
-    variance_phnoise : 2-D ndarray
-        Photon noise component of the variance.
-
-    variance_flat : 2-D ndarray
-        Flat component of the variance.
-
-    weights : 2-D ndarray or None
-        Weights for the individual pixels in fitting a profile.  If None
+    variance_rn : ndarray
+        2D read noise component of the variance.
+    variance_phnoise : ndarray
+        2D photon noise component of the variance.
+    variance_flat : ndarray
+        2D flat component of the variance.
+    weights : ndarray or None, optional
+        2D weights for the individual pixels in fitting a profile.  If None
         (default), use uniform weights (ones for all valid pixels).
-
-    profile_bg : 2-D ndarray or None
-        Array of the same shape as image, with nonzero elements where the
+    profile_bg : ndarray or None, optional
+        2D array of the same shape as image, with nonzero elements where the
         background is to be estimated.
-
-    extraction_type : string
-        Type of spectral extraction.  Currently must be either "box"
-        or "optimal".
-
-    bg_smooth_length : int
+    extraction_type : {"box", "optimal"}, optional
+        Type of spectral extraction.
+    bg_smooth_length : int, optional
         Smoothing length for box smoothing of the background along the
         dispersion direction.  Should be odd, >=1.
-
-    fit_bkg : bool
+    fit_bkg : bool, optional
         Fit a background?  Default False
-
-    bkg_fit_type : string
+    bkg_fit_type : str, optional
         Type of fitting to apply to background values in each column (or
         row, if the dispersion is vertical).
-
-    bkg_order : int
+    bkg_order : int, optional
         Polynomial order for fitting to each column of background.  A value
         of 0 means that a simple average of the background regions, column
         by column, will be used.
         This argument must be positive or zero, and it is only used if
         background regions have been specified and if `bkg_fit` is `poly`.
 
-    Returns:
-    --------
-    fluxes : ndarray, n-D, float64
+    Returns
+    -------
+    fluxes : ndarray of float64
         The extracted spectrum/spectra.  Units are currently arbitrary.
-        The first dimension is the same as the length of profiles_2d
-
-    var_rn : ndarray, n-D, float64
+        The first dimension is the same as the length of profiles_2d.
+    var_rn : ndarray of float64
         The variances of the extracted spectrum/spectra due to read noise.
         Units are the same as flux^2, shape is the same as flux.
-
-    var_phnoise : ndarray, n-D, float64
+    var_phnoise : ndarray of float64
         The variances of the extracted spectrum/spectra due to photon noise.
         Units are the same as flux^2, shape is the same as flux.
-
-    var_flat : ndarray, n-D, float64
+    var_flat : ndarray of float64
         The variances of the extracted spectrum/spectra due to flatfield
         uncertainty. Units are the same as flux^2, shape is the same as flux.
-
-    bkg : ndarray, n-D, float64
+    bkg : ndarray of float64
         Background level that would be obtained for each source if performing
         a 1-D extraction on the 2D background.
-
-    var_bkg_rn : ndarray, n-D, float64
+    var_bkg_rn : ndarray of float64
         As above, for read noise.  Nonzero because read noise adds an error term
         to the derived background level.
-
-    var_bkg_phnoise : ndarray, n-D, float64
+    var_bkg_phnoise : ndarray of float64
         The variances of the extracted spectrum/spectra due to background photon
         noise. Units are the same as flux^2, shape is the same as flux.  This
         background contribution is already included in var_phnoise.
-
-    var_bkg_flat : ndarray, n-D, float64
+    var_bkg_flat : ndarray of float64
         As above, for the flatfield.
-
-    npixels : ndarray, n-D, int64
+    npixels : ndarray of int64
         Number of pixels that contribute to the flux measurement for each source
-
-    model : ndarray, 2-D, float64
+    model : ndarray of float64
         The model of the scene, the same shape as the input image (and
         hopefully also similar in value).
-
     """
-
     nobjects = len(profiles_2d)  # hopefully at least one!
     model = np.zeros(image.shape)
 
@@ -438,11 +512,19 @@ def extract1d(image, profiles_2d, variance_rn, variance_phnoise, variance_flat,
     # boolean variable to fit is set, and we are using box extraction.
     # Inverse variance weights should be used with care, as they have the
     # potential to introduce biases.
-    if profile_bg is not None and fit_bkg and extraction_type == 'box':
-        (bkg_2d, var_bkg_rn,
-         var_bkg_phnoise, var_bkg_flat) = _fit_background_for_box_extraction(
-            image, profiles_2d, variance_rn, variance_phnoise, variance_flat,
-            profile_bg, weights, bg_smooth_length, bkg_fit_type, bkg_order)
+    if profile_bg is not None and fit_bkg and extraction_type == "box":
+        (bkg_2d, var_bkg_rn, var_bkg_phnoise, var_bkg_flat) = _fit_background_for_box_extraction(
+            image,
+            profiles_2d,
+            variance_rn,
+            variance_phnoise,
+            variance_flat,
+            profile_bg,
+            weights,
+            bg_smooth_length,
+            bkg_fit_type,
+            bkg_order,
+        )
 
         model += bkg_2d
         image_sub = image - bkg_2d
@@ -458,32 +540,80 @@ def extract1d(image, profiles_2d, variance_rn, variance_phnoise, variance_flat,
         var_bkg_flat = np.zeros((nobjects, image.shape[1]))
 
     # This is the case of box extraction.
-    if extraction_type == 'box' and len(profiles_2d) == 1:
-
-        (fluxes, var_rn, var_phnoise, var_flat,
-         bkg, var_bkg_rn, var_bkg_phnoise,
-         var_bkg_flat, npixels, model) = _box_extract(
-            image_sub, profiles_2d, variance_rn, variance_phnoise, variance_flat,
-            bkg_2d, var_bkg_rn, var_bkg_phnoise, var_bkg_flat, model)
+    if extraction_type == "box" and len(profiles_2d) == 1:
+        (
+            fluxes,
+            var_rn,
+            var_phnoise,
+            var_flat,
+            bkg,
+            var_bkg_rn,
+            var_bkg_phnoise,
+            var_bkg_flat,
+            npixels,
+            model,
+        ) = _box_extract(
+            image_sub,
+            profiles_2d,
+            variance_rn,
+            variance_phnoise,
+            variance_flat,
+            bkg_2d,
+            var_bkg_rn,
+            var_bkg_phnoise,
+            var_bkg_flat,
+            model,
+        )
 
     # This is optimal extraction (well, profile-based extraction).  It
     # is "optimal extraction" if the weights are the inverse variances,
     # but you must be careful about biases in this case.
-    elif extraction_type == 'optimal':
-
-        (fluxes, var_rn, var_phnoise, var_flat,
-         bkg, var_bkg_rn, var_bkg_phnoise,
-         var_bkg_flat, npixels, model) = _optimal_extract(
-            image_sub, profiles_2d, variance_rn, variance_phnoise, variance_flat,
-            weights, profile_bg, fit_bkg, bkg_order,
-            bkg_2d, var_bkg_rn, var_bkg_phnoise, var_bkg_flat, model)
+    elif extraction_type == "optimal":
+        (
+            fluxes,
+            var_rn,
+            var_phnoise,
+            var_flat,
+            bkg,
+            var_bkg_rn,
+            var_bkg_phnoise,
+            var_bkg_flat,
+            npixels,
+            model,
+        ) = _optimal_extract(
+            image_sub,
+            profiles_2d,
+            variance_rn,
+            variance_phnoise,
+            variance_flat,
+            weights,
+            profile_bg,
+            fit_bkg,
+            bkg_order,
+            bkg_2d,
+            var_bkg_rn,
+            var_bkg_phnoise,
+            var_bkg_flat,
+            model,
+        )
 
     else:
-        raise ValueError(f"Extraction method {extraction_type} not "
-                         f"supported with {nobjects} input profiles.")
+        raise ValueError(
+            f"Extraction method {extraction_type} not supported with {nobjects} input profiles."
+        )
 
     no_data = np.isclose(npixels, 0)
     fluxes[no_data] = np.nan
 
-    return (fluxes, var_rn, var_phnoise, var_flat,
-            bkg, var_bkg_rn, var_bkg_phnoise, var_bkg_flat, npixels, model)
+    return (
+        fluxes,
+        var_rn,
+        var_phnoise,
+        var_flat,
+        bkg,
+        var_bkg_rn,
+        var_bkg_phnoise,
+        var_bkg_flat,
+        npixels,
+        model,
+    )

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -11,7 +11,8 @@ __all__ = ["Extract1dStep"]
 
 
 class Extract1dStep(Step):
-    """Extract a 1-d spectrum from 2-d data
+    """
+    Extract a 1D spectrum from 2D data.
 
     Attributes
     ----------
@@ -20,53 +21,44 @@ class Extract1dStep(Step):
         If None, the value in the extract_1d reference file will be used.
         If not None, this parameter overrides the value in the
         extract_1d reference file.
-
     apply_apcorr : bool
         Switch to select whether to apply an APERTURE correction during
         the Extract1dStep. Default is True.
-
     extraction_type : str or None
         If 'box', a standard extraction is performed, summing over an
         aperture box. If 'optimal', a PSF-based extraction is performed.
         If None, optimal extraction is attempted whenever use_source_posn is
         True. Currently, optimal extraction is only available for MIRI LRS
         Fixed Slit data.
-
     use_source_posn : bool or None
         If True, the source and background extraction regions specified in
         the extract1d reference file will be shifted to account for the computed
         position of the source in the data.  If None (the default), this parameter
         is set to True for point sources in NIRSpec and MIRI LRS fixed slit modes.
-
     position_offset : float
         Number of pixels to offset the source and background extraction regions
         in the cross-dispersion direction.  This is intended to allow a manual
         tweak to the aperture defined via reference file; the default value is 0.0.
-
     model_nod_pair : bool
         If True, and the extraction type is 'optimal', then a negative trace
         from nod subtraction is modeled alongside the positive source during
         extraction.  Even if set to True, this will be attempted only if the
         input data has been background subtracted and the dither pattern
         indicates that only 2 nods were used.
-
     optimize_psf_location : bool
         If True, and the extraction type is 'optimal', then the placement of
         the PSF model for the source location (and negative nod, if present)
         will be iteratively optimized. This parameter is recommended if
         negative nods are modeled.
-
     smoothing_length : int or None
         If not None, the background regions (if any) will be smoothed
         with a boxcar function of this width along the dispersion
         direction.  This should be an odd integer.
-
     bkg_fit : str
         A string indicating the type of fitting to be applied to
         background values in each column (or row, if the dispersion is
         vertical). Allowed values are `poly`, `mean`, and `median`.
         Default is `None`.
-
     bkg_order : int or None
         If not None, a polynomial with order `bkg_order` will be fit to
         each column (or row, if the dispersion direction is vertical)
@@ -77,107 +69,83 @@ class Extract1dStep(Step):
         will be subtracted from the data value at that pixel.
         If both `smoothing_length` and `bkg_order` are not None, the
         boxcar smoothing will be done first.
-
     log_increment : int
         if `log_increment` is greater than 0 (the default is 50) and the
         input data are multi-integration (which can be CubeModel or
         SlitModel), a message will be written to the log with log level
         INFO every `log_increment` integrations.  This is intended to
         provide progress information when invoking the step interactively.
-
     save_profile : bool
         If True, the spatial profile containing the extraction aperture
         is saved to disk.  Ignored for IFU and NIRISS SOSS extractions.
-
     save_scene_model : bool
         If True, a model of the 2D flux as defined by the extraction aperture
         is saved to disk.  Ignored for IFU and NIRISS SOSS extractions.
-
     save_residual_image : bool
         If True, the residual image (from the input minus the scene model)
         is saved to disk.  Ignored for IFU and NIRISS SOSS extractions.
-
     center_xy : int or None
         A list of 2 pixel coordinate values at which to place the center
         of the IFU extraction aperture, overriding any centering done by the step.
         Two values, in x,y order, are used for extraction from IFU cubes.
         Default is None.
-
     ifu_autocen : bool
         Switch to turn on auto-centering for point source spectral extraction
         in IFU mode.  Default is False.
-
     bkg_sigma_clip : float
         Background sigma clipping value to use on background to remove outliers
         and maximize the quality of the 1d spectrum. Used for IFU mode only.
-
     ifu_rfcorr : bool
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
-
     ifu_set_srctype : str
         For MIRI MRS IFU data override srctype and set it to either POINT or EXTENDED.
-
     ifu_rscale : float
         For MRS IFU data a value for changing the extraction radius. The value provided is
         the number of PSF FWHMs to use for the extraction radius. Values accepted are between
         0.5 to 3.0. The default extraction size is set to 2 * FWHM. Values below 2 will result
         in a smaller radius, a value of 2 results in no change to the radius and a value above
         2 results in a larger extraction radius.
-
     ifu_covar_scale : float
         Scaling factor by which to multiply the ERR values in extracted spectra to account
         for covariance between adjacent spaxels in the IFU data cube.
-
     soss_atoca : bool, default=False
         Switch to toggle extraction of SOSS data with the ATOCA algorithm.
         WARNING: ATOCA results not fully validated, and require the photom step
         be turned off. Default is False, meaning SOSS data use box extraction.
-
     soss_threshold : float
         Threshold value above which a pixel will be included when modeling the SOSS
         trace in ATOCA. Default is 0.01.
-
     soss_n_os : int
         Oversampling factor of the underlying wavelength grid when modeling the SOSS
         trace in ATOCA. Default is 2.
-
     soss_wave_grid_in : str or SossWaveGrid or None
         Filename or SossWaveGrid containing the wavelength grid used by ATOCA
         to model each pixel valid pixel of the detector. If not given, the grid is determined
         based on an estimate of the flux (soss_estimate), the relative tolerance (soss_rtol)
         required on each pixel model and the maximum grid size (soss_max_grid_size).
-
     soss_wave_grid_out : str or None
         Filename to hold the wavelength grid calculated by ATOCA.
-
     soss_estimate : str or SpecModel or None
         Filename or SpecModel of the estimate of the target flux. The estimate must
         be a SpecModel with wavelength and flux values.
-
     soss_rtol : float
         The relative tolerance needed on a pixel model. It is used to determine the sampling
         of the soss_wave_grid when not directly given.
-
     soss_max_grid_size: int
         Maximum grid size allowed. It is used when soss_wave_grid is not provided
         to make sure the computation time or the memory used stays reasonable.
-
     soss_tikfac : float
         The regularization factor used for extraction in ATOCA. If left to default
         value of None, ATOCA will find an optimized value.
-
     soss_width : float
         Aperture width used to extract the SOSS spectrum from the decontaminated
         trace in ATOCA. Default is 40.
-
     soss_bad_pix : str
         Method used to handle bad pixels, accepts either "model" or "masking". Default
         method is "model".
-
     soss_modelname : str
         Filename for optional model output of ATOCA traces and pixel weights.
-
     """
 
     class_alias = "extract_1d"
@@ -219,91 +187,126 @@ class Extract1dStep(Step):
     soss_width = float(default=40.)  # aperture width used to extract the 1D spectrum from the de-contaminated trace.
     soss_bad_pix = option("model", "masking", default="masking")  # method used to handle bad pixels
     soss_modelname = output_file(default = None)  # Filename for optional model output of traces and pixel weights
-    """ # noqa: E501
+    """  # noqa: E501
 
-    reference_file_types = ['extract1d', 'apcorr', 'pastasoss', 'specprofile',
-                            'speckernel', 'psf']
+    reference_file_types = ["extract1d", "apcorr", "pastasoss", "specprofile", "speckernel", "psf"]
 
     def _get_extract_reference_files_by_mode(self, model, exp_type):
-        """Get extraction reference files with special handling by exposure type."""
+        """
+        Get extraction reference files with special handling by exposure type.
+
+        Parameters
+        ----------
+        model : DataModel
+            The input model.
+        exp_type : str
+            Exposure type.
+
+        Returns
+        -------
+        extract_ref : str
+            EXTRACT1D reference file or N/A.
+        apcorr_ref : str
+            APCORR reference file or N/A.
+        psf_ref : str
+            PSF reference file or N/A.
+        """
         if isinstance(model, ModelContainer):
             model = model[0]
 
         if exp_type not in extract.WFSS_EXPTYPES:
-            extract_ref = self.get_reference_file(model, 'extract1d')
+            extract_ref = self.get_reference_file(model, "extract1d")
         else:
-            extract_ref = 'N/A'
-        if extract_ref != 'N/A':
-            self.log.info(f'Using EXTRACT1D reference file {extract_ref}')
+            extract_ref = "N/A"
+        if extract_ref != "N/A":
+            self.log.info(f"Using EXTRACT1D reference file {extract_ref}")
 
         if self.apply_apcorr:
-            apcorr_ref = self.get_reference_file(model, 'apcorr')
+            apcorr_ref = self.get_reference_file(model, "apcorr")
         else:
-            apcorr_ref = 'N/A'
-        if apcorr_ref != 'N/A':
-            self.log.info(f'Using APCORR file {apcorr_ref}')
+            apcorr_ref = "N/A"
+        if apcorr_ref != "N/A":
+            self.log.info(f"Using APCORR file {apcorr_ref}")
 
         try:
-            psf_ref = self.get_reference_file(model, 'psf')
+            psf_ref = self.get_reference_file(model, "psf")
         except crds.core.exceptions.CrdsLookupError:
-            psf_ref = 'N/A'
-        if psf_ref != 'N/A':
-            self.log.info(f'Using PSF reference file {psf_ref}')
+            psf_ref = "N/A"
+        if psf_ref != "N/A":
+            self.log.info(f"Using PSF reference file {psf_ref}")
 
         return extract_ref, apcorr_ref, psf_ref
 
     def _extract_soss(self, model):
-        """Extract NIRISS SOSS spectra."""
+        """
+        Extract NIRISS SOSS spectra.
+
+        Parameters
+        ----------
+        model : DataModel
+            Input model.
+
+        Returns
+        -------
+        DataModel
+            The output spectra.
+        """
         # Set the filter configuration
-        if model.meta.instrument.filter == 'CLEAR':
-            self.log.info('Exposure is through the GR700XD + CLEAR (science).')
-            soss_filter = 'CLEAR'
+        if model.meta.instrument.filter == "CLEAR":
+            self.log.info("Exposure is through the GR700XD + CLEAR (science).")
+            soss_filter = "CLEAR"
         else:
-            self.log.error('The SOSS extraction is implemented for the CLEAR filter only. '
-                           f'Requested filter is {model.meta.instrument.filter}.')
-            self.log.error('extract_1d will be skipped.')
-            model.meta.cal_step.extract_1d = 'SKIPPED'
+            self.log.error(
+                "The SOSS extraction is implemented for the CLEAR filter only. "
+                f"Requested filter is {model.meta.instrument.filter}."
+            )
+            self.log.error("extract_1d will be skipped.")
+            model.meta.cal_step.extract_1d = "SKIPPED"
             return model
 
         # Set the subarray mode being processed
-        if model.meta.subarray.name == 'SUBSTRIP256':
-            self.log.info('Exposure is in the SUBSTRIP256 subarray.')
-            self.log.info('Traces 1 and 2 will be modelled and decontaminated before extraction.')
-            subarray = 'SUBSTRIP256'
-        elif model.meta.subarray.name == 'SUBSTRIP96':
-            self.log.info('Exposure is in the SUBSTRIP96 subarray.')
-            self.log.info('Traces of orders 1 and 2 will be modelled but only order 1 '
-                          'will be decontaminated before extraction.')
-            subarray = 'SUBSTRIP96'
+        if model.meta.subarray.name == "SUBSTRIP256":
+            self.log.info("Exposure is in the SUBSTRIP256 subarray.")
+            self.log.info("Traces 1 and 2 will be modelled and decontaminated before extraction.")
+            subarray = "SUBSTRIP256"
+        elif model.meta.subarray.name == "SUBSTRIP96":
+            self.log.info("Exposure is in the SUBSTRIP96 subarray.")
+            self.log.info(
+                "Traces of orders 1 and 2 will be modelled but only order 1 "
+                "will be decontaminated before extraction."
+            )
+            subarray = "SUBSTRIP96"
         else:
-            self.log.error('The SOSS extraction is implemented for the SUBSTRIP256 '
-                           'and SUBSTRIP96 subarrays only. Subarray is currently '
-                           f'{model.meta.subarray.name}.')
-            self.log.error('Extract1dStep will be skipped.')
-            model.meta.cal_step.extract_1d = 'SKIPPED'
+            self.log.error(
+                "The SOSS extraction is implemented for the SUBSTRIP256 "
+                "and SUBSTRIP96 subarrays only. Subarray is currently "
+                f"{model.meta.subarray.name}."
+            )
+            self.log.error("Extract1dStep will be skipped.")
+            model.meta.cal_step.extract_1d = "SKIPPED"
             return model
 
         # Load reference files.
-        pastasoss_ref_name = self.get_reference_file(model, 'pastasoss')
-        specprofile_ref_name = self.get_reference_file(model, 'specprofile')
-        speckernel_ref_name = self.get_reference_file(model, 'speckernel')
+        pastasoss_ref_name = self.get_reference_file(model, "pastasoss")
+        specprofile_ref_name = self.get_reference_file(model, "specprofile")
+        speckernel_ref_name = self.get_reference_file(model, "speckernel")
 
         # Build SOSS kwargs dictionary.
-        soss_kwargs = dict()
-        soss_kwargs['threshold'] = self.soss_threshold
-        soss_kwargs['n_os'] = self.soss_n_os
-        soss_kwargs['tikfac'] = self.soss_tikfac
-        soss_kwargs['width'] = self.soss_width
-        soss_kwargs['bad_pix'] = self.soss_bad_pix
-        soss_kwargs['subtract_background'] = self.subtract_background
-        soss_kwargs['rtol'] = self.soss_rtol
-        soss_kwargs['max_grid_size'] = self.soss_max_grid_size
-        soss_kwargs['wave_grid_in'] = self.soss_wave_grid_in
-        soss_kwargs['wave_grid_out'] = self.soss_wave_grid_out
-        soss_kwargs['estimate'] = self.soss_estimate
-        soss_kwargs['atoca'] = self.soss_atoca
+        soss_kwargs = {}
+        soss_kwargs["threshold"] = self.soss_threshold
+        soss_kwargs["n_os"] = self.soss_n_os
+        soss_kwargs["tikfac"] = self.soss_tikfac
+        soss_kwargs["width"] = self.soss_width
+        soss_kwargs["bad_pix"] = self.soss_bad_pix
+        soss_kwargs["subtract_background"] = self.subtract_background
+        soss_kwargs["rtol"] = self.soss_rtol
+        soss_kwargs["max_grid_size"] = self.soss_max_grid_size
+        soss_kwargs["wave_grid_in"] = self.soss_wave_grid_in
+        soss_kwargs["wave_grid_out"] = self.soss_wave_grid_out
+        soss_kwargs["estimate"] = self.soss_estimate
+        soss_kwargs["atoca"] = self.soss_atoca
         # Set flag to output the model and the tikhonov tests
-        soss_kwargs['model'] = True if self.soss_modelname else False
+        soss_kwargs["model"] = True if self.soss_modelname else False
 
         # Run the extraction.
         result, ref_outputs, atoca_outputs = soss_extract.run_extract1d(
@@ -313,65 +316,100 @@ class Extract1dStep(Step):
             speckernel_ref_name,
             subarray,
             soss_filter,
-            soss_kwargs)
+            soss_kwargs,
+        )
 
         # Set the step flag to complete
         if result is None:
             return None
         else:
-            result.meta.cal_step.extract_1d = 'COMPLETE'
+            result.meta.cal_step.extract_1d = "COMPLETE"
             result.meta.target.source_type = None
 
             model.close()
 
             if self.soss_modelname:
                 soss_modelname = self.make_output_path(
-                    basepath=self.soss_modelname,
-                    suffix='SossExtractModel'
+                    basepath=self.soss_modelname, suffix="SossExtractModel"
                 )
                 ref_outputs.save(soss_modelname)
 
         if self.soss_modelname:
             soss_modelname = self.make_output_path(
-                basepath=self.soss_modelname,
-                suffix='AtocaSpectra'
+                basepath=self.soss_modelname, suffix="AtocaSpectra"
             )
             atoca_outputs.save(soss_modelname)
 
         return result
 
     def _extract_ifu(self, model, exp_type, extract_ref, apcorr_ref):
-        """Extract IFU spectra from a single datamodel."""
+        """
+        Extract IFU spectra from a single datamodel.
+
+        Parameters
+        ----------
+        model : DataModel
+            Input model.
+        exp_type : str
+            Exposure type.
+        extract_ref : str
+            Path to the EXTRACT1D reference file or N/A.
+        apcorr_ref : str
+            Path to the APCORR reference file or N/A.
+
+        Returns
+        -------
+        DataModel
+            The output spectra.
+        """
         source_type = model.meta.target.source_type
-        if self.ifu_set_srctype is not None and exp_type == 'MIR_MRS':
+        if self.ifu_set_srctype is not None and exp_type == "MIR_MRS":
             source_type = self.ifu_set_srctype
             self.log.info(f"Overriding source type and setting it to {self.ifu_set_srctype}")
 
         result = ifu_extract1d(
-            model, extract_ref, source_type, self.subtract_background,
-            self.bkg_sigma_clip, apcorr_ref, self.center_xy,
-            self.ifu_autocen, self.ifu_rfcorr, self.ifu_rscale,
-            self.ifu_covar_scale
+            model,
+            extract_ref,
+            source_type,
+            self.subtract_background,
+            self.bkg_sigma_clip,
+            apcorr_ref,
+            self.center_xy,
+            self.ifu_autocen,
+            self.ifu_rfcorr,
+            self.ifu_rscale,
+            self.ifu_covar_scale,
         )
         return result
 
     def _save_intermediate(self, intermediate_model, suffix, idx):
-        """Save an intermediate output file."""
+        """
+        Save an intermediate output file.
+
+        Parameters
+        ----------
+        intermediate_model : DataModel
+            A model to save
+        suffix : str
+            Suffix to append to the output filename.
+        idx : int or None
+            Index to append to the output filename.
+        """
         if isinstance(intermediate_model, ModelContainer):
             # Save the profile with the slit name + index + suffix 'profile'
             for model in intermediate_model:
                 slit = str(model.name).lower()
                 if idx is not None:
-                    complete_suffix = f'{slit}_{idx}_{suffix}'
+                    complete_suffix = f"{slit}_{idx}_{suffix}"
                 else:
-                    complete_suffix = f'{slit}_{suffix}'
+                    complete_suffix = f"{slit}_{suffix}"
                 output_path = self.make_output_path(suffix=complete_suffix)
                 self.log.info(f"Saving {suffix} {output_path}")
                 model.save(output_path)
         else:
             # Only one profile - just use the index and suffix 'profile'
             if idx is not None:
-                complete_suffix = f'{idx}_{suffix}'
+                complete_suffix = f"{idx}_{suffix}"
             else:
                 complete_suffix = suffix
             output_path = self.make_output_path(suffix=complete_suffix)
@@ -379,43 +417,52 @@ class Extract1dStep(Step):
             intermediate_model.save(output_path)
         intermediate_model.close()
 
-    def process(self, input):
-        """Execute the step.
+    def process(self, input_data):
+        """
+        Execute the step.
 
         Parameters
         ----------
-        input: JWST data model
+        input_data : DataModel
+            The input model.
 
         Returns
         -------
-        JWST data model
+        DataModel
             This will be `input_model` if the step was skipped; otherwise,
             it will be a model containing 1-D extracted spectra.
         """
-
         # Open the input and figure out what type of model it is
-        if isinstance(input, ModelContainer):
-            input_model = input
+        if isinstance(input_data, ModelContainer):
+            input_model = input_data
         else:
-            input_model = datamodels.open(input)
+            input_model = datamodels.open(input_data)
 
-        if isinstance(input_model, (datamodels.CubeModel, datamodels.ImageModel,
-                                    datamodels.SlitModel, datamodels.IFUCubeModel,
-                                    ModelContainer, SourceModelContainer)):
+        if isinstance(
+            input_model,
+            (
+                datamodels.CubeModel,
+                datamodels.ImageModel,
+                datamodels.SlitModel,
+                datamodels.IFUCubeModel,
+                ModelContainer,
+                SourceModelContainer,
+            ),
+        ):
             # Acceptable input type, just log it
-            self.log.debug(f'Input is a {str(type(input_model))}.')
+            self.log.debug(f"Input is a {str(type(input_model))}.")
         elif isinstance(input_model, datamodels.MultiSlitModel):
             # If input is multislit, with 3D calints, skip the step
-            self.log.debug('Input is a MultiSlitModel')
+            self.log.debug("Input is a MultiSlitModel")
             if len((input_model[0]).shape) == 3:
-                self.log.warning('3D input is unsupported; step will be skipped')
-                input_model.meta.cal_step.extract_1d = 'SKIPPED'
+                self.log.warning("3D input is unsupported; step will be skipped")
+                input_model.meta.cal_step.extract_1d = "SKIPPED"
                 return input_model
         else:
-            self.log.error(f'Input is a {str(type(input_model))}, ')
-            self.log.error('which was not expected for extract_1d.')
-            self.log.error('The extract_1d step will be skipped.')
-            input_model.meta.cal_step.extract_1d = 'SKIPPED'
+            self.log.error(f"Input is a {str(type(input_model))}, ")
+            self.log.error("which was not expected for extract_1d.")
+            self.log.error("The extract_1d step will be skipped.")
+            input_model.meta.cal_step.extract_1d = "SKIPPED"
             return input_model
 
         if not isinstance(input_model, ModelContainer):
@@ -434,11 +481,12 @@ class Extract1dStep(Step):
             # into extract1d and put all results in a single product.
             input_model = [input_model]
 
-        if exp_type == 'NIS_SOSS':
+        if exp_type == "NIS_SOSS":
             # Data is NIRISS SOSS observation, use its own extraction routines
             self.log.info(
-                'Input is a NIRISS SOSS observation, the specialized SOSS '
-                'extraction (ATOCA) will be used.')
+                "Input is a NIRISS SOSS observation, the specialized SOSS "
+                "extraction (ATOCA) will be used."
+            )
 
             # There is only one input model for this mode
             model = input_model[0]
@@ -448,8 +496,9 @@ class Extract1dStep(Step):
             result = ModelContainer()
             for i, model in enumerate(input_model):
                 # Get the reference file names
-                extract_ref, apcorr_ref, psf_ref = \
-                    self._get_extract_reference_files_by_mode(model, exp_type)
+                extract_ref, apcorr_ref, psf_ref = self._get_extract_reference_files_by_mode(
+                    model, exp_type
+                )
 
                 profile = None
                 scene_model = None
@@ -480,7 +529,7 @@ class Extract1dStep(Step):
                     )
 
                 # Set the step flag to complete in each model
-                extracted.meta.cal_step.extract_1d = 'COMPLETE'
+                extracted.meta.cal_step.extract_1d = "COMPLETE"
                 result.append(extracted)
                 del extracted
 
@@ -490,15 +539,15 @@ class Extract1dStep(Step):
                 else:
                     idx = None
                 if self.save_profile and profile is not None:
-                    self._save_intermediate(profile, 'profile', idx)
+                    self._save_intermediate(profile, "profile", idx)
 
                 # Save model if needed
                 if self.save_scene_model and scene_model is not None:
-                    self._save_intermediate(scene_model, 'scene_model', idx)
+                    self._save_intermediate(scene_model, "scene_model", idx)
 
                 # Save residual if needed
                 if self.save_residual_image and residual is not None:
-                    self._save_intermediate(residual, 'residual', idx)
+                    self._save_intermediate(residual, "residual", idx)
 
             # If only one result, return the model instead of the container
             if len(result) == 1:

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -3,8 +3,12 @@ import logging
 import numpy as np
 from astropy import stats
 from astropy.stats import sigma_clipped_stats as sigclip
-from photutils.aperture import (CircularAperture, CircularAnnulus,
-                                RectangularAperture, aperture_photometry)
+from photutils.aperture import (
+    CircularAperture,
+    CircularAnnulus,
+    RectangularAperture,
+    aperture_photometry,
+)
 from photutils.detection import DAOStarFinder
 from scipy.interpolate import interp1d
 
@@ -17,90 +21,87 @@ from jwst.extract_1d.apply_apcorr import select_apcorr
 from jwst.extract_1d.extract import read_apcorr_ref
 from jwst.residual_fringe import utils as rfutils
 
-__all__ = ['ifu_extract1d']
+__all__ = ["ifu_extract1d"]
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-# This is to prevent calling offset_from_offset multiple times for
-# multi-integration data.
-OFFSET_NOT_ASSIGNED_YET = "not assigned yet"
-
 # This is intended to be larger than any possible distance (in pixels)
 # between the target and any point in the image; used by locn_from_wcs().
-HUGE_DIST = 1.e10
+HUGE_DIST = 1.0e10
 
 
-def ifu_extract1d(input_model, ref_file, source_type, subtract_background,
-                  bkg_sigma_clip, apcorr_ref_file=None, center_xy=None,
-                  ifu_autocen=False, ifu_rfcorr=False, ifu_rscale=None, ifu_covar_scale=1.0):
-    """Extract a 1-D spectrum from an IFU cube.
+def ifu_extract1d(
+    input_model,
+    ref_file,
+    source_type,
+    subtract_background,
+    bkg_sigma_clip,
+    apcorr_ref_file=None,
+    center_xy=None,
+    ifu_autocen=False,
+    ifu_rfcorr=False,
+    ifu_rscale=None,
+    ifu_covar_scale=1.0,
+):
+    """
+    Extract a 1D spectrum from an IFU cube.
 
     Parameters
     ----------
     input_model : JWST data model for an IFU cube (IFUCubeModel)
         The input model.
-
     ref_file : str
         File name for the extract1d reference file, in ASDF format.
-
-    source_type : string
+    source_type : str
         "POINT" or "EXTENDED"
-
     subtract_background : bool or None
         User supplied flag indicating whether the background should be subtracted.
         If None, the value in the extract_1d reference file will be used.
         If not None, this parameter overrides the value in the
         extract_1d reference file.
-
     bkg_sigma_clip : float
         Background sigma clipping value to use to remove noise/outliers in background
-
-    apcorr_ref_file : str or None
+    apcorr_ref_file : str or None, optional
         File name for aperture correction reference file.
-
-    center_xy : float or None
+    center_xy : float or None, optional
         A list of 2 pixel coordinate values at which to place the center
         of the extraction aperture for IFU data, overriding any centering
         done by the step.  Two values, in x,y order, are used for extraction
         from IFU cubes. Default is None.
-
-    ifu_autocen : bool
+    ifu_autocen : bool, optional
         Switch to turn on auto-centering for point source spectral extraction
         in IFU mode.  Default is False.
-
-    ifu_rfcorr : bool
+    ifu_rfcorr : bool, optional
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
-
-    ifu_rscale: float
-        For MRS IFU data a value for changing the extraction radius. The value provided is the number of PSF
-        FWHMs to use for the extraction radius. Values accepted are between 0.5 to 3.0. The
-        default extraction size is set to 2 * FWHM. Values below 2 will result in a smaller
-        radius, a value of 2 results in no change to radius and a value above 2 results in a larger
+    ifu_rscale : float, optional
+        For MRS IFU data a value for changing the extraction radius. The value
+        provided is the number of PSF FWHMs to use for the extraction radius.
+        Values accepted are between 0.5 to 3.0. The default extraction size is
+        set to 2 * FWHM. Values below 2 will result in a smaller radius, a value
+        of 2 results in no change to radius and a value above 2 results in a larger
         extraction radius.
-
-    ifu_covar_scale : float
-        Scaling factor by which to multiply the ERR values in extracted spectra to account
-        for covariance between adjacent spaxels in the IFU data cube.
+    ifu_covar_scale : float, optional
+        Scaling factor by which to multiply the ERR values in extracted spectra to
+        account for covariance between adjacent spaxels in the IFU data cube.
 
     Returns
     -------
     output_model : MultiSpecModel
         This will contain the extracted spectrum.
     """
-
     if not isinstance(input_model, datamodels.IFUCubeModel):
         log.error("Expected an IFU cube.")
-        raise RuntimeError("Expected an IFU cube.")
+        raise TypeError("Expected an IFU cube.")
 
     instrument = input_model.meta.instrument.name
     if instrument is not None:
         instrument = instrument.upper()
     if source_type is not None:
         source_type = source_type.upper()
-    if source_type != 'POINT' and source_type != 'EXTENDED':
-        default_source_type = 'EXTENDED'
+    if source_type != "POINT" and source_type != "EXTENDED":
+        default_source_type = "EXTENDED"
         log.warning(f"Source type was '{source_type}'; setting to '{default_source_type}'.")
         source_type = default_source_type
     else:
@@ -117,38 +118,52 @@ def ifu_extract1d(input_model, ref_file, source_type, subtract_background,
 
     # Add info about IFU auto-centroiding, residual fringe correction and extraction radius scale
     # to extract_params for use later
-    extract_params['ifu_autocen'] = ifu_autocen
-    extract_params['ifu_rfcorr'] = ifu_rfcorr
-    extract_params['ifu_rscale'] = ifu_rscale
-    extract_params['ifu_covar_scale'] = ifu_covar_scale
+    extract_params["ifu_autocen"] = ifu_autocen
+    extract_params["ifu_rfcorr"] = ifu_rfcorr
+    extract_params["ifu_rscale"] = ifu_rscale
+    extract_params["ifu_covar_scale"] = ifu_covar_scale
 
     # If the user supplied extraction center coords,
     # load them into extract_params for use later.
-    extract_params['x_center'] = None
-    extract_params['y_center'] = None
+    extract_params["x_center"] = None
+    extract_params["y_center"] = None
 
     if center_xy is not None:
         if len(center_xy) == 2:
-            extract_params['x_center'] = float(center_xy[0])
-            extract_params['y_center'] = float(center_xy[1])
-            log.info(f'Using user-supplied x_center={center_xy[0]}, y_center={center_xy[1]}')
+            extract_params["x_center"] = float(center_xy[0])
+            extract_params["y_center"] = float(center_xy[1])
+            log.info(f"Using user-supplied x_center={center_xy[0]}, y_center={center_xy[1]}")
         else:
-            log.warning('Incorrect number of values in center_xy; should be two.')
+            log.warning("Incorrect number of values in center_xy; should be two.")
 
     if subtract_background is not None:
         if subtract_background and source_type == "EXTENDED":
             subtract_background = False
-            log.info("Turning off background subtraction because "
-                     "the source is extended.")
-        extract_params['subtract_background'] = subtract_background
+            log.info("Turning off background subtraction because the source is extended.")
+        extract_params["subtract_background"] = subtract_background
 
-    (ra, dec, wavelength, temp_flux, f_var_poisson, f_var_rnoise, f_var_flat,
-     background, b_var_poisson, b_var_rnoise, b_var_flat, npixels, dq, npixels_bkg,
-     radius_match, x_center, y_center) = \
-        extract_ifu(input_model, source_type, extract_params)
+    (
+        ra,
+        dec,
+        wavelength,
+        temp_flux,
+        f_var_poisson,
+        f_var_rnoise,
+        f_var_flat,
+        background,
+        b_var_poisson,
+        b_var_rnoise,
+        b_var_flat,
+        npixels,
+        dq,
+        npixels_bkg,
+        radius_match,
+        x_center,
+        y_center,
+    ) = extract_ifu(input_model, source_type, extract_params)
 
-    npixels_temp = np.where(npixels > 0., npixels, 1.)
-    npixels_bkg_temp = np.where(npixels_bkg > 0., npixels_bkg, 1.)
+    npixels_temp = np.where(npixels > 0.0, npixels, 1.0)
+    npixels_bkg_temp = np.where(npixels_bkg > 0.0, npixels_bkg, 1.0)
 
     # Convert the sum to an average, for surface brightness.
     # Remember variance requires dividing by N^2
@@ -165,54 +180,56 @@ def ifu_extract1d(input_model, ref_file, source_type, subtract_background,
     del npixels_bkg_temp
 
     # If selected, apply 1d residual fringe correction to the extracted spectrum
-    if ((input_model.meta.instrument.name == 'MIRI') & (extract_params['ifu_rfcorr'] is True)):
+    if (input_model.meta.instrument.name == "MIRI") & (extract_params["ifu_rfcorr"] is True):
         log.info("Applying 1d residual fringe correction.")
         # Determine which MRS channel the spectrum is from
         thischannel = input_model.meta.instrument.channel
         # Valid single-channel values
-        validch = ['1', '2', '3', '4']
+        validch = ["1", "2", "3", "4"]
 
         # If a valid single channel, specify it in call to residual fringe code
-        if (thischannel in validch):
+        if thischannel in validch:
             channel = int(thischannel)
         else:
-            channel = ''
+            channel = ""
 
         # Embed all calls to residual fringe code in try/except blocks as the default behavior
         # if problems are encountered should be to not apply this optional step
 
         # Apply residual fringe to the flux array
         try:
-            temp_flux = rfutils.fit_residual_fringes_1d(temp_flux, wavelength, channel=channel,
-                                                        dichroic_only=False, max_amp=None)
+            temp_flux = rfutils.fit_residual_fringes_1d(
+                temp_flux, wavelength, channel=channel, dichroic_only=False, max_amp=None
+            )
         except Exception:
             log.info("Flux residual fringe correction failed- skipping.")
 
         # Apply residual fringe to the surf_bright array
         try:
-            surf_bright = rfutils.fit_residual_fringes_1d(surf_bright, wavelength, channel=channel,
-                                                          dichroic_only=False, max_amp=None)
+            surf_bright = rfutils.fit_residual_fringes_1d(
+                surf_bright, wavelength, channel=channel, dichroic_only=False, max_amp=None
+            )
         except Exception:
             log.info("Surf bright residual fringe correction failed- skipping.")
 
         # Apply residual fringe to the background array
         try:
-            background = rfutils.fit_residual_fringes_1d(background, wavelength, channel=channel,
-                                                         dichroic_only=False, max_amp=None)
+            background = rfutils.fit_residual_fringes_1d(
+                background, wavelength, channel=channel, dichroic_only=False, max_amp=None
+            )
         except Exception:
             log.info("Background residual fringe correction failed- skipping.")
 
     pixel_solid_angle = input_model.meta.photometry.pixelarea_steradians
     if pixel_solid_angle is None:
-        log.warning("Pixel area (solid angle) is not populated; "
-                    "the flux will not be correct.")
-        pixel_solid_angle = 1.
+        log.warning("Pixel area (solid angle) is not populated; the flux will not be correct.")
+        pixel_solid_angle = 1.0
 
     # Convert flux from MJy / steradian to Jy.
-    flux = temp_flux * pixel_solid_angle * 1.e6
-    f_var_poisson *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
-    f_var_rnoise *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
-    f_var_flat *= (pixel_solid_angle ** 2 * 1.e12)  # (MJy / sr)**2 --> Jy**2
+    flux = temp_flux * pixel_solid_angle * 1.0e6
+    f_var_poisson *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
+    f_var_rnoise *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
+    f_var_flat *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
     # surf_bright and background were computed above
     del temp_flux
     error = np.sqrt(f_var_poisson + f_var_rnoise + f_var_flat)
@@ -223,56 +240,72 @@ def ifu_extract1d(input_model, ref_file, source_type, subtract_background,
     # If we only used the Poisson variance array as a vehicle to pass through
     # non-differentiated errors, clear it again here so that only the total
     # errors pass out into the 1d spectra files.
-    try:
-        input_model.var_poisson
-    except AttributeError:
+    if not hasattr(input_model, "var_poisson"):
         f_var_poisson *= 0
         sb_var_poisson *= 0
         b_var_poisson *= 0
 
     # Deal with covariance in the IFU cube by multiplying 1d spectra errors by a scaling factor
-    if (extract_params['ifu_covar_scale'] != 1.0):
-        log.info("Applying ERR covariance prefactor of %g", extract_params['ifu_covar_scale'])
-        error *= extract_params['ifu_covar_scale']
-        sb_error *= extract_params['ifu_covar_scale']
-        berror *= extract_params['ifu_covar_scale']
-        f_var_poisson *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
-        f_var_rnoise *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
-        f_var_flat *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
-        sb_var_poisson *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
-        sb_var_rnoise *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
-        sb_var_flat *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
-        b_var_poisson *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
-        b_var_rnoise *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
-        b_var_flat *= extract_params['ifu_covar_scale'] * extract_params['ifu_covar_scale']
+    if extract_params["ifu_covar_scale"] != 1.0:
+        log.info("Applying ERR covariance prefactor of %g", extract_params["ifu_covar_scale"])
+        error *= extract_params["ifu_covar_scale"]
+        sb_error *= extract_params["ifu_covar_scale"]
+        berror *= extract_params["ifu_covar_scale"]
+        f_var_poisson *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
+        f_var_rnoise *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
+        f_var_flat *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
+        sb_var_poisson *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
+        sb_var_rnoise *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
+        sb_var_flat *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
+        b_var_poisson *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
+        b_var_rnoise *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
+        b_var_flat *= extract_params["ifu_covar_scale"] * extract_params["ifu_covar_scale"]
 
     otab = np.array(
         list(
-            zip(wavelength, flux, error, f_var_poisson, f_var_rnoise, f_var_flat,
-                surf_bright, sb_error, sb_var_poisson, sb_var_rnoise, sb_var_flat,
-                dq, background, berror, b_var_poisson, b_var_rnoise, b_var_flat, npixels)
+            zip(
+                wavelength,
+                flux,
+                error,
+                f_var_poisson,
+                f_var_rnoise,
+                f_var_flat,
+                surf_bright,
+                sb_error,
+                sb_var_poisson,
+                sb_var_rnoise,
+                sb_var_flat,
+                dq,
+                background,
+                berror,
+                b_var_poisson,
+                b_var_rnoise,
+                b_var_flat,
+                npixels,
+                strict=False,
+            )
         ),
-        dtype=spec_dtype
+        dtype=spec_dtype,
     )
 
     spec = datamodels.SpecModel(spec_table=otab)
     spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
-    spec.spec_table.columns['wavelength'].unit = 'um'
-    spec.spec_table.columns['flux'].unit = "Jy"
-    spec.spec_table.columns['flux_error'].unit = "Jy"
-    spec.spec_table.columns['flux_var_poisson'].unit = "Jy^2"
-    spec.spec_table.columns['flux_var_rnoise'].unit = "Jy^2"
-    spec.spec_table.columns['flux_var_flat'].unit = "Jy^2"
-    spec.spec_table.columns['surf_bright'].unit = "MJy/sr"
-    spec.spec_table.columns['sb_error'].unit = "MJy/sr"
-    spec.spec_table.columns['sb_var_poisson'].unit = "(MJy/sr)^2"
-    spec.spec_table.columns['sb_var_rnoise'].unit = "(MJy/sr)^2"
-    spec.spec_table.columns['sb_var_flat'].unit = "(MJy/sr)^2"
-    spec.spec_table.columns['background'].unit = "MJy/sr"
-    spec.spec_table.columns['bkgd_error'].unit = "MJy/sr"
-    spec.spec_table.columns['bkgd_var_poisson'].unit = "(MJy/sr)^2"
-    spec.spec_table.columns['bkgd_var_rnoise'].unit = "(MJy/sr)^2"
-    spec.spec_table.columns['bkgd_var_flat'].unit = "(MJy/sr)^2"
+    spec.spec_table.columns["wavelength"].unit = "um"
+    spec.spec_table.columns["flux"].unit = "Jy"
+    spec.spec_table.columns["flux_error"].unit = "Jy"
+    spec.spec_table.columns["flux_var_poisson"].unit = "Jy^2"
+    spec.spec_table.columns["flux_var_rnoise"].unit = "Jy^2"
+    spec.spec_table.columns["flux_var_flat"].unit = "Jy^2"
+    spec.spec_table.columns["surf_bright"].unit = "MJy/sr"
+    spec.spec_table.columns["sb_error"].unit = "MJy/sr"
+    spec.spec_table.columns["sb_var_poisson"].unit = "(MJy/sr)^2"
+    spec.spec_table.columns["sb_var_rnoise"].unit = "(MJy/sr)^2"
+    spec.spec_table.columns["sb_var_flat"].unit = "(MJy/sr)^2"
+    spec.spec_table.columns["background"].unit = "MJy/sr"
+    spec.spec_table.columns["bkgd_error"].unit = "MJy/sr"
+    spec.spec_table.columns["bkgd_var_poisson"].unit = "(MJy/sr)^2"
+    spec.spec_table.columns["bkgd_var_rnoise"].unit = "(MJy/sr)^2"
+    spec.spec_table.columns["bkgd_var_flat"].unit = "(MJy/sr)^2"
     spec.slit_ra = ra
     spec.slit_dec = dec
     if slitname is not None and slitname != "ANY":
@@ -282,25 +315,22 @@ def ifu_extract1d(input_model, ref_file, source_type, subtract_background,
     spec.extraction_x = x_center
     spec.extraction_y = y_center
 
-    if source_type == 'POINT' and apcorr_ref_file is not None and apcorr_ref_file != 'N/A':
+    if source_type == "POINT" and apcorr_ref_file is not None and apcorr_ref_file != "N/A":
         apcorr_ref_model = read_apcorr_ref(apcorr_ref_file, input_model.meta.exposure.type)
 
-        log.info('Applying Aperture correction.')
-        if instrument == 'NIRSPEC':
+        log.info("Applying Aperture correction.")
+        if instrument == "NIRSPEC":
             wl = np.median(wavelength)
         else:
             wl = wavelength.min()
 
-        apcorr = select_apcorr(input_model)(
-            input_model,
-            apcorr_ref_model,
-            location=(ra, dec, wl)
-        )
+        apcorr = select_apcorr(input_model)(input_model, apcorr_ref_model, location=(ra, dec, wl))
 
         # determine apcor function and apcor radius to use at each wavelength
         apcorr.match_wavelengths(wavelength)
 
-        # at each IFU wavelength we have the extraction radius defined by radius_match (radius size in pixels)
+        # at each IFU wavelength we have the extraction radius
+        # defined by radius_match (radius size in pixels)
         for i in range(wavelength.size):
             radius = radius_match[i]
             apcorr.find_apcorr_func(i, radius)
@@ -318,13 +348,13 @@ def ifu_extract1d(input_model, ref_file, source_type, subtract_background,
 
 
 def get_extract_parameters(ref_file, bkg_sigma_clip):
-    """Read extraction parameters for an IFU.
+    """
+    Read extraction parameters for an IFU.
 
     Parameters
     ----------
     ref_file : dict
         File name for the extract1d reference file, in ASDF format
-
     bkg_sigma_clip : float
         Background sigma clipping value to use to remove noise/outliers in background.
 
@@ -336,7 +366,7 @@ def get_extract_parameters(ref_file, bkg_sigma_clip):
     extract_params = {}
 
     # for consistency put the bkg_sigma_clip in dictionary: extract_params
-    extract_params['bkg_sigma_clip'] = bkg_sigma_clip
+    extract_params["bkg_sigma_clip"] = bkg_sigma_clip
 
     refmodel = datamodels.Extract1dIFUModel(ref_file)
     subtract_background = refmodel.meta.subtract_background
@@ -349,41 +379,38 @@ def get_extract_parameters(ref_file, bkg_sigma_clip):
     inner_bkg = data.inner_bkg
     outer_bkg = data.outer_bkg
 
-    extract_params['subtract_background'] = bool(subtract_background)
-    extract_params['method'] = method
-    extract_params['subpixels'] = subpixels
-    extract_params['wavelength'] = wavelength
-    extract_params['radius'] = radius
-    extract_params['inner_bkg'] = inner_bkg
-    extract_params['outer_bkg'] = outer_bkg
+    extract_params["subtract_background"] = bool(subtract_background)
+    extract_params["method"] = method
+    extract_params["subpixels"] = subpixels
+    extract_params["wavelength"] = wavelength
+    extract_params["radius"] = radius
+    extract_params["inner_bkg"] = inner_bkg
+    extract_params["outer_bkg"] = outer_bkg
 
     return extract_params
 
 
 def extract_ifu(input_model, source_type, extract_params):
-    """This function does the extraction.
+    """
+    Perform 1D extraction for IFU data.
 
     Parameters
     ----------
     input_model : IFUCubeModel
         The input model.
-
-    source_type : string
+    source_type : str
         "POINT" or "EXTENDED"
-
     extract_params : dict
         The extraction parameters for aperture photometry.
 
     Returns
     -------
     ra, dec : float
-        ra and dec are the right ascension and declination respectively
+        RA and Dec are the right ascension and declination respectively
         at the nominal center of the image.
-
-    wavelength : ndarray, 1-D
+    wavelength : ndarray, 1D
         The wavelength in micrometers at each plane of the IFU cube.
-
-    temp_flux : ndarray, 1-D
+    temp_flux : ndarray, 1D
         The sum of the data values in the extraction aperture minus the
         sum of the data values in the background region (scaled by the
         ratio of areas), for each plane.
@@ -392,63 +419,52 @@ def extract_ifu(input_model, source_type, extract_params):
         `npixels` (to compute the average) will give the value for the
         `surf_bright` (surface brightness) column, and multiplying by
         the solid angle of a pixel will give the flux for a point source.
-
-    f_var_poisson : ndarray, 1-D
+    f_var_poisson : ndarray, 1D
         The extracted poisson variance values to go along with the
         temp_flux array.
-
-    f_var_rnoise : ndarray, 1-D
+    f_var_rnoise : ndarray, 1D
         The extracted read noise variance values to go along with the
         temp_flux array.
-
-    f_var_flat : ndarray, 1-D
+    f_var_flat : ndarray, 1D
         The extracted flat field variance values to go along with the
         temp_flux array.
-
-    background : ndarray, 1-D
+    background : ndarray, 1D
         For point source data, the background array is the count rate that was subtracted
         from the total source data values to get `temp_flux`. This background is determined
         for annulus region. For extended source data, the background array is the sigma clipped
         extracted region.
-
-    b_var_poisson : ndarray, 1-D
+    b_var_poisson : ndarray, 1D
         The extracted poisson variance values to go along with the
         background array.
-
-    b_var_rnoise : ndarray, 1-D
+    b_var_rnoise : ndarray, 1D
         The extracted read noise variance values to go along with the
         background array.
-
-    b_var_flat : ndarray, 1-D
+    b_var_flat : ndarray, 1D
         The extracted flat field variance values to go along with the
         background array.
-
-    npixels : ndarray, 1-D, float64
+    npixels : ndarray, 1D, float64
         For each slice, this is the number of pixels that were added
         together to get `temp_flux`.
-
-    dq : ndarray, 1-D, uint32
+    dq : ndarray, 1D, uint32
         The data quality array.
-
-    npixels_bkg : ndarray, 1-D, float64
+    npixels_bkg : ndarray, 1D, float64
         For each slice, for point source data  this is the number of pixels that were added
         together to get `temp_flux` for an annulus region or for extended source
         data it is the number of pixels used to determine the background
-
-    radius_match : ndarray,1-D, float64
+    radius_match : ndarray,1D, float64
         The size of the extract radius in pixels used at each wavelength of the IFU cube
-
     x_center, y_center : float
         The x and y center of the extraction region
     """
-
     data = input_model.data
     try:
         var_poisson = input_model.var_poisson
         var_rnoise = input_model.var_rnoise
         var_flat = input_model.var_flat
     except AttributeError:
-        log.info("Input model does not break out variance information. Passing only generalized errors.")
+        log.info(
+            "Input model does not break out variance information. Passing only generalized errors."
+        )
         var_poisson = input_model.err * input_model.err
         var_rnoise = np.zeros_like(input_model.data)
         var_flat = np.zeros_like(input_model.data)
@@ -456,8 +472,8 @@ def extract_ifu(input_model, source_type, extract_params):
 
     shape = data.shape
     if len(shape) != 3:
-        log.error("Expected a 3-D IFU cube; dimension is %d.", len(shape))
-        raise RuntimeError("The IFU cube should be 3-D.")
+        log.error("Expected a 3D IFU cube; dimension is %d.", len(shape))
+        raise RuntimeError("The IFU cube should be 3D.")
 
     # We need to allocate temp_flux, background, npixels, and dq arrays
     # no matter what.  We may need to divide by npixels, so the default
@@ -482,17 +498,17 @@ def extract_ifu(input_model, source_type, extract_params):
 
     # If the user supplied extraction center coords, use them and
     # ignore all other source type and source position values
-    if extract_params['x_center'] is not None:
-        x_center = extract_params['x_center']
-        y_center = extract_params['y_center']
+    if extract_params["x_center"] is not None:
+        x_center = extract_params["x_center"]
+        y_center = extract_params["y_center"]
         locn = None
 
     # For a point source, try to compute the extraction center
     # from the source location
     elif source_type != "EXTENDED":
         # If ifu_autocen is set, try to find the source in the field using DAOphot
-        if extract_params['ifu_autocen'] is True:
-            log.info('Using auto source detection.')
+        if extract_params["ifu_autocen"] is True:
+            log.info("Using auto source detection.")
 
             # Median collapse across wavelengths, but ignore wavelengths above
             # 26 microns where MRS throughput is extremely low
@@ -505,74 +521,86 @@ def extract_ifu(input_model, source_type, extract_params):
             # Find source in the collapsed image above 3 sigma
             daofind = DAOStarFinder(fwhm=3.0, threshold=3 * cliprms)
             sources = daofind(collapse - clipmed)
-            if (sources is None):
+            if sources is None:
                 log.warning("Auto source detection failed.")
             else:
-                vals = sources['flux'].value
+                vals = sources["flux"].value
                 # Identify brightest source as the target
                 indx = np.argmax(vals)
-                x_center, y_center = sources[indx]['xcentroid'], sources[indx]['ycentroid']
+                x_center, y_center = sources[indx]["xcentroid"], sources[indx]["ycentroid"]
                 locn = None
                 log.info("Auto source detection success.")
                 log.info("Using x_center = %g, y_center = %g", x_center, y_center)
 
-        if (x_center is None):
-            log.info('Using target coordinates.')
+        if x_center is None:
+            log.info("Using target coordinates.")
             ra_targ = input_model.meta.target.ra
             dec_targ = input_model.meta.target.dec
             locn = locn_from_wcs(input_model, ra_targ, dec_targ)
 
             if locn is None or np.isnan(locn[0]):
-                log.warning("Couldn't determine source location from WCS, so "
-                            "extraction region will be centered.")
-                x_center = float(shape[-1]) / 2.
-                y_center = float(shape[-2]) / 2.
+                log.warning(
+                    "Couldn't determine source location from WCS, so "
+                    "extraction region will be centered."
+                )
+                x_center = float(shape[-1]) / 2.0
+                y_center = float(shape[-2]) / 2.0
             else:
                 (x_center, y_center) = locn
-                log.info("Using x_center = %g, y_center = %g, based on "
-                         "TARG_RA and TARG_DEC", x_center, y_center)
+                log.info(
+                    "Using x_center = %g, y_center = %g, based on TARG_RA and TARG_DEC",
+                    x_center,
+                    y_center,
+                )
 
-    method = extract_params['method']
-    subpixels = extract_params['subpixels']
-    subtract_background = extract_params['subtract_background']
+    method = extract_params["method"]
+    subpixels = extract_params["subpixels"]
+    subtract_background = extract_params["subtract_background"]
 
     width = None
     height = None
     theta = None
     # pull wavelength plane out of input data.
-    # using extract 1d wavelength, interpolate the radius, inner_bkg, outer_bkg to match input wavelength
+    # using extract 1d wavelength, interpolate the radius,
+    # inner_bkg, outer_bkg to match input wavelength
 
     # find the wavelength array of the IFU cube
-    x0 = float(shape[2]) / 2.
-    y0 = float(shape[1]) / 2.
+    x0 = float(shape[2]) / 2.0
+    y0 = float(shape[1]) / 2.0
     (ra, dec, wavelength) = get_coordinates(input_model, x0, y0)
 
     # interpolate the extraction parameters to the wavelength of the IFU cube
     radius_match = None
-    if source_type == 'POINT':
-        wave_extract = extract_params['wavelength'].flatten()
-        inner_bkg = extract_params['inner_bkg'].flatten()
-        outer_bkg = extract_params['outer_bkg'].flatten()
-        radius = extract_params['radius'].flatten()
+    if source_type == "POINT":
+        wave_extract = extract_params["wavelength"].flatten()
+        inner_bkg = extract_params["inner_bkg"].flatten()
+        outer_bkg = extract_params["outer_bkg"].flatten()
+        radius = extract_params["radius"].flatten()
 
-        if ((input_model.meta.instrument.name == 'MIRI') & (extract_params['ifu_rscale'] is not None)):
-            radius = radius * extract_params['ifu_rscale']/2.0
-            log.info("Scaling radius by factor =  %g", extract_params['ifu_rscale'] / 2.0)
+        if (input_model.meta.instrument.name == "MIRI") & (
+            extract_params["ifu_rscale"] is not None
+        ):
+            radius = radius * extract_params["ifu_rscale"] / 2.0
+            log.info("Scaling radius by factor =  %g", extract_params["ifu_rscale"] / 2.0)
 
         frad = interp1d(wave_extract, radius, bounds_error=False, fill_value="extrapolate")
         radius_match = frad(wavelength)
         # radius_match is in arc seconds - need to convert to pixels
-        # the spatial scale is the same for all wavelengths do we only need to call compute_scale once.
+        # the spatial scale is the same for all wavelengths so we
+        # only need to call compute_scale once.
 
         if locn is None:
-            locn_use = (input_model.meta.wcsinfo.crval1, input_model.meta.wcsinfo.crval2, wavelength[0])
+            locn_use = (
+                input_model.meta.wcsinfo.crval1,
+                input_model.meta.wcsinfo.crval2,
+                wavelength[0],
+            )
         else:
             locn_use = (ra_targ, dec_targ, wavelength[0])
 
         scale_degrees = compute_scale(
-            input_model.meta.wcs,
-            locn_use,
-            disp_axis=input_model.meta.wcsinfo.dispersion_direction)
+            input_model.meta.wcs, locn_use, disp_axis=input_model.meta.wcsinfo.dispersion_direction
+        )
 
         scale_arcsec = scale_degrees * 3600.00
         radius_match /= scale_arcsec
@@ -583,20 +611,20 @@ def extract_ifu(input_model, source_type, extract_params):
         fouter = interp1d(wave_extract, outer_bkg, bounds_error=False, fill_value="extrapolate")
         outer_bkg_match = fouter(wavelength) / scale_arcsec
 
-    elif source_type == 'EXTENDED':
+    elif source_type == "EXTENDED":
         # Ignore any input parameters, and extract the whole image.
         width = float(shape[-1])
         height = float(shape[-2])
-        x_center = width / 2. - 0.5
-        y_center = height / 2. - 0.5
-        theta = 0.
+        x_center = width / 2.0 - 0.5
+        y_center = height / 2.0 - 0.5
+        theta = 0.0
         subtract_background = False
-        bkg_sigma_clip = extract_params['bkg_sigma_clip']
+        bkg_sigma_clip = extract_params["bkg_sigma_clip"]
 
-    log.debug("IFU 1-D extraction parameters:")
+    log.debug("IFU 1D extraction parameters:")
     log.debug("  x_center = %s", str(x_center))
     log.debug("  y_center = %s", str(y_center))
-    if source_type == 'POINT':
+    if source_type == "POINT":
         log.debug("  method = %s", method)
         if method == "subpixel":
             log.debug("  subpixels = %s", str(subpixels))
@@ -613,21 +641,23 @@ def extract_ifu(input_model, source_type, extract_params):
     position = (x_center, y_center)
 
     # get aperture for extended it will not change with wavelength
-    if source_type == 'EXTENDED':
+    if source_type == "EXTENDED":
         aperture = RectangularAperture(position, width, height, theta)
 
     for k in range(shape[0]):  # looping over wavelength
         inner_bkg = None
         outer_bkg = None
 
-        if source_type == 'POINT':
+        if source_type == "POINT":
             radius = radius_match[k]  # this radius has been converted to pixels
             aperture = CircularAperture(position, r=radius)
             inner_bkg = inner_bkg_match[k]
             outer_bkg = outer_bkg_match[k]
-            if inner_bkg <= 0. or outer_bkg <= 0. or inner_bkg >= outer_bkg:
-                log.debug("Turning background subtraction off, due to "
-                          "the values of inner_bkg and outer_bkg.")
+            if inner_bkg <= 0.0 or outer_bkg <= 0.0 or inner_bkg >= outer_bkg:
+                log.debug(
+                    "Turning background subtraction off, due to "
+                    "the values of inner_bkg and outer_bkg."
+                )
                 subtract_background = False
 
         if subtract_background and inner_bkg is not None and outer_bkg is not None:
@@ -638,7 +668,7 @@ def extract_ifu(input_model, source_type, extract_params):
         subtract_background_plane = subtract_background
         # Compute the area of the aperture and possibly also of the annulus.
         # for each wavelength bin (taking into account empty spaxels)
-        normalization = 1.
+        normalization = 1.0
         temp_weightmap = weightmap[k, :, :]
         temp_weightmap[temp_weightmap > 1] = 1
         annulus_area = 0
@@ -648,14 +678,15 @@ def extract_ifu(input_model, source_type, extract_params):
         bmask[np.where(temp_weightmap == 0)] = True
 
         # aperture_photometry - using weight map
-        phot_table = aperture_photometry(temp_weightmap, aperture, mask=bmask,
-                                         method=method, subpixels=subpixels)
+        phot_table = aperture_photometry(
+            temp_weightmap, aperture, mask=bmask, method=method, subpixels=subpixels
+        )
 
-        aperture_area = float(phot_table['aperture_sum'][0])
+        aperture_area = float(phot_table["aperture_sum"][0])
         # if aperture_area = 0, then there is no valid data for this wavelength
         # set the DQ flag to DO_NOT_USE
         if aperture_area == 0:
-            dq[k] = dqflags.pixel['DO_NOT_USE']
+            dq[k] = dqflags.pixel["DO_NOT_USE"]
 
         # There is no valid data for this region. To prevent the code from
         # crashing set aperture_area to a nonzero value. It will have the dq flag
@@ -664,18 +695,21 @@ def extract_ifu(input_model, source_type, extract_params):
 
         if subtract_background and annulus is not None:
             # Compute the area of the annulus.
-            phot_table = aperture_photometry(temp_weightmap, annulus, mask=bmask,
-                                             method=method, subpixels=subpixels)
-            annulus_area = float(phot_table['aperture_sum'][0])
+            phot_table = aperture_photometry(
+                temp_weightmap, annulus, mask=bmask, method=method, subpixels=subpixels
+            )
+            annulus_area = float(phot_table["aperture_sum"][0])
 
             if annulus_area == 0 and annulus.area > 0:
                 annulus_area = annulus.area
 
-            if annulus_area > 0.:
+            if annulus_area > 0.0:
                 normalization = aperture_area / annulus_area
             else:
-                log.warning("Background annulus has no area, so background "
-                            f"subtraction will be turned off. {k}")
+                log.warning(
+                    "Background annulus has no area, so background "
+                    f"subtraction will be turned off. {k}"
+                )
                 subtract_background_plane = False
 
         npixels[k] = aperture_area
@@ -685,40 +719,48 @@ def extract_ifu(input_model, source_type, extract_params):
             npixels_bkg[k] = annulus_area
         # aperture_photometry - using data
 
-        phot_table = aperture_photometry(data[k, :, :], aperture, mask=bmask,
-                                         method=method, subpixels=subpixels)
-        temp_flux[k] = float(phot_table['aperture_sum'][0])
+        phot_table = aperture_photometry(
+            data[k, :, :], aperture, mask=bmask, method=method, subpixels=subpixels
+        )
+        temp_flux[k] = float(phot_table["aperture_sum"][0])
 
-        var_poisson_table = aperture_photometry(var_poisson[k, :, :], aperture, mask=bmask,
-                                                method=method, subpixels=subpixels)
-        f_var_poisson[k] = float(var_poisson_table['aperture_sum'][0])
+        var_poisson_table = aperture_photometry(
+            var_poisson[k, :, :], aperture, mask=bmask, method=method, subpixels=subpixels
+        )
+        f_var_poisson[k] = float(var_poisson_table["aperture_sum"][0])
 
-        var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], aperture, mask=bmask,
-                                               method=method, subpixels=subpixels)
-        f_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
+        var_rnoise_table = aperture_photometry(
+            var_rnoise[k, :, :], aperture, mask=bmask, method=method, subpixels=subpixels
+        )
+        f_var_rnoise[k] = float(var_rnoise_table["aperture_sum"][0])
 
-        var_flat_table = aperture_photometry(var_flat[k, :, :], aperture, mask=bmask,
-                                             method=method, subpixels=subpixels)
-        f_var_flat[k] = float(var_flat_table['aperture_sum'][0])
+        var_flat_table = aperture_photometry(
+            var_flat[k, :, :], aperture, mask=bmask, method=method, subpixels=subpixels
+        )
+        f_var_flat[k] = float(var_flat_table["aperture_sum"][0])
 
         # Point source type of data with defined annulus size
         if subtract_background_plane:
-            bkg_table = aperture_photometry(data[k, :, :], annulus, mask=bmask,
-                                            method=method, subpixels=subpixels)
-            background[k] = float(bkg_table['aperture_sum'][0])
+            bkg_table = aperture_photometry(
+                data[k, :, :], annulus, mask=bmask, method=method, subpixels=subpixels
+            )
+            background[k] = float(bkg_table["aperture_sum"][0])
             temp_flux[k] = temp_flux[k] - background[k] * normalization
 
-            var_poisson_table = aperture_photometry(var_poisson[k, :, :], annulus, mask=bmask,
-                                                    method=method, subpixels=subpixels)
-            b_var_poisson[k] = float(var_poisson_table['aperture_sum'][0])
+            var_poisson_table = aperture_photometry(
+                var_poisson[k, :, :], annulus, mask=bmask, method=method, subpixels=subpixels
+            )
+            b_var_poisson[k] = float(var_poisson_table["aperture_sum"][0])
 
-            var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], annulus, mask=bmask,
-                                                   method=method, subpixels=subpixels)
-            b_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
+            var_rnoise_table = aperture_photometry(
+                var_rnoise[k, :, :], annulus, mask=bmask, method=method, subpixels=subpixels
+            )
+            b_var_rnoise[k] = float(var_rnoise_table["aperture_sum"][0])
 
-            var_flat_table = aperture_photometry(var_flat[k, :, :], annulus, mask=bmask,
-                                                 method=method, subpixels=subpixels)
-            b_var_flat[k] = float(var_flat_table['aperture_sum'][0])
+            var_flat_table = aperture_photometry(
+                var_flat[k, :, :], annulus, mask=bmask, method=method, subpixels=subpixels
+            )
+            b_var_flat[k] = float(var_flat_table["aperture_sum"][0])
 
             # Propagate errors in background to the background-subtracted science spectrum
             f_var_poisson[k] += b_var_poisson[k] * normalization * normalization
@@ -726,7 +768,7 @@ def extract_ifu(input_model, source_type, extract_params):
             f_var_flat[k] += b_var_flat[k] * normalization * normalization
 
         # Extended source data - background determined from sigma clipping
-        if source_type == 'EXTENDED':
+        if source_type == "EXTENDED":
             bkg_data = data[k, :, :]
             # pull out the data with coverage in IFU cube. We do not want to use
             # the edge data that is zero to define the statistics on clipping
@@ -734,8 +776,9 @@ def extract_ifu(input_model, source_type, extract_params):
 
             # If there are good data, work out the statistics
             if len(bkg_stat_data) > 0:
-                bkg_mean, _, bkg_stddev = stats.sigma_clipped_stats(bkg_stat_data,
-                                                                    sigma=bkg_sigma_clip, maxiters=5)
+                bkg_mean, _, bkg_stddev = stats.sigma_clipped_stats(
+                    bkg_stat_data, sigma=bkg_sigma_clip, maxiters=5
+                )
                 low = bkg_mean - bkg_sigma_clip * bkg_stddev
                 high = bkg_mean + bkg_sigma_clip * bkg_stddev
 
@@ -745,24 +788,33 @@ def extract_ifu(input_model, source_type, extract_params):
                 # Reject data outside the valid data footprint
                 maskclip = np.logical_or(maskclip, bmask)
 
-                bkg_table = aperture_photometry(bkg_data, aperture, mask=maskclip,
-                                                method=method, subpixels=subpixels)
-                background[k] = float(bkg_table['aperture_sum'][0])
-                phot_table = aperture_photometry(temp_weightmap, aperture, mask=maskclip,
-                                                 method=method, subpixels=subpixels)
-                npixels_bkg[k] = float(phot_table['aperture_sum'][0])
+                bkg_table = aperture_photometry(
+                    bkg_data, aperture, mask=maskclip, method=method, subpixels=subpixels
+                )
+                background[k] = float(bkg_table["aperture_sum"][0])
+                phot_table = aperture_photometry(
+                    temp_weightmap, aperture, mask=maskclip, method=method, subpixels=subpixels
+                )
+                npixels_bkg[k] = float(phot_table["aperture_sum"][0])
 
-                var_poisson_table = aperture_photometry(var_poisson[k, :, :], aperture, mask=maskclip,
-                                                        method=method, subpixels=subpixels)
-                b_var_poisson[k] = float(var_poisson_table['aperture_sum'][0])
+                var_poisson_table = aperture_photometry(
+                    var_poisson[k, :, :],
+                    aperture,
+                    mask=maskclip,
+                    method=method,
+                    subpixels=subpixels,
+                )
+                b_var_poisson[k] = float(var_poisson_table["aperture_sum"][0])
 
-                var_rnoise_table = aperture_photometry(var_rnoise[k, :, :], aperture, mask=maskclip,
-                                                       method=method, subpixels=subpixels)
-                b_var_rnoise[k] = float(var_rnoise_table['aperture_sum'][0])
+                var_rnoise_table = aperture_photometry(
+                    var_rnoise[k, :, :], aperture, mask=maskclip, method=method, subpixels=subpixels
+                )
+                b_var_rnoise[k] = float(var_rnoise_table["aperture_sum"][0])
 
-                var_flat_table = aperture_photometry(var_flat[k, :, :], aperture, mask=maskclip,
-                                                     method=method, subpixels=subpixels)
-                b_var_flat[k] = float(var_flat_table['aperture_sum'][0])
+                var_flat_table = aperture_photometry(
+                    var_flat[k, :, :], aperture, mask=maskclip, method=method, subpixels=subpixels
+                )
+                b_var_flat[k] = float(var_flat_table["aperture_sum"][0])
 
         del temp_weightmap
         # done looping over wavelength bins
@@ -782,19 +834,35 @@ def extract_ifu(input_model, source_type, extract_params):
     b_var_rnoise = b_var_rnoise[nan_slc]
     b_var_flat = b_var_flat[nan_slc]
 
-    return (ra, dec, wavelength, temp_flux, f_var_poisson, f_var_rnoise, f_var_flat,
-            background, b_var_poisson, b_var_rnoise, b_var_flat,
-            npixels, dq, npixels_bkg, radius_match, x_center, y_center)
+    return (
+        ra,
+        dec,
+        wavelength,
+        temp_flux,
+        f_var_poisson,
+        f_var_rnoise,
+        f_var_flat,
+        background,
+        b_var_poisson,
+        b_var_rnoise,
+        b_var_flat,
+        npixels,
+        dq,
+        npixels_bkg,
+        radius_match,
+        x_center,
+        y_center,
+    )
 
 
 def locn_from_wcs(input_model, ra_targ, dec_targ):
-    """Get the location of the spectrum, based on the WCS.
+    """
+    Get the location of the spectrum, based on the WCS.
 
     Parameters
     ----------
     input_model : JWSTDataModel
         The input science model.
-
     ra_targ, dec_targ : float or None
         The right ascension and declination of the target (degrees).
 
@@ -805,20 +873,18 @@ def locn_from_wcs(input_model, ra_targ, dec_targ):
         ascension and declination coordinates closest to the target
         location.  The spectral extraction region should be centered here.
     """
-
     if ra_targ is None or dec_targ is None:
-        log.warning("TARG_RA and/or TARG_DEC not found; can't compute "
-                    "pixel location of target.")
+        log.warning("TARG_RA and/or TARG_DEC not found; can't compute pixel location of target.")
         locn = None
     else:
         shape = input_model.data.shape
         grid = np.indices(shape[-2:])
         z = np.zeros(shape[-2:], dtype=np.float64) + shape[0] // 2
         # The arguments are the X, Y, and Z pixel coordinates, and the
-        # output arrays will be 2-D.
+        # output arrays will be 2D.
         (ra_i, dec_i, wl) = input_model.meta.wcs(grid[1], grid[0], z)
         cart = celestial_to_cartesian(ra_i, dec_i)
-        v = celestial_to_cartesian(ra_targ, dec_targ)   # a single vector
+        v = celestial_to_cartesian(ra_targ, dec_targ)  # a single vector
         diff = cart - v
         # We want the pixel with the minimum distance from v, but the pixel
         # with the minimum value of distance squared will be the same.
@@ -827,20 +893,21 @@ def locn_from_wcs(input_model, ra_targ, dec_targ):
         dist2[..., :] = np.where(nan_mask, HUGE_DIST, dist2[..., :])
         del nan_mask
         k = np.argmin(dist2.ravel())
-        (j, i) = divmod(k, dist2.shape[1])      # y, x coordinates
+        (j, i) = divmod(k, dist2.shape[1])  # y, x coordinates
 
         if i <= 0 or j <= 0 or i >= shape[-1] - 1 or j >= shape[-2] - 1:
             log.warning("WCS implies the target is beyond the edge of the image")
             log.warning("This location will not be used")
             locn = None
         else:
-            locn = (i, j)                       # x, y coordinates
+            locn = (i, j)  # x, y coordinates
 
     return locn
 
 
 def celestial_to_cartesian(ra, dec):
-    """Convert celestial coordinates to Cartesian.
+    """
+    Convert celestial coordinates to Cartesian.
 
     Parameters
     ----------
@@ -862,29 +929,28 @@ def celestial_to_cartesian(ra, dec):
         degrees (6 hours) and declination = 0, and z is toward the north
         celestial pole.
     """
-
-    if hasattr(ra, 'shape'):
+    if hasattr(ra, "shape"):
         shape = ra.shape + (3,)
     else:
         shape = (3,)
 
     cart = np.zeros(shape, dtype=np.float64)
-    cart[..., 2] = np.sin(dec * np.pi / 180.)
-    r_xy = np.cos(dec * np.pi / 180.)
-    cart[..., 1] = r_xy * np.sin(ra * np.pi / 180.)
-    cart[..., 0] = r_xy * np.cos(ra * np.pi / 180.)
+    cart[..., 2] = np.sin(dec * np.pi / 180.0)
+    r_xy = np.cos(dec * np.pi / 180.0)
+    cart[..., 1] = r_xy * np.sin(ra * np.pi / 180.0)
+    cart[..., 0] = r_xy * np.cos(ra * np.pi / 180.0)
 
     return cart
 
 
 def get_coordinates(input_model, x0, y0):
-    """Get celestial coordinates and wavelengths.
+    """
+    Get celestial coordinates and wavelengths.
 
     Parameters
     ----------
     input_model : IFUCubeModel
         The input model.
-
     x0, y0 : float
         The pixel number at which the coordinates should be determined.
         If the extract1d reference file is JSON format, this point will be the
@@ -894,14 +960,12 @@ def get_coordinates(input_model, x0, y0):
     Returns
     -------
     ra, dec : float
-        ra and dec are the right ascension and declination respectively
+        RA and Dec are the right ascension and declination respectively
         at pixel (0, y0, x0).
-
-    wavelength : ndarray, 1-D
+    wavelength : ndarray, 1D
         The wavelength in micrometers at each pixel.
     """
-
-    if hasattr(input_model.meta, 'wcs'):
+    if hasattr(input_model.meta, "wcs"):
         wcs = input_model.meta.wcs
     else:
         log.warning("WCS function not found in input.")
@@ -920,14 +984,15 @@ def get_coordinates(input_model, x0, y0):
         ra = ra[nelem // 2]
         dec = dec[nelem // 2]
     else:
-        (ra, dec) = (0., 0.)
+        (ra, dec) = (0.0, 0.0)
         wavelength = np.arange(1, nelem + 1, dtype=np.float64)
 
     return ra, dec, wavelength
 
 
 def nans_in_wavelength(wavelength, dq):
-    """Check for NaNs in the wavelength array.
+    """
+    Check for NaNs in the wavelength array.
 
     If NaNs are found in the wavelength array, flag them in the dq array,
     and truncate the arrays at either or both ends if NaNs are found at
@@ -935,21 +1000,20 @@ def nans_in_wavelength(wavelength, dq):
 
     Parameters
     ----------
-    wavelength : ndarray, 1-D, float64
+    wavelength : ndarray, 1D, float64
         The wavelength in micrometers at each pixel.
-
-    dq : ndarray, 1-D, uint32
+    dq : ndarray, 1D, uint32
         The data quality array.
 
     Returns
     -------
-    wavelength : ndarray, 1-D, float64
-
-    dq : ndarray, 1-D, uint32
-
+    wavelength : ndarray, 1D, float64
+        Truncated wavelength array
+    dq : ndarray, 1D, uint32
+        Truncated DQ array.
     slc : slice
+        Slice used for truncation.
     """
-
     nelem = np.size(wavelength)
     slc = slice(nelem)
     if nelem == 0:
@@ -960,12 +1024,12 @@ def nans_in_wavelength(wavelength, dq):
     n_nan = nan_mask.sum(dtype=np.intp)
     if n_nan == nelem:
         log.warning("Wavelength array is all NaN!")
-        dq = np.bitwise_or(dq[:], dqflags.pixel['DO_NOT_USE'])
+        dq = np.bitwise_or(dq[:], dqflags.pixel["DO_NOT_USE"])
         return wavelength, dq, slice(0)
 
     if n_nan > 0:
         log.warning("%d NaNs in wavelength array.", n_nan)
-        dq[nan_mask] = np.bitwise_or(dq[nan_mask], dqflags.pixel['DO_NOT_USE'])
+        dq[nan_mask] = np.bitwise_or(dq[nan_mask], dqflags.pixel["DO_NOT_USE"])
         not_nan = np.logical_not(nan_mask)
         flag = np.where(not_nan)
         if len(flag[0]) > 0:
@@ -974,21 +1038,21 @@ def nans_in_wavelength(wavelength, dq):
                 slc = slice(flag[0][0], flag[0][-1] + 1)
                 wavelength = wavelength[slc]
                 dq = dq[slc]
-                log.info("Output arrays have been trimmed by %d elements",
-                         n_trimmed)
+                log.info("Output arrays have been trimmed by %d elements", n_trimmed)
 
     return wavelength, dq, slc
 
 
 def separate_target_and_background(ref):
-    """Create masks for target and background.
+    """
+    Create masks for target and background.
 
     Parameters
     ----------
-    ref : ndarray, 2-D or 3-D
+    ref : ndarray, 2D or 3D
         This is the reference image data array.  This should be the same
         shape as one plane of the science data (or the same shape as the
-        entire 3-D science data array).  A value of 1 in a pixel indicates
+        entire 3D science data array).  A value of 1 in a pixel indicates
         that the pixel should be included when computing the target
         spectrum.  A value of 0 means the pixel is not part of either the
         target or background.  A value of -1 means the pixel should be
@@ -996,25 +1060,23 @@ def separate_target_and_background(ref):
 
     Returns
     -------
-    mask_target : ndarray, 2-D or 3-D
+    mask_target : ndarray, 2D or 3D
         This is an array of the same type and shape as the reference
         image, but with values of only 0 or 1.  A value of 1 indicates
         that the corresponding pixel of the science data array should be
-        included when adding up values to make the 1-D spectrum, and a
+        included when adding up values to make the 1D spectrum, and a
         value of 0 means that it should not be included.
-
-    mask_bkg : ndarray, 2-D or 3-D, or None.
+    mask_bkg : ndarray, 2D or 3D, or None.
         This is like `mask_target` (i.e. values are 0 or 1) but for
         background regions.  A value of -1 in `mask_bkg` indicates a pixel
         that should be included as part of the background.  If there is no
         pixel in the reference image with a value of -1, `mask_bkg` will
         be set to None.
     """
+    mask_target = np.where(ref == 1.0, 1.0, 0.0)
 
-    mask_target = np.where(ref == 1., 1., 0.)
-
-    if np.any(ref == -1.):
-        mask_bkg = np.where(ref == -1., 1., 0.)
+    if np.any(ref == -1.0):
+        mask_bkg = np.where(ref == -1.0, 1.0, 0.0)
     else:
         mask_bkg = None
 
@@ -1022,16 +1084,16 @@ def separate_target_and_background(ref):
 
 
 def im_centroid(data, mask_target):
-    """Compute the mean location of the target.
+    """
+    Compute the mean location of the target.
 
     Parameters
     ----------
-    data : ndarray, 3-D
+    data : ndarray, 3D
         This is the science image data array.
-
-    mask_target : ndarray, 2-D or 3-D
+    mask_target : ndarray, 2D or 3D
         This is an array of the same type and shape as one plane of the
-        science image (or the same type and shape of the entire 3-D science
+        science image (or the same type and shape of the entire 3D science
         image), but with values of 0 or 1, where 1 indicates a pixel within
         the source.
 
@@ -1040,20 +1102,19 @@ def im_centroid(data, mask_target):
     y0, x0 : tuple of two float
         The centroid of pixels flagged as source.
     """
-
     # Collapse the science data along the dispersion direction to get a
-    # 2-D image of the IFU field of view.  Multiplying by mask_target
+    # 2D image of the IFU field of view.  Multiplying by mask_target
     # zeros out all pixels that are not regarded as part of the target
     # (or targets).
     if len(mask_target.shape) == 2:
         data_2d = data.sum(axis=0, dtype=np.float64) * mask_target
     else:
         data_2d = (data * mask_target).sum(axis=0, dtype=np.float64)
-    if data_2d.sum() == 0.:
+    if data_2d.sum() == 0.0:
         log.warning("Couldn't compute image centroid.")
         shape = data_2d.shape
-        y0 = shape[0] / 2.
-        x0 = shape[0] / 2.
+        y0 = shape[0] / 2.0
+        x0 = shape[0] / 2.0
         return y0, x0
 
     x_profile = data_2d.sum(axis=0, dtype=np.float64)
@@ -1070,11 +1131,12 @@ def im_centroid(data, mask_target):
 
 
 def shift_ref_image(mask, delta_y, delta_x, fill=0):
-    """Apply source position offset to target or background for ref image.
+    """
+    Apply source position offset to target or background for ref image.
 
     Parameters
     ----------
-    mask : ndarray, 2-D or 3-D
+    mask : ndarray, 2D or 3D
         This is either the target mask or the background mask, which was
         created from an image extract1d reference file.
         It is assumed that all pixels in the science data are good.  If
@@ -1082,11 +1144,9 @@ def shift_ref_image(mask, delta_y, delta_x, fill=0):
         quality array as the first argument, in order to obtain a shifted
         data quality array.  In this case, `fill` should be set to a
         positive value, e.g. 1.
-
     delta_y, delta_x : int
         These are the shifts to be applied to the vertical and horizontal
         axes respectively.
-
     fill : int or float
         The output array will be initialized to this value.  This should
         be 0 (the default) if `mask` is a target or background mask, but
@@ -1098,14 +1158,12 @@ def shift_ref_image(mask, delta_y, delta_x, fill=0):
     temp : ndarray, same type and shape as `mask`
         A copy of `mask`, but shifted by `delta_y` and `delta_x`.
     """
-
     if delta_x == 0 and delta_y == 0:
         return mask.copy()
 
     shape = mask.shape
     if abs(delta_y) >= shape[-2] or abs(delta_x) >= shape[-1]:
-        log.warning("Nod offset %d or %d is too large, skipping ...",
-                    delta_y, delta_x)
+        log.warning("Nod offset %d or %d is too large, skipping ...", delta_y, delta_x)
         return None
 
     if delta_y > 0:
@@ -1134,38 +1192,42 @@ def shift_ref_image(mask, delta_y, delta_x, fill=0):
     return temp
 
 
-def sigma_clip_extended_region(data, var_poisson, var_rnoise, var_flat, mask_targ, wmap, sigma_clip):
-    """ sigma clip the extraction region
+def sigma_clip_extended_region(
+    data, var_poisson, var_rnoise, var_flat, mask_targ, wmap, sigma_clip
+):
+    """
+    Sigma clip the extraction region.
 
     Parameters
     ----------
-    data : ndarray, 3-D
-        Input data array to perform extraction from
-
-    var_poisson : ndarray, 2-D
+    data : ndarray, 3D
+        Input data array to perform extraction from.
+    var_poisson : ndarray, 2D
         Poisson noise variance array to be extracted following data extraction method.
-
-    var_rnoise : ndarray, 2-D
+    var_rnoise : ndarray, 2D
         Read noise variance array to be extracted following data extraction method.
-
-    var_flat : ndarray, 2-D
+    var_flat : ndarray, 2D
         Flat noise variance array to be extracted following data extraction method.
-
-    mask_targ : ndarray, 2-D or 3-D
+    mask_targ : ndarray, 2D or 3D
         Mask of pixels defining the extended source region. A value of 1 indicated
         pixel is in the extraction region.
-    wmap : ndarray, 3-D
-       weight map for IFU
+    wmap : ndarray, 3D
+        Weight map for IFU.
     sigma_clip : float
-        outlier sigma clipping parameter
+        Outlier sigma clipping parameter.
 
     Returns
     -------
-    sigma_clip_region : ndarray, 1-D. Summed extracted region with sigma clipping for each wavelength plane
-    d_var_poisson : ndarray, 1-D. Sigma-clipped var_poisson array
-    d_var_rnoise : ndarray, 1-D. Sigma-clipped var_rnoise array
-    d_var_flat : ndarray, 1-D. Sigma-clipped var_flat array
-    n_bkg : ndarray, 1-D, sum of pixels used in sigma clipped extracted region
+    sigma_clip_region : ndarray, 1D
+        Summed extracted region with sigma clipping for each wavelength plane.
+    d_var_poisson : ndarray, 1D
+        Sigma-clipped var_poisson array.
+    d_var_rnoise : ndarray, 1D
+        Sigma-clipped var_rnoise array.
+    d_var_flat : ndarray, 1D
+        Sigma-clipped var_flat array.
+    n_bkg : ndarray, 1D
+        Sum of pixels used in sigma clipped extracted region.
     """
     shape = data.shape
     shape_ref = mask_targ.shape
@@ -1188,8 +1250,9 @@ def sigma_clip_extended_region(data, var_poisson, var_rnoise, var_flat, mask_tar
         var_flat_plane = var_flat[k, :, :]
         # pull out extract source region to determined stats on for sigma clipping
         extract_data = data_plane[extract_region == 1]
-        ext_mean, _, ext_stddev = stats.sigma_clipped_stats(extract_data,
-                                                            sigma=sigma_clip, maxiters=5)
+        ext_mean, _, ext_stddev = stats.sigma_clipped_stats(
+            extract_data, sigma=sigma_clip, maxiters=5
+        )
         low = ext_mean - sigma_clip * ext_stddev
         high = ext_mean + sigma_clip * ext_stddev
 

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -76,7 +76,7 @@ def ifu_extract1d(
         Switch to select whether or not to apply a 1d residual fringe correction
         for MIRI MRS IFU spectra.  Default is False.
     ifu_rscale : float, optional
-        For MRS IFU data a value for changing the extraction radius. The value
+        For MRS IFU data, a value for changing the extraction radius. The value
         provided is the number of PSF FWHMs to use for the extraction radius.
         Values accepted are between 0.5 to 3.0. The default extraction size is
         set to 2 * FWHM. Values below 2 will result in a smaller radius, a value

--- a/jwst/extract_1d/psf_profile.py
+++ b/jwst/extract_1d/psf_profile.py
@@ -147,7 +147,7 @@ def _profile_residual(
         The first value is used as the `extra_shift` parameter to
         `_make_cutout_profile`.  If two are provided, the second value is
         used as the `nod_offset` parameter to `_make_cutout_profile`.
-        Otherwise, no nod offset is applied.
+        If only one value is provided, no nod offset is applied.
     cutout : ndarray
         Input data array, trimmed to the bounding box.
     cutout_var : ndarray

--- a/jwst/extract_1d/psf_profile.py
+++ b/jwst/extract_1d/psf_profile.py
@@ -5,10 +5,9 @@ from scipy import ndimage, optimize
 from stdatamodels.jwst.datamodels import SpecPsfModel
 
 from jwst.extract_1d.extract1d import extract1d
-from jwst.extract_1d.source_location import (
-    middle_from_wcs, nod_pair_location, trace_from_wcs)
+from jwst.extract_1d.source_location import middle_from_wcs, nod_pair_location, trace_from_wcs
 
-__all__ = ['psf_profile']
+__all__ = ["psf_profile"]
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -17,11 +16,12 @@ HORIZONTAL = 1
 VERTICAL = 2
 """Dispersion direction, predominantly horizontal or vertical."""
 
-NOD_PAIR_PATTERN = ['ALONG-SLIT-NOD', '2-POINT-NOD']
+NOD_PAIR_PATTERN = ["ALONG-SLIT-NOD", "2-POINT-NOD"]
 
 
 def open_psf(psf_refname, exp_type):
-    """Open the PSF reference file.
+    """
+    Open the PSF reference file.
 
     Parameters
     ----------
@@ -34,9 +34,8 @@ def open_psf(psf_refname, exp_type):
     -------
     psf_model : SpecPsfModel
         Returns the EPSF model.
-
     """
-    if exp_type == 'MIR_LRS-FIXEDSLIT':
+    if exp_type == "MIR_LRS-FIXEDSLIT":
         # The information we read in from PSF file is:
         # center_col: psf_model.meta.psf.center_col
         # super sample factor: psf_model.meta.psf.subpix)
@@ -50,8 +49,9 @@ def open_psf(psf_refname, exp_type):
         try:
             psf_model = SpecPsfModel(psf_refname)
         except (ValueError, AttributeError):
-            raise NotImplementedError(f'PSF file for EXP_TYPE {exp_type} '
-                                      f'could not be read as SpecPsfModel.') from None
+            raise NotImplementedError(
+                f"PSF file for EXP_TYPE {exp_type} could not be read as SpecPsfModel."
+            ) from None
     return psf_model
 
 
@@ -59,20 +59,22 @@ def _normalize_profile(profile, dispaxis):
     """Normalize a spatial profile along the cross-dispersion axis."""
     if dispaxis == HORIZONTAL:
         psum = np.nansum(profile, axis=0)
-        nz = (psum != 0)
+        nz = psum != 0
         profile[:, nz] = profile[:, nz] / psum[nz]
         profile[:, ~nz] = 0.0
     else:
         psum = np.nansum(profile, axis=1)
-        nz = (psum != 0)
+        nz = psum != 0
         profile[nz, :] = profile[nz, :] / psum[nz, None]
         profile[~nz, :] = 0.0
     profile[~np.isfinite(profile)] = 0.0
 
 
-def _make_cutout_profile(xidx, yidx, psf_subpix, psf_data, dispaxis,
-                         extra_shift=0.0, nod_offset=None):
-    """Make a spatial profile corresponding to the data cutout.
+def _make_cutout_profile(
+    xidx, yidx, psf_subpix, psf_data, dispaxis, extra_shift=0.0, nod_offset=None
+):
+    """
+    Make a spatial profile corresponding to the data cutout.
 
     Input index values should already contain the shift to the trace location
     in the cross-dispersion direction and any wavelength shifts necessary
@@ -129,37 +131,84 @@ def _make_cutout_profile(xidx, yidx, psf_subpix, psf_data, dispaxis,
     return [sprofile, nod_profile * -1]
 
 
-def _profile_residual(shifts_to_optimize, cutout, cutout_var, xidx, yidx,
-                      psf_subpix, psf_data, dispaxis, fit_bkg=True):
-    """Residual function to minimize for optimizing trace locations."""
+def _profile_residual(
+    shifts_to_optimize, cutout, cutout_var, xidx, yidx, psf_subpix, psf_data, dispaxis, fit_bkg=True
+):
+    """
+    Residual function to minimize for optimizing trace locations.
+
+    Call `_make_cutout_profile` to generate a profile from input parameters.
+    Call `extract1d` to generate a scene model from the data and the new profile.
+    Compute a residual value from the sum of (model - cutout) ** 2 / cutout_var.
+
+    Parameters
+    ----------
+    shifts_to_optimize : list of float
+        The first value is used as the `extra_shift` parameter to
+        `_make_cutout_profile`.  If two are provided, the second value is
+        used as the `nod_offset` parameter to `_make_cutout_profile`.
+        Otherwise, no nod offset is applied.
+    cutout : ndarray
+        Input data array, trimmed to the bounding box.
+    cutout_var : ndarray
+        Input variance, matching the data array, used for weighting the
+        output residuals.
+    xidx : ndarray of float
+        Index array for x values.
+    yidx : ndarray of float
+        Index array for y values.
+    psf_subpix : float
+        Scaling factor for pixel size in the PSF data.
+    psf_data : ndarray of float
+        2D PSF model.
+    dispaxis : int
+        Dispersion axis.
+    fit_bkg : bool, optional
+        If True, background subtraction is performed during extraction.
+
+    Returns
+    -------
+    float
+        The residual value to minimize.
+    """
     if len(shifts_to_optimize) > 1:
         nod_offset = shifts_to_optimize[1]
     else:
         nod_offset = None
-    sprofiles = _make_cutout_profile(xidx, yidx, psf_subpix, psf_data, dispaxis,
-                                     extra_shift=shifts_to_optimize[0],
-                                     nod_offset=nod_offset)
-    extract_kwargs = {'extraction_type': 'optimal',
-                      'fit_bkg': fit_bkg,
-                      'bkg_fit_type': 'poly',
-                      'bkg_order': 0}
+    sprofiles = _make_cutout_profile(
+        xidx,
+        yidx,
+        psf_subpix,
+        psf_data,
+        dispaxis,
+        extra_shift=shifts_to_optimize[0],
+        nod_offset=nod_offset,
+    )
+    extract_kwargs = {
+        "extraction_type": "optimal",
+        "fit_bkg": fit_bkg,
+        "bkg_fit_type": "poly",
+        "bkg_order": 0,
+    }
     if dispaxis == HORIZONTAL:
         empty_var = np.zeros_like(cutout)
-        result = extract1d(cutout, sprofiles, cutout_var, empty_var, empty_var,
-                           **extract_kwargs)
+        result = extract1d(cutout, sprofiles, cutout_var, empty_var, empty_var, **extract_kwargs)
         model = result[-1]
     else:
         sprofiles = [profile.T for profile in sprofiles]
         empty_var = np.zeros_like(cutout.T)
-        result = extract1d(cutout.T, sprofiles, cutout_var.T, empty_var, empty_var,
-                           **extract_kwargs)
+        result = extract1d(
+            cutout.T, sprofiles, cutout_var.T, empty_var, empty_var, **extract_kwargs
+        )
         model = result[-1].T
     return np.nansum((model - cutout) ** 2 / cutout_var)
 
 
-def psf_profile(input_model, trace, wl_array, psf_ref_name,
-                optimize_shifts=True, model_nod_pair=True):
-    """Create a spatial profile from a PSF reference.
+def psf_profile(
+    input_model, trace, wl_array, psf_ref_name, optimize_shifts=True, model_nod_pair=True
+):
+    """
+    Create a spatial profile from a PSF reference.
 
     Provides PSF-based profiles for point sources in slit-like data containing
     one positive trace and, optionally, one negative trace resulting from nod
@@ -235,24 +284,27 @@ def psf_profile(input_model, trace, wl_array, psf_ref_name,
     psf_wave = psf_model.wave
     sort_idx = np.argsort(psf_wave)
     valid_wave = np.isfinite(psf_wave[sort_idx])
-    wave_idx = np.interp(cutout_wl, psf_wave[sort_idx][valid_wave], sort_idx[valid_wave],
-                         left=np.nan, right=np.nan)
+    wave_idx = np.interp(
+        cutout_wl, psf_wave[sort_idx][valid_wave], sort_idx[valid_wave], left=np.nan, right=np.nan
+    )
 
     if trace is None:
         # Don't try to model a negative pair if we don't have a trace to start
         if model_nod_pair:
-            log.warning('Cannot model a negative nod without position information')
+            log.warning("Cannot model a negative nod without position information")
             model_nod_pair = False
 
         # Set the location to the middle of the cross-dispersion
         # all the way across the array
         location = middle_xdisp
         if dispaxis == HORIZONTAL:
-            trace = trace_from_wcs(exp_type, data_shape, bbox, wcs,
-                                   middle_disp, middle_xdisp, dispaxis)
+            trace = trace_from_wcs(
+                exp_type, data_shape, bbox, wcs, middle_disp, middle_xdisp, dispaxis
+            )
         else:
-            trace = trace_from_wcs(exp_type, data_shape, bbox, wcs,
-                                   middle_xdisp, middle_disp, dispaxis)
+            trace = trace_from_wcs(
+                exp_type, data_shape, bbox, wcs, middle_xdisp, middle_disp, dispaxis
+            )
 
     else:
         # Nominal location from the middle dispersion point
@@ -267,29 +319,28 @@ def psf_profile(input_model, trace, wl_array, psf_ref_name,
     # Check if we need to add a negative nod pair trace
     nod_offset = None
     if model_nod_pair:
-        nod_subtracted = str(input_model.meta.cal_step.back_sub) == 'COMPLETE'
+        nod_subtracted = str(input_model.meta.cal_step.back_sub) == "COMPLETE"
         pattype_ok = str(input_model.meta.dither.primary_type) in NOD_PAIR_PATTERN
         if not nod_subtracted:
-            log.info('Input data was not nod-subtracted. '
-                     'A negative trace will not be modeled.')
+            log.info("Input data was not nod-subtracted. A negative trace will not be modeled.")
         elif not pattype_ok:
-            log.info('Input data was not a two-point nod. '
-                     'A negative trace will not be modeled.')
+            log.info("Input data was not a two-point nod. A negative trace will not be modeled.")
         else:
             nod_center = nod_pair_location(input_model, middle_wl)
             if np.isnan(nod_center) or (np.abs(location - nod_center) < 2):
-                log.warning('Nod center could not be estimated from the WCS.')
-                log.warning('The negative nod will not be modeled.')
+                log.warning("Nod center could not be estimated from the WCS.")
+                log.warning("The negative nod will not be modeled.")
             else:
                 if not optimize_shifts:
-                    log.warning('Negative nod locations are currently approximations only.')
-                    log.warning('PSF location optimization is recommended when '
-                                'negative nods are modeled.')
+                    log.warning("Negative nod locations are currently approximations only.")
+                    log.warning(
+                        "PSF location optimization is recommended when negative nods are modeled."
+                    )
                 nod_offset = location - nod_center
 
     # Get an index grid for the data cutout
     cutout_shape = cutout.shape
-    _y, _x = np.mgrid[:cutout_shape[0], :cutout_shape[1]]
+    _y, _x = np.mgrid[: cutout_shape[0], : cutout_shape[1]]
 
     # Scale the trace location to the subsampled psf and
     # add the wavelength and spatial shifts to the coordinates to map to
@@ -307,30 +358,42 @@ def psf_profile(input_model, trace, wl_array, psf_ref_name,
     # If desired, add additional spatial shifts to the starting locations of
     # the primary trace (and negative nod pair trace if necessary)
     if optimize_shifts:
-        log.info('Optimizing trace locations')
+        log.info("Optimizing trace locations")
         if nod_offset is None:
-            extra_shift, = optimize.minimize(
-                _profile_residual, [0.0],
-                (cutout, cutout_var, xidx, yidx,
-                 psf_subpix, psf_model.data, dispaxis), method='Nelder-Mead').x
+            (extra_shift,) = optimize.minimize(
+                _profile_residual,
+                [0.0],
+                (cutout, cutout_var, xidx, yidx, psf_subpix, psf_model.data, dispaxis),
+                method="Nelder-Mead",
+            ).x
         else:
             extra_shift, nod_offset = optimize.minimize(
-                _profile_residual, [0.0, nod_offset],
-                (cutout, cutout_var, xidx, yidx,
-                 psf_subpix, psf_model.data, dispaxis), method='Nelder-Mead').x
+                _profile_residual,
+                [0.0, nod_offset],
+                (cutout, cutout_var, xidx, yidx, psf_subpix, psf_model.data, dispaxis),
+                method="Nelder-Mead",
+            ).x
         location -= extra_shift
     else:
         extra_shift = 0.0
 
-    log.info(f'Centering profile on spectrum at {location:.2f}, wavelength {middle_wl:.2f}')
+    log.info(f"Centering profile on spectrum at {location:.2f}, wavelength {middle_wl:.2f}")
     if nod_offset is not None:
-        log.info(f'Also modeling a negative trace at {location - nod_offset:.2f} '
-                 f'(offset: {nod_offset:.2f})')
+        log.info(
+            f"Also modeling a negative trace at {location - nod_offset:.2f} "
+            f"(offset: {nod_offset:.2f})"
+        )
 
     # Make a spatial profile from the shifted PSF data
-    sprofiles = _make_cutout_profile(xidx, yidx, psf_subpix, psf_model.data,
-                                     dispaxis, extra_shift=extra_shift,
-                                     nod_offset=nod_offset)
+    sprofiles = _make_cutout_profile(
+        xidx,
+        yidx,
+        psf_subpix,
+        psf_model.data,
+        dispaxis,
+        extra_shift=extra_shift,
+        nod_offset=nod_offset,
+    )
 
     # Make the output profile, matching the input data
     output_y = _y + y0

--- a/jwst/extract_1d/spec_wcs.py
+++ b/jwst/extract_1d/spec_wcs.py
@@ -1,10 +1,9 @@
 import logging
-import numpy as np
 
+import numpy as np
 from astropy.modeling.models import Mapping, Const1D, Tabular1D
 from astropy import units as u
 from astropy import coordinates as coord
-
 from gwcs.wcs import WCS
 from gwcs import coordinate_frames as cf
 
@@ -13,61 +12,58 @@ log.setLevel(logging.DEBUG)
 
 
 def create_spectral_wcs(ra, dec, wavelength):
-    """Assign a WCS for sky coordinates and a table of wavelengths
+    """
+    Assign a WCS for sky coordinates and a table of wavelengths.
 
     Parameters
     ----------
-    ra: float
+    ra : float
         The right ascension (in degrees) at the nominal location of the
         entrance aperture (slit).
-
-    dec: float
+    dec : float
         The declination (in degrees) at the nominal location of the
         entrance aperture.
-
-    wavelength: ndarray
+    wavelength : ndarray
         The wavelength in microns at each pixel of the extracted spectrum.
 
-    Returns:
-    --------
+    Returns
+    -------
     wcs: a gwcs.wcs.WCS object
         This takes a float or sequence of float and returns a tuple of
         the right ascension, declination, and wavelength (or sequence of
         wavelengths) at the pixel(s) specified by the input argument.
     """
+    input_frame = cf.CoordinateFrame(
+        naxes=1, axes_type=("SPATIAL",), axes_order=(0,), unit=(u.pix,), name="pixel_frame"
+    )
 
-    input_frame = cf.CoordinateFrame(naxes=1, axes_type=("SPATIAL",),
-                                     axes_order=(0,), unit=(u.pix,),
-                                     name="pixel_frame")
-
-    sky = cf.CelestialFrame(name='sky', axes_order=(0, 1),
-                            reference_frame=coord.ICRS())
-    spec = cf.SpectralFrame(name='spectral', axes_order=(2,), unit=(u.micron,),
-                            axes_names=('wavelength',))
-    world = cf.CompositeFrame([sky, spec], name='world')
+    sky = cf.CelestialFrame(name="sky", axes_order=(0, 1), reference_frame=coord.ICRS())
+    spec = cf.SpectralFrame(
+        name="spectral", axes_order=(2,), unit=(u.micron,), axes_names=("wavelength",)
+    )
+    world = cf.CompositeFrame([sky, spec], name="world")
 
     pixel = np.arange(len(wavelength), dtype=float)
-    tab = Mapping((0, 0, 0)) | \
-        Const1D(ra) & Const1D(dec) & Tabular1D(points=pixel,
-                                               lookup_table=wavelength,
-                                               bounds_error=False,
-                                               fill_value=None)
+    tab = Mapping((0, 0, 0)) | Const1D(ra) & Const1D(dec) & Tabular1D(
+        points=pixel, lookup_table=wavelength, bounds_error=False, fill_value=None
+    )
     tab.name = "pixel_to_world"
 
     if all(np.diff(wavelength) > 0):
-        tab.inverse = Mapping((2,)) | Tabular1D(points=wavelength,
-                                                lookup_table=pixel,
-                                                bounds_error=False,
-                                                )
+        tab.inverse = Mapping((2,)) | Tabular1D(
+            points=wavelength,
+            lookup_table=pixel,
+            bounds_error=False,
+        )
     elif all(np.diff(wavelength) < 0):
-        tab.inverse = Mapping((2,)) | Tabular1D(points=wavelength[::-1],
-                                                lookup_table=pixel[::-1],
-                                                bounds_error=False,
-                                                )
+        tab.inverse = Mapping((2,)) | Tabular1D(
+            points=wavelength[::-1],
+            lookup_table=pixel[::-1],
+            bounds_error=False,
+        )
     else:
         log.warning("Wavelengths are not strictly monotonic, inverse transform is not set")
 
-    pipeline = [(input_frame, tab),
-                (world, None)]
+    pipeline = [(input_frame, tab), (world, None)]
 
     return WCS(pipeline)

--- a/jwst/extract_1d/tests/conftest.py
+++ b/jwst/extract_1d/tests/conftest.py
@@ -10,11 +10,24 @@ from jwst.exp_to_source import multislit_to_container
 
 @pytest.fixture()
 def simple_wcs():
+    """
+    Mock a horizontal dispersion WCS with a simple callable function.
+
+    Some other expected WCS attributes are also mocked with placeholder values:
+       - bounding_box
+       - get_transform
+       - available_frames
+
+    Returns
+    -------
+    callable
+        A function that will return mock values for RA, Dec, wave,
+        given x and y coordinates.
+    """
     shape = (50, 50)
     xcenter = shape[1] // 2.0
 
-    def simple_wcs_function(x, y):
-        """ Simple WCS for testing """
+    def simple_wcs_function(x, y):  # noqa: ARG001
         crpix1 = xcenter
         crpix3 = 1.0
         cdelt1 = 0.1
@@ -35,8 +48,8 @@ def simple_wcs():
     simple_wcs_function.bounding_box = wcs_bbox_from_shape(shape)
 
     # Define a simple transform
-    def get_transform(*args, **kwargs):
-        def return_results(*args, **kwargs):
+    def get_transform(*args, **kwargs):  # noqa: ARG001
+        def return_results(*args, **kwargs):  # noqa: ARG001
             if len(args) == 2:
                 try:
                     zeros = np.zeros(args[0].shape)
@@ -54,6 +67,7 @@ def simple_wcs():
                     pix = 0
                     trace = 1.0
                 return pix, trace
+
         return return_results
 
     simple_wcs_function.get_transform = get_transform
@@ -64,11 +78,25 @@ def simple_wcs():
 
 @pytest.fixture()
 def simple_wcs_transpose():
+    """
+    Mock a vertical dispersion WCS with a simple callable function.
+
+    Some other expected WCS attributes are also mocked with placeholder values:
+       - bounding_box
+       - get_transform
+       - backward_transform
+       - available_frames
+
+    Returns
+    -------
+    callable
+        A function that will return mock values for RA, Dec, wave,
+        given x and y coordinates.
+    """
     shape = (50, 50)
     ycenter = shape[0] // 2.0
 
-    def simple_wcs_function(x, y):
-        """ Simple WCS for testing """
+    def simple_wcs_function(x, y):  # noqa: ARG001
         crpix2 = ycenter
         crpix3 = 1.0
         cdelt1 = 0.1
@@ -89,7 +117,7 @@ def simple_wcs_transpose():
     simple_wcs_function.bounding_box = wcs_bbox_from_shape(shape)
 
     # Mock a simple backward transform
-    def backward_transform(*args, **kwargs):
+    def backward_transform(*args, **kwargs):  # noqa: ARG001
         try:
             nx = len(args[0])
             pix = np.arange(nx)
@@ -100,9 +128,10 @@ def simple_wcs_transpose():
         return trace, pix
 
     # Mock a simple forward transform, for mocking a v2v3 frame
-    def get_transform(*args, **kwargs):
-        def return_results(*args, **kwargs):
+    def get_transform(*args, **kwargs):  # noqa: ARG001
+        def return_results(*args, **kwargs):  # noqa: ARG001
             return 1.0, 1.0, 1.0
+
         return return_results
 
     simple_wcs_function.get_transform = get_transform
@@ -114,11 +143,21 @@ def simple_wcs_transpose():
 
 @pytest.fixture()
 def simple_wcs_ifu():
+    """
+    Mock an IFU WCS with a simple callable function.
+
+    The bounding_box attribute is also mocked with a placeholder value.
+
+    Returns
+    -------
+    callable
+        A function that will return mock values for RA, Dec, wave,
+        given x and y coordinates.
+    """
     shape = (10, 50, 50)
     xcenter = shape[1] // 2.0
 
-    def simple_wcs_function(x, y, z):
-        """ Simple WCS for testing """
+    def simple_wcs_function(x, y, z):  # noqa: ARG001
         crpix1 = xcenter
         crpix3 = 1.0
         cdelt1 = 0.1
@@ -142,18 +181,26 @@ def simple_wcs_ifu():
 
 @pytest.fixture()
 def mock_nirspec_fs_one_slit(simple_wcs):
+    """
+    Mock one slit in NIRSpec FS mode.
+
+    Yields
+    ------
+    SlitModel
+        The mock model.
+    """
     model = dm.SlitModel()
-    model.meta.instrument.name = 'NIRSPEC'
-    model.meta.instrument.detector = 'NRS1'
-    model.meta.instrument.filter = 'F290LP'
-    model.meta.instrument.grating = 'G395H'
-    model.meta.observation.date = '2023-07-22'
-    model.meta.observation.time = '06:24:45.569'
-    model.meta.instrument.fixed_slit = 'S200A1'
+    model.meta.instrument.name = "NIRSPEC"
+    model.meta.instrument.detector = "NRS1"
+    model.meta.instrument.filter = "F290LP"
+    model.meta.instrument.grating = "G395H"
+    model.meta.observation.date = "2023-07-22"
+    model.meta.observation.time = "06:24:45.569"
+    model.meta.instrument.fixed_slit = "S200A1"
     model.meta.exposure.nints = 1
-    model.meta.exposure.type = 'NRS_FIXEDSLIT'
-    model.meta.subarray.name = 'ALLSLITS'
-    model.source_type = 'EXTENDED'
+    model.meta.exposure.type = "NRS_FIXEDSLIT"
+    model.meta.subarray.name = "ALLSLITS"
+    model.source_type = "EXTENDED"
 
     model.meta.wcsinfo.dispersion_direction = 1
     model.meta.wcs = simple_wcs
@@ -168,12 +215,20 @@ def mock_nirspec_fs_one_slit(simple_wcs):
 
 @pytest.fixture()
 def mock_nirspec_mos(mock_nirspec_fs_one_slit):
+    """
+    Mock three slits in NIRSpec MOS mode.
+
+    Yields
+    ------
+    MultiSlitModel
+        The mock model.
+    """
     model = dm.MultiSlitModel()
-    model.meta.instrument.name = 'NIRSPEC'
-    model.meta.instrument.detector = 'NRS1'
-    model.meta.observation.date = '2023-07-22'
-    model.meta.observation.time = '06:24:45.569'
-    model.meta.exposure.type = 'NRS_MSASPEC'
+    model.meta.instrument.name = "NIRSPEC"
+    model.meta.instrument.detector = "NRS1"
+    model.meta.observation.date = "2023-07-22"
+    model.meta.observation.time = "06:24:45.569"
+    model.meta.exposure.type = "NRS_MSASPEC"
     model.meta.exposure.nints = 1
 
     nslit = 3
@@ -188,21 +243,29 @@ def mock_nirspec_mos(mock_nirspec_fs_one_slit):
 
 @pytest.fixture()
 def mock_nirspec_bots(simple_wcs):
+    """
+    Mock a single slit with 10 integrations in NIRSpec BOTS mode.
+
+    Yields
+    ------
+    CubeModel
+        The mock model.
+    """
     model = dm.CubeModel()
-    model.meta.instrument.name = 'NIRSPEC'
-    model.meta.instrument.detector = 'NRS1'
-    model.meta.instrument.filter = 'F290LP'
-    model.meta.instrument.grating = 'G395H'
-    model.meta.observation.date = '2022-05-30'
-    model.meta.observation.time = '01:03:16.369'
-    model.meta.instrument.fixed_slit = 'S1600A1'
-    model.meta.exposure.type = 'NRS_BRIGHTOBJ'
-    model.meta.subarray.name = 'SUB2048'
+    model.meta.instrument.name = "NIRSPEC"
+    model.meta.instrument.detector = "NRS1"
+    model.meta.instrument.filter = "F290LP"
+    model.meta.instrument.grating = "G395H"
+    model.meta.observation.date = "2022-05-30"
+    model.meta.observation.time = "01:03:16.369"
+    model.meta.instrument.fixed_slit = "S1600A1"
+    model.meta.exposure.type = "NRS_BRIGHTOBJ"
+    model.meta.subarray.name = "SUB2048"
     model.meta.exposure.nints = 10
     model.meta.visit.tsovisit = True
 
-    model.name = 'S1600A1'
-    model.meta.target.source_type = 'POINT'
+    model.name = "S1600A1"
+    model.meta.target.source_type = "POINT"
     model.meta.wcsinfo.dispersion_direction = 1
     model.meta.wcs = simple_wcs
 
@@ -213,25 +276,110 @@ def mock_nirspec_bots(simple_wcs):
 
     # Add an int_times table
     integrations = [
-        (1, 59729.04367729, 59729.04378181, 59729.04388632, 59729.04731706, 59729.04742158, 59729.04752609),
-        (2, 59729.04389677, 59729.04400128, 59729.04410579, 59729.04753654, 59729.04764105, 59729.04774557),
-        (3, 59729.04411625, 59729.04422076, 59729.04432527, 59729.04775602, 59729.04786053, 59729.04796504),
-        (4, 59729.04433572, 59729.04444023, 59729.04454475, 59729.04797549, 59729.04808001, 59729.04818452),
-        (5, 59729.0445552, 59729.04465971, 59729.04476422, 59729.04819497, 59729.04829948, 59729.048404),
-        (6, 59729.04477467, 59729.04487918, 59729.0449837, 59729.04841445, 59729.04851896, 59729.04862347),
-        (7, 59729.04499415, 59729.04509866, 59729.04520317, 59729.04863392, 59729.04873844, 59729.04884295),
-        (8, 59729.04521362, 59729.04531813, 59729.04542265, 59729.0488534 , 59729.04895791, 59729.04906242),
-        (9, 59729.0454331, 59729.04553761, 59729.04564212, 59729.04907288, 59729.04917739, 59729.0492819),
-        (10, 59729.04565257, 59729.04575709, 59729.0458616, 59729.04929235, 59729.04939686, 59729.04950138),
+        (
+            1,
+            59729.04367729,
+            59729.04378181,
+            59729.04388632,
+            59729.04731706,
+            59729.04742158,
+            59729.04752609,
+        ),
+        (
+            2,
+            59729.04389677,
+            59729.04400128,
+            59729.04410579,
+            59729.04753654,
+            59729.04764105,
+            59729.04774557,
+        ),
+        (
+            3,
+            59729.04411625,
+            59729.04422076,
+            59729.04432527,
+            59729.04775602,
+            59729.04786053,
+            59729.04796504,
+        ),
+        (
+            4,
+            59729.04433572,
+            59729.04444023,
+            59729.04454475,
+            59729.04797549,
+            59729.04808001,
+            59729.04818452,
+        ),
+        (
+            5,
+            59729.0445552,
+            59729.04465971,
+            59729.04476422,
+            59729.04819497,
+            59729.04829948,
+            59729.048404,
+        ),
+        (
+            6,
+            59729.04477467,
+            59729.04487918,
+            59729.0449837,
+            59729.04841445,
+            59729.04851896,
+            59729.04862347,
+        ),
+        (
+            7,
+            59729.04499415,
+            59729.04509866,
+            59729.04520317,
+            59729.04863392,
+            59729.04873844,
+            59729.04884295,
+        ),
+        (
+            8,
+            59729.04521362,
+            59729.04531813,
+            59729.04542265,
+            59729.0488534,
+            59729.04895791,
+            59729.04906242,
+        ),
+        (
+            9,
+            59729.0454331,
+            59729.04553761,
+            59729.04564212,
+            59729.04907288,
+            59729.04917739,
+            59729.0492819,
+        ),
+        (
+            10,
+            59729.04565257,
+            59729.04575709,
+            59729.0458616,
+            59729.04929235,
+            59729.04939686,
+            59729.04950138,
+        ),
     ]
 
-    integration_table = np.array(integrations, dtype=[('integration_number', 'i4'),
-                                                      ('int_start_MJD_UTC', 'f8'),
-                                                      ('int_mid_MJD_UTC', 'f8'),
-                                                      ('int_end_MJD_UTC', 'f8'),
-                                                      ('int_start_BJD_TDB', 'f8'),
-                                                      ('int_mid_BJD_TDB', 'f8'),
-                                                      ('int_end_BJD_TDB', 'f8')])
+    integration_table = np.array(
+        integrations,
+        dtype=[
+            ("integration_number", "i4"),
+            ("int_start_MJD_UTC", "f8"),
+            ("int_mid_MJD_UTC", "f8"),
+            ("int_end_MJD_UTC", "f8"),
+            ("int_start_BJD_TDB", "f8"),
+            ("int_mid_BJD_TDB", "f8"),
+            ("int_end_BJD_TDB", "f8"),
+        ],
+    )
     model.int_times = integration_table
 
     yield model
@@ -240,16 +388,24 @@ def mock_nirspec_bots(simple_wcs):
 
 @pytest.fixture()
 def mock_miri_lrs_fs(simple_wcs_transpose):
+    """
+    Mock a spectral image in MIRI LRS FS mode.
+
+    Yields
+    ------
+    ImageModel
+        The mock model.
+    """
     model = dm.ImageModel()
-    model.meta.instrument.name = 'MIRI'
-    model.meta.instrument.detector = 'MIRIMAGE'
-    model.meta.instrument.filter = 'P750L'
-    model.meta.observation.date = '2023-07-22'
-    model.meta.observation.time = '06:24:45.569'
+    model.meta.instrument.name = "MIRI"
+    model.meta.instrument.detector = "MIRIMAGE"
+    model.meta.instrument.filter = "P750L"
+    model.meta.observation.date = "2023-07-22"
+    model.meta.observation.time = "06:24:45.569"
     model.meta.exposure.nints = 1
-    model.meta.exposure.type = 'MIR_LRS-FIXEDSLIT'
-    model.meta.subarray.name = 'FULL'
-    model.meta.target.source_type = 'EXTENDED'
+    model.meta.exposure.type = "MIR_LRS-FIXEDSLIT"
+    model.meta.subarray.name = "FULL"
+    model.meta.target.source_type = "EXTENDED"
     model.meta.dither.dithered_ra = 45.0
     model.meta.dither.dithered_ra = 45.0
 
@@ -266,12 +422,20 @@ def mock_miri_lrs_fs(simple_wcs_transpose):
 
 @pytest.fixture()
 def mock_miri_ifu(simple_wcs_ifu):
+    """
+    Mock an IFU cube in MIRI MRS mode.
+
+    Yields
+    ------
+    IFUCubeModel
+        The mock model.
+    """
     model = dm.IFUCubeModel()
-    model.meta.instrument.name = 'MIRI'
-    model.meta.instrument.detector = 'MIRIFULONG'
-    model.meta.observation.date = '2023-07-22'
-    model.meta.observation.time = '06:24:45.569'
-    model.meta.exposure.type = 'MIR_MRS'
+    model.meta.instrument.name = "MIRI"
+    model.meta.instrument.detector = "MIRIFULONG"
+    model.meta.observation.date = "2023-07-22"
+    model.meta.observation.time = "06:24:45.569"
+    model.meta.exposure.type = "MIR_MRS"
 
     model.meta.wcsinfo.dispersion_direction = 2
     model.meta.photometry.pixelarea_steradians = 1.0
@@ -288,21 +452,29 @@ def mock_miri_ifu(simple_wcs_ifu):
 
 @pytest.fixture()
 def mock_niriss_wfss_l3(mock_nirspec_fs_one_slit):
+    """
+    Mock 3 slits in NIRISS WFSS mode, level 3 style.
+
+    Yields
+    ------
+    MultiSlitModel
+        The mock model.
+    """
     model = dm.MultiSlitModel()
-    model.meta.instrument.name = 'NIRISS'
-    model.meta.instrument.detector = 'NIS'
-    model.meta.observation.date = '2023-07-22'
-    model.meta.observation.time = '06:24:45.569'
-    model.meta.exposure.type = 'NIS_WFSS'
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.detector = "NIS"
+    model.meta.observation.date = "2023-07-22"
+    model.meta.observation.time = "06:24:45.569"
+    model.meta.exposure.type = "NIS_WFSS"
 
     nslit = 3
     for i in range(nslit):
         slit = mock_nirspec_fs_one_slit.copy()
         slit.name = str(i + 1)
-        slit.meta.exposure.type = 'NIS_WFSS'
+        slit.meta.exposure.type = "NIS_WFSS"
         model.slits.append(slit)
 
-    container = multislit_to_container([model])['0']
+    container = multislit_to_container([model])["0"]
 
     yield container
     container.close()
@@ -310,17 +482,25 @@ def mock_niriss_wfss_l3(mock_nirspec_fs_one_slit):
 
 @pytest.fixture()
 def mock_niriss_soss(simple_wcs):
+    """
+    Mock a multi-integration cube with metadata for NIRISS SOSS mode.
+
+    Yields
+    ------
+    CubeModel
+        The mock model.
+    """
     model = dm.CubeModel()
-    model.meta.instrument.name = 'NIRISS'
-    model.meta.instrument.detector = 'NIS'
-    model.meta.instrument.filter = 'CLEAR'
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.detector = "NIS"
+    model.meta.instrument.filter = "CLEAR"
     model.meta.instrument.pupil_position = 245.79
-    model.meta.observation.date = '2023-07-22'
-    model.meta.observation.time = '06:24:45.569'
-    model.meta.exposure.type = 'NIS_SOSS'
+    model.meta.observation.date = "2023-07-22"
+    model.meta.observation.time = "06:24:45.569"
+    model.meta.exposure.type = "NIS_SOSS"
     model.meta.exposure.nints = 3
 
-    model.meta.target.source_type = 'POINT'
+    model.meta.target.source_type = "POINT"
     model.meta.wcsinfo.dispersion_direction = 1
     model.meta.wcs = simple_wcs
 
@@ -330,8 +510,16 @@ def mock_niriss_soss(simple_wcs):
 
 @pytest.fixture()
 def mock_niriss_soss_256(mock_niriss_soss):
+    """
+    Mock 3 integrations in NIRISS SOSS mode, subarray SUBSTRIP256.
+
+    Returns
+    -------
+    CubeModel
+        The mock model.
+    """
     model = mock_niriss_soss
-    model.meta.subarray.name = 'SUBSTRIP256'
+    model.meta.subarray.name = "SUBSTRIP256"
 
     shape = (3, 256, 2048)
     model.data = np.ones(shape, dtype=np.float32)
@@ -345,8 +533,16 @@ def mock_niriss_soss_256(mock_niriss_soss):
 
 @pytest.fixture()
 def mock_niriss_soss_96(mock_niriss_soss):
+    """
+    Mock 3 integrations in NIRISS SOSS mode, subarray SUBSTRIP96.
+
+    Returns
+    -------
+    CubeModel
+        The mock model.
+    """
     model = mock_niriss_soss
-    model.meta.subarray.name = 'SUBSTRIP96'
+    model.meta.subarray.name = "SUBSTRIP96"
 
     shape = (3, 96, 2048)
     model.data = np.ones(shape, dtype=np.float32)
@@ -365,11 +561,19 @@ def mock_niriss_soss_96(mock_niriss_soss):
     return model
 
 
-def make_spec_model(name='slit1', value=1.0):
+def make_spec_model(name="slit1", value=1.0):
+    """
+    Make a simple spectrum.
+
+    Returns
+    -------
+    SpecModel
+        The mock model.
+    """
     wavelength = np.arange(20, dtype=np.float32)
     flux = np.full(10, value)
     error = 0.05 * flux
-    f_var_poisson = error ** 2
+    f_var_poisson = error**2
     f_var_rnoise = np.zeros_like(flux)
     f_var_flat = np.zeros_like(flux)
     surf_bright = flux / 10
@@ -389,12 +593,28 @@ def make_spec_model(name='slit1', value=1.0):
     otab = np.array(
         list(
             zip(
-                wavelength, flux, error, f_var_poisson, f_var_rnoise, f_var_flat,
-                surf_bright, sb_error, sb_var_poisson, sb_var_rnoise, sb_var_flat,
-                dq, background, berror, b_var_poisson, b_var_rnoise, b_var_flat,
-                npixels
+                wavelength,
+                flux,
+                error,
+                f_var_poisson,
+                f_var_rnoise,
+                f_var_flat,
+                surf_bright,
+                sb_error,
+                sb_var_poisson,
+                sb_var_rnoise,
+                sb_var_flat,
+                dq,
+                background,
+                berror,
+                b_var_poisson,
+                b_var_rnoise,
+                b_var_flat,
+                npixels,
+                strict=False,
             ),
-        ), dtype=spec_dtype
+        ),
+        dtype=spec_dtype,
     )
 
     spec_model = dm.SpecModel(spec_table=otab)
@@ -405,6 +625,14 @@ def make_spec_model(name='slit1', value=1.0):
 
 @pytest.fixture()
 def mock_one_spec():
+    """
+    Mock one simple spectrum in a MultiSpecModel.
+
+    Yields
+    ------
+    MultiSpecModel
+        The mock model.
+    """
     model = dm.MultiSpecModel()
     spec_model = make_spec_model()
     model.spec.append(spec_model)
@@ -414,11 +642,19 @@ def mock_one_spec():
 
 
 @pytest.fixture()
-def mock_10_spec(mock_one_spec):
+def mock_10_spec():
+    """
+    Mock 10 simple spectra in a MultiSpecModel.
+
+    Yields
+    ------
+    MultiSpecModel
+        The mock model.
+    """
     model = dm.MultiSpecModel()
 
     for i in range(10):
-        spec_model = make_spec_model(name=f'slit{i + 1}', value=i + 1)
+        spec_model = make_spec_model(name=f"slit{i + 1}", value=i + 1)
         model.spec.append(spec_model)
 
     yield model
@@ -427,20 +663,28 @@ def mock_10_spec(mock_one_spec):
 
 @pytest.fixture()
 def miri_lrs_apcorr():
+    """
+    Mock a MIRI LRS aperture correction model.
+
+    Yields
+    ------
+    MirLrsApcorrModel
+        The mock model.
+    """
     table = Table(
         {
-            'subarray': ['FULL', 'SLITLESSPRISM'],
-            'wavelength': [[1, 2, 3], [1, 2, 3]],
-            'nelem_wl': [3, 3],
-            'size': [[1, 2, 3], [1, 2, 3]],
-            'nelem_size': [3, 3],
-            'apcorr': np.full((2, 3, 3), 0.5),
-            'apcorr_err': np.full((2, 3, 3), 0.01)
+            "subarray": ["FULL", "SLITLESSPRISM"],
+            "wavelength": [[1, 2, 3], [1, 2, 3]],
+            "nelem_wl": [3, 3],
+            "size": [[1, 2, 3], [1, 2, 3]],
+            "nelem_size": [3, 3],
+            "apcorr": np.full((2, 3, 3), 0.5),
+            "apcorr_err": np.full((2, 3, 3), 0.01),
         }
     )
     table = fits.table_to_hdu(table)
-    table.header['EXTNAME'] = 'APCORR'
-    table.header['SIZEUNIT'] = 'pixels'
+    table.header["EXTNAME"] = "APCORR"
+    table.header["SIZEUNIT"] = "pixels"
     hdul = fits.HDUList([fits.PrimaryHDU(), table])
 
     apcorr_model = dm.MirLrsApcorrModel(hdul)
@@ -450,30 +694,46 @@ def miri_lrs_apcorr():
 
 @pytest.fixture()
 def miri_lrs_apcorr_file(tmp_path, miri_lrs_apcorr):
-    filename = str(tmp_path / 'miri_lrs_apcorr.fits')
+    """
+    Mock a MIRI LRS aperture correction reference file.
+
+    Returns
+    -------
+    str
+        Path to the reference file.
+    """
+    filename = str(tmp_path / "miri_lrs_apcorr.fits")
     miri_lrs_apcorr.save(filename)
     return filename
 
 
 @pytest.fixture()
 def nirspec_fs_apcorr():
+    """
+    Mock a NIRSpec FS aperture correction model.
+
+    Yields
+    ------
+    NrsFsApcorrModel
+        The mock model.
+    """
     table = Table(
         {
-            'filter': ['clear', 'f290lp'],
-            'grating': ['prism', 'g395h'],
-            'slit': ['S200A1', 'S200A1'],
-            'wavelength': [[1, 2, 3], [1, 2, 3]],
-            'nelem_wl': [3, 3],
-            'size': np.full((2, 3, 3), [0.3, 0.5, 1]),
-            'nelem_size': [3, 3],
-            'pixphase': [[0.0, 0.25, 0.5], [0.0, 0.25, 0.5]],
-            'apcorr': np.full((2, 3, 3, 3), 0.5),
-            'apcorr_err': np.full((2, 3, 3, 3), 0.01)
+            "filter": ["clear", "f290lp"],
+            "grating": ["prism", "g395h"],
+            "slit": ["S200A1", "S200A1"],
+            "wavelength": [[1, 2, 3], [1, 2, 3]],
+            "nelem_wl": [3, 3],
+            "size": np.full((2, 3, 3), [0.3, 0.5, 1]),
+            "nelem_size": [3, 3],
+            "pixphase": [[0.0, 0.25, 0.5], [0.0, 0.25, 0.5]],
+            "apcorr": np.full((2, 3, 3, 3), 0.5),
+            "apcorr_err": np.full((2, 3, 3, 3), 0.01),
         }
     )
     table = fits.table_to_hdu(table)
-    table.header['EXTNAME'] = 'APCORR'
-    table.header['SIZEUNIT'] = 'pixels'
+    table.header["EXTNAME"] = "APCORR"
+    table.header["SIZEUNIT"] = "pixels"
     hdul = fits.HDUList([fits.PrimaryHDU(), table])
 
     apcorr_model = dm.NrsFsApcorrModel(hdul)
@@ -483,13 +743,29 @@ def nirspec_fs_apcorr():
 
 @pytest.fixture()
 def nirspec_fs_apcorr_file(tmp_path, nirspec_fs_apcorr):
-    filename = str(tmp_path / 'nirspec_fs_apcorr.fits')
+    """
+    Mock a NIRSpec FS aperture correction reference file.
+
+    Returns
+    -------
+    str
+        Path to the reference file.
+    """
+    filename = str(tmp_path / "nirspec_fs_apcorr.fits")
     nirspec_fs_apcorr.save(filename)
     return filename
 
 
 @pytest.fixture()
 def psf_reference():
+    """
+    Mock a flat spectral PSF model.
+
+    Yields
+    ------
+    SpecPsfModel
+        The mock model.
+    """
     psf_model = dm.SpecPsfModel()
     psf_model.data = np.ones((50, 50), dtype=float)
     psf_model.wave = np.linspace(0, 10, 50)
@@ -502,13 +778,29 @@ def psf_reference():
 
 @pytest.fixture()
 def psf_reference_file(tmp_path, psf_reference):
-    filename = str(tmp_path / 'psf_reference.fits')
+    """
+    Mock a spectral PSF reference file.
+
+    Returns
+    -------
+    str
+        Path to the reference file.
+    """
+    filename = str(tmp_path / "psf_reference.fits")
     psf_reference.save(filename)
     return filename
 
 
 @pytest.fixture()
 def psf_reference_with_source():
+    """
+    Mock a spectral PSF model with a simple PSF structure.
+
+    Yields
+    ------
+    SpecPsfModel
+        The mock model.
+    """
     psf_model = dm.SpecPsfModel()
     psf_model.data = np.full((50, 50), 1e-6)
     psf_model.data[:, 24:27] += 1.0
@@ -523,13 +815,29 @@ def psf_reference_with_source():
 
 @pytest.fixture()
 def psf_reference_file_with_source(tmp_path, psf_reference_with_source):
-    filename = str(tmp_path / 'psf_reference_with_source.fits')
+    """
+    Mock a spectral PSF reference file with a simple PSF structure.
+
+    Returns
+    -------
+    str
+        Path to the reference file.
+    """
+    filename = str(tmp_path / "psf_reference_with_source.fits")
     psf_reference_with_source.save(filename)
     return filename
 
 
 @pytest.fixture()
 def simple_profile():
+    """
+    Create a simple profile with a central region marked for extraction.
+
+    Returns
+    -------
+    ndarray of float
+        The profile array, with shape (50, 50).
+    """
     profile = np.zeros((50, 50), dtype=np.float32)
     profile[20:30, :] = 1.0
     return profile
@@ -537,6 +845,14 @@ def simple_profile():
 
 @pytest.fixture()
 def background_profile():
+    """
+    Create a simple profile with two regions marked for background.
+
+    Returns
+    -------
+    ndarray of float
+        The profile array, with shape (50, 50).
+    """
     profile = np.zeros((50, 50), dtype=np.float32)
     profile[:10, :] = 1.0
     profile[40:, :] = 1.0
@@ -545,6 +861,14 @@ def background_profile():
 
 @pytest.fixture()
 def nod_profile():
+    """
+    Create a simple profile with an off-center region marked for a positive source.
+
+    Returns
+    -------
+    ndarray of float
+        The profile array, with shape (50, 50).
+    """
     profile = np.zeros((50, 50), dtype=np.float32)
     profile[10:20, :] = 1.0 / 10
     return profile
@@ -552,6 +876,14 @@ def nod_profile():
 
 @pytest.fixture()
 def negative_nod_profile():
+    """
+    Create a simple profile with an off-center region marked for a negative source.
+
+    Returns
+    -------
+    ndarray of float
+        The profile array, with shape (50, 50).
+    """
     profile = np.zeros((50, 50), dtype=np.float32)
     profile[30:40, :] = -1.0 / 10
     return profile

--- a/jwst/extract_1d/tests/test_apply_apcorr_ifu.py
+++ b/jwst/extract_1d/tests/test_apply_apcorr_ifu.py
@@ -7,87 +7,87 @@ from stdatamodels.jwst.datamodels import IFUCubeModel, NrsIfuApcorrModel, MirMrs
 from jwst.extract_1d.apply_apcorr import ApCorrRadial, select_apcorr
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def dummy_nirspec_ref(tmp_path_factory):
-    """ Generate a dummy apcorr ref file """
-    filename = tmp_path_factory.mktemp('dummy_apcorr')
-    filename = filename / 'dummy_nirspec_apcorr.asdf'
+    """Generate a dummy apcorr ref file"""
+    filename = tmp_path_factory.mktemp("dummy_apcorr")
+    filename = filename / "dummy_nirspec_apcorr.asdf"
 
     refap = {}
-    refap['meta'] = {}
-    refap['apcorr_table'] = {}
-    refap['meta']['telescope'] = 'JWST'
-    refap['meta']['reftype'] = 'APCORR'
-    refap['meta']['exp_type'] = 'P_EXP_TY'
-    refap['meta']['detector'] = 'N/A'
-    refap['meta']['datamodel'] = 'NrsIfuApcorrModel'
-    refap['meta']['version'] = '1.0'
-    refap['meta']['name'] = 'NIRSPEC'
-    refap['meta']['origin'] = 'STScI'
+    refap["meta"] = {}
+    refap["apcorr_table"] = {}
+    refap["meta"]["telescope"] = "JWST"
+    refap["meta"]["reftype"] = "APCORR"
+    refap["meta"]["exp_type"] = "P_EXP_TY"
+    refap["meta"]["detector"] = "N/A"
+    refap["meta"]["datamodel"] = "NrsIfuApcorrModel"
+    refap["meta"]["version"] = "1.0"
+    refap["meta"]["name"] = "NIRSPEC"
+    refap["meta"]["origin"] = "STScI"
 
     dummy_wave = np.zeros(100) + 0.5
     dummy_radius = np.zeros((3, 100)) + 0.5
     dummy_apcorr = np.ones((3, 100))
     dummy_apcorr_error = np.zeros((3, 100))
 
-    refap['apcorr_table'] = {}
-    refap['apcorr_table']['wavelength'] = dummy_wave.copy()
-    refap['apcorr_table']['radius'] = dummy_radius.copy()
-    refap['apcorr_table']['apcorr'] = dummy_apcorr.copy()
-    refap['apcorr_table']['apcorr_err'] = dummy_apcorr_error.copy()
-    refap['apcorr_table']['wavelength_units'] = 'microns'
-    refap['apcorr_table']['radius_units'] = 'arcseconds'
-    refap['apcorr_table']['filter'] = 'ANY'
-    refap['apcorr_table']['grating'] = 'ANY'
+    refap["apcorr_table"] = {}
+    refap["apcorr_table"]["wavelength"] = dummy_wave.copy()
+    refap["apcorr_table"]["radius"] = dummy_radius.copy()
+    refap["apcorr_table"]["apcorr"] = dummy_apcorr.copy()
+    refap["apcorr_table"]["apcorr_err"] = dummy_apcorr_error.copy()
+    refap["apcorr_table"]["wavelength_units"] = "microns"
+    refap["apcorr_table"]["radius_units"] = "arcseconds"
+    refap["apcorr_table"]["filter"] = "ANY"
+    refap["apcorr_table"]["grating"] = "ANY"
 
     ff = AsdfFile(refap)
-    ff.set_array_storage(refap['apcorr_table']['wavelength'], 'inline')
-    ff.set_array_storage(refap['apcorr_table']['radius'], 'inline')
-    ff.set_array_storage(refap['apcorr_table']['apcorr'], 'inline')
-    ff.set_array_storage(refap['apcorr_table']['apcorr_err'], 'inline')
+    ff.set_array_storage(refap["apcorr_table"]["wavelength"], "inline")
+    ff.set_array_storage(refap["apcorr_table"]["radius"], "inline")
+    ff.set_array_storage(refap["apcorr_table"]["apcorr"], "inline")
+    ff.set_array_storage(refap["apcorr_table"]["apcorr_err"], "inline")
 
     ff.write_to(filename)
     return filename
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def dummy_miri_ref(tmp_path_factory):
-    """ Generate a dummy apcorr ref file """
-    filename = tmp_path_factory.mktemp('dummy_apcorr')
-    filename = filename / 'dummy_miri_apcorr.asdf'
+    """Generate a dummy apcorr ref file"""
+    filename = tmp_path_factory.mktemp("dummy_apcorr")
+    filename = filename / "dummy_miri_apcorr.asdf"
 
     refap = {}
-    refap['meta'] = {}
-    refap['apcorr_table'] = {}
-    refap['meta']['telescope'] = 'JWST'
-    refap['meta']['reftype'] = 'APCORR'
-    refap['meta']['exp_type'] = 'MIRI_MRS'
-    refap['meta']['detector'] = 'N/A'
-    refap['meta']['datamodel'] = 'MirMrsApcorrModel'
-    refap['meta']['version'] = '1.0'
-    refap['meta']['name'] = 'MIRI'
-    refap['meta']['origin'] = 'STScI'
+    refap["meta"] = {}
+    refap["apcorr_table"] = {}
+    refap["meta"]["telescope"] = "JWST"
+    refap["meta"]["reftype"] = "APCORR"
+    refap["meta"]["exp_type"] = "MIRI_MRS"
+    refap["meta"]["detector"] = "N/A"
+    refap["meta"]["datamodel"] = "MirMrsApcorrModel"
+    refap["meta"]["version"] = "1.0"
+    refap["meta"]["name"] = "MIRI"
+    refap["meta"]["origin"] = "STScI"
 
     dummy_wave = np.zeros(100) + 0.5
     dummy_radius = np.zeros((3, 100)) + 0.5
     dummy_apcorr = np.ones((3, 100))
     dummy_apcorr_error = np.zeros((3, 100))
 
-    refap['apcorr_table'] = {}
-    refap['apcorr_table']['wavelength'] = dummy_wave.copy()
-    refap['apcorr_table']['radius'] = dummy_radius.copy()
-    refap['apcorr_table']['apcorr'] = dummy_apcorr.copy()
-    refap['apcorr_table']['apcorr_err'] = dummy_apcorr_error.copy()
-    refap['apcorr_table']['wavelength_units'] = 'microns'
-    refap['apcorr_table']['radius_units'] = 'arcseconds'
-    refap['apcorr_table']['channel'] = 'ANY'
-    refap['apcorr_table']['band'] = 'ANY'
+    refap["apcorr_table"] = {}
+    refap["apcorr_table"]["wavelength"] = dummy_wave.copy()
+    refap["apcorr_table"]["radius"] = dummy_radius.copy()
+    refap["apcorr_table"]["apcorr"] = dummy_apcorr.copy()
+    refap["apcorr_table"]["apcorr_err"] = dummy_apcorr_error.copy()
+    refap["apcorr_table"]["wavelength_units"] = "microns"
+    refap["apcorr_table"]["radius_units"] = "arcseconds"
+    refap["apcorr_table"]["channel"] = "ANY"
+    refap["apcorr_table"]["band"] = "ANY"
 
     ff = AsdfFile(refap)
-    ff.set_array_storage(refap['apcorr_table']['wavelength'], 'inline')
-    ff.set_array_storage(refap['apcorr_table']['radius'], 'inline')
-    ff.set_array_storage(refap['apcorr_table']['apcorr'], 'inline')
-    ff.set_array_storage(refap['apcorr_table']['apcorr_err'], 'inline')
+    ff.set_array_storage(refap["apcorr_table"]["wavelength"], "inline")
+    ff.set_array_storage(refap["apcorr_table"]["radius"], "inline")
+    ff.set_array_storage(refap["apcorr_table"]["apcorr"], "inline")
+    ff.set_array_storage(refap["apcorr_table"]["apcorr_err"], "inline")
 
     ff.write_to(filename)
     return filename
@@ -96,35 +96,33 @@ def dummy_miri_ref(tmp_path_factory):
 @pytest.fixture
 def miri_cube():
     model = IFUCubeModel((15, 10, 10))
-    instrument = 'MIRI'
-    exptype = 'MIR_MRS'
+    instrument = "MIRI"
+    exptype = "MIR_MRS"
     model.meta.instrument.name = instrument
     model.meta.exposure.type = exptype
-    model.meta.instrument.channel = '1'
-    model.meta.instrument.band = 'SHORT'
+    model.meta.instrument.channel = "1"
+    model.meta.instrument.band = "SHORT"
     return model
 
 
 @pytest.fixture
 def nirspec_cube():
     model = IFUCubeModel((15, 10, 10))
-    instrument = 'NIRSPEC'
-    exptype = 'NRS_IFU'
+    instrument = "NIRSPEC"
+    exptype = "NRS_IFU"
     model.meta.instrument.name = instrument
     model.meta.exposure.type = exptype
-    model.meta.instrument.filter = 'CLEAR'
-    model.meta.instrument.prism = 'PRISM'
+    model.meta.instrument.filter = "CLEAR"
+    model.meta.instrument.prism = "PRISM"
     return model
 
 
 def test_select_apcorr_miri(miri_cube):
-
     apcorr_cls = select_apcorr(miri_cube)
     assert apcorr_cls == ApCorrRadial
 
 
 def test_select_apcorr_nirspec(nirspec_cube):
-
     apcorr_cls = select_apcorr(nirspec_cube)
     assert apcorr_cls == ApCorrRadial
 
@@ -134,8 +132,8 @@ def test_table_type_miri(tmp_cwd, dummy_miri_ref, miri_cube):
     with MirMrsApcorrModel(dummy_miri_ref) as apcorr_model:
         table = apcorr_model.apcorr_table
 
-        assert table.channel == 'ANY'
-        assert table.band == 'ANY'
+        assert table.channel == "ANY"
+        assert table.band == "ANY"
         assert np.all(table.wavelength == dummy_wave)
 
 
@@ -144,6 +142,6 @@ def test_table_type_nirspec(tmp_cwd, dummy_nirspec_ref, nirspec_cube):
     with NrsIfuApcorrModel(dummy_nirspec_ref) as apcorr_model:
         table = apcorr_model.apcorr_table
 
-        assert table.filter == 'ANY'
-        assert table.grating == 'ANY'
+        assert table.filter == "ANY"
+        assert table.grating == "ANY"
         assert np.all(table.wavelength == dummy_wave)

--- a/jwst/extract_1d/tests/test_apply_apcorr_nonifu.py
+++ b/jwst/extract_1d/tests/test_apply_apcorr_nonifu.py
@@ -9,25 +9,25 @@ from stdatamodels.jwst.datamodels import JwstDataModel
 
 from jwst.extract_1d.apply_apcorr import ApCorr, ApCorrPhase, select_apcorr
 
-data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
+data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 NIR_TEST_FILES = {
-    'MSASPEC': os.path.join(data_dir, 'jwst_nirspec_apcorr_msa_dummy.fits'),
-    'FIXEDSLIT/BRIGHTOBJ': os.path.join(data_dir, 'jwst_nirspec_apcorr_fs_dummy.fits')
+    "MSASPEC": os.path.join(data_dir, "jwst_nirspec_apcorr_msa_dummy.fits"),
+    "FIXEDSLIT/BRIGHTOBJ": os.path.join(data_dir, "jwst_nirspec_apcorr_fs_dummy.fits"),
 }
 
 
 @pytest.fixture(
-    scope='module',
+    scope="module",
     params=[
-        ('MIRI', 'MIR_LRS-FIXEDSLIT'),
-        ('MIRI', 'MIR_LRS-SLITLESS'),
-        ('NIRCAM', 'NRC_GRISM'),
-        ('NIRCAM', 'NRC_WFSS'),
-        ('NIRISS', 'NIS_WFSS'),
-        ('NIRSPEC', 'NRS_BRIGHTOBJ'),
-        ('NIRSPEC', 'NRS_FIXEDSLIT'),
-        ('NIRSPEC', 'NRS_MSASPEC')
-    ]
+        ("MIRI", "MIR_LRS-FIXEDSLIT"),
+        ("MIRI", "MIR_LRS-SLITLESS"),
+        ("NIRCAM", "NRC_GRISM"),
+        ("NIRCAM", "NRC_WFSS"),
+        ("NIRISS", "NIS_WFSS"),
+        ("NIRSPEC", "NRS_BRIGHTOBJ"),
+        ("NIRSPEC", "NRS_FIXEDSLIT"),
+        ("NIRSPEC", "NRS_MSASPEC"),
+    ],
 )
 def inputs(request):
     table = None
@@ -38,115 +38,122 @@ def inputs(request):
     dm.meta.instrument.name = instrument
     dm.meta.exposure.type = exptype
 
-    if instrument == 'MIRI':
-        if 'LRS' in exptype:
-            dm.meta.subarray.name = 'FULL'
+    if instrument == "MIRI":
+        if "LRS" in exptype:
+            dm.meta.subarray.name = "FULL"
             table = Table(
                 {
-                    'subarray': ['FULL', 'sub02'],
-                    'nelem_wl': [3, 3],
-                    'nelem_size': [3, 3],
-                    'wavelength': [[1, 2, 3, 0], [1, 2, 3, 0]],
-                    'size': [[1, 2, 3, 0], [1, 2, 3, 0]],
-                    'apcorr': np.full((2, 4, 4), 0.5)
+                    "subarray": ["FULL", "sub02"],
+                    "nelem_wl": [3, 3],
+                    "nelem_size": [3, 3],
+                    "wavelength": [[1, 2, 3, 0], [1, 2, 3, 0]],
+                    "size": [[1, 2, 3, 0], [1, 2, 3, 0]],
+                    "apcorr": np.full((2, 4, 4), 0.5),
                 }
             )
 
-    if instrument == 'NIRSPEC':  # Too complicated to come up with silly example data; using "dummy" ref file
-        dm.meta.instrument.filter = 'CLEAR'
-        dm.meta.instrument.grating = 'PRISM'
+    if (
+        instrument == "NIRSPEC"
+    ):  # Too complicated to come up with silly example data; using "dummy" ref file
+        dm.meta.instrument.filter = "CLEAR"
+        dm.meta.instrument.grating = "PRISM"
 
-        if 'FIXEDSLIT' in dm.meta.exposure.type:
-            dm.meta.instrument.fixed_slit = 'S200A1'
-            table = Table.read(NIR_TEST_FILES['FIXEDSLIT/BRIGHTOBJ'], format='fits')[:2]
+        if "FIXEDSLIT" in dm.meta.exposure.type:
+            dm.meta.instrument.fixed_slit = "S200A1"
+            table = Table.read(NIR_TEST_FILES["FIXEDSLIT/BRIGHTOBJ"], format="fits")[:2]
         else:
-            table = Table.read(NIR_TEST_FILES['MSASPEC'], format='fits')[:2]
+            table = Table.read(NIR_TEST_FILES["MSASPEC"], format="fits")[:2]
 
-        table['APCORR'] = table['APCORR'].reshape((len(table), 3, 2048, 3))  # Reshape test data to expected shape
+        table["APCORR"] = table["APCORR"].reshape(
+            (len(table), 3, 2048, 3)
+        )  # Reshape test data to expected shape
 
-    if instrument == 'NIRCAM':
-        dm.meta.instrument.filter = 'F322W2'
-        dm.meta.instrument.pupil = 'GRISMR'
+    if instrument == "NIRCAM":
+        dm.meta.instrument.filter = "F322W2"
+        dm.meta.instrument.pupil = "GRISMR"
 
         table = Table(
             {
-                'filter': ['F322W2', 'filter02'],
-                'pupil': ['GRISMR', 'pupil02'],
-                'nelem_wl': [3, 3],
-                'nelem_size': [3, 3],
-                'wavelength': [[1, 2, 3, 0], [1, 2, 3, 0]],
-                'size': [[1, 2, 3, 0], [1, 2, 3, 0]],
-                'apcorr': np.full((2, 4, 4), 0.5)
+                "filter": ["F322W2", "filter02"],
+                "pupil": ["GRISMR", "pupil02"],
+                "nelem_wl": [3, 3],
+                "nelem_size": [3, 3],
+                "wavelength": [[1, 2, 3, 0], [1, 2, 3, 0]],
+                "size": [[1, 2, 3, 0], [1, 2, 3, 0]],
+                "apcorr": np.full((2, 4, 4), 0.5),
             }
         )
 
-    if instrument == 'NIRISS':
-        dm.meta.instrument.filter = 'GR150R'
-        dm.meta.instrument.pupil = 'F090W'
+    if instrument == "NIRISS":
+        dm.meta.instrument.filter = "GR150R"
+        dm.meta.instrument.pupil = "F090W"
 
         table = Table(
             {
-                'filter': ['GR150R', 'filter02'],
-                'pupil': ['F090W', 'pupil02'],
-                'nelem_wl': [3, 3],
-                'nelem_size': [3, 3],
-                'wavelength': [[1, 2, 3, 0], [1, 2, 3, 0]],
-                'size': [[1, 2, 3, 0], [1, 2, 3, 0]],
-                'apcorr': np.full((2, 4, 4), 0.5)
+                "filter": ["GR150R", "filter02"],
+                "pupil": ["F090W", "pupil02"],
+                "nelem_wl": [3, 3],
+                "nelem_size": [3, 3],
+                "wavelength": [[1, 2, 3, 0], [1, 2, 3, 0]],
+                "size": [[1, 2, 3, 0], [1, 2, 3, 0]],
+                "apcorr": np.full((2, 4, 4), 0.5),
             }
         )
 
     return dm, fits.table_to_hdu(table).data
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def apcorr_instance(inputs):
     dm, table = inputs
     apcorr = select_apcorr(dm)
 
-    if dm.meta.instrument.name == 'NIRSPEC' and 'FIXEDSLIT' in dm.meta.exposure.type:
-        return apcorr(dm, table, 'pixels', slit='S200A1')
+    if dm.meta.instrument.name == "NIRSPEC" and "FIXEDSLIT" in dm.meta.exposure.type:
+        return apcorr(dm, table, "pixels", slit="S200A1")
 
-    return apcorr(dm, table, 'pixels')
+    return apcorr(dm, table, "pixels")
 
 
 def test_select_apcorr(inputs):
     dm, _ = inputs
     apcorr_cls = select_apcorr(dm)
 
-    if dm.meta.instrument.name == 'NIRSPEC':
+    if dm.meta.instrument.name == "NIRSPEC":
         assert apcorr_cls == ApCorrPhase
     else:
         assert apcorr_cls == ApCorr
 
 
 class TestApCorr:
-
     def test_match_parameters(self, apcorr_instance):
-        if apcorr_instance.model.meta.instrument.name == 'MIRI':
-            assert apcorr_instance.match_pars == {'subarray': 'FULL'}
+        if apcorr_instance.model.meta.instrument.name == "MIRI":
+            assert apcorr_instance.match_pars == {"subarray": "FULL"}
 
-        if apcorr_instance.model.meta.instrument.name == 'NIRSPEC':
-            if 'FIXEDSLIT' in apcorr_instance.model.meta.exposure.type:
-                assert apcorr_instance.match_pars == {'filter': 'CLEAR', 'grating': 'PRISM', 'slit': 'S200A1'}
+        if apcorr_instance.model.meta.instrument.name == "NIRSPEC":
+            if "FIXEDSLIT" in apcorr_instance.model.meta.exposure.type:
+                assert apcorr_instance.match_pars == {
+                    "filter": "CLEAR",
+                    "grating": "PRISM",
+                    "slit": "S200A1",
+                }
             else:
-                assert apcorr_instance.match_pars == {'filter': 'CLEAR', 'grating': 'PRISM'}
+                assert apcorr_instance.match_pars == {"filter": "CLEAR", "grating": "PRISM"}
 
-        if apcorr_instance.model.meta.instrument.name == 'NIRCAM':
-            assert apcorr_instance.match_pars == {'filter': 'F322W2', 'pupil': 'GRISMR'}
+        if apcorr_instance.model.meta.instrument.name == "NIRCAM":
+            assert apcorr_instance.match_pars == {"filter": "F322W2", "pupil": "GRISMR"}
 
-        if apcorr_instance.model.meta.instrument.name == 'NIRISS':
-            assert apcorr_instance.match_pars == {'filter': 'GR150R', 'pupil': 'F090W'}
+        if apcorr_instance.model.meta.instrument.name == "NIRISS":
+            assert apcorr_instance.match_pars == {"filter": "GR150R", "pupil": "F090W"}
 
     def test_approximate(self, apcorr_instance):
         if isinstance(apcorr_instance, ApCorrPhase):
             assert np.isclose(
                 apcorr_instance.apcorr_func(
-                    apcorr_instance.reference['wavelength'][0],
-                    apcorr_instance.reference['size'][0],
-                    0.5
+                    apcorr_instance.reference["wavelength"][0],
+                    apcorr_instance.reference["size"][0],
+                    0.5,
                 )[0],
-                1
+                1,
             )
         else:
             assert np.isclose(apcorr_instance.apcorr_func(0.5, 0.5)[0], 0.5)

--- a/jwst/extract_1d/tests/test_expected_skips.py
+++ b/jwst/extract_1d/tests/test_expected_skips.py
@@ -5,55 +5,53 @@ import pytest
 import numpy as np
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def mock_niriss_full():
     model = dm.CubeModel((3, 3, 3))
-    model.meta.instrument.name = 'NIRISS'
-    model.meta.instrument.detector = 'NIS'
-    model.meta.observation.date = '2023-07-22'
-    model.meta.observation.time = '06:24:45.569'
-    model.meta.instrument.name = 'NIRISS'
-    model.meta.instrument.detector = 'NIS'
-    model.meta.instrument.filter = 'CLEAR'
-    model.meta.exposure.type = 'NIS_SOSS'
-    model.meta.subarray.name = 'FULL'
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.detector = "NIS"
+    model.meta.observation.date = "2023-07-22"
+    model.meta.observation.time = "06:24:45.569"
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.detector = "NIS"
+    model.meta.instrument.filter = "CLEAR"
+    model.meta.exposure.type = "NIS_SOSS"
+    model.meta.subarray.name = "FULL"
     model.data = np.arange(27).reshape((3, 3, 3))
     return model
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def mock_niriss_f277w():
     model = dm.CubeModel((3, 3, 3))
-    model.meta.instrument.name = 'NIRISS'
-    model.meta.instrument.detector = 'NIS'
-    model.meta.observation.date = '2023-07-22'
-    model.meta.observation.time = '06:24:45.569'
-    model.meta.instrument.name = 'NIRISS'
-    model.meta.instrument.detector = 'NIS'
-    model.meta.instrument.filter = 'F277W'
-    model.meta.exposure.type = 'NIS_SOSS'
-    model.meta.subarray.name = 'FULL'
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.detector = "NIS"
+    model.meta.observation.date = "2023-07-22"
+    model.meta.observation.time = "06:24:45.569"
+    model.meta.instrument.name = "NIRISS"
+    model.meta.instrument.detector = "NIS"
+    model.meta.instrument.filter = "F277W"
+    model.meta.exposure.type = "NIS_SOSS"
+    model.meta.subarray.name = "FULL"
     model.data = np.arange(27).reshape((3, 3, 3))
     return model
 
 
 def test_expected_skip_niriss_soss_full(mock_niriss_full):
-
     with mock_niriss_full as model:
         result = Extract1dStep().process(model)
         result2 = PhotomStep().process(result)
-        assert result2.meta.cal_step.photom == 'SKIPPED'
-        assert result2.meta.cal_step.extract_1d == 'SKIPPED'
+        assert result2.meta.cal_step.photom == "SKIPPED"
+        assert result2.meta.cal_step.extract_1d == "SKIPPED"
         assert np.all(result2.data == model.data)
 
 
 def test_expected_skip_niriss_soss_f277w(mock_niriss_f277w):
-
     with mock_niriss_f277w as model:
         result = Extract1dStep().process(model)
         result2 = PhotomStep().process(result)
-        assert result2.meta.cal_step.photom == 'SKIPPED'
-        assert result2.meta.cal_step.extract_1d == 'SKIPPED'
+        assert result2.meta.cal_step.photom == "SKIPPED"
+        assert result2.meta.cal_step.extract_1d == "SKIPPED"
         assert np.all(result2.data == model.data)
 
 
@@ -61,7 +59,7 @@ def test_expected_skip_multi_int_multi_slit():
     model = dm.MultiSlitModel()
     model.slits.append(dm.SlitModel(np.zeros((10, 10, 10))))
     result = Extract1dStep().process(model)
-    assert result.meta.cal_step.extract_1d == 'SKIPPED'
+    assert result.meta.cal_step.extract_1d == "SKIPPED"
     assert np.all(result.slits[0].data == model.slits[0].data)
     model.close()
     result.close()
@@ -70,6 +68,6 @@ def test_expected_skip_multi_int_multi_slit():
 def test_expected_skip_unexpected_model():
     model = dm.MultiExposureModel()
     result = Extract1dStep().process(model)
-    assert result.meta.cal_step.extract_1d == 'SKIPPED'
+    assert result.meta.cal_step.extract_1d == "SKIPPED"
     model.close()
     result.close()

--- a/jwst/extract_1d/tests/test_extract.py
+++ b/jwst/extract_1d/tests/test_extract.py
@@ -15,60 +15,63 @@ from jwst.tests.helpers import LogWatcher
 def log_watcher(monkeypatch):
     # Set a log watcher to check for a log message at any level
     # in the extract_1d.extract module
-    watcher = LogWatcher('')
-    logger = logging.getLogger('jwst.extract_1d.extract')
-    for level in ['debug', 'info', 'warning', 'error']:
+    watcher = LogWatcher("")
+    logger = logging.getLogger("jwst.extract_1d.extract")
+    for level in ["debug", "info", "warning", "error"]:
         monkeypatch.setattr(logger, level, watcher)
     return watcher
 
 
 @pytest.fixture()
 def extract1d_ref_dict():
-    apertures = [{'id': 'slit1'},
-                 {'id': 'slit2', 'region_type': 'other'},
-                 {'id': 'slit3', 'xstart': 10, 'xstop': 20, 'ystart': 10, 'ystop': 20},
-                 {'id': 'slit4', 'bkg_coeff': [[10], [20]]},
-                 {'id': 'slit5', 'bkg_coeff': None},
-                 {'id': 'slit6', 'use_source_posn': True},
-                 {'id': 'slit7', 'spectral_order': 20},
-                 {'id': 'S200A1'},
-                 {'id': 'S1600A1', 'use_source_posn': False}
-                 ]
-    ref_dict = {'apertures': apertures}
+    apertures = [
+        {"id": "slit1"},
+        {"id": "slit2", "region_type": "other"},
+        {"id": "slit3", "xstart": 10, "xstop": 20, "ystart": 10, "ystop": 20},
+        {"id": "slit4", "bkg_coeff": [[10], [20]]},
+        {"id": "slit5", "bkg_coeff": None},
+        {"id": "slit6", "use_source_posn": True},
+        {"id": "slit7", "spectral_order": 20},
+        {"id": "S200A1"},
+        {"id": "S1600A1", "use_source_posn": False},
+    ]
+    ref_dict = {"apertures": apertures}
     return ref_dict
 
 
 @pytest.fixture()
 def extract1d_ref_file(tmp_path, extract1d_ref_dict):
-    filename = str(tmp_path / 'extract1d_ref.json')
-    with open(filename, 'w') as fh:
+    filename = str(tmp_path / "extract1d_ref.json")
+    with open(filename, "w") as fh:
         json.dump(extract1d_ref_dict, fh)
     return filename
 
 
 @pytest.fixture()
 def extract_defaults():
-    default = {'bkg_coeff': None,
-               'bkg_fit': None,
-               'bkg_order': 0,
-               'extract_width': None,
-               'extraction_type': 'box',
-               'independent_var': 'pixel',
-               'match': 'exact match',
-               'smoothing_length': 0,
-               'spectral_order': 1,
-               'src_coeff': None,
-               'subtract_background': False,
-               'position_offset': 0.0,
-               'trace': None,
-               'use_source_posn': False,
-               'model_nod_pair': False,
-               'optimize_psf_location': False,
-               'xstart': 0,
-               'xstop': 49,
-               'ystart': 0,
-               'ystop': 49,
-               'psf': 'N/A'}
+    default = {
+        "bkg_coeff": None,
+        "bkg_fit": None,
+        "bkg_order": 0,
+        "extract_width": None,
+        "extraction_type": "box",
+        "independent_var": "pixel",
+        "match": "exact match",
+        "smoothing_length": 0,
+        "spectral_order": 1,
+        "src_coeff": None,
+        "subtract_background": False,
+        "position_offset": 0.0,
+        "trace": None,
+        "use_source_posn": False,
+        "model_nod_pair": False,
+        "optimize_psf_location": False,
+        "xstart": 0,
+        "xstop": 49,
+        "ystart": 0,
+        "ystop": 49,
+        "psf": "N/A",
+    }
     return default
 
 
@@ -78,11 +81,10 @@ def create_extraction_inputs(mock_nirspec_fs_one_slit, extract1d_ref_dict):
     slit = None
     output_model = dm.MultiSpecModel()
     ref_dict = extract1d_ref_dict
-    slitname = 'S200A1'
+    slitname = "S200A1"
     sp_order = 1
-    exp_type = 'NRS_FIXEDSLIT'
-    yield [input_model, slit, output_model, ref_dict,
-           slitname, sp_order, exp_type]
+    exp_type = "NRS_FIXEDSLIT"
+    yield [input_model, slit, output_model, ref_dict, slitname, sp_order, exp_type]
     output_model.close()
 
 
@@ -92,45 +94,47 @@ def test_read_extract1d_ref(extract1d_ref_dict, extract1d_ref_file):
 
 
 def test_read_extract1d_ref_bad_json(tmp_path):
-    filename = str(tmp_path / 'bad_ref.json')
-    with open(filename, 'w') as fh:
-        fh.write('apertures: [bad,]\n')
+    filename = str(tmp_path / "bad_ref.json")
+    with open(filename, "w") as fh:
+        fh.write("apertures: [bad,]\n")
 
-    with pytest.raises(RuntimeError, match='Invalid JSON extract1d reference'):
+    with pytest.raises(RuntimeError, match="Invalid JSON extract1d reference"):
         ex.read_extract1d_ref(filename)
 
 
 def test_read_extract1d_ref_bad_type(tmp_path):
-    filename = str(tmp_path / 'bad_ref.fits')
-    with open(filename, 'w') as fh:
-        fh.write('bad file\n')
+    filename = str(tmp_path / "bad_ref.fits")
+    with open(filename, "w") as fh:
+        fh.write("bad file\n")
 
-    with pytest.raises(RuntimeError, match='must be JSON'):
+    with pytest.raises(RuntimeError, match="must be JSON"):
         ex.read_extract1d_ref(filename)
 
 
 def test_read_extract1d_ref_na():
-    ref_dict = ex.read_extract1d_ref('N/A')
+    ref_dict = ex.read_extract1d_ref("N/A")
     assert ref_dict is None
 
 
 def test_read_apcorr_ref():
-    apcorr_model = ex.read_apcorr_ref(None, 'MIR_LRS-FIXEDSLIT')
+    apcorr_model = ex.read_apcorr_ref(None, "MIR_LRS-FIXEDSLIT")
     assert isinstance(apcorr_model, dm.MirLrsApcorrModel)
 
 
 def test_get_extract_parameters_default(
-        mock_nirspec_fs_one_slit, extract1d_ref_dict, extract_defaults):
+    mock_nirspec_fs_one_slit, extract1d_ref_dict, extract_defaults
+):
     input_model = mock_nirspec_fs_one_slit
 
     # match a bare entry
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit1', 1, input_model.meta)
+        extract1d_ref_dict, input_model, "slit1", 1, input_model.meta
+    )
 
     # returned value has defaults except that use_source_posn
     # is switched on for NRS_FIXEDSLIT
     expected = extract_defaults
-    expected['use_source_posn'] = True
+    expected["use_source_posn"] = True
 
     assert params == expected
 
@@ -139,26 +143,33 @@ def test_get_extract_parameters_na(mock_nirspec_fs_one_slit, extract_defaults):
     input_model = mock_nirspec_fs_one_slit
 
     # no reference input: defaults returned
-    params = ex.get_extract_parameters(None, input_model, 'slit1', 1, input_model.meta)
+    params = ex.get_extract_parameters(None, input_model, "slit1", 1, input_model.meta)
     assert params == extract_defaults
 
 
-@pytest.mark.parametrize('bgsub', [None, True])
-@pytest.mark.parametrize('bgfit', ['poly', 'mean', None])
+@pytest.mark.parametrize("bgsub", [None, True])
+@pytest.mark.parametrize("bgfit", ["poly", "mean", None])
 def test_get_extract_parameters_background(
-        mock_nirspec_fs_one_slit, extract1d_ref_dict, bgsub, bgfit):
+    mock_nirspec_fs_one_slit, extract1d_ref_dict, bgsub, bgfit
+):
     input_model = mock_nirspec_fs_one_slit
 
     # match a slit with background defined
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit4', 1, input_model.meta,
-        subtract_background=bgsub, bkg_fit=bgfit)
+        extract1d_ref_dict,
+        input_model,
+        "slit4",
+        1,
+        input_model.meta,
+        subtract_background=bgsub,
+        bkg_fit=bgfit,
+    )
 
     # returned value has background switched on
-    assert params['subtract_background'] is True
-    assert params['bkg_coeff'] is not None
-    assert params['bkg_fit'] == 'poly'
-    assert params['bkg_order'] == 0
+    assert params["subtract_background"] is True
+    assert params["bkg_coeff"] is not None
+    assert params["bkg_fit"] == "poly"
+    assert params["bkg_order"] == 0
 
 
 def test_get_extract_parameters_bg_ignored(mock_nirspec_fs_one_slit, extract1d_ref_dict):
@@ -166,127 +177,138 @@ def test_get_extract_parameters_bg_ignored(mock_nirspec_fs_one_slit, extract1d_r
 
     # match a slit with background defined
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit4', 1, input_model.meta,
-        subtract_background=False)
+        extract1d_ref_dict, input_model, "slit4", 1, input_model.meta, subtract_background=False
+    )
 
     # background parameters are ignored
-    assert params['subtract_background'] is False
-    assert params['bkg_fit'] is None
+    assert params["subtract_background"] is False
+    assert params["bkg_fit"] is None
 
 
-@pytest.mark.parametrize('slit', ['slit2', 'no_match'])
-def test_get_extract_parameters_no_match(
-        mock_nirspec_fs_one_slit, extract1d_ref_dict, slit):
+@pytest.mark.parametrize("slit", ["slit2", "no_match"])
+def test_get_extract_parameters_no_match(mock_nirspec_fs_one_slit, extract1d_ref_dict, slit):
     input_model = mock_nirspec_fs_one_slit
 
     # no slit with an appropriate region_type matched
-    params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, slit, 1, input_model.meta)
-    assert params == {'match': ex.NO_MATCH}
+    params = ex.get_extract_parameters(extract1d_ref_dict, input_model, slit, 1, input_model.meta)
+    assert params == {"match": ex.NO_MATCH}
 
 
-def test_get_extract_parameters_source_posn_exptype(
-        mock_nirspec_bots, extract1d_ref_dict):
+def test_get_extract_parameters_source_posn_exptype(mock_nirspec_bots, extract1d_ref_dict):
     input_model = mock_nirspec_bots
-    input_model.meta.exposure.type = 'NRS_LAMP'
+    input_model.meta.exposure.type = "NRS_LAMP"
 
     # match a bare entry
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit1', 1, input_model.meta,
-        use_source_posn=None)
+        extract1d_ref_dict, input_model, "slit1", 1, input_model.meta, use_source_posn=None
+    )
 
     # use_source_posn is switched off for unknown exptypes
-    assert params['use_source_posn'] is False
+    assert params["use_source_posn"] is False
 
 
-def test_get_extract_parameters_source_posn_from_ref(
-        mock_nirspec_bots, extract1d_ref_dict):
+def test_get_extract_parameters_source_posn_from_ref(mock_nirspec_bots, extract1d_ref_dict):
     input_model = mock_nirspec_bots
 
     # match an entry that explicitly sets use_source_posn
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit6', 1, input_model.meta,
-        use_source_posn=None)
+        extract1d_ref_dict, input_model, "slit6", 1, input_model.meta, use_source_posn=None
+    )
 
     # returned value has use_source_posn switched off by default
     # for NRS_BRIGHTOBJ, but ref file overrides
-    assert params['use_source_posn'] is True
+    assert params["use_source_posn"] is True
 
 
-@pytest.mark.parametrize('length', [3, 4, 2.8, 3.5])
-def test_get_extract_parameters_smoothing(
-        mock_nirspec_fs_one_slit, extract1d_ref_dict, length):
+@pytest.mark.parametrize("length", [3, 4, 2.8, 3.5])
+def test_get_extract_parameters_smoothing(mock_nirspec_fs_one_slit, extract1d_ref_dict, length):
     input_model = mock_nirspec_fs_one_slit
 
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit1', 1, input_model.meta,
-        smoothing_length=length)
+        extract1d_ref_dict, input_model, "slit1", 1, input_model.meta, smoothing_length=length
+    )
 
     # returned value has input smoothing length, rounded to an
     # odd integer if necessary
-    assert params['smoothing_length'] == 3
+    assert params["smoothing_length"] == 3
 
 
-@pytest.mark.parametrize('length', [-1, 1, 2, 1.3])
+@pytest.mark.parametrize("length", [-1, 1, 2, 1.3])
 def test_get_extract_parameters_smoothing_bad_value(
-        mock_nirspec_fs_one_slit, extract1d_ref_dict, length):
+    mock_nirspec_fs_one_slit, extract1d_ref_dict, length
+):
     input_model = mock_nirspec_fs_one_slit
 
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit1', 1, input_model.meta,
-        smoothing_length=length)
+        extract1d_ref_dict, input_model, "slit1", 1, input_model.meta, smoothing_length=length
+    )
 
     # returned value has smoothing length 0
-    assert params['smoothing_length'] == 0
+    assert params["smoothing_length"] == 0
 
 
-@pytest.mark.parametrize('use_source', [None, True, False])
+@pytest.mark.parametrize("use_source", [None, True, False])
 def test_get_extract_parameters_extraction_type_none(
-        mock_nirspec_fs_one_slit, extract1d_ref_dict, use_source, log_watcher):
+    mock_nirspec_fs_one_slit, extract1d_ref_dict, use_source, log_watcher
+):
     input_model = mock_nirspec_fs_one_slit
 
     log_watcher.message = "Using extraction type"
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit1', 1, input_model.meta,
-        extraction_type=None, use_source_posn=use_source, psf_ref_name='available')
+        extract1d_ref_dict,
+        input_model,
+        "slit1",
+        1,
+        input_model.meta,
+        extraction_type=None,
+        use_source_posn=use_source,
+        psf_ref_name="available",
+    )
     log_watcher.assert_seen()
 
     # Extraction type is set to optimal if use_source_posn is True
     if use_source is None or use_source is True:
-        assert params['use_source_posn'] is True
-        assert params['extraction_type'] == 'optimal'
+        assert params["use_source_posn"] is True
+        assert params["extraction_type"] == "optimal"
     else:
-        assert params['use_source_posn'] is False
-        assert params['extraction_type'] == 'box'
+        assert params["use_source_posn"] is False
+        assert params["extraction_type"] == "box"
 
 
-@pytest.mark.parametrize('extraction_type', [None, 'box', 'optimal'])
+@pytest.mark.parametrize("extraction_type", [None, "box", "optimal"])
 def test_get_extract_parameters_no_psf(
-        mock_nirspec_fs_one_slit, extract1d_ref_dict, extraction_type, log_watcher):
+    mock_nirspec_fs_one_slit, extract1d_ref_dict, extraction_type, log_watcher
+):
     input_model = mock_nirspec_fs_one_slit
 
     log_watcher.message = "Setting extraction type to 'box'"
     params = ex.get_extract_parameters(
-        extract1d_ref_dict, input_model, 'slit1', 1, input_model.meta,
-        extraction_type=extraction_type, psf_ref_name='N/A')
+        extract1d_ref_dict,
+        input_model,
+        "slit1",
+        1,
+        input_model.meta,
+        extraction_type=extraction_type,
+        psf_ref_name="N/A",
+    )
 
     # Warning message issued if extraction type was not already 'box'
-    if extraction_type != 'box':
+    if extraction_type != "box":
         log_watcher.assert_seen()
 
     # Extraction type is always box if no psf is available
-    assert params['extraction_type'] == 'box'
+    assert params["extraction_type"] == "box"
 
 
 def test_log_params(extract_defaults, log_watcher):
-    log_watcher.message = 'Extraction parameters'
+    log_watcher.message = "Extraction parameters"
 
     # Defaults don't have dispaxis assigned yet - parameters are not logged
     ex.log_initial_parameters(extract_defaults)
     assert not log_watcher.seen
 
     # Add dispaxis: parameters are now logged
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
     ex.log_initial_parameters(extract_defaults)
     log_watcher.assert_seen()
 
@@ -310,8 +332,8 @@ def test_populate_time_keywords(mock_nirspec_bots, mock_10_spec):
     # time keywords now added to output spectra
     for i, spec in enumerate(mock_10_spec.spec):
         assert spec.int_num == i + 1
-        assert spec.start_time_mjd == mock_nirspec_bots.int_times['int_start_MJD_UTC'][i]
-        assert spec.end_tdb == mock_nirspec_bots.int_times['int_end_BJD_TDB'][i]
+        assert spec.start_time_mjd == mock_nirspec_bots.int_times["int_start_MJD_UTC"][i]
+        assert spec.end_tdb == mock_nirspec_bots.int_times["int_end_BJD_TDB"][i]
 
 
 def test_populate_time_keywords_no_table(mock_nirspec_fs_one_slit, mock_one_spec):
@@ -332,11 +354,12 @@ def test_populate_time_keywords_multislit(mock_nirspec_mos, mock_10_spec):
 
 
 def test_populate_time_keywords_multislit_table(
-        mock_nirspec_mos, mock_nirspec_bots, mock_10_spec, log_watcher):
+    mock_nirspec_mos, mock_nirspec_bots, mock_10_spec, log_watcher
+):
     mock_nirspec_mos.meta.exposure.nints = 10
     mock_nirspec_mos.int_times = mock_nirspec_bots.int_times
 
-    log_watcher.message = 'Not using INT_TIMES table'
+    log_watcher.message = "Not using INT_TIMES table"
     ex.populate_time_keywords(mock_nirspec_mos, mock_10_spec)
     log_watcher.assert_seen()
 
@@ -345,11 +368,12 @@ def test_populate_time_keywords_multislit_table(
 
 
 def test_populate_time_keywords_averaged(
-        mock_nirspec_fs_one_slit, mock_nirspec_bots, mock_10_spec, log_watcher):
+    mock_nirspec_fs_one_slit, mock_nirspec_bots, mock_10_spec, log_watcher
+):
     mock_nirspec_fs_one_slit.meta.exposure.nints = 10
     mock_nirspec_fs_one_slit.int_times = mock_nirspec_bots.int_times
 
-    log_watcher.message = 'Not using INT_TIMES table'
+    log_watcher.message = "Not using INT_TIMES table"
     ex.populate_time_keywords(mock_nirspec_fs_one_slit, mock_10_spec)
     log_watcher.assert_seen()
 
@@ -360,7 +384,7 @@ def test_populate_time_keywords_averaged(
 def test_populate_time_keywords_mismatched_table(mock_nirspec_bots, mock_10_spec, log_watcher):
     # mock 20 integrations - table has 10
     mock_nirspec_bots.data = np.vstack([mock_nirspec_bots.data, mock_nirspec_bots.data])
-    log_watcher.message = 'Not using INT_TIMES table'
+    log_watcher.message = "Not using INT_TIMES table"
     ex.populate_time_keywords(mock_nirspec_bots, mock_10_spec)
     log_watcher.assert_seen()
 
@@ -370,7 +394,7 @@ def test_populate_time_keywords_mismatched_table(mock_nirspec_bots, mock_10_spec
 
 def test_populate_time_keywords_missing_ints(mock_nirspec_bots, mock_10_spec, log_watcher):
     mock_nirspec_bots.meta.exposure.integration_start = 20
-    log_watcher.message = 'does not include rows'
+    log_watcher.message = "does not include rows"
     ex.populate_time_keywords(mock_nirspec_bots, mock_10_spec)
     log_watcher.assert_seen()
 
@@ -379,11 +403,12 @@ def test_populate_time_keywords_missing_ints(mock_nirspec_bots, mock_10_spec, lo
 
 
 def test_populate_time_keywords_ifu_table(
-        mock_miri_ifu, mock_nirspec_bots, mock_10_spec, log_watcher):
+    mock_miri_ifu, mock_nirspec_bots, mock_10_spec, log_watcher
+):
     mock_miri_ifu.meta.exposure.nints = 10
     mock_miri_ifu.int_times = mock_nirspec_bots.int_times
 
-    log_watcher.message = 'ignored for IFU'
+    log_watcher.message = "ignored for IFU"
     ex.populate_time_keywords(mock_miri_ifu, mock_10_spec)
     log_watcher.assert_seen()
 
@@ -391,8 +416,7 @@ def test_populate_time_keywords_ifu_table(
     assert mock_10_spec.spec[0].int_num is None
 
 
-def test_populate_time_keywords_mismatched_spec(
-        mock_nirspec_bots, mock_one_spec, log_watcher):
+def test_populate_time_keywords_mismatched_spec(mock_nirspec_bots, mock_one_spec, log_watcher):
     log_watcher.message = "Don't understand n_output_spec"
     ex.populate_time_keywords(mock_nirspec_bots, mock_one_spec)
     log_watcher.assert_seen()
@@ -427,69 +451,86 @@ def test_is_prism_false_conditions(mock_nirspec_fs_one_slit):
 
 
 def test_is_prism_nirspec(mock_nirspec_fs_one_slit):
-    mock_nirspec_fs_one_slit.meta.instrument.grating = 'PRISM'
+    mock_nirspec_fs_one_slit.meta.instrument.grating = "PRISM"
     assert ex.is_prism(mock_nirspec_fs_one_slit) is True
 
 
 def test_is_prism_miri(mock_miri_ifu):
-    mock_miri_ifu.meta.instrument.filter = 'P750L'
+    mock_miri_ifu.meta.instrument.filter = "P750L"
     assert ex.is_prism(mock_miri_ifu) is True
 
+
 def test_copy_keyword_info(mock_nirspec_fs_one_slit, mock_one_spec):
-    expected = {'slitlet_id': 2,
-                'source_id': 3,
-                'source_name': '4',
-                'source_alias': '5',
-                'source_type': 'POINT',
-                'stellarity': 0.5,
-                'source_xpos': -0.5,
-                'source_ypos': -0.5,
-                'source_ra': 10.0,
-                'source_dec': 10.0,
-                'shutter_state': 'x'}
+    expected = {
+        "slitlet_id": 2,
+        "source_id": 3,
+        "source_name": "4",
+        "source_alias": "5",
+        "source_type": "POINT",
+        "stellarity": 0.5,
+        "source_xpos": -0.5,
+        "source_ypos": -0.5,
+        "source_ra": 10.0,
+        "source_dec": 10.0,
+        "shutter_state": "x",
+    }
     for key, value in expected.items():
         setattr(mock_nirspec_fs_one_slit, key, value)
         assert not hasattr(mock_one_spec, key)
 
-    ex.copy_keyword_info(mock_nirspec_fs_one_slit, 'slit_name', mock_one_spec)
-    assert mock_one_spec.name == 'slit_name'
+    ex.copy_keyword_info(mock_nirspec_fs_one_slit, "slit_name", mock_one_spec)
+    assert mock_one_spec.name == "slit_name"
     for key, value in expected.items():
         assert getattr(mock_one_spec, key) == value
 
 
 @pytest.mark.parametrize("partial", [True, False])
-@pytest.mark.parametrize("lower,upper",
-                         [(0, 19), (-1, 21),
-                          (np.full(10, 0.0), np.full(10, 19.0)),
-                          (np.linspace(-1, 0, 10), np.linspace(19, 20, 10)),])
+@pytest.mark.parametrize(
+    "lower,upper",
+    [
+        (0, 19),
+        (-1, 21),
+        (np.full(10, 0.0), np.full(10, 19.0)),
+        (np.linspace(-1, 0, 10), np.linspace(19, 20, 10)),
+    ],
+)
 def test_set_weights_from_limits_whole_array(lower, upper, partial):
     shape = (20, 10)
     profile = np.zeros(shape, dtype=float)
-    yidx, _ = np.mgrid[:shape[0], :shape[1]]
+    yidx, _ = np.mgrid[: shape[0], : shape[1]]
 
     ex._set_weight_from_limits(profile, yidx, lower, upper, allow_partial=partial)
     assert np.all(profile == 1.0)
 
 
-@pytest.mark.parametrize("lower,upper",
-                         [(10, 12), (9.5, 12.5),
-                          (np.linspace(9.5, 10, 10), np.linspace(12, 12.5, 10)),])
+@pytest.mark.parametrize(
+    "lower,upper",
+    [
+        (10, 12),
+        (9.5, 12.5),
+        (np.linspace(9.5, 10, 10), np.linspace(12, 12.5, 10)),
+    ],
+)
 def test_set_weights_from_limits_whole_pixel(lower, upper):
     shape = (20, 10)
     profile = np.zeros(shape, dtype=np.float32)
-    yidx, _ = np.mgrid[:shape[0], :shape[1]]
+    yidx, _ = np.mgrid[: shape[0], : shape[1]]
 
     ex._set_weight_from_limits(profile, yidx, lower, upper, allow_partial=False)
     assert np.all(profile[10:13] == 1.0)
 
 
-@pytest.mark.parametrize("lower,upper",
-                         [(9.5, 12.5),
-                          (np.linspace(9.5, 10, 10), np.linspace(12, 12.5, 10)),])
+@pytest.mark.parametrize(
+    "lower,upper",
+    [
+        (9.5, 12.5),
+        (np.linspace(9.5, 10, 10), np.linspace(12, 12.5, 10)),
+    ],
+)
 def test_set_weights_from_limits_partial_pixel(lower, upper):
     shape = (20, 10)
     profile = np.zeros(shape, dtype=np.float32)
-    yidx, _ = np.mgrid[:shape[0], :shape[1]]
+    yidx, _ = np.mgrid[: shape[0], : shape[1]]
 
     ex._set_weight_from_limits(profile, yidx, lower, upper, allow_partial=True)
     assert np.allclose(profile[10:13], 1.0)
@@ -500,7 +541,7 @@ def test_set_weights_from_limits_partial_pixel(lower, upper):
 def test_set_weights_from_limits_overlap():
     shape = (20, 10)
     profile = np.zeros(shape, dtype=np.float32)
-    yidx, _ = np.mgrid[:shape[0], :shape[1]]
+    yidx, _ = np.mgrid[: shape[0], : shape[1]]
 
     # Set an aperture with partial pixel edges
     ex._set_weight_from_limits(profile, yidx, 9.5, 10.5, allow_partial=True)
@@ -527,16 +568,16 @@ def test_box_profile_horizontal(extract_defaults):
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = 1
+    params["dispaxis"] = 1
 
     # Exclude 2 pixels at left and right
-    params['xstart'] = 1.5
-    params['xstop'] = 7.5
+    params["xstart"] = 1.5
+    params["xstop"] = 7.5
 
     # Exclude 2 pixels at top and bottom, set half pixel weights
     # for another pixel at top and bottom edges
-    params['ystart'] = 2.5
-    params['ystop'] = 6.5
+    params["ystart"] = 2.5
+    params["ystop"] = 6.5
     profile = ex.box_profile(shape, extract_defaults, wl_array)
 
     # ystart/stop sets partial weights, xstart/stop sets whole pixels only
@@ -555,16 +596,16 @@ def test_box_profile_vertical(extract_defaults):
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = 2
+    params["dispaxis"] = 2
 
     # Exclude 2 pixels at "left" and "right" - in transposed aperture
-    params['ystart'] = 1.5
-    params['ystop'] = 7.5
+    params["ystart"] = 1.5
+    params["ystop"] = 7.5
 
     # Exclude 2 pixels at "top" and "bottom", set half pixel weights
     # for another pixel at top and bottom edges
-    params['xstart'] = 2.5
-    params['xstop'] = 6.5
+    params["xstart"] = 2.5
+    params["xstop"] = 6.5
     profile = ex.box_profile(shape, extract_defaults, wl_array)
 
     # xstart/stop sets partial weights, ystart/stop sets whole pixels only
@@ -578,23 +619,23 @@ def test_box_profile_vertical(extract_defaults):
     assert np.all(profile[:, 8:] == 0.0)
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_box_profile_bkg_coeff(extract_defaults, dispaxis):
     shape = (10, 10)
     wl_array = np.empty(shape)
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = dispaxis
+    params["dispaxis"] = dispaxis
 
     # the definition for bkg_coeff is half a pixel off from start/stop definitions -
     # this will set the equivalent of start/stop 0-2, 7-9 -
     # 3 pixels at top and bottom of the array
-    params['bkg_coeff'] = [[-0.5], [2.5], [6.5], [9.5]]
+    params["bkg_coeff"] = [[-0.5], [2.5], [6.5], [9.5]]
 
-    profile, lower, upper = (
-        ex.box_profile(shape, extract_defaults, wl_array,
-                       coefficients='bkg_coeff', return_limits=True))
+    profile, lower, upper = ex.box_profile(
+        shape, extract_defaults, wl_array, coefficients="bkg_coeff", return_limits=True
+    )
     if dispaxis == 2:
         profile = profile.T
 
@@ -611,15 +652,15 @@ def test_box_profile_bkg_coeff_median(extract_defaults):
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = 1
-    params['bkg_fit'] = 'median'
+    params["dispaxis"] = 1
+    params["bkg_fit"] = "median"
 
     # Attempt to set partial pixels at middle edges
-    params['bkg_coeff'] = [[-0.5], [3.0], [6.0], [9.5]]
+    params["bkg_coeff"] = [[-0.5], [3.0], [6.0], [9.5]]
 
-    profile, lower, upper = (
-        ex.box_profile(shape, extract_defaults, wl_array,
-                       coefficients='bkg_coeff', return_limits=True))
+    profile, lower, upper = ex.box_profile(
+        shape, extract_defaults, wl_array, coefficients="bkg_coeff", return_limits=True
+    )
 
     # partial pixels are not allowed for fit type median - the profile is
     # set for whole pixels only
@@ -630,26 +671,26 @@ def test_box_profile_bkg_coeff_median(extract_defaults):
     assert upper == 9.0
 
 
-@pytest.mark.parametrize('swap_order', [False, True])
+@pytest.mark.parametrize("swap_order", [False, True])
 def test_box_profile_bkg_coeff_poly(extract_defaults, swap_order):
     shape = (10, 10)
     wl_array = np.empty(shape)
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = 1
-    params['bkg_fit'] = 'poly'
+    params["dispaxis"] = 1
+    params["bkg_fit"] = "poly"
 
     # Attempt to set partial pixels at middle edges
     if swap_order:
         # upper region first - this should make no difference.
-        params['bkg_coeff'] = [[6.0], [9.5], [-0.5], [3.0]]
+        params["bkg_coeff"] = [[6.0], [9.5], [-0.5], [3.0]]
     else:
-        params['bkg_coeff'] = [[-0.5], [3.0], [6.0], [9.5]]
+        params["bkg_coeff"] = [[-0.5], [3.0], [6.0], [9.5]]
 
-    profile, lower, upper = (
-        ex.box_profile(shape, extract_defaults, wl_array,
-                       coefficients='bkg_coeff', return_limits=True))
+    profile, lower, upper = ex.box_profile(
+        shape, extract_defaults, wl_array, coefficients="bkg_coeff", return_limits=True
+    )
 
     # partial pixels are allowed for fit type poly
     assert np.all(profile[:3] == 1.0)
@@ -661,24 +702,24 @@ def test_box_profile_bkg_coeff_poly(extract_defaults, swap_order):
     assert upper == 9.0
 
 
-@pytest.mark.parametrize('independent_var', ['pixel', 'wavelength'])
+@pytest.mark.parametrize("independent_var", ["pixel", "wavelength"])
 def test_box_profile_src_coeff_constant(extract_defaults, independent_var):
     shape = (10, 10)
     wl_array = np.empty(shape)
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = 1
-    params['independent_var'] = independent_var
+    params["dispaxis"] = 1
+    params["independent_var"] = independent_var
 
     # the definition for src_coeff is half a pixel off from start/stop definitions -
     # this will set the equivalent of start/stop 3-6, excluding
     # 3 pixels at top and bottom of the array
-    params['src_coeff'] = [[2.5], [6.5]]
+    params["src_coeff"] = [[2.5], [6.5]]
 
-    profile, lower, upper = (
-        ex.box_profile(shape, extract_defaults, wl_array,
-                       coefficients='src_coeff', return_limits=True))
+    profile, lower, upper = ex.box_profile(
+        shape, extract_defaults, wl_array, coefficients="src_coeff", return_limits=True
+    )
     assert np.all(profile[3:7] == 1.0)
     assert np.all(profile[:3] == 0.0)
     assert np.all(profile[7:] == 0.0)
@@ -686,17 +727,17 @@ def test_box_profile_src_coeff_constant(extract_defaults, independent_var):
     assert upper == 6.0
 
 
-@pytest.mark.parametrize('independent_var', ['pixel', 'wavelength'])
+@pytest.mark.parametrize("independent_var", ["pixel", "wavelength"])
 def test_box_profile_src_coeff_linear(extract_defaults, independent_var):
     shape = (10, 10)
     wl_array = np.empty(shape)
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = 1
-    params['independent_var'] = independent_var
+    params["dispaxis"] = 1
+    params["independent_var"] = independent_var
 
-    if independent_var == 'wavelength':
+    if independent_var == "wavelength":
         slope = 1 / (wl_array[0, 1] - wl_array[0, 0])
         start = -0.5 - wl_array[0, 0] * slope
         stop = start + 4
@@ -707,21 +748,23 @@ def test_box_profile_src_coeff_linear(extract_defaults, independent_var):
 
     # Set linearly increasing upper and lower edges,
     # starting at the bottom of the array, with a width of 4 pixels
-    params['src_coeff'] = [[start, slope], [stop, slope]]
-    expected = [[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
-                [0, 1, 1, 1, 1, 0, 0, 0, 0, 0],
-                [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
-                [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
-                [0, 0, 0, 0, 1, 1, 1, 1, 0, 0],
-                [0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0, 0, 1, 1, 1, 1]]
+    params["src_coeff"] = [[start, slope], [stop, slope]]
+    expected = [
+        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+        [0, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+        [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+        [0, 0, 0, 0, 1, 1, 1, 1, 0, 0],
+        [0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
+        [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+    ]
 
-    profile, lower, upper = (
-        ex.box_profile(shape, extract_defaults, wl_array,
-                       coefficients='src_coeff', return_limits=True))
+    profile, lower, upper = ex.box_profile(
+        shape, extract_defaults, wl_array, coefficients="src_coeff", return_limits=True
+    )
     assert np.allclose(profile, expected)
 
     # upper and lower limits are averages
@@ -735,35 +778,35 @@ def test_box_profile_mismatched_coeff(extract_defaults):
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = 1
+    params["dispaxis"] = 1
 
     # set some mismatched coefficients limits
-    params['src_coeff'] = [[2.5], [6.5], [9.5]]
+    params["src_coeff"] = [[2.5], [6.5], [9.5]]
 
-    with pytest.raises(RuntimeError, match='must contain alternating lists'):
+    with pytest.raises(RuntimeError, match="must contain alternating lists"):
         ex.box_profile(shape, extract_defaults, wl_array)
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_box_profile_from_width(extract_defaults, dispaxis):
     shape = (10, 10)
     wl_array = np.empty(shape)
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = dispaxis
+    params["dispaxis"] = dispaxis
 
     if dispaxis == 1:
         # Set ystart and ystop to center on pixel 4
-        params['ystart'] = 2.0
-        params['ystop'] = 6.0
+        params["ystart"] = 2.0
+        params["ystop"] = 6.0
     else:
         # Set xstart and xstop to center on pixel 4
-        params['xstart'] = 2.0
-        params['xstop'] = 6.0
+        params["xstart"] = 2.0
+        params["xstop"] = 6.0
 
     # Set a width to 6 pixels
-    params['extract_width'] = 6.0
+    params["extract_width"] = 6.0
 
     profile = ex.box_profile(shape, extract_defaults, wl_array)
     if dispaxis == 2:
@@ -777,37 +820,38 @@ def test_box_profile_from_width(extract_defaults, dispaxis):
     assert np.all(profile[8:] == 0.0)
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_box_profile_from_trace(extract_defaults, dispaxis):
     shape = (10, 10)
     wl_array = np.empty(shape)
     wl_array[:] = np.linspace(3, 5, 10)
 
     params = extract_defaults
-    params['dispaxis'] = dispaxis
+    params["dispaxis"] = dispaxis
 
     # Set a linear trace
-    params['trace'] = np.arange(10) + 1.5
+    params["trace"] = np.arange(10) + 1.5
 
     # Set the width to 4 pixels
-    params['extract_width'] = 4.0
+    params["extract_width"] = 4.0
 
     # Make the profile
-    profile, lower, upper = ex.box_profile(
-        shape, extract_defaults, wl_array, return_limits=True)
+    profile, lower, upper = ex.box_profile(shape, extract_defaults, wl_array, return_limits=True)
     if dispaxis == 2:
         profile = profile.T
 
-    expected = [[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
-                [0, 1, 1, 1, 1, 0, 0, 0, 0, 0],
-                [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
-                [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
-                [0, 0, 0, 0, 1, 1, 1, 1, 0, 0],
-                [0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0, 0, 1, 1, 1, 1]]
+    expected = [
+        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+        [0, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+        [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+        [0, 0, 0, 0, 1, 1, 1, 1, 0, 0],
+        [0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
+        [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+    ]
 
     assert np.allclose(profile, expected)
 
@@ -816,15 +860,14 @@ def test_box_profile_from_trace(extract_defaults, dispaxis):
     assert np.isclose(upper, 7.5)
 
 
-@pytest.mark.parametrize('middle', [None, 7])
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("middle", [None, 7])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_aperture_center(middle, dispaxis):
     profile = np.zeros((10, 10), dtype=np.float32)
     profile[1:4] = 1.0
     if dispaxis != 1:
         profile = profile.T
-    slit_center, spec_center = ex.aperture_center(
-        profile, dispaxis=dispaxis, middle_pix=middle)
+    slit_center, spec_center = ex.aperture_center(profile, dispaxis=dispaxis, middle_pix=middle)
     assert slit_center == 2.0
     if middle is None:
         assert spec_center == 4.5
@@ -832,12 +875,11 @@ def test_aperture_center(middle, dispaxis):
         assert spec_center == middle
 
 
-@pytest.mark.parametrize('middle', [None, 7])
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("middle", [None, 7])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_aperture_center_zero_weight(middle, dispaxis):
     profile = np.zeros((10, 10), dtype=np.float32)
-    slit_center, spec_center = ex.aperture_center(
-        profile, dispaxis=dispaxis, middle_pix=middle)
+    slit_center, spec_center = ex.aperture_center(profile, dispaxis=dispaxis, middle_pix=middle)
     assert slit_center == 4.5
     if middle is None:
         assert spec_center == 4.5
@@ -845,15 +887,14 @@ def test_aperture_center_zero_weight(middle, dispaxis):
         assert spec_center == middle
 
 
-@pytest.mark.parametrize('middle', [None, 7])
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("middle", [None, 7])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_aperture_center_variable_weight_by_slit(middle, dispaxis):
     profile = np.zeros((10, 10), dtype=np.float32)
     profile[1:4] = np.arange(10)
     if dispaxis != 1:
         profile = profile.T
-    slit_center, spec_center = ex.aperture_center(
-        profile, dispaxis=dispaxis, middle_pix=middle)
+    slit_center, spec_center = ex.aperture_center(profile, dispaxis=dispaxis, middle_pix=middle)
     assert slit_center == 2.0
     if middle is None:
         assert np.isclose(spec_center, 6.3333333)
@@ -861,15 +902,14 @@ def test_aperture_center_variable_weight_by_slit(middle, dispaxis):
         assert spec_center == middle
 
 
-@pytest.mark.parametrize('middle', [None, 7])
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("middle", [None, 7])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_aperture_center_variable_weight_by_spec(middle, dispaxis):
     profile = np.zeros((10, 10), dtype=np.float32)
     profile[:, 1:4] = np.arange(10)[:, None]
     if dispaxis != 1:
         profile = profile.T
-    slit_center, spec_center = ex.aperture_center(
-        profile, dispaxis=dispaxis, middle_pix=middle)
+    slit_center, spec_center = ex.aperture_center(profile, dispaxis=dispaxis, middle_pix=middle)
     if middle is None:
         assert np.isclose(slit_center, 6.3333333)
         assert np.isclose(spec_center, 2.0)
@@ -878,84 +918,86 @@ def test_aperture_center_variable_weight_by_spec(middle, dispaxis):
         assert spec_center == middle
 
 
-
-
 def test_shift_by_offset_horizontal(extract_defaults):
     offset = 2.5
 
     extract_params = extract_defaults.copy()
-    extract_params['dispaxis'] = 1
-    extract_params['position_offset'] = offset
+    extract_params["dispaxis"] = 1
+    extract_params["position_offset"] = offset
 
     ex.shift_by_offset(offset, extract_params)
-    assert extract_params['xstart'] == extract_defaults['xstart']
-    assert extract_params['xstop'] == extract_defaults['xstop']
-    assert extract_params['ystart'] == extract_defaults['ystart'] + offset
-    assert extract_params['ystop'] == extract_defaults['ystop'] + offset
+    assert extract_params["xstart"] == extract_defaults["xstart"]
+    assert extract_params["xstop"] == extract_defaults["xstop"]
+    assert extract_params["ystart"] == extract_defaults["ystart"] + offset
+    assert extract_params["ystop"] == extract_defaults["ystop"] + offset
 
 
 def test_shift_by_offset_vertical(extract_defaults):
     offset = 2.5
 
     extract_params = extract_defaults.copy()
-    extract_params['dispaxis'] = 2
-    extract_params['position_offset'] = offset
+    extract_params["dispaxis"] = 2
+    extract_params["position_offset"] = offset
 
     ex.shift_by_offset(offset, extract_params)
-    assert extract_params['xstart'] == extract_defaults['xstart'] + offset
-    assert extract_params['xstop'] == extract_defaults['xstop'] + offset
-    assert extract_params['ystart'] == extract_defaults['ystart']
-    assert extract_params['ystop'] == extract_defaults['ystop']
+    assert extract_params["xstart"] == extract_defaults["xstart"] + offset
+    assert extract_params["xstop"] == extract_defaults["xstop"] + offset
+    assert extract_params["ystart"] == extract_defaults["ystart"]
+    assert extract_params["ystop"] == extract_defaults["ystop"]
 
 
 def test_shift_by_offset_coeff(extract_defaults):
     offset = 2.5
 
     extract_params = extract_defaults.copy()
-    extract_params['dispaxis'] = 1
-    extract_params['position_offset'] = offset
-    extract_params['src_coeff'] = [[2.5, 1.0], [6.5, 1.0]]
-    extract_params['bkg_coeff'] = [[-0.5], [3.0], [6.0], [9.5]]
+    extract_params["dispaxis"] = 1
+    extract_params["position_offset"] = offset
+    extract_params["src_coeff"] = [[2.5, 1.0], [6.5, 1.0]]
+    extract_params["bkg_coeff"] = [[-0.5], [3.0], [6.0], [9.5]]
 
     ex.shift_by_offset(offset, extract_params)
-    assert extract_params['src_coeff'] == [[2.5 + offset, 1.0], [6.5 + offset, 1.0]]
-    assert extract_params['bkg_coeff'] == [[-0.5 + offset], [3.0 + offset],
-                                           [6.0 + offset], [9.5 + offset]]
+    assert extract_params["src_coeff"] == [[2.5 + offset, 1.0], [6.5 + offset, 1.0]]
+    assert extract_params["bkg_coeff"] == [
+        [-0.5 + offset],
+        [3.0 + offset],
+        [6.0 + offset],
+        [9.5 + offset],
+    ]
 
 
 def test_shift_by_offset_trace(extract_defaults):
     offset = 2.5
 
     extract_params = extract_defaults.copy()
-    extract_params['dispaxis'] = 1
-    extract_params['position_offset'] = offset
-    extract_params['trace'] = np.arange(10, dtype=float)
+    extract_params["dispaxis"] = 1
+    extract_params["position_offset"] = offset
+    extract_params["trace"] = np.arange(10, dtype=float)
 
     ex.shift_by_offset(offset, extract_params, update_trace=True)
-    assert np.all(extract_params['trace'] == np.arange(10) + offset)
+    assert np.all(extract_params["trace"] == np.arange(10) + offset)
 
 
 def test_shift_by_offset_trace_no_update(extract_defaults):
     offset = 2.5
 
     extract_params = extract_defaults.copy()
-    extract_params['dispaxis'] = 1
-    extract_params['position_offset'] = offset
-    extract_params['trace'] = np.arange(10, dtype=float)
+    extract_params["dispaxis"] = 1
+    extract_params["position_offset"] = offset
+    extract_params["trace"] = np.arange(10, dtype=float)
 
     ex.shift_by_offset(offset, extract_params, update_trace=False)
-    assert np.all(extract_params['trace'] == np.arange(10))
+    assert np.all(extract_params["trace"] == np.arange(10))
 
 
-@pytest.mark.parametrize('is_slit', [True, False])
+@pytest.mark.parametrize("is_slit", [True, False])
 def test_define_aperture_nirspec(mock_nirspec_fs_one_slit, extract_defaults, is_slit):
     model = mock_nirspec_fs_one_slit
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
     if is_slit:
         slit = model
     else:
         slit = None
-    exptype = 'NRS_FIXEDSLIT'
+    exptype = "NRS_FIXEDSLIT"
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     ra, dec, wavelength, profile, bg_profile, nod_profile, limits = result
     assert np.isclose(ra, 45.05)
@@ -971,15 +1013,15 @@ def test_define_aperture_nirspec(mock_nirspec_fs_one_slit, extract_defaults, is_
     assert bg_profile is None
 
 
-@pytest.mark.parametrize('is_slit', [True, False])
+@pytest.mark.parametrize("is_slit", [True, False])
 def test_define_aperture_miri(mock_miri_lrs_fs, extract_defaults, is_slit):
     model = mock_miri_lrs_fs
-    extract_defaults['dispaxis'] = 2
+    extract_defaults["dispaxis"] = 2
     if is_slit:
         slit = model
     else:
         slit = None
-    exptype = 'MIR_LRS-FIXEDSLIT'
+    exptype = "MIR_LRS-FIXEDSLIT"
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     ra, dec, wavelength, profile, bg_profile, nod_profile, limits = result
     assert np.isclose(ra, 45.05)
@@ -997,12 +1039,12 @@ def test_define_aperture_miri(mock_miri_lrs_fs, extract_defaults, is_slit):
 
 def test_define_aperture_with_bg(mock_nirspec_fs_one_slit, extract_defaults):
     model = mock_nirspec_fs_one_slit
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
     slit = None
-    exptype = 'NRS_FIXEDSLIT'
+    exptype = "NRS_FIXEDSLIT"
 
-    extract_defaults['subtract_background'] = True
-    extract_defaults['bkg_coeff'] = [[-0.5], [2.5]]
+    extract_defaults["subtract_background"] = True
+    extract_defaults["bkg_coeff"] = [[-0.5], [2.5]]
 
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     bg_profile = result[-3]
@@ -1015,13 +1057,13 @@ def test_define_aperture_with_bg(mock_nirspec_fs_one_slit, extract_defaults):
 
 def test_define_aperture_empty_aperture(mock_nirspec_fs_one_slit, extract_defaults):
     model = mock_nirspec_fs_one_slit
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
     slit = None
-    exptype = 'NRS_FIXEDSLIT'
+    exptype = "NRS_FIXEDSLIT"
 
     # Set the extraction limits out of range
-    extract_defaults['ystart'] = 2000
-    extract_defaults['ystop'] = 3000
+    extract_defaults["ystart"] = 2000
+    extract_defaults["ystop"] = 3000
 
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     _, _, _, profile, _, _, limits = result
@@ -1032,9 +1074,9 @@ def test_define_aperture_empty_aperture(mock_nirspec_fs_one_slit, extract_defaul
 
 def test_define_aperture_bad_wcs(monkeypatch, mock_nirspec_fs_one_slit, extract_defaults):
     model = mock_nirspec_fs_one_slit
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
     slit = None
-    exptype = 'NRS_FIXEDSLIT'
+    exptype = "NRS_FIXEDSLIT"
 
     # Set a wavelength so wcs is not called to retrieve it
     model.wavelength = np.empty_like(model.data)
@@ -1044,7 +1086,7 @@ def test_define_aperture_bad_wcs(monkeypatch, mock_nirspec_fs_one_slit, extract_
     def return_nan(*args):
         return np.nan, np.nan, np.nan
 
-    monkeypatch.setattr(model.meta, 'wcs', return_nan)
+    monkeypatch.setattr(model.meta, "wcs", return_nan)
 
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     ra, dec = result[:2]
@@ -1054,22 +1096,21 @@ def test_define_aperture_bad_wcs(monkeypatch, mock_nirspec_fs_one_slit, extract_
     assert dec is None
 
 
-def test_define_aperture_use_source(
-        monkeypatch, mock_nirspec_fs_one_slit, extract_defaults):
+def test_define_aperture_use_source(monkeypatch, mock_nirspec_fs_one_slit, extract_defaults):
     model = mock_nirspec_fs_one_slit
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
     slit = None
-    exptype = 'NRS_FIXEDSLIT'
+    exptype = "NRS_FIXEDSLIT"
 
     # mock the source location function
     def mock_source_location(*args):
         return 24, 7.74, 9.5, np.full(model.data.shape[-1], 9.5)
 
-    monkeypatch.setattr(ex, 'location_from_wcs', mock_source_location)
+    monkeypatch.setattr(ex, "location_from_wcs", mock_source_location)
 
     # set parameters to extract a 6 pixel aperture, centered on source location
-    extract_defaults['use_source_posn'] = True
-    extract_defaults['extract_width'] = 6.0
+    extract_defaults["use_source_posn"] = True
+    extract_defaults["extract_width"] = 6.0
 
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     _, _, _, profile, _, _, limits = result
@@ -1081,11 +1122,11 @@ def test_define_aperture_use_source(
 
 def test_define_aperture_extra_offset(mock_nirspec_fs_one_slit, extract_defaults):
     model = mock_nirspec_fs_one_slit
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
     slit = None
-    exptype = 'NRS_FIXEDSLIT'
+    exptype = "NRS_FIXEDSLIT"
 
-    extract_defaults['position_offset'] = 2.0
+    extract_defaults["position_offset"] = 2.0
 
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     _, _, _, profile, _, _, limits = result
@@ -1099,14 +1140,14 @@ def test_define_aperture_extra_offset(mock_nirspec_fs_one_slit, extract_defaults
 
 def test_define_aperture_optimal(mock_miri_lrs_fs, extract_defaults, psf_reference_file):
     model = mock_miri_lrs_fs
-    extract_defaults['dispaxis'] = 2
+    extract_defaults["dispaxis"] = 2
     slit = None
-    exptype = 'MIR_LRS-FIXEDSLIT'
+    exptype = "MIR_LRS-FIXEDSLIT"
 
     # set parameters for optimal extraction
-    extract_defaults['extraction_type'] = 'optimal'
-    extract_defaults['use_source_posn'] = True
-    extract_defaults['psf'] = psf_reference_file
+    extract_defaults["extraction_type"] = "optimal"
+    extract_defaults["use_source_posn"] = True
+    extract_defaults["psf"] = psf_reference_file
 
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     _, _, _, profile, bg_profile, nod_profile, limits = result
@@ -1129,27 +1170,28 @@ def test_define_aperture_optimal(mock_miri_lrs_fs, extract_defaults, psf_referen
 
 
 def test_define_aperture_optimal_with_nod(
-        monkeypatch, mock_miri_lrs_fs, extract_defaults, psf_reference_file):
+    monkeypatch, mock_miri_lrs_fs, extract_defaults, psf_reference_file
+):
     model = mock_miri_lrs_fs
-    extract_defaults['dispaxis'] = 2
+    extract_defaults["dispaxis"] = 2
     slit = None
-    exptype = 'MIR_LRS-FIXEDSLIT'
+    exptype = "MIR_LRS-FIXEDSLIT"
 
     # mock nod subtraction
-    mock_miri_lrs_fs.meta.cal_step.back_sub = 'COMPLETE'
-    mock_miri_lrs_fs.meta.dither.primary_type = 'ALONG-SLIT-NOD'
+    mock_miri_lrs_fs.meta.cal_step.back_sub = "COMPLETE"
+    mock_miri_lrs_fs.meta.dither.primary_type = "ALONG-SLIT-NOD"
 
     # mock a nod position at the opposite end of the array
     def mock_nod(*args, **kwargs):
         return 48.0
 
-    monkeypatch.setattr(pp, 'nod_pair_location', mock_nod)
+    monkeypatch.setattr(pp, "nod_pair_location", mock_nod)
 
     # set parameters for optimal extraction
-    extract_defaults['extraction_type'] = 'optimal'
-    extract_defaults['use_source_posn'] = True
-    extract_defaults['psf'] = psf_reference_file
-    extract_defaults['model_nod_pair'] = True
+    extract_defaults["extraction_type"] = "optimal"
+    extract_defaults["use_source_posn"] = True
+    extract_defaults["psf"] = psf_reference_file
+    extract_defaults["model_nod_pair"] = True
 
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     _, _, _, profile, bg_profile, nod_profile, limits = result
@@ -1178,19 +1220,21 @@ def test_define_aperture_optimal_with_nod(
     assert np.allclose(nod_profile[:, :-npix], 0.0)
 
 
-def test_extract_one_slit_horizontal(mock_nirspec_fs_one_slit, extract_defaults,
-                                     simple_profile, background_profile):
+def test_extract_one_slit_horizontal(
+    mock_nirspec_fs_one_slit, extract_defaults, simple_profile, background_profile
+):
     # update parameters to subtract background
-    extract_defaults['dispaxis'] = 1
-    extract_defaults['subtract_background'] = True
-    extract_defaults['bkg_fit'] = 'poly'
-    extract_defaults['bkg_order'] = 1
+    extract_defaults["dispaxis"] = 1
+    extract_defaults["subtract_background"] = True
+    extract_defaults["bkg_fit"] = "poly"
+    extract_defaults["bkg_order"] = 1
 
     # set a source in the profile region
     mock_nirspec_fs_one_slit.data[simple_profile != 0] += 1.0
 
-    result = ex.extract_one_slit(mock_nirspec_fs_one_slit, -1, simple_profile,
-                                 background_profile, None, extract_defaults)
+    result = ex.extract_one_slit(
+        mock_nirspec_fs_one_slit, -1, simple_profile, background_profile, None, extract_defaults
+    )
 
     for data in result[:-2]:
         assert np.all(data > 0)
@@ -1215,17 +1259,18 @@ def test_extract_one_slit_horizontal(mock_nirspec_fs_one_slit, extract_defaults,
     assert np.all(npixels == np.sum(simple_profile, axis=0))
 
 
-def test_extract_one_slit_vertical(mock_miri_lrs_fs, extract_defaults,
-                                   simple_profile, background_profile):
+def test_extract_one_slit_vertical(
+    mock_miri_lrs_fs, extract_defaults, simple_profile, background_profile
+):
     model = mock_miri_lrs_fs
     profile = simple_profile.T
     profile_bg = background_profile.T
 
     # update parameters to subtract background
-    extract_defaults['dispaxis'] = 2
-    extract_defaults['subtract_background'] = True
-    extract_defaults['bkg_fit'] = 'poly'
-    extract_defaults['bkg_order'] = 1
+    extract_defaults["dispaxis"] = 2
+    extract_defaults["subtract_background"] = True
+    extract_defaults["bkg_fit"] = "poly"
+    extract_defaults["bkg_order"] = 1
 
     # set a source in the profile region
     model.data[profile != 0] += 1.0
@@ -1255,11 +1300,10 @@ def test_extract_one_slit_vertical(mock_miri_lrs_fs, extract_defaults,
     assert np.all(npixels == np.sum(profile, axis=1))
 
 
-def test_extract_one_slit_vertical_no_bg(mock_miri_lrs_fs, extract_defaults,
-                                         simple_profile):
+def test_extract_one_slit_vertical_no_bg(mock_miri_lrs_fs, extract_defaults, simple_profile):
     model = mock_miri_lrs_fs
     profile = simple_profile.T
-    extract_defaults['dispaxis'] = 2
+    extract_defaults["dispaxis"] = 2
 
     result = ex.extract_one_slit(model, -1, profile, None, None, extract_defaults)
 
@@ -1281,10 +1325,11 @@ def test_extract_one_slit_vertical_no_bg(mock_miri_lrs_fs, extract_defaults,
     assert result[-1].shape == model.data.shape
 
 
-def test_extract_one_slit_multi_int(mock_nirspec_bots, extract_defaults,
-                                    simple_profile, log_watcher):
+def test_extract_one_slit_multi_int(
+    mock_nirspec_bots, extract_defaults, simple_profile, log_watcher
+):
     model = mock_nirspec_bots
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
 
     log_watcher.message = "Extracting integration 2"
     result = ex.extract_one_slit(model, 1, simple_profile, None, None, extract_defaults)
@@ -1308,10 +1353,9 @@ def test_extract_one_slit_multi_int(mock_nirspec_bots, extract_defaults,
     assert result[-1].shape == model.data.shape[-2:]
 
 
-def test_extract_one_slit_missing_var(mock_nirspec_fs_one_slit, extract_defaults,
-                                      simple_profile):
+def test_extract_one_slit_missing_var(mock_nirspec_fs_one_slit, extract_defaults, simple_profile):
     model = mock_nirspec_fs_one_slit
-    extract_defaults['dispaxis'] = 1
+    extract_defaults["dispaxis"] = 1
 
     # Test that mismatched variances still extract okay.
     # This is probably only possible for var_flat, which is optional and
@@ -1334,14 +1378,15 @@ def test_extract_one_slit_missing_var(mock_nirspec_fs_one_slit, extract_defaults
 
 
 def test_extract_one_slit_optimal_horizontal(
-        mock_nirspec_fs_one_slit, extract_defaults,
-        nod_profile, negative_nod_profile):
+    mock_nirspec_fs_one_slit, extract_defaults, nod_profile, negative_nod_profile
+):
     model = mock_nirspec_fs_one_slit
-    extract_defaults['dispaxis'] = 1
-    extract_defaults['extraction_type'] = 'optimal'
+    extract_defaults["dispaxis"] = 1
+    extract_defaults["extraction_type"] = "optimal"
 
-    result = ex.extract_one_slit(model, -1, nod_profile, None,
-                                 negative_nod_profile, extract_defaults)
+    result = ex.extract_one_slit(
+        model, -1, nod_profile, None, negative_nod_profile, extract_defaults
+    )
 
     # flux and variances are nonzero
     for data in result[:4]:
@@ -1362,14 +1407,17 @@ def test_extract_one_slit_optimal_horizontal(
 
 
 def test_extract_one_slit_optimal_vertical(
-        mock_miri_lrs_fs, extract_defaults, nod_profile, negative_nod_profile):
+    mock_miri_lrs_fs, extract_defaults, nod_profile, negative_nod_profile
+):
     model = mock_miri_lrs_fs
     nod_profile = nod_profile.T
     negative_nod_profile = negative_nod_profile.T
-    extract_defaults['dispaxis'] = 2
-    extract_defaults['extraction_type'] = 'optimal'
+    extract_defaults["dispaxis"] = 2
+    extract_defaults["extraction_type"] = "optimal"
 
-    result = ex.extract_one_slit(model, -1, nod_profile, None, negative_nod_profile, extract_defaults)
+    result = ex.extract_one_slit(
+        model, -1, nod_profile, None, negative_nod_profile, extract_defaults
+    )
 
     # flux and variances are nonzero
     for data in result[:4]:
@@ -1391,46 +1439,46 @@ def test_extract_one_slit_optimal_vertical(
 
 def test_create_extraction_with_photom(create_extraction_inputs):
     model = create_extraction_inputs[0]
-    model.meta.cal_step.photom = 'COMPLETE'
+    model.meta.cal_step.photom = "COMPLETE"
 
     ex.create_extraction(*create_extraction_inputs)
 
     output_model = create_extraction_inputs[2]
-    assert output_model.spec[0].spec_table.columns['flux'].unit == 'Jy'
+    assert output_model.spec[0].spec_table.columns["flux"].unit == "Jy"
 
 
 def test_create_extraction_without_photom(create_extraction_inputs):
     model = create_extraction_inputs[0]
-    model.meta.cal_step.photom = 'SKIPPED'
+    model.meta.cal_step.photom = "SKIPPED"
 
     ex.create_extraction(*create_extraction_inputs)
 
     output_model = create_extraction_inputs[2]
-    assert output_model.spec[0].spec_table.columns['flux'].unit == 'DN/s'
+    assert output_model.spec[0].spec_table.columns["flux"].unit == "DN/s"
 
 
 def test_create_extraction_missing_src_type(create_extraction_inputs):
     model = create_extraction_inputs[0]
     model.source_type = None
-    model.meta.target.source_type = 'EXTENDED'
+    model.meta.target.source_type = "EXTENDED"
 
     ex.create_extraction(*create_extraction_inputs)
 
     output_model = create_extraction_inputs[2]
-    assert output_model.spec[0].source_type == 'EXTENDED'
+    assert output_model.spec[0].source_type == "EXTENDED"
 
 
 def test_create_extraction_no_match(create_extraction_inputs):
-    create_extraction_inputs[4] = 'bad slitname'
+    create_extraction_inputs[4] = "bad slitname"
     with pytest.raises(ValueError, match="Missing extraction parameters"):
         ex.create_extraction(*create_extraction_inputs)
 
 
 def test_create_extraction_partial_match(create_extraction_inputs, log_watcher):
     # match a slit that has a mismatched spectral order specified
-    create_extraction_inputs[4] = 'slit7'
+    create_extraction_inputs[4] = "slit7"
 
-    log_watcher.message = 'Spectral order 1 not found'
+    log_watcher.message = "Spectral order 1 not found"
     with pytest.raises(ex.ContinueError):
         ex.create_extraction(*create_extraction_inputs)
     log_watcher.assert_seen()
@@ -1438,7 +1486,7 @@ def test_create_extraction_partial_match(create_extraction_inputs, log_watcher):
 
 def test_create_extraction_missing_dispaxis(create_extraction_inputs, log_watcher):
     create_extraction_inputs[0].meta.wcsinfo.dispersion_direction = None
-    log_watcher.message = 'dispersion direction information is missing'
+    log_watcher.message = "dispersion direction information is missing"
     with pytest.raises(ex.ContinueError):
         ex.create_extraction(*create_extraction_inputs)
     log_watcher.assert_seen()
@@ -1447,23 +1495,25 @@ def test_create_extraction_missing_dispaxis(create_extraction_inputs, log_watche
 def test_create_extraction_missing_wavelengths(create_extraction_inputs, log_watcher):
     model = create_extraction_inputs[0]
     model.wavelength = np.full_like(model.data, np.nan)
-    log_watcher.message = 'Spectrum is empty; no valid data'
+    log_watcher.message = "Spectrum is empty; no valid data"
     with pytest.raises(ex.ContinueError):
-        with pytest.warns(RuntimeWarning, match='All-NaN'):
+        with pytest.warns(RuntimeWarning, match="All-NaN"):
             ex.create_extraction(*create_extraction_inputs)
     log_watcher.assert_seen()
 
 
-def test_create_extraction_nrs_apcorr(create_extraction_inputs, nirspec_fs_apcorr,
-                                      mock_nirspec_bots, log_watcher):
+def test_create_extraction_nrs_apcorr(
+    create_extraction_inputs, nirspec_fs_apcorr, mock_nirspec_bots, log_watcher
+):
     model = mock_nirspec_bots
-    model.source_type = 'POINT'
-    model.meta.cal_step.photom = 'COMPLETE'
+    model.source_type = "POINT"
+    model.meta.cal_step.photom = "COMPLETE"
     create_extraction_inputs[0] = model
 
-    log_watcher.message = 'Tabulating aperture correction'
-    ex.create_extraction(*create_extraction_inputs, apcorr_ref_model=nirspec_fs_apcorr,
-                         use_source_posn=False)
+    log_watcher.message = "Tabulating aperture correction"
+    ex.create_extraction(
+        *create_extraction_inputs, apcorr_ref_model=nirspec_fs_apcorr, use_source_posn=False
+    )
     log_watcher.assert_seen()
 
 
@@ -1472,32 +1522,35 @@ def test_create_extraction_one_int(create_extraction_inputs, mock_nirspec_bots, 
     model = mock_nirspec_bots
     model.data = model.data[0].reshape(1, *model.data.shape[-2:])
     create_extraction_inputs[0] = model
-    create_extraction_inputs[4] = 'S1600A1'
+    create_extraction_inputs[4] = "S1600A1"
 
-    log_watcher.message = '1 integration done'
-    ex.create_extraction(
-        *create_extraction_inputs, log_increment=1)
+    log_watcher.message = "1 integration done"
+    ex.create_extraction(*create_extraction_inputs, log_increment=1)
     output_model = create_extraction_inputs[2]
     assert len(output_model.spec) == 1
     log_watcher.assert_seen()
 
 
-def test_create_extraction_log_increment(
-        create_extraction_inputs, mock_nirspec_bots, log_watcher):
+def test_create_extraction_log_increment(create_extraction_inputs, mock_nirspec_bots, log_watcher):
     create_extraction_inputs[0] = mock_nirspec_bots
-    create_extraction_inputs[4] = 'S1600A1'
+    create_extraction_inputs[4] = "S1600A1"
 
     # all integrations are logged
-    log_watcher.message = '... 9 integrations done'
+    log_watcher.message = "... 9 integrations done"
     ex.create_extraction(*create_extraction_inputs, log_increment=1)
     log_watcher.assert_seen()
 
 
-@pytest.mark.parametrize('use_source', [True, False, None])
-@pytest.mark.parametrize('source_type', ['POINT', 'EXTENDED'])
+@pytest.mark.parametrize("use_source", [True, False, None])
+@pytest.mark.parametrize("source_type", ["POINT", "EXTENDED"])
 def test_create_extraction_use_source(
-        monkeypatch, create_extraction_inputs, mock_nirspec_fs_one_slit,
-        use_source, source_type, log_watcher):
+    monkeypatch,
+    create_extraction_inputs,
+    mock_nirspec_fs_one_slit,
+    use_source,
+    source_type,
+    log_watcher,
+):
     model = mock_nirspec_fs_one_slit
     model.source_type = source_type
     create_extraction_inputs[0] = model
@@ -1506,70 +1559,73 @@ def test_create_extraction_use_source(
     def mock_source_location(*args):
         return 24, 7.74, 9.5, np.full(model.data.shape[-1], 9.5)
 
-    monkeypatch.setattr(ex, 'location_from_wcs', mock_source_location)
+    monkeypatch.setattr(ex, "location_from_wcs", mock_source_location)
 
-    if source_type != 'POINT' and use_source is None:
+    if source_type != "POINT" and use_source is None:
         # If not specified, source position should be used only if POINT
-        log_watcher.message = 'Setting use_source_posn to False'
-    elif use_source is True or (source_type == 'POINT' and use_source is None):
+        log_watcher.message = "Setting use_source_posn to False"
+    elif use_source is True or (source_type == "POINT" and use_source is None):
         # If explicitly set to True, or unspecified + source type is POINT,
         # source position is used
-        log_watcher.message = 'Aperture start/stop: -15'
+        log_watcher.message = "Aperture start/stop: -15"
     else:
         # If False, source position is not used
-        log_watcher.message = 'Aperture start/stop: 0'
+        log_watcher.message = "Aperture start/stop: 0"
     ex.create_extraction(*create_extraction_inputs, use_source_posn=use_source)
     log_watcher.assert_seen()
 
 
-@pytest.mark.parametrize('extract_width', [None, 7])
+@pytest.mark.parametrize("extract_width", [None, 7])
 def test_create_extraction_use_trace(
-        monkeypatch, create_extraction_inputs, mock_nirspec_bots,
-        extract_width, log_watcher):
+    monkeypatch, create_extraction_inputs, mock_nirspec_bots, extract_width, log_watcher
+):
     model = mock_nirspec_bots
     create_extraction_inputs[0] = model
-    aper = create_extraction_inputs[3]['apertures']
-    create_extraction_inputs[4] = 'S1600A1'
+    aper = create_extraction_inputs[3]["apertures"]
+    create_extraction_inputs[4] = "S1600A1"
     for i in range(len(aper)):
-        if aper[i]['id'] == 'S1600A1':
-            aper[i]['use_source_posn'] = True
-            aper[i]['extract_width'] = extract_width
-            aper[i]['position_offset'] = 0
+        if aper[i]["id"] == "S1600A1":
+            aper[i]["use_source_posn"] = True
+            aper[i]["extract_width"] = extract_width
+            aper[i]["position_offset"] = 0
 
     # mock the source location function
     def mock_source_location(*args):
         return 24, 7.74, 25, np.full(model.data.shape[-1], 25)
 
-    monkeypatch.setattr(ex, 'location_from_wcs', mock_source_location)
+    monkeypatch.setattr(ex, "location_from_wcs", mock_source_location)
     if extract_width is not None:
         # If explicitly set to True, or unspecified + source type is POINT,
         # source position is used
-        log_watcher.message = 'aperture start/stop from trace: 22'
+        log_watcher.message = "aperture start/stop from trace: 22"
     else:
         # If False, source trace is not used
-        log_watcher.message = 'Aperture start/stop: 0'
+        log_watcher.message = "Aperture start/stop: 0"
     ex.create_extraction(*create_extraction_inputs)
     log_watcher.assert_seen()
 
 
-def test_create_extraction_optimal(
-        monkeypatch, create_extraction_inputs, psf_reference_file):
+def test_create_extraction_optimal(monkeypatch, create_extraction_inputs, psf_reference_file):
     model = create_extraction_inputs[0]
 
     # mock nod subtraction
-    model.meta.cal_step.back_sub = 'COMPLETE'
-    model.meta.dither.primary_type = '2-POINT-NOD'
+    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.dither.primary_type = "2-POINT-NOD"
 
     # mock a nod position at the opposite end of the array
     def mock_nod(*args, **kwargs):
         return 48.0
 
-    monkeypatch.setattr(pp, 'nod_pair_location', mock_nod)
+    monkeypatch.setattr(pp, "nod_pair_location", mock_nod)
 
     profile_model, _, _ = ex.create_extraction(
-        *create_extraction_inputs,  save_profile=True,
-        psf_ref_name=psf_reference_file, use_source_posn=True,
-        extraction_type='optimal', model_nod_pair=True)
+        *create_extraction_inputs,
+        save_profile=True,
+        psf_ref_name=psf_reference_file,
+        use_source_posn=True,
+        extraction_type="optimal",
+        model_nod_pair=True,
+    )
 
     assert profile_model is not None
 
@@ -1593,7 +1649,8 @@ def test_run_extract1d(mock_nirspec_mos):
 def test_run_extract1d_save_models(mock_niriss_wfss_l3):
     model = mock_niriss_wfss_l3
     output_model, profile_model, scene_model, residual = ex.run_extract1d(
-        model, save_profile=True, save_scene_model=True, save_residual_image=True)
+        model, save_profile=True, save_scene_model=True, save_residual_image=True
+    )
     assert isinstance(output_model, dm.MultiSpecModel)
     assert isinstance(profile_model, ModelContainer)
     assert isinstance(scene_model, ModelContainer)
@@ -1619,7 +1676,8 @@ def test_run_extract1d_save_models(mock_niriss_wfss_l3):
 def test_run_extract1d_save_cube_scene(mock_nirspec_bots):
     model = mock_nirspec_bots
     output_model, profile_model, scene_model, residual = ex.run_extract1d(
-        model, save_profile=True, save_scene_model=True, save_residual_image=True)
+        model, save_profile=True, save_scene_model=True, save_residual_image=True
+    )
     assert isinstance(output_model, dm.MultiSpecModel)
     assert isinstance(profile_model, dm.ImageModel)
     assert isinstance(scene_model, dm.CubeModel)
@@ -1646,27 +1704,27 @@ def test_run_extract1d_tso(mock_nirspec_bots):
     output_model.close()
 
 
-@pytest.mark.parametrize('from_name_attr', [True, False])
+@pytest.mark.parametrize("from_name_attr", [True, False])
 def test_run_extract1d_slitmodel_name(mock_nirspec_fs_one_slit, from_name_attr):
     model = mock_nirspec_fs_one_slit
-    slit_name = 'S200A1'
+    slit_name = "S200A1"
     if from_name_attr:
         model.name = slit_name
         model.meta.instrument.fixed_slit = None
     else:
         model.name = None
-        model.meta.instrument.fixed_slit = 'S200A1'
+        model.meta.instrument.fixed_slit = "S200A1"
 
     output_model, _, _, _ = ex.run_extract1d(model)
-    assert output_model.spec[0].name == 'S200A1'
+    assert output_model.spec[0].name == "S200A1"
 
     output_model.close()
 
 
-@pytest.mark.parametrize('from_name_attr', [True, False])
+@pytest.mark.parametrize("from_name_attr", [True, False])
 def test_run_extract1d_imagemodel_name(mock_miri_lrs_fs, from_name_attr):
     model = mock_miri_lrs_fs
-    slit_name = 'test_slit_name'
+    slit_name = "test_slit_name"
     if from_name_attr:
         model.name = slit_name
     else:
@@ -1674,17 +1732,17 @@ def test_run_extract1d_imagemodel_name(mock_miri_lrs_fs, from_name_attr):
 
     output_model, _, _, _ = ex.run_extract1d(model)
     if from_name_attr:
-        assert output_model.spec[0].name == 'test_slit_name'
+        assert output_model.spec[0].name == "test_slit_name"
     else:
-        assert output_model.spec[0].name == 'MIR_LRS-FIXEDSLIT'
+        assert output_model.spec[0].name == "MIR_LRS-FIXEDSLIT"
     output_model.close()
 
 
 def test_run_extract1d_apcorr(mock_miri_lrs_fs, miri_lrs_apcorr_file, log_watcher):
     model = mock_miri_lrs_fs
-    model.meta.target.source_type = 'POINT'
+    model.meta.target.source_type = "POINT"
 
-    log_watcher.message = 'Creating aperture correction'
+    log_watcher.message = "Creating aperture correction"
     output_model, _, _, _ = ex.run_extract1d(model, apcorr_ref_name=miri_lrs_apcorr_file)
     log_watcher.assert_seen()
 
@@ -1692,16 +1750,20 @@ def test_run_extract1d_apcorr(mock_miri_lrs_fs, miri_lrs_apcorr_file, log_watche
 
 
 def test_run_extract1d_apcorr_optimal(
-        mock_miri_lrs_fs, miri_lrs_apcorr_file, psf_reference_file, log_watcher):
+    mock_miri_lrs_fs, miri_lrs_apcorr_file, psf_reference_file, log_watcher
+):
     model = mock_miri_lrs_fs
-    model.meta.target.source_type = 'POINT'
+    model.meta.target.source_type = "POINT"
 
     # Aperture correction that is otherwise valid is nonetheless
     # turned off for optimal extraction
-    log_watcher.message = 'Turning off aperture correction for optimal extraction'
-    output_model, _, _, _ = ex.run_extract1d(model, apcorr_ref_name=miri_lrs_apcorr_file,
-                                             psf_ref_name=psf_reference_file,
-                                             extraction_type='optimal')
+    log_watcher.message = "Turning off aperture correction for optimal extraction"
+    output_model, _, _, _ = ex.run_extract1d(
+        model,
+        apcorr_ref_name=miri_lrs_apcorr_file,
+        psf_ref_name=psf_reference_file,
+        extraction_type="optimal",
+    )
     log_watcher.assert_seen()
 
     output_model.close()
@@ -1709,18 +1771,19 @@ def test_run_extract1d_apcorr_optimal(
 
 def test_run_extract1d_optimal_no_psf(mock_miri_lrs_fs, log_watcher):
     model = mock_miri_lrs_fs
-    model.meta.target.source_type = 'POINT'
+    model.meta.target.source_type = "POINT"
 
     # Optimal extraction is turned off if there is no psf file provided
-    log_watcher.message = 'Optimal extraction is not available'
-    output_model, _, _, _ = ex.run_extract1d(model, extraction_type='optimal')
+    log_watcher.message = "Optimal extraction is not available"
+    output_model, _, _, _ = ex.run_extract1d(model, extraction_type="optimal")
     log_watcher.assert_seen()
 
     output_model.close()
 
+
 def test_run_extract1d_invalid():
     model = dm.MultiSpecModel()
-    with pytest.raises(RuntimeError, match="Can't extract a spectrum"):
+    with pytest.raises(TypeError, match="Can't extract a spectrum"):
         ex.run_extract1d(model)
 
 
@@ -1769,9 +1832,9 @@ def test_run_extract1d_no_data(mock_niriss_wfss_l3):
 
 def test_run_extract1d_continue_error_slit(monkeypatch, mock_nirspec_fs_one_slit):
     def raise_continue_error(*args, **kwargs):
-        raise ex.ContinueError('Test error')
+        raise ex.ContinueError("Test error")
 
-    monkeypatch.setattr(ex, 'create_extraction', raise_continue_error)
+    monkeypatch.setattr(ex, "create_extraction", raise_continue_error)
     output_model, _, _, _ = ex.run_extract1d(mock_nirspec_fs_one_slit)
 
     # no spectra extracted
@@ -1781,9 +1844,9 @@ def test_run_extract1d_continue_error_slit(monkeypatch, mock_nirspec_fs_one_slit
 
 def test_run_extract1d_continue_error_image(monkeypatch, mock_miri_lrs_fs):
     def raise_continue_error(*args, **kwargs):
-        raise ex.ContinueError('Test error')
+        raise ex.ContinueError("Test error")
 
-    monkeypatch.setattr(ex, 'create_extraction', raise_continue_error)
+    monkeypatch.setattr(ex, "create_extraction", raise_continue_error)
     output_model, _, _, _ = ex.run_extract1d(mock_miri_lrs_fs)
 
     # no spectra extracted
@@ -1793,9 +1856,9 @@ def test_run_extract1d_continue_error_image(monkeypatch, mock_miri_lrs_fs):
 
 def test_run_extract1d_continue_error_multislit(monkeypatch, mock_nirspec_mos):
     def raise_continue_error(*args, **kwargs):
-        raise ex.ContinueError('Test error')
+        raise ex.ContinueError("Test error")
 
-    monkeypatch.setattr(ex, 'create_extraction', raise_continue_error)
+    monkeypatch.setattr(ex, "create_extraction", raise_continue_error)
     output_model, _, _, _ = ex.run_extract1d(mock_nirspec_mos)
 
     # no spectra extracted

--- a/jwst/extract_1d/tests/test_extract_1d_step.py
+++ b/jwst/extract_1d/tests/test_extract_1d_step.py
@@ -9,104 +9,103 @@ from jwst.extract_1d.extract_1d_step import Extract1dStep
 from jwst.extract_1d.soss_extract import soss_extract
 
 
-@pytest.mark.parametrize('slit_name', [None, 'S200A1', 'S1600A1'])
+@pytest.mark.parametrize("slit_name", [None, "S200A1", "S1600A1"])
 def test_extract_nirspec_fs_slit(mock_nirspec_fs_one_slit, simple_wcs, slit_name):
     mock_nirspec_fs_one_slit.name = slit_name
     result = Extract1dStep.call(mock_nirspec_fs_one_slit)
-    assert result.meta.cal_step.extract_1d == 'COMPLETE'
+    assert result.meta.cal_step.extract_1d == "COMPLETE"
 
     if slit_name is None:
-        assert (result.spec[0].name
-                == mock_nirspec_fs_one_slit.meta.instrument.fixed_slit)
+        assert result.spec[0].name == mock_nirspec_fs_one_slit.meta.instrument.fixed_slit
     else:
         assert result.spec[0].name == slit_name
 
     # output wavelength is the same as input
     _, _, expected_wave = simple_wcs(np.arange(50), np.arange(50))
-    assert np.allclose(result.spec[0].spec_table['WAVELENGTH'], expected_wave)
+    assert np.allclose(result.spec[0].spec_table["WAVELENGTH"], expected_wave)
 
     # output flux and errors are non-zero, exact values will depend
     # on extraction parameters
-    assert np.all(result.spec[0].spec_table['FLUX'] > 0)
-    assert np.all(result.spec[0].spec_table['FLUX_ERROR'] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX"] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX_ERROR"] > 0)
     result.close()
 
 
 def test_extract_nirspec_mos_multi_slit(mock_nirspec_mos, simple_wcs):
     result = Extract1dStep.call(mock_nirspec_mos)
-    assert result.meta.cal_step.extract_1d == 'COMPLETE'
+    assert result.meta.cal_step.extract_1d == "COMPLETE"
 
     for i, spec in enumerate(result.spec):
         assert spec.name == str(i + 1)
 
         # output wavelength is the same as input
         _, _, expected_wave = simple_wcs(np.arange(50), np.arange(50))
-        assert np.allclose(spec.spec_table['WAVELENGTH'], expected_wave)
+        assert np.allclose(spec.spec_table["WAVELENGTH"], expected_wave)
 
         # output flux and errors are non-zero, exact values will depend
         # on extraction parameters
-        assert np.all(spec.spec_table['FLUX'] > 0)
-        assert np.all(spec.spec_table['FLUX_ERROR'] > 0)
+        assert np.all(spec.spec_table["FLUX"] > 0)
+        assert np.all(spec.spec_table["FLUX_ERROR"] > 0)
 
     result.close()
 
 
 def test_extract_nirspec_bots(mock_nirspec_bots, simple_wcs):
-    result = Extract1dStep.call(
-        mock_nirspec_bots, apply_apcorr=False, use_source_posn=False)
-    assert result.meta.cal_step.extract_1d == 'COMPLETE'
-    assert (result.spec[0].name == 'S1600A1')
+    result = Extract1dStep.call(mock_nirspec_bots, apply_apcorr=False, use_source_posn=False)
+    assert result.meta.cal_step.extract_1d == "COMPLETE"
+    assert result.spec[0].name == "S1600A1"
 
     # output wavelength is the same as input
     _, _, expected_wave = simple_wcs(np.arange(50), np.arange(50))
-    assert np.allclose(result.spec[0].spec_table['WAVELENGTH'], expected_wave)
+    assert np.allclose(result.spec[0].spec_table["WAVELENGTH"], expected_wave)
 
     # output flux and errors are non-zero, exact values will depend
     # on extraction parameters
-    assert np.all(result.spec[0].spec_table['FLUX'] > 0)
-    assert np.all(result.spec[0].spec_table['FLUX_ERROR'] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX"] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX_ERROR"] > 0)
     result.close()
 
 
 def test_extract_miri_lrs_fs(mock_miri_lrs_fs, simple_wcs_transpose):
     result = Extract1dStep.call(mock_miri_lrs_fs)
-    assert result.meta.cal_step.extract_1d == 'COMPLETE'
-    assert result.spec[0].name == 'MIR_LRS-FIXEDSLIT'
+    assert result.meta.cal_step.extract_1d == "COMPLETE"
+    assert result.spec[0].name == "MIR_LRS-FIXEDSLIT"
 
     # output wavelength is the same as input
     _, _, expected_wave = simple_wcs_transpose(np.arange(50), np.arange(50))
-    assert np.allclose(result.spec[0].spec_table['WAVELENGTH'], expected_wave)
+    assert np.allclose(result.spec[0].spec_table["WAVELENGTH"], expected_wave)
 
     # output flux and errors are non-zero, exact values will depend
     # on extraction parameters
-    assert np.all(result.spec[0].spec_table['FLUX'] > 0)
-    assert np.all(result.spec[0].spec_table['FLUX_ERROR'] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX"] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX_ERROR"] > 0)
     result.close()
 
 
-@pytest.mark.parametrize('ifu_set_srctype', [None, 'EXTENDED'])
+@pytest.mark.parametrize("ifu_set_srctype", [None, "EXTENDED"])
 def test_extract_miri_ifu(mock_miri_ifu, simple_wcs_ifu, ifu_set_srctype):
     # Source type defaults to extended, results should be the
     # same with and without override
-    result = Extract1dStep.call(mock_miri_ifu, ifu_covar_scale=1.0,
-                                ifu_set_srctype=ifu_set_srctype)
-    assert result.meta.cal_step.extract_1d == 'COMPLETE'
+    result = Extract1dStep.call(mock_miri_ifu, ifu_covar_scale=1.0, ifu_set_srctype=ifu_set_srctype)
+    assert result.meta.cal_step.extract_1d == "COMPLETE"
 
     # output wavelength is the same as input
     _, _, expected_wave = simple_wcs_ifu(np.arange(50), np.arange(50), np.arange(10))
-    assert np.allclose(result.spec[0].spec_table['WAVELENGTH'], expected_wave)
+    assert np.allclose(result.spec[0].spec_table["WAVELENGTH"], expected_wave)
 
     # output flux for extended data is a simple sum over all data
     # with a conversion factor for Jy
-    assert np.allclose(result.spec[0].spec_table['FLUX'],
-                       1e6 * np.sum(mock_miri_ifu.data, axis=(1, 2)))
+    assert np.allclose(
+        result.spec[0].spec_table["FLUX"], 1e6 * np.sum(mock_miri_ifu.data, axis=(1, 2))
+    )
 
     # output error comes from the sum of the variance components
-    variance_sum = (np.sum(mock_miri_ifu.var_rnoise, axis=(1, 2))
-                    + np.sum(mock_miri_ifu.var_poisson, axis=(1, 2))
-                    + np.sum(mock_miri_ifu.var_flat, axis=(1, 2)))
-    assert np.allclose(result.spec[0].spec_table['FLUX_ERROR'],
-                       1e6 * np.sqrt(variance_sum))
+    variance_sum = (
+        np.sum(mock_miri_ifu.var_rnoise, axis=(1, 2))
+        + np.sum(mock_miri_ifu.var_poisson, axis=(1, 2))
+        + np.sum(mock_miri_ifu.var_flat, axis=(1, 2))
+    )
+    assert np.allclose(result.spec[0].spec_table["FLUX_ERROR"], 1e6 * np.sqrt(variance_sum))
     result.close()
 
 
@@ -120,12 +119,12 @@ def test_extract_container(mock_nirspec_mos, mock_nirspec_fs_one_slit, simple_wc
         for spec in model.spec:
             # output wavelength is the same as input
             _, _, expected_wave = simple_wcs(np.arange(50), np.arange(50))
-            assert np.allclose(spec.spec_table['WAVELENGTH'], expected_wave)
+            assert np.allclose(spec.spec_table["WAVELENGTH"], expected_wave)
 
             # output flux and errors are non-zero, exact values will depend
             # on extraction parameters
-            assert np.all(spec.spec_table['FLUX'] > 0)
-            assert np.all(spec.spec_table['FLUX_ERROR'] > 0)
+            assert np.all(spec.spec_table["FLUX"] > 0)
+            assert np.all(spec.spec_table["FLUX_ERROR"] > 0)
 
     result.close()
 
@@ -136,64 +135,71 @@ def test_extract_niriss_wfss(mock_niriss_wfss_l3, simple_wcs):
 
     # output is a single spectral model (not a container)
     assert isinstance(result, dm.MultiSpecModel)
-    assert result.meta.cal_step.extract_1d == 'COMPLETE'
+    assert result.meta.cal_step.extract_1d == "COMPLETE"
 
     for i, spec in enumerate(result.spec):
         assert spec.name == str(i + 1)
 
         # output wavelength is the same as input
         _, _, expected_wave = simple_wcs(np.arange(50), np.arange(50))
-        assert np.allclose(spec.spec_table['WAVELENGTH'], expected_wave)
+        assert np.allclose(spec.spec_table["WAVELENGTH"], expected_wave)
 
         # output flux and errors are non-zero, exact values will depend
         # on extraction parameters
-        assert np.all(spec.spec_table['FLUX'] > 0)
-        assert np.all(spec.spec_table['FLUX_ERROR'] > 0)
+        assert np.all(spec.spec_table["FLUX"] > 0)
+        assert np.all(spec.spec_table["FLUX_ERROR"] > 0)
 
     result.close()
 
 
 @pytest.mark.slow
 def test_extract_niriss_soss_256(tmp_path, mock_niriss_soss_256):
-    result = Extract1dStep.call(mock_niriss_soss_256, soss_rtol=0.1,
-                                soss_modelname='soss_model.fits',
-                                output_dir=str(tmp_path))
-    assert result.meta.cal_step.extract_1d == 'COMPLETE'
+    result = Extract1dStep.call(
+        mock_niriss_soss_256,
+        soss_rtol=0.1,
+        soss_modelname="soss_model.fits",
+        output_dir=str(tmp_path),
+    )
+    assert result.meta.cal_step.extract_1d == "COMPLETE"
 
     # output flux and errors are non-zero, exact values will depend
     # on extraction parameters
-    assert np.all(result.spec[0].spec_table['FLUX'] > 0)
-    assert np.all(result.spec[0].spec_table['FLUX_ERROR'] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX"] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX_ERROR"] > 0)
     result.close()
 
     # soss output files are saved
-    assert os.path.isfile(tmp_path / 'soss_model_SossExtractModel.fits')
-    assert os.path.isfile(tmp_path / 'soss_model_AtocaSpectra.fits')
+    assert os.path.isfile(tmp_path / "soss_model_SossExtractModel.fits")
+    assert os.path.isfile(tmp_path / "soss_model_AtocaSpectra.fits")
 
 
 @pytest.mark.slow
 def test_extract_niriss_soss_96(tmp_path, mock_niriss_soss_96):
-    result = Extract1dStep.call(mock_niriss_soss_96, soss_rtol=0.1,
-                                soss_modelname='soss_model.fits',
-                                output_dir=str(tmp_path))
-    assert result.meta.cal_step.extract_1d == 'COMPLETE'
+    result = Extract1dStep.call(
+        mock_niriss_soss_96,
+        soss_rtol=0.1,
+        soss_modelname="soss_model.fits",
+        output_dir=str(tmp_path),
+    )
+    assert result.meta.cal_step.extract_1d == "COMPLETE"
 
     # output flux and errors are non-zero, exact values will depend
     # on extraction parameters
-    assert np.all(result.spec[0].spec_table['FLUX'] > 0)
-    assert np.all(result.spec[0].spec_table['FLUX_ERROR'] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX"] > 0)
+    assert np.all(result.spec[0].spec_table["FLUX_ERROR"] > 0)
     result.close()
 
     # soss output files are saved
-    assert os.path.isfile(tmp_path / 'soss_model_SossExtractModel.fits')
-    assert os.path.isfile(tmp_path / 'soss_model_AtocaSpectra.fits')
+    assert os.path.isfile(tmp_path / "soss_model_SossExtractModel.fits")
+    assert os.path.isfile(tmp_path / "soss_model_AtocaSpectra.fits")
 
 
 def test_extract_niriss_soss_fail(tmp_path, monkeypatch, mock_niriss_soss_96):
     # Mock an error condition in the soss extraction
     def mock(*args, **kwargs):
         return None, None, None
-    monkeypatch.setattr(soss_extract, 'run_extract1d', mock)
+
+    monkeypatch.setattr(soss_extract, "run_extract1d", mock)
 
     # None is returned
     result = Extract1dStep.call(mock_niriss_soss_96)
@@ -201,84 +207,102 @@ def test_extract_niriss_soss_fail(tmp_path, monkeypatch, mock_niriss_soss_96):
 
 
 def test_save_output_single(tmp_path, mock_nirspec_fs_one_slit):
-    mock_nirspec_fs_one_slit.meta.filename = 'test_s2d.fits'
-    result = Extract1dStep.call(mock_nirspec_fs_one_slit,
-                                save_results=True, save_profile=True,
-                                save_scene_model=True, save_residual_image=True,
-                                output_dir=str(tmp_path), suffix='x1d')
+    mock_nirspec_fs_one_slit.meta.filename = "test_s2d.fits"
+    result = Extract1dStep.call(
+        mock_nirspec_fs_one_slit,
+        save_results=True,
+        save_profile=True,
+        save_scene_model=True,
+        save_residual_image=True,
+        output_dir=str(tmp_path),
+        suffix="x1d",
+    )
 
-    output_path = str(tmp_path / 'test_x1d.fits')
+    output_path = str(tmp_path / "test_x1d.fits")
 
     assert os.path.isfile(output_path)
-    assert os.path.isfile(output_path.replace('x1d', 'profile'))
-    assert os.path.isfile(output_path.replace('x1d', 'scene_model'))
-    assert os.path.isfile(output_path.replace('x1d', 'residual'))
+    assert os.path.isfile(output_path.replace("x1d", "profile"))
+    assert os.path.isfile(output_path.replace("x1d", "scene_model"))
+    assert os.path.isfile(output_path.replace("x1d", "residual"))
 
     result.close()
 
 
 def test_save_output_multiple(tmp_path, mock_nirspec_fs_one_slit):
-    input_container = ModelContainer([mock_nirspec_fs_one_slit.copy(),
-                                      mock_nirspec_fs_one_slit.copy()])
+    input_container = ModelContainer(
+        [mock_nirspec_fs_one_slit.copy(), mock_nirspec_fs_one_slit.copy()]
+    )
 
-    result = Extract1dStep.call(input_container,
-                                save_results=True, save_profile=True,
-                                save_scene_model=True, save_residual_image=True,
-                                output_dir=str(tmp_path),
-                                suffix='x1d', output_file='test')
+    result = Extract1dStep.call(
+        input_container,
+        save_results=True,
+        save_profile=True,
+        save_scene_model=True,
+        save_residual_image=True,
+        output_dir=str(tmp_path),
+        suffix="x1d",
+        output_file="test",
+    )
 
-    output_paths = [str(tmp_path / 'test_0_x1d.fits'),
-                    str(tmp_path / 'test_1_x1d.fits')]
+    output_paths = [str(tmp_path / "test_0_x1d.fits"), str(tmp_path / "test_1_x1d.fits")]
 
     for output_path in output_paths:
         assert os.path.isfile(output_path)
-        assert os.path.isfile(output_path.replace('x1d', 'profile'))
-        assert os.path.isfile(output_path.replace('x1d', 'scene_model'))
-        assert os.path.isfile(output_path.replace('x1d', 'residual'))
+        assert os.path.isfile(output_path.replace("x1d", "profile"))
+        assert os.path.isfile(output_path.replace("x1d", "scene_model"))
+        assert os.path.isfile(output_path.replace("x1d", "residual"))
 
     result.close()
     input_container.close()
 
 
 def test_save_output_multislit(tmp_path, mock_nirspec_mos):
-    mock_nirspec_mos.meta.filename = 'test_s2d.fits'
-    result = Extract1dStep.call(mock_nirspec_mos,
-                                save_results=True, save_profile=True,
-                                save_scene_model=True, save_residual_image=True,
-                                output_dir=str(tmp_path),
-                                suffix='x1d')
+    mock_nirspec_mos.meta.filename = "test_s2d.fits"
+    result = Extract1dStep.call(
+        mock_nirspec_mos,
+        save_results=True,
+        save_profile=True,
+        save_scene_model=True,
+        save_residual_image=True,
+        output_dir=str(tmp_path),
+        suffix="x1d",
+    )
 
-    output_path = str(tmp_path / 'test_x1d.fits')
+    output_path = str(tmp_path / "test_x1d.fits")
 
     assert os.path.isfile(output_path)
 
     # intermediate files for multislit data contain the slit name
     for slit in mock_nirspec_mos.slits:
-        assert os.path.isfile(output_path.replace('x1d', f'{slit.name}_profile'))
-        assert os.path.isfile(output_path.replace('x1d', f'{slit.name}_scene_model'))
-        assert os.path.isfile(output_path.replace('x1d', f'{slit.name}_residual'))
+        assert os.path.isfile(output_path.replace("x1d", f"{slit.name}_profile"))
+        assert os.path.isfile(output_path.replace("x1d", f"{slit.name}_scene_model"))
+        assert os.path.isfile(output_path.replace("x1d", f"{slit.name}_residual"))
 
     result.close()
 
 
 def test_save_output_multiple_multislit(tmp_path, mock_nirspec_mos):
-    input_container = ModelContainer([mock_nirspec_mos.copy(),
-                                      mock_nirspec_mos.copy()])
-    result = Extract1dStep.call(input_container,
-                                save_results=True, save_profile=True,
-                                save_scene_model=True, save_residual_image=True,
-                                output_dir=str(tmp_path),
-                                suffix='x1d', output_file='test')
+    input_container = ModelContainer([mock_nirspec_mos.copy(), mock_nirspec_mos.copy()])
+    result = Extract1dStep.call(
+        input_container,
+        save_results=True,
+        save_profile=True,
+        save_scene_model=True,
+        save_residual_image=True,
+        output_dir=str(tmp_path),
+        suffix="x1d",
+        output_file="test",
+    )
 
     for i in range(2):
-        output_path = str(tmp_path / f'test_{i}_x1d.fits')
+        output_path = str(tmp_path / f"test_{i}_x1d.fits")
         assert os.path.isfile(output_path)
 
         # intermediate files for multislit data contain the slit name
         for slit in mock_nirspec_mos.slits:
-            assert os.path.isfile(str(tmp_path / f'test_{slit.name}_{i}_profile.fits'))
-            assert os.path.isfile(str(tmp_path / f'test_{slit.name}_{i}_scene_model.fits'))
-            assert os.path.isfile(str(tmp_path / f'test_{slit.name}_{i}_residual.fits'))
+            assert os.path.isfile(str(tmp_path / f"test_{slit.name}_{i}_profile.fits"))
+            assert os.path.isfile(str(tmp_path / f"test_{slit.name}_{i}_scene_model.fits"))
+            assert os.path.isfile(str(tmp_path / f"test_{slit.name}_{i}_residual.fits"))
 
     result.close()
     input_container.close()

--- a/jwst/extract_1d/tests/test_extract_src_flux.py
+++ b/jwst/extract_1d/tests/test_extract_src_flux.py
@@ -1,6 +1,7 @@
 """
 Test for extract_1d._extract_src_flux
 """
+
 import math
 
 import numpy as np
@@ -20,12 +21,11 @@ def inputs_constant():
     profile_bg = None
 
     profile = np.zeros_like(image)
-    profile[3] = 0.5    # lower limit: middle of pixel 3
+    profile[3] = 0.5  # lower limit: middle of pixel 3
     profile[4:7] = 1.0  # center of aperture
-    profile[7] = 0.5    # upper limit: middle of pixel 7
+    profile[7] = 0.5  # upper limit: middle of pixel 7
 
-    return (image, var_rnoise, var_poisson, var_rflat,
-            profile, weights, profile_bg)
+    return (image, var_rnoise, var_poisson, var_rflat, profile, weights, profile_bg)
 
 
 @pytest.fixture
@@ -46,84 +46,132 @@ def inputs_with_source():
     profile[4] = 0.5
     profile[5] = 0.25
 
-    return (image, var_rnoise, var_poisson, var_rflat,
-            profile, weights, profile_bg)
+    return (image, var_rnoise, var_poisson, var_rflat, profile, weights, profile_bg)
 
 
 def test_extract_src_flux(inputs_constant):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg) = inputs_constant
+    (image, var_rnoise, var_poisson, var_rflat, profile, weights, profile_bg) = inputs_constant
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image, [profile], var_rnoise, var_poisson, var_rflat, weights=weights, profile_bg=profile_bg
+    )
 
     # check the value at column 2
     # 0.5 * 17. + 22. + 27. + 32. + 0.5 * 37.
-    assert math.isclose(total_flux[0][2], 108., rel_tol=1.e-8, abs_tol=1.e-8)
-    assert bkg_flux[0][2] == 0.
-    assert math.isclose(npixels[0][2], 4., rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(total_flux[0][2], 108.0, rel_tol=1.0e-8, abs_tol=1.0e-8)
+    assert bkg_flux[0][2] == 0.0
+    assert math.isclose(npixels[0][2], 4.0, rel_tol=1.0e-8, abs_tol=1.0e-8)
 
     # set a NaN value in the column of interest
     image[5, 2] = np.nan
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image, [profile], var_rnoise, var_poisson, var_rflat, weights=weights, profile_bg=profile_bg
+    )
 
     # 0.5 * 17. + 22. + 32. + 0.5 * 37.
-    assert math.isclose(total_flux[0][2], 81., rel_tol=1.e-8, abs_tol=1.e-8)
-    assert math.isclose(npixels[0][2], 3., rel_tol=1.e-8, abs_tol=1.e-8)
+    assert math.isclose(total_flux[0][2], 81.0, rel_tol=1.0e-8, abs_tol=1.0e-8)
+    assert math.isclose(npixels[0][2], 3.0, rel_tol=1.0e-8, abs_tol=1.0e-8)
 
     # set the whole column to NaN
     image[:, 2] = np.nan
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image, [profile], var_rnoise, var_poisson, var_rflat, weights=weights, profile_bg=profile_bg
+    )
 
     assert np.isnan(total_flux[0][2])
-    assert npixels[0][2] == 0.
+    assert npixels[0][2] == 0.0
 
 
 def test_extract_src_flux_empty_interval(inputs_constant):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg) = inputs_constant
+    (image, var_rnoise, var_poisson, var_rflat, profile, weights, profile_bg) = inputs_constant
 
     # empty extraction range
     profile[:] = 0.0
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image, [profile], var_rnoise, var_poisson, var_rflat, weights=weights, profile_bg=profile_bg
+    )
 
     # empty interval, so no flux returned
     assert np.all(np.isnan(total_flux))
-    assert np.all(bkg_flux == 0.)
-    assert np.all(npixels == 0.)
+    assert np.all(bkg_flux == 0.0)
+    assert np.all(npixels == 0.0)
 
 
-@pytest.mark.parametrize('use_weights', [True, False])
+@pytest.mark.parametrize("use_weights", [True, False])
 def test_extract_optimal(inputs_with_source, use_weights):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg) = inputs_with_source
+    (image, var_rnoise, var_poisson, var_rflat, profile, weights, profile_bg) = inputs_with_source
 
     if use_weights:
         weights = 1 / var_rnoise
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg, extraction_type='optimal')
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image,
+        [profile],
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        weights=weights,
+        profile_bg=profile_bg,
+        extraction_type="optimal",
+    )
 
     # Total flux should be well modeled
     assert np.allclose(total_flux[0], 20)
@@ -135,11 +183,27 @@ def test_extract_optimal(inputs_with_source, use_weights):
     if use_weights:
         weights[4, 2] = 0
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg, extraction_type='optimal')
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image,
+        [profile],
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        weights=weights,
+        profile_bg=profile_bg,
+        extraction_type="optimal",
+    )
 
     # Total flux is still well modeled from 2 pixels
     assert np.allclose(total_flux[0], 20)
@@ -148,21 +212,28 @@ def test_extract_optimal(inputs_with_source, use_weights):
     # set the whole column to NaN
     image[:, 2] = np.nan
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image, [profile], var_rnoise, var_poisson, var_rflat, weights=weights, profile_bg=profile_bg
+    )
 
     # Now the flux can no longer be estimated in that column
     assert np.isnan(total_flux[0][2])
-    assert npixels[0][2] == 0.
+    assert npixels[0][2] == 0.0
 
 
 def test_too_many_profiles(inputs_constant):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg) = inputs_constant
+    (image, var_rnoise, var_poisson, var_rflat, profile, weights, profile_bg) = inputs_constant
 
     with pytest.raises(ValueError, match="not supported with 2 input profiles"):
-        extract1d.extract1d(image, [profile, profile.copy()],
-                            var_rnoise, var_poisson, var_rflat)
+        extract1d.extract1d(image, [profile, profile.copy()], var_rnoise, var_poisson, var_rflat)

--- a/jwst/extract_1d/tests/test_fit_background_model.py
+++ b/jwst/extract_1d/tests/test_fit_background_model.py
@@ -1,6 +1,7 @@
 """
 Tests for extract_1d background fitting
 """
+
 import numpy as np
 import pytest
 
@@ -24,8 +25,17 @@ def inputs_constant():
     bkg_order = 0
     bkg_fit = "poly"
 
-    return (image, var_rnoise, var_poisson, var_rflat,
-            profile, weights, profile_bg, bkg_fit, bkg_order)
+    return (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    )
 
 
 @pytest.fixture
@@ -56,24 +66,49 @@ def inputs_with_source():
 
     profile_bg = None
 
-    return (image, var_rnoise, var_poisson, var_rflat,
-            profile, weights, profile_bg)
+    return (image, var_rnoise, var_poisson, var_rflat, profile, weights, profile_bg)
 
 
-@pytest.mark.parametrize('bkg_fit_type', ['poly', 'median'])
+@pytest.mark.parametrize("bkg_fit_type", ["poly", "median"])
 def test_fit_background(inputs_constant, bkg_fit_type):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg, bkg_fit, bkg_order) = inputs_constant
+    (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    ) = inputs_constant
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg, fit_bkg=True,
-        bkg_fit_type=bkg_fit_type, bkg_order=bkg_order)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image,
+        [profile],
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        weights=weights,
+        profile_bg=profile_bg,
+        fit_bkg=True,
+        bkg_fit_type=bkg_fit_type,
+        bkg_order=bkg_order,
+    )
 
-    if bkg_fit_type == 'median':
-        extra_factor = 1.2 ** 2
+    if bkg_fit_type == "median":
+        extra_factor = 1.2**2
     else:
         extra_factor = 1.0
 
@@ -83,20 +118,47 @@ def test_fit_background(inputs_constant, bkg_fit_type):
     assert np.allclose(b_var_flat[0], extra_factor * np.sum(image[4:8], axis=0) / 16)
 
 
-@pytest.mark.parametrize('bkg_fit_type', ['poly', 'median'])
+@pytest.mark.parametrize("bkg_fit_type", ["poly", "median"])
 def test_fit_background_with_smoothing(inputs_constant, bkg_fit_type):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg, bkg_fit, bkg_order) = inputs_constant
+    (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    ) = inputs_constant
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg, fit_bkg=True,
-        bkg_fit_type=bkg_fit_type, bkg_order=bkg_order, bg_smooth_length=3)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image,
+        [profile],
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        weights=weights,
+        profile_bg=profile_bg,
+        fit_bkg=True,
+        bkg_fit_type=bkg_fit_type,
+        bkg_order=bkg_order,
+        bg_smooth_length=3,
+    )
 
-    if bkg_fit_type == 'median':
-        extra_factor = 1.2 ** 2
+    if bkg_fit_type == "median":
+        extra_factor = 1.2**2
     else:
         extra_factor = 1.0
 
@@ -110,16 +172,42 @@ def test_fit_background_with_smoothing(inputs_constant, bkg_fit_type):
 
 
 def test_handles_nan(inputs_constant):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg, bkg_fit, bkg_order) = inputs_constant
+    (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    ) = inputs_constant
     image[:, 2] = np.nan
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg, fit_bkg=True,
-        bkg_fit_type=bkg_fit, bkg_order=bkg_order)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image,
+        [profile],
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        weights=weights,
+        profile_bg=profile_bg,
+        fit_bkg=True,
+        bkg_fit_type=bkg_fit,
+        bkg_order=bkg_order,
+    )
 
     assert np.allclose(bkg_flux[0], np.nansum(image[4:8], axis=0) / 4)
     assert np.allclose(b_var_rnoise[0], np.nansum(image[4:8], axis=0) / 16)
@@ -127,20 +215,46 @@ def test_handles_nan(inputs_constant):
     assert np.allclose(b_var_flat[0], np.nansum(image[4:8], axis=0) / 16)
 
 
-@pytest.mark.parametrize('bkg_order_val', [0, 1, 2])
+@pytest.mark.parametrize("bkg_order_val", [0, 1, 2])
 def test_handles_one_value(inputs_constant, bkg_order_val):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg, bkg_fit, bkg_order) = inputs_constant
+    (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    ) = inputs_constant
     profile_bg[:] = 0.0
     profile_bg[4:6] = 1.0
     image[4] = np.nan
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg, fit_bkg=True,
-        bkg_fit_type=bkg_fit, bkg_order=bkg_order_val)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image,
+        [profile],
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        weights=weights,
+        profile_bg=profile_bg,
+        fit_bkg=True,
+        bkg_fit_type=bkg_fit,
+        bkg_order=bkg_order_val,
+    )
 
     if bkg_order_val == 0:
         expected = image[5]
@@ -155,16 +269,42 @@ def test_handles_one_value(inputs_constant, bkg_order_val):
 
 
 def test_handles_empty_interval(inputs_constant):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg, bkg_fit, bkg_order) = inputs_constant
+    (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    ) = inputs_constant
     profile_bg[:] = 0.0
 
-    (total_flux, f_var_rnoise, f_var_poisson, f_var_flat,
-     bkg_flux, b_var_rnoise, b_var_poisson, b_var_flat,
-     npixels, model) = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg, fit_bkg=True,
-        bkg_fit_type=bkg_fit, bkg_order=bkg_order)
+    (
+        total_flux,
+        f_var_rnoise,
+        f_var_poisson,
+        f_var_flat,
+        bkg_flux,
+        b_var_rnoise,
+        b_var_poisson,
+        b_var_flat,
+        npixels,
+        model,
+    ) = extract1d.extract1d(
+        image,
+        [profile],
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        weights=weights,
+        profile_bg=profile_bg,
+        fit_bkg=True,
+        bkg_fit_type=bkg_fit,
+        bkg_order=bkg_order,
+    )
 
     assert np.allclose(bkg_flux[0], 0.0)
     assert np.allclose(b_var_rnoise[0], 0.0)
@@ -173,53 +313,112 @@ def test_handles_empty_interval(inputs_constant):
 
 
 def test_bad_fit_type(inputs_constant):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg, bkg_fit, bkg_order) = inputs_constant
+    (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    ) = inputs_constant
     with pytest.raises(ValueError, match="bkg_fit_type should be 'median' or 'poly'"):
         extract1d.extract1d(
-            image, [profile], var_rnoise, var_poisson, var_rflat,
-            weights=weights, profile_bg=profile_bg, fit_bkg=True,
-            bkg_fit_type='mean', bkg_order=bkg_order)
+            image,
+            [profile],
+            var_rnoise,
+            var_poisson,
+            var_rflat,
+            weights=weights,
+            profile_bg=profile_bg,
+            fit_bkg=True,
+            bkg_fit_type="mean",
+            bkg_order=bkg_order,
+        )
 
 
-@pytest.mark.parametrize('smooth', [1.5, 2])
+@pytest.mark.parametrize("smooth", [1.5, 2])
 def test_smooth_length(inputs_constant, smooth):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg, bkg_fit, bkg_order) = inputs_constant
+    (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    ) = inputs_constant
     with pytest.raises(ValueError, match="should be an odd integer >= 1"):
         extract1d.extract1d(
-            image, [profile], var_rnoise, var_poisson, var_rflat,
-            weights=weights, profile_bg=profile_bg, fit_bkg=True,
-            bkg_fit_type=bkg_fit, bkg_order=bkg_order, bg_smooth_length=smooth)
+            image,
+            [profile],
+            var_rnoise,
+            var_poisson,
+            var_rflat,
+            weights=weights,
+            profile_bg=profile_bg,
+            fit_bkg=True,
+            bkg_fit_type=bkg_fit,
+            bkg_order=bkg_order,
+            bg_smooth_length=smooth,
+        )
 
 
-@pytest.mark.parametrize('extraction_type', ['box', 'optimal'])
-@pytest.mark.parametrize('bkg_order_val', [-1, 2.3])
+@pytest.mark.parametrize("extraction_type", ["box", "optimal"])
+@pytest.mark.parametrize("bkg_order_val", [-1, 2.3])
 def test_bad_fit_order(inputs_constant, extraction_type, bkg_order_val):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg, bkg_fit, bkg_order) = inputs_constant
+    (
+        image,
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        profile,
+        weights,
+        profile_bg,
+        bkg_fit,
+        bkg_order,
+    ) = inputs_constant
     with pytest.raises(ValueError, match="bkg_order must be an integer >= 0"):
         extract1d.extract1d(
-            image, [profile], var_rnoise, var_poisson, var_rflat,
-            weights=weights, profile_bg=profile_bg, fit_bkg=True,
-            bkg_fit_type='poly', bkg_order=bkg_order_val,
-            extraction_type=extraction_type)
+            image,
+            [profile],
+            var_rnoise,
+            var_poisson,
+            var_rflat,
+            weights=weights,
+            profile_bg=profile_bg,
+            fit_bkg=True,
+            bkg_fit_type="poly",
+            bkg_order=bkg_order_val,
+            extraction_type=extraction_type,
+        )
 
 
-@pytest.mark.parametrize('use_weights', [True, False])
-@pytest.mark.parametrize('bkg_order_val', [0, 1, 2])
+@pytest.mark.parametrize("use_weights", [True, False])
+@pytest.mark.parametrize("bkg_order_val", [0, 1, 2])
 def test_fit_background_optimal(inputs_with_source, use_weights, bkg_order_val):
-    (image, var_rnoise, var_poisson, var_rflat,
-     profile, weights, profile_bg) = inputs_with_source
+    (image, var_rnoise, var_poisson, var_rflat, profile, weights, profile_bg) = inputs_with_source
 
     if not use_weights:
         weights = None
 
     result = extract1d.extract1d(
-        image, [profile], var_rnoise, var_poisson, var_rflat,
-        weights=weights, profile_bg=profile_bg, fit_bkg=True,
-        bkg_fit_type='poly', bkg_order=bkg_order_val,
-        extraction_type='optimal')
+        image,
+        [profile],
+        var_rnoise,
+        var_poisson,
+        var_rflat,
+        weights=weights,
+        profile_bg=profile_bg,
+        fit_bkg=True,
+        bkg_fit_type="poly",
+        bkg_order=bkg_order_val,
+        extraction_type="optimal",
+    )
 
     flux = result[0][0]
     background = result[4][0]

--- a/jwst/extract_1d/tests/test_psf_profile.py
+++ b/jwst/extract_1d/tests/test_psf_profile.py
@@ -12,14 +12,14 @@ from jwst.tests.helpers import LogWatcher
 def log_watcher(monkeypatch):
     # Set a log watcher to check for a log message at any level
     # in the extract_1d.psf_profile module
-    watcher = LogWatcher('')
-    logger = logging.getLogger('jwst.extract_1d.psf_profile')
-    for level in ['debug', 'info', 'warning', 'error']:
+    watcher = LogWatcher("")
+    logger = logging.getLogger("jwst.extract_1d.psf_profile")
+    for level in ["debug", "info", "warning", "error"]:
         monkeypatch.setattr(logger, level, watcher)
     return watcher
 
 
-@pytest.mark.parametrize('exp_type', ['MIR_LRS-FIXEDSLIT', 'NRS_FIXEDSLIT', 'UNKNOWN'])
+@pytest.mark.parametrize("exp_type", ["MIR_LRS-FIXEDSLIT", "NRS_FIXEDSLIT", "UNKNOWN"])
 def test_open_psf(psf_reference_file, exp_type):
     # for any exptype, a model that can be read
     # as SpecPsfModel will be, since it's the only
@@ -29,11 +29,11 @@ def test_open_psf(psf_reference_file, exp_type):
 
 
 def test_open_psf_fail():
-    with pytest.raises(NotImplementedError, match='could not be read'):
-        pp.open_psf('bad_file', 'UNKNOWN')
+    with pytest.raises(NotImplementedError, match="could not be read"):
+        pp.open_psf("bad_file", "UNKNOWN")
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_normalize_profile(nod_profile, dispaxis):
     profile = 2 * nod_profile
     if dispaxis == 2:
@@ -42,7 +42,7 @@ def test_normalize_profile(nod_profile, dispaxis):
     assert np.allclose(np.sum(profile, axis=dispaxis - 1), 1.0)
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_normalize_profile_with_nans(nod_profile, dispaxis):
     profile = -1 * nod_profile
     profile[10, :] = np.nan
@@ -54,10 +54,10 @@ def test_normalize_profile_with_nans(nod_profile, dispaxis):
     assert np.all(np.isfinite(profile))
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_make_cutout_profile_default(psf_reference, dispaxis):
     data_shape = psf_reference.data.shape
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
 
     psf_subpix = psf_reference.meta.psf.subpix
     profiles = pp._make_cutout_profile(xidx, yidx, psf_subpix, psf_reference.data, dispaxis)
@@ -71,15 +71,16 @@ def test_make_cutout_profile_default(psf_reference, dispaxis):
         assert np.all(profiles[0] == 1 / data_shape[1])
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
-@pytest.mark.parametrize('extra_shift', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
+@pytest.mark.parametrize("extra_shift", [1, 2])
 def test_make_cutout_profile_shift_down(psf_reference, dispaxis, extra_shift):
     data_shape = psf_reference.data.shape
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     psf_subpix = psf_reference.meta.psf.subpix
 
-    profiles = pp._make_cutout_profile(xidx, yidx, psf_subpix, psf_reference.data,
-                                       dispaxis, extra_shift=extra_shift)
+    profiles = pp._make_cutout_profile(
+        xidx, yidx, psf_subpix, psf_reference.data, dispaxis, extra_shift=extra_shift
+    )
     assert len(profiles) == 1
     assert profiles[0].shape == data_shape
 
@@ -94,15 +95,16 @@ def test_make_cutout_profile_shift_down(psf_reference, dispaxis, extra_shift):
         assert np.all(profiles[0][:, -extra_shift:] == 0.0)
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
-@pytest.mark.parametrize('extra_shift', [-1, -2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
+@pytest.mark.parametrize("extra_shift", [-1, -2])
 def test_make_cutout_profile_shift_up(psf_reference, dispaxis, extra_shift):
     data_shape = psf_reference.data.shape
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     psf_subpix = psf_reference.meta.psf.subpix
 
-    profiles = pp._make_cutout_profile(xidx, yidx, psf_subpix, psf_reference.data,
-                                       dispaxis, extra_shift=extra_shift)
+    profiles = pp._make_cutout_profile(
+        xidx, yidx, psf_subpix, psf_reference.data, dispaxis, extra_shift=extra_shift
+    )
     assert len(profiles) == 1
     assert profiles[0].shape == data_shape
 
@@ -117,15 +119,16 @@ def test_make_cutout_profile_shift_up(psf_reference, dispaxis, extra_shift):
         assert np.all(profiles[0][:, :-extra_shift] == 0.0)
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_make_cutout_profile_with_nod(psf_reference, dispaxis):
     data_shape = psf_reference.data.shape
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     psf_subpix = psf_reference.meta.psf.subpix
 
     offset = 2
-    profiles = pp._make_cutout_profile(xidx, yidx, psf_subpix, psf_reference.data,
-                                       dispaxis, nod_offset=offset)
+    profiles = pp._make_cutout_profile(
+        xidx, yidx, psf_subpix, psf_reference.data, dispaxis, nod_offset=offset
+    )
     assert len(profiles) == 2
     source, nod = profiles
     assert source.shape == data_shape
@@ -147,10 +150,10 @@ def test_make_cutout_profile_with_nod(psf_reference, dispaxis):
         assert np.all(nod[:, -offset:] == 0.0)
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_profile_residual(psf_reference, dispaxis):
     data_shape = (50, 50)
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     psf_subpix = psf_reference.meta.psf.subpix
 
     # Set data to all ones, so residual should be zero
@@ -160,15 +163,15 @@ def test_profile_residual(psf_reference, dispaxis):
 
     param = [0, None]
     residual = pp._profile_residual(
-        param, data, var, xidx, yidx,
-        psf_subpix, psf_reference.data, dispaxis, fit_bkg=False)
+        param, data, var, xidx, yidx, psf_subpix, psf_reference.data, dispaxis, fit_bkg=False
+    )
     assert np.isclose(residual, 0.0)
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_profile_residual_with_bkg(psf_reference, dispaxis):
     data_shape = (50, 50)
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     psf_subpix = psf_reference.meta.psf.subpix
 
     # Set data to all ones, so it is all background - residual
@@ -178,12 +181,12 @@ def test_profile_residual_with_bkg(psf_reference, dispaxis):
 
     param = [0, None]
     residual = pp._profile_residual(
-        param, data, var, xidx, yidx,
-        psf_subpix, psf_reference.data, dispaxis, fit_bkg=True)
-    assert np.isclose(residual, np.sum(data ** 2 / var))
+        param, data, var, xidx, yidx, psf_subpix, psf_reference.data, dispaxis, fit_bkg=True
+    )
+    assert np.isclose(residual, np.sum(data**2 / var))
 
 
-@pytest.mark.parametrize('use_trace', [True, False])
+@pytest.mark.parametrize("use_trace", [True, False])
 def test_psf_profile(mock_miri_lrs_fs, psf_reference_file, use_trace):
     data_shape = mock_miri_lrs_fs.data.shape
     if use_trace:
@@ -191,15 +194,20 @@ def test_psf_profile(mock_miri_lrs_fs, psf_reference_file, use_trace):
         trace = np.full(data_shape[0], (data_shape[1] - 1) / 2.0)
     else:
         # Avoid miri specific behavior for trace - the mock WCS is not complete enough
-        mock_miri_lrs_fs.meta.exposure.type = 'ANY'
+        mock_miri_lrs_fs.meta.exposure.type = "ANY"
         trace = None
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = mock_miri_lrs_fs.meta.wcs(xidx, yidx)
 
     profiles, lower, upper = pp.psf_profile(
-        mock_miri_lrs_fs, trace, wl_array, psf_reference_file,
-        optimize_shifts=False, model_nod_pair=False)
+        mock_miri_lrs_fs,
+        trace,
+        wl_array,
+        psf_reference_file,
+        optimize_shifts=False,
+        model_nod_pair=False,
+    )
 
     # no nod profile, data cutout matches full shape
     assert len(profiles) == 1
@@ -211,7 +219,7 @@ def test_psf_profile(mock_miri_lrs_fs, psf_reference_file, use_trace):
     assert np.allclose(profiles[0], 1 / data_shape[1])
 
 
-@pytest.mark.parametrize('use_trace', [True, False])
+@pytest.mark.parametrize("use_trace", [True, False])
 def test_psf_profile_multi_int(mock_nirspec_bots, psf_reference_file, use_trace):
     data_shape = mock_nirspec_bots.data.shape[-2:]
 
@@ -220,15 +228,20 @@ def test_psf_profile_multi_int(mock_nirspec_bots, psf_reference_file, use_trace)
     else:
         # Avoid nirspec specific behavior for trace -
         # the mock WCS is not complete enough
-        mock_nirspec_bots.meta.exposure.type = 'ANY'
+        mock_nirspec_bots.meta.exposure.type = "ANY"
         trace = None
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = mock_nirspec_bots.meta.wcs(xidx, yidx)
 
     profiles, lower, upper = pp.psf_profile(
-        mock_nirspec_bots, trace, wl_array, psf_reference_file,
-        optimize_shifts=False, model_nod_pair=False)
+        mock_nirspec_bots,
+        trace,
+        wl_array,
+        psf_reference_file,
+        optimize_shifts=False,
+        model_nod_pair=False,
+    )
 
     # no nod profile, data cutout matches full shape
     assert len(profiles) == 1
@@ -245,22 +258,22 @@ def test_psf_profile_model_nod(monkeypatch, mock_miri_lrs_fs, psf_reference_file
     data_shape = model.data.shape
     trace = np.full(data_shape[0], (data_shape[1] - 1) / 2.0)
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
     # mock nod subtraction
-    model.meta.cal_step.back_sub = 'COMPLETE'
-    model.meta.dither.primary_type = '2-POINT-NOD'
+    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.dither.primary_type = "2-POINT-NOD"
 
     # mock a nod position at the opposite end of the array
     def mock_nod(*args, **kwargs):
         return 48.0
 
-    monkeypatch.setattr(pp, 'nod_pair_location', mock_nod)
+    monkeypatch.setattr(pp, "nod_pair_location", mock_nod)
 
     profiles, lower, upper = pp.psf_profile(
-        model, trace, wl_array, psf_reference_file,
-        optimize_shifts=False, model_nod_pair=True)
+        model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
+    )
 
     # now returns nod profile
     assert len(profiles) == 2
@@ -275,90 +288,86 @@ def test_psf_profile_model_nod(monkeypatch, mock_miri_lrs_fs, psf_reference_file
     assert np.allclose(nod[:, -2:], -1 / 26)
 
 
-def test_psf_profile_model_nod_no_trace(
-        mock_miri_lrs_fs, psf_reference_file, log_watcher):
+def test_psf_profile_model_nod_no_trace(mock_miri_lrs_fs, psf_reference_file, log_watcher):
     model = mock_miri_lrs_fs
-    model.meta.exposure.type = 'ANY'
+    model.meta.exposure.type = "ANY"
     data_shape = model.data.shape
     trace = None
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = 'Cannot model a negative nod without position'
+    log_watcher.message = "Cannot model a negative nod without position"
     profiles, lower, upper = pp.psf_profile(
-        model, trace, wl_array, psf_reference_file,
-        optimize_shifts=False, model_nod_pair=True)
+        model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
+    )
     log_watcher.assert_seen()
 
     # does not return nod profile
     assert len(profiles) == 1
 
 
-def test_psf_profile_model_nod_not_subtracted(
-        mock_miri_lrs_fs, psf_reference_file, log_watcher):
+def test_psf_profile_model_nod_not_subtracted(mock_miri_lrs_fs, psf_reference_file, log_watcher):
     model = mock_miri_lrs_fs
     data_shape = model.data.shape
     trace = np.full(data_shape[0], (data_shape[1] - 1) / 2.0)
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = 'data was not nod-subtracted'
+    log_watcher.message = "data was not nod-subtracted"
     profiles, lower, upper = pp.psf_profile(
-        model, trace, wl_array, psf_reference_file,
-        optimize_shifts=False, model_nod_pair=True)
+        model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
+    )
     log_watcher.assert_seen()
 
     # does not return nod profile
     assert len(profiles) == 1
 
 
-def test_psf_profile_model_nod_wrong_pattern(
-        mock_miri_lrs_fs, psf_reference_file, log_watcher):
+def test_psf_profile_model_nod_wrong_pattern(mock_miri_lrs_fs, psf_reference_file, log_watcher):
     model = mock_miri_lrs_fs
     data_shape = model.data.shape
     trace = np.full(data_shape[0], (data_shape[1] - 1) / 2.0)
-    model.meta.cal_step.back_sub = 'COMPLETE'
+    model.meta.cal_step.back_sub = "COMPLETE"
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = 'data was not a two-point nod'
+    log_watcher.message = "data was not a two-point nod"
     profiles, lower, upper = pp.psf_profile(
-        model, trace, wl_array, psf_reference_file,
-        optimize_shifts=False, model_nod_pair=True)
+        model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
+    )
     log_watcher.assert_seen()
 
     # does not return nod profile
     assert len(profiles) == 1
 
 
-def test_psf_profile_model_nod_bad_position(
-        mock_miri_lrs_fs, psf_reference_file, log_watcher):
+def test_psf_profile_model_nod_bad_position(mock_miri_lrs_fs, psf_reference_file, log_watcher):
     model = mock_miri_lrs_fs
     data_shape = model.data.shape
     trace = np.full(data_shape[0], (data_shape[1] - 1) / 2.0)
-    model.meta.cal_step.back_sub = 'COMPLETE'
-    model.meta.dither.primary_type = '2-POINT-NOD'
+    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.dither.primary_type = "2-POINT-NOD"
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = 'Nod center could not be estimated'
+    log_watcher.message = "Nod center could not be estimated"
     profiles, lower, upper = pp.psf_profile(
-        model, trace, wl_array, psf_reference_file,
-        optimize_shifts=False, model_nod_pair=True)
+        model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
+    )
     log_watcher.assert_seen()
 
     # does not return nod profile
     assert len(profiles) == 1
 
 
-@pytest.mark.parametrize('start_offset', [0.0, 0.1, 2.0, -1.0])
+@pytest.mark.parametrize("start_offset", [0.0, 0.1, 2.0, -1.0])
 def test_psf_profile_optimize(
-        mock_miri_lrs_fs, psf_reference_file_with_source, start_offset,
-        log_watcher):
+    mock_miri_lrs_fs, psf_reference_file_with_source, start_offset, log_watcher
+):
     model = mock_miri_lrs_fs
     data_shape = model.data.shape
     trace = np.full(data_shape[0], (data_shape[1] - 1) / 2.0)
@@ -369,13 +378,18 @@ def test_psf_profile_optimize(
     model.data[:, 24:27] += 1.0
     model.var_rnoise[:] = 0.1
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = 'Centering profile on spectrum at 24.5'
+    log_watcher.message = "Centering profile on spectrum at 24.5"
     profiles, lower, upper = pp.psf_profile(
-        model, trace, wl_array, psf_reference_file_with_source,
-        optimize_shifts=True, model_nod_pair=False)
+        model,
+        trace,
+        wl_array,
+        psf_reference_file_with_source,
+        optimize_shifts=True,
+        model_nod_pair=False,
+    )
     log_watcher.assert_seen()
 
     # profile is centered at 24.5
@@ -385,16 +399,16 @@ def test_psf_profile_optimize(
     assert np.allclose(profile[:, 27:], 0.0, atol=1e-4)
 
 
-@pytest.mark.parametrize('start_offset', [0.0, 0.1, 2.0, -1.0])
+@pytest.mark.parametrize("start_offset", [0.0, 0.1, 2.0, -1.0])
 def test_psf_profile_optimize_with_nod(
-        monkeypatch, mock_miri_lrs_fs, psf_reference_file_with_source,
-        start_offset, log_watcher):
+    monkeypatch, mock_miri_lrs_fs, psf_reference_file_with_source, start_offset, log_watcher
+):
     model = mock_miri_lrs_fs
     data_shape = model.data.shape
 
     # mock nod subtraction
-    model.meta.cal_step.back_sub = 'COMPLETE'
-    model.meta.dither.primary_type = '2-POINT-NOD'
+    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.dither.primary_type = "2-POINT-NOD"
 
     # trace at pixel 9.5
     trace = np.full(data_shape[0], 9.5)
@@ -407,7 +421,7 @@ def test_psf_profile_optimize_with_nod(
     def mock_nod(*args, **kwargs):
         return 39.5 + start_offset + 0.1
 
-    monkeypatch.setattr(pp, 'nod_pair_location', mock_nod)
+    monkeypatch.setattr(pp, "nod_pair_location", mock_nod)
 
     # add a peak at pixel 10, negative peak at pixel 40
     model.data[:] = 0.0
@@ -415,13 +429,18 @@ def test_psf_profile_optimize_with_nod(
     model.data[:, 39:42] -= 1.0
     model.var_rnoise[:] = 0.1
 
-    yidx, xidx = np.mgrid[:data_shape[0], :data_shape[1]]
+    yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = 'Also modeling a negative trace at 39.50'
+    log_watcher.message = "Also modeling a negative trace at 39.50"
     profiles, lower, upper = pp.psf_profile(
-        model, trace, wl_array, psf_reference_file_with_source,
-        optimize_shifts=True, model_nod_pair=True)
+        model,
+        trace,
+        wl_array,
+        psf_reference_file_with_source,
+        optimize_shifts=True,
+        model_nod_pair=True,
+    )
     log_watcher.assert_seen()
 
     # profile is centered at 10

--- a/jwst/extract_1d/tests/test_source_location.py
+++ b/jwst/extract_1d/tests/test_source_location.py
@@ -10,14 +10,14 @@ from jwst.tests.helpers import LogWatcher
 def log_watcher(monkeypatch):
     # Set a log watcher to check for a log message at any level
     # in the extract_1d.extract module
-    watcher = LogWatcher('')
-    logger = logging.getLogger('jwst.extract_1d.source_location')
-    for level in ['debug', 'info', 'warning', 'error']:
+    watcher = LogWatcher("")
+    logger = logging.getLogger("jwst.extract_1d.source_location")
+    for level in ["debug", "info", "warning", "error"]:
         monkeypatch.setattr(logger, level, watcher)
     return watcher
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_middle_from_wcs_constant_wl(dispaxis):
     # mock a wcs that returns a constant wavelength
     def mock_wcs(x, y):
@@ -35,7 +35,7 @@ def test_middle_from_wcs_constant_wl(dispaxis):
     assert mw == 10.0
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_middle_from_wcs_variable_wl(dispaxis):
     # mock a wcs that returns a variable wavelength
     def mock_wcs(x, y):
@@ -51,21 +51,22 @@ def test_middle_from_wcs_variable_wl(dispaxis):
     assert mw == 4.5
 
 
-@pytest.mark.parametrize('resampled', [True, False])
-@pytest.mark.parametrize('is_slit', [True, False])
-@pytest.mark.parametrize('missing_bbox', [True, False])
+@pytest.mark.parametrize("resampled", [True, False])
+@pytest.mark.parametrize("is_slit", [True, False])
+@pytest.mark.parametrize("missing_bbox", [True, False])
 def test_location_from_wcs_nirspec(
-        monkeypatch, mock_nirspec_fs_one_slit, resampled, is_slit, missing_bbox):
+    monkeypatch, mock_nirspec_fs_one_slit, resampled, is_slit, missing_bbox
+):
     model = mock_nirspec_fs_one_slit
 
     if not resampled:
         # mock available frames, so it looks like unresampled cal data
-        monkeypatch.setattr(model.meta.wcs, 'available_frames', ['gwa'])
+        monkeypatch.setattr(model.meta.wcs, "available_frames", ["gwa"])
 
     if missing_bbox:
         # mock a missing bounding box - should have same results
         # for the test data
-        monkeypatch.setattr(model.meta.wcs, 'bounding_box', None)
+        monkeypatch.setattr(model.meta.wcs, "bounding_box", None)
 
     if is_slit:
         middle, middle_wl, location, trace = sl.location_from_wcs(model, model)
@@ -85,7 +86,7 @@ def test_location_from_wcs_nirspec(
     assert np.all(trace == 1.0)
 
 
-@pytest.mark.parametrize('is_slit', [True, False])
+@pytest.mark.parametrize("is_slit", [True, False])
 def test_location_from_wcs_miri(monkeypatch, mock_miri_lrs_fs, is_slit):
     model = mock_miri_lrs_fs
 
@@ -93,15 +94,16 @@ def test_location_from_wcs_miri(monkeypatch, mock_miri_lrs_fs, is_slit):
     def radec2det(*args, **kwargs):
         def return_one(*args, **kwargs):
             return 1.0, 0.0
+
         return return_one
 
-    monkeypatch.setattr(model.meta.wcs, 'backward_transform', radec2det())
+    monkeypatch.setattr(model.meta.wcs, "backward_transform", radec2det())
 
     # mock the trace function
     def mock_trace(*args, **kwargs):
         return np.full(model.data.shape[-2], 1.0)
 
-    monkeypatch.setattr(sl, '_miri_trace_from_wcs', mock_trace)
+    monkeypatch.setattr(sl, "_miri_trace_from_wcs", mock_trace)
 
     # Get the slit center from the WCS
     if is_slit:
@@ -141,17 +143,17 @@ def test_location_from_wcs_wrong_exptype(mock_niriss_soss, log_watcher):
     log_watcher.assert_seen()
 
 
-def test_location_from_wcs_bad_location(
-        monkeypatch, mock_nirspec_fs_one_slit, log_watcher):
+def test_location_from_wcs_bad_location(monkeypatch, mock_nirspec_fs_one_slit, log_watcher):
     model = mock_nirspec_fs_one_slit
 
     # monkey patch in a transform for the wcs
     def slit2det(*args, **kwargs):
         def return_one(*args, **kwargs):
             return 0.0, np.nan
+
         return return_one
 
-    monkeypatch.setattr(model.meta.wcs, 'get_transform', slit2det)
+    monkeypatch.setattr(model.meta.wcs, "get_transform", slit2det)
 
     # WCS transform returns NaN for the location
     log_watcher.message = "Source position could not be determined"
@@ -161,22 +163,24 @@ def test_location_from_wcs_bad_location(
 
 
 def test_location_from_wcs_location_out_of_range(
-        monkeypatch, mock_nirspec_fs_one_slit, log_watcher):
+    monkeypatch, mock_nirspec_fs_one_slit, log_watcher
+):
     model = mock_nirspec_fs_one_slit
 
     # monkey patch in a transform for the wcs
     def slit2det(*args, **kwargs):
         def return_one(*args, **kwargs):
             return 0.0, 2000
+
         return return_one
 
-    monkeypatch.setattr(model.meta.wcs, 'get_transform', slit2det)
+    monkeypatch.setattr(model.meta.wcs, "get_transform", slit2det)
 
     # mock the trace function
     def mock_trace(*args, **kwargs):
         return np.full(model.data.shape[-1], 1.0)
 
-    monkeypatch.setattr(sl, '_nirspec_trace_from_wcs', mock_trace)
+    monkeypatch.setattr(sl, "_nirspec_trace_from_wcs", mock_trace)
 
     # WCS transform a value outside the bounding box
     log_watcher.message = "outside the bounding box"
@@ -187,16 +191,18 @@ def test_location_from_wcs_location_out_of_range(
 
 def test_nirspec_trace_from_wcs(mock_nirspec_fs_one_slit):
     model = mock_nirspec_fs_one_slit
-    trace = sl._nirspec_trace_from_wcs(model.data.shape, model.meta.wcs.bounding_box,
-                                       model.meta.wcs, 1.0, 1.0)
+    trace = sl._nirspec_trace_from_wcs(
+        model.data.shape, model.meta.wcs.bounding_box, model.meta.wcs, 1.0, 1.0
+    )
     # mocked model contains some mock transforms as well - all ones are expected
     assert np.all(trace == np.ones(model.data.shape[1]))
 
 
 def test_miri_trace_from_wcs(mock_miri_lrs_fs):
     model = mock_miri_lrs_fs
-    trace = sl._miri_trace_from_wcs(model.data.shape, model.meta.wcs.bounding_box,
-                                    model.meta.wcs, 1.0, 1.0)
+    trace = sl._miri_trace_from_wcs(
+        model.data.shape, model.meta.wcs.bounding_box, model.meta.wcs, 1.0, 1.0
+    )
 
     # mocked model contains some mock transforms as well - all ones are expected
     assert np.all(trace == np.ones(model.data.shape[0]))
@@ -205,8 +211,8 @@ def test_miri_trace_from_wcs(mock_miri_lrs_fs):
 def test_trace_from_wcs_nirspec(mock_nirspec_fs_one_slit):
     model = mock_nirspec_fs_one_slit
     trace = sl.trace_from_wcs(
-        'NRS_FIXEDSLIT', model.data.shape, model.meta.wcs.bounding_box,
-        model.meta.wcs, 1.0, 1.0, 1)
+        "NRS_FIXEDSLIT", model.data.shape, model.meta.wcs.bounding_box, model.meta.wcs, 1.0, 1.0, 1
+    )
 
     # mocked model contains some mock transforms as well - all ones are expected
     assert np.all(trace == np.ones(model.data.shape[1]))
@@ -215,15 +221,21 @@ def test_trace_from_wcs_nirspec(mock_nirspec_fs_one_slit):
 def test_trace_from_wcs_miri(mock_miri_lrs_fs):
     model = mock_miri_lrs_fs
     trace = sl.trace_from_wcs(
-        'MIR_LRS-FIXEDSLIT', model.data.shape, model.meta.wcs.bounding_box,
-        model.meta.wcs, 1.0, 1.0, 2)
+        "MIR_LRS-FIXEDSLIT",
+        model.data.shape,
+        model.meta.wcs.bounding_box,
+        model.meta.wcs,
+        1.0,
+        1.0,
+        2,
+    )
 
     # mocked model contains some mock transforms as well - all ones are expected
     assert np.all(trace == np.ones(model.data.shape[0]))
 
 
 def test_trace_from_wcs_other_horizontal():
-    exp_type = 'ANY'
+    exp_type = "ANY"
     shape = (10, 20)
     bbox = (1.5, 17.5), (1.5, 8.5)
     wcs = None
@@ -244,7 +256,7 @@ def test_trace_from_wcs_other_horizontal():
 
 
 def test_trace_from_wcs_other_vertical():
-    exp_type = 'ANY'
+    exp_type = "ANY"
     shape = (10, 20)
     bbox = (1.5, 17.5), (1.5, 8.5)
     wcs = None
@@ -277,7 +289,7 @@ def test_nod_pair_location_nirspec(mock_nirspec_fs_one_slit):
 def test_nod_pair_location_nirspec_unresampled(mock_nirspec_fs_one_slit):
     model = mock_nirspec_fs_one_slit
     middle_wl = 7.5
-    model.meta.wcs.available_frames = ['gwa']
+    model.meta.wcs.available_frames = ["gwa"]
 
     nod_center = sl.nod_pair_location(model, middle_wl)
 
@@ -285,7 +297,7 @@ def test_nod_pair_location_nirspec_unresampled(mock_nirspec_fs_one_slit):
     assert nod_center == 1.0
 
 
-@pytest.mark.parametrize('dispaxis', [1, 2])
+@pytest.mark.parametrize("dispaxis", [1, 2])
 def test_nod_pair_location_miri(mock_miri_lrs_fs, dispaxis):
     model = mock_miri_lrs_fs
     middle_wl = 7.5
@@ -296,7 +308,7 @@ def test_nod_pair_location_miri(mock_miri_lrs_fs, dispaxis):
     assert np.isnan(nod_center)
 
     # mock v2v3 transform
-    model.meta.wcs.available_frames = ['v2v3']
+    model.meta.wcs.available_frames = ["v2v3"]
     model.meta.wcsinfo.v3yangle = 1.0
     model.meta.wcsinfo.v2_ref = 1.0
     model.meta.wcsinfo.v3_ref = 1.0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-3859](https://jira.stsci.edu/browse/JP-3859)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Update remaining extract_1d modules for code style fixes.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
