### PR TITLE
release metadata for `1.19.0`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,350 @@
+1.19.0 (2025-06-26)
+===================
+
+General
+-------
+
+- Bumped minversions of requests to 2.31, spherical-geometry to 1.3, synphot to
+  1.3, and wiimatch to 0.3.2 to avoid using deprecated infrastructure from
+  those packages. (`#9317
+  <https://github.com/spacetelescope/jwst/issues/9317>`_)
+- Implementing STFITSDiff for our regression tests instead of FITSDiff to
+  improve reports. (`#9414
+  <https://github.com/spacetelescope/jwst/issues/9414>`_)
+- Remove unused cube_skymatch step (`#9426
+  <https://github.com/spacetelescope/jwst/issues/9426>`_)
+- Replaced relative imports with absolute imports (`#9540
+  <https://github.com/spacetelescope/jwst/issues/9540>`_)
+- Style updates completed for all modules. (`#9569
+  <https://github.com/spacetelescope/jwst/issues/9569>`_)
+
+
+Documentation
+-------------
+
+- Remove description of non-working step-specific log configuration. (`#9565
+  <https://github.com/spacetelescope/jwst/issues/9565>`_)
+
+
+``stpipe``
+----------
+
+- Read only metadata, not whole datamodel, when getting CRDS references (`#9429
+  <https://github.com/spacetelescope/jwst/issues/9429>`_)
+- Remove the deprecated ``Step.__call__`` method. (`#9548
+  <https://github.com/spacetelescope/jwst/issues/9548>`_)
+
+
+Associations
+------------
+
+- For nodded NIRSpec FS or MOS spec2 associations, exclude background
+  candidates that do not match the science target ID.
+  For NIRSpec FS spec3 associations, update the product name to include the
+  target ID. (`#8943 <https://github.com/spacetelescope/jwst/issues/8943>`_)
+- Provide subarray name to ``Lv2WFSSNIS`` association rule so that direct image
+  association members have correct Level 3 product name. (`#9334
+  <https://github.com/spacetelescope/jwst/issues/9334>`_)
+- Update associations module for code style and docstrings; remove some unused
+  functions and files. (`#9393
+  <https://github.com/spacetelescope/jwst/issues/9393>`_)
+- Revert #9098 and instead use duplication checking to weed out level 2
+  observation-type associations that have duplicate product IDs with their
+  background candidate association counterparts. (`#9501
+  <https://github.com/spacetelescope/jwst/issues/9501>`_)
+
+
+Scripts
+-------
+
+- Removed ``verify_install_requires`` command. This was a test script that
+  should not have been installed. (`#9297
+  <https://github.com/spacetelescope/jwst/issues/9297>`_)
+
+
+Pipeline
+--------
+
+- Pipeline utility function ``match_nans_and_flags()`` now raises ``TypeError``
+  instead of ``ValueError`` on invalid input model. (`#9283
+  <https://github.com/spacetelescope/jwst/issues/9283>`_)
+- In calwebb_ami3, revert change to strictness of zip function linking science
+  exposures to psf exposures, to allow successful processing of associations
+  with differing numbers of science and psf members. (`#9361
+  <https://github.com/spacetelescope/jwst/issues/9361>`_)
+
+
+ami_analyze / ami_normalize / ami_average (ami3)
+------------------------------------------------
+
+- Remove unused code and fix various small bugs found while adding test suite.
+
+  Deprecate unused and out-of-date AmiAverageStep. (`#9263
+  <https://github.com/spacetelescope/jwst/issues/9263>`_)
+- Improve memory usage of AmiAnalyzeStep: for test dataset with 400
+  integrations
+  and default parameter settings, the memory usage is reduced from 12 GB to 0.5
+  GB.
+  (Note the scaling is not necessarily linear with the number of integrations.)
+  (`#9442 <https://github.com/spacetelescope/jwst/issues/9442>`_)
+- Move pointing information in AmiOIModel from model.meta.ami to
+  model.meta.guidestar (FITS headers remain identical) (`#9560
+  <https://github.com/spacetelescope/jwst/issues/9560>`_)
+
+
+assign_mtwcs (image3, spec3)
+----------------------------
+
+- Fixed a bug where ``assign_moving_target_wcs`` could crash (instead of
+  skipping the step) for some invalid RA or Dec values. (`#9552
+  <https://github.com/spacetelescope/jwst/issues/9552>`_)
+
+
+assign_wcs (image2, spec2)
+--------------------------
+
+- Expanded the hard-coded NIRSpec wavelength range to safer limits. (`#9314
+  <https://github.com/spacetelescope/jwst/issues/9314>`_)
+- Remove util.reproject function (deprecated since 1.18.0). Use
+  ``stcal.alignment.util.reproject`` instead. (`#9322
+  <https://github.com/spacetelescope/jwst/issues/9322>`_)
+- Populate the wavelength array for MIRI LRS fixed slit data, for consistency
+  with the MIRI LRS slitless mode. (`#9372
+  <https://github.com/spacetelescope/jwst/issues/9372>`_)
+- Rework the NIRSpec WCS to propagate the slit name through all transforms for
+  all modes. (`#9404 <https://github.com/spacetelescope/jwst/issues/9404>`_)
+- Attach a pixel-to-slice map to NIRSpec IFU images, in a ``regions``
+  attribute.
+  Optionally (but on by default), use the slice map to revise the WCS to be
+  fully coordinate-based,
+  so it does not require the slice number on input nor report it on output.
+  (`#9452 <https://github.com/spacetelescope/jwst/issues/9452>`_)
+
+
+background (image2, spec2)
+--------------------------
+
+- In WFSS background calculations, use higher precision for mean and sum
+  calculations for better numerical consistency across build environments.
+  (`#9376 <https://github.com/spacetelescope/jwst/issues/9376>`_)
+- Implementing capability to be run as a standalone step with asn or fits
+  files, and adding header keyword for step completed or skipped. (`#9451
+  <https://github.com/spacetelescope/jwst/issues/9451>`_)
+- Fix a bug where highly-masked input data for wfss modes were raising errors
+  instead of skipping (`#9507
+  <https://github.com/spacetelescope/jwst/issues/9507>`_)
+- Implement background subtraction for NIRISS SOSS data, fitting reference
+  background templates to background regions of the science data. (`#9523
+  <https://github.com/spacetelescope/jwst/issues/9523>`_)
+- Change background alias to "bkg_subtract" to fix conflicting aliases for the
+  step. The new alias is the one currently used for running the step or
+  changing parameters from the stage2 pipelines. (`#9533
+  <https://github.com/spacetelescope/jwst/issues/9533>`_)
+
+
+barshadow (spec2 MOS)
+---------------------
+
+- For NIRSpec multislit data, add a metadata keyword to each slit to record
+  whether it has been barshadow corrected. (`#9254
+  <https://github.com/spacetelescope/jwst/issues/9254>`_)
+
+
+clean_flicker_noise (detector1)
+-------------------------------
+
+- Use higher precision for sigma clipping statistics for better numerical
+  consistency across build environments. (`#9376
+  <https://github.com/spacetelescope/jwst/issues/9376>`_)
+
+
+combine_1d (spec3)
+------------------
+
+- For WFSS modes, reorganize output such that a single table extension holds
+  the spectra
+  from all the sources, with different extensions representing different
+  spectral orders.
+  The output datamodel type is now WFSSMultiCombinedSpecModel for those modes.
+  (`#9402 <https://github.com/spacetelescope/jwst/issues/9402>`_)
+- Allow spectra from TSOMultiSpecModel to be combined. (`#9430
+  <https://github.com/spacetelescope/jwst/issues/9430>`_)
+
+
+cube_build (spec2 IFU, spec3)
+-----------------------------
+
+- Updated cube_build function names to adhere to Python standards and updated
+  some of the exception names. (`#9347
+  <https://github.com/spacetelescope/jwst/issues/9347>`_)
+
+
+dark_current (detector1 NIR)
+----------------------------
+
+- Remove mention and use of dark error array; document extrapolation of darks
+  when science array has more frames than the dark. (`#9468
+  <https://github.com/spacetelescope/jwst/issues/9468>`_)
+
+
+emicorr (detector1 MIR)
+-----------------------
+
+- Change the default fitting algorithm for MIRI EMI correction to the 'joint'
+  method to improve performance for low numbers of groups. (`#9510
+  <https://github.com/spacetelescope/jwst/issues/9510>`_)
+
+
+extract_1d (spec2, spec3)
+-------------------------
+
+- For WFSS modes, reorganize output such that a single table extension holds
+  the spectra
+  from all the sources for a given exposure and spectral order.
+  The output datamodel type is now WFSSMultiSpecModel for those modes. (`#9402
+  <https://github.com/spacetelescope/jwst/issues/9402>`_)
+- Reorganize multi-integration spectra into a single table, in which each row
+  is a 1D spectrum.
+  The datamodel for TSO x1dints files is now TSOMultiSpecModel, instead of
+  MultiSpecModel. (`#9430
+  <https://github.com/spacetelescope/jwst/issues/9430>`_)
+- Fix crashes in the SOSS ATOCA algorithm when adaptive refinement reaches max
+  grid size (`#9491 <https://github.com/spacetelescope/jwst/issues/9491>`_)
+
+
+flatfield (image2, spec2)
+-------------------------
+
+- Fixed error and variance propagation for inverse steps. (`#9356
+  <https://github.com/spacetelescope/jwst/issues/9356>`_)
+- Set pixels with negative flat fields to NaN and flag as them DNU for NIRSpec
+  data. (`#9522 <https://github.com/spacetelescope/jwst/issues/9522>`_)
+
+
+fringe (spec2 IFU)
+------------------
+
+- Apply fringe correction to VAR_POISSON, VAR_RNOISE, and VAR_FLAT also.
+  (`#9320 <https://github.com/spacetelescope/jwst/issues/9320>`_)
+
+
+msaflagopen (spec2 IFU, spec2 MOS)
+----------------------------------
+
+- Removed confusing log and warning messages in ``msa_flagging``. (`#9412
+  <https://github.com/spacetelescope/jwst/issues/9412>`_)
+
+
+pathloss (spec2 IFU, spec2 MOS)
+-------------------------------
+
+- For NIRSpec multislit data, add a metadata keyword to each slit to record the
+  pathloss correction type applied (POINT or UNIFORM). (`#9254
+  <https://github.com/spacetelescope/jwst/issues/9254>`_)
+
+
+photom (image2, spec2)
+----------------------
+
+- Apply MRS IFU time-dependent correction to VAR_POISSON, VAR_RNOISE, and
+  VAR_FLAT also. (`#9320
+  <https://github.com/spacetelescope/jwst/issues/9320>`_)
+- Fixed error and variance propagation for inverse steps. (`#9356
+  <https://github.com/spacetelescope/jwst/issues/9356>`_)
+- Update handling for NIRISS SOSS to expect multi-integration spectra in
+  TSOMultiSpecModel datamodels. (`#9430
+  <https://github.com/spacetelescope/jwst/issues/9430>`_)
+- Allow NIRCam imaging to match calibration values by subarray, if the photom
+  reference file contains subarray information. (`#9485
+  <https://github.com/spacetelescope/jwst/issues/9485>`_)
+
+
+ramp_fitting (detector1)
+------------------------
+
+- Removing OLS and GLS code and all related tests from ramp fitting. (`#9332
+  <https://github.com/spacetelescope/jwst/issues/9332>`_)
+
+
+refpix (detector1)
+------------------
+
+- Fixed malformed log messages for some off-nominal parameter settings. (`#9478
+  <https://github.com/spacetelescope/jwst/issues/9478>`_)
+
+
+resample (image2, image3, coron3)
+---------------------------------
+
+- Remove make_output_wcs function (deprecated since 1.18.0). Use
+  ``resampled_wcs_from_models`` instead.
+
+  Remove build_driz_weight function (deprecated since 1.18.0). Use
+  ``stcal.resample.utils.build_driz_weight`` instead.
+
+  Remove decode_context function (deprecated since 1.18.0). Use
+  ``drizzle.utils.decode_context`` instead. (`#9322
+  <https://github.com/spacetelescope/jwst/issues/9322>`_)
+- Updated documentation to reflect correct definition of ``pixel_scale_ratio``
+  for *imaging* data: ratio of output to input pixel scales. (`#9403
+  <https://github.com/spacetelescope/jwst/issues/9403>`_)
+- Add options to disable computation of context and variance arrays (`#9517
+  <https://github.com/spacetelescope/jwst/issues/9517>`_)
+
+
+saturation (detector1)
+----------------------
+
+- Account for non-zero bias in group 2 saturation flagging in frame-averaged
+  groups. (`#9302 <https://github.com/spacetelescope/jwst/issues/9302>`_)
+
+
+straylight (spec2 IFU)
+----------------------
+
+- Added option to save shower model when running straylight with clean_showers
+  turned on (`#9378 <https://github.com/spacetelescope/jwst/issues/9378>`_)
+
+
+tso_photometry (tso3)
+---------------------
+
+- In TSO photometry reductions, added support for processing data in units of
+  DN/s by using the gain reference file to convert to flatfielded electrons.
+  (`#9299 <https://github.com/spacetelescope/jwst/issues/9299>`_)
+
+
+tweakreg (image3)
+-----------------
+
+- Update docs to clarify format of tweakreg catalogs (`#9301
+  <https://github.com/spacetelescope/jwst/issues/9301>`_)
+- Make segmentation algorithm respect kernel_fwhm parameter (`#9463
+  <https://github.com/spacetelescope/jwst/issues/9463>`_)
+
+
+wavecorr (spec2 MOS)
+--------------------
+
+- For NIRSpec multislit data, add a metadata keyword to each slit to record
+  whether it has been wavelength corrected. (`#9254
+  <https://github.com/spacetelescope/jwst/issues/9254>`_)
+
+
+white_light
+-----------
+
+- Update handling to expect multi-integration spectra in TSOMultiSpecModel
+  datamodels.
+  Separate fluxes from different detectors into different output columns.
+  (`#9430 <https://github.com/spacetelescope/jwst/issues/9430>`_)
+- Update output table to show correct timestamps and spectral orders for NIRISS
+  tsgrism observations. (`#9431
+  <https://github.com/spacetelescope/jwst/issues/9431>`_)
+- Add BJD_TDB times to output table (`#9445
+  <https://github.com/spacetelescope/jwst/issues/9445>`_)
+
+
 1.18.0 (2025-04-08)
 ===================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -96,7 +96,7 @@ authors:
   given-names: "Joseph"
   orcid: "https://orcid.org/0000-0002-0201-8306"
 title: "JWST Calibration Pipeline"
