### PR TITLE
JP-3116: Use duplication checking to prevent undesirable associations in DMS operations

### DIFF
--- a/jwst/associations/generator/generate_per_candidate.py
+++ b/jwst/associations/generator/generate_per_candidate.py
@@ -1,5 +1,6 @@
 import collections
 import logging
+import numpy as np
 from timeit import default_timer as timer
 
 from .generate import generate
@@ -74,6 +75,18 @@ def generate_per_candidate(
     """
     logger.info("Generating based on the per-candidate algorithm.")
 
+    # If DMS flag is present, add all c-type ids associated with input ids to generation
+    if dms_enabled and candidate_ids is not None:
+        # Generate a selection mask to find all cids associated with DMS-provided ids
+        row_mask = np.zeros((len(pool),), dtype=bool)
+        for cid in candidate_ids:
+            row_mask |= [cid in x for x in pool["asn_candidate"]]
+        input_candidate_ids = list(candidate_ids)
+        bkg_cids = ids_by_ctype(pool[row_mask]).get("background", None)
+        if bkg_cids is not None:
+            for key in bkg_cids:
+                candidate_ids.append(key)
+
     # Get the candidates
     cids_by_type = ids_by_ctype(pool)
     if candidate_ids is None:
@@ -98,7 +111,6 @@ def generate_per_candidate(
             rule_defs,
             version_id=version_id,
             ignore_default=ignore_default,
-            dms_enabled=dms_enabled,
         )
 
         # Add to the list
@@ -145,13 +157,19 @@ def generate_per_candidate(
         except AttributeError:
             pass
 
+    if dms_enabled:
+        # We now must remove the asns that were used to duplicate-check the input candidates.
+        finalized_asns = [
+            asn
+            for asn in finalized_asns
+            if any(cid in asn["asn_id"] for cid in input_candidate_ids)
+        ]
+
     logger.info("Total associations generated: %s", len(finalized_asns))
     return finalized_asns
 
 
-def generate_on_candidate(
-    cid_ctype, pool, rule_defs, version_id=None, ignore_default=False, dms_enabled=False
-):
+def generate_on_candidate(cid_ctype, pool, rule_defs, version_id=None, ignore_default=False):
     """
     Generate associations based on a candidate ID.
 
@@ -175,9 +193,6 @@ def generate_on_candidate(
     ignore_default : bool
         Ignore the default rules. Use only the user-specified ones.
 
-    dms_enabled : bool
-        Flag for DMS processing, true if command-line argument '--DMS' was used.
-
     Returns
     -------
     associations : [Association[,...]]
@@ -188,21 +203,6 @@ def generate_on_candidate(
 
     # Get the pool
     pool_cid = pool_from_candidate(pool, cid)
-
-    # DMS processing excludes generation of o-type candidates for science exposures
-    # with linked backgrounds, i.e. without the background member present, as it
-    # would be for c-type background association candidates.
-    if dms_enabled and "observation" in ctype:
-        skip_rows = []
-        for i, row in enumerate(pool_cid):
-            if "background" in row["asn_candidate"] and row["bkgdtarg"] == "f":
-                skip_rows.append(i)
-        logger.debug(
-            f"Dropping {len(skip_rows)} exposures from pool - observation "
-            "candidate type does not allow association generation when a "
-            "background candidate is present."
-        )
-        pool_cid.remove_rows(skip_rows)
 
     pool_cid["asn_candidate"] = [f"[('{cid}', '{ctype}')]"] * len(pool_cid)
     logger.info(f"Length of pool for {cid}: {len(pool_cid)}")

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -43,6 +43,7 @@ def _assoc_sdp_against_standard(rtdata, resource_tracker, request, pool_args):
     with resource_tracker.track(log=request):
         asn_generate.cli(args + ["-p", rtdata.output,
                                  "--version-id", version_id,
+                                 "--DMS",
                                  input_csv])
     out_paths = sorted(glob("*.json"))
 

--- a/jwst/regtest/test_associations_standards.py
+++ b/jwst/regtest/test_associations_standards.py
@@ -137,6 +137,7 @@ def test_against_standard(rtdata, standard_pars, slow):
         args = standard_pars.main_args + [
             '-p', str(output_path),
             '--version-id', version_id,
+            '--DMS',
         ]
         pool = combine_pools([
             t_path(Path('data') / (standard_pars.pool_root + '.csv'))


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3116](https://jira.stsci.edu/browse/JP-3116)

<!-- describe the changes comprising this PR here -->
This PR attempts a new solution for the issue of association generation when a science exposure has a dedicated background exposure associated. The desired outcome in DMS operations is to not produce the observation candidate ('o-type asn') for the science exposures, but to wait for the dedicated background exposures and only generate the background candidate associations ('c-type').

The first implementation checked against the bkgdtarg flag in the pool rows, and discarded rows that were labeled as a background target and also part of a background candidate, if the input candidate was of type "observation".

This implementation instead gathers all background candidate ids listed in the pool rows selected by the input candidate ids, generates associations for them, then uses the association duplication check to trim the undesirable associations. It then further trims the output of the associations used for duplication checking but not generated as part of the input candidate ids.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
