### PR TITLE
JP-3775: Test ci_watson resource_tracker implementation

### DIFF
--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -9,6 +9,9 @@ from stdatamodels.jwst import datamodels
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
 def run_detector1(rtdata_module):
@@ -162,7 +165,6 @@ def test_log_tracked_resources_image2(log_tracked_resources, run_image2):
     log_tracked_resources()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["dq_init", "saturation", "firstframe", "lastframe", "reset",
                                     "linearity", "rscd", "dark_current", "ramp", "rate",
                                     "rateints"])
@@ -171,19 +173,16 @@ def test_miri_image_detector1(run_detector1, rtdata_module, fitsdiff_default_kwa
     _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix)
 
 
-@pytest.mark.bigdata
 def test_miri_image_detector1_multiprocess_rate(run_detector1_multiprocess_rate, rtdata_module, fitsdiff_default_kwargs):
     """Regression test of detector1 pipeline performed on MIRI imaging data."""
     _assert_is_same(rtdata_module, fitsdiff_default_kwargs, "rate")
 
 
-@pytest.mark.bigdata
 def test_miri_image_detector1_multiprocess_jump(run_detector1_multiprocess_jump, rtdata_module, fitsdiff_default_kwargs):
     """Regression test of detector1 pipeline performed on MIRI imaging data."""
     _assert_is_same(rtdata_module, fitsdiff_default_kwargs, "rate")
 
 
-@pytest.mark.bigdata
 def test_detector1_mem_usage(rtdata_module):
     """Determine the memory usage for Detector 1"""
     rtdata = rtdata_module
@@ -216,7 +215,6 @@ def test_detector1_mem_usage(rtdata_module):
     assert peak_mem <= mem_benchmark, "Max memory used is greater than 11 GB"
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["dark_current", "ramp", "rate",
                                     "rateints"])
 def test_miri_image_detector1_with_avg_dark_current(run_detector1_with_average_dark_current,
@@ -238,7 +236,6 @@ def test_miri_image_detector1_with_avg_dark_current(run_detector1_with_average_d
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix",
                          ["cfn_clean_flicker_noise", "mask",
                           "flicker_bkg", "flicker_noise",
@@ -261,14 +258,12 @@ def test_miri_image_detector1_with_clean_flicker_noise(
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["assign_wcs", "flat_field", "cal", "i2d"])
 def test_miri_image_image2(run_image2, rtdata_module, fitsdiff_default_kwargs, suffix):
     """Regression test of image2 pipeline performed on MIRI imaging data."""
     _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix)
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["o001_crf"])
 def test_miri_image_image3(run_image3, rtdata_module, fitsdiff_default_kwargs, suffix):
     """Regression test of image3 pipeline performed on MIRI imaging data."""
@@ -292,7 +287,6 @@ def _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_miri_image3_i2d(run_image3, rtdata_module, fitsdiff_default_kwargs):
     rtdata = rtdata_module
     rtdata.input = "jw01024-o001_20220501t155404_image3_001_asn.json"
@@ -304,7 +298,6 @@ def test_miri_image3_i2d(run_image3, rtdata_module, fitsdiff_default_kwargs):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_miri_image3_catalog(run_image3, rtdata_module, diff_astropy_tables):
     rtdata = rtdata_module
     rtdata.input = "jw01024-o001_20220501t155404_image3_001_asn.json"
@@ -314,7 +307,6 @@ def test_miri_image3_catalog(run_image3, rtdata_module, diff_astropy_tables):
     assert diff_astropy_tables(rtdata.output, rtdata.truth, rtol=1e-3, atol=1e-4)
 
 
-@pytest.mark.bigdata
 def test_miri_image_wcs(run_image2, rtdata_module, fitsdiff_default_kwargs):
     rtdata = rtdata_module
 

--- a/jwst/regtest/test_nircam_coron3.py
+++ b/jwst/regtest/test_nircam_coron3.py
@@ -4,9 +4,12 @@ from astropy.io.fits.diff import FITSDiff
 from jwst.stpipe import Step
 import warnings
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, request_tracker):
     """Run calwebb_coron3 on coronographic data."""
     rtdata = rtdata_module
     rtdata.get_asn("nircam/coron/jw01386-c1020_20220909t073458_coron3_002a_asn.json")
