### PR TITLE
JP-4029: fix conflicting aliases for the background step

### DIFF
--- a/docs/jwst/background_step/description.rst
+++ b/docs/jwst/background_step/description.rst
@@ -2,7 +2,7 @@ Description
 ===========
 
 :Class: `jwst.background.BackgroundStep`
-:Alias: background
+:Alias: bkg_subtract
 
 The background subtraction step performs
 image-from-image subtraction in order to accomplish subtraction of background

--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -15,7 +15,7 @@ __all__ = ["BackgroundStep"]
 class BackgroundStep(Step):
     """Subtract background exposures from target exposures."""
 
-    class_alias = "background"
+    class_alias = "bkg_subtract"
 
     spec = """
         bkg_list = force_list(default=None)  # List of background files. Ignored for WFSS or if asn is provided
@@ -77,9 +77,9 @@ class BackgroundStep(Step):
             )
             if result is None:
                 result = input_model.copy()
-                result.meta.cal_step.back_sub = "SKIPPED"
+                result.meta.cal_step.bkg_subtract = "SKIPPED"
             else:
-                result.meta.cal_step.back_sub = "COMPLETE"
+                result.meta.cal_step.bkg_subtract = "COMPLETE"
 
         else:
             # Get the background files to be subtracted
@@ -104,7 +104,7 @@ class BackgroundStep(Step):
             # or report and skip the step
             if bkg_list is None or len(bkg_list) == 0:
                 self.log.warning("* No background list provided * Skipping step.")
-                result.meta.cal_step.back_sub = "SKIPPED"
+                result.meta.cal_step.bkg_subtract = "SKIPPED"
                 return result
 
             # check if input data is NRS_IFU
@@ -132,13 +132,13 @@ class BackgroundStep(Step):
             # Do the background subtraction
             if do_sub:
                 bkg_model, result = background_sub(result, bkg_list, self.sigma, self.maxiters)
-                result.meta.cal_step.back_sub = "COMPLETE"
+                result.meta.cal_step.bkg_subtract = "COMPLETE"
                 if self.save_combined_background:
                     comb_bkg_path = self.save_model(bkg_model, suffix=self.bkg_suffix, force=True)
                     self.log.info(f"Combined background written to {comb_bkg_path}.")
 
             else:
-                result.meta.cal_step.back_sub = "SKIPPED"
+                result.meta.cal_step.bkg_subtract = "SKIPPED"
                 self.log.warning("Skipping background subtraction")
                 self.log.warning(
                     "GWA_XTIL and GWA_YTIL source values are not the same as bkg values"

--- a/jwst/background/tests/test_background.py
+++ b/jwst/background/tests/test_background.py
@@ -177,7 +177,7 @@ def test_nirspec_gwa(tmp_cwd, background, science_image):
     test = science_image.data - back_image.data
     assert_allclose(result.data, test)
     assert type(result) is type(science_image)
-    assert result.meta.cal_step.back_sub == 'COMPLETE'
+    assert result.meta.cal_step.bkg_subtract == 'COMPLETE'
     back_image.close()
 
 
@@ -199,7 +199,7 @@ def test_nirspec_gwa_xtilt(tmp_cwd, background, science_image):
     result = BackgroundStep.call(science_image, bkg)
 
     assert type(result) is type(science_image)
-    assert result.meta.cal_step.back_sub == 'SKIPPED'
+    assert result.meta.cal_step.bkg_subtract == 'SKIPPED'
     back_image.close()
 
 
@@ -221,7 +221,7 @@ def test_nirspec_gwa_ytilt(tmp_cwd, background, science_image):
     result = BackgroundStep.call(science_image, bkg)
 
     assert type(result) is type(science_image)
-    assert result.meta.cal_step.back_sub == 'SKIPPED'
+    assert result.meta.cal_step.bkg_subtract == 'SKIPPED'
 
     back_image.close()
 
@@ -245,7 +245,7 @@ def test_miri_subarray_full_overlap(data_shape, background_shape):
 
     assert_allclose(result.data, image_value - background_value)
     assert type(result) is type(image)
-    assert result.meta.cal_step.back_sub == 'COMPLETE'
+    assert result.meta.cal_step.bkg_subtract == 'COMPLETE'
 
     image.close()
     background.close()
@@ -269,7 +269,7 @@ def test_miri_subarray_partial_overlap(data_shape, background_shape):
     assert_allclose(result.data[..., background_shape[-2]:, :], image_value)
     assert_allclose(result.data[..., :, background_shape[-1]:], image_value)
     assert type(result) is type(image)
-    assert result.meta.cal_step.back_sub == 'COMPLETE'
+    assert result.meta.cal_step.bkg_subtract == 'COMPLETE'
 
     image.close()
     background.close()
@@ -283,7 +283,7 @@ def test_asn_input(mk_asn):
     bgs = datamodels.open(bg_subtracted)
 
     assert_allclose(result.data, bgs.data)
-    assert result.meta.cal_step.back_sub == 'COMPLETE'
+    assert result.meta.cal_step.bkg_subtract == 'COMPLETE'
 
     result.close()
     bgs.close()
@@ -304,11 +304,11 @@ def test_bg_file_list(mk_asn):
     assert_allclose(result1.data, bgs.data)
     assert_allclose(result2.data, bgs.data)
     assert_allclose(result3.data, bgs.data)
-    assert result1.meta.cal_step.back_sub == 'COMPLETE'
-    assert result2.meta.cal_step.back_sub == 'COMPLETE'
-    assert result3.meta.cal_step.back_sub == 'COMPLETE'
-    assert result4.meta.cal_step.back_sub == 'SKIPPED'
-    assert result5.meta.cal_step.back_sub == 'SKIPPED'
+    assert result1.meta.cal_step.bkg_subtract == 'COMPLETE'
+    assert result2.meta.cal_step.bkg_subtract == 'COMPLETE'
+    assert result3.meta.cal_step.bkg_subtract == 'COMPLETE'
+    assert result4.meta.cal_step.bkg_subtract == 'SKIPPED'
+    assert result5.meta.cal_step.bkg_subtract == 'SKIPPED'
 
     result1.close()
     result2.close()

--- a/jwst/background/tests/test_background_wfss.py
+++ b/jwst/background/tests/test_background_wfss.py
@@ -458,5 +458,5 @@ def test_wfss_asn_input(mock_asn_and_data):
     assert result.meta.source_catalog == "test_cat.ecsv"
     assert result.meta.direct_image == i2dfile.name
     assert result.meta.segmentation_map == segmfile.name
-    assert result.meta.cal_step.back_sub == "COMPLETE"
+    assert result.meta.cal_step.bkg_subtract == "COMPLETE"
 

--- a/jwst/extract_1d/tests/test_extract.py
+++ b/jwst/extract_1d/tests/test_extract.py
@@ -1174,7 +1174,7 @@ def test_define_aperture_optimal_with_nod(
     exptype = "MIR_LRS-FIXEDSLIT"
 
     # mock nod subtraction
-    mock_miri_lrs_fs.meta.cal_step.back_sub = "COMPLETE"
+    mock_miri_lrs_fs.meta.cal_step.bkg_subtract = "COMPLETE"
     mock_miri_lrs_fs.meta.dither.primary_type = "ALONG-SLIT-NOD"
 
     # mock a nod position at the opposite end of the array
@@ -1607,7 +1607,7 @@ def test_create_extraction_optimal(monkeypatch, create_extraction_inputs, psf_re
     model = create_extraction_inputs[0]
 
     # mock nod subtraction
-    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.cal_step.bkg_subtract = "COMPLETE"
     model.meta.dither.primary_type = "2-POINT-NOD"
 
     # mock a nod position at the opposite end of the array

--- a/jwst/extract_1d/tests/test_psf_profile.py
+++ b/jwst/extract_1d/tests/test_psf_profile.py
@@ -248,7 +248,7 @@ def test_psf_profile_model_nod(monkeypatch, mock_miri_lrs_fs, psf_reference_file
     _, _, wl_array = model.meta.wcs(xidx, yidx)
 
     # mock nod subtraction
-    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.cal_step.bkg_subtract = "COMPLETE"
     model.meta.dither.primary_type = "2-POINT-NOD"
 
     # mock a nod position at the opposite end of the array
@@ -316,7 +316,7 @@ def test_psf_profile_model_nod_wrong_pattern(mock_miri_lrs_fs, psf_reference_fil
     model = mock_miri_lrs_fs
     data_shape = model.data.shape
     trace = np.full(data_shape[0], (data_shape[1] - 1) / 2.0)
-    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.cal_step.bkg_subtract = "COMPLETE"
 
     yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
     _, _, wl_array = model.meta.wcs(xidx, yidx)
@@ -335,7 +335,7 @@ def test_psf_profile_model_nod_bad_position(mock_miri_lrs_fs, psf_reference_file
     model = mock_miri_lrs_fs
     data_shape = model.data.shape
     trace = np.full(data_shape[0], (data_shape[1] - 1) / 2.0)
-    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.cal_step.bkg_subtract = "COMPLETE"
     model.meta.dither.primary_type = "2-POINT-NOD"
 
     yidx, xidx = np.mgrid[: data_shape[0], : data_shape[1]]
@@ -394,7 +394,7 @@ def test_psf_profile_optimize_with_nod(
     data_shape = model.data.shape
 
     # mock nod subtraction
-    model.meta.cal_step.back_sub = "COMPLETE"
+    model.meta.cal_step.bkg_subtract = "COMPLETE"
     model.meta.dither.primary_type = "2-POINT-NOD"
 
     # trace at pixel 9.5

--- a/jwst/master_background/tests/test_master_background.py
+++ b/jwst/master_background/tests/test_master_background.py
@@ -231,7 +231,7 @@ def test_master_background_medfilt(tmp_cwd, nirspec_asn):
 def test_master_background_logic(tmp_cwd, user_background, science_image):
     """Verify if calspec2 background step was run the master background step is skipped."""
     # the background step in calspec2 was done
-    science_image.meta.cal_step.back_sub = "COMPLETE"
+    science_image.meta.cal_step.bkg_subtract = "COMPLETE"
 
     # Run with a user-supplied background
     result = MasterBackgroundStep.call(

--- a/jwst/pipeline/background.cfg
+++ b/jwst/pipeline/background.cfg
@@ -1,2 +1,2 @@
-name = "background" 
+name = "bkg_subtract"
 class = "jwst.background.BackgroundStep"

--- a/jwst/stpipe/integration.py
+++ b/jwst/stpipe/integration.py
@@ -35,7 +35,7 @@ def get_steps():
         ("jwst.step.AmiNormalizeStep", "ami_normalize", False),
         ("jwst.step.AssignMTWcsStep", "assign_mtwcs", False),
         ("jwst.step.AssignWcsStep", "assign_wcs", False),
-        ("jwst.step.BackgroundStep", "background", False),
+        ("jwst.step.BackgroundStep", "bkg_subtract", False),
         ("jwst.step.BadpixSelfcalStep", "badpix_selfcal", False),
         ("jwst.step.BarShadowStep", "barshadow", False),
         ("jwst.step.Combine1dStep", "combine_1d", False),


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4029](https://jira.stsci.edu/browse/JP-4029)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses convergence of aliases for the background step in favor of bkg_subtract. Merging should be coordinated with https://github.com/spacetelescope/stdatamodels/pull/495.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
