### PR TITLE
Apply code style checks to skymatch step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,6 @@ repos:
             jwst/rscd/.* |
             jwst/saturation/.* |
             jwst/scripts/.* |
-            jwst/skymatch/.* |
             jwst/spectral_leak/.* |
             jwst/srctype/.* |
             jwst/straylight/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -53,7 +53,6 @@ exclude = [
     "jwst/rscd/**.py",
     "jwst/saturation/**.py",
     "jwst/scripts/**.py",
-    "jwst/skymatch/**.py",
     "jwst/spectral_leak/**.py",
     "jwst/srctype/**.py",
     "jwst/straylight/**.py",
@@ -156,7 +155,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/rscd/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/saturation/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/scripts/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/skymatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/spectral_leak/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/srctype/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/straylight/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/skymatch/__init__.py
+++ b/jwst/skymatch/__init__.py
@@ -1,12 +1,9 @@
-"""
-This package provides support for sky background subtraction and equalization
-(matching).
+"""Provide support for sky background subtraction and equalization (matching)."""
 
-"""
 import logging
 from .skymatch_step import SkyMatchStep
 
-__author__ = 'Mihai Cara'
+__author__ = "Mihai Cara"
 
 
 log = logging.getLogger(__name__)

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -33,7 +33,7 @@ __all__ = ["SkyMatchStep"]
 
 
 class SkyMatchStep(Step):
-    """SkyMatchStep: Subtraction or equalization of sky background in scienceimages."""
+    """SkyMatchStep: Subtraction or equalization of sky background in science images."""
 
     class_alias = "skymatch"
 

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -3,8 +3,6 @@
 JWST pipeline step for sky matching.
 
 :Authors: Mihai Cara
-
-
 """
 
 from copy import deepcopy
@@ -31,14 +29,11 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-__all__ = ['SkyMatchStep']
+__all__ = ["SkyMatchStep"]
 
 
 class SkyMatchStep(Step):
-    """
-    SkyMatchStep: Subtraction or equalization of sky background in science
-    images.
-    """
+    """SkyMatchStep: Subtraction or equalization of sky background in scienceimages."""
 
     class_alias = "skymatch"
 
@@ -72,6 +67,19 @@ class SkyMatchStep(Step):
         super().__init__(*args, **kwargs)
 
     def process(self, input_models):
+        """
+        Run the step.
+
+        Parameters
+        ----------
+        input_models : Any data type readable into a ModelLibrary, e.g. an asn file
+            An association of datamodels to input.
+
+        Returns
+        -------
+        ModelLibrary
+            A library of datamodels with the skymatch step applied.
+        """
         self.log.setLevel(logging.DEBUG)
 
         if isinstance(input_models, ModelLibrary):
@@ -80,7 +88,7 @@ class SkyMatchStep(Step):
             library = ModelLibrary(input_models, on_disk=not self.in_memory)
 
         # Method: "user". Use user-provided sky values, and bypass skymatch() altogether.
-        if self.skymethod == 'user':
+        if self.skymethod == "user":
             return self._user_sky(library)
 
         self._dqbits = interpret_bit_flags(self.dqbits, flag_name_map=pixel)
@@ -93,12 +101,12 @@ class SkyMatchStep(Step):
             nclip=self.nclip,
             lsig=self.lsigma,
             usig=self.usigma,
-            binwidth=self.binwidth
+            binwidth=self.binwidth,
         )
 
         images = []
         with library:
-            for group_index, (group_id, group_inds) in enumerate(library.group_indices.items()):
+            for group_index, (_group_id, group_inds) in enumerate(library.group_indices.items()):
                 sky_images = []
                 for index in group_inds:
                     model = library.borrow(index)
@@ -112,38 +120,31 @@ class SkyMatchStep(Step):
                     images.append(SkyGroup(sky_images, sky_id=group_index))
 
         # match/compute sky values:
-        skymatch(images, skymethod=self.skymethod, match_down=self.match_down,
-              subtract=self.subtract)
+        skymatch(
+            images, skymethod=self.skymethod, match_down=self.match_down, subtract=self.subtract
+        )
 
         # set sky background value in each image's meta:
         with library:
             for im in images:
                 if isinstance(im, SkyImage):
                     self._set_sky_background(
-                        im,
-                        library,
-                        "COMPLETE" if im.is_sky_valid else "SKIPPED"
+                        im, library, "COMPLETE" if im.is_sky_valid else "SKIPPED"
                     )
                 else:
                     for gim in im:
                         self._set_sky_background(
-                            gim,
-                            library,
-                            "COMPLETE" if gim.is_sky_valid else "SKIPPED"
+                            gim, library, "COMPLETE" if gim.is_sky_valid else "SKIPPED"
                         )
 
         return library
 
     def _imodel2skyim(self, image_model, index):
-
         if self._dqbits is None:
             dqmask = np.isfinite(image_model.data).astype(dtype=np.uint8)
         else:
             dqmask = bitfield_to_boolean_mask(
-                image_model.dq,
-                self._dqbits,
-                good_mask_value=1,
-                dtype=np.uint8
+                image_model.dq, self._dqbits, good_mask_value=1, dtype=np.uint8
             ) * np.isfinite(image_model.data)
 
         # see if 'skymatch' was previously run and raise an exception
@@ -151,8 +152,9 @@ class SkyMatchStep(Step):
         if image_model.meta.background.subtracted is None:
             if image_model.meta.background.level is not None:
                 # report inconsistency:
-                raise ValueError("Background level was set but the "
-                                 "'subtracted' property is undefined (None).")
+                raise ValueError(
+                    "Background level was set but the 'subtracted' property is undefined (None)."
+                )
             level = 0.0
 
         else:
@@ -163,17 +165,19 @@ class SkyMatchStep(Step):
                 # at this moment I think it is saver to quit and...
                 #
                 # report inconsistency:
-                raise ValueError("Background level was subtracted but the "
-                                 "'level' property is undefined (None).")
+                raise ValueError(
+                    "Background level was subtracted but the 'level' property is undefined (None)."
+                )
 
             if image_model.meta.background.subtracted != self.subtract:
                 # cannot run 'skymatch' step on already "skymatched" images
                 # when 'subtract' spec is inconsistent with
                 # meta.background.subtracted:
-                raise ValueError("'subtract' step's specification is "
-                                 "inconsistent with background info already "
-                                 "present in image '{:s}' meta."
-                                 .format(image_model.meta.filename))
+                raise ValueError(
+                    "'subtract' step's specification is "
+                    "inconsistent with background info already "
+                    f"present in image '{image_model.meta.filename:s}' meta."
+                )
 
         wcs = deepcopy(image_model.meta.wcs)
 
@@ -188,7 +192,7 @@ class SkyMatchStep(Step):
             skystat=self._skystat,
             stepsize=self.stepsize,
             reduce_memory_usage=False,  # this overwrote input files
-            meta={'index': index}
+            meta={"index": index},
         )
 
         if self.subtract:
@@ -198,6 +202,8 @@ class SkyMatchStep(Step):
 
     def _set_sky_background(self, sky_image, library, step_status):
         """
+        Set sky background values in the image's metadata.
+
         Parameters
         ----------
         sky_image : SkyImage
@@ -210,7 +216,7 @@ class SkyMatchStep(Step):
             Status of the sky subtraction step. Must be one of the following:
             'COMPLETE', 'SKIPPED'.
         """
-        index = sky_image.meta['index']
+        index = sky_image.meta["index"]
         dm = library.borrow(index)
         sky = sky_image.sky
 
@@ -224,31 +230,44 @@ class SkyMatchStep(Step):
         dm.meta.cal_step.skymatch = step_status
         library.shelve(dm, index)
 
-
     def _user_sky(self, library):
-        """Handle user-provided sky values for each image.
         """
+        Handle user-provided sky values for each image.
 
+        Parameters
+        ----------
+        library : ModelLibrary
+            Library of input data models.
+
+        Returns
+        -------
+        ModelLibrary
+            Library of input data models with sky background values set to user-provided values.
+        """
         if self.skylist is None:
             raise ValueError('skymethod set to "user", but no sky value file provided.')
 
         log.info(" ")
-        log.info("Setting sky background of input images to user-provided values "
-                 f"from `skylist` ({self.skylist}).")
+        log.info(
+            "Setting sky background of input images to user-provided values "
+            f"from `skylist` ({self.skylist})."
+        )
 
         # read the comma separated file and get just the stem of the filename
         skylist = np.genfromtxt(
             self.skylist,
-            dtype=[("fname", "<S128"),  ("sky", "f")],
+            dtype=[("fname", "<S128"), ("sky", "f")],
         )
-        skyfnames, skyvals = skylist['fname'], skylist['sky']
+        skyfnames, skyvals = skylist["fname"], skylist["sky"]
         skyfnames = skyfnames.astype(str)
         skyfnames = [remove_suffix(Path(fname).stem)[0] for fname in skyfnames]
         skyfnames = np.array(skyfnames)
 
         if len(skyvals) != len(library):
-            raise ValueError(f"Number of entries in skylist ({len(self.skylist)}) does not match "
-                             f"number of input images ({len(library)}).")
+            raise ValueError(
+                f"Number of entries in skylist ({len(self.skylist)}) does not match "
+                f"number of input images ({len(library)})."
+            )
 
         with library:
             for model in library:
@@ -257,9 +276,13 @@ class SkyMatchStep(Step):
                 if len(sky) == 0:
                     raise ValueError(f"Image with stem '{fname}' not found in the skylist.")
                 if len(sky) > 1:
-                    raise ValueError(f"Image with stem '{fname}' found multiple times in the skylist.")
+                    raise ValueError(
+                        f"Image with stem '{fname}' found multiple times in the skylist."
+                    )
 
-                log.debug(f"Setting sky background of image '{model.meta.filename}' to {float(sky)}.")
+                log.debug(
+                    f"Setting sky background of image '{model.meta.filename}' to {float(sky)}."
+                )
 
                 model.meta.background.level = float(sky)
                 model.meta.background.subtracted = self.subtract


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially Resolves [JP-3860](https://jira.stsci.edu/browse/JP-3860)

<!-- describe the changes comprising this PR here -->
This PR applies code style changes to the skymatch step.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
