### PR TITLE
JP-3989 cube build bug 

### DIFF
--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -368,8 +368,7 @@ class CubeData:
 
                 num_cubes = 1
                 cube_pars["1"] = {}
-                cube_pars["1"]["par1"] = {}
-                cube_pars["1"]["par2"] = {}
+
                 cube_pars["1"]["par1"] = self.all_channel
                 cube_pars["1"]["par2"] = self.all_subchannel
 

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -380,8 +380,8 @@ class CubeData:
                     num_cubes = num_cubes + 1
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
-                    cube_pars[cube_no]["pars1"] = {}
-                    cube_pars[cube_no]["pars2"] = {}
+                    #cube_pars[cube_no]["pars1"] = {}
+                    #cube_pars[cube_no]["pars2"] = {}
                     this_channel = []
                     this_subchannel = []
                     this_channel.append(band_channel[i])
@@ -399,8 +399,8 @@ class CubeData:
                     num_cubes = num_cubes + 1
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
-                    cube_pars[cube_no]["pars1"] = {}
-                    cube_pars[cube_no]["pars2"] = {}
+                    #cube_pars[cube_no]["pars1"] = {}
+                    #cube_pars[cube_no]["pars2"] = {}
                     this_channel = []
                     this_subchannel = []
                     for k, j in enumerate(band_channel):
@@ -434,8 +434,8 @@ class CubeData:
 
                 num_cubes = 1
                 cube_pars["1"] = {}
-                cube_pars["1"]["par1"] = {}
-                cube_pars["1"]["par2"] = {}
+                #cube_pars["1"]["par1"] = {}
+                #cube_pars["1"]["par2"] = {}
                 cube_pars["1"]["par1"] = self.all_grating
                 cube_pars["1"]["par2"] = self.all_filter
 
@@ -446,8 +446,8 @@ class CubeData:
                     num_cubes = num_cubes + 1
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
-                    cube_pars[cube_no]["pars1"] = {}
-                    cube_pars[cube_no]["pars2"] = {}
+                    #cube_pars[cube_no]["pars1"] = {}
+                    #cube_pars[cube_no]["pars2"] = {}
                     this_grating = []
                     this_filter = []
                     this_grating.append(band_grating[i])
@@ -462,8 +462,8 @@ class CubeData:
                     num_cubes = num_cubes + 1
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
-                    cube_pars[cube_no]["pars1"] = {}
-                    cube_pars[cube_no]["pars2"] = {}
+                    #cube_pars[cube_no]["pars1"] = {}
+                    #cube_pars[cube_no]["pars2"] = {}
                     this_grating = []
                     this_filter = band_subchannel
                     this_grating.append(i)

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -368,7 +368,6 @@ class CubeData:
 
                 num_cubes = 1
                 cube_pars["1"] = {}
-
                 cube_pars["1"]["par1"] = self.all_channel
                 cube_pars["1"]["par2"] = self.all_subchannel
 
@@ -380,8 +379,6 @@ class CubeData:
                     num_cubes = num_cubes + 1
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
-                    #cube_pars[cube_no]["pars1"] = {}
-                    #cube_pars[cube_no]["pars2"] = {}
                     this_channel = []
                     this_subchannel = []
                     this_channel.append(band_channel[i])
@@ -399,8 +396,6 @@ class CubeData:
                     num_cubes = num_cubes + 1
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
-                    #cube_pars[cube_no]["pars1"] = {}
-                    #cube_pars[cube_no]["pars2"] = {}
                     this_channel = []
                     this_subchannel = []
                     for k, j in enumerate(band_channel):
@@ -434,8 +429,6 @@ class CubeData:
 
                 num_cubes = 1
                 cube_pars["1"] = {}
-                #cube_pars["1"]["par1"] = {}
-                #cube_pars["1"]["par2"] = {}
                 cube_pars["1"]["par1"] = self.all_grating
                 cube_pars["1"]["par2"] = self.all_filter
 
@@ -446,8 +439,6 @@ class CubeData:
                     num_cubes = num_cubes + 1
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
-                    #cube_pars[cube_no]["pars1"] = {}
-                    #cube_pars[cube_no]["pars2"] = {}
                     this_grating = []
                     this_filter = []
                     this_grating.append(band_grating[i])
@@ -462,8 +453,6 @@ class CubeData:
                     num_cubes = num_cubes + 1
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
-                    #cube_pars[cube_no]["pars1"] = {}
-                    #cube_pars[cube_no]["pars2"] = {}
                     this_grating = []
                     this_filter = band_subchannel
                     this_grating.append(i)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3989](https://jira.stsci.edu/browse/JP-3989)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9415 

<!-- describe the changes comprising this PR here -->
This PR addresses removes how a dictionary is setup. A reassignment of a values in the pipeline caused an error in some pipeline tests. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions]
  Regression tests passing: https://github.com/spacetelescope/RegressionTests/actions/runs/14715951406
  - [ ] (https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
