### PR TITLE
Fix importing fixtures across subfolders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         - linux: py311-oldestdeps-xdist-cov
         - linux: py311-xdist
         - linux: py312-xdist
+        - linux: py312-pyargs-xdist
         # `tox` does not currently respect `requires-python` versions when creating testing environments;
         # if this breaks, add an upper pin to `requires-python` and revert this py3 to the latest working version
         - linux: py3-cov-xdist

--- a/jwst/combine_1d/tests/test_combine1d.py
+++ b/jwst/combine_1d/tests/test_combine1d.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from jwst import datamodels
-from jwst.datamodels.utils.tests.test_wfss_multispec import wfss_multiexposure, wfss_spec3_multispec, example_spec, N_SOURCES
+from jwst.datamodels.utils.tests.test_wfss_multispec import wfss_multi, N_SOURCES
 from jwst.combine_1d import Combine1dStep
 from jwst.combine_1d.combine1d import InputSpectrumModel, check_exptime
 
@@ -203,7 +203,11 @@ def create_spec_model(npoints=10, flux=1e-9, error=1e-10, wave_range=(11, 13)):
     spec_model = datamodels.SpecModel(spec_table=otab)
 
     return spec_model
-        
+
+
+@pytest.fixture
+def wfss_multiexposure():
+    return wfss_multi()
 
 def test_wfss_multi_input(wfss_multiexposure):
     """Smoke test to ensure combine_1d works with WFSSMultiSpecModel"""

--- a/jwst/combine_1d/tests/test_combine1d.py
+++ b/jwst/combine_1d/tests/test_combine1d.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from jwst import datamodels
-from jwst.datamodels.utils.tests.test_wfss_multispec import wfss_multi, N_SOURCES
+from jwst.datamodels.utils.tests.wfss_helpers import wfss_multi, N_SOURCES
 from jwst.combine_1d import Combine1dStep
 from jwst.combine_1d.combine1d import InputSpectrumModel, check_exptime
 

--- a/jwst/datamodels/utils/tests/test_wfss_multispec.py
+++ b/jwst/datamodels/utils/tests/test_wfss_multispec.py
@@ -1,129 +1,50 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.io import fits
+
 import stdatamodels.jwst.datamodels as dm
