### PR TITLE
JP-3862: Fix Path methods issue found by sonarscan

### DIFF
--- a/jwst/associations/tests/make_headers.py
+++ b/jwst/associations/tests/make_headers.py
@@ -25,7 +25,7 @@ def actual_path(path):
     Path
         The fully qualified path.
     """
-    return Path(ospath.expandvars(Path(path).expanduser())).resolve()
+    return Path(ospath.expandvars(path)).expanduser().resolve()
 
 
 def get_headers(files, outpath):

--- a/jwst/associations/tests/make_headers.py
+++ b/jwst/associations/tests/make_headers.py
@@ -25,7 +25,7 @@ def actual_path(path):
     Path
         The fully qualified path.
     """
-    return Path.abspath(ospath.expandvars(Path.expanduser(path)))
+    return Path(ospath.expandvars(Path(path).expanduser())).resolve()
 
 
 def get_headers(files, outpath):
@@ -40,7 +40,7 @@ def get_headers(files, outpath):
         The output path to place the header-only files
     """
     for path in files:
-        name = Path.name(path)
+        name = Path(path).name
         hdul = fits.open(path)
         nhdu = fits.PrimaryHDU(header=hdul[0].header)
         nhdul = fits.HDUList([nhdu])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3862](https://jira.stsci.edu/browse/JP-3862)


<!-- describe the changes comprising this PR here -->
This PR addresses incorrect pathlib usage found by sonarscan.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
