### PR TITLE
TST: Add RELAX_TOL for regtests devdeps

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -404,7 +404,7 @@ def fitsdiff_default_kwargs():
         rtol = 1e-5
         atol = 1e-7
     else:
-        rtol = 1e-5
+        rtol = 0.01
         atol = 0.01
 
     ignore_keywords = ["DATE", "CAL_VER", "CAL_VCS", "CRDS_VER", "CRDS_CTX", "NAXIS1", "TFORM*"]

--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -1,22 +1,21 @@
+from datetime import datetime
 import copy
 import json
 import os
-from datetime import datetime
 from pathlib import Path
 
 import getpass
 import pytest
-from astropy.io.fits import conf
-from astropy.table import Table
 from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
+from astropy.table import Table
 from numpy.testing import assert_allclose, assert_equal
+from astropy.io.fits import conf
 
 from jwst.regtest.regtestdata import RegtestData
 from jwst.regtest.sdp_pools_source import SDPPoolsSource
 
 
 TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
-RELAX_TOL = os.environ.get("RELAX_TOL", "false") == "true"
 
 # Turn of FITS memmap for all regtests (affects FITSDiff)
 conf.use_memmap = False
@@ -400,20 +399,13 @@ def fitsdiff_default_kwargs():
     dict
         Keyword arguments to pass into FITSDiff.
     """
-    if not RELAX_TOL:
-        rtol = 1e-5
-        atol = 1e-7
-    else:
-        rtol = 0.01
-        atol = 0.01
-
     ignore_keywords = ["DATE", "CAL_VER", "CAL_VCS", "CRDS_VER", "CRDS_CTX", "NAXIS1", "TFORM*"]
     return {
         "ignore_hdus": ["ASDF"],
         "ignore_keywords": ignore_keywords,
         "ignore_fields": ignore_keywords,
-        "rtol": rtol,
-        "atol": atol,
+        "rtol": 1e-5,
+        "atol": 1e-7,
     }
 
 

--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -1,21 +1,22 @@
-from datetime import datetime
 import copy
 import json
 import os
+from datetime import datetime
 from pathlib import Path
 
 import getpass
 import pytest
-from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
-from astropy.table import Table
-from numpy.testing import assert_allclose, assert_equal
 from astropy.io.fits import conf
+from astropy.table import Table
+from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
+from numpy.testing import assert_allclose, assert_equal
 
 from jwst.regtest.regtestdata import RegtestData
 from jwst.regtest.sdp_pools_source import SDPPoolsSource
 
 
 TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
+RELAX_TOL = os.environ.get("RELAX_TOL", "false") == "true"
 
 # Turn of FITS memmap for all regtests (affects FITSDiff)
 conf.use_memmap = False
@@ -399,13 +400,20 @@ def fitsdiff_default_kwargs():
     dict
         Keyword arguments to pass into FITSDiff.
     """
+    if not RELAX_TOL:
+        rtol = 1e-5
+        atol = 1e-7
+    else:
+        rtol = 1e-5
+        atol = 0.01
+
     ignore_keywords = ["DATE", "CAL_VER", "CAL_VCS", "CRDS_VER", "CRDS_CTX", "NAXIS1", "TFORM*"]
     return {
         "ignore_hdus": ["ASDF"],
         "ignore_keywords": ignore_keywords,
         "ignore_fields": ignore_keywords,
-        "rtol": 1e-5,
-        "atol": 1e-7,
+        "rtol": rtol,
+        "atol": atol,
     }
 
 

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -1,12 +1,12 @@
-from difflib import unified_diff
-from glob import glob as _sys_glob
 import os
 import os.path as op
-from pathlib import Path
 import pprint
 import requests
 import shutil
 import sys
+from difflib import unified_diff
+from glob import glob as _sys_glob
+from pathlib import Path
 
 import asdf
 from astropy.io.fits.diff import FITSDiff
