### PR TITLE
Update logging unit test

### DIFF
--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -51,19 +51,14 @@ CRDS_ERROR_STRING = "PARS-WITHDEFAULTSSTEP: No parameters found"
         ("--verbose", "t", lambda stream: CRDS_ERROR_STRING not in stream),
     ],
 )
-def test_disable_crds_steppars_cmdline(capsys, arg, env_set, expected_fn):
+def test_disable_crds_steppars_cmdline(capsys, arg, env_set, expected_fn, monkeypatch):
     """Test setting of disable_crds_steppars"""
     data_path = get_pkg_data_filename("data/miri_data.fits", package="jwst.stpipe.tests")
 
     if env_set:
-        os.environ["STPIPE_DISABLE_CRDS_STEPPARS"] = env_set
+        monkeypatch.setenv("STPIPE_DISABLE_CRDS_STEPPARS", env_set)
 
-    try:
-        step, step_class, positional, debug_on_exception = cmdline.just_the_step_from_cmdline(
-            ["jwst.stpipe.tests.steps.WithDefaultsStep", data_path, arg]
-        )
-    finally:
-        os.environ.pop("STPIPE_DISABLE_CRDS_STEPPARS", None)
+    Step.from_cmdline(["jwst.stpipe.tests.steps.WithDefaultsStep", data_path, arg])
 
     captured = capsys.readouterr()
     assert expected_fn(captured.err)


### PR DESCRIPTION
This PR updates one unit test, the only usage of `just_the_step_from_cmdline` outside of stpipe to instead use the [documented](https://jwst-pipeline.readthedocs.io/en/latest/jwst/stpipe/user_step.html#step-from-cmdline) `Step.from_cmdline` API.

The updated test passes with stpipe main and with stpipe PR: https://github.com/spacetelescope/stpipe/pull/240

The updated test also uses monkeypatching to set environment variables instead of a `try/finally`.

As this is only a unit test change no regtests will be started.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