-version: 1.18.0
+version: 1.19.0
 doi: 10.5281/zenodo.7038885
-date-released: 2025-04-08
+date-released: 2025-06-26
 url: "https://github.com/spacetelescope/jwst"

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ the specified context and less than the context for the next release.
 
 | jwst tag            | DMS build | SDP_VER  | CRDS_CONTEXT | Released   | Ops Install | Notes                                         |
 |---------------------|-----------|----------|--------------|------------|-------------|-----------------------------------------------|
-| 1.19.0              | B11.4     | 2025.2.0 | 1386         | 2025-06-26 |             | First release candidate for B11.4             |
+| 1.19.0              | B12.0     | 2025.2.0 | 1386         | 2025-06-26 |             | First release candidate for B12.0             |
 | 1.18.1              | B11.3.1   | 2025.2.0 | 1364         | 2025-06-10 |             | Patch release for B11.3.1                     |
 | 1.18.0              | B11.3     | 2025.2.0 | 1364         | 2025-04-01 | 2025-05-20  | First release for B11.3                       |
 | 1.17.1              | B11.2     | 2025.1.0 | 1321         | 2025-01-02 | 2025-03-05  | Final release candidate for B11.2             |

--- a/README.md
+++ b/README.md
@@ -260,9 +260,10 @@ the specified context and less than the context for the next release.
 
 | jwst tag            | DMS build | SDP_VER  | CRDS_CONTEXT | Released   | Ops Install | Notes                                         |
 |---------------------|-----------|----------|--------------|------------|-------------|-----------------------------------------------|
