### PR TITLE
Fix the ResampleStep pixel_scale units in the docs

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -205,7 +205,7 @@ class ResampleImage(Resample):
 
                 - ``pixel_scale`` : float, None
 
-                    Desired pixel scale (in degrees) of the output WCS. When
+                    Desired pixel scale (in arcsec) of the output WCS. When
                     provided, overrides ``pixel_scale_ratio``. Default value
                     is `None`.
 
@@ -314,7 +314,7 @@ class ResampleImage(Resample):
             # determine output WCS:
             shape = wcs_pars.get("output_shape")
             if (pscale := wcs_pars.get("pixel_scale")) is not None:
-                pscale /= 3600.0
+                pscale /= 3600.0  # convert pixel_scale to degrees/pix
             wcs, _, ps, ps_ratio = resample_utils.resampled_wcs_from_models(
                 input_models,
                 pixel_scale_ratio=wcs_pars.get("pixel_scale_ratio", 1.0),


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR corrects the `ResampleStep` `pixel_scale` units in the docs and step spec.  The correct units for this parameter are degees not arcsec.

https://github.com/spacetelescope/jwst/blob/main/jwst/resample/resample_utils.py#L52


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
