### PR TITLE
JP-1497: Pass datamodel open kwargs through ModelContainer

### DIFF
--- a/changes/9590.datamodels.rst
+++ b/changes/9590.datamodels.rst
@@ -1,0 +1,1 @@
+Expose kwargs to be passed to datamodels.open in ModelContainer

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -145,15 +145,13 @@ to supply custom catalogs.
         self.asn_pool_name = None
         self.asn_file_path = None
 
-        self._guess = kwargs.get("guess", True)
-
         if init is None:
             # Don't populate the container with models
             pass
         elif isinstance(init, list):
             if all(isinstance(x, (str, fits.HDUList, JwstDataModel)) for x in init):
                 for m in init:
-                    self._models.append(datamodel_open(m, guess=self._guess, **kwargs))
+                    self._models.append(datamodel_open(m, **kwargs))
                 # set asn_table_name and product name to first datamodel stem
                 # since they were not provided
                 fname = self._models[0].meta.filename
@@ -170,7 +168,7 @@ to supply custom catalogs.
                 )
         elif isinstance(init, self.__class__):
             for m in init:
-                self._models.append(datamodel_open(m, guess=self._guess, **kwargs))
+                self._models.append(datamodel_open(m, **kwargs))
             self.asn_exptypes = init.asn_exptypes
             self.asn_n_members = init.asn_n_members
             self.asn_table = init.asn_table

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -131,6 +131,11 @@ to supply custom catalogs.
 
         asn_n_members : int
             Open only the first N qualifying members.
+
+        **kwargs : dict
+            Additional keyword arguments passed to `datamodel_open()`, such as
+            `memmap`, `guess`, `strict_validation`, etc. See `datamodels.open()`
+            for a full list of available keyword arguments.
         """
         self._models = []
         self.asn_exptypes = asn_exptypes
@@ -141,6 +146,7 @@ to supply custom catalogs.
         self.asn_file_path = None
 
         self._memmap = kwargs.get("memmap", False)
+        self._guess = kwargs.get("guess", True)
 
         if init is None:
             # Don't populate the container with models
@@ -148,7 +154,9 @@ to supply custom catalogs.
         elif isinstance(init, list):
             if all(isinstance(x, (str, fits.HDUList, JwstDataModel)) for x in init):
                 for m in init:
-                    self._models.append(datamodel_open(m, memmap=self._memmap))
+                    self._models.append(
+                        datamodel_open(m, guess=self._guess, memmap=self._memmap, **kwargs)
+                    )
                 # set asn_table_name and product name to first datamodel stem
                 # since they were not provided
                 fname = self._models[0].meta.filename
@@ -165,7 +173,9 @@ to supply custom catalogs.
                 )
         elif isinstance(init, self.__class__):
             for m in init:
-                self._models.append(datamodel_open(m, memmap=self._memmap))
+                self._models.append(
+                    datamodel_open(m, guess=self._guess, memmap=self._memmap, **kwargs)
+                )
             self.asn_exptypes = init.asn_exptypes
             self.asn_n_members = init.asn_n_members
             self.asn_table = init.asn_table

--- a/jwst/datamodels/tests/test_model_container.py
+++ b/jwst/datamodels/tests/test_model_container.py
@@ -153,3 +153,24 @@ def test_save(tmp_cwd, container, path):
         container.save(path)
         expected_fname = path.replace(".fits", "") + ".fits"
         assert os.path.exists(expected_fname)
+
+
+def test_open_guess(container):
+    # test that open() accepts guess arg
+    assert not container[0].meta.hasattr("model_type")
+    ModelContainer(container)  # this should work with default options
+    with pytest.raises(TypeError):
+        ModelContainer(container, guess=False)
+
+
+def test_open_kwargs(container):
+    wrong_schema = datamodels.NRMModel()._schema
+    asn_file_path, _asn_file_name = os.path.split(ASN_FILE)
+    fnames = [m.meta.filename for m in container]
+    with pushdir(asn_file_path):
+        # opening it normally works fine
+        ModelContainer(fnames)
+        with pytest.raises(AttributeError):
+            # but schema can be passed all the way through to DataModel.__init__ on the
+            # individual datamodels, and cause AttributeError
+            ModelContainer(fnames, schema=wrong_schema)

--- a/jwst/datamodels/tests/test_model_container.py
+++ b/jwst/datamodels/tests/test_model_container.py
@@ -162,7 +162,9 @@ def test_open_guess(container):
     with pushdir(asn_file_path):
         # opening it normally works fine
         ModelContainer(fnames, guess=True)
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            TypeError, match="Model type is not specifically defined and guessing has been disabled"
+        ):
             # but if you don't allow guessing the model type, it raises TypeError
             ModelContainer(fnames, guess=False)
 

--- a/jwst/datamodels/tests/test_model_container.py
+++ b/jwst/datamodels/tests/test_model_container.py
@@ -156,11 +156,15 @@ def test_save(tmp_cwd, container, path):
 
 
 def test_open_guess(container):
-    # test that open() accepts guess arg
-    assert not container[0].meta.hasattr("model_type")
-    ModelContainer(container)  # this should work with default options
-    with pytest.raises(TypeError):
-        ModelContainer(container, guess=False)
+    """Test that `guess` keyword argument works in ModelContainer."""
+    asn_file_path, _asn_file_name = os.path.split(ASN_FILE)
+    fnames = [m.meta.filename for m in container]
+    with pushdir(asn_file_path):
+        # opening it normally works fine
+        ModelContainer(fnames, guess=True)
+        with pytest.raises(TypeError):
+            # but if you don't allow guessing the model type, it raises TypeError
+            ModelContainer(fnames, guess=False)
 
 
 def test_open_kwargs(container):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-1497](https://jira.stsci.edu/browse/JP-1497)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #5023 

<!-- describe the changes comprising this PR here -->
This PR updates `ModelContainer` to pass kwargs to `datamodels.open()` for opening the individual datamodels in that container.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