@@ -16,12 +19,15 @@ def run_pipeline(rtdata_module):
     with warnings.catch_warnings():
         # warning is explicitly raised by the pipeline
         warnings.filterwarnings("ignore", category=RuntimeWarning, message="'var_rnoise' array not available")
-        Step.from_cmdline(args)
+        with request_tracker.track():
+            Step.from_cmdline(args)
 
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
 @pytest.mark.parametrize("suffix", ["psfalign", "psfsub", "crfints"])
 @pytest.mark.parametrize("obs", ["002", "003"])
 def test_nircam_coron3_sci_exp(run_pipeline, suffix, obs, fitsdiff_default_kwargs):
@@ -37,7 +43,6 @@ def test_nircam_coron3_sci_exp(run_pipeline, suffix, obs, fitsdiff_default_kwarg
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["crfints"])
 @pytest.mark.parametrize("exposure", ["00001", "00002", "00003", "00004"])
 def test_nircam_coron3_psf_exp(run_pipeline, suffix, exposure, fitsdiff_default_kwargs):
@@ -53,7 +58,6 @@ def test_nircam_coron3_psf_exp(run_pipeline, suffix, exposure, fitsdiff_default_
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["psfstack", "i2d"])
 def test_nircam_coron3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
     """Check final products of calwebb_coron3"""

--- a/jwst/regtest/test_nircam_coron3.py
+++ b/jwst/regtest/test_nircam_coron3.py
@@ -9,7 +9,7 @@ pytestmark = [pytest.mark.bigdata]
 
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module, request_tracker):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run calwebb_coron3 on coronographic data."""
     rtdata = rtdata_module
     rtdata.get_asn("nircam/coron/jw01386-c1020_20220909t073458_coron3_002a_asn.json")
@@ -19,7 +19,7 @@ def run_pipeline(rtdata_module, request_tracker):
     with warnings.catch_warnings():
         # warning is explicitly raised by the pipeline
         warnings.filterwarnings("ignore", category=RuntimeWarning, message="'var_rnoise' array not available")
-        with request_tracker.track():
+        with resource_tracker.track():
             Step.from_cmdline(args)
 
     return rtdata

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -5,6 +5,9 @@ from jwst.stpipe import Step
 from stdatamodels.jwst.datamodels import SossWaveGridModel
 import numpy as np
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
 def run_tso_spec2(rtdata_module):
@@ -43,7 +46,7 @@ def run_tso_spec3(rtdata_module, run_tso_spec2):
 
 
 @pytest.fixture(scope="module")
-def run_atoca_extras(rtdata_module):
+def run_atoca_extras(rtdata_module, request_tracker):
     """Run stage 2 pipeline on NIRISS SOSS data using enhanced modes via parameter settings."""
     rtdata = rtdata_module
 
@@ -56,10 +59,14 @@ def run_atoca_extras(rtdata_module):
             "--steps.extract_1d.soss_bad_pix=model",
             "--steps.extract_1d.soss_rtol=1.e-3",
             ]
-    Step.from_cmdline(args)
+    with request_tracker.track():
+        Step.from_cmdline(args)
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources(log_tracked_resources, run_atoca_extras):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", ["calints", "flat_field", "srctype", "x1dints"])
 def test_niriss_soss_stage2(rtdata_module, run_tso_spec2, fitsdiff_default_kwargs, suffix):
     """Regression test of tso-spec2 pipeline performed on NIRISS SOSS data."""
@@ -74,7 +81,6 @@ def test_niriss_soss_stage2(rtdata_module, run_tso_spec2, fitsdiff_default_kwarg
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_niriss_soss_stage3_crfints(rtdata_module, run_tso_spec3, fitsdiff_default_kwargs):
     """Regression test of tso-spec3 pipeline outlier_detection results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