-| 1.18.1              | B11.3.1   | 2025.2.0 | 1364         | 2025-06-10 |             | Patch release for B11.3.1                       |
+| 1.19.0              | B11.4     | 2025.2.0 | 1386         | 2025-06-26 |             | First release candidate for B11.4             |
+| 1.18.1              | B11.3.1   | 2025.2.0 | 1364         | 2025-06-10 |             | Patch release for B11.3.1                     |
 | 1.18.0              | B11.3     | 2025.2.0 | 1364         | 2025-04-01 | 2025-05-20  | First release for B11.3                       |
-| 1.17.1              | B11.2     | 2025.1.0 | 1321         | 2025-01-02 | 2025-03-05  | Final release candidate for B11.2            |
+| 1.17.1              | B11.2     | 2025.1.0 | 1321         | 2025-01-02 | 2025-03-05  | Final release candidate for B11.2             |
 | 1.17.0              | B11.2     | 2025.1.0 | 1321         | 2024-12-20 | TBD         | First release candidate for B11.2             |
 | 1.16.1              | B11.1.1   | 2024.3.1 | 1303         | 2024-11-13 | 2024-12-06  | Final release candidate for B11.1             |
 | 1.16.0              | B11.1     | 2024.3.0 | 1298         | 2024-09-20 |             | First release candidate for B11.1             |

