### PR TITLE
Add flexible log_watcher fixture

### DIFF
--- a/jwst/clean_flicker_noise/tests/test_clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/tests/test_clean_flicker_noise.py
@@ -1,5 +1,3 @@
-import logging
-
 import gwcs
 import numpy as np
 import pytest
@@ -9,7 +7,6 @@ from jwst.assign_wcs.tests.test_nirspec import (
     create_nirspec_ifu_file, create_nirspec_fs_file)
 from jwst.msaflagopen.tests.test_msa_open import make_nirspec_mos_model, get_file_path
 from jwst.clean_flicker_noise import clean_flicker_noise as cfn
-from jwst.tests.helpers import LogWatcher
 
 
 def add_metadata(model, shape):
@@ -122,22 +119,11 @@ class MockUpdate:
         return mask
 
 
-@pytest.fixture
-def log_watcher(monkeypatch):
-    # Set a log watcher to check for a log message at any level
-    # in the clean_flicker_noise module
-    watcher = LogWatcher('')
-    logger = logging.getLogger('jwst.clean_flicker_noise.clean_flicker_noise')
-    for level in ['debug', 'info', 'warning', 'error']:
-        monkeypatch.setattr(logger, level, watcher)
-    return watcher
-
-
 def test_make_rate(log_watcher):
     shape = (3, 5, 10, 10)
     ramp_model = make_small_ramp_model(shape)
 
-    log_watcher.message = 'Creating draft rate file'
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise", message="Creating draft rate file")
     result = cfn.make_rate(ramp_model, return_cube=True)
     assert isinstance(result, datamodels.CubeModel)
     assert result.data.shape == (shape[0], shape[2], shape[3])
@@ -152,22 +138,22 @@ def test_make_rate(log_watcher):
     result.close()
 
     # Check for expected log message
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
 
 def test_postprocess_rate_nirspec(log_watcher):
     rate_model = make_nirspec_mos_model()
 
-    log_watcher.message = 'Assigning a WCS'
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise", message="Assigning a WCS")
     result = cfn.post_process_rate(rate_model, assign_wcs=True)
     assert isinstance(result.meta.wcs, gwcs.WCS)
     assert np.sum(result.dq & datamodels.dqflags.pixel['MSA_FAILED_OPEN']) == 0
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
-    log_watcher.message = 'Flagging failed-open'
+    watcher.message = 'Flagging failed-open'
     result = cfn.post_process_rate(result, msaflagopen=True)
     assert np.sum(result.dq & datamodels.dqflags.pixel['MSA_FAILED_OPEN']) > 0
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     rate_model.close()
     result.close()
@@ -177,9 +163,9 @@ def test_postprocess_rate_miri(log_watcher):
     rate_model = make_small_rate_model()
     assert np.sum(rate_model.dq & datamodels.dqflags.pixel['DO_NOT_USE']) == 0
 
-    log_watcher.message = 'Retrieving flat DQ'
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise", message="Retrieving flat DQ")
     result = cfn.post_process_rate(rate_model, flat_dq=True)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
     assert np.sum(result.dq & datamodels.dqflags.pixel['DO_NOT_USE']) > 0
     assert np.all(result.data == rate_model.data)
 
@@ -239,11 +225,11 @@ def test_clip_to_background(log_watcher, fit_histogram, lower_half_only):
     image[1, 1] += -1
 
     # Center found is close to zero, printed when verbose=True
-    log_watcher.message = "center: 0.000"
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise", message="center: 0.000")
     cfn.clip_to_background(
         image, mask, fit_histogram=fit_histogram,
         lower_half_only=lower_half_only, verbose=True)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # All outliers clipped with defaults, as well as a small
     # percent of the remaining data
@@ -272,15 +258,16 @@ def test_clip_to_background(log_watcher, fit_histogram, lower_half_only):
 
 def test_clip_to_background_fit_fails(log_watcher):
     shape = (10, 10)
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise")
 
     # histogram failure: all data NaN
-    log_watcher.message = "Histogram failed"
     image = np.full(shape, np.nan)
     mask = np.full(shape, True)
