### PR TITLE
JP-3608: Document slit low/high parameters

### DIFF
--- a/docs/jwst/assign_wcs/arguments.rst
+++ b/docs/jwst/assign_wcs/arguments.rst
@@ -54,5 +54,5 @@ the behavior of the processing.
   Please note that significantly expanding the slit limit values may introduce
   contamination from adjacent open slits when the slit images are extracted
   in the :ref:`extract_2d <extract_2d_step>` step, and/or may expand the slits
-  into regions that cannot be flat fielded in the :ref:`flat_field <flat_field_step>`
+  into regions that cannot be flat fielded in the :ref:`flat_field <flatfield_step>`
   step.  These parameters should be used with caution.

--- a/docs/jwst/assign_wcs/arguments.rst
+++ b/docs/jwst/assign_wcs/arguments.rst
@@ -32,9 +32,9 @@ the behavior of the processing.
   Upper edge of a NIRSpec slit in slit units.
 
   Slit units are specified as a fraction of the nominal slit or shutter height.
-  In these relative units, -0.5 is the nominal *top*
-  edge of the slit open area in science orientation, 0.0 is the center of the slit,
-  and 0.5 is the nominal *bottom* edge of the slit open area in science orientation.
+  In these relative units, -0.5 is the nominal *top* edge of the slit open area in
+  the image frame, 0.0 is the center of the slit, and 0.5 is the nominal *bottom* edge
+  of the slit open area in the image frame.
 
   Set the `slit_y_low` value to a larger negative value to include more pixels
   at the *top* of a slit bounding box; a smaller negative value to to include fewer

--- a/docs/jwst/assign_wcs/arguments.rst
+++ b/docs/jwst/assign_wcs/arguments.rst
@@ -26,7 +26,31 @@ the behavior of the processing.
   Number of points for the SIP fit.
 
 ``--slit_y_low`` (float, default=-0.55)
-  Lower edge of a NIRSpec slit.
+  Lower edge of a NIRSpec slit in slit units (see below).
 
 ``--slit_y_high`` (float, default=0.55)
-  Upper edge of a NIRSpec slit.
+  Upper edge of a NIRSpec slit in slit units.
+
+  Slit units are specified as a fraction of the nominal slit or shutter height
+  in detector orientation. In these relative units, -0.5 is the nominal *top*
+  edge of the slit open area in science orientation, 0.0 is the center of the slit,
+  and 0.5 is the nominal *bottom* edge of the slit open area in science orientation.
+
+  Set the `slit_y_low` value to a larger negative value to include more pixels
+  at the *top* of a slit bounding box; a smaller negative value to to include fewer
+  pixels.
+
+  Set the `slit_y_high` value to a larger positive value to include more pixels
+  at the *bottom* of a slit bounding box; a smaller positive value to to include fewer
+  pixels.
+
+  For MSA slits in NIRSpec MOS mode, the slit units are relative to a single open shutter
+  height, not a full "slitlet" composed of multiple shutters.  For this mode, an
+  extra margin of half a shutter is automatically added to the slit boundaries specified
+  here, corresponding to a couple extra detector pixels at the top and bottom of each
+  slitlet.
+
+  Please note that significantly enlarging the slit limit values may introduce
+  contamination from adjacent open slits when the slit images are extracted
+  in the :ref:`extract_2d <extract_2d_step>` step, so these parameters should be used
+  with caution.

--- a/docs/jwst/assign_wcs/arguments.rst
+++ b/docs/jwst/assign_wcs/arguments.rst
@@ -31,8 +31,8 @@ the behavior of the processing.
 ``--slit_y_high`` (float, default=0.55)
   Upper edge of a NIRSpec slit in slit units.
 
-  Slit units are specified as a fraction of the nominal slit or shutter height
-  in detector orientation. In these relative units, -0.5 is the nominal *top*
+  Slit units are specified as a fraction of the nominal slit or shutter height.
+  In these relative units, -0.5 is the nominal *top*
   edge of the slit open area in science orientation, 0.0 is the center of the slit,
   and 0.5 is the nominal *bottom* edge of the slit open area in science orientation.
 
@@ -45,12 +45,14 @@ the behavior of the processing.
   pixels.
 
   For MSA slits in NIRSpec MOS mode, the slit units are relative to a single open shutter
-  height, not a full "slitlet" composed of multiple shutters.  For this mode, an
-  extra margin of half a shutter is automatically added to the slit boundaries specified
-  here, corresponding to a couple extra detector pixels at the top and bottom of each
-  slitlet.
+  height, not a full "slitlet" composed of multiple shutters.  For this mode,
+  the `slit_y_low` and `slit_y_high` values determine the padding of the slitlet edges relative
+  to the centers of the edge shutters. An additional margin of half a shutter is also
+  automatically added to the slit boundaries specified by these parameters, corresponding
+  to a couple extra detector pixels at the top and bottom of each slitlet.
 
-  Please note that significantly enlarging the slit limit values may introduce
+  Please note that significantly expanding the slit limit values may introduce
   contamination from adjacent open slits when the slit images are extracted
-  in the :ref:`extract_2d <extract_2d_step>` step, so these parameters should be used
-  with caution.
+  in the :ref:`extract_2d <extract_2d_step>` step, and/or may expand the slits
+  into regions that cannot be flat fielded in the :ref:`flat_field <flat_field_step>`
+  step.  These parameters should be used with caution.

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -57,8 +57,8 @@ class AssignWcsStep(Step):
         sip_max_inv_pix_error = float(default=0.01)  # max err for SIP fit, inverse.
         sip_inv_degree = integer(max=6, default=None)  # degree for inverse SIP fit, None to use best fit.
         sip_npoints = integer(default=12)  #  number of points for SIP
-        slit_y_low = float(default=-.55)  # The lower edge of a slit.
-        slit_y_high = float(default=.55)  # The upper edge of a slit.
+        slit_y_low = float(default=-.55)  # The lower edge of a slit (NIRSpec only).
+        slit_y_high = float(default=.55)  # The upper edge of a slit (NIRSpec only).
     """ # noqa: E501
 
     reference_file_types = ['distortion', 'filteroffset', 'specwcs', 'regions',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3608](https://jira.stsci.edu/browse/JP-3608)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Document the `slit_y_low` and `slit_y_high` parameter values for the assign_wcs step.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