--- a/changes/8943.associations.rst
+++ b/changes/8943.associations.rst
@@ -1,2 +1,0 @@
-For nodded NIRSpec FS or MOS spec2 associations, exclude background candidates that do not match the science target ID.
-For NIRSpec FS spec3 associations, update the product name to include the target ID.

--- a/changes/9254.barshadow.rst
+++ b/changes/9254.barshadow.rst
@@ -1,1 +1,0 @@
-For NIRSpec multislit data, add a metadata keyword to each slit to record whether it has been barshadow corrected.

--- a/changes/9254.pathloss.rst
+++ b/changes/9254.pathloss.rst
@@ -1,1 +1,0 @@
-For NIRSpec multislit data, add a metadata keyword to each slit to record the pathloss correction type applied (POINT or UNIFORM).

--- a/changes/9254.wavecorr.rst
+++ b/changes/9254.wavecorr.rst
@@ -1,1 +1,0 @@
-For NIRSpec multislit data, add a metadata keyword to each slit to record whether it has been wavelength corrected.

--- a/changes/9263.ami.rst
+++ b/changes/9263.ami.rst
@@ -1,3 +1,0 @@
-Remove unused code and fix various small bugs found while adding test suite.
-
-Deprecate unused and out-of-date AmiAverageStep.

