### PR TITLE
update readme for new regtests

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,9 +387,7 @@ Need to parallelize your test runs over all available cores?
 
 Latest regression test results can be found here (STScI staff only):
 
-https://plwishmaster.stsci.edu:8081/job/RT/job/JWST/
-
-The test builds start at 6pm local Baltimore time Monday through Saturday on `jwcalibdev`.
+ihttps://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml?query=event%3Aschedule
 
 To run the regression tests on your local machine, get the test dependencies
 and set the environment variable TEST_BIGDATA to our Artifactory server

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Need to parallelize your test runs over all available cores?
 
 Latest regression test results can be found here (STScI staff only):
 
-ihttps://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml?query=event%3Aschedule
+https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml?query=event%3Aschedule
 
 To run the regression tests on your local machine, get the test dependencies
 and set the environment variable TEST_BIGDATA to our Artifactory server


### PR DESCRIPTION
Remove plwishmaster link, update with link to new scheduled regtests.

I removed the description of the schedule as it's redundant to the workflows in the regtest repo and unlikely to stay in sync if those workflows are updated.

Only a readme change so no regtests will be run.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
