### PR TITLE
JP-3857 rscd code style updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,6 @@ repos:
             jwst/mrs_imatch/.* |
             jwst/persistence/.* |
             jwst/photom/.* |
-            jwst/rscd/.* |
             jwst/saturation/.* |
             jwst/scripts/.* |
             jwst/spectral_leak/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -33,7 +33,6 @@ exclude = [
     "jwst/mrs_imatch/**.py",
     "jwst/persistence/**.py",
     "jwst/photom/**.py",
-    "jwst/rscd/**.py",
     "jwst/saturation/**.py",
     "jwst/scripts/**.py",
     "jwst/spectral_leak/**.py",
@@ -121,7 +120,6 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/mrs_imatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/persistence/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/photom/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/rscd/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/saturation/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/scripts/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/spectral_leak/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/docs/jwst/references_general/rscd_reffile.inc
+++ b/docs/jwst/references_general/rscd_reffile.inc
@@ -7,7 +7,7 @@ RSCD Reference File
 :Data model: `~jwst.datamodels.RSCDModel`
 
 The RSCD reference file contains the number of groups to flag as 'DO_NOT_USE' based on
-readout mode and subarray size. Integrations two and higher are flagged, the first integration
+readout mode and subarray size. Integrations two and higher are flagged; the first integration
 groups values are not flagged. 
 
 .. include:: ../references_general/rscd_selection.inc
@@ -29,8 +29,8 @@ DETECTOR   model.meta.instrument.detector
 
 Reference File Format
 +++++++++++++++++++++
-RSCD reference files are FITS format. The number of groups to set to 'DO_NOT_USE'
-is contained  the first BINTABLE extension.
+RSCD reference files are in  FITS format. The number of groups to set to 'DO_NOT_USE'
+is contained in the first BINTABLE extension.
 The FITS primary HDU does not contain a data array.
 The BINTABLE extension uses the identifier EXTNAME = "RSCD_GROUP_SKIP" and
 the characteristics of the table columns are as follows:
@@ -44,7 +44,7 @@ group_skip   int         number of initial groups in an integration to flag
 ===========  ==========  ==================================================
 
 The entries in the first two columns of the table are used as selection criteria, matching
-the exposure properties of the data. The last  column contains the
+the exposure properties of the data. The last column contains the
 number of initial groups in an integration to flag as 'DO_NOT_USE' for integrations 2 and higher.
 These initial groups are affected by the RSCD effect.  The groups in the first integration are not flagged. 
 

--- a/docs/jwst/references_general/rscd_reffile.inc
+++ b/docs/jwst/references_general/rscd_reffile.inc
@@ -29,7 +29,7 @@ DETECTOR   model.meta.instrument.detector
 
 Reference File Format
 +++++++++++++++++++++
-RSCD reference files are in  FITS format. The number of groups to set to 'DO_NOT_USE'
+RSCD reference files are in FITS format. The number of groups to set to 'DO_NOT_USE'
 is contained in the first BINTABLE extension.
 The FITS primary HDU does not contain a data array.
 The BINTABLE extension uses the identifier EXTNAME = "RSCD_GROUP_SKIP" and

--- a/docs/jwst/references_general/rscd_reffile.inc
+++ b/docs/jwst/references_general/rscd_reffile.inc
@@ -6,8 +6,9 @@ RSCD Reference File
 :REFTYPE: RSCD
 :Data model: `~jwst.datamodels.RSCDModel`
 
-The RSCD reference file contains the number of groups to set to 'DO_NOT_USE' based on
-readout mode and subarray size. 
+The RSCD reference file contains the number of groups to flag as 'DO_NOT_USE' based on
+readout mode and subarray size. Integrations two and higher are flagged, the first integration
+groups values are not flagged. 
 
 .. include:: ../references_general/rscd_selection.inc
 

--- a/docs/jwst/references_general/rscd_reffile.inc
+++ b/docs/jwst/references_general/rscd_reffile.inc
@@ -6,8 +6,8 @@ RSCD Reference File
 :REFTYPE: RSCD
 :Data model: `~jwst.datamodels.RSCDModel`
 
-The RSCD reference file contains coefficients used to compute the
-correction.
+The RSCD reference file contains the number of groups to set to 'DO_NOT_USE' based on
+readout mode and subarray size. 
 
 .. include:: ../references_general/rscd_selection.inc
 
@@ -28,79 +28,22 @@ DETECTOR   model.meta.instrument.detector
 
 Reference File Format
 +++++++++++++++++++++
-RSCD reference files are FITS format, with 1 BINTABLE extension.
+RSCD reference files are FITS format. The number of groups to set to 'DO_NOT_USE'
+is contained  the first BINTABLE extension.
 The FITS primary HDU does not contain a data array.
-The BINTABLE extension uses the identifier EXTNAME = "RSCD" and
+The BINTABLE extension uses the identifier EXTNAME = "RSCD_GROUP_SKIP" and
 the characteristics of the table columns are as follows:
 
-===========  ==========  =============================================
+===========  ==========  ==================================================
 Column name  Data type   Notes
-===========  ==========  =============================================
+===========  ==========  ==================================================
 subarray     char\*13    FULL or subarray name
-readpatt     char\*4     SLOW or FAST
-rows         char\*4     EVEN or ODD
-tau          float32     e-folding time scale, in units of frames
-ascale       float32     :math:`b{1}` in equation 2
-pow          float32     :math:`b{2}` in equation 2
-illum_zp     float32     :math:`illum_{zpt}` in equation 2.1
-illum_slope  float32     :math:`illum_{slope}` in equation 2.1
-illum2       float32     :math:`illum2` in equation 2.1
-param3       float32     :math:`b{3}` in equation 2
-crossopt     float32     :math:`Crossover Point` in equation 2.2
-sat_zp       float32     :math:`sat_\text{zp}` in equation 3.1
-sat_slope    float32     :math:`sat_\text{slope}` in equation 3.1
-sat_2        float32     :math:`sat_2` in equation 3.1
-sat_mzp      float32     :math:`sat_\text{mzp}` in equation 3
-sat_rowterm  float32     :math:`evenrow_{corrections}` in equation 3.1
-sat_scale    float32     :math:`scale_\text{sat}` in equation 3
-===========  ==========  =============================================
+readpatt     char\*8     SLOWR1, FASTR1, SLOW, or FAST
+group_skip   int         number of initial groups in an integration to flag
+===========  ==========  ==================================================
 
-The entries in the first 3 columns of the table are used as row selection criteria, matching
-the exposure properties and row type of the data. The remaining 14 columns contain the
-parameter values for the double-exponential correction function.
+The entries in the first two columns of the table are used as selection criteria, matching
+the exposure properties of the data. The last  column contains the
+number of initial groups in an integration to flag as 'DO_NOT_USE' for integrations 2 and higher.
+These initial groups are affected by the RSCD effect.  The groups in the first integration are not flagged. 
 
-The general form of  the correction to be added to the input data is::
-
-   corrected data = input data + dn_accumulated * scale * exp(-T / tau)  (Equation 1)
-
-where:
-
- - T is the time since the last group in the previous integration
- - tau is the exponential time constant found in the RSCD table
- - dn_accumulated is the DN level that was accumulated for the pixel from the previous integration.
-
-In cases where the last integration does not saturate, the :math:`scale` term in equation 1
-is determined according to:
-
-  :math:`scale = b{1}* [Counts{2}^{b{2}} * [1/exp(Counts{2}/b{3}) -1 ]\; \; (Equation \; 2)`
-
-The following two additional equations are used in Equation 2:
-
-  :math:`b{1} = ascale * (illum_{zpt} + illum_{slope}*N + illum2* N^2) \; \; (Equation \; 2.1)`
-
-  :math:`Counts{2} = Final \, DN \, in \, the \,  last \, group \, in \; the \, previous \, integration \, - Crossover \, Point \; \; (Equation \; 2.2)`
-      
-where:
-
- - N in equation 2.1 is the number of groups per integration
- - Crossover Point in equation 2.2 is column CROSSOPT in the RSCD table.
-
-If the previous integration saturates, :math:`scale` is no longer calculated using equations
-2 - 2.2. Instead it is calculated using equations 3 and 3.1:
-
-   :math:`scale_\text{sat} = slope * Counts{3} + sat_\text{mzp} \; \; (Equation \; 3)`
- 
-   :math:`slope = sat_{zp} + sat_{slope} * N + sat_2*N^2 + evenrow_{corrections} \; \; (Equation \; 3.1)`
-
-where:
-
-    - :math:`Counts{3}` is an estimate of what the last group in the
-      previous integration would have been if saturation did not exist
-    - :math:`scale_\text{sat}` is sat_scale in the RSCD table
-    - :math:`sat_\text{mzp}` is sat_mzp in the RSCD table
-    - :math:`sat_\text{zp}` is sat_zp in the RSCD table
-    - :math:`sat_\text{slope}` is sat_slope in the RSCD table
-    - :math:`sat_2` is sat2 in the RSCD table
-    - :math:`evenrow_{corrections}` is sat_rowterm in the RSCD table
-    - N is the number of groups per integration
- 

--- a/docs/jwst/rscd/description.rst
+++ b/docs/jwst/rscd/description.rst
@@ -20,7 +20,7 @@ There are a number of non-ideal detector and readout effects that produce reset 
 nonlinearities at the start of an integration, non-linear ramps with increasing signal,
 latent images, and drifts in the slopes.
 
-THE MIRI readout electronics use field effect transistors (FETs) in their opertation,
+The MIRI readout electronics use field effect transistors (FETs) in their operation,
 which have been shown to be the source of the ramp offsets, the nonlinearities at the start
 of an integration, and the overall changes in the slopes. The FET acts as a switch to allow
 charge to build up and to also initialize (clear) the charge.

--- a/docs/jwst/rscd/description.rst
+++ b/docs/jwst/rscd/description.rst
@@ -20,9 +20,9 @@ There are a number of non-ideal detector and readout effects that produce reset 
 nonlinearities at the start of an integration, non-linear ramps with increasing signal,
 latent images, and drifts in the slopes.
 
-THE MIRI readout electronics use field effect transisitors (FETs) in their opertation,
-which have been shown to be the source of the ramp offsets, nonlinearities at the start
-of an integration, and overall changes in the slopes. The FET acts as a switch to allow
+THE MIRI readout electronics use field effect transistors (FETs) in their opertation,
+which have been shown to be the source of the ramp offsets, the nonlinearities at the start
+of an integration, and the overall changes in the slopes. The FET acts as a switch to allow
 charge to build up and to also initialize (clear) the charge.
 However, the reset FETs do not instantaneously reset the level. Instead, the exponential
 adjustment of the FET after a reset causes the initial frames in an integration to be offset

--- a/docs/jwst/rscd/description.rst
+++ b/docs/jwst/rscd/description.rst
@@ -20,17 +20,17 @@ There are a number of non-ideal detector and readout effects that produce reset 
 nonlinearities at the start of an integration, non-linear ramps with increasing signal,
 latent images, and drifts in the slopes.
 
-The manner in which the MIRI readout electronics operate have been shown to be the source of
-the ramp offsets, nonlinearities at the start of the integration, and overall changes in slopes.
-Basically the MIRI reset electronics use field effect transistors (FETs) in their operation.
-The FET acts as a switch to allow charge to build up and to also initialize (clear) the charge.
-However, the reset FETS do not instantaneously reset the level, instead the exponential
-adjustment of the  FET after a reset causes the initial frames in an integration to be offset
-from their expected values. Between exposures the MIRI detectors are continually reset;
-however for a multiple integration exposure there is a single reset between integrations.
-The effects of this decay are not measurable in the first integration  because a number
+THE MIRI readout electronics use field effect transisitors (FETs) in their opertation,
+which have been show to be the source of the ramp offsets, nonlinearities at the start
+of an integration, and overall changes in the slopes. The FET acts as a switch to allow
+charge to build up and to also initialize (clear) the charge.
+However, the reset FETs do not instantaneously reset the level. Instead, the exponential
+adjustment of the FET after a reset causes the initial frames in an integration to be offset
+from their expected values. Between exposures, the MIRI detectors are continually reset;
+however, for a multiple integration exposure there is a single reset between integrations.
+The effects of this decay are not measurable in the first integration because a number
 of resets have occurred from the last exposure and the effect has decayed away by the time
-it takes to read out the last exposure, set up the next exposure and begin exposing.
+it takes to read out the last exposure, set up the next exposure, and begin exposing.
 There are low level reset effects in the first integration that are related to the strength of the dark
 current and can be removed with an integration-dependent dark.
 

--- a/docs/jwst/rscd/description.rst
+++ b/docs/jwst/rscd/description.rst
@@ -20,17 +20,18 @@ There are a number of non-ideal detector and readout effects that produce reset 
 nonlinearities at the start of an integration, non-linear ramps with increasing signal,
 latent images, and drifts in the slopes.
 
-The manner in which the MIRI readout electronics operate have been
-shown to be the source of the ramp offsets, nonlinearities at the start of the integration, and overall changes in slopes.
-Basically the MIRI reset electronics use field effect transistors (FETs) in their operation.  The FET acts as a switch
-to allow charge to build up and to also initialize (clear) the charge. However, the reset FETS do not instantaneously
-reset the level, instead the exponential adjustment of the  FET after a reset causes the initial frames in an integration
-to be offset from their expected values. Between exposures the MIRI detectors
-are continually reset; however for a multiple integration exposure there is a single reset between integrations.
-The effects of this decay are
-not measurable in the first integration  because a number of resets have occurred from the last exposure and
-the effect has decayed away by the time it takes to read out the last exposure, set up the next exposure and begin
-exposing. There are low level reset effects in the first integration that are related to the strength of the dark
+The manner in which the MIRI readout electronics operate have been shown to be the source of
+the ramp offsets, nonlinearities at the start of the integration, and overall changes in slopes.
+Basically the MIRI reset electronics use field effect transistors (FETs) in their operation.
+The FET acts as a switch to allow charge to build up and to also initialize (clear) the charge.
+However, the reset FETS do not instantaneously reset the level, instead the exponential
+adjustment of the  FET after a reset causes the initial frames in an integration to be offset
+from their expected values. Between exposures the MIRI detectors are continually reset;
+however for a multiple integration exposure there is a single reset between integrations.
+The effects of this decay are not measurable in the first integration  because a number
+of resets have occurred from the last exposure and the effect has decayed away by the time
+it takes to read out the last exposure, set up the next exposure and begin exposing.
+There are low level reset effects in the first integration that are related to the strength of the dark
 current and can be removed with an integration-dependent dark.
 
 The Reset Switch Charge Decay (RSCD) step corrects for these effects by simply
@@ -53,62 +54,3 @@ groups to work with in later steps.
 
 Only the GROUPDQ array is modified. The SCI, ERR, and PIXELDQ arrays are unchanged.
 
-..
-    This text refers to an earlier version of the enhanced RSCD correction.
-    It needs updating to the latest version of this correction once that has been
-    decided and the code updated.
-
-    The step applies an exponential decay correction based on coefficients in the "RSCD"
-    reference file. The reference files are selected based on readout pattern
-    (READPATT=FAST or SLOW) and subarray type (FULL or one of the MIRI defined subarray types).
-    The reference file contains the information necessary to derive the scale factor and decay time
-    to correct for the reset effects. The correction differs for even and odd row numbers.
-
-    The correction to be added to the input data has the form::
-
-        corrected data = input data data + dn_accumulated * scale * exp(-T / tau)  (Equation 1)
-
-    where T is the time since the last group in the previous integration, tau is the exponential time constant and
-    dn_accumulated is the DN level that was accumulated for the pixel from the previous integration.
-    Because of the last frame effect the value of the last group in an integration is not measured accurately. Therefore,
-    the accumulated DN of the pixel from the previous integration (last group value)  is estimated by extrapolating
-    the ramp using the second to last  and third to last groups.
-
-    In the case where the previous integration does not saturate the :math:`scale` term in Equation 1  is determined as follows:
-
-     :math:`scale = b{1}* [Counts{2}^{b{2}} * [1/exp(Counts{2}/b{3}) -1] \; \; Equation \;  2`
-
-    The terms :math:`b{2}` and :math:`b{3}` are read in from the RSCD reference file.
-    The following two additional equations are needed to calculate the :math:`b{1}` and :math:`Counts{2}` terms:
-
-    	  :math:`b{1} = ascale * (illum_{zpt} + illum_{slope}*N + illum2* N^2) \; \; (Equation \; 2.1)`
-    	  :math:`Counts{2} = Final \, DN \, in \, the \,  last \, group \, in \; the \, last \, integration
-    	  \, - Crossover \, Point \; \; (Equation \; 2.2)`
-
-
-    In equation 2.1, N is the number of groups per integration and :math:`ascale`, :math:`illum_{zpt}`,
-    :math:`illum_{slope}`, and :math:`illum2` are read in from the RSCD reference file. The :math:`Crossover \, Point`
-    in equation 2.2 is also read in from the RSCD reference file.
-
-    If the previous integration saturates, the  :math:`scale` term in Equation 1 is found in the  following manner:
-
-       :math:`scale_\text{sat} = slope * Counts{3} + sat_\text{mzp} \; \; (Equation \; 3)`
-
-    where :math:`Counts{3}` is an  estimate of what the last group in the previous integration would have been if
-    saturation did not exist. The :math:`slope` in equation 3  is calculated according to the formula:
-
-       :math:`slope = sat_{zp} + sat_{slope} * N + sat_2*N^2 + evenrow_{corrections} \; \; (Equation 3.1)`.
-
-    The terms :math:`sat_\text{mzp}`, :math:`sat_{zp}`, :math:`sat_2`, :math:`evenrow_{corrections}`
-    are read in from the RSCD reference file.
-
-    All fourteen  parameters :math:`tau`, :math:`b{1}`, :math:`b{2}`, :math:`b{3}`, :math:`illum_{zpt}`,
-    :math:`illum_{slope}`, :math:`illum2`, :math:`Crossover Point`, :math:`sat_{zp}`, :math:`sat_{slope}`, :math:`sat_2`,
-    :math:`sat_{scale}`, :math:`sat_\text{mzp}`, and :math:`evenrow_{corrections}` are found in the RSCD reference files.
-    There is a separate set for even and odd rows for each readout (READPATT) mode and subarray type.
-
-    Subarrays
-    ----------
-
-    Currently the RSCD correction for subarray data is the same as it is for full array data. However,
-    we anticipate a separate set of correction coefficients in the future.

--- a/docs/jwst/rscd/description.rst
+++ b/docs/jwst/rscd/description.rst
@@ -21,7 +21,7 @@ nonlinearities at the start of an integration, non-linear ramps with increasing 
 latent images, and drifts in the slopes.
 
 THE MIRI readout electronics use field effect transisitors (FETs) in their opertation,
-which have been show to be the source of the ramp offsets, nonlinearities at the start
+which have been shown to be the source of the ramp offsets, nonlinearities at the start
 of an integration, and overall changes in the slopes. The FET acts as a switch to allow
 charge to build up and to also initialize (clear) the charge.
 However, the reset FETs do not instantaneously reset the level. Instead, the exponential

--- a/jwst/rscd/__init__.py
+++ b/jwst/rscd/__init__.py
@@ -1,4 +1,4 @@
-"""Set the groupdq flag for the initial groups of MIRI ramp data do not use in integrations 2 and higher."""
+"""Flag initial groups of MIRI ramp data to 'DO_NOT_USE' in integrations 2 and higher."""
 
 from .rscd_step import RscdStep
 

--- a/jwst/rscd/__init__.py
+++ b/jwst/rscd/__init__.py
@@ -1,3 +1,5 @@
+"""Set the groupdq flag for the initial groups of MIRI ramp data do not use in integrations 2 and higher."""
+
 from .rscd_step import RscdStep
 
-__all__ = ['RscdStep']
+__all__ = ["RscdStep"]

--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -11,9 +11,12 @@ class RscdStep(Step):
     Flags the first N groups of MIRI data to 'DO_NOT_USE' in the 2nd and later integrations.
 
     Input data is expected to be a ramp file (RampModel). The number of groups, N,  to
-    set to 'DO_NOT_USE' is read in from the RSCD reference file. The RSCD reference file
-    contains the number of groups to set to DO_NOT_USE based on readout mode and
-    subarray size.
+    set the GROUPDQ flag to 'DO_NOT_USE' is read in from the RSCD reference file. The RSCD
+    reference file contains the number of groups to set to 'DO_NOT_USE' based on readout mode and
+    subarray size. The step checks that the total number of groups in an integration is
+    greater than N+3 before flagging the GROUPDQ array. If the number of groups is less than
+    N+3 then no flagging is performed, because doing so would leave too few groups to work
+    with in later steps.
     """
 
     class_alias = "rscd"

--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -8,25 +8,20 @@ __all__ = ["RscdStep"]
 
 class RscdStep(Step):
     """
-    Flags the first N groups of MIRI data to 'DO_NOT_USE' in the 2nd and later integrations.
+    Flag the first N groups of MIRI data to 'DO_NOT_USE' in the 2nd and later integrations.
 
-    Input data is expected to be a ramp file (RampModel). The number of groups, N,  to
-    set the GROUPDQ flag to 'DO_NOT_USE' is read in from the RSCD reference file. The RSCD
-    reference file contains the number of groups to set to 'DO_NOT_USE' based on readout mode and
-    subarray size. The step checks that the total number of groups in an integration is
-    greater than N+3 before flagging the GROUPDQ array. If the number of groups is less than
-    N+3 then no flagging is performed, because doing so would leave too few groups to work
-    with in later steps.
+    The number of groups, N, for which to
+    set the GROUPDQ flag to 'DO_NOT_USE' is read in from the RSCD reference file. This number
+    depends on the readout model and subarray size. The step checks that the total number of groups
+    in an integration is greater than N+3 before flagging the GROUPDQ array. If the number of groups
+    is less than N+3 then no flagging is performed, because doing so would leave too few groups
+    to work with in later steps.
     """
 
     class_alias = "rscd"
 
-    # allow switching between baseline and enhanced algorithms
     spec = """
         """  # noqa: E501
-
-    #  only do this for the 2nd+ integrations
-    #  do nothing for single integration exposures
 
     reference_file_types = ["rscd"]
 
@@ -39,12 +34,12 @@ class RscdStep(Step):
 
         Parameters
         ----------
-        step_input : Ramp DataModel
-            Ramp datamodel to be corrected
+        step_input : RampModel
+            Ramp datamodel to be corrected, or the path to the ramp file.
 
         Returns
         -------
-        result : Ramp DataModel
+        result : RampModel
             Ramp datamodel with initial groups in an integration flagged as DO_NOT_USE.
             Flags are only set of integration 2 and higher.
         """

--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -8,19 +8,18 @@ __all__ = ["RscdStep"]
 
 class RscdStep(Step):
     """
-    Flags the first N groups of MIRI data as 'DO_NOT_USE' in the 2nd and later integrations.
+    Flags the first N groups of MIRI data to 'DO_NOT_USE' in the 2nd and later integrations.
 
-    Input data is expected to be a ramp file (RampModel). The number of groups to 
+    Input data is expected to be a ramp file (RampModel). The number of groups, N,  to
     set to 'DO_NOT_USE' is read in from the RSCD reference file. The RSCD reference file
-    contains the number of groups to set to DO_NOT_USE based on readout mode and 
-    subarray size. 
+    contains the number of groups to set to DO_NOT_USE based on readout mode and
+    subarray size.
     """
 
     class_alias = "rscd"
 
     # allow switching between baseline and enhanced algorithms
     spec = """
-        type = option('baseline','enhanced',default = 'baseline') # Type of correction
         """  # noqa: E501
 
     #  only do this for the 2nd+ integrations
@@ -29,7 +28,23 @@ class RscdStep(Step):
     reference_file_types = ["rscd"]
 
     def process(self, step_input):
-        """ Sets the dqgroup of the first N groups as 'DO_NOT_USE' in the 2nd and later integrations."""
+        """
+        Flag the initial groups to 'DO_NOT_USE' in the 2nd and later integrations.
+
+        The number of initial groups to flag is read in from the RSCD reference file. This number
+        varies based on readout mode and subarray size.
+
+        Parameters
+        ----------
+        step_input : Ramp DataModel
+            Ramp datamodel to be corrected
+
+        Returns
+        -------
+        result : Ramp DataModel
+            Ramp datamodel with initial groups in an integration flagged as DO_NOT_USE.
+            Flags are only set of integration 2 and higher.
+        """
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
             # check the data is MIRI data
@@ -58,7 +73,7 @@ class RscdStep(Step):
             result = input_model.copy()
 
             # Do the rscd correction
-            result = rscd_sub.do_correction(result, rscd_model, self.type)
+            result = rscd_sub.do_correction(result, rscd_model)
 
             # Cleanup
             del rscd_model

--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -8,11 +8,12 @@ __all__ = ["RscdStep"]
 
 class RscdStep(Step):
     """
-    RscdStep: Performs an RSCD correction to MIRI data.
-    Baseline version flags the first N groups as 'DO_NOT_USE' in
-    the 2nd and later integrations in a copy of the input
-    science data model.
-    Enhanced version is not ready nor enabled.
+    Flags the first N groups of MIRI data as 'DO_NOT_USE' in the 2nd and later integrations.
+
+    Input data is expected to be a ramp file (RampModel). The number of groups to 
+    set to 'DO_NOT_USE' is read in from the RSCD reference file. The RSCD reference file
+    contains the number of groups to set to DO_NOT_USE based on readout mode and 
+    subarray size. 
     """
 
     class_alias = "rscd"
@@ -20,35 +21,34 @@ class RscdStep(Step):
     # allow switching between baseline and enhanced algorithms
     spec = """
         type = option('baseline','enhanced',default = 'baseline') # Type of correction
-        """ # noqa: E501
+        """  # noqa: E501
 
-    #  TBD - only do this for the 2nd+ integrations
+    #  only do this for the 2nd+ integrations
     #  do nothing for single integration exposures
 
-    reference_file_types = ['rscd']
+    reference_file_types = ["rscd"]
 
     def process(self, step_input):
-
+        """ Sets the dqgroup of the first N groups as 'DO_NOT_USE' in the 2nd and later integrations."""
         # Open the input data model
         with datamodels.RampModel(step_input) as input_model:
-
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector
-            if not detector.startswith('MIR'):
-                self.log.warning('RSCD correction is only for MIRI data')
-                self.log.warning('RSCD step will be skipped')
-                input_model.meta.cal_step.rscd = 'SKIPPED'
+            if not detector.startswith("MIR"):
+                self.log.warning("RSCD correction is only for MIRI data")
+                self.log.warning("RSCD step will be skipped")
+                input_model.meta.cal_step.rscd = "SKIPPED"
                 return input_model
 
             # Get the name of the rscd reference file to use
-            self.rscd_name = self.get_reference_file(input_model, 'rscd')
-            self.log.info('Using RSCD reference file %s', self.rscd_name)
+            self.rscd_name = self.get_reference_file(input_model, "rscd")
+            self.log.info("Using RSCD reference file %s", self.rscd_name)
 
             # Check for a valid reference file
-            if self.rscd_name == 'N/A':
-                self.log.warning('No RSCD reference file found')
-                self.log.warning('RSCD step will be skipped')
-                input_model.meta.cal_step.rscd = 'SKIPPED'
+            if self.rscd_name == "N/A":
+                self.log.warning("No RSCD reference file found")
+                self.log.warning("RSCD step will be skipped")
+                input_model.meta.cal_step.rscd = "SKIPPED"
                 return input_model
 
             # Load the rscd ref file data model

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -55,7 +55,7 @@ def correction_skip_groups(output, group_skip):
     output : RampModel
         Science data to be flagged
 
-    group_skip : Int
+    group_skip : int
         Number of groups to skip at the beginning of the ramp
 
     Returns

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -11,33 +11,25 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def do_correction(output_model, rscd_model, type):
+def do_correction(output_model, rscd_model):
     """
-    Sets the initial groups in MIRI data to DO_NOT_USE for integration 2 and higher. 
+    Set the initial groups of MIRI data to 'DO_NOT_USE' for integrations 2 and higher.
 
-    The baseline correction sets the initial groups to DO_NOT_USE. An enhanced correction
-    is a test algorithm and should only be used by 
-    -------------
-    if type = baseline the correction sets initial groups in the integration
-    to skip
-    if type = enhanced the correction corrects the groups using a decay function
+    The number of initial groups to set to 'DO_NOT_USE' is read in from the RSCD reference
+    file. No flagging is done for the first integration.
 
     Parameters
     ----------
-    output_model: ~jwst.datamodels.RampModel
-        science data to be corrected
+    output_model : Ramp datamodel
+        Input ramp datamodel
 
-    rscd_model: ~jwst.datamodels.RSCDModel
-        rscd reference data
-
-    type: string
-        type of algorithm ['baseline' or 'enhanced']
+    rscd_model : RSCD datamodel
+        RSCD reference datamodel
 
     Returns
     -------
-    output_model: ~jwst.datamodels.RampModel
-        RSCD-corrected science data
-
+    output_model : Ramp datamodel
+        Ramp datamodel with RSCD affected groups flagged as DO_NOT_USE
     """
     # Retrieve the reference parameters for this exposure type
     param = get_rscd_parameters(output_model, rscd_model)
@@ -49,39 +41,27 @@ def do_correction(output_model, rscd_model, type):
         output_model.meta.cal_step.rscd = "SKIPPED"
         return output_model
 
-    if type == "baseline":
-        group_skip = param["skip"]
-        output_model = correction_skip_groups(output_model, group_skip)
-    else:
-        # enhanced algorithm is not enabled yet (updated code and validation needed)
-        log.warning("Enhanced algorithm not support yet: RSCD correction will be skipped")
-        output_model.meta.cal_step.rscd = "SKIPPED"
-        return output_model
-        # decay function algorithm update needed
-        # output_model = correction_decay_function(input_model, param)
-
+    group_skip = param["skip"]
+    output_model = correction_skip_groups(output_model, group_skip)
     return output_model
 
 
 def correction_skip_groups(output, group_skip):
     """
-    Short Summary
-    -------------
-    Set the initial groups in integration to DO_NOT_USE to skip groups
-    affected by RSCD effect
+    Set the initial groups in integration to DO_NOT_USE to skip groups affected by RSCD effect.
 
     Parameters
     ----------
-    output: ~jwst.datamodels.RampModel
-        science data to be corrected
+    output : Ramp datamodel
+        Science data to be flagged
 
-    group_skip: int
-        number of groups to skip at the beginning of the ramp
+    group_skip : Int
+        Number of groups to skip at the beginning of the ramp
 
     Returns
     -------
-    output_model: ~jwst.datamodels.RampModel
-        RSCD-corrected science data
+    output_model: Ramp datamodel
+        Ramp datamodel with RSCD affected groups flagged as DO_NOT_USE
     """
     # General exposure parameters
     sci_ngroups = output.meta.exposure.ngroups
@@ -93,9 +73,9 @@ def correction_skip_groups(output, group_skip):
     if sci_int_start is None:
         sci_int_start = 1
 
-    log.debug("RSCD correction using: nints=%d, ngroups=%d" % (sci_nints, sci_ngroups))
-    log.debug("The first integration in the data is integration: %d" % (sci_int_start))
-    log.info("Number of groups to skip for integrations 2 and higher: %d " % group_skip)
+    log.debug(f"RSCD correction using: nints={sci_nints}, ngroups={sci_ngroups}")
+    log.debug(f"The first integration in the data is integration: {sci_int_start}")
+    log.info(f"Number of groups to skip for integrations 2 and higher: {group_skip}")
 
     # If ngroups <= group_skip+3, skip the flagging
     # the +3 is to ensure there is a slope to be fit including the flagging for
@@ -107,11 +87,11 @@ def correction_skip_groups(output, group_skip):
         return output
 
     # The RSCD correction is applied to integrations 2 and higher.
-    # For segmented data the first integration in the file may not be the first integration in the
-    # exposure. The value in meta.exposure.integration_start holds the value of the first integration
-    # in the file.
-    # If a correction is to be done and if  ngroups > group_skip+3, then  set all of the GROUPDQ
-    # in 0: group_skip to 'DO_NOT_USE'
+    # For segmented data the first integration in the file may not be the first
+    # integration in the exposure. The value in meta.exposure.integration_start
+    # holds the value of the first integration in the file.
+    # If a correction is to be done and if ngroups > group_skip+3, then set all
+    # of the GROUPDQ flags from groups 0 to group_skip to 'DO_NOT_USE'.
 
     int_start = 1
     if sci_int_start != 1:  # we have segmented data
@@ -126,190 +106,22 @@ def correction_skip_groups(output, group_skip):
     return output
 
 
-def correction_decay_function(output, param):
-    """
-    Short Summary
-    -------------
-    Applies rscd correction to science arrays
-    The last frame value from the previous integration is calculated two ways:
-    1. using second and third to last frames to extrapolated to the last frame
-    2. using the non saturating data, fit the data and extrapolate to last frame
-    Because of the uncertainty of how well effects in th early part of the
-    integration are corrected in the previous integration (reset anomaly, rscd
-    effects, persistence) the lastframe determined from the second and third to
-    last frames is considered a better estimate than that derived from a fit to
-    the ramp.
-    The last frame derived from fitting the non-saturating data is used in the
-    correction if the previous integration saturated. This fit is extrapolated
-    past saturation to estimate what the total number of electrons would have
-    been.
-
-    This correction has different correction parameters depending on whether
-    the pixel is from an even row or odd row. The first row is define as an odd
-    row. This even/odd row effect is likely a result of the reset electronics
-    (MIRI resets in row pairs).
-
-    Parameters
-    ----------
-    output: ~jwst.datamodels.RampModel
-        science data to be corrected
-
-    param: dict
-        parameters of correction
-
-    Returns
-    -------
-    output_model: ~jwst.datamodels.RampModel
-        RSCD-corrected science data
-
-    """
-    # Save some data params for easy use later
-    sci_nints = output.data.shape[0]  # number of integrations
-    sci_ngroups = output.data.shape[1]  # number of groups
-
-    log.debug("RSCD correction using: nints=%d, ngroups=%d" % (sci_nints, sci_ngroups))
-
-    # Check for valid parameters
-    if sci_ngroups < 2:
-        log.warning("RSCD correction requires > 1 group per integration")
-        log.warning("Step will be skipped")
-        output.meta.cal_step.rscd = "SKIPPED"
-        return output
-
-    if param is None:
-        log.warning("RSCD correction will be skipped")
-        output.meta.cal_step.rscd = "SKIPPED"
-        return output
-
-    # Determine the parameters that rely only on ngroups
-    ngroups2 = sci_ngroups * sci_ngroups
-    b1_even = param["even"]["ascale"] * (
-        param["even"]["illum_zp"]
-        + param["even"]["illum_slope"] * sci_ngroups
-        + param["even"]["illum2"] * ngroups2
-    )
-
-    b1_odd = param["odd"]["ascale"] * (
-        param["odd"]["illum_zp"]
-        + param["odd"]["illum_slope"] * sci_ngroups
-        + param["odd"]["illum2"] * ngroups2
-    )
-
-    sat_final_slope_even = (
-        param["even"]["sat_zp"]
-        + param["even"]["sat_slope"] * sci_ngroups
-        + param["even"]["sat2"] * ngroups2
-        + param["even"]["sat_rowterm"]
-    )
-
-    sat_final_slope_odd = (
-        param["odd"]["sat_zp"]
-        + param["odd"]["sat_slope"] * sci_ngroups
-        + param["odd"]["sat2"] * ngroups2
-        + param["odd"]["sat_rowterm"]
-    )
-
-    b2_even = param["even"]["pow"].item()
-    b2_odd = param["odd"]["pow"].item()
-    b3_even = param["even"]["param3"].item()
-    b3_odd = param["odd"]["param3"].item()
-    crossopt_even = param["even"]["crossopt"].item()
-    crossopt_odd = param["odd"]["crossopt"].item()
-    sat_mzp_even = param["even"]["sat_mzp"].item()
-    sat_mzp_odd = param["odd"]["sat_mzp"].item()
-    sat_scale_even = param["even"]["sat_scale"].item()
-    sat_scale_odd = param["odd"]["sat_scale"].item()
-    tau_even = param["even"]["tau"].item()
-    tau_odd = param["odd"]["tau"].item()
-
-    # loop over all integrations except the first
-    mdelta = int(sci_nints / 10) + 1
-    for i in range(1, sci_nints):
-        if ((i + 1) % mdelta) == 0:
-            log.info(" Working on integration %d", i + 1)
-
-        sat, dn_last23, dn_lastfit = get_DNaccumulated_last_int(output, i, sci_ngroups)
-
-        lastframe_even = dn_last23[1::2, :]
-        lastframe_odd = dn_last23[0::2, :]
-
-        factor2_even = lastframe_even.copy() * 0.0
-        factor2_odd = lastframe_odd.copy() * 0.0
-        # these will be created in the loop: correction_even, correction_odd,
-        # a1_even, and a1_odd
-
-        counts2_even = lastframe_even - crossopt_even
-        counts2_odd = lastframe_odd - crossopt_odd
-
-        counts2_even[np.where(counts2_even < 0)] = 0.0
-        counts2_odd[np.where(counts2_odd < 0)] = 0.0
-
-        # Find where counts2 > 0 and is finite
-        good_even = np.where((counts2_even > 0) & np.isfinite(counts2_even))
-        good_odd = np.where((counts2_odd > 0) & np.isfinite(counts2_odd))
-        # __________________________________________________________________
-        # even row values
-        factor2_even[good_even] = 1.0 / (np.exp(counts2_even[good_even] / b3_even) - 1)
-        a1_even = b1_even * (np.power(counts2_even, b2_even)) * factor2_even
-        # ___________________________________________________________________
-        # odd row values
-        factor2_odd[good_odd] = 1.0 / (np.exp(counts2_odd[good_odd] / b3_odd) - 1)
-        a1_odd = b1_odd * (np.power(counts2_odd, b2_odd)) * factor2_odd
-        # ___________________________________________________________________
-        # SATURATED DATA
-        counts3_even = dn_lastfit[1::2, :] * sat_scale_even
-        counts3_odd = dn_lastfit[0::2, :] * sat_scale_odd
-
-        a1_sat_even = sat_final_slope_even * counts3_even + sat_mzp_even
-        a1_sat_odd = sat_final_slope_odd * counts3_odd + sat_mzp_odd
-
-        sat_even = sat[1::2, :]
-        sat_odd = sat[0::2, :]
-
-        # loop over groups in input science data:
-        for j in range(sci_ngroups):
-            # Compute the correction factors for even and odd rows
-            T = j + 1
-            eterm_even = np.exp(-T / tau_even)
-            eterm_odd = np.exp(-T / tau_odd)
-
-            # Apply the corrections to even and odd rows:
-            # the first row is defined as odd (python index 0)
-            # the second row is the first even row (python index of 1)
-            correction_odd = lastframe_odd * a1_odd * 0.01 * eterm_odd
-            correction_even = lastframe_even * a1_even * 0.01 * eterm_even
-            correction_sat_odd = lastframe_odd * a1_sat_odd * 0.01 * eterm_odd
-            correction_sat_even = lastframe_even * a1_sat_even * 0.01 * eterm_even
-            sat_index_even = np.where(sat_even)
-            sat_index_odd = np.where(sat_odd)
-            correction_even[sat_index_even] = correction_sat_even[sat_index_even]
-            correction_odd[sat_index_odd] = correction_sat_odd[sat_index_odd]
-            output.data[i, j, 0::2, :] += correction_odd
-            output.data[i, j, 1::2, :] += correction_even
-
-    output.meta.cal_step.rscd = "COMPLETE"
-
-    return output
-
-
 def get_rscd_parameters(input_model, rscd_model):
     """
-    Read in the parameters from the reference file
-    Store the parameters in a param dictionary
+    Read in the parameters from the reference file and store the parameters in a dictionary.
 
     Parameters
     ----------
-    input_model: ~jwst.datamodels.RampModel
-        science data to be corrected
+    input_model : Ramp datamodel
+        Science data to be flagged
 
-    rscd_model: ~jwst.datamodels.RSCDModel
-        rscd reference data
+    rscd_model : RSCD datamodel
+        RSCD reference file data
 
     Returns
     -------
-    param: dict
-        dictionary of parameters
-
+    param : Dictionary
+        Dictionary of parameters
     """
     # Reference file parameters held in dictionary: param
     param = {}
@@ -332,186 +144,4 @@ def get_rscd_parameters(input_model, rscd_model):
             param["skip"] = group_skip_table
             break
 
-    # read table 2: General RSCD enhanced parameters
-    for tabdata in rscd_model.rscd_gen_table:
-        readpatt_gen = tabdata["readpatt"]
-        subarray_gen = tabdata["subarray"]
-        lower_cutoff_gen = tabdata["lower_cutoff"]
-        alpha_even_gen = tabdata["alpha_even"]
-        alpha_odd_gen = tabdata["alpha_even"]
-        if subarray_gen == subarray and readpatt_gen == readpatt:
-            param["gen"] = {}
-            param["gen"]["lower_cutoff"] = lower_cutoff_gen
-            param["gen"]["lower_alpha_odd"] = alpha_odd_gen
-            param["gen"]["lower_alpha_even"] = alpha_even_gen
-            break
-
-    # read table 3: Enhanced RSCD integration 1 parameters
-    for tabdata in rscd_model.rscd_int1_table:
-        readpatt_int1 = tabdata["readpatt"]
-        subarray_int1 = tabdata["subarray"]
-        rows_int1 = tabdata["rows"]
-        a0_int1 = tabdata["a0"]
-        a1_int1 = tabdata["a1"]
-        a2_int1 = tabdata["a2"]
-        a3_int1 = tabdata["a3"]
-        if subarray_int1 == subarray and readpatt_int1 == readpatt:
-            param["int1"] = {}
-            param["int1"]["even"] = {}
-            param["int1"]["odd"] = {}
-            if rows_int1 == "EVEN":
-                param["int1"]["even"]["a0"] = a0_int1
-                param["int1"]["even"]["a1"] = a1_int1
-                param["int1"]["even"]["a2"] = a2_int1
-                param["int1"]["even"]["a3"] = a3_int1
-            if rows_int1 == "ODD":
-                param["int1"]["odd"]["a0"] = a0_int1
-                param["int1"]["odd"]["a1"] = a1_int1
-                param["int1"]["odd"]["a2"] = a2_int1
-                param["int1"]["odd"]["a3"] = a3_int1
-            break
-
-    # read table 4: Enhanced RSCD integration 2 parameters
-    for tabdata in rscd_model.rscd_int2_table:
-        readpatt_int2 = tabdata["readpatt"]
-        subarray_int2 = tabdata["subarray"]
-        rows_int2 = tabdata["rows"]
-        a0_int2 = tabdata["b0"]
-        a1_int2 = tabdata["b1"]
-        a2_int2 = tabdata["b2"]
-        a3_int2 = tabdata["b3"]
-        if subarray_int2 == subarray and readpatt_int2 == readpatt:
-            param["int2"] = {}
-            param["int2"]["even"] = {}
-            param["int2"]["odd"] = {}
-            if rows_int2 == "EVEN":
-                param["int2"]["even"]["a0"] = a0_int2
-                param["int2"]["even"]["a1"] = a1_int2
-                param["int2"]["even"]["a2"] = a2_int2
-                param["int2"]["even"]["a3"] = a3_int2
-            if rows_int2 == "ODD":
-                param["int2"]["odd"]["a0"] = a0_int2
-                param["int2"]["odd"]["a1"] = a1_int2
-                param["int2"]["odd"]["a2"] = a2_int2
-                param["int2"]["odd"]["a3"] = a3_int2
-            break
-
-    # read table 5: Enhanced RSCD integration 3 parameters
-    for tabdata in rscd_model.rscd_int3_table:
-        readpatt_int3 = tabdata["readpatt"]
-        subarray_int3 = tabdata["subarray"]
-        rows_int3 = tabdata["rows"]
-        a0_int3 = tabdata["c0"]
-        a1_int3 = tabdata["c1"]
-        a2_int3 = tabdata["c2"]
-        a3_int3 = tabdata["c3"]
-        if subarray_int3 == subarray and readpatt_int3 == readpatt:
-            param["int3"] = {}
-            param["int3"]["even"] = {}
-            param["int3"]["odd"] = {}
-            if rows_int3 == "EVEN":
-                param["int3"]["even"]["a0"] = a0_int3
-                param["int3"]["even"]["a1"] = a1_int3
-                param["int3"]["even"]["a2"] = a2_int3
-                param["int3"]["even"]["a3"] = a3_int3
-            if rows_int3 == "ODD":
-                param["int3"]["odd"]["a0"] = a0_int3
-                param["int3"]["odd"]["a1"] = a1_int3
-                param["int3"]["odd"]["a2"] = a2_int3
-                param["int3"]["odd"]["a3"] = a3_int3
-            break
-
     return param
-
-
-def get_DNaccumulated_last_int(input_model, i, sci_ngroups):
-    """
-    Find the accumulated DN from the last integration
-    This data should already have the Reset Anomaly correction
-    applied (if not - should we skip frames at the beginning ?)
-
-    a Check has already been made to make sure we have at least
-    4 frames
-
-    Parameters
-    ----------
-    input_model: ~jwst.datamodels.RampModel
-    i: integration #
-    sci_ngroups: number of frames/integration
-
-    return values
-    -------------
-    sat: the previous integration for this pixel saturated: yes/no
-    dn_lastframe_23: extrapolated last frame using 2nd and 3rd to last frames
-    dn_lastframe_fit: extrapolated last frame using the fit to the entire ramp
-    """
-    dn_lastframe2 = input_model.data[i - 1][sci_ngroups - 2]
-    dn_lastframe3 = input_model.data[i - 1][sci_ngroups - 3]
-
-    diff = dn_lastframe2 - dn_lastframe3
-    dn_lastframe23 = dn_lastframe2 + diff
-
-    # get saturation and reference pixel DQ flag values
-    sat_flag = dqflags.group["SATURATED"]
-    ref_flag = dqflags.pixel["REFERENCE_PIXEL"]
-
-    # mark the locations of reference pixels
-    refpix_2d = np.bitwise_and(input_model.pixeldq, ref_flag)
-    dn_lastframe23[np.where(refpix_2d)] = 0.0
-
-    # load the ramp data needed for computing slopes
-    ramp3d = input_model.data[i - 1, 1 : sci_ngroups - 1]
-    groupdq3d = input_model.groupdq[i - 1, 1 : sci_ngroups - 1]
-    satmask3d = groupdq3d == sat_flag
-    saturated = satmask3d.any(axis=0)
-
-    # compute the slopes
-    slope, intercept, ngood = ols_fit(ramp3d, groupdq3d)
-
-    dn_lastframe_fit = slope * sci_ngroups + intercept
-
-    # reset the results for pixels with zero slope
-    slope0 = np.where(slope == 0)
-    dn_lastframe_fit[slope0] = dn_lastframe23[slope0]
-
-    # reset the results for reference pixels
-    dn_lastframe23[np.where(refpix_2d)] = 0.0
-    dn_lastframe_fit[np.where(refpix_2d)] = 0.0
-
-    return saturated, dn_lastframe23, dn_lastframe_fit
-
-
-def ols_fit(y, dq):
-    """
-    An estimation of the lastframe value from the previous integration is
-    needed for the RSCD correction.
-    This routine does a simple ordinary least squares fit to
-    non-saturating data.
-    """
-    sat_flag = dqflags.group["SATURATED"]
-    shape = y.shape
-
-    # Find ramp values that are saturated
-    x = np.arange(shape[0], dtype=np.float64)[:, np.newaxis, np.newaxis] * np.ones(shape)
-    good_data = np.bitwise_and(dq, sat_flag) == 0
-    ngood = good_data.sum(axis=0)
-
-    # Compute sums of unsaturated (good) x/y values
-    sumx = (x * good_data).sum(axis=0)
-    sumy = (y * good_data).sum(axis=0)
-    sumxy = (x * y * good_data).sum(axis=0)
-    sumxx = (x * x * good_data).sum(axis=0)
-    nelem = good_data.sum(axis=0)
-
-    # Compute the slopes and intercepts
-    denom = nelem * sumxx - sumx * sumx
-    with np.errstate(invalid="ignore"):  # ignore division warnings
-        slope = (nelem * sumxy - sumx * sumy) / denom
-        intercept = (sumxx * sumy - sumx * sumxy) / denom
-
-    # Reset results to zero for pixels having < 3 unsaturated values
-    bad = np.where(ngood < 3)
-    slope[bad] = 0.0
-    intercept[bad] = 0.0
-
-    return (slope, intercept, ngood)

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -20,15 +20,15 @@ def do_correction(output_model, rscd_model):
 
     Parameters
     ----------
-    output_model : Ramp datamodel
+    output_model : RampModel
         Input ramp datamodel
 
-    rscd_model : RSCD datamodel
+    rscd_model : RSCDModel
         RSCD reference datamodel
 
     Returns
     -------
-    output_model : Ramp datamodel
+    output_model : RampModel
         Ramp datamodel with RSCD affected groups flagged as DO_NOT_USE
     """
     # Retrieve the reference parameters for this exposure type
@@ -52,7 +52,7 @@ def correction_skip_groups(output, group_skip):
 
     Parameters
     ----------
-    output : Ramp datamodel
+    output : RampModel
         Science data to be flagged
 
     group_skip : Int
@@ -60,7 +60,7 @@ def correction_skip_groups(output, group_skip):
 
     Returns
     -------
-    output_model: Ramp datamodel
+    output_model: RampModel
         Ramp datamodel with RSCD affected groups flagged as DO_NOT_USE
     """
     # General exposure parameters
@@ -112,15 +112,15 @@ def get_rscd_parameters(input_model, rscd_model):
 
     Parameters
     ----------
-    input_model : Ramp datamodel
+    input_model : RampModel
         Science data to be flagged
 
-    rscd_model : RSCD datamodel
+    rscd_model : RSCDModel
         RSCD reference file data
 
     Returns
     -------
-    param : Dictionary
+    param : dict
         Dictionary of parameters
     """
     # Reference file parameters held in dictionary: param

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -13,7 +13,10 @@ log.setLevel(logging.DEBUG)
 
 def do_correction(output_model, rscd_model, type):
     """
-    Short Summary
+    Sets the initial groups in MIRI data to DO_NOT_USE for integration 2 and higher. 
+
+    The baseline correction sets the initial groups to DO_NOT_USE. An enhanced correction
+    is a test algorithm and should only be used by 
     -------------
     if type = baseline the correction sets initial groups in the integration
     to skip
@@ -36,22 +39,23 @@ def do_correction(output_model, rscd_model, type):
         RSCD-corrected science data
 
     """
-
     # Retrieve the reference parameters for this exposure type
     param = get_rscd_parameters(output_model, rscd_model)
 
     if not bool(param):  # empty dictionary
-        log.warning('READPATT, SUBARRAY combination not found in ref file: RSCD correction will be skipped')
-        output_model.meta.cal_step.rscd = 'SKIPPED'
+        log.warning(
+            "READPATT, SUBARRAY combination not found in ref file: RSCD correction will be skipped"
+        )
+        output_model.meta.cal_step.rscd = "SKIPPED"
         return output_model
 
-    if type == 'baseline':
-        group_skip = param['skip']
+    if type == "baseline":
+        group_skip = param["skip"]
         output_model = correction_skip_groups(output_model, group_skip)
     else:
         # enhanced algorithm is not enabled yet (updated code and validation needed)
-        log.warning('Enhanced algorithm not support yet: RSCD correction will be skipped')
-        output_model.meta.cal_step.rscd = 'SKIPPED'
+        log.warning("Enhanced algorithm not support yet: RSCD correction will be skipped")
+        output_model.meta.cal_step.rscd = "SKIPPED"
         return output_model
         # decay function algorithm update needed
         # output_model = correction_decay_function(input_model, param)
@@ -79,7 +83,6 @@ def correction_skip_groups(output, group_skip):
     output_model: ~jwst.datamodels.RampModel
         RSCD-corrected science data
     """
-
     # General exposure parameters
     sci_ngroups = output.meta.exposure.ngroups
     sci_nints = output.meta.exposure.nints
@@ -90,12 +93,9 @@ def correction_skip_groups(output, group_skip):
     if sci_int_start is None:
         sci_int_start = 1
 
-
-    log.debug("RSCD correction using: nints=%d, ngroups=%d" %
-              (sci_nints, sci_ngroups))
-    log.debug("The first integration in the data is integration: %d" %
-              (sci_int_start))
-    log.info("Number of groups to skip for integrations 2 and higher: %d " %group_skip)
+    log.debug("RSCD correction using: nints=%d, ngroups=%d" % (sci_nints, sci_ngroups))
+    log.debug("The first integration in the data is integration: %d" % (sci_int_start))
+    log.info("Number of groups to skip for integrations 2 and higher: %d " % group_skip)
 
     # If ngroups <= group_skip+3, skip the flagging
     # the +3 is to ensure there is a slope to be fit including the flagging for
@@ -103,7 +103,7 @@ def correction_skip_groups(output, group_skip):
     if sci_ngroups <= (group_skip + 3):
         log.warning("Too few groups to apply RSCD correction")
         log.warning("RSCD step will be skipped")
-        output.meta.cal_step.rscd = 'SKIPPED'
+        output.meta.cal_step.rscd = "SKIPPED"
         return output
 
     # The RSCD correction is applied to integrations 2 and higher.
@@ -114,13 +114,14 @@ def correction_skip_groups(output, group_skip):
     # in 0: group_skip to 'DO_NOT_USE'
 
     int_start = 1
-    if sci_int_start !=1: # we have segmented data
+    if sci_int_start != 1:  # we have segmented data
         int_start = 0
 
-    output.groupdq[int_start:, 0:group_skip, :, :] = \
-        np.bitwise_or(output.groupdq[int_start:, 0:group_skip, :, :], dqflags.group['DO_NOT_USE'])
+    output.groupdq[int_start:, 0:group_skip, :, :] = np.bitwise_or(
+        output.groupdq[int_start:, 0:group_skip, :, :], dqflags.group["DO_NOT_USE"]
+    )
     log.debug(f"RSCD Sub: adding DO_NOT_USE to GROUPDQ for the first {group_skip} groups")
-    output.meta.cal_step.rscd = 'COMPLETE'
+    output.meta.cal_step.rscd = "COMPLETE"
 
     return output
 
@@ -162,67 +163,72 @@ def correction_decay_function(output, param):
         RSCD-corrected science data
 
     """
-
     # Save some data params for easy use later
-    sci_nints = output.data.shape[0]       # number of integrations
-    sci_ngroups = output.data.shape[1]     # number of groups
+    sci_nints = output.data.shape[0]  # number of integrations
+    sci_ngroups = output.data.shape[1]  # number of groups
 
-    log.debug("RSCD correction using: nints=%d, ngroups=%d" %
-              (sci_nints, sci_ngroups))
+    log.debug("RSCD correction using: nints=%d, ngroups=%d" % (sci_nints, sci_ngroups))
 
     # Check for valid parameters
     if sci_ngroups < 2:
-        log.warning('RSCD correction requires > 1 group per integration')
-        log.warning('Step will be skipped')
-        output.meta.cal_step.rscd = 'SKIPPED'
+        log.warning("RSCD correction requires > 1 group per integration")
+        log.warning("Step will be skipped")
+        output.meta.cal_step.rscd = "SKIPPED"
         return output
 
     if param is None:
-        log.warning('RSCD correction will be skipped')
-        output.meta.cal_step.rscd = 'SKIPPED'
+        log.warning("RSCD correction will be skipped")
+        output.meta.cal_step.rscd = "SKIPPED"
         return output
 
     # Determine the parameters that rely only on ngroups
     ngroups2 = sci_ngroups * sci_ngroups
-    b1_even = param['even']['ascale'] * (
-        param['even']['illum_zp'] +
-        param['even']['illum_slope'] * sci_ngroups +
-        param['even']['illum2'] * ngroups2)
+    b1_even = param["even"]["ascale"] * (
+        param["even"]["illum_zp"]
+        + param["even"]["illum_slope"] * sci_ngroups
+        + param["even"]["illum2"] * ngroups2
+    )
 
-    b1_odd = param['odd']['ascale'] * (
-        param['odd']['illum_zp'] +
-        param['odd']['illum_slope'] * sci_ngroups +
-        param['odd']['illum2'] * ngroups2)
+    b1_odd = param["odd"]["ascale"] * (
+        param["odd"]["illum_zp"]
+        + param["odd"]["illum_slope"] * sci_ngroups
+        + param["odd"]["illum2"] * ngroups2
+    )
 
     sat_final_slope_even = (
-        param['even']['sat_zp'] + param['even']['sat_slope'] * sci_ngroups +
-        param['even']['sat2'] * ngroups2 + param['even']['sat_rowterm'])
+        param["even"]["sat_zp"]
+        + param["even"]["sat_slope"] * sci_ngroups
+        + param["even"]["sat2"] * ngroups2
+        + param["even"]["sat_rowterm"]
+    )
 
     sat_final_slope_odd = (
-        param['odd']['sat_zp'] + param['odd']['sat_slope'] * sci_ngroups +
-        param['odd']['sat2'] * ngroups2 + param['odd']['sat_rowterm'])
+        param["odd"]["sat_zp"]
+        + param["odd"]["sat_slope"] * sci_ngroups
+        + param["odd"]["sat2"] * ngroups2
+        + param["odd"]["sat_rowterm"]
+    )
 
