### PR TITLE
Remove handling for deprecation warnings

### DIFF
--- a/jwst/regtest/test_nirspec_ifu_internal_cal.py
+++ b/jwst/regtest/test_nirspec_ifu_internal_cal.py
@@ -19,10 +19,7 @@ def test_cube_build_nirspec_internal_cal(rtdata, fitsdiff_default_kwargs):
         '--save_results=true',
         '--coord_system=internal_cal'
     ]
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
     output = input_file.replace('cal', 'g395h-f290lp_internal_s3d')
     rtdata.output = output

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -117,10 +117,7 @@ def run_photom(rtdata):
         'args': ['--save_results=True', ]
     }
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    rtdata = rt.run_step_from_dict(rtdata, **step_params)
     return rtdata
 
 

--- a/jwst/regtest/test_nirspec_ifu_spec3.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3.py
@@ -29,10 +29,7 @@ def run_spec3_multi(rtdata_module, resource_tracker):
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: All-NaN slice encountered
     with resource_tracker.track():
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-            warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-            rtdata = rt.run_step_from_dict(rtdata, **step_params)
+        rtdata = rt.run_step_from_dict(rtdata, **step_params)
     return rtdata
 
 

--- a/jwst/regtest/test_nirspec_ifu_spec3_emsm.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_emsm.py
@@ -27,10 +27,7 @@ def run_spec3_multi_emsm(rtdata_module):
     }
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: All-NaN slice encountered
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    rtdata = rt.run_step_from_dict(rtdata, **step_params)
     return rtdata
 
 

--- a/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
@@ -21,10 +21,7 @@ def run_pipeline(rtdata_module):
     args = ["calwebb_spec3", rtdata.input]
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: overflow encountered in multiply
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        Step.from_cmdline(args)
+    Step.from_cmdline(args)
 
 
 @pytest.mark.bigdata

--- a/jwst/regtest/test_nirspec_ifu_spec3_pixelreplace.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_pixelreplace.py
@@ -26,10 +26,7 @@ def run_spec3_multi_pixel_replace(rtdata_module):
     }
     # FIXME: Handle warnings properly.
     # Example: RuntimeWarning: All-NaN slice encountered
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        rtdata = rt.run_step_from_dict(rtdata, **step_params)
+    rtdata = rt.run_step_from_dict(rtdata, **step_params)
     return rtdata
 
 

--- a/jwst/regtest/test_nirspec_masterbackground.py
+++ b/jwst/regtest/test_nirspec_masterbackground.py
@@ -164,11 +164,8 @@ def test_nirspec_ifu_mbkg_user(rtdata, fitsdiff_default_kwargs):
     # Get input data
     rtdata.get_data("nirspec/ifu/jw01252001001_03101_00001_nrs1_cal.fits")
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        MasterBackgroundStep.call(rtdata.input, user_background=user_background,
-                                  save_results=True, suffix='mbsub')
+    MasterBackgroundStep.call(rtdata.input, user_background=user_background,
+                              save_results=True, suffix='mbsub')
 
     output = "jw01252001001_03101_00001_nrs1_mbsub.fits"
     rtdata.output = output
@@ -193,11 +190,8 @@ def test_nirspec_ifu_mbkg_nod(rtdata, fitsdiff_default_kwargs, output_file):
     # Get input data
     rtdata.get_asn("nirspec/ifu/jw01252-o001_spec3_00003_asn_with_bg.json")
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        MasterBackgroundStep.call(rtdata.input, save_background=True, save_results=True,
-                                  suffix='mbsub')
+    MasterBackgroundStep.call(rtdata.input, save_background=True, save_results=True,
+                              suffix='mbsub')
 
     rtdata.output = output_file
 

