### PR TITLE
JP-3982: numpy 2.3.0 accommodation

### DIFF
--- a/changes/9376.background.rst
+++ b/changes/9376.background.rst
@@ -1,0 +1,1 @@
+In WFSS background calculations, use higher precision for mean and sum calculations for better numerical consistency across build environments.

--- a/changes/9376.clean_flicker_noise.rst
+++ b/changes/9376.clean_flicker_noise.rst
@@ -1,0 +1,1 @@
+Use higher precision for sigma clipping statistics for better numerical consistency across build environments.

--- a/jwst/background/background_sub_wfss.py
+++ b/jwst/background/background_sub_wfss.py
@@ -206,7 +206,7 @@ class _ScalingFactorComputer:
         """Remove any var=0 values, which can happen for real data"""
         mask = (var == 0)
         self._update_nans(sci, bkg, var, mask)
-        return np.nansum(sci*bkg/var) / np.nansum(bkg*bkg/var)
+        return np.nansum(sci*bkg/var, dtype='f8') / np.nansum(bkg*bkg/var, dtype='f8')
 
 
     def _update_nans(self, sci, bkg, var, mask):
@@ -223,7 +223,7 @@ class _ScalingFactorComputer:
         So we need to """
         collapsing_axis = int(self.dispersion_axis - 1)
         sci_sub_profile = np.nanmedian(sci_sub, axis=collapsing_axis)
-        return np.sqrt(np.nanmean(sci_sub_profile**2))
+        return np.sqrt(np.nanmean(sci_sub_profile**2, dtype='f8'))
 
 
 def _sufficient_background_pixels(dq_array, bkg_mask, min_pixels=100):

--- a/jwst/clean_flicker_noise/clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise.py
@@ -315,6 +315,9 @@ def clip_to_background(
         If set, DEBUG level messages are issued with details on the
         computed statistics.
     """
+    # Use float64 for stats computations
+    image = image.astype(np.float64)
+
     # Sigma limit for basic stats
     sigma_limit = 3.0
 

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -51,11 +51,12 @@ def run_atoca_extras(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
     # Run spec2 pipeline on the second _rateints file, using wavegrid generated from first segment.
-    rtdata.get_data("niriss/soss/seg001_wavegrid.fits")
-    rtdata.get_data("niriss/soss/atoca_extras_rateints.fits")
+    rtdata.get_data("niriss/soss/jw01091002001_03101_00001-seg001_wavegrid.fits")
+    rtdata.get_data("niriss/soss/jw01091002001_03101_00001-seg002_nis_short_rateints.fits")
     args = ["calwebb_spec2", rtdata.input,
+            "--output_file=atoca_extras",
             "--steps.extract_1d.soss_modelname=atoca_extras",
-            "--steps.extract_1d.soss_wave_grid_in=seg001_wavegrid.fits",
+            "--steps.extract_1d.soss_wave_grid_in=jw01091002001_03101_00001-seg001_wavegrid.fits",
             "--steps.extract_1d.soss_bad_pix=model",
             "--steps.extract_1d.soss_rtol=1.e-3",
             ]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3982](https://jira.stsci.edu/browse/JP-3982)
 
<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Testing changes in preparation for numpy 2.3.0, to fix devdeps tests.

I added higher float precision in some sum and mean calculations that are affected by a change in buffer sizes in numpy 2.3.0.  This introduces some regtest changes for clean_flicker_noise and WFSS background steps in the current build, but they should now be the same changes in devdeps with numpy 2.3.0.dev0 and in the standard run.  The differences are not scientifically significant.  When this is okified, devdeps should have fewer failures.  It's a little hard to make sure of this from the regtest reports, though, so a follow up PR may be needed if there are other changes revealed by resolving these ones.

I also introduced a change here to the SOSS extras regtest data, to make it take less time (locally: ~1 minute, instead of 30).  This test is also currently failing in devdeps. It's hard to tell if it still will after this PR is merged, but if it does, I'd like to address it in a separate PR.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
