### PR TITLE
JP-3980: Move TSO photometry radii to parameters

### DIFF
--- a/jwst/tso_photometry/tests/test_tso_photometry.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry.py
@@ -1,41 +1,22 @@
 import math
 
 import numpy as np
-import pytest
 import astropy.units as u
+import pytest
 
 from stdatamodels.jwst import datamodels
 from jwst.lib import reffile_utils
 from jwst.tso_photometry.tso_photometry_step import TSOPhotometryStep
 from jwst.tso_photometry.tso_photometry import tso_aperture_photometry
 
-shape = (7, 100, 150)
-xcenter = 75.0
-ycenter = 50.0
-
-
-def mk_data_array(shape, value, background, xcenter, ycenter, radius):
-    """Create a data array"""
-
-    data = np.zeros(shape, dtype=np.float32) + background
-
-    xlow = int(math.floor(xcenter - radius))
-    xhigh = int(math.ceil(xcenter + radius)) + 1
-    ylow = int(math.floor(ycenter - radius))
-    yhigh = int(math.ceil(ycenter + radius)) + 1
-    xlow = max(xlow, 0)
-    xhigh = min(xhigh, shape[-1])
-    ylow = max(ylow, 0)
-    yhigh = min(yhigh, shape[-2])
-
-    radius2 = radius**2
-    for j in range(ylow, yhigh):
-        for i in range(xlow, xhigh):
-            dist2 = (float(i) - xcenter) ** 2 + (float(j) - ycenter) ** 2
-            if dist2 < radius2:
-                data[:, j, i] = value + background
-
-    return data
+# Default values for mock data
+XCENTER = 75.0
+YCENTER = 50.0
+VALUE = 17.0
+BACKGROUND = 0.8
+RADIUS = 5.0
+RADIUS_INNER = 8.0
+RADIUS_OUTER = 11.0
 
 
 def get_gain_2d(datamodel):
@@ -66,26 +47,51 @@ def get_gain_2d(datamodel):
     return gain_2d
 
 
-def dummy_wcs(x, y):
+def mk_data_array(shape, value, background, xcenter, ycenter, radius):
+    """Create a data array"""
+
+    data = np.zeros(shape, dtype=np.float32) + background
+
+    xlow = int(math.floor(xcenter - radius))
+    xhigh = int(math.ceil(xcenter + radius)) + 1
+    ylow = int(math.floor(ycenter - radius))
+    yhigh = int(math.ceil(ycenter + radius)) + 1
+    xlow = max(xlow, 0)
+    xhigh = min(xhigh, shape[-1])
+    ylow = max(ylow, 0)
+    yhigh = min(yhigh, shape[-2])
+
+    radius2 = radius**2
+    for j in range(ylow, yhigh):
+        for i in range(xlow, xhigh):
+            dist2 = (float(i) - xcenter) ** 2 + (float(j) - ycenter) ** 2
+            if dist2 < radius2:
+                data[:, j, i] = value + background
+
+    return data
+
+
+def make_mock_wcs(xcenter, ycenter):
     """Placeholder WCS"""
 
-    global xcenter, ycenter
+    def mock_wcs(x, y):
+        crpix1 = xcenter
+        crpix2 = ycenter
+        cdelt1 = 0.031
+        cdelt2 = 0.031
+        crval1 = 15.0 * (((34.4147 / 60.0 + 48.0) / 60.0) + 15.0)  # 15h 48m 34.4147s
+        crval2 = ((24.295 / 60.0 + 9.0) / 60.0) + 28.0  # 28d 09' 24.295"
 
-    crpix1 = xcenter
-    crpix2 = ycenter
-    cdelt1 = 0.031
-    cdelt2 = 0.031
-    crval1 = 15.0 * (((34.4147 / 60.0 + 48.0) / 60.0) + 15.0)  # 15h 48m 34.4147s
-    crval2 = ((24.295 / 60.0 + 9.0) / 60.0) + 28.0  # 28d 09' 24.295"
+        dec = (y + 1.0 - crpix2) * cdelt2 + crval2
+        cosdec = math.cos(dec * math.pi / 180.0)
+        ra = (x + 1.0 - crpix1) * cdelt1 / cosdec + crval1
 