@@ -88,7 +94,6 @@ def test_niriss_soss_stage3_crfints(rtdata_module, run_tso_spec3, fitsdiff_defau
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_niriss_soss_stage3_x1dints(run_tso_spec3, rtdata_module, fitsdiff_default_kwargs):
     """Regression test of tso-spec3 pipeline extract_1d results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
@@ -101,7 +106,6 @@ def test_niriss_soss_stage3_x1dints(run_tso_spec3, rtdata_module, fitsdiff_defau
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_niriss_soss_stage3_whtlt(run_tso_spec3, rtdata_module, diff_astropy_tables):
     """Regression test of tso-spec3 pipeline white_light results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
@@ -113,7 +117,6 @@ def test_niriss_soss_stage3_whtlt(run_tso_spec3, rtdata_module, diff_astropy_tab
     assert diff_astropy_tables(rtdata.output, rtdata.truth)
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["calints", "x1dints", "AtocaSpectra", "SossExtractModel"])
 def test_niriss_soss_extras(rtdata_module, run_atoca_extras, fitsdiff_default_kwargs, suffix):
     """Regression test of ATOCA enhanced algorithm performed on NIRISS SOSS data."""
@@ -144,7 +147,6 @@ def run_extract1d_null_order2(rtdata_module):
     Step.from_cmdline(args)
 
 
-@pytest.mark.bigdata
 def test_extract1d_null_order2(rtdata_module, run_extract1d_null_order2, fitsdiff_default_kwargs):
 
     rtdata = rtdata_module
@@ -186,7 +188,6 @@ def run_spec2_substrip96(rtdata_module):
     Step.from_cmdline(args)
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["calints", "x1dints"])
 def test_spec2_substrip96(rtdata_module, run_spec2_substrip96, fitsdiff_default_kwargs, suffix):
     """Regression test of tso-spec2 pipeline performed on NIRISS SOSS data."""

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -46,7 +46,7 @@ def run_tso_spec3(rtdata_module, run_tso_spec2):
 
 
 @pytest.fixture(scope="module")
-def run_atoca_extras(rtdata_module, request_tracker):
+def run_atoca_extras(rtdata_module, resource_tracker):
     """Run stage 2 pipeline on NIRISS SOSS data using enhanced modes via parameter settings."""
     rtdata = rtdata_module
 
@@ -59,7 +59,7 @@ def run_atoca_extras(rtdata_module, request_tracker):
             "--steps.extract_1d.soss_bad_pix=model",
             "--steps.extract_1d.soss_rtol=1.e-3",
             ]
-    with request_tracker.track():
+    with resource_tracker.track():
         Step.from_cmdline(args)
 
 

--- a/jwst/regtest/test_nirspec_mos_spec3.py
+++ b/jwst/regtest/test_nirspec_mos_spec3.py
@@ -6,21 +6,28 @@ from gwcs import wcstools
 from jwst.stpipe import Step
 from stdatamodels.jwst import datamodels
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, request_tracker):
     """Run calwebb_spec3 on NIRSpec MOS data."""
     rtdata = rtdata_module
     rtdata.get_asn("nirspec/mos/jw01345-o066_20230831t181155_spec3_00002_asn.json")
 
     # Run the calwebb_spec3 pipeline on the association
     args = ["calwebb_spec3", rtdata.input]
-    Step.from_cmdline(args)
+    with request_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d"])
 @pytest.mark.parametrize("source_id", ["b000000030", "b000000031",
                                        "s000004385", "s000007380",

--- a/jwst/regtest/test_nirspec_mos_spec3.py
+++ b/jwst/regtest/test_nirspec_mos_spec3.py
@@ -11,14 +11,14 @@ pytestmark = [pytest.mark.bigdata]
 
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module, request_tracker):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run calwebb_spec3 on NIRSpec MOS data."""
     rtdata = rtdata_module
     rtdata.get_asn("nirspec/mos/jw01345-o066_20230831t181155_spec3_00002_asn.json")
 
     # Run the calwebb_spec3 pipeline on the association
     args = ["calwebb_spec3", rtdata.input]
-    with request_tracker.track():
+    with resource_tracker.track():
         Step.from_cmdline(args)
 
     return rtdata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ sdp = [
     "pysiaf>=0.13.0",
 ]
 test = [
-    "ci-watson>=0.5.0",
+    "ci-watson @ git+https://github.com/spacetelescope/ci_watson.git@main",
     "pysiaf>=0.13.0",
     "pytest>=6.0.0",
     "pytest-cov>=2.9.0",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-3775](https://jira.stsci.edu/browse/JP-3775)

<!-- describe the changes comprising this PR here -->
This PR tests the implementation of the new resource_tracker pytest fixture to track memory usage and runtime.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