+    watcher.message = "Histogram failed"
     with pytest.warns(RuntimeWarning):
         cfn.clip_to_background(image, mask, fit_histogram=True, verbose=True)
     assert np.all(mask)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # if mask is all False, warning is avoided, mask is unchanged
     mask[:] = False
@@ -288,13 +275,13 @@ def test_clip_to_background_fit_fails(log_watcher):
     assert not np.all(mask)
 
     # fit failure: data is not normal
-    log_watcher.message = "Gaussian fit failed"
+    watcher.message = "Gaussian fit failed"
     image = np.full(shape, 0.0)
     mask = np.full(shape, True)
     image[5:, 5:] = 0.1
     cfn.clip_to_background(image, mask, fit_histogram=True, verbose=True)
     assert np.all(mask)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
 
 @pytest.mark.parametrize('exptype', ['mos', 'mos_fs', 'ifu'])
@@ -392,6 +379,8 @@ def test_create_mask_from_rateints():
 
 
 def test_background_level(log_watcher):
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise")
+
     shape = (100, 100)
     image = np.full(shape, 1.0)
     mask = np.full(shape, True)
@@ -415,31 +404,31 @@ def test_background_level(log_watcher):
 
     # model method with mismatched box size:
     # warns, but completes successfully
-    log_watcher.message = "does not divide evenly"
+    watcher.message = "does not divide evenly"
     background = cfn.background_level(
         image, mask, background_method='model', background_box_size=(32, 32))
     assert background.shape == shape
     assert np.all(background == 1.0)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # model method with None box size: picks the largest even divisor < 32
-    log_watcher.message = "box size [25, 25]"
+    watcher.message = "box size [25, 25]"
     background = cfn.background_level(
         image, mask, background_method='model', background_box_size=None)
     assert background.shape == shape
     assert np.all(background == 1.0)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # make image mostly bad, one good region
     image[:] = np.nan
     image[20:25, 20:25] = 1.0
 
     # background fit fails: falls back on simple median
-    log_watcher.message = "Background fit failed, using median"
+    watcher.message = "Background fit failed, using median"
     background = cfn.background_level(
         image, mask, background_method='model', background_box_size=(10, 10))
     assert background == 1.0
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
 
 @pytest.mark.parametrize('array_type,fraction_good', [('full', 0.65), ('subarray', 0.37)])
@@ -482,29 +471,31 @@ def test_fft_clean_error(monkeypatch, log_watcher):
     mask = np.full(shape, True)
     image = np.full(shape, 1.0)
 
-    log_watcher.message = "Error cleaning image"
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise", message="Error cleaning image")
     cleaned_image = cfn.fft_clean_full_frame(image.copy(), mask, 'NRS1')
     assert cleaned_image is None
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
 
 def test_fft_subarray_clean_error(monkeypatch, log_watcher):
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise")
+
     shape = (10, 10)
     image = np.full(shape, 1.0)
 
     # Mask is all bad: error message, returns None
     mask = np.full(shape, False)
-    log_watcher.message = "No good pixels"
+    watcher.message = "No good pixels"
     cleaned_image = cfn.fft_clean_subarray(image.copy(), mask, 'NRS1')
     assert cleaned_image is None
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # Mask is mostly bad: warns but continues
     mask[5, 5] = True
-    log_watcher.message = "Insufficient reference pixels"
+    watcher.message = "Insufficient reference pixels"
     cleaned_image = cfn.fft_clean_subarray(image.copy(), mask, 'NRS1', minfrac=0.5)
     assert np.allclose(cleaned_image, image)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # Trigger a linear algebra error
     # This may occur when the mask is not completely bad,
@@ -514,10 +505,10 @@ def test_fft_subarray_clean_error(monkeypatch, log_watcher):
 
     monkeypatch.setattr(cfn.NSCleanSubarray, 'clean', raise_error)
 
-    log_watcher.message = "Error cleaning image"
+    watcher.message = "Error cleaning image"
     cleaned_image = cfn.fft_clean_subarray(image.copy(), mask, 'NRS1')
     assert cleaned_image is None
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
 
 def test_median_clean():