-    dec = (y + 1.0 - crpix2) * cdelt2 + crval2
-    cosdec = math.cos(dec * math.pi / 180.0)
-    ra = (x + 1.0 - crpix1) * cdelt1 / cosdec + crval1
+        return ra, dec
 
-    return ra, dec
+    return mock_wcs
 
 
-def set_meta(datamodel, sub64p=False):
+def set_meta(datamodel, xcenter, ycenter, sub64p=False):
     """Assign some metadata"""
 
     datamodel.meta.exposure.nints = datamodel.data.shape[0]
@@ -121,23 +127,25 @@ def set_meta(datamodel, sub64p=False):
 
     datamodel.meta.bunit_data = "MJy/sr"
     datamodel.meta.bunit_err = "MJy/sr"
-    # NOTE: this is a dummy value that leaves the mock test data values
+    # NOTE: this is a placeholder value that leaves the mock test data values
     # unchanged during the unit conversion in tso_photometry.
     datamodel.meta.photometry.pixelarea_steradians = 1.0e-6
 
-    datamodel.meta.wcs = dummy_wcs
+    datamodel.meta.wcs = make_mock_wcs(xcenter, ycenter)
+    datamodel.meta.wcsinfo.siaf_xref_sci = xcenter + 1
+    datamodel.meta.wcsinfo.siaf_yref_sci = ycenter + 1
 
 
 def include_int_times(datamodel):
     """Create an int_times table and copy it into the data model."""
 
     int_start = datamodel.meta.exposure.integration_start
-
+    shape = datamodel.data.shape
     nrows = int_start + shape[0] + 2  # create a few extra rows
     # integration_number and time_arr are one_indexed
     integration_number = np.arange(1, nrows + 1, dtype=np.float32)
     time_arr = np.arange(1, nrows + 1, dtype=np.float64) + 58700.0
-    dummy = np.arange(nrows, dtype=np.float64)
+    mock_data = np.arange(nrows, dtype=np.float64)
 
     it_dtype = [
         ("integration_number", "<i4"),
@@ -150,33 +158,40 @@ def include_int_times(datamodel):
     ]
 
     otab = np.array(
-        list(zip(integration_number, dummy, time_arr, dummy, dummy, dummy, dummy)), dtype=it_dtype
+        list(
+            zip(integration_number, mock_data, time_arr, mock_data, mock_data, mock_data, mock_data)
+        ),
+        dtype=it_dtype,
     )
     datamodel.int_times = otab.copy()
 
     return time_arr
 
 
-def test_tso_phot_1():
-    global shape, xcenter, ycenter
-
-    # pupil = 'CLEAR' and subarray = 'FULL'
-
-    value = 17.0
-    background = 0.8
-    radius = 5.0
-    radius_inner = 8.0
-    radius_outer = 11.0
+def mock_nircam_image(
+    shape=(7, 100, 150),
+    xcenter=XCENTER,
+    ycenter=YCENTER,
+    value=VALUE,
+    background=BACKGROUND,
+    radius=RADIUS,
+    sub64p=False,
+):
     data = mk_data_array(shape, value, background, xcenter, ycenter, radius)
     datamodel = datamodels.CubeModel(data)
-    set_meta(datamodel, sub64p=False)
+    set_meta(datamodel, xcenter, ycenter, sub64p=sub64p)
+    return datamodel
+
+
+def test_tso_phot():
+    datamodel = mock_nircam_image()
 
     # Get the gain reference file
     gain_2d = get_gain_2d(datamodel)
 
     # Use a larger radius than was used for creating the data.
     catalog = tso_aperture_photometry(
-        datamodel, xcenter, ycenter, radius + 1.0, radius_inner, radius_outer, gain_2d
+        datamodel, XCENTER, YCENTER, RADIUS + 1.0, RADIUS_INNER, RADIUS_OUTER, gain_2d
     )
 
     assert catalog.meta["instrument"] == datamodel.meta.instrument.name
