### PR TITLE
JP-3516: Fix duplicate association removal

### DIFF
--- a/changes/9607.associations.rst
+++ b/changes/9607.associations.rst
@@ -1,0 +1,1 @@
+Fix an edge case in duplicate association checks affecting NIRCam coranagraphy associations, where a duplicate "rateints" association should be removed, but an equivalent "rate" association is present, and was accidentally removed instead.

--- a/changes/README.rst
+++ b/changes/README.rst
@@ -16,6 +16,7 @@ News fragment change types
 - ``<PR#>.scripts.rst``
 - ``<PR#>.set_telescope_pointing.rst``
 - ``<PR#>.pipeline.rst``
+- ``<PR#>.associations.rst``
 
 Stage 1
 ^^^^^^^

--- a/jwst/associations/lib/prune.py
+++ b/jwst/associations/lib/prune.py
@@ -207,7 +207,24 @@ def prune_remove(remove_from, to_remove, known_dups):
     if to_remove:
         logger.debug("Duplicate associations found: %s", to_remove)
     for asn in to_remove:
-        remove_from.remove(asn)
+        # Check for an association in the list that "is" the
+        # intended removal (not "equals" the intended removal).
+        # That is, ``remove_from.remove(asn)`` will not work here because
+        # there may be multiple associations in the list that are
+        # equivalent, but only one of them should be removed. For
+        # example, there may be associations present containing rate and
+        # rateints members from the same source file -- these are considered
+        # "equal", but only one of them is the duplicate.
+        remove_index = None
+        for i, test_asn in enumerate(remove_from):
+            if test_asn is asn:
+                remove_index = i
+                break
+        if remove_index is not None:
+            remove_from.pop(remove_index)
+        else:
+            raise IndexError("Expected duplicate association not found in list")
+
         if config.DEBUG:
             DupCount += 1
             asn.asn_name = f"dup{DupCount:05d}_{asn.asn_name}"

--- a/jwst/associations/lib/tests/test_prune.py
+++ b/jwst/associations/lib/tests/test_prune.py
@@ -1,0 +1,52 @@
+import json
+from copy import deepcopy
+
+import pytest
+
+from jwst.associations.asn_from_list import asn_from_list
+from jwst.associations.lib.rules_level2b import Asn_Lv2Image
+from jwst.associations.lib.prune import prune_remove
+
+
+def test_prune_duplicate():
+    """
+    Test pruning when two equivalent associations are in a list.
+
+    Here, the second rateints association is the duplicate and should
+    be removed. The others should stay.
+    """
+    rate = asn_from_list(["jw00016006001_04105_00001_nrca4_rate.fits"], rule=Asn_Lv2Image)
+    rateints = asn_from_list(["jw00016006001_04105_00001_nrca4_rateints.fits"], rule=Asn_Lv2Image)
+    rateints_duplicate = deepcopy(rateints)
+
+    # all three asns are equal, according to comparison rules
+    assert rate == rateints
+    assert rateints == rateints_duplicate
+    assert rateints is not rateints_duplicate
+
+    asn_list = [rate, rateints, rateints_duplicate]
+    to_remove = [rateints_duplicate]
+    known_dups = []
+
+    prune_remove(asn_list, to_remove, known_dups)
+
+    assert len(asn_list) == 2
+    assert asn_list[0] is rate
+    assert asn_list[1] is rateints
+
+
+def test_prune_duplicate_not_found():
+    """Test pruning error condition."""
+    rate = asn_from_list(["jw00016006001_04105_00001_nrca4_rate.fits"], rule=Asn_Lv2Image)
+    rateints = asn_from_list(["jw00016006001_04105_00001_nrca4_rateints.fits"], rule=Asn_Lv2Image)
+    rateints_duplicate = deepcopy(rateints)
+    asn_list = [rate, rateints, rateints_duplicate]
+
+    # Specify an equivalent association to remove, but it
+    # is not the exact same object as the one in the list.
+    # This should raise an error.
+    to_remove = [deepcopy(rateints_duplicate)]
+    known_dups = []
+
+    with pytest.raises(IndexError, match="Expected duplicate association not found"):
+        prune_remove(asn_list, to_remove, known_dups)

--- a/jwst/associations/lib/tests/test_prune.py
+++ b/jwst/associations/lib/tests/test_prune.py
@@ -1,11 +1,10 @@
-import json
 from copy import deepcopy
 
 import pytest
 
 from jwst.associations.asn_from_list import asn_from_list
-from jwst.associations.lib.rules_level2b import Asn_Lv2Image
 from jwst.associations.lib.prune import prune_remove
+from jwst.associations.lib.rules_level2b import Asn_Lv2Image
 
 
 def test_prune_duplicate():

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -52,6 +52,7 @@ def _assoc_sdp_against_standard(rtdata, resource_tracker, request, pool_args):
 @pytest.mark.parametrize(
     "pool_args",
     [
+        ("jw00016_20230331t130733_pool", []),  # This pool checks coronagraphy associations
         ("jw00217_20200921t181631_pool", []),
         ("jw00217_nrsfss_pool", []),
         ("jw00620_20210113t123511_pool", []),
@@ -155,7 +156,6 @@ def test_slow(tmp_cwd, rtdata, resource_tracker, request, pool_args):
 @pytest.mark.parametrize(
     "pool_args",
     [
-        ("jw00016_20230331t130733_pool", []),  # JP-3516
         ("jw80600_20171108T041522_pool", []),  # PR 3450
         ("jw98010_20171108T062332_pool", []),  # PR 3450
     ],


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3516](https://jira.stsci.edu/browse/JP-3516)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Fix an edge case in duplicate association checks, where a duplicate "rateints" association should be removed, but an equivalent "rate" association is present, and was accidentally removed instead.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