-    b2_even = param['even']['pow'].item()
-    b2_odd = param['odd']['pow'].item()
-    b3_even = param['even']['param3'].item()
-    b3_odd = param['odd']['param3'].item()
-    crossopt_even = param['even']['crossopt'].item()
-    crossopt_odd = param['odd']['crossopt'].item()
-    sat_mzp_even = param['even']['sat_mzp'].item()
-    sat_mzp_odd = param['odd']['sat_mzp'].item()
-    sat_scale_even = param['even']['sat_scale'].item()
-    sat_scale_odd = param['odd']['sat_scale'].item()
-    tau_even = param['even']['tau'].item()
-    tau_odd = param['odd']['tau'].item()
+    b2_even = param["even"]["pow"].item()
+    b2_odd = param["odd"]["pow"].item()
+    b3_even = param["even"]["param3"].item()
+    b3_odd = param["odd"]["param3"].item()
+    crossopt_even = param["even"]["crossopt"].item()
+    crossopt_odd = param["odd"]["crossopt"].item()
+    sat_mzp_even = param["even"]["sat_mzp"].item()
+    sat_mzp_odd = param["odd"]["sat_mzp"].item()
+    sat_scale_even = param["even"]["sat_scale"].item()
+    sat_scale_odd = param["odd"]["sat_scale"].item()
+    tau_even = param["even"]["tau"].item()
+    tau_odd = param["odd"]["tau"].item()
 
     # loop over all integrations except the first
     mdelta = int(sci_nints / 10) + 1
     for i in range(1, sci_nints):
         if ((i + 1) % mdelta) == 0:
-            log.info(' Working on integration %d', i + 1)
+            log.info(" Working on integration %d", i + 1)
 
-        sat, dn_last23, dn_lastfit = \
-            get_DNaccumulated_last_int(output, i, sci_ngroups)
+        sat, dn_last23, dn_lastfit = get_DNaccumulated_last_int(output, i, sci_ngroups)
 
         lastframe_even = dn_last23[1::2, :]
         lastframe_odd = dn_last23[0::2, :]
@@ -243,13 +249,11 @@ def correction_decay_function(output, param):
         good_odd = np.where((counts2_odd > 0) & np.isfinite(counts2_odd))
         # __________________________________________________________________
         # even row values
-        factor2_even[good_even] = 1.0 / \
-            (np.exp(counts2_even[good_even] / b3_even) - 1)
+        factor2_even[good_even] = 1.0 / (np.exp(counts2_even[good_even] / b3_even) - 1)
         a1_even = b1_even * (np.power(counts2_even, b2_even)) * factor2_even
         # ___________________________________________________________________
         # odd row values
-        factor2_odd[good_odd] = 1.0 / \
-            (np.exp(counts2_odd[good_odd] / b3_odd) - 1)
+        factor2_odd[good_odd] = 1.0 / (np.exp(counts2_odd[good_odd] / b3_odd) - 1)
         a1_odd = b1_odd * (np.power(counts2_odd, b2_odd)) * factor2_odd
         # ___________________________________________________________________
         # SATURATED DATA
