### PR TITLE
JP-3808: Store scaling factor for WFSS data in background step

### DIFF
--- a/changes/9204.background.rst
+++ b/changes/9204.background.rst
@@ -1,0 +1,1 @@
+Store background scaling factor for WFSS data

--- a/jwst/background/background_sub_wfss.py
+++ b/jwst/background/background_sub_wfss.py
@@ -91,6 +91,7 @@ def subtract_wfss_bkg(
     result = input_model.copy()
     result.data = input_model.data - subtract_this
     result.dq = np.bitwise_or(input_model.dq, bkg_ref.dq)
+    result.meta.background.scaling_factor = factor
 
     log.info(f"Average of scaled background image = {np.nanmean(subtract_this):.3e}")
     log.info(f"Scaling factor = {factor:.5e}")

--- a/jwst/background/tests/test_background_wfss.py
+++ b/jwst/background/tests/test_background_wfss.py
@@ -168,10 +168,13 @@ def bkg_file(tmp_cwd, make_wfss_datamodel, known_bkg):
 
 
 def shared_tests(sci, mask, original_data_mean):
-    """Tests that are common to all WFSS modes
+    """
+    Tests that are common to all WFSS modes.
+    
     Note that NaN fraction test in test_nrc_wfss_background and test_nis_wfss_background
     cannot be applied to the full run tests because the background reference files contain
-    NaNs in some cases (specifically for NIRISS)"""
+    NaNs in some cases (specifically for NIRISS)
+    """
 
     # re-mask data so "real" sources are ignored here
     sci[~mask] = np.nan
@@ -237,6 +240,7 @@ def test_nrc_wfss_full_run(pupil, make_nrc_wfss_datamodel):
     while the data is synthetic and just has a mock gradient"""
     data = make_nrc_wfss_datamodel.copy()
     data.meta.instrument.pupil = pupil
+    assert not hasattr(data.meta.background, "scaling_factor")
 
     # do the subtraction. set all options to ensure they are at least recognized
     result = BackgroundStep.call(data, None,
@@ -249,6 +253,7 @@ def test_nrc_wfss_full_run(pupil, make_nrc_wfss_datamodel):
     wavelenrange = Step().get_reference_file(data, "wavelengthrange")
     mask = _mask_from_source_cat(result, wavelenrange)
     shared_tests(sci, mask, data.original_data_mean)
+    assert isinstance(result.meta.background.scaling_factor, float)
 
 
 @pytest.mark.parametrize("filt", ["GR150C", "GR150R"])
@@ -260,6 +265,7 @@ def test_nis_wfss_full_run(filt, make_nis_wfss_datamodel):
     while the data is synthetic and just has a mock gradient"""
     data = make_nis_wfss_datamodel.copy()
     data.meta.instrument.filter = filt
+    assert not hasattr(data.meta.background, "scaling_factor")
 
     # do the subtraction. set all options to ensure they are at least recognized
     result = BackgroundStep.call(data, None,
@@ -272,6 +278,7 @@ def test_nis_wfss_full_run(filt, make_nis_wfss_datamodel):
     wavelenrange = Step().get_reference_file(data, "wavelengthrange")
     mask = _mask_from_source_cat(result, wavelenrange)
     shared_tests(sci, mask, data.original_data_mean)
+    assert isinstance(result.meta.background.scaling_factor, float)
 
 
 def test_sufficient_background_pixels():

--- a/jwst/background/tests/test_background_wfss.py
+++ b/jwst/background/tests/test_background_wfss.py
@@ -233,14 +233,16 @@ def test_nis_wfss_background(make_nis_wfss_datamodel, bkg_file):
 # test both filters because they have opposite dispersion directions
 @pytest.mark.parametrize("pupil", ["GRISMC", "GRISMR"])
 def test_nrc_wfss_full_run(pupil, make_nrc_wfss_datamodel):
-    """Test full run of NIRCAM WFSS background subtraction.
+    """
+    Test full run of NIRCAM WFSS background subtraction.
+
     The residual structure in the background will not look as nice as in
     test_nis_wfss_background because here it's taken from a reference file,
     so the bkg has real detector imperfections
-    while the data is synthetic and just has a mock gradient"""
+    while the data is synthetic and just has a mock gradient
+    """
     data = make_nrc_wfss_datamodel.copy()
     data.meta.instrument.pupil = pupil
-    assert not hasattr(data.meta.background, "scaling_factor")
 
     # do the subtraction. set all options to ensure they are at least recognized
     result = BackgroundStep.call(data, None,
@@ -258,14 +260,16 @@ def test_nrc_wfss_full_run(pupil, make_nrc_wfss_datamodel):
 
 @pytest.mark.parametrize("filt", ["GR150C", "GR150R"])
 def test_nis_wfss_full_run(filt, make_nis_wfss_datamodel):
-    """Test full run of NIRISS WFSS background subtraction.
+    """
+    Test full run of NIRISS WFSS background subtraction.
+
     The residual structure in the background will not look as nice as in
     test_nis_wfss_background because here it's taken from a reference file,
     so the bkg has real detector imperfections
-    while the data is synthetic and just has a mock gradient"""
+    while the data is synthetic and just has a mock gradient
+    """
     data = make_nis_wfss_datamodel.copy()
     data.meta.instrument.filter = filt
-    assert not hasattr(data.meta.background, "scaling_factor")
 
     # do the subtraction. set all options to ensure they are at least recognized
     result = BackgroundStep.call(data, None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "scikit-image>=0.20.0",
     "scipy>=1.14.1",
     "spherical-geometry>=1.2.22",
-    "stdatamodels @ git+https://github.com/emolter/stdatamodels.git@main",
+    "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stpipe>=0.8.0,<0.9.0",
     "stsci.imagestats>=1.6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "scikit-image>=0.20.0",
     "scipy>=1.14.1",
     "spherical-geometry>=1.2.22",
-    "stdatamodels @ git+https://github.com/emolter/stdatamodels.git@JP-3808",
+    "stdatamodels @ git+https://github.com/emolter/stdatamodels.git@main",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stpipe>=0.8.0,<0.9.0",
     "stsci.imagestats>=1.6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "scikit-image>=0.20.0",
     "scipy>=1.14.1",
     "spherical-geometry>=1.2.22",
-    "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",
+    "stdatamodels @ git+https://github.com/emolter/stdatamodels.git@JP-3808",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stpipe>=0.8.0,<0.9.0",
     "stsci.imagestats>=1.6.3",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3808](https://jira.stsci.edu/browse/JP-3808)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8992 

<!-- describe the changes comprising this PR here -->
https://github.com/spacetelescope/stdatamodels/pull/407 defines a new schema attribute, `model.meta.background.scaling_factor`, to store the scaling factor from the background step.

This PR stores the scaling factor computed for WFSS data during the background step into that attribute.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