@@ -649,11 +640,11 @@ def test_do_correction_unsupported(log_watcher):
     ramp_model = make_small_ramp_model()
     ramp_model.meta.exposure.type = 'MIR_MRS'
 
-    log_watcher.message = "not supported"
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise", message="not supported")
     cleaned, _, _, _, status = cfn.do_correction(ramp_model)
     assert cleaned is ramp_model
     assert status == 'SKIPPED'
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     ramp_model.close()
 
@@ -663,10 +654,11 @@ def test_do_correction_no_fit_by_channel(log_watcher):
 
     # fit_by_channel is only used for NIR data -
     # log a warning, but step still completes
-    log_watcher.message = "can only be used for full-frame NIR"
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise",
+                          message="can only be used for full-frame NIR")
     cleaned, _, _, _, status = cfn.do_correction(ramp_model, fit_by_channel=True)
     assert status == 'COMPLETE'
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     ramp_model.close()
     cleaned.close()
@@ -678,11 +670,12 @@ def test_do_correction_fft_not_allowed(log_watcher, exptype):
     ramp_model.meta.exposure.type = exptype
 
     # not allowed for MIRI, NIRCAM, NIRISS
-    log_watcher.message = f"cannot be applied to exp_type {exptype}"
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise",
+                          message=f"cannot be applied to exp_type {exptype}")
     cleaned, _, _, _, status = cfn.do_correction(ramp_model, fit_method='fft')
     assert cleaned is ramp_model
     assert status == 'SKIPPED'
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     ramp_model.close()
 
@@ -745,11 +738,12 @@ def test_do_correction_user_mask_mismatch(tmp_path, input_type, log_watcher):
     mask_model.save(user_mask)
     mask_model.close()
 
-    log_watcher.message = 'Mask does not match'
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise",
+                          message='Mask does not match')
     cleaned, output_mask, _, _, status = cfn.do_correction(
         model, user_mask=user_mask, save_mask=True)
 
-    log_watcher.assert_seen()
+    watcher.assert_seen()
     assert status == 'SKIPPED'
     assert output_mask is None
 
@@ -767,11 +761,12 @@ def test_do_correction_user_mask_mismatch_integ(tmp_path, log_watcher):
     mask_model.save(user_mask)
     mask_model.close()
 
-    log_watcher.message = 'Mask does not match'
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise",
+                          message='Mask does not match')
     cleaned, output_mask, _, _, status = cfn.do_correction(
         model, user_mask=user_mask, save_mask=True)
 
-    log_watcher.assert_seen()
+    watcher.assert_seen()
     assert status == 'SKIPPED'
     assert output_mask is None
 
@@ -833,13 +828,14 @@ def test_do_correction_clean_fails(monkeypatch, log_watcher):
     monkeypatch.setattr(cfn, 'fft_clean_subarray', lambda *args, **kwargs: None)
 
     # Call again
-    log_watcher.message = "Cleaning failed"
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise",
+                          message="Cleaning failed")
     cleaned, _, _, _, status = cfn.do_correction(
         ramp_model, fit_method='fft')
 
     # Error message issued, status is skipped,
     # output data is the same as input
-    log_watcher.assert_seen()
+    watcher.assert_seen()
     assert status == 'SKIPPED'
     assert np.allclose(cleaned.data, ramp_model.data)
 
@@ -897,9 +893,10 @@ def test_do_correction_with_flat_unity(tmp_path, input_type, log_watcher):
     flat_file = str(tmp_path / 'flat.fits')
     flat.save(flat_file)
 
-    log_watcher.message = 'Dividing by flat'
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise",
+                          message='Dividing by flat')
     cleaned, _, _, _, status = cfn.do_correction(model, flat_filename=flat_file, background_method=None)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
     assert status == 'COMPLETE'
 
     # output is flat with uniform flat, background is perfectly removed