--- a/changes/9283.pipeline.rst
+++ b/changes/9283.pipeline.rst
@@ -1,1 +1,0 @@
-Pipeline utility function ``match_nans_and_flags()`` now raises ``TypeError`` instead of ``ValueError`` on invalid input model.

--- a/changes/9297.scripts.rst
+++ b/changes/9297.scripts.rst
@@ -1,1 +1,0 @@
-Removed ``verify_install_requires`` command. This was a test script that should not have been installed.

--- a/changes/9299.tso_photometry.rst
+++ b/changes/9299.tso_photometry.rst
@@ -1,1 +1,0 @@
-In TSO photometry reductions, added support for processing data in units of DN/s by using the gain reference file to convert to flatfielded electrons.

--- a/changes/9301.tweakreg.rst
+++ b/changes/9301.tweakreg.rst
@@ -1,1 +1,0 @@
-Update docs to clarify format of tweakreg catalogs

--- a/changes/9302.saturation.rst
+++ b/changes/9302.saturation.rst
@@ -1,1 +1,0 @@
-Account for non-zero bias in group 2 saturation flagging in frame-averaged groups.

--- a/changes/9314.assign_wcs.rst
+++ b/changes/9314.assign_wcs.rst
@@ -1,1 +1,0 @@
-Expanded the hard-coded NIRSpec wavelength range to safer limits.

