### PR TITLE
JP-3940: Change EMIcorr default algorithm

### DIFF
--- a/changes/9510.emicorr.rst
+++ b/changes/9510.emicorr.rst
@@ -1,0 +1,1 @@
+Change the default fitting algorithm for MIRI EMI correction to the 'joint' method to improve performance for low numbers of groups.

--- a/docs/jwst/emicorr/arguments.rst
+++ b/docs/jwst/emicorr/arguments.rst
@@ -2,7 +2,7 @@ Step Arguments
 ==============
 The ``emicorr`` step has the following step-specific arguments.
 
-``--algorithm`` (string, default='sequential')
+``--algorithm`` (string, default='joint')
     Algorithm for fitting EMI noise in ramps.  If 'sequential', ramps are fit
     and then EMI noise is fit to the residuals.  If 'joint', ramps and noise
     are fit simultaneously.  The sequential algorithm can be used without

--- a/jwst/emicorr/emicorr_step.py
+++ b/jwst/emicorr/emicorr_step.py
@@ -14,7 +14,7 @@ class EmiCorrStep(Step):
     class_alias = "emicorr"
 
     spec = """
-        algorithm = option('sequential', 'joint', default='sequential')  # EMI fitting algorithm
+        algorithm = option('sequential', 'joint', default='joint')  # EMI fitting algorithm
         nints_to_phase = integer(default=None)  # Number of integrations to phase
         nbins = integer(default=None)  # Number of bins in one phased wave
         scale_reference = boolean(default=True)  # If True, the reference wavelength will be scaled to the data's phase amplitude


### PR DESCRIPTION
This PR changes the emicorr default algorithm to the 'joint' method based on performance tests by the MIRI team.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
