### PR TITLE
Update docs to reflect correct definition for pixel scale ratio

### DIFF
--- a/changes/9403.resample.rst
+++ b/changes/9403.resample.rst
@@ -1,0 +1,1 @@
+Updated documentation to reflect correct definition of ``pixel_scale_ratio`` for *imaging* data: ratio of output to input pixel scales.

--- a/docs/jwst/resample/arguments.rst
+++ b/docs/jwst/resample/arguments.rst
@@ -16,7 +16,7 @@ image.
     `turbo`, `lanczos2`, and `lanczos3`.
 
 ``--pixel_scale_ratio`` (float, default=1.0)
-    Ratio of input to output pixel scale.
+    Ratio of output pixel scale to input pixel scale.
     For imaging data, a value of 0.5 means the output
     image would have 4 pixels sampling each input pixel.
     Ignored when ``pixel_scale`` or ``output_wcs`` are provided.

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -85,7 +85,7 @@ def compute_scale(
     disp_axis : int
         Dispersion axis integer. Assumes the same convention as `wcsinfo.dispersion_direction`
     pscale_ratio : int
-        Ratio of input to output pixel scale
+        Ratio of output pixel scale to input pixel scale.
 
     Returns
     -------

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -858,7 +858,7 @@ class ResampleSpec(ResampleImage):
         input_models : list
             List of data models, one for each input image
         pixel_scale_ratio : float
-            The ratio of input pixel scale to the the output pixel scale.
+            The ratio of the input pixel scale to the output pixel scale.
 
         Returns
         -------

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -590,7 +590,7 @@ class ResampleSpec(ResampleImage):
         input_models : list
             List of data models, one for each input image
         pixel_scale_ratio : float
-            The ratio of input pixel scale to the the output pixel scale.
+            The ratio of the input pixel scale to the output pixel scale.
 
         Returns
         -------

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -590,7 +590,7 @@ class ResampleSpec(ResampleImage):
         input_models : list
             List of data models, one for each input image
         pixel_scale_ratio : float
-            The ratio of the output pixel scale to the input pixel scale
+            The ratio of input pixel scale to the the output pixel scale.
 
         Returns
         -------
@@ -858,7 +858,7 @@ class ResampleSpec(ResampleImage):
         input_models : list
             List of data models, one for each input image
         pixel_scale_ratio : float
-            The ratio of the output pixel scale to the input pixel scale
+            The ratio of input pixel scale to the the output pixel scale.
 
         Returns
         -------

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -40,7 +40,7 @@ class ResampleStep(Step):
         crpix = float_list(min=2, max=2, default=None)  # 0-based image coordinates of the reference pixel
         crval = float_list(min=2, max=2, default=None)  # world coordinates of the reference pixel
         rotation = float(default=None)  # Output image Y-axis PA relative to North
-        pixel_scale_ratio = float(default=1.0)  # Ratio of input to output pixel scale
+        pixel_scale_ratio = float(default=1.0)  # Ratio of output to input pixel scale.
         pixel_scale = float(default=None)  # Absolute pixel scale in arcsec
         output_wcs = string(default='')  # Custom output WCS
         single = boolean(default=False)  # Resample each input to its own output grid


### PR DESCRIPTION
Related to [RCAL-1054](https://jira.stsci.edu/browse/RCAL-1054)

This PR corrects the definition of pixel scale ratio as used in resampling of imaging data (NOTE: for JWST, spectral resampling may use opposite definition to the one used in imaging)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
