### PR TITLE
Remove unused niriss_bounding_box function from assign_wcs

### DIFF
--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -6,7 +6,6 @@ from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling import bind_bounding_box
 from astropy.modeling.models import Const1D, Mapping, Identity, Shift
-from astropy.modeling.bounding_box import CompoundBoundingBox
 import gwcs.coordinate_frames as cf
 from gwcs import wcs
 
@@ -112,27 +111,6 @@ def _niriss_order_bounding_box(input_model, order):
         raise ValueError(
             f"Invalid spectral order: {order} provided. Spectral order must be 1, 2, or 3."
         )
-
-
-def niriss_bounding_box(input_model):
-    """
-    Create a bounding box for the NIRISS model.
-
-    Parameters
-    ----------
-    input_model : JwstDataModel
-        The input datamodel.
-
-    Returns
-    -------
-    CompoundBoundingBox
-        The bounding box for the NIRISS model.
-    """
-    bbox = {(order,): _niriss_order_bounding_box(input_model, order) for order in [1, 2, 3]}
-    model = input_model.meta.wcs.forward_transform
-    return CompoundBoundingBox.validate(
-        model, bbox, slice_args=[("spectral_order", True)], order="F"
-    )
 
 
 def niriss_soss(input_model, reference_files):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3970](https://jira.stsci.edu/browse/JP-3970)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes #9256 -->

<!-- describe the changes comprising this PR here -->
This PR addresses removal of the unused `niriss_bounding_box` function from `assign_wcs`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
