### PR TITLE
resolve bug in `build.yml`, and bump `OpenAstronomy/github-actions-workflows` to `2.0.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     if: always() && (needs.check.result == 'success' || needs.check.result == 'skipped')
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@a2e0af7c20b84890b3a72de89c24c3382d6847fb  # v1.17.0
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@d83bb11581e517f1e786ae76f146781fdd21cd2f # v2.0.0
     with:
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
       targets: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ concurrency:
 
 jobs:
   build:
-    if: always() && (needs.check.result == 'success' || needs.check.result == 'skipped')
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@d83bb11581e517f1e786ae76f146781fdd21cd2f # v2.0.0
     with:
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: '3.12'
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
   check:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@a2e0af7c20b84890b3a72de89c24c3382d6847fb  # v1.17.0
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d83bb11581e517f1e786ae76f146781fdd21cd2f # v2.0.0
     with:
       default_python: "3.12"
       envs: |

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -34,7 +34,7 @@ jobs:
       context: ${{ steps.context.outputs.context }}
   test:
     if: (github.repository == 'spacetelescope/jwst' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run scheduled tests')))
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@a2e0af7c20b84890b3a72de89c24c3382d6847fb  # v1.17.0
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d83bb11581e517f1e786ae76f146781fdd21cd2f # v2.0.0
     needs: [ crds_context ]
     with:
       setenv: |

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -43,7 +43,7 @@ jobs:
       context: ${{ steps.context.outputs.context }}
   test:
     if: (github.repository == 'spacetelescope/jwst' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@a2e0af7c20b84890b3a72de89c24c3382d6847fb  # v1.17.0
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d83bb11581e517f1e786ae76f146781fdd21cd2f # v2.0.0
     needs: [ crds_context ]
     with:
       setenv: |


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
There was a bug in `build.yml` where the job was skipped because it was looking for the `requirements-sdp.txt` check, which no longer exists.

Also, bumps [`OpenAstronomy/github-actions-workflows`](https://github.com/openastronomy/github-actions-workflows) to `2.0.0`
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/openastronomy/github-actions-workflows/releases">OpenAstronomy/github-actions-workflows's releases</a>.</em></p>
<blockquote>
<h2>v2.0.0</h2>
<h1>Breaking Changes in cibuildwheel</h1>
<p>This release updates the version of cibuildwheel to 3.0. This release has many changes, including support for Python 3.14 wheels, however it also has some breaking changes you should be aware of. Please see <a href="https://iscinumpy.dev/post/cibuildwheel-3-0-0/">the release post</a> and <a href="https://cibuildwheel.pypa.io/en/stable/changelog/#v300">changelog</a>.</p>
<h2>What's Changed</h2>
<ul>
<li>DEP: upgrade cibuildwheel to 3.0.0 by <a href="https://github.com/neutrinoceros"><code>@​neutrinoceros</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/278">OpenAstronomy/github-actions-workflows#278</a></li>
<li>Bump the actions group in /.github/workflows with 5 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/274">OpenAstronomy/github-actions-workflows#274</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/OpenAstronomy/github-actions-workflows/compare/v1.17.0...v2.0.0">https://github.com/OpenAstronomy/github-actions-workflows/compare/v1.17.0...v2.0.0</a></p>
<h2>v1.17.0</h2>
<!-- raw HTML omitted -->
<h2>What's Changed</h2>
<ul>
<li>Bump the actions group across 1 directory with 10 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/272">OpenAstronomy/github-actions-workflows#272</a></li>
<li>Update pyproject.toml by <a href="https://github.com/prabhat-kumar96"><code>@​prabhat-kumar96</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/271">OpenAstronomy/github-actions-workflows#271</a></li>
<li>Add ability to select free-threaded Python interpreter by <a href="https://github.com/astrofrog"><code>@​astrofrog</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/281">OpenAstronomy/github-actions-workflows#281</a></li>
<li>Fix regular expression by <a href="https://github.com/astrofrog"><code>@​astrofrog</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/282">OpenAstronomy/github-actions-workflows#282</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/prabhat-kumar96"><code>@​prabhat-kumar96</code></a> made their first contribution in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/271">OpenAstronomy/github-actions-workflows#271</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/OpenAstronomy/github-actions-workflows/compare/v1...v1.17.0">https://github.com/OpenAstronomy/github-actions-workflows/compare/v1...v1.17.0</a></p>
<h2>v1.16.0</h2>
<!-- raw HTML omitted -->
<h2>What's Changed</h2>
<ul>
<li>build sdist with python 3.12 by <a href="https://github.com/braingram"><code>@​braingram</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/264">OpenAstronomy/github-actions-workflows#264</a></li>
<li>Bump the actions group in /.github/workflows with 6 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/261">OpenAstronomy/github-actions-workflows#261</a></li>
<li>Update pip before we use it by <a href="https://github.com/Cadair"><code>@​Cadair</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/266">OpenAstronomy/github-actions-workflows#266</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/braingram"><code>@​braingram</code></a> made their first contribution in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/264">OpenAstronomy/github-actions-workflows#264</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/OpenAstronomy/github-actions-workflows/compare/v1...v1.16.0">https://github.com/OpenAstronomy/github-actions-workflows/compare/v1...v1.16.0</a></p>
<h2>v1.15.0</h2>
<!-- raw HTML omitted -->
<h2>What's Changed</h2>
<ul>
<li>Default to arm64 builders for macos wheels and cross compile x86_64 by default by <a href="https://github.com/Cadair"><code>@​Cadair</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/257">OpenAstronomy/github-actions-workflows#257</a></li>
<li>Bump the actions group in /.github/workflows with 2 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/OpenAstronomy/github-actions-workflows/pull/254">OpenAstronomy/github-actions-workflows#254</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/OpenAstronomy/github-actions-workflows/compare/v1...v1.15.0">https://github.com/OpenAstronomy/github-actions-workflows/compare/v1...v1.15.0</a></p>
<h2>v1.14.0</h2>
<!-- raw HTML omitted -->
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/d83bb11581e517f1e786ae76f146781fdd21cd2f"><code>d83bb11</code></a> DEP: upgrade cibuildwheel to 3.0.0 (<a href="https://redirect.github.com/openastronomy/github-actions-workflows/issues/278">#278</a>)</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/b04ccdac3dc8beb518b92f0289f9111cf669c4fc"><code>b04ccda</code></a> Bump the actions group in /.github/workflows with 5 updates (<a href="https://redirect.github.com/openastronomy/github-actions-workflows/issues/274">#274</a>)</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/dbcfad332697eaf85fac11da63162633da451dcf"><code>dbcfad3</code></a> Merge pull request <a href="https://redirect.github.com/openastronomy/github-actions-workflows/issues/284">#284</a> from OpenAstronomy/pre-commit-ci-update-config</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/823719c3a1bcf99b91dc2d5d852612ddae387f87"><code>823719c</code></a> [pre-commit.ci] pre-commit autoupdate</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/a2e0af7c20b84890b3a72de89c24c3382d6847fb"><code>a2e0af7</code></a> Merge pull request <a href="https://redirect.github.com/openastronomy/github-actions-workflows/issues/282">#282</a> from astrofrog/fix-regexpr</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/9410624341ae9cc49cca7f8facfdadc4dd21788c"><code>9410624</code></a> Update ubuntu image</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/7b3cd6f85b42314fc6199fc602ee42d132d9c11c"><code>7b3cd6f</code></a> Fix regular expression</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/817bf128eb02177310d42ead3d6d2922e9bf22d6"><code>817bf12</code></a> Merge pull request <a href="https://redirect.github.com/openastronomy/github-actions-workflows/issues/281">#281</a> from astrofrog/freethreaded</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/0f298d14a4278de5b1721542a07d5183b002a586"><code>0f298d1</code></a> Update docs</li>
<li><a href="https://github.com/OpenAstronomy/github-actions-workflows/commit/0c5c52b822592cee49069671e8bb358028eee41a"><code>0c5c52b</code></a> Add support for using free-threaded Python interpreter</li>
<li>Additional commits viewable in <a href="https://github.com/openastronomy/github-actions-workflows/compare/924441154cf3053034c6513d5e06c69d262fb9a6...d83bb11581e517f1e786ae76f146781fdd21cd2f">compare view</a></li>
</ul>
</details>
<br />

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
