### PR TITLE
JP-3857 Saturation code style changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,6 @@ repos:
             jwst/mrs_imatch/.* |
             jwst/persistence/.* |
             jwst/photom/.* |
-            jwst/saturation/.* |
             jwst/scripts/.* |
             jwst/straylight/.* |
             jwst/tests/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -30,7 +30,6 @@ exclude = [
     "jwst/mrs_imatch/**.py",
     "jwst/persistence/**.py",
     "jwst/photom/**.py",
-    "jwst/saturation/**.py",
     "jwst/scripts/**.py",
     "jwst/straylight/**.py",
 ]
@@ -124,6 +123,5 @@ ignore-fully-untyped = true  # Turn off annotation checking for fully untyped co
 "jwst/mrs_imatch/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/persistence/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/photom/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
-"jwst/saturation/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/scripts/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]
 "jwst/straylight/**.py" = ["D", "N", "A", "ARG", "B", "C4", "ICN", "INP", "ISC", "LOG", "NPY", "PGH", "PTH", "S", "SLF", "SLOT", "T20", "TRY", "UP", "YTT", "E501"]

--- a/jwst/saturation/__init__.py
+++ b/jwst/saturation/__init__.py
@@ -1,3 +1,5 @@
+"""Set saturation flags for pixels."""
+
 from .saturation_step import SaturationStep
 
-__all__ = ['SaturationStep']
+__all__ = ["SaturationStep"]

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -1,4 +1,3 @@
-
 #  Module for 2d saturation
 #
 import logging
@@ -15,17 +14,15 @@ from stcal.saturation.saturation import flag_saturated_pixels
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-DONOTUSE = dqflags.pixel['DO_NOT_USE']
-SATURATED = dqflags.pixel['SATURATED']
-AD_FLOOR = dqflags.pixel['AD_FLOOR']
-NO_SAT_CHECK = dqflags.pixel['NO_SAT_CHECK']
-ATOD_LIMIT = 65535.  # Hard DN limit of 16-bit A-to-D converter
+DONOTUSE = dqflags.pixel["DO_NOT_USE"]
+SATURATED = dqflags.pixel["SATURATED"]
+AD_FLOOR = dqflags.pixel["AD_FLOOR"]
+NO_SAT_CHECK = dqflags.pixel["NO_SAT_CHECK"]
+ATOD_LIMIT = 65535.0  # Hard DN limit of 16-bit A-to-D converter
 
 
 def flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_model=None):
     """
-    Short Summary
-    -------------
     Call function in stcal for flagging for saturated pixels.
 
     Parameters
@@ -53,7 +50,6 @@ def flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_
         Data model with saturation, A/D floor, and do not use flags set in
         the GROUPDQ array
     """
-
     ngroups = output_model.meta.exposure.ngroups
     nframes = output_model.meta.exposure.nframes
 
@@ -68,7 +64,7 @@ def flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_
         sat_thresh = ref_model.data
         sat_dq = ref_model.dq
     else:
-        log.info('Extracting reference file subarray to match science data')
+        log.info("Extracting reference file subarray to match science data")
         ref_sub_model = reffile_utils.get_subarray_model(output_model, ref_model)
         sat_thresh = ref_sub_model.data.copy()
         sat_dq = ref_sub_model.dq.copy()
@@ -76,10 +72,12 @@ def flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_
 
     # Enable use of read_pattern specific treatment if selected
     if use_readpatt:
-        read_pattern = [[x + 1 + groupstart * nframes for x in range(nframes)] for groupstart in range(ngroups)]
+        read_pattern = [
+            [x + 1 + groupstart * nframes for x in range(nframes)] for groupstart in range(ngroups)
+        ]
         log.info(f"Using read_pattern with nframes {nframes}")
     else:
-        read_pattern=None
+        read_pattern = None
 
     bias = None
     if bias_model is not None:
@@ -87,8 +85,18 @@ def flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_
         bias = bias_model.data
 
     gdq_new, pdq_new, zframe = flag_saturated_pixels(
-        data, gdq, pdq, sat_thresh, sat_dq, ATOD_LIMIT, dqflags.pixel,
-        n_pix_grow_sat=n_pix_grow_sat, read_pattern=read_pattern, zframe=zframe, bias=bias)
+        data,
+        gdq,
+        pdq,
+        sat_thresh,
+        sat_dq,
+        ATOD_LIMIT,
+        dqflags.pixel,
+        n_pix_grow_sat=n_pix_grow_sat,
+        read_pattern=read_pattern,
+        zframe=zframe,
+        bias=bias,
+    )
 
     # Save the flags in the output GROUPDQ array
     output_model.groupdq = gdq_new
@@ -102,14 +110,10 @@ def flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_
     return output_model
 
 
-def irs2_flag_saturation(output_model,
-                         ref_model,
-                         n_pix_grow_sat,
-                         use_readpatt,
-                         bias_model=None):
+def irs2_flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_model=None):
     """
-    Short Summary
-    -------------
+    Apply saturation flagging for NIRSpec IRS2 mode data.
+
     For NIRSPEC IRS2 mode only, apply flagging for saturation based on threshold
     values stored in the saturation reference file and A/D floor based on
     testing for 0 DN values. For A/D floor flagged groups, the DO_NOT_USE flag
@@ -140,7 +144,6 @@ def irs2_flag_saturation(output_model,
         Data model with saturation, A/D floor, and do not use flags set in
         the GROUPDQ array
     """
-
     # Create the output model as a copy of the input
     groupdq = output_model.groupdq
 
