### PR TITLE
JP-3968: Restore ModelContainer to docs, add ModelLibrary and SourceModelContainer to docs

### DIFF
--- a/docs/jwst/user_documentation/datamodels.rst
+++ b/docs/jwst/user_documentation/datamodels.rst
@@ -5,7 +5,7 @@ JWST Datamodels
 ===============
 
 The `stdatamodels` package contains the interface for JWST datamodels. This package
-is separated from the `jwst` pipeline (to allow models to be manipulated without needing
+is separated from the `jwst` pipeline package (to allow models to be manipulated without needing
 to install the whole pipeline), but the contents of ``stdatamodels.jwst.datamodels``
 are also accessible from ``jwst.datamodels``.
 
@@ -36,21 +36,22 @@ file on disk. E.g:
 	input_model = dm.open('jw00001001001_01101_00001_mirimage_uncal.fits')
 	result = LinearityStep.call(input_model)
 
-If a string path to a file on disk is passed in, a ``JwstDataModel`` object will be
+If a string path to a file on disk is passed in, a ``DataModel`` object will be
 created internally when the pipeline/step is run.
 
 By default, when running in Python, the corrected data will be returned in-memory
-as a ``JwstDataModel`` instead of being written as an output file.
-See :ref:`controlling output file behavior`<python_outputs>` for instructions on
-how to write the returned ``JwstDataModel`` to an output file.
+as a ``DataModel`` instead of being written as an output file.
+See :ref:`controlling output file behavior`<python_outputs> for instructions on
+how to write the returned ``DataModel`` to an output file.
 
 Groups of Datamodels
 ====================
 
 Many of the JWST calibration steps and pipelines expect an
 :ref:`Association <associations>` file as input. When opened with
-:meth:`~jwst.datamodels.open`, a
-:class:`~jwst.datamodels.ModelContainer` is returned. ``ModelContainer``
+:meth:`~stdatamodels.jwst.datamodels.util.open`, a
+:class:`~jwst.datamodels.container.ModelContainer` is returned.
+:class:`~jwst.datamodels.container.ModelContainer`
 is a list-like object where each element is the
 ``DataModel`` of each member of the association. The ``asn_table`` attribute is
 populated with the association data structure, allowing direct access

--- a/docs/jwst/user_documentation/datamodels.rst
+++ b/docs/jwst/user_documentation/datamodels.rst
@@ -4,7 +4,7 @@
 JWST Datamodels
 ===============
 
-The `jwst` package also contains the interface for JWST Datamodels. ``Datamodels``
+The `stdatamodels` package contains the interface for JWST Datamodels. ``Datamodels``
 are the recommended way of reading and writing JWST data files (.fits) and
 reference files (.fits and .asdf). JWST data are encoded in FITS files, and reference
 files consist of a mix of FITS and ASDF - datamodels were designed to
@@ -12,8 +12,7 @@ abstract away these intricacies and provide a simple interface to the data. They
 represent the data in FITS extensions and meta data in FITS headers in a Python object
 with a tree-like structure. The following section gives a brief overview of
 ``Datamodels`` as they pertain to the pipeline - see :ref:`stdatamodels:data-models`
-for more
-detailed documentation on Datamodels.
+for more detailed documentation on Datamodels.
 
 Datamodels and the JWST pipeline
 ================================
@@ -39,3 +38,29 @@ By default, when running in Python, the corrected data will be returned in-memor
 as a ``DataModel`` instead of being written as an output file.
 See :ref:`controlling output file behavior`<python_outputs>` for instructions on
 how to write the returned ``DataModel`` to an output file.
+
+Groups of Datamodels
+====================
+
+Many of the JWST calibration steps and pipelines expect an
+:ref:`Association <associations>` file as input. When opened with
+:meth:`~jwst.datamodels.open`, a
+:class:`~jwst.datamodels.ModelContainer` is returned. `ModelContainer`
+is a list-like object where each element is the
+`DataModel` of each member of the association. The `asn_table` attribute is
+populated with the association data structure, allowing direct access
+to the association itself.  The association file, as well as the files
+listed in the association file, must be in the input directory.
+
+Data structures that handle groups of datamodels are stored in the `jwst`
+repository instead of inside `stdatamodels`. The API for these data structures
+is documented here:
+
+.. automodapi:: jwst.datamodels.container
+	:no-inheritance-diagram:
+
+.. automodapi:: jwst.datamodels.library
+	:no-inheritance-diagram:
+
+.. automodapi:: jwst.datamodels.source_container
+	:no-inheritance-diagram:

--- a/docs/jwst/user_documentation/datamodels.rst
+++ b/docs/jwst/user_documentation/datamodels.rst
@@ -4,23 +4,28 @@
 JWST Datamodels
 ===============
 
-The `stdatamodels` package contains the interface for JWST Datamodels. ``Datamodels``
-are the recommended way of reading and writing JWST data files (.fits) and
-reference files (.fits and .asdf). JWST data are encoded in FITS files, and reference
+The `stdatamodels` package contains the interface for JWST datamodels. This package
+is separated from the `jwst` pipeline (to allow models to be manipulated without needing
+to install the whole pipeline), but the contents of ``stdatamodels.jwst.datamodels``
+are also accessible from ``jwst.datamodels``.
+
+Datamodels are the recommended way of reading and writing JWST data files and
+reference files (.fits and .asdf). JWST data are usually encoded in FITS files 
+(although they can also be saved to/read from ASDF), and reference
 files consist of a mix of FITS and ASDF - datamodels were designed to
 abstract away these intricacies and provide a simple interface to the data. They
-represent the data in FITS extensions and meta data in FITS headers in a Python object
+represent the data in FITS extensions and metadata in FITS headers in a Python object
 with a tree-like structure. The following section gives a brief overview of
-``Datamodels`` as they pertain to the pipeline - see :ref:`stdatamodels:data-models`
-for more detailed documentation on Datamodels.
+datamodels as they pertain to the pipeline - see :ref:`stdatamodels:data-models`
+for more detailed documentation on datamodels.
 
 Datamodels and the JWST pipeline
 ================================
 
 When :ref:`running the pipeline in python <run_from_python>`, the inputs and 
-outputs of running a pipeline or a step are JWST ``Datamodels``. 
+outputs of running a pipeline or a step are JWST datamodels. 
 
-The input to a pipeline/step can be a ``Datamodel``, created from an input
+The input to a pipeline/step can be a datamodel created from an input
 file on disk. E.g:
 
 ::
@@ -31,13 +36,13 @@ file on disk. E.g:
 	input_model = dm.open('jw00001001001_01101_00001_mirimage_uncal.fits')
 	result = LinearityStep.call(input_model)
 
-If a string path to a file on disk is passed in, a ``DataModel`` object will be
+If a string path to a file on disk is passed in, a ``JwstDataModel`` object will be
 created internally when the pipeline/step is run.
 
 By default, when running in Python, the corrected data will be returned in-memory
-as a ``DataModel`` instead of being written as an output file.
+as a ``JwstDataModel`` instead of being written as an output file.
 See :ref:`controlling output file behavior`<python_outputs>` for instructions on
-how to write the returned ``DataModel`` to an output file.
+how to write the returned ``JwstDataModel`` to an output file.
 
 Groups of Datamodels
 ====================
@@ -45,9 +50,9 @@ Groups of Datamodels
 Many of the JWST calibration steps and pipelines expect an
 :ref:`Association <associations>` file as input. When opened with
 :meth:`~jwst.datamodels.open`, a
-:class:`~jwst.datamodels.ModelContainer` is returned. `ModelContainer`
+:class:`~jwst.datamodels.ModelContainer` is returned. ``ModelContainer``
 is a list-like object where each element is the
-`DataModel` of each member of the association. The `asn_table` attribute is
+``DataModel`` of each member of the association. The ``asn_table`` attribute is
 populated with the association data structure, allowing direct access
 to the association itself.  The association file, as well as the files
 listed in the association file, must be in the input directory.

--- a/docs/jwst/user_documentation/datamodels.rst
+++ b/docs/jwst/user_documentation/datamodels.rst
@@ -41,7 +41,7 @@ created internally when the pipeline/step is run.
 
 By default, when running in Python, the corrected data will be returned in-memory
 as a ``DataModel`` instead of being written as an output file.
-See :ref:`controlling output file behavior`<python_outputs> for instructions on
+See :ref:`controlling output file behavior<python_outputs>` for instructions on
 how to write the returned ``DataModel`` to an output file.
 
 Groups of Datamodels

--- a/jwst/datamodels/library.py
+++ b/jwst/datamodels/library.py
@@ -16,8 +16,8 @@ class ModelLibrary(AbstractModelLibrary):
 
     ModelLibrary is a container designed to allow
     efficient processing of datamodel instances created from an association.
-    See the `stpipe library documentation <https://stpipe.readthedocs.io/en/latest/model_library.html`
-    for details.
+    See the `stpipe library documentation <https://stpipe.readthedocs.io/en/latest/model_library.html>`_
+    for more information.
     """
 
     @property


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3968](https://jira.stsci.edu/browse/JP-3968)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9038 

<!-- describe the changes comprising this PR here -->
This PR puts ModelContainer, ModelLibrary, and SourceModelContainer API into the JWST docs.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
