### PR TITLE
JP-3947 Fix MIRI LRS Flux error

### DIFF
--- a/changes/9337.resample.rst
+++ b/changes/9337.resample.rst
@@ -1,0 +1,1 @@
+Fixed bug in MIRI LRS resample affect flux conservation

--- a/changes/9337.resample.rst
+++ b/changes/9337.resample.rst
@@ -1,1 +1,1 @@
-Fixed bug in MIRI LRS resample affect flux conservation
+Fixed bug in the resample_spec step, affecting flux conservation for MIRI LRS.

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -693,7 +693,6 @@ class ResampleSpec(ResampleImage):
                 pix_to_xtan = fitter(fit_model, x_idx, x_tan_array)
                 pix_to_ytan = fitter(fit_model, y_idx, y_tan_array)
 
-            
             # append all ra and dec values to use later to find min and max
             # ra and dec
             ra_use = ra[~np.isnan(ra)].flatten()
@@ -779,7 +778,6 @@ class ResampleSpec(ResampleImage):
         ra_min = np.amin(all_ra)
         ra_max = np.amax(all_ra)
         ra_center_final = (ra_max + ra_min) / 2.0
-
         dec_min = np.amin(all_dec)
         dec_max = np.amax(all_dec)
         dec_center_final = (dec_max + dec_min) / 2.0
@@ -810,11 +808,11 @@ class ResampleSpec(ResampleImage):
         else:
             ny = int(np.ceil(diff_x / pix_to_tan_slope_x))
 
-        offset_y = 0.5 * (ny-1) * pix_to_tan_slope_y
-        offset_x = 0.5 * (ny-1) * pix_to_tan_slope_x
+        offset_y = 0.5 * (ny - 1) * pix_to_tan_slope_y
+        offset_x = 0.5 * (ny - 1) * pix_to_tan_slope_x
 
         pix_to_ytan.intercept = -slope_sign_y * offset_y
-        pix_to_xtan.intercept = -slope_sign_x * offset_x 
+        pix_to_xtan.intercept = -slope_sign_x * offset_x
 
         # define the output wcs
         transform = mapping | (pix_to_xtan & pix_to_ytan | undist2sky) & pix_to_wavelength

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -686,7 +686,6 @@ class ResampleSpec(ResampleImage):
                 # estimate the spatial sampling
                 fitter = LinearLSQFitter()
                 fit_model = Linear1D()
-
                 xstop = x_tan_array.shape[0] * pixel_scale_ratio
                 x_idx = np.linspace(0, xstop, x_tan_array.shape[0], endpoint=False)
                 ystop = y_tan_array.shape[0] * pixel_scale_ratio
@@ -694,6 +693,7 @@ class ResampleSpec(ResampleImage):
                 pix_to_xtan = fitter(fit_model, x_idx, x_tan_array)
                 pix_to_ytan = fitter(fit_model, y_idx, y_tan_array)
 
+            
             # append all ra and dec values to use later to find min and max
             # ra and dec
             ra_use = ra[~np.isnan(ra)].flatten()
@@ -799,6 +799,7 @@ class ResampleSpec(ResampleImage):
         )
         diff_y = np.abs(max_tan_y - min_tan_y)
         diff_x = np.abs(max_tan_x - min_tan_x)
+
         pix_to_tan_slope_y = np.abs(pix_to_ytan.slope)
         slope_sign_y = np.sign(pix_to_ytan.slope)
         pix_to_tan_slope_x = np.abs(pix_to_xtan.slope)
@@ -809,10 +810,11 @@ class ResampleSpec(ResampleImage):
         else:
             ny = int(np.ceil(diff_x / pix_to_tan_slope_x))
 
-        offset_y = (ny) / 2 * pix_to_tan_slope_y
-        offset_x = (ny) / 2 * pix_to_tan_slope_x
+        offset_y = 0.5 * (ny-1) * pix_to_tan_slope_y
+        offset_x = 0.5 * (ny-1) * pix_to_tan_slope_x
+
         pix_to_ytan.intercept = -slope_sign_y * offset_y
-        pix_to_xtan.intercept = -slope_sign_x * offset_x
+        pix_to_xtan.intercept = -slope_sign_x * offset_x 
 
         # define the output wcs
         transform = mapping | (pix_to_xtan & pix_to_ytan | undist2sky) & pix_to_wavelength


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3947](https://jira.stsci.edu/browse/JP-3947)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #9309 

<!-- describe the changes comprising this PR here -->
This PR addresses fixes a bug in how MIRI LRS data are resampled. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
