### PR TITLE
stfitsdiff bug in comparison of header keywords and comments

### DIFF
--- a/jwst/regtest/st_fitsdiff.py
+++ b/jwst/regtest/st_fitsdiff.py
@@ -794,25 +794,22 @@ class STHeaderDiff(HeaderDiff):
             if counta != countb:
                 self.diff_duplicate_keywords[keyword] = (counta, countb)
 
-            # The following lines include STScI's changes:
-            # - Make sure that the keyword in 'a' exists in 'b', or continue
-
             # Compare keywords' values and comments
-            for a in valuesa[keyword]:
-                if a not in valuesb[keyword]:
-                    continue
-                bidx = valuesb[keyword].index(a)
-                b = valuesb[keyword][bidx]
 
-                # The following lines are identical to the original HeaderDiff code
+            # The following lines include STScI's changes:
+            # - Compare only common keywords
+            a = valuesa[keyword]
+            b = valuesb[keyword]
 
-                if diff_values(a, b, rtol=self.rtol, atol=self.atol):
-                    self.diff_keyword_values[keyword].append((a, b))
-                else:
-                    # If there are duplicate keywords we need to be able to
-                    # index each duplicate; if the values of a duplicate
-                    # are identical use None here
-                    self.diff_keyword_values[keyword].append(None)
+            # The following lines are identical to the original HeaderDiff code
+
+            if diff_values(a, b, rtol=self.rtol, atol=self.atol):
+                self.diff_keyword_values[keyword].append((a, b))
+            else:
+                # If there are duplicate keywords we need to be able to
+                # index each duplicate; if the values of a duplicate
+                # are identical use None here
+                self.diff_keyword_values[keyword].append(None)
 
             if not any(self.diff_keyword_values[keyword]):
                 # No differences found; delete the array of Nones
@@ -830,20 +827,16 @@ class STHeaderDiff(HeaderDiff):
                     continue
 
             # The following lines include STScI's changes:
-            # - Make sure that the comment in 'a' exists in 'b', or continue
+            # - Compare comments of common keywords
+            a = commentsa[keyword]
+            b = commentsb[keyword]
 
-            for a in commentsa[keyword]:
-                if a not in commentsb[keyword]:
-                    continue
-                bidx = commentsb[keyword].index(a)
-                b = commentsb[keyword][bidx]
+            # The following lines are identical to the original HeaderDiff code
 
-                # The following lines are identical to the original HeaderDiff code
-
-                if diff_values(a, b):
-                    self.diff_keyword_comments[keyword].append((a, b))
-                else:
-                    self.diff_keyword_comments[keyword].append(None)
+            if diff_values(a, b):
+                self.diff_keyword_comments[keyword].append((a, b))
+            else:
+                self.diff_keyword_comments[keyword].append(None)
 
             if not any(self.diff_keyword_comments[keyword]):
                 del self.diff_keyword_comments[keyword]

--- a/jwst/regtest/st_fitsdiff.py
+++ b/jwst/regtest/st_fitsdiff.py
@@ -803,7 +803,7 @@ class STHeaderDiff(HeaderDiff):
 
             # The following lines are identical to the original HeaderDiff code
 
-            if diff_values(a, b, rtol=self.rtol, atol=self.atol):
+            if diff_values(a[0], b[0], rtol=self.rtol, atol=self.atol):
                 self.diff_keyword_values[keyword].append((a, b))
             else:
                 # If there are duplicate keywords we need to be able to

--- a/jwst/regtest/st_fitsdiff.py
+++ b/jwst/regtest/st_fitsdiff.py
@@ -11,7 +11,6 @@ from astropy import __version__
 from astropy.table import Table
 from astropy.utils.diff import diff_values, report_diff_values, where_not_allclose
 
-from astropy.io.fits.card import BLANK_CARD
 
 from astropy.io.fits.hdu.table import _TableLikeHDU
 