--- a/jwst/regtest/test_nirspec_steps_spec2.py
+++ b/jwst/regtest/test_nirspec_steps_spec2.py
@@ -20,15 +20,12 @@ def test_nirspec_ifu_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
     """Test using predefined interpolated flat"""
     basename = 'jw01251004001_03107_00001_nrs1'
     output_file = f'{basename}_flat_from_user_model.fits'
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        with dm.open(rtdata.get_data(f'nirspec/ifu/{basename}_assign_wcs.fits')) as data:
-            with dm.open(rtdata.get_data(
-                    f'nirspec/ifu/{basename}_interpolatedflat.fits')) as user_supplied_flat:
+    with dm.open(rtdata.get_data(f'nirspec/ifu/{basename}_assign_wcs.fits')) as data:
+        with dm.open(rtdata.get_data(
+                f'nirspec/ifu/{basename}_interpolatedflat.fits')) as user_supplied_flat:
 
-                # Call the flat field function directly with a user flat
-                nirspec_ifu(data, None, None, None, None, user_supplied_flat=user_supplied_flat)
+            # Call the flat field function directly with a user flat
+            nirspec_ifu(data, None, None, None, None, user_supplied_flat=user_supplied_flat)
 
     rtdata.output = output_file
     data.save(rtdata.output)
@@ -48,11 +45,8 @@ def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
     user_supplied_flat = rtdata.get_data(f'nirspec/ifu/{basename}_interpolatedflat.fits')
 
     # Call the step with a user flat
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        data_flat_fielded = FlatFieldStep.call(
-            data, user_supplied_flat=user_supplied_flat, save_results=False)
+    data_flat_fielded = FlatFieldStep.call(
+        data, user_supplied_flat=user_supplied_flat, save_results=False)
 
     rtdata.output = output_file
     data_flat_fielded.save(rtdata.output)
@@ -67,12 +61,9 @@ def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_ff_inv(rtdata, fitsdiff_default_kwargs):
     """Test flat field inversion"""
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_assign_wcs.fits')) as data:
-            flatted = FlatFieldStep.call(data)
-            unflatted = FlatFieldStep.call(flatted, inverse=True)
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_assign_wcs.fits')) as data:
+        flatted = FlatFieldStep.call(data)
+        unflatted = FlatFieldStep.call(flatted, inverse=True)
 
     # flat fielding may set some new NaN values - ignore these in test
     is_nan = np.isnan(unflatted.data)
@@ -92,15 +83,12 @@ def test_ff_inv(rtdata, fitsdiff_default_kwargs):
 @pytest.mark.bigdata
 def test_pathloss_corrpars(rtdata):
     """Test PathLossStep using correction_pars"""
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
-            pls = PathLossStep()
-            corrected = pls.run(data)
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
+        pls = PathLossStep()
+        corrected = pls.run(data)
 
-            pls.use_correction_pars = True
-            corrected_corrpars = pls.run(data)
+        pls.use_correction_pars = True
+        corrected_corrpars = pls.run(data)
 
     assert np.allclose(corrected.data, corrected_corrpars.data, equal_nan=True)
 
@@ -109,16 +97,13 @@ def test_pathloss_corrpars(rtdata):
 @pytest.mark.bigdata
 def test_pathloss_inverse(rtdata):
     """Test PathLossStep using correction_pars"""
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
-            pls = PathLossStep()
-            corrected = pls.run(data)
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
+        pls = PathLossStep()
+        corrected = pls.run(data)
 
-            pls.inverse = True
-            corrected_inverse = pls.run(corrected)
-            non_nan = ~np.isnan(corrected_inverse.data)
+        pls.inverse = True
+        corrected_inverse = pls.run(corrected)
+        non_nan = ~np.isnan(corrected_inverse.data)
 
     assert np.allclose(corrected.data[non_nan], corrected_inverse.data[non_nan])
 