--- a/changes/9317.general.rst
+++ b/changes/9317.general.rst
@@ -1,1 +1,0 @@
-Bumped minversions of requests to 2.31, spherical-geometry to 1.3, synphot to 1.3, and wiimatch to 0.3.2 to avoid using deprecated infrastructure from those packages.

--- a/changes/9320.fringe.rst
+++ b/changes/9320.fringe.rst
@@ -1,1 +1,0 @@
-Apply fringe correction to VAR_POISSON, VAR_RNOISE, and VAR_FLAT also.

--- a/changes/9320.photom.rst
+++ b/changes/9320.photom.rst
@@ -1,1 +1,0 @@
-Apply MRS IFU time-dependent correction to VAR_POISSON, VAR_RNOISE, and VAR_FLAT also.

--- a/changes/9322.assign_wcs.rst
+++ b/changes/9322.assign_wcs.rst
@@ -1,1 +1,0 @@
-Remove util.reproject function (deprecated since 1.18.0). Use ``stcal.alignment.util.reproject`` instead.

--- a/changes/9322.resample.rst
+++ b/changes/9322.resample.rst
@@ -1,5 +1,0 @@
-Remove make_output_wcs function (deprecated since 1.18.0). Use ``resampled_wcs_from_models`` instead.
-
-Remove build_driz_weight function (deprecated since 1.18.0). Use ``stcal.resample.utils.build_driz_weight`` instead.
-
-Remove decode_context function (deprecated since 1.18.0). Use ``drizzle.utils.decode_context`` instead.

--- a/changes/9332.ramp_fitting.rst
+++ b/changes/9332.ramp_fitting.rst
@@ -1,1 +1,0 @@
-Removing OLS and GLS code and all related tests from ramp fitting.

--- a/changes/9334.associations.rst
+++ b/changes/9334.associations.rst
@@ -1,1 +1,0 @@
-Provide subarray name to ``Lv2WFSSNIS`` association rule so that direct image association members have correct Level 3 product name. 

--- a/changes/9347.cube_build.rst
+++ b/changes/9347.cube_build.rst
@@ -1,1 +1,0 @@
-Updated cube_build function names to adhere to Python standards and updated some of the exception names.

--- a/changes/9356.flatfield.rst
+++ b/changes/9356.flatfield.rst
@@ -1,1 +1,0 @@
-Fixed error and variance propagation for inverse steps.

--- a/changes/9356.photom.rst
+++ b/changes/9356.photom.rst
@@ -1,1 +1,0 @@
-Fixed error and variance propagation for inverse steps.

--- a/changes/9361.pipeline.rst
+++ b/changes/9361.pipeline.rst
@@ -1,1 +1,0 @@
-In calwebb_ami3, revert change to strictness of zip function linking science exposures to psf exposures, to allow successful processing of associations with differing numbers of science and psf members.

--- a/changes/9372.assign_wcs.rst
+++ b/changes/9372.assign_wcs.rst
@@ -1,1 +1,0 @@
-Populate the wavelength array for MIRI LRS fixed slit data, for consistency with the MIRI LRS slitless mode.

--- a/changes/9376.background.rst
+++ b/changes/9376.background.rst
@@ -1,1 +1,0 @@
-In WFSS background calculations, use higher precision for mean and sum calculations for better numerical consistency across build environments.

--- a/changes/9376.clean_flicker_noise.rst
+++ b/changes/9376.clean_flicker_noise.rst
@@ -1,1 +1,0 @@
-Use higher precision for sigma clipping statistics for better numerical consistency across build environments.

--- a/changes/9378.straylight.rst
+++ b/changes/9378.straylight.rst
@@ -1,1 +1,0 @@
-Added option to save shower model when running straylight with clean_showers turned on

--- a/changes/9393.associations.rst
+++ b/changes/9393.associations.rst
@@ -1,1 +1,0 @@
-Update associations module for code style and docstrings; remove some unused functions and files.

