### PR TITLE
JP-3872: Remove deprecated resample utilities

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -3,7 +3,6 @@
 import logging
 import functools
 import numpy as np
-import warnings
 
 from astropy.coordinates import SkyCoord
 from astropy.modeling import models as astmodels
@@ -30,7 +29,6 @@ _MAX_SIP_DEGREE = 6
 
 
 __all__ = [
-    "reproject",
     "velocity_correction",
     "MSAFileError",
     "NoDataOnDetectorError",
@@ -67,40 +65,6 @@ class NoDataOnDetectorError(StpipeExitException):
         # The first argument instructs stpipe CLI tools to exit with status
         # 64 when this exception is raised.
         super().__init__(64, message)
-
-
-def reproject(wcs1, wcs2):
-    """
-    Take in pixel coordinates in the first WCS and compute their location in the second one.
-
-    .. deprecated:: 1.17.2
-        :py:func:`reproject()` has been deprecated and will be removed
-        in a future release. Use :py:func:`stcal.alignment.util.reproject` instead.
-
-    Parameters
-    ----------
-    wcs1, wcs2 : `~gwcs.wcs.WCS`
-        WCS objects.
-
-    Returns
-    -------
-    _reproject : func
-        Function to compute the transformations.  It takes x, y
-        positions in ``wcs1`` and returns x, y positions in ``wcs2``.
-    """
-    warnings.warn(
-        "'reproject()' has been deprecated since 1.17.2 and "
-        "will be removed in a future release. "
-        "Use 'stcal.alignment.util.reproject()' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    def _reproject(x, y):
-        sky = wcs1.forward_transform(x, y)
-        return wcs2.backward_transform(*sky)
-
-    return _reproject
 
 
 def compute_scale(

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -1,12 +1,10 @@
 from copy import deepcopy
 import logging
 import math
-import warnings
 
 import asdf
 import numpy as np
 from astropy import units as u
-from drizzle.utils import decode_context as _drizzle_decode_context
 
 from stdatamodels.jwst.datamodels.dqflags import pixel
 from astropy.coordinates import SkyCoord
@@ -20,13 +18,10 @@ from gwcs import wcstools
 from stcal.alignment.util import compute_s_region_keyword
 from stcal.resample import UnsupportedWCSError
 from stcal.resample.utils import compute_mean_pixel_area
-from stcal.resample.utils import (
-    build_driz_weight as _stcal_build_driz_weight,
-    build_mask as _stcal_build_mask,
-)
+from stcal.resample.utils import build_mask as _stcal_build_mask
 
 
-__all__ = ["build_mask", "decode_context", "make_output_wcs", "resampled_wcs_from_models"]
+__all__ = ["build_mask", "resampled_wcs_from_models"]
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -143,136 +138,6 @@ def resampled_wcs_from_models(
     return wcs, pscale_in0, pixel_scale, pixel_scale_ratio
 
 
-def make_output_wcs(
-    input_models,
-    ref_wcs=None,
-    pscale_ratio=None,
-    pscale=None,
-    rotation=None,
-    shape=None,
-    crpix=None,
-    crval=None,
-):
-    """
-    Generate output WCS here based on footprints of all input WCS objects.
-
-    .. deprecated:: 1.17.2
-        :py:func:`make_output_wcs` has been deprecated and will be removed
-        in a future release. Use :py:func:`resampled_wcs_from_models` instead.
-
-    Parameters
-    ----------
-    input_models : `~jwst.datamodel.ModelLibrary`
-        The datamodels to combine into a single output WCS. Each datamodel must
-        have a ``meta.wcs.s_region`` attribute.
-    ref_wcs : gwcs.WCS, None, optional
-        Custom WCS to use as the output WCS. If not provided,
-        the reference WCS will be taken as the WCS of the first input model, with
-        its bounding box adjusted to encompass all input frames.
-    pscale_ratio : float, None, optional
-        Ratio of input to output pixel scale. Ignored when ``pscale``
-        is provided.
-    pscale : float, None, optional
-        Absolute pixel scale in degrees. When provided, overrides
-        ``pscale_ratio``.
-    rotation : float, None, optional
-        Position angle of output image Y-axis relative to North.
-        A value of 0.0 would orient the final output image to be North up.
-        The default of `None` specifies that the images will not be rotated,
-        but will instead be resampled in the default orientation for the camera
-        with the x and y axes of the resampled image corresponding
-        approximately to the detector axes.
-    shape : tuple of int, None, optional
-        Shape of the image (data array) using ``numpy.ndarray`` convention
-        (``ny`` first and ``nx`` second). This value will be assigned to
-        ``pixel_shape`` and ``array_shape`` properties of the returned
-        WCS object.
-    crpix : tuple of float, None, optional
-        Position of the reference pixel in the image array. If ``crpix`` is not
-        specified, it will be set to the center of the bounding box of the
-        returned WCS object.
-    crval : tuple of float, None, optional
-        Right ascension and declination of the reference pixel. Automatically
-        computed if not provided.
-
-    Returns
-    -------
-    output_wcs : object
-        WCS object, with defined domain, covering entire set of input frames
-    """
-    warnings.warn(
-        "'make_output_wcs()' has been deprecated since 1.17.2 and "
-        "will be removed in a future release. "
-        "Use 'resampled_wcs_from_models()' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    if ref_wcs is None:
-        sregion_list = []
-        with input_models:
-            for i, model in enumerate(input_models):
-                sregion_list.append(model.meta.wcsinfo.s_region)
-                if i == 0:
-                    example_model = model
-                    ref_wcs = example_model.meta.wcs
-                    ref_wcsinfo = example_model.meta.wcsinfo.instance
-                input_models.shelve(model)
-        naxes = ref_wcs.output_frame.naxes
-
-        if naxes != 2:
-            msg = f"Output WCS needs 2 spatial axes but the supplied WCS has {naxes} axes."
-            raise RuntimeError(msg)
-
-        output_wcs = wcs_from_sregions(
-            sregion_list,
-            ref_wcs=ref_wcs,
-            ref_wcsinfo=ref_wcsinfo,
-            pscale_ratio=pscale_ratio,
-            pscale=pscale,
-            rotation=rotation,
-            shape=shape,
-            crpix=crpix,
-            crval=crval,
-        )
-        del example_model
-
-    else:
-        naxes = ref_wcs.output_frame.naxes
-        if naxes != 2:
-            msg = f"Output WCS needs 2 spatial axes but the supplied WCS has {naxes} axes."
-            raise RuntimeError(msg)
-        output_wcs = deepcopy(ref_wcs)
-        if shape is not None:
-            output_wcs.array_shape = shape
-
-    # Check that the output data shape has no zero-length dimensions
-    if not np.prod(output_wcs.array_shape):
-        msg = f"Invalid output frame shape: {tuple(output_wcs.array_shape)}"
-        raise ValueError(msg)
-
-    return output_wcs
-
-
-def build_driz_weight(model, weight_type=None, good_bits=None):
-    """
-    Create a weight map for use by drizzle.
-
-    .. deprecated:: 1.17.2
-        :py:func:`build_driz_weight` has been deprecated and will be removed
-        in a future release. Use :py:func:`stcal.utils.build_driz_weight`
-        instead.
-    """  # numpydoc ignore=RT01
-    warnings.warn(
-        "'build_driz_weight()' has been deprecated since 1.17.2 and "
-        "will be removed in a future release. "
-        "Use 'stcal.utils.build_driz_weight()' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _stcal_build_driz_weight(model=model, weight_type=weight_type, good_bits=good_bits)
-
-
 def build_mask(dqarr, bitvalue):
     """
     Build a bit mask from an input DQ array and a bitvalue flag.
@@ -310,85 +175,6 @@ def is_sky_like(frame):
         ``True`` if the frame is sky-like, ``False`` otherwise.
     """
     return u.Unit("deg") in frame.unit or u.Unit("arcsec") in frame.unit
-
-
-def decode_context(context, x, y):
-    """
-    Get 0-based indices of input images that contributed to (resampled) output pixel.
-
-    .. deprecated:: 1.17.2
-        :py:func:`decode_context` has been deprecated and will be removed in a
-        future release. Use :py:func:`drizzle.utils.decode_context` instead.
-
-    Parameters
-    ----------
-    context : numpy.ndarray
-        A 3D `~numpy.ndarray` of integral data type.
-    x : int, list of integers, numpy.ndarray of integers
-        X-coordinate of pixels to decode (3rd index into the ``context`` array)
-    y : int, list of integers, numpy.ndarray of integers
-        Y-coordinate of pixels to decode (2nd index into the ``context`` array)
-
-    Returns
-    -------
-    list
-        A list of `numpy.ndarray` objects each containing indices of input images
-        that have contributed to an output pixel with coordinates ``x`` and ``y``.
-        The length of returned list is equal to the number of input coordinate
-        arrays ``x`` and ``y``.
-
-    Examples
-    --------
-    An example context array for an output image of array shape ``(5, 6)``
-    obtained by resampling 80 input images.
-
-    >>> import numpy as np
-    >>> from jwst.resample.resample_utils import decode_context
-    >>> con = np.array(
-    ...     [
-    ...         [
-    ...             [0, 0, 0, 0, 0, 0],
-    ...             [0, 0, 0, 36196864, 0, 0],
-    ...             [0, 0, 0, 0, 0, 0],
-    ...             [0, 0, 0, 0, 0, 0],
-    ...             [0, 0, 537920000, 0, 0, 0],
-    ...         ],
-    ...         [
-    ...             [
-    ...                 0,
-    ...                 0,
-    ...                 0,
-    ...                 0,
-    ...                 0,
-    ...                 0,
-    ...             ],
-    ...             [0, 0, 0, 67125536, 0, 0],
-    ...             [0, 0, 0, 0, 0, 0],
-    ...             [0, 0, 0, 0, 0, 0],
-    ...             [0, 0, 163856, 0, 0, 0],
-    ...         ],
-    ...         [
-    ...             [0, 0, 0, 0, 0, 0],
-    ...             [0, 0, 0, 8203, 0, 0],
-    ...             [0, 0, 0, 0, 0, 0],
-    ...             [0, 0, 0, 0, 0, 0],
-    ...             [0, 0, 32865, 0, 0, 0],
-    ...         ],
-    ...     ],
-    ...     dtype=np.int32,
-    ... )
-    >>> decode_context(con, [3, 2], [1, 4])
-    [array([ 9, 12, 14, 19, 21, 25, 37, 40, 46, 58, 64, 65, 67, 77]),
-     array([ 9, 20, 29, 36, 47, 49, 64, 69, 70, 79])]
-    """
-    warnings.warn(
-        "'decode_context()' has been deprecated since 1.17.2 and "
-        "will be removed in a future release. "
-        "Use 'drizzle.utils.decode_context()' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _drizzle_decode_context(context, x, y)
 
 
 def load_custom_wcs(asdf_wcs_file, output_shape=None):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
