### PR TITLE
fix the bounding box of SOSS

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -76,6 +76,8 @@ def load_wcs(input_model, reference_files=None, nrs_slit_y_range=None):
     wcs = WCS(pipeline)
     output_model.meta.wcs = wcs
     output_model.meta.cal_step.assign_wcs = "COMPLETE"
+    if output_model.meta.exposure.type.lower() == "nis_soss":
+        output_model.meta.wcs.bounding_box = mod.niriss_bounding_box(output_model)
     exclude_types = [
         "nrc_wfss",
         "nrc_tsgrism",

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -102,12 +102,8 @@ def _niriss_order_bounding_box(input_model, order):
     bbox_y = np.array([-0.5, input_model.meta.subarray.ysize - 0.5])
     bbox_x = np.array([-0.5, input_model.meta.subarray.xsize - 0.5])
 
-    if order == 1:
-        return tuple(bbox_y), tuple(bbox_x)
-    elif order == 2:
-        return tuple(bbox_y), tuple(bbox_x)
-    elif order == 3:
-        return tuple(bbox_y), tuple(bbox_x)
+    if order in (1, 2, 3):
+        return tuple(bbox_x), tuple(bbox_y)
     else:
         raise ValueError(
             f"Invalid spectral order: {order} provided. Spectral order must be 1, 2, or 3."
@@ -131,7 +127,7 @@ def niriss_bounding_box(input_model):
     bbox = {(order,): _niriss_order_bounding_box(input_model, order) for order in [1, 2, 3]}
     model = input_model.meta.wcs.forward_transform
     return CompoundBoundingBox.validate(
-        model, bbox, slice_args=[("spectral_order", True)], order="F"
+        model, bbox, selector_args=[("spectral_order", True)], order="F"
     )
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR completes work done earlier where a non-coordinate input (`spectral_order`) is enabled in the the WCS for NIRISS SOSS mode. To complete this a fix in gwcs is needed as well. Related to #9399

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