--- a/changes/9402.combine_1d.rst
+++ b/changes/9402.combine_1d.rst
@@ -1,3 +1,0 @@
-For WFSS modes, reorganize output such that a single table extension holds the spectra
-from all the sources, with different extensions representing different spectral orders.
-The output datamodel type is now WFSSMultiCombinedSpecModel for those modes.

--- a/changes/9402.extract_1d.rst
+++ b/changes/9402.extract_1d.rst
@@ -1,3 +1,0 @@
-For WFSS modes, reorganize output such that a single table extension holds the spectra
-from all the sources for a given exposure and spectral order.
-The output datamodel type is now WFSSMultiSpecModel for those modes.

--- a/changes/9403.resample.rst
+++ b/changes/9403.resample.rst
@@ -1,1 +1,0 @@
-Updated documentation to reflect correct definition of ``pixel_scale_ratio`` for *imaging* data: ratio of output to input pixel scales.

--- a/changes/9404.assign_wcs.rst
+++ b/changes/9404.assign_wcs.rst
@@ -1,1 +1,0 @@
-Rework the NIRSpec WCS to propagate the slit name through all transforms for all modes.

--- a/changes/9412.msaflagopen.rst
+++ b/changes/9412.msaflagopen.rst
@@ -1,1 +1,0 @@
-Removed confusing log and warning messages in ``msa_flagging``.

--- a/changes/9414.general.rst
+++ b/changes/9414.general.rst
@@ -1,1 +1,0 @@
-Implementing STFITSDiff for our regression tests instead of FITSDiff to improve reports.

--- a/changes/9426.general.rst
+++ b/changes/9426.general.rst
@@ -1,1 +1,0 @@
-Remove unused cube_skymatch step

--- a/changes/9429.stpipe.rst
+++ b/changes/9429.stpipe.rst
@@ -1,1 +1,0 @@
-Read only metadata, not whole datamodel, when getting CRDS references

--- a/changes/9430.combine_1d.rst
+++ b/changes/9430.combine_1d.rst
@@ -1,1 +1,0 @@
-Allow spectra from TSOMultiSpecModel to be combined.

--- a/changes/9430.extract_1d.rst
+++ b/changes/9430.extract_1d.rst
@@ -1,2 +1,0 @@
-Reorganize multi-integration spectra into a single table, in which each row is a 1D spectrum.
-The datamodel for TSO x1dints files is now TSOMultiSpecModel, instead of MultiSpecModel.

--- a/changes/9430.photom.rst
+++ b/changes/9430.photom.rst
@@ -1,1 +1,0 @@
-Update handling for NIRISS SOSS to expect multi-integration spectra in TSOMultiSpecModel datamodels.

--- a/changes/9430.white_light.rst
+++ b/changes/9430.white_light.rst
@@ -1,2 +1,0 @@
-Update handling to expect multi-integration spectra in TSOMultiSpecModel datamodels.
-Separate fluxes from different detectors into different output columns.

--- a/changes/9431.white_light.rst
+++ b/changes/9431.white_light.rst
@@ -1,1 +1,0 @@
-Update output table to show correct timestamps and spectral orders for NIRISS tsgrism observations.

--- a/changes/9442.ami.rst
+++ b/changes/9442.ami.rst
@@ -1,3 +1,0 @@
-Improve memory usage of AmiAnalyzeStep: for test dataset with 400 integrations
-and default parameter settings, the memory usage is reduced from 12 GB to 0.5 GB.
-(Note the scaling is not necessarily linear with the number of integrations.)

--- a/changes/9445.white_light.rst
+++ b/changes/9445.white_light.rst
@@ -1,1 +1,0 @@
-Add BJD_TDB times to output table

--- a/changes/9451.background.rst
+++ b/changes/9451.background.rst
@@ -1,1 +1,0 @@
-Implementing capability to be run as a standalone step with asn or fits files, and adding header keyword for step completed or skipped.

--- a/changes/9452.assign_wcs.rst
+++ b/changes/9452.assign_wcs.rst
@@ -1,3 +1,0 @@
-Attach a pixel-to-slice map to NIRSpec IFU images, in a ``regions`` attribute.
-Optionally (but on by default), use the slice map to revise the WCS to be fully coordinate-based,
-so it does not require the slice number on input nor report it on output.

