### PR TITLE
remove description of non-working logging configuration

### DIFF
--- a/changes/9565.docs.rst
+++ b/changes/9565.docs.rst
@@ -1,0 +1,1 @@
+Remove description of non-working step-specific log configuration.

--- a/docs/jwst/stpipe/user_logging.rst
+++ b/docs/jwst/stpipe/user_logging.rst
@@ -41,17 +41,7 @@ ignored:
 #. ``/etc/stpipe-log.cfg``
 
 The logging configuration file is in the standard ini-file format.
-
-Each section name is a Unix-style filename glob pattern used to match
-a particular Step’s logger.  The settings in that section apply only
-to that Steps that match that pattern.  For example, to have the
-settings apply to all steps, create a section called ``[*]``.  To have
-the settings apply only to a Step called ``MyStep``, create a section
-called ``[*.MyStep]``.  To apply settings to all Steps that are
-substeps of a step called ``MyStep``, call the section
-``[*.MyStep.*]``.
-
-In each section, the following may be configured:
+The file should contain a single section called ``[*]`` that contains:
 
 #. ``level``: The level at and above which logging messages will be
    displayed.  May be one of (from least important to most
@@ -84,8 +74,8 @@ In each section, the following may be configured:
    <https://docs.python.org/3/library/logging.html#logrecord-attributes>`_
    section of the Python standard library.
 
-Examples
-========
+Example
+=======
 
 The following configuration turns on all log messages and saves them
 in the file myrun.log:
@@ -95,17 +85,3 @@ in the file myrun.log:
     [*]
     level = INFO
     handler = file:myrun.log
-
-In a scenario where the user is debugging a particular Step, they may
-want to hide all logging messages except for that Step, and stop when
-hitting any warning for that Step:
-
-.. code-block:: ini
-
-    [*]
-    level = CRITICAL
-
-    [*.MyStep]
-    level = INFO
-    break_level = WARNING
-


### PR DESCRIPTION
This PR cleans up the docs section pertaining to logging configuration removing descriptions of per-step configuration (which does not work: https://github.com/spacetelescope/stpipe/issues/241).

Link to updated page: https://jwst-pipeline--9565.org.readthedocs.build/en/9565/jwst/stpipe/user_logging.html

As this is only a docs change no regtests will be run.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
