### PR TITLE
JP-3906: Support extrapolation of dark files to match arbitrary science input size

### DIFF
--- a/changes/9468.dark_current.rst
+++ b/changes/9468.dark_current.rst
@@ -1,0 +1,1 @@
+Remove mention and use of dark error array; document extrapolation of darks when science array has more frames than the dark.

--- a/docs/jwst/dark_current/description.rst
+++ b/docs/jwst/dark_current/description.rst
@@ -56,9 +56,11 @@ Any pixel values in the dark reference data that are set to NaN will have their
 values reset to zero before being subtracted from the science data, which
 will effectively skip the dark subtraction operation for those pixels.
 
-**Note**: If the input science exposure contains more groups than the available
-dark reference file, no dark subtraction will be applied and the input data
-will be returned unchanged.
+If the input science exposure contains more groups than the available
+dark reference file, the dark reference file will be extrapolated to match the
+number of groups present in the science exposure. This extrapolation generates
+new frames using the difference of the last two frames provided in the dark
+reference file.
 
 Subarrays
 ---------

--- a/docs/jwst/dark_current/description.rst
+++ b/docs/jwst/dark_current/description.rst
@@ -31,7 +31,7 @@ reference file data are reconstructed on-the-fly by the step to match the frame
 averaging and groupgap settings of the science exposure. The reconstructed dark
 data are created by averaging NFRAMES adjacent dark frames and skipping
 GROUPGAP intervening frames; the frame-averaged dark data is constructed by
-computing the mean of the original dark SCI arrays across NFRAMES.
+computing the mean of the original dark SCI array across NFRAMES.
 
 The dark reference data are not integration-dependent for most instruments,
 hence the same group-by-group dark current data are subtracted from every

--- a/docs/jwst/dark_current/description.rst
+++ b/docs/jwst/dark_current/description.rst
@@ -30,13 +30,8 @@ If the science exposure used NFRAMES>1 or GROUPGAP>0, the dark
 reference file data are reconstructed on-the-fly by the step to match the frame
 averaging and groupgap settings of the science exposure. The reconstructed dark
 data are created by averaging NFRAMES adjacent dark frames and skipping
-GROUPGAP intervening frames.
-
-The frame-averaged dark is constructed using the following scheme:
-
-#. SCI arrays are computed as the mean of the original dark SCI arrays
-#. ERR arrays are computed as the uncertainty in the mean, using
-   :math:`\frac{\sqrt {\sum \mathrm{ERR}^2}}{nframes}`
+GROUPGAP intervening frames; the frame-averaged dark data is constructed by
+computing the mean of the original dark SCI arrays across NFRAMES.
 
 The dark reference data are not integration-dependent for most instruments,
 hence the same group-by-group dark current data are subtracted from every

--- a/docs/jwst/references_general/dark_reffile.inc
+++ b/docs/jwst/references_general/dark_reffile.inc
@@ -31,7 +31,6 @@ the Near-IR instruments are as follows (see `~jwst.datamodels.DarkModel`):
 EXTNAME  NAXIS  Dimensions               Data type
 =======  =====  =======================  =========
 SCI      3      ncols x nrows x ngroups  float
-ERR      3      ncols x nrows x ngroups  float
 DQ       2      ncols x nrows            integer
 DQ_DEF   2      TFIELDS = 4              N/A
 =======  =====  =======================  =========
@@ -51,7 +50,6 @@ The format of the MIRI DARK reference files is as follows
 EXTNAME  NAXIS  Dimensions                       Data type
 =======  =====  ===============================  =========
 SCI      4      ncols x nrows x ngroups x nints  float
-ERR      4      ncols x nrows x ngroups x nints  float
 DQ       4      ncols x nrows x 1 x nints        integer
 DQ_DEF   2      TFIELDS = 4                      N/A
 =======  =====  ===============================  =========

--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -137,11 +137,11 @@ def save_dark_data_as_dark_model(dark_data, dark_model, instrument):
     """
     if instrument == "MIRI":
         out_dark_model = datamodels.DarkMIRIModel(
-            data=dark_data.data, dq=dark_data.groupdq, err=dark_data.err
+            data=dark_data.data, dq=dark_data.groupdq
         )
     else:
         out_dark_model = datamodels.DarkModel(
-            data=dark_data.data, dq=dark_data.groupdq, err=dark_data.err
+            data=dark_data.data, dq=dark_data.groupdq
         )
     out_dark_model.update(dark_model)
 

--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -136,13 +136,9 @@ def save_dark_data_as_dark_model(dark_data, dark_model, instrument):
         The instrument name.
     """
     if instrument == "MIRI":
