### PR TITLE
Follow up on using custom reference files

### DIFF
--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -10,6 +10,8 @@ from .grisms import extract_grism_objects, extract_tso_object
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+slitless_modes = ["NIS_WFSS", "NRC_WFSS", "NRC_TSGRISM"]
+
 
 def extract2d(
     input_model,
@@ -65,7 +67,6 @@ def extract2d(
         "NRS_AUTOFLAT",
         "NRS_AUTOWAVE",
     ]
-    slitless_modes = ["NIS_WFSS", "NRC_WFSS", "NRC_TSGRISM"]
 
     exp_type = input_model.meta.exposure.type.upper()
     log.info(f"EXP_TYPE is {exp_type}")

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -41,9 +41,10 @@ class Extract2dStep(Step):
             The resulting DataModel of the extract_2d step
         """
         reference_file_names = {}
-        for reftype in self.reference_file_types:
-            reffile = self.get_reference_file(input_model, reftype)
-            reference_file_names[reftype] = reffile if reffile else ""
+        if input_model.meta.exposure.type in extract_2d.slitless_modes:
+            for reftype in self.reference_file_types:
+                reffile = self.get_reference_file(input_model, reftype)
+                reference_file_names[reftype] = reffile if reffile else ""
         with datamodels.open(input_model) as dm:
             output_model = extract_2d.extract2d(
                 dm,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
<!--Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)-->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses an issue with recording the name of a custom reference file in the science header, following up on [JP-4018](https://jira.stsci.edu/browse/JP-4018). 
The specific symptom was that although it looked like assign_wcs and msaflagopen used a custom `wavelengthrange` file when one was supplied, the name of the file in CRDS was recorded in the science header (meta.ref_file.wavelengthrange.name`.

This was caused by the extract_2d step which uses a `wavelengthrange` file for the NIRCam and NIRISS WFSS modes but the reference file is retrieved for all exposure modes, including NIRSpec modes. Since the name of the file in the science header is recorded after each step is completed, it was overwritten by the extract_2d step which runs after assign_wcs. 
The fix in this PR is to not retrieve the `wavelengthrange` file for NIRSpec modes. 

This also brings the question if there are other steps with similar problems where not all reference files are used for all modes.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
