### PR TITLE
mention cal_logs in docs

### DIFF
--- a/changes/9257.docs.rst
+++ b/changes/9257.docs.rst
@@ -1,0 +1,1 @@
+Add cal_logs documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ is also available on `JDox <https://jwst-docs.stsci.edu>`__.
    jwst/user_documentation/running_pipeline_command_line.rst
    jwst/user_documentation/available_pipelines.rst
    jwst/user_documentation/input_output_file_conventions.rst
-   jwst/user_documentation/logging_configuration.rst
+   jwst/user_documentation/logging.rst
    jwst/user_documentation/datamodels.rst
    jwst/user_documentation/pub_deprecation.rst
    jwst/user_documentation/more_information.rst

--- a/docs/jwst/stpipe/user_logging.rst
+++ b/docs/jwst/stpipe/user_logging.rst
@@ -109,30 +109,3 @@ hitting any warning for that Step:
     level = INFO
     break_level = WARNING
 
-.. _cal_logs:
-
-DataModel cal_logs
-==================
-
-Saved files that contain :ref:`jwst-data-models` will contain log messages
-from the run that produced the file. These are stored in the ASDF portion
-of the file and can be inspected by opening the file as a
-:ref:`jwst-data-models`.
-
-The ``cal_logs`` attribute contains log messages as lists of strings
-organized by step or pipeline name. For example to see log messages from
-:ref:`calwebb_detector1`:
-
-::
-
-        import stdatamodels.jwst.datamodels as dm
-        model = dm.open("jw00001001001_01101_00001_mirimage_cal.fits")
-        print(model.cal_logs.calwebb_detector1)
-
-Files processed by a pipeline will contain all logs messages for that
-run under the pipeline name (and not contain ``cal_logs`` for individual
-steps that were part of the pipeline).
-
-Log messages that contain sensitive information (user, hostname, paths,
-IP addresses) are replaced with empty strings. Please see the console
-logs for those messages.

--- a/docs/jwst/stpipe/user_logging.rst
+++ b/docs/jwst/stpipe/user_logging.rst
@@ -109,3 +109,30 @@ hitting any warning for that Step:
     level = INFO
     break_level = WARNING
 
+.. _cal_logs:
+
+DataModel cal_logs
+==================
+
+Saved files that contain :ref:`jwst-data-models` will contain log messages
+from the run that produced the file. These are stored in the ASDF portion
+of the file and can be inspected by opening the file as a
+:ref:`jwst-data-models`.
+
+The ``cal_logs`` attribute contains log messages as lists of strings
+organized by step or pipeline name. For example to see log messages from
+:ref:`calwebb_detector1`:
+
+::
+
+        import stdatamodels.jwst.datamodels as dm
+        model = dm.open("jw00001001001_01101_00001_mirimage_cal.fits")
+        print(model.cal_logs.calwebb_detector1)
+
+Files processed by a pipeline will contain all logs messages for that
+run under the pipeline name (and not contain ``cal_logs`` for individual
+steps that were part of the pipeline).
+
+Log messages that contain sensitive information (user, hostname, paths,
+IP addresses) are replaced with empty strings. Please see the console
+logs for those messages.

--- a/docs/jwst/user_documentation/logging.rst
+++ b/docs/jwst/user_documentation/logging.rst
@@ -1,6 +1,39 @@
-=====================
-Logging Configuration
-=====================
+.. _logging:
+
+=======
+Logging
+=======
+
+.. _cal_logs:
+
+DataModel cal_logs
+==================
+
+Saved files that contain :ref:`jwst-data-models` will contain log messages
+from the run that produced the file. These are stored in the ASDF portion
+of the file and can be inspected by opening the file as a
+:ref:`jwst-data-models`.
+
+The ``cal_logs`` attribute contains log messages as lists of strings
+organized by step or pipeline name. For example to see log messages from
+:ref:`calwebb_detector1`:
+
+::
+
+        import stdatamodels.jwst.datamodels as dm
+        model = dm.open("jw00001001001_01101_00001_mirimage_cal.fits")
+        print(model.cal_logs.calwebb_detector1)
+
+Files processed by a pipeline will contain all logs messages for that
+run under the pipeline name (and not contain ``cal_logs`` for individual
+steps that were part of the pipeline).
+
+Log messages that contain sensitive information (user, hostname, paths,
+IP addresses) are replaced with empty strings. Please see the console
+logs for those messages.
+
+Configuration
+=============
 
 The name of a file in which to save log information, as well as the desired
 level of logging messages, can be specified in an optional configuration file.


### PR DESCRIPTION
This PR adds a docs section describing the `cal_logs` added in https://github.com/spacetelescope/jwst/pull/9211

To aid in the discovery of this section this PR renames the `Logging Configuration` section of `User Documentation` to the more general `Logging`.

Link to docs: https://jwst-pipeline--9257.org.readthedocs.build/en/9257/jwst/user_documentation/logging.html#datamodel-cal-logs

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
