### PR TITLE
JP-3775: Expand usage of resource_tracker for benchmarking

### DIFF
--- a/jwst/regtest/test_miri_coron3.py
+++ b/jwst/regtest/test_miri_coron3.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.bigdata]
 
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run calwebb_coron3 on MIRI 4QPM coronographic data."""
     rtdata = rtdata_module
     rtdata.get_asn("miri/coron/jw01386-c1002_20230109t015044_coron3_00001_asn.json")
@@ -19,7 +19,8 @@ def run_pipeline(rtdata_module):
     ]
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: Mean of empty slice
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 

--- a/jwst/regtest/test_miri_coron3.py
+++ b/jwst/regtest/test_miri_coron3.py
@@ -3,6 +3,9 @@ from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
 def run_pipeline(rtdata_module):
@@ -21,7 +24,10 @@ def run_pipeline(rtdata_module):
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_coron3(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", ["crfints", "psfalign", "psfsub"])
 @pytest.mark.parametrize("exposure", ["4", "5"])
 def test_miri_coron3_sci_exp(run_pipeline, suffix, exposure, fitsdiff_default_kwargs):
@@ -37,7 +43,6 @@ def test_miri_coron3_sci_exp(run_pipeline, suffix, exposure, fitsdiff_default_kw
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["psfstack", "i2d"])
 def test_miri_coron3_product(run_pipeline, suffix, fitsdiff_default_kwargs):
     """Check final products of calwebb_coron3"""

--- a/jwst/regtest/test_miri_coron_image2.py
+++ b/jwst/regtest/test_miri_coron_image2.py
@@ -6,8 +6,11 @@ from jwst.regtest import regtestdata as rt
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 @pytest.fixture(scope='module')
-def run_image2(rtdata_module):
+def run_image2(rtdata_module, resource_tracker):
     """Run the calwebb_image2 pipeline"""
 
     rtdata = rtdata_module
@@ -18,12 +21,16 @@ def run_image2(rtdata_module):
             "--steps.bkg_subtract.save_combined_background=true",
             "--steps.assign_wcs.save_results=true",
             "--steps.flat_field.save_results=true"]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_image2(log_tracked_resources, run_image2):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", ["bsubints", "combinedbackground", "assign_wcs", "flat_field", "calints"])
 def test_miri_coron_image2(run_image2, fitsdiff_default_kwargs, suffix):
     """Regression test for image2 processing of MIRI coronagraphic data with background exposures"""

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -159,9 +159,10 @@ def run_image3(run_image2, rtdata_module, resource_tracker):
     rtdata = rtdata_module
     rtdata.get_data("miri/image/jw01024-o001_20220501t155404_image3_001_asn.json")
     args = ["jwst.pipeline.Image3Pipeline", rtdata.input]
-    with resource_tracker.track():
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="Failed to achieve requested SIP approximation accuracy")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore",
+                                message="Failed to achieve requested SIP approximation accuracy")
+        with resource_tracker.track():
             Step.from_cmdline(args)
 
 

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -131,7 +131,9 @@ def run_image2(run_detector1, rtdata_module, resource_tracker):
             "--steps.flat_field.save_results=True"
             ]
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Failed to achieve requested SIP approximation accuracy")
+        warnings.filterwarnings(
+            "ignore", message="Failed to achieve requested SIP approximation accuracy"
+        )
         Step.from_cmdline(args)
 
         # Grab rest of _rate files for the asn and run image2 pipeline on each to
@@ -151,15 +153,16 @@ def run_image2(run_detector1, rtdata_module, resource_tracker):
 
 
 @pytest.fixture(scope="module")
-def run_image3(run_image2, rtdata_module):
+def run_image3(run_image2, rtdata_module, resource_tracker):
     """Get the level3 association json file (though not its members) and run
     image3 pipeline on all _cal files listed in association"""
     rtdata = rtdata_module
     rtdata.get_data("miri/image/jw01024-o001_20220501t155404_image3_001_asn.json")
     args = ["jwst.pipeline.Image3Pipeline", rtdata.input]
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Failed to achieve requested SIP approximation accuracy")
-        Step.from_cmdline(args)
+    with resource_tracker.track():
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Failed to achieve requested SIP approximation accuracy")
+            Step.from_cmdline(args)
 
 
 def test_log_tracked_resources_det1(log_tracked_resources, run_detector1_with_average_dark_current):
@@ -167,6 +170,10 @@ def test_log_tracked_resources_det1(log_tracked_resources, run_detector1_with_av
 
 
 def test_log_tracked_resources_image2(log_tracked_resources, run_image2):
+    log_tracked_resources()
+
+
+def test_log_tracked_resources_image3(log_tracked_resources, run_image3):
     log_tracked_resources()
 
 
@@ -186,38 +193,6 @@ def test_miri_image_detector1_multiprocess_rate(run_detector1_multiprocess_rate,
 def test_miri_image_detector1_multiprocess_jump(run_detector1_multiprocess_jump, rtdata_module, fitsdiff_default_kwargs):
     """Regression test of detector1 pipeline performed on MIRI imaging data."""
     _assert_is_same(rtdata_module, fitsdiff_default_kwargs, "rate")
-
-
-def test_detector1_mem_usage(rtdata_module):
-    """Determine the memory usage for Detector 1"""
-    rtdata = rtdata_module
-    rtdata.get_data("miri/image/jw01024001001_04101_00001_mirimage_uncal.fits")
-    args = ["jwst.pipeline.Detector1Pipeline", rtdata.input]
-
-    # starting the monitoring
-    tracemalloc.start()
-
-    # run Detector1
-    Step.from_cmdline(args)
-
-    # displaying the memory
-    current_mem, peak_mem = tracemalloc.get_traced_memory()
-    # convert bytes to GB
-    peak_mem *= 1e-9
-    peak_mem = np.round(peak_mem, decimals=1)
-
-    # stopping the monitoring
-    tracemalloc.stop()
-
-    # set comparison values in GB
-    mem_threshold = 16.0  # average user's available memory
-    mem_benchmark = 11.0   # benchmark run with build 1.15.1 + 1 additional GB
-
-    # test that max memory is less than threshold
-    assert peak_mem < mem_threshold, "Max memory used is greater than 16 GB!"
-
-    # test that max memory is less or equal to benchmark
-    assert peak_mem <= mem_benchmark, "Max memory used is greater than 11 GB"
 
 
 @pytest.mark.parametrize("suffix", ["dark_current", "ramp", "rate",

--- a/jwst/regtest/test_miri_lrs_slit_spec2.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec2.py
@@ -9,8 +9,12 @@ from jwst.stpipe import Step
 from jwst.extract_1d import Extract1dStep
 from stcal.alignment import util
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
+
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run the calwebb_spec2 pipeline on an ASN of nodded MIRI LRS
        fixedslit exposures."""
     rtdata = rtdata_module
