### PR TITLE
TST: xpass is now a failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ addopts = [
     "--report-crds-context",
     "--color=yes",
 ]
+xfail_strict = true
 # This is for regtests. All unhandled warnings become exceptions for
 # regular CI in tox.ini file.
 filterwarnings = [


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
In looking into association tests, I see that xfail was used liberally. The way I want to refactor them, I want xpass to fail because that means we can move a test case out of xfail expectation. To make that possible, I need to utilize `@pytest.mark.xfail` instead of brute-forcing `pytest.xfail` *and* I need `xfail_strict=true`.

This might smoke out other unrelated xpass cases, so I will keep it as draft for now until testing completes.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/15008169284 (devdeps failures are unrelated as they also appear on `main`)
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
