### PR TITLE
Atoca utils test should use numpy isclose

### DIFF
--- a/jwst/extract_1d/soss_extract/tests/test_atoca_utils.py
+++ b/jwst/extract_1d/soss_extract/tests/test_atoca_utils.py
@@ -439,7 +439,7 @@ def test_get_c_matrix(kernels_unity, webb_kernels, wave_grid):
     assert matrix.dtype == np.float64
 
     # ensure normalized
-    assert matrix.sum() == matrix.shape[0]
+    assert np.isclose(matrix.sum(), matrix.shape[0])
 
     # test where input kernel is a 2-D array instead of callable
     i_bounds = [0, len(wave_grid)]


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses devdeps failure due to numerical issues in a SOSS ATOCA test.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