@@ -264,9 +268,8 @@ def correction_decay_function(output, param):
 
         # loop over groups in input science data:
         for j in range(sci_ngroups):
-
             # Compute the correction factors for even and odd rows
-            T = (j + 1)
+            T = j + 1
             eterm_even = np.exp(-T / tau_even)
             eterm_odd = np.exp(-T / tau_odd)
 
@@ -276,17 +279,15 @@ def correction_decay_function(output, param):
             correction_odd = lastframe_odd * a1_odd * 0.01 * eterm_odd
             correction_even = lastframe_even * a1_even * 0.01 * eterm_even
             correction_sat_odd = lastframe_odd * a1_sat_odd * 0.01 * eterm_odd
-            correction_sat_even = lastframe_even * a1_sat_even * 0.01 * \
-                eterm_even
+            correction_sat_even = lastframe_even * a1_sat_even * 0.01 * eterm_even
             sat_index_even = np.where(sat_even)
             sat_index_odd = np.where(sat_odd)
-            correction_even[sat_index_even] = \
-                correction_sat_even[sat_index_even]
+            correction_even[sat_index_even] = correction_sat_even[sat_index_even]
             correction_odd[sat_index_odd] = correction_sat_odd[sat_index_odd]
             output.data[i, j, 0::2, :] += correction_odd
             output.data[i, j, 1::2, :] += correction_even
 