@@ -185,15 +200,15 @@ def test_tso_phot_1():
     assert catalog.meta["detector"] == datamodel.meta.instrument.detector
     assert catalog.meta["channel"] == datamodel.meta.instrument.channel
     assert catalog.meta["target_name"] == datamodel.meta.target.catalog_name
-    assert math.isclose(catalog.meta["xcenter"], xcenter, abs_tol=0.01)
-    assert math.isclose(catalog.meta["ycenter"], ycenter, abs_tol=0.01)
+    assert math.isclose(catalog.meta["xcenter"], XCENTER, abs_tol=0.01)
+    assert math.isclose(catalog.meta["ycenter"], YCENTER, abs_tol=0.01)
 
     assert np.allclose(catalog["aperture_sum"].value, 1263.4778, rtol=1.0e-7)
     assert np.allclose(catalog["aperture_sum_err"].value, 0.0, atol=1.0e-7)
     assert np.allclose(catalog["net_aperture_sum"].value, 1173.0, rtol=1.0e-7)
     assert np.allclose(catalog["annulus_sum"].value, 143.256627, rtol=1.0e-7)
     assert np.allclose(catalog["annulus_sum_err"].value, 0.0, atol=1.0e-7)
-    assert np.allclose(catalog["annulus_mean"].value, background, rtol=1.0e-7)
+    assert np.allclose(catalog["annulus_mean"].value, BACKGROUND, rtol=1.0e-7)
 
     assert np.allclose(catalog["annulus_mean"].value, 0.8, rtol=1.0e-6)
     assert np.allclose(catalog["annulus_mean_err"].value, 0.0, rtol=1.0e-7)
@@ -201,21 +216,19 @@ def test_tso_phot_1():
     assert np.allclose(catalog["net_aperture_sum_err"].value, 0.0, atol=1.0e-7)
 
 
-def test_tso_phot_2():
-    # pupil = 'WLP8' and subarray = 'SUB64P'
+def test_tso_phot_sub64p():
+    """Test with pupil = 'WLP8' and subarray = 'SUB64P'."""
 
     shape = (7, 64, 64)
     xcenter = 31.0
     ycenter = 31.0
-
-    value = 17.0
-    background = 0.8
     radius = 50.0
     radius_inner = None
     radius_outer = None
-    data = mk_data_array(shape, value, background, xcenter, ycenter, radius)
-    datamodel = datamodels.CubeModel(data)
-    set_meta(datamodel, sub64p=True)
+
+    datamodel = mock_nircam_image(
+        shape=shape, xcenter=xcenter, ycenter=ycenter, radius=radius, sub64p=True
+    )
 
     # Get the gain reference file
     gain_2d = get_gain_2d(datamodel)
@@ -232,53 +245,36 @@ def test_tso_phot_2():
     assert math.isclose(catalog.meta["ycenter"], ycenter, abs_tol=0.01)
 
     assert np.allclose(
-        catalog["aperture_sum"].value, (value + background) * shape[-1] * shape[-2], rtol=1.0e-6
+        catalog["aperture_sum"].value, (VALUE + BACKGROUND) * shape[-1] * shape[-2], rtol=1.0e-6
     )
     assert np.allclose(catalog["aperture_sum_err"].value, 0.0, atol=1.0e-7)
 
 
-def test_tso_phot_3():
-    global shape, xcenter, ycenter
-
-    value = 17.0
-    background = 0.8
-    radius = 5.0
-    radius_inner = 8.0
-    radius_outer = 11.0
-    data = mk_data_array(shape, value, background, xcenter, ycenter, radius)
-    datamodel = datamodels.CubeModel(data)
-    set_meta(datamodel, sub64p=False)
+def test_tso_phot_with_int_times():
+    datamodel = mock_nircam_image()
 
     # Get the gain reference file
     gain_2d = get_gain_2d(datamodel)
 
