### PR TITLE
BUG: Fix is_nrs_msaspec_flatlamp and remove redundant if-else in gs_position_acq

### DIFF
--- a/jwst/lib/exposure_types.py
+++ b/jwst/lib/exposure_types.py
@@ -221,7 +221,7 @@ def is_nrs_msaspec_flatlamp(datamodel):
         `True` if it is.
     """
     lamp_mode = datamodel.meta.instrument.lamp_mode.lower()
-    return lamp_mode == "msaspec" and is_nrs_flatlamp()
+    return lamp_mode == "msaspec" and is_nrs_flatlamp(datamodel)
 
 
 def is_nrs_autoflat(datamodel):

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -2962,12 +2962,8 @@ def gs_position_acq(mnemonics_to_read, mnemonics, exp_type="fgs_acq1"):  # noqa:
         )
 
     # Setup parameters depending on ACQ1 vs ACQ2
-    if exp_type == "fgs_acq1":
-        subarray = valid[FGS_ACQ_WINDOW_INDEX[exp_type]]
-        posg_slice = FGS_ACQ_SLICES[exp_type]
-    else:
-        subarray = valid[FGS_ACQ_WINDOW_INDEX[exp_type]]
-        posg_slice = FGS_ACQ_SLICES[exp_type]
+    subarray = valid[FGS_ACQ_WINDOW_INDEX[exp_type]]
+    posg_slice = FGS_ACQ_SLICES[exp_type]
 
     position = (
         np.average(valid["IFGS_ACQ_XPOSG"][posg_slice]),


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses two checks that SonarQube isn't happy about. Not new stuff but still good to fix. Since the bug been there for 5 years and no one complained, probably no need with change log.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/14382345024
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