-    output.meta.cal_step.rscd = 'COMPLETE'
+    output.meta.cal_step.rscd = "COMPLETE"
 
     return output
 
@@ -310,7 +311,6 @@ def get_rscd_parameters(input_model, rscd_model):
         dictionary of parameters
 
     """
-
     # Reference file parameters held in dictionary: param
     param = {}
 
@@ -320,105 +320,105 @@ def get_rscd_parameters(input_model, rscd_model):
 
     # Check for old values of the MIRI LRS slitless subarray name
     # in the science data and change to the new
-    if subarray.upper() == 'SUBPRISM':
-        subarray = 'SLITLESSPRISM'
+    if subarray.upper() == "SUBPRISM":
+        subarray = "SLITLESSPRISM"
 
     # read table 1: containing the number of groups to skip
     for tabdata in rscd_model.rscd_group_skip_table:
-        subarray_table = tabdata['subarray']
-        readpatt_table = tabdata['readpatt']
-        group_skip_table = tabdata['group_skip']
+        subarray_table = tabdata["subarray"]
+        readpatt_table = tabdata["readpatt"]
+        group_skip_table = tabdata["group_skip"]
         if subarray_table == subarray and readpatt_table == readpatt:
-            param['skip'] = group_skip_table
+            param["skip"] = group_skip_table
             break
 
     # read table 2: General RSCD enhanced parameters
     for tabdata in rscd_model.rscd_gen_table:
-        readpatt_gen = tabdata['readpatt']
-        subarray_gen = tabdata['subarray']
-        lower_cutoff_gen = tabdata['lower_cutoff']
-        alpha_even_gen = tabdata['alpha_even']
-        alpha_odd_gen = tabdata['alpha_even']
+        readpatt_gen = tabdata["readpatt"]
+        subarray_gen = tabdata["subarray"]
+        lower_cutoff_gen = tabdata["lower_cutoff"]
+        alpha_even_gen = tabdata["alpha_even"]
+        alpha_odd_gen = tabdata["alpha_even"]
         if subarray_gen == subarray and readpatt_gen == readpatt:
-            param['gen'] = {}
-            param['gen']['lower_cutoff'] = lower_cutoff_gen
-            param['gen']['lower_alpha_odd'] = alpha_odd_gen
-            param['gen']['lower_alpha_even'] = alpha_even_gen
+            param["gen"] = {}
+            param["gen"]["lower_cutoff"] = lower_cutoff_gen
+            param["gen"]["lower_alpha_odd"] = alpha_odd_gen
+            param["gen"]["lower_alpha_even"] = alpha_even_gen
             break
 
     # read table 3: Enhanced RSCD integration 1 parameters
     for tabdata in rscd_model.rscd_int1_table:
-        readpatt_int1 = tabdata['readpatt']
-        subarray_int1 = tabdata['subarray']
-        rows_int1 = tabdata['rows']
-        a0_int1 = tabdata['a0']
-        a1_int1 = tabdata['a1']
-        a2_int1 = tabdata['a2']
-        a3_int1 = tabdata['a3']
+        readpatt_int1 = tabdata["readpatt"]
+        subarray_int1 = tabdata["subarray"]
+        rows_int1 = tabdata["rows"]
+        a0_int1 = tabdata["a0"]
+        a1_int1 = tabdata["a1"]
+        a2_int1 = tabdata["a2"]
+        a3_int1 = tabdata["a3"]
         if subarray_int1 == subarray and readpatt_int1 == readpatt:
-            param['int1'] = {}
-            param['int1']['even'] = {}
-            param['int1']['odd'] = {}
-            if rows_int1 == 'EVEN':
-                param['int1']['even']['a0'] = a0_int1
-                param['int1']['even']['a1'] = a1_int1
-                param['int1']['even']['a2'] = a2_int1
-                param['int1']['even']['a3'] = a3_int1
-            if rows_int1 == 'ODD':
-                param['int1']['odd']['a0'] = a0_int1
-                param['int1']['odd']['a1'] = a1_int1
-                param['int1']['odd']['a2'] = a2_int1
-                param['int1']['odd']['a3'] = a3_int1
+            param["int1"] = {}
+            param["int1"]["even"] = {}
+            param["int1"]["odd"] = {}
+            if rows_int1 == "EVEN":
+                param["int1"]["even"]["a0"] = a0_int1
+                param["int1"]["even"]["a1"] = a1_int1
+                param["int1"]["even"]["a2"] = a2_int1
+                param["int1"]["even"]["a3"] = a3_int1
+            if rows_int1 == "ODD":
+                param["int1"]["odd"]["a0"] = a0_int1
+                param["int1"]["odd"]["a1"] = a1_int1
+                param["int1"]["odd"]["a2"] = a2_int1
+                param["int1"]["odd"]["a3"] = a3_int1
             break
 
     # read table 4: Enhanced RSCD integration 2 parameters
     for tabdata in rscd_model.rscd_int2_table:
-        readpatt_int2 = tabdata['readpatt']
-        subarray_int2 = tabdata['subarray']
-        rows_int2 = tabdata['rows']
-        a0_int2 = tabdata['b0']
-        a1_int2 = tabdata['b1']
-        a2_int2 = tabdata['b2']
-        a3_int2 = tabdata['b3']
+        readpatt_int2 = tabdata["readpatt"]
+        subarray_int2 = tabdata["subarray"]
+        rows_int2 = tabdata["rows"]
+        a0_int2 = tabdata["b0"]
+        a1_int2 = tabdata["b1"]
+        a2_int2 = tabdata["b2"]
+        a3_int2 = tabdata["b3"]
         if subarray_int2 == subarray and readpatt_int2 == readpatt:
-            param['int2'] = {}
-            param['int2']['even'] = {}
-            param['int2']['odd'] = {}
-            if rows_int2 == 'EVEN':
-                param['int2']['even']['a0'] = a0_int2
-                param['int2']['even']['a1'] = a1_int2
-                param['int2']['even']['a2'] = a2_int2
-                param['int2']['even']['a3'] = a3_int2
-            if rows_int2 == 'ODD':
-                param['int2']['odd']['a0'] = a0_int2
-                param['int2']['odd']['a1'] = a1_int2
-                param['int2']['odd']['a2'] = a2_int2
-                param['int2']['odd']['a3'] = a3_int2
+            param["int2"] = {}
+            param["int2"]["even"] = {}
+            param["int2"]["odd"] = {}
+            if rows_int2 == "EVEN":
+                param["int2"]["even"]["a0"] = a0_int2
+                param["int2"]["even"]["a1"] = a1_int2
+                param["int2"]["even"]["a2"] = a2_int2
+                param["int2"]["even"]["a3"] = a3_int2
+            if rows_int2 == "ODD":
+                param["int2"]["odd"]["a0"] = a0_int2
+                param["int2"]["odd"]["a1"] = a1_int2
+                param["int2"]["odd"]["a2"] = a2_int2
+                param["int2"]["odd"]["a3"] = a3_int2
             break
 
     # read table 5: Enhanced RSCD integration 3 parameters
     for tabdata in rscd_model.rscd_int3_table:
-        readpatt_int3 = tabdata['readpatt']
-        subarray_int3 = tabdata['subarray']
-        rows_int3 = tabdata['rows']
-        a0_int3 = tabdata['c0']
-        a1_int3 = tabdata['c1']
-        a2_int3 = tabdata['c2']
-        a3_int3 = tabdata['c3']
+        readpatt_int3 = tabdata["readpatt"]
+        subarray_int3 = tabdata["subarray"]
+        rows_int3 = tabdata["rows"]
+        a0_int3 = tabdata["c0"]
+        a1_int3 = tabdata["c1"]
+        a2_int3 = tabdata["c2"]
+        a3_int3 = tabdata["c3"]
         if subarray_int3 == subarray and readpatt_int3 == readpatt:
-            param['int3'] = {}
-            param['int3']['even'] = {}
-            param['int3']['odd'] = {}
-            if rows_int3 == 'EVEN':
-                param['int3']['even']['a0'] = a0_int3
-                param['int3']['even']['a1'] = a1_int3
-                param['int3']['even']['a2'] = a2_int3
-                param['int3']['even']['a3'] = a3_int3
-            if rows_int3 == 'ODD':
-                param['int3']['odd']['a0'] = a0_int3
-                param['int3']['odd']['a1'] = a1_int3
-                param['int3']['odd']['a2'] = a2_int3
-                param['int3']['odd']['a3'] = a3_int3
+            param["int3"] = {}
+            param["int3"]["even"] = {}
+            param["int3"]["odd"] = {}
+            if rows_int3 == "EVEN":
+                param["int3"]["even"]["a0"] = a0_int3
+                param["int3"]["even"]["a1"] = a1_int3
+                param["int3"]["even"]["a2"] = a2_int3
+                param["int3"]["even"]["a3"] = a3_int3
+            if rows_int3 == "ODD":
+                param["int3"]["odd"]["a0"] = a0_int3
+                param["int3"]["odd"]["a1"] = a1_int3
+                param["int3"]["odd"]["a2"] = a2_int3
+                param["int3"]["odd"]["a3"] = a3_int3
             break
 
     return param
@@ -445,7 +445,6 @@ def get_DNaccumulated_last_int(input_model, i, sci_ngroups):
     dn_lastframe_23: extrapolated last frame using 2nd and 3rd to last frames
     dn_lastframe_fit: extrapolated last frame using the fit to the entire ramp
     """