+    # Add integration times to the model
     int_times = include_int_times(datamodel)
 
     catalog = tso_aperture_photometry(
-        datamodel, xcenter, ycenter, radius + 1.0, radius_inner, radius_outer, gain_2d
+        datamodel, XCENTER, YCENTER, RADIUS + 1.0, RADIUS_INNER, RADIUS_OUTER, gain_2d
     )
 
     offset = datamodel.meta.exposure.integration_start - 1
-    slc = slice(offset, offset + shape[0])
+    slc = slice(offset, offset + datamodel.data.shape[0])
     assert np.allclose(catalog["MJD"], int_times[slc], atol=1.0e-8)
 
 
-def test_tso_phot_4():
-    global shape, xcenter, ycenter
-
-    value = 17.0
-    background = 0.8
-    radius = 5.0
-    radius_inner = 8.0
-    radius_outer = 11.0
-    data = mk_data_array(shape, value, background, xcenter, ycenter, radius)
-    datamodel = datamodels.CubeModel(data)
-    set_meta(datamodel, sub64p=False)
-
-    # Get the gain reference file
+def test_tso_phot_int_times_out_of_range():
+    datamodel = mock_nircam_image()
     gain_2d = get_gain_2d(datamodel)
 
-    int_times = include_int_times(datamodel)
+    # Add integration times
+    include_int_times(datamodel)
+
     # Modify the column of integration numbers so that they extend outside
     # the range of integration numbers in the science data.  This shouldn't
     # happen, i.e. this is to test an edge case.