-from jwst.datamodels.utils.wfss_multispec import make_wfss_multiexposure, make_wfss_multicombined, wfss_multiexposure_to_multispec
-
-
-N_SOURCES = 5
-N_EXPOSURES = 4
-N_ROWS = 3
-
-
-def example_spec():
-
-    def mock_wcs(*args, **kwargs):
-        return 0.0, 0.0, 0.0
-    spec = dm.SpecModel()
-    spectable_dtype = spec.schema["properties"]["spec_table"]["datatype"]
-    recarray_dtype = [(d["name"], d["datatype"]) for d in spectable_dtype]
-    spec.meta.wcs = mock_wcs
-    spec_table = np.recarray((N_ROWS,), dtype=recarray_dtype)
-    spec_table["WAVELENGTH"] = np.linspace(1.0, 10.0, N_ROWS)
-    spec_table["FLUX"] = np.ones(N_ROWS)
-    spec.spec_table = spec_table
-    spec.spec_table.columns["wavelength"].unit = "um"
-    return spec
-
-def _add_multispec_meta(spec):
-    """
-    Add specmeta attributes to a spec-like ObjectNode inside a MultiSpecModel.
-    
-    This only includes attributes that do NOT need to change for each source/exposure
-    for the purposes of this test.
-
-    input spec is updated in place.
-    """
-    spec.source_type = "POINT"
-    spec.source_ra = 0.0
-    spec.source_dec = 0.0
-    spec.extract2d_xstart = 0.0
-    spec.extract2d_ystart = 0.0
-    spec.extract2d_xstop = 0.0
-    spec.extract2d_ystop = 0.0
-    spec.extraction_xstart = 0.0
-    spec.extraction_ystart = 0.0
-    spec.extraction_xstop = 0.0
-    spec.extraction_ystop = 0.0
-
-
-def wfss_spec2_multi():
-    """
-    Set up a MultiSpecModel object that looks like outputs from extract_1d during calwebb_spec2.
-    
-    Each of the spectra is from the SAME exposure, but DIFFERENT sources.
-    """
-    spec0 = example_spec()
-    multi = dm.MultiSpecModel()
-    for i in range(N_SOURCES):
-        # create a new SpecModel for each source
-        spec = spec0.copy()
-        spec.meta.filename = f"exposure_1.fits" # all sources in the same exposure
-        spec.meta.group_id = "1" # all sources in the same exposure
-        spec.source_id = N_SOURCES - i # reverse the order to test sorting
-        spec.name = str(spec.source_id)
-        _add_multispec_meta(spec)
-        multi.spec.append(spec)
-
-    return multi
-
-
-def wfss_spec3_multi():
-    """
-    Set up a MultiSpecModel object that looks like outputs from extract_1d during calwebb_spec3.
-    
-    Each of the spectra is from the SAME source, but DIFFERENT exposures.
-    """
-    spec0 = example_spec()
-    multi = dm.MultiSpecModel()
-    multi.meta.exposure.exposure_time = 7.0
-    multi.meta.exposure.integration_time = 7.0
-    for j in range(N_EXPOSURES):
-        # create a new SpecModel for each exposure
-        spec = spec0.copy()
-        spec.meta.filename = f"exposure_{j}.fits"
-        spec.meta.group_id = str(j + 1)
-        spec.source_id = 999 # all sources are the same
-        spec.dispersion_direction = 3
-        spec.name = str(spec.source_id)
-        _add_multispec_meta(spec)
-        multi.spec.append(spec)
-
-    return multi
-
-
-def wfss_multi():
-    """Make a MultiExposureSpecModel object with N_EXPOSURES exposures and N_SOURCES sources."""
-    inputs_list = []
-    source0 = wfss_spec3_multi()
-    for i in range(N_SOURCES):
-        this_source = source0.copy()
-        for spec in this_source.spec:
-            spec.source_id = N_SOURCES - i
-        inputs_list.append(this_source)
-    output_model = make_wfss_multiexposure(inputs_list)
-    return output_model
+from jwst.datamodels.utils.wfss_multispec import (
+    make_wfss_multiexposure,
+    make_wfss_multicombined,
+    wfss_multiexposure_to_multispec,
+)
+from jwst.datamodels.utils.tests.wfss_helpers import (
+    wfss_spec2_multi,
+    wfss_spec3_multi,
+    wfss_multi,
+    wfss_comb,
+    N_EXPOSURES,
+    N_SOURCES,
+    N_ROWS,
+)
 
 
 @pytest.fixture
 def wfss_spec2_multispec():
     return wfss_spec2_multi()
 
+
 @pytest.fixture
 def wfss_spec3_multispec():
     return wfss_spec3_multi()
+
 
 @pytest.fixture
 def wfss_multiexposure():
     return wfss_multi()
 
 