--- a/changes/9463.tweakreg.rst
+++ b/changes/9463.tweakreg.rst
@@ -1,1 +1,0 @@
-Make segmentation algorithm respect kernel_fwhm parameter

--- a/changes/9468.dark_current.rst
+++ b/changes/9468.dark_current.rst
@@ -1,1 +1,0 @@
-Remove mention and use of dark error array; document extrapolation of darks when science array has more frames than the dark.

--- a/changes/9478.refpix.rst
+++ b/changes/9478.refpix.rst
@@ -1,1 +1,0 @@
-Fixed malformed log messages for some off-nominal parameter settings.

--- a/changes/9485.photom.rst
+++ b/changes/9485.photom.rst
@@ -1,1 +1,0 @@
-Allow NIRCam imaging to match calibration values by subarray, if the photom reference file contains subarray information.

--- a/changes/9491.extract_1d.rst
+++ b/changes/9491.extract_1d.rst
@@ -1,1 +1,0 @@
-Fix crashes in the SOSS ATOCA algorithm when adaptive refinement reaches max grid size

--- a/changes/9501.associations.rst
+++ b/changes/9501.associations.rst
@@ -1,1 +1,0 @@
-Revert #9098 and instead use duplication checking to weed out level 2 observation-type associations that have duplicate product IDs with their background candidate association counterparts.

--- a/changes/9507.background.rst
+++ b/changes/9507.background.rst
@@ -1,1 +1,0 @@
-Fix a bug where highly-masked input data for wfss modes were raising errors instead of skipping

--- a/changes/9510.emicorr.rst
+++ b/changes/9510.emicorr.rst
@@ -1,1 +1,0 @@
-Change the default fitting algorithm for MIRI EMI correction to the 'joint' method to improve performance for low numbers of groups.

--- a/changes/9517.resample.rst
+++ b/changes/9517.resample.rst
@@ -1,1 +1,0 @@
-Add options to disable computation of context and variance arrays

--- a/changes/9522.flatfield.rst
+++ b/changes/9522.flatfield.rst
@@ -1,1 +1,0 @@
-Set pixels with negative flat fields to NaN and flag as them DNU for NIRSpec data.

--- a/changes/9523.background.rst
+++ b/changes/9523.background.rst
@@ -1,1 +1,0 @@
-Implement background subtraction for NIRISS SOSS data, fitting reference background templates to background regions of the science data.

--- a/changes/9533.background.rst
+++ b/changes/9533.background.rst
@@ -1,1 +1,0 @@
-Change background alias to "bkg_subtract" to fix conflicting aliases for the step. The new alias is the one currently used for running the step or changing parameters from the stage2 pipelines.

--- a/changes/9540.general.rst
+++ b/changes/9540.general.rst
@@ -1,1 +1,0 @@
-Replaced relative imports with absolute imports

--- a/changes/9548.stpipe.rst
+++ b/changes/9548.stpipe.rst
@@ -1,1 +1,0 @@
-Remove the deprecated ``Step.__call__`` method.

--- a/changes/9552.assign_mtwcs.rst
+++ b/changes/9552.assign_mtwcs.rst
@@ -1,1 +1,0 @@
-Fixed a bug where ``assign_moving_target_wcs`` could crash (instead of skipping the step) for some invalid RA or Dec values.

--- a/changes/9560.ami.rst
+++ b/changes/9560.ami.rst
@@ -1,1 +1,0 @@
-Move pointing information in AmiOIModel from model.meta.ami to model.meta.guidestar (FITS headers remain identical)

--- a/changes/9565.docs.rst
+++ b/changes/9565.docs.rst
@@ -1,1 +1,0 @@
-Remove description of non-working step-specific log configuration.

--- a/changes/9569.general.rst
+++ b/changes/9569.general.rst
@@ -1,1 +1,0 @@
-Style updates completed for all modules.


### PR DESCRIPTION
I'm not going to update the dependencies in `pyproject.toml` for now, until we can finalize the patch