### PR TITLE
Update resample unit tests

### DIFF
--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -501,13 +501,21 @@ def test_pixel_scale_ratio_spec_miri(miri_cal, ratio, units):
         # needs to be about the same, other than the edges
         # Check the maximum sums, to avoid edges.
         assert np.allclose(np.max(np.nansum(result1.data, axis=1)),
-                           np.max(np.nansum(result1.data, axis=1)), rtol=0.05)
+                           np.max(np.nansum(result2.data, axis=1)), rtol=0.05)
     else:
-        # surface brightness conservation: mean values are the same
-        assert np.allclose(np.nanmean(result1.data, axis=1),
-                           np.nanmean(result2.data, axis=1), rtol=0.05,
-                           equal_nan=True)
-
+        # surface brightness conservation: weighted total values are the same
+        assert np.allclose(
+            np.nansum(result1.data * result1.wht),
+            np.nansum(result2.data * result2.wht),
+            rtol=5.0e-3,
+            equal_nan=True
+        )
+        assert np.allclose(
+            np.nansum(result1.data * result1.wht, axis=1),
+            np.nansum(result2.data * result2.wht, axis=1),
+            rtol=5.0e-3,
+            equal_nan=True
+        )
     # output area is updated either way
     area1 = result1.meta.photometry.pixelarea_steradians
     area2 = result2.meta.photometry.pixelarea_steradians
@@ -567,12 +575,21 @@ def test_pixel_scale_ratio_1spec_miri_pair(miri_rate_pair, ratio, units):
         # needs to be about the same, other than the edges
         # Check the maximum sums, to avoid edges.
         assert np.allclose(np.max(np.nansum(result1.data, axis=1)),
-                           np.max(np.nansum(result1.data, axis=1)), rtol=0.05)
+                           np.max(np.nansum(result2.data, axis=1)), rtol=0.05)
     else:
-        # surface brightness conservation: mean values are the same
-        assert np.allclose(np.nanmean(result1.data, axis=1),
-                           np.nanmean(result2.data, axis=1), rtol=0.05,
-                           equal_nan=True)
+        # surface brightness conservation: weighted total values are the same
+        assert np.allclose(
+            np.sum(result1.data * result1.wht),
+            np.sum(result2.data * result2.wht),
+            rtol=1.0e-5,
+            equal_nan=True
+        )
+        assert np.allclose(
+            np.nanmedian(result1.data, axis=1),
+            np.nanmedian(result2.data, axis=1),
+            rtol=1.0e-5,
+            equal_nan=True
+        )
 
     # output area is updated either way
     area1 = result1.meta.photometry.pixelarea_steradians
@@ -630,10 +647,13 @@ def test_pixel_scale_ratio_spec_nirspec(nirspec_cal, ratio, units):
             assert np.allclose(np.max(np.nansum(slit1.data, axis=0)),
                                np.max(np.nansum(slit2.data, axis=0)), rtol=0.05)
         else:
-            # surface brightness conservation: mean values are the same
-            assert np.allclose(np.nanmean(slit1.data, axis=0),
-                               np.nanmean(slit2.data, axis=0), rtol=0.05,
-                               equal_nan=True)
+            # surface brightness conservation: weighted total values are the same
+            assert np.allclose(
+                np.nansum(slit1.data * slit1.wht, axis=0),
+                np.nansum(slit2.data * slit2.wht, axis=0),
+                rtol=1.0e-5,
+                equal_nan=True
+            )
 
         # output area is updated either way
         area1 = slit1.meta.photometry.pixelarea_steradians


### PR DESCRIPTION
This PR improves/updates resample unit tests to work after https://github.com/spacetelescope/stcal/pull/352 is merged. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
