### PR TITLE
JP-4047: Update regtests for niriss and nircam wfss

### DIFF
--- a/jwst/regtest/test_nircam_wfss_spec3.py
+++ b/jwst/regtest/test_nircam_wfss_spec3.py
@@ -1,0 +1,39 @@
+import pytest
+from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
+
+from jwst.stpipe import Step
+
+
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
+
+@pytest.fixture(scope="module")
+def run_nircam_wfss_spec3(rtdata_module, resource_tracker):
+    """Run the calwebb_spec3 pipeline"""
+    rtdata = rtdata_module
+
+    # Get the level3 association file and run the spec3 pipeline on it.
+    rtdata.get_asn("nircam/wfss/jw02279-o001_spec3_00001_asn.json")
+    args = ["calwebb_spec3", rtdata.input]
+    with resource_tracker.track():
+        Step.from_cmdline(args)
+
+
+def test_log_tracked_resources(log_tracked_resources, run_nircam_wfss_spec3):
+    log_tracked_resources()
+
+
+@pytest.mark.parametrize("suffix", ["x1d", "c1d"])
+def test_nircam_wfss_spec3(run_nircam_wfss_spec3, rtdata_module, suffix, fitsdiff_default_kwargs):
+    """Regression test of the calwebb_spec3 pipeline applied to NIRISS WFSS data"""
+    rtdata = rtdata_module
+    rtdata.input = "jw02279-o001_spec3_00001_asn.json"
+    output = "jw02279-o001_t0000_nircam_grismr_" + suffix + ".fits"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/test_nircam_wfss_spec3/{output}")
+
+    # Compare the results
+    fitsdiff_default_kwargs["atol"] = 1e-5
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_niriss_wfss.py
+++ b/jwst/regtest/test_niriss_wfss.py
@@ -57,7 +57,7 @@ def run_nis_wfss_spec3(run_nis_wfss_spec2, rtdata_module, resource_tracker):
     # Get the level3 association file and run the spec3 pipeline on it.
     # We don't need to retrieve any of the cal members of the association,
     # because they were all just created by the preceding spec2 test.
-    rtdata.get_data("niriss/wfss/jw01324-o001_20220629t171902_spec3_003_asn.json")
+    rtdata.get_data("niriss/wfss/jw01324-o001_spec3_00005_asn.json")
     args = ["calwebb_spec3", rtdata.input]
     with resource_tracker.track():
         Step.from_cmdline(args)
@@ -91,8 +91,8 @@ def test_nis_wfss_spec2(run_nis_wfss_spec2, rtdata_module, fitsdiff_default_kwar
 def test_nis_wfss_spec3(run_nis_wfss_spec3, rtdata_module, suffix, fitsdiff_default_kwargs):
     """Regression test of the calwebb_spec3 pipeline applied to NIRISS WFSS data"""
     rtdata = rtdata_module
-    rtdata.input = "jw01324-o001_20220629t171902_spec3_003_asn.json"
-    output = "jw01324-o001_t0000_niriss_f115w-gr150c-gr150r_" + suffix + ".fits"
+    rtdata.input = "jw01324-o001_spec3_00005_asn.json"
+    output = "jw01324-o001_t0000_niriss_f115w-gr150c_" + suffix + ".fits"
     rtdata.output = output
     rtdata.get_truth(f"truth/test_niriss_wfss/{output}")
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4047](https://jira.stsci.edu/browse/JP-4047)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9596 

<!-- describe the changes comprising this PR here -->
This PR adds regression test coverage of level 3 products for NIRCam WFSS.

This PR updates the association requested by the regression test for level3 NIRISS WFSS to be reflective of the current asn rules for that mode.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