-
     dn_lastframe2 = input_model.data[i - 1][sci_ngroups - 2]
     dn_lastframe3 = input_model.data[i - 1][sci_ngroups - 3]
 
@@ -453,17 +452,17 @@ def get_DNaccumulated_last_int(input_model, i, sci_ngroups):
     dn_lastframe23 = dn_lastframe2 + diff
 
     # get saturation and reference pixel DQ flag values
-    sat_flag = dqflags.group['SATURATED']
-    ref_flag = dqflags.pixel['REFERENCE_PIXEL']
+    sat_flag = dqflags.group["SATURATED"]
+    ref_flag = dqflags.pixel["REFERENCE_PIXEL"]
 
     # mark the locations of reference pixels
     refpix_2d = np.bitwise_and(input_model.pixeldq, ref_flag)
     dn_lastframe23[np.where(refpix_2d)] = 0.0
 
     # load the ramp data needed for computing slopes
-    ramp3d = input_model.data[i - 1, 1:sci_ngroups - 1]
-    groupdq3d = input_model.groupdq[i - 1, 1:sci_ngroups - 1]
-    satmask3d = (groupdq3d == sat_flag)
+    ramp3d = input_model.data[i - 1, 1 : sci_ngroups - 1]
+    groupdq3d = input_model.groupdq[i - 1, 1 : sci_ngroups - 1]
+    satmask3d = groupdq3d == sat_flag
     saturated = satmask3d.any(axis=0)
 
     # compute the slopes