@@ -286,7 +282,7 @@ def test_tso_phot_4():
     datamodel.int_times["integration_number"] += 2 * int_start
 
     catalog = tso_aperture_photometry(
-        datamodel, xcenter, ycenter, radius + 1.0, radius_inner, radius_outer, gain_2d
+        datamodel, XCENTER, YCENTER, RADIUS + 1.0, RADIUS_INNER, RADIUS_OUTER, gain_2d
     )
 
     int_times = np.array(
@@ -303,21 +299,38 @@ def test_tso_phot_4():
     assert np.allclose(catalog["MJD"], int_times, rtol=1.0e-8)
 
 
-def test_tso_phot_5():
-    # pupil = 'WLP8' and subarray = 'SUB64P'
+def test_tso_phot_missing_int_start():
+    datamodel = mock_nircam_image()
+    gain_2d = get_gain_2d(datamodel)
 
+    # Add integration times
+    int_times = include_int_times(datamodel)
+
+    # Remove the integration start: it sill be assumed to be 1
+    datamodel.meta.exposure.integration_start = None
+
+    catalog = tso_aperture_photometry(
+        datamodel, XCENTER, YCENTER, RADIUS + 1.0, RADIUS_INNER, RADIUS_OUTER, gain_2d
+    )
+
+    offset = 0
+    slc = slice(offset, offset + datamodel.data.shape[0])
+    assert np.allclose(catalog["MJD"], int_times[slc], atol=1.0e-8)
+
+
+def test_tso_phot_uncalibrated():
+    # pupil = 'WLP8' and subarray = 'SUB64P'
     shape = (7, 64, 64)
     xcenter = 31.0
     ycenter = 31.0
-
-    value = 17.0
-    background = 0.8
     radius = 50.0
     radius_inner = None
     radius_outer = None
-    data = mk_data_array(shape, value, background, xcenter, ycenter, radius)
-    datamodel = datamodels.CubeModel(data)
-    set_meta(datamodel, sub64p=True)
+    datamodel = mock_nircam_image(
+        shape=shape, xcenter=xcenter, ycenter=ycenter, radius=radius, sub64p=True
+    )
+
+    # Set uncalibrated data units
     datamodel.meta.bunit_data = "DN/s"
     datamodel.meta.bunit_err = "DN/s"
 
@@ -336,3 +349,30 @@ def test_tso_phot_5():
     assert math.isclose(catalog.meta["ycenter"], ycenter, abs_tol=0.01)
 
     assert catalog["aperture_sum"][0].unit == u.Unit("electron")
+
+
+def test_tso_phot_unexpected_units():
+    datamodel = mock_nircam_image()
+
+    # Set unknown data units
+    datamodel.meta.bunit_data = "DN"
+    datamodel.meta.bunit_err = "DN"
+
+    # Get the gain reference file
+    gain_2d = get_gain_2d(datamodel)
+
+    catalog = tso_aperture_photometry(
+        datamodel, XCENTER, YCENTER, RADIUS + 1.0, RADIUS_INNER, RADIUS_OUTER, gain_2d
+    )
+
+    # Unexpected units are left alone
+    assert np.allclose(catalog["aperture_sum"].value, 1263.4778, rtol=1.0e-7)
+    assert catalog["aperture_sum"][0].unit == u.Unit("DN")
+
+
+def test_tso_phot_wrong_model():
+    model = datamodels.ImageModel()
+    with pytest.raises(TypeError, match="must be a CubeModel"):
+        tso_aperture_photometry(
+            model, XCENTER, YCENTER, RADIUS + 1.0, RADIUS_INNER, RADIUS_OUTER, None
+        )

--- a/jwst/tso_photometry/tests/test_tso_photometry_step.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry_step.py
@@ -1,25 +1,81 @@
+import numpy as np
 import pytest
-
-from astropy.io import fits
+from astropy.table import QTable
 
 from jwst.tso_photometry.tso_photometry_step import TSOPhotometryStep
+from jwst.tso_photometry.tests.test_tso_photometry import mock_nircam_image
 
 
-@pytest.fixture
-def test_hdu():
-    hdu = fits.HDUList()
-    phdu = fits.PrimaryHDU()
-    phdu.header["telescop"] = "JWST"
-    phdu.header["time-obs"] = "8:59:37"
-    phdu.header["date-obs"] = "2017-09-05"
+@pytest.mark.parametrize("missing", ["xref", "yref", "bunit_data", "bunit_err"])
+def test_tsophotometry_step_missing_values(missing):
+    datamodel = mock_nircam_image()
+    if missing == "xref":
+        datamodel.meta.wcsinfo.siaf_xref_sci = None
+    elif missing == "yref":
+        datamodel.meta.wcsinfo.siaf_yref_sci = None
+    elif missing == "bunit_data":
+        datamodel.meta.bunit_data = None
+    elif missing == "bunit_err":
+        datamodel.meta.bunit_err = None
 
-    scihdu = fits.ImageHDU()
-    scihdu.header["EXTNAME"] = "SCI"
-    hdu.append(phdu)
-    hdu.append(scihdu)
-    return hdu
+    with pytest.raises(ValueError, match="missing"):
+        TSOPhotometryStep.call(datamodel)
 
 
-def test_tsophotometry_process_fails_with_missing_crpix(test_hdu):
-    with pytest.raises(ValueError):
-        TSOPhotometryStep().process(test_hdu)
+def test_tsophotometry_step_subarray(log_watcher):
+    datamodel = mock_nircam_image()
+
+    watcher = log_watcher("stpipe.TSOPhotometryStep", message="Extracting gain subarray")
+    catalog = TSOPhotometryStep.call(datamodel, radius=6.0, radius_inner=8.0, radius_outer=11.0)
+    watcher.assert_seen()
+
+    # Output is a table
+    assert isinstance(catalog, QTable)
+
+    # Spot check some values to make sure they are as expected
+    assert np.isclose(catalog.meta["xcenter"], datamodel.meta.wcsinfo.siaf_xref_sci - 1, atol=0.01)
+    assert np.isclose(catalog.meta["ycenter"], datamodel.meta.wcsinfo.siaf_yref_sci - 1, atol=0.01)
+    assert np.allclose(catalog["aperture_sum"].value, 1263.4778, rtol=1.0e-7)
+
+
+def test_tsophotometry_step_full_frame(log_watcher):
+    datamodel = mock_nircam_image(shape=(7, 2048, 2048))
+
+    # Gain reference already matches data, no need to extract subarray
+    watcher = log_watcher("stpipe.TSOPhotometryStep", message="Extracting gain subarray")
+    catalog = TSOPhotometryStep.call(datamodel, radius=6.0, radius_inner=8.0, radius_outer=11.0)
+    watcher.assert_not_seen()
+
+    # Results are otherwise the same as for the subarray
+    assert isinstance(catalog, QTable)
+
+    # Spot check some values to make sure they are as expected
+    assert np.isclose(catalog.meta["xcenter"], datamodel.meta.wcsinfo.siaf_xref_sci - 1, atol=0.01)
+    assert np.isclose(catalog.meta["ycenter"], datamodel.meta.wcsinfo.siaf_yref_sci - 1, atol=0.01)
+    assert np.allclose(catalog["aperture_sum"].value, 1263.4778, rtol=1.0e-7)
+
+
+def test_tsophotometry_step_save_catalog(tmp_path, log_watcher):
+    datamodel = mock_nircam_image()
+    datamodel.meta.filename = "test_calints.fits"
+
+    watcher = log_watcher("stpipe.TSOPhotometryStep", message="Wrote TSO photometry catalog")
+    TSOPhotometryStep.call(
+        datamodel,
+        radius=6.0,
+        radius_inner=8.0,
+        radius_outer=11.0,
+        save_catalog=True,
+        output_dir=str(tmp_path),
+    )
+    watcher.assert_seen()
+
+    # Catalog is saved
+    cat_file = tmp_path / "test_phot.ecsv"
+    assert cat_file.exists()
+
+    # Spot check some values to make sure they are as expected
+    catalog = QTable.read(cat_file)
+    assert np.isclose(catalog.meta["xcenter"], datamodel.meta.wcsinfo.siaf_xref_sci - 1, atol=0.01)
+    assert np.isclose(catalog.meta["ycenter"], datamodel.meta.wcsinfo.siaf_yref_sci - 1, atol=0.01)
+    assert np.allclose(catalog["aperture_sum"].value, 1263.4778, rtol=1.0e-7)

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -142,7 +142,7 @@ def tso_aperture_photometry(
     tbl = QTable(meta=meta)
 
     # check for the INT_TIMES table extension
-    if hasattr(datamodel, "int_times") and datamodel.int_times is not None:
+    if datamodel.hasattr("int_times") and datamodel.int_times is not None:
         nrows = len(datamodel.int_times)
     else:
         nrows = 0
@@ -151,9 +151,8 @@ def tso_aperture_photometry(
     # load the INT_TIMES table data
     if nrows > 0:
         shape = datamodel.data.shape
-        if len(shape) == 2:
-            num_integ = 1
-        else:  # len(shape) == 3
+        num_integ = 1
+        if len(shape) > 2:
             num_integ = shape[0]
         int_start = datamodel.meta.exposure.integration_start
         if int_start is None:
@@ -178,8 +177,8 @@ def tso_aperture_photometry(
             time_arr = mid_utc[offset : offset + num_integ]
             int_times = Time(time_arr, format="mjd", scale="utc")
 
-    # compute integration time stamps on the fly
     if nrows == 0:
+        # compute integration time stamps on the fly
         log.debug("Times computed from EXPSTART and EFFINTTM")
         dt = datamodel.meta.exposure.integration_time
         n_dt = (

--- a/jwst/tso_photometry/tso_photometry_step.py
+++ b/jwst/tso_photometry/tso_photometry_step.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from stdatamodels.jwst.datamodels import CubeModel, TsoPhotModel, GainModel
+from stdatamodels.jwst.datamodels import CubeModel, GainModel
 
 from jwst.stpipe import Step
 from jwst.lib.catalog_utils import replace_suffix_ext
@@ -15,6 +14,9 @@ class TSOPhotometryStep(Step):
     class_alias = "tso_photometry"
 
     spec = """
+        radius = float(default=3.0) # Aperture radius in pixels
+        radius_inner = float(default=4.0) # Background annulus inner radius in pixels
+        radius_outer = float(default=5.0) # Background annulus outer radius in pixels
         save_catalog = boolean(default=False)  # save exposure-level catalog
     """  # noqa: E501
 
@@ -50,14 +52,6 @@ class TSOPhotometryStep(Step):
             xcenter = model.meta.wcsinfo.siaf_xref_sci - 1  # 1-based origin
             ycenter = model.meta.wcsinfo.siaf_yref_sci - 1  # 1-based origin
 
-            # Get the tsophot reference file
-            tsophot_filename = self.get_reference_file(model, "tsophot")
-            self.log.debug(f"Reference file name = {tsophot_filename}")
-            if tsophot_filename == "N/A":
-                self.log.warning("No TSOPHOT reference file found;")
-                self.log.warning("the tso_photometry step will be skipped.")
-                return None
-
             # Get the gain reference file
             gain_filename = self.get_reference_file(model, "gain")
             gain_m = GainModel(gain_filename)
@@ -68,22 +62,15 @@ class TSOPhotometryStep(Step):
                 self.log.info("Extracting gain subarray to match science data")
                 gain_2d = reffile_utils.get_subarray_model(model, gain_m).data
 
-            # Retrieve aperture info from the reference file
-            pupil_name = "ANY"
-            if model.meta.instrument.pupil is not None:
-                pupil_name = model.meta.instrument.pupil
-
-            (radius, radius_inner, radius_outer) = get_ref_data(tsophot_filename, pupil=pupil_name)
-
-            self.log.debug(f"radius = {radius}")
-            self.log.debug(f"radius_inner = {radius_inner}")
-            self.log.debug(f"radius_outer = {radius_outer}")
+            self.log.debug(f"radius = {self.radius}")
+            self.log.debug(f"radius_inner = {self.radius_inner}")
+            self.log.debug(f"radius_outer = {self.radius_outer}")
             self.log.debug(f"xcenter = {xcenter}")
             self.log.debug(f"ycenter = {ycenter}")
 
             # Compute the aperture photometry
             catalog = tso_aperture_photometry(
-                model, xcenter, ycenter, radius, radius_inner, radius_outer, gain_2d
+                model, xcenter, ycenter, self.radius, self.radius_inner, self.radius_outer, gain_2d
             )
 
             # Save the photometry in an output catalog
@@ -101,29 +88,3 @@ class TSOPhotometryStep(Step):
                 self.log.info(f"Wrote TSO photometry catalog: {cat_filepath}")
 
         return catalog
-
-
-def get_ref_data(reffile, pupil="ANY"):
-    ref_model = TsoPhotModel(reffile)
-    radii = ref_model.radii
-    value = None
-    val_any_pupil = None
-    for item in radii:
-        if item.pupil == pupil.upper():
-            value = (item.radius, item.radius_inner, item.radius_outer)
-            break
-        elif item.pupil == "ANY" and val_any_pupil is None:
-            # Save this value as a fallback, in case we don't find a match
-            # to an actual pupil name.
-            val_any_pupil = (item.radius, item.radius_inner, item.radius_outer)
-
-    if value is not None:
-        (radius, radius_inner, radius_outer) = value
-    elif val_any_pupil is not None:
-        (radius, radius_inner, radius_outer) = val_any_pupil
-    else:
-        (radius, radius_inner, radius_outer) = (0.0, 0.0, 0.0)
-
-    ref_model.close()
-
-    return radius, radius_inner, radius_outer


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3980](https://jira.stsci.edu/browse/JP-3980)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
The TSOPHOT reference file contains just a few simple floating point values.  Replace the reference file use here with step parameters instead.

This will require delivery of new step parameter files to maintain the current defaults for all instruments.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