@@ -29,10 +33,14 @@ def run_pipeline(rtdata_module):
             "--steps.pixel_replace.save_results=true",
             "--steps.bkg_subtract.save_combined_background=true"
             ]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec2(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", [
     "assign_wcs", "combinedbackground", "bsub", "srctype", "flat_field", "pathloss",
     "cal", "pixel_replace", "s2d", "x1d"])
@@ -52,7 +60,6 @@ def test_miri_lrs_slit_spec2(run_pipeline, fitsdiff_default_kwargs, suffix, rtda
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_miri_lrs_extract1d_from_cal(run_pipeline, rtdata_module, fitsdiff_default_kwargs):
     rtdata = rtdata_module
     rtdata.input = "jw01530005001_03103_00001_mirimage_cal.fits"
@@ -64,7 +71,6 @@ def test_miri_lrs_extract1d_from_cal(run_pipeline, rtdata_module, fitsdiff_defau
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_miri_lrs_slit_wcs(run_pipeline, rtdata_module, fitsdiff_default_kwargs):
     rtdata = rtdata_module
     # get input assign_wcs and truth file

--- a/jwst/regtest/test_miri_lrs_slit_spec3.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec3.py
@@ -78,7 +78,7 @@ def run_pipeline(rtdata_module, request, resource_tracker):
         args.append(f"--steps.resample_spec.output_file={output_file}")
 
     # Run the calwebb_spec3 pipeline; save results from intermediate steps
-    with resource_tracker.track() if request.param == "user_wcs+shape" else nullcontext():
+    with resource_tracker.track():
         Step.from_cmdline(args)
 
 

--- a/jwst/regtest/test_miri_lrs_slit_spec3.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec3.py
@@ -2,20 +2,24 @@
     This takes an association and generates the level 3 products."""
 import pytest
 import numpy as np
-from gwcs import wcstools
+from contextlib import nullcontext
 
+from gwcs import wcstools
 import asdf
 from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
 from jwst import datamodels
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(
     scope="module",
     params=["default_wcs", "user_wcs", "user_wcs+shape", "user_wcs+shape1"]
 )
-def run_pipeline(rtdata_module, request):
+def run_pipeline(rtdata_module, request, resource_tracker):
     """
     Run the calwebb_spec3 pipeline on an ASN of nodded MIRI LRS
     fixed-slit exposures using different options for the WCS and output
@@ -74,10 +78,14 @@ def run_pipeline(rtdata_module, request):
         args.append(f"--steps.resample_spec.output_file={output_file}")
 
     # Run the calwebb_spec3 pipeline; save results from intermediate steps
-    Step.from_cmdline(args)
+    with resource_tracker.track() if request.param == "user_wcs+shape" else nullcontext():
+        Step.from_cmdline(args)
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec3(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", ["s2d", "x1d"])
 def test_miri_lrs_slit_spec3(run_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix):
     """Regression test of the calwebb_spec3 pipeline on MIRI

--- a/jwst/regtest/test_miri_lrs_slit_spec3.py
+++ b/jwst/regtest/test_miri_lrs_slit_spec3.py
@@ -2,7 +2,7 @@
     This takes an association and generates the level 3 products."""
 import pytest
 import numpy as np
-from contextlib import nullcontext
+
 
 from gwcs import wcstools
 import asdf

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -15,6 +15,9 @@ ASN3_FILENAME = "jw01536-o028_20221202t215749_tso3_00001_asn.json"
 PRODUCT_NAME = "jw01536-o028_t008_miri_p750l-slitlessprism"
 ASN_ID = "o028"
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
 def run_tso1_pipeline(rtdata_module):
@@ -72,7 +75,7 @@ def run_detector1_pipeline_emicorr_joint(rtdata_module):
 
 
 @pytest.fixture(scope="module")
-def run_tso_spec2_pipeline(run_tso1_pipeline, rtdata_module):
+def run_tso_spec2_pipeline(run_tso1_pipeline, rtdata_module, resource_tracker):
     """Run the calwebb_tso-spec2 pipeline on a MIRI LRS slitless exposure."""
     rtdata = rtdata_module
 
@@ -89,11 +92,12 @@ def run_tso_spec2_pipeline(run_tso1_pipeline, rtdata_module):
     ]
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: invalid value encountered in multiply
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
 @pytest.fixture(scope="module")
-def run_tso3_pipeline(run_tso_spec2_pipeline, rtdata_module):
+def run_tso3_pipeline(run_tso_spec2_pipeline, rtdata_module, resource_tracker):
     """Run the calwebb_tso3 pipeline on the output of run_spec2_pipeline."""
     rtdata = rtdata_module
     rtdata.get_data(f"miri/lrs/{DATASET2_ID}_calints.fits")
@@ -105,10 +109,18 @@ def run_tso3_pipeline(run_tso_spec2_pipeline, rtdata_module):
         "--steps.outlier_detection.save_results=true",
         "--steps.outlier_detection.save_intermediate_results=true"
     ]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec2(log_tracked_resources, run_tso_spec2_pipeline):
+    log_tracked_resources()
+
+
+def test_log_tracked_resources_spec3(log_tracked_resources, run_tso3_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("step_suffix", ['dq_init', 'saturation', 'lastframe', 'reset', 'linearity',
                                          'dark_current', 'ramp', 'rate', 'rateints'])
 def test_miri_lrs_slitless_tso1(run_tso1_pipeline, rtdata_module, fitsdiff_default_kwargs, step_suffix):
@@ -123,7 +135,6 @@ def test_miri_lrs_slitless_tso1(run_tso1_pipeline, rtdata_module, fitsdiff_defau
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("step_suffix", ['rscd', 'emicorr',
                                          'dark_current', 'ramp', 'rate', 'rateints'])
 def test_miri_lrs_slitless_detector1(run_detector1_pipeline, rtdata_module,
@@ -160,7 +171,6 @@ def test_miri_lrs_slitless_detector1_emicorr_joint(
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("step_suffix", ["assign_wcs", "srctype", "flat_field",
                                          "pixel_replace", "calints", "x1dints"])
 def test_miri_lrs_slitless_tso_spec2(run_tso_spec2_pipeline, rtdata_module, fitsdiff_default_kwargs,
@@ -176,7 +186,6 @@ def test_miri_lrs_slitless_tso_spec2(run_tso_spec2_pipeline, rtdata_module, fits
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("step_suffix", ["outlier_detection", "crfints"])
 def test_miri_lrs_slitless_tso3(run_tso3_pipeline, rtdata_module,
                                 fitsdiff_default_kwargs, step_suffix):
@@ -194,7 +203,6 @@ def test_miri_lrs_slitless_tso3(run_tso3_pipeline, rtdata_module,
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_miri_lrs_slitless_tso3_x1dints(run_tso3_pipeline, rtdata_module,
                                         fitsdiff_default_kwargs):
     """Compare the output of a MIRI LRS slitless calwebb_tso3 pipeline."""
@@ -208,7 +216,6 @@ def test_miri_lrs_slitless_tso3_x1dints(run_tso3_pipeline, rtdata_module,
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_miri_lrs_slitless_tso3_whtlt(run_tso3_pipeline,
                                       rtdata_module, diff_astropy_tables):
     """Compare the whitelight output of a MIRI LRS slitless calwebb_tso3 pipeline."""
@@ -221,7 +228,6 @@ def test_miri_lrs_slitless_tso3_whtlt(run_tso3_pipeline,
     assert diff_astropy_tables(rtdata.output, rtdata.truth)
 
 
-@pytest.mark.bigdata
 def test_miri_lrs_slitless_wcs(run_tso_spec2_pipeline, fitsdiff_default_kwargs,
                                rtdata_module):
     """Compare the assign_wcs output of a MIRI LRS slitless calwebb_tso3 pipeline."""

--- a/jwst/regtest/test_miri_lrs_slitless.py
+++ b/jwst/regtest/test_miri_lrs_slitless.py
@@ -155,7 +155,6 @@ def test_miri_lrs_slitless_detector1(run_detector1_pipeline, rtdata_module,
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("step_suffix", ['emicorr', 'rate', 'rateints'])
 def test_miri_lrs_slitless_detector1_emicorr_joint(
         run_detector1_pipeline_emicorr_joint, rtdata_module,

--- a/jwst/regtest/test_miri_mrs_spec2.py
+++ b/jwst/regtest/test_miri_mrs_spec2.py
@@ -11,6 +11,9 @@ from jwst.regtest import regtestdata as rt
 INPUT_PATH = 'miri/mrs'
 TRUTH_PATH = 'truth/test_miri_mrs'
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata, pytest.mark.slow]
+
 
 @pytest.fixture(scope='module')
 def run_spec2(rtdata_module):
@@ -44,7 +47,7 @@ def run_spec2(rtdata_module):
 
 
 @pytest.fixture(scope='module')
-def run_spec2_with_residual_fringe(rtdata_module):
+def run_spec2_with_residual_fringe(rtdata_module, resource_tracker):
     """Run the Spec2Pipeline on a single exposure"""
     rtdata = rtdata_module
 
@@ -58,11 +61,14 @@ def run_spec2_with_residual_fringe(rtdata_module):
             '--steps.residual_fringe.save_results=true',
             ]
 
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
-@pytest.mark.slow
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec2(log_tracked_resources, run_spec2_with_residual_fringe):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize(
     'suffix',
     ['assign_wcs', 'cal', 'flat_field', 'fringe', 'photom', 's3d', 'srctype', 'straylight', 'x1d']
@@ -74,8 +80,6 @@ def test_miri_mrs_spec2(run_spec2, fitsdiff_default_kwargs, suffix, rtdata_modul
     rt.is_like_truth(rtdata, fitsdiff_default_kwargs, suffix, truth_path=TRUTH_PATH)
 
 
-@pytest.mark.slow
-@pytest.mark.bigdata
 def test_miri_mrs_wcs(run_spec2, fitsdiff_default_kwargs, rtdata_module):
 
     rtdata = rtdata_module
@@ -101,8 +105,6 @@ def test_miri_mrs_wcs(run_spec2, fitsdiff_default_kwargs, rtdata_module):
         assert_allclose(ytest, ytruth)
 
 
-@pytest.mark.slow
-@pytest.mark.bigdata
 @pytest.mark.parametrize('suffix', ['residual_fringe', 'rf_s3d', 'rf_x1d', 'rf_cal'])
 def test_miri_mrs_spec2_with_rf(run_spec2_with_residual_fringe,
                                 fitsdiff_default_kwargs, suffix, rtdata_module):

--- a/jwst/regtest/test_miri_mrs_spec2.py
+++ b/jwst/regtest/test_miri_mrs_spec2.py
@@ -12,7 +12,7 @@ INPUT_PATH = 'miri/mrs'
 TRUTH_PATH = 'truth/test_miri_mrs'
 
 # Mark all tests in this module
-pytestmark = [pytest.mark.bigdata, pytest.mark.slow]
+pytestmark = [pytest.mark.bigdata]
 
 
 @pytest.fixture(scope='module')

--- a/jwst/regtest/test_miri_mrs_spec3.py
+++ b/jwst/regtest/test_miri_mrs_spec3.py
@@ -9,9 +9,12 @@ from jwst.stpipe import Step
 # Define artifactory source and truth
 TRUTH_PATH = 'truth/test_miri_mrs'
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata, pytest.mark.slow]
+
 
 @pytest.fixture(scope='module')
-def run_spec3_ifushort(rtdata_module):
+def run_spec3_ifushort(rtdata_module, resource_tracker):
     """Run the Spec3Pipeline on association with 2 bands on IFUSHORT"""
 
     # Test has bands medium and long for IFUSHORT
@@ -28,12 +31,13 @@ def run_spec3_ifushort(rtdata_module):
     ]
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: All-NaN slice encountered
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
     return rtdata
 
 
 @pytest.fixture(scope='module')
-def run_spec3_ifulong(rtdata_module):
+def run_spec3_ifulong(rtdata_module, resource_tracker):
     """Run the Spec3Pipeline dithered flight data """
 
     # Test has bands medium and long for IFULONG
@@ -49,7 +53,8 @@ def run_spec3_ifulong(rtdata_module):
     ]
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: All-NaN slice encountered
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
     return rtdata
 
 
@@ -102,8 +107,14 @@ def run_spec3_ifushort_extract1d(rtdata_module):
     return rtdata
 
 
-@pytest.mark.slow
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec3short(log_tracked_resources, run_spec3_ifushort):
+    log_tracked_resources()
+
+
+def test_log_tracked_resources_spec3long(log_tracked_resources, run_spec3_ifulong):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize(
     'output',
     [
@@ -128,8 +139,6 @@ def test_spec3_ifulong(run_spec3_ifulong, fitsdiff_default_kwargs, output):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.slow
-@pytest.mark.bigdata
 @pytest.mark.parametrize(
     'output',
     [
@@ -155,8 +164,6 @@ def test_spec3_ifushort(run_spec3_ifushort, fitsdiff_default_kwargs, output):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.slow
-@pytest.mark.bigdata
 @pytest.mark.parametrize(
     'output',
     [
@@ -182,8 +189,6 @@ def test_spec3_ifushort_emsm(run_spec3_ifushort_emsm, fitsdiff_default_kwargs, o
     assert diff.identical, diff.report()
 
 
-@pytest.mark.slow
-@pytest.mark.bigdata
 @pytest.mark.parametrize(
     'output',
     [

--- a/jwst/regtest/test_miri_mrs_tso.py
+++ b/jwst/regtest/test_miri_mrs_tso.py
@@ -8,9 +8,12 @@ from jwst.stpipe import Step
 INPUT_PATH = 'miri/mrs'
 TRUTH_PATH = 'truth/test_miri_mrs_tso'
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope='module')
-def run_spec2(rtdata_module):
+def run_spec2(rtdata_module, resource_tracker):
     """Run the Spec2Pipeline on a single exposure"""
     rtdata = rtdata_module
 
@@ -29,7 +32,12 @@ def run_spec2(rtdata_module):
             ]
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: invalid value encountered in add
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
+
+
+def test_log_tracked_resources_spec2(log_tracked_resources, run_spec2):
+    log_tracked_resources()
 
 
 @pytest.mark.bigdata

--- a/jwst/regtest/test_miri_mrs_tso.py
+++ b/jwst/regtest/test_miri_mrs_tso.py
@@ -40,7 +40,6 @@ def test_log_tracked_resources_spec2(log_tracked_resources, run_spec2):
     log_tracked_resources()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize(
     'suffix', ['assign_wcs', 'calints', 'flat_field', 'fringe', 'photom', 'srctype'])
 def test_spec2(rtdata_module, run_spec2, fitsdiff_default_kwargs, suffix):

--- a/jwst/regtest/test_nircam_dhs.py
+++ b/jwst/regtest/test_nircam_dhs.py
@@ -3,9 +3,12 @@ from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_detector1pipeline(rtdata_module):
+def run_detector1pipeline(rtdata_module, resource_tracker):
     """Run calwebb_detector1 on NIRCam imaging long data"""
     rtdata = rtdata_module
     rtdata.get_data("nircam/dhs/sub164stripe4_dhs_mock_dark.fits")
@@ -23,10 +26,14 @@ def run_detector1pipeline(rtdata_module):
             "--steps.jump.save_results=True",
             "--steps.jump.rejection_threshold=50.0",
             ]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_det1(log_tracked_resources, run_detector1pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", ["dq_init", "saturation", "superbias",
                                     "refpix", "linearity",
                                     "dark_current", "jump", "rate", "rateints"])

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -32,7 +32,7 @@ def run_detector1pipeline(rtdata_module):
 
 
 @pytest.fixture(scope="module")
-def run_detector1pipeline_with_sirs(rtdata_module):
+def run_detector1pipeline_with_sirs(rtdata_module, resource_tracker):
     """Run calwebb_detector1 on NIRCam imaging long data using SIRS.
 
     SIRS is the convolution kernel algorithm - Simple Improved Reference Subtraction.
@@ -46,7 +46,8 @@ def run_detector1pipeline_with_sirs(rtdata_module):
             "--steps.refpix.refpix_algorithm=sirs",
             "--steps.refpix.save_results=True",
             ]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
 @pytest.fixture(scope="module")
@@ -69,7 +70,7 @@ def run_detector1_with_clean_flicker_noise(rtdata_module):
 
 
 @pytest.fixture(scope="module")
-def run_image2pipeline(run_detector1pipeline, rtdata_module):
+def run_image2pipeline(run_detector1pipeline, rtdata_module, resource_tracker):
     """Run calwebb_image2 on NIRCam imaging long data"""
     rtdata = rtdata_module
     rtdata.input = "jw01538046001_03105_00001_nrcalong_rate.fits"
@@ -77,11 +78,12 @@ def run_image2pipeline(run_detector1pipeline, rtdata_module):
             "--steps.assign_wcs.save_results=True",
             "--steps.flat_field.save_results=True",
             ]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
 @pytest.fixture(scope="module")
-def run_image3pipeline(run_image2pipeline, rtdata_module):
+def run_image3pipeline(run_image2pipeline, rtdata_module, resource_tracker):
     """Run calwebb_image3 on NIRCam imaging long data"""
     rtdata = rtdata_module
     # Grab rest of _rate files for the asn and run image2 pipeline on each to
@@ -105,7 +107,20 @@ def run_image3pipeline(run_image2pipeline, rtdata_module):
             "--steps.tweakreg.save_results=True",
             "--steps.source_catalog.snr_threshold=20",
             ]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
+
+
+def test_log_tracked_resources_detector1(log_tracked_resources, run_detector1pipeline_with_sirs):
+    log_tracked_resources()
+
+
+def test_log_tracked_resources_image2(log_tracked_resources, run_image2pipeline):
+    log_tracked_resources()
+
+
+def test_log_tracked_resources_image3(log_tracked_resources, run_image3pipeline):
+    log_tracked_resources()
 
 
 @pytest.mark.bigdata

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -9,6 +9,9 @@ from stdatamodels.jwst import datamodels
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
 def run_detector1pipeline(rtdata_module):

--- a/jwst/regtest/test_nircam_image.py
+++ b/jwst/regtest/test_nircam_image.py
@@ -126,7 +126,6 @@ def test_log_tracked_resources_image3(log_tracked_resources, run_image3pipeline)
     log_tracked_resources()
 
 
-@pytest.mark.bigdata
 def test_nircam_image_sirs(run_detector1pipeline_with_sirs, rtdata_module, fitsdiff_default_kwargs):
     """Regression test of detector1 and image2 pipelines performed on NIRCam data."""
     rtdata = rtdata_module
@@ -142,7 +141,6 @@ def test_nircam_image_sirs(run_detector1pipeline_with_sirs, rtdata_module, fitsd
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["dq_init", "saturation", "superbias",
                                     "refpix", "linearity",
                                     "dark_current", "jump", "rate",
@@ -164,7 +162,6 @@ def test_nircam_image_stages12(run_image2pipeline, rtdata_module, fitsdiff_defau
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_nircam_image_stage2_wcs(run_image2pipeline, rtdata_module):
     """Test that WCS object works as expected"""
     rtdata = rtdata_module
@@ -183,7 +180,6 @@ def test_nircam_image_stage2_wcs(run_image2pipeline, rtdata_module):
         assert_allclose(dec, dec_truth)
 
 
-@pytest.mark.bigdata
 def test_nircam_image_stage3_tweakreg(run_image3pipeline):
     """Test that tweakreg doesn't attach a catalog and that it updates the wcs"""
     files = glob("*tweakreg.fits")
@@ -199,7 +195,6 @@ def test_nircam_image_stage3_tweakreg(run_image3pipeline):
                 assert "v2v3corr" in model.meta.wcs.available_frames
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["i2d"])
 def test_nircam_image_stage3(run_image3pipeline, rtdata_module, fitsdiff_default_kwargs, suffix):
     """Test that resampled i2d looks good for NIRCam imaging"""
@@ -217,7 +212,6 @@ def test_nircam_image_stage3(run_image3pipeline, rtdata_module, fitsdiff_default
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_nircam_image_stage3_catalog(run_image3pipeline, rtdata_module, diff_astropy_tables):
     rtdata = rtdata_module
     rtdata.input = "jw01538-o046_20230331t102920_image3_00009_asn.json"
@@ -228,7 +222,6 @@ def test_nircam_image_stage3_catalog(run_image3pipeline, rtdata_module, diff_ast
     assert diff_astropy_tables(rtdata.output, rtdata.truth, rtol=1e-4, atol=1e-5)
 
 
-@pytest.mark.bigdata
 def test_nircam_image_stage3_segm(run_image3pipeline, rtdata_module, fitsdiff_default_kwargs):
     """Test that segmentation map looks good for NIRCam imaging"""
     rtdata = rtdata_module
@@ -241,7 +234,6 @@ def test_nircam_image_stage3_segm(run_image3pipeline, rtdata_module, fitsdiff_de
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_nircam_frame_averaged_darks(rtdata, fitsdiff_default_kwargs):
     """Test optional frame-averaged darks output from DarkCurrentStep"""
     rtdata.get_data("nircam/image/jw01205015001_03101_00001_nrcb1_ramp.fits")
@@ -259,7 +251,6 @@ def test_nircam_frame_averaged_darks(rtdata, fitsdiff_default_kwargs):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_imaging_distortion(rtdata, fitsdiff_default_kwargs):
     """Verify that the distortion correction round trips."""
     rtdata.get_data("nircam/image/jw01538046002_02103_00002_nrca1_cal.fits")
@@ -281,7 +272,6 @@ def test_imaging_distortion(rtdata, fitsdiff_default_kwargs):
     assert_allclose(decout, dec)
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix",
                          ["cfn_clean_flicker_noise", "mask",
                           "flicker_bkg", "flicker_noise",

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -4,9 +4,12 @@ from astropy.io.fits.diff import FITSDiff
 from jwst.lib.set_telescope_pointing import add_wcs
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_pipelines(rtdata_module):
+def run_pipelines(rtdata_module, resource_tracker):
     """Run stage 2 and 3 pipelines on NIRCam TSO image data."""
 
     rtdata = rtdata_module
@@ -24,9 +27,14 @@ def run_pipelines(rtdata_module):
     # the tso3 pipeline on all _calints files listed in association
     rtdata.get_data("nircam/tsimg/jw01068-o006_20240401t151322_tso3_00002_asn.json")
     args = ["calwebb_tso3", rtdata.input]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
+
+
+def test_log_tracked_resources_tsimg(log_tracked_resources, run_pipelines):
+    log_tracked_resources()
 
 
 @pytest.mark.bigdata

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -37,7 +37,6 @@ def test_log_tracked_resources_tsimg(log_tracked_resources, run_pipelines):
     log_tracked_resources()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ["calints", "o006_crfints"])
 def test_nircam_tsimg_stage2(run_pipelines, fitsdiff_default_kwargs, suffix):
     """Regression test of tso-image2 pipeline performed on NIRCam TSIMG data."""
@@ -52,7 +51,6 @@ def test_nircam_tsimg_stage2(run_pipelines, fitsdiff_default_kwargs, suffix):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_nircam_tsimage_stage3_phot(run_pipelines, diff_astropy_tables):
     rtdata = run_pipelines
     rtdata.input = "jw01068-o006_20240401t151322_tso3_00002_asn.json"
@@ -62,7 +60,6 @@ def test_nircam_tsimage_stage3_phot(run_pipelines, diff_astropy_tables):
     assert diff_astropy_tables(rtdata.output, rtdata.truth)
 
 
-@pytest.mark.bigdata
 def test_nircam_setpointing_tsimg(rtdata, fitsdiff_default_kwargs):
     """
     Regression test of the set_telescope_pointing script on a level-1b

--- a/jwst/regtest/test_nircam_wfss_contam.py
+++ b/jwst/regtest/test_nircam_wfss_contam.py
@@ -3,9 +3,12 @@ import pytest
 
 from jwst.regtest import regtestdata as rt
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope='module')
-def run_wfss_contam(rtdata_module):
+def run_wfss_contam(rtdata_module, resource_tracker):
     """Run the wfss_contam step"""
     rtdata = rtdata_module
 
@@ -24,11 +27,17 @@ def run_wfss_contam(rtdata_module):
             '--skip=False',
         ]
     }
-    rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    with resource_tracker.track():
+        rtdata = rt.run_step_from_dict(rtdata, **step_params)
     return rtdata
 
-@pytest.mark.skip(reason='Test too slow until stdatamodels PR#165 merged')
-@pytest.mark.bigdata
+
+@pytest.mark.skip(reason='Test too slow until contam is updated')
+def test_log_tracked_resources_tsimg(log_tracked_resources, run_wfss_contam):
+    log_tracked_resources()
+
+
+@pytest.mark.skip(reason='Test too slow until contam is updated')
 @pytest.mark.parametrize(
     'suffix',
     ['simul', 'contam', 'wfsscontamstep']

--- a/jwst/regtest/test_nircam_wfss_spec2.py
+++ b/jwst/regtest/test_nircam_wfss_spec2.py
@@ -4,9 +4,12 @@ from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run the calwebb_spec2 pipeline on a single NIRSpec WFSS exposure."""
 
     rtdata = rtdata_module
@@ -27,12 +30,16 @@ def run_pipeline(rtdata_module):
             "--steps.extract_2d.wfss_nbright=20",
             "--steps.srctype.save_results=true",
             "--steps.flat_field.save_results=true"]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec2(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", [
     "assign_wcs", "bsub", "extract_2d", "flat_field", "srctype",
     "cal", "x1d"])

--- a/jwst/regtest/test_niriss_ami3.py
+++ b/jwst/regtest/test_niriss_ami3.py
@@ -3,16 +3,20 @@ from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run calwebb_ami3 on NIRISS AMI data."""
     rtdata = rtdata_module
     rtdata.get_asn("niriss/ami/ami3_test_asn.json")
 
     # Run the calwebb_ami3 pipeline on the association
     args = ["calwebb_ami3", rtdata.input]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 
@@ -32,7 +36,10 @@ def run_step_with_cal(rtdata_module):
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_ami3(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("obs, suffix", [("012", "ami-oi"), ("015", "psf-ami-oi")])
 def test_niriss_ami3_exp(run_pipeline, obs, suffix, fitsdiff_default_kwargs):
     """Check exposure-level results of calwebb_ami3"""
@@ -47,7 +54,6 @@ def test_niriss_ami3_exp(run_pipeline, obs, suffix, fitsdiff_default_kwargs):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 def test_niriss_ami3_product(run_pipeline, fitsdiff_default_kwargs):
     """Check final products of calwebb_ami3"""
     rtdata = run_pipeline
@@ -61,7 +67,6 @@ def test_niriss_ami3_product(run_pipeline, fitsdiff_default_kwargs):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.bigdata
 @pytest.mark.parametrize("suffix", ("ami-oi", "amimulti-oi", "amilg"))
 def test_niriss_ami3_cal(run_step_with_cal, suffix, fitsdiff_default_kwargs):
     rtdata = run_step_with_cal

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -35,7 +35,7 @@ def run_tso_spec2(rtdata_module):
 
 
 @pytest.fixture(scope="module")
-def run_tso_spec3(rtdata_module, run_tso_spec2):
+def run_tso_spec3(rtdata_module, run_tso_spec2, resource_tracker):
     """Run stage 3 pipeline on NIRISS SOSS data."""
     rtdata = rtdata_module
     # Get the level3 association json file (though not its members) and run
@@ -44,7 +44,8 @@ def run_tso_spec3(rtdata_module, run_tso_spec2):
     args = ["calwebb_tso3", rtdata.input,
             "--steps.extract_1d.soss_rtol=1.e-3",
             ]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
 @pytest.fixture(scope="module")
@@ -66,7 +67,11 @@ def run_atoca_extras(rtdata_module, resource_tracker):
         Step.from_cmdline(args)
 
 
-def test_log_tracked_resources(log_tracked_resources, run_atoca_extras):
+def test_log_tracked_resources_spec2(log_tracked_resources, run_atoca_extras):
+    log_tracked_resources()
+
+
+def test_log_tracked_resources_spec3(log_tracked_resources, run_tso_spec3):
     log_tracked_resources()
 
 

--- a/jwst/regtest/test_niriss_soss.py
+++ b/jwst/regtest/test_niriss_soss.py
@@ -90,7 +90,7 @@ def test_niriss_soss_stage2(rtdata_module, run_tso_spec2, fitsdiff_default_kwarg
 
 
 def test_niriss_soss_stage3_crfints(rtdata_module, run_tso_spec3, fitsdiff_default_kwargs):
-    """Regression test of tso-spec3 pipeline outlier_detection results performed on NIRISS SOSS data."""
+    """Regression test of tso3pipeline outlier_detection results performed on NIRISS SOSS data."""
     rtdata = rtdata_module
 
     output = "jw01091002001_03101_00001-seg001_nis_short_o002_crfints.fits"

--- a/jwst/regtest/test_nirspec_fs_spec3.py
+++ b/jwst/regtest/test_nirspec_fs_spec3.py
@@ -8,9 +8,12 @@ from stdatamodels.jwst import datamodels
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, resource_tracker):
     """
     Run the calwebb_spec3 pipeline on NIRSpec Fixed-Slit exposures.
     """
@@ -27,10 +30,14 @@ def run_pipeline(rtdata_module):
             "--steps.extract_1d.save_results=true"]
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: Mean of empty slice
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec3(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d", "median"])
 @pytest.mark.parametrize("source_id,slit_name", [("s000000001","s200a2"), ("s000000021","s200a1"),
     ("s000000023","s400a1"), ("s000000024","s1600a1"), ("s000000025","s200b1")])

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -40,10 +40,10 @@ def run_spec2(rtdata_module, resource_tracker):
         rtdata = rt.run_step_from_dict(rtdata, **step_params)
     return rtdata
 
+
 @pytest.mark.slow
 def test_log_tracked_resources_spec2(log_tracked_resources, run_spec2):
     log_tracked_resources()
-
 
 
 @pytest.mark.slow

--- a/jwst/regtest/test_nirspec_ifu_spec3.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3.py
@@ -3,9 +3,12 @@ import pytest
 
 from jwst.regtest import regtestdata as rt
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata, pytest.mark.slow]
+
 
 @pytest.fixture(scope='module')
-def run_spec3_multi(rtdata_module):
+def run_spec3_multi(rtdata_module, resource_tracker):
     """Run Spec3Pipeline"""
     rtdata = rtdata_module
 
@@ -23,12 +26,15 @@ def run_spec3_multi(rtdata_module):
     }
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: All-NaN slice encountered
-    rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    with resource_tracker.track():
+        rtdata = rt.run_step_from_dict(rtdata, **step_params)
     return rtdata
 
 
-@pytest.mark.slow
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec3(log_tracked_resources, run_spec3_multi):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize(
     'output',
     [

--- a/jwst/regtest/test_nirspec_mos_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_fs_spec2.py
@@ -3,9 +3,12 @@ from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run the calwebb_spec2 pipeline on a single NIRSpec MOS/FS exposure."""
 
     rtdata = rtdata_module
@@ -30,12 +33,16 @@ def run_pipeline(rtdata_module):
             "--steps.barshadow.save_results=true"]
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: Invalid interval: upper bound XXX is strictly less than lower bound XXX
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec2(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", [
     "assign_wcs", "msa_flagging", "extract_2d", "srctype",
     "master_background_mos", "wavecorr", "flat_field", "interpolatedflat",

--- a/jwst/regtest/test_nirspec_mos_fs_spec3.py
+++ b/jwst/regtest/test_nirspec_mos_fs_spec3.py
@@ -8,19 +8,23 @@ pytestmark = [pytest.mark.bigdata]
 
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run calwebb_spec3 on NIRSpec MOS data."""
     rtdata = rtdata_module
     rtdata.get_asn("nirspec/mos/jw02674-o004_20240305t054741_spec3_00001_asn.json")
 
     # Run the calwebb_spec3 pipeline on the association
     args = ["calwebb_spec3", rtdata.input]
-    Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources_spec3(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", ["cal", "crf", "s2d", "x1d"])
 @pytest.mark.parametrize("source_id", ["b000000003", "b000000004", "b000000048",
                                        "b000000052", "s000001354", "s000012105",

--- a/jwst/regtest/test_nirspec_mos_fs_spec3.py
+++ b/jwst/regtest/test_nirspec_mos_fs_spec3.py
@@ -3,6 +3,9 @@ from astropy.io.fits.diff import FITSDiff
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
 def run_pipeline(rtdata_module):

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -4,9 +4,12 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 from jwst.stpipe import Step
 
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
 
 @pytest.fixture(scope="module")
-def run_pipeline(rtdata_module):
+def run_pipeline(rtdata_module, resource_tracker):
     """Run the calwebb_spec2 pipeline on a single NIRSpec MOS exposure."""
 
     rtdata = rtdata_module
@@ -33,12 +36,16 @@ def run_pipeline(rtdata_module):
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: Invalid interval: upper bound XXX is strictly less than lower bound XXX
     with pytest.warns(AstropyUserWarning, match="Input data contains invalid values"):
-        Step.from_cmdline(args)
+        with resource_tracker.track():
+            Step.from_cmdline(args)
 
     return rtdata
 
 
-@pytest.mark.bigdata
+def test_log_tracked_resources(log_tracked_resources, run_pipeline):
+    log_tracked_resources()
+
+
 @pytest.mark.parametrize("suffix", [
     "assign_wcs", "msa_flagging", "nsclean", "bsub", "extract_2d", "wavecorr", "flat_field",
     "srctype", "pathloss", "barshadow", "cal", "s2d", "x1d"])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3775](https://jira.stsci.edu/browse/JP-3775)

<!-- describe the changes comprising this PR here -->
This PR expands coverage of resource tracking to more regression tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