+@pytest.fixture
+def multi_combined():
+    return wfss_comb()
+
+
+
 @pytest.mark.parametrize("input_model_maker", ["wfss_spec2_multispec", "wfss_spec3_multispec"])
 def test_make_wfss_multiexposure(input_model_maker, request):
     """
     Test reorganization of x1d data to flat file format.
-    
+
     The two fixtures wfss_spec2_multispec and wfss_spec3_multispec have spectra that are
     identical, except that in the first case, all spectra are from the same exposure,
     and in the second case, all spectra are from the same source.
@@ -139,12 +60,12 @@ def test_make_wfss_multiexposure(input_model_maker, request):
     elif input_model_maker == "wfss_spec3_multispec":
         assert len(output_model.spec) == 4
         assert output_model.spec[0].spec_table.shape == (1,)
-    
+
     # check the required metadata attributes
     assert not hasattr(output_model.meta, "wcs")
     for i, exposure in enumerate(output_model.spec):
         assert exposure.group_id == str(i + 1)
-    
+
     # check that units are present
     # test one vector-like column, which should come from the input specmodels
     # and one meta column, which should be copied from the schema by set_schema_units
@@ -173,7 +94,7 @@ def test_orders_are_separated(wfss_spec3_multispec):
     # ensure spectral order is in the metadata
     for i, exposure in enumerate(output_model.spec):
         assert exposure.spectral_order == (i // 4) + 1  # first 4 are order 1, next 4 are order 2
-        assert exposure.group_id == str(i%4 + 1) + str(exposure.spectral_order - 1)
+        assert exposure.group_id == str(i % 4 + 1) + str(exposure.spectral_order - 1)
 
 
 def test_wfss_flat_to_multispec(wfss_multiexposure):
@@ -193,7 +114,7 @@ def test_wfss_flat_to_multispec(wfss_multiexposure):
         assert isinstance(multispec, dm.MultiSpecModel)
         assert len(multispec.spec) == N_EXPOSURES
         for j, spec in enumerate(multispec.spec):
-            assert spec.source_id == i + 1 # they will now be sorted
+            assert spec.source_id == i + 1  # they will now be sorted
 
             # check that the data is the same as the original
             assert_allclose(spec.spec_table["WAVELENGTH"], np.linspace(1.0, 10.0, N_ROWS))
@@ -206,8 +127,14 @@ def test_wfss_flat_to_multispec(wfss_multiexposure):
 
             # test that the rest of the metadata exist and are default values
             assert spec.source_type == "POINT"
-            for name in ["source_ra", "source_dec", "extract2d_xstart", "extract2d_ystart",
-                         "extract2d_xstop", "extract2d_ystop"]:
+            for name in [
+                "source_ra",
+                "source_dec",
+                "extract2d_xstart",
+                "extract2d_ystart",
+                "extract2d_xstop",
+                "extract2d_ystop",
+            ]:
                 assert getattr(spec, name) == 0.0
 
 
@@ -233,50 +160,19 @@ def test_wfss_multi_from_wfss_multi(wfss_multiexposure):
     # check that the output model has the correct dimensions
     assert isinstance(output_model, dm.WFSSMultiSpecModel)
     assert len(output_model.spec) == N_EXPOSURES
-    assert output_model.spec[0].spec_table.shape == (N_SOURCES*2,)
+    assert output_model.spec[0].spec_table.shape == (N_SOURCES * 2,)
 
     # test that the data has all the appropriate data and metadata
     for i, exposure in enumerate(output_model.spec):
         assert exposure.group_id == str(i + 1)
-        assert exposure.spec_table.shape == (N_SOURCES*2,)
-    
-
-def wfss_comb():
-    """
-    Make a MultiCombinedSpecModel object with N_SOURCES sources, N_ROWS rows, and 2 orders.
-    
-    This looks like the output of combine_1d.
-    """
-    multi = dm.MultiCombinedSpecModel()
-    spec = dm.CombinedSpecModel()
-    _add_multispec_meta(spec)
-    spectable_dtype = spec.schema["properties"]["spec_table"]["datatype"]
-    recarray_dtype = [(d["name"], d["datatype"]) for d in spectable_dtype]
-    spec_table = np.recarray((N_ROWS,), dtype=recarray_dtype)
-    spec_table["WAVELENGTH"] = np.linspace(1.0, 10.0, N_ROWS)
-    spec_table["FLUX"] = np.ones(N_ROWS)
-    spec.spec_table = spec_table
-    spec.spec_table.columns["wavelength"].unit = "um"
-    spec.dispersion_direction = 3
-
-    spec.spectral_order = 1
-    spec2 = spec.copy()
-    spec2.spectral_order = 2
-    multi.spec.append(spec)
-    multi.spec.append(spec2)
-    return multi
-
-
-@pytest.fixture
-def multi_combined():
-    return wfss_comb()
+        assert exposure.spec_table.shape == (N_SOURCES * 2,)
 
 
 @pytest.fixture
 def comb1d_list(multi_combined):
     """
     Make a list of MultiCombinedSpecModel objects with N_SOURCES sources in list.
