### PR TITLE
JP-3630: Add slit-specific processing metadata

### DIFF
--- a/changes/9254.barshadow.rst
+++ b/changes/9254.barshadow.rst
@@ -1,0 +1,1 @@
+For NIRSpec multislit data, add a metadata keyword to each slit to record whether it has been barshadow corrected.

--- a/changes/9254.pathloss.rst
+++ b/changes/9254.pathloss.rst
@@ -1,0 +1,1 @@
+For NIRSpec multislit data, add a metadata keyword to each slit to record the pathloss correction type applied (POINT or UNIFORM).

--- a/changes/9254.wavecorr.rst
+++ b/changes/9254.wavecorr.rst
@@ -1,0 +1,1 @@
+For NIRSpec multislit data, add a metadata keyword to each slit to record whether it has been wavelength corrected.

--- a/docs/jwst/barshadow/description.rst
+++ b/docs/jwst/barshadow/description.rst
@@ -54,3 +54,8 @@ Output product
 The output is a new copy of the input `~jwst.datamodels.MultiSlitModel`, with the
 corrections applied to the slit data arrays. The 2-D correction array for each slit
 is also added to the datamodel in the "BARSHADOW" extension.
+
+Upon successful completion of the step, the status keyword "S_BARSHA"
+in the primary header is set to "COMPLETE".  For each SCI extension, the "BARSHDW"
+keyword is set to True if the slit was barshadow corrected (it is an extended
+source) or False if it was not corrected (it is a point source).

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -109,6 +109,12 @@ Like for the point source case, the 1-d arrays of pathloss correction and wavele
 are used to interpolate the correction for each pixel in the science data, using the
 wavelength of each pixel to interpolate into the pathloss correction array.
 
+Upon successful completion of the step, the status keyword "S_PTHLOS"
+in the primary header is set to "COMPLETE".  For each SCI extension, the "PTHLOSS"
+keyword is set to "POINT" if the point source correction type was applied to the
+slit data. It is set to "UNIFORM" if the uniform correction type was applied.
+The keyword is not set if no correction was applied.
+
 MIRI LRS
 ++++++++
 The algorithm for MIRI LRS mode is largely the same as that for NIRSpec described

--- a/docs/jwst/wavecorr/description.rst
+++ b/docs/jwst/wavecorr/description.rst
@@ -9,6 +9,11 @@ The wavelength correction (``wavecorr``) step in the
 assignments for NIRSpec fixed-slit (FS) and MOS point sources that are
 known to be off center (in the dispersion direction) in their slit.
 
+Upon successful completion of the step, the status keyword "S_WAVCOR"
+in the primary header is set to "COMPLETE".  For each SCI extension, the "WAVECOR"
+keyword is set to True if the slit was wavelength corrected (it is a point
+source) or False if it was not corrected (it is a point source).
+
 NIRSpec MOS
 -----------
 For NIRSpec MOS exposures (EXP_TYPE="NRS_MSASPEC"), wavelength
@@ -47,7 +52,4 @@ target coordinates and aperture reference point during the
 :ref:`extract_2d <extract_2d_step>` step. This estimated position (in the 
 dispersion direction) is used in the same manner as described above
 for MOS slitlets to update the slit WCS and compute corrected wavelengths
-for the primary slit only. 
-
-Upon successful completion of the step, the status keyword "S_WAVCOR"
-is set to "COMPLETE".
+for the primary slit only.

--- a/docs/jwst/wavecorr/description.rst
+++ b/docs/jwst/wavecorr/description.rst
@@ -12,7 +12,7 @@ known to be off center (in the dispersion direction) in their slit.
 Upon successful completion of the step, the status keyword "S_WAVCOR"
 in the primary header is set to "COMPLETE".  For each SCI extension, the "WAVECOR"
 keyword is set to True if the slit was wavelength corrected (it is a point
-source) or False if it was not corrected (it is a point source).
+source) or False if it was not corrected (it is not a point source).
 
 NIRSpec MOS
 -----------

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -74,7 +74,7 @@ def do_correction(
         corrections.slits.append(correction)
 
         if correction is None:
-            # For extended sources, there is no real correction applied.
+            # For point sources, there is no real correction applied.
             # Record the correction status as False in this case.
             slitlet.barshadow_corrected = False
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -742,6 +742,9 @@ def copy_keyword_info(slit, slitname, spec):
         "quadrant",
         "slit_xscale",
         "slit_yscale",
+        "wavelength_corrected",
+        "pathloss_correction_type",
+        "barshadow_corrected",
     ]
     for key in copy_populated_attributes:
         if getattr(slit, key, None) is not None:

--- a/jwst/extract_1d/tests/test_extract.py
+++ b/jwst/extract_1d/tests/test_extract.py
@@ -462,6 +462,9 @@ def test_copy_keyword_info(mock_nirspec_fs_one_slit, mock_one_spec):
         "source_ra": 10.0,
         "source_dec": 10.0,
         "shutter_state": "x",
+        "wavelength_corrected": True,
+        "pathloss_correction_type": "POINT",
+        "barshadow_corrected": False
     }
     for key, value in expected.items():
         setattr(mock_nirspec_fs_one_slit, key, value)

--- a/jwst/pathloss/tests/test_pathloss_step.py
+++ b/jwst/pathloss/tests/test_pathloss_step.py
@@ -1,0 +1,214 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from stdatamodels.jwst import datamodels
+
+import jwst
+from jwst.assign_wcs import AssignWcsStep
+from jwst.assign_wcs.tests.test_nirspec import (
+    create_nirspec_mos_file, create_nirspec_fs_file, create_nirspec_ifu_file)
+from jwst.extract_2d import Extract2dStep
+from jwst.pathloss import PathLossStep
+
+
+def create_nirspec_fs_model(source_type="POINT"):
+    hdul = create_nirspec_fs_file(grating="G140M", filter="F100LP")
+    im = datamodels.ImageModel(hdul)
+    hdul.close()
+
+    im.data = np.full((2048, 2048), 1.0)
+    im_wcs = AssignWcsStep.call(im)
+    im_ex2d = Extract2dStep.call(im_wcs)
+
+    # add error/variance arrays
+    im_ex2d.slits[0].err = im_ex2d.slits[0].data * 0.1
+    im_ex2d.slits[0].var_rnoise = im_ex2d.slits[0].data * 0.01
+    im_ex2d.slits[0].var_poisson = im_ex2d.slits[0].data * 0.01
+    im_ex2d.slits[0].var_flat = im_ex2d.slits[0].data * 0.01
+
+    # set source type and position off center
+    im_ex2d.slits[0].source_type = source_type
+    im_ex2d.slits[0].source_xpos = 0.25
+    im_ex2d.slits[0].source_ypos = 0.25
+
+    return im_ex2d
+
+
+def create_nirspec_mos_model(source_type="POINT"):
+    hdul = create_nirspec_mos_file()
+    msa_meta = Path(jwst.__path__[0]) / "assign_wcs" / "tests" / "data" / "msa_configuration.fits"
+    hdul[0].header["MSAMETFL"] = str(msa_meta)
+    hdul[0].header["MSAMETID"] = 12
+    im = datamodels.ImageModel(hdul)
+    hdul.close()
+
+    im.data = np.full((2048, 2048), 1.0)
+    im_wcs = AssignWcsStep.call(im)
+    im_ex2d = Extract2dStep.call(im_wcs)
+
+    # add error/variance arrays
+    im_ex2d.slits[0].err = im_ex2d.slits[0].data * 0.1
+    im_ex2d.slits[0].var_rnoise = im_ex2d.slits[0].data * 0.01
+    im_ex2d.slits[0].var_poisson = im_ex2d.slits[0].data * 0.01
+    im_ex2d.slits[0].var_flat = im_ex2d.slits[0].data * 0.01
+
+    # set source type and position off center
+    im_ex2d.slits[0].source_type = source_type
+    im_ex2d.slits[0].source_xpos = 0.25
+    im_ex2d.slits[0].source_ypos = 0.25
+
+    return im_ex2d
+
+
+@pytest.fixture(scope="module")
+def nirspec_mos_model_point():
+    return create_nirspec_mos_model(source_type="POINT")
+
+
+@pytest.fixture(scope="module")
+def nirspec_mos_model_extended():
+    return create_nirspec_mos_model(source_type="EXTENDED")
+
+
+@pytest.fixture(scope="module")
+def nirspec_fs_model_point():
+    return create_nirspec_fs_model(source_type="POINT")
+
+
+@pytest.fixture(scope="module")
+def nirspec_fs_model_extended():
+    return create_nirspec_fs_model(source_type="EXTENDED")
+
+
+def test_pathloss_step_mos_point(nirspec_mos_model_point):
+    model = nirspec_mos_model_point.copy()
+    result = PathLossStep.call(model)
+    assert result.meta.cal_step.pathloss == "COMPLETE"
+
+    # correction type should be "POINT"
+    assert result.slits[0].pathloss_correction_type == "POINT"
+
+    # uniform also present, but point is used
+    pathloss = result.slits[0].pathloss_point
+    pathloss_un = result.slits[0].pathloss_uniform
+    assert not np.all(pathloss == 1)
+    assert not np.all(pathloss == pathloss_un)
+
+    # maximum correction value should be 1.0, minimum should be above zero
+    assert np.nanmax(pathloss) <= 1.0
+    assert np.nanmin(pathloss) > 0.0
+
+    # data should have been divided by pathloss
+    nnan = ~np.isnan(result.slits[0].data)
+    assert np.allclose(
+        result.slits[0].data[nnan] * pathloss[nnan], model.slits[0].data[nnan]
+    )
+    assert np.allclose(
+        result.slits[0].err[nnan] * pathloss[nnan], model.slits[0].err[nnan]
+    )
+    assert np.allclose(
+        result.slits[0].var_rnoise[nnan] * pathloss[nnan] ** 2,
+        model.slits[0].var_rnoise[nnan],
+    )
+    assert np.allclose(
+        result.slits[0].var_poisson[nnan] * pathloss[nnan] ** 2,
+        model.slits[0].var_poisson[nnan],
+    )
+    assert np.allclose(
+        result.slits[0].var_flat[nnan] * pathloss[nnan] ** 2,
+        model.slits[0].var_flat[nnan],
+    )
+
+    result.close()
+
+
+def test_pathloss_step_mos_uniform(nirspec_mos_model_extended):
+    model = nirspec_mos_model_extended.copy()
+    result = PathLossStep.call(model)
+    assert result.meta.cal_step.pathloss == "COMPLETE"
+
+    # correction type should be "UNIFORM"
+    assert result.slits[0].pathloss_correction_type == "UNIFORM"
+
+    # point also present, but uniform is used
+    pathloss = result.slits[0].pathloss_uniform
+    pathloss_pt = result.slits[0].pathloss_point
+    assert not np.all(pathloss == 1)
+    assert not np.all(pathloss == pathloss_pt)
+
+    # maximum correction value can be > 1.0 for uniform correction,
+    # minimum should be above zero
+    assert np.nanmin(pathloss) > 0.0
+
+    # data should have been divided by pathloss
+    nnan = ~np.isnan(result.slits[0].data)
+    assert np.allclose(
+        result.slits[0].data[nnan] * pathloss[nnan], model.slits[0].data[nnan]
+    )
+    assert np.allclose(
+        result.slits[0].err[nnan] * pathloss[nnan], model.slits[0].err[nnan]
+    )
+    assert np.allclose(
+        result.slits[0].var_rnoise[nnan] * pathloss[nnan] ** 2,
+        model.slits[0].var_rnoise[nnan],
+    )
+    assert np.allclose(
+        result.slits[0].var_poisson[nnan] * pathloss[nnan] ** 2,
+        model.slits[0].var_poisson[nnan],
+    )
+    assert np.allclose(
+        result.slits[0].var_flat[nnan] * pathloss[nnan] ** 2,
+        model.slits[0].var_flat[nnan],
+    )
+
+    result.close()
+
+
+def test_pathloss_step_fs_point(nirspec_fs_model_point):
+    model = nirspec_fs_model_point.copy()
+    result = PathLossStep.call(model)
+    assert result.meta.cal_step.pathloss == "COMPLETE"
+
+    # correction type should be "POINT"
+    assert result.slits[0].pathloss_correction_type == "POINT"
+
+
+def test_pathloss_step_fs_uniform(nirspec_fs_model_extended):
+    model = nirspec_fs_model_extended.copy()
+    result = PathLossStep.call(model)
+    assert result.meta.cal_step.pathloss == "COMPLETE"
+
+    # correction type should be "UNIFORM"
+    assert result.slits[0].pathloss_correction_type == "UNIFORM"
+
+
+@pytest.mark.parametrize('mode', ['mos', 'fs'])
+def test_pathloss_correction_pars(mode, nirspec_mos_model_point, nirspec_fs_model_point):
+    if mode == 'mos':
+        model = nirspec_mos_model_point.copy()
+    else:
+        model = nirspec_fs_model_point.copy()
+    step = PathLossStep()
+    result = step.run(model)
+
+    # output data is not the same
+    nnan = ~np.isnan(model.slits[0].data) & ~np.isnan(result.slits[0].data)
+    assert not np.allclose(result.slits[0].data[nnan], model.slits[0].data[nnan])
+
+    # use the computed correction and invert
+    new_step = PathLossStep()
+    new_step.use_correction_pars = True
+    new_step.correction_pars = step.correction_pars
+    new_step.inverse = True
+    inverse_result = new_step.run(result)
+
+    # output data is the same as input, except that NaNs do not invert
+    assert np.allclose(inverse_result.slits[0].data[nnan], model.slits[0].data[nnan])
+    assert np.allclose(inverse_result.slits[0].err[nnan], model.slits[0].err[nnan])
+    assert np.allclose(inverse_result.slits[0].var_rnoise[nnan], model.slits[0].var_rnoise[nnan])
+    assert np.allclose(inverse_result.slits[0].var_poisson[nnan], model.slits[0].var_poisson[nnan])
+    assert np.allclose(inverse_result.slits[0].var_flat[nnan], model.slits[0].var_flat[nnan])
+
+    result.close()
+    inverse_result.close()

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -219,8 +219,8 @@ def test_mos_slit_status():
     # since no slits were corrected
     assert im_wave.meta.cal_step.wavecorr == "SKIPPED"
 