@@ -127,13 +112,10 @@ def test_pathloss_inverse(rtdata):
 @pytest.mark.bigdata
 def test_pathloss_source_type(rtdata):
     """Test PathLossStep forcing source type"""
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
-            pls = PathLossStep()
-            pls.source_type = 'extended'
-            pls.run(data)
+    with dm.open(rtdata.get_data('nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits')) as data:
+        pls = PathLossStep()
+        pls.source_type = 'extended'
+        pls.run(data)
 
     assert np.allclose(pls.correction_pars.data,
                        pls.correction_pars.pathloss_uniform,

--- a/jwst/regtest/test_nirspec_wcs.py
+++ b/jwst/regtest/test_nirspec_wcs.py
@@ -24,16 +24,13 @@ def test_nirspec_fixedslit_wcs(rtdata, input_file):
 
     rtdata.get_truth(f"truth/test_nirspec_wcs/{output}")
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        with datamodels.open(rtdata.output) as im, datamodels.open(rtdata.truth) as im_truth:
-            # Check the 4 science slits
-            for slit in ['S200A1', 'S200A2', 'S400A1', 'S1600A1']:
-                wcs = nirspec.nrs_wcs_set_input(im, slit)
-                wcs_truth = nirspec.nrs_wcs_set_input(im_truth, slit)
+    with datamodels.open(rtdata.output) as im, datamodels.open(rtdata.truth) as im_truth:
+        # Check the 4 science slits
+        for slit in ['S200A1', 'S200A2', 'S400A1', 'S1600A1']:
+            wcs = nirspec.nrs_wcs_set_input(im, slit)
+            wcs_truth = nirspec.nrs_wcs_set_input(im_truth, slit)
 
-                assert_wcs_grid_allclose(wcs, wcs_truth)
+            assert_wcs_grid_allclose(wcs, wcs_truth)
 
 
 @pytest.mark.bigdata
@@ -53,20 +50,17 @@ def test_nirspec_mos_wcs(rtdata, input_file, msa_file):
 
     rtdata.get_truth(f"truth/test_nirspec_wcs/{output}")
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        with datamodels.open(rtdata.output) as im, datamodels.open(rtdata.truth) as im_truth:
-            # Get validated open slits from WCS transform
-            transform = im_truth.meta.wcs.get_transform('gwa', 'slit_frame')
-            open_slits = transform.slits[:]
-            names = [slit.name for slit in open_slits]
+    with datamodels.open(rtdata.output) as im, datamodels.open(rtdata.truth) as im_truth:
+        # Get validated open slits from WCS transform
+        transform = im_truth.meta.wcs.get_transform('gwa', 'slit_frame')
+        open_slits = transform.slits[:]
+        names = [slit.name for slit in open_slits]
 
-            for name in names:
-                wcs = nirspec.nrs_wcs_set_input(im, name)
-                wcs_truth = nirspec.nrs_wcs_set_input(im_truth, name)
+        for name in names:
+            wcs = nirspec.nrs_wcs_set_input(im, name)
+            wcs_truth = nirspec.nrs_wcs_set_input(im_truth, name)
 
-                assert_wcs_grid_allclose(wcs, wcs_truth)
+            assert_wcs_grid_allclose(wcs, wcs_truth)
 
 
 @pytest.mark.bigdata
@@ -85,15 +79,12 @@ def test_nirspec_ifu_wcs(rtdata, input_file):
 
     rtdata.get_truth(f"truth/test_nirspec_wcs/{output}")
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*Slit2Msa.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*NIRSpec WCS.*")
-        with datamodels.open(rtdata.output) as im, datamodels.open(rtdata.truth) as im_truth:
-            # Test all the IFU slices
-            for k in range(30):
-                wcs = nirspec.nrs_wcs_set_input(im, k)
-                wcs_truth = nirspec.nrs_wcs_set_input(im_truth, k)
-                assert_wcs_grid_allclose(wcs, wcs_truth)
+    with datamodels.open(rtdata.output) as im, datamodels.open(rtdata.truth) as im_truth:
+        # Test all the IFU slices
+        for k in range(30):
+            wcs = nirspec.nrs_wcs_set_input(im, k)
+            wcs_truth = nirspec.nrs_wcs_set_input(im_truth, k)
+            assert_wcs_grid_allclose(wcs, wcs_truth)
 
 
 def assert_wcs_grid_allclose(wcs, wcs_truth):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Follow up to #9404: remove DeprecationWarning handling from regtests that used to use input NIRSpec products with old-style WCS.  They have now been replaced on artifactory, so the warnings should no longer be needed.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
