### PR TITLE
JP-3776: Improve AmiAnalyze memory usage

### DIFF
--- a/changes/9442.ami.rst
+++ b/changes/9442.ami.rst
@@ -1,0 +1,1 @@
+Improve memory usage of AmiAnalyzeStep

--- a/changes/9442.ami.rst
+++ b/changes/9442.ami.rst
@@ -1,1 +1,3 @@
-Improve memory usage of AmiAnalyzeStep
+Improve memory usage of AmiAnalyzeStep: for test dataset with 400 integrations
+and default parameter settings, the memory usage is reduced from 12 GB to 0.5 GB.
+(Note the scaling is not linear with the number of integrations.)

--- a/changes/9442.ami.rst
+++ b/changes/9442.ami.rst
@@ -1,3 +1,3 @@
 Improve memory usage of AmiAnalyzeStep: for test dataset with 400 integrations
 and default parameter settings, the memory usage is reduced from 12 GB to 0.5 GB.
-(Note the scaling is not linear with the number of integrations.)
+(Note the scaling is not necessarily linear with the number of integrations.)

--- a/jwst/ami/lg_model.py
+++ b/jwst/ami/lg_model.py
@@ -79,7 +79,7 @@ class LgModel:
         )
         self.ctrs = self.mask.ctrs
         self.d = self.mask.hdia
-        self.D = self.mask.active_D
+        self.active_D = self.mask.active_D
 
         self.N = len(self.ctrs)
         self.fmt = "%10.4e"

--- a/jwst/ami/lg_model.py
+++ b/jwst/ami/lg_model.py
@@ -79,7 +79,7 @@ class LgModel:
         )
         self.ctrs = self.mask.ctrs
         self.d = self.mask.hdia
-        self.active_D = self.mask.active_D
+        self.D = self.mask.active_D
 
         self.N = len(self.ctrs)
         self.fmt = "%10.4e"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3776](https://jira.stsci.edu/browse/JP-3776)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #8860 

<!-- describe the changes comprising this PR here -->
This PR refactors the `AmiAnalyze` step to avoid creating a long list of 3-D arrays, reducing memory usage by a factor of ~13 for my test dataset (`jw01349-c1007_20250319t131303_ami3_00002_asn.json`).  See ticket for memory usage flamegraphs - the one for this PR branch is named `memray-flamegraph-output_refactor.html`.

A beneficial side-effect of this refactor is that it removes a code pattern in which `RawOifits` objects required `FringeFitter` object as input, but some methods of `FringeFitter` required a `RawOifits` that was being initialized with that very same `FringeFitter` object, i.e. `RawOifits(self)`.  Now both classes require only an instrument data object, which I feel makes more logical sense and more cleanly splits up the roles of `RawOifits` and `FringeFitter`.

Memory usage tests to prevent a regression will be added by https://github.com/spacetelescope/jwst/pull/9433 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