-    # check that the step is listed as skipped for extended mos sources
-    assert im_wave.slits[0].meta.cal_step.wavecorr == "SKIPPED"
+    # check that wavelength_corrected is False for extended mos sources
+    assert im_wave.slits[0].wavelength_corrected is False
 
     # test the mock msa source as a point source
     im_src.slits[0].source_type = "POINT"
@@ -229,8 +229,8 @@ def test_mos_slit_status():
     # check that the step is recorded as completed
     assert im_wave.meta.cal_step.wavecorr == "COMPLETE"
 
-    # check that the step is listed as complete for mos point sources
-    assert im_wave.slits[0].meta.cal_step.wavecorr == "COMPLETE"
+    # check that wavelength_corrected is True for mos point sources
+    assert im_wave.slits[0].wavelength_corrected is True
 
 
 def test_wavecorr_fs():

--- a/jwst/wavecorr/wavecorr.py
+++ b/jwst/wavecorr/wavecorr.py
@@ -50,13 +50,13 @@ def do_correction(input_model, wavecorr_file):
                 completed = apply_zero_point_correction(slit, wavecorr_file)
                 if completed:
                     corrected = True
-                    slit.meta.cal_step.wavecorr = "COMPLETE"
+                    slit.wavelength_corrected = True
                 else:  # pragma: no cover
                     log.warning(f"Corrections are not invertible for slit {slit.name}")
                     log.warning("Skipping wavecorr correction")
-                    slit.meta.cal_step.wavecorr = "SKIPPED"
+                    slit.wavelength_corrected = False
             else:
-                slit.meta.cal_step.wavecorr = "SKIPPED"
+                slit.wavelength_corrected = False
 
     if corrected:
         output_model.meta.cal_step.wavecorr = "COMPLETE"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3630](https://jira.stsci.edu/browse/JP-3630)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Add some new informational keys to multi-slit data to make clear which slit-specific processing has taken place.  Affected data is NIRSpec MOS and FS; keys are added for wavecorr, pathloss, and barshadow steps.

Requires an stdatamodels change to add the new keys to the slit and spec datamodels: https://github.com/spacetelescope/stdatamodels/pull/431,
now merged.

Also, I noticed in passing a small bug in pathloss and corrected it here: the error propagation is incorrect when the step is inverted.  Error values are not currently used in steps that require the inversion, so there should be no impact to current data products. I added unit tests to verify the change as well as some basic coverage tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
