### PR TITLE
add upper pin to drizzle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "astropy>=6.1",
     "BayesicFitting>=3.2.2",
     "crds>=12.0.3",
-    "drizzle>=2.0.1",
+    "drizzle>=2.0.1,<2.1.0",
     # "gwcs>=0.22.0,<0.23.0",
     "gwcs @ git+https://github.com/spacetelescope/gwcs.git@master",
     "numpy>=1.25",


### PR DESCRIPTION
Add an upper pin to drizzle to disallow 2.1.0:
https://github.com/spacetelescope/drizzle/releases/tag/2.1.0
which is causing unit and regtest failures.

The thought here is to add the pin (to allow other PRs and regtests to run) then a follow-up PR can:
- remove the pin
- fix the unit test
- run regtests (which can then be okified)

If the above approach is not preferred we can close this PR.

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/15879813351

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