@@ -29,7 +28,7 @@ from astropy.io.fits.diff import (
 __all__ = [
     "STFITSDiff",
     "STHDUDiff",
-    "STHeaderDiff",
+    "HeaderDiff",
     "STImageDataDiff",
     "STRawDataDiff",
     "STTableDataDiff",
@@ -484,7 +483,7 @@ class STHDUDiff(HDUDiff):
             self.rtol, self.atol = self.header_tolerances["rtol"], self.header_tolerances["atol"]
 
         # Get the header differences
-        self.diff_headers = STHeaderDiff.fromdiff(self, self.a.header.copy(), self.b.header.copy())
+        self.diff_headers = HeaderDiff.fromdiff(self, self.a.header.copy(), self.b.header.copy())
         # Reset the object tolerances
         if self.header_tolerances:
             self.rtol, self.atol = rtol, atol
@@ -661,185 +660,6 @@ class STHDUDiff(HDUDiff):
             if [self.nans, self.percentages, self.stats] != [None, None, None]:
                 report_data_diff()
             self.diff_data.report(self._fileobj, indent=self._indent + 1)
-
-
-class STHeaderDiff(HeaderDiff):
-    """
-    HeaderDiff class from astropy with the STScI ad hoc changes for STScI regression test reports.
-
-    STScI changes include making sure that the keyword and comments in 'a' exist in 'b' (regardless
-    of order), otherwise continue without error.
-
-    Full documentation of the base class is provided at:
-    https://docs.astropy.org/en/stable/io/fits/api/diff.html
-    """
-
-    def __init__(
-        self,
-        a,
-        b,
-        ignore_keywords=None,
-        ignore_comments=None,
-        rtol=0.0,
-        atol=0.0,
-        ignore_blanks=True,
-        ignore_blank_cards=True,
-    ):
-        """
-        For full documentation on variables, see original astropy code.
-
-        Parameters
-        ----------
-        a : `~astropy.io.fits.Header` or str or bytes
-            A header.
-
-        b : `~astropy.io.fits.Header` or str or bytes
-            A header to compare to the first header.
-
-        ignore_keywords : sequence, optional
-            Header keywords to ignore when comparing two headers.
-
-        ignore_comments : sequence, optional
-            List of header keywords whose comments should be ignored.
-
-        rtol : float, optional
-            Relative difference to allow when comparing two float values.
-
-        atol : float, optional
-            Allowed absolute difference when comparing two float values.
-
-        ignore_blanks : bool, optional
-            Ignore extra whitespace at the end of string values either in
-            headers or data. Extra leading whitespace is not ignored.
-
-        ignore_blank_cards : bool, optional
-            Ignore all cards that are blank, i.e. they only contain whitespace.
-        """
-        super().__init__(
-            a,
-            b,
-            ignore_keywords=set_variable_to_empty_list(ignore_keywords),
-            ignore_comments=set_variable_to_empty_list(ignore_comments),
-            rtol=rtol,
-            atol=atol,
-            ignore_blanks=ignore_blanks,
-            ignore_blank_cards=ignore_blank_cards,
-        )
-
-    def _diff(self):
-        # The following lines are identical to the original HeaderDiff code
-
-        if self.ignore_blank_cards:
-            cardsa = [c for c in self.a.cards if str(c) != BLANK_CARD]
-            cardsb = [c for c in self.b.cards if str(c) != BLANK_CARD]
-        else:
-            cardsa = list(self.a.cards)
-            cardsb = list(self.b.cards)
-
-        # Build dictionaries of keyword values and comments
-        def get_header_values_comments(cards):
-            values = {}
-            comments = {}
-            for card in cards:
-                value = card.value
-                if self.ignore_blanks and isinstance(value, str):
-                    value = value.rstrip()
-                values.setdefault(card.keyword, []).append(value)
-                comments.setdefault(card.keyword, []).append(card.comment)
-            return values, comments
-
-        valuesa, commentsa = get_header_values_comments(cardsa)
-        valuesb, commentsb = get_header_values_comments(cardsb)
-
-        keywordsa = set(valuesa)
-        keywordsb = set(valuesb)
-
-        self.common_keywords = sorted(keywordsa.intersection(keywordsb))
-        if len(cardsa) != len(cardsb):
-            self.diff_keyword_count = (len(cardsa), len(cardsb))
-
-        # Any other diff attributes should exclude ignored keywords
-        keywordsa = keywordsa.difference(self.ignore_keywords)
-        keywordsb = keywordsb.difference(self.ignore_keywords)
-        if self.ignore_keyword_patterns:
-            for pattern in self.ignore_keyword_patterns:
-                keywordsa = keywordsa.difference(fnmatch.filter(keywordsa, pattern))
-                keywordsb = keywordsb.difference(fnmatch.filter(keywordsb, pattern))
-
-        if "*" in self.ignore_keywords:
-            # Any other differences between keywords are to be ignored
-            return
-
-        left_only_keywords = sorted(keywordsa.difference(keywordsb))
-        right_only_keywords = sorted(keywordsb.difference(keywordsa))
-
-        if left_only_keywords or right_only_keywords:
-            self.diff_keywords = (left_only_keywords, right_only_keywords)
-
-        # Compare count of each common keyword
-        for keyword in self.common_keywords:
-            if keyword in self.ignore_keywords:
-                continue
-            if self.ignore_keyword_patterns:
-                skip = False
-                for pattern in self.ignore_keyword_patterns:
-                    if fnmatch.fnmatch(keyword, pattern):
-                        skip = True
-                        break
-                if skip:
-                    continue
-
-            counta = len(valuesa[keyword])
-            countb = len(valuesb[keyword])
-            if counta != countb:
-                self.diff_duplicate_keywords[keyword] = (counta, countb)
-
-            # Compare keywords' values and comments
-
-            # The following lines include STScI's changes:
-            # - Compare only common keywords
-            a = valuesa[keyword]
-            b = valuesb[keyword]
-
-            # The following lines are identical to the original HeaderDiff code
-
-            if diff_values(a[0], b[0], rtol=self.rtol, atol=self.atol):
-                self.diff_keyword_values[keyword].append((a, b))
-            else:
-                # If there are duplicate keywords we need to be able to
-                # index each duplicate; if the values of a duplicate
-                # are identical use None here
-                self.diff_keyword_values[keyword].append(None)
-
-            if not any(self.diff_keyword_values[keyword]):
-                # No differences found; delete the array of Nones
-                del self.diff_keyword_values[keyword]
-
-            if "*" in self.ignore_comments or keyword in self.ignore_comments:
-                continue
-            if self.ignore_comment_patterns:
-                skip = False
-                for pattern in self.ignore_comment_patterns:
-                    if fnmatch.fnmatch(keyword, pattern):
-                        skip = True
-                        break
-                if skip:
-                    continue
-
-            # The following lines include STScI's changes:
-            # - Compare comments of common keywords
-            a = commentsa[keyword]
-            b = commentsb[keyword]
-
-            # The following lines are identical to the original HeaderDiff code
-
-            if diff_values(a, b):
-                self.diff_keyword_comments[keyword].append((a, b))
-            else:
-                self.diff_keyword_comments[keyword].append(None)
-
-            if not any(self.diff_keyword_comments[keyword]):
-                del self.diff_keyword_comments[keyword]
 
 
 class STImageDataDiff(ImageDataDiff):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9499

<!-- describe the changes comprising this PR here -->
This PR addresses a bug in the comparison of common header keywords.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
