### PR TITLE
JP-3995: Make background step able to run with asn files as well

### DIFF
--- a/jwst/background/asn_intake.py
+++ b/jwst/background/asn_intake.py
@@ -1,0 +1,77 @@
+#! /usr/bin/env python
+from pathlib import Path
+from collections import defaultdict
+import logging
+import json
+
+from stdatamodels.jwst import datamodels
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+WFSS_TYPES = ["NIS_WFSS", "NRC_GRISM", "NRC_WFSS"]
+
+
+def asn_get_data(step_input):
+    """
+    Check if the input is an asn file and get the targets and catalog.
+
+    Parameters
+    ----------
+    step_input : ImageModel or IFUImageModel or asn file
+        Input target data
+
+    Returns
+    -------
+    step_input : ImageModel or IFUImageModel
+        Input target data model
+    bkg_list : list
+        File name list of background exposures
+    """
+    try:
+        with Path(step_input).open("r") as asn_data:
+            asn = json.load(asn_data)
+    except UnicodeDecodeError:
+        return
+
+    members_by_type = defaultdict(list)
+
+    if len(asn["products"]) > 1:
+        log.warning("Multiple products in input association. Output file name will be ignored.")
+
+    # Get the grism image and the catalog, direct image, and segmentation map
+    for exp_product in asn["products"]:
+        # Find all the member types in the product
+        for member in exp_product["members"]:
+            members_by_type[member["exptype"].lower()].append(member["expname"])
+
+        # Get the science member. Technically there should only be one. Even if
+        # there are more, we'll just get the first one found.
+        science_member = members_by_type["science"]
+        if len(science_member) != 1:
+            log.warning(
+                "Wrong number of science exposures found in {}".format(exp_product["name"])  # noqa: E501
+            )
+            log.warning("    Using only first one.")
+        science_member = science_member[0]
+        log.info("Working on input %s ...", science_member)
+
+        # Open the datamodel and update it with the relevant info for the background step
+        with datamodels.open(science_member) as sci:
+            exp_type = sci.meta.exposure.type
+            if exp_type in WFSS_TYPES:
+                try:
+                    sci.meta.source_catalog = Path(members_by_type["sourcecat"][0]).name
+                    log.info(f"Using sourcecat file {sci.meta.source_catalog}")
+                    sci.meta.segmentation_map = Path(members_by_type["segmap"][0]).name
+                    log.info(f"Using segmentation map {sci.meta.segmentation_map}")
+                    sci.meta.direct_image = Path(members_by_type["direct_image"][0]).name
+                    log.info(f"Using direct image {sci.meta.direct_image}")
+                except IndexError:
+                    if sci.meta.source_catalog is None:
+                        raise IndexError(
+                            "No source catalog specified in association or datamodel."
+                        ) from None
+
+    return sci, members_by_type

--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -4,9 +4,15 @@ from stdatamodels.jwst import datamodels
 from ..stpipe import Step
 from .background_sub import background_sub
 from .background_sub_wfss import subtract_wfss_bkg
+from .asn_intake import asn_get_data
+
 import numpy as np
 
+
 __all__ = ["BackgroundStep"]
+
+
+WFSS_TYPES = ["NIS_WFSS", "NRC_GRISM", "NRC_WFSS"]
 
 
 class BackgroundStep(Step):
@@ -22,6 +28,7 @@ class BackgroundStep(Step):
         wfss_maxiter = integer(default=5)  # WFSS iterative outlier rejection max iterations
         wfss_rms_stop = float(default=0)  # WFSS iterative outlier rejection RMS improvement threshold (percent)
         wfss_outlier_percent = float(default=1)  # WFSS outlier percentile to reject per iteration
+        bkg_list = list(default=None)  # List of background files
     """  # noqa: E501
 
     # These reference files are only used for WFSS/GRISM data.
@@ -30,16 +37,16 @@ class BackgroundStep(Step):
     # Define a suffix for optional saved output of the combined background
     bkg_suffix = "combinedbackground"
 
-    def process(self, step_input, bkg_list):
+    def process(self, step_input, input_bkg_list=None):
         """
         Subtract designated background images from target exposures.
 
         Parameters
         ----------
-        step_input : ImageModel or IFUImageModel
-            Input target data model to which background subtraction is applied
+        step_input : str, ImageModel or IFUImageModel
+            Input target data model to which background subtraction is applied or asn file
 
-        bkg_list : list
+        input_bkg_list : list, optional
             File name list of background exposures
 
         Returns
