### PR TITLE
JP-3857 update reset step to new code style rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,6 @@ repos:
             jwst/persistence/.* |
             jwst/photom/.* |
             jwst/refpix/.* |
-            jwst/reset/.* |
             jwst/residual_fringe/.* |
             jwst/rscd/.* |
             jwst/saturation/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -38,7 +38,6 @@ exclude = [
     "jwst/persistence/**.py",
     "jwst/photom/**.py",
     "jwst/refpix/**.py",
-    "jwst/reset/**.py",
     "jwst/residual_fringe/**.py",
     "jwst/rscd/**.py",
     "jwst/saturation/**.py",
@@ -134,7 +133,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/persistence/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/photom/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/refpix/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/reset/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/residual_fringe/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/rscd/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/saturation/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/reset/__init__.py
+++ b/jwst/reset/__init__.py
@@ -1,3 +1,5 @@
+"""Correct ramp data for reset correction."""
+
 from .reset_step import ResetStep
 
-__all__ = ['ResetStep']
+__all__ = ["ResetStep"]

--- a/jwst/reset/reset_step.py
+++ b/jwst/reset/reset_step.py
@@ -7,7 +7,7 @@ __all__ = ["ResetStep"]
 
 
 class ResetStep(Step):
-    """Subtracting the reset correction reference data from the MIRI input science data model."""
+    """Subtract the reset correction reference data from the MIRI input science data model."""
 
     class_alias = "reset"
 
@@ -18,7 +18,7 @@ class ResetStep(Step):
 
     def process(self, step_input):
         """
-        Open reset data model and subtracted the reset correction from the MIRI ramp model.
+        Subtract the reset correction from the MIRI ramp model.
 
         Parameters
         ----------
@@ -42,7 +42,7 @@ class ResetStep(Step):
 
             # Get the name of the reset reference file to use
             self.reset_name = self.get_reference_file(input_model, "reset")
-            self.log.info("Using RESET reference file %s", self.reset_name)
+            self.log.info(f"Using RESET reference file {self.reset_name}")
 
             # Check for a valid reference file
             if self.reset_name == "N/A":

--- a/jwst/reset/reset_step.py
+++ b/jwst/reset/reset_step.py
@@ -7,40 +7,48 @@ __all__ = ["ResetStep"]
 
 
 class ResetStep(Step):
-    """
-    ResetStep: Performs a reset  correction by subtracting
-    the reset correction reference data from the input science data model.
-    """
+    """Subtracting the reset correction reference data from the MIRI input science data model."""
 
     class_alias = "reset"
 
     spec = """
-    """ # noqa: E501
+    """  # noqa: E501
 
-    reference_file_types = ['reset']
+    reference_file_types = ["reset"]
 
     def process(self, step_input):
+        """
+        Open reset data model and subtracted the reset correction from the MIRI ramp model.
 
+        Parameters
+        ----------
+        step_input : DataModel
+           Input datamodel to be corrected
+
+        Returns
+        -------
+        reset: DataModel
+           The reset corrected ramp model.
+        """
         # Open the input data model
         with datamodels.open(step_input) as input_model:
-
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector
-            if not detector.startswith('MIR'):
-                self.log.warning('Reset Correction is only for MIRI data')
-                self.log.warning('Reset step will be skipped')
-                input_model.meta.cal_step.reset = 'SKIPPED'
+            if not detector.startswith("MIR"):
+                self.log.warning("Reset Correction is only for MIRI data")
+                self.log.warning("Reset step will be skipped")
+                input_model.meta.cal_step.reset = "SKIPPED"
                 return input_model
 
             # Get the name of the reset reference file to use
-            self.reset_name = self.get_reference_file(input_model, 'reset')
-            self.log.info('Using RESET reference file %s', self.reset_name)
+            self.reset_name = self.get_reference_file(input_model, "reset")
+            self.log.info("Using RESET reference file %s", self.reset_name)
 
             # Check for a valid reference file
-            if self.reset_name == 'N/A':
-                self.log.warning('No RESET reference file found')
-                self.log.warning('Reset step will be skipped')
-                input_model.meta.cal_step.reset = 'SKIPPED'
+            if self.reset_name == "N/A":
+                self.log.warning("No RESET reference file found")
+                self.log.warning("Reset step will be skipped")
+                input_model.meta.cal_step.reset = "SKIPPED"
                 return input_model
 
             # Open the reset ref file data model
@@ -51,7 +59,7 @@ class ResetStep(Step):
 
             # Do the reset correction subtraction
             result = reset_sub.do_correction(result, reset_model)
-            result.meta.cal_step.reset = 'COMPLETE'
+            result.meta.cal_step.reset = "COMPLETE"
 
             # Cleanup
             del reset_model

--- a/jwst/reset/reset_sub.py
+++ b/jwst/reset/reset_sub.py
@@ -10,33 +10,31 @@ log.setLevel(logging.DEBUG)
 
 def do_correction(output_model, reset_model):
     """
-    Short Summary
-    -------------
-    Subtracts reset correction from science arrays, combines
-    error arrays in quadrature, and updates data quality array based on
-    DQ flags in the reset arrays. When applying correction, if integration
-    # of input data > reset_nints, use  correction of reset_nints to
-    correct data. When apply correction, if group # of input data >
-    reset_ngroups, use correction of reset_ngroups (which = 0).
+    Subtract the reset correction from science arrays.
+
+    Subtracts the reset correction from science arrays and updates data quality array based
+    on DQ flags in the reset arrays. The reset data model contains the number of initial
+    frames in an integration to correct in the reset_ngroups parameter and the number
+    integrations a  correction exists for in the reset_nints parameter. Only the
+    first reset_ngroups in each integration will have a reset correction applied. If the
+    number of integrations in the science data is larger than reset_nints, then the reset correction
+    applied is the correction contained  in the reset_nints integration.
 
     Parameters
     ----------
-    output_model: data model object
-        science data to be corrected
+    output_model : `~jwst.datamodel.RampModel`
+        Science data to be corrected
 
-    reset_model: reset model object
-        reset data
-
+    reset_model : `~jwst.datamodel.ResetModel`
+        Reset reference file model
 
     Returns
     -------
-    output_model: data model object
-        reset-subtracted science data
-
+    output_model : `~jwst.datamodel.RampModel`
+        Reset-subtracted science data
     """
-
     # Save some data params for easy use later
-    sci_nints = output_model.meta.exposure.nints      # num ints in input data
+    sci_nints = output_model.meta.exposure.nints  # num ints in input data
     sci_ngroups = output_model.meta.exposure.ngroups  # num groups in input data
     sci_integration_start = output_model.meta.exposure.integration_start
     sci_integration_end = output_model.meta.exposure.integration_end
@@ -48,12 +46,12 @@ def do_correction(output_model, reset_model):
     if sci_integration_end is not None:
         iend = sci_integration_end
 
-    reset_nints = reset_model.meta.exposure.nints      # num of int in ref file
+    reset_nints = reset_model.meta.exposure.nints  # num of int in ref file
     reset_ngroups = reset_model.meta.exposure.ngroups  # num of groups
 
     # Replace NaN's in the reset with zeros(should not happen but just in case)
     reset_model.data[np.isnan(reset_model.data)] = 0.0
-    log.debug("Reset Sub using: nints = {}, ngroups = {}".format(sci_nints, sci_ngroups))
+    log.debug(f"Reset Sub using: nints = {sci_nints}, ngroups = {sci_ngroups}")
 
     # find out how many groups  we are correcting
     # the maximum number of groups to correct is reset_ngroups

--- a/jwst/reset/reset_sub.py
+++ b/jwst/reset/reset_sub.py
@@ -14,8 +14,8 @@ def do_correction(output_model, reset_model):
 
     Subtracts the reset correction from science arrays and updates data quality array based
     on DQ flags in the reset arrays. The reset data model contains the number of initial
-    frames in an integration to correct in the reset_ngroups parameter and the number
-    integrations a  correction exists for in the reset_nints parameter. Only the
+    frames in an integration to correct in the reset_ngroups parameter and the number of
+    integrations for which a correction exists in the reset_nints parameter. Only the
     first reset_ngroups in each integration will have a reset correction applied. If the
     number of integrations in the science data is larger than reset_nints, then the reset correction
     applied is the correction contained  in the reset_nints integration.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves part of  [JP-3857](https://jira.stsci.edu/browse/JP-3857)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses applies the new code style rules to the reset step. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions]
  - [ ] https://github.com/spacetelescope/RegressionTests/actions/runs/13795475527
  (https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
