### PR TITLE
Remove python upper pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,5 @@ jobs:
         - linux: py3-cov-xdist
           coverage: codecov
           pytest-results-summary: true
-          python-version: '>3.12 <3.13.4'
         - macos: py3-xdist
           pytest-results-summary: true
-          python-version: '>3.12 <3.13.4'

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -57,13 +57,9 @@ jobs:
       envs: |
         - linux: py3-stdevdeps-xdist
           pytest-results-summary: true
-          python-version: '>3.12 <3.13.4'
         - macos: py3-stdevdeps-xdist
           pytest-results-summary: true
-          python-version: '>3.12 <3.13.4'
         - linux: py3-devdeps-xdist
           pytest-results-summary: true
-          python-version: '>3.12 <3.13.4'
         - macos: py3-devdeps-xdist
           pytest-results-summary: true
-          python-version: '>3.12 <3.13.4'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "spherical-geometry>=1.3",
     "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
-    "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",
+    "stpipe>=0.10.0,<0.11.0",
     "stsci.imagestats>=1.6.3",
     "synphot>=1.3",
     "tweakwcs>=0.8.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jwst"
 description = "Library for calibration of science observations from the James Webb Space Telescope"
-requires-python = ">=3.11,<3.13.4"
+requires-python = ">=3.11"
 authors = [
     { name = "JWST calibration pipeline developers" },
 ]


### PR DESCRIPTION
Remove the temporary upper pin added in https://github.com/spacetelescope/jwst/pull/9582 and https://github.com/spacetelescope/jwst/pull/9592 now that the work-around in stpipe is merged https://github.com/spacetelescope/stpipe/pull/240

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