@@ -932,17 +929,18 @@ def test_do_correction_with_flat_structure(tmp_path, log_watcher, input_type, ap
     # multiply the data by the flat to mock real structure
     model.data *= flat.data
 
-    log_watcher.message = 'Dividing by flat'
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise",
+                          message='Dividing by flat')
     cleaned, _, _, _, status = cfn.do_correction(model, flat_filename=flat_file)
     assert status == 'COMPLETE'
 
     if apply_flat:
-        log_watcher.assert_seen()
+        watcher.assert_seen()
 
         # output is the same as input: flat structure is not removed
         assert np.all(cleaned.data == model.data)
     else:
-        log_watcher.assert_not_seen()
+        watcher.assert_not_seen()
 
         # output is not the same as input: flat structure is fit as background/noise
         assert not np.all(cleaned.data == model.data)
@@ -965,10 +963,11 @@ def test_do_correction_with_flat_subarray(tmp_path, log_watcher):
     # multiply the data by the flat to mock real structure
     model.data *= flat.data[:20, :20]
 
-    log_watcher.message = 'Extracting matching subarray'
+    watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise",
+                          message='Extracting matching subarray')
     cleaned, _, _, _, status = cfn.do_correction(model, flat_filename=flat_file)
     assert status == 'COMPLETE'
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # output is the same as input: flat structure is not removed by the
     # cleaning process

--- a/jwst/extract_1d/tests/test_psf_profile.py
+++ b/jwst/extract_1d/tests/test_psf_profile.py
@@ -1,22 +1,8 @@
-import logging
-
 import numpy as np
 import pytest
 from stdatamodels.jwst.datamodels import SpecPsfModel
 
 from jwst.extract_1d import psf_profile as pp
-from jwst.tests.helpers import LogWatcher
-
-
-@pytest.fixture
-def log_watcher(monkeypatch):
-    # Set a log watcher to check for a log message at any level
-    # in the extract_1d.psf_profile module
-    watcher = LogWatcher("")
-    logger = logging.getLogger("jwst.extract_1d.psf_profile")
-    for level in ["debug", "info", "warning", "error"]:
-        monkeypatch.setattr(logger, level, watcher)
-    return watcher
 
 
 @pytest.mark.parametrize("exp_type", ["MIR_LRS-FIXEDSLIT", "NRS_FIXEDSLIT", "UNKNOWN"])