@@ -22,6 +22,10 @@ from jwst.lib.file_utils import pushdir
 from jwst.lib.suffix import replace_suffix
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 from jwst.stpipe import Step
+
+# Relax tolerance for tests that pass FITSDiff on stable deps job but
+# fails on devdeps only.
+RELAX_TOL = os.environ.get("RELAX_TOL", "false") == "true"
 
 # Define location of default Artifactory API key
 ARTIFACTORY_API_KEY_FILE = "/eng/ssb2/keys/svc_rodata.key"

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -1,3 +1,4 @@
+import os
 from glob import glob
 
 import pytest
@@ -8,6 +9,8 @@ from numpy.testing import assert_allclose
 from stdatamodels.jwst import datamodels
 
 from jwst.stpipe import Step
+
+RELAX_TOL = os.environ.get("RELAX_TOL", "false") == "true"
 
 
 @pytest.fixture(scope="module")
@@ -280,7 +283,8 @@ def test_nircam_image_detector1_with_clean_flicker_noise(
     rtdata.get_truth(f"truth/test_nircam_image_clean_flicker_noise/{output}")
 
     # Set tolerances so the file comparisons work across architectures
-    fitsdiff_default_kwargs["rtol"] = 1e-4
-    fitsdiff_default_kwargs["atol"] = 1e-4
+    if not RELAX_TOL:
+        fitsdiff_default_kwargs["rtol"] = 1e-4
+        fitsdiff_default_kwargs["atol"] = 1e-4
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -1,4 +1,3 @@
-import os
 from glob import glob
 
 import pytest
@@ -8,9 +7,8 @@ from numpy.testing import assert_allclose
 
 from stdatamodels.jwst import datamodels
 
+from jwst.regtest.regtestdata import RELAX_TOL
 from jwst.stpipe import Step
-
-RELAX_TOL = os.environ.get("RELAX_TOL", "false") == "true"
 
 
 @pytest.fixture(scope="module")
@@ -283,8 +281,33 @@ def test_nircam_image_detector1_with_clean_flicker_noise(
     rtdata.get_truth(f"truth/test_nircam_image_clean_flicker_noise/{output}")
 
     # Set tolerances so the file comparisons work across architectures
-    if not RELAX_TOL:
+    if RELAX_TOL and suffix in ("cfn_clean_flicker_noise", "cfn_ramp"):
+        # 1472 different pixels found (0.01% different).
+        # Maximum relative difference: 0.6280834674835205
+        # Maximum absolute difference: 0.0031576156616210938
+        fitsdiff_default_kwargs["rtol"] = 0.63
+        fitsdiff_default_kwargs["atol"] = 0.005
+    elif RELAX_TOL and suffix == "flicker_noise":
+        # 2048 different pixels found (0.01% different).
+        # Maximum relative difference: 0.003016822040081024
+        # Maximum absolute difference: 0.0031585693359375
+        fitsdiff_default_kwargs["rtol"] = 0.004
+        fitsdiff_default_kwargs["atol"] = 0.004
+    elif RELAX_TOL and suffix == "cfn_rate":
+        # 278 different pixels found (0.01% different).
+        # Maximum relative difference: 0.0014149226481094956
+        # Maximum absolute difference: 0.00014707446098327637
+        fitsdiff_default_kwargs["rtol"] = 0.002
+        fitsdiff_default_kwargs["atol"] = 0.0002
+    elif RELAX_TOL and suffix == "cfn_rateints":
+        # 1821 different pixels found (0.02% different).
+        # Maximum relative difference: 0.022895148023962975
+        # Maximum absolute difference: 0.00029408931732177734
+        fitsdiff_default_kwargs["rtol"] = 0.03
+        fitsdiff_default_kwargs["atol"] = 0.0003
+    else:
         fitsdiff_default_kwargs["rtol"] = 1e-4
         fitsdiff_default_kwargs["atol"] = 1e-4
+
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_nircam_wfss_spec2.py
+++ b/jwst/regtest/test_nircam_wfss_spec2.py
@@ -2,6 +2,7 @@ import pytest
 
 from astropy.io.fits.diff import FITSDiff
 
+from jwst.regtest.regtestdata import RELAX_TOL
 from jwst.stpipe import Step
 
 
@@ -49,5 +50,37 @@ def test_nircam_wfss_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     rtdata.get_truth("truth/test_nircam_wfss_spec2/" + output)
 
     # Compare the results
+    if RELAX_TOL and suffix == "bsub":
+        # 1671 different pixels found (0.04% different).
+        # Maximum relative difference: 0.00041919932118617
+        # Maximum absolute difference: 1.1920928955078125e-07
+        fitsdiff_default_kwargs["rtol"] = 5e-4
+        fitsdiff_default_kwargs["atol"] = 2e-7
+    elif RELAX_TOL and suffix == "extract_2d":
+        # 16 different pixels found (0.03% different).
+        # Maximum relative difference: 0.0020618431735783815
+        # Maximum absolute difference: 1.2549571692943573e-07
+        fitsdiff_default_kwargs["rtol"] = 0.003
+        fitsdiff_default_kwargs["atol"] = 2e-7
+    elif RELAX_TOL and suffix == "flat_field":
+        # 2614 different pixels found (0.06% different).
+        # Maximum relative difference: 0.0283019058406353
+        # Maximum absolute difference: 1.2980308383703232e-07
+        fitsdiff_default_kwargs["rtol"] = 0.03
+        fitsdiff_default_kwargs["atol"] = 2e-7
+    elif RELAX_TOL and suffix == "srctype":
+        # 48 different pixels found (0.05% different).
+        # Maximum relative difference: 0.00050398672465235
+        # Maximum absolute difference: 1.310836523771286e-07
+        fitsdiff_default_kwargs["rtol"] = 6e-4
+        fitsdiff_default_kwargs["atol"] = 2e-7
+    elif RELAX_TOL and suffix == "cal":
+        # Each extension has different failures so using max from combo tol.
+        fitsdiff_default_kwargs["rtol"] = 0.2
+        fitsdiff_default_kwargs["atol"] = 8
+    elif RELAX_TOL and suffix == "x1d":
+        # Each extension has different failures so using max from combo tol.
+        fitsdiff_default_kwargs["rtol"] = 0.01
+        fitsdiff_default_kwargs["atol"] = 0.2
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_niriss_image.py
+++ b/jwst/regtest/test_niriss_image.py
@@ -2,6 +2,7 @@
     an uncal file. Results from all intermediate steps, including
     charge_migration, are saved for comparisons with truth files.
 """
+import os
 
 import pytest
 from astropy.io.fits.diff import FITSDiff
@@ -9,6 +10,8 @@ from astropy.io.fits.diff import FITSDiff
 from jwst import datamodels
 from jwst.stpipe import Step
 from jwst.tweakreg import TweakRegStep
+
+RELAX_TOL = os.environ.get("RELAX_TOL", "false") == "true"
 
 
 @pytest.fixture(scope="module")
@@ -237,7 +240,8 @@ def _assert_is_same(rtdata_module, fitsdiff_default_kwargs, suffix, truth_dir):
 
     # Set tolerances so the crf, rscd and rateints file comparisons work across
     # architectures
-    fitsdiff_default_kwargs["rtol"] = 1e-4
-    fitsdiff_default_kwargs["atol"] = 1e-4
+    if not RELAX_TOL:
+        fitsdiff_default_kwargs["rtol"] = 1e-4
+        fitsdiff_default_kwargs["atol"] = 1e-4
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -1,6 +1,7 @@
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
+from jwst.regtest.regtestdata import RELAX_TOL
 from jwst.stpipe import Step
 from stdatamodels.jwst.datamodels import SossWaveGridModel
 import numpy as np
@@ -124,6 +125,10 @@ def test_niriss_soss_extras(rtdata_module, run_atoca_extras, fitsdiff_default_kw
 
     rtdata.get_truth(f"truth/test_niriss_soss_stages/{output}")
 
+    if RELAX_TOL and suffix == "AtocaSpectra":
+        # Each extension has different failures so using max from combo tol.
+        fitsdiff_default_kwargs["rtol"] = 0.01
+        fitsdiff_default_kwargs["atol"] = 0.1
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 

--- a/jwst/regtest/test_niriss_wfss.py
+++ b/jwst/regtest/test_niriss_wfss.py
@@ -2,6 +2,7 @@
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
+from jwst.regtest.regtestdata import RELAX_TOL
 from jwst.stpipe import Step
 
 
@@ -55,6 +56,36 @@ def test_nis_wfss_spec2(run_nis_wfss_spec2, rtdata_module, fitsdiff_default_kwar
     rtdata.output = output
     rtdata.get_truth(f"truth/test_niriss_wfss/{output}")
 
+    if RELAX_TOL and suffix == "bsub":
+        # 3394682 different pixels found (80.94% different).
+        # Maximum relative difference: 0.00017860707885120064
+        # Maximum absolute difference: 1.0728836059570312e-06
+        fitsdiff_default_kwargs["rtol"] = 2e-4
+        fitsdiff_default_kwargs["atol"] = 2e-6
+    elif RELAX_TOL and suffix in ("cal", "photom"):
+        # 13 different pixels found (0.02% different).
+        # Maximum relative difference: 2.5724053557496518e-05
+        # Maximum absolute difference: 0.01300048828125
+        fitsdiff_default_kwargs["rtol"] = 3e-5
+        fitsdiff_default_kwargs["atol"] = 0.02
+    elif RELAX_TOL and suffix == "esec":
+        # 418922 different pixels found (81.51% different).
+        # Maximum relative difference: 0.00017855942132882774
+        # Maximum absolute difference: 1.666136085987091e-06
+        fitsdiff_default_kwargs["rtol"] = 2e-4
+        fitsdiff_default_kwargs["atol"] = 2e-6
+    elif RELAX_TOL and suffix in ("extract_2d", "srctype"):
+        # 9565 different pixels found (12.02% different).
+        # Maximum relative difference: 5.518057514564134e-05
+        # Maximum absolute difference: 1.0654330253601074e-06
+        fitsdiff_default_kwargs["rtol"] = 6e-5
+        fitsdiff_default_kwargs["atol"] = 2e-6
+    elif RELAX_TOL and suffix == "flat_field":
+        # 3394723 different pixels found (80.94% different).
+        # Maximum relative difference: 0.0001786387147149071
+        # Maximum absolute difference: 1.0272487998008728e-06
+        fitsdiff_default_kwargs["rtol"] = 2e-4
+        fitsdiff_default_kwargs["atol"] = 2e-6
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
 
@@ -84,6 +115,19 @@ def test_nis_wfss_spec3(run_nis_wfss_spec3, rtdata_module, suffix, source_id, fi
     rtdata.get_truth(f"truth/test_niriss_wfss/{output}")
 
     # Compare the results
-    fitsdiff_default_kwargs['atol'] = 1e-5
+    if RELAX_TOL and source_id == "s000000015" and suffix == "cal":
+        # 2804 different pixels found (10.60% different).
+        # Maximum relative difference: 4.917978003504686e-05
+        # Maximum absolute difference: 0.0076446533203125
+        fitsdiff_default_kwargs["rtol"] = 5e-5
+        fitsdiff_default_kwargs["atol"] = 0.008
+    elif RELAX_TOL and source_id == "s000000104" and suffix == "cal":
+        # 743 different pixels found (1.68% different).
+        # Maximum relative difference: 0.00018466946494299918
+        # Maximum absolute difference: 0.01251220703125
+        fitsdiff_default_kwargs["rtol"] = 2e-4
+        fitsdiff_default_kwargs["atol"] = 0.02
+    else:
+        fitsdiff_default_kwargs['atol'] = 1e-5
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_niriss_wfss.py
+++ b/jwst/regtest/test_niriss_wfss.py
@@ -116,11 +116,11 @@ def test_nis_wfss_spec3(run_nis_wfss_spec3, rtdata_module, suffix, source_id, fi
 
     # Compare the results
     if RELAX_TOL and source_id == "s000000015" and suffix == "cal":
-        # 2804 different pixels found (10.60% different).
-        # Maximum relative difference: 4.917978003504686e-05
-        # Maximum absolute difference: 0.0076446533203125
-        fitsdiff_default_kwargs["rtol"] = 5e-5
-        fitsdiff_default_kwargs["atol"] = 0.008
+        # 4 different pixels found (0.02% different).
+        # Maximum relative difference: 0.0009792582131922245
+        # Maximum absolute difference: 0.011031150817871094
+        fitsdiff_default_kwargs["rtol"] = 1e-3
+        fitsdiff_default_kwargs["atol"] = 0.02
     elif RELAX_TOL and source_id == "s000000104" and suffix == "cal":
         # 743 different pixels found (1.68% different).
         # Maximum relative difference: 0.00018466946494299918

--- a/jwst/regtest/test_nirspec_irs2_detector1.py
+++ b/jwst/regtest/test_nirspec_irs2_detector1.py
@@ -5,6 +5,7 @@
 import pytest
 from astropy.io.fits.diff import FITSDiff
 
+from jwst.regtest.regtestdata import RELAX_TOL
 from jwst.stpipe import Step
 
 
@@ -90,7 +91,20 @@ def test_nirspec_irs2_detector1_with_clean_flicker_noise(
     rtdata.get_truth(f"truth/test_nirspec_irs2_clean_flicker_noise/{output_filename}")
 
     # Set tolerances so comparisons work across architectures
-    fitsdiff_default_kwargs["rtol"] = 1e-4
-    fitsdiff_default_kwargs["atol"] = 1e-4
+    if RELAX_TOL and suffix in ("cfn_clean_flicker_noise", "cfn_ramp"):
+        # 12666 different pixels found (0.02% different).
+        # Maximum relative difference: 0.003790903137996793
+        # Maximum absolute difference: 0.004589080810546875
+        fitsdiff_default_kwargs["rtol"] = 0.004
+        fitsdiff_default_kwargs["atol"] = 0.005
+    elif RELAX_TOL and suffix == "flicker_noise":
+        # 33827 different pixels found (0.05% different).
+        # Maximum relative difference: 0.0023980815894901752
+        # Maximum absolute difference: 0.001953125
+        fitsdiff_default_kwargs["rtol"] = 0.003
+        fitsdiff_default_kwargs["atol"] = 0.002
+    else:
+        fitsdiff_default_kwargs["rtol"] = 1e-4
+        fitsdiff_default_kwargs["atol"] = 1e-4
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()

--- a/jwst/regtest/test_nirspec_irs2_detector1.py
+++ b/jwst/regtest/test_nirspec_irs2_detector1.py
@@ -98,11 +98,11 @@ def test_nirspec_irs2_detector1_with_clean_flicker_noise(
         fitsdiff_default_kwargs["rtol"] = 0.004
         fitsdiff_default_kwargs["atol"] = 0.005
     elif RELAX_TOL and suffix == "flicker_noise":
-        # 33827 different pixels found (0.05% different).
-        # Maximum relative difference: 0.0023980815894901752
-        # Maximum absolute difference: 0.001953125
-        fitsdiff_default_kwargs["rtol"] = 0.003
-        fitsdiff_default_kwargs["atol"] = 0.002
+        # 2071 different pixels found (0.00% different).
+        # Maximum relative difference: 0.0714285746216774
+        # Maximum absolute difference: 0.004589080810546875
+        fitsdiff_default_kwargs["rtol"] = 0.08
+        fitsdiff_default_kwargs["atol"] = 0.005
     else:
         fitsdiff_default_kwargs["rtol"] = 1e-4
         fitsdiff_default_kwargs["atol"] = 1e-4


### PR DESCRIPTION
This PR brings us a step closer to #9362 though the regtest workflow might need updating downstream to really take advantage of it.

Link to POC regtest run: https://github.com/spacetelescope/RegressionTests/actions/runs/14333786520

* ~Only targets `jwst/regtest/test_niriss_soss.py -k test_niriss_soss_extras`, one of the failing tests on devdeps regtests.~ (That test is slow and the entire suite is only 30 mins longer... so just run the whole thing or maybe try `jwst/regtest/test_nircam_image.py -k test_nircam_image_detector1_with_clean_flicker_noise` instead) Example failing log: https://github.com/spacetelescope/RegressionTests/actions/runs/14255060733/job/39956210262
* Injected `RELAX_TOL=true` to "environment variables" input field (hope that works). Maybe we also need https://github.com/spacetelescope/RegressionTests/pull/209

Expectation: devdeps would be green

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
