### PR TITLE
TST: Move association pool regtest truth to somewhere more intuitive

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -41,7 +41,7 @@ def artifactory_repos(pytestconfig):
     # see: https://github.com/pytest-dev/pytest/pull/11594
     # using "not inputs_root" will handle both cases
     if not inputs_root:
-        inputs_root = "jwst-pipeline"
+        inputs_root = "scratch-lim"
     else:
         inputs_root = inputs_root[0]
 

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -33,7 +33,7 @@ class RegtestData:
     def __init__(
         self,
         env="dev",
-        inputs_root="jwst-pipeline",
+        inputs_root="scratch-lim",
         results_root="jwst-pipeline-results",
         docopy=True,
         input=None,

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -47,7 +47,7 @@ def _assoc_sdp_against_standard(rtdata, resource_tracker, request, pool_args):
     out_paths = sorted(glob("*.json"))
 
     # Compare to the truth associations.
-    truth_pool_path = f"associations/sdp/truth/{pool}"
+    truth_pool_path = f"truth/{pool}"
     rtdata.truth_remote = truth_pool_path
     truth_paths = sorted([rtdata.get_truth(p) for p in
                           rtdata.data_glob(truth_pool_path, glob="*.json")])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ norecursedirs = [
     "venv",
 ]
 junit_family = "xunit2"
-inputs_root = "jwst-pipeline"
+inputs_root = "scratch-lim"
 results_root = "jwst-pipeline-results"
 text_file_format = "rst"
 doctest_plus = "enabled"


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses part of #8806

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
