### PR TITLE
JP-3597: Add new algorithm for EMI fit; clean up existing code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,6 @@ repos:
             jwst/cube_build/.* |
             jwst/cube_skymatch/.* |
             jwst/dark_current/.* |
-            jwst/emicorr/.* |
             jwst/engdblog/.* |
             jwst/extract_2d/.* |
             jwst/flatfield/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -26,7 +26,6 @@ exclude = [
     "jwst/cube_build/**.py",
     "jwst/cube_skymatch/**.py",
     "jwst/dark_current/**.py",
-    "jwst/emicorr/**.py",
     "jwst/engdblog/**.py",
     "jwst/extract_2d/**.py",
     "jwst/flatfield/**.py",
@@ -121,7 +120,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/cube_build/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/cube_skymatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/dark_current/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/emicorr/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/engdblog/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/extract_2d/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/flatfield/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/changes/9187.emicorr.rst
+++ b/changes/9187.emicorr.rst
@@ -1,0 +1,4 @@
+Implement a new EMIcorr algorithm that optimizes the phase and amplitude of
+a reference waveform of known frequency. The best phase and amplitude are the
+ones that, when applied to the waveform and subtracted from the data, produce
+ramps for the pixels that are as linear as possible.

--- a/changes/9216.emicorr.rst
+++ b/changes/9216.emicorr.rst
@@ -1,4 +1,5 @@
 Implement a new EMIcorr algorithm that optimizes the phase and amplitude of
 a reference waveform of known frequency. The best phase and amplitude are the
 ones that, when applied to the waveform and subtracted from the data, produce
-ramps for the pixels that are as linear as possible.
+ramps for the pixels that are as linear as possible. Also, fix a minor bug in
+the existing algorithm that prevented saving intermediate reference files.

--- a/docs/jwst/emicorr/arguments.rst
+++ b/docs/jwst/emicorr/arguments.rst
@@ -2,26 +2,40 @@ Step Arguments
 ==============
 The ``emicorr`` step has the following step-specific arguments.
 
+``--algorithm`` (string, default='sequential')
+    Algorithm for fitting EMI noise in ramps.  If 'sequential', ramps are fit
+    and then EMI noise is fit to the residuals.  If 'joint', ramps and noise
+    are fit simultaneously.  The sequential algorithm can be used without
+    a reference waveform, generating a new reference file on-the-fly, but it
+    requires 10 or more groups for a reliable fit.  The joint algorithm
+    requires a reference waveform but can successfully fit EMI noise in ramps
+    with 3 or more groups.
+
 ``--nints_to_phase`` (integer, default=None)
-    Number of integrations to phase.
+    Number of integrations to phase, when `algorithm` is 'sequential'.
 
 ``--nbins`` (integer, default=None)
-    Number of bins in one phased wave.
+    Number of bins in one phased wave, when `algorithm` is 'sequential'.
 
 ``--scale_reference`` (boolean, default=True)
-    If True, the reference wavelength will be scaled to the
-    data's phase amplitude.
-
-``--save_intermediate_results``  (string, default=False)
-    This is a boolean flag to specify whether to write a step output
-    file with the EMI correction, and a reference file with all the
-    on-the-fly frequencies' phase amplitudes. The file will have an
-    ASDF output with the same format as an EMI reference file.
+    If True and `algorithm` is 'sequential', the reference wavelength will be scaled
+    to the data's phase amplitude.
 
 ``--onthefly_corr_freq``  (list, default=None)
-    This is to tell the code to do correction for the frequencies in
-    the list with a reference file created on-the-fly instead of CRDS.
+    Frequency values to use to create a correction on-the-fly.  If provided,
+    any input EMICORR reference model is ignored and the `algorithm` is set to
+    'sequential'.
 
 ``--use_n_cycles`` (integer, default=3)
-    Number of cycles to use to calculate the phase. To use all
-    integrations, set to None.
+    Number of cycles to use to calculate the phase when `algorithm` is 'sequential'.
+    To use all cycles, set to None.
+
+``--fit_ints_separately`` (boolean, default=False)
+    If True, fit and remove EMI noise for each integration separately, when
+    `algorithm` is 'joint'.
+
+``--save_intermediate_results``  (string, default=False)
+    If True, and input frequencies are provided in `onthefly_corr_freq`,
+    save a reference file with the fit phase amplitudes for the provided frequencies
+    to disk. The file will be in ASDF output with the same format as an
+    EMICORR reference file.

--- a/docs/jwst/emicorr/description.rst
+++ b/docs/jwst/emicorr/description.rst
@@ -6,65 +6,83 @@ Description
 
 Overview
 --------
-The ``emicorr`` step corrects for known noise patterns in the raw MIRI data.
-The majority of the MIRI subarrays have an 390 Hz or other electromagnetic
-interference (EMI) noise pattern in the raw data. The known frequencies to
-correct for are in the EMI reference file, under the key ``frequencies``.
-The effect of these EMI frequencies is to imprint each into the rate
-images. For short integrations in ``LRSSLITLESS`` the correlated noise from
-this is quite apparent in the rate images. For longer integrations the net
-effect is to increase the read noise by about 20\%.
+The ``emicorr`` step corrects for known noise patterns in raw MIRI ramp data.
+The majority of the MIRI subarrays have a 390 Hz or other electromagnetic
+interference (EMI) noise pattern in the raw data.
+The effect of these EMI frequencies is to imprint periodic noise into each ramp
+image, depending on the readout timing of each pixel. For short integrations
+in the LRS slitless mode, the correlated noise is quite apparent in the rate images.
+For longer integrations the net effect is to increase the read noise by about 20\%.
 
-The process to do the correction is the following (repeated
-recursively for each discrete EMI frequency desired):
+In the long term, it may be possible to eliminate the most significant sources
+of EMI noise by changing the sizes and locations of the subarrays, to get
+readout times in phase with the known noise frequencies. For existing and
+near-term observations, this step is required to correct for the noise.  In the
+future, it is likely this step will still be useful to correct for lower level
+EMI noise sources.
 
-#. Read image data.
+The known frequencies to correct for are stored in the
+:ref:`EMICORR reference file <emicorr_reffile>`.
+This reference file is expected to be in ASDF format, containing
+the exact frequency numbers and the corresponding 1D array for the phase
+amplitudes in the reference waveform.  The reference file also contains
+a ``subarray_cases`` dictionary that maps a specific subarray, read pattern, and
+detector to the necessary frequencies to correct for.
 
-#. Make very crude slope image and fixed pattern "super" bias for each
-   integration, ignoring everything (nonlin, saturation, badpix, etc).
+There are two algorithms available for fitting EMI noise in the input ramps: a
+"sequential" fit and a "joint" fit.
 
-#. Subtract scaled slope image and bias from each frame of each integration.
+For the sequential fitting algorithm, the process to correct for EMI noise is
+the following (repeated iteratively for each discrete EMI frequency desired):
 
-#. Calculate phase of every pixel in the image at the desired EMI frequency
-   (e.g. 390 Hz) relative to the first pixel in the image.
+#. Read the image data.
 
-#. Make a binned, phased amplitude (pa) wave from the cleaned data (plot
-   cleaned vs phase, then bin by phase).
+#. Make a very crude slope image and fixed pattern bias image for each
+   integration, ignoring the effects of nonlinearity, saturation, bad pixels, etc.
 