-    
+
     Each MultiCombinedSpecModel object has only one spec, but the source_id is different.
     This looks like the output of calwebb_spec3 after calling combine_1d a bunch of times.
     """
@@ -304,7 +200,7 @@ def test_make_wfss_combined(comb1d_list):
         for col in to_check:
             assert col in spec.spec_table.columns.names
             assert spec.spec_table.columns[col].unit == expected_units[to_check.index(col)]
-        
+
         # check metadata
         assert spec.dispersion_direction == 3
-        assert spec.spectral_order == i + 1 
+        assert spec.spectral_order == i + 1

--- a/jwst/datamodels/utils/tests/wfss_helpers.py
+++ b/jwst/datamodels/utils/tests/wfss_helpers.py
@@ -1,0 +1,164 @@
+import numpy as np
+import stdatamodels.jwst.datamodels as dm
+from jwst.datamodels.utils.wfss_multispec import make_wfss_multiexposure
+
+
+N_SOURCES = 5
+N_EXPOSURES = 4
+N_ROWS = 3
+
+
+def example_spec():
+    """
+    Create a mock SpecModel with spec_table generated from the spec schema.
+
+    Returns
+    -------
+    spec : dm.SpecModel
+        A SpecModel with a mock WCS and a spec_table with N_ROWS rows.
+        The spec_table has columns "WAVELENGTH" and "FLUX".
+    """
+
+    def mock_wcs(*args, **kwargs):  # Noqa: ARG001
+        return 0.0, 0.0, 0.0
+
+    spec = dm.SpecModel()
+    spectable_dtype = spec.schema["properties"]["spec_table"]["datatype"]
+    recarray_dtype = [(d["name"], d["datatype"]) for d in spectable_dtype]
+    spec.meta.wcs = mock_wcs
+    spec_table = np.recarray((N_ROWS,), dtype=recarray_dtype)
+    spec_table["WAVELENGTH"] = np.linspace(1.0, 10.0, N_ROWS)
+    spec_table["FLUX"] = np.ones(N_ROWS)
+    spec.spec_table = spec_table
+    spec.spec_table.columns["wavelength"].unit = "um"
+    return spec
+
+
+def _add_multispec_meta(spec):
+    """
+    Add specmeta attributes to a spec-like ObjectNode inside a MultiSpecModel.
+
+    This only includes attributes that do NOT need to change for each source/exposure
+    for the purposes of this test.
+
+    input spec is updated in place.
+    """
+    spec.source_type = "POINT"
+    spec.source_ra = 0.0
+    spec.source_dec = 0.0
+    spec.extract2d_xstart = 0.0
+    spec.extract2d_ystart = 0.0
+    spec.extract2d_xstop = 0.0
+    spec.extract2d_ystop = 0.0
+    spec.extraction_xstart = 0.0
+    spec.extraction_ystart = 0.0
+    spec.extraction_xstop = 0.0
+    spec.extraction_ystop = 0.0
+
+
+def wfss_spec2_multi():
+    """
+    Set up a MultiSpecModel object that looks like outputs from extract_1d during calwebb_spec2.
+
+    Each of the spectra is from the SAME exposure, but DIFFERENT sources.
+
+    Returns
+    -------
+    multi : dm.MultiSpecModel
+        A MultiSpecModel with N_SOURCES in its spec list.
+    """
+    spec0 = example_spec()
+    multi = dm.MultiSpecModel()
+    for i in range(N_SOURCES):
+        # create a new SpecModel for each source
+        spec = spec0.copy()
+        spec.meta.filename = "exposure_1.fits"  # all sources in the same exposure
+        spec.meta.group_id = "1"  # all sources in the same exposure
+        spec.source_id = N_SOURCES - i  # reverse the order to test sorting
+        spec.name = str(spec.source_id)
+        _add_multispec_meta(spec)
+        multi.spec.append(spec)
+
+    return multi
+
+
+def wfss_spec3_multi():
+    """
+    Set up a MultiSpecModel object that looks like outputs from extract_1d during calwebb_spec3.
+
+    Each of the spectra is from the SAME source, but DIFFERENT exposures.
+
+    Returns
+    -------
+    multi : dm.MultiSpecModel
+        A MultiSpecModel with N_EXPOSURES in its spec list.
+    """
+    spec0 = example_spec()
+    multi = dm.MultiSpecModel()
+    multi.meta.exposure.exposure_time = 7.0
+    multi.meta.exposure.integration_time = 7.0
+    for j in range(N_EXPOSURES):
+        # create a new SpecModel for each exposure
+        spec = spec0.copy()
+        spec.meta.filename = f"exposure_{j}.fits"
+        spec.meta.group_id = str(j + 1)
+        spec.source_id = 999  # all sources are the same
+        spec.dispersion_direction = 3
+        spec.name = str(spec.source_id)
+        _add_multispec_meta(spec)
+        multi.spec.append(spec)
+
+    return multi
+
+
+def wfss_multi():
+    """
+    Make a MultiExposureSpecModel object with N_EXPOSURES exposures and N_SOURCES sources.
+
+    Returns
+    -------
+    dm.MultiExposureSpecModel
+        A MultiExposureSpecModel with N_EXPOSURES in its spec list,
+        each containing N_SOURCES sources.
+    """
+    inputs_list = []
+    source0 = wfss_spec3_multi()
+    for i in range(N_SOURCES):
+        this_source = source0.copy()
+        for spec in this_source.spec:
+            spec.source_id = N_SOURCES - i
+        inputs_list.append(this_source)
+    output_model = make_wfss_multiexposure(inputs_list)
+    return output_model
+
+
+def wfss_comb():
+    """
+    Make a MultiCombinedSpecModel object with N_SOURCES sources, N_ROWS rows, and 2 orders.
+
+    This looks like the output of combine_1d.
+
+    Returns
+    -------
+    dm.MultiCombinedSpecModel
+        A MultiCombinedSpecModel with 2 SpecModels from different spectral orders,
+        each containing a spec_table with N_ROWS rows.
+    """
+    multi = dm.MultiCombinedSpecModel()
+    spec = dm.CombinedSpecModel()
+    _add_multispec_meta(spec)
+    spectable_dtype = spec.schema["properties"]["spec_table"]["datatype"]
+    recarray_dtype = [(d["name"], d["datatype"]) for d in spectable_dtype]
+    spec_table = np.recarray((N_ROWS,), dtype=recarray_dtype)
+    spec_table["WAVELENGTH"] = np.linspace(1.0, 10.0, N_ROWS)
+    spec_table["FLUX"] = np.ones(N_ROWS)
+    spec.spec_table = spec_table
+    spec.spec_table.columns["wavelength"].unit = "um"
+    spec.dispersion_direction = 3
+
+    spec.spectral_order = 1
+    spec2 = spec.copy()
+    spec2.spectral_order = 2
+    multi.spec.append(spec)
+    multi.spec.append(spec2)
+    return multi

--- a/jwst/pipeline/tests/test_calwebb_spec3.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3.py
@@ -5,7 +5,7 @@ import numpy as np
 import stdatamodels.jwst.datamodels as dm
 import jwst
 from jwst.datamodels import SourceModelContainer
-from jwst.datamodels.utils.tests.test_wfss_multispec import wfss_multi
+from jwst.datamodels.utils.tests.wfss_helpers import wfss_multi
 from jwst.stpipe import Step
 from jwst.extract_1d.tests.conftest import mock_nis_wfss_l2
 

--- a/jwst/pipeline/tests/test_calwebb_spec3.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3.py
@@ -5,8 +5,7 @@ import numpy as np
 import stdatamodels.jwst.datamodels as dm
 import jwst
 from jwst.datamodels import SourceModelContainer
-from jwst.datamodels.utils.wfss_multispec import make_wfss_multiexposure
-from jwst.datamodels.utils.tests.test_wfss_multispec import wfss_multiexposure, wfss_spec3_multispec, example_spec
+from jwst.datamodels.utils.tests.test_wfss_multispec import wfss_multi
 from jwst.stpipe import Step
 from jwst.extract_1d.tests.conftest import mock_niriss_wfss_l2, mock_nirspec_fs_one_slit, simple_wcs
 
@@ -14,6 +13,12 @@ from jwst.extract_1d.tests.conftest import mock_niriss_wfss_l2, mock_nirspec_fs_
 INPUT_WFSS = "mock_wfss_cal.fits"
 INPUT_WFSS_2 = "mock_wfss_2_cal.fits"
 INPUT_ASN = "mock_wfss_asn.json"
+
+
+@pytest.fixture
+def wfss_multiexposure():
+    return wfss_multi()
+
 
 @pytest.fixture
 def spec3_wfss_asn(mock_niriss_wfss_l2, tmp_cwd):

--- a/jwst/pipeline/tests/test_calwebb_spec3.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3.py
@@ -7,7 +7,7 @@ import jwst
 from jwst.datamodels import SourceModelContainer
 from jwst.datamodels.utils.tests.test_wfss_multispec import wfss_multi
 from jwst.stpipe import Step
-from jwst.extract_1d.tests.conftest import mock_niriss_wfss_l2, mock_nirspec_fs_one_slit, simple_wcs
+from jwst.extract_1d.tests.conftest import mock_nis_wfss_l2
 
 
 INPUT_WFSS = "mock_wfss_cal.fits"
@@ -19,6 +19,11 @@ INPUT_ASN = "mock_wfss_asn.json"
 def wfss_multiexposure():
     return wfss_multi()
 
+@pytest.fixture
+def mock_niriss_wfss_l2():
+    model = mock_nis_wfss_l2()
+    yield model
+    model.close()
 
 @pytest.fixture
 def spec3_wfss_asn(mock_niriss_wfss_l2, tmp_cwd):


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9543 

<!-- describe the changes comprising this PR here -->
This PR stops importing fixtures across subfolders, fixing an issue that was originally introduced by https://github.com/spacetelescope/jwst/pull/9402.  This code pattern was causing the stdatamodels downstream tests to fail.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
