### PR TITLE
Separate nsclean tests from standard runs

### DIFF
--- a/jwst/regtest/test_nirspec_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_fs_spec2.py
@@ -52,8 +52,6 @@ def run_pipeline(rtdata_module, request, resource_tracker):
     # Run the calwebb_spec2 pipeline; save results from intermediate steps
     args = ["calwebb_spec2", rtdata.input,
             "--steps.assign_wcs.save_results=true",
-            "--steps.nsclean.skip=False",
-            "--steps.nsclean.save_results=true",
             "--steps.extract_2d.save_results=true",
             "--steps.wavecorr.save_results=true",
             "--steps.srctype.save_results=true",
@@ -63,6 +61,28 @@ def run_pipeline(rtdata_module, request, resource_tracker):
     # Example: RuntimeWarning: overflow encountered in square
     with resource_tracker.track():
         Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.fixture(scope="module")
+def run_pipeline_nsclean(rtdata_module):
+    """Run the calwebb_spec2 pipeline on NIRSpec Fixed-Slit exposures with nsclean."""
+
+    rtdata = rtdata_module
+
+    filename = "jw01245-o002_20230107t223023_spec2_00001_asn.json"
+    rtdata.get_asn('nirspec/fs/' + filename)
+
+    # Run the calwebb_spec2 pipeline with nsclean
+    args = ["calwebb_spec2", rtdata.input,
+            "--output_file=jw01245002001_04102_00002_nrs1_nsc",
+            "--steps.nsclean.skip=False",
+            "--steps.nsclean.save_results=true"]
+
+    # FIXME: Handle warnings properly.
+    # Example: RuntimeWarning: overflow encountered in square
+    Step.from_cmdline(args)
 
     return rtdata
 
@@ -93,7 +113,7 @@ def test_log_tracked_resources_spec2(log_tracked_resources, run_pipeline):
 
 
 @pytest.mark.parametrize("suffix", [
-    "assign_wcs", "nsclean", "extract_2d", "wavecorr", "flat_field", "pathloss", "srctype",
+    "assign_wcs", "extract_2d", "wavecorr", "flat_field", "pathloss", "srctype",
     "cal", "s2d", "x1d"])
 def test_nirspec_fs_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     """Regression test of the calwebb_spec2 pipeline on a
@@ -103,6 +123,24 @@ def test_nirspec_fs_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     rtdata = run_pipeline
     output = replace_suffix(
         os.path.splitext(asn_memberdict[os.path.basename(rtdata.input)][0])[0], suffix) + '.fits'
+    rtdata.output = output
+
+    # Get the truth files
+    rtdata.get_truth(os.path.join("truth/test_nirspec_fs_spec2", output))
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.parametrize("suffix", ["nsclean", "cal", "s2d", "x1d"])
+def test_nirspec_fs_nsclean(run_pipeline_nsclean, fitsdiff_default_kwargs, suffix):
+    """Regression test of the calwebb_spec2 pipeline with nsclean."""
+
+    # Run the pipeline and retrieve outputs
+    rtdata = run_pipeline_nsclean
+    basename = "jw01245002001_04102_00002_nrs1_nsc"
+    output = f"{basename}_{suffix}.fits"
     rtdata.output = output
 
     # Get the truth files

--- a/jwst/regtest/test_nirspec_mos_spec2.py
+++ b/jwst/regtest/test_nirspec_mos_spec2.py
@@ -1,7 +1,6 @@
 import pytest
-from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
-from astropy.utils.exceptions import AstropyUserWarning
 
+from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
 from jwst.stpipe import Step
 
 # Mark all tests in this module
@@ -24,8 +23,6 @@ def run_pipeline(rtdata_module, resource_tracker):
     args = ["calwebb_spec2", rtdata.input,
             "--steps.assign_wcs.save_results=true",
             "--steps.msa_flagging.save_results=true",
-            "--steps.nsclean.skip=False",
-            "--steps.nsclean.save_results=true",
             "--steps.bkg_subtract.save_results=true",
             "--steps.extract_2d.save_results=true",
             "--steps.srctype.save_results=true",
@@ -33,11 +30,33 @@ def run_pipeline(rtdata_module, resource_tracker):
             "--steps.flat_field.save_results=true",
             "--steps.pathloss.save_results=true",
             "--steps.barshadow.save_results=true"]
-    # FIXME: Handle warnings properly.
-    # Example: RuntimeWarning: Invalid interval: upper bound XXX is strictly less than lower bound XXX
-    with pytest.warns(AstropyUserWarning, match="Input data contains invalid values"):
-        with resource_tracker.track():
-            Step.from_cmdline(args)
+
+    with resource_tracker.track():
+        Step.from_cmdline(args)
+
+    return rtdata
+
+
+@pytest.fixture(scope="module")
+def run_pipeline_nsclean(rtdata_module, resource_tracker):
+    """Run the calwebb_spec2 pipeline on NIRSpec MOS with nsclean."""
+
+    rtdata = rtdata_module
+
+    # Get the MSA metadata file referenced in the input exposure
+    rtdata.get_data("nirspec/mos/jw01345066001_01_msa.fits")
+
+    # Get the input ASN file and exposures
+    rtdata.get_asn("nirspec/mos/jw01345-o066_20230831t181155_spec2_00010_asn.json")
+
+    # Run the calwebb_spec2 pipeline; save results from intermediate steps
+    args = ["calwebb_spec2", rtdata.input,
+            "--output_file=jw01345066001_05101_00003_nrs1_nsc",
+            "--steps.nsclean.skip=False",
+            "--steps.nsclean.save_results=True"]
+
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 
@@ -47,7 +66,7 @@ def test_log_tracked_resources(log_tracked_resources, run_pipeline):
 
 
 @pytest.mark.parametrize("suffix", [
-    "assign_wcs", "msa_flagging", "nsclean", "bsub", "extract_2d", "wavecorr", "flat_field",
+    "assign_wcs", "msa_flagging", "bsub", "extract_2d", "wavecorr", "flat_field",
     "srctype", "pathloss", "barshadow", "cal", "s2d", "x1d"])
 def test_nirspec_mos_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     """Regression test of the calwebb_spec2 pipeline on a
@@ -58,6 +77,23 @@ def test_nirspec_mos_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
     # Run the pipeline and retrieve outputs
     rtdata = run_pipeline
     output = f"jw01345066001_05101_00003_nrs1_{suffix}.fits"
+    rtdata.output = output
+
+    # Get the truth files
+    rtdata.get_truth("truth/test_nirspec_mos_spec2/" + output)
+
+    # Compare the results
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.parametrize("suffix", ["nsclean", "cal", "s2d", "x1d"])
+def test_nirspec_mos_spec2_nsclean(run_pipeline_nsclean, fitsdiff_default_kwargs, suffix):
+    """Regression test of the calwebb_spec2 pipeline with nsclean."""
+
+    # Run the pipeline and retrieve outputs
+    rtdata = run_pipeline_nsclean
+    output = f"jw01345066001_05101_00003_nrs1_nsc_{suffix}.fits"
     rtdata.output = output
 
     # Get the truth files


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Currently most NIRSpec spec2 tests explicitly turn nsclean on, but it is off by default, it is a deprecated step, and it is a numerically sensitive algorithm.  It would be helpful to separate out nsclean test results from standard runs.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