@@ -47,74 +54,87 @@ class BackgroundStep(Step):
         result : ImageModel or IFUImageModel
             The background-subtracted target data model
         """
-        # Load the input data model
-        with datamodels.open(step_input) as input_model:
-            if input_model.meta.exposure.type in ["NIS_WFSS", "NRC_WFSS"]:
-                # Get the reference file names
-                bkg_name = self.get_reference_file(input_model, "wfssbkg")
-                wlrange_name = self.get_reference_file(input_model, "wavelengthrange")
-                self.log.info("Using WFSSBKG reference file %s", bkg_name)
-                self.log.info("Using WavelengthRange reference file %s", wlrange_name)
-
-                # Do the background subtraction for WFSS/GRISM data
-                rescaler_kwargs = {
-                    "p": self.wfss_outlier_percent,
-                    "maxiter": self.wfss_maxiter,
-                    "delta_rms_thresh": self.wfss_rms_stop / 100,
-                }
-                result = subtract_wfss_bkg(
-                    input_model,
-                    bkg_name,
-                    wlrange_name,
-                    self.wfss_mmag_extract,
-                    rescaler_kwargs=rescaler_kwargs,
-                )
-                if result is None:
-                    result = input_model
-                    result.meta.cal_step.back_sub = "SKIPPED"
-                else:
-                    result.meta.cal_step.back_sub = "COMPLETE"
+        # If the input is an asn get all the info, otherwise assume input is a fits file
+        if isinstance(step_input, str) and ".fits" not in step_input:
+            input_model, members_by_type = asn_get_data(step_input)
+            bkg_list = members_by_type["background"]
+        else:
+            input_model = datamodels.open(step_input)
+            if input_bkg_list is not None:
+                bkg_list = input_bkg_list
             else:
-                # check if input data is NRS_IFU
-                tolerance = 1.0e-8
-                do_sub = True
-                if input_model.meta.instrument.name in ["NIRSPEC"]:
-                    # check if GWA_XTIL & GWA_YTIL values of source
-                    # background are the same. If not skip step
-                    input_xtilt = input_model.meta.instrument.gwa_xtilt
-                    input_ytilt = input_model.meta.instrument.gwa_ytilt
-                    for bkg_file in bkg_list:
-                        with datamodels.open(bkg_file) as bkg_model:
-                            bkg_xtilt = bkg_model.meta.instrument.gwa_xtilt
-                            bkg_ytilt = bkg_model.meta.instrument.gwa_ytilt
-                            if np.allclose(
-                                (input_xtilt, input_ytilt),
-                                (bkg_xtilt, bkg_ytilt),
-                                atol=tolerance,
-                                rtol=0,
-                            ):
-                                pass
-                            else:
-                                do_sub = False
-                                break
-                # Do the background subtraction
-                if do_sub:
-                    bkg_model, result = background_sub(
-                        input_model, bkg_list, self.sigma, self.maxiters
-                    )
-                    result.meta.cal_step.back_sub = "COMPLETE"
-                    if self.save_combined_background:
-                        comb_bkg_path = self.save_model(
-                            bkg_model, suffix=self.bkg_suffix, force=True
-                        )
-                        self.log.info(f"Combined background written to {comb_bkg_path}.")
+                bkg_list = self.bkg_list
+            if bkg_list is None:
+                self.log.warning("* No background list provided * Skipping step.")
+                input_model.meta.cal_step.background = "SKIPPED"
+                return input_model
 
-                else:
-                    result = input_model.copy()
-                    result.meta.cal_step.back_sub = "SKIPPED"
-                    self.log.warning("Skipping background subtraction")
-                    self.log.warning(
-                        "GWA_XTIL and GWA_YTIL source values are not the same as bkg values"
-                    )
+        if input_model.meta.exposure.type in ["NIS_WFSS", "NRC_WFSS"]:
+            # Get the reference file names
+            bkg_name = self.get_reference_file(input_model, "wfssbkg")
+            wlrange_name = self.get_reference_file(input_model, "wavelengthrange")
+            self.log.info("Using WFSSBKG reference file %s", bkg_name)
+            self.log.info("Using WavelengthRange reference file %s", wlrange_name)
+
+            # Do the background subtraction for WFSS/GRISM data
+            rescaler_kwargs = {
+                "p": self.wfss_outlier_percent,
+                "maxiter": self.wfss_maxiter,
+                "delta_rms_thresh": self.wfss_rms_stop / 100,
+            }
+            result = subtract_wfss_bkg(
+                input_model,
+                bkg_name,
+                wlrange_name,
+                self.wfss_mmag_extract,
+                rescaler_kwargs=rescaler_kwargs,
+            )
+            if result is None:
+                result = input_model
+                result.meta.cal_step.background = "SKIPPED"
+            else:
+                result.meta.cal_step.background = "COMPLETE"
+
+        else:
+            # check if input data is NRS_IFU
+            tolerance = 1.0e-8
+            do_sub = True
+            if input_model.meta.instrument.name in ["NIRSPEC"]:
+                # check if GWA_XTIL & GWA_YTIL values of source
+                # background are the same. If not skip step
+                input_xtilt = input_model.meta.instrument.gwa_xtilt
+                input_ytilt = input_model.meta.instrument.gwa_ytilt
+                for bkg_file in bkg_list:
+                    with datamodels.open(bkg_file) as bkg_model:
+                        bkg_xtilt = bkg_model.meta.instrument.gwa_xtilt
+                        bkg_ytilt = bkg_model.meta.instrument.gwa_ytilt
+                        if np.allclose(
+                            (input_xtilt, input_ytilt),
+                            (bkg_xtilt, bkg_ytilt),
+                            atol=tolerance,
+                            rtol=0,
+                        ):
+                            pass
+                        else:
+                            do_sub = False
+                            break
+            # Do the background subtraction
+            if do_sub:
+                bkg_model, result = background_sub(input_model, bkg_list, self.sigma, self.maxiters)
+                result.meta.cal_step.background = "COMPLETE"
+                if self.save_combined_background:
+                    comb_bkg_path = self.save_model(bkg_model, suffix=self.bkg_suffix, force=True)
+                    self.log.info(f"Combined background written to {comb_bkg_path}.")
+
+            else:
+                result = input_model.copy()
+                result.meta.cal_step.background = "SKIPPED"
+                self.log.warning("Skipping background subtraction")
+                self.log.warning(
+                    "GWA_XTIL and GWA_YTIL source values are not the same as bkg values"
+                )
+
+        # Cleanup
+        del input_model
 
         return result


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3995](https://jira.stsci.edu/browse/JP-3995)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR implements the option to run the step as a standalone with either fits or asn files as input. Also included, is the header keyword when the step completes or skips. This PR affects all modes but does not break any current pipeline. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