@@ -489,13 +488,11 @@ def ols_fit(y, dq):
     This routine does a simple ordinary least squares fit to
     non-saturating data.
     """
-
-    sat_flag = dqflags.group['SATURATED']
+    sat_flag = dqflags.group["SATURATED"]
     shape = y.shape
 
     # Find ramp values that are saturated
-    x = np.arange(shape[0], dtype=np.float64)[:, np.newaxis, np.newaxis] * \
-        np.ones(shape)
+    x = np.arange(shape[0], dtype=np.float64)[:, np.newaxis, np.newaxis] * np.ones(shape)
     good_data = np.bitwise_and(dq, sat_flag) == 0
     ngood = good_data.sum(axis=0)
 
@@ -508,7 +505,7 @@ def ols_fit(y, dq):
 
     # Compute the slopes and intercepts
     denom = nelem * sumxx - sumx * sumx
-    with np.errstate(invalid='ignore'):  # ignore division warnings
+    with np.errstate(invalid="ignore"):  # ignore division warnings
         slope = (nelem * sumxy - sumx * sumy) / denom
         intercept = (sumxx * sumy - sumx * sumxy) / denom
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3857](https://jira.stsci.edu/browse/JP-3857)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
#Closes #

<!-- describe the changes comprising this PR here -->
This PR updates the RSCD code to conform the code style standards. In addition, this PR has remove code and documentation related to the enhanced algorithm. That algorithm was a possible method based on preflight information. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
  regression test run: https://github.com/spacetelescope/RegressionTests/actions/runs/13860246842
All test passed
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