@@ -151,11 +154,12 @@ def irs2_flag_saturation(output_model,
     nframes = output_model.meta.exposure.nframes
 
     if use_readpatt:
-        read_pattern = [[x + 1 + groupstart * nframes for x in range(nframes)] for groupstart in range(ngroups)]
+        read_pattern = [
+            [x + 1 + groupstart * nframes for x in range(nframes)] for groupstart in range(ngroups)
+        ]
         log.info(f"Using read_pattern with nframes {nframes}")
     else:
-        read_pattern=None
-
+        read_pattern = None
 
     # create a mask of the appropriate size
     irs2_mask = x_irs2.make_mask(output_model)
@@ -165,13 +169,13 @@ def irs2_flag_saturation(output_model,
         sat_thresh = ref_model.data
         sat_dq = ref_model.dq
     else:
-        log.info('Extracting reference file subarray to match science data')
+        log.info("Extracting reference file subarray to match science data")
         ref_sub_model = reffile_utils.get_subarray_model(output_model, ref_model)
         sat_thresh = ref_sub_model.data.copy()
         sat_dq = ref_sub_model.dq.copy()
         ref_sub_model.close()
 
-    bias = 0.
+    bias = 0.0
     if bias_model is not None:
         # Trim the irs2 bias to only the science regions
         bias = x_irs2.from_irs2(bias_model.data, irs2_mask, detector)
@@ -196,22 +200,25 @@ def irs2_flag_saturation(output_model,
     for ints in range(nints):
         for group in range(ngroups):
             # Update the 4D groupdq array with the saturation flag.
-            sci_temp = x_irs2.from_irs2(data[ints, group, :, :],
-                                        irs2_mask, detector)
+            sci_temp = x_irs2.from_irs2(data[ints, group, :, :], irs2_mask, detector)
             # check for saturation
             flag_temp = np.where(sci_temp >= sat_thresh, SATURATED, 0)
             # Additional checks for group 2 saturation in grouped data
-            if ((group == 2) & (read_pattern is not None)):
+            if (group == 2) & (read_pattern is not None):
                 # Identify groups which we wouldn't expect to saturate by the third group,
                 # on the basis of the first group
                 scigp1 = x_irs2.from_irs2(data[ints, 0, :, :], irs2_mask, detector) - bias
-                mask = ((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1]) + bias < sat_thresh
+                mask = (
+                    (scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1]
+                ) + bias < sat_thresh
 
                 # Identify groups with suspiciously large values in the second group
                 # by comparing the change between group 1 and 2 to the dynamic range between
                 # the group 1 and saturation threshold.  Flag any differences sufficiently large
                 # that they could come from a saturating event in the last frame of the group.
-                scigp2 = x_irs2.from_irs2(data[ints, 1, :, :] - data[ints, 0, :, :], irs2_mask, detector)
+                scigp2 = x_irs2.from_irs2(
+                    data[ints, 1, :, :] - data[ints, 0, :, :], irs2_mask, detector
+                )
                 scigp1_counts = x_irs2.from_irs2(data[ints, 0, :, :], irs2_mask, detector)
                 mask &= scigp2 > (sat_thresh - scigp1_counts) / len(read_pattern[1])
 
@@ -220,15 +227,14 @@ def irs2_flag_saturation(output_model,
                 mask &= gp3mask
 
                 # Flag the 2nd group for the pixels passing that gauntlet in the 3rd group
-                dq_temp = np.zeros_like(mask,dtype='uint8')
+                dq_temp = np.zeros_like(mask, dtype="uint8")
                 dq_temp[mask] = SATURATED
                 # flag any pixels that border saturated pixels
                 if n_pix_grow_sat > 0:
                     dq_temp = adjacency_sat(dq_temp, SATURATED, n_pix_grow_sat)
                 # set the flags in dq array for group 2, i.e. index 1
                 x_irs2.to_irs2(flagarray, dq_temp, irs2_mask, detector)
-                np.bitwise_or(groupdq[ints, 1, ...], flagarray,
-                              groupdq[ints, 1, ...])
+                np.bitwise_or(groupdq[ints, 1, ...], flagarray, groupdq[ints, 1, ...])
 
             # check for A/D floor
             flaglow_temp = np.where(sci_temp <= 0, AD_FLOOR | DONOTUSE, 0)
@@ -243,11 +249,9 @@ def irs2_flag_saturation(output_model,
 
             # for saturation, the flag is set in the current plane
             # and all following planes.
-            np.bitwise_or(groupdq[ints, group:, :, :], flagarray,
-                          groupdq[ints, group:, :, :])
+            np.bitwise_or(groupdq[ints, group:, :, :], flagarray, groupdq[ints, group:, :, :])
             # for A/D floor, the flag is only set of the current plane
-            np.bitwise_or(groupdq[ints, group, :, :], flaglowarray,
-                          groupdq[ints, group, :, :])
+            np.bitwise_or(groupdq[ints, group, :, :], flaglowarray, groupdq[ints, group, :, :])
 
         # Process ZEROFRAME.  Instead of setting a ZEROFRAME DQ array, data
         # in the ZEROFRAME that is flagged will be set to 0.
@@ -268,7 +272,7 @@ def irs2_flag_saturation(output_model,
             np.bitwise_or(zdq[:, :], zflagarray, zdq[:, :])
             np.bitwise_or(zdq[:, :], zflaglowarray, zdq[:, :])
 
-            zplane[zdq != 0] = 0.
+            zplane[zdq != 0] = 0.0
             output_model.zeroframe[ints, :, :] = zplane[:, :]
             del zdq
 
@@ -276,13 +280,12 @@ def irs2_flag_saturation(output_model,
     output_model.groupdq = groupdq
 
     n_sat = np.any(np.any(np.bitwise_and(groupdq, SATURATED), axis=0), axis=0).sum()
-    log.info(f'Detected {n_sat} saturated pixels')
+    log.info(f"Detected {n_sat} saturated pixels")
     n_floor = np.any(np.any(np.bitwise_and(groupdq, AD_FLOOR), axis=0), axis=0).sum()
-    log.info(f'Detected {n_floor} A/D floor pixels')
+    log.info(f"Detected {n_floor} A/D floor pixels")
 
     # Save the NO_SAT_CHECK flags in the output PIXELDQ array
-    pixeldq_temp = x_irs2.from_irs2(output_model.pixeldq, irs2_mask,
-                                    detector)
+    pixeldq_temp = x_irs2.from_irs2(output_model.pixeldq, irs2_mask, detector)
     pixeldq_temp = np.bitwise_or(pixeldq_temp, sat_dq)
     x_irs2.to_irs2(output_model.pixeldq, pixeldq_temp, irs2_mask, detector)
 
@@ -291,6 +294,10 @@ def irs2_flag_saturation(output_model,
 
 def adjacency_sat(flag_temp, saturated, n_pix_grow_sat):
     """
+    Apply saturation flags for pixel next to saturated pixels.
+
+    Parameters
+    ----------
     flag_temp : ndarray
         2D array of saturated groups.
 
@@ -301,6 +308,11 @@ def adjacency_sat(flag_temp, saturated, n_pix_grow_sat):
         Number of layers of pixels adjacent to a saturated pixel to also flag
         as saturated (i.e '1' will flag the surrounding 8 pixels) to account for
         charge spilling.
+
+    Returns
+    -------
+    flag_temp : ndarray
+        2D array of saturated groups for pixel next to saturated pixels.
     """
     only_sat = np.bitwise_and(flag_temp, saturated).astype(np.uint8)
     box_dim = (n_pix_grow_sat * 2) + 1

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -1,5 +1,3 @@
-#  Module for 2d saturation
-#
 import logging
 import numpy as np
 from scipy.ndimage import binary_dilation

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -3,11 +3,10 @@ import numpy as np
 from scipy.ndimage import binary_dilation
 
 from stdatamodels.jwst.datamodels import dqflags
+from stcal.saturation.saturation import flag_saturated_pixels
 
 from ..lib import reffile_utils
 from . import x_irs2
-
-from stcal.saturation.saturation import flag_saturated_pixels
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/jwst/saturation/saturation_step.py
+++ b/jwst/saturation/saturation_step.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 from stdatamodels.jwst import datamodels
-
 from ..stpipe import Step
 from ..lib import pipe_utils, reffile_utils
 from . import saturation

--- a/jwst/saturation/saturation_step.py
+++ b/jwst/saturation/saturation_step.py
@@ -32,7 +32,7 @@ class SaturationStep(Step):
         Returns
         -------
         result : DataModel
-            Result of setting the saturation flags to saturated pixels to the data model.
+            Output datamodel with saturation flags set for saturated pixels.
         """
         # Open the input data model
         with datamodels.open(step_input) as input_model:

--- a/jwst/saturation/saturation_step.py
+++ b/jwst/saturation/saturation_step.py
@@ -27,8 +27,8 @@ class SaturationStep(Step):
 
         Parameters
         ----------
-        step_input : DataModel
-            Input datamodel to the step.
+        step_input : DataModel or str
+            Input datamodel or string name of the fits file.
 
         Returns
         -------

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -36,7 +36,7 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     ----------
     input_model : DataModel or numpy.ndarray
         Model from which we retrieve the width of the reference
-        output and the values of NRS_NORM and NRS_REF. It the input_model
+        output and the values of NRS_NORM and NRS_REF. If the input_model
         is a ndarray the parameters will be assigned default values.
 
     n : int or None

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -30,37 +30,41 @@ ReadoutParam = namedtuple("ReadoutParam", ["refout", "n", "r"])
 
 
 def _get_irs2_parameters(input_model, n=None, r=None):
-    """Get the parameters describing IRS2 readout format.
+    """
+    Get the parameters describing IRS2 readout format.
 
     Parameters
     ----------
-    input_model: most likely a RampModel object
+    input_model : DataModel
+        This model is most likely a RampModel object
         This is used for getting the width of the reference output and
         the values of NRS_NORM and NRS_REF.
 
-    n: int or None (default is None)
+    n : int or None
+        Default is None.
         If not None, overrides the default.
 
-    r: int or None (default is None)
+    r : int or None
+        Default is None.
         If not None, overrides the default.
 
     Returns
     -------
-    param: a ReadoutParam object
+    param : ReadoutParam object
+        ReadoutParam objects contains the following information:
         param.refout: int
             The length (in the last image axis) of the reference output
             section.  The reference output is assumed to be on the left
             side of the IRS2-format image.
 
-        param.n: int
+        param.n : int
             The number of "normal" (as opposed to reference) pixels read
             out before jumping to the reference pixel region.
 
-        param.r: int
+        param.r : int
             The number of reference pixels read out before jumping back to
             the normal pixel region.
     """
-
     try:
         # Try to get keyword values
         n_norm = input_model.meta.exposure.nrs_normal
@@ -76,15 +80,38 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     if r is not None:
         n_ref = r
 
-    param = ReadoutParam(refout=(512 + 512 // n_norm * n_ref),
-                         n=n_norm, r=n_ref)
+    param = ReadoutParam(refout=(512 + 512 // n_norm * n_ref), n=n_norm, r=n_ref)
 
     return param
 
 
 def normal_shape(input_model, n=None, r=None, detector=None):
-    """Determine the shape of the 'normal' pixel data."""
+    """
+    Determine the shape of the 'normal' pixel data.
 
+    Parameters
+    ----------
+    input_model : DataModel
+        This is used to get the shape of the input data.
+
+    n : int or None
+        Default is None.
+        If not None, overrides the default.
+
+    r : int or None
+        Default is None.
+        If not None overrides the default.
+
+    detector : str
+       Detector of data. Valid values are None, NRS1, or NRS2. Other detector
+       values will result in a run time error.
+
+    Returns
+    -------
+    data_shape : 2 D array
+        The shape of the data array when excluding interleaved reference
+        pixels.
+    """
     if isinstance(input_model, np.ndarray):
         shape = input_model.shape
     else:
@@ -92,7 +119,7 @@ def normal_shape(input_model, n=None, r=None, detector=None):
         if detector is None:
             detector = input_model.meta.instrument.detector
 
-    if not pipe_utils.is_irs2(input_model):     # not IRS2 format
+    if not pipe_utils.is_irs2(input_model):  # not IRS2 format
         return shape
 
     param = _get_irs2_parameters(input_model, n=n, r=r)
@@ -102,8 +129,7 @@ def normal_shape(input_model, n=None, r=None, detector=None):
     elif detector == "NRS1" or detector == "NRS2":
         irs2_nx = shape[-2]
     else:
-        raise RuntimeError("Detector %s is not supported for IRS2 data" %
-                           detector)
+        raise RuntimeError(f"Detector {detector} is not supported for IRS2 data.")
 
     k = (irs2_nx - param.refout) // (param.n + param.r)
     n_output = (irs2_nx - param.refout) - k * param.r
@@ -117,27 +143,29 @@ def normal_shape(input_model, n=None, r=None, detector=None):
 
 
 def make_mask(input_model, n=None, r=None):
-    """Create a mask to extract "normal" pixels.
+    """
+    Create a mask to extract "normal" pixels.
 
     Parameters
     ----------
-    input_model: the model for the input data, or a numpy.ndarray
+    input_model : the model for the input data, or a numpy.ndarray
         This is used for getting the IRS2 parameters and the length of
         the X image axis.
 
-    n: int or None (default is None)
+    n : int or None
+        Default is None.
         If not None, overrides the default.
 
-    r: int or None (default is None)
+    r : int or None
+        Default is None.
         If not None, overrides the default.
 
     Returns
     -------
-    irs2_mask: 1-D boolean array
+    irs2_mask : 1-D bool array
         Boolean index mask with length equal to the last axis of
         the data shape.
     """
-
     param = _get_irs2_parameters(input_model, n=n, r=r)
     refout = param.refout
     n_norm = param.n
@@ -164,40 +192,41 @@ def make_mask(input_model, n=None, r=None):
         # The interspersed reference pixels are in the same locations
         # regardless of readout direction.
         for i in range(refout + n_norm // 2, irs2_nx + 1, n_norm + n_ref):
-            irs2_mask[i:i + n_ref] = False
+            irs2_mask[i : i + n_ref] = False
     else:
         # Set the flags for each readout direction separately.
-        nelem = (irs2_nx - refout) // 4         # number of elements per output
+        nelem = (irs2_nx - refout) // 4  # number of elements per output
         temp = np.ones(nelem, dtype=bool)
         for i in range(n_norm // 2, nelem + 1, n_norm + n_ref):
-            temp[i:i + n_ref] = False
+            temp[i : i + n_ref] = False
         j = refout
-        irs2_mask[j:j + nelem] = temp.copy()
+        irs2_mask[j : j + nelem] = temp.copy()
         j = refout + nelem
-        irs2_mask[j + nelem - 1:j - 1:-1] = temp.copy()
+        irs2_mask[j + nelem - 1 : j - 1 : -1] = temp.copy()
         j = refout + 2 * nelem
-        irs2_mask[j:j + nelem] = temp.copy()
+        irs2_mask[j : j + nelem] = temp.copy()
         j = refout + 3 * nelem
-        irs2_mask[j + nelem - 1:j - 1:-1] = temp.copy()
+        irs2_mask[j + nelem - 1 : j - 1 : -1] = temp.copy()
 
     return irs2_mask
 
 
 def from_irs2(irs2_data, irs2_mask, detector=None):
-    """Extract 'normal' pixel data from an IRS2 image.
+    """
+    Extract 'normal' pixel data from an IRS2 image.
 
     Parameters
     ----------
-    irs2_data: ndarray
+    irs2_data : ndarray
         Data in IRS2 format.  This can be a slice in the Y direction, but
         it should include the entire X (last) axis.
 
-    irs2_mask: 1-D array, boolean
+    irs2_mask : 1-D array, bool
         Boolean mask to extract the "normal" pixels.  This is a 1-D array
         with length equal to the size of the next-to-last axis (for data
         in DMS orientation) of `irs2_data`.
 
-    detector: str or None
+    detector : str or None
         For IRS2 data in DMS orientation, `detector` should be either
         "NRS1" or "NRS2"; NIRSpec is currently the only instrument
         supported in this module.  The mask will be applied to the rows,
@@ -207,9 +236,9 @@ def from_irs2(irs2_data, irs2_mask, detector=None):
 
     Returns
     -------
-    The normal pixel data (i.e. without embedded reference pixels).
+    norm_data : ndarray
+       The normal pixel data (i.e. without embedded reference pixels).
     """
-
     if detector is None:
         # Select columns.
         norm_data = irs2_data[..., irs2_mask]
@@ -221,31 +250,31 @@ def from_irs2(irs2_data, irs2_mask, detector=None):
         temp_mask = irs2_mask[::-1]
         norm_data = irs2_data[..., temp_mask, :]
     else:
-        raise RuntimeError("Detector %s is not supported for IRS2 data" %
-                           detector)
+        raise RuntimeError(f"Detector {detector} is not supported for IRS2 data.")
 
     return norm_data
 
 
 def to_irs2(irs2_data, norm_data, irs2_mask, detector=None):
-    """Copy 'normal' pixel data into an IRS2 image.
+    """
+    Copy 'normal' pixel data into an IRS2 image.
 
     Parameters
     ----------
-    irs2_data: ndarray
+    irs2_data : ndarray
         Data in IRS2 format.  This will be modified in-place.
 
-    norm_data: ndarray
+    norm_data : ndarray
         The normal data, for example previously extracted from irs2_data
         but then modified in some way.  This will be copied back into
         irs2_data in the correct locations, as specified by `irs2_mask`.
 
-    irs2_mask: 1-D array, boolean
+    irs2_mask : 1-D array, bool
         Boolean mask identifying the locations of the "normal" pixels
         within irs2_data.  The length is equal to the size of the
         next-to-last axis (for data in DMS orientation) of `irs2_data`.
 
-    detector: str or None
+    detector : str or None
         For IRS2 data in DMS orientation, `detector` should be either
         "NRS1" or "NRS2"; NIRSpec is currently the only instrument
         supported in this module.  The mask will be applied to the rows,
@@ -253,7 +282,6 @@ def to_irs2(irs2_data, norm_data, irs2_mask, detector=None):
         For IRS2 data in detector orientation, `detector` should be None
         (the default), and the mask will be applied to the columns.
     """
-
     if detector is None:
         # Mask specifies columns.
         irs2_data[..., irs2_mask] = norm_data.copy()
@@ -266,5 +294,4 @@ def to_irs2(irs2_data, norm_data, irs2_mask, detector=None):
         temp_mask = irs2_mask[::-1]
         irs2_data[..., temp_mask, :] = norm_data.copy()
     else:
-        raise RuntimeError("Detector %s is not supported for IRS2 data" %
-                           detector)
+        raise RuntimeError(f"Detector {detector} is not supported for IRS2 data.")

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -36,11 +36,8 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     Parameters
     ----------
     input_model : DataModel or numpy.ndarray
-        Usually it is a RampModel but it can be an ndarray.
-        If it is an ndarray, parameters will be assigned
-        default values, unless specified explicitly.
-        This is used for getting the width of the reference output and
-        the values of NRS_NORM and NRS_REF.
+        Model from which we retrieve the width of the reference
+        output and the values of NRS_NORM and NRS_REF.
 
     n : int or None
         The number of "normal" (as opposed to reference) pixels read

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 
 import numpy as np
-
 from ..lib import pipe_utils
 
 """ This is the interface:

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -37,7 +37,7 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     ----------
     input_model : DataModel or numpy.ndarray
         Usually it is a RampModel but it can be an ndarray.
-        If it is an ndarray parameters will be assigned
+        If it is an ndarray, parameters will be assigned
         default values, unless specified explicitly.
         This is used for getting the width of the reference output and
         the values of NRS_NORM and NRS_REF.

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -35,18 +35,20 @@ def _get_irs2_parameters(input_model, n=None, r=None):
 
     Parameters
     ----------
-    input_model : DataModel
-        This model is most likely a RampModel object
+    input_model : DataModel or numpy.ndarray
+        Usually it is a RampModel but it can be an ndarray.
+        If it is an ndarray parameters will be assigned
+        default values, unless specified explicitly.
         This is used for getting the width of the reference output and
         the values of NRS_NORM and NRS_REF.
 
     n : int or None
-        Default is None.
-        If not None, overrides the default.
+        The number of "normal" (as opposed to reference) pixels read
+        out before jumping to the reference pixel region.
 
     r : int or None
-        Default is None.
-        If not None, overrides the default.
+        The number of reference pixels read out before jumping back to
+        the normal pixel region.
 
     Returns
     -------
@@ -95,12 +97,12 @@ def normal_shape(input_model, n=None, r=None, detector=None):
         This is used to get the shape of the input data.
 
     n : int or None
-        Default is None.
-        If not None, overrides the default.
+        The number of "normal" (as opposed to reference) pixels read
+        out before jumping to the reference pixel region.
 
     r : int or None
-        Default is None.
-        If not None overrides the default.
+        The number of reference pixels read out before jumping back to
+        the normal pixel region.
 
     detector : str
        Detector of data. Valid values are None, NRS1, or NRS2. Other detector
@@ -153,12 +155,12 @@ def make_mask(input_model, n=None, r=None):
         the X image axis.
 
     n : int or None
-        Default is None.
-        If not None, overrides the default.
+        The number of "normal" (as opposed to reference) pixels read
+        out before jumping to the reference pixel region.
 
     r : int or None
-        Default is None.
-        If not None, overrides the default.
+        The number of reference pixels read out before jumping back to
+        the normal pixel region.
 
     Returns
     -------

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -36,7 +36,8 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     ----------
     input_model : DataModel or numpy.ndarray
         Model from which we retrieve the width of the reference
-        output and the values of NRS_NORM and NRS_REF.
+        output and the values of NRS_NORM and NRS_REF. It the input_model
+        is a ndarray the parameters will be assigned default values.
 
     n : int or None
         The number of "normal" (as opposed to reference) pixels read


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3857](https://jira.stsci.edu/browse/JP-3857)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR updates the saturation step to conform to code style rules. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions]
  Regression test passed: https://github.com/spacetelescope/RegressionTests/actions/runs/14601643348
  (https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