-        out_dark_model = datamodels.DarkMIRIModel(
-            data=dark_data.data, dq=dark_data.groupdq
-        )
+        out_dark_model = datamodels.DarkMIRIModel(data=dark_data.data, dq=dark_data.groupdq)
     else:
-        out_dark_model = datamodels.DarkModel(
-            data=dark_data.data, dq=dark_data.groupdq
-        )
+        out_dark_model = datamodels.DarkModel(data=dark_data.data, dq=dark_data.groupdq)
     out_dark_model.update(dark_model)
 
     out_dark_model.meta.exposure.nframes = dark_data.exp_nframes

--- a/jwst/dark_current/tests/test_dark_sub.py
+++ b/jwst/dark_current/tests/test_dark_sub.py
@@ -113,7 +113,6 @@ def test_frame_averaging(setup_nrc_cube, readpatt, ngroups, nframes, groupgap, n
 
     # Add ramp values to dark model data array
     dark.data[:, 10, 10] = np.arange(0, NGROUPS_DARK)
-    dark.err[:, 10, 10] = np.arange(10, NGROUPS_DARK + 10)
 
     # Run the pipeline's averaging function
     with np.errstate(divide="ignore", invalid="ignore"), warnings.catch_warnings():
@@ -130,7 +129,6 @@ def test_frame_averaging(setup_nrc_cube, readpatt, ngroups, nframes, groupgap, n
 
     # Prepare arrays to hold results of averaging
     manual_avg = np.zeros((ngroups), dtype=np.float32)
-    manual_errs = np.zeros((ngroups), dtype=np.float32)
 
     # Manually average the input data to compare with pipeline output
     for newgp, gstart, gend in zip(range(ngroups), gstrt_ind, gend_ind):
@@ -142,59 +140,13 @@ def test_frame_averaging(setup_nrc_cube, readpatt, ngroups, nframes, groupgap, n
             newframe = np.mean(dark.data[gstart:gend, 10, 10])
         manual_avg[newgp] = newframe
 
-        # ERR arrays will be quadratic sum of error values
-        manual_errs[newgp] = np.sqrt(np.sum(dark.err[gstart:gend, 10, 10]**2)) / (gend - gstart)
-
     # Check that pipeline output matches manual averaging results
     assert_allclose(manual_avg, avg_dark.data[:, 10, 10], rtol=1e-5)
-    assert_allclose(manual_errs, avg_dark.err[:, 10, 10], rtol=1e-5)
 
     # Check that meta data was properly updated
     assert avg_dark.exp_nframes == nframes
     assert avg_dark.exp_ngroups == ngroups
     assert avg_dark.exp_groupgap == groupgap
-
-
-# Refac done
-def test_more_sci_frames(make_rampmodel, make_darkmodel):
-    '''Check that data is unchanged if there are more frames in the science
-    data is than in the dark reference file and verify that when the dark is not applied,
-    the data is correctly flagged as such'''
-
-    # size of integration
-    nints = 1
-    ngroups = 7
-    xsize = 200
-    ysize = 200
-
-    # create raw input data for step
-    dm_ramp = make_rampmodel(nints, ngroups, ysize, xsize)
-    dm_ramp.meta.exposure.nframes = 1
-    dm_ramp.meta.exposure.groupgap = 0
-
-    # populate data array of science cube
-    for i in range(0, ngroups - 1):
-        dm_ramp.data[0, i] = i
-
-    refgroups = 5
-    # create dark reference file model with fewer frames than science data
-    dark = make_darkmodel(refgroups, ysize, xsize)
-
-    # populate data array of reference file
-    for i in range(0, refgroups - 1):
-        dark.data[0, i] = i * 0.1
-
-    # apply correction
-    out_data, avg_data = darkcorr(dm_ramp, dark)
-
-    # test that the science data are not changed; input file = output file
-    np.testing.assert_array_equal(dm_ramp.data, out_data.data)
-
-    # get dark correction status from header
-    # darkstatus = outfile.meta.cal_step.dark_sub
-    darkstatus = out_data.cal_step
-
-    assert darkstatus == 'SKIPPED'
 
 
 # Refac done


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3906](https://jira.stsci.edu/browse/JP-3906)

<!-- describe the changes comprising this PR here -->
This PR makes changes required to support JP-3906 updates in the stcal and stdatamodels repos: https://github.com/spacetelescope/stcal/pull/368 and https://github.com/spacetelescope/stdatamodels/pull/480

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