@@ -297,11 +283,12 @@ def test_psf_profile_model_nod_no_trace(mock_miri_lrs_fs, psf_reference_file, lo
     yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = "Cannot model a negative nod without position"
+    watcher = log_watcher("jwst.extract_1d.psf_profile",
+                          message="Cannot model a negative nod without position")
     profiles, lower, upper = pp.psf_profile(
         model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
     )
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # does not return nod profile
     assert len(profiles) == 1
@@ -315,11 +302,11 @@ def test_psf_profile_model_nod_not_subtracted(mock_miri_lrs_fs, psf_reference_fi
     yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = "data was not nod-subtracted"
+    watcher = log_watcher("jwst.extract_1d.psf_profile", message="data was not nod-subtracted")
     profiles, lower, upper = pp.psf_profile(
         model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
     )
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # does not return nod profile
     assert len(profiles) == 1
@@ -334,11 +321,11 @@ def test_psf_profile_model_nod_wrong_pattern(mock_miri_lrs_fs, psf_reference_fil
     yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = "data was not a two-point nod"
+    watcher = log_watcher("jwst.extract_1d.psf_profile", message="data was not a two-point nod")
     profiles, lower, upper = pp.psf_profile(
         model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
     )
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # does not return nod profile
     assert len(profiles) == 1
@@ -354,11 +341,11 @@ def test_psf_profile_model_nod_bad_position(mock_miri_lrs_fs, psf_reference_file
     yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = "Nod center could not be estimated"
+    watcher = log_watcher("jwst.extract_1d.psf_profile", message="Nod center could not be estimated")
     profiles, lower, upper = pp.psf_profile(
         model, trace, wl_array, psf_reference_file, optimize_shifts=False, model_nod_pair=True
     )
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # does not return nod profile
     assert len(profiles) == 1
@@ -381,7 +368,7 @@ def test_psf_profile_optimize(
     yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = "Centering profile on spectrum at 24.5"
+    watcher = log_watcher("jwst.extract_1d.psf_profile", message="Centering profile on spectrum at 24.5")
     profiles, lower, upper = pp.psf_profile(
         model,
         trace,
@@ -390,7 +377,7 @@ def test_psf_profile_optimize(
         optimize_shifts=True,
         model_nod_pair=False,
     )
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # profile is centered at 24.5
     profile = profiles[0]
@@ -432,7 +419,7 @@ def test_psf_profile_optimize_with_nod(
     yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
-    log_watcher.message = "Also modeling a negative trace at 39.50"
+    watcher = log_watcher("jwst.extract_1d.psf_profile", message="Also modeling a negative trace at 39.50")
     profiles, lower, upper = pp.psf_profile(
         model,
         trace,
@@ -441,7 +428,7 @@ def test_psf_profile_optimize_with_nod(
         optimize_shifts=True,
         model_nod_pair=True,
     )
-    log_watcher.assert_seen()
+    watcher.assert_seen()
 
     # profile is centered at 10
     source, nod = profiles

--- a/jwst/ramp_fitting/tests/test_ramp_fit_step.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_step.py
@@ -1,21 +1,9 @@
 import pytest
-import logging
 import numpy as np
 
 from stdatamodels.jwst.datamodels import dqflags, RampModel, GainModel, ReadnoiseModel
 
 from jwst.ramp_fitting.ramp_fit_step import RampFitStep, set_groupdq
-from jwst.tests.helpers import LogWatcher
-
-@pytest.fixture
-def log_watcher(monkeypatch):
-    # Set a log watcher to check for a log message at any level
-    # in RampFitStep
-    watcher = LogWatcher('')
-    logger = logging.getLogger('jwst.ramp_fitting.ramp_fit_step')
-    for level in ['debug', 'info', 'warning', 'error']:
-        monkeypatch.setattr(logger, level, watcher)
-    return watcher
 
 DELIM = "-" * 80
 
@@ -276,7 +264,8 @@ def test_int_times2(generate_miri_reffiles, setup_inputs):
 
     assert len(cube_model.int_times) == nints
 
-def test_set_groups(generate_miri_reffiles, setup_inputs, log_watcher):
+
+def test_set_groups(generate_miri_reffiles, setup_inputs):
     # Test results when using the firstgroup and lastgroup options
     ngroups = 20
     rampmodel, gdq, rnmodel, pixdq, err, gain = setup_inputs(ngroups=ngroups)
@@ -290,15 +279,18 @@ def test_set_groups(generate_miri_reffiles, setup_inputs, log_watcher):
                                          firstgroup=firstgroup, lastgroup=lastgroup)
     np.testing.assert_allclose(slopes.data, firstgroup+lastgroup, rtol=1e-7)
 
+
 @pytest.mark.parametrize("firstgroup, lastgroup, message", GROUP_SELECTION_PARAMETERS)
 def test_set_group_warnings(firstgroup, lastgroup, message, log_watcher):
     # Test user warnings
     ngroups = 20
     groupdqflags = dqflags.group
     groupdq = np.zeros((1, ngroups, 1024, 1024), dtype=np.uint16)
-    log_watcher.message = message
+
+    watcher = log_watcher("jwst.ramp_fitting.ramp_fit_step", message=message)
     set_groupdq(firstgroup, lastgroup, ngroups, groupdq, groupdqflags)
-    log_watcher.assert_seen()
+    watcher.assert_seen()
+
 
 def one_group_suppressed(nints, suppress, setup_inputs):
     """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #9244 

<!-- describe the changes comprising this PR here -->
Add a log_watcher fixture that can be configured with a specific log name, for use in unit tests.  Replace all local `log_watcher` fixtures with calls to the more general implementation

This should cut down on code duplication and make log message testing easier to use.

If this is merged first, #9216 should be updated to use the new fixture.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