-#. Measure the phase shift between the binned pa wave and the input
-   reference wave. [#f1]_
+#. Subtract the scaled slope image and bias from each frame of each integration.
 
-#. Use look-up table to get the aligned reference wave value for each pixel
+#. Calculate the phase of every pixel in the image at the desired EMI frequency
+   (e.g. 390 Hz), relative to the first pixel in the image.
+
+#. Make a binned phased amplitude (PA) waveform from the cleaned data.
+
+#. Measure the phase shift between the binned PA waveform and the input
+   reference waveform. [#f1]_
+
+#. Use a look-up table to get the aligned reference waveform value for each pixel
    (the noise array corresponding to the input image). [#f1]_
 
 #. Subtract the noise array from the input image and return the cleaned result.
 
-.. [#f1] Alternately, use the binned pa wave instead of the reference wave to "self-correct".
+.. [#f1] Alternately, if a reference waveform is not available, use the binned
+   PA waveform to "self-correct" the noise.
 
-The long term plan is a change to the sizes and locations of the subarrays
-to get the frame times to be in phase with the known noise frequencies like
-the full frame images. For the previous and near term observations this can
-be fixed through application of the ``emicorr`` step.
+The joint algorithm proceeds similarly, except that the linear ramps and
+the EMI noise are fit simultaneously. It works by choosing pixels with modest
+scatter among the reads, and then finding the amplitude and phase of a supplied
+reference waveform that, when subtracted, makes these pixels' ramps as straight
+as possible. The straightness of the ramps is measured by a chi-squared metric, after
+fitting lines to each one.  As for the sequential algorithm, the noise at each
+frequency is fit and removed iteratively, for each desired frequency.
 
-An EMICORR reference file can be used to correct for all known noise
-patterns. The reference file is expected to be in ASDF format, containing
-the exact frequency numbers, the corresponding 1D array for the phase
-amplitudes, and a ``subarray_cases`` dictionary that contains
-the frequencies to correct for according to subarray, read pattern, and
-detector. If there is no reference file found in CRDS, the step has a set
-of default frequencies and subarray cases for which the correction is
-applied.
+The optimal choice for the fitting algorithm depends on the input.
+The sequential algorithm can be used without a reference waveform, generating
+a new reference file on-the-fly for user-specified frequencies, but it
+requires 10 or more groups for a reliable fit.  The joint algorithm
+requires a reference waveform but can successfully fit EMI in ramps with
+3 or more groups.  Currently, the default algorithm is "sequential", but users
+should consider specifying the joint algorithm if the number of groups
+in the input data is less than 10.
 
 Input
 -----
 The input file is the ``_uncal`` file after the
-:ref:`dq_init_step <dq_init_step>` step has been
-applied, in the in the :ref:`calwebb_detector1 <calwebb_detector1>`
-pipeline.
+:ref:`dq_init_step <dq_init_step>` step has been applied, in the
+:ref:`calwebb_detector1 <calwebb_detector1>` pipeline.
 
 Output
 ------
 The output will be a partially-processed ``RampModel`` with the
-corrected data in the SCI extension, meaning, the effect of the
-EMI frequencies (either the default values or the ones in the
-reference file) removed. All other extensions will remain the same.
+EMI-corrected data in the SCI extension. All other extensions will
+remain the same.

--- a/docs/jwst/emicorr/description.rst
+++ b/docs/jwst/emicorr/description.rst
@@ -63,7 +63,7 @@ the EMI noise are fit simultaneously. It works by choosing pixels with modest
 scatter among the reads, and then finding the amplitude and phase of a supplied
 reference waveform that, when subtracted, makes these pixels' ramps as straight
 as possible. The straightness of the ramps is measured by a chi-squared metric, after
-fitting lines to each one.  As for the sequential algorithm, the noise at each
+fitting lines to each one.  As for the sequential algorithm, the EMI signal at each
 frequency is fit and removed iteratively, for each desired frequency.
 
 The optimal choice for the fitting algorithm depends on the input.

--- a/docs/jwst/emicorr/description.rst
+++ b/docs/jwst/emicorr/description.rst
@@ -71,9 +71,7 @@ The sequential algorithm can be used without a reference waveform, generating
 a new reference file on-the-fly for user-specified frequencies, but it
 requires 10 or more groups for a reliable fit.  The joint algorithm
 requires a reference waveform but can successfully fit EMI in ramps with
-3 or more groups.  Currently, the default algorithm is "sequential", but users
-should consider specifying the joint algorithm if the number of groups
-in the input data is less than 10.
+3 or more groups.
 
 Input
 -----

--- a/docs/jwst/emicorr/reference_files.rst
+++ b/docs/jwst/emicorr/reference_files.rst
@@ -1,6 +1,6 @@
 Reference Files
 ===============
 
-The ``emicorr`` step can use an EMI reference file.
+The ``emicorr`` step uses an EMI reference file.
 
 .. include:: ../references_general/emi_reffile.inc

--- a/docs/jwst/references_general/emi_reffile.inc
+++ b/docs/jwst/references_general/emi_reffile.inc
@@ -7,7 +7,7 @@ EMICORR Reference File
 :Data model: `~jwst.datamodels.EmiModel`
 
 The EMICORR reference file contains data necessary for removing
-contaminating MIRI EMI frequencies.
+noise from contaminating EMI frequencies in MIRI ramp data.
 
 .. include:: ../references_general/emi_selection.inc
 
@@ -19,6 +19,7 @@ EMICORR Reference File Format
 MIRI EMICORR reference files are in ASDF format.  The EMICORR
 reference file contains the frequencies for which the image will
 be corrected.
+
 Example file contents::
 
   root (AsdfObject)
@@ -66,5 +67,5 @@ Frequency Selection
 
 The frequency to be corrected for will be selected according to the
 dictionary contained in the key ``subarray_cases`` in the reference
-file. This contains the subarray names and the names of the
-corresponding frequencies to be used in the correction.
+file. This contains the subarray name, readout pattern, and detector
+to match to the names of the frequencies to be used in the correction.

--- a/jwst/emicorr/__init__.py
+++ b/jwst/emicorr/__init__.py
@@ -1,3 +1,5 @@
+"""Apply MIRI EMI correction."""
+
 from .emicorr_step import EmiCorrStep
 
 __all__ = ['EmiCorrStep']

--- a/jwst/emicorr/__init__.py
+++ b/jwst/emicorr/__init__.py
@@ -2,4 +2,4 @@
 
 from .emicorr_step import EmiCorrStep
 
-__all__ = ['EmiCorrStep']
+__all__ = ["EmiCorrStep"]

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -11,57 +11,32 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 subarray_clocks = {
-
-    "SLITLESSPRISM": {
-        "rowclocks": 28,
-        "frameclocks": 15904},
-
-    "MASKLYOT": {
-        "rowclocks": 90,
-        "frameclocks": 32400},
-
-    "SUB64": {
-        "rowclocks": 28,
-        "frameclocks": 8512},
-
-    "SUB128": {
-        "rowclocks": 44,
-        "frameclocks": 11904},
-
-    "MASK1140": {
-        "rowclocks": 82,
-        "frameclocks": 23968},
-
-    "MASK1550": {
-        "rowclocks": 82,
-        "frameclocks": 23968},
-
-    "MASK1065": {
-        "rowclocks": 82,
-        "frameclocks": 23968},
-
-    "FULL_FAST": {
-        "rowclocks": 271,
-        "frameclocks": 277504},
-
-    "FULL_SLOW": {
-        "rowclocks": 2333,
-        "frameclocks": 2388992},
-
-    "BRIGHTSKY": {
-        "rowclocks": 162,
-        "frameclocks": 86528},
-
-    "SUB256": {
-        "rowclocks": 96,
-        "frameclocks": 29952},
+    "SLITLESSPRISM": {"rowclocks": 28, "frameclocks": 15904},
+    "MASKLYOT": {"rowclocks": 90, "frameclocks": 32400},
+    "SUB64": {"rowclocks": 28, "frameclocks": 8512},
+    "SUB128": {"rowclocks": 44, "frameclocks": 11904},
+    "MASK1140": {"rowclocks": 82, "frameclocks": 23968},
+    "MASK1550": {"rowclocks": 82, "frameclocks": 23968},
+    "MASK1065": {"rowclocks": 82, "frameclocks": 23968},
+    "FULL_FAST": {"rowclocks": 271, "frameclocks": 277504},
+    "FULL_SLOW": {"rowclocks": 2333, "frameclocks": 2388992},
+    "BRIGHTSKY": {"rowclocks": 162, "frameclocks": 86528},
+    "SUB256": {"rowclocks": 96, "frameclocks": 29952},
 }
 
 
-def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile=None,
-                  algorithm='sequential', nints_to_phase=None,
-                  nbins=None, scale_reference=True, onthefly_corr_freq=None,
-                  use_n_cycles=3, fit_ints_separately=False):
+def apply_emicorr(
+    input_model,
+    emicorr_model,
+    save_onthefly_reffile=None,
+    algorithm="sequential",
+    nints_to_phase=None,
+    nbins=None,
+    scale_reference=True,
+    onthefly_corr_freq=None,
+    use_n_cycles=3,
+    fit_ints_separately=False,
+):
     """
     Apply an EMI correction to MIRI ramps.
 
@@ -131,7 +106,7 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile=None,
     Returns
     -------
     output_model : JWST data model
-        input science data model which has been emi-corrected
+        Input science data model, corrected for EMI.
     """
     # Get the subarray case and other info
     detector = input_model.meta.instrument.detector
@@ -148,30 +123,34 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile=None,
     # Check algorithm against input data shape
     ngroups = input_model.data.shape[1]
     if ngroups < 3:
-        log.warning(f'EMI correction cannot be performed for ngroups={ngroups}')
+        log.warning(f"EMI correction cannot be performed for ngroups={ngroups}")
         return None
-    if ngroups < 10 and algorithm == 'sequential':
+    if ngroups < 10 and algorithm == "sequential":
         log.warning(f"The 'sequential' algorithm is selected and ngroups={ngroups}.")
         log.warning("The 'joint' algorithm is recommended for ngroups < 10.")
-    if algorithm == 'joint' and emicorr_model is None:
-        log.warning("The 'joint' algorithm cannot be used without an EMICORR "
-                    "reference file.  Setting the algorithm to 'sequential'.")
-        algorithm = 'sequential'
+    if algorithm == "joint" and emicorr_model is None:
+        log.warning(
+            "The 'joint' algorithm cannot be used without an EMICORR "
+            "reference file.  Setting the algorithm to 'sequential'."
+        )
+        algorithm = "sequential"
 
     # Get the subarray case from either the ref file or set default values
     freq_numbers = []
     reference_wave_list = []
     subname, rowclocks, frameclocks, freqs2correct = None, None, None, None
     if emicorr_model is not None:
-        log.info('Using reference file to get subarray case.')
+        log.info("Using reference file to get subarray case.")
         subname, rowclocks, frameclocks, freqs2correct = get_subarcase(
-            emicorr_model, subarray, readpatt, detector)
+            emicorr_model, subarray, readpatt, detector
+        )
 
-        log.info(f'With configuration: Subarray={subarray}, '
-                 f'Read_pattern={readpatt}, Detector={detector}')
+        log.info(
+            f"With configuration: Subarray={subarray}, Read_pattern={readpatt}, Detector={detector}"
+        )
         if freqs2correct is not None:
-            log.info(f'Will correct data for the following {len(freqs2correct)} frequencies: ')
-            log.info(f'   {freqs2correct}')
+            log.info(f"Will correct data for the following {len(freqs2correct)} frequencies: ")
+            log.info(f"   {freqs2correct}")
 
             for freq_val in freqs2correct:
                 # Collect the frequency numbers and reference wave list
@@ -181,45 +160,64 @@ def apply_emicorr(input_model, emicorr_model, save_onthefly_reffile=None,
     else:
         # if we got here, the user requested to do correction with on-the-fly reference file
         subname = subarray
-        if subname == 'FULL':
-            if 'FAST' in readpatt.upper():
-                subname += '_FAST'
-            elif 'SLOW' in readpatt.upper():
-                subname += '_SLOW'
+        if subname == "FULL":
+            if "FAST" in readpatt.upper():
+                subname += "_FAST"
+            elif "SLOW" in readpatt.upper():
+                subname += "_SLOW"
         if subname in subarray_clocks:
-            rowclocks = subarray_clocks[subname]['rowclocks']
-            frameclocks = subarray_clocks[subname]['frameclocks']
+            rowclocks = subarray_clocks[subname]["rowclocks"]
+            frameclocks = subarray_clocks[subname]["frameclocks"]
             freq_numbers = onthefly_corr_freq
             freqs2correct = [repr(freq) for freq in onthefly_corr_freq]
 
-            log.info(f'Will correct data for the following {len(freqs2correct)} frequencies: ')
-            log.info(f'   {freqs2correct}')
+            log.info(f"Will correct data for the following {len(freqs2correct)} frequencies: ")
+            log.info(f"   {freqs2correct}")
 
     # No subarray or read pattern match found, print to log and skip correction
     if rowclocks is None or len(freq_numbers) == 0:
-        log.warning('No correction match for this configuration')
+        log.warning("No correction match for this configuration")
         return None
 
     # For the joint algorithm, use the reference wave to correct the data
-    if algorithm == 'joint':
+    if algorithm == "joint":
         output_model = _run_joint_algorithm(
-            input_model, freq_numbers, reference_wave_list,
-            nsamples, rowclocks, frameclocks,
-            fit_ints_separately=fit_ints_separately)
+            input_model,
+            freq_numbers,
+            reference_wave_list,
+            nsamples,
+            rowclocks,
+            frameclocks,
+            fit_ints_separately=fit_ints_separately,
+        )
     else:
         output_model = _run_sequential_algorithm(
-            input_model, freqs2correct, freq_numbers, reference_wave_list,
-            nsamples, rowclocks, frameclocks,
+            input_model,
+            freqs2correct,
+            freq_numbers,
+            reference_wave_list,
+            nsamples,
+            rowclocks,
+            frameclocks,
             save_onthefly_reffile=save_onthefly_reffile,
             nints_to_phase=nints_to_phase,
-            nbins=nbins, scale_reference=scale_reference,
-            use_n_cycles=use_n_cycles)
+            nbins=nbins,
+            scale_reference=scale_reference,
+            use_n_cycles=use_n_cycles,
+        )
 
     return output_model
 
 
-def _run_joint_algorithm(input_model, freq_numbers, reference_wave_list,
-                         nsamples, rowclocks, frameclocks, fit_ints_separately=False):
+def _run_joint_algorithm(
+    input_model,
+    freq_numbers,
+    reference_wave_list,
+    nsamples,
+    rowclocks,
+    frameclocks,
+    fit_ints_separately=False,
+):
     """
     Remove EMI noise with a joint fit to ramps and EMI signal.
 
@@ -249,18 +247,24 @@ def _run_joint_algorithm(input_model, freq_numbers, reference_wave_list,
         The output datamodel, with noise fit and subtracted.
     """
     readpatt = str(input_model.meta.exposure.readpatt).upper()
-    if readpatt == 'FASTR1' or readpatt == 'SLOWR1':
+    if readpatt == "FASTR1" or readpatt == "SLOWR1":
         _frameclocks = frameclocks
     else:
         _frameclocks = 0
 
     for freq, ref_wave in zip(freq_numbers, reference_wave_list, strict=True):
-        period_in_pixels = (1. / freq) / 10.0e-6
+        period_in_pixels = (1.0 / freq) / 10.0e-6
 
         corrected_data = emicorr_refwave(
-            input_model.data, input_model.pixeldq, np.array(ref_wave),
-            nsamples, rowclocks, _frameclocks,
-            period_in_pixels, fit_ints_separately=fit_ints_separately)
+            input_model.data,
+            input_model.pixeldq,
+            np.array(ref_wave),
+            nsamples,
+            rowclocks,
+            _frameclocks,
+            period_in_pixels,
+            fit_ints_separately=fit_ints_separately,
+        )
 
         # Data is updated in place, so it is corrected iteratively
         input_model.data[:] = corrected_data
@@ -270,12 +274,19 @@ def _run_joint_algorithm(input_model, freq_numbers, reference_wave_list,
 
 
 def _run_sequential_algorithm(
-        input_model, freqs2correct, freq_numbers, reference_wave_list,
-        nsamples, rowclocks, frameclocks,
-        save_onthefly_reffile=None,
-        nints_to_phase=None,
-        nbins=None, scale_reference=True,
-        use_n_cycles=3):
+    input_model,
+    freqs2correct,
+    freq_numbers,
+    reference_wave_list,
+    nsamples,
+    rowclocks,
+    frameclocks,
+    save_onthefly_reffile=None,
+    nints_to_phase=None,
+    nbins=None,
+    scale_reference=True,
+    use_n_cycles=3,
+):
     """
     Remove EMI noise with a sequential fit to ramps and EMI signal.
 
@@ -319,18 +330,17 @@ def _run_sequential_algorithm(
     The 'sequential' algorithm was originally translated from the IDL
     procedure 'fix_miri_emi.pro', written by E. Bergeron.
     """
-
     # Get the shape and metadata for the input data
     nints, ngroups, ny, nx = np.shape(input_model.data)
-    xsize = input_model.meta.subarray.xsize   # SUBSIZE1 keyword
-    xstart = input_model.meta.subarray.xstart   # SUBSTRT1 keyword
+    xsize = input_model.meta.subarray.xsize  # SUBSIZE1 keyword
+    xstart = input_model.meta.subarray.xstart  # SUBSTRT1 keyword
     detector = input_model.meta.instrument.detector
     subarray = input_model.meta.subarray.name
     readpatt = input_model.meta.exposure.readpatt
 
     # create the dictionary to store the frequencies and corresponding phase amplitudes
     if save_onthefly_reffile is not None:
-        freq_pa_dict = {'frequencies': {}, 'subarray_cases': {}}
+        freq_pa_dict = {"frequencies": {}, "subarray_cases": {}}
 
     # Copy the input nbins setting, so it can be set to different values for different frequencies
     nbins_all = nbins
@@ -338,7 +348,9 @@ def _run_sequential_algorithm(
     # Loop over the frequencies to correct
     for fi, frequency_name in enumerate(freqs2correct):
         frequency = freq_numbers[fi]
-        log.info(f'Correcting for frequency: {frequency} Hz  ({fi+1} out of {len(freqs2correct)})')
+        log.info(
+            f"Correcting for frequency: {frequency} Hz  ({fi + 1} out of {len(freqs2correct)})"
+        )
 
         # Set up some variables
 
@@ -348,10 +360,10 @@ def _run_sequential_algorithm(
         # sz[2] = ny
         # sz[3] = ngroups
         # sz[4] = nints
-        nx4 = int(nx/4)
+        nx4 = int(nx / 4)
 
         dd_all = np.zeros((nints, ngroups, ny, nx4))
-        log.info('Subtracting self-superbias from each group of each integration')
+        log.info("Subtracting self-superbias from each group of each integration")
 
         # Calculate times of all pixels in the input integration, then use that to calculate
         # phase of all pixels. Times here is in integer numbers of 10us pixels starting from
@@ -363,18 +375,20 @@ def _run_sequential_algorithm(
         # int, with less risk of datatype overflow. Still, use the largest datatype available
         # for the time_this_int array.
 
-        times_this_int = np.zeros((ngroups, ny, nx4), dtype='ulonglong')
+        times_this_int = np.zeros((ngroups, ny, nx4), dtype="ulonglong")
         phaseall = np.zeros((nints, ngroups, ny, nx4))
 
         # non-roi rowclocks between subarray frames (this will be 0 for fullframe)
-        extra_rowclocks = (1024. - ny) * (4 + 3.)
+        extra_rowclocks = (1024.0 - ny) * (4 + 3.0)
         # e.g. ((1./390.625) / 10e-6) = 256.0 pix and ((1./218.52055) / 10e-6) = 457.62287 pix
-        period_in_pixels = (1./frequency) / 10.0e-6
+        period_in_pixels = (1.0 / frequency) / 10.0e-6
 
         if nints_to_phase is None and use_n_cycles is None:  # user wats to use all integrations
             # use all integrations
             nints_to_phase = nints
-        elif nints_to_phase is None and use_n_cycles is not None: # user wants to use nints_to_phase
+        elif (
+            nints_to_phase is None and use_n_cycles is not None
+        ):  # user wants to use nints_to_phase
             # Calculate how many integrations you need to get that many cycles for
             # a given frequency (rounding up to the nearest Nintegrations)
             nints_to_phase = (use_n_cycles * period_in_pixels) / (frameclocks * ngroups)
@@ -391,11 +405,11 @@ def _run_sequential_algorithm(
         # this number comes from the subarray definition (see subarray_cases dict above), but
         # calculate it from the input image header here just in case the subarray definitions
         # are not available to this routine.
-        colstop = int(xsize/4 + xstart - 1)
-        log.info('Doing phase calculation per integration')
+        colstop = int(xsize / 4 + xstart - 1)
+        log.info("Doing phase calculation per integration")
 
         for ninti in range(nints):
-            log.debug('  Working on integration: {}'.format(ninti+1))
+            log.debug(f"  Working on integration: {ninti + 1}")
             # Read in this integration
             data = input_model.data[ninti].copy()
 
@@ -403,14 +417,14 @@ def _run_sequential_algorithm(
             # (linear is good enough for phase finding)
 
             # do linear fit for source + sky
-            s0, mm0 = sloper(data[1:ngroups-1, :, :])
+            s0, mm0 = sloper(data[1 : ngroups - 1, :, :])
 
             # subtract source+sky from each frame of this ramp
             for ngroupi in range(ngroups):
                 data[ngroupi, ...] = input_model.data[ninti, ngroupi, ...] - (s0 * ngroupi)
 
             # make a self-superbias
-            m0 = minmed(data[1:ngroups-1, :, :])
+            m0 = minmed(data[1 : ngroups - 1, :, :])
 
             # subtract self-superbias from each frame of this ramp
             for ngroupi in range(ngroups):
@@ -422,18 +436,20 @@ def _run_sequential_algorithm(
                 d1 = data[ngroupi, :, 1:nx:4]
                 d2 = data[ngroupi, :, 2:nx:4]
                 d3 = data[ngroupi, :, 3:nx:4]
-                dd = (d0 + d1 + d2 + d3)/4.
+                dd = (d0 + d1 + d2 + d3) / 4.0
 
                 # fix a bad ref col
-                dd[:, 1] = (dd[:, 0] + dd[:, 3])/2
-                dd[:, 2] = (dd[:, 0] + dd[:, 3])/2
+                dd[:, 1] = (dd[:, 0] + dd[:, 3]) / 2
+                dd[:, 2] = (dd[:, 0] + dd[:, 3]) / 2
                 # This is the quad-averaged, cleaned, input image data for the exposure
                 dd_all[ninti, ngroupi, ...] = dd - np.median(dd)
 
-            for k in range(ngroups):   # frames
-                for j in range(ny):    # rows
+            for k in range(ngroups):  # frames
+                for j in range(ny):  # rows
                     # nsamples= 1 for fast, 9 for slow (from metadata)
-                    times_this_int[k, j, :] = np.arange(nx4, dtype='ulonglong') * nsamples + start_time
+                    times_this_int[k, j, :] = (
+                        np.arange(nx4, dtype="ulonglong") * nsamples + start_time
+                    )
 
                     # If the last pixel in a row is a reference pixel, need to push it out
                     # by ref_pix_sample sample times. The same thing happens for the first
@@ -446,7 +462,9 @@ def _run_sequential_algorithm(
 
                     if colstop == 258:
                         ulonglong_ref_pix_sample = ref_pix_sample + 2**32
-                        times_this_int[k, j, nx4-1] = times_this_int[k, j, nx4-1] + ulonglong_ref_pix_sample
+                        times_this_int[k, j, nx4 - 1] = (
+                            times_this_int[k, j, nx4 - 1] + ulonglong_ref_pix_sample
+                        )
 
                     # point to the first pixel of the next row (add "end-of-row" pad)
                     start_time += rowclocks
@@ -458,10 +476,10 @@ def _run_sequential_algorithm(
             # number of 10us from the first data pixel in this integration, so to
             # convert to phase, divide by the waveform *period* in float pixels
             phase_this_int = times_this_int / period_in_pixels
-            phaseall[ninti, ...] = phase_this_int - phase_this_int.astype('ulonglong')
+            phaseall[ninti, ...] = phase_this_int - phase_this_int.astype("ulonglong")
 
             # add a frame time to account for the extra frame reset between MIRI integrations
-            if readpatt.upper() == 'FASTR1' or readpatt.upper() == 'SLOWR1':
+            if readpatt.upper() == "FASTR1" or readpatt.upper() == "SLOWR1":
                 start_time += frameclocks
 
         # use phaseall vs dd_all
@@ -476,29 +494,29 @@ def _run_sequential_algorithm(
         # number of bins in one phased wave (e.g. 255, 218, etc)
         if nbins_all is None:
             # the IDL code sets nbins as ulong type (ulonglong in python)
-            nbins = int(period_in_pixels/2.0)
+            nbins = int(period_in_pixels / 2.0)
         else:
             nbins = nbins_all
         if nbins > 501:
             nbins = 500
 
         # bin the whole set
-        log.info('Calculating the phase amplitude for {} bins'.format(nbins))
+        log.info(f"Calculating the phase amplitude for {nbins} bins")
         # Define the binned waveform amplitude (pa = phase amplitude)
         pa = np.arange(nbins, dtype=float)
         # keep track of n per bin to check for low n
-        nb_over_nbins = [nb/nbins for nb in range(nbins)]
-        nbp1_over_nbins = [(nb + 1)/nbins for nb in range(nbins)]
+        nb_over_nbins = [nb / nbins for nb in range(nbins)]
+        nbp1_over_nbins = [(nb + 1) / nbins for nb in range(nbins)]
         # Construct a phase map and dd map for only the nints_to_phase
-        phase_temp = phaseall[0: nints_to_phase, :, :, :]
-        dd_temp = dd_all[0: nints_to_phase, :, :, :]
+        phase_temp = phaseall[0:nints_to_phase, :, :, :]
+        dd_temp = dd_all[0:nints_to_phase, :, :, :]
         for nb in range(nbins):
             u = (phase_temp > nb_over_nbins[nb]) & (phase_temp <= nbp1_over_nbins[nb])
             # calculate the sigma-clipped mean
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
                 dmean, _, _ = scs(dd_temp[u])
-            pa[nb] = dmean   # amplitude in this bin
+            pa[nb] = dmean  # amplitude in this bin
 
         pa -= np.median(pa)
 
@@ -508,19 +526,19 @@ def _run_sequential_algorithm(
         # reference_wave, but perfectly matched in phase by definition so no need for a
         # crosscor or other phase-finder against a reference_wave). This may not be
         # necessary. Can just assume pa and the reference_wave are exactly 1.0 waves long.
-        #pa_phase = (np.arange(nbins, dtype=np.float32) + 0.5) / nbins
+        # pa_phase = (np.arange(nbins, dtype=np.float32) + 0.5) / nbins
 
         # Correction using direct look-up from either pa (self-correction) or
         # the reference wave (if provided)
         # Make a vector to hold a version of pa that is close to an integer number of
         # pixels long. This will be the noise amplitude look-up table.
-        lut = rebin(pa, [period_in_pixels])   # shift and resample reference_wave at pa's phase
+        lut = rebin(pa, [period_in_pixels])  # shift and resample reference_wave at pa's phase
 
         # If a reference waveform was provided, use it to measure phase shift between
         # pa (binned phased wave) from the input image vs. the reference_wave using xcorr.
         # These two methods give the same integer-reference_wave-element resolution results.
         if len(reference_wave_list) > 0:
-            log.info('Using reference file to measure phase shift')
+            log.info("Using reference file to measure phase shift")
             reference_wave = np.array(reference_wave_list[fi])
             reference_wave_size = np.size(reference_wave)
             rebinned_pa = rebin(pa, [reference_wave_size])
@@ -544,7 +562,7 @@ def _run_sequential_algorithm(
             # in the intercept (and to avoid potential divide-by-zeros)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
-                m, b = np.polyfit(lut_reference, lut, 1)   # the slope is the amplitude ratio
+                m, b = np.polyfit(lut_reference, lut, 1)  # the slope is the amplitude ratio
 
             # check pa-to-reference_wave phase match and optional scale
             if scale_reference:
@@ -553,10 +571,12 @@ def _run_sequential_algorithm(
             lut = lut_reference
 
         if save_onthefly_reffile is not None:
-            freq_pa_dict['frequencies'][frequency_name] = {'frequency': frequency,
-                                                           'phase_amplitudes': pa}
+            freq_pa_dict["frequencies"][frequency_name] = {
+                "frequency": frequency,
+                "phase_amplitudes": pa,
+            }
 
-        log.info('Creating phased-matched noise model to subtract from data')
+        log.info("Creating phased-matched noise model to subtract from data")
         # This is the phase matched noise model to subtract from each pixel of the input image
         dd_noise = lut[(phaseall * period_in_pixels).astype(int)]
 
@@ -564,7 +584,7 @@ def _run_sequential_algorithm(
         dd_noise[~np.isfinite(dd_noise)] = 0.0
 
         # Subtract EMI noise from the input data
-        log.info('Subtracting EMI noise from data')
+        log.info("Subtracting EMI noise from data")
 
         # Interleave (straight copy) into 4 amps
         for k in range(4):
@@ -577,41 +597,40 @@ def _run_sequential_algorithm(
         del dd_noise
 
     if save_onthefly_reffile is not None:
-        if 'FAST' in readpatt:
+        if "FAST" in readpatt:
             freqs_dict = {readpatt: freqs2correct}
         else:
-            freqs_dict = {readpatt: {detector: freqs2correct} }
+            freqs_dict = {readpatt: {detector: freqs2correct}}
         on_the_fly_subarr_case = {}
         on_the_fly_subarr_case[subarray] = {
-            'rowclocks': rowclocks,
-            'frameclocks': frameclocks,
-            'freqs': freqs_dict
+            "rowclocks": rowclocks,
+            "frameclocks": frameclocks,
+            "freqs": freqs_dict,
         }
-        freq_pa_dict['subarray_cases'] = on_the_fly_subarr_case
+        freq_pa_dict["subarray_cases"] = on_the_fly_subarr_case
         mk_reffile(freq_pa_dict, save_onthefly_reffile)
 
     return input_model
 
 
 def sloper(data):
-    """ Fit slopes to all pix of a ramp, using numerical recipes plane-adding
-     returning intercept image.
+    """
+    Fit slopes to all pix of a ramp.
 
     Parameters
     ----------
-    data : numpy array
+    data : ndarray
         3-D integration data array
 
     Returns
     -------
-    outarray : numpy array
+    outarray : ndarray
         3-D integration data array
-
-    intercept: numpy array
-        slope intercept values
+    intercept: ndarray
+        Slope intercept values
     """
     ngroups, ny, nx = np.shape(data)
-    frametime = 1.0   # use 1.0 for per-frame slopes, otherwise put a real time here
+    frametime = 1.0  # use 1.0 for per-frame slopes, otherwise put a real time here
     grouptimes = np.arange(ngroups) * frametime
 
     sxy = np.zeros((ny, nx))
@@ -624,13 +643,13 @@ def sloper(data):
         sxy = sxy + grouptimes[groupcount] * data[groupcount, ...]
         sx = sx + grouptimes[groupcount]
         sy = sy + data[groupcount, ...]
-        sxx = sxx + grouptimes[groupcount]**2
+        sxx = sxx + grouptimes[groupcount] ** 2
 
     # calculate the final per-pixel slope values
-    outarray = (ngroups * sxy - sx * sy)/(ngroups * sxx - sx * sx)
+    outarray = (ngroups * sxy - sx * sy) / (ngroups * sxx - sx * sx)
 
     # calculate the final per-pixel intercept values
-    intercept = (sxx * sy - sx * sxy)/(ngroups * sxx - sx * sx)
+    intercept = (sxx * sy - sx * sxy) / (ngroups * sxx - sx * sx)
 
     return outarray, intercept
 
@@ -697,20 +716,20 @@ def get_subarcase(emi_model, subarray, readpatt, detector):
     elif "FAST" in readpatt:
         readout_speed = "FAST"
     else:
-        log.warning(f'Read pattern {readpatt} does not include expected string FAST or SLOW')
+        log.warning(f"Read pattern {readpatt} does not include expected string FAST or SLOW")
         return subname, rowclocks, frameclocks, frequencies
 
     # modify the subarray name for matching if needed,
     # appending FAST or SLOW for full frame data
     subname = subarray
-    if 'FULL' in subarray:
+    if "FULL" in subarray:
         subname = f"{subarray}_{readout_speed}"
 
     try:
         subarray_case = getattr(emi_model.subarray_cases, subname)
-        rowclocks = getattr(subarray_case, 'rowclocks')
-        frameclocks = getattr(subarray_case, 'frameclocks')
-        freqs = getattr(subarray_case, 'freqs')
+        rowclocks = subarray_case.rowclocks
+        frameclocks = subarray_case.frameclocks
+        freqs = subarray_case.freqs
         rp_freqs = getattr(freqs, readout_speed)
         if readout_speed == "FAST":
             frequencies = rp_freqs
@@ -718,7 +737,7 @@ def get_subarcase(emi_model, subarray, readpatt, detector):
             frequencies = getattr(rp_freqs, detector)
     except AttributeError:
         # match not found, will return None for all values
-        log.debug(f'Subarray {subname} not found')
+        log.debug(f"Subarray {subname} not found")
         pass
 
     return subname, rowclocks, frameclocks, frequencies
@@ -730,7 +749,7 @@ def get_frequency_info(emi_model, frequency_name):
 
     Parameters
     ----------
-    freqs_names_vals : EmiModel
+    emi_model : EmiModel
         EMI reference datamodel.
     frequency_name : str
         Frequency of interest.
@@ -782,11 +801,13 @@ def rebin(arr, newshape):
         raise ValueError("New shape dimensions must match old shape")
 
     # get coordinates for old values in the new array
-    slices = [slice(0, old, float(old)/new) for old, new in zip(arr.shape, newshape)]
+    slices = [
+        slice(0, old, float(old) / new) for old, new in zip(arr.shape, newshape, strict=False)
+    ]
     coordinates = np.mgrid[slices]
 
     # take the nearest smaller integer value (truncate to an integer index)
-    indices = coordinates.astype('i')
+    indices = coordinates.astype("i")
 
     # take elements from the array at the specified indices
     return arr[tuple(indices)]
@@ -806,27 +827,34 @@ def mk_reffile(freq_pa_dict, emicorr_ref_filename):
     """
     # Save the reference file if desired
     emicorr_model = datamodels.EmiModel()
-    emicorr_model.frequencies = freq_pa_dict['frequencies']
-    emicorr_model.subarray_cases = freq_pa_dict['subarray_cases']
+    emicorr_model.frequencies = freq_pa_dict["frequencies"]
+    emicorr_model.subarray_cases = freq_pa_dict["subarray_cases"]
 
     # Add some placeholder values required for validation
-    emicorr_model.meta.reftype = 'emicorr'
-    emicorr_model.meta.author = 'JWST calibration pipeline'
-    emicorr_model.meta.description = 'EMI correction file'
-    emicorr_model.meta.pedigree = 'GROUND'
+    emicorr_model.meta.reftype = "emicorr"
+    emicorr_model.meta.author = "JWST calibration pipeline"
+    emicorr_model.meta.description = "EMI correction file"
+    emicorr_model.meta.pedigree = "GROUND"
     emicorr_model.meta.useafter = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S")
 
-    if emicorr_ref_filename.endswith('.fits'):
-        emicorr_ref_filename = emicorr_ref_filename.replace('.fits', '.asdf')
-    log.info(f'Writing on-the-fly reference file to: {emicorr_ref_filename}')
+    if emicorr_ref_filename.endswith(".fits"):
+        emicorr_ref_filename = emicorr_ref_filename.replace(".fits", ".asdf")
+    log.info(f"Writing on-the-fly reference file to: {emicorr_ref_filename}")
     emicorr_model.save(emicorr_ref_filename)
     emicorr_model.close()
 
 
-def emicorr_refwave(data, pdq, refwave, nsamples, rowclocks, frameclocks,
-                    period_in_pixels, fit_ints_separately=False,
-                    nphases_opt=500):
-
+def emicorr_refwave(
+    data,
+    pdq,
+    refwave,
+    nsamples,
+    rowclocks,
+    frameclocks,
+    period_in_pixels,
+    fit_ints_separately=False,
+    nphases_opt=500,
+):
     """
     Derive the best amplitude and phase for the EMI waveform, subtract it off.
 
@@ -867,16 +895,15 @@ def emicorr_refwave(data, pdq, refwave, nsamples, rowclocks, frameclocks,
         The input 4D data array with the model waveform phased, scaled,
         and subtracted.
     """
-
     nints, ngroups, ny, nx = data.shape
 
     # divide ncols by the four output channels (which are read simultaneously)
     nx4 = nx // 4
 
     # non-roi rowclocks between subarray frames (this will be 0 for fullframe)
-    extra_rowclocks = (1024. - ny) * (4 + 3.)
+    extra_rowclocks = (1024.0 - ny) * (4 + 3.0)
 
-    frametime = ny*rowclocks + extra_rowclocks
+    frametime = ny * rowclocks + extra_rowclocks
 
     # Times of the individual reads in pixel clock times
     t0_arr = np.zeros((ny, nx4))
@@ -897,8 +924,8 @@ def emicorr_refwave(data, pdq, refwave, nsamples, rowclocks, frameclocks,
     # extrapolation, and use a cubic spline.
 
     refwave_extended = np.array([refwave[-1]] + list(refwave) + [refwave[0]])
-    phase_extended = (np.arange(len(refwave) + 2) - 0.5)/len(refwave)
-    phasefunc = interpolate.interp1d(phase_extended, refwave_extended, kind='cubic')
+    phase_extended = (np.arange(len(refwave) + 2) - 0.5) / len(refwave)
+    phasefunc = interpolate.interp1d(phase_extended, refwave_extended, kind="cubic")
 
     phases_template = (phase_extended[1:-1, np.newaxis] + grouptimes * dphase) % 1
     nphases = phases_template.shape[0]
@@ -909,7 +936,7 @@ def emicorr_refwave(data, pdq, refwave, nsamples, rowclocks, frameclocks,
     # groups will have the appropriate phase delay added.
 
     all_y = np.zeros((nints, nphases, ngroups))
-    all_N = np.zeros((nints, nphases))
+    all_n = np.zeros((nints, nphases))
 
     # "Good" pixel here has no more than twice the median standard
     # deviation among group differences and is not flagged in the pdq
@@ -920,7 +947,6 @@ def emicorr_refwave(data, pdq, refwave, nsamples, rowclocks, frameclocks,
 
     for j in range(ny):
         for k in range(nx4):
-
             # Bad reference column?  I am not sure whether this is needed,
             # but I think so. I carried it from the current routine.
 
@@ -935,25 +961,22 @@ def emicorr_refwave(data, pdq, refwave, nsamples, rowclocks, frameclocks,
             # All four output channels.
             for l in range(4):
                 pixok = pixel_ok[:, j, k * 4 + l]
-                all_y[:, indx] += data[:, :, j, k * 4 + l]*pixok[:, np.newaxis]
-                all_N[:, indx] += pixok
+                all_y[:, indx] += data[:, :, j, k * 4 + l] * pixok[:, np.newaxis]
+                all_n[:, indx] += pixok
 
     # We'll compute chi2 at nphases_opt evenly spaced phases.
-    phaselist = np.arange(nphases_opt) * 1. / nphases_opt
+    phaselist = np.arange(nphases_opt) * 1.0 / nphases_opt
 
     # Class that computes and holds all of the intermediate
     # information needed for the fits.
 
-    emifitter = EMIfitter(all_y, all_N, phasefunc,
-                          phases_template, phaselist, dphase_frame)
+    emifitter = EMIfitter(all_y, all_n, phasefunc, phases_template, phaselist, dphase_frame)
 
     # The case where each integration gets its own phase and amplitude
     if fit_ints_separately:
-
         amplitudes_to_correct = []
         phases_to_correct = []
         for i in range(nints):
-
             # Compute chi squared at all phase offsets, then find the
             # phase offset that gives the best answer, then get the
             # corresponding amplitude.
@@ -967,7 +990,6 @@ def emicorr_refwave(data, pdq, refwave, nsamples, rowclocks, frameclocks,
 
     # One phase and amplitude fit to all integrations
     else:
-
         chisq, _ = calc_chisq_amplitudes(emifitter)
         best_phase = get_best_phase(phaselist, chisq)
         _, c = calc_chisq_amplitudes(emifitter, phases=[best_phase])
@@ -982,7 +1004,6 @@ def emicorr_refwave(data, pdq, refwave, nsamples, rowclocks, frameclocks,
 
     for i in range(nints):
         for j in range(ngroups):
-
             # Place the reference waveform at the appropriate phase,
             # scale, and subtract from each output channel.
 
@@ -1008,12 +1029,12 @@ def get_best_phase(phases, chisq):
     Returns
     -------
     bestphase : float
-        phase where chisq is minimized, computed by fitting a parabola
+        Phase where chisq is minimized, computed by fitting a parabola
         to the three points centered on the input phase with the
         lowest chisq.
     """
     if np.all(~np.isfinite(chisq)):
-        log.warning('Chi squared values are all NaN')
+        log.warning("Chi squared values are all NaN")
         return phases[0]
 
     ibest = np.nanargmin(chisq)
@@ -1033,8 +1054,9 @@ def get_best_phase(phases, chisq):
     # Just in case all of these chi squared values are equal
     # (in which case fitting a parabola would give a=0)
     if np.nanstd(chisq_opt) == 0:
-        log.warning('Chi squared values as a function of phase offset are '
-                    'unexpectedly equal in EMIcorr')
+        log.warning(
+            "Chi squared values as a function of phase offset are unexpectedly equal in EMIcorr"
+        )
         return phases[ibest]
 
     a, b, _ = np.polyfit(x, chisq_opt, 2)
@@ -1066,13 +1088,12 @@ def calc_chisq_amplitudes(emifitter, ints=None, phases=None):
     Returns
     -------
     chisq : list of float
-        best chi squared value for each phase used. Will be the same
+        Best chi squared value for each phase used. Will be the same
         length as phases (or emifitter.phaselist, if phases is None).
     amplitudes : list of float
-        best-fit amplitudes for each phase used. Will be the same
+        Best-fit amplitudes for each phase used. Will be the same
         length as phases (or emifitter.phaselist, if phases is None).
     """
-
     ef = emifitter  # Alias to simplify subsequent references
 
     # By default, compute a single phase and amplitudes over all
@@ -1094,43 +1115,54 @@ def calc_chisq_amplitudes(emifitter, ints=None, phases=None):
     # requested phase using the math in the writeup.
 
     for phase in phases:
-        A = 0
-        B = 0
+        a_ = 0
+        b_ = 0
 
         for i in ints:
-
             y = ef.all_y[i]
-            N = ef.all_N[i]
-            Sy = ef.all_Sy[i]
-            Sty = ef.all_Sty[i]
+            n_ = ef.all_n[i]
+            s_y = ef.all_sy[i]
+            s_ty = ef.all_sty[i]
 
             # Phase difference between the start of this integration
             # and the start of the first integration
 
-            phase_diff = ef.dphase_frame*i
+            phase_diff = ef.dphase_frame * i
 
             # Choose the closest phase in emifitter's phaselist
 
-            k = np.argmin(np.abs((ef.phaselist - phase - phase_diff)%1))
+            k = np.argmin(np.abs((ef.phaselist - phase - phase_diff) % 1))
 
             z = ef.zlist[k]
-            Stz = ef.Stzlist[k]
-            Sz = ef.Szlist[k]
-            Szz = ef.Szzlist[k]
-            Syz = np.sum(z * y, axis=1)
+            s_tz = ef.stzlist[k]
+            s_z = ef.szlist[k]
+            s_zz = ef.szzlist[k]
+            s_yz = np.sum(z * y, axis=1)
 
-            A += np.sum(N / ef.Delta*(-ef.Stt * Sz**2 + 2 * ef.St * Sz * Stz
-                                      - ef.ngroups * Stz**2 + Szz * ef.Delta))
-            B += (2 / ef.Delta)*np.sum(ef.Stt * Sz * Sy - ef.St * Stz * Sy
-                                       - ef.St * Sz * Sty + ef.ngroups * Stz * Sty)
-            B -= 2 * np.sum(Syz)
+            a_ += np.sum(
+                n_
+                / ef.delta
+                * (
+                    -ef.s_tt * s_z**2
+                    + 2 * ef.s_t * s_z * s_tz
+                    - ef.ngroups * s_tz**2
+                    + s_zz * ef.delta
+                )
+            )
+            b_ += (2 / ef.delta) * np.sum(
+                ef.s_tt * s_z * s_y
+                - ef.s_t * s_tz * s_y
+                - ef.s_t * s_z * s_ty
+                + ef.ngroups * s_tz * s_ty
+            )
+            b_ -= 2 * np.sum(s_yz)
 
-        if A == 0 or ~np.isfinite(A) or ~np.isfinite(B):
+        if a_ == 0 or ~np.isfinite(a_) or ~np.isfinite(b_):
             chisq.append(np.nan)
             amplitudes.append(0.0)
         else:
-            c = -B / (2 * A)
-            chisq.append(A * c**2 + B * c)
+            c = -b_ / (2 * a_)
+            chisq.append(a_ * c**2 + b_ * c)
             amplitudes.append(c)
 
     return chisq, amplitudes
@@ -1138,8 +1170,8 @@ def calc_chisq_amplitudes(emifitter, ints=None, phases=None):
 
 class EMIfitter:
     """Convenience class to facilitate chi2, amplitude calculation."""
-    def __init__(self, all_y, all_N, phasefunc, phases_template,
-                 phaselist, dphase_frame):
+
+    def __init__(self, all_y, all_n, phasefunc, phases_template, phaselist, dphase_frame):
         """
         Compute and store quantities needed for chi2, amplitude calculation.
 
@@ -1150,7 +1182,7 @@ class EMIfitter:
         all_y : ndarray
             3D array of phased, summed y values,
             shape (nints, nphases, ngroups)
-        all_N : ndarray
+        all_n : ndarray
             2D array of the number of pixels used for the calculation
             shape (nints, nphases): number of values summed to create
             all_y at each group
@@ -1166,19 +1198,18 @@ class EMIfitter:
         dphase_frame : float
             Phase difference between successive integrations
         """
-
         self.all_y = all_y
-        self.all_N = all_N
+        self.all_n = all_n
 
         self.nints, self.nphases, self.ngroups = all_y.shape
 
         self.grouptimes = np.arange(self.ngroups)
-        self.Stt = np.sum(self.grouptimes**2)
-        self.St = np.sum(self.grouptimes)
-        self.Delta = self.ngroups * self.Stt - self.St**2
+        self.s_tt = np.sum(self.grouptimes**2)
+        self.s_t = np.sum(self.grouptimes)
+        self.delta = self.ngroups * self.s_tt - self.s_t**2
 
-        self.all_Sy = np.sum(self.all_y, axis=2)
-        self.all_Sty = np.sum(self.all_y * self.grouptimes, axis=2)
+        self.all_sy = np.sum(self.all_y, axis=2)
+        self.all_sty = np.sum(self.all_y * self.grouptimes, axis=2)
 
         self.phaselist = phaselist
         self.phases_template = phases_template
@@ -1187,13 +1218,12 @@ class EMIfitter:
         self.dphase_frame = dphase_frame
 
         self.zlist = []
-        self.Szlist = []
-        self.Stzlist = []
-        self.Szzlist = []
+        self.szlist = []
+        self.stzlist = []
+        self.szzlist = []
 
         # Waveform for each pixel when the first one is at dphaseval.
         for dphaseval in phaselist:
-
             # The transposes help ensure that similar phases are evaluated
             # consecutively, which significantly improves runtime when
             # there is a very large number of groups.
@@ -1201,6 +1231,6 @@ class EMIfitter:
             z = self.phasefunc((self.phases_template.T + dphaseval) % 1).T
 
             self.zlist += [z]
-            self.Stzlist += [np.sum(self.grouptimes * z, axis=1)]
-            self.Szlist += [np.sum(z, axis=1)]
-            self.Szzlist += [np.sum(z**2, axis=1)]
+            self.stzlist += [np.sum(self.grouptimes * z, axis=1)]
+            self.szlist += [np.sum(z, axis=1)]
+            self.szzlist += [np.sum(z**2, axis=1)]

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -7,11 +7,6 @@ from scipy import interpolate
 import logging
 from astropy.stats import sigma_clipped_stats as scs
 from stdatamodels.jwst import datamodels
-import matplotlib.pyplot as plt
-try:
-    plt.style.use('/Users/tbrandt/tim.mplstyle')
-except:
-    pass
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -1002,10 +1002,8 @@ class EMIfitter:
         self.St = np.sum(self.grouptimes)
         self.Delta = self.ngroups*self.Stt - self.St**2
 
-        self.all_Sy = [np.sum(self.all_y[i], axis=1)
-                       for i in range(self.nints)]
-        self.all_Sty = [np.sum(self.all_y[i]*self.grouptimes, axis=1)
-                        for i in range(self.nints)]
+        self.all_Sy = np.sum(self.all_y, axis=2)
+        self.all_Sty = np.sum(self.all_y*self.grouptimes, axis=2)
 
         self.phaselist = phaselist
         self.phases_template = phases_template
@@ -1021,7 +1019,13 @@ class EMIfitter:
 
         # Waveform for each pixel when the first one is at dphaseval.
         for dphaseval in phaselist:
-            z = self.phasefunc((self.phases_template + dphaseval)%1)
+
+            # The transposes help ensure that similar phases are evaluated
+            # consecutively, which significantly improves runtime when
+            # there is a very large number of groups.
+
+            z = self.phasefunc((self.phases_template.T + dphaseval)%1).T
+
             self.zlist += [z]
             self.Stzlist += [np.sum(self.grouptimes*z, axis=1)]
             self.Szlist += [np.sum(z, axis=1)]

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -135,7 +135,7 @@ def apply_emicorr(
         )
         algorithm = "sequential"
 
-    # Get the subarray case from either the ref file or set default values
+    # Get the subarray case from the ref file
     freq_numbers = []
     reference_wave_list = []
     subname, rowclocks, frameclocks, freqs2correct = None, None, None, None
@@ -179,7 +179,8 @@ def apply_emicorr(
         log.warning("No correction match for this configuration")
         return None
 
-    # For the joint algorithm, use the reference wave to correct the data
+    # Run either the joint or sequential fitting algorithm
+    # to fit and correct for EMI data
     if algorithm == "joint":
         output_model = _run_joint_algorithm(
             input_model,

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -94,9 +94,9 @@ def apply_emicorr(
         If True and `algorithm` is 'sequential', the reference wavelength will be scaled
         to the data's phase amplitude.
     onthefly_corr_freq : list of float or None, optional
-        Frequency values to use to create a correction on-the-fly, when
-        `algorithm` is 'sequential'.  If provided, any input `emicorr_model` is
-        ignored.
+        Frequency values to use to create a correction on-the-fly.  If provided,
+        any input `emicorr_model` is ignored and the `algorithm` is set to
+        'sequential'.
     use_n_cycles : int, optional
         Only use N cycles to calculate the phase to reduce code running time,
         when `algorithm` is 'sequential'.

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -387,7 +387,7 @@ def _run_sequential_algorithm(
         # e.g. ((1./390.625) / 10e-6) = 256.0 pix and ((1./218.52055) / 10e-6) = 457.62287 pix
         period_in_pixels = (1.0 / frequency) / 10.0e-6
 
-        if nints_to_phase is None and use_n_cycles is None:  # user wats to use all integrations
+        if nints_to_phase is None and use_n_cycles is None:  # user wants to use all integrations
             # use all integrations
             nints_to_phase = nints
         elif (

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -964,7 +964,7 @@ def calc_chisq_amplitudes(emifitter, ints=None, phases=None):
 
     This routine has the math from the writeup in it; see that for the
     definitions and derivations.
-    
+
     Parameters
     ----------
     emifitter : EMIfitter class

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -249,12 +249,12 @@ def _run_joint_algorithm(input_model, freq_numbers, reference_wave_list,
         The output datamodel, with noise fit and subtracted.
     """
     readpatt = str(input_model.meta.exposure.readpatt).upper()
-    for freq, ref_wave in zip(freq_numbers, reference_wave_list, strict=True):
-        if readpatt == 'FASTR1' or readpatt == 'SLOWR1':
-            _frameclocks = frameclocks
-        else:
-            _frameclocks = 0
+    if readpatt == 'FASTR1' or readpatt == 'SLOWR1':
+        _frameclocks = frameclocks
+    else:
+        _frameclocks = 0
 
+    for freq, ref_wave in zip(freq_numbers, reference_wave_list, strict=True):
         period_in_pixels = (1. / freq) / 10.0e-6
 
         corrected_data = emicorr_refwave(
@@ -262,7 +262,7 @@ def _run_joint_algorithm(input_model, freq_numbers, reference_wave_list,
             nsamples, rowclocks, _frameclocks,
             period_in_pixels, fit_ints_separately=fit_ints_separately)
 
-        # Data is updated in place, to be corrected iteratively
+        # Data is updated in place, so it is corrected iteratively
         input_model.data[:] = corrected_data
 
     # Return the corrected model.
@@ -718,6 +718,7 @@ def get_subarcase(emi_model, subarray, readpatt, detector):
             frequencies = getattr(rp_freqs, detector)
     except AttributeError:
         # match not found, will return None for all values
+        log.debug(f'Subarray {subname} not found')
         pass
 
     return subname, rowclocks, frameclocks, frequencies

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -181,6 +181,7 @@ def apply_emicorr(
 
     # Run either the joint or sequential fitting algorithm
     # to fit and correct for EMI data
+    log.info(f"Running EMI fit with algorithm = '{algorithm}'.")
     if algorithm == "joint":
         output_model = _run_joint_algorithm(
             input_model,

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -8,7 +8,10 @@ import logging
 from astropy.stats import sigma_clipped_stats as scs
 from stdatamodels.jwst import datamodels
 import matplotlib.pyplot as plt
-plt.style.use('/Users/tbrandt/tim.mplstyle')
+try:
+    plt.style.use('/Users/tbrandt/tim.mplstyle')
+except:
+    pass
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/jwst/emicorr/emicorr_step.py
+++ b/jwst/emicorr/emicorr_step.py
@@ -9,7 +9,7 @@ __all__ = ["EmiCorrStep"]
 
 
 class EmiCorrStep(Step):
-    """EmiCorrStep: Apply MIRI EMI correction to a science image."""
+    """Correct MIRI ramp data for EMI noise."""
 
     class_alias = "emicorr"
 

--- a/jwst/emicorr/emicorr_step.py
+++ b/jwst/emicorr/emicorr_step.py
@@ -9,9 +9,7 @@ __all__ = ["EmiCorrStep"]
 
 
 class EmiCorrStep(Step):
-    """
-    EmiCorrStep: Apply MIRI EMI correction to a science image.
-    """
+    """EmiCorrStep: Apply MIRI EMI correction to a science image."""
 
     class_alias = "emicorr"
 
@@ -28,25 +26,36 @@ class EmiCorrStep(Step):
         skip = boolean(default=True)  # Skip the step
     """  # noqa: E501
 
-    reference_file_types = ['emicorr']
+    reference_file_types = ["emicorr"]
 
     def process(self, step_input):
+        """
+        Apply EMI correction to input data.
 
+        Parameters
+        ----------
+        step_input : str or DataModel
+            Input ramp data.
+
+        Returns
+        -------
+        RampModel
+            EMI corrected output datamodel.
+        """
         # Open the input data model as a RampModel
         with datamodels.RampModel(step_input) as input_model:
-
             # Catch the cases to skip
             instrument = input_model.meta.instrument.name
-            if instrument != 'MIRI':
-                self.log.warning(f'EMI correction not implemented for instrument: {instrument}')
-                input_model.meta.cal_step.emicorr = 'SKIPPED'
+            if instrument != "MIRI":
+                self.log.warning(f"EMI correction not implemented for instrument: {instrument}")
+                input_model.meta.cal_step.emicorr = "SKIPPED"
                 return input_model
 
             readpatt = input_model.meta.exposure.readpatt
-            allowed_readpatts = ['FAST', 'FASTR1', 'SLOW', 'SLOWR1']
+            allowed_readpatts = ["FAST", "FASTR1", "SLOW", "SLOWR1"]
             if readpatt.upper() not in allowed_readpatts:
-                self.log.warning(f'EMI correction not implemented for read pattern: {readpatt}')
-                input_model.meta.cal_step.emicorr = 'SKIPPED'
+                self.log.warning(f"EMI correction not implemented for read pattern: {readpatt}")
+                input_model.meta.cal_step.emicorr = "SKIPPED"
                 return input_model
 
             # Work on a copy
@@ -54,35 +63,35 @@ class EmiCorrStep(Step):
 
             # Setup parameters
             pars = {
-                'algorithm': self.algorithm,
-                'nints_to_phase': self.nints_to_phase,
-                'nbins': self.nbins,
-                'scale_reference': self.scale_reference,
-                'onthefly_corr_freq': self.onthefly_corr_freq,
-                'use_n_cycles': self.use_n_cycles,
-                'fit_ints_separately': self.fit_ints_separately,
+                "algorithm": self.algorithm,
+                "nints_to_phase": self.nints_to_phase,
+                "nbins": self.nbins,
+                "scale_reference": self.scale_reference,
+                "onthefly_corr_freq": self.onthefly_corr_freq,
+                "use_n_cycles": self.use_n_cycles,
+                "fit_ints_separately": self.fit_ints_separately,
             }
 
             # Get the reference file
             save_onthefly_reffile, emicorr_ref_filename, emicorr_model = None, None, None
             if self.onthefly_corr_freq is not None:
                 emicorr_ref_filename = None
-                self.log.info('Correcting with reference file created on-the-fly.')
+                self.log.info("Correcting with reference file created on-the-fly.")
 
             elif self.user_supplied_reffile is None:
-                emicorr_ref_filename = self.get_reference_file(result, 'emicorr')
+                emicorr_ref_filename = self.get_reference_file(result, "emicorr")
                 # Skip the step if no reference file is found
-                if emicorr_ref_filename == 'N/A':
-                    self.log.warning('No reference file found.')
-                    self.log.warning('EMICORR step will be skipped')
-                    result.meta.cal_step.emicorr = 'SKIPPED'
+                if emicorr_ref_filename == "N/A":
+                    self.log.warning("No reference file found.")
+                    self.log.warning("EMICORR step will be skipped")
+                    result.meta.cal_step.emicorr = "SKIPPED"
                     return result
                 else:
-                    self.log.info(f'Using CRDS reference file: {emicorr_ref_filename}')
+                    self.log.info(f"Using CRDS reference file: {emicorr_ref_filename}")
                     emicorr_model = datamodels.EmiModel(emicorr_ref_filename)
 
             else:
-                self.log.info(f'Using user-supplied reference file: {self.user_supplied_reffile}')
+                self.log.info(f"Using user-supplied reference file: {self.user_supplied_reffile}")
                 emicorr_model = datamodels.EmiModel(self.user_supplied_reffile)
 
             # Do the correction
@@ -90,17 +99,18 @@ class EmiCorrStep(Step):
             if self.save_intermediate_results:
                 if emicorr_ref_filename is None and self.user_supplied_reffile is None:
                     # get the same full path as input file to save the on-the-fly reference file
-                    emicorr_ref_filename = Step._make_output_path(self, suffix='emi_ref_waves')
+                    emicorr_ref_filename = self.make_output_path(suffix="emi_ref_waves")
                     save_onthefly_reffile = emicorr_ref_filename
             emicorr_output = emicorr.apply_emicorr(
-                result, emicorr_model, save_onthefly_reffile=save_onthefly_reffile, **pars)
+                result, emicorr_model, save_onthefly_reffile=save_onthefly_reffile, **pars
+            )
             if emicorr_output is None:
-                self.log.warning('Step skipped')
-                result.meta.cal_step.emicorr = 'SKIPPED'
+                self.log.warning("Step skipped")
+                result.meta.cal_step.emicorr = "SKIPPED"
                 return result
             else:
                 result = emicorr_output
-                result.meta.cal_step.emicorr = 'COMPLETE'
+                result.meta.cal_step.emicorr = "COMPLETE"
 
             # Cleanup
             del emicorr_model

--- a/jwst/emicorr/emicorr_step.py
+++ b/jwst/emicorr/emicorr_step.py
@@ -32,8 +32,8 @@ class EmiCorrStep(Step):
 
     def process(self, step_input):
 
-        # Open the input data model
-        with datamodels.open(step_input) as input_model:
+        # Open the input data model as a RampModel
+        with datamodels.RampModel(step_input) as input_model:
 
             # Catch the cases to skip
             instrument = input_model.meta.instrument.name
@@ -86,15 +86,12 @@ class EmiCorrStep(Step):
                 emicorr_model = datamodels.EmiModel(self.user_supplied_reffile)
 
             # Do the correction
+            save_onthefly_reffile = None
             if self.save_intermediate_results:
                 if emicorr_ref_filename is None and self.user_supplied_reffile is None:
                     # get the same full path as input file to save the on-the-fly reference file
                     emicorr_ref_filename = Step._make_output_path(self, suffix='emi_ref_waves')
                     save_onthefly_reffile = emicorr_ref_filename
-                else:
-                    save_onthefly_reffile = None
-            else:
-                save_onthefly_reffile = None
             emicorr_output = emicorr.apply_emicorr(
                 result, emicorr_model, save_onthefly_reffile=save_onthefly_reffile, **pars)
             if emicorr_output is None:

--- a/jwst/emicorr/tests/test_emicorr.py
+++ b/jwst/emicorr/tests/test_emicorr.py
@@ -9,6 +9,7 @@ from stdatamodels.jwst.datamodels import RampModel, EmiModel
 from jwst.emicorr import emicorr, emicorr_step
 from jwst.tests.helpers import LogWatcher
 
+
 @pytest.fixture()
 def subarray_example_case():
     example = {
@@ -46,7 +47,7 @@ def subarray_example_case():
                 },
             },
             "rowclocks": 2333,
-        }
+        },
     }
     return example
 
@@ -93,15 +94,15 @@ def add_emi(data):
 
     freq = 10.0
     rowclocks = 2000
-    period = (1. / freq) / 10.0e-6
+    period = (1.0 / freq) / 10.0e-6
 
     ni, ng, ny, nx = data.shape
-    extra_rowclocks = (1024. - ny) * (4 + 3.)
+    extra_rowclocks = (1024.0 - ny) * (4 + 3.0)
     readtimes = np.zeros((ng, ny, nx))
     for i in range(ng):
         for j in range(ny):
             for k in range(nx // 4):
-                readtimes[i, j, k*4:k*4+4] = i * extra_rowclocks + j * rowclocks + k
+                readtimes[i, j, k * 4 : k * 4 + 4] = i * extra_rowclocks + j * rowclocks + k
 
     emi = amp * np.sin(2 * np.pi * readtimes / period + phase)
     data = data + emi[None, :, :, :]
@@ -292,7 +293,7 @@ def test_emicorrstep_succeeds(algorithm, subarray):
     assert result.meta.cal_step.emicorr == "COMPLETE"
 
 
-@pytest.mark.parametrize('readpatt', ['FAST', 'SLOW'])
+@pytest.mark.parametrize("readpatt", ["FAST", "SLOW"])
 def test_emicorrstep_user_freq(tmp_path, readpatt):
     data = np.ones((1, 5, 20, 20))
     input_model = mk_data_mdl(data, "FULL", readpatt, "MIRIMAGE")
@@ -358,8 +359,8 @@ def test_apply_emicorr_noiseless(data_case, algorithm, emicorr_model, readpatt):
 
 @pytest.mark.parametrize("algorithm,accuracy", [("sequential", 0.1), ("joint", 0.0001)])
 def test_apply_emicorr(data_without_emi, data_with_emi, model_with_emi, algorithm, accuracy):
-    input_model = mk_data_mdl(data_with_emi, 'FULL', 'FAST', 'MIRIMAGE')
-    expected_model = mk_data_mdl(data_without_emi, 'FULL', 'FAST', 'MIRIMAGE')
+    input_model = mk_data_mdl(data_with_emi, "FULL", "FAST", "MIRIMAGE")
+    expected_model = mk_data_mdl(data_without_emi, "FULL", "FAST", "MIRIMAGE")
 
     outmdl = emicorr.apply_emicorr(input_model.copy(), model_with_emi, algorithm=algorithm)
 
@@ -368,11 +369,12 @@ def test_apply_emicorr(data_without_emi, data_with_emi, model_with_emi, algorith
 
 
 def test_apply_emicorr_separate_ints(data_without_emi_3int, data_with_emi_3int, model_with_emi):
-    input_model = mk_data_mdl(data_with_emi_3int, 'FULL', 'FAST', 'MIRIMAGE')
-    expected_model = mk_data_mdl(data_without_emi_3int, 'FULL', 'FAST', 'MIRIMAGE')
+    input_model = mk_data_mdl(data_with_emi_3int, "FULL", "FAST", "MIRIMAGE")
+    expected_model = mk_data_mdl(data_without_emi_3int, "FULL", "FAST", "MIRIMAGE")
 
-    outmdl = emicorr.apply_emicorr(input_model.copy(), model_with_emi, algorithm='joint',
-                                   fit_ints_separately=True)
+    outmdl = emicorr.apply_emicorr(
+        input_model.copy(), model_with_emi, algorithm="joint", fit_ints_separately=True
+    )
 
     # Corrected ramp should be close to ramp without noise
     assert np.allclose(outmdl.data, expected_model.data, rtol=1e-2)
@@ -429,25 +431,25 @@ def test_apply_emicorr_no_config_found(module_log_watcher, emicorr_model):
     module_log_watcher.assert_seen()
 
 
-@pytest.mark.parametrize('detector', ['MIRIMAGE', 'MIRIFULONG'])
-@pytest.mark.parametrize('subarray', ['FULL', 'MASK1550'])
-@pytest.mark.parametrize('readpatt', ['FAST', 'SLOW'])
+@pytest.mark.parametrize("detector", ["MIRIMAGE", "MIRIFULONG"])
+@pytest.mark.parametrize("subarray", ["FULL", "MASK1550"])
+@pytest.mark.parametrize("readpatt", ["FAST", "SLOW"])
 def test_get_subarcase(emicorr_model, subarray_example_case, detector, subarray, readpatt):
     subarray_info_r = emicorr.get_subarcase(emicorr_model, subarray, readpatt, detector)
     subname_r, rowclocks_r, frameclocks_r, freqs2correct_r = subarray_info_r
 
     # test if we get the right configuration
-    if subarray == 'FULL':
-        if readpatt == 'FAST':
+    if subarray == "FULL":
+        if readpatt == "FAST":
             subname_real = "FULL_FAST"
         else:
             subname_real = "FULL_SLOW"
     else:
         subname_real = subarray
-    rowclocks_real = subarray_example_case[subname_real]['rowclocks']
-    frameclocks_real = subarray_example_case[subname_real]['frameclocks']
-    freqs2correct_real = subarray_example_case[subname_real]['freqs'][readpatt]
-    if readpatt == 'SLOW':
+    rowclocks_real = subarray_example_case[subname_real]["rowclocks"]
+    frameclocks_real = subarray_example_case[subname_real]["frameclocks"]
+    freqs2correct_real = subarray_example_case[subname_real]["freqs"][readpatt]
+    if readpatt == "SLOW":
         freqs2correct_real = freqs2correct_real[detector]
 
     assert subname_real == subname_r
@@ -457,11 +459,11 @@ def test_get_subarcase(emicorr_model, subarray_example_case, detector, subarray,
 
 
 def test_get_subarcase_bad_readpatt(emicorr_model, module_log_watcher):
-    subarray = 'FULL'
-    detector = 'MIRIMAGE'
+    subarray = "FULL"
+    detector = "MIRIMAGE"
 
     # readpattern not recognized
-    readpatt = 'ANY'
+    readpatt = "ANY"
     module_log_watcher.message = "does not include expected string"
     subarray_info_r = emicorr.get_subarcase(emicorr_model, subarray, readpatt, detector)
     module_log_watcher.assert_seen()
@@ -470,11 +472,11 @@ def test_get_subarcase_bad_readpatt(emicorr_model, module_log_watcher):
 
 
 def test_get_subarcase_missing_subarray(emicorr_model, module_log_watcher):
-    detector = 'MIRIMAGE'
-    readpatt = 'FAST'
+    detector = "MIRIMAGE"
+    readpatt = "FAST"
 
     # subarray not recognized
-    subarray = 'ANY'
+    subarray = "ANY"
     module_log_watcher.message = "Subarray ANY not found"
     subarray_info_r = emicorr.get_subarcase(emicorr_model, subarray, readpatt, detector)
     module_log_watcher.assert_seen()
@@ -482,23 +484,23 @@ def test_get_subarcase_missing_subarray(emicorr_model, module_log_watcher):
     assert subarray_info_r == (subarray, None, None, None)
 
 
-
 def test_get_frequency_info(emicorr_model):
-    freqname = 'Hz10'
+    freqname = "Hz10"
     expected = (10.039216, np.full(20, 1.5))
     freq, pa = emicorr.get_frequency_info(emicorr_model, freqname)
     assert freq == expected[0]
     assert np.all(pa == expected[1])
 
-    freqname = 'Hz390'
+    freqname = "Hz390"
     expected = (390.625, np.full(20, 1.1))
     freq, pa = emicorr.get_frequency_info(emicorr_model, freqname)
     assert freq == expected[0]
     assert np.all(pa == expected[1])
 
-    freqname = 'Hz218'
+    freqname = "Hz218"
     with pytest.raises(AttributeError, match=f"No attribute '{freqname}'"):
         emicorr.get_frequency_info(emicorr_model, freqname)
+
 
 def test_sloper():
     data = np.ones((5, 5, 5))

--- a/jwst/emicorr/tests/test_emicorr.py
+++ b/jwst/emicorr/tests/test_emicorr.py
@@ -10,38 +10,53 @@ from jwst.emicorr import emicorr, emicorr_step
 from jwst.tests.helpers import LogWatcher
 
 
-subarray_example_case = {
-    'MASK1550': {'frameclocks': 23968,
-        'freqs': {
-            'FAST': ["Hz390", "Hz10"],
-            'SLOW': {
-                'MIRIFULONG': ['Hz390', 'Hz10_slow_MIRIFULONG'],
-                'MIRIFUSHORT': ['Hz390', 'Hz10_slow_MIRIFUSHORT'],
-                'MIRIMAGE': ['Hz390', 'Hz10_slow_MIRIMAGE']}},
-        'rowclocks': 82}
-}
-
-emimdl = {'frequencies': {
-            "Hz390": {'frequency': 390.625,
-                'phase_amplitudes': np.ones(20)+0.1},
-            "Hz10": { 'frequency': 10.039216,
-                'phase_amplitudes': np.ones(20)+0.5}},
-        'subarray_cases': subarray_example_case
+@pytest.fixture()
+def emicorr_model():
+    subarray_example_case = {
+        "MASK1550": {
+            "frameclocks": 23968,
+            "freqs": {
+                "FAST": ["Hz390", "Hz10"],
+                "SLOW": {
+                    "MIRIFULONG": ["Hz390", "Hz10_slow_MIRIFULONG"],
+                    "MIRIFUSHORT": ["Hz390", "Hz10_slow_MIRIFUSHORT"],
+                    "MIRIMAGE": ["Hz390", "Hz10_slow_MIRIMAGE"],
+                },
+            },
+            "rowclocks": 82,
         }
-emicorr_model = EmiModel(emimdl)
+    }
+    frequencies = {
+            "Hz390": {"frequency": 390.625, "phase_amplitudes": np.ones(20) + 0.1},
+            "Hz10": {"frequency": 10.039216, "phase_amplitudes": np.ones(20) + 0.5},
+        }
+
+    emi_model = EmiModel()
+    emi_model.frequencies = frequencies
+    emi_model.subarray_cases = subarray_example_case
+
+    emi_model.meta.reftype = 'emicorr'
+    emi_model.meta.author = 'JWST calibration pipeline'
+    emi_model.meta.description = 'EMI correction file'
+    emi_model.meta.pedigree = 'GROUND'
+    emi_model.meta.useafter = "2024-01-01T00:00:00"
+
+    return emi_model
 
 
 def mk_data_mdl(data, subarray, readpatt, detector):
     # create input_model
     input_model = RampModel(data=data)
-    input_model.meta.instrument.name = 'MIRI'
+    input_model.meta.instrument.name = "MIRI"
     input_model.meta.instrument.detector = detector
-    input_model.meta.exposure.type = 'MIR_4QPM'
+    input_model.meta.exposure.type = "MIR_4QPM"
     input_model.meta.subarray.name = subarray
     input_model.meta.exposure.readpatt = readpatt
     input_model.meta.subarray.xsize = 288
     input_model.meta.subarray.xstart = 1
     input_model.meta.exposure.nsamples = 1
+    input_model.meta.observation.date = "2024-01-01"
+    input_model.meta.observation.time = "00:00:00"
     return input_model
 
 
@@ -49,44 +64,162 @@ def mk_data_mdl(data, subarray, readpatt, detector):
 def log_watcher(monkeypatch):
     # Set a log watcher to check for a log message at any level
     # in the emicorr module
-    watcher = LogWatcher('')
-    logger = logging.getLogger('jwst.emicorr.emicorr')
-    for level in ['debug', 'info', 'warning', 'error']:
+    watcher = LogWatcher("")
+    logger = logging.getLogger("jwst.emicorr.emicorr")
+    for level in ["debug", "info", "warning", "error"]:
         monkeypatch.setattr(logger, level, watcher)
     return watcher
 
 
-def test_emicorrstep():
+@pytest.fixture
+def step_log_watcher(monkeypatch):
+    # Set a log watcher to check for a log message at any level
+    # in the emicorr step
+    watcher = LogWatcher("")
+    logger = logging.getLogger("stpipe.EmiCorrStep")
+    for level in ["debug", "info", "warning", "error"]:
+        monkeypatch.setattr(logger, level, watcher)
+    return watcher
+
+
+def test_emicorrstep_skip_default():
     data = np.ones((1, 5, 20, 20))
-    input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
-    expected_outmdl = input_model.copy()
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
+
+    step = emicorr_step.EmiCorrStep()
+    result = step.call(input_model)
+
+    # expect no change because step is skipped by default
+    assert np.all(input_model.data == result.data)
+    assert result.meta.cal_step.emicorr == "SKIPPED"
+
+
+def test_emicorrstep_skip_instrument(step_log_watcher):
+    data = np.ones((1, 5, 20, 20))
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
 
     nirmdl = input_model.copy()
-    nirmdl.meta.instrument.name = 'NIRISS'
+    nirmdl.meta.instrument.name = "NIRISS"
 
-    stp = emicorr_step.EmiCorrStep()
-    nir_result = stp.call(nirmdl)
+    step_log_watcher.message = "not implemented for instrument"
+    step = emicorr_step.EmiCorrStep()
+    nir_result = step.call(nirmdl, skip=False)
+    step_log_watcher.assert_seen()
 
     # expect no change because instrument is not MIRI
-    assert expected_outmdl.data.all() == nir_result.data.all()
+    assert np.all(input_model.data == nir_result.data)
+    assert nir_result.meta.cal_step.emicorr == "SKIPPED"
 
 
-@pytest.mark.parametrize('data_case', ['flat', 'linear'])
-@pytest.mark.parametrize('algorithm', ['sequential', 'joint'])
-def test_apply_emicorr(data_case, algorithm):
+def test_emicorrstep_skip_readpatt(step_log_watcher):
     data = np.ones((1, 5, 20, 20))
-    if data_case == 'linear':
+    input_model = mk_data_mdl(data, "MASK1550", "ANY", "MIRIMAGE")
+
+    step_log_watcher.message = "not implemented for read pattern"
+    step = emicorr_step.EmiCorrStep()
+    result = step.call(input_model, skip=False)
+    step_log_watcher.assert_seen()
+
+    # expect no change because read pattern is not supported
+    assert np.all(input_model.data == result.data)
+    assert result.meta.cal_step.emicorr == "SKIPPED"
+
+
+def test_emicorrstep_skip_no_reffile(monkeypatch, step_log_watcher):
+    data = np.ones((1, 5, 20, 20))
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
+
+    # mock no reference file found
+    monkeypatch.setattr(emicorr_step.EmiCorrStep, 'get_reference_file', lambda *args: 'N/A')
+    step = emicorr_step.EmiCorrStep()
+
+    step_log_watcher.message = 'No reference file'
+    result = step.call(input_model, skip=False)
+    step_log_watcher.assert_seen()
+
+    # expect no change because step is skipped
+    assert np.all(input_model.data == result.data)
+    assert result.meta.cal_step.emicorr == "SKIPPED"
+
+
+def test_emicorrstep_skip_for_failure(monkeypatch, step_log_watcher):
+    data = np.ones((1, 5, 20, 20))
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
+
+    # mock a failure internal to the correction algorithm
+    monkeypatch.setattr(emicorr, 'apply_emicorr', lambda *args, **kwargs: None)
+    step = emicorr_step.EmiCorrStep()
+
+    step_log_watcher.message = 'Step skipped'
+    result = step.call(input_model, skip=False)
+    step_log_watcher.assert_seen()
+
+    # expect no change because step is skipped
+    assert np.all(input_model.data == result.data)
+    assert result.meta.cal_step.emicorr == "SKIPPED"
+
+
+def test_emicorrstep_succeeds():
+    data = np.ones((1, 5, 20, 20))
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
+
+    step = emicorr_step.EmiCorrStep()
+    result = step.call(input_model, skip=False)
+
+    # step completes but we expect no change for flat data
+    assert np.all(input_model.data == result.data)
+    assert result.meta.cal_step.emicorr == "COMPLETE"
+
+
+def test_emicorrstep_user_freq(tmp_path):
+    data = np.ones((1, 5, 20, 20))
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
+    input_model.meta.filename = 'test.fits'
+
+    corr_freq = [218.3]
+    step = emicorr_step.EmiCorrStep()
+    result = step.call(input_model, skip=False, onthefly_corr_freq=corr_freq,
+                       save_intermediate_results=True, output_dir=str(tmp_path))
+
+    # step completes but we expect no change for flat data
+    assert np.all(input_model.data == result.data)
+    assert result.meta.cal_step.emicorr == "COMPLETE"
+
+    # on-the-fly reference file is saved
+    assert (tmp_path / 'test_emi_ref_waves.asdf').exists()
+
+
+def test_emicorrstep_user_reffile(tmp_path, emicorr_model):
+    data = np.ones((1, 5, 20, 20))
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
+
+    model_name = str(tmp_path / 'emicorr.asdf')
+    emicorr_model.save(model_name)
+
+    step = emicorr_step.EmiCorrStep()
+    result = step.call(input_model, skip=False, user_supplied_reffile=model_name)
+
+    # step completes but we expect no change for flat data
+    assert np.all(input_model.data == result.data)
+    assert result.meta.cal_step.emicorr == "COMPLETE"
+
+
+@pytest.mark.parametrize("data_case", ["flat", "linear"])
+@pytest.mark.parametrize("algorithm", ["sequential", "joint"])
+def test_apply_emicorr(data_case, algorithm, emicorr_model):
+    data = np.ones((1, 5, 20, 20))
+    if data_case == "linear":
         linear_ramp = np.arange(1, 6, dtype=float)
         data[0, :, ...] = linear_ramp[:, None, None]
-    input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
     pars = {
-        'save_onthefly_reffile': None,
-        'nints_to_phase': None,
-        'nbins': None,
-        'scale_reference': True,
-        'onthefly_corr_freq': None,
-        'use_n_cycles': None,
-        'algorithm': algorithm
+        "save_onthefly_reffile": None,
+        "nints_to_phase": None,
+        "nbins": None,
+        "scale_reference": True,
+        "onthefly_corr_freq": None,
+        "use_n_cycles": None,
+        "algorithm": algorithm,
     }
     outmdl = emicorr.apply_emicorr(input_model.copy(), emicorr_model, **pars)
     assert isinstance(outmdl, RampModel)
@@ -95,30 +228,37 @@ def test_apply_emicorr(data_case, algorithm):
     assert np.allclose(outmdl.data, input_model.data)
 
 
-@pytest.mark.parametrize('algorithm', ['sequential', 'joint'])
-@pytest.mark.parametrize('emicorr_model', ['bad_model', None])
-@pytest.mark.parametrize('output_ext', ['fits', 'asdf'])
-def test_apply_emicorr_with_freq(tmp_path, algorithm, log_watcher, emicorr_model, output_ext):
+@pytest.mark.parametrize("algorithm", ["sequential", "joint"])
+@pytest.mark.parametrize("model_placeholder", ["bad_model", None])
+@pytest.mark.parametrize("output_ext", ["fits", "asdf"])
+def test_apply_emicorr_with_freq(tmp_path, algorithm, log_watcher, model_placeholder, output_ext):
     data = np.ones((1, 5, 20, 20))
-    input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
+    input_model = mk_data_mdl(data, "MASK1550", "FAST", "MIRIMAGE")
 
-    # emicorr_model is ignored if user frequencies are provided
     onthefly_corr_freq = [218.3]
 
-    output_name = tmp_path / f'otf_reffile.{output_ext}'
-    expected_output_name = tmp_path / 'otf_reffile.asdf'
+    output_name = tmp_path / f"otf_reffile.{output_ext}"
+    expected_output_name = tmp_path / "otf_reffile.asdf"
 
     log_watcher.message = "'joint' algorithm cannot be used"
+
+    # emicorr model is ignored if user frequencies are provided - any placeholder will work
     outmdl = emicorr.apply_emicorr(
-        input_model.copy(), emicorr_model, onthefly_corr_freq=onthefly_corr_freq,
-        save_onthefly_reffile=str(output_name), nints_to_phase=None,
-        nbins=None, scale_reference=True, algorithm=algorithm)
+        input_model.copy(),
+        model_placeholder,
+        onthefly_corr_freq=onthefly_corr_freq,
+        save_onthefly_reffile=str(output_name),
+        nints_to_phase=None,
+        nbins=None,
+        scale_reference=True,
+        algorithm=algorithm,
+    )
 
     # flat data has no correction
     assert np.allclose(outmdl.data, input_model.data)
 
     # joint model should warn and fall back to sequential for user frequencies
-    if algorithm == 'joint':
+    if algorithm == "joint":
         log_watcher.assert_seen()
     else:
         log_watcher.assert_not_seen()
@@ -127,13 +267,13 @@ def test_apply_emicorr_with_freq(tmp_path, algorithm, log_watcher, emicorr_model
     assert expected_output_name.exists()
 
 
-def test_get_subarcase():
-    subarray, readpatt, detector = 'MASK1550', 'FAST', 'MIRIMAGE'
+def test_get_subarcase(emicorr_model):
+    subarray, readpatt, detector = "MASK1550", "FAST", "MIRIMAGE"
     subarray_info_r = emicorr.get_subarcase(emicorr_model, subarray, readpatt, detector)
     subname_r, rowclocks_r, frameclocks_r, freqs2correct_r = subarray_info_r
 
     # test if we get the right configuration
-    compare_real = ['MASK1550', 82, 23968, ["Hz390", "Hz10"]]
+    compare_real = ["MASK1550", 82, 23968, ["Hz390", "Hz10"]]
     subname_real, rowclocks_real, frameclocks_real, freqs2correct_real = compare_real
 
     assert subname_real == subname_r
@@ -147,15 +287,15 @@ def test_sloper():
     outarray, intercept = emicorr.sloper(data)
 
     compare_arr, compare_intercept = np.zeros((5, 5)), np.ones((5, 5))
-    assert compare_arr.all() == outarray.all()
-    assert compare_intercept.all() == intercept.all()
+    assert np.all(compare_arr == outarray)
+    assert np.all(compare_intercept == intercept)
 
 
 def test_minmed():
     data = np.ones((5, 5, 5))
     compare_arr = data.copy()
     medimg = emicorr.minmed(data)
-    assert compare_arr.all() == medimg.all()
+    assert np.all(compare_arr == medimg)
 
 
 def test_rebin():
@@ -164,5 +304,5 @@ def test_rebin():
     data[5] = 1.55
     data[9] = 2.0
     rebinned_data = emicorr.rebin(data, [7])
-    compare_arr = np.array([1., 0.55, 1., 1., 1.55, 1., 1.])
-    assert compare_arr.all() == rebinned_data.all()
+    compare_arr = np.array([1.0, 0.55, 1.0, 1.0, 1.55, 1.0, 1.0])
+    assert np.all(compare_arr == rebinned_data)

--- a/jwst/emicorr/tests/test_emicorr.py
+++ b/jwst/emicorr/tests/test_emicorr.py
@@ -45,7 +45,7 @@ def mk_data_mdl(data, subarray, readpatt, detector):
     return input_model
 
 
-def test_EmiCorrStep():
+def test_emicorrstep():
     data = np.ones((1, 5, 20, 20))
     input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
     expected_outmdl = input_model.copy()
@@ -60,30 +60,30 @@ def test_EmiCorrStep():
     assert expected_outmdl.data.all() == nir_result.data.all()
 
 
-def test_do_correction():
+def test_apply_emicorr():
     data = np.ones((1, 5, 20, 20))
     input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
     pars = {
-        'save_intermediate_results': False,
+        'save_onthefly_reffile': None,
         'nints_to_phase': None,
         'nbins': None,
         'scale_reference': True,
         'onthefly_corr_freq': None,
         'use_n_cycles': None
     }
-    save_onthefly_reffile = None
-    outmdl = emicorr.do_correction(input_model, emicorr_model, save_onthefly_reffile, **pars)
+    outmdl = emicorr.apply_emicorr(input_model, emicorr_model, **pars)
 
     assert outmdl is not None
 
 
-def test_apply_emicorr():
+def test_apply_emicorr_with_freq():
     data = np.ones((1, 5, 20, 20))
     input_model = mk_data_mdl(data, 'MASK1550', 'FAST', 'MIRIMAGE')
     emicorr_model, onthefly_corr_freq, save_onthefly_reffile = None, [218.3], None
-    outmdl = emicorr.apply_emicorr(input_model, emicorr_model, onthefly_corr_freq,
-                save_onthefly_reffile, save_intermediate_results=False,
-                nints_to_phase=None, nbins_all=None, scale_reference=True)
+    outmdl = emicorr.apply_emicorr(
+        input_model, emicorr_model, onthefly_corr_freq=onthefly_corr_freq,
+        save_onthefly_reffile=save_onthefly_reffile, nints_to_phase=None,
+        nbins=None, scale_reference=True)
 
     assert outmdl is not None
 

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -46,9 +46,26 @@ def run_detector1_pipeline(rtdata_module):
         "calwebb_detector1",
         rtdata.input,
         "--steps.emicorr.save_results=True",
+        "--steps.emicorr.algorithm=sequential",
         "--steps.rscd.skip=False",
         "--steps.rscd.save_results=True",
         "--steps.dark_current.save_results=True",
+    ]
+    Step.from_cmdline(args)
+
+
+@pytest.fixture(scope="module")
+def run_detector1_pipeline_emicorr_joint(rtdata_module):
+    """Run detector1 with an alternate emicorr algorithm."""
+    rtdata = rtdata_module
+    rtdata.get_data(f"miri/lrs/{DATASET3_ID}_uncal.fits")
+
+    args = [
+        "calwebb_detector1",
+        rtdata.input,
+        f"--output_file={DATASET3_ID}_emijoint",
+        "--steps.emicorr.algorithm=joint",
+        "--steps.emicorr.save_results=True",
     ]
     Step.from_cmdline(args)
 
@@ -92,9 +109,7 @@ def run_tso3_pipeline(run_tso_spec2_pipeline, rtdata_module):
 @pytest.mark.parametrize("step_suffix", ['dq_init', 'saturation', 'lastframe', 'reset', 'linearity',
                                          'dark_current', 'ramp', 'rate', 'rateints'])
 def test_miri_lrs_slitless_tso1(run_tso1_pipeline, rtdata_module, fitsdiff_default_kwargs, step_suffix):
-    """
-    Regression test of tso1 pipeline performed on MIRI LRS slitless TSO data.
-    """
+    """Regression test of tso1 pipeline performed on MIRI LRS slitless TSO data."""
     rtdata = rtdata_module
     output_filename = f"{DATASET1_ID}_{step_suffix}.fits"
     rtdata.output = output_filename
@@ -111,7 +126,9 @@ def test_miri_lrs_slitless_tso1(run_tso1_pipeline, rtdata_module, fitsdiff_defau
 def test_miri_lrs_slitless_detector1(run_detector1_pipeline, rtdata_module,
                                           fitsdiff_default_kwargs, step_suffix):
     """
-    Regression test of  detector1 pipeline performed on MIRI LRS slitless TSO data.
+    Regression test of  detector1 pipeline.
+
+    Performed on MIRI LRS slitless TSO data.
     Testing segment 2 data for RSCD, emicorr and dark_current.
     """
     rtdata = rtdata_module
@@ -125,8 +142,24 @@ def test_miri_lrs_slitless_detector1(run_detector1_pipeline, rtdata_module,
 
 
 @pytest.mark.bigdata
+@pytest.mark.parametrize("step_suffix", ['emicorr', 'rate', 'rateints'])
+def test_miri_lrs_slitless_detector1_emicorr_joint(
+        run_detector1_pipeline_emicorr_joint, rtdata_module,
+        fitsdiff_default_kwargs, step_suffix):
+    """Regression test of  detector1 pipeline with an alternate emicorr algorithm."""
+    rtdata = rtdata_module
+    output_filename = f"{DATASET3_ID}_emijoint_{step_suffix}.fits"
+    rtdata.output = output_filename
+
+    rtdata.get_truth(f"truth/test_miri_lrs_slitless_detector1_emicorr_joint/{output_filename}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
 @pytest.mark.parametrize("step_suffix", ["assign_wcs", "srctype", "flat_field",
-                                          "pixel_replace", "calints", "x1dints"])
+                                         "pixel_replace", "calints", "x1dints"])
 def test_miri_lrs_slitless_tso_spec2(run_tso_spec2_pipeline, rtdata_module, fitsdiff_default_kwargs,
                                      step_suffix):
     """Compare the output of a MIRI LRS slitless calwebb_tso-spec2 pipeline."""

--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -82,7 +82,7 @@ class LogWatcher:
             The message of interest
         """
         self.seen = False
-        self.message = message
+        self._message = message
 
     def __call__(self, *args):
         """Watch the logs for a specific message."""
@@ -91,8 +91,26 @@ class LogWatcher:
         if self.message in args[0]:
             self.seen = True
 
+    @property
+    def message(self):
+        return self._message
+
+    @message.setter
+    def message(self, new_message):
+        """
+        When message is set, clear the `seen` flag.
+
+        Parameters
+        ----------
+        new_message : str
+            New value for the `message` property.
+        """
+        self.seen = False
+        self._message = new_message
+
     def assert_seen(self):
-        """Check if message has been seen.
+        """
+        Check if message has been seen.
 
         After calling, the `seen` attribute is reset to False.
         """
@@ -102,7 +120,8 @@ class LogWatcher:
         self.seen = False
 
     def assert_not_seen(self):
-        """Check if message has not been seen.
+        """
+        Check if message has not been seen.
 
         After calling, the `seen` attribute is reset to False.
         """

--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -93,18 +93,15 @@ class LogWatcher:
 
     @property
     def message(self):
+        """
+        str: The message to watch for.
+
+        When the message is set, the `seen` flag is set to False.
+        """
         return self._message
 
     @message.setter
     def message(self, new_message):
-        """
-        When message is set, clear the `seen` flag.
-
-        Parameters
-        ----------
-        new_message : str
-            New value for the `message` property.
-        """
         self.seen = False
         self._message = new_message
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3597](https://jira.stsci.edu/browse/JP-3597)
Resolves [JP-3674](https://jira.stsci.edu/browse/JP-3674)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->

Add a new algorithm for fitting and removing EMI noise in MIRI ramps. 

In addition, a few minor bugs in the existing algorithm are fixed here:
- intermediate reference files generated on-the-fly were not formatted correctly and could not be saved
- retrieving subarray cases from the reference file sometimes returned incorrect matches
- the `minmed` function was not performing minimum calculations instead of median when nframes <= 2 as described

I have also added almost-complete unit test coverage for the new and existing algorithms, fixed code style for the new standards, updated documentation, and added a regression test for the new algorithm.  Truth files for the new regression test were generated locally with this branch, so I do not expect diffs.

This PR replaces #9187, which implemented the new algorithm only.  Changes introduced in that PR are all included here, with these further edits:
- style fixes for code and documentation
- edge case handling for fits to bad or trivially flat input data

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
